### PR TITLE
#463: Simplify Rollbar source map upload configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
       - 'release/**'
 
 jobs:
-  build-chrome-web-store:
+  build-for-store:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,7 +17,6 @@ jobs:
       - uses: bahmutov/npm-install@v1
       - run: npm run build
         env:
-          ROLLBAR_PUBLIC_PATH: chrome-extension://production/
           GOOGLE_APP_ID: ${{ secrets.GOOGLE_APP_ID }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
@@ -26,11 +25,11 @@ jobs:
           SUPPORT_WIDGET_ID: ${{ secrets.SUPPORT_WIDGET_ID }}
       - uses: actions/upload-artifact@v2
         with:
-          name: chrome-web-store
+          name: build-for-store
           path: browsers/dist
           retention-days: 5
 
-  build-chrome-with-key:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -41,7 +40,6 @@ jobs:
       - uses: bahmutov/npm-install@v1
       - run: npm run build
         env:
-          ROLLBAR_PUBLIC_PATH: chrome-extension://production/
           GOOGLE_APP_ID: ${{ secrets.GOOGLE_APP_ID }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
@@ -51,7 +49,7 @@ jobs:
           CHROME_MANIFEST_KEY: ${{ secrets.CHROME_MANIFEST_PROD_PUBLIC_KEY }}
       - uses: actions/upload-artifact@v2
         with:
-          name: chrome-production
+          name: build-production
           path: browsers/dist
           retention-days: 5
       - name: Slack Notification
@@ -60,24 +58,3 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: "release"
           SLACK_MESSAGE: 'Chrome release build succeeded :rocket:'
-
-  build-firefox:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '14.x'
-      - uses: bahmutov/npm-install@v1
-      - run: npm run build
-        env:
-          ROLLBAR_PUBLIC_PATH: moz-extension://production/
-          ROLLBAR_BROWSER_ACCESS_TOKEN: ${{ secrets.ROLLBAR_BROWSER_ACCESS_TOKEN }}
-          ROLLBAR_POST_SERVER_ITEM_TOKEN: ${{ secrets.ROLLBAR_POST_SERVER_ITEM_TOKEN }}
-          SUPPORT_WIDGET_ID: ${{ secrets.SUPPORT_WIDGET_ID }}
-      - uses: actions/upload-artifact@v2
-        with:
-          name: firefox-production
-          path: browsers/dist
-          retention-days: 5

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: bahmutov/npm-install@v1
       - run: npm test
 
-  stage-chrome:
+  stage:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,7 +26,6 @@ jobs:
       - run: npm run build
         env:
           ENVIRONMENT: staging
-          ROLLBAR_PUBLIC_PATH: chrome-extension://staging/
           EXTERNALLY_CONNECTABLE: ${{ secrets.STAGING_SERVICE_URL }}*,http://127.0.0.1/*
           SERVICE_URL: ${{ secrets.STAGING_SERVICE_URL }}
           ROLLBAR_BROWSER_ACCESS_TOKEN: ${{ secrets.ROLLBAR_BROWSER_ACCESS_TOKEN }}
@@ -39,41 +38,12 @@ jobs:
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.STAGE_GOOGLE_OAUTH_CLIENT_ID }}
       - uses: actions/upload-artifact@v2
         with:
-          name: chrome-staging
+          name: build-staging
           path: browsers/dist
           retention-days: 5
       - uses: actions/upload-artifact@v2
         with:
-          name: chrome-bundle-size
-          path: report.html
-          retention-days: 5
-
-  stage-firefox:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '14.x'
-      - uses: bahmutov/npm-install@v1
-      - run: npm run build
-        env:
-          ENVIRONMENT: staging
-          ROLLBAR_PUBLIC_PATH: moz-extension://staging/
-          EXTERNALLY_CONNECTABLE: ${{ secrets.STAGING_SERVICE_URL }}*,http://127.0.0.1/*
-          SERVICE_URL: ${{ secrets.STAGING_SERVICE_URL }}
-          ROLLBAR_BROWSER_ACCESS_TOKEN: ${{ secrets.ROLLBAR_BROWSER_ACCESS_TOKEN }}
-          ROLLBAR_POST_SERVER_ITEM_TOKEN: ${{ secrets.ROLLBAR_POST_SERVER_ITEM_TOKEN }}
-          SUPPORT_WIDGET_ID: ${{ secrets.SUPPORT_WIDGET_ID }}
-      - uses: actions/upload-artifact@v2
-        with:
-          name: firefox-staging
-          path: browsers/dist
-          retention-days: 5
-      - uses: actions/upload-artifact@v2
-        with:
-          name: firefox-bundle-size
+          name: staging-build-size
           path: report.html
           retention-days: 5
 

--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -36,6 +36,7 @@ const rootDir = path.resolve(__dirname, "../");
 
 const defaults = {
   CHROME_EXTENSION_ID: "mpjjildhmpddojocokjkgmlkkkfjnepo",
+  ROLLBAR_PUBLIC_PATH: "extension://dynamichost",
 
   // PixieBrix URL to enable connection to for credential exchange
   SERVICE_URL: "https://app.pixiebrix.com",

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -86,12 +86,11 @@ export function initRollbar(): void {
         const trace = payload.body.trace;
         if (trace && trace.frames) {
           for (let i = 0; i < trace.frames.length; i++) {
-            const [, filename] =
-              trace.frames[i].filename?.split(location.origin) ?? [];
-            if (filename) {
-              // Be sure that the minified_url when uploading includes 'dynamichost'
-              trace.frames[i].filename = `extension://dynamichost${filename}`;
-            }
+            // Be sure that the minified_url when uploading includes 'dynamichost'
+            trace.frames[i].filename = trace.frames[i].filename?.replace(
+              location.origin,
+              process.env.ROLLBAR_PUBLIC_PATH
+            );
           }
         }
       },

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -82,18 +82,15 @@ export function initRollbar(): void {
         environment: process.env.ENVIRONMENT,
       },
       transform: function (payload: Record<string, unknown>) {
-        // @ts-ignore: copied this example from Rollbar's documentation, so should presumably always be available
+        // @ts-ignore: copied this example from Rollbar's documentation, so should presumably always be available https://docs.rollbar.com/docs/source-maps#section-using-source-maps-on-many-domains
         const trace = payload.body.trace;
-        const locRegex = /^(chrome-extension|moz-extension):\/\/(.*?)\/(.*)/;
         if (trace && trace.frames) {
           for (let i = 0; i < trace.frames.length; i++) {
-            const filename = trace.frames[i].filename;
+            const [, filename] =
+              trace.frames[i].filename?.split(location.origin) ?? [];
             if (filename) {
-              const m = filename.match(locRegex);
-              // Be sure that the minified_url when uploading includes the build type
-              trace.frames[
-                i
-              ].filename = `${m[1]}://${process.env.ENVIRONMENT}/${m[3]}`;
+              // Be sure that the minified_url when uploading includes 'dynamichost'
+              trace.frames[i].filename = `extension://dynamichost${filename}`;
             }
           }
         }


### PR DESCRIPTION
Fixes #463
Follows the instructions in https://github.com/pixiebrix/pixiebrix-extension/pull/435#discussion_r648706876

- uses single ROLLBAR_PUBLIC_PATH
- drops browser-specific builds everywhere
- simplifies transformer code