### PR TITLE
Clean `selectError` + drop unnecessary `ary`

### DIFF
--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -18,7 +18,6 @@
 import { liftBackground } from "@/background/protocol";
 import { browser, ContextMenus, Menus, Tabs } from "webextension-polyfill-ts";
 import { isBackgroundPage } from "webext-detect-page";
-import { unary } from "lodash";
 import { reportError } from "@/telemetry/logging";
 import { handleMenuAction } from "@/contentScript/contextMenus";
 import { showNotification } from "@/contentScript/notify";
@@ -72,20 +71,20 @@ async function dispatchMenu(
     showNotification(target, {
       message: "Ran content menu item action",
       className: "success",
-    }).catch(unary(reportError));
+    }).catch(reportError);
   } catch (err) {
     if (hasCancelRootCause(err)) {
       showNotification(target, {
         message: "The action was cancelled",
         className: "info",
-      }).catch(unary(reportError));
+      }).catch(reportError);
     } else {
       const message = `Error processing context menu action: ${getErrorMessage(
         err
       )}`;
       reportError(new Error(message));
       showNotification(target, { message, className: "error" }).catch(
-        unary(reportError)
+        reportError
       );
     }
   }

--- a/src/devTools/editor/SelectorSelectorField.tsx
+++ b/src/devTools/editor/SelectorSelectorField.tsx
@@ -24,7 +24,7 @@ import React, {
 } from "react";
 import { useField } from "formik";
 import { OptionsType, components } from "react-select";
-import { uniqBy, compact, sortBy, unary, isEmpty } from "lodash";
+import { uniqBy, compact, sortBy, isEmpty } from "lodash";
 import Creatable from "react-select/creatable";
 
 import { Badge, Button } from "react-bootstrap";
@@ -222,7 +222,7 @@ export const SelectorSelectorControl: React.FunctionComponent<
                 selector: null,
                 on: false,
               })
-              .catch(unary(reportError));
+              .catch(reportError);
           }}
           onChange={async (option) => {
             console.debug("selected", { option });
@@ -232,7 +232,7 @@ export const SelectorSelectorControl: React.FunctionComponent<
                 selector: null,
                 on: false,
               })
-              .catch(unary(reportError));
+              .catch(reportError);
           }}
         />
       </div>

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -21,14 +21,17 @@ import { MessageContext, SerializedError } from "@/core";
 import { serializeError } from "serialize-error";
 import { isExtensionContext } from "@/chrome";
 
-function selectError(exc: any): SerializedError {
-  if (exc?.message && exc?.type === "unhandledrejection") {
-    exc = {
-      // @ts-ignore: OK given the type of reason on unhandledrejection
-      message: exc.reason?.message ?? "Uncaught error in promise",
-    };
+function selectError(exc: unknown): SerializedError {
+  if (exc instanceof PromiseRejectionEvent) {
+    // convert the project rejection to an error instance
+    if (exc.reason instanceof Error) {
+      exc = exc.reason;
+    } else if (typeof exc.reason === "string") {
+      exc = new Error(exc.reason);
+    } else {
+      exc = new Error(exc.reason?.message ?? "Uncaught error in promise");
+    }
   }
-
   return serializeError(exc);
 }
 

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -21,22 +21,15 @@ import { MessageContext, SerializedError } from "@/core";
 import { serializeError } from "serialize-error";
 import { isExtensionContext } from "@/chrome";
 
-function selectError(exc: unknown): SerializedError {
-  if (exc instanceof Error) {
-    return serializeError(exc);
-  } else if (typeof exc === "object") {
-    const obj = exc as Record<string, unknown>;
-    if (obj.type === "unhandledrejection") {
-      return serializeError({
-        // @ts-ignore: OK given the type of reason on unhandledrejection
-        message: obj.reason?.message ?? "Uncaught error in promise",
-      });
-    } else {
-      return serializeError(obj);
-    }
-  } else {
-    return serializeError(exc);
+function selectError(exc: any): SerializedError {
+  if (exc?.message && exc?.type === "unhandledrejection") {
+    exc = {
+      // @ts-ignore: OK given the type of reason on unhandledrejection
+      message: exc.reason?.message ?? "Uncaught error in promise",
+    };
   }
+
+  return serializeError(exc);
 }
 
 export function reportError(exc: unknown, context?: MessageContext): void {


### PR DESCRIPTION
Replacing #488, I might add similar code changes here

Related:

I saw a few simple `reportError(error)` calls across the code, I wonder if they could all be dropped in lieu of just letting the `unhandledrejection` handlers catch it. I don't think that there's any advantage in catching an error that doesn't otherwise affect nearby code (e.g. it's not awaited at all). Example:

```js
setUninstallURL().catch((err) => {
  reportError(err);
});
```