### PR TITLE
Drop `clipboardWrite` optional permission

### DIFF
--- a/browsers/manifest.json
+++ b/browsers/manifest.json
@@ -20,7 +20,7 @@
       "run_at": "document_idle"
     }
   ],
-  "optional_permissions": ["notifications", "clipboardWrite", "*://*/*"],
+  "optional_permissions": ["notifications", "*://*/*"],
   "permissions": [
     "activeTab",
     "storage",

--- a/src/blocks/effects/clipboard.ts
+++ b/src/blocks/effects/clipboard.ts
@@ -19,7 +19,6 @@ import { Effect } from "@/types";
 import { registerBlock } from "@/blocks/registry";
 import copy from "copy-to-clipboard";
 import { BlockArg, Schema } from "@/core";
-import { Permissions } from "webextension-polyfill-ts";
 
 export class CopyToClipboard extends Effect {
   constructor() {
@@ -29,10 +28,6 @@ export class CopyToClipboard extends Effect {
       "Copy content to your clipboard"
     );
   }
-
-  permissions: Permissions.Permissions = {
-    permissions: ["clipboardWrite"],
-  };
 
   inputSchema: Schema = {
     $schema: "https://json-schema.org/draft/2019-09/schema#",


### PR DESCRIPTION
It appears that `cliboardWrite` is not required to write into the clipboard with regular browser APIs from the content script, but I'm not entirely sure whether this has some limitations. You can see the brick working even if I deny the extra permission:

![gif](https://user-images.githubusercontent.com/1402241/124876864-ae0c7b80-dff4-11eb-8681-604dc2317d0e.gif)

I also tried delaying the `copy` call via setTimeout (to check whether user input was required) and the copy did in fact fail **but** it failed regardless of clipboardWrite. The module used to wrap the clipboard API works around this by showing a `prompt()` either way:

<img width="545" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/124878645-83232700-dff6-11eb-9393-19a0a7171de6.png">


Related:

- https://github.com/sindresorhus/refined-github/pull/1756