### PR TITLE
#444: support for blueprint options

### DIFF
--- a/schemas/recipe.json
+++ b/schemas/recipe.json
@@ -14,6 +14,30 @@
       "const": "recipe"
     },
     "metadata": {"$ref": "https://app.pixiebrix.com/schemas/metadata#"},
+    "options": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "description": "JSON schema for options to show user during activation",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["boolean", "number", "string"]
+              },
+              "format": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
     "extensionPoints": {
       "type": "array",
       "minItems": 1,
@@ -28,20 +52,20 @@
             "type": "object",
             "additionalProperties": {
               "$ref": "https://app.pixiebrix.com/schemas/ref#/service"
-              }
             }
-          },
-          "label": {
-            "type": "string",
-            "description": "A human-readable name for the installed brick"
-          },
-          "config": {
-            "type": "object",
-            "description": "Configuration for the extension"
           }
         },
-        "required": ["id", "config"]
-      }
+        "label": {
+          "type": "string",
+          "description": "A human-readable name for the installed brick"
+        },
+        "config": {
+          "type": "object",
+          "description": "Configuration for the extension"
+        }
+      },
+      "required": ["id", "config"]
+    }
   },
   "additionalProperties": false,
   "required": ["apiVersion", "kind", "metadata"]

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -32,6 +32,7 @@ import {
   BlockArg,
   ReaderRoot,
   MessageContext,
+  OptionsArgs,
 } from "@/core";
 import { validateInput } from "@/validators/generic";
 import { OutputUnit } from "@cfworker/json-schema";
@@ -163,6 +164,7 @@ interface ReduceOptions {
   validate?: boolean;
   logValues?: boolean;
   headless?: boolean;
+  optionsArgs?: OptionsArgs;
   serviceArgs?: RenderedArgs;
 }
 
