### PR TITLE
#417: effect brick for hiding/removing elements

### DIFF
--- a/src/blocks/effects/hide.ts
+++ b/src/blocks/effects/hide.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2021 Pixie Brix, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Effect } from "@/types";
+import { Schema } from "@/core";
+import { propertiesToSchema } from "@/validators/generic";
+import { registerBlock } from "@/blocks/registry";
+
+export class HideEffect extends Effect {
+  constructor() {
+    super(
+      "@pixiebrix/hide",
+      "Hide",
+      "Hide or remove one or more elements on a page"
+    );
+  }
+
+  inputSchema: Schema = propertiesToSchema(
+    {
+      selector: {
+        type: "string",
+        format: "selector",
+      },
+      mode: {
+        type: "string",
+        enum: ["hide", "remove"],
+      },
+    },
+    ["selector"]
+  );
+
+  async effect({
+    selector,
+    mode = "hide",
+  }: {
+    selector: string;
+    mode?: "hide" | "remove";
+  }): Promise<void> {
+    const $elt = $(document).find(selector);
+    if (mode === "hide") {
+      $elt.hide();
+    } else {
+      $elt.remove();
+    }
+  }
+}
+
+registerBlock(new HideEffect());

--- a/src/blocks/effects/index.ts
+++ b/src/blocks/effects/index.ts
@@ -28,3 +28,4 @@ export * from "./wait";
 export * from "./sound";
 export * from "./alert";
 export * from "./pageState";
+export * from "./hide";


### PR DESCRIPTION
Simple brick for hiding/removing elements

In future, could also support an array of selectors so people don't have to add multiple instances of the brick

Only hides the element once. So if it gets re-added, the effect will be undone