### PR TITLE
Ignore, attempt at recreating handlers code

### DIFF
--- a/src/messaging/protocol.ts
+++ b/src/messaging/protocol.ts
@@ -77,7 +77,7 @@ export type MessageListener = (
 ) => Promise<unknown> | void;
 
 // Unlike MessageListener, the return type of this method means the message has been handled
-type MessageHandler<T extends ActionType> = (
+export type MessageHandler<T extends ActionType> = (
   request: Message<T>,
   sender: Runtime.MessageSender
 ) => Promise<unknown>;

--- a/src/popup/executor.ts
+++ b/src/popup/executor.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Message } from "@/core";
+import { HandlerMap, MessageHandler } from "@/messaging/protocol";
+
+const popupPingMessage: Message = { type: "POPUP_INIT" } as const;
+const _popupPing: MessageHandler<typeof popupPingMessage.type> = async () => {
+  // No return, it just resolves
+};
+export const popupPing = async (): Promise<void> => {
+  await browser.runtime.sendMessage(popupPingMessage);
+};
+
+function getHandlers(): HandlerMap {
+  const handlers = new HandlerMap();
+  handlers.set(popupPingMessage.type, _popupPing);
+  return handlers;
+}
+
+export default function listen() {
+  browser.runtime.onMessage.addListener(getHandlers().asListener());
+}


### PR DESCRIPTION
Incomplete code, just posting it here to possibly reference it later.

---

While working on #745, I was looking for a simple way to communicate with the new popup page and thought of a possible solution to:

- #669
- https://github.com/pixiebrix/pixiebrix-extension/issues/578

In short, the code is set up in a way that allows easy treeshaking:

- the receiver context calls `listen()` which then uses all the functions
- the sender context just imports a plain sendMessage-backed function and its types

This is not finalized and the types have to be improved to preserve the return value of the message sender (every function is `Promise<unknown>` in this POC)