### PR TITLE
Add expect/forbid context helpers

### DIFF
--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -25,7 +25,7 @@ import {
   getRandomString,
 } from "vendors/pkce";
 import { BusinessError } from "@/errors";
-import { expectContext } from "@/utils";
+import { expectBackgroundPage } from "@/utils/expect-context";
 
 const OAUTH2_STORAGE_KEY = "OAUTH2";
 
@@ -33,8 +33,7 @@ async function setCachedAuthData(
   key: string,
   data: Record<string, string>
 ): Promise<void> {
-  expectContext(
-    "background",
+  expectBackgroundPage(
     "Only the background page can access oauth2 information"
   );
 
@@ -51,8 +50,7 @@ async function setCachedAuthData(
 export async function getCachedAuthData<T extends AuthData>(
   key: string
 ): Promise<T> {
-  expectContext(
-    "background",
+  expectBackgroundPage(
     "Only the background page can access oauth2 information"
   );
 
@@ -63,8 +61,7 @@ export async function getCachedAuthData<T extends AuthData>(
 }
 
 export async function deleteCachedAuthData(key: string): Promise<void> {
-  expectContext(
-    "background",
+  expectBackgroundPage(
     "Only the background page can access oauth2 information"
   );
 

--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -17,7 +17,6 @@
 
 import axios, { AxiosResponse } from "axios";
 import { readStorage, setStorage } from "@/chrome";
-import { isBackgroundPage } from "webext-detect-page";
 import { IService, AuthData, RawServiceConfiguration } from "@/core";
 import { browser } from "webextension-polyfill-ts";
 import {
@@ -26,6 +25,7 @@ import {
   getRandomString,
 } from "vendors/pkce";
 import { BusinessError } from "@/errors";
+import { expectContext } from "@/utils";
 
 const OAUTH2_STORAGE_KEY = "OAUTH2";
 
@@ -33,9 +33,11 @@ async function setCachedAuthData(
   key: string,
   data: Record<string, string>
 ): Promise<void> {
-  if (!isBackgroundPage()) {
-    throw new Error("Only the background page can access oauth2 information");
-  }
+  expectContext(
+    "background",
+    "Only the background page can access oauth2 information"
+  );
+
   const current = JSON.parse((await readStorage(OAUTH2_STORAGE_KEY)) ?? "{}");
   await setStorage(
     OAUTH2_STORAGE_KEY,
@@ -49,9 +51,11 @@ async function setCachedAuthData(
 export async function getCachedAuthData<T extends AuthData>(
   key: string
 ): Promise<T> {
-  if (!isBackgroundPage()) {
-    throw new Error("Only the background page can access oauth2 information");
-  }
+  expectContext(
+    "background",
+    "Only the background page can access oauth2 information"
+  );
+
   const current = new Map<string, T>(
     Object.entries(JSON.parse((await readStorage(OAUTH2_STORAGE_KEY)) ?? "{}"))
   );
@@ -59,9 +63,11 @@ export async function getCachedAuthData<T extends AuthData>(
 }
 
 export async function deleteCachedAuthData(key: string): Promise<void> {
-  if (!isBackgroundPage()) {
-    throw new Error("Only the background page can access oauth2 information");
-  }
+  expectContext(
+    "background",
+    "Only the background page can access oauth2 information"
+  );
+
   const current = JSON.parse((await readStorage(OAUTH2_STORAGE_KEY)) ?? "{}");
   if (Object.prototype.hasOwnProperty.call(current, key)) {
     // OK because we're guarding with hasOwnProperty

--- a/src/background/devtools/external.ts
+++ b/src/background/devtools/external.ts
@@ -31,7 +31,7 @@ import {
 import { browser, Runtime, WebNavigation } from "webextension-polyfill-ts";
 import { v4 as uuidv4 } from "uuid";
 import { SimpleEvent } from "@/hooks/events";
-import { isBackgroundPage } from "webext-detect-page";
+import { forbidContext } from "@/utils";
 
 const devtoolsHandlers = new Map<Nonce, PromiseHandler>();
 
@@ -112,12 +112,12 @@ export async function callBackground(
 }
 
 export function installPortListeners(port: Runtime.Port): void {
-  if (isBackgroundPage()) {
-    // can't use isDevtoolsPage since this will be called from the pane and other places
-    throw new Error(
-      "installPortListeners should only be called from the devtools"
-    );
-  }
+  // can't use isDevtoolsPage since this will be called from the pane and other places
+  forbidContext(
+    "background",
+    "installPortListeners should only be called from the devtools"
+  );
+
   port.onMessage.addListener(devtoolsMessageListener);
   port.onMessage.addListener(devtoolsEventListener);
 }

--- a/src/background/devtools/external.ts
+++ b/src/background/devtools/external.ts
@@ -31,7 +31,7 @@ import {
 import { browser, Runtime, WebNavigation } from "webextension-polyfill-ts";
 import { v4 as uuidv4 } from "uuid";
 import { SimpleEvent } from "@/hooks/events";
-import { forbidContext } from "@/utils";
+import { forbidBackgroundPage } from "@/utils/expect-context";
 
 const devtoolsHandlers = new Map<Nonce, PromiseHandler>();
 
@@ -113,8 +113,7 @@ export async function callBackground(
 
 export function installPortListeners(port: Runtime.Port): void {
   // can't use isDevtoolsPage since this will be called from the pane and other places
-  forbidContext(
-    "background",
+  forbidBackgroundPage(
     "installPortListeners should only be called from the devtools"
   );
 

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -41,7 +41,12 @@ import { callBackground } from "@/background/devtools/external";
 import { ensureContentScript } from "@/background/util";
 import * as nativeEditorProtocol from "@/nativeEditor";
 import { reactivate } from "@/background/navigation";
-import { isErrorObject, isPrivatePageError } from "@/utils";
+import {
+  expectContext,
+  forbidContext,
+  isErrorObject,
+  isPrivatePageError,
+} from "@/utils";
 
 const TOP_LEVEL_FRAME_ID = 0;
 
@@ -175,11 +180,9 @@ export function liftBackground<R extends SerializableResponse>(
   }
 
   return async (port: Runtime.Port, ...args: unknown[]): Promise<R> => {
-    if (isBackgroundPage()) {
-      throw new Error(
-        "This method should not be called from the background page"
-      );
-    } else if (!port) {
+    forbidContext("background");
+
+    if (!port) {
       throw new Error("Devtools port is required");
     }
     return callBackground(port, fullType, args, options) as Promise<R>;
@@ -226,11 +229,9 @@ function deleteStaleConnections(port: Runtime.Port) {
 }
 
 function connectDevtools(port: Runtime.Port): void {
-  if (!isBackgroundPage()) {
-    throw new Error(
-      "connectDevtools can only be called from the background page"
-    );
-  } else if (allowBackgroundSender(port.sender) && port.name === PORT_NAME) {
+  expectContext("background");
+
+  if (allowBackgroundSender(port.sender) && port.name === PORT_NAME) {
     // sender.tab won't be available if we don't have permissions for it yet
     console.debug(
       `Adding devtools listeners for port ${port.name} for tab: ${

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -41,12 +41,11 @@ import { callBackground } from "@/background/devtools/external";
 import { ensureContentScript } from "@/background/util";
 import * as nativeEditorProtocol from "@/nativeEditor";
 import { reactivate } from "@/background/navigation";
+import { isErrorObject, isPrivatePageError } from "@/utils";
 import {
-  expectContext,
-  forbidContext,
-  isErrorObject,
-  isPrivatePageError,
-} from "@/utils";
+  expectBackgroundPage,
+  forbidBackgroundPage,
+} from "@/utils/expect-context";
 
 const TOP_LEVEL_FRAME_ID = 0;
 
@@ -180,7 +179,7 @@ export function liftBackground<R extends SerializableResponse>(
   }
 
   return async (port: Runtime.Port, ...args: unknown[]): Promise<R> => {
-    forbidContext("background");
+    forbidBackgroundPage();
 
     if (!port) {
       throw new Error("Devtools port is required");
@@ -229,7 +228,7 @@ function deleteStaleConnections(port: Runtime.Port) {
 }
 
 function connectDevtools(port: Runtime.Port): void {
-  expectContext("background");
+  expectBackgroundPage();
 
   if (allowBackgroundSender(port.sender) && port.name === PORT_NAME) {
     // sender.tab won't be available if we don't have permissions for it yet

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -27,10 +27,10 @@ import {
 import { browser, Runtime, Tabs } from "webextension-polyfill-ts";
 import { MESSAGE_PREFIX } from "@/background/protocol";
 import { RenderedArgs } from "@/core";
-import { isBackgroundPage, isContentScript } from "webext-detect-page";
 import { emitDevtools } from "@/background/devtools/internal";
 import { Availability } from "@/blocks/types";
 import { BusinessError } from "@/errors";
+import { expectContext } from "@/utils";
 
 const MESSAGE_RUN_BLOCK_OPENER = `${MESSAGE_PREFIX}RUN_BLOCK_OPENER`;
 const MESSAGE_RUN_BLOCK_TARGET = `${MESSAGE_PREFIX}RUN_BLOCK_TARGET`;
@@ -307,19 +307,15 @@ async function linkTabListener(tab: Tabs.Tab): Promise<void> {
 }
 
 function initExecutor(): void {
-  if (!isBackgroundPage()) {
-    throw new Error(
-      "initExecutor can only be called from the background thread"
-    );
-  }
+  expectContext("background");
+
   browser.tabs.onCreated.addListener(linkTabListener);
   browser.runtime.onMessage.addListener(backgroundListener);
 }
 
 export async function activateTab(): Promise<void> {
-  if (!isContentScript()) {
-    throw new Error("activateTab can only be run from a content script");
-  }
+  expectContext("contentScript");
+
   return browser.runtime.sendMessage({
     type: MESSAGE_ACTIVATE_TAB,
     payload: {},
@@ -327,9 +323,8 @@ export async function activateTab(): Promise<void> {
 }
 
 export async function closeTab(): Promise<void> {
-  if (!isContentScript()) {
-    throw new Error("closeTab can only be run from a content script");
-  }
+  expectContext("contentScript");
+
   return browser.runtime.sendMessage({
     type: MESSAGE_CLOSE_TAB,
     payload: {},

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -30,7 +30,10 @@ import { RenderedArgs } from "@/core";
 import { emitDevtools } from "@/background/devtools/internal";
 import { Availability } from "@/blocks/types";
 import { BusinessError } from "@/errors";
-import { expectContext } from "@/utils";
+import {
+  expectBackgroundPage,
+  expectContentScript,
+} from "@/utils/expect-context";
 
 const MESSAGE_RUN_BLOCK_OPENER = `${MESSAGE_PREFIX}RUN_BLOCK_OPENER`;
 const MESSAGE_RUN_BLOCK_TARGET = `${MESSAGE_PREFIX}RUN_BLOCK_TARGET`;
@@ -307,14 +310,14 @@ async function linkTabListener(tab: Tabs.Tab): Promise<void> {
 }
 
 function initExecutor(): void {
-  expectContext("background");
+  expectBackgroundPage();
 
   browser.tabs.onCreated.addListener(linkTabListener);
   browser.runtime.onMessage.addListener(backgroundListener);
 }
 
 export async function activateTab(): Promise<void> {
-  expectContext("contentScript");
+  expectContentScript();
 
   return browser.runtime.sendMessage({
     type: MESSAGE_ACTIVATE_TAB,
@@ -323,7 +326,7 @@ export async function activateTab(): Promise<void> {
 }
 
 export async function closeTab(): Promise<void> {
-  expectContext("contentScript");
+  expectContentScript();
 
   return browser.runtime.sendMessage({
     type: MESSAGE_CLOSE_TAB,

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -24,7 +24,7 @@ import { deserializeError, serializeError } from "serialize-error";
 import { DBSchema, openDB } from "idb/with-async-ittr";
 import { reverse, sortBy } from "lodash";
 import { _getDNT } from "@/background/telemetry";
-import { isBackgroundPage, isContentScript } from "webext-detect-page";
+import { isContentScript } from "webext-detect-page";
 import { readStorage, setStorage } from "@/chrome";
 import {
   hasBusinessRootCause,
@@ -33,6 +33,7 @@ import {
 } from "@/errors";
 import { showConnectionLost } from "@/contentScript/connection";
 import { errorMessage } from "@/telemetry/logging";
+import { expectContext } from "@/utils";
 
 const STORAGE_KEY = "LOG";
 const ENTRY_OBJECT_STORE = "entries";
@@ -291,11 +292,8 @@ const LOG_CONFIG_STORAGE_KEY = "LOG_OPTIONS";
 let _config: LoggingConfig = null;
 
 export async function _getLoggingConfig(): Promise<LoggingConfig> {
-  if (!isBackgroundPage()) {
-    throw new Error(
-      "_getLoggingConfig should only be called from the background page"
-    );
-  }
+  expectContext("background");
+
   if (_config != null) {
     return _config;
   }
@@ -305,11 +303,8 @@ export async function _getLoggingConfig(): Promise<LoggingConfig> {
 }
 
 export async function _setLoggingConfig(config: LoggingConfig): Promise<void> {
-  if (!isBackgroundPage()) {
-    throw new Error(
-      "_setLoggingConfig should only be called from the background page"
-    );
-  }
+  expectContext("background");
+
   await setStorage(LOG_CONFIG_STORAGE_KEY, JSON.stringify(config));
   _config = config;
 }

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -33,7 +33,7 @@ import {
 } from "@/errors";
 import { showConnectionLost } from "@/contentScript/connection";
 import { errorMessage } from "@/telemetry/logging";
-import { expectContext } from "@/utils";
+import { expectBackgroundPage } from "@/utils/expect-context";
 
 const STORAGE_KEY = "LOG";
 const ENTRY_OBJECT_STORE = "entries";
@@ -292,7 +292,7 @@ const LOG_CONFIG_STORAGE_KEY = "LOG_OPTIONS";
 let _config: LoggingConfig = null;
 
 export async function _getLoggingConfig(): Promise<LoggingConfig> {
-  expectContext("background");
+  expectBackgroundPage();
 
   if (_config != null) {
     return _config;
@@ -303,7 +303,7 @@ export async function _getLoggingConfig(): Promise<LoggingConfig> {
 }
 
 export async function _setLoggingConfig(config: LoggingConfig): Promise<void> {
-  expectContext("background");
+  expectBackgroundPage();
 
   await setStorage(LOG_CONFIG_STORAGE_KEY, JSON.stringify(config));
   _config = config;

--- a/src/background/requests.test.ts
+++ b/src/background/requests.test.ts
@@ -19,11 +19,17 @@ import { SanitizedServiceConfiguration, ServiceConfig } from "@/core";
 import serviceRegistry, { PIXIEBRIX_SERVICE_ID } from "@/services/registry";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
+import { isBackgroundPage } from "webext-detect-page";
 
 const axiosMock = new MockAdapter(axios);
+const mockIsBackgroundPage = isBackgroundPage as jest.MockedFunction<
+  typeof isBackgroundPage
+>;
+mockIsBackgroundPage.mockImplementation(() => false);
 
 jest.mock("@/background/protocol");
 jest.mock("@/auth/token");
+jest.mock("webext-detect-page");
 
 import * as token from "@/auth/token";
 import { AxiosRequestConfig } from "axios";

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -25,6 +25,7 @@ import serviceRegistry, { PIXIEBRIX_SERVICE_ID } from "@/services/registry";
 import { getExtensionToken } from "@/auth/token";
 import { locator } from "@/background/locator";
 import { ContextError } from "@/errors";
+import { isBackgroundPage } from "webext-detect-page";
 import { isEmpty } from "lodash";
 import {
   deleteCachedAuthData,
@@ -34,7 +35,6 @@ import {
 } from "@/background/auth";
 import { isAbsoluteURL } from "@/hooks/fetch";
 import urljoin from "url-join";
-import { expectContext } from "@/utils";
 
 interface ProxyResponseSuccessData {
   json: unknown;
@@ -122,7 +122,9 @@ async function authenticate(
   config: SanitizedServiceConfiguration,
   request: AxiosRequestConfig
 ): Promise<AxiosRequestConfig> {
-  expectContext("background");
+  if (!isBackgroundPage()) {
+    throw new Error("authenticate can only be called from the background page");
+  }
 
   const service = await serviceRegistry.lookup(config.serviceId);
 

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -25,7 +25,6 @@ import serviceRegistry, { PIXIEBRIX_SERVICE_ID } from "@/services/registry";
 import { getExtensionToken } from "@/auth/token";
 import { locator } from "@/background/locator";
 import { ContextError } from "@/errors";
-import { isBackgroundPage } from "webext-detect-page";
 import { isEmpty } from "lodash";
 import {
   deleteCachedAuthData,
@@ -35,6 +34,7 @@ import {
 } from "@/background/auth";
 import { isAbsoluteURL } from "@/hooks/fetch";
 import urljoin from "url-join";
+import { expectBackgroundPage } from "@/utils/expect-context";
 
 interface ProxyResponseSuccessData {
   json: unknown;
@@ -122,9 +122,7 @@ async function authenticate(
   config: SanitizedServiceConfiguration,
   request: AxiosRequestConfig
 ): Promise<AxiosRequestConfig> {
-  if (!isBackgroundPage()) {
-    throw new Error("authenticate can only be called from the background page");
-  }
+  expectBackgroundPage();
 
   const service = await serviceRegistry.lookup(config.serviceId);
 

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -25,7 +25,6 @@ import serviceRegistry, { PIXIEBRIX_SERVICE_ID } from "@/services/registry";
 import { getExtensionToken } from "@/auth/token";
 import { locator } from "@/background/locator";
 import { ContextError } from "@/errors";
-import { isBackgroundPage } from "webext-detect-page";
 import { isEmpty } from "lodash";
 import {
   deleteCachedAuthData,
@@ -35,6 +34,7 @@ import {
 } from "@/background/auth";
 import { isAbsoluteURL } from "@/hooks/fetch";
 import urljoin from "url-join";
+import { expectContext } from "@/utils";
 
 interface ProxyResponseSuccessData {
   json: unknown;
@@ -122,9 +122,7 @@ async function authenticate(
   config: SanitizedServiceConfiguration,
   request: AxiosRequestConfig
 ): Promise<AxiosRequestConfig> {
-  if (!isBackgroundPage()) {
-    throw new Error("authenticate can only be called from the background page");
-  }
+  expectContext("background");
 
   const service = await serviceRegistry.lookup(config.serviceId);
 

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -21,7 +21,7 @@ import { getAdditionalPermissions } from "webext-additional-permissions";
 import { patternToRegex } from "webext-patterns";
 import { ENSURE_CONTENT_SCRIPT_READY } from "@/messaging/constants";
 import { isRemoteProcedureCallRequest } from "@/messaging/protocol";
-import { expectContext } from "@/utils";
+import { expectBackgroundPage } from "@/utils/expect-context";
 
 export type Target = {
   tabId: number;
@@ -45,7 +45,7 @@ interface TargetState {
 
 /** Fetches the URL from a tab/frame. It will throw if we don't have permission to access it */
 export async function getTargetState(target: Target): Promise<TargetState> {
-  expectContext("background");
+  expectBackgroundPage();
 
   const [state] = await browser.tabs.executeScript(target.tabId, {
     // This imitates the new chrome.scripting API by wrapping a function in a IIFE
@@ -88,7 +88,7 @@ export async function onReadyNotification(signal: AbortSignal): Promise<void> {
  * If it's been injected, it will resolve once the content script is ready.
  */
 export async function ensureContentScript(target: Target): Promise<void> {
-  expectContext("background");
+  expectBackgroundPage();
 
   console.debug(`ensureContentScript: requested`, target);
 

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -16,12 +16,12 @@
  */
 
 import pDefer from "p-defer";
-import { isBackgroundPage } from "webext-detect-page";
 import { browser } from "webextension-polyfill-ts";
 import { getAdditionalPermissions } from "webext-additional-permissions";
 import { patternToRegex } from "webext-patterns";
 import { ENSURE_CONTENT_SCRIPT_READY } from "@/messaging/constants";
 import { isRemoteProcedureCallRequest } from "@/messaging/protocol";
+import { expectContext } from "@/utils";
 
 export type Target = {
   tabId: number;
@@ -45,11 +45,7 @@ interface TargetState {
 
 /** Fetches the URL from a tab/frame. It will throw if we don't have permission to access it */
 export async function getTargetState(target: Target): Promise<TargetState> {
-  if (!isBackgroundPage()) {
-    throw new Error(
-      "getTargetState can only be called from the background page"
-    );
-  }
+  expectContext("background");
 
   const [state] = await browser.tabs.executeScript(target.tabId, {
     // This imitates the new chrome.scripting API by wrapping a function in a IIFE
@@ -92,11 +88,7 @@ export async function onReadyNotification(signal: AbortSignal): Promise<void> {
  * If it's been injected, it will resolve once the content script is ready.
  */
 export async function ensureContentScript(target: Target): Promise<void> {
-  if (!isBackgroundPage()) {
-    throw new Error(
-      "ensureContentScript can only be called from the background page"
-    );
-  }
+  expectContext("background");
 
   console.debug(`ensureContentScript: requested`, target);
 

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -24,7 +24,7 @@ import {
   isContentScript,
   isOptionsPage,
 } from "webext-detect-page";
-import { forbidContext } from "@/utils";
+import { forbidBackgroundPage } from "./utils/expect-context";
 
 export const CHROME_EXTENSION_STORAGE_KEY = "chrome_extension_id";
 const CHROME_EXTENSION_ID = process.env.CHROME_EXTENSION_ID;
@@ -105,7 +105,7 @@ export function getChromeExtensionId(): string {
  * needs to send one message back within a second.
  * */
 export async function runtimeConnect(name: string): Promise<Runtime.Port> {
-  forbidContext("background");
+  forbidBackgroundPage();
 
   const { resolve, reject, promise: connectionPromise } = pDefer();
 

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -24,6 +24,7 @@ import {
   isContentScript,
   isOptionsPage,
 } from "webext-detect-page";
+import { forbidContext } from "@/utils";
 
 export const CHROME_EXTENSION_STORAGE_KEY = "chrome_extension_id";
 const CHROME_EXTENSION_ID = process.env.CHROME_EXTENSION_ID;
@@ -104,9 +105,7 @@ export function getChromeExtensionId(): string {
  * needs to send one message back within a second.
  * */
 export async function runtimeConnect(name: string): Promise<Runtime.Port> {
-  if (isBackgroundPage()) {
-    throw new Error("runtimeConnect cannot be called from the background page");
-  }
+  forbidContext("background");
 
   const { resolve, reject, promise: connectionPromise } = pDefer();
 

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -24,9 +24,10 @@ import {
   SerializableResponse,
   toErrorResponse,
 } from "@/messaging/protocol";
-import { isBackgroundPage, isContentScript } from "webext-detect-page";
+import { isContentScript } from "webext-detect-page";
 import { deserializeError } from "serialize-error";
 import { browser, Runtime } from "webextension-polyfill-ts";
+import { expectContext } from "@/utils";
 
 export const MESSAGE_PREFIX = "@@pixiebrix/contentScript/";
 export const ROOT_FRAME_ID = 0;
@@ -110,11 +111,8 @@ export function notifyContentScripts(
   }
 
   return async (tabId: number | null, ...args: unknown[]) => {
-    if (!isBackgroundPage()) {
-      throw new ContentScriptActionError(
-        "This method can only be called from the background page"
-      );
-    }
+    expectContext("background", ContentScriptActionError);
+
     console.debug(
       `Broadcasting content script notification ${fullType} to tab: ${
         tabId ?? "<all>"
@@ -196,11 +194,9 @@ export function liftContentScript<R extends SerializableResponse>(
     if (isContentScript()) {
       console.debug("Resolving call from the contentScript immediately");
       return method(...args);
-    } else if (!isBackgroundPage()) {
-      throw new ContentScriptActionError(
-        "Unexpected call from origin other than the background page"
-      );
     }
+
+    expectContext("background", ContentScriptActionError);
 
     console.debug(
       `Sending content script action ${fullType} to tab ${
@@ -254,11 +250,7 @@ export function liftContentScript<R extends SerializableResponse>(
 }
 
 function addContentScriptListener(): void {
-  if (!isContentScript()) {
-    throw new Error(
-      "addContentScriptListener should only be run from the content script"
-    );
-  }
+  expectContext("contentScript");
 
   browser.runtime.onMessage.addListener(contentScriptListener);
   console.debug(

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -27,7 +27,10 @@ import {
 import { isContentScript } from "webext-detect-page";
 import { deserializeError } from "serialize-error";
 import { browser, Runtime } from "webextension-polyfill-ts";
-import { expectContext } from "@/utils";
+import {
+  expectBackgroundPage,
+  expectContentScript,
+} from "@/utils/expect-context";
 
 export const MESSAGE_PREFIX = "@@pixiebrix/contentScript/";
 export const ROOT_FRAME_ID = 0;
@@ -111,7 +114,7 @@ export function notifyContentScripts(
   }
 
   return async (tabId: number | null, ...args: unknown[]) => {
-    expectContext("background", ContentScriptActionError);
+    expectBackgroundPage(ContentScriptActionError);
 
     console.debug(
       `Broadcasting content script notification ${fullType} to tab: ${
@@ -196,7 +199,7 @@ export function liftContentScript<R extends SerializableResponse>(
       return method(...args);
     }
 
-    expectContext("background", ContentScriptActionError);
+    expectBackgroundPage(ContentScriptActionError);
 
     console.debug(
       `Sending content script action ${fullType} to tab ${
@@ -250,7 +253,7 @@ export function liftContentScript<R extends SerializableResponse>(
 }
 
 function addContentScriptListener(): void {
-  expectContext("contentScript");
+  expectContentScript();
 
   browser.runtime.onMessage.addListener(contentScriptListener);
   console.debug(

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -24,11 +24,11 @@ import {
   allowSender,
   liftContentScript,
 } from "@/contentScript/backgroundProtocol";
-import { isContentScript } from "webext-detect-page";
 import { Availability } from "@/blocks/types";
 import { checkAvailable } from "@/blocks/available";
 import { markReady } from "./context";
 import { ENSURE_CONTENT_SCRIPT_READY } from "@/messaging/constants";
+import { expectContext } from "@/utils";
 
 export const MESSAGE_CHECK_AVAILABILITY = `${MESSAGE_PREFIX}CHECK_AVAILABILITY`;
 export const MESSAGE_RUN_BLOCK = `${MESSAGE_PREFIX}RUN_BLOCK`;
@@ -124,13 +124,9 @@ export async function notifyReady(): Promise<void> {
 }
 
 function addExecutorListener(): void {
-  if (isContentScript()) {
-    browser.runtime.onMessage.addListener(runBlockAction);
-  } else {
-    throw new Error(
-      "addExecutorListener should only be called from the content script"
-    );
-  }
+  expectContext("contentScript");
+
+  browser.runtime.onMessage.addListener(runBlockAction);
 }
 
 export default addExecutorListener;

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -28,7 +28,7 @@ import { Availability } from "@/blocks/types";
 import { checkAvailable } from "@/blocks/available";
 import { markReady } from "./context";
 import { ENSURE_CONTENT_SCRIPT_READY } from "@/messaging/constants";
-import { expectContext } from "@/utils";
+import { expectContentScript } from "@/utils/expect-context";
 
 export const MESSAGE_CHECK_AVAILABILITY = `${MESSAGE_PREFIX}CHECK_AVAILABILITY`;
 export const MESSAGE_RUN_BLOCK = `${MESSAGE_PREFIX}RUN_BLOCK`;
@@ -124,7 +124,7 @@ export async function notifyReady(): Promise<void> {
 }
 
 function addExecutorListener(): void {
-  expectContext("contentScript");
+  expectContentScript();
 
   browser.runtime.onMessage.addListener(runBlockAction);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,6 @@ import {
 } from "lodash";
 import { ErrorObject } from "serialize-error";
 import { Primitive } from "type-fest";
-import { isBackgroundPage, isContentScript } from "webext-detect-page";
 
 export function mostCommonElement<T>(items: T[]): T {
   // https://stackoverflow.com/questions/49731282/the-most-frequent-item-of-an-array-using-lodash
@@ -355,60 +354,4 @@ export function isPrivatePageError(error: unknown): boolean {
     isErrorObject(error) &&
     /cannot be scripted|(chrome|about|extension):\/\//.test(error.message)
   );
-}
-
-// TODO: Use keyof Map instead of inlining the contexts in the parameters https://github.com/sindresorhus/type-fest/issues/225
-type Context = "background" | "contentScript";
-
-const contextsMap = new Map<Context, () => boolean>([
-  ["background", isBackgroundPage],
-  ["contentScript", isContentScript],
-]);
-
-/**
- * Accepts 'This is my error' | new Error('This is my error') | Error;
- * The constructor would be used to create a custom error with the defalt message
- */
-type ErrorBaseType = string | Error | { new (message?: string): Error };
-function createError(
-  defaultMessage: string,
-  error: ErrorBaseType = Error
-): Error {
-  if (typeof error === "string") {
-    // eslint-disable-next-line unicorn/prefer-type-error
-    throw new Error(error);
-  }
-
-  if (error instanceof Error) {
-    throw error;
-  }
-
-  throw new error(defaultMessage);
-}
-
-/**
- * @example expectContext('background')
- * @example expectContext('background', WrongContextError)
- * @example expectContext('background', 'Wrong context and this is my custom error')
- * @example expectContext('background', new Error('Wrong context and this is my custom error'))
- */
-export function expectContext(context: Context, error?: ErrorBaseType): void {
-  if (!contextsMap.get(context)()) {
-    throw createError(
-      `This code can only run in the ${context} context`,
-      error
-    );
-  }
-}
-
-/**
- * @example forbidContext('background')
- * @example forbidContext('background', WrongContextError)
- * @example forbidContext('background', 'Wrong context and this is my custom error')
- * @example forbidContext('background', new Error('Wrong context and this is my custom error'))
- */
-export function forbidContext(context: Context, error?: ErrorBaseType): void {
-  if (contextsMap.get(context)()) {
-    throw createError(`This code cannot run in the ${context} context`, error);
-  }
 }

--- a/src/utils/expect-context.ts
+++ b/src/utils/expect-context.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2021 Pixie Brix, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { isBackgroundPage, isContentScript } from "webext-detect-page";
+
+/**
+ * Accepts 'This is my error' | new Error('This is my error') | Error;
+ * The constructor would be used to create a custom error with the defalt message
+ */
+type ErrorBaseType = string | Error | { new (message?: string): Error };
+function createError(
+  defaultMessage: string,
+  error: ErrorBaseType = Error
+): Error {
+  if (typeof error === "string") {
+    // eslint-disable-next-line unicorn/prefer-type-error
+    return new Error(error);
+  }
+
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new error(defaultMessage);
+}
+
+/**
+ * @example expectBackgroundPage()
+ * @example expectBackgroundPage(WrongContextError)
+ * @example expectBackgroundPage('Wrong context and this is my custom error')
+ * @example expectBackgroundPage(new Error('Wrong context and this is my custom error'))
+ */
+export function expectBackgroundPage(error?: ErrorBaseType): void {
+  if (!isBackgroundPage()) {
+    throw createError(`This code can only run in the background page`, error);
+  }
+}
+
+/**
+ * @example expectContentScript()
+ * @example expectContentScript(WrongContextError)
+ * @example expectContentScript('Wrong context and this is my custom error')
+ * @example expectContentScript(new Error('Wrong context and this is my custom error'))
+ */
+export function expectContentScript(error?: ErrorBaseType): void {
+  if (!isContentScript()) {
+    throw createError(`This code can only run in the content script`, error);
+  }
+}
+
+/**
+ * @example expectBackgroundPage()
+ * @example expectBackgroundPage(WrongContextError)
+ * @example expectBackgroundPage('Wrong context and this is my custom error')
+ * @example expectBackgroundPage(new Error('Wrong context and this is my custom error'))
+ */
+export function forbidBackgroundPage(error?: ErrorBaseType): void {
+  if (isBackgroundPage()) {
+    throw createError(`This code cannot run in the background page`, error);
+  }
+}
+
+/**
+ * @example forbidContentScript()
+ * @example forbidContentScript(WrongContextError)
+ * @example forbidContentScript('Wrong context and this is my custom error')
+ * @example forbidContentScript(new Error('Wrong context and this is my custom error'))
+ */
+export function forbidContentScript(error?: ErrorBaseType): void {
+  if (isContentScript()) {
+    throw createError(`This code cannot run in the content script`, error);
+  }
+}


### PR DESCRIPTION
Such utility functions make context-limiting it short and consistent. The functions are still flexible enough to let you customize the error type and/or the error message.

There are some other context exclusions in the code (e.g. multiple contexts allowed) but I left those out for now since they're one or two.