### PR TITLE
# 708: http input schema

### DIFF
--- a/src/blocks/transformers/remoteMethod.ts
+++ b/src/blocks/transformers/remoteMethod.ts
@@ -58,11 +58,10 @@ export class RemoteMethod extends Transformer {
         description: "Additional request headers",
         additionalProperties: { type: "string" },
       },
-      data: {
-        type: "object",
-        additionalProperties: true,
-      },
+      // Match anything, as valid values are determined by the API being called
+      data: {},
     },
+    // XXX: data should not be required for GET/DELETE requests
     ["url", "data"]
   );
 

--- a/src/components/fields/FieldTable.tsx
+++ b/src/components/fields/FieldTable.tsx
@@ -199,9 +199,9 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
   // allow additional properties for empty schema (empty schema allows shape)
   const additionalProperties = isEmpty(schema) || schema.additionalProperties;
 
-  // PERFORMANCE: helpers.setValue changes on every render, so use setFieldValue instead
-  // // https://github.com/formium/formik/issues/2268
-  const [field, ,] = useField(props);
+  // helpers.setValue changes on every render, so use setFieldValue instead
+  // https://github.com/formium/formik/issues/2268
+  const [field] = useField(props);
   const { setFieldValue } = useFormikContext();
 
   // useRef indirection layer so the callbacks below don't re-calculate on every change

--- a/src/components/fields/TextField.tsx
+++ b/src/components/fields/TextField.tsx
@@ -41,7 +41,7 @@ const TextField: FunctionComponent<FieldProps<string>> = ({
       ? uniq([...created, ...values]).map((x) => ({ value: x, label: x }))
       : [];
     return [schema?.enum == null, options];
-  }, [schema?.examples, schema?.enum]);
+  }, [created, schema?.examples, schema?.enum]);
 
   let control;
 
@@ -52,7 +52,7 @@ const TextField: FunctionComponent<FieldProps<string>> = ({
         options={options}
         onCreateOption={(value) => setCreated(uniq([...created, value]))}
         value={options.find((x) => x.value === value)}
-        onChange={(option) => helpers.setValue((option as any)?.value)}
+        onChange={(option) => helpers.setValue(option?.value)}
       />
     );
   } else if (options.length > 0 && !creatable) {
@@ -61,7 +61,7 @@ const TextField: FunctionComponent<FieldProps<string>> = ({
         isClearable
         options={options}
         value={options.find((x) => x.value === value)}
-        onChange={(option) => helpers.setValue((option as any)?.value)}
+        onChange={(option) => helpers.setValue(option?.value)}
       />
     );
   } else if (schema.format === "markdown") {

--- a/src/components/fields/blockOptions.tsx
+++ b/src/components/fields/blockOptions.tsx
@@ -328,7 +328,8 @@ export function getDefaultField(fieldSchema: Schema): FieldComponent {
   } else if (fieldSchema.type === "object") {
     return ObjectField;
   } else if (booleanPredicate(fieldSchema)) {
-    // should this be a TextField so it can be dynamically determined?
+    // Should this be a TextField so it can be dynamically determined?
+    // see https://github.com/pixiebrix/pixiebrix-extension/issues/709
     return BooleanField;
   } else if (textPredicate(fieldSchema)) {
     return TextField;

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -397,7 +397,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
       $toggle.attr("aria-expanded", String(startExpanded));
       $toggle.toggleClass("active", startExpanded);
 
-      $toggle.on("click", () => {
+      $toggle.on("click", async () => {
         $bodyContainers.toggleClass("show");
         const showing = $bodyContainers.hasClass("show");
         $toggle.attr("aria-expanded", String(showing));
@@ -407,7 +407,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
           console.debug(
             `Installing body for collapsible panel: ${extension.id}`
           );
-          installBody();
+          await installBody();
         }
       });
 


### PR DESCRIPTION
Closes #708

- Allow any data in `@pixiebrix/http` brick
- Show object configuration for empty field schemas
- Avoid unnecessary re-renders in ObjectField