### PR TITLE
#634: bricks to open/close the sidebar

### DIFF
--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -139,7 +139,7 @@ export function isActionPanelVisible(): boolean {
 }
 
 export function getStore(): ActionPanelStore {
-  return { panels: panels };
+  return { panels };
 }
 
 function renderPanels() {
@@ -148,7 +148,7 @@ function renderPanels() {
       type: FORWARD_FRAME_NOTIFICATION,
       payload: {
         type: RENDER_PANELS_MESSAGE,
-        payload: { panels: panels },
+        payload: { panels },
       },
     });
   }

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -76,16 +76,16 @@ function restoreDocumentStyle(): void {
 }
 
 function insertActionPanel(): string {
+  const nonce = uuidv4();
+
   const actionURL = browser.runtime.getURL("action.html");
 
   const $panelContainer = $(
-    `<div id="${PANEL_CONTAINER_ID}" style="height: 100%; margin: 0; padding: 0; border-radius: 0; width: ${SIDEBAR_WIDTH_PX}px; position: fixed; top: 0; right: 0; z-index: 2147483647; border: 1px solid lightgray; background-color: rgb(255, 255, 255); display: block;"></div>`
+    `<div id="${PANEL_CONTAINER_ID}" data-nonce="${nonce}" style="height: 100%; margin: 0; padding: 0; border-radius: 0; width: ${SIDEBAR_WIDTH_PX}px; position: fixed; top: 0; right: 0; z-index: 2147483647; border: 1px solid lightgray; background-color: rgb(255, 255, 255); display: block;"></div>`
   );
 
-  const nonce = uuidv4();
-
   const $frame = $(
-    `<iframe id="pixiebrix-frame" src="${actionURL}?nonce=${nonce}" data-nonce="${nonce}" style="height: 100%; width: ${SIDEBAR_WIDTH_PX}px" allowtransparency="false" frameborder="0" scrolling="no" ></iframe>`
+    `<iframe id="pixiebrix-frame" src="${actionURL}?nonce=${nonce}" style="height: 100%; width: ${SIDEBAR_WIDTH_PX}px" allowtransparency="false" frameborder="0" scrolling="no" ></iframe>`
   );
 
   $panelContainer.append($frame);

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -75,14 +75,7 @@ function restoreDocumentStyle(): void {
   html.css("margin-right", _originalMarginRight);
 }
 
-export function showActionPanel(): string {
-  adjustDocumentStyle();
-
-  if ($("#pixiebrix-chrome-extension").length > 0) {
-    console.warn("Action panel already in DOM");
-    return;
-  }
-
+function appendActionPanel(): void {
   const actionURL = browser.runtime.getURL("action.html");
 
   const $panelContainer = $(
@@ -98,6 +91,19 @@ export function showActionPanel(): string {
   $panelContainer.append($frame);
 
   $("body").append($panelContainer);
+}
+
+export function showActionPanel(): string {
+  adjustDocumentStyle();
+
+  if ($("#pixiebrix-chrome-extension").length > 0) {
+    console.debug("Action panel already in DOM");
+    if (!_nonce) {
+      throw new Error("nonce not set for action panel on page");
+    }
+  } else {
+    appendActionPanel();
+  }
 
   // run the extension points available on the page
   for (const callback of _callbacks) {

--- a/src/actionPanel/protocol.tsx
+++ b/src/actionPanel/protocol.tsx
@@ -69,25 +69,28 @@ export function removeListener(fn: StoreListener): void {
   _listeners = _listeners.filter((x) => x !== fn);
 }
 
+// eslint-disable-next-line @typescript-eslint/promise-function-async -- message listeners cannot be use async keyword
 function actionPanelListener(
   request: RenderPanelsMessage,
   sender: Runtime.MessageSender
 ): Promise<unknown> | undefined {
-  if (allowSender(sender)) {
-    switch (request.type) {
-      case RENDER_PANELS_MESSAGE: {
-        const renderRequest = request as RenderPanelsMessage;
-        console.debug(
-          `Running render panels listeners for ${_listeners.length} listeners`
-        );
-        for (const listener of _listeners) {
-          listener(renderRequest.payload);
-        }
-        return undefined;
+  if (!allowSender(sender)) {
+    return;
+  }
+
+  switch (request.type) {
+    case RENDER_PANELS_MESSAGE: {
+      const renderRequest = request as RenderPanelsMessage;
+      console.debug(
+        `Running render panels listeners for ${_listeners.length} listeners`
+      );
+      for (const listener of _listeners) {
+        listener(renderRequest.payload);
       }
-      default: {
-        // NOP
-      }
+      return undefined;
+    }
+    default: {
+      // NOP
     }
   }
 }

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -18,18 +18,20 @@
 import { isBackgroundPage } from "webext-detect-page";
 import * as contentScript from "@/contentScript/browserAction";
 import { reportError } from "@/telemetry/logging";
-import { ensureContentScript } from "@/background/util";
+import { ensureContentScript, showErrorInOptions } from "@/background/util";
 import { browser, Runtime } from "webextension-polyfill-ts";
 import { allowSender } from "@/actionPanel/protocol";
-import { sleep, isPrivatePageError } from "@/utils";
+import { isPrivatePageError, sleep } from "@/utils";
 import { JsonObject, JsonValue } from "type-fest";
 
-export const MESSAGE_PREFIX = "@@pixiebrix/background/browserAction/";
-
+const MESSAGE_PREFIX = "@@pixiebrix/background/browserAction/";
 export const REGISTER_ACTION_FRAME = `${MESSAGE_PREFIX}/REGISTER_ACTION_FRAME`;
 export const FORWARD_FRAME_NOTIFICATION = `${MESSAGE_PREFIX}/FORWARD_ACTION_FRAME_NOTIFICATION`;
 export const SHOW_ACTION_FRAME = `${MESSAGE_PREFIX}/SHOW_ACTION_FRAME`;
 export const HIDE_ACTION_FRAME = `${MESSAGE_PREFIX}/HIDE_ACTION_FRAME`;
+
+// The sidebar is always injected to into the top level frame
+const TOP_LEVEL_FRAME_ID = 0;
 
 /**
  * Mapping from tabId to the nonce for the browser action iframe
@@ -37,25 +39,16 @@ export const HIDE_ACTION_FRAME = `${MESSAGE_PREFIX}/HIDE_ACTION_FRAME`;
 const tabNonces = new Map<number, string>();
 const tabFrames = new Map<number, number>();
 
-async function showErrorInOptions(id: string, tabIndex: number): Promise<void> {
-  const url = new URL(browser.runtime.getURL("options.html"));
-  url.searchParams.set("error", id);
-  await browser.tabs.create({
-    url: url.toString(),
-    index: tabIndex + 1,
-  });
-}
-
 async function handleBrowserAction(tab: chrome.tabs.Tab): Promise<void> {
-  // We're either getting a new frame, or getting rid of the existing one. Therefore, forget the old frame
+  // We're either getting a new frame, or getting rid of the existing one. Forget the old frame
   // id so we're not sending messages to a dead frame
   tabFrames.delete(tab.id);
 
   try {
-    await ensureContentScript({ tabId: tab.id, frameId: 0 });
+    await ensureContentScript({ tabId: tab.id, frameId: TOP_LEVEL_FRAME_ID });
     const nonce = await contentScript.toggleActionPanel({
       tabId: tab.id,
-      frameId: 0,
+      frameId: TOP_LEVEL_FRAME_ID,
     });
     tabNonces.set(tab.id, nonce);
   } catch (error: unknown) {
@@ -98,7 +91,7 @@ type ForwardActionFrameNotification = {
   };
 };
 
-const RETRY_INTERVAL_MILLIS = 50;
+const FORWARD_RETRY_INTERVAL_MILLIS = 50;
 
 async function forwardWhenReady(
   tabId: number,
@@ -109,7 +102,7 @@ async function forwardWhenReady(
     frameId = tabFrames.get(tabId);
     if (frameId == null) {
       console.debug(`Action frame not ready for tab ${tabId}, waiting...`);
-      await sleep(RETRY_INTERVAL_MILLIS);
+      await sleep(FORWARD_RETRY_INTERVAL_MILLIS);
     }
   } while (frameId == null);
 
@@ -121,7 +114,7 @@ async function forwardWhenReady(
       return await browser.tabs.sendMessage(tabId, message, { frameId });
     } catch (error) {
       if (error?.message?.includes("Could not establish connection")) {
-        await sleep(RETRY_INTERVAL_MILLIS);
+        await sleep(FORWARD_RETRY_INTERVAL_MILLIS);
       } else {
         throw error;
       }
@@ -129,7 +122,8 @@ async function forwardWhenReady(
   }
 }
 
-async function backgroundListener(
+// eslint-disable-next-line @typescript-eslint/promise-function-async -- message listener cannot use async keyword
+function backgroundMessageListener(
   request:
     | RegisterActionFrameMessage
     | ForwardActionFrameNotification
@@ -137,48 +131,52 @@ async function backgroundListener(
     | HideFrameMessage,
   sender: Runtime.MessageSender
 ): Promise<unknown> | undefined {
-  if (allowSender(sender)) {
-    switch (request.type) {
-      case REGISTER_ACTION_FRAME: {
-        const registerAction = request as RegisterActionFrameMessage;
-        if (tabNonces.get(sender.tab.id) !== registerAction.payload.nonce) {
-          console.warn("Action frame nonce mismatch", {
-            expected: tabNonces.get(sender.tab.id),
-            actual: registerAction.payload.nonce,
-          });
-        }
-        console.debug("Setting action frame metadata", {
-          tabId: sender.tab.id,
-          frameId: sender.frameId,
+  if (!allowSender(sender)) {
+    return;
+  }
+
+  switch (request.type) {
+    case REGISTER_ACTION_FRAME: {
+      const registerAction = request as RegisterActionFrameMessage;
+      if (tabNonces.get(sender.tab.id) !== registerAction.payload.nonce) {
+        console.warn("Action frame nonce mismatch", {
+          expected: tabNonces.get(sender.tab.id),
+          actual: registerAction.payload.nonce,
         });
-        tabFrames.set(sender.tab.id, sender.frameId);
-        return;
       }
-      case FORWARD_FRAME_NOTIFICATION: {
-        const forwardAction = request as ForwardActionFrameNotification;
-        return forwardWhenReady(sender.tab.id, forwardAction.payload).catch(
-          reportError
-        );
-      }
-      case SHOW_ACTION_FRAME: {
-        tabFrames.delete(sender.tab.id);
-        return contentScript
-          .showActionPanel({ tabId: sender.tab.id, frameId: 0 })
-          .then((nonce) => {
-            tabNonces.set(sender.tab.id, nonce);
-          });
-      }
-      case HIDE_ACTION_FRAME: {
-        tabFrames.delete(sender.tab.id);
-        return contentScript
-          .hideActionPanel({ tabId: sender.tab.id, frameId: 0 })
-          .then(() => {
-            tabNonces.delete(sender.tab.id);
-          });
-      }
-      default: {
-        // NOOP
-      }
+      console.debug("Setting action frame metadata", {
+        tabId: sender.tab.id,
+        frameId: sender.frameId,
+      });
+      tabFrames.set(sender.tab.id, sender.frameId);
+      return;
+    }
+    case FORWARD_FRAME_NOTIFICATION: {
+      const forwardAction = request as ForwardActionFrameNotification;
+      return forwardWhenReady(sender.tab.id, forwardAction.payload).catch(
+        reportError
+      );
+    }
+    case SHOW_ACTION_FRAME: {
+      console.debug("Handle %s", SHOW_ACTION_FRAME, { sender });
+      tabFrames.delete(sender.tab.id);
+      return contentScript
+        .showActionPanel({ tabId: sender.tab.id, frameId: TOP_LEVEL_FRAME_ID })
+        .then((nonce) => {
+          tabNonces.set(sender.tab.id, nonce);
+        });
+    }
+    case HIDE_ACTION_FRAME: {
+      console.debug("Handle %s", HIDE_ACTION_FRAME, { sender });
+      tabFrames.delete(sender.tab.id);
+      return contentScript
+        .hideActionPanel({ tabId: sender.tab.id, frameId: TOP_LEVEL_FRAME_ID })
+        .then(() => {
+          tabNonces.delete(sender.tab.id);
+        });
+    }
+    default: {
+      // NOOP
     }
   }
 }
@@ -186,5 +184,5 @@ async function backgroundListener(
 if (isBackgroundPage()) {
   chrome.browserAction.onClicked.addListener(handleBrowserAction);
   console.debug("Installed browserAction click listener");
-  browser.runtime.onMessage.addListener(backgroundListener);
+  browser.runtime.onMessage.addListener(backgroundMessageListener);
 }

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -126,6 +126,7 @@ async function waitReady(
   return true;
 }
 
+// eslint-disable-next-line @typescript-eslint/promise-function-async -- message listener cannot use async keyword
 function backgroundListener(
   request: RunBlockAction | OpenTabAction,
   sender: Runtime.MessageSender
@@ -194,7 +195,7 @@ function backgroundListener(
       console.debug(`Waiting for frame with nonce ${nonce} to be ready`);
       return waitNonceReady(nonce, {
         isAvailable: payload.options.isAvailable,
-      }).then(() => {
+      }).then(async () => {
         const target = nonceToTarget.get(nonce);
         console.debug(
           `Sending ${CONTENT_MESSAGE_RUN_BLOCK} to target tab ${target.tabId} frame ${target.frameId} (sender=${sender.tab.id})`
@@ -221,7 +222,7 @@ function backgroundListener(
 
       console.debug(`Waiting for target tab ${target} to be ready`);
       // for now, only support top-level frame as target
-      return waitReady({ tabId: target, frameId: 0 }).then(() => {
+      return waitReady({ tabId: target, frameId: 0 }).then(async () => {
         console.debug(
           `Sending ${CONTENT_MESSAGE_RUN_BLOCK} to target tab ${target} (sender=${sender.tab.id})`
         );
@@ -289,6 +290,9 @@ function backgroundListener(
       return Promise.resolve();
     }
     case MESSAGE_CONTENT_SCRIPT_ECHO_SENDER: {
+      console.debug("Responding %s", MESSAGE_CONTENT_SCRIPT_ECHO_SENDER, {
+        sender,
+      });
       return Promise.resolve(sender);
     }
     default: {

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -53,7 +53,7 @@ const handlers: Map<string, HandlerEntry> = new Map();
 export function allowBackgroundSender(
   sender: ChromeMessageSender | Runtime.MessageSender
 ): boolean {
-  if (!sender) {
+  if (sender == null) {
     return false;
   }
   const { externally_connectable } = chrome.runtime.getManifest();
@@ -64,6 +64,7 @@ export function allowBackgroundSender(
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/promise-function-async -- message listener cannot use async keyword
 function backgroundListener(
   request: RemoteProcedureCallRequest,
   sender: Runtime.MessageSender

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -139,3 +139,20 @@ export async function ensureContentScript(target: Target): Promise<void> {
     controller.abort();
   }
 }
+
+/**
+ * Open a new tab for the options page, showing an error message with the given errorId
+ * @param errorId unique identifier for the error message
+ * @param tabIndex index of the source tab, to determine location of new tab
+ */
+export async function showErrorInOptions(
+  errorId: string,
+  tabIndex?: number
+): Promise<void> {
+  const url = new URL(browser.runtime.getURL("options.html"));
+  url.searchParams.set("error", errorId);
+  await browser.tabs.create({
+    url: url.toString(),
+    index: tabIndex == null ? undefined : tabIndex + 1,
+  });
+}

--- a/src/blocks/effects/index.ts
+++ b/src/blocks/effects/index.ts
@@ -30,3 +30,4 @@ export * from "./alert";
 export * from "./pageState";
 export * from "./hide";
 export * from "./exportCSV";
+export * from "./sidebar";

--- a/src/blocks/effects/sidebar.ts
+++ b/src/blocks/effects/sidebar.ts
@@ -24,7 +24,7 @@ import {
   SHOW_ACTION_FRAME,
 } from "@/background/browserAction";
 
-const noParams: Schema = {
+const NO_PARAMS: Schema = {
   $schema: "https://json-schema.org/draft/2019-09/schema#",
   type: "object",
   properties: {},
@@ -39,11 +39,13 @@ export class ShowSidebar extends Effect {
     );
   }
 
-  inputSchema: Schema = noParams;
+  inputSchema: Schema = NO_PARAMS;
 
   async effect(): Promise<void> {
+    console.debug("show sidebar");
     await browser.runtime.sendMessage({
       type: SHOW_ACTION_FRAME,
+      payload: {},
     });
   }
 }
@@ -57,11 +59,12 @@ export class HideSidebar extends Effect {
     );
   }
 
-  inputSchema: Schema = noParams;
+  inputSchema: Schema = NO_PARAMS;
 
   async effect(): Promise<void> {
     await browser.runtime.sendMessage({
       type: HIDE_ACTION_FRAME,
+      payload: {},
     });
   }
 }

--- a/src/blocks/effects/sidebar.ts
+++ b/src/blocks/effects/sidebar.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 Pixie Brix, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Effect } from "@/types";
+import { registerBlock } from "@/blocks/registry";
+import { Schema } from "@/core";
+import { browser } from "webextension-polyfill-ts";
+import {
+  HIDE_ACTION_FRAME,
+  SHOW_ACTION_FRAME,
+} from "@/background/browserAction";
+
+const noParams: Schema = {
+  $schema: "https://json-schema.org/draft/2019-09/schema#",
+  type: "object",
+  properties: {},
+};
+
+export class ShowSidebar extends Effect {
+  constructor() {
+    super(
+      "@pixiebrix/sidebar/show",
+      "Show Sidebar",
+      "Show/open the PixieBrix sidebar"
+    );
+  }
+
+  inputSchema: Schema = noParams;
+
+  async effect(): Promise<void> {
+    await browser.runtime.sendMessage({
+      type: SHOW_ACTION_FRAME,
+    });
+  }
+}
+
+export class HideSidebar extends Effect {
+  constructor() {
+    super(
+      "@pixiebrix/sidebar/hide",
+      "Hide Sidebar",
+      "Hide/close the PixieBrix sidebar"
+    );
+  }
+
+  inputSchema: Schema = noParams;
+
+  async effect(): Promise<void> {
+    await browser.runtime.sendMessage({
+      type: HIDE_ACTION_FRAME,
+    });
+  }
+}
+
+registerBlock(new ShowSidebar());
+registerBlock(new HideSidebar());

--- a/src/contentScript/browserAction.ts
+++ b/src/contentScript/browserAction.ts
@@ -16,11 +16,21 @@
  */
 
 import { liftContentScript } from "@/contentScript/backgroundProtocol";
-import { toggleActionPanel as toggle } from "@/actionPanel/native";
+import * as native from "@/actionPanel/native";
 
 export const toggleActionPanel = liftContentScript(
   "TOGGLE_ACTION_PANEL",
   async () => {
-    return toggle();
+    return native.toggleActionPanel();
   }
+);
+
+export const showActionPanel = liftContentScript(
+  "SHOW_ACTION_PANEL",
+  async () => native.showActionPanel()
+);
+
+export const hideActionPanel = liftContentScript(
+  "HIDE_ACTION_PANEL",
+  async () => native.hideActionPanel()
 );

--- a/src/contentScript/connection.ts
+++ b/src/contentScript/connection.ts
@@ -21,8 +21,10 @@ let _hooks: NotificationCallbacks = null;
 
 export function showConnectionLost(): void {
   if (_hooks) {
+    // Don't show connection notification if it's already being displayed
     return null;
   }
+
   const element = $.notify(
     "Connection to PixieBrix lost. Please reload the page",
     {

--- a/src/contentScript/errors.ts
+++ b/src/contentScript/errors.ts
@@ -20,20 +20,20 @@ import { showConnectionLost } from "@/contentScript/connection";
 import { reportError } from "@/telemetry/logging";
 
 function addErrorListeners(): void {
-  window.addEventListener("error", function (e) {
-    if (isConnectionError(e)) {
+  window.addEventListener("error", function (error) {
+    if (isConnectionError(error)) {
       showConnectionLost();
     } else {
-      reportError(e);
+      reportError(error);
       return false;
     }
   });
 
-  window.addEventListener("unhandledrejection", function (e) {
-    if (isConnectionError(e)) {
+  window.addEventListener("unhandledrejection", function (error) {
+    if (isConnectionError(error)) {
       showConnectionLost();
     } else {
-      reportError(e);
+      reportError(error);
     }
   });
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -160,5 +160,8 @@ export const isChrome =
   typeof navigator === "object" &&
   navigator.userAgent.toLowerCase().includes("chrome");
 
+/**
+ * True if the script is executing in a web browser context.
+ */
 export const isBrowser =
   typeof window !== "undefined" && typeof window.document !== "undefined";

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -159,3 +159,6 @@ export function inputProperties(inputSchema: Schema): SchemaProperties {
 export const isChrome =
   typeof navigator === "object" &&
   navigator.userAgent.toLowerCase().includes("chrome");
+
+export const isBrowser =
+  typeof window !== "undefined" && typeof window.document !== "undefined";

--- a/src/utils/expectContext.ts
+++ b/src/utils/expectContext.ts
@@ -46,7 +46,7 @@ function createError(
  */
 export function expectBackgroundPage(error?: ErrorBaseType): void {
   if (!isBackgroundPage()) {
-    throw createError(`This code can only run in the background page`, error);
+    throw createError("This code can only run in the background page", error);
   }
 }
 
@@ -58,7 +58,7 @@ export function expectBackgroundPage(error?: ErrorBaseType): void {
  */
 export function expectContentScript(error?: ErrorBaseType): void {
   if (!isContentScript()) {
-    throw createError(`This code can only run in the content script`, error);
+    throw createError("This code can only run in the content script", error);
   }
 }
 
@@ -70,7 +70,7 @@ export function expectContentScript(error?: ErrorBaseType): void {
  */
 export function forbidBackgroundPage(error?: ErrorBaseType): void {
   if (isBackgroundPage()) {
-    throw createError(`This code cannot run in the background page`, error);
+    throw createError("This code cannot run in the background page", error);
   }
 }
 


### PR DESCRIPTION
- Add warning suppressions for `promise-function-async` on message listeners because the async keyword breaks the behavior (and the warning is auto-fixable, so eslint was breaking them)
- Simplifies the sidebar state logic. Instead of tracking the nonce/state separately separately in the content script, it just uses the HTML element for it
- Adds `@pixiebrix/sidebar/hide` and `@pixiebrix/sidebar/show` bricks. The show brick is more important, as there's situations where we want to show a panel if certain conditions are met on the page

@fregante adding you as a reviewer since this touches the messaging code

Closes #634 