### PR TITLE
#580: Don't handle non-awaited rejections

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,9 @@
   "env": {
     "browser": true
   },
+  "parserOptions": {
+    "project": "tsconfig.json"
+  },
   "settings": {
     "import/resolver": {
       "webpack": {
@@ -16,9 +19,11 @@
     }
   },
   "extends": [
+    // TODO: replace the following 3 with the stricter xo-typescript config
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
+
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:import/typescript",
@@ -61,7 +66,7 @@
       }
     ],
 
-    // Soft-enable some rules
+    // Soft-enable some rules, maybe enforce them later
     "@typescript-eslint/ban-types": "warn",
     "@typescript-eslint/no-explicit-any": "warn",
     "unicorn/no-array-callback-reference": "warn", // Buggy with jQuery
@@ -69,7 +74,22 @@
     "unicorn/no-nested-ternary": "warn", // Sometimes it conflicts with Prettier
     "unicorn/consistent-function-scoping": "warn", // Complains about some of the lifted functions
     "unicorn/prefer-prototype-methods": "warn", // Buggy with abstract classes
-    "unicorn/prefer-switch": "warn", // TODO: Enforce later
+    "unicorn/prefer-switch": "warn",
+
+    // Config copied from https://github.com/xojs/eslint-config-xo-typescript/blob/7842d05deaadff1ced9a46f3e56d786e7b2922d2/index.js#L306
+    "@typescript-eslint/promise-function-async": [
+      "warn",
+      {
+        "allowAny": true
+      }
+    ],
+    "@typescript-eslint/no-floating-promises": [
+      "warn",
+      {
+        "ignoreVoid": true, // Prepend a function call with `void` to mark it as not needing to be await'ed, which silences this rule.
+        "ignoreIIFE": true
+      }
+    ],
 
     // Disable recommended rules
     "@typescript-eslint/no-empty-function": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -69,6 +69,7 @@
     // Soft-enable some rules, maybe enforce them later
     "@typescript-eslint/ban-types": "warn",
     "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/promise-function-async": "warn",
     "unicorn/no-array-callback-reference": "warn", // Buggy with jQuery
     "unicorn/no-useless-undefined": "warn", // Buggy with React
     "unicorn/no-nested-ternary": "warn", // Sometimes it conflicts with Prettier
@@ -77,12 +78,6 @@
     "unicorn/prefer-switch": "warn",
 
     // Config copied from https://github.com/xojs/eslint-config-xo-typescript/blob/7842d05deaadff1ced9a46f3e56d786e7b2922d2/index.js#L306
-    "@typescript-eslint/promise-function-async": [
-      "warn",
-      {
-        "allowAny": true
-      }
-    ],
     "@typescript-eslint/no-floating-promises": [
       "warn",
       {

--- a/src/action.tsx
+++ b/src/action.tsx
@@ -26,7 +26,6 @@ import React from "react";
 import { browser } from "webextension-polyfill-ts";
 
 import { REGISTER_ACTION_FRAME } from "@/background/browserAction";
-import { reportError } from "@/telemetry/logging";
 import "@/actionPanel/protocol";
 
 // keep in order so precedence is preserved
@@ -37,14 +36,13 @@ import "@/vendors/overrides.scss";
 const url = new URL(location.href);
 const nonce = url.searchParams.get("nonce");
 
-browser.runtime
+void browser.runtime
   .sendMessage({
     type: REGISTER_ACTION_FRAME,
     payload: { nonce },
   })
   .then(() => {
     console.debug("Registered action frame with background page");
-  })
-  .catch(reportError);
+  });
 
 ReactDOM.render(<App />, document.querySelector("#container"));

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -138,15 +138,13 @@ export function getStore(): ActionPanelStore {
 
 function renderPanels() {
   if (_showPanel) {
-    browser.runtime
-      .sendMessage({
-        type: FORWARD_FRAME_NOTIFICATION,
-        payload: {
-          type: RENDER_PANELS_MESSAGE,
-          payload: { panels: _panels },
-        },
-      })
-      .catch(reportError);
+    void browser.runtime.sendMessage({
+      type: FORWARD_FRAME_NOTIFICATION,
+      payload: {
+        type: RENDER_PANELS_MESSAGE,
+        payload: { panels: _panels },
+      },
+    });
   }
 }
 

--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -68,24 +68,22 @@ async function dispatchMenu(
       args: info,
       maxWaitMillis: CONTEXT_MENU_INSTALL_MS,
     });
