### PR TITLE
#679: Disable unsupported API call in Firefox in dev tools

### DIFF
--- a/src/background/devtools/external.ts
+++ b/src/background/devtools/external.ts
@@ -89,7 +89,9 @@ export async function callBackground(
     meta: { nonce, tabId: browser.devtools.inspectedWindow.tabId },
   };
 
-  if (!port.onMessage.hasListeners()) {
+  // Firefox does not support the API yet
+  // https://github.com/pixiebrix/pixiebrix-extension/issues/679
+  if (port.onMessage.hasListeners && !port.onMessage.hasListeners()) {
     throw new Error("Listeners not installed on devtools port");
   }
 


### PR DESCRIPTION
Fixes #679 

It seems to work for me and it enables the PixieBrix tab in the devtools: (screenshot taken on pixiebrix.com)


<img width="1135" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/124595351-1ccdc580-de8b-11eb-8bf2-c0dda428bfec.png">
