### PR TITLE
Allow use of `await` in message handlers

### DIFF
--- a/src/actionPanel/protocol.tsx
+++ b/src/actionPanel/protocol.tsx
@@ -69,7 +69,7 @@ export function removeListener(fn: StoreListener): void {
   _listeners = _listeners.filter((x) => x !== fn);
 }
 
-const handlers = new Map<string, typeof actionPanelListener>([]);
+const handlers = new Map<string, typeof actionPanelListener>();
 
 handlers.set(RENDER_PANELS_MESSAGE, async (request) => {
   const renderRequest = request as RenderPanelsMessage;

--- a/src/actionPanel/protocol.tsx
+++ b/src/actionPanel/protocol.tsx
@@ -69,11 +69,10 @@ export function removeListener(fn: StoreListener): void {
   _listeners = _listeners.filter((x) => x !== fn);
 }
 
-// eslint-disable-next-line @typescript-eslint/promise-function-async -- message listeners cannot be use async keyword
 function actionPanelListener(
   request: RenderPanelsMessage,
   sender: Runtime.MessageSender
-): Promise<unknown> | undefined {
+): Promise<unknown> | void {
   if (!allowSender(sender)) {
     return;
   }

--- a/src/actionPanel/protocol.tsx
+++ b/src/actionPanel/protocol.tsx
@@ -17,14 +17,11 @@
 
 import { browser, Runtime } from "webextension-polyfill-ts";
 import { isBrowserActionPanel } from "@/chrome";
+import { allowSender } from "@/messaging/protocol";
 
 export const MESSAGE_PREFIX = "@@pixiebrix/browserAction/";
 
 export const RENDER_PANELS_MESSAGE = `${MESSAGE_PREFIX}RENDER_PANELS`;
-
-export function allowSender(sender: Runtime.MessageSender): boolean {
-  return sender.id === browser.runtime.id;
-}
 
 /**
  * Information required to run a renderer
@@ -71,13 +68,12 @@ export function removeListener(fn: StoreListener): void {
 
 const handlers = new Map<string, typeof actionPanelListener>();
 
-handlers.set(RENDER_PANELS_MESSAGE, async (request) => {
-  const renderRequest = request as RenderPanelsMessage;
+handlers.set(RENDER_PANELS_MESSAGE, async (request: RenderPanelsMessage) => {
   console.debug(
     `Running render panels listeners for ${_listeners.length} listeners`
   );
   for (const listener of _listeners) {
-    listener(renderRequest.payload);
+    listener(request.payload);
   }
 });
 

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -154,23 +154,20 @@ handlers.set(FORWARD_FRAME_NOTIFICATION, async (request, sender) => {
 handlers.set(SHOW_ACTION_FRAME, async (_, sender) => {
   const tabId = sender.tab.id;
   tabFrames.delete(tabId);
-  return contentScript
-    .showActionPanel({ tabId, frameId: TOP_LEVEL_FRAME_ID })
-    .then((nonce) => {
-      console.debug("Setting action frame nonce", { sender, nonce });
-      tabNonces.set(tabId, nonce);
-    });
+  const nonce = await contentScript.showActionPanel({
+    tabId,
+    frameId: TOP_LEVEL_FRAME_ID,
+  });
+  console.debug("Setting action frame nonce", { sender, nonce });
+  tabNonces.set(tabId, nonce);
 });
 
 handlers.set(HIDE_ACTION_FRAME, async (_, sender) => {
   const tabId = sender.tab.id;
   tabFrames.delete(tabId);
-  return contentScript
-    .hideActionPanel({ tabId, frameId: TOP_LEVEL_FRAME_ID })
-    .then(() => {
-      console.debug("Clearing action frame nonce", { sender, nonce });
-      tabNonces.delete(tabId);
-    });
+  await contentScript.hideActionPanel({ tabId, frameId: TOP_LEVEL_FRAME_ID });
+  console.debug("Clearing action frame nonce", { sender, nonce });
+  tabNonces.delete(tabId);
 });
 
 function backgroundMessageListener(

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -126,7 +126,6 @@ async function forwardWhenReady(
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/promise-function-async -- message listener cannot use async keyword
 function backgroundMessageListener(
   request:
     | RegisterActionFrameMessage
@@ -134,7 +133,7 @@ function backgroundMessageListener(
     | ShowFrameMessage
     | HideFrameMessage,
   sender: Runtime.MessageSender
-): Promise<unknown> | undefined {
+): Promise<unknown> | void {
   if (!allowSender(sender)) {
     return;
   }

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -126,7 +126,7 @@ async function forwardWhenReady(
   }
 }
 
-const handlers = new Map<string, typeof backgroundMessageListener>([]);
+const handlers = new Map<string, typeof backgroundMessageListener>();
 
 handlers.set(REGISTER_ACTION_FRAME, async (request, sender) => {
   const tabId = sender.tab.id;

--- a/src/background/devtools/contract.ts
+++ b/src/background/devtools/contract.ts
@@ -57,4 +57,5 @@ export interface Meta {
   nonce: Nonce;
   tabId: TabId;
   frameId: number;
+  [index: string]: unknown;
 }

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -28,11 +28,11 @@ import {
   BackgroundEventType,
   HandlerEntry,
   MESSAGE_PREFIX,
-  Meta,
   PORT_NAME,
   PromiseHandler,
   TabId,
   Target,
+  Meta,
 } from "@/background/devtools/contract";
 import { reportError } from "@/telemetry/logging";
 import { isBackgroundPage } from "webext-detect-page";

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -285,11 +285,15 @@ handlers.set(MESSAGE_CONTENT_SCRIPT_ECHO_SENDER, async (request, sender) => {
   return sender;
 });
 
+function allowSender(sender: Runtime.MessageSender): boolean {
+  return sender.id === browser.runtime.id;
+}
+
 function backgroundListener(
   request: RunBlockAction | OpenTabAction,
   sender: Runtime.MessageSender
 ): Promise<unknown> | void {
-  if (sender.id !== browser.runtime.id) {
+  if (!allowSender(sender)) {
     return;
   }
 

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -34,6 +34,7 @@ import {
   expectBackgroundPage,
   expectContentScript,
 } from "@/utils/expectContext";
+import { allowSender } from "@/messaging/protocol";
 
 const MESSAGE_RUN_BLOCK_OPENER = `${MESSAGE_PREFIX}RUN_BLOCK_OPENER`;
 const MESSAGE_RUN_BLOCK_TARGET = `${MESSAGE_PREFIX}RUN_BLOCK_TARGET`;
@@ -284,10 +285,6 @@ handlers.set(MESSAGE_CONTENT_SCRIPT_ECHO_SENDER, async (request, sender) => {
   });
   return sender;
 });
-
-function allowSender(sender: Runtime.MessageSender): boolean {
-  return sender.id === browser.runtime.id;
-}
 
 function backgroundListener(
   request: RunBlockAction | OpenTabAction,

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -126,7 +126,7 @@ async function waitReady(
   return true;
 }
 
-const handlers = new Map<string, typeof backgroundListener>([]);
+const handlers = new Map<string, typeof backgroundListener>();
 
 handlers.set(MESSAGE_RUN_BLOCK_OPENER, async (request, sender) => {
   const opener = tabToOpener.get(sender.tab.id);

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -126,11 +126,10 @@ async function waitReady(
   return true;
 }
 
-// eslint-disable-next-line @typescript-eslint/promise-function-async -- message listener cannot use async keyword
 function backgroundListener(
   request: RunBlockAction | OpenTabAction,
   sender: Runtime.MessageSender
-): Promise<unknown> | undefined {
+): Promise<unknown> | void {
   if (sender.id !== browser.runtime.id) {
     return;
   }

--- a/src/background/iframes.ts
+++ b/src/background/iframes.ts
@@ -18,7 +18,7 @@
 import { FORWARD_FRAME_DATA, REQUEST_FRAME_DATA } from "@/messaging/constants";
 type MessageSender = chrome.runtime.MessageSender;
 
-const _frameData: { [key: string]: string } = {};
+const frameHTML = new Map<string, string>();
 
 type Request =
   | {
@@ -39,15 +39,14 @@ function initFrames(): void {
       case FORWARD_FRAME_DATA: {
         console.log("request", { request });
         const { frameId, html } = request.payload;
-        _frameData[frameId] = html;
+        frameHTML.set(frameId, html);
         sendResponse({});
         return true;
       }
       case REQUEST_FRAME_DATA: {
         const { id } = request.payload;
-        console.log(`Frame data for ${id}`, { _frameData });
-        sendResponse({ html: _frameData[id] });
-        delete _frameData[id];
+        sendResponse({ html: frameHTML.get(id) });
+        frameHTML.delete(id);
         return true;
       }
       default: {

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -64,11 +64,10 @@ export function allowBackgroundSender(
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/promise-function-async -- message listener cannot use async keyword
 function backgroundListener(
   request: RemoteProcedureCallRequest,
   sender: Runtime.MessageSender
-): Promise<unknown> | undefined {
+): Promise<unknown> | void {
   // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
   // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage
 

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -64,7 +64,7 @@ async function handleRequest(
   }
 
   try {
-    await handler(...payload);
+    return await handler(...payload);
   } catch (error) {
     console.debug(`Handler returning error response for ${type}`, {
       error,

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -50,11 +50,10 @@ export function allowSender(sender: Runtime.MessageSender): boolean {
   return sender.id === browser.runtime.id;
 }
 
-// eslint-disable-next-line @typescript-eslint/promise-function-async -- message listener cannot use async keyword
 function contentScriptListener(
   request: RemoteProcedureCallRequest,
   sender: Runtime.MessageSender
-): Promise<unknown> | undefined {
+): Promise<unknown> | void {
   const { type, payload } = request;
   const { handler, options } = handlers.get(type) ?? {};
 

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -72,18 +72,6 @@ async function handleRequest(
     );
   }
 }
-function contentScriptListener(
-  request: RemoteProcedureCallRequest,
-  sender: Runtime.MessageSender
-): Promise<unknown> | void {
-  if (!allowSender(sender)) {
-    return;
-  }
-
-  if (handlers.has(request.type)) {
-    return handleRequest(request);
-  }
-}
 
 async function getTabIds(): Promise<number[]> {
   const tabs = await browser.tabs.query({});
@@ -258,6 +246,21 @@ export function liftContentScript<R extends SerializableResponse>(
 
     return response;
   };
+}
+
+function contentScriptListener(
+  request: RemoteProcedureCallRequest,
+  sender: Runtime.MessageSender
+): Promise<unknown> | void {
+  // Returning "undefined" indicates that the message has not been handled
+
+  if (!allowSender(sender)) {
+    return;
+  }
+
+  if (handlers.has(request.type)) {
+    return handleRequest(request);
+  }
 }
 
 function addContentScriptListener(): void {

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  allowSender,
   HandlerEntry,
   HandlerOptions,
   isErrorResponse,
@@ -45,10 +46,6 @@ export class ContentScriptActionError extends Error {
 }
 
 const handlers = new Map<string, HandlerEntry>();
-
-export function allowSender(sender: Runtime.MessageSender): boolean {
-  return sender.id === browser.runtime.id;
-}
 
 async function handleRequest(
   request: RemoteProcedureCallRequest

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -58,20 +58,21 @@ async function handleRequest(
 
   console.debug(`Handling contentScript action ${type}`);
 
-  const handlerPromise = new Promise((resolve) => resolve(handler(...payload)));
-
   if (isNotification(options)) {
+    handler(...payload);
     return;
-  } else {
-    return handlerPromise.catch((error) => {
-      console.debug(`Handler returning error response for ${type}`, {
-        error,
-      });
-      return toErrorResponse(
-        type,
-        error ?? new Error("Unknown error in content script handler")
-      );
+  }
+
+  try {
+    await handler(...payload);
+  } catch (error) {
+    console.debug(`Handler returning error response for ${type}`, {
+      error,
     });
+    return toErrorResponse(
+      type,
+      error ?? new Error("Unknown error in content script handler")
+    );
   }
 }
 function contentScriptListener(

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -21,7 +21,6 @@ import { BackgroundLogger } from "@/background/logging";
 import { MessageContext } from "@/core";
 import {
   MESSAGE_PREFIX,
-  allowSender,
   liftContentScript,
 } from "@/contentScript/backgroundProtocol";
 import { Availability } from "@/blocks/types";
@@ -30,6 +29,7 @@ import { markReady } from "./context";
 import { ENSURE_CONTENT_SCRIPT_READY } from "@/messaging/constants";
 import { expectContentScript } from "@/utils/expectContext";
 import { ConnectionError } from "@/errors";
+import { allowSender } from "@/messaging/protocol";
 
 export const MESSAGE_CHECK_AVAILABILITY = `${MESSAGE_PREFIX}CHECK_AVAILABILITY`;
 export const MESSAGE_RUN_BLOCK = `${MESSAGE_PREFIX}RUN_BLOCK`;

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -63,7 +63,7 @@ export interface RunBlockAction {
 
 const childTabs = new Set<number>();
 
-const handlers = new Map<string, typeof runBlockAction>([]);
+const handlers = new Map<string, typeof runBlockAction>();
 
 handlers.set(MESSAGE_RUN_BLOCK, async (request) => {
   const { blockId, blockArgs, options } = (request as RunBlockAction).payload;

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -63,11 +63,10 @@ export interface RunBlockAction {
 
 const childTabs = new Set<number>();
 
-// eslint-disable-next-line @typescript-eslint/promise-function-async -- message listeners cannot use async keyword
 function runBlockAction(
   request: RunBlockAction | CheckAvailabilityAction,
   sender: Runtime.MessageSender
-): Promise<unknown> | undefined {
+): Promise<unknown> | void {
   const { type } = request;
 
   if (!allowSender(sender)) {

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -71,13 +71,12 @@ handlers.set(MESSAGE_RUN_BLOCK, async (request) => {
   // if (!childTabs.has(sourceTabId)) {
   //   return Promise.reject("Unknown source tab id");
   // }
-  return blockRegistry.lookup(blockId).then(async (block) => {
-    const logger = new BackgroundLogger(options.messageContext);
-    return block.run(blockArgs, {
-      ctxt: options.ctxt,
-      logger,
-      root: document,
-    });
+  const block = await blockRegistry.lookup(blockId);
+  const logger = new BackgroundLogger(options.messageContext);
+  return block.run(blockArgs, {
+    ctxt: options.ctxt,
+    logger,
+    root: document,
   });
 });
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -31,9 +31,25 @@ export type SchemaProperties = Record<string, SchemaDefinition>;
 
 export type RenderedHTML = string;
 
-export interface Message<Type extends string = string> {
+export type ActionType = string;
+
+export interface Meta {
+  nonce?: string;
+  [index: string]: unknown;
+}
+
+/**
+ * Standard message format for cross-context messaging.
+ *
+ * Inspired by: https://github.com/redux-utilities/flux-standard-action
+ */
+export interface Message<
+  Type extends ActionType = ActionType,
+  TMeta extends Meta = Meta
+> {
   type: Type;
   payload?: unknown;
+  meta?: TMeta;
 }
 
 export interface MessageContext {

--- a/src/core.ts
+++ b/src/core.ts
@@ -31,8 +31,8 @@ export type SchemaProperties = Record<string, SchemaDefinition>;
 
 export type RenderedHTML = string;
 
-export interface Message {
-  type: string;
+export interface Message<Type extends string = string> {
+  type: Type;
   payload?: unknown;
 }
 


### PR DESCRIPTION
An extension to this other PR that I never did because it required moving around a bit more code

- https://github.com/pixiebrix/pixiebrix-extension/pull/487

Improvements:

- instead of an ever-growing number of unrelated message handlers in a single function under a `switch`, now we have independent one-message-type handlers
- separate handlers means we can finally use async/await 
- Many of these onMessage listeners are now actually identical (makes you wonder if these intermediary handlers could be deduplicated even further!)

I tried not to change the behavior at all, even when sometimes I'm not sure whether returning a Promised value was intentional or just a way to `await` a value before responding (e.g. `return browser.runtime.sendMessage()` doesn't immediately make sense to me)


Review advice:

- Hiding whitespace changes in the diff might make the most sense
- Changes are committed by type, ~~so it might be easier to understand them one by one first~~
- The "extract" commits make no changes to the handlers themselves except moving it around

