### PR TITLE
#570: Extract and deduplicate webpack resolution config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
   "settings": {
     "import/resolver": {
       "webpack": {
-        "config": "./browsers/webpack.config.js"
+        "config": "./browsers/resolve.config.js"
       }
     },
     "react": {
@@ -28,11 +28,11 @@
     "plugin:react-hooks/recommended",
     "plugin:import/typescript",
     "plugin:security/recommended",
-    "plugin:unicorn/recommended"
+    "plugin:unicorn/recommended",
 
-    // TODO: Restore these after https://github.com/benmosher/eslint-plugin-import/issues/1931
+    // TODO: Restore this after linting the codebase
     // "plugin:import/errors",
-    // "plugin:import/warnings",
+    "plugin:import/warnings"
   ],
   "rules": {
     "@typescript-eslint/no-unused-vars": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -29,12 +29,10 @@
 
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
+    "plugin:import/recommended",
     "plugin:import/typescript",
     "plugin:security/recommended",
-    "plugin:unicorn/recommended",
-
-    "plugin:import/errors",
-    "plugin:import/warnings"
+    "plugin:unicorn/recommended"
   ],
   "rules": {
     "@typescript-eslint/no-unused-vars": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,9 @@
         "config": "./browsers/resolve.config.js"
       }
     },
+    "import/ignore": [
+      "react-select" // For some reason it points to a flow JS file
+    ],
     "react": {
       "version": "detect"
     }
@@ -30,8 +33,7 @@
     "plugin:security/recommended",
     "plugin:unicorn/recommended",
 
-    // TODO: Restore this after linting the codebase
-    // "plugin:import/errors",
+    "plugin:import/errors",
     "plugin:import/warnings"
   ],
   "rules": {
@@ -54,6 +56,14 @@
       }
     ],
 
