### PR TITLE
#411: Use exact `react-spinners` import

### DIFF
--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -36,7 +36,7 @@ import DeploymentBanner from "@/options/pages/deployments/DeploymentBanner";
 import { ToastProvider } from "react-toast-notifications";
 import store, { persistor } from "@/options/store";
 import { Provider } from "react-redux";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { PersistGate } from "redux-persist/integration/react";
 
 const ActionPanelTabs: React.FunctionComponent<{ panels: PanelEntry[] }> = ({

--- a/src/actionPanel/PanelBody.tsx
+++ b/src/actionPanel/PanelBody.tsx
@@ -18,7 +18,7 @@
 import { ComponentRef } from "@/extensionPoints/dom";
 import React, { useMemo } from "react";
 import { PanelEntry } from "@/actionPanel/protocol";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import blockRegistry from "@/blocks/registry";
 import { useAsyncState } from "@/hooks/common";
 import ConsoleLogger from "@/tests/ConsoleLogger";

--- a/src/components/fields/BlockField.tsx
+++ b/src/components/fields/BlockField.tsx
@@ -41,7 +41,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "./BlockField.scss";
 import Button from "react-bootstrap/Button";
 import useAsyncEffect from "use-async-effect";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { reportError } from "@/telemetry/logging";
 import BlockModal from "@/components/fields/BlockModal";
 import optionsRegistry from "@/components/fields/optionsRegistry";

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -32,7 +32,7 @@ import { fieldLabel } from "@/components/fields/fieldUtils";
 import Select from "react-select";
 import { FieldProps } from "@/components/fields/propTypes";
 import { inputProperties } from "@/helpers";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { useDependency } from "@/services/hooks";
 import {
   Bot,

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -28,7 +28,7 @@ import { useAsyncState } from "@/hooks/common";
 import { APPEND_SCHEMA } from "@/contrib/google/sheets/append";
 import { DevToolsContext } from "@/devTools/context";
 import { ObjectField } from "@/components/fields/FieldTable";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { isNullOrBlank } from "@/utils";
 import { SheetMeta } from "@/contrib/google/sheets/types";
 import FileField from "@/contrib/google/sheets/FileField";

--- a/src/devTools/Locator.tsx
+++ b/src/devTools/Locator.tsx
@@ -20,7 +20,7 @@ import { useAsyncState } from "@/hooks/common";
 import InputGroup from "react-bootstrap/InputGroup";
 import Form from "react-bootstrap/Form";
 import { useDebounce } from "use-debounce";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import Table from "react-bootstrap/Table";
 import { searchWindow, detectFrameworks } from "@/background/devtools";
 import { browser } from "webextension-polyfill-ts";

--- a/src/devTools/Panel.tsx
+++ b/src/devTools/Panel.tsx
@@ -20,7 +20,7 @@ import { Button, Container } from "react-bootstrap";
 import { HashRouter as Router } from "react-router-dom";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { DevToolsContext, useDevConnection } from "@/devTools/context";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import Editor from "@/devTools/Editor";
 
 import store, { persistor, RootState } from "./store";

--- a/src/devTools/editor/tabs/EffectTab.tsx
+++ b/src/devTools/editor/tabs/EffectTab.tsx
@@ -49,7 +49,7 @@ import {
 } from "formik";
 import hash from "object-hash";
 import Centered from "@/devTools/editor/components/Centered";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import BlockModal from "@/components/fields/BlockModal";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { useBlockOptions } from "@/components/fields/BlockField";

--- a/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
@@ -21,7 +21,7 @@ import { useFormikContext } from "formik";
 import { Alert, Col, Form, Row } from "react-bootstrap";
 import { SchemaTree } from "@/options/pages/extensionEditor/DataSourceCard";
 import useAsyncEffect from "use-async-effect";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { jsonTreeTheme as theme } from "@/themes/light";
 import JSONTree from "react-json-tree";
 import { useDebounce } from "use-debounce";

--- a/src/devTools/editor/tabs/reader/ReaderConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderConfig.tsx
@@ -26,7 +26,7 @@ import { Framework, FrameworkMeta } from "@/messaging/constants";
 import SelectorSelectorField from "@/devTools/editor/SelectorSelectorField";
 import { SchemaTree } from "@/options/pages/extensionEditor/DataSourceCard";
 import useAsyncEffect from "use-async-effect";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { runReader } from "@/background/devtools/index";
 import { jsonTreeTheme as theme } from "@/themes/light";
 import JSONTree from "react-json-tree";

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -19,7 +19,7 @@ import React, { useEffect } from "react";
 import store, { hashHistory, persistor } from "./store";
 import { Provider, useSelector } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import Container from "react-bootstrap/Container";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import InstalledPage from "@/options/pages/InstalledPage";

--- a/src/options/pages/Settings.tsx
+++ b/src/options/pages/Settings.tsx
@@ -32,7 +32,7 @@ import useAsyncEffect from "use-async-effect";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import AuthContext from "@/auth/context";
 import { useLoggingConfig } from "@/hooks/logging";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { clearLogs } from "@/background/logging";
 import { reportError } from "@/telemetry/logging";
 

--- a/src/options/pages/SetupPage.tsx
+++ b/src/options/pages/SetupPage.tsx
@@ -26,7 +26,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import cx from "classnames";
 import { useAsyncState } from "@/hooks/common";
 import { hasAppAccount } from "@/background/installer";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 
 import "./SetupPage.scss";
 import { reportError } from "@/telemetry/logging";

--- a/src/options/pages/brickEditor/BrickLogs.tsx
+++ b/src/options/pages/brickEditor/BrickLogs.tsx
@@ -23,7 +23,7 @@ import {
   MessageLevel,
   LogEntry,
 } from "@/background/logging";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { Table, Form, Pagination, Card, Button } from "react-bootstrap";
 import { range } from "lodash";
 import { useToasts } from "react-toast-notifications";

--- a/src/options/pages/brickEditor/BrickReference.tsx
+++ b/src/options/pages/brickEditor/BrickReference.tsx
@@ -39,7 +39,7 @@ import "./BrickReference.scss";
 import { SchemaTree } from "@/options/pages/extensionEditor/DataSourceCard";
 import { faClipboard } from "@fortawesome/free-solid-svg-icons";
 import { useToasts } from "react-toast-notifications";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 
 const DetailSection: React.FunctionComponent<{ title: string }> = ({
   title,

--- a/src/options/pages/brickEditor/EditPage.tsx
+++ b/src/options/pages/brickEditor/EditPage.tsx
@@ -23,7 +23,7 @@ import { Formik, useField } from "formik";
 import { useFetch } from "@/hooks/fetch";
 import { useParams } from "react-router";
 import Editor from "./Editor";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import useSubmitBrick from "./useSubmitBrick";
 import yaml from "js-yaml";
 import BootstrapSwitchButton from "bootstrap-switch-button-react";

--- a/src/options/pages/extensionEditor/DataSourceCard.tsx
+++ b/src/options/pages/extensionEditor/DataSourceCard.tsx
@@ -26,7 +26,7 @@ import isEmpty from "lodash/isEmpty";
 
 import "./DataSourceCard.scss";
 import { useAsyncState } from "@/hooks/common";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 
 const ObjectEntry: React.FunctionComponent<{
   prop: string;

--- a/src/options/pages/extensionEditor/ExtensionEditor.tsx
+++ b/src/options/pages/extensionEditor/ExtensionEditor.tsx
@@ -26,7 +26,7 @@ import { useExtension } from "@/selectors";
 import ExtensionPointDetail, { Config } from "./ExtensionPointDetail";
 import WorkshopPage from "@/options/pages/extensionEditor/WorkshopPage";
 import { reactivate } from "@/background/navigation";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 
 import "./ExtensionEditor.scss";
 import { reportError } from "@/telemetry/logging";

--- a/src/options/pages/extensionEditor/RunLogCard.tsx
+++ b/src/options/pages/extensionEditor/RunLogCard.tsx
@@ -23,7 +23,7 @@ import {
   MessageLevel,
   LogEntry,
 } from "@/background/logging";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { Table, Form, Pagination, Card, Button } from "react-bootstrap";
 
 import range from "lodash/range";

--- a/src/options/pages/marketplace/ActivateBody.tsx
+++ b/src/options/pages/marketplace/ActivateBody.tsx
@@ -36,7 +36,7 @@ import {
   ServiceAuthPair,
 } from "@/permissions";
 import { locator } from "@/background/locator";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { useAsyncState } from "@/hooks/common";
 import { faCubes, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/options/pages/marketplace/ActivatePage.tsx
+++ b/src/options/pages/marketplace/ActivatePage.tsx
@@ -25,7 +25,7 @@ import { useParams } from "react-router";
 import { useFetch } from "@/hooks/fetch";
 import { RecipeDefinition } from "@/types/definitions";
 import { Card, Col, Row } from "react-bootstrap";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import ActivateWizard from "@/options/pages/marketplace/ActivateWizard";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { Link } from "react-router-dom";

--- a/src/options/pages/services/ServicesEditor.tsx
+++ b/src/options/pages/services/ServicesEditor.tsx
@@ -33,7 +33,7 @@ import { RootState } from "../../store";
 import { RawServiceConfiguration } from "@/core";
 import { SanitizedAuth } from "@/types/contract";
 import { refresh as refreshServices } from "@/background/locator";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import ZapierModal from "@/options/pages/services/ZapierModal";
 import { AuthContext } from "@/auth/context";
 import { sleep } from "@/utils";

--- a/src/options/pages/services/SharedServicesCard.tsx
+++ b/src/options/pages/services/SharedServicesCard.tsx
@@ -21,7 +21,7 @@ import React from "react";
 import { useAsyncState } from "@/hooks/common";
 import { getBaseURL } from "@/services/baseService";
 import urljoin from "url-join";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { SanitizedAuth } from "@/types/contract";
 import { faUsers } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/options/pages/templates/TemplatesPage.tsx
+++ b/src/options/pages/templates/TemplatesPage.tsx
@@ -49,7 +49,7 @@ import cx from "classnames";
 
 import "./TemplatesPage.scss";
 import AuthContext from "@/auth/context";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 
 export interface TemplatesProps {
   installedRecipes: Set<string>;

--- a/src/pages/marketplace/MarketplacePage.tsx
+++ b/src/pages/marketplace/MarketplacePage.tsx
@@ -17,7 +17,7 @@
 
 import React, { useMemo, useState } from "react";
 import { useFetch } from "@/hooks/fetch";
-import { GridLoader } from "react-spinners";
+import GridLoader from "react-spinners/GridLoader";
 import { PageTitle } from "@/layout/Page";
 import sortBy from "lodash/sortBy";
 import { faStoreAlt } from "@fortawesome/free-solid-svg-icons";


### PR DESCRIPTION
Replaces #462 
Part of #411 

This is manual tree shaking, but given it's a single, constant spinner, maybe it's worth it. If not, feel free to close it, I just cherry-picked a previous commit.