@@ -332,12 +334,14 @@ export async function reducePipeline(
     validate: true,
     logValues: false,
     headless: false,
-    serviceArgs: {} as RenderedArgs,
+    optionsArgs: {},
+    serviceArgs: {},
   }
 ): Promise<unknown> {
   const extraContext: RenderedArgs = {
     "@input": renderedArgs,
     ...options.serviceArgs,
+    "@options": options.optionsArgs,
   };
 
   // If logValues not provided explicitly by the extension point, use the global value
@@ -458,6 +462,7 @@ async function resolveObj<T>(
 ): Promise<Record<string, T>> {
   const result: Record<string, T> = {};
   for (const [key, promise] of Object.entries(obj)) {
+    // eslint-disable-next-line security/detect-object-injection -- safe because we're using Object.entries
     result[key] = await promise;
   }
   return result;

--- a/src/blocks/renderers/customForm.tsx
+++ b/src/blocks/renderers/customForm.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { Renderer } from "@/types";
-import { BlockArg, BlockOptions, RenderedHTML, Schema } from "@/core";
+import { BlockArg, BlockOptions, RenderedHTML, Schema, UiSchema } from "@/core";
 import { registerBlock } from "@/blocks/registry";
 import Form from "@rjsf/core";
 import { JsonObject } from "type-fest";
@@ -35,7 +35,7 @@ const custom = require("!!raw-loader!@/blocks/renderers/customForm.css?esModule=
 
 const CustomFormComponent: React.FunctionComponent<{
   schema: Schema;
-  uiSchema: any;
+  uiSchema: UiSchema;
   formData: JsonObject;
   onSubmit: (values: JsonObject) => Promise<void>;
 }> = ({ schema, uiSchema, formData, onSubmit }) => {

--- a/src/blocks/transformers/blockFactory.ts
+++ b/src/blocks/transformers/blockFactory.ts
@@ -112,7 +112,12 @@ class ExternalBlock extends Block {
       renderedInputs,
       options.logger,
       options.root,
-      { headless: options.headless }
+      {
+        headless: options.headless,
+        // optionsArgs are set at the blueprint level. For composite bricks, they options should be passed in
+        // at part of the brick inputs
+        optionsArgs: undefined,
+      }
     );
   }
 }

--- a/src/blocks/transformers/template.ts
+++ b/src/blocks/transformers/template.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2021 Pixie Brix, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Transformer } from "@/types";
+import { registerBlock } from "@/blocks/registry";
+import { BlockArg, BlockOptions, Schema } from "@/core";
+import { propertiesToSchema } from "@/validators/generic";
+import Mustache from "mustache";
+import { BusinessError } from "@/errors";
+
+/**
+ * Transformer that fills a template using the current context.
+ */
+export class TemplateTransformer extends Transformer {
+  constructor() {
+    super(
+      "@pixiebrix/template",
+      "Fill template",
+      "Fill in a template using the current context",
+      "faCode"
+    );
+  }
+
+  inputSchema: Schema = propertiesToSchema(
+    {
+      template: {
+        type: "string",
+        description: "The template to render",
+      },
+      templateEngine: {
+        type: "string",
+        enum: ["mustache"],
+        default: "mustache",
+      },
+    },
+    ["template"]
+  );
+
+  async transform(
+    { template, templateEngine = "mustache" }: BlockArg,
+    { ctxt }: BlockOptions
+  ): Promise<unknown> {
+    if (templateEngine !== "mustache") {
+      throw new BusinessError(
+        "Only 'mustache' is currently supported for templateEngine"
+      );
+    }
+    return Mustache.render(template, ctxt);
+  }
+}
+
+registerBlock(new TemplateTransformer());

--- a/src/components/fields/propTypes.ts
+++ b/src/components/fields/propTypes.ts
@@ -16,7 +16,7 @@
  */
 
 import PropTypes from "prop-types";
-import { Schema } from "@/core";
+import { Schema, UiSchema } from "@/core";
 
 // https://json-schema.org/understanding-json-schema/reference/generic.html
 
@@ -38,4 +38,5 @@ export interface FieldProps<TValue> {
   name: string;
   label?: string;
   schema: Schema;
+  uiSchema?: UiSchema;
 }

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -33,8 +33,9 @@ if (!window[PIXIEBRIX_SYMBOL]) {
 } else {
   // Don't load script multiple times. Required since we can't do conditional imports to no-op the
   // content script if it's already installed
-  // eslint-disable-next-line security/detect-object-injection
+
   console.debug(
+    // eslint-disable-next-line security/detect-object-injection -- safe because it's using the symbol we create
     `PixieBrix contentScript already installed: ${window[PIXIEBRIX_SYMBOL]}`
   );
   throw Error(`PixieBrix contentScript already installed`);

--- a/src/contrib/pipedrive/calendar.ts
+++ b/src/contrib/pipedrive/calendar.ts
@@ -119,6 +119,7 @@ class CalendarTimeRange extends ExtensionPoint<CalendarConfig> {
       {
         validate: true,
         serviceArgs: serviceContext,
+        optionsArgs: extension.optionsArgs,
       }
     )) as RangeConfig[];
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -16,6 +16,7 @@
  */
 
 import { JSONSchema7, JSONSchema7Definition } from "json-schema";
+import { UiSchema as StandardUiSchema } from "@rjsf/core";
 import { AxiosRequestConfig } from "axios";
 import { Primitive } from "type-fest";
 import { ErrorObject } from "serialize-error";
@@ -24,6 +25,7 @@ import { pick } from "lodash";
 
 export type TemplateEngine = "mustache" | "nunjucks" | "handlebars";
 export type Schema = JSONSchema7;
+export type UiSchema = StandardUiSchema;
 export type SchemaDefinition = JSONSchema7Definition;
 export type SchemaProperties = { [key: string]: SchemaDefinition };
 
@@ -134,6 +136,9 @@ export interface IExtension<
 
   label?: string;
 
+  /**
+   * Default template engine when running the extension
+   */
   templateEngine?: TemplateEngine;
 
   /**
@@ -141,7 +146,15 @@ export interface IExtension<
    */
   permissions?: Permissions.Permissions;
 
+  /**
+   * Configured services/integrations for the extension
+   */
   services: ServiceDependency[];
+
+  /**
+   * Options the end-user has configured (i.e., during blueprint activation)
+   */
+  optionsArgs?: OptionsArgs;
 
   config: T;
 }
