### PR TITLE
Use consistent HTML doctype and encoding

### DIFF
--- a/browsers/src/action.html
+++ b/browsers/src/action.html
@@ -15,11 +15,10 @@
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<!DOCTYPE html PUBLIC"-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html lang="en">
   <head>
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
-    <meta content="utf-8" http-equiv="encoding" />
+    <meta charset="utf-8" />
     <title>PixieBrix: Page Panel</title>
     <link rel="stylesheet" href="action.css" />
   </head>

--- a/browsers/src/devtools.html
+++ b/browsers/src/devtools.html
@@ -14,8 +14,11 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
-<!DOCTYPE html PUBLIC"-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+  </head>
   <body>
     <script src="devtools.js"></script>
   </body>

--- a/browsers/src/frame.html
+++ b/browsers/src/frame.html
@@ -15,11 +15,10 @@
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<!DOCTYPE html PUBLIC"-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html lang="en">
   <head>
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
-    <meta content="utf-8" http-equiv="encoding" />
+    <meta charset="utf-8" />
     <title>PixieBrix Frame</title>
     <link rel="stylesheet" href="frame.css" />
   </head>

--- a/browsers/src/options.html
+++ b/browsers/src/options.html
@@ -15,11 +15,10 @@
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<!DOCTYPE html PUBLIC"-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html lang="en">
   <head>
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
-    <meta content="utf-8" http-equiv="encoding" />
+    <meta charset="utf-8" />
     <title>Browser Extension | PixieBrix</title>
     <link rel="stylesheet" href="options.css" />
   </head>

--- a/browsers/src/support.html
+++ b/browsers/src/support.html
@@ -14,9 +14,10 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
-<!DOCTYPE html PUBLIC"-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
+    <meta charset="utf-8" />
     <title>Support Chat</title>
     <meta
       http-equiv="Content-Security-Policy"


### PR DESCRIPTION
- Uses HTML5 doctype
- Specifies utf-8 everywhere the same way

<img width="870" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/123394379-4a805800-d5c9-11eb-9b23-757cd995a508.png">

https://www.w3.org/International/questions/qa-html-encoding-declarations