### PR TITLE
#411: Drop `babel-loader`

### DIFF
--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -307,15 +307,14 @@ module.exports = (env, options) => ({
       {
         test: /\.tsx?$/,
         use: [
-          "babel-loader",
-          { loader: "ts-loader?configFile=tsconfig.webpack.json" },
+          {
+            loader: "ts-loader",
+            options: {
+              configFile: "tsconfig.webpack.json",
+            },
+          },
         ],
-        exclude: /(node_modules|bower_components)/,
-      },
-      {
-        test: /\.m?js$/,
-        exclude: /(node_modules|bower_components)/,
-        use: ["babel-loader"],
+        exclude: /node_modules/,
       },
       {
         test: /\.(svg|png|jpg|gif)?$/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6714,18 +6714,6 @@
         }
       }
     },
-    "babel-loader": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
-      "integrity": "sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==",
-      "dev": true,
-      "requires": {
-        "find-cache-dir": "^3.3.1",
-        "loader-utils": "^1.4.0",
-        "make-dir": "^3.1.0",
-        "schema-utils": "^2.6.5"
-      }
-    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -10381,28 +10369,6 @@
       "optional": true,
       "requires": {
         "traverse-chain": "~0.1.0"
-      }
-    },
-    "find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
-      "dev": true,
-      "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
-      },
-      "dependencies": {
-        "pkg-dir": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-          "dev": true,
-          "requires": {
-            "find-up": "^4.0.0"
-          }
-        }
       }
     },
     "find-root": {
@@ -16950,17 +16916,6 @@
         "uniq": "^1.0.1",
         "uppercamelcase": "^3.0.0",
         "yup": "^0.27.0"
-      }
-    },
-    "schema-utils": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
-      "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.5",
-        "ajv": "^6.12.4",
-        "ajv-keywords": "^3.5.2"
       }
     },
     "scss-tokenizer": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "@typescript-eslint/parser": "^4.20.0",
     "axios-mock-adapter": "^1.19.0",
     "babel-jest": "^27.0.2",
-    "babel-loader": "^8.2.2",
     "compass-mixins": "^0.12.10",
     "copy-webpack-plugin": "^9.0.0",
     "csp-parse": "0.0.2",

--- a/scripts/webpack.scripts.js
+++ b/scripts/webpack.scripts.js
@@ -74,15 +74,14 @@ module.exports = {
       {
         test: /\.tsx?$/,
         use: [
-          "babel-loader",
-          { loader: "ts-loader?configFile=tsconfig.webpack.json" },
+          {
+            loader: "ts-loader",
+            options: {
+              configFile: "tsconfig.webpack.json",
+            },
+          },
         ],
-        exclude: /(node_modules|bower_components)/,
-      },
-      {
-        test: /\.m?js$/,
-        exclude: /(node_modules|bower_components)/,
-        use: ["babel-loader"],
+        exclude: /node_modules/,
       },
       {
         test: /\.(svg|png|jpg|gif)?$/,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "sourceMap": true,
     "noImplicitAny": true,
     "module": "es2020",
-    "target": "es2019",
+    "target": "es2020",
     "jsx": "react",
     "allowJs": false,
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "sourceMap": true,
     "noImplicitAny": true,
     "module": "es2020",
-    "target": "es6",
+    "target": "es2019",
     "jsx": "react",
     "allowJs": false,
     "resolveJsonModule": true,


### PR DESCRIPTION
Related to #411 

TypeScript projects don't need babel for the most part. #420 reduced the transforms required, this PR drops it entirely — except for Jest, which supports TypeScript through babel.

### `build` time

2m 16s -> 2m 

A week ago, this build time was 2m 38s if I remember correctly.

## CRX savings

Negligible (0.1MB)