@@ -336,6 +349,10 @@ export interface IconConfig {
   library?: IconLibrary;
   size?: number;
   color?: string;
+}
+
+export interface OptionsArgs {
+  [prop: string]: Primitive;
 }
 
 export interface RenderedArgs {

--- a/src/extensionPoints/actionPanelExtension.ts
+++ b/src/extensionPoints/actionPanelExtension.ts
@@ -53,6 +53,7 @@ import Mustache from "mustache";
 import { reportError } from "@/telemetry/logging";
 import { v4 as uuidv4 } from "uuid";
 import { getErrorMessage } from "@/extensionPoints/helpers";
+import { BusinessError } from "@/errors";
 
 export interface ActionPanelConfig {
   heading: string;
@@ -120,9 +121,12 @@ export abstract class ActionPanelExtensionPoint extends ExtensionPoint<ActionPan
       await reducePipeline(body, readerContext, extensionLogger, document, {
         validate: true,
         serviceArgs: serviceContext,
+        optionsArgs: extension.optionsArgs,
         headless: true,
       });
-      throw new Error("No renderer attached to body");
+      // We're expecting a HeadlessModeError (or other error) to be thrown in the line above
+      // noinspection ExceptionCaughtLocallyJS
+      throw new BusinessError("No renderer attached to body");
     } catch (err) {
       if (err instanceof HeadlessModeError) {
         upsertPanel(

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -284,6 +284,8 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
       extensionId: extension.id,
     });
 
+    console.debug("Got extension", { extension });
+
     registerHandler(extension.id, async (clickData) => {
       const reader = await this.getBaseReader();
       const serviceContext = await makeServiceContext(extension.services);
@@ -302,6 +304,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
       await reducePipeline(actionConfig, ctxt, extensionLogger, document, {
         validate: true,
         serviceArgs: serviceContext,
+        optionsArgs: extension.optionsArgs,
       });
     });
   }

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -449,6 +449,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
         {
           validate: true,
           serviceArgs: serviceContext,
+          optionsArgs: extension.optionsArgs,
         }
       );
 
@@ -492,6 +493,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
         await reducePipeline(actionConfig, ctxt, extensionLogger, document, {
           validate: true,
           serviceArgs: serviceContext,
+          optionsArgs: extension.optionsArgs,
         });
 
         extensionLogger.info("Successfully ran menu action");

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -367,6 +367,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
           {
             validate: true,
             serviceArgs: serviceContext,
+            optionsArgs: extension.optionsArgs,
           }
         ) as Promise<PanelComponent>;
 

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -124,6 +124,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
       await reducePipeline(actionConfig, ctxt, extensionLogger, root, {
         validate: true,
         serviceArgs: serviceContext,
+        optionsArgs: extension.optionsArgs,
       });
       extensionLogger.info("Successfully ran trigger");
     } catch (ex) {

--- a/src/options/loader.ts
+++ b/src/options/loader.ts
@@ -18,6 +18,7 @@
 import { readStorage, setStorage } from "@/chrome";
 import { Metadata, ServiceDependency } from "@/core";
 import { Permissions } from "webextension-polyfill-ts";
+import { Primitive } from "type-fest";
 
 const storageKey = "persist:extensionOptions";
 
@@ -34,6 +35,7 @@ export interface ExtensionOptions {
   label: string;
   permissions?: Permissions.Permissions;
   services: ServiceDependency[];
+  optionsArgs?: Record<string, Primitive>;
   config: { [prop: string]: unknown };
 }
 

--- a/src/options/pages/extensionEditor/DataSourceCard.tsx
+++ b/src/options/pages/extensionEditor/DataSourceCard.tsx
@@ -181,7 +181,7 @@ const DataSourceCard: React.FunctionComponent<{
     } else {
       return <SchemaTree schema={outputSchema} />;
     }
-  }, [outputSchema, isPending]);
+  }, [error, outputSchema, isPending]);
 
   return <div className="DataSourceCard">{body}</div>;
 };

