### PR TITLE
#682: Wait for content script before sending external messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16345,6 +16345,11 @@
         "wrappy": "1"
       }
     },
+    "one-mutation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/one-mutation/-/one-mutation-2.0.0.tgz",
+      "integrity": "sha512-uxZBzkaGhKWy9bdj1peVBhgCP4abF1Rss6wIVzBi1VoaTVEMmFc3pp/hhkVKr5VL5SsmLanBy8i2mmTGQreVPQ=="
+    },
     "onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "notifyjs-browser": "^0.4.2",
     "nunjucks": "^3.2.3",
     "object-hash": "^2.2.0",
+    "one-mutation": "^2.0.0",
     "p-defer": "^4.0.0",
     "p-timeout": "^5.0.0",
     "page-metadata-parser": "^1.1.4",

--- a/src/contentScript/context.ts
+++ b/src/contentScript/context.ts
@@ -27,6 +27,7 @@ export let tabId: number;
 export let frameId: number;
 
 const PIXIEBRIX_READY_SYMBOL = Symbol.for("pixiebrix-content-script-ready");
+export const PIXIEBRIX_READY_ATTRIBUTE = "data-pb-ready";
 
 declare global {
   interface Window {
@@ -53,7 +54,7 @@ export function markReady(): void {
   // eslint-disable-next-line security/detect-object-injection -- Static symbol
   window[PIXIEBRIX_READY_SYMBOL] = true;
 
-  document.documentElement.dataset.pixieBrixReady = "true";
+  document.documentElement.setAttribute(PIXIEBRIX_READY_ATTRIBUTE, "");
 }
 
 export function updateTabInfo(info: { tabId: number; frameId: number }): void {

--- a/src/contentScript/context.ts
+++ b/src/contentScript/context.ts
@@ -52,6 +52,8 @@ export function getNavigationId(): string {
 export function markReady(): void {
   // eslint-disable-next-line security/detect-object-injection -- Static symbol
   window[PIXIEBRIX_READY_SYMBOL] = true;
+
+  document.documentElement.dataset.pixieBrixReady = "true";
 }
 
 export function updateTabInfo(info: { tabId: number; frameId: number }): void {

--- a/src/contentScript/externalProtocol.ts
+++ b/src/contentScript/externalProtocol.ts
@@ -180,16 +180,18 @@ export function liftExternal<R extends SerializableResponse>(
       throw new ContentScriptActionError("Expected call from external page");
     }
     // Wait for the extension to load before sending the message
-    await Promise.race([
-      oneMutation(document.documentElement, {
-        attributes: true,
-        attributeFilter: [PIXIEBRIX_READY_ATTRIBUTE],
-      }),
+    if (!document.documentElement.hasAttribute(PIXIEBRIX_READY_ATTRIBUTE)) {
+      await Promise.race([
+        oneMutation(document.documentElement, {
+          attributes: true,
+          attributeFilter: [PIXIEBRIX_READY_ATTRIBUTE],
+        }),
 
-      // TODO: Replace `sleep` with `p-timeout`
-      // Timeouts are temporarily being let through just for backwards compatibility.
-      sleep(POLL_READY_TIMEOUT),
-    ]);
+        // TODO: Replace `sleep` with `p-timeout`
+        // Timeouts are temporarily being let through just for backwards compatibility.
+        sleep(POLL_READY_TIMEOUT),
+      ]);
+    }
 
     return new Promise((resolve, reject) => {
       const nonce = uuidv4();

--- a/src/contentScript/externalProtocol.ts
+++ b/src/contentScript/externalProtocol.ts
@@ -133,32 +133,32 @@ function initExternalPageListener() {
 
 export function liftExternal<R extends SerializableResponse>(
   type: string,
-  method: () => R | Promise<R>,
+  method: () => Promise<R>,
   options?: HandlerOptions
 ): () => Promise<R>;
 export function liftExternal<T, R extends SerializableResponse>(
   type: string,
-  method: (a0: T) => R | Promise<R>,
+  method: (a0: T) => Promise<R>,
   options?: HandlerOptions
 ): (a0: T) => Promise<R>;
 export function liftExternal<T0, T1, R extends SerializableResponse>(
   type: string,
-  method: (a0: T0, a1: T1) => R | Promise<R>,
+  method: (a0: T0, a1: T1) => Promise<R>,
   options?: HandlerOptions
 ): (a0: T0, a1: T1) => Promise<R>;
 export function liftExternal<T0, T1, T2, R extends SerializableResponse>(
   type: string,
-  method: (a0: T0, a1: T1, a2: T2) => R | Promise<R>,
+  method: (a0: T0, a1: T1, a2: T2) => Promise<R>,
   options?: HandlerOptions
 ): (a0: T0, a1: T1, a2: T2) => Promise<R>;
 export function liftExternal<T0, T1, T2, T3, R extends SerializableResponse>(
   type: string,
-  method: (a0: T0, a1: T1, a2: T2, a3: T3) => R | Promise<R>,
+  method: (a0: T0, a1: T1, a2: T2, a3: T3) => Promise<R>,
   options?: HandlerOptions
 ): (a0: T0, a1: T1, a2: T2, a3: T3) => Promise<R>;
 export function liftExternal<R extends SerializableResponse>(
   type: string,
-  method: (...args: unknown[]) => R | Promise<R>,
+  method: (...args: unknown[]) => Promise<R>,
   options?: HandlerOptions
 ): (tabId: number, ...args: unknown[]) => Promise<R> {
   const fullType = `${MESSAGE_PREFIX}${type}`;
@@ -166,15 +166,13 @@ export function liftExternal<R extends SerializableResponse>(
   if (isContentScript()) {
     // console.debug(`Installed content script handler for ${type}`);
     contentScriptHandlers.set(fullType, { handler: method, options });
+    return method;
   }
 
   const targetOrigin = document.defaultView.origin;
 
   return async (...args: unknown[]) => {
-    if (isContentScript()) {
-      console.debug("Resolving call from the contentScript immediately");
-      return method(...args);
-    } else if (isExtensionContext()) {
+    if (isExtensionContext()) {
       throw new ContentScriptActionError("Expected call from external page");
     }
     return new Promise((resolve, reject) => {

--- a/src/contentScript/externalProtocol.ts
+++ b/src/contentScript/externalProtocol.ts
@@ -186,7 +186,13 @@ export function liftExternal<R extends SerializableResponse>(
         meta: { nonce },
       };
       console.debug("Sending message from page to content script", message);
-      document.defaultView.postMessage(message, targetOrigin);
+      (function check() {
+        if ("pixieBrixReady" in document.documentElement.dataset) {
+          document.defaultView.postMessage(message, targetOrigin);
+        } else {
+          setTimeout(check, 100);
+        }
+      })();
     });
   };
 }

--- a/src/messaging/external.ts
+++ b/src/messaging/external.ts
@@ -23,31 +23,10 @@ import { liftBackground } from "@/background/protocol";
 import { liftExternal } from "@/contentScript/externalProtocol";
 
 import { browser } from "webextension-polyfill-ts";
-import { SerializableResponse } from "@/messaging/protocol";
 import { reportEvent } from "@/telemetry/events";
 import { isChrome } from "@/helpers";
 
-function lift<R extends SerializableResponse = SerializableResponse>(
-  type: string,
-  method: (...args: unknown[]) => Promise<R>
-): (...args: unknown[]) => Promise<R> {
-  const backgroundMethod: (...args: unknown[]) => Promise<R> = liftBackground(
-    type,
-    method
-  );
-  const contentScriptMethod: (...args: unknown[]) => Promise<R> = liftExternal(
-    type,
-    method
-  );
-
-  return async (...args: unknown[]) => {
-    if (isChrome) {
-      return backgroundMethod(...args);
-    }
-
-    return contentScriptMethod(...args);
-  };
-}
+const lift = isChrome ? liftBackground : liftExternal;
 
 export const connectPage = lift("CONNECT_PAGE", async () => {
   return browser.runtime.getManifest();


### PR DESCRIPTION
Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/682

Quick and dirty solution to see what you think about the idea.

Problem:

- The app needs to know whether the extension is ready to receive messages

Solution:

- The extension adds an attribute to the `body` after loading

Explanation:

- The app doesn't have access to `PIXIEBRIX_READY_SYMBOL` and other local variables. Either we have a "very public" marker that the extension has loaded (an attribute) or we have to resort to polling via messages + timeouts, probably. Alternative solutions welcome.

If this is accepted, I'll probably turn the poller into a MutationObserver on `body`