### PR TITLE
Don't await non-promises

### DIFF
--- a/src/background/__mocks__/protocol.ts
+++ b/src/background/__mocks__/protocol.ts
@@ -32,7 +32,7 @@ const MESSAGE_PREFIX = "@@pixiebrix/background-mock/";
 
 export function liftBackground<R extends SerializableResponse>(
   type: string,
-  method: (...args: unknown[]) => R,
+  method: ((...args: unknown[]) => R) | ((...args: unknown[]) => Promise<R>),
   options: HandlerOptions = { asyncResponse: true }
 ): (...args: unknown[]) => Promise<R> {
   const fullType = `${MESSAGE_PREFIX}${type}`;

--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -91,7 +91,7 @@ export async function getToken(
     throw new Error(`Service ${service.id} does not use token authentication`);
   }
 
-  const { url, data: tokenData } = await service.getTokenContext(auth.config);
+  const { url, data: tokenData } = service.getTokenContext(auth.config);
 
   const { status, statusText, data: responseData } = await axios.post(
     url,
@@ -116,7 +116,7 @@ export async function launchOAuth2Flow(
     throw new Error(`Service ${service.id} is not an OAuth2 service`);
   }
 
-  const oauth2 = await service.getOAuth2Context(auth.config);
+  const oauth2 = service.getOAuth2Context(auth.config);
 
   const {
     code_challenge_method,

--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -161,7 +161,7 @@ export const ensureContextMenu = liftBackground(
           });
         } catch (err) {
           console.debug("Cannot update context menu", { err });
-          const menuId = await browser.contextMenus.create({
+          const menuId = browser.contextMenus.create({
             ...createProperties,
             id: makeMenuId(extensionId),
           });
@@ -178,7 +178,7 @@ export const ensureContextMenu = liftBackground(
           );
         }
       } else {
-        const menuId = await browser.contextMenus.create({
+        const menuId = browser.contextMenus.create({
           ...createProperties,
           id: makeMenuId(extensionId),
         });

--- a/src/blocks/effects/sound.ts
+++ b/src/blocks/effects/sound.ts
@@ -61,7 +61,7 @@ export class SoundEffect extends Effect {
     );
 
     if (!_howl) {
-      const url = await browser.runtime.getURL("audio/sprite.mp3");
+      const url = browser.runtime.getURL("audio/sprite.mp3");
       _howl = new Howl({
         src: [url],
         sprite,


### PR DESCRIPTION
More context about these PRs in #484 

---

`await` was being called on non-promises. In one case the type was incorrect, so I fixed that instead.

Context: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/await-thenable.md