--- a/src/options/pages/extensionEditor/ExtensionEditor.tsx
+++ b/src/options/pages/extensionEditor/ExtensionEditor.tsx
@@ -29,6 +29,7 @@ import { reactivate } from "@/background/navigation";
 import { GridLoader } from "react-spinners";
 
 import "./ExtensionEditor.scss";
+import { reportError } from "@/telemetry/logging";
 
 const { saveExtension } = optionsSlice.actions;
 
@@ -65,7 +66,7 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
   );
 
   const save = useCallback(
-    ({ config, label, services }, { setSubmitting }) => {
+    ({ config, label, services, optionsArgs }, { setSubmitting }) => {
       if (!extensionPoint) {
         return;
       }
@@ -78,6 +79,7 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
           config,
           services,
           label,
+          optionsArgs,
         });
 
         const toastMsg = extensionConfig?.id
@@ -93,12 +95,14 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
           navigate(`/workshop/extensions/${extensionId}`);
         }
 
-        reactivate();
+        reactivate().catch((err) => {
+          reportError(err);
+        });
       } finally {
         setSubmitting(false);
       }
     },
-    [extensionPoint, extensionConfig, saveExtension, addToast]
+    [extensionPoint, extensionConfig, saveExtension, addToast, navigate]
   );
 
   if (isPending) {
@@ -112,6 +116,7 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
           label: extensionConfig?.label,
           config: extensionConfig?.config,
           services: extensionConfig?.services ?? [],
+          optionsArgs: extensionConfig?.optionsArgs ?? {},
         }}
         extensionId={extensionId}
         extensionPoint={extensionPoint}
@@ -121,6 +126,7 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
   }
 };
 
-export default connect(undefined, { saveExtension, navigate: push })(
-  ExtensionEditor
-);
+const mapStateToProps: null = undefined;
+const mapDispatchToProps = { saveExtension, navigate: push };
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExtensionEditor);

--- a/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
+++ b/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
@@ -27,7 +27,7 @@ import {
 import { Form, Row, Col, Card, Nav, Button } from "react-bootstrap";
 import ServicesFormCard from "@/options/pages/extensionEditor/ServicesFormCard";
 import ExtensionConfigurationCard from "@/options/pages/extensionEditor/ExtensionConfigurationCard";
-import { IExtensionPoint, ServiceDependency } from "@/core";
+import { IExtensionPoint, OptionsArgs, ServiceDependency } from "@/core";
 import DataSourceCard from "@/options/pages/extensionEditor/DataSourceCard";
 import { Formik, FormikProps, getIn, useFormikContext } from "formik";
 import TextField from "@/components/fields/TextField";
@@ -46,6 +46,7 @@ import { saveAs } from "file-saver";
 import { useToasts } from "react-toast-notifications";
 import { reportError } from "@/telemetry/logging";
 import { configToYaml } from "@/devTools/editor/useCreate";
+import OptionsArgsCard from "@/options/pages/extensionEditor/OptionsArgsCard";
 
 type TopConfig = { [prop: string]: unknown };
 
@@ -53,6 +54,7 @@ export interface Config {
   config: TopConfig;
   label: string;
   services: ServiceDependency[];
+  optionsArgs: OptionsArgs;
 }
 
 interface OwnProps {
@@ -185,7 +187,9 @@ const ExtensionForm: React.FunctionComponent<{
         autoDismiss: true,
       });
     }
