### PR TITLE
Avoid unnecessary `return await`

### DIFF
--- a/src/background/dataStore.ts
+++ b/src/background/dataStore.ts
@@ -41,7 +41,7 @@ async function _setRecord(uuid: string, value: JsonObject): Promise<void> {
 export const getRecord = liftBackground(
   "GET_DATA_STORE",
   async (uuid: string) => {
-    return await _getRecord(uuid);
+    return _getRecord(uuid);
   }
 );
 

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -42,7 +42,7 @@ async function deploymentPermissions(
   const blueprint = deployment.package.config;
   // Deployments can only use proxied services, so there's no additional permissions to request for the
   // the serviceAuths.
-  return await collectPermissions(blueprint, []);
+  return collectPermissions(blueprint, []);
 }
 
 type ActiveDeployment = {

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -170,7 +170,7 @@ export function liftBackground<R extends SerializableResponse>(
     }
   }
 
-  return async (port: Runtime.Port, ...args: unknown[]) => {
+  return async (port: Runtime.Port, ...args: unknown[]): Promise<R> => {
     if (isBackgroundPage()) {
       throw new Error(
         "This method should not be called from the background page"
@@ -178,7 +178,7 @@ export function liftBackground<R extends SerializableResponse>(
     } else if (!port) {
       throw new Error("Devtools port is required");
     }
-    return (await callBackground(port, fullType, args, options)) as R;
+    return callBackground(port, fullType, args, options) as Promise<R>;
   };
 }
 

--- a/src/background/devtools/protocol.ts
+++ b/src/background/devtools/protocol.ts
@@ -92,9 +92,9 @@ export const detectFrameworks: (
 ) => Promise<FrameworkMeta[]> = liftBackground(
   "DETECT_FRAMEWORKS",
   (target: Target) => async () => {
-    return (await contentScriptProtocol.detectFrameworks(
-      target
-    )) as FrameworkMeta[];
+    return contentScriptProtocol.detectFrameworks(target) as Promise<
+      FrameworkMeta[]
+    >;
   }
 );
 

--- a/src/background/devtools/protocol.ts
+++ b/src/background/devtools/protocol.ts
@@ -61,7 +61,7 @@ export const getTabInfo = liftBackground(
 export const injectScript = liftBackground(
   "INJECT_SCRIPT",
   (target: Target) => async ({ file }: { file: string }) => {
-    return await injectContentScript(target, file);
+    return injectContentScript(target, file);
   }
 );
 
@@ -83,7 +83,7 @@ export const waitReady = liftBackground(
 export const readSelectedElement = liftBackground(
   "READ_ELEMENT",
   (target: Target) => async () => {
-    return await contentScriptProtocol.readSelected(target);
+    return contentScriptProtocol.readSelected(target);
   }
 );
 
@@ -114,7 +114,7 @@ export const detectFrameworks: (
 export const cancelSelectElement = liftBackground(
   "CANCEL_SELECT_ELEMENT",
   (target: Target) => async () => {
-    return await nativeSelectionProtocol.cancelSelect(target);
+    return nativeSelectionProtocol.cancelSelect(target);
   }
 );
 
@@ -147,14 +147,14 @@ export const selectElement = liftBackground(
 export const dragButton = liftBackground(
   "DRAG_BUTTON",
   (target: Target) => async ({ uuid }: { uuid: string }) => {
-    return await nativeEditorProtocol.dragButton(target, { uuid });
+    return nativeEditorProtocol.dragButton(target, { uuid });
   }
 );
 
 export const insertButton = liftBackground(
   "INSERT_BUTTON",
   (target: Target) => async () => {
-    return await nativeEditorProtocol.insertButton(target);
+    return nativeEditorProtocol.insertButton(target);
   }
 );
 
@@ -163,7 +163,7 @@ export const insertPanel: (
 ) => Promise<PanelSelectionResult> = liftBackground(
   "INSERT_PANEL",
   (target: Target) => async () => {
-    return await nativeEditorProtocol.insertPanel(target);
+    return nativeEditorProtocol.insertPanel(target);
   }
 );
 
@@ -172,14 +172,14 @@ export const updateDynamicElement = liftBackground(
   (target: Target) => async (
     element: nativeEditorProtocol.DynamicDefinition
   ) => {
-    return await nativeEditorProtocol.updateDynamicElement(target, element);
+    return nativeEditorProtocol.updateDynamicElement(target, element);
   }
 );
 
 export const clearDynamicElements = liftBackground(
   "CLEAR_DYNAMIC",
   (target: Target) => async ({ uuid }: { uuid?: string }) => {
-    return await nativeEditorProtocol.clear(target, { uuid });
+    return nativeEditorProtocol.clear(target, { uuid });
   }
 );
 
@@ -192,7 +192,7 @@ export const toggleOverlay = liftBackground(
     uuid: string;
     on: boolean;
   }) => {
-    return await nativeEditorProtocol.toggleOverlay(target, {
+    return nativeEditorProtocol.toggleOverlay(target, {
       selector: `[data-uuid="${uuid}"]`,
       on,
     });
@@ -208,21 +208,21 @@ export const toggleSelector = liftBackground(
     selector: string;
     on: boolean;
   }) => {
-    return await nativeEditorProtocol.toggleOverlay(target, { selector, on });
+    return nativeEditorProtocol.toggleOverlay(target, { selector, on });
   }
 );
 
 export const getInstalledExtensionPointIds = liftBackground(
   "INSTALLED_EXTENSION_POINT_IDS",
   (target: Target) => async () => {
-    return await nativeEditorProtocol.getInstalledExtensionPointIds(target);
+    return nativeEditorProtocol.getInstalledExtensionPointIds(target);
   }
 );
 
 export const checkAvailable = liftBackground(
   "CHECK_AVAILABLE",
   (target: Target) => async (availability: Availability) => {
-    return await nativeEditorProtocol.checkAvailable(target, availability);
+    return nativeEditorProtocol.checkAvailable(target, availability);
   }
 );
 
@@ -232,7 +232,7 @@ export const searchWindow: (
 ) => Promise<{ results: unknown[] }> = liftBackground(
   "SEARCH_WINDOW",
   (target: Target) => async (query: string) => {
-    return await contentScriptProtocol.searchWindow(target, query);
+    return contentScriptProtocol.searchWindow(target, query);
   }
 );
 
@@ -245,7 +245,7 @@ export const runReaderBlock = liftBackground(
     id: string;
     rootSelector?: string;
   }) => {
-    return await contentScriptProtocol.runReaderBlock(target, {
+    return contentScriptProtocol.runReaderBlock(target, {
       id,
       rootSelector,
     });
@@ -261,7 +261,7 @@ export const runReader = liftBackground(
     config: ReaderTypeConfig;
     rootSelector?: string;
   }) => {
-    return await contentScriptProtocol.runReader(target, {
+    return contentScriptProtocol.runReader(target, {
       config,
       rootSelector,
     });
@@ -271,20 +271,20 @@ export const runReader = liftBackground(
 export const uninstallContextMenu = liftBackground(
   "UNINSTALL_CONTEXT_MENU",
   () => async ({ extensionId }: { extensionId: string }) => {
-    return await contextMenuProtocol.uninstall(extensionId);
+    return contextMenuProtocol.uninstall(extensionId);
   }
 );
 
 export const initUiPathRobot = liftBackground(
   "UIPATH_INIT",
   (target: Target) => async () => {
-    return await robotProtocol.initRobot(target);
+    return robotProtocol.initRobot(target);
   }
 );
 
 export const getUiPathProcesses = liftBackground(
   "UIPATH_GET_PROCESSES",
   (target: Target) => async () => {
-    return await robotProtocol.getProcesses(target);
+    return robotProtocol.getProcesses(target);
   }
 );

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -83,7 +83,7 @@ async function waitNonceReady(
     }
 
     if (isAvailable) {
-      return await browser.tabs.sendMessage(
+      return browser.tabs.sendMessage(
         target.tabId,
         {
           type: MESSAGE_CHECK_AVAILABILITY,
@@ -324,7 +324,7 @@ export async function activateTab(): Promise<void> {
   if (!isContentScript()) {
     throw new Error("activateTab can only be run from a content script");
   }
-  return await browser.runtime.sendMessage({
+  return browser.runtime.sendMessage({
     type: MESSAGE_ACTIVATE_TAB,
     payload: {},
   });
@@ -334,7 +334,7 @@ export async function closeTab(): Promise<void> {
   if (!isContentScript()) {
     throw new Error("closeTab can only be run from a content script");
   }
-  return await browser.runtime.sendMessage({
+  return browser.runtime.sendMessage({
     type: MESSAGE_CLOSE_TAB,
     payload: {},
   });
@@ -343,7 +343,7 @@ export async function closeTab(): Promise<void> {
 export async function openTab(
   options: Tabs.CreateCreatePropertiesType
 ): Promise<void> {
-  return await browser.runtime.sendMessage({
+  return browser.runtime.sendMessage({
     type: MESSAGE_OPEN_TAB,
     payload: options,
   });
@@ -435,7 +435,7 @@ export async function executeInAll(
   options: RemoteBlockOptions
 ): Promise<unknown> {
   console.debug(`Running ${blockId} in all tabs`);
-  return await browser.runtime.sendMessage({
+  return browser.runtime.sendMessage({
     type: MESSAGE_RUN_BLOCK_BROADCAST,
     payload: {
       blockId,
@@ -451,7 +451,7 @@ export async function executeInOpener(
   options: RemoteBlockOptions
 ): Promise<unknown> {
   console.debug(`Running ${blockId} in the opener tab`);
-  return await browser.runtime.sendMessage({
+  return browser.runtime.sendMessage({
     type: MESSAGE_RUN_BLOCK_OPENER,
     payload: {
       blockId,

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -80,7 +80,7 @@ const indexKeys = [
 ];
 
 async function getDB() {
-  return await openDB<LogDB>(STORAGE_KEY, 1, {
+  return openDB<LogDB>(STORAGE_KEY, 1, {
     upgrade(db) {
       // Create a store of objects
       const store = db.createObjectStore(ENTRY_OBJECT_STORE, {
@@ -315,13 +315,13 @@ export async function _setLoggingConfig(config: LoggingConfig): Promise<void> {
 export const getLoggingConfig = liftBackground(
   "GET_LOGGING_CONFIG",
   async () => {
-    return await _getLoggingConfig();
+    return _getLoggingConfig();
   }
 );
 
 export const setLoggingConfig = liftBackground(
   "SET_LOGGING_CONFIG",
   async (config: LoggingConfig) => {
-    return await _setLoggingConfig(config);
+    return _setLoggingConfig(config);
   }
 );

--- a/src/background/notifications.ts
+++ b/src/background/notifications.ts
@@ -22,6 +22,6 @@ export const createNotification = liftBackground(
   "CREATE_NOTIFICATION",
   async (options: Notifications.CreateNotificationOptions) => {
     // generate id automatically
-    return await browser.notifications.create(undefined, options);
+    return browser.notifications.create(undefined, options);
   }
 );

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -248,7 +248,8 @@ export function liftBackground<R extends SerializableResponse>(
       console.log(`Resolving ${type} immediately from background page`);
       return new Promise((resolve) => resolve(method(...args)));
     }
-    return (await callBackground(fullType, args, options)) as any;
+
+    return callBackground(fullType, args, options) as any;
   };
 }
 

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -210,7 +210,7 @@ const _proxyService = liftBackground(
     requestConfig: AxiosRequestConfig
   ): Promise<RemoteResponse> => {
     if (serviceConfig.proxy) {
-      return await proxyRequest(serviceConfig, requestConfig);
+      return proxyRequest(serviceConfig, requestConfig);
     } else {
       try {
         return await backgroundRequest(

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -97,11 +97,11 @@ const debouncedFlush = debounce(flush, EVENT_BUFFER_DEBOUNCE_MS, {
 });
 
 export const getDNT = liftBackground("GET_DNT", async () => {
-  return await _getDNT();
+  return _getDNT();
 });
 
 export const getUID = liftBackground("GET_UID", async () => {
-  return await uid();
+  return uid();
 });
 
 export const getExtensionVersion = liftBackground(
@@ -114,7 +114,7 @@ export const getExtensionVersion = liftBackground(
 export const toggleDNT = liftBackground(
   "TOGGLE_DNT",
   async (enabled: boolean) => {
-    return await _toggleDNT(enabled);
+    return _toggleDNT(enabled);
   }
 );
 

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -155,7 +155,7 @@ export async function blockList(
           config
         );
       }
-      return await blockRegistry.lookup(id);
+      return blockRegistry.lookup(id);
     })
   );
 }

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -473,7 +473,7 @@ export async function mergeReaders(
   readerConfig: ReaderConfig
 ): Promise<IReader> {
   if (typeof readerConfig === "string") {
-    return (await blockRegistry.lookup(readerConfig)) as IReader;
+    return blockRegistry.lookup(readerConfig) as Promise<IReader>;
   } else if (Array.isArray(readerConfig)) {
     return new ArrayCompositeReader(
       await Promise.all(readerConfig.map(mergeReaders))

--- a/src/blocks/readers/ArrayCompositeReader.ts
+++ b/src/blocks/readers/ArrayCompositeReader.ts
@@ -54,9 +54,10 @@ class ArrayCompositeReader extends Reader {
   }
 
   async isAvailable(): Promise<boolean> {
-    return (await Promise.all(this._readers.map((x) => x.isAvailable()))).every(
-      identity
+    const availability = await Promise.all(
+      this._readers.map((x) => x.isAvailable())
     );
+    return availability.every(identity);
   }
 
   async read(root: HTMLElement | Document): Promise<ReaderOutput> {

--- a/src/blocks/readers/CompositeReader.ts
+++ b/src/blocks/readers/CompositeReader.ts
@@ -39,9 +39,10 @@ class CompositeReader extends Reader {
   async isAvailable() {
     const readerArray = Object.values(this._readers);
     // PERFORMANCE: could return quicker if any came back false using Promise.any
-    return (await Promise.all(readerArray.map((x) => x.isAvailable()))).every(
-      identity
+    const availability = await Promise.all(
+      readerArray.map((x) => x.isAvailable())
     );
+    return availability.every(identity);
   }
 
   async read(root: HTMLElement | Document): Promise<ReaderOutput> {

--- a/src/blocks/readers/factory.ts
+++ b/src/blocks/readers/factory.ts
@@ -107,7 +107,7 @@ export function readerFactory(component: unknown): IReader {
     outputSchema: Schema = outputSchema;
 
     async isAvailable() {
-      return await checkAvailable(isAvailable);
+      return checkAvailable(isAvailable);
     }
 
     async read(root: ReaderRoot): Promise<ReaderOutput> {

--- a/src/blocks/readers/frameworkReader.ts
+++ b/src/blocks/readers/frameworkReader.ts
@@ -60,7 +60,7 @@ function makeRead(framework: Framework): Read<FrameworkConfig> {
       ? await asyncFastCssSelector(root as HTMLElement)
       : null;
 
-    return await getComponentData({
+    return getComponentData({
       framework,
       selector: compact([rootSelector, selector]).join(" "),
       rootProp,

--- a/src/blocks/readers/jquery.ts
+++ b/src/blocks/readers/jquery.ts
@@ -85,9 +85,7 @@ async function processFind(
   $elt: JQuery<HTMLElement | Document>,
   selector: ChildrenSelector
 ): Promise<{ [key: string]: Result }> {
-  return await asyncMapValues(selector.find, (selector) =>
-    select(selector, $elt)
-  );
+  return asyncMapValues(selector.find, (selector) => select(selector, $elt));
 }
 
 function processElement($elt: JQuery<HTMLElement>, selector: SingleSelector) {
@@ -224,7 +222,7 @@ async function read(
   if ($root.length === 0) {
     throw new Error("JQuery reader requires the document or element(s)");
   }
-  return await asyncMapValues(selectors, (selector) => select(selector, $root));
+  return asyncMapValues(selectors, (selector) => select(selector, $root));
 }
 
 registerFactory("jquery", read);

--- a/src/blocks/readers/meta.ts
+++ b/src/blocks/readers/meta.ts
@@ -41,7 +41,7 @@ class ChromeProfileReader extends Reader {
       throw new Error("No access to the Chrome Identity API");
     }
     // https://developer.chrome.com/apps/identity#method-getProfileUserInfo
-    return await new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       chrome.identity.getProfileUserInfo((userInfo) => {
         if (browser.runtime.lastError) {
           reject(browser.runtime.lastError.message);

--- a/src/blocks/readers/meta.ts
+++ b/src/blocks/readers/meta.ts
@@ -175,7 +175,7 @@ class PixieBrixProfileReader extends Reader {
   }
 
   async read() {
-    return (await getExtensionAuth()) as ReaderOutput;
+    return getExtensionAuth() as Promise<ReaderOutput>;
   }
 
   outputSchema: Schema = {

--- a/src/blocks/readers/window.ts
+++ b/src/blocks/readers/window.ts
@@ -40,7 +40,7 @@ async function handleFlatten(
 
 async function doRead(reader: WindowConfig): Promise<ReaderOutput> {
   const { pathSpec: rawPathSpec, waitMillis } = reader;
-  return await handleFlatten(rawPathSpec, (pathSpec) =>
+  return handleFlatten(rawPathSpec, (pathSpec) =>
     withReadWindow({
       pathSpec,
       waitMillis,

--- a/src/blocks/transformers/blockFactory.ts
+++ b/src/blocks/transformers/blockFactory.ts
@@ -107,7 +107,7 @@ class ExternalBlock extends Block {
   }
 
   async run(renderedInputs: BlockArg, options: BlockOptions): Promise<unknown> {
-    return await reducePipeline(
+    return reducePipeline(
       this.component.pipeline,
       renderedInputs,
       options.logger,

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -77,7 +77,8 @@ function contentScriptListener(
 }
 
 async function getTabIds(): Promise<number[]> {
-  return (await browser.tabs.query({})).map((x) => x.id);
+  const tabs = await browser.tabs.query({});
+  return tabs.map((x) => x.id);
 }
 
 export function notifyContentScripts(

--- a/src/contentScript/devTools.ts
+++ b/src/contentScript/devTools.ts
@@ -85,7 +85,7 @@ export async function isInstalled(target: Target): Promise<PingResponse> {
 export const detectFrameworks = liftContentScript(
   "DETECT_FRAMEWORKS",
   async () => {
-    return await withDetectFrameworkVersions(null);
+    return withDetectFrameworkVersions(null);
   }
 );
 
@@ -95,7 +95,7 @@ export const searchWindow: (
 ) => Promise<{ results: unknown[] }> = liftContentScript(
   "SEARCH_WINDOW",
   async (query: string) => {
-    return await withSearchWindow({ query });
+    return withSearchWindow({ query });
   }
 );
 
@@ -125,7 +125,7 @@ export const runReaderBlock = liftContentScript(
       }
     } else {
       const reader = (await blockRegistry.lookup(id)) as IReader;
-      return await reader.read(root);
+      return reader.read(root);
     }
   }
 );
@@ -146,7 +146,7 @@ export const runReader = liftContentScript(
         ? $(document).find(rootSelector).get(0)
         : document;
 
-    return await makeRead(config)(root);
+    return makeRead(config)(root);
   }
 );
 

--- a/src/contentScript/uipath.ts
+++ b/src/contentScript/uipath.ts
@@ -61,7 +61,7 @@ async function _initRobot(): Promise<InitResponse> {
 }
 
 export const initRobot = liftContentScript("UIPATH_INIT", async () => {
-  return await _initRobot();
+  return _initRobot();
 });
 
 export const getProcesses = liftContentScript(

--- a/src/contrib/google/geocode.ts
+++ b/src/contrib/google/geocode.ts
@@ -118,7 +118,7 @@ export class GeocodeTransformer extends Transformer {
   });
 
   async transform({ service, address }: BlockArg): Promise<GeocodedAddress> {
-    return await geocodeAddress(service, address);
+    return geocodeAddress(service, address);
   }
 }
 

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -42,7 +42,7 @@ const TabField: React.FunctionComponent<
 
   const [tabNames, tabsPending, tabsError] = useAsyncState(async () => {
     if (doc?.id && port) {
-      return await devtoolsProtocol.getTabNames(port, doc.id);
+      return devtoolsProtocol.getTabNames(port, doc.id);
     } else {
       return [];
     }

--- a/src/contrib/google/sheets/handlers.ts
+++ b/src/contrib/google/sheets/handlers.ts
@@ -213,13 +213,13 @@ export const devtoolsProtocol = {
   getTabNames: liftDevtools(
     "GET_TAB_NAMES",
     () => async (spreadsheetId: string) => {
-      return await getTabNames(spreadsheetId);
+      return getTabNames(spreadsheetId);
     }
   ),
   getSheetProperties: liftDevtools(
     "GET_SHEET_PROPERTIES",
     () => async (spreadsheetId: string) => {
-      return await getSheetProperties(spreadsheetId);
+      return getSheetProperties(spreadsheetId);
     }
   ),
   getHeaders: liftDevtools(
@@ -231,7 +231,7 @@ export const devtoolsProtocol = {
       spreadsheetId: string;
       tabName: string;
     }) => {
-      return await getHeaders(spreadsheetId, tabName);
+      return getHeaders(spreadsheetId, tabName);
     }
   ),
 };

--- a/src/contrib/pipedrive/calendar.ts
+++ b/src/contrib/pipedrive/calendar.ts
@@ -82,7 +82,7 @@ class CalendarTimeRange extends ExtensionPoint<CalendarConfig> {
   }
 
   async defaultReader() {
-    return (await blockRegistry.lookup(`@pixiebrix/blank`)) as IReader;
+    return blockRegistry.lookup(`@pixiebrix/blank`) as Promise<IReader>;
   }
 
   protected removeExtensions(): void {

--- a/src/contrib/pipedrive/readers.ts
+++ b/src/contrib/pipedrive/readers.ts
@@ -53,12 +53,12 @@ class PipedriveReader extends Reader {
   }
 
   async isAvailable() {
-    return await checkRoute(this.resourceType);
+    return checkRoute(this.resourceType);
   }
 
   async read() {
     // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31265
-    return await withReadWindow({
+    return withReadWindow({
       pathSpec: mapValues(
         this.pathSpec,
         (x: string) => `${this.ROOT_PATH}.${x}`

--- a/src/contrib/techcrunch/mentionExtensionPoint.ts
+++ b/src/contrib/techcrunch/mentionExtensionPoint.ts
@@ -83,9 +83,9 @@ class MentionAction extends ExtensionPoint<MentionConfig> {
   }
 
   async defaultReader() {
-    return (await blockRegistry.lookup(
+    return blockRegistry.lookup(
       `techcrunch/${this.entityType}-mention`
-    )) as IReader;
+    ) as Promise<IReader>;
   }
 
   protected removeExtensions(): void {

--- a/src/contrib/uipath/localProcessOptions.tsx
+++ b/src/contrib/uipath/localProcessOptions.tsx
@@ -155,7 +155,7 @@ const LocalProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
     Array<RobotProcess>
   >(async () => {
     if (robotAvailable) {
-      return await getUiPathProcesses(port);
+      return getUiPathProcesses(port);
     } else {
       return [];
     }

--- a/src/devTools/Editor.tsx
+++ b/src/devTools/Editor.tsx
@@ -354,7 +354,7 @@ const NoExtensionsPane: React.FunctionComponent<{
           <a
             href="#"
             onClick={async () =>
-              await openTab({
+              openTab({
                 url: "https://docs.pixiebrix.com/quick-start-guide",
                 active: true,
               })
@@ -373,7 +373,7 @@ const NoExtensionsPane: React.FunctionComponent<{
             className="ml-2"
             variant="info"
             onClick={async () =>
-              await openTab({
+              openTab({
                 url: "https://calendly.com/pixiebrix-todd/live-support-session",
                 active: true,
               })
@@ -402,7 +402,7 @@ const WelcomePane: React.FunctionComponent<{ showSupport: () => void }> = ({
           <a
             href="#"
             onClick={async () =>
-              await openTab({
+              openTab({
                 url: "https://docs.pixiebrix.com/quick-start-guide",
                 active: true,
               })
@@ -421,7 +421,7 @@ const WelcomePane: React.FunctionComponent<{ showSupport: () => void }> = ({
             className="ml-2"
             variant="info"
             onClick={async () =>
-              await openTab({
+              openTab({
                 url: "https://calendly.com/pixiebrix-todd/live-support-session",
                 active: true,
               })
@@ -465,7 +465,7 @@ const SupportWidget: React.FunctionComponent<{ onClose: () => void }> = ({
             <a
               href="#"
               onClick={async () =>
-                await openTab({
+                openTab({
                   url:
                     "https://calendly.com/pixiebrix-todd/live-support-session",
                   active: true,
@@ -482,7 +482,7 @@ const SupportWidget: React.FunctionComponent<{ onClose: () => void }> = ({
             <a
               href="#"
               onClick={async () =>
-                await openTab({
+                openTab({
                   url: "https://docs.pixiebrix.com/",
                   active: true,
                 })

--- a/src/devTools/editor/ElementWizard.tsx
+++ b/src/devTools/editor/ElementWizard.tsx
@@ -79,7 +79,7 @@ const ElementWizard: React.FunctionComponent<{
 
   const [available] = useAsyncState(
     async () =>
-      await checkAvailable(port, element.extensionPoint.definition.isAvailable),
+      checkAvailable(port, element.extensionPoint.definition.isAvailable),
     [port, element.extensionPoint.definition.isAvailable]
   );
 

--- a/src/devTools/editor/Sidebar.tsx
+++ b/src/devTools/editor/Sidebar.tsx
@@ -356,7 +356,7 @@ export function useInstallState(
 
   const [installedIds] = useAsyncState(async () => {
     if (meta) {
-      return await getInstalledExtensionPointIds(port);
+      return getInstalledExtensionPointIds(port);
     } else {
       return [];
     }

--- a/src/devTools/editor/extensionPoints/adapter.ts
+++ b/src/devTools/editor/extensionPoints/adapter.ts
@@ -71,5 +71,5 @@ export async function extensionToFormState(
       `Editing existing extensions of type '${type}' not implemented`
     );
   }
-  return await formState(extension);
+  return formState(extension);
 }

--- a/src/devTools/editor/tabs/EffectTab.tsx
+++ b/src/devTools/editor/tabs/EffectTab.tsx
@@ -350,13 +350,13 @@ const EffectTab: React.FunctionComponent<{
   } = useFormikContext<FormState>();
 
   const [blocks] = useAsyncState(async () => {
-    return await blockRegistry.all();
+    return blockRegistry.all();
   }, []);
 
   const [relevantBlocks] = useAsyncState(async () => {
     const excludeTypes: BlockType[] =
       type === "panel" ? ["reader", "effect"] : ["reader", "renderer"];
-    return await filterBlocks(blocks, { excludeTypes });
+    return filterBlocks(blocks, { excludeTypes });
   }, [blocks, type]);
 
   const [{ value: actions = [] }, , helpers] = useField<BlockPipeline>(

--- a/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
@@ -231,7 +231,7 @@ const ReaderBlockConfig: React.FunctionComponent<{
     // readerIndex is a number
     // eslint-disable-next-line security/detect-object-injection
     const reader = values.readers[readerIndex];
-    return (await blockRegistry.lookup(reader.metadata.id)) as IReader;
+    return blockRegistry.lookup(reader.metadata.id) as Promise<IReader>;
   }, [readerIndex, values.readers]);
 
   if (!readerBlock) {

--- a/src/extensionPoints/actionPanelExtension.ts
+++ b/src/extensionPoints/actionPanelExtension.ts
@@ -234,11 +234,11 @@ class RemotePanelExtensionPoint extends ActionPanelExtensionPoint {
   }
 
   async defaultReader(): Promise<IReader> {
-    return await mergeReaders(this._definition.reader);
+    return mergeReaders(this._definition.reader);
   }
 
   async isAvailable(): Promise<boolean> {
-    return await checkAvailable(this._definition.isAvailable);
+    return checkAvailable(this._definition.isAvailable);
   }
 }
 

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -362,7 +362,7 @@ class RemoteContextMenuExtensionPoint extends ContextMenuExtensionPoint {
   }
 
   async getBaseReader() {
-    return await mergeReaders(this._definition.reader);
+    return mergeReaders(this._definition.reader);
   }
 
   public get defaultOptions(): {

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -834,7 +834,7 @@ class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
   }
 
   async isAvailable(): Promise<boolean> {
-    return await checkAvailable(this._definition.isAvailable);
+    return checkAvailable(this._definition.isAvailable);
   }
 }
 

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -507,7 +507,7 @@ class RemotePanelExtensionPoint extends PanelExtensionPoint {
   }
 
   async defaultReader(): Promise<IReader> {
-    return await mergeReaders(this._definition.reader);
+    return mergeReaders(this._definition.reader);
   }
 
   addPanel($panel: JQuery): void {
@@ -541,7 +541,7 @@ class RemotePanelExtensionPoint extends PanelExtensionPoint {
 
   async isAvailable(): Promise<boolean> {
     const { isAvailable } = this._definition;
-    return await checkAvailable(isAvailable);
+    return checkAvailable(isAvailable);
   }
 }
 

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -71,7 +71,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
   }
 
   async install(): Promise<boolean> {
-    return await this.isAvailable();
+    return this.isAvailable();
   }
 
   removeExtensions(): void {
@@ -300,7 +300,7 @@ class RemoteTriggerExtensionPoint extends TriggerExtensionPoint {
   }
 
   async isAvailable(): Promise<boolean> {
-    return await checkAvailable(this._definition.isAvailable);
+    return checkAvailable(this._definition.isAvailable);
   }
 }
 

--- a/src/messaging/external.ts
+++ b/src/messaging/external.ts
@@ -168,24 +168,24 @@ const _openActivate = liftBackground(
 export const openActivateBlueprint = lift(
   "OPEN_ACTIVATE_BLUEPRINT",
   async (options: ActivateBlueprintOptions) => {
-    return await _openActivate(options);
+    return _openActivate(options);
   }
 );
 
 export const openExtensionOptions = lift("OPEN_OPTIONS", async () => {
-  return await _openOptions();
+  return _openOptions();
 });
 
 export const openMarketplace = lift(
   "OPEN_MARKETPLACE",
   async (options: OpenOptionsOptions = {}) => {
-    return await _openMarketplace(options);
+    return _openMarketplace(options);
   }
 );
 
 export const openTemplates = lift(
   "OPEN_TEMPLATES",
   async (options: OpenOptionsOptions = {}) => {
-    return await _openTemplates(options);
+    return _openTemplates(options);
   }
 );

--- a/src/nativeEditor/dynamic.ts
+++ b/src/nativeEditor/dynamic.ts
@@ -84,7 +84,7 @@ async function buildSingleReader(config: ReaderLike): Promise<IReader> {
   } else if (isCustomReader(config)) {
     return readerFactory(config);
   } else {
-    return (await blockRegistry.lookup(config.metadata.id)) as IReader;
+    return blockRegistry.lookup(config.metadata.id) as Promise<IReader>;
   }
 }
 

--- a/src/nativeEditor/insertButton.tsx
+++ b/src/nativeEditor/insertButton.tsx
@@ -107,7 +107,7 @@ function dragPromise(uuid: string): Promise<DragResult | null> {
 export const dragButton = liftContentScript(
   "DRAG_BUTTON",
   async ({ uuid }: { uuid: string }) => {
-    return await dragPromise(uuid);
+    return dragPromise(uuid);
   }
 );
 

--- a/src/nativeEditor/selector.ts
+++ b/src/nativeEditor/selector.ts
@@ -183,7 +183,7 @@ export const selectElement = liftContentScript(
 
         requireSingleElement(selectors[0]);
 
-        return await pageScript.getElementInfo({
+        return pageScript.getElementInfo({
           selector: selectors[0],
           framework,
           traverseUp,
@@ -197,7 +197,7 @@ export const selectElement = liftContentScript(
         // double-check we have a valid selector
         requireSingleElement(selector);
 
-        return await pageScript.getElementInfo({
+        return pageScript.getElementInfo({
           selector,
           framework,
           traverseUp,

--- a/src/options/pages/brickEditor/useSubmitBrick.tsx
+++ b/src/options/pages/brickEditor/useSubmitBrick.tsx
@@ -57,7 +57,7 @@ function useSubmitBrick({
   const dispatch = useDispatch();
 
   const validate = useCallback(
-    async (values: EditorValues) => await validateSchema(values.config),
+    async (values: EditorValues) => validateSchema(values.config),
     []
   );
 

--- a/src/options/pages/deployments/DeploymentBanner.tsx
+++ b/src/options/pages/deployments/DeploymentBanner.tsx
@@ -37,7 +37,7 @@ function useEnsurePermissions(deployments: Deployment[]) {
   const [permissions, isPending] = useAsyncState(async () => {
     // Deployments can only use proxied services, so there's no additional permissions to request for the
     // the serviceAuths.
-    return await collectPermissions(
+    return collectPermissions(
       blueprints.flatMap((x) => x.extensionPoints),
       []
     );

--- a/src/options/pages/deployments/hooks.ts
+++ b/src/options/pages/deployments/hooks.ts
@@ -48,7 +48,7 @@ export function useEnsurePermissions(deployments: Deployment[]) {
   const [permissions, isPending] = useAsyncState(async () => {
     // Deployments can only use proxied services, so there's no additional permissions to request for the
     // the serviceAuths.
-    return await collectPermissions(
+    return collectPermissions(
       blueprints.flatMap((x) => x.extensionPoints),
       []
     );

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -39,7 +39,7 @@ const MANDATORY_PERMISSIONS = ["storage", "identity", "tabs", "webNavigation"];
 export async function ensureAllPermissions(
   permissionsList: Permissions.Permissions[]
 ): Promise<boolean> {
-  return await browser.permissions.request(mergePermissions(permissionsList));
+  return browser.permissions.request(mergePermissions(permissionsList));
   // On FF can't check if we already have the permission because promise chains break it's detection of
   // whether or not we're in a user-triggered event. That also prevents making multiple permissions requests
   // for a single button click
@@ -160,14 +160,14 @@ export async function checkPermissions(
 export async function permissionsEnabled(
   extension: IExtension
 ): Promise<boolean> {
-  return await checkPermissions(await extensionPermissions(extension));
+  return checkPermissions(await extensionPermissions(extension));
 }
 
 export async function ensureExtensionPermissions(
   extension: IExtension
 ): Promise<boolean> {
   const permissions = await extensionPermissions(extension);
-  return await ensureAllPermissions(permissions);
+  return ensureAllPermissions(permissions);
 }
 
 /**

--- a/src/registry/localRegistry.ts
+++ b/src/registry/localRegistry.ts
@@ -72,7 +72,7 @@ function getKey(obj: Package): [string, number, number, number] {
 }
 
 async function getBrickDB() {
-  return await openDB<LogDB>(STORAGE_KEY, VERSION, {
+  return openDB<LogDB>(STORAGE_KEY, VERSION, {
     upgrade(db) {
       // Create a store of objects
       const store = db.createObjectStore(BRICK_STORE, {
@@ -112,7 +112,7 @@ export const getKind = liftBackground(
 
 export const getLocal = liftBackground("REGISTRY_GET_LOCAL", async () => {
   const db = await getBrickDB();
-  return await db.getAllFromIndex(BRICK_STORE, "scope", LOCAL_SCOPE);
+  return db.getAllFromIndex(BRICK_STORE, "scope", LOCAL_SCOPE);
 });
 
 export const add = liftBackground("REGISTRY_PUT", async (obj: Package) => {

--- a/src/script.ts
+++ b/src/script.ts
@@ -103,7 +103,7 @@ attachListener(SEARCH_WINDOW, ({ query }) => {
 });
 
 attachListener(DETECT_FRAMEWORK_VERSIONS, async () => {
-  return await detectLibraries();
+  return detectLibraries();
 });
 
 // needs to be object because we want window to be a valid argument
@@ -228,7 +228,7 @@ attachListener(
     if (!adapter) {
       throw new Error(`No read adapter available for ${framework}`);
     }
-    return await read(adapter, selector, options);
+    return read(adapter, selector, options);
   }
 );
 

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -65,11 +65,9 @@ export function useExtension(
 
   const [extensionPoint, isPending] = useAsyncState(async () => {
     if (extensionConfig) {
-      return await extensionPointRegistry.lookup(
-        extensionConfig.extensionPointId
-      );
+      return extensionPointRegistry.lookup(extensionConfig.extensionPointId);
     } else if (extensionPointId) {
-      return await extensionPointRegistry.lookup(extensionPointId);
+      return extensionPointRegistry.lookup(extensionPointId);
     }
     return null;
   }, [extensionPointRegistry, extensionConfig, extensionPointId]);

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -60,7 +60,7 @@ export function useDependency(
 
   const [hasPermissions] = useAsyncState(async () => {
     if (origins != null) {
-      return await checkPermissions([{ origins }]);
+      return checkPermissions([{ origins }]);
     } else {
       return false;
     }

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -117,7 +117,7 @@ class LazyLocatorFactory {
 
   async refresh(): Promise<void> {
     if (this._refreshPromise) {
-      return await this._refreshPromise;
+      return this._refreshPromise;
     }
     const timestamp = Date.now();
     this._refreshPromise = Promise.all([
@@ -175,7 +175,7 @@ class LazyLocatorFactory {
 
     if (serviceId === PIXIEBRIX_SERVICE_ID) {
       // HACK: for now use the separate storage for the extension key
-      return await pixieServiceFactory();
+      return pixieServiceFactory();
     } else if (!authId) {
       throw new NotConfiguredError(
         `No configuration selected for ${serviceId}`,

--- a/src/validators/generic.ts
+++ b/src/validators/generic.ts
@@ -217,16 +217,16 @@ const pixieResolver: ResolverOptions = {
 };
 
 export async function bundle(schema: Schema): Promise<Schema> {
-  return (await $RefParser.bundle(schema as any, {
+  return $RefParser.bundle(schema as any, {
     resolve: { pixieResolver },
-  })) as Schema;
+  }) as Promise<Schema>;
 }
 
 export async function dereference(schema: Schema): Promise<Schema> {
-  return (await $RefParser.dereference(schema as any, {
+  return $RefParser.dereference(schema as any, {
     resolve: { pixieResolver },
     dereference: {
       circular: "ignore",
     },
-  })) as Schema;
+  }) as Promise<Schema>;
 }


### PR DESCRIPTION
I was making some changes to the code and found myself having to fix a few Promise-related issues, so I thought I'd start pushing some fixes for it, one PR per kind. These changes help us avoid callback hell and recover errors that have been falling through the cracks.

---

This minor change is the application of [no-return-await](https://eslint.org/docs/rules/no-return-await) eslint rule. Nothing changed here except removing some code.

In short, `return await` is only ever needed if you want to await a promise in the current `try/catch` block.


For example, given that `bar` is an async function:
```js
async function foo() {
    try {
        return await bar(); // The error from `bar` is caught inside foo
    } catch (error) {}
}
```


```js
async function foo() {
    try {
        return bar(); // The error from `bar` is NOT caught inside foo
    } catch (error) {}
}
```