-    showNotification(target, {
+    void showNotification(target, {
       message: "Ran content menu item action",
       className: "success",
-    }).catch(reportError);
+    });
   } catch (error) {
     if (hasCancelRootCause(error)) {
-      showNotification(target, {
+      void showNotification(target, {
         message: "The action was cancelled",
         className: "info",
-      }).catch(reportError);
+      });
     } else {
       const message = `Error processing context menu action: ${getErrorMessage(
         error
       )}`;
       reportError(new Error(message));
-      showNotification(target, { message, className: "error" }).catch(
-        reportError
-      );
+      void showNotification(target, { message, className: "error" });
     }
   }
 

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -192,7 +192,7 @@ async function updateDeployments() {
             currentOptions = installDeployment(currentOptions, deployment);
           }
           await saveOptions(currentOptions);
-          queueReactivate().catch(reportError);
+          void queueReactivate();
           console.info(
             `Applied automatic updates for ${automatic.length} deployment(s)`
           );
@@ -216,7 +216,7 @@ async function updateDeployments() {
 
 export function initDeploymentUpdater(): void {
   setInterval(updateDeployments, UPDATE_INTERVAL_MS);
-  updateDeployments().catch(reportError);
+  void updateDeployments();
 }
 
 export default initDeploymentUpdater;

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -217,11 +217,7 @@ function deleteStaleConnections(port: Runtime.Port) {
         const listeners = permissionsListeners.get(tabId);
         permissionsListeners.delete(tabId);
         for (const [, reject] of listeners) {
-          try {
-            reject(new Error(`Cleaning up stale connection`));
-          } catch (error) {
-            reportError(error);
-          }
+          reject(new Error(`Cleaning up stale connection`));
         }
       }
     }

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -294,15 +294,15 @@ function backgroundListener(
   }
 }
 