-  }, [values, extensionPoint]);
+  }, [addToast, values, extensionPoint]);
+
+  const hasOptions = !isEmpty(values.optionsArgs);
 
   return (
     <Form noValidate onSubmit={handleSubmit}>
@@ -239,6 +243,7 @@ const ExtensionForm: React.FunctionComponent<{
                   eventKey="services"
                   fieldName="services"
                 />
+                {hasOptions && <NavItem caption="Options" eventKey="options" />}
                 <NavItem caption="Data" eventKey="reader" />
                 <NavItem
                   caption="Configuration"
@@ -272,6 +277,7 @@ const ExtensionForm: React.FunctionComponent<{
                 <DataSourceCard extensionPoint={extensionPoint} />
               </ErrorBoundary>
             )}
+            {activeTab === "options" && <OptionsArgsCard name="optionsArgs" />}
             {activeTab === "configuration" && (
               <ExtensionConfigurationCard
                 name="config"
@@ -300,6 +306,7 @@ const ExtensionPointDetail: React.FunctionComponent<OwnProps> = ({
     config: initialConfig,
     label: initialLabel,
     services: initialServices,
+    optionsArgs: initialOptionsArgs,
   },
 }) => {
   const initialValues = useMemo(
@@ -307,8 +314,15 @@ const ExtensionPointDetail: React.FunctionComponent<OwnProps> = ({
       label: initialLabel,
       services: initialServices ?? [],
       config: normalizeConfig(initialConfig, extensionPoint),
+      optionsArgs: initialOptionsArgs,
     }),
-    [initialConfig, extensionPoint]
+    [
+      initialOptionsArgs,
+      initialLabel,
+      initialServices,
+      initialConfig,
+      extensionPoint,
+    ]
   );
 
   const validationSchema = useMemo(() => {

--- a/src/options/pages/extensionEditor/OptionsArgsCard.tsx
+++ b/src/options/pages/extensionEditor/OptionsArgsCard.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2021 Pixie Brix, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+import { useField } from "formik";
+import { OptionsArgs } from "@/core";
+import { Card, Table } from "react-bootstrap";
+
+const OptionsArgsCard: React.FunctionComponent<{
+  name: string;
+}> = (props) => {
+  const [field] = useField<OptionsArgs>(props);
+
+  return (
+    <div className="OptionsArgsCard">
+      <Card.Body className="pb-2">
+        <p>
+          Options selected during activation. You can refer to these in the
+          configuration as <code>@options.name</code>
+        </p>
+      </Card.Body>
+      <Table>
+        <thead>
+          <tr>
+            <th>Option</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(field.value).map(([optionProp, value]) => (
+            <tr key={optionProp}>
+              <td>{optionProp}</td>
+              <td>{value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
+};
+
+export default OptionsArgsCard;

--- a/src/options/pages/marketplace/ActivatePage.tsx
+++ b/src/options/pages/marketplace/ActivatePage.tsx
@@ -112,7 +112,7 @@ const ActivatePage: React.FunctionComponent = () => {
     } else {
       return <GridLoader />;
     }
-  }, [blueprint, sourcePage]);
+  }, [blueprintId, blueprint, sourcePage]);
 
   return (
     <div>

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -20,7 +20,7 @@ import { RecipeDefinition } from "@/types/definitions";
 import { Button, Card, Form, Nav, Tab } from "react-bootstrap";
 import { ExtensionOptions, optionsSlice, OptionsState } from "@/options/slices";
 import { useToasts } from "react-toast-notifications";
-import { groupBy, uniq, pickBy } from "lodash";
+import { groupBy, uniq, pickBy, isEmpty, mapValues } from "lodash";
 import { useDispatch, useSelector } from "react-redux";
 import { push } from "connected-react-router";
 import "./ActivateWizard.scss";
@@ -40,6 +40,7 @@ import ActivateBody, {
 import { reactivate } from "@/background/navigation";
 import { reportError } from "@/telemetry/logging";
 import { useParams } from "react-router";
+import OptionsBody from "@/options/pages/marketplace/OptionsBody";
 
 const { installRecipe, removeExtension } = optionsSlice.actions;
 
@@ -63,22 +64,23 @@ function selectAuths(
     } else if (configs.length > 1) {
       throw new Error(`Service ${id} has multiple configurations`);
     }
+    // eslint-disable-next-line security/detect-object-injection -- safe because it's from Object.entries
     result[id] = configs[0];
   }
   return result;
 }
 
+const selectExtensions = ({ options }: { options: OptionsState }) => {
+  return Object.values(options.extensions).flatMap((extensionPointOptions) =>
+    Object.values(extensionPointOptions)
+  );
+};
+
 export function useReinstall(): (recipe: RecipeDefinition) => Promise<void> {
   const dispatch = useDispatch();
 
   const extensions = useSelector<{ options: OptionsState }, ExtensionOptions[]>(
-    ({ options }) => {
-      return Object.values(
-        options.extensions
-      ).flatMap((extensionPointOptions) =>
-        Object.values(extensionPointOptions)
-      );
-    }
+    selectExtensions
   );
 
   return useCallback(
@@ -178,6 +180,7 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
             recipe,
             extensionPoints: selected,
             services: values.services,
+            optionsArgs: values.optionsArgs,
           })
         );
 
@@ -204,7 +207,7 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
         setSubmitting(false);
       }
     },
-    [installRecipe, addToast, dispatch, sourcePage]
+    [addToast, dispatch, sourcePage, recipe]
   );
 }
 
