### PR TITLE
Fix Firefox "injection on grant" compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8054,9 +8054,9 @@
       "dev": true
     },
     "content-scripts-register-polyfill": {
-      "version": "3.0.0-0",
-      "resolved": "https://registry.npmjs.org/content-scripts-register-polyfill/-/content-scripts-register-polyfill-3.0.0-0.tgz",
-      "integrity": "sha512-p7tQihCyy1TxfY30T8YBDIgXv9RIQok+64f1xe6VtHNKpH0Rkj9CNfHrME+G4E7H1Zjo3xzn0DLk1wDGiUD6Lw==",
+      "version": "2.2.0-2",
+      "resolved": "https://registry.npmjs.org/content-scripts-register-polyfill/-/content-scripts-register-polyfill-2.2.0-2.tgz",
+      "integrity": "sha512-Ha9NafEqfGXfNttV/c2F2Vj/z4xSjwyFkzOnmkD/NmyBx5cak+vYvsNRYwzvv/2ltbkLhioqrNcYfgqEfhUEvQ==",
       "requires": {
         "@types/firefox-webext-browser": "^82.0.0",
         "webext-patterns": "^1.1.0",
@@ -19156,11 +19156,11 @@
       "integrity": "sha512-IGpAHdsHz9mwpT8nHyzbdVz1ArUnsRf3PNGMprk3MgEtyN+jhcV4JqkOjNiKIb3k9sZ4WKY4lCxi5MtV1MuTYg=="
     },
     "webext-dynamic-content-scripts": {
-      "version": "8.0.0-0",
-      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-8.0.0-0.tgz",
-      "integrity": "sha512-ay8zb+YiFQnN9Hx7YO4NTjqnvDxDPrDV0BHCukvK3yNmuo66ns14E0uXgUJfTC9VLpLCfuS56bc/r4u2LdkkYw==",
+      "version": "8.0.0-1",
+      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-8.0.0-1.tgz",
+      "integrity": "sha512-bG9qzQc8/e1LynlTblhAs2pL2aaQgvJzhlQ3z7OMe6YiDSKSEJiSOW+e9VhsGorRppdQB3Lrsf//t7QmQh4vRg==",
       "requires": {
-        "content-scripts-register-polyfill": "^3.0.0-0",
+        "content-scripts-register-polyfill": "^2.2.0-2",
         "webext-additional-permissions": "^2.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "uuid": "^8.3.2",
     "webext-additional-permissions": "^2.0.1",
     "webext-detect-page": "^2.0.6",
-    "webext-dynamic-content-scripts": "^8.0.0-0",
+    "webext-dynamic-content-scripts": "^8.0.0-1",
     "webext-patterns": "^1.1.0",
     "webext-polyfill-kinda": "^0.1.0",
     "webextension-polyfill-ts": "^0.25.0"


### PR DESCRIPTION
This is a rework of https://github.com/pixiebrix/pixiebrix-extension/pull/675 due to a misunderstanding of the contentScripts.register API. That PR was undone/closed:

- https://github.com/fregante/content-scripts-register-polyfill/pull/27#issuecomment-873398462

And that logic was moved to:

- https://github.com/fregante/webext-dynamic-content-scripts/pull/24

This change regards Firefox because the polyfill’s behavior did not match Firefox’ and therefore the issue described in #671 still existed there. This is untested in Firefox due to large incompatibilities (#490), but it works in Chrome.

The red text here is to show that the style is also injected. The console shows that the JS is injected once.

![gif](https://user-images.githubusercontent.com/1402241/124357956-434fee80-dc48-11eb-8d4f-fa484df6744d.gif)
