### PR TITLE
Include build timestamp in version during development

### DIFF
--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -94,22 +94,15 @@ function rollbarPlugins() {
 }
 
 function getVersionName(isProduction) {
-  if (process.env.ENVIRONMENT === "staging") {
-    return (
-      process.env.npm_package_version + "-rc-" + process.env.SOURCE_VERSION
-    );
-  }
-
   if (isProduction) {
     return process.env.npm_package_version;
+  } else if (process.env.ENVIRONMENT === "staging") {
+    return `${process.env.npm_package_version}-alpha+${process.env.SOURCE_VERSION}`;
+  } else {
+    return `${
+      process.env.npm_package_version
+    }-local+${new Date().toISOString()}`;
   }
-
-  const buildTime = new Date()
-    .toISOString() // 2021-06-21T11:25:41.707Z
-    .replace(/\..+$/g, "") // 2021-06-21T11:25:41
-    .replace(/\D/g, "."); // 2021.06.21.11.25.41
-
-  return process.env.npm_package_version + ".local+" + buildTime;
 }
 
 function getConditionalPlugins(isProduction) {

--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -125,7 +125,7 @@ function customizeManifest(manifest, options) {
     manifest.name = "PixieBrix - Development";
     const date = new Date();
     manifest.version +=
-      "." + date.getHours() + String(date.getMinutes()).padStart("0", 2);
+      "." + date.getHours() + String(date.getMinutes()).padStart(2, "0");
   }
   if (process.env.CHROME_MANIFEST_KEY) {
     manifest.key = process.env.CHROME_MANIFEST_KEY;

--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -94,10 +94,11 @@ function rollbarPlugins() {
 }
 
 function getVersionName(isProduction) {
-  if (isProduction) {
-    return process.env.npm_package_version;
-  } else if (process.env.ENVIRONMENT === "staging") {
+  if (process.env.ENVIRONMENT === "staging") {
+    // staging builds (i.e., from CI) are production builds, so check ENVIRONMENT first
     return `${process.env.npm_package_version}-alpha+${process.env.SOURCE_VERSION}`;
+  } else if (isProduction) {
+    return process.env.npm_package_version;
   } else {
     return `${
       process.env.npm_package_version

--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -120,13 +120,16 @@ function getConditionalPlugins(isProduction) {
 const isProd = (options) => options.mode === "production";
 
 function customizeManifest(manifest, options) {
+  manifest.version = process.env.npm_package_version;
   if (!isProd(options)) {
     manifest.name = "PixieBrix - Development";
+    const date = new Date();
+    manifest.version +=
+      "." + date.getHours() + String(date.getMinutes()).padStart("0", 2);
   }
   if (process.env.CHROME_MANIFEST_KEY) {
     manifest.key = process.env.CHROME_MANIFEST_KEY;
   }
-  manifest.version = process.env.npm_package_version;
   const internal = isProd(options)
     ? []
     : ["http://127.0.0.1:8000/*", "http://127.0.0.1/*", "http://localhost/*"];

--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -121,12 +121,18 @@ const isProd = (options) => options.mode === "production";
 
 function customizeManifest(manifest, options) {
   manifest.version = process.env.npm_package_version;
-  if (!isProd(options)) {
+  if (process.env.ENVIRONMENT === "staging") {
+    manifest.version_name += "-rc-" + process.env.SOURCE_VERSION;
+  } else if (!isProd(options)) {
+    const buildTime = new Date()
+      .toISOString() // 2021-06-21T11:25:41.707Z
+      .replace(/\..+$/g, "") // 2021-06-21T11:25:41
+      .replace(/\D/g, "."); // 2021.06.21.11.25.41
+
     manifest.name = "PixieBrix - Development";
-    const date = new Date();
-    manifest.version +=
-      "." + date.getHours() + String(date.getMinutes()).padStart(2, "0");
+    manifest.version_name = manifest.version + ".local+" + buildTime;
   }
+
   if (process.env.CHROME_MANIFEST_KEY) {
     manifest.key = process.env.CHROME_MANIFEST_KEY;
   }

--- a/src/layout/Banner.tsx
+++ b/src/layout/Banner.tsx
@@ -23,7 +23,7 @@ import useAsyncEffect from "use-async-effect";
 import AuthContext from "@/auth/AuthContext";
 
 const environment = process.env.ENVIRONMENT;
-const version = process.env.NPM_PACKAGE_VERSION;
+const versionName = process.env.VERSION_NAME;
 const source_version = process.env.SOURCE_VERSION;
 
 const classMap: { [key: string]: string } = {
@@ -65,7 +65,7 @@ const Banner: React.FunctionComponent = () => {
       })}
     >
       You are using {extension ? "extension" : "server"}{" "}
-      {environment ?? "unknown"} build {version} (
+      {environment ?? "unknown"} build {versionName} (
       {source_version.substring(0, 8).trim()}) {extension && syncText}
     </div>
   );

--- a/src/layout/Banner.tsx
+++ b/src/layout/Banner.tsx
@@ -24,13 +24,13 @@ import AuthContext from "@/auth/AuthContext";
 
 const environment = process.env.ENVIRONMENT;
 const versionName = process.env.VERSION_NAME;
-const source_version = process.env.SOURCE_VERSION;
 
-const classMap: { [key: string]: string } = {
-  "": "development",
-  development: "development",
-  staging: "staging",
-};
+const classMap = new Map([
+  [null, "development"],
+  ["", "development"],
+  ["development", "development"],
+  ["staging", "staging"],
+]);
 
 function useSyncedHostname() {
   const { extension } = useContext(AuthContext);
@@ -61,12 +61,11 @@ const Banner: React.FunctionComponent = () => {
   return (
     <div
       className={cx("environment-banner", "w-100", {
-        [classMap[environment] ?? "unknown"]: true,
+        [classMap.get(environment) ?? "unknown"]: true,
       })}
     >
       You are using {extension ? "extension" : "server"}{" "}
-      {environment ?? "unknown"} build {versionName} (
-      {source_version.substring(0, 8).trim()}) {extension && syncText}
+      {environment ?? "unknown"} build {versionName} {extension && syncText}
     </div>
   );
 };


### PR DESCRIPTION
_"Am I looking at the latest version?"_ 

Tiny improvement: This should help us see if the build is working and we're looking at what we expect to be looking at.

You can see below that we're looking at a build that started after 15:23

<img width="417" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/122667224-ebdb6880-d1db-11eb-8cda-550942b8eab0.png">
<img width="685" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/122667228-eda52c00-d1db-11eb-9795-adb4ba41fb99.png">