@@ -213,7 +216,8 @@ interface OwnProps {
 }
 
 const STEPS = [
-  { key: "review", label: "Configure", Component: ConfigureBody },
+  { key: "review", label: "Select", Component: ConfigureBody },
+  { key: "options", label: "Configure", Component: OptionsBody },
   { key: "services", label: "Select Services", Component: ServicesBody },
   { key: "activate", label: "Review & Activate", Component: ActivateBody },
 ];
@@ -243,10 +247,27 @@ const ActivateWizard: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
     const services = uniq(
       extensionPoints.flatMap((x) => Object.values(x.services ?? {}))
     );
-    const steps = STEPS.filter((x) => x.key !== "services" || services.length);
-    const initialValues = {
+    const steps = STEPS.filter((x) => {
+      switch (x.key) {
+        case "services": {
+          return services.length;
+        }
+        case "options": {
+          return !isEmpty(blueprint.options?.schema);
+        }
+        default: {
+          return true;
+        }
+      }
+    });
+    const initialValues: WizardValues = {
       extensions: Object.fromEntries(extensionPoints.map((x, i) => [i, true])),
       services: Object.fromEntries(services.map((x) => [x, undefined])),
+      optionsArgs: mapValues(
+        blueprint.options?.schema ?? {},
+        (x) => (x as any).default
+      ),
+      grantPermissions: false,
     };
     return [steps, initialValues];
   }, [blueprint]);
