### PR TITLE
Do not track on DEBUG, but allow enabling

### DIFF
--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -82,6 +82,4 @@ browser.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
 browser.runtime.onInstalled.addListener(install);
 browser.runtime.onStartup.addListener(init);
 
-if (!process.env.DEBUG) {
-  setUninstallURL().catch(reportError);
-}
+setUninstallURL();

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -20,7 +20,7 @@ import { reportError } from "@/telemetry/logging";
 import { liftBackground } from "@/background/protocol";
 import urljoin from "url-join";
 import { reportEvent, initTelemetry } from "@/telemetry/events";
-import { getDNT, getUID } from "@/background/telemetry";
+import { DNT_STORAGE_KEY, getDNT, getUID } from "@/background/telemetry";
 
 const SERVICE_URL = process.env.SERVICE_URL;
 
@@ -71,7 +71,9 @@ export const getAvailableVersion = liftBackground(
 );
 
 async function setUninstallURL(): Promise<void> {
-  if (!(await getDNT())) {
+  if (await getDNT()) {
+    await browser.runtime.setUninstallURL();
+  } else {
     const url = new URL("https://www.pixiebrix.com/uninstall/");
     url.searchParams.set("uid", await getUID());
     await browser.runtime.setUninstallURL(url.toString());
@@ -81,5 +83,11 @@ async function setUninstallURL(): Promise<void> {
 browser.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
 browser.runtime.onInstalled.addListener(install);
 browser.runtime.onStartup.addListener(init);
+
+browser.storage.onChanged.addListener((changes) => {
+  if (DNT_STORAGE_KEY in changes) {
+    void setUninstallURL();
+  }
+});
 
 setUninstallURL();

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -62,7 +62,7 @@ async function uid(): Promise<string> {
 
 export async function _toggleDNT(enable: boolean): Promise<boolean> {
   _dnt = enable;
-  await setStorage(DNT_STORAGE_KEY, enable.toString());
+  await browser.storage.local.set({ [DNT_STORAGE_KEY]: enable });
   return enable;
 }
 

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -70,7 +70,7 @@ export async function _getDNT(): Promise<boolean> {
   if (_dnt != null) {
     return _dnt;
   }
-  _dnt = boolean(await readStorage<string>(DNT_STORAGE_KEY));
+  _dnt = boolean(await readStorage<boolean | string>(DNT_STORAGE_KEY) ?? process.env.DEBUG);
   return _dnt;
 }
 

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -37,7 +37,7 @@ interface UserEvent {
   data: JsonObject;
 }
 
-const DNT_STORAGE_KEY = "DNT";
+export const DNT_STORAGE_KEY = "DNT";
 const UUID_STORAGE_KEY = "USER_UUID";
 
 let _uid: string = null;


### PR DESCRIPTION
Fixes #491 
Follows #483 

I also fixed a bug: The uninstall page only followed the DNT setting after a browser restart