### PR TITLE
#557: confirm remove in page editor

### DIFF
--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2021 Pixie Brix, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import React, { useCallback, useState, useEffect, useContext } from "react";
+import { Modal, Button } from "react-bootstrap";
+
+type ModalProps = {
+  title?: string;
+  message: string;
+  submitCaption?: string;
+  cancelCaption?: string;
+};
+
+type ModalContextProps = {
+  showConfirmation: (modalProps: ModalProps) => Promise<boolean>;
+};
+
+const initialModalState: ModalContextProps = {
+  showConfirmation: () => {
+    throw new Error("showConfirmation not configured");
+  },
+};
+
+export const ModalContext = React.createContext<ModalContextProps>(
+  initialModalState
+);
+
+const ConfirmationModal: React.FunctionComponent<
+  ModalProps & { onCancel: () => void; onSubmit: () => void }
+> = ({ title, message, submitCaption, onCancel, onSubmit }) => {
+  return (
+    <Modal show onHide={onCancel} backdrop="static" keyboard={false}>
+      <Modal.Header closeButton>
+        <Modal.Title>{title ?? "Confirm?"}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>{message}</Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="danger" onClick={onSubmit}>
+          {submitCaption ?? "Continue"}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+type Callback = (submit: boolean) => void;
+
+export const ModalProvider: React.FunctionComponent<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [modalProps, setModalProps] = useState<ModalProps>();
+  const [callback, setCallback] = useState<Callback>();
+
+  useEffect(() => {
+    return () => {
+      callback?.(false);
+    };
+  }, [callback]);
+
+  const showConfirmation = useCallback(
+    async (modalProps: ModalProps) => {
+      // cancel any previous modal that was showing
+      callback?.(false);
+      return new Promise<boolean>((resolve) => {
+        setModalProps(modalProps);
+        const newCallback = (submit: boolean) => {
+          setModalProps(undefined);
+          resolve(submit);
+          setCallback(undefined);
+        };
+        setCallback((_prevState: Callback) => newCallback);
+      });
+    },
+    [callback, setModalProps]
+  );
+
+  return (
+    <ModalContext.Provider value={{ showConfirmation }}>
+      {modalProps && (
+        <ConfirmationModal
+          {...modalProps}
+          onSubmit={() => callback(true)}
+          onCancel={() => callback(false)}
+        />
+      )}
+      {children}
+    </ModalContext.Provider>
+  );
+};
+
+export function useModals(): ModalContextProps {
+  return useContext(ModalContext);
+}

--- a/src/devTools/Panel.tsx
+++ b/src/devTools/Panel.tsx
@@ -43,6 +43,7 @@ import "@/blocks/transformers";
 import "@/blocks/renderers";
 import "@/contrib/index";
 import "@/contrib/editors";
+import { ModalProvider } from "@/components/ConfirmationModal";
 
 const defaultState: AuthState = {
   isLoggedIn: false,
@@ -119,15 +120,17 @@ const Panel: React.FunctionComponent = () => {
         <AuthContext.Provider value={authState ?? defaultState}>
           <DevToolsContext.Provider value={context}>
             <ToastProvider>
-              <ErrorBoundary>
-                <Router>
-                  <Container fluid className="DevToolsContainer">
-                    <RequireScope scope={authState?.scope}>
-                      <Editor />
-                    </RequireScope>
-                  </Container>
-                </Router>
-              </ErrorBoundary>
+              <ModalProvider>
+                <ErrorBoundary>
+                  <Router>
+                    <Container fluid className="DevToolsContainer">
+                      <RequireScope scope={authState?.scope}>
+                        <Editor />
+                      </RequireScope>
+                    </Container>
+                  </Router>
+                </ErrorBoundary>
+              </ModalProvider>
             </ToastProvider>
           </DevToolsContext.Provider>
         </AuthContext.Provider>

--- a/src/devTools/editor/editorHooks.ts
+++ b/src/devTools/editor/editorHooks.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2021 Pixie Brix, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { IExtension } from "@/core";
+import { actions, FormState } from "@/devTools/editor/editorSlice";
+import { useDispatch } from "react-redux";
+import { useCallback, useContext } from "react";
+import { extensionToFormState } from "@/devTools/editor/extensionPoints/adapter";
+import { reportError } from "@/telemetry/logging";
+import { DevToolsContext } from "@/devTools/context";
+import { useToasts } from "react-toast-notifications";
+import { useFormikContext } from "formik";
+import { uninstallContextMenu } from "@/background/devtools";
+import * as nativeOperations from "@/background/devtools";
+import { optionsSlice } from "@/options/slices";
+import { useModals } from "@/components/ConfirmationModal";
+
+export function useReset(
+  installed: IExtension[],
+  element: FormState
+): () => void {
+  const dispatch = useDispatch();
+
+  return useCallback(async () => {
+    try {
+      const extension = installed.find((x) => x.id === element.uuid);
+      const state = await extensionToFormState(extension);
+      dispatch(actions.resetInstalled(state));
+    } catch (error) {
+      reportError(error);
+      dispatch(actions.adapterError({ uuid: element.uuid, error }));
+    }
+  }, [dispatch, element.uuid, installed]);
+}
+
+export function useRemove(element: FormState): () => void {
+  const { port } = useContext(DevToolsContext);
+  const { addToast } = useToasts();
+  const { values } = useFormikContext<FormState>();
+  const dispatch = useDispatch();
+  const { showConfirmation } = useModals();
+
+  return useCallback(async () => {
+    console.debug(`pageEditor: remove element ${element.uuid}`);
+
+    const confirm = await showConfirmation({
+      title: "Remove Brick?",
+      message: "Remove this brick? This action cannot be undone",
+      submitCaption: "Remove",
+    });
+
+    if (!confirm) {
+      return;
+    }
+
+    try {
+      if (element.type === "contextMenu") {
+        try {
+          await uninstallContextMenu(port, { extensionId: element.uuid });
+        } catch (error) {
+          // The context menu may not currently be registered if it's not on a page that has a contentScript
+          // with a pattern that matches
+          console.info("Cannot unregister contextMenu", { error });
+        }
+      }
+      try {
+        await nativeOperations.clearDynamicElements(port, {
+          uuid: element.uuid,
+        });
+      } catch (error) {
+        // element might not be on the page anymore
+        console.info("Cannot clear dynamic element from page", { error });
+      }
+      if (values.installed) {
+        dispatch(
+          optionsSlice.actions.removeExtension({
+            extensionPointId: values.extensionPoint.metadata.id,
+            extensionId: values.uuid,
+          })
+        );
+      }
+      dispatch(actions.removeElement(element.uuid));
+    } catch (error) {
+      reportError(error);
+      addToast(
+        `Error removing element: ${
+          error.message?.toString() ?? "Unknown Error"
+        }`,
+        {
+          appearance: "error",
+          autoDismiss: true,
+        }
+      );
+    }
+  }, [showConfirmation, values, addToast, port, element, dispatch]);
+}


### PR DESCRIPTION
Closes #557 

Provides a generic React component/hook we can use for confirmation dialogs

![image](https://user-images.githubusercontent.com/1879821/123115144-df3e5680-d40d-11eb-8ed0-46efc9353877.png)