@@ -255,7 +276,7 @@ const ActivateWizard: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
   const install = useInstall(blueprint);
 
   return (
-    <Formik initialValues={initialValues as WizardValues} onSubmit={install}>
+    <Formik initialValues={initialValues} onSubmit={install}>
       {({ handleSubmit }) => (
         <Form id="activate-wizard" noValidate onSubmit={handleSubmit}>
           <Tab.Container activeKey={stepKey}>

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -217,7 +217,7 @@ interface OwnProps {
 
 const STEPS = [
   { key: "review", label: "Select", Component: ConfigureBody },
-  { key: "options", label: "Configure", Component: OptionsBody },
+  { key: "options", label: "Personalize", Component: OptionsBody },
   { key: "services", label: "Select Services", Component: ServicesBody },
   { key: "activate", label: "Review & Activate", Component: ActivateBody },
 ];

--- a/src/options/pages/marketplace/OptionsBody.tsx
+++ b/src/options/pages/marketplace/OptionsBody.tsx
@@ -19,6 +19,9 @@ import React, { useMemo } from "react";
 import { Card } from "react-bootstrap";
 import { RecipeDefinition } from "@/types/definitions";
 import genericOptionsFactory from "@/components/fields/blockOptions";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { Link } from "react-router-dom";
 
 interface OwnProps {
   blueprint: RecipeDefinition;
@@ -26,13 +29,28 @@ interface OwnProps {
 
 const OptionsBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
   const Component = useMemo(
-    () => genericOptionsFactory(blueprint.options.schema),
-    [blueprint.options.schema]
+    () =>
+      genericOptionsFactory(
+        blueprint.options.schema,
+        blueprint.options.uiSchema
+      ),
+    [blueprint.options.schema, blueprint.options.uiSchema]
   );
   return (
-    <Card.Body className="p-3">
-      <Component name="optionsArgs" />
-    </Card.Body>
+    <>
+      <Card.Body className="px-3 pb-1">
+        <Card.Title>Personalize the Blueprint</Card.Title>
+
+        <p className="text-info">
+          <FontAwesomeIcon icon={faInfoCircle} /> After activating this brick,
+          you&apos;ll be able to modify it at any time on the{" "}
+          <Link to="/installed">Active Bricks page</Link>
+        </p>
+      </Card.Body>
+      <Card.Body className="p-3">
+        <Component name="optionsArgs" />
+      </Card.Body>
+    </>
   );
 };
 

--- a/src/options/pages/marketplace/OptionsBody.tsx
+++ b/src/options/pages/marketplace/OptionsBody.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Pixie Brix, LLC
+ * Copyright (C) 2021 Pixie Brix, LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,17 +15,25 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-export * from "./jq";
-export * from "./jsonPath";
-export * from "./httpGet";
-export * from "./remoteMethod";
-export * from "./regex";
-export * from "./mapping";
-export * from "./identity";
-export * from "./FormData";
-export * from "./parseURL";
-export * from "./prompt";
-export * from "./detect";
-export * from "./modal";
-export * from "./encode";
-export * from "./template";
+import React, { useMemo } from "react";
+import { Card } from "react-bootstrap";
+import { RecipeDefinition } from "@/types/definitions";
+import genericOptionsFactory from "@/components/fields/blockOptions";
+
+interface OwnProps {
+  blueprint: RecipeDefinition;
+}
+
+const OptionsBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
+  const Component = useMemo(
+    () => genericOptionsFactory(blueprint.options.schema),
+    [blueprint.options.schema]
+  );
+  return (
+    <Card.Body className="p-3">
+      <Component name="optionsArgs" />
+    </Card.Body>
+  );
+};
+
+export default OptionsBody;

--- a/src/options/pages/marketplace/ServicesBody.tsx
+++ b/src/options/pages/marketplace/ServicesBody.tsx
@@ -19,7 +19,7 @@ import React, { useMemo } from "react";
 import ServiceAuthSelector, {
   useAuthOptions,
 } from "@/options/pages/extensionEditor/ServiceAuthSelector";
-import uniq from "lodash/uniq";
+import { uniq } from "lodash";
 import { Card, Table } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { RecipeDefinition } from "@/types/definitions";

--- a/src/options/pages/marketplace/wizard.ts
+++ b/src/options/pages/marketplace/wizard.ts
@@ -15,8 +15,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import { Primitive } from "type-fest";
+
 export interface WizardValues {
-  extensions: { [key: string]: boolean };
-  services: { [key: string]: string };
+  extensions: Record<string, boolean>;
+  /**
+   * Mapping from service id to auth id
+   */
+  services: Record<string, string>;
+  optionsArgs: Record<string, Primitive>;
   grantPermissions: boolean;
 }

--- a/src/types/definitions.ts
+++ b/src/types/definitions.ts
@@ -17,6 +17,7 @@
 
 import { Metadata, Schema } from "@/core";
 import { Permissions } from "webextension-polyfill-ts";
+import { UiSchema } from "@rjsf/core";
 
 export interface ExtensionPointDefinition {
   id: string;
@@ -26,9 +27,15 @@ export interface ExtensionPointDefinition {
   config: Record<string, unknown>;
 }
 
+export interface OptionsDefinition {
+  schema: Schema;
+  uiSchema?: UiSchema;
+}
+
 export interface RecipeDefinition {
   metadata: Metadata;
   extensionPoints: ExtensionPointDefinition[];
+  options?: OptionsDefinition;
 }
 
 export interface KeyAuthenticationDefinition {


### PR DESCRIPTION
Add support for an `options` section in blueprints where a blueprint author can expose options for a user to configure when activating