-function linkTabListener(tab: Tabs.Tab): void {
+async function linkTabListener(tab: Tabs.Tab): Promise<void> {
   if (tab.openerTabId) {
     tabToOpener.set(tab.id, tab.openerTabId);
     tabToTarget.set(tab.openerTabId, tab.id);
-    linkChildTab({ tabId: tab.openerTabId, frameId: 0 }, tab.id).catch(
-      (error) => {
-        console.warn("Error linking child tab", error);
-      }
-    );
+    try {
+      await linkChildTab({ tabId: tab.openerTabId, frameId: 0 }, tab.id);
+    } catch (error: unknown) {
+      console.warn("Error linking child tab", error);
+    }
   }
 }
 

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -16,7 +16,6 @@
  */
 
 import { browser, Runtime } from "webextension-polyfill-ts";
-import { reportError } from "@/telemetry/logging";
 import { liftBackground } from "@/background/protocol";
 import urljoin from "url-join";
 import { reportEvent, initTelemetry } from "@/telemetry/events";
@@ -33,7 +32,7 @@ async function openInstallPage() {
 
 function install({ reason }: Runtime.OnInstalledDetailsType) {
   if (reason === "install") {
-    openInstallPage().catch(reportError);
+    void openInstallPage();
     initTelemetry();
     reportEvent("PixieBrixInstall", {
       version: browser.runtime.getManifest().version,

--- a/src/background/navigation.ts
+++ b/src/background/navigation.ts
@@ -17,17 +17,24 @@
 
 import * as contentScript from "@/contentScript/lifecycle";
 import { liftBackground } from "@/background/protocol";
-import { browser } from "webextension-polyfill-ts";
+import { browser, WebNavigation } from "webextension-polyfill-ts";
+
+async function historyListener(
+  details: WebNavigation.OnHistoryStateUpdatedDetailsType
+) {
+  try {
+    await contentScript.notifyNavigation(
+      { tabId: details.tabId, frameId: details.frameId },
+      {}
+    );
+  } catch (error) {
+    console.warn("Error notifying page navigation", error);
+  }
+}
 
 function initNavigation(): void {
   // updates from the history API
-  browser.webNavigation.onHistoryStateUpdated.addListener(function (details) {
-    contentScript
-      .notifyNavigation({ tabId: details.tabId, frameId: details.frameId }, {})
-      .catch((error) => {
-        console.warn("Error notifying page navigation", error);
-      });
-  });
+  browser.webNavigation.onHistoryStateUpdated.addListener(historyListener);
 }
 
 export const reactivate = liftBackground(

--- a/src/background/preload.ts
+++ b/src/background/preload.ts
@@ -63,5 +63,5 @@ export async function preloadAllMenus(): Promise<void> {
 }
 
 export default (): void => {
-  preloadAllMenus().catch(reportError);
+  void preloadAllMenus();
 };

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -47,7 +47,6 @@ import { boolean } from "@/utils";
 import { getLoggingConfig } from "@/background/logging";
 import { NotificationCallbacks, notifyProgress } from "@/contentScript/notify";
 import { sendDeploymentAlert } from "@/background/telemetry";
-import { reportError } from "@/telemetry/logging";
 import { serializeError } from "serialize-error";
 
 export type ReaderConfig =
@@ -427,18 +426,14 @@ export async function reducePipeline(
 
       if (stage.onError?.alert) {
         if (logger.context.deploymentId) {
-          try {
-            void sendDeploymentAlert({
-              deploymentId: logger.context.deploymentId,
-              data: {
-                id: stage.id,
-                args: currentArgs,
-                error: serializeError(error),
-              },
-            }).catch(reportError);
-          } catch (error_) {
-            reportError(error_);
-          }
+          void sendDeploymentAlert({
+            deploymentId: logger.context.deploymentId,
+            data: {
+              id: stage.id,
+              args: currentArgs,
+              error: serializeError(error),
+            },
+          });
         } else {
           console.warn("Can only send alert from deployment context");
         }

--- a/src/devTools/editor/fields/SelectorSelectorField.tsx
+++ b/src/devTools/editor/fields/SelectorSelectorField.tsx
@@ -215,22 +215,18 @@ export const SelectorSelectorControl: React.FunctionComponent<
           }}
           value={options.find((x) => x.value === value)}
           onMenuClose={() => {
-            nativeOperations
-              .toggleSelector(port, {
-                selector: null,
-                on: false,
-              })
-              .catch(reportError);
+            void nativeOperations.toggleSelector(port, {
+              selector: null,
+              on: false,
+            });
           }}
           onChange={async (option) => {
             console.debug("selected", { option });
             onSelect(option ? option.value : null);
-            nativeOperations
-              .toggleSelector(port, {
-                selector: null,
-                on: false,
-              })
-              .catch(reportError);
+            void nativeOperations.toggleSelector(port, {
+              selector: null,
+              on: false,
+            });
           }}
         />
       </div>

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -230,7 +230,7 @@ export function useCreate(): CreateCallback {
         try {
           dispatch(saveExtension(adapter.extension(element)));
           dispatch(markSaved(element.uuid));
-          reactivate().catch(reportError);
+          void reactivate();
           addToast("Saved extension", {
             appearance: "success",
             autoDismiss: true,

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -62,16 +62,11 @@ let selectionHandlerInstalled = false;
 const BUTTON_SECONDARY = 2;
 
 function setActiveElement(event: MouseEvent): void {
-  try {
-    if (event?.button === BUTTON_SECONDARY) {
-      clickedElement = event?.target as HTMLElement;
-    }
-  } catch (error) {
-    try {
-      reportError(error);
-    } catch (error) {
-      console.error(error);
-    }
+  // This method can't throw, otherwise I think it breaks event dispatching because we're passing
+  // useCapture: true to the event listener
+  clickedElement = null;
+  if (event?.button === BUTTON_SECONDARY) {
+    clickedElement = event?.target as HTMLElement;
   }
 }
 

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -62,9 +62,6 @@ let selectionHandlerInstalled = false;
 const BUTTON_SECONDARY = 2;
 
 function setActiveElement(event: MouseEvent): void {
-  // This method can't throw, otherwise I think it breaks event dispatching because we're passing
-  // useCapture: true to the event listener
-  clickedElement = null;
   try {
     if (event?.button === BUTTON_SECONDARY) {
       clickedElement = event?.target as HTMLElement;

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -144,8 +144,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
         try {
           await this.runExtension(readerContext, extension, root);
         } catch (error) {
-          // eslint-disable-next-line require-await
-          reportError(error, extensionLogger.context);
+          void reportError(error, extensionLogger.context);
           return error;
         }
         reportEvent("TriggerRun", {

--- a/src/options/pages/deployments/DeploymentBanner.tsx
+++ b/src/options/pages/deployments/DeploymentBanner.tsx
@@ -157,7 +157,7 @@ function useDeployments() {
             deployment: deployment.id,
           });
         }
-        queueReactivate().catch(reportError);
+        void queueReactivate();
         addToast("Activated team bricks", {
           appearance: "success",
           autoDismiss: true,

--- a/src/options/pages/extensionEditor/ExtensionEditor.tsx
+++ b/src/options/pages/extensionEditor/ExtensionEditor.tsx
@@ -29,7 +29,6 @@ import { reactivate } from "@/background/navigation";
 import GridLoader from "react-spinners/GridLoader";
 
 import "./ExtensionEditor.scss";
-import { reportError } from "@/telemetry/logging";
 
 const { saveExtension } = optionsSlice.actions;
 
@@ -95,7 +94,7 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
           navigate(`/workshop/extensions/${extensionId}`);
         }
 
-        reactivate().catch(reportError);
+        void reactivate();
       } finally {
         setSubmitting(false);
       }

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -38,7 +38,6 @@ import ActivateBody, {
   useEnsurePermissions,
 } from "@/options/pages/marketplace/ActivateBody";
 import { reactivate } from "@/background/navigation";
-import { reportError } from "@/telemetry/logging";
 import { useParams } from "react-router";
 import OptionsBody from "@/options/pages/marketplace/OptionsBody";
 import { selectExtensions } from "@/options/selectors";
@@ -186,7 +185,7 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
 
         setSubmitting(false);
 
-        reactivate().catch(reportError);
+        void reactivate();
 
         dispatch(
           push(sourcePage === "templates" ? "/templates" : "/installed")

--- a/src/options/slices.ts
+++ b/src/options/slices.ts
@@ -27,7 +27,6 @@ import { orderBy } from "lodash";
 import { Permissions } from "webextension-polyfill-ts";
 import { reportEvent } from "@/telemetry/events";
 import { preloadMenus } from "@/background/preload";
-import { reportError } from "@/telemetry/logging";
 import { Primitive } from "type-fest";
 
 type InstallMode = "local" | "remote";
@@ -244,7 +243,7 @@ export const optionsSlice = createSlice({
 
         state.extensions[extensionPointId][extensionId] = extensionConfig;
 
-        preloadMenus({ extensions: [extensionConfig] }).catch(reportError);
+        void preloadMenus({ extensions: [extensionConfig] });
       }
     },
     saveExtension(state, { payload }) {

--- a/src/vendors/libraryDetector/libraries.js
+++ b/src/vendors/libraryDetector/libraries.js
@@ -46,7 +46,7 @@ export default {
               gwtVersion = frames[n].contentWindow.$gwt_version;
               break;
             }
-          } catch (e) {}
+          } catch {}
         }
 
         if (gwtVersion == "0.0.999") {

--- a/src/vendors/libraryDetector/libraries.js
+++ b/src/vendors/libraryDetector/libraries.js
@@ -46,7 +46,7 @@ export default {
               gwtVersion = frames[n].contentWindow.$gwt_version;
               break;
             }
-          } catch {}
+          } catch (e) {}
         }
 
         if (gwtVersion == "0.0.999") {
@@ -1789,13 +1789,14 @@ export default {
             });
         });
 
-      try {
-        return await Promise.race([workerPromise, timeoutPromise]);
-      } catch {
-        return false;
-      } finally {
-        clearTimeout();
-      }
+      return Promise.race([workerPromise, timeoutPromise])
+        .catch(function (exception) {
+          return false;
+        })
+        .finally((result) => {
+          clearTimeout();
+          return result;
+        });
     },
   },
   Boq: {

--- a/src/vendors/libraryDetector/libraries.js
+++ b/src/vendors/libraryDetector/libraries.js
@@ -1789,14 +1789,13 @@ export default {
             });
         });
 
-      return Promise.race([workerPromise, timeoutPromise])
-        .catch(function (exception) {
-          return false;
-        })
-        .finally((result) => {
-          clearTimeout();
-          return result;
-        });
+      try {
+        return await Promise.race([workerPromise, timeoutPromise]);
+      } catch {
+        return false;
+      } finally {
+        clearTimeout();
+      }
     },
   },
   Boq: {

--- a/src/vendors/notify.js
+++ b/src/vendors/notify.js
@@ -157,7 +157,7 @@ function init($) {
     $("head").append(elem);
     try {
       elem.html(cssText);
-    } catch (_) {
+    } catch {
       elem[0].styleSheet.cssText = cssText;
     }
     return elem;


### PR DESCRIPTION
Part of https://github.com/pixiebrix/pixiebrix-extension/issues/580

> ### Automatic error handling
> Where possible, use top-level handlers to simplify error handling code (including unhandled promise rejections).

Assumptions:

- promise-returning functions should never throw synchronously (this will be enforced by the `promise-function-async` rule)
- some functions aren't expected to throw (reportError) so they should handle their own errors internally. 


Therefore, these 2 are exactly equivalent:

```diff
- preloadMenus({ extensions: [extensionConfig] }).catch(reportError);
+ void preloadMenus({ extensions: [extensionConfig] });
```