### PR TITLE
No explicit `Promise.resolve`

### DIFF
--- a/src/background/devtools/external.ts
+++ b/src/background/devtools/external.ts
@@ -76,7 +76,7 @@ function devtoolsMessageListener(response: BackgroundResponse) {
   }
 }
 
-export function callBackground(
+export async function callBackground(
   port: Runtime.Port,
   type: string,
   args: unknown[],
@@ -96,11 +96,11 @@ export function callBackground(
   if (isNotification(options)) {
     port.postMessage(message);
     if (browser.runtime.lastError) {
-      return Promise.reject(
+      throw new Error(
         `Error sending devtools notification: ${browser.runtime.lastError.message}`
       );
     } else {
-      return Promise.resolve();
+      return;
     }
   } else {
     return new Promise((resolve, reject) => {

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -103,13 +103,13 @@ function backgroundListener(
         console.debug(
           `Handler FULFILLED action ${type} (nonce: ${meta?.nonce}, tab: ${sender.tab?.id}, frame: ${sender.frameId})`
         );
-        return Promise.resolve(value);
+        return value;
       })
       .catch((reason) => {
         console.debug(
           `Handler REJECTED action ${type} (nonce: ${meta?.nonce}, tab: ${sender.tab?.id}, frame: ${sender.frameId})`
         );
-        return Promise.resolve(toErrorResponse(type, reason));
+        return toErrorResponse(type, reason);
       });
   }
 }

--- a/src/devTools/context.ts
+++ b/src/devTools/context.ts
@@ -90,7 +90,7 @@ export interface Context {
 }
 
 const initialValue: Context = {
-  connect: () => Promise.resolve(),
+  connect: async () => {},
   connecting: false,
   port: null,
   portError: undefined,

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Promisable } from "type-fest";
 import { castArray, noop, once } from "lodash";
 // @ts-ignore: no type definitions
 import initialize from "vendors/initialize";
@@ -188,7 +187,7 @@ function _initialize(
 export function awaitElementOnce(
   selector: string | string[],
   rootElement: JQuery<HTMLElement | Document> = undefined
-): [Promisable<JQuery<HTMLElement | Document>>, () => void] {
+): [Promise<JQuery<HTMLElement | Document>>, () => void] {
   if (selector == null) {
     throw new Error("awaitElementOnce expected selector");
   }
@@ -197,7 +196,7 @@ export function awaitElementOnce(
   const $root = rootElement ? $(rootElement) : $(document);
 
   if (!selectors.length) {
-    return [$root, noop];
+    return [Promise.resolve($root), noop];
   }
 
   // console.debug("Awaiting selectors", selectors);
@@ -229,7 +228,7 @@ export function awaitElementOnce(
       },
     ];
   } else if (rest.length === 0) {
-    return [$element, noop];
+    return [Promise.resolve($element), noop];
   } else {
     return awaitElementOnce(rest, $element);
   }

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import { Promisable } from "type-fest";
 import { castArray, noop, once } from "lodash";
 // @ts-ignore: no type definitions
 import initialize from "vendors/initialize";
@@ -187,7 +188,7 @@ function _initialize(
 export function awaitElementOnce(
   selector: string | string[],
   rootElement: JQuery<HTMLElement | Document> = undefined
-): [Promise<JQuery<HTMLElement | Document>>, () => void] {
+): [Promisable<JQuery<HTMLElement | Document>>, () => void] {
   if (selector == null) {
     throw new Error("awaitElementOnce expected selector");
   }
@@ -196,7 +197,7 @@ export function awaitElementOnce(
   const $root = rootElement ? $(rootElement) : $(document);
 
   if (!selectors.length) {
-    return [Promise.resolve($root), noop];
+    return [$root, noop];
   }
 
   // console.debug("Awaiting selectors", selectors);
@@ -228,7 +229,7 @@ export function awaitElementOnce(
       },
     ];
   } else if (rest.length === 0) {
-    return [Promise.resolve($element), noop];
+    return [$element, noop];
   } else {
     return awaitElementOnce(rest, $element);
   }

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -172,7 +172,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     // TODO: add logic for cancelWait
     const [rootPromise] = rootSelector
       ? awaitElementOnce(rootSelector)
-      : [Promise.resolve($(document))];
+      : [$(document)];
 
     let $root = await rootPromise;
 

--- a/src/messaging/chrome.ts
+++ b/src/messaging/chrome.ts
@@ -25,7 +25,9 @@ export function createSendScriptMessage<TReturn = unknown, TPayload = unknown>(
   messageType: string
 ): SendScriptMessage<TReturn, TPayload> {
   if (typeof document === "undefined" || document.defaultView == null) {
-    return () => Promise.reject("Not running in a browser context");
+    return async () => {
+      throw new Error("Not running in a browser context");
+    };
   }
 
   let messageSeq = 0;


### PR DESCRIPTION
More context about these PRs in #484 

---

Context:
- https://github.com/typescript-eslint/typescript-eslint/issues/282
- https://eslint.org/docs/rules/prefer-promise-reject-errors

In short:

- `async` functions automatically wrap/unwrap their return values, so `Promise.resolve` is redundant.
- When an async function throws, one generally expects `err` in `catch(err)` to be an error, not a string

