### PR TITLE
#410: Use native npm caching on CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: "14.x"
+          node-version: "14"
           cache: npm
       - run: npm ci
       - run: npm run build
@@ -35,9 +35,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: "14.x"
+          node-version: "14"
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"
-      - uses: bahmutov/npm-install@v1
+          cache: npm
+      - run: npm ci
       - run: npm run build
         env:
           GOOGLE_APP_ID: ${{ secrets.GOOGLE_APP_ID }}
@@ -37,7 +38,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"
-      - uses: bahmutov/npm-install@v1
+          cache: npm
+      - run: npm ci
       - run: npm run build
         env:
           GOOGLE_APP_ID: ${{ secrets.GOOGLE_APP_ID }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"
-      - uses: bahmutov/npm-install@v1
+          cache: npm
+      - run: npm ci
       - run: npm test
 
   stage:
@@ -22,7 +23,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"
-      - uses: bahmutov/npm-install@v1
+          cache: npm
+      - run: npm ci
       - run: npm run build
         env:
           ENVIRONMENT: staging
@@ -57,7 +59,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"
-      - uses: bahmutov/npm-install@v1
+          cache: npm
+      - run: npm ci
       - run: npm run build:scripts
       - run: node scripts/bin/headers.js
       - uses: actions/upload-artifact@v2
@@ -75,7 +78,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14.x"
-      - uses: bahmutov/npm-install@v1
+          cache: npm
+      - run: npm ci
         # Run eslint without GitHub Actions annotations
         # https://stackoverflow.com/a/65964721/288906
       - name: npm run lint

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,9 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: "14.x"
+          node-version: "14"
           cache: npm
       - run: npm ci
       - run: npm test
@@ -20,9 +20,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: "14.x"
+          node-version: "14"
           cache: npm
       - run: npm ci
       - run: npm run build
@@ -56,9 +56,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: "14.x"
+          node-version: "14"
           cache: npm
       - run: npm ci
       - run: npm run build:scripts
@@ -75,9 +75,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: "14.x"
+          node-version: "14"
           cache: npm
       - run: npm ci
         # Run eslint without GitHub Actions annotations


### PR DESCRIPTION
https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

Also might I suggest moving the project to Node 15 or 16? They use `npm 7` and the lockfile v2 which probably has worthwhile improvements. Maybe it avoids "broken npm installs" (https://github.com/pixiebrix/pixiebrix-extension/issues/595#issuecomment-867650460) (one can dream)