### PR TITLE
#727: Inject content script CSS in `ensureContentScript`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33001,6 +33001,11 @@
         }
       }
     },
+    "webext-content-scripts": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-0.9.0.tgz",
+      "integrity": "sha512-ZWu7Qzn7muMz8Ml+HAyvq3RApqqf++h7mMEjM69oXs8tk4tdcMtTLuYN8MF8Z5ncYVd5irVM0l4puRhWUbJOwg=="
+    },
     "webext-detect-page": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-2.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "use-immer": "^0.6.0",
     "uuid": "^8.3.2",
     "webext-additional-permissions": "^2.0.1",
+    "webext-content-scripts": "^0.9.0",
     "webext-detect-page": "^2.0.6",
     "webext-dynamic-content-scripts": "^8.0.0-1",
     "webext-patterns": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
       "^.+\\.txt$": "jest-raw-loader"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!@cfworker|webext-detect-page|idb|webext-patterns|webext-polyfill-kinda|webext-additional-permissions|p-timeout|p-defer)"
+      "node_modules/(?!@cfworker|idb|webext-|p-timeout|p-defer)"
     ],
     "setupFiles": [
       "<rootDir>/src/test-env.js",


### PR DESCRIPTION
- Fixes #727 

## Test

1. Add some visible styles to `styles.css` like `*{background: red}`
2. Open permissionless website, like https://www.gov.uk
3. Open sidebar
4. Notice styles being applied