### PR TITLE
#662: fix permissions check for context menus

### DIFF
--- a/browsers/manifest.json
+++ b/browsers/manifest.json
@@ -20,12 +20,7 @@
       "run_at": "document_idle"
     }
   ],
-  "optional_permissions": [
-    "notifications",
-    "clipboardWrite",
-    "https://*/",
-    "<all_urls>"
-  ],
+  "optional_permissions": ["notifications", "clipboardWrite", "*://*/*  "],
   "permissions": [
     "activeTab",
     "storage",

--- a/browsers/manifest.json
+++ b/browsers/manifest.json
@@ -24,7 +24,7 @@
     "notifications",
     "clipboardWrite",
     "https://*/",
-    "http://*/"
+    "<all_urls>"
   ],
   "permissions": [
     "activeTab",

--- a/browsers/manifest.json
+++ b/browsers/manifest.json
@@ -20,7 +20,7 @@
       "run_at": "document_idle"
     }
   ],
-  "optional_permissions": ["notifications", "clipboardWrite", "*://*/*  "],
+  "optional_permissions": ["notifications", "clipboardWrite", "*://*/*"],
   "permissions": [
     "activeTab",
     "storage",

--- a/src/devTools/editor/extensionPoints/actionPanel.ts
+++ b/src/devTools/editor/extensionPoints/actionPanel.ts
@@ -19,7 +19,6 @@ import { IExtension, Metadata } from "@/core";
 import { FrameworkMeta } from "@/messaging/constants";
 import { ActionPanelFormState } from "@/devTools/editor/editorSlice";
 import {
-  getDomain,
   makeBaseState,
   makeExtensionReaders,
   makeIsAvailable,
@@ -45,6 +44,7 @@ import { DynamicDefinition } from "@/nativeEditor";
 import EffectTab from "@/devTools/editor/tabs/EffectTab";
 import MetaTab from "@/devTools/editor/tabs/MetaTab";
 import { v4 as uuidv4 } from "uuid";
+import { getDomain } from "@/permissions/patterns";
 
 export const wizard: WizardStep[] = [
   { step: "Name", Component: MetaTab },

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -23,7 +23,6 @@ import {
   ReaderFormState,
   ReaderReferenceFormState,
 } from "@/devTools/editor/editorSlice";
-import psl, { ParsedDomain } from "psl";
 import { castArray, identity, isPlainObject } from "lodash";
 import brickRegistry from "@/blocks/registry";
 import { ReaderConfig, ReaderReference } from "@/blocks/readers/factory";
@@ -37,6 +36,7 @@ import {
 } from "@/extensionPoints/types";
 import { find as findBrick } from "@/registry/localRegistry";
 import React from "react";
+import { defaultMatchPattern, getDomain } from "@/permissions/patterns";
 
 export interface WizardStep {
   step: string;
@@ -46,26 +46,6 @@ export interface WizardStep {
     available?: boolean;
   }>;
   extraProps?: Record<string, unknown>;
-}
-
-function getPathFromUrl(url: string): string {
-  return url.split("?")[0];
-}
-
-function defaultMatchPattern(url: string): string {
-  const cleanURL = getPathFromUrl(url);
-  console.debug(`Clean URL: ${cleanURL}`);
-  const obj = new URL(cleanURL);
-  // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/entries
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TypeScript definitions are incorrect
-  for (const [name] of (obj.searchParams as any).entries()) {
-    console.debug(`Deleting param ${name}`);
-    obj.searchParams.delete(name);
-  }
-  obj.pathname = "*";
-  obj.hash = "";
-  console.debug(`Generate match pattern`, { href: obj.href });
-  return obj.href;
 }
 
 function defaultReader(frameworks: FrameworkMeta[]): Framework {
@@ -143,12 +123,6 @@ export function makeBaseState(
     extension: {},
     extensionPoint: {},
   };
-}
-
-export function getDomain(url: string): string {
-  const urlClass = new URL(url);
-  const { domain } = psl.parse(urlClass.host.split(":")[0]) as ParsedDomain;
-  return domain;
 }
 
 export async function generateExtensionPointMetadata(

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -23,7 +23,7 @@ import {
   ReaderFormState,
   ReaderReferenceFormState,
 } from "@/devTools/editor/editorSlice";
-import { castArray, identity, isPlainObject } from "lodash";
+import { castArray, isPlainObject } from "lodash";
 import brickRegistry from "@/blocks/registry";
 import { ReaderConfig, ReaderReference } from "@/blocks/readers/factory";
 import {
@@ -36,7 +36,7 @@ import {
 } from "@/extensionPoints/types";
 import { find as findBrick } from "@/registry/localRegistry";
 import React from "react";
-import { defaultMatchPattern, getDomain } from "@/permissions/patterns";
+import { createSitePattern, getDomain } from "@/permissions/patterns";
 
 export interface WizardStep {
   step: string;
@@ -59,7 +59,7 @@ export function makeIsAvailable(
   url: string
 ): { matchPatterns: string; selectors: string | null } {
   return {
-    matchPatterns: defaultMatchPattern(url),
+    matchPatterns: createSitePattern(url),
     selectors: null,
   };
 }
@@ -155,7 +155,7 @@ export async function generateExtensionPointMetadata(
 
     const ok = (
       await Promise.all([allowId(id), allowId(makeReaderId(id))])
-    ).every(identity);
+    ).every((allowed) => allowed);
 
     if (ok) {
       return {

--- a/src/devTools/editor/extensionPoints/menuItem.ts
+++ b/src/devTools/editor/extensionPoints/menuItem.ts
@@ -23,7 +23,6 @@ import {
 import { FrameworkMeta } from "@/messaging/constants";
 import { ActionFormState } from "@/devTools/editor/editorSlice";
 import {
-  getDomain,
   makeBaseState,
   makeExtensionReaders,
   makeIsAvailable,
@@ -47,6 +46,7 @@ import LogsTab from "@/devTools/editor/tabs/LogsTab";
 import AvailabilityTab from "@/devTools/editor/tabs/AvailabilityTab";
 import MetaTab from "@/devTools/editor/tabs/MetaTab";
 import { v4 as uuidv4 } from "uuid";
+import { getDomain } from "@/permissions/patterns";
 
 export const wizard: WizardStep[] = [
   { step: "Name", Component: MetaTab },

--- a/src/devTools/editor/extensionPoints/panel.ts
+++ b/src/devTools/editor/extensionPoints/panel.ts
@@ -19,7 +19,6 @@ import { IExtension, Metadata } from "@/core";
 import { FrameworkMeta } from "@/messaging/constants";
 import { PanelFormState, PanelTraits } from "@/devTools/editor/editorSlice";
 import {
-  getDomain,
   makeBaseState,
   makeExtensionReaders,
   makeIsAvailable,
@@ -44,6 +43,7 @@ import EffectTab from "@/devTools/editor/tabs/EffectTab";
 import MetaTab from "@/devTools/editor/tabs/MetaTab";
 import { v4 as uuidv4 } from "uuid";
 import { boolean } from "@/utils";
+import { getDomain } from "@/permissions/patterns";
 
 export const wizard: WizardStep[] = [
   { step: "Name", Component: MetaTab },

--- a/src/devTools/editor/extensionPoints/trigger.ts
+++ b/src/devTools/editor/extensionPoints/trigger.ts
@@ -19,7 +19,6 @@ import { IExtension, Metadata } from "@/core";
 import { FrameworkMeta } from "@/messaging/constants";
 import { TriggerFormState } from "@/devTools/editor/editorSlice";
 import {
-  getDomain,
   lookupExtensionPoint,
   makeBaseState,
   makeExtensionReaders,
@@ -43,6 +42,7 @@ import LogsTab from "@/devTools/editor/tabs/LogsTab";
 import AvailabilityTab from "@/devTools/editor/tabs/AvailabilityTab";
 import FoundationTab from "@/devTools/editor/tabs/trigger/FoundationTab";
 import MetaTab from "@/devTools/editor/tabs/MetaTab";
+import { getDomain } from "@/permissions/patterns";
 
 export const wizard: WizardStep[] = [
   { step: "Name", Component: MetaTab },

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -157,7 +157,7 @@ export function useCreate(): CreateCallback {
         } catch (error) {
           // continue to allow saving (because there's a workaround)
           reportError(error);
-          console.error("Error checking/enabling permissions", { error });
+          console.error("Error  checking/enabling permissions", { error });
           addToast(
             `An error occurred checking/enabling permissions. Grant permissions on the Active Bricks page`,
             {

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -29,7 +29,7 @@ import { getExtensionToken } from "@/auth/token";
 import { optionsSlice } from "@/options/slices";
 import { FormikHelpers } from "formik";
 import { uniq } from "lodash";
-import { useToasts } from "react-toast-notifications";
+import { AddToast, useToasts } from "react-toast-notifications";
 import { reportError } from "@/telemetry/logging";
 import blockRegistry from "@/blocks/registry";
 import extensionPointRegistry from "@/extensionPoints/registry";
@@ -39,11 +39,7 @@ import { reactivate } from "@/background/navigation";
 import { reportEvent } from "@/telemetry/events";
 import { removeUndefined } from "@/utils";
 import { fromJS as extensionPointFactory } from "@/extensionPoints/factory";
-import {
-  checkPermissions,
-  ensureExtensionPermissions,
-  extensionPermissions,
-} from "@/permissions";
+import { ensureAllPermissions, extensionPermissions } from "@/permissions";
 
 const { saveExtension } = optionsSlice.actions;
 const { markSaved } = editorSlice.actions;
@@ -71,11 +67,71 @@ async function makeRequestConfig(
   }
 }
 
+function selectErrorMessage(error: unknown): string {
+  if (typeof error === "object" && (error as AxiosError).isAxiosError) {
+    const error_ = error as AxiosError;
+    return (
+      error_.response?.data["config"]?.toString() ??
+      error_.response?.statusText ??
+      "No response from PixieBrix server"
+    );
+  }
+  return error.toString();
+}
+
 /**
  * Dump to YAML, removing keys with undefined values.
  */
 export function configToYaml(content: unknown): string {
   return safeDump(removeUndefined(content));
+}
+
+async function ensurePermissions(element: FormState, addToast: AddToast) {
+  try {
+    const adapter = ADAPTERS.get(element.type);
+
+    const {
+      extension,
+      extensionPoint: extensionPointConfig,
+    } = adapter.definition(element);
+
+    const extensionPoint = await extensionPointFactory(extensionPointConfig);
+
+    // Pass the extensionPoint in directly because the foundation will not have been saved/added to the
+    // registry at this point when called from useCreate
+    const permissions = await extensionPermissions(extension, {
+      extensionPoint,
+    });
+
+    console.debug("Ensuring permissions", {
+      permissions,
+      extensionPointConfig,
+      extension,
+    });
+
+    // FIXME: Firefox probably won't realize this permissions request is user-initiated
+    const hasPermissions = await ensureAllPermissions(permissions);
+
+    if (!hasPermissions) {
+      addToast(
+        `You declined the additional required permissions. This brick won't work on other tabs until you grant the permissions`,
+        {
+          appearance: "warning",
+          autoDismiss: true,
+        }
+      );
+    }
+  } catch (error) {
+    reportError(error);
+    console.error("Error checking/enabling permissions", { error });
+    addToast(
+      `An error occurred checking/enabling permissions. You will need to grant permissions on the active extensions page`,
+      {
+        appearance: "warning",
+        autoDismiss: true,
+      }
+    );
+  }
 }
 
 type CreateCallback = (
@@ -93,33 +149,22 @@ export function useCreate(): CreateCallback {
       element: FormState,
       { setSubmitting, setStatus }: FormikHelpers<FormState>
     ) => {
+      const onStepError = (error: unknown, step: string) => {
+        const message = selectErrorMessage(error);
+        reportError(error);
+        console.warn(`Error %s: %s`, step, message, { error });
+        setStatus(`Error ${step}: ${message}`);
+        addToast(`Error ${step}: ${message}`, {
+          appearance: "error",
+          autoDismiss: true,
+        });
+        setSubmitting(false);
+      };
+
       try {
         const adapter = ADAPTERS.get(element.type);
-        const {
-          extension,
-          extensionPoint: extensionPointConfig,
-        } = adapter.definition(element);
-        const extensionPoint = await extensionPointFactory(
-          extensionPointConfig
-        );
 
-        // We don't want the extension point availability because we already have access to it on the page
-        // because the user is using the devtools. We can request additional permissions on save
-        const permissions = await extensionPermissions(extension, {
-          extensionPoint,
-        });
-        const hasPermissions = await checkPermissions(permissions);
-
-        // FIREFOX: FF probably won't realize this permissions request is user initiated
-        if (!hasPermissions && !(await ensureExtensionPermissions(extension))) {
-          addToast(
-            `You declined the additional required permissions. This brick won't work on other tabs until you grant the permissions`,
-            {
-              appearance: "warning",
-              autoDismiss: true,
-            }
-          );
-        }
+        await ensurePermissions(element, addToast);
 
         // PERFORMANCE: inefficient, grabbing all visible bricks prior to save. Not a big deal for now given
         // number of bricks implemented and frequency of saves
@@ -155,7 +200,7 @@ export function useCreate(): CreateCallback {
               await axios({
                 ...(await makeRequestConfig(packageId)),
                 data: { config: configToYaml(readerConfig), kind: "reader" },
-              } as AxiosRequestConfig);
+              });
 
               setSavedReaders((prev) =>
                 uniq([...prev, readerConfig.metadata.id])
@@ -163,20 +208,7 @@ export function useCreate(): CreateCallback {
             }
           }
         } catch (error) {
-          let msg = error.toString();
-          if (error.isAxiosError) {
-            const error_ = error as AxiosError;
-            msg =
-              error_.response?.data["config"]?.toString() ??
-              error_.response?.statusText ??
-              "No response from PixieBrix server";
-          }
-          setStatus(`Error saving reader: ${msg}`);
-          addToast(`Error saving reader definition: ${msg}`, {
-            appearance: "error",
-            autoDismiss: true,
-          });
-          setSubmitting(false);
+          onStepError(error, "saving reader definition");
           return;
         }
 
@@ -203,26 +235,13 @@ export function useCreate(): CreateCallback {
                 config: configToYaml(extensionPointConfig),
                 kind: "extensionPoint",
               },
-            } as AxiosRequestConfig);
+            });
 
             reportEvent("PageEditorCreate", {
               type: element.type,
             });
           } catch (error) {
-            let msg = error.toString();
-            if (error.isAxiosError) {
-              const error_ = error as AxiosError;
-              msg =
-                error_.response?.data["config"]?.toString() ??
-                error_.response?.statusText ??
-                "No response from PixieBrix server";
-            }
-            setStatus(`Error saving foundation: ${msg}`);
-            addToast(`Error saving foundation definition: ${msg}`, {
-              appearance: "error",
-              autoDismiss: true,
-            });
-            setSubmitting(false);
+            onStepError(error, "saving foundation");
             return;
           }
         }
@@ -236,21 +255,18 @@ export function useCreate(): CreateCallback {
             autoDismiss: true,
           });
         } catch (error) {
-          reportError(error);
-          addToast(`Error saving extension: ${error.toString()}`, {
-            appearance: "error",
-            autoDismiss: true,
-          });
+          onStepError(error, "saving extension");
           return;
-        } finally {
-          setSubmitting(false);
         }
+
+        setSubmitting(false);
 
         await Promise.all([
           blockRegistry.fetch(),
           extensionPointRegistry.fetch(),
         ]);
       } catch (error) {
+        console.error("Error saving extension", { error });
         reportError(error);
         addToast(`Error saving extension: ${error.toString()}`, {
           appearance: "error",

--- a/src/devTools/editor/tabs/AvailabilityTab.tsx
+++ b/src/devTools/editor/tabs/AvailabilityTab.tsx
@@ -89,7 +89,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setMatchPattern("https://*/*")}
+                onClick={() => setMatchPattern("https://*/")}
               >
                 HTTPS
               </a>{" "}
@@ -97,7 +97,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setMatchPattern("*://*/*")}
+                onClick={() => setMatchPattern("*://*/")}
               >
                 All URLs
               </a>
@@ -112,7 +112,7 @@ const AvailabilityTab: React.FunctionComponent<{
             URL match pattern for which pages to run the extension on. See{" "}
             <a
               href="#"
-              onClick={() =>
+              onClick={async () =>
                 openTab({
                   url:
                     "https://developer.chrome.com/docs/extensions/mv2/match_patterns/",

--- a/src/devTools/editor/tabs/AvailabilityTab.tsx
+++ b/src/devTools/editor/tabs/AvailabilityTab.tsx
@@ -22,8 +22,13 @@ import SelectorSelectorField from "@/devTools/editor/fields/SelectorSelectorFiel
 import { FormState } from "@/devTools/editor/editorSlice";
 import { openTab } from "@/background/executor";
 import { getTabInfo } from "@/background/devtools";
-import { getDomain } from "@/devTools/editor/extensionPoints/base";
 import { DevToolsContext } from "@/devTools/context";
+import {
+  createDomainPattern,
+  createSitePattern,
+  HTTPS_PATTERN,
+  SITES_PATTERN,
+} from "@/permissions/patterns";
 
 const AvailabilityTab: React.FunctionComponent<{
   eventKey?: string;
@@ -67,8 +72,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 role="button"
                 onClick={async () => {
                   const url = (await getTabInfo(port)).url;
-                  const parsed = new URL(url);
-                  setMatchPattern(`${parsed.protocol}//${parsed.hostname}/*`);
+                  setMatchPattern(createSitePattern(url));
                 }}
               >
                 Site
@@ -79,8 +83,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 role="button"
                 onClick={async () => {
                   const url = (await getTabInfo(port)).url;
-                  const parsed = new URL(url);
-                  setMatchPattern(`${parsed.protocol}//*.${getDomain(url)}/*`);
+                  setMatchPattern(createDomainPattern(url));
                 }}
               >
                 Domain
@@ -89,7 +92,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setMatchPattern("https://*/")}
+                onClick={() => setMatchPattern(HTTPS_PATTERN)}
               >
                 HTTPS
               </a>{" "}
@@ -97,7 +100,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setMatchPattern("*://*/")}
+                onClick={() => setMatchPattern(SITES_PATTERN)}
               >
                 All URLs
               </a>

--- a/src/devTools/editor/tabs/contextMenu/AvailabilityTab.tsx
+++ b/src/devTools/editor/tabs/contextMenu/AvailabilityTab.tsx
@@ -150,7 +150,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setDocumentPattern("https://*/*")}
+                onClick={() => setDocumentPattern("https://*/")}
               >
                 HTTPS
               </a>{" "}
@@ -158,7 +158,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setDocumentPattern("*://*/*")}
+                onClick={() => setDocumentPattern("*://*/")}
               >
                 All URLs
               </a>
@@ -173,7 +173,7 @@ const AvailabilityTab: React.FunctionComponent<{
             Show context menu on documents whose URL matches the pattern. See{" "}
             <a
               href="#"
-              onClick={() =>
+              onClick={async () =>
                 openTab({
                   url:
                     "https://developer.chrome.com/docs/extensions/mv2/match_patterns/",
@@ -286,7 +286,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setMatchPattern("https://*/*")}
+                onClick={() => setMatchPattern("https://*/")}
               >
                 HTTPS
               </a>{" "}
@@ -294,7 +294,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setMatchPattern("*://*/*")}
+                onClick={() => setMatchPattern("*://*/")}
               >
                 All URLs
               </a>

--- a/src/devTools/editor/tabs/contextMenu/AvailabilityTab.tsx
+++ b/src/devTools/editor/tabs/contextMenu/AvailabilityTab.tsx
@@ -27,11 +27,16 @@ import {
 import { ContextMenuFormState } from "@/devTools/editor/editorSlice";
 import { getTabInfo } from "@/background/devtools";
 import { DevToolsContext } from "@/devTools/context";
-import { getDomain } from "@/devTools/editor/extensionPoints/base";
 import { openTab } from "@/background/executor";
 import Select from "react-select";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import {
+  createDomainPattern,
+  createSitePattern,
+  HTTPS_PATTERN,
+  SITES_PATTERN,
+} from "@/permissions/patterns";
 
 const CONTEXTS = [
   "page",
@@ -124,10 +129,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 role="button"
                 onClick={async () => {
                   const url = (await getTabInfo(port)).url;
-                  const parsed = new URL(url);
-                  setDocumentPattern(
-                    `${parsed.protocol}//${parsed.hostname}/*`
-                  );
+                  setDocumentPattern(createSitePattern(url));
                 }}
               >
                 Site
@@ -138,10 +140,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 role="button"
                 onClick={async () => {
                   const url = (await getTabInfo(port)).url;
-                  const parsed = new URL(url);
-                  setDocumentPattern(
-                    `${parsed.protocol}//*.${getDomain(url)}/*`
-                  );
+                  setDocumentPattern(createDomainPattern(url));
                 }}
               >
                 Domain
@@ -150,7 +149,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setDocumentPattern("https://*/")}
+                onClick={() => setDocumentPattern(HTTPS_PATTERN)}
               >
                 HTTPS
               </a>{" "}
@@ -158,7 +157,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setDocumentPattern("*://*/")}
+                onClick={() => setDocumentPattern(SITES_PATTERN)}
               >
                 All URLs
               </a>
@@ -264,8 +263,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 role="button"
                 onClick={async () => {
                   const url = (await getTabInfo(port)).url;
-                  const parsed = new URL(url);
-                  setMatchPattern(`${parsed.protocol}//${parsed.hostname}/*`);
+                  setMatchPattern(createSitePattern(url));
                 }}
               >
                 Site
@@ -276,8 +274,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 role="button"
                 onClick={async () => {
                   const url = (await getTabInfo(port)).url;
-                  const parsed = new URL(url);
-                  setMatchPattern(`${parsed.protocol}//*.${getDomain(url)}/*`);
+                  setMatchPattern(createDomainPattern(url));
                 }}
               >
                 Domain
@@ -286,7 +283,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setMatchPattern("https://*/")}
+                onClick={() => setMatchPattern(HTTPS_PATTERN)}
               >
                 HTTPS
               </a>{" "}
@@ -294,7 +291,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 href="#"
                 role="button"
                 className="mx-2"
-                onClick={() => setMatchPattern("*://*/")}
+                onClick={() => setMatchPattern(SITES_PATTERN)}
               >
                 All URLs
               </a>

--- a/src/extensionPoints/factory.ts
+++ b/src/extensionPoints/factory.ts
@@ -18,7 +18,7 @@
 import { fromJS as deserializePanel } from "@/extensionPoints/panelExtension";
 import { fromJS as deserializeMenuItem } from "@/extensionPoints/menuItemExtension";
 import { fromJS as deserializeTrigger } from "@/extensionPoints/triggerExtension";
-import { fromJS as deserializeSelectionAction } from "@/extensionPoints/contextMenu";
+import { fromJS as deserializeContextMenu } from "@/extensionPoints/contextMenu";
 import { fromJS as deserializeActionPanel } from "@/extensionPoints/actionPanelExtension";
 import { IExtensionPoint } from "@/core";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
@@ -27,7 +27,7 @@ const TYPE_MAP = {
   panel: deserializePanel,
   menuItem: deserializeMenuItem,
   trigger: deserializeTrigger,
-  contextMenu: deserializeSelectionAction,
+  contextMenu: deserializeContextMenu,
   actionPanel: deserializeActionPanel,
 };
 

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -86,7 +86,9 @@ export async function collectPermissions(
     : recipeOrExtensionPoints.extensionPoints;
 
   const servicePermissions = await Promise.all(
-    serviceAuths.map((serviceAuth) => serviceOriginPermissions(serviceAuth))
+    serviceAuths.map(async (serviceAuth) =>
+      serviceOriginPermissions(serviceAuth)
+    )
   );
 
   const permissions = await Promise.all(
@@ -145,7 +147,9 @@ export async function extensionPermissions(
   const services = await Promise.all(
     extension.services
       .filter((x) => x.config)
-      .map((x) => serviceOriginPermissions({ id: x.id, config: x.config }))
+      .map(async (x) =>
+        serviceOriginPermissions({ id: x.id, config: x.config })
+      )
   );
   const blocks = await extensionPoint.getBlocks(extension);
   const blockPermissions = blocks.map((x) => x.permissions);
@@ -163,7 +167,7 @@ export async function checkPermissions(
 ): Promise<boolean> {
   return every(
     await Promise.all(
-      permissionsList.map((permissions) =>
+      permissionsList.map(async (permissions) =>
         browser.permissions.contains(permissions)
       )
     )

--- a/src/permissions/patterns.ts
+++ b/src/permissions/patterns.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021 Pixie Brix, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import psl, { ParsedDomain } from "psl";
+
+export const HTTPS_PATTERN = "https://*/*";
+
+// https://developer.chrome.com/docs/extensions/mv3/match_patterns/
+// If the scheme is *, then it matches either http or https, and not file, ftp, or urn
+export const SITES_PATTERN = "*://*/*";
+
+/**
+ * Get domain using Mozilla's public suffix list
+ * @see https://publicsuffix.org/
+ */
+export function getDomain(url: string): string {
+  const urlClass = new URL(url);
+  const { domain } = psl.parse(urlClass.host.split(":")[0]) as ParsedDomain;
+  return domain;
+}
+
+export function createSitePattern(url: string): string {
+  const parsed = new URL(url);
+  return `${parsed.protocol}//${parsed.hostname}/*`;
+}
+
+export function createDomainPattern(url: string): string {
+  const parsed = new URL(url);
+  return `${parsed.protocol}//*.${getDomain(url)}/*`;
+}
+
+function getPathFromUrl(url: string): string {
+  return url.split("?")[0];
+}
+
+export function defaultMatchPattern(url: string): string {
+  const cleanURL = getPathFromUrl(url);
+  console.debug(`Clean URL: ${cleanURL}`);
+  const obj = new URL(cleanURL);
+  // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/entries
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TypeScript definitions are incorrect
+  for (const [name] of (obj.searchParams as any).entries()) {
+    console.debug(`Deleting param ${name}`);
+    obj.searchParams.delete(name);
+  }
+  obj.pathname = "*";
+  obj.hash = "";
+  console.debug(`Generate match pattern`, { href: obj.href });
+  return obj.href;
+}

--- a/src/permissions/patterns.ts
+++ b/src/permissions/patterns.ts
@@ -29,7 +29,7 @@ export const SITES_PATTERN = "*://*/*";
  */
 export function getDomain(url: string): string {
   const urlClass = new URL(url);
-  const { domain } = psl.parse(urlClass.host.split(":")[0]) as ParsedDomain;
+  const { domain } = psl.parse(urlClass.hostname) as ParsedDomain;
   return domain;
 }
 
@@ -41,24 +41,4 @@ export function createSitePattern(url: string): string {
 export function createDomainPattern(url: string): string {
   const parsed = new URL(url);
   return `${parsed.protocol}//*.${getDomain(url)}/*`;
-}
-
-function getPathFromUrl(url: string): string {
-  return url.split("?")[0];
-}
-
-export function defaultMatchPattern(url: string): string {
-  const cleanURL = getPathFromUrl(url);
-  console.debug(`Clean URL: ${cleanURL}`);
-  const obj = new URL(cleanURL);
-  // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/entries
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TypeScript definitions are incorrect
-  for (const [name] of (obj.searchParams as any).entries()) {
-    console.debug(`Deleting param ${name}`);
-    obj.searchParams.delete(name);
-  }
-  obj.pathname = "*";
-  obj.hash = "";
-  console.debug(`Generate match pattern`, { href: obj.href });
-  return obj.href;
 }


### PR DESCRIPTION
- Fixes bug where permissions check on save would fail if the extension foundation did not already exist
- Switches to `<all_urls>` in optional permissions instead of `*://*/`
- Fixes match pattern shortcuts in devtools panel to remove trailing `*`