### PR TITLE
#509: fix rollbar stack trace telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16505,9 +16505,9 @@
       }
     },
     "rollbar": {
-      "version": "2.19.4",
-      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.19.4.tgz",
-      "integrity": "sha512-8ErcMfJE2zkhgrFtpGRyejHBhyO0hU7dZ3EvG2ylNZ7qSu4yw5PZfhGx+Qyq3ksKshLFeQh9Y/Bh2S1TOPIhvw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.22.0.tgz",
+      "integrity": "sha512-fMTKtzSnoE2ODnMAqzH/Soocb/o7Qy7U5tdRjzljKoz1vMRKkMYbW7E0s0Qraoo3xaTzd5UxDNP3c8jmrlWgug==",
       "requires": {
         "async": "~1.2.1",
         "console-polyfill": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "redux-persist-webextension-storage": "^1.0.2",
     "regenerator-runtime": "^0.13.7",
     "reselect": "^4.0.0",
-    "rollbar": "^2.19.4",
+    "rollbar": "^2.22.0",
     "schema-to-yup": "1.10.0",
     "serialize-error": "^8.1.0",
     "simple-icons": "^4.16.0",

--- a/src/action.tsx
+++ b/src/action.tsx
@@ -16,11 +16,15 @@
  */
 
 import "@/extensionContext";
+
+// init rollbar early so we get error reporting on the other initialization
+import "@/telemetry/rollbar";
+
 import App from "./actionPanel/ActionPanelApp";
 import ReactDOM from "react-dom";
 import React from "react";
 import { browser } from "webextension-polyfill-ts";
-import { initRollbar } from "@/telemetry/rollbar";
+
 import { REGISTER_ACTION_FRAME } from "@/background/browserAction";
 import { reportError } from "@/telemetry/logging";
 import "@/actionPanel/protocol";
@@ -29,8 +33,6 @@ import "@/actionPanel/protocol";
 import "vendors/theme/app/app.scss";
 import "./action.scss";
 import "@/vendors/overrides.scss";
-
-initRollbar();
 
 const url = new URL(location.href);
 const nonce = url.searchParams.get("nonce");

--- a/src/background.ts
+++ b/src/background.ts
@@ -18,10 +18,9 @@
 // extensionContext needs to be imported before webpack-target-webextension to
 // ensure the webpack path is correct
 import "@/extensionContext";
-import { initRollbar } from "@/telemetry/rollbar";
 
-// init first so we get error reporting on the other initialization
-initRollbar();
+// init rollbar early so we get error reporting on the other initialization
+import "@/telemetry/rollbar";
 
 import "webpack-target-webextension/lib/background";
 import "@/polyfills/registerPolyfill";

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -17,16 +17,17 @@
 
 import "@/extensionContext";
 
+// init rollbar early so we get error reporting on the other initialization
+import "@/telemetry/rollbar";
+
 import ReactDOM from "react-dom";
 import React from "react";
 import App from "@/options/App";
-import { initRollbar } from "@/telemetry/rollbar";
 import initGoogle from "@/contrib/google/initGoogle";
 
 import "@/options.scss";
 import "@/vendors/overrides.scss";
 
-initRollbar();
 initGoogle();
 
 ReactDOM.render(<App />, document.getElementById("container"));

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -16,10 +16,14 @@
  */
 
 import { recordError } from "@/background/logging";
-import Rollbar from "rollbar";
+import { rollbar, toLogArgument } from "@/telemetry/rollbar";
 import { MessageContext, SerializedError } from "@/core";
 import { serializeError } from "serialize-error";
 import { isExtensionContext } from "@/chrome";
+
+export function errorMessage(err: SerializedError): string {
+  return typeof err === "object" ? err.message : String(err);
+}
 
 function selectError(exc: unknown): SerializedError {
   if (exc instanceof PromiseRejectionEvent) {
@@ -43,6 +47,6 @@ export function reportError(exc: unknown, context?: MessageContext): void {
       console.error("Another error occurred while reporting an error", { exc });
     });
   } else {
-    (Rollbar as any).error(exc);
+    rollbar.error(toLogArgument(exc));
   }
 }


### PR DESCRIPTION
* Use rollbar instance instead of namespace so Typescript typing is correct (remove `any` casts)
* Deserialize the error before passing to Rollbar so it sees it as an error object and not context data

Not implemented:
* `actions.tsx` and `options.tsx` don't ever have the user identifier set on them. When rollbar catches a top-level error via `captureUncaught: true` (and same for unhandledrejections) in these apps, the telemetry won't have the user assigned