### PR TITLE
#505: Add lint CI job

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,11 +38,15 @@
     }]
   },
   "ignorePatterns": [
-    "browsers/chrome/webpack/**",
-    "browsers/firefox/webpack/**",
+    "node_modules",
+    ".idea",
+    "assets/bundles",
+    "browsers/dist",
+    "artifacts",
+    "scripts/bin",
     "browsers/webpack.config.js",
     "scripts/webpack.scripts.js",
-    "src/vendors/libraryDetector/**",
+    "src/vendors",
     "src/**/*.test.ts",
     "src/**/*.test.js",
     "src/support.js"

--- a/.eslintrc
+++ b/.eslintrc
@@ -22,8 +22,6 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
-    "plugin:import/errors",
-    "plugin:import/warnings",
     "plugin:import/typescript",
     "plugin:react-redux/recommended",
     "plugin:security/recommended"

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -12,11 +12,4 @@ jobs:
         with:
           node-version: '14.x'
       - uses: bahmutov/npm-install@v1
-      - name: npx eslint $FILES_CHANGED
-        run: |
-          git fetch origin main
-          FILES_CHANGED=$(git diff origin/${{ github.base_ref }}.. --name-only -- "*.ts" "*.tsx" "*.js" "*.jsx")
-          echo Will check these files:
-          echo $FILES_CHANGED
-          echo -----------------------
-          npx eslint $FILES_CHANGED || true
+      - run: npm run lint || true

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,0 +1,22 @@
+name: Lint
+
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - uses: bahmutov/npm-install@v1
+      - name: npx eslint $FILES_CHANGED
+        run: |
+          git fetch origin main
+          FILES_CHANGED=$(git diff origin/${{ github.base_ref }}.. --name-only -- "*.ts" "*.tsx" "*.js" "*.jsx")
+          echo Will check these files:
+          echo $FILES_CHANGED
+          echo -----------------------
+          npx eslint $FILES_CHANGED || true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watchAll",
-    "lint": "eslint src/**",
+    "lint": "eslint src",
     "watch": "ENV_FILE='.env.development' webpack --mode development --config browsers/webpack.config.js --watch",
     "build": "NODE_OPTIONS=--max_old_space_size=8192 webpack --mode production --config browsers/webpack.config.js",
     "build:scripts": "webpack --mode production --config scripts/webpack.scripts.js",

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -54,7 +54,7 @@ window.addEventListener("error", function (e) {
   }
 });
 
-window.addEventListener("unhandledrejection", function (e) {
+window.addEventListener("unhandledrejection", function (e: any) {
   if (isConnectionError(e)) {
     showConnectionLost();
   } else {


### PR DESCRIPTION
Closes #505
Replaces https://github.com/pixiebrix/pixiebrix-extension/pull/443

The ironic part is that annotations appear for everything except what PR touches. I think this is a GitHub bug because:

- the annotation is shown [on the check itself](https://github.com/pixiebrix/pixiebrix-extension/actions/runs/942449372), but not on the Files changed tab
- the _other_ annotations are shown on the Files tab
- if I run the lint just on the changed files, no annotations are shown at all, except [on the check’s page](https://github.com/pixiebrix/pixiebrix-extension/actions/runs/942449372)

Notes:

- The `--max-warnings` flag you had mentioned only refers to warnings, there's no way to change the [exit code](https://eslint.org/docs/user-guide/command-line-interface#exit-codes) when errors are countered, so I used `|| true` 
- Every eslint action out there just makes the build fail, which is an irreversible state, plus they use their own eslint version
- There are no "passing with warning" states for GitHub Action. It either passes or it doesn't.
- [eslint-annotate-action](https://github.com/ataylorme/eslint-annotate-action)’s annotation don't appear on the Files tab either

Further comments may be found in the commits

Possible changes to this PR

- [ ] Limit eslint only to the changed files, reverting 05cd321
- [ ] Somehow include the eslint output in a new comment, but I think that would be noisy 