### PR TITLE
#428: only install window handlers once for content script

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,5 +2,36 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="HttpUrlsUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredUrls">
+        <list>
+          <option value="http://localhost" />
+          <option value="http://127.0.0.1" />
+          <option value="http://0.0.0.0" />
+          <option value="http://www.w3.org/" />
+          <option value="http://json-schema.org/draft" />
+          <option value="http://java.sun.com/" />
+          <option value="http://xmlns.jcp.org/" />
+          <option value="http://javafx.com/javafx/" />
+          <option value="http://javafx.com/fxml" />
+          <option value="http://maven.apache.org/xsd/" />
+          <option value="http://maven.apache.org/POM/" />
+          <option value="http://www.springframework.org/schema/" />
+          <option value="http://www.springframework.org/tags" />
+          <option value="http://www.springframework.org/security/tags" />
+          <option value="http://www.thymeleaf.org" />
+          <option value="http://www.jboss.org/j2ee/schema/" />
+          <option value="http://www.jboss.com/xml/ns/" />
+          <option value="http://www.ibm.com/webservices/xsd" />
+          <option value="http://activemq.apache.org/schema/" />
+          <option value="http://schema.cloudfoundry.org/spring/" />
+          <option value="http://schemas.xmlsoap.org/" />
+          <option value="http://cxf.apache.org/schemas/" />
+          <option value="http://primefaces.org/ui" />
+          <option value="http://tiles.apache.org/" />
+          <option value="http://" />
+        </list>
+      </option>
+    </inspection_tool>
   </profile>
 </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,36 +2,5 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="HttpUrlsUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
