### PR TITLE
#753: button to refresh service auths in page editor

### DIFF
--- a/src/background/locator.ts
+++ b/src/background/locator.ts
@@ -27,7 +27,7 @@ async function initLocator() {
 
 export const locate = liftBackground(
   "LOCATE_SERVICE",
-  (serviceId: string, id: string | null) => locator.locate(serviceId, id)
+  async (serviceId: string, id: string | null) => locator.locate(serviceId, id)
 );
 
 export const refresh: (options?: {
@@ -50,7 +50,7 @@ export const refresh: (options?: {
 );
 
 if (isBackgroundPage()) {
-  initLocator().then(() => {
+  void initLocator().then(() => {
     console.debug("Eagerly initialized service locator");
   });
 }

--- a/src/components/logViewer/details/NetworkErrorDetail.tsx
+++ b/src/components/logViewer/details/NetworkErrorDetail.tsx
@@ -120,7 +120,7 @@ const NetworkErrorDetail: React.FunctionComponent<{ error: AxiosError }> = ({
                 that PixieBrix has permission to the access the host. If
                 PixieBrix is not showing a Grant Permissions button, ensure that
                 the integration has an{" "}
-                <code className="px-0 mx-0">isAvailable</code> defined
+                <code className="px-0 mx-0">isAvailable</code> section defined
               </li>
               <li>The remote server did not respond. Try the request again</li>
             </ul>

--- a/src/devTools/editor/tabs/ServicesTab.scss
+++ b/src/devTools/editor/tabs/ServicesTab.scss
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.ServicesTable {
+  td {
+    vertical-align: middle !important;
+  }
+
+  .form-group {
+    margin-bottom: 0;
+  }
+}

--- a/src/devTools/editor/tabs/ServicesTab.tsx
+++ b/src/devTools/editor/tabs/ServicesTab.tsx
@@ -15,17 +15,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from "react";
-import { Tab, Table } from "react-bootstrap";
+import React, { useCallback, useState } from "react";
+import { Button, Tab, Table } from "react-bootstrap";
 import { FieldArray, useField } from "formik";
 import { ServiceDependency } from "@/core";
 import { DependencyRow } from "@/options/pages/extensionEditor/ServicesFormCard";
 import { useAuthOptions } from "@/options/pages/extensionEditor/ServiceAuthSelector";
 import { head } from "lodash";
-import { useFetch } from "@/hooks/fetch";
 import { ServiceDefinition } from "@/types/definitions";
 import ServiceModal from "@/components/fields/ServiceModal";
 import { PACKAGE_REGEX } from "@/blocks/types";
+import useFetch from "@/hooks/useFetch";
+import AsyncButton from "@/components/AsyncButton";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCloud, faPlus, faSync } from "@fortawesome/free-solid-svg-icons";
+import { browser } from "webextension-polyfill-ts";
+import { useToasts } from "react-toast-notifications";
+
+import "./ServicesTab.scss";
 
 function defaultOutputKey(serviceId: string): string {
   const match = PACKAGE_REGEX.exec(serviceId);
@@ -36,10 +43,18 @@ const ServicesTab: React.FunctionComponent<{
   name?: string;
   eventKey?: string;
 }> = ({ name = "services", eventKey = "services" }) => {
+  const { addToast } = useToasts();
   const [field, meta] = useField(name);
   const [selectKey, setKey] = useState(0);
-  const [authOptions] = useAuthOptions();
-  const services = useFetch<ServiceDefinition[]>("/api/services/");
+
+  const [authOptions, refreshAuths] = useAuthOptions();
+  const { data: services, refresh: refreshServices } = useFetch<
+    ServiceDefinition[]
+  >("/api/services/");
+
+  const refresh = useCallback(async () => {
+    return Promise.all([refreshServices(), refreshAuths()]);
+  }, [refreshAuths, refreshServices]);
 
   return (
     <Tab.Pane eventKey={eventKey} className="h-100">
@@ -51,55 +66,91 @@ const ServicesTab: React.FunctionComponent<{
       <FieldArray name={name}>
         {({ push, remove }) => (
           <div>
-            <div>
-              <ServiceModal
-                key={selectKey}
-                caption="Add Integration"
-                services={services}
-                onSelect={(x) => {
-                  push({
-                    id: x.metadata.id,
-                    outputKey: defaultOutputKey(x.metadata.id),
-                    config: head(
-                      authOptions.filter(
-                        (option) =>
-                          option.local && option.serviceId === x.metadata.id
-                      )
-                    )?.value,
-                  });
-                  // reset value in dropdown
-                  setKey((k) => k + 1);
-                }}
-              />
+            <div className="d-flex">
+              <div>
+                <ServiceModal
+                  key={selectKey}
+                  caption="Add Integration"
+                  services={services}
+                  renderButton={({ setShow }) => (
+                    <Button variant="primary" onClick={() => setShow(true)}>
+                      <FontAwesomeIcon icon={faPlus} /> Add Integration
+                    </Button>
+                  )}
+                  onSelect={(x) => {
+                    push({
+                      id: x.metadata.id,
+                      outputKey: defaultOutputKey(x.metadata.id),
+                      config: head(
+                        authOptions.filter(
+                          (option) =>
+                            option.local && option.serviceId === x.metadata.id
+                        )
+                      )?.value,
+                    });
+                    // reset value in dropdown
+                    setKey((k) => k + 1);
+                  }}
+                />
+              </div>
+              {/* spacer */}
+              <div className="flex-grow-1" />
+              <div>
+                <Button
+                  variant="link"
+                  onClick={async () => {
+                    const baseUrl = browser.runtime.getURL("options.html");
+                    const url = `${baseUrl}#/services`;
+                    await browser.tabs.create({ url, active: true });
+                  }}
+                >
+                  <FontAwesomeIcon icon={faCloud} /> Open Services Page
+                </Button>
+                <AsyncButton
+                  onClick={async () => {
+                    await refresh();
+                    addToast("Refreshed available integration configurations", {
+                      appearance: "success",
+                      autoDismiss: true,
+                    });
+                  }}
+                  variant="info"
+                >
+                  <FontAwesomeIcon icon={faSync} /> Refresh Available
+                </AsyncButton>
+              </div>
             </div>
             {typeof meta.error === "string" && <span>{meta.error}</span>}
-
-            {field.value?.length > 0 && (
-              <Table>
-                <thead>
+            <Table className="ServicesTable">
+              <thead>
+                <tr>
+                  <th style={{ width: 250 }}>Key</th>
+                  <th>Type</th>
+                  <th style={{ width: 350 }}>Service</th>
+                  <th>&nbsp;</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(field.value ?? []).length === 0 && (
                   <tr>
-                    <th style={{ width: 250 }}>Key</th>
-                    <th>Type</th>
-                    <th style={{ width: 350 }}>Service</th>
-                    <th>&nbsp;</th>
+                    <td colSpan={4}>No integrations added yet</td>
                   </tr>
-                </thead>
-                <tbody>
-                  {field.value.map(
-                    (dependency: ServiceDependency, index: number) => (
-                      <DependencyRow
-                        key={index}
-                        field={field}
-                        authOptions={authOptions}
-                        dependency={dependency}
-                        index={index}
-                        remove={remove}
-                      />
-                    )
-                  )}
-                </tbody>
-              </Table>
-            )}
+                )}
+
+                {(field.value ?? []).map(
+                  (dependency: ServiceDependency, index: number) => (
+                    <DependencyRow
+                      key={index}
+                      field={field}
+                      authOptions={authOptions}
+                      dependency={dependency}
+                      index={index}
+                      remove={remove}
+                    />
+                  )
+                )}
+              </tbody>
+            </Table>
           </div>
         )}
       </FieldArray>

--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -54,7 +54,7 @@ export class SimpleEvent<TValue> implements TabEvent<TValue> {
 }
 
 /**
- * React Hook that calls handler whenever event is emitted for the given tag
+ * React Hook that calls handler whenever event is emitted for the given tab
  * @param tabId the tab to listen to
  * @param event the tab event
  * @param handler the handler to call

--- a/src/hooks/fetch.ts
+++ b/src/hooks/fetch.ts
@@ -75,6 +75,7 @@ export async function fetch<TData>(
 /**
  * Hook for fetching information from a URL.
  * @param relativeOrAbsoluteUrl
+ * @deprecated use the useFetch hook, which tracks loading state and errors
  */
 export function useFetch<TData>(
   relativeOrAbsoluteUrl: string
@@ -86,6 +87,7 @@ export function useFetch<TData>(
   useAsyncEffect(
     async (isMounted) => {
       if (host) {
+        // eslint-disable-next-line unicorn/no-useless-undefined -- TypeScript requires argument here
         setData(undefined);
         try {
           const data = (await fetch(relativeOrAbsoluteUrl)) as TData;

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useAsyncState } from "@/hooks/common";
+import { getBaseURL } from "@/services/baseService";
+import { useToasts } from "react-toast-notifications";
+import { useCallback, useState } from "react";
+import useAsyncEffect from "use-async-effect";
+import { fetch } from "@/hooks/fetch";
+
+type FetchState<TData> = {
+  data: TData | undefined;
+  isLoading: boolean;
+  error: unknown;
+  refresh: () => Promise<void>;
+};
+
+function useFetch<TData>(relativeOrAbsoluteUrl: string): FetchState<TData> {
+  const [host] = useAsyncState(getBaseURL);
+  const { addToast } = useToasts();
+  const [data, setData] = useState<TData>();
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<unknown>();
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await fetch<TData>(relativeOrAbsoluteUrl);
+      setData(data);
+    } catch (error_) {
+      setError(error_);
+      addToast(`An error occurred fetching data from the server`, {
+        appearance: "error",
+        autoDismiss: true,
+      });
+    }
+  }, [addToast, relativeOrAbsoluteUrl, setData]);
+
+  useAsyncEffect(
+    async (isMounted) => {
+      if (host) {
+        setIsLoading(true);
+        // eslint-disable-next-line unicorn/no-useless-undefined -- be explicit about resetting value
+        setData(undefined);
+        try {
+          const data = await fetch<TData>(relativeOrAbsoluteUrl);
+          if (!isMounted()) return;
+          setData(data);
+        } catch (error_) {
+          if (!isMounted()) return;
+          setError(error_);
+          addToast(`An error occurred fetching data from the server`, {
+            appearance: "error",
+            autoDismiss: true,
+          });
+        } finally {
+          if (isMounted()) {
+            setIsLoading(false);
+          }
+        }
+      }
+    },
+    [host, relativeOrAbsoluteUrl, setData, setIsLoading, setError]
+  );
+
+  return {
+    data,
+    isLoading,
+    error,
+    refresh,
+  };
+}
+
+export default useFetch;

--- a/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
+++ b/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
@@ -261,7 +261,7 @@ const ExtensionForm: React.FunctionComponent<{
                   eventKey="configuration"
                   fieldName="config"
                 />
-                {extensionId && <NavItem caption="Log Stream" eventKey="log" />}
+                {extensionId && <NavItem caption="Logs" eventKey="log" />}
               </Nav>
             </Card.Header>
 

--- a/src/options/pages/extensionEditor/ServiceAuthSelector.tsx
+++ b/src/options/pages/extensionEditor/ServiceAuthSelector.tsx
@@ -41,10 +41,11 @@ function defaultLabel(label: string): string {
 }
 
 export function useAuthOptions(): [AuthOption[], () => Promise<void>] {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- clarify which state values are being skipped
   const [
     configuredServices,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- clarify which state values ignoring for now
     _localLoading,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- clarify which state values ignoring for now
     _localError,
     refreshLocal,
   ] = useAsyncState<RawServiceConfiguration[]>(readRawConfigurations);

--- a/src/options/pages/extensionEditor/ServicesFormCard.tsx
+++ b/src/options/pages/extensionEditor/ServicesFormCard.tsx
@@ -86,7 +86,7 @@ export const DependencyRow: React.FunctionComponent<{
       <td>
         <Form.Group>
           <Button variant="danger" size="sm" onClick={() => remove(index)}>
-            <FontAwesomeIcon icon={faTrash} />
+            <FontAwesomeIcon icon={faTrash} /> Remove
           </Button>
         </Form.Group>
       </td>

--- a/src/options/pages/services/ServicesEditor.tsx
+++ b/src/options/pages/services/ServicesEditor.tsx
@@ -85,8 +85,8 @@ const ServicesEditor: React.FunctionComponent<OwnProps> = ({
         autoDismiss: true,
       });
 
-      // wait 1000 to allow changes to propagate to storage
-      sleep(1000).then(async () => {
+      // wait 1000ms to allow changes to propagate to storage (via redux persist)
+      void sleep(1000).then(async () => {
         try {
           await refreshServices();
         } catch (error) {
@@ -115,7 +115,8 @@ const ServicesEditor: React.FunctionComponent<OwnProps> = ({
         autoDismiss: true,
       });
 
-      sleep(1000).then(async () => {
+      // don't need to wait before navigating, as this window has the updated state immediately
+      void sleep(1000).then(async () => {
         try {
           await refreshServices();
         } catch (error) {

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -52,11 +52,11 @@ type ConfiguredHostResult = [ConfiguredHost, (url: string) => Promise<void>];
  * Hook for retrieving/setting the manually configured host.
  */
 export function useConfiguredHost(): ConfiguredHostResult {
-  const [state, setState] = useState(undefined);
+  const [state, setState] = useState<ConfiguredHost>();
 
   useAsyncEffect(
     async (isMounted) => {
-      const configured = await readStorage(SERVICE_STORAGE_KEY);
+      const configured = await readStorage<ConfiguredHost>(SERVICE_STORAGE_KEY);
       if (!isMounted()) return;
       setState(configured);
     },

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -106,7 +106,7 @@ class LazyLocatorFactory {
 
   async refreshRemote(): Promise<void> {
     this.remote = await fetch("/api/services/shared/?meta=1");
-    console.debug(`Fetched ${this.remote.length} remote auths`);
+    console.debug(`Fetched ${this.remote.length} remote service auths`);
     this.makeOptions();
   }
 
@@ -117,9 +117,9 @@ class LazyLocatorFactory {
 
   // TODO: Replace with proper debouncer when one exists https://github.com/sindresorhus/promise-fun/issues/15
   async refresh(): Promise<void> {
-    this._refreshPromise = this._refreshPromise || this._refresh();
+    this._refreshPromise = this._refreshPromise ?? this._refresh();
     await this._refreshPromise;
-    this._refreshPromise = null;
+    this._refreshPromise = undefined;
   }
 
   private async _refresh(): Promise<void> {
@@ -128,7 +128,7 @@ class LazyLocatorFactory {
     this.makeOptions();
     this._initialized = true;
     this.updateTimestamp = timestamp;
-    console.debug(`Refreshed service locator`, {
+    console.debug(`Refreshed service configuration locator`, {
       updateTimestamp: this.updateTimestamp,
     });
   }
@@ -153,7 +153,7 @@ class LazyLocatorFactory {
   }
 
   getLocator(): ServiceLocator {
-    return this.locate.bind(this);
+    return LazyLocatorFactory.prototype.locate.bind(this);
   }
 
   async getLocalConfig(authId: string): Promise<RawServiceConfiguration> {

--- a/src/validators/generic.ts
+++ b/src/validators/generic.ts
@@ -17,7 +17,7 @@
 
 import extensionPointRegistry from "@/extensionPoints/registry";
 import { useMemo } from "react";
-import { useAsyncState } from "@/hooks/common";
+import { AsyncState, useAsyncState } from "@/hooks/common";
 import { locate } from "@/background/locator";
 import {
   Validator,
@@ -85,7 +85,7 @@ export async function validateKind(
   const finalSchema = await dereference(KIND_SCHEMAS[kind] as Schema);
   const validator = new Validator(finalSchema as any);
 
-  validator.addSchema(draft07 as any);
+  validator.addSchema(draft07 as ValidatorSchema);
 
   return validator.validate(instance);
 }
@@ -199,8 +199,8 @@ async function validateExtension(
 
 export function useExtensionValidator(
   extension: IExtension
-): [ExtensionValidationResult | undefined, boolean, unknown] {
-  const validationPromise = useMemo(() => validateExtension(extension), [
+): AsyncState<ExtensionValidationResult> {
+  const validationPromise = useMemo(async () => validateExtension(extension), [
     extension,
   ]);
   return useAsyncState(validationPromise);


### PR DESCRIPTION
Closes #753

- Adds link to service configuration page in page editor
- Adds button to refresh available service auths in page editor
- Cleans up integration table formatting
- Adds better useFetch hook