+    "import/no-unresolved": [
+      "error",
+      {
+        "ignore": [
+          "json-schema" // @types-only package
+        ]
+      }
+    ],
     "unicorn/prevent-abbreviations": [
       "error",
       {
@@ -88,6 +98,7 @@
 
     // Disable recommended rules
     "@typescript-eslint/no-empty-function": "off",
+    "import/named": "off", // TypeScript does this natively
     "react/prop-types": "off",
     "unicorn/no-null": "off", // Maybe later
     "unicorn/filename-case": "off", // Contrasts with React

--- a/browsers/resolve.config.js
+++ b/browsers/resolve.config.js
@@ -1,0 +1,26 @@
+// Resolve-only webpack configuration for ESlint
+
+const path = require("path");
+const rootDir = path.resolve(__dirname, "../");
+
+module.exports = {
+  resolve: {
+    // Need to set these fields manually as their default values rely on `web` target.
+    // See https://v4.webpack.js.org/configuration/resolve/#resolvemainfields
+    alias: {
+      "@": path.resolve(rootDir, "src"),
+      "@img": path.resolve(rootDir, "img"),
+      "@contrib": path.resolve(rootDir, "contrib"),
+      "@schemas": path.resolve(rootDir, "schemas"),
+      vendors: path.resolve(rootDir, "src/vendors"),
+      "@microsoft/applicationinsights-web": path.resolve(
+        rootDir,
+        "src/contrib/uipath/quietLogger"
+      ),
+
+      // An existence check triggers webpack’s warnings https://github.com/handlebars-lang/handlebars.js/issues/953
+      handlebars: "handlebars/dist/handlebars.js",
+    },
+    extensions: [".ts", ".tsx", ".jsx", ".js"],
+  },
+};

--- a/browsers/resolve.config.js
+++ b/browsers/resolve.config.js
@@ -5,8 +5,6 @@ const rootDir = path.resolve(__dirname, "../");
 
 module.exports = {
   resolve: {
-    // Need to set these fields manually as their default values rely on `web` target.
-    // See https://v4.webpack.js.org/configuration/resolve/#resolvemainfields
     alias: {
       "@": path.resolve(rootDir, "src"),
       "@img": path.resolve(rootDir, "img"),

--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -30,6 +30,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 const { uniq, isEmpty } = require("lodash");
 const Policy = require("csp-parse");
 
+const { resolve: sharedResolutions } = require("./resolve.config.js");
 const rootDir = path.resolve(__dirname, "../");
 
 // Include defaults required for webpack here. Add defaults for the extension bundle to EnvironmentPlugin
@@ -211,24 +212,9 @@ module.exports = (env, options) => ({
     action: path.resolve(rootDir, "src/action"),
   },
   resolve: {
-    // Need to set these fields manually as their default values rely on `web` target.
-    // See https://v4.webpack.js.org/configuration/resolve/#resolvemainfields
+    ...sharedResolutions,
     mainFields: ["browser", "module", "main"],
     aliasFields: ["browser"],
-    alias: {
-      "@": path.resolve(rootDir, "src"),
-      "@img": path.resolve(rootDir, "img"),
-      "@contrib": path.resolve(rootDir, "contrib"),
-      "@schemas": path.resolve(rootDir, "schemas"),
-      vendors: path.resolve(rootDir, "src/vendors"),
-      "@microsoft/applicationinsights-web": path.resolve(
-        rootDir,
-        "src/contrib/uipath/quietLogger"
-      ),
-
-      // An existence check triggers webpack’s warnings https://github.com/handlebars-lang/handlebars.js/issues/953
-      handlebars: "handlebars/dist/handlebars.js",
-    },
     fallback: {
       fs: false,
       crypto: false,
@@ -236,7 +222,6 @@ module.exports = (env, options) => ({
       vm: false,
       path: false,
     },
-    extensions: [".ts", ".tsx", ".jsx", ".js"],
   },
 
   // https://github.com/webpack/webpack/issues/3017#issuecomment-285954512

--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -30,7 +30,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 const { uniq, isEmpty } = require("lodash");
 const Policy = require("csp-parse");
 
-const { resolve: sharedResolutions } = require("./resolve.config.js");
+const { resolve } = require("./resolve.config.js");
 const rootDir = path.resolve(__dirname, "../");
 
 // Include defaults required for webpack here. Add defaults for the extension bundle to EnvironmentPlugin
@@ -212,7 +212,9 @@ module.exports = (env, options) => ({
     action: path.resolve(rootDir, "src/action"),
   },
   resolve: {
-    ...sharedResolutions,
+    ...resolve,
+    // Need to set these fields manually as their default values rely on `web` target.
+    // See https://v4.webpack.js.org/configuration/resolve/#resolvemainfields
     mainFields: ["browser", "module", "main"],
     aliasFields: ["browser"],
     fallback: {

--- a/scripts/webpack.scripts.js
+++ b/scripts/webpack.scripts.js
@@ -19,6 +19,15 @@ const path = require("path");
 const rootDir = path.resolve(__dirname, "../");
 const webpack = require("webpack");
 
+const { resolve: sharedResolutions } = require("../browsers/resolve.config.js");
+sharedResolutions.alias["@uipath/robot"] = path.resolve(
+  rootDir,
+  "src/__mocks__/robotMock"
+);
+sharedResolutions.fallback = {
+  chokidar: false,
+};
+
 module.exports = {
   mode: "development",
   target: "node",
@@ -37,22 +46,7 @@ module.exports = {
     // https://github.com/yan-foto/electron-reload/issues/71#issuecomment-588988382
     fsevents: "require('fsevents')",
   },
-  resolve: {
-    alias: {
-      "@": path.resolve(rootDir, "src"),
-      "@img": path.resolve(rootDir, "img"),
-      "@contrib": path.resolve(rootDir, "contrib"),
-      "@schemas": path.resolve(rootDir, "schemas"),
-      vendors: path.resolve(rootDir, "src/vendors"),
-      "@uipath/robot": path.resolve(rootDir, "src/__mocks__/robotMock"),
-      // An existence check triggers webpack’s warnings https://github.com/handlebars-lang/handlebars.js/issues/953
-      handlebars: "handlebars/dist/handlebars.js",
-    },
-    extensions: [".ts", ".tsx", ".jsx", ".js"],
-    fallback: {
-      chokidar: false,
-    },
-  },
+  resolve: sharedResolutions,
   plugins: [
     new webpack.ProvidePlugin({
       window: "global/window.js",

--- a/scripts/webpack.scripts.js
+++ b/scripts/webpack.scripts.js
@@ -15,18 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+const { merge } = require("lodash");
 const path = require("path");
 const rootDir = path.resolve(__dirname, "../");
 const webpack = require("webpack");
 
-const { resolve: sharedResolutions } = require("../browsers/resolve.config.js");
-sharedResolutions.alias["@uipath/robot"] = path.resolve(
-  rootDir,
-  "src/__mocks__/robotMock"
-);
-sharedResolutions.fallback = {
-  chokidar: false,
-};
+const { resolve } = require("../browsers/resolve.config.js");
 
 module.exports = {
   mode: "development",
@@ -46,7 +40,14 @@ module.exports = {
     // https://github.com/yan-foto/electron-reload/issues/71#issuecomment-588988382
     fsevents: "require('fsevents')",
   },
-  resolve: sharedResolutions,
+  resolve: merge(resolve, {
+    alias: {
+      "@uipath/robot": path.resolve(rootDir, "src/__mocks__/robotMock"),
+    },
+    fallback: {
+      chokidar: false,
+    },
+  }),
   plugins: [
     new webpack.ProvidePlugin({
       window: "global/window.js",

--- a/src/blocks/readers/index.ts
+++ b/src/blocks/readers/index.ts
@@ -15,15 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export * from "./meta";
-export * from "./PageMetadataReader";
-export * from "./PageSemanticReader";
-export * from "./BlankReader";
-export * from "./ImageReader";
-export * from "./ImageEXIFReader";
-export * from "./ElementReader";
+import "./meta";
+import "./PageMetadataReader";
+import "./PageSemanticReader";
+import "./BlankReader";
+import "./ImageReader";
+import "./ImageEXIFReader";
+import "./ElementReader";
 
 // generic readers
-export * from "./frameworkReader";
+import "./frameworkReader";
 export * from "./jquery";
 export * from "./window";


### PR DESCRIPTION
- Fixes #570

This was low priority but the solution was pretty simple:

- extract resolutions into shared file
- point eslint to this file
- import file from both webpack.browsers.js and webpack.scripts.js

In the future:

- [ ] import file from Jest config, maybe as part of #684 

Side note: The plugin is quite buggy in general (350 open issues for a single eslint plugin) so we might not always be able to follow its suggestions.