-      <option name="ignoredUrls">
-        <list>
-          <option value="http://localhost" />
-          <option value="http://127.0.0.1" />
-          <option value="http://0.0.0.0" />
-          <option value="http://www.w3.org/" />
-          <option value="http://json-schema.org/draft" />
-          <option value="http://java.sun.com/" />
-          <option value="http://xmlns.jcp.org/" />
-          <option value="http://javafx.com/javafx/" />
-          <option value="http://javafx.com/fxml" />
-          <option value="http://maven.apache.org/xsd/" />
-          <option value="http://maven.apache.org/POM/" />
-          <option value="http://www.springframework.org/schema/" />
-          <option value="http://www.springframework.org/tags" />
-          <option value="http://www.springframework.org/security/tags" />
-          <option value="http://www.thymeleaf.org" />
-          <option value="http://www.jboss.org/j2ee/schema/" />
-          <option value="http://www.jboss.com/xml/ns/" />
-          <option value="http://www.ibm.com/webservices/xsd" />
-          <option value="http://activemq.apache.org/schema/" />
-          <option value="http://schema.cloudfoundry.org/spring/" />
-          <option value="http://schemas.xmlsoap.org/" />
-          <option value="http://cxf.apache.org/schemas/" />
-          <option value="http://primefaces.org/ui" />
-          <option value="http://tiles.apache.org/" />
-          <option value="http://" />
-        </list>
-      </option>
-    </inspection_tool>
   </profile>
 </component>

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -51,6 +51,7 @@ declare global {
 async function init(): Promise<void> {
   // Add error listeners first so they can catch any initialization errors
   addErrorListeners();
+
   addContentScriptListener();
   addExternalListener();
   addExecutorListener();
@@ -84,10 +85,10 @@ async function init(): Promise<void> {
 // Make sure we don't install the content script multiple times
 // eslint-disable-next-line security/detect-object-injection -- using PIXIEBRIX_SYMBOL
 const existing: string = window[PIXIEBRIX_SYMBOL];
-if (!existing) {
+if (existing) {
+  console.debug(`PixieBrix contentScript already installed: ${existing}`);
+} else {
   // eslint-disable-next-line security/detect-object-injection -- using PIXIEBRIX_SYMBOL
   window[PIXIEBRIX_SYMBOL] = uuid;
   void init();
-} else {
-  console.debug(`PixieBrix contentScript already installed: ${existing}`);
 }

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -100,7 +100,8 @@ export function notifyContentScripts(
   const fullType = `${MESSAGE_PREFIX}${type}`;
 
   if (isContentScript()) {
-    console.debug(`Installed content script handler for notification ${type}`);
+    // Don't log here because the message is confusing -- the handler isn't installed until addContentScriptListener
+    // console.debug(`Installed content script handler for notification ${type}`);
     handlers.set(fullType, {
       // HandlerEntry's Handler field has a return value, not void
       handler: method as (...args: unknown[]) => null,
@@ -186,7 +187,8 @@ export function liftContentScript<R extends SerializableResponse>(
   const fullType = `${MESSAGE_PREFIX}${type}`;
 
   if (isContentScript()) {
-    console.debug(`Installed content script handler for action ${type}`);
+    // Don't log here because the message is confusing -- the handler isn't installed until addContentScriptListener
+    // console.debug(`Installed content script handler for action ${type}`);
     handlers.set(fullType, { handler: method, options });
   }
 
@@ -251,6 +253,21 @@ export function liftContentScript<R extends SerializableResponse>(
   };
 }
 
-if (isContentScript()) {
-  browser.runtime.onMessage.addListener(contentScriptListener);
+function addContentScriptListener(): void {
+  if (isContentScript()) {
+    browser.runtime.onMessage.addListener(contentScriptListener);
+    console.debug(
+      "Installed handlers for %d actions/notifications",
+      handlers.size,
+      {
+        actions: Array.from(handlers.keys()),
+      }
+    );
+  } else {
+    throw new Error(
+      "addContentScriptListener should only be run from the content script"
+    );
+  }
 }
+
+export default addContentScriptListener;

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -100,8 +100,8 @@ export function notifyContentScripts(
   const fullType = `${MESSAGE_PREFIX}${type}`;
 
   if (isContentScript()) {
-    // Don't log here because the message is confusing -- the handler isn't installed until addContentScriptListener
-    // console.debug(`Installed content script handler for notification ${type}`);
+    // addContentScriptListener logs to console when the handler is installed on the window. So it would be confusing
+    // to include a console.debug statement here
     handlers.set(fullType, {
       // HandlerEntry's Handler field has a return value, not void
       handler: method as (...args: unknown[]) => null,
@@ -187,8 +187,8 @@ export function liftContentScript<R extends SerializableResponse>(
   const fullType = `${MESSAGE_PREFIX}${type}`;
 
   if (isContentScript()) {
-    // Don't log here because the message is confusing -- the handler isn't installed until addContentScriptListener
-    // console.debug(`Installed content script handler for action ${type}`);
+    // addContentScriptListener logs to console when the handler is installed on the window. So it would be confusing
+    // to include a console.debug statement here
     handlers.set(fullType, { handler: method, options });
   }
 
@@ -254,20 +254,20 @@ export function liftContentScript<R extends SerializableResponse>(
 }
 
 function addContentScriptListener(): void {
-  if (isContentScript()) {
-    browser.runtime.onMessage.addListener(contentScriptListener);
-    console.debug(
-      "Installed handlers for %d actions/notifications",
-      handlers.size,
-      {
-        actions: Array.from(handlers.keys()),
-      }
-    );
-  } else {
+  if (!isContentScript()) {
     throw new Error(
       "addContentScriptListener should only be run from the content script"
     );
   }
+
+  browser.runtime.onMessage.addListener(contentScriptListener);
+  console.debug(
+    "Installed handlers for %d actions/notifications",
+    handlers.size,
+    {
+      actions: Array.from(handlers.keys()),
+    }
+  );
 }
 
 export default addContentScriptListener;

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -109,12 +109,20 @@ export async function whoAmI(): Promise<Runtime.MessageSender> {
 }
 
 export async function notifyReady(): Promise<void> {
-  await browser.runtime.sendMessage({
+  return browser.runtime.sendMessage({
     type: MESSAGE_CONTENT_SCRIPT_READY,
     payload: {},
   });
 }
 
-if (isContentScript()) {
-  browser.runtime.onMessage.addListener(runBlockAction);
+function addExecutorListener(): void {
+  if (isContentScript()) {
+    browser.runtime.onMessage.addListener(runBlockAction);
+  } else {
+    throw new Error(
+      "addExecutorListener should only be called from the content script"
+    );
+  }
 }
+
+export default addExecutorListener;

--- a/src/contentScript/externalProtocol.ts
+++ b/src/contentScript/externalProtocol.ts
@@ -16,9 +16,6 @@
  */
 
 import { isExtensionContext } from "@/chrome";
-
-const MESSAGE_PREFIX = "@@pixiebrix/external/";
-
 import { v4 as uuidv4 } from "uuid";
 import {
   HandlerEntry,
@@ -31,6 +28,7 @@ import { isContentScript } from "webext-detect-page";
 import { deserializeError } from "serialize-error";
 import { ContentScriptActionError } from "@/contentScript/backgroundProtocol";
 
+const MESSAGE_PREFIX = "@@pixiebrix/external/";
 const fulfilledSuffix = "_FULFILLED";
 const rejectedSuffix = "_REJECTED";
 
@@ -194,8 +192,16 @@ export function liftExternal<R extends SerializableResponse>(
   };
 }
 
-if (isContentScript()) {
-  initContentScriptListener();
-} else if (!isExtensionContext()) {
-  initExternalPageListener();
+function addExternalListener(): void {
+  if (isContentScript()) {
+    initContentScriptListener();
+  } else if (!isExtensionContext()) {
+    initExternalPageListener();
+  } else {
+    throw new Error(
+      "addExternalListener can only be called from the content script or an external page"
+    );
+  }
 }
+
+export default addExternalListener;

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -244,7 +244,6 @@ async function waitLoaded(cancel: () => boolean): Promise<void> {
 
 /**
  * Handle a website navigation, e.g., page load or a URL change in an SPA.
- * @returns {Promise<void>}
  */
 export async function handleNavigate({
   openerTabId,

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -209,7 +209,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
     const extensions = this.extensions.splice(0, this.extensions.length);
     if (global) {
       for (const extension of extensions) {
-        uninstallContextMenu({ extensionId: extension.id });
+        void uninstallContextMenu({ extensionId: extension.id });
       }
     }
   }
@@ -283,8 +283,6 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
       deploymentId: extension._deployment?.id,
       extensionId: extension.id,
     });
-
-    console.debug("Got extension", { extension });
 
     registerHandler(extension.id, async (clickData) => {
       const reader = await this.getBaseReader();

--- a/src/hooks/fetch.ts
+++ b/src/hooks/fetch.ts
@@ -25,6 +25,8 @@ import { isExtensionContext } from "@/chrome";
 import { getExtensionToken } from "@/auth/token";
 
 export function isAbsoluteURL(url: string): boolean {
+  // We're testing if a URL is absolute here, not creating a URL to call
+  // noinspection HttpUrlsUsage
   return url.indexOf("http://") === 0 || url.indexOf("https://") === 0;
 }
 


### PR DESCRIPTION
Closes #540  

- Refactors contentScript imports to have default export to install the window listeners
- contentScript now performs NOP if a copy is already installed instead of throwing an error
- Improve logging of which handlers were installed (previously, we being logged when the lift methods were processed on module load, not when the handlers were actually installed)
