### PR TITLE
#411: Remove most `moment` usage

### DIFF
--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -21,6 +21,7 @@ const webpack = require("webpack");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const WebExtensionTarget = require("webpack-target-webextension");
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
+const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
 
 const TerserJSPlugin = require("terser-webpack-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
@@ -244,6 +245,10 @@ module.exports = (env, options) => ({
   },
   plugins: [
     ...getConditionalPlugins(isProd(options)),
+
+    // To strip all locales except “en”
+    new MomentLocalesPlugin(),
+
     new NodePolyfillPlugin(),
     new WebExtensionTarget(nodeConfig),
     new webpack.ProvidePlugin({

--- a/package-lock.json
+++ b/package-lock.json
@@ -13212,6 +13212,12 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -13726,6 +13732,15 @@
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
+    "moment-locales-webpack-plugin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz",
+      "integrity": "sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==",
+      "dev": true,
+      "requires": {
+        "lodash.difference": "^4.5.0"
+      }
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "jest-webextension-mock": "^3.7.8",
     "jest-yaml-transform": "^0.2.0",
     "mini-css-extract-plugin": "~1.6.0",
+    "moment-locales-webpack-plugin": "^1.2.0",
     "node-polyfill-webpack-plugin": "^1.1.2",
     "node-sass": "^5.0.0",
     "raw-loader": "^4.0.1",

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -18,7 +18,6 @@
 import { ExtensionOptions, loadOptions, saveOptions } from "@/options/loader";
 import { Deployment } from "@/types/contract";
 import { browser, Permissions } from "webextension-polyfill-ts";
-import moment from "moment";
 import { partition, fromPairs, uniqBy } from "lodash";
 import { reportError } from "@/telemetry/logging";
 import axios from "axios";
@@ -128,13 +127,13 @@ async function updateDeployments() {
   ).flatMap(([, xs]) => Object.values(xs));
 
   if (extensions.some((x) => x._deployment?.id)) {
-    const timestamps = new Map<string, moment.Moment>();
+    const timestamps = new Map<string, Date>();
 
     for (const extension of extensions) {
       if (extension._deployment?.id) {
         timestamps.set(
           extension._deployment?.id,
-          moment(extension._deployment?.timestamp)
+          new Date(extension._deployment?.timestamp)
         );
       }
     }
@@ -153,8 +152,7 @@ async function updateDeployments() {
 
     const updatedDeployments = deployments.filter(
       (x: Deployment) =>
-        !timestamps.has(x.id) ||
-        moment(x.updated_at).isAfter(timestamps.get(x.id))
+        !timestamps.has(x.id) || new Date(x.updated_at) > timestamps.get(x.id)
     );
 
     if (updatedDeployments.length > 0) {

--- a/src/options/pages/deployments/DeploymentBanner.tsx
+++ b/src/options/pages/deployments/DeploymentBanner.tsx
@@ -4,7 +4,6 @@ import { Button } from "react-bootstrap";
 import "@/layout/Banner";
 import { useDispatch, useSelector } from "react-redux";
 import { selectExtensions } from "@/options/pages/InstalledPage";
-import moment from "moment";
 import { useToasts } from "react-toast-notifications";
 import useAsyncEffect from "use-async-effect";
 import {
@@ -116,9 +115,7 @@ function useDeployments() {
       );
       return (
         !match ||
-        moment(match._deployment.timestamp).isBefore(
-          moment(deployment.updated_at)
-        )
+        new Date(match._deployment.timestamp) < new Date(deployment.updated_at)
       );
     });
   }, [installed, deployments]);

--- a/src/options/pages/deployments/hooks.ts
+++ b/src/options/pages/deployments/hooks.ts
@@ -29,7 +29,6 @@ import useAsyncEffect from "use-async-effect";
 import { useFetch } from "@/hooks/fetch";
 import { useDispatch, useSelector } from "react-redux";
 import { selectExtensions } from "@/options/pages/InstalledPage";
-import moment from "moment";
 import { fromPairs } from "lodash";
 import { reportEvent } from "@/telemetry/events";
 import { optionsSlice } from "@/options/slices";
@@ -112,9 +111,7 @@ export function useDeployments() {
       );
       return (
         !match ||
-        moment(match._deployment.timestamp).isBefore(
-          moment(deployment.updated_at)
-        )
+        new Date(match._deployment.timestamp) < new Date(deployment.updated_at)
       );
     });
   }, [installed, deployments]);


### PR DESCRIPTION
Replaces #462 
Part of #411 

`moment` is rather large when it bundles the many unnecessary locales. 

This PR excludes locales and drops `moment` entirely from most bundles. Now it only appears in `options` and `devtoolsPanel` because I don't think an exact [`moment#calendar`](https://momentjs.com/docs/#/displaying/calendar-time/) alternative exists.

Requires testing of the remaining `moment#calendar` call in `EntryRow.tsx`