### PR TITLE
Fix Chrome detection

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -157,4 +157,4 @@ export function inputProperties(inputSchema: Schema): SchemaProperties {
 }
 
 export const isChrome =
-  typeof navigator === "object" && navigator.userAgent.includes("chrome");
+  typeof navigator === "object" && navigator.userAgent.includes("Chrome");

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -157,4 +157,4 @@ export function inputProperties(inputSchema: Schema): SchemaProperties {
 }
 
 export const isChrome =
-  typeof navigator === "object" && navigator.userAgent.includes("Chrome");
+  typeof navigator === "object" && navigator.userAgent.toLowerCase().includes("chrome");


### PR DESCRIPTION
Fix Chrome detection broken in #435

For reference, this is what the UAs look like in Chrome and Firefox respectively:

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36
```


```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:89.0) Gecko/20100101 Firefox/89.0
```