### PR TITLE
Feature/555 warn unsaved yaml changes

### DIFF
--- a/src/options/pages/brickEditor/Editor.tsx
+++ b/src/options/pages/brickEditor/Editor.tsx
@@ -83,6 +83,7 @@ const Editor: React.FunctionComponent<OwnProps> = ({
   const { addToast } = useToasts();
   const [activeTab, setTab] = useState("edit");
   const [editorWidth, setEditorWidth] = useState();
+  const [modalVisible, setModalVisibility] = useState(false);
   const [selectedReference, setSelectedReference] = useState<ReferenceEntry>();
   const { errors, values, dirty } = useFormikContext<EditorValues>();
 
@@ -94,6 +95,15 @@ const Editor: React.FunctionComponent<OwnProps> = ({
     ]);
     return [...extensionPoints, ...blocks, ...services];
   }, []);
+
+  const showModal = () => {
+    setModalVisibility(true);
+  };
+
+  const unsavedNavigation = () => {
+    showModal();
+    return false;
+  };
 
   const openReference = useCallback(
     (id: string) => {
@@ -144,11 +154,8 @@ const Editor: React.FunctionComponent<OwnProps> = ({
 
   return (
     <div>
-      <Prompt
-        when={dirty}
-        message="You have unsaved changes. Are you sure you want to leave?"
-      />
-      <Modal>
+      <Prompt when={dirty} message={unsavedNavigation} />
+      <Modal show={modalVisible}>
         <Modal.Header>
           <Modal.Title>Unsaved changes</Modal.Title>
         </Modal.Header>
@@ -173,7 +180,6 @@ const Editor: React.FunctionComponent<OwnProps> = ({
           </li>
         </ul>
       </div>
-
       <Card ref={editorRef}>
         <Tab.Container
           id="editor-container"

--- a/src/options/pages/brickEditor/Editor.tsx
+++ b/src/options/pages/brickEditor/Editor.tsx
@@ -42,7 +42,7 @@ import { useToasts } from "react-toast-notifications";
 import { fetch } from "@/hooks/fetch";
 import { Brick } from "@/types/contract";
 import { browser } from "webextension-polyfill-ts";
-import { Prompt } from "react-router";
+import { Prompt, useHistory } from "react-router";
 
 const SharingIcon: React.FunctionComponent<{
   isPublic: boolean;
@@ -84,8 +84,10 @@ const Editor: React.FunctionComponent<OwnProps> = ({
   const [activeTab, setTab] = useState("edit");
   const [editorWidth, setEditorWidth] = useState();
   const [modalVisible, setModalVisibility] = useState(false);
+  const [nextLocation, setNextLocation] = useState(null);
   const [selectedReference, setSelectedReference] = useState<ReferenceEntry>();
   const { errors, values, dirty } = useFormikContext<EditorValues>();
+  let history = useHistory();
 
   const [blocks] = useAsyncState(async () => {
     const [extensionPoints, blocks, services] = await Promise.all([
@@ -104,9 +106,19 @@ const Editor: React.FunctionComponent<OwnProps> = ({
     setModalVisibility(false);
   };
 
-  const unsavedNavigation = () => {
+  const unsavedNavigation = (location) => {
     showModal();
+    setNextLocation(location);
     return false;
+  };
+
+  const confirmNavigation = () => {
+    closeModal();
+    console.log(history);
+    console.log(nextLocation);
+    if (nextLocation) {
+      history.push(nextLocation.pathname);
+    }
   };
 
   const openReference = useCallback(
@@ -167,7 +179,9 @@ const Editor: React.FunctionComponent<OwnProps> = ({
           Are you sure you want to leave? Unsaved changes will be lost.
         </Modal.Body>
         <Modal.Footer>
-          <Button variant="danger">Discard changes</Button>
+          <Button variant="danger" onClick={confirmNavigation}>
+            Discard changes
+          </Button>
           <Button variant="primary" onClick={closeModal}>
             Stay on this page
           </Button>

--- a/src/options/pages/brickEditor/Editor.tsx
+++ b/src/options/pages/brickEditor/Editor.tsx
@@ -17,6 +17,7 @@
 
 import { Card, Nav, Tab } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Prompt } from "react-router";
 import {
   faBuilding,
   faEyeSlash,
@@ -142,6 +143,7 @@ const Editor: React.FunctionComponent<OwnProps> = ({
 
   return (
     <div>
+      <Prompt message="You have unsaved changes. Are you sure you want to leave?" />
       <div className="mb-3">
         <ul className="list-unstyled list-inline">
           <li className="list-inline-item">

--- a/src/options/pages/brickEditor/Editor.tsx
+++ b/src/options/pages/brickEditor/Editor.tsx
@@ -15,14 +15,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Card, Nav, Tab } from "react-bootstrap";
+import { Card, Nav, Tab, Modal, Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Prompt } from "react-router";
 import {
   faBuilding,
   faEyeSlash,
   faGlobe,
   faTimesCircle,
+  faSave,
 } from "@fortawesome/free-solid-svg-icons";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useFormikContext } from "formik";
@@ -42,6 +42,7 @@ import { useToasts } from "react-toast-notifications";
 import { fetch } from "@/hooks/fetch";
 import { Brick } from "@/types/contract";
 import { browser } from "webextension-polyfill-ts";
+import { Prompt } from "react-router";
 
 const SharingIcon: React.FunctionComponent<{
   isPublic: boolean;
@@ -83,7 +84,7 @@ const Editor: React.FunctionComponent<OwnProps> = ({
   const [activeTab, setTab] = useState("edit");
   const [editorWidth, setEditorWidth] = useState();
   const [selectedReference, setSelectedReference] = useState<ReferenceEntry>();
-  const { errors, values } = useFormikContext<EditorValues>();
+  const { errors, values, dirty } = useFormikContext<EditorValues>();
 
   const [blocks] = useAsyncState(async () => {
     const [extensionPoints, blocks, services] = await Promise.all([
@@ -143,7 +144,22 @@ const Editor: React.FunctionComponent<OwnProps> = ({
 
   return (
     <div>
-      <Prompt message="You have unsaved changes. Are you sure you want to leave?" />
+      <Prompt
+        when={dirty}
+        message="You have unsaved changes. Are you sure you want to leave?"
+      />
+      <Modal>
+        <Modal.Header>
+          <Modal.Title>Unsaved changes</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          Are you sure you want to leave? Unsaved changes will be lost.
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="danger">Discard changes</Button>
+          <Button variant="primary">Stay on this page</Button>
+        </Modal.Footer>
+      </Modal>
       <div className="mb-3">
         <ul className="list-unstyled list-inline">
           <li className="list-inline-item">
@@ -167,9 +183,14 @@ const Editor: React.FunctionComponent<OwnProps> = ({
           <Card.Header>
             <Nav variant="tabs" onSelect={setTab}>
               <Nav.Link eventKey="edit">
-                {errors.config ? (
+                {dirty ? (
                   <span className="text-danger">
-                    Editor <FontAwesomeIcon icon={faTimesCircle} />
+                    Editor{" "}
+                    {errors.config ? (
+                      <FontAwesomeIcon icon={faTimesCircle} />
+                    ) : (
+                      <FontAwesomeIcon icon={faSave} />
+                    )}
                   </span>
                 ) : (
                   "Editor"

--- a/src/options/pages/brickEditor/Editor.tsx
+++ b/src/options/pages/brickEditor/Editor.tsx
@@ -100,6 +100,10 @@ const Editor: React.FunctionComponent<OwnProps> = ({
     setModalVisibility(true);
   };
 
+  const closeModal = () => {
+    setModalVisibility(false);
+  };
+
   const unsavedNavigation = () => {
     showModal();
     return false;
@@ -164,7 +168,9 @@ const Editor: React.FunctionComponent<OwnProps> = ({
         </Modal.Body>
         <Modal.Footer>
           <Button variant="danger">Discard changes</Button>
-          <Button variant="primary">Stay on this page</Button>
+          <Button variant="primary" onClick={closeModal}>
+            Stay on this page
+          </Button>
         </Modal.Footer>
       </Modal>
       <div className="mb-3">

--- a/src/options/pages/brickEditor/Editor.tsx
+++ b/src/options/pages/brickEditor/Editor.tsx
@@ -87,7 +87,7 @@ const Editor: React.FunctionComponent<OwnProps> = ({
   const [nextLocation, setNextLocation] = useState(null);
   const [selectedReference, setSelectedReference] = useState<ReferenceEntry>();
   const { errors, values, dirty } = useFormikContext<EditorValues>();
-  let history = useHistory();
+  const history = useHistory();
 
   const [blocks] = useAsyncState(async () => {
     const [extensionPoints, blocks, services] = await Promise.all([
@@ -114,8 +114,6 @@ const Editor: React.FunctionComponent<OwnProps> = ({
 
   const confirmNavigation = () => {
     closeModal();
-    console.log(history);
-    console.log(nextLocation);
     if (nextLocation) {
       history.push(nextLocation.pathname);
     }

--- a/src/options/pages/brickEditor/useSubmitBrick.tsx
+++ b/src/options/pages/brickEditor/useSubmitBrick.tsx
@@ -84,7 +84,7 @@ function useSubmitBrick({
   }, [addToast, url, dispatch]);
 
   const submit = useCallback(
-    async (values, { setErrors }) => {
+    async (values, { setErrors, resetForm }) => {
       const { config, reactivate: reinstallBlueprint } = values;
 
       const json = yaml.safeLoad(config) as Definition | RecipeDefinition;
@@ -122,6 +122,8 @@ function useSubmitBrick({
               autoDismiss: true,
             });
           });
+
+        resetForm({ values: values });
 
         if (create) {
           history.push(`/workshop/bricks/${data.id}/`);


### PR DESCRIPTION
This is a new feature for warning users upon page navigation in the YAML editor that unsaved changes will be lost. Additionally, this adds an icon to the editor tab when unsaved changes are present.