### PR TITLE
Create dev tab and panels immediately

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -79,12 +79,14 @@ async function initialize() {
     await clearDynamicElements(port, {}).catch((error) => {
       console.warn(
         "Error clearing dynamic elements from previous devtools sessions",
-        error
+        {
+          error,
+        }
       );
     });
   } catch (error) {
-    // Can install without having content script on the page; they just won't do much
-    console.debug("Could not inject contextScript for devtools", {
+    // We could install without having content script on the page; they just won't do much
+    console.error("Could not inject contentScript for devtools", {
       error,
     });
   }

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -86,7 +86,13 @@ function installPanel() {
 }
 
 async function initialize() {
+  installPanel();
+
   const port = await connectDevtools();
+  installSidebarPane(port).catch((error) => {
+    console.error("Error adding data viewer elements pane", { error });
+  });
+
   let injected = false;
 
   try {
@@ -98,12 +104,6 @@ async function initialize() {
       error,
     });
   }
-
-  installSidebarPane(port).catch((error) => {
-    console.error("Error adding data viewer elements pane", { error });
-  });
-
-  installPanel();
 
   if (injected) {
     try {

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -46,12 +46,12 @@ async function keepSidebarUpToDate(
       useContentScriptContext: true,
     });
 
-    sidebar.setObject({ state: "loading..." });
+    void sidebar.setObject({ state: "loading..." });
 
     try {
-      sidebar.setObject(await readSelectedElement(port));
+      void sidebar.setObject(await readSelectedElement(port));
     } catch (error) {
-      sidebar.setObject({ error: error ?? "Unknown error" });
+      void sidebar.setObject({ error: error ?? "Unknown error" });
     }
   }
 
@@ -76,28 +76,21 @@ async function initialize() {
     console.error("Error adding data viewer elements pane", { error });
   });
 
-  let injected = false;
-
   try {
     await ensureScript(port);
-    injected = true;
+
+    // clear out any dynamic stuff from any previous devtools sessions
+    await clearDynamicElements(port, {}).catch((error) => {
+      console.debug(
+        "Error clearing dynamic elements previous devtools sessions",
+        error
+      );
+    });
   } catch (error) {
     // Can install without having content script on the page; they just won't do much
     console.debug("Could not inject contextScript for devtools", {
       error,
     });
-  }
-
-  if (injected) {
-    try {
-      // clear out any dynamic stuff from any previous devtools sessions
-      await clearDynamicElements(port, {});
-    } catch (error) {
-      console.debug(
-        "Error clearing dynamic elements previous devtools sessions",
-        error
-      );
-    }
   }
 }
 

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -66,27 +66,8 @@ async function installSidebarPane(port: Runtime.Port) {
   );
 }
 
-function installPanel() {
-  // https://developer.chrome.com/extensions/devtools_panels#method-create
-  // https://github.com/facebook/react/blob/master/packages/react-devtools-extensions/src/main.js#L298
-
-  let currentPanel = null;
-
-  chrome.devtools.panels.create(
-    "PixieBrix",
-    "",
-    "devtoolsPanel.html",
-    (panel) => {
-      currentPanel = panel;
-      if (currentPanel === panel) {
-        return;
-      }
-    }
-  );
-}
-
 async function initialize() {
-  installPanel();
+  await browser.devtools.panels.create("PixieBrix", "", "devtoolsPanel.html");
 
   const port = await connectDevtools();
   installSidebarPane(port).catch((error) => {


### PR DESCRIPTION
I was always annoyed by how long it takes for the _tab_ to show up and that it never did if there was an error with the content script.

Both issues could be alleviated this way. You can follow the commits one by one to make more sense of the changes.

However it's still not instant during development, likely because it still needs to execute 13MB of devtools.js