### PR TITLE
Clean `reportError` up

### DIFF
--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -171,6 +171,7 @@ function buildContext(
   return context;
 }
 
+// Ensure this whole function’s content is wrapped in try/catch to avoid uncaught error loops
 export const recordError = liftBackground(
   "RECORD_ERROR",
   async (


### PR DESCRIPTION
Disregard this PR. The code was right


<details>
<summary>Previous text</summary>

More context about these PRs in #484 

---

More info in the review below. I thought about including `selectError` in the try/catch too but `liftBackground` requires already-serializable parameters. Maybe in the future.

</details>
