### PR TITLE
#427: Don't include hash when generating the pattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7393,6 +7393,13 @@
       "requires": {
         "@types/firefox-webext-browser": "^78.0.1",
         "webext-patterns": "^0.9.0"
+      },
+      "dependencies": {
+        "webext-patterns": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/webext-patterns/-/webext-patterns-0.9.1.tgz",
+          "integrity": "sha512-ZbzznXSq3/p0XwXRtMLjoFFPM7BIKVsGaEA44ZZ5OsnX085NpB3D3zzJkzpN0fQCrvuk6XRtao1YM3WN2/94VA=="
+        }
       }
     },
     "contra": {
@@ -13357,11 +13364,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
       "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw=="
     },
-    "match-pattern": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/match-pattern/-/match-pattern-0.0.2.tgz",
-      "integrity": "sha1-KXbkrFuXbR1AtL3i8SRlgCUsKnA="
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -18521,9 +18523,9 @@
       }
     },
     "webext-patterns": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/webext-patterns/-/webext-patterns-0.9.0.tgz",
-      "integrity": "sha512-eJDQjdJ8QmbURZtmRVnkLm4xHoG3YUNJzpIIJPmBKC4rjfT89IzZvUn70qJSKM9+S3sqefI1hzQIvSLp2uGWfw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webext-patterns/-/webext-patterns-1.1.0.tgz",
+      "integrity": "sha512-u2xQUdengcXxBFaSy2CF89RmlQCv3SRWNW6J2+EKZPRvnRARf+UyzwVZZJJogUCgqzNhn5mswOYchnHCfh/nmA=="
     },
     "webextension-polyfill": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "jsonschema": "^1.4.0",
     "lodash": "^4.17.21",
     "marked": "^2.0.1",
-    "match-pattern": "0.0.2",
     "moment": "^2.29.1",
     "mustache": "^4.0.1",
     "notifyjs-browser": "^0.4.2",
@@ -108,6 +107,7 @@
     "uuid": "^8.3.2",
     "webext-detect-page": "^2.0.5",
     "webext-dynamic-content-scripts": "^7.0.0",
+    "webext-patterns": "^1.1.0",
     "webextension-polyfill-ts": "^0.22.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
       "^.+\\.txt$": "jest-raw-loader"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!@cfworker|webext-detect-page|idb)"
+      "node_modules/(?!@cfworker|webext-detect-page|idb|webext-patterns)"
     ],
     "setupFiles": [
       "<rootDir>/src/test-env.js",

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -22,8 +22,7 @@ import {
   RuntimeNotFoundError,
 } from "@/chrome";
 import { browser, Runtime } from "webextension-polyfill-ts";
-// @ts-ignore: types not defined for match-pattern
-import matchPattern from "match-pattern";
+import { patternToRegex } from "webext-patterns";
 import {
   isBackgroundPage,
   isContentScript,
@@ -60,9 +59,7 @@ export function allowBackgroundSender(
   return (
     sender.id === browser.runtime.id ||
     ("origin" in sender &&
-      externally_connectable.matches?.some((x) =>
-        matchPattern.parse(x).test(sender.origin)
-      ))
+      patternToRegex(...externally_connectable.matches).test(sender.origin))
   );
 }
 

--- a/src/blocks/available.ts
+++ b/src/blocks/available.ts
@@ -24,7 +24,10 @@ import { Availability } from "@/blocks/types";
 import { Permissions } from "webextension-polyfill-ts";
 import { BusinessError } from "@/errors";
 
-export function testMatchPatterns(url: string, ...patterns: string[]): boolean {
+export function testMatchPatterns(
+  patterns: string[],
+  url: string = document.location.href
+): boolean {
   let re;
 
   try {
@@ -58,10 +61,7 @@ export async function checkAvailable({
   const selectors = rawSelectors ? castArray(rawSelectors) : [];
 
   // check matchPatterns first b/c they'll be faster
-  if (
-    matchPatterns.length &&
-    !testMatchPatterns(document.location.href, ...matchPatterns)
-  ) {
+  if (matchPatterns.length && !testMatchPatterns(matchPatterns)) {
     // console.debug(
     //   `Location doesn't match any pattern: ${document.location.href}`,
     //   matchPatterns

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -197,7 +197,7 @@ function getNavSequence() {
 async function waitLoaded(cancel: () => boolean): Promise<void> {
   const url = document.location.href;
   const rules = NAVIGATION_RULES.filter((rule) =>
-    testMatchPatterns(url, ...rule.matchPatterns)
+    testMatchPatterns(rule.matchPatterns, url)
   );
   if (rules.length > 0) {
     const $document = $(document);

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -25,7 +25,7 @@ import {
 import * as context from "@/contentScript/context";
 import { PromiseCancelled, sleep } from "@/utils";
 import { NAVIGATION_RULES } from "@/contrib/navigationRules";
-import { testMatchPattern } from "@/blocks/available";
+import { testMatchPatterns } from "@/blocks/available";
 
 let _scriptPromise: Promise<void>;
 const _dynamic: Map<string, IExtensionPoint> = new Map();
@@ -197,7 +197,7 @@ function getNavSequence() {
 async function waitLoaded(cancel: () => boolean): Promise<void> {
   const url = document.location.href;
   const rules = NAVIGATION_RULES.filter((rule) =>
-    rule.matchPatterns.some((pattern) => testMatchPattern(pattern, url))
+    testMatchPatterns(url, ...rule.matchPatterns)
   );
   if (rules.length > 0) {
     const $document = $(document);

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -58,6 +58,7 @@ function defaultMatchPattern(url: string): string {
     obj.searchParams.delete(name);
   }
   obj.pathname = "*";
+  obj.hash = "";
   console.debug(`Generate match pattern`, { href: obj.href });
   return obj.href;
 }

--- a/src/services/factory.ts
+++ b/src/services/factory.ts
@@ -68,7 +68,7 @@ class LocalDefinedService<
     const patterns = castArray(
       this._definition.isAvailable?.matchPatterns ?? []
     );
-    return patterns.length == 0 || testMatchPatterns(url, ...patterns);
+    return patterns.length == 0 || testMatchPatterns(patterns, url);
   }
 
   /**

--- a/src/services/factory.ts
+++ b/src/services/factory.ts
@@ -30,7 +30,7 @@ import {
   TokenContext,
   SanitizedConfig,
 } from "@/core";
-import { testMatchPattern } from "@/blocks/available";
+import { testMatchPatterns } from "@/blocks/available";
 import { isEmpty, castArray, uniq, compact } from "lodash";
 import urljoin from "url-join";
 import {
@@ -68,9 +68,7 @@ class LocalDefinedService<
     const patterns = castArray(
       this._definition.isAvailable?.matchPatterns ?? []
     );
-    return (
-      patterns.length == 0 || patterns.some((x) => testMatchPattern(x, url))
-    );
+    return patterns.length == 0 || testMatchPatterns(url, ...patterns);
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/427

Changes:

- The generated pattern no longer includes the hash
- The patterns are validated and converted following WebExtensions’ logic rather than generic glob/pattern logic
- The code has been changed to convert and match all patterns at once since [webext-patterns](https://github.com/fregante/webext-patterns) can create a single regex from multiple patterns

What didn't change:

- The hash is still included in the pattern if the user manually specifies it.

If we preserve the current support for hash, we _might_ have issues, especially around `contentScript.register` (native vs polyfill). If we instead drop support, do we just silently ignore it?

For the record, I tried a pattern with a has in `content_scripts.matches` in both Chrome and Firefox in a test extension. Both detected the permission (i.e. it's "valid") but then they do never inject the content script (regardless of hash in the current tab)