### PR TITLE
#410: Set up dependency caching in GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - run: npm install
+      - uses: c-hive/gha-npm-cache@v1
+      - run: npm ci
       - run: npm run build:chrome
         env:
           NODE_ENV: production
@@ -44,7 +45,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - run: npm install
+      - uses: c-hive/gha-npm-cache@v1
+      - run: npm ci
       - run: npm run build:chrome
         env:
           NODE_ENV: production
@@ -81,7 +83,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - run: npm install
+      - uses: c-hive/gha-npm-cache@v1
+      - run: npm ci
       - run: npm run build:firefox
         env:
           NODE_ENV: production

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,8 +14,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - uses: c-hive/gha-npm-cache@v1
-      - run: npm ci
+      - uses: bahmutov/npm-install@v1
       - run: npm run build:chrome
         env:
           NODE_ENV: production
@@ -45,8 +44,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - uses: c-hive/gha-npm-cache@v1
-      - run: npm ci
+      - uses: bahmutov/npm-install@v1
       - run: npm run build:chrome
         env:
           NODE_ENV: production
@@ -83,8 +81,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - uses: c-hive/gha-npm-cache@v1
-      - run: npm ci
+      - uses: bahmutov/npm-install@v1
       - run: npm run build:firefox
         env:
           NODE_ENV: production

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,8 +16,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: c-hive/gha-npm-cache@v1
-      - run: npm ci
+      - uses: bahmutov/npm-install@v1
       - run: npm test
         env:
           CI: true
@@ -30,8 +29,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - uses: c-hive/gha-npm-cache@v1
-      - run: npm ci
+      - uses: bahmutov/npm-install@v1
       - run: npm run build:chrome
         env:
           NODE_ENV: production
@@ -67,8 +65,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - uses: c-hive/gha-npm-cache@v1
-      - run: npm ci
+      - uses: bahmutov/npm-install@v1
       - run: npm run build:firefox
         env:
           NODE_ENV: production
@@ -97,9 +94,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - uses: c-hive/gha-npm-cache@v1
-      - uses: c-hive/gha-npm-cache@v1
-      - run: npm ci
+      - uses: bahmutov/npm-install@v1
       - run: npm run build:scripts
       - run: node scripts/bin/headers.js
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+      - uses: c-hive/gha-npm-cache@v1
+      - run: npm ci
       - run: npm test
         env:
           CI: true
@@ -29,7 +30,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - run: npm install
+      - uses: c-hive/gha-npm-cache@v1
+      - run: npm ci
       - run: npm run build:chrome
         env:
           NODE_ENV: production
@@ -65,7 +67,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - run: npm install
+      - uses: c-hive/gha-npm-cache@v1
+      - run: npm ci
       - run: npm run build:firefox
         env:
           NODE_ENV: production
@@ -94,7 +97,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      - run: npm install
+      - uses: c-hive/gha-npm-cache@v1
+      - uses: c-hive/gha-npm-cache@v1
+      - run: npm ci
       - run: npm run build:scripts
       - run: node scripts/bin/headers.js
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Fixes #410

Hopefully this will help with the frequent `npm install` failures I'm seeing on GHA here.