### PR TITLE
Enable 4 condition lint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,12 +35,6 @@
     "plugin:unicorn/recommended"
   ],
   "rules": {
-    // Enable a few more rules
-    "no-lonely-if": "error",
-    "no-else-return": "error",
-    "no-negated-condition": "warn",
-    "no-useless-return": "error",
-
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,12 @@
     "plugin:unicorn/recommended"
   ],
   "rules": {
+    // Enable a few more rules
+    "no-lonely-if": "error",
+    "no-else-return": "error",
+    "no-negated-condition": "warn",
+    "no-useless-return": "error",
+
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
   "settings": {
     "import/resolver": {
       "webpack": {
-        "config": "./browsers/webpack.config.js"
+        "config": "./browsers/resolve.config.js"
       }
     },
     "react": {
@@ -28,11 +28,11 @@
     "plugin:react-hooks/recommended",
     "plugin:import/typescript",
     "plugin:security/recommended",
-    "plugin:unicorn/recommended"
+    "plugin:unicorn/recommended",
 
-    // TODO: Restore these after https://github.com/benmosher/eslint-plugin-import/issues/1931
+    // TODO: Restore this after linting the codebase
     // "plugin:import/errors",
-    // "plugin:import/warnings",
+    "plugin:import/warnings"
   ],
   "rules": {
     "@typescript-eslint/no-unused-vars": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -29,12 +29,10 @@
 
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
+    "plugin:import/recommended",
     "plugin:import/typescript",
     "plugin:security/recommended",
-    "plugin:unicorn/recommended",
-
-    "plugin:import/errors",
-    "plugin:import/warnings"
+    "plugin:unicorn/recommended"
   ],
   "rules": {
     "@typescript-eslint/no-unused-vars": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,9 @@
         "config": "./browsers/resolve.config.js"
       }
     },
+    "import/ignore": [
+      "react-select" // For some reason it points to a flow JS file
+    ],
     "react": {
       "version": "detect"
     }
@@ -30,8 +33,7 @@
     "plugin:security/recommended",
     "plugin:unicorn/recommended",
 
-    // TODO: Restore this after linting the codebase
-    // "plugin:import/errors",
+    "plugin:import/errors",
     "plugin:import/warnings"
   ],
   "rules": {
@@ -54,6 +56,14 @@
       }
     ],
 
+    "import/no-unresolved": [
+      "error",
+      {
+        "ignore": [
+          "json-schema" // @types-only package
+        ]
+      }
+    ],
     "unicorn/prevent-abbreviations": [
       "error",
       {
@@ -88,6 +98,7 @@
 
     // Disable recommended rules
     "@typescript-eslint/no-empty-function": "off",
+    "import/named": "off", // TypeScript does this natively
     "react/prop-types": "off",
     "unicorn/no-null": "off", // Maybe later
     "unicorn/filename-case": "off", // Contrasts with React

--- a/browsers/resolve.config.js
+++ b/browsers/resolve.config.js
@@ -1,0 +1,26 @@
+// Resolve-only webpack configuration for ESlint
+
+const path = require("path");
+const rootDir = path.resolve(__dirname, "../");
+
+module.exports = {
+  resolve: {
+    // Need to set these fields manually as their default values rely on `web` target.
+    // See https://v4.webpack.js.org/configuration/resolve/#resolvemainfields
+    alias: {
+      "@": path.resolve(rootDir, "src"),
+      "@img": path.resolve(rootDir, "img"),
+      "@contrib": path.resolve(rootDir, "contrib"),
+      "@schemas": path.resolve(rootDir, "schemas"),
+      vendors: path.resolve(rootDir, "src/vendors"),
+      "@microsoft/applicationinsights-web": path.resolve(
+        rootDir,
+        "src/contrib/uipath/quietLogger"
+      ),
+
+      // An existence check triggers webpack’s warnings https://github.com/handlebars-lang/handlebars.js/issues/953
+      handlebars: "handlebars/dist/handlebars.js",
+    },
+    extensions: [".ts", ".tsx", ".jsx", ".js"],
+  },
+};

--- a/browsers/resolve.config.js
+++ b/browsers/resolve.config.js
@@ -5,8 +5,6 @@ const rootDir = path.resolve(__dirname, "../");
 
 module.exports = {
   resolve: {
-    // Need to set these fields manually as their default values rely on `web` target.
-    // See https://v4.webpack.js.org/configuration/resolve/#resolvemainfields
     alias: {
       "@": path.resolve(rootDir, "src"),
       "@img": path.resolve(rootDir, "img"),

--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -30,6 +30,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 const { uniq, isEmpty } = require("lodash");
 const Policy = require("csp-parse");
 
+const { resolve: sharedResolutions } = require("./resolve.config.js");
 const rootDir = path.resolve(__dirname, "../");
 
 // Include defaults required for webpack here. Add defaults for the extension bundle to EnvironmentPlugin
@@ -211,24 +212,9 @@ module.exports = (env, options) => ({
     action: path.resolve(rootDir, "src/action"),
   },
   resolve: {
-    // Need to set these fields manually as their default values rely on `web` target.
-    // See https://v4.webpack.js.org/configuration/resolve/#resolvemainfields
+    ...sharedResolutions,
     mainFields: ["browser", "module", "main"],
     aliasFields: ["browser"],
-    alias: {
-      "@": path.resolve(rootDir, "src"),
-      "@img": path.resolve(rootDir, "img"),
-      "@contrib": path.resolve(rootDir, "contrib"),
-      "@schemas": path.resolve(rootDir, "schemas"),
-      vendors: path.resolve(rootDir, "src/vendors"),
-      "@microsoft/applicationinsights-web": path.resolve(
-        rootDir,
-        "src/contrib/uipath/quietLogger"
-      ),
-
-      // An existence check triggers webpack’s warnings https://github.com/handlebars-lang/handlebars.js/issues/953
-      handlebars: "handlebars/dist/handlebars.js",
-    },
     fallback: {
       fs: false,
       crypto: false,
@@ -236,7 +222,6 @@ module.exports = (env, options) => ({
       vm: false,
       path: false,
     },
-    extensions: [".ts", ".tsx", ".jsx", ".js"],
   },
 
   // https://github.com/webpack/webpack/issues/3017#issuecomment-285954512

--- a/browsers/webpack.config.js
+++ b/browsers/webpack.config.js
@@ -30,7 +30,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 const { uniq, isEmpty } = require("lodash");
 const Policy = require("csp-parse");
 
-const { resolve: sharedResolutions } = require("./resolve.config.js");
+const { resolve } = require("./resolve.config.js");
 const rootDir = path.resolve(__dirname, "../");
 
 // Include defaults required for webpack here. Add defaults for the extension bundle to EnvironmentPlugin
@@ -212,7 +212,9 @@ module.exports = (env, options) => ({
     action: path.resolve(rootDir, "src/action"),
   },
   resolve: {
-    ...sharedResolutions,
+    ...resolve,
+    // Need to set these fields manually as their default values rely on `web` target.
+    // See https://v4.webpack.js.org/configuration/resolve/#resolvemainfields
     mainFields: ["browser", "module", "main"],
     aliasFields: ["browser"],
     fallback: {

--- a/scripts/webpack.scripts.js
+++ b/scripts/webpack.scripts.js
@@ -19,6 +19,15 @@ const path = require("path");
 const rootDir = path.resolve(__dirname, "../");
 const webpack = require("webpack");
 
+const { resolve: sharedResolutions } = require("../browsers/resolve.config.js");
+sharedResolutions.alias["@uipath/robot"] = path.resolve(
+  rootDir,
+  "src/__mocks__/robotMock"
+);
+sharedResolutions.fallback = {
+  chokidar: false,
+};
+
 module.exports = {
   mode: "development",
   target: "node",
@@ -37,22 +46,7 @@ module.exports = {
     // https://github.com/yan-foto/electron-reload/issues/71#issuecomment-588988382
     fsevents: "require('fsevents')",
   },
-  resolve: {
-    alias: {
-      "@": path.resolve(rootDir, "src"),
-      "@img": path.resolve(rootDir, "img"),
-      "@contrib": path.resolve(rootDir, "contrib"),
-      "@schemas": path.resolve(rootDir, "schemas"),
-      vendors: path.resolve(rootDir, "src/vendors"),
-      "@uipath/robot": path.resolve(rootDir, "src/__mocks__/robotMock"),
-      // An existence check triggers webpack’s warnings https://github.com/handlebars-lang/handlebars.js/issues/953
-      handlebars: "handlebars/dist/handlebars.js",
-    },
-    extensions: [".ts", ".tsx", ".jsx", ".js"],
-    fallback: {
-      chokidar: false,
-    },
-  },
+  resolve: sharedResolutions,
   plugins: [
     new webpack.ProvidePlugin({
       window: "global/window.js",

--- a/scripts/webpack.scripts.js
+++ b/scripts/webpack.scripts.js
@@ -15,18 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+const { merge } = require("lodash");
 const path = require("path");
 const rootDir = path.resolve(__dirname, "../");
 const webpack = require("webpack");
 
-const { resolve: sharedResolutions } = require("../browsers/resolve.config.js");
-sharedResolutions.alias["@uipath/robot"] = path.resolve(
-  rootDir,
-  "src/__mocks__/robotMock"
-);
-sharedResolutions.fallback = {
-  chokidar: false,
-};
+const { resolve } = require("../browsers/resolve.config.js");
 
 module.exports = {
   mode: "development",
@@ -46,7 +40,14 @@ module.exports = {
     // https://github.com/yan-foto/electron-reload/issues/71#issuecomment-588988382
     fsevents: "require('fsevents')",
   },
-  resolve: sharedResolutions,
+  resolve: merge(resolve, {
+    alias: {
+      "@uipath/robot": path.resolve(rootDir, "src/__mocks__/robotMock"),
+    },
+    fallback: {
+      chokidar: false,
+    },
+  }),
   plugins: [
     new webpack.ProvidePlugin({
       window: "global/window.js",

--- a/src/actionPanel/PanelBody.tsx
+++ b/src/actionPanel/PanelBody.tsx
@@ -42,10 +42,9 @@ const BodyComponent: React.FunctionComponent<{
           dangerouslySetInnerHTML={{ __html: body }}
         />
       );
-    } else {
-      const { Component, props } = body;
-      return <Component {...props} />;
     }
+    const { Component, props } = body;
+    return <Component {...props} />;
   }, [body]);
 };
 
@@ -58,23 +57,22 @@ const PanelBody: React.FunctionComponent<{ panel: PanelEntry }> = ({
     } else if ("error" in panel.payload) {
       const { error } = panel.payload;
       return <div className="text-danger">Error running panel: {error}</div>;
-    } else {
-      const { blockId, ctxt, args } = panel.payload;
-      console.debug("Render panel body", panel.payload);
-      const block = await blockRegistry.lookup(blockId);
-      const body = await block.run(args, {
-        ctxt,
-        root: null,
-        logger: new ConsoleLogger(),
-      });
-      return (
-        <div className="h-100">
-          <ReactShadowRoot>
-            <BodyComponent body={body as PanelComponent} />
-          </ReactShadowRoot>
-        </div>
-      );
     }
+    const { blockId, ctxt, args } = panel.payload;
+    console.debug("Render panel body", panel.payload);
+    const block = await blockRegistry.lookup(blockId);
+    const body = await block.run(args, {
+      ctxt,
+      root: null,
+      logger: new ConsoleLogger(),
+    });
+    return (
+      <div className="h-100">
+        <ReactShadowRoot>
+          <BodyComponent body={body as PanelComponent} />
+        </ReactShadowRoot>
+      </div>
+    );
   }, [panel.payload?.key]);
 
   if (error) {
@@ -85,9 +83,8 @@ const PanelBody: React.FunctionComponent<{ panel: PanelEntry }> = ({
     );
   } else if (pending || component == null) {
     return <GridLoader />;
-  } else {
-    return component;
   }
+  return component;
 };
 
 export default PanelBody;

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -62,8 +62,9 @@ function getHTMLElement(): JQuery<HTMLElement> {
     return $(document.querySelector("html"));
   } else if ($("html").length > -1) {
     return $("html");
+  } else {
+    throw new Error("HTML node not found");
   }
-  throw new Error("HTML node not found");
 }
 
 function storeOriginalCSS() {
@@ -135,8 +136,9 @@ export function toggleActionPanel(): string | null {
   if (isActionPanelVisible()) {
     hideActionPanel();
     return null;
+  } else {
+    return showActionPanel();
   }
-  return showActionPanel();
 }
 
 export function isActionPanelVisible(): boolean {

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -62,9 +62,8 @@ function getHTMLElement(): JQuery<HTMLElement> {
     return $(document.querySelector("html"));
   } else if ($("html").length > -1) {
     return $("html");
-  } else {
-    throw new Error("HTML node not found");
   }
+  throw new Error("HTML node not found");
 }
 
 function storeOriginalCSS() {
@@ -136,9 +135,8 @@ export function toggleActionPanel(): string | null {
   if (isActionPanelVisible()) {
     hideActionPanel();
     return null;
-  } else {
-    return showActionPanel();
   }
+  return showActionPanel();
 }
 
 export function isActionPanelVisible(): boolean {

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -64,8 +64,9 @@ export async function getExtensionAuth(): Promise<UserData> {
   if (valueJSON) {
     const { user, email, hostname } = JSON.parse(valueJSON as string);
     return { user, email, hostname };
+  } else {
+    return {};
   }
-  return {};
 }
 
 export async function clearExtensionAuth(): Promise<void> {

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -64,9 +64,8 @@ export async function getExtensionAuth(): Promise<UserData> {
   if (valueJSON) {
     const { user, email, hostname } = JSON.parse(valueJSON as string);
     return { user, email, hostname };
-  } else {
-    return {};
   }
+  return {};
 }
 
 export async function clearExtensionAuth(): Promise<void> {

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -135,6 +135,7 @@ handlers.set(
       frameId: sender.frameId,
     });
     tabFrames.set(tabId, sender.frameId);
+    return;
   }
 );
 

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -135,7 +135,6 @@ handlers.set(
       frameId: sender.frameId,
     });
     tabFrames.set(tabId, sender.frameId);
-    return;
   }
 );
 

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -72,6 +72,7 @@ function backgroundMessageListener(
       `Ignoring devtools message to background page from unknown sender`,
       port.sender
     );
+    return;
   } else if (handler) {
     const notification = isNotification(options);
 

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -72,7 +72,6 @@ function backgroundMessageListener(
       `Ignoring devtools message to background page from unknown sender`,
       port.sender
     );
-    return;
   } else if (handler) {
     const notification = isNotification(options);
 

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -100,9 +100,8 @@ async function waitNonceReady(
         },
         { frameId: target.frameId }
       );
-    } else {
-      return true;
     }
+    return true;
   };
 
   while (!(await isReady())) {

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -100,8 +100,9 @@ async function waitNonceReady(
         },
         { frameId: target.frameId }
       );
+    } else {
+      return true;
     }
-    return true;
   };
 
   while (!(await isReady())) {

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -98,14 +98,13 @@ async function handleRequest(
 export function getExtensionId(): string {
   if (isContentScript() || isOptionsPage() || isBackgroundPage()) {
     return browser.runtime.id;
-  } else {
-    if (chrome.runtime == null) {
-      throw new RuntimeNotFoundError(
-        "Browser runtime is unavailable; is the extension externally connectable?"
-      );
-    }
-    return getChromeExtensionId();
   }
+  if (chrome.runtime == null) {
+    throw new RuntimeNotFoundError(
+      "Browser runtime is unavailable; is the extension externally connectable?"
+    );
+  }
+  return getChromeExtensionId();
 }
 
 export async function callBackground(
@@ -133,7 +132,6 @@ export async function callBackground(
         error
       );
     });
-    return;
   } else {
     console.debug(`Sending background action ${type} (nonce: ${nonce})`, {
       extensionId,

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -98,13 +98,14 @@ async function handleRequest(
 export function getExtensionId(): string {
   if (isContentScript() || isOptionsPage() || isBackgroundPage()) {
     return browser.runtime.id;
+  } else {
+    if (chrome.runtime == null) {
+      throw new RuntimeNotFoundError(
+        "Browser runtime is unavailable; is the extension externally connectable?"
+      );
+    }
+    return getChromeExtensionId();
   }
-  if (chrome.runtime == null) {
-    throw new RuntimeNotFoundError(
-      "Browser runtime is unavailable; is the extension externally connectable?"
-    );
-  }
-  return getChromeExtensionId();
 }
 
 export async function callBackground(
@@ -132,6 +133,7 @@ export async function callBackground(
         error
       );
     });
+    return;
   } else {
     console.debug(`Sending background action ${type} (nonce: ${nonce})`, {
       extensionId,

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -65,12 +65,11 @@ function proxyResponseToAxiosResponse(data: ProxyResponseData) {
       status: data.status_code,
       statusText: data.reason ?? data.message,
     } as AxiosResponse;
-  } else {
-    return {
-      data: data.json,
-      status: data.status_code,
-    } as AxiosResponse;
   }
+  return {
+    data: data.json,
+    status: data.status_code,
+  } as AxiosResponse;
 }
 
 function isErrorResponse(
@@ -162,10 +161,9 @@ async function authenticate(
       throw new Error("No auth data found for token authentication");
     }
     return service.authenticateRequest(localConfig.config, request, data);
-  } else {
-    const localConfig = await locator.getLocalConfig(config.id);
-    return service.authenticateRequest(localConfig.config, request);
   }
+  const localConfig = await locator.getLocalConfig(config.id);
+  return service.authenticateRequest(localConfig.config, request);
 }
 
 async function proxyRequest<T>(
@@ -221,30 +219,29 @@ const _proxyService = liftBackground(
     if (serviceConfig.proxy) {
       // Service uses the PixieBrix remote proxy to perform authentication. Proxy the request.
       return proxyRequest(serviceConfig, requestConfig);
-    } else {
-      try {
-        return await backgroundRequest(
-          await authenticate(serviceConfig, requestConfig)
-        );
-      } catch (error) {
-        if (UNAUTHORIZED_STATUS_CODES.includes(error.response?.status)) {
-          // try again - have the user login again, or automatically try to get a new token
-          const service = await serviceRegistry.lookup(serviceConfig.serviceId);
-          if (service.isOAuth2 || service.isToken) {
-            await deleteCachedAuthData(serviceConfig.id);
-            return await backgroundRequest(
-              await authenticate(serviceConfig, requestConfig)
-            );
-          }
+    }
+    try {
+      return await backgroundRequest(
+        await authenticate(serviceConfig, requestConfig)
+      );
+    } catch (error) {
+      if (UNAUTHORIZED_STATUS_CODES.includes(error.response?.status)) {
+        // try again - have the user login again, or automatically try to get a new token
+        const service = await serviceRegistry.lookup(serviceConfig.serviceId);
+        if (service.isOAuth2 || service.isToken) {
+          await deleteCachedAuthData(serviceConfig.id);
+          return await backgroundRequest(
+            await authenticate(serviceConfig, requestConfig)
+          );
         }
-        console.debug(
-          "Error occurred when making a request from the background page",
-          { error }
-        );
-        // caught outside to add additional context to the exception
-        // noinspection ExceptionCaughtLocallyJS
-        throw error;
       }
+      console.debug(
+        "Error occurred when making a request from the background page",
+        { error }
+      );
+      // caught outside to add additional context to the exception
+      // noinspection ExceptionCaughtLocallyJS
+      throw error;
     }
   }
 );

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -119,12 +119,11 @@ type SchemaProperties = { [key: string]: Schema };
 function castSchema(schemaOrProperties: Schema | SchemaProperties): Schema {
   if (schemaOrProperties["type"] && schemaOrProperties["properties"]) {
     return schemaOrProperties as Schema;
-  } else {
-    return {
-      type: "object",
-      properties: schemaOrProperties as SchemaProperties,
-    };
   }
+  return {
+    type: "object",
+    properties: schemaOrProperties as SchemaProperties,
+  };
 }
 
 function excludeUndefined(obj: unknown): unknown {
@@ -133,9 +132,8 @@ function excludeUndefined(obj: unknown): unknown {
       pickBy(obj, (x) => x !== undefined),
       excludeUndefined
     );
-  } else {
-    return obj;
   }
+  return obj;
 }
 
 function isReader(block: IBlock): block is IReader {
@@ -262,9 +260,8 @@ async function runStage(
       });
     } else if (stage.window ?? "self" === "self") {
       return await block.run(blockArgs, { ctxt: args, logger, root, headless });
-    } else {
-      throw new BusinessError(`Unexpected stage window ${stage.window}`);
     }
+    throw new BusinessError(`Unexpected stage window ${stage.window}`);
   } finally {
     progressCallbacks?.hide();
   }
@@ -358,12 +355,10 @@ export async function reducePipeline(
           console.warn(`Effect ${block.id} produced an output`, { output });
           logger.warn(`Ignoring output produced by effect ${block.id}`);
         }
+      } else if (stage.outputKey) {
+        extraContext[`@${stage.outputKey}`] = output;
       } else {
-        if (stage.outputKey) {
-          extraContext[`@${stage.outputKey}`] = output;
-        } else {
-          currentArgs = output as any;
-        }
+        currentArgs = output as any;
       }
     } catch (error) {
       if (error instanceof HeadlessModeError) {
@@ -421,9 +416,8 @@ export async function mergeReaders(
     return new CompositeReader(
       await resolveObj(mapValues(readerConfig, mergeReaders))
     );
-  } else {
-    throw new BusinessError("Unexpected value for readerConfig");
   }
+  throw new BusinessError("Unexpected value for readerConfig");
 }
 
 export type ServiceContext = {

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -119,11 +119,12 @@ type SchemaProperties = { [key: string]: Schema };
 function castSchema(schemaOrProperties: Schema | SchemaProperties): Schema {
   if (schemaOrProperties["type"] && schemaOrProperties["properties"]) {
     return schemaOrProperties as Schema;
+  } else {
+    return {
+      type: "object",
+      properties: schemaOrProperties as SchemaProperties,
+    };
   }
-  return {
-    type: "object",
-    properties: schemaOrProperties as SchemaProperties,
-  };
 }
 
 function excludeUndefined(obj: unknown): unknown {
@@ -132,8 +133,9 @@ function excludeUndefined(obj: unknown): unknown {
       pickBy(obj, (x) => x !== undefined),
       excludeUndefined
     );
+  } else {
+    return obj;
   }
-  return obj;
 }
 
 function isReader(block: IBlock): block is IReader {
@@ -260,8 +262,9 @@ async function runStage(
       });
     } else if (stage.window ?? "self" === "self") {
       return await block.run(blockArgs, { ctxt: args, logger, root, headless });
+    } else {
+      throw new BusinessError(`Unexpected stage window ${stage.window}`);
     }
-    throw new BusinessError(`Unexpected stage window ${stage.window}`);
   } finally {
     progressCallbacks?.hide();
   }
@@ -355,10 +358,12 @@ export async function reducePipeline(
           console.warn(`Effect ${block.id} produced an output`, { output });
           logger.warn(`Ignoring output produced by effect ${block.id}`);
         }
-      } else if (stage.outputKey) {
-        extraContext[`@${stage.outputKey}`] = output;
       } else {
-        currentArgs = output as any;
+        if (stage.outputKey) {
+          extraContext[`@${stage.outputKey}`] = output;
+        } else {
+          currentArgs = output as any;
+        }
       }
     } catch (error) {
       if (error instanceof HeadlessModeError) {
@@ -416,8 +421,9 @@ export async function mergeReaders(
     return new CompositeReader(
       await resolveObj(mapValues(readerConfig, mergeReaders))
     );
+  } else {
+    throw new BusinessError("Unexpected value for readerConfig");
   }
-  throw new BusinessError("Unexpected value for readerConfig");
 }
 
 export type ServiceContext = {

--- a/src/blocks/effects/highlight.ts
+++ b/src/blocks/effects/highlight.ts
@@ -119,12 +119,14 @@ export class HighlightEffect extends Effect {
         for (const element of elements) {
           if (typeof element === "string") {
             $(this).find(element).css({ backgroundColor });
-          } else if (element.condition && boolean(condition)) {
-            const {
-              selector,
-              backgroundColor: elementColor = backgroundColor,
-            } = element;
-            $(this).find(selector).css({ backgroundColor: elementColor });
+          } else {
+            if (element.condition && boolean(condition)) {
+              const {
+                selector,
+                backgroundColor: elementColor = backgroundColor,
+              } = element;
+              $(this).find(selector).css({ backgroundColor: elementColor });
+            }
           }
         }
       } else {

--- a/src/blocks/effects/highlight.ts
+++ b/src/blocks/effects/highlight.ts
@@ -119,14 +119,12 @@ export class HighlightEffect extends Effect {
         for (const element of elements) {
           if (typeof element === "string") {
             $(this).find(element).css({ backgroundColor });
-          } else {
-            if (element.condition && boolean(condition)) {
-              const {
-                selector,
-                backgroundColor: elementColor = backgroundColor,
-              } = element;
-              $(this).find(selector).css({ backgroundColor: elementColor });
-            }
+          } else if (element.condition && boolean(condition)) {
+            const {
+              selector,
+              backgroundColor: elementColor = backgroundColor,
+            } = element;
+            $(this).find(selector).css({ backgroundColor: elementColor });
           }
         }
       } else {

--- a/src/blocks/effects/redirectPage.ts
+++ b/src/blocks/effects/redirectPage.ts
@@ -64,11 +64,12 @@ function makeURL(
 
   if (spaceEncoding === "plus" || result.search.length === 0) {
     return fullURL;
+  } else {
+    return fullURL.replace(
+      result.search,
+      result.search.replaceAll("+", SPACE_ENCODED_VALUE)
+    );
   }
-  return fullURL.replace(
-    result.search,
-    result.search.replaceAll("+", SPACE_ENCODED_VALUE)
-  );
 }
 
 export class NavigateURLEffect extends Effect {

--- a/src/blocks/effects/redirectPage.ts
+++ b/src/blocks/effects/redirectPage.ts
@@ -64,12 +64,11 @@ function makeURL(
 
   if (spaceEncoding === "plus" || result.search.length === 0) {
     return fullURL;
-  } else {
-    return fullURL.replace(
-      result.search,
-      result.search.replaceAll("+", SPACE_ENCODED_VALUE)
-    );
   }
+  return fullURL.replace(
+    result.search,
+    result.search.replaceAll("+", SPACE_ENCODED_VALUE)
+  );
 }
 
 export class NavigateURLEffect extends Effect {

--- a/src/blocks/readers/ImageEXIFReader.ts
+++ b/src/blocks/readers/ImageEXIFReader.ts
@@ -43,12 +43,15 @@ async function getData(img: HTMLImageElement): Promise<ArrayBuffer> {
     // Object URL
     const blob = await fetch(img.src).then((r) => r.blob());
     return await blob.arrayBuffer();
+  } else {
+    const response = await axios.get(img.src, { responseType: "arraybuffer" });
+    if (response.status !== 200) {
+      throw new Error(
+        `Error fetching image ${img.src}: ${response.statusText}`
+      );
+    }
+    return response.data;
   }
-  const response = await axios.get(img.src, { responseType: "arraybuffer" });
-  if (response.status !== 200) {
-    throw new Error(`Error fetching image ${img.src}: ${response.statusText}`);
-  }
-  return response.data;
 }
 
 class ImageEXIFReader extends Reader {
@@ -66,10 +69,11 @@ class ImageEXIFReader extends Reader {
     if (element?.tagName == "IMG") {
       const buffer = await getData(element);
       return ExifReader.load(buffer);
+    } else {
+      throw new Error(
+        `Expected an image element, got ${element.tagName ?? "document"}`
+      );
     }
-    throw new Error(
-      `Expected an image element, got ${element.tagName ?? "document"}`
-    );
   }
 
   outputSchema: Schema = {

--- a/src/blocks/readers/ImageEXIFReader.ts
+++ b/src/blocks/readers/ImageEXIFReader.ts
@@ -43,15 +43,12 @@ async function getData(img: HTMLImageElement): Promise<ArrayBuffer> {
     // Object URL
     const blob = await fetch(img.src).then((r) => r.blob());
     return await blob.arrayBuffer();
-  } else {
-    const response = await axios.get(img.src, { responseType: "arraybuffer" });
-    if (response.status !== 200) {
-      throw new Error(
-        `Error fetching image ${img.src}: ${response.statusText}`
-      );
-    }
-    return response.data;
   }
+  const response = await axios.get(img.src, { responseType: "arraybuffer" });
+  if (response.status !== 200) {
+    throw new Error(`Error fetching image ${img.src}: ${response.statusText}`);
+  }
+  return response.data;
 }
 
 class ImageEXIFReader extends Reader {
@@ -69,11 +66,10 @@ class ImageEXIFReader extends Reader {
     if (element?.tagName == "IMG") {
       const buffer = await getData(element);
       return ExifReader.load(buffer);
-    } else {
-      throw new Error(
-        `Expected an image element, got ${element.tagName ?? "document"}`
-      );
     }
+    throw new Error(
+      `Expected an image element, got ${element.tagName ?? "document"}`
+    );
   }
 
   outputSchema: Schema = {

--- a/src/blocks/readers/ImageReader.ts
+++ b/src/blocks/readers/ImageReader.ts
@@ -58,8 +58,11 @@ class ImageReader extends Reader {
         src: element.src,
         img: getBase64Image(element as HTMLImageElement),
       };
+    } else {
+      throw new Error(
+        `Expected an image, got ${element.tagName ?? "document"}`
+      );
     }
-    throw new Error(`Expected an image, got ${element.tagName ?? "document"}`);
   }
 
   outputSchema: Schema = {

--- a/src/blocks/readers/ImageReader.ts
+++ b/src/blocks/readers/ImageReader.ts
@@ -58,11 +58,8 @@ class ImageReader extends Reader {
         src: element.src,
         img: getBase64Image(element as HTMLImageElement),
       };
-    } else {
-      throw new Error(
-        `Expected an image, got ${element.tagName ?? "document"}`
-      );
     }
+    throw new Error(`Expected an image, got ${element.tagName ?? "document"}`);
   }
 
   outputSchema: Schema = {

--- a/src/blocks/readers/factory.ts
+++ b/src/blocks/readers/factory.ts
@@ -114,9 +114,8 @@ export function readerFactory(component: unknown): IReader {
       const doRead = _readerFactories.get(reader.type);
       if (doRead) {
         return doRead(reader as any, root);
-      } else {
-        throw new Error(`Reader type ${reader.type} not implemented`);
       }
+      throw new Error(`Reader type ${reader.type} not implemented`);
     }
   }
 

--- a/src/blocks/readers/factory.ts
+++ b/src/blocks/readers/factory.ts
@@ -114,8 +114,9 @@ export function readerFactory(component: unknown): IReader {
       const doRead = _readerFactories.get(reader.type);
       if (doRead) {
         return doRead(reader as any, root);
+      } else {
+        throw new Error(`Reader type ${reader.type} not implemented`);
       }
-      throw new Error(`Reader type ${reader.type} not implemented`);
     }
   }
 

--- a/src/blocks/readers/index.ts
+++ b/src/blocks/readers/index.ts
@@ -15,15 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export * from "./meta";
-export * from "./PageMetadataReader";
-export * from "./PageSemanticReader";
-export * from "./BlankReader";
-export * from "./ImageReader";
-export * from "./ImageEXIFReader";
-export * from "./ElementReader";
+import "./meta";
+import "./PageMetadataReader";
+import "./PageSemanticReader";
+import "./BlankReader";
+import "./ImageReader";
+import "./ImageEXIFReader";
+import "./ElementReader";
 
 // generic readers
-export * from "./frameworkReader";
+import "./frameworkReader";
 export * from "./jquery";
 export * from "./window";

--- a/src/blocks/renderers/iframe.ts
+++ b/src/blocks/renderers/iframe.ts
@@ -64,12 +64,11 @@ export class IFrameRenderer extends Renderer {
   }: BlockArg): Promise<string> {
     if (safeMode) {
       return `<iframe src="${url}" title="${title}" height="${height}" width="${width}" style="border:none;" allowfullscreen="false" allowpaymentrequest="false"></iframe>`;
-    } else {
-      // https://transitory.technology/browser-extensions-and-csp-headers/
-      const frameSrc = chrome.extension.getURL("frame.html");
-      const src = `${frameSrc}?url=${encodeURIComponent(url)}`;
-      return `<iframe src="${src}" title="${title}" height="${height}" width="${width}" style="border:none;"></iframe>`;
     }
+    // https://transitory.technology/browser-extensions-and-csp-headers/
+    const frameSrc = chrome.extension.getURL("frame.html");
+    const src = `${frameSrc}?url=${encodeURIComponent(url)}`;
+    return `<iframe src="${src}" title="${title}" height="${height}" width="${width}" style="border:none;"></iframe>`;
   }
 }
 

--- a/src/blocks/renderers/iframe.ts
+++ b/src/blocks/renderers/iframe.ts
@@ -64,11 +64,12 @@ export class IFrameRenderer extends Renderer {
   }: BlockArg): Promise<string> {
     if (safeMode) {
       return `<iframe src="${url}" title="${title}" height="${height}" width="${width}" style="border:none;" allowfullscreen="false" allowpaymentrequest="false"></iframe>`;
+    } else {
+      // https://transitory.technology/browser-extensions-and-csp-headers/
+      const frameSrc = chrome.extension.getURL("frame.html");
+      const src = `${frameSrc}?url=${encodeURIComponent(url)}`;
+      return `<iframe src="${src}" title="${title}" height="${height}" width="${width}" style="border:none;"></iframe>`;
     }
-    // https://transitory.technology/browser-extensions-and-csp-headers/
-    const frameSrc = chrome.extension.getURL("frame.html");
-    const src = `${frameSrc}?url=${encodeURIComponent(url)}`;
-    return `<iframe src="${src}" title="${title}" height="${height}" width="${width}" style="border:none;"></iframe>`;
   }
 }
 

--- a/src/blocks/renderers/propertyTable.tsx
+++ b/src/blocks/renderers/propertyTable.tsx
@@ -47,8 +47,9 @@ function richValue(value: unknown): unknown {
         {value}
       </a>
     );
+  } else {
+    return value;
   }
-  return value;
 }
 
 function shapeData(inputs: unknown, keyPrefix = "root"): Item[] {
@@ -64,12 +65,13 @@ function shapeData(inputs: unknown, keyPrefix = "root"): Item[] {
           data: { name, value: null },
           children: shapeData(value, key),
         };
+      } else {
+        return {
+          key,
+          data: { name, value: richValue(value) },
+          children: [],
+        };
       }
-      return {
-        key,
-        data: { name, value: richValue(value) },
-        children: [],
-      };
     });
   } else if (Array.isArray(inputs)) {
     return inputs.map((value, index) => {
@@ -81,21 +83,23 @@ function shapeData(inputs: unknown, keyPrefix = "root"): Item[] {
           data: { name: `${index}`, value: null },
           children: shapeData(value, key),
         };
+      } else {
+        return {
+          key,
+          data: { name: `${index}`, value: richValue(value) },
+          children: [],
+        };
       }
-      return {
-        key,
-        data: { name: `${index}`, value: richValue(value) },
-        children: [],
-      };
     });
+  } else {
+    return [
+      {
+        key: keyPrefix,
+        data: { name: null, value: inputs as any },
+        children: [],
+      },
+    ];
   }
-  return [
-    {
-      key: keyPrefix,
-      data: { name: null, value: inputs as any },
-      children: [],
-    },
-  ];
 }
 
 export class PropertyTableRenderer extends Renderer {

--- a/src/blocks/renderers/propertyTable.tsx
+++ b/src/blocks/renderers/propertyTable.tsx
@@ -47,9 +47,8 @@ function richValue(value: unknown): unknown {
         {value}
       </a>
     );
-  } else {
-    return value;
   }
+  return value;
 }
 
 function shapeData(inputs: unknown, keyPrefix = "root"): Item[] {
@@ -65,13 +64,12 @@ function shapeData(inputs: unknown, keyPrefix = "root"): Item[] {
           data: { name, value: null },
           children: shapeData(value, key),
         };
-      } else {
-        return {
-          key,
-          data: { name, value: richValue(value) },
-          children: [],
-        };
       }
+      return {
+        key,
+        data: { name, value: richValue(value) },
+        children: [],
+      };
     });
   } else if (Array.isArray(inputs)) {
     return inputs.map((value, index) => {
@@ -83,23 +81,21 @@ function shapeData(inputs: unknown, keyPrefix = "root"): Item[] {
           data: { name: `${index}`, value: null },
           children: shapeData(value, key),
         };
-      } else {
-        return {
-          key,
-          data: { name: `${index}`, value: richValue(value) },
-          children: [],
-        };
       }
-    });
-  } else {
-    return [
-      {
-        key: keyPrefix,
-        data: { name: null, value: inputs as any },
+      return {
+        key,
+        data: { name: `${index}`, value: richValue(value) },
         children: [],
-      },
-    ];
+      };
+    });
   }
+  return [
+    {
+      key: keyPrefix,
+      data: { name: null, value: inputs as any },
+      children: [],
+    },
+  ];
 }
 
 export class PropertyTableRenderer extends Renderer {

--- a/src/blocks/util.ts
+++ b/src/blocks/util.ts
@@ -32,6 +32,7 @@ export async function getType(
     return "transform";
   } else if ("render" in block) {
     return "renderer";
+  } else {
+    return null;
   }
-  return null;
 }

--- a/src/blocks/util.ts
+++ b/src/blocks/util.ts
@@ -32,7 +32,6 @@ export async function getType(
     return "transform";
   } else if ("render" in block) {
     return "renderer";
-  } else {
-    return null;
   }
+  return null;
 }

--- a/src/components/fields/BlockField.tsx
+++ b/src/components/fields/BlockField.tsx
@@ -98,9 +98,8 @@ export function useBlockOptions(
       return (
         registered ?? genericOptionsFactory(inputProperties(block.inputSchema))
       );
-    } else {
-      return null;
     }
+    return null;
   }, [block?.id, block?.inputSchema]);
 
   return [{ block, error }, BlockOptions];

--- a/src/components/fields/BlockField.tsx
+++ b/src/components/fields/BlockField.tsx
@@ -98,8 +98,9 @@ export function useBlockOptions(
       return (
         registered ?? genericOptionsFactory(inputProperties(block.inputSchema))
       );
+    } else {
+      return null;
     }
-    return null;
   }, [block?.id, block?.inputSchema]);
 
   return [{ block, error }, BlockOptions];

--- a/src/components/fields/ServiceModal.tsx
+++ b/src/components/fields/ServiceModal.tsx
@@ -114,9 +114,8 @@ const ServiceModal: React.FunctionComponent<{
         ),
         (x) => x.label
       );
-    } else {
-      return sortBy(serviceOptions, (x) => x.label);
     }
+    return sortBy(serviceOptions, (x) => x.label);
   }, [serviceOptions, debouncedQuery]);
 
   const close = useCallback(() => {

--- a/src/components/fields/ServiceModal.tsx
+++ b/src/components/fields/ServiceModal.tsx
@@ -114,8 +114,9 @@ const ServiceModal: React.FunctionComponent<{
         ),
         (x) => x.label
       );
+    } else {
+      return sortBy(serviceOptions, (x) => x.label);
     }
-    return sortBy(serviceOptions, (x) => x.label);
   }, [serviceOptions, debouncedQuery]);
 
   const close = useCallback(() => {

--- a/src/components/fields/blockOptions.tsx
+++ b/src/components/fields/blockOptions.tsx
@@ -129,8 +129,9 @@ function extractServiceIds(schema: Schema): string[] {
     return schema.anyOf
       .filter((x) => x != false)
       .flatMap((x) => extractServiceIds(x as Schema));
+  } else {
+    throw new Error("Expected $ref or anyOf in schema for service");
   }
-  throw new Error("Expected $ref or anyOf in schema for service");
 }
 
 export const ServiceField: React.FunctionComponent<
@@ -314,8 +315,9 @@ function getDefaultArrayItem(schema: Schema): unknown {
     return false;
   } else if (findOneOf(schema, textPredicate)) {
     return "";
+  } else {
+    return null;
   }
-  return null;
 }
 
 export function getDefaultField(fieldSchema: Schema): FieldComponent {
@@ -340,9 +342,10 @@ export function getDefaultField(fieldSchema: Schema): FieldComponent {
     // in the @pixiebrix/http brick.
     // https://github.com/pixiebrix/pixiebrix-extension/issues/709
     return ObjectField;
+  } else {
+    // number, string, other primitives, etc.
+    return TextField;
   }
-  // number, string, other primitives, etc.
-  return TextField;
 }
 
 /**

--- a/src/components/fields/blockOptions.tsx
+++ b/src/components/fields/blockOptions.tsx
@@ -129,9 +129,8 @@ function extractServiceIds(schema: Schema): string[] {
     return schema.anyOf
       .filter((x) => x != false)
       .flatMap((x) => extractServiceIds(x as Schema));
-  } else {
-    throw new Error("Expected $ref or anyOf in schema for service");
   }
+  throw new Error("Expected $ref or anyOf in schema for service");
 }
 
 export const ServiceField: React.FunctionComponent<
@@ -315,9 +314,8 @@ function getDefaultArrayItem(schema: Schema): unknown {
     return false;
   } else if (findOneOf(schema, textPredicate)) {
     return "";
-  } else {
-    return null;
   }
+  return null;
 }
 
 export function getDefaultField(fieldSchema: Schema): FieldComponent {
@@ -342,10 +340,9 @@ export function getDefaultField(fieldSchema: Schema): FieldComponent {
     // in the @pixiebrix/http brick.
     // https://github.com/pixiebrix/pixiebrix-extension/issues/709
     return ObjectField;
-  } else {
-    // number, string, other primitives, etc.
-    return TextField;
   }
+  // number, string, other primitives, etc.
+  return TextField;
 }
 
 /**

--- a/src/components/logViewer/EntryRow.tsx
+++ b/src/components/logViewer/EntryRow.tsx
@@ -76,8 +76,9 @@ const EntryRow: React.FunctionComponent<{ entry: LogEntry }> = ({ entry }) => {
       return InputDetail;
     } else if (entry.data?.output != null) {
       return OutputDetail;
+    } else {
+      return null;
     }
-    return null;
   }, [entry]);
 
   const expandable = !!Detail;

--- a/src/components/logViewer/EntryRow.tsx
+++ b/src/components/logViewer/EntryRow.tsx
@@ -76,9 +76,8 @@ const EntryRow: React.FunctionComponent<{ entry: LogEntry }> = ({ entry }) => {
       return InputDetail;
     } else if (entry.data?.output != null) {
       return OutputDetail;
-    } else {
-      return null;
     }
+    return null;
   }, [entry]);
 
   const expandable = !!Detail;

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -130,7 +130,6 @@ export function notifyContentScripts(
         );
       }
     );
-    return;
   };
 }
 
@@ -235,9 +234,8 @@ export function liftContentScript<R extends SerializableResponse>(
 
       if (isNotification(options)) {
         return;
-      } else {
-        throw error;
       }
+      throw error;
     }
 
     if (isErrorResponse(response)) {

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -130,6 +130,7 @@ export function notifyContentScripts(
         );
       }
     );
+    return;
   };
 }
 
@@ -234,8 +235,9 @@ export function liftContentScript<R extends SerializableResponse>(
 
       if (isNotification(options)) {
         return;
+      } else {
+        throw error;
       }
-      throw error;
     }
 
     if (isErrorResponse(response)) {

--- a/src/contentScript/devTools.ts
+++ b/src/contentScript/devTools.ts
@@ -51,8 +51,9 @@ async function read(factory: () => Promise<unknown>): Promise<unknown> {
   } catch (error) {
     if (deserializeError(error).name === "ComponentNotFoundError") {
       return "Component not detected";
+    } else {
+      return { error: error };
     }
-    return { error: error };
   }
 }
 
@@ -93,14 +94,16 @@ export const runReaderBlock = liftContentScript(
           srcUrl: root.getAttribute("src"),
           documentUrl: document.location.href,
         };
+      } else {
+        return {
+          selectionText: window.getSelection().toString(),
+          documentUrl: document.location.href,
+        };
       }
-      return {
-        selectionText: window.getSelection().toString(),
-        documentUrl: document.location.href,
-      };
+    } else {
+      const reader = (await blockRegistry.lookup(id)) as IReader;
+      return reader.read(root);
     }
-    const reader = (await blockRegistry.lookup(id)) as IReader;
-    return reader.read(root);
   }
 );
 
@@ -141,8 +144,9 @@ export const readSelected = liftContentScript("READ_SELECTED", async () => {
       );
     }
     return base;
+  } else {
+    return {
+      error: "No element selected",
+    };
   }
-  return {
-    error: "No element selected",
-  };
 });

--- a/src/contentScript/devTools.ts
+++ b/src/contentScript/devTools.ts
@@ -51,9 +51,8 @@ async function read(factory: () => Promise<unknown>): Promise<unknown> {
   } catch (error) {
     if (deserializeError(error).name === "ComponentNotFoundError") {
       return "Component not detected";
-    } else {
-      return { error: error };
     }
+    return { error: error };
   }
 }
 
@@ -94,16 +93,14 @@ export const runReaderBlock = liftContentScript(
           srcUrl: root.getAttribute("src"),
           documentUrl: document.location.href,
         };
-      } else {
-        return {
-          selectionText: window.getSelection().toString(),
-          documentUrl: document.location.href,
-        };
       }
-    } else {
-      const reader = (await blockRegistry.lookup(id)) as IReader;
-      return reader.read(root);
+      return {
+        selectionText: window.getSelection().toString(),
+        documentUrl: document.location.href,
+      };
     }
+    const reader = (await blockRegistry.lookup(id)) as IReader;
+    return reader.read(root);
   }
 );
 
@@ -144,9 +141,8 @@ export const readSelected = liftContentScript("READ_SELECTED", async () => {
       );
     }
     return base;
-  } else {
-    return {
-      error: "No element selected",
-    };
   }
+  return {
+    error: "No element selected",
+  };
 });

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -71,9 +71,8 @@ async function runExtensionPoint(
         `Skipping ${extensionPoint.id} because user navigated away from the page`
       );
       return;
-    } else {
-      throw error;
     }
+    throw error;
   }
 
   if (!installed) {

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -71,8 +71,9 @@ async function runExtensionPoint(
         `Skipping ${extensionPoint.id} because user navigated away from the page`
       );
       return;
+    } else {
+      throw error;
     }
-    throw error;
   }
 
   if (!installed) {

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -204,6 +204,8 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
         method: "GET",
       });
       return interfaceToInputSchema(response.data);
+    } else {
+      return;
     }
   }, [fileId, hasPermissions]);
 

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -204,8 +204,6 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
         method: "GET",
       });
       return interfaceToInputSchema(response.data);
-    } else {
-      return;
     }
   }, [fileId, hasPermissions]);
 

--- a/src/contrib/google/auth.ts
+++ b/src/contrib/google/auth.ts
@@ -77,7 +77,6 @@ export async function handleRejection(
       `Permission denied, re-authenticate with Google and try again. Details: ${error.result.error?.message}`,
       status
     );
-  } else {
-    return new Error(error.result.error?.message ?? "Unknown error");
   }
+  return new Error(error.result.error?.message ?? "Unknown error");
 }

--- a/src/contrib/google/auth.ts
+++ b/src/contrib/google/auth.ts
@@ -77,6 +77,7 @@ export async function handleRejection(
       `Permission denied, re-authenticate with Google and try again. Details: ${error.result.error?.message}`,
       status
     );
+  } else {
+    return new Error(error.result.error?.message ?? "Unknown error");
   }
-  return new Error(error.result.error?.message ?? "Unknown error");
 }

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -43,8 +43,9 @@ const TabField: React.FunctionComponent<
   const [tabNames, tabsPending, tabsError] = useAsyncState(async () => {
     if (doc?.id && port) {
       return devtoolsProtocol.getTabNames(port, doc.id);
+    } else {
+      return [];
     }
-    return [];
   }, [doc?.id, port]);
 
   const sheetOptions = useMemo(() => {
@@ -111,19 +112,21 @@ const PropertiesField: React.FunctionComponent<{
             .map((header) => [header, { type: "string" }])
         ),
       } as Schema;
+    } else {
+      return {
+        type: "object",
+        additionalProperties: true,
+      } as Schema;
     }
-    return {
-      type: "object",
-      additionalProperties: true,
-    } as Schema;
   }, [doc?.id, tabName]);
 
   if (schemaPending) {
     return <GridLoader />;
   } else if (schemaError) {
     return <span className="text-danger">Error fetching column headers</span>;
+  } else {
+    return <ObjectField label="Row Values" name={name} schema={sheetSchema} />;
   }
-  return <ObjectField label="Row Values" name={name} schema={sheetSchema} />;
 };
 
 const AppendSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -43,9 +43,8 @@ const TabField: React.FunctionComponent<
   const [tabNames, tabsPending, tabsError] = useAsyncState(async () => {
     if (doc?.id && port) {
       return devtoolsProtocol.getTabNames(port, doc.id);
-    } else {
-      return [];
     }
+    return [];
   }, [doc?.id, port]);
 
   const sheetOptions = useMemo(() => {
@@ -112,21 +111,19 @@ const PropertiesField: React.FunctionComponent<{
             .map((header) => [header, { type: "string" }])
         ),
       } as Schema;
-    } else {
-      return {
-        type: "object",
-        additionalProperties: true,
-      } as Schema;
     }
+    return {
+      type: "object",
+      additionalProperties: true,
+    } as Schema;
   }, [doc?.id, tabName]);
 
   if (schemaPending) {
     return <GridLoader />;
   } else if (schemaError) {
     return <span className="text-danger">Error fetching column headers</span>;
-  } else {
-    return <ObjectField label="Row Values" name={name} schema={sheetSchema} />;
   }
+  return <ObjectField label="Row Values" name={name} schema={sheetSchema} />;
 };
 
 const AppendSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({

--- a/src/contrib/uipath/localProcessOptions.tsx
+++ b/src/contrib/uipath/localProcessOptions.tsx
@@ -156,9 +156,8 @@ const LocalProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
   >(async () => {
     if (robotAvailable) {
       return getUiPathProcesses(port);
-    } else {
-      return [];
     }
+    return [];
   }, [robotAvailable]);
 
   const process = useMemo(() => {

--- a/src/contrib/uipath/localProcessOptions.tsx
+++ b/src/contrib/uipath/localProcessOptions.tsx
@@ -156,8 +156,9 @@ const LocalProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
   >(async () => {
     if (robotAvailable) {
       return getUiPathProcesses(port);
+    } else {
+      return [];
     }
-    return [];
   }, [robotAvailable]);
 
   const process = useMemo(() => {

--- a/src/contrib/uipath/processOptions.tsx
+++ b/src/contrib/uipath/processOptions.tsx
@@ -91,9 +91,8 @@ export function useReleases(): {
         method: "get",
       });
       return response.data.value;
-    } else {
-      return null;
     }
+    return null;
   }, [config, hasPermissions]);
 
   console.debug("releases", { releases, isPending, error });
@@ -110,9 +109,8 @@ function useRobots(): { robots: Robot[]; isPending: boolean; error: unknown } {
         method: "get",
       });
       return response.data.value;
-    } else {
-      return [];
     }
+    return [];
   }, [config, hasPermissions]);
 
   return { robots, isPending, error };
@@ -211,9 +209,8 @@ function toType(type: string) {
     ["Decimal", "Double"].includes(typeName)
   ) {
     return "number";
-  } else {
-    throw new BusinessError(`Unsupported input type: ${type}`);
   }
+  throw new BusinessError(`Unsupported input type: ${type}`);
 }
 
 export function releaseSchema(release: Release): Schema {

--- a/src/contrib/uipath/processOptions.tsx
+++ b/src/contrib/uipath/processOptions.tsx
@@ -91,8 +91,9 @@ export function useReleases(): {
         method: "get",
       });
       return response.data.value;
+    } else {
+      return null;
     }
-    return null;
   }, [config, hasPermissions]);
 
   console.debug("releases", { releases, isPending, error });
@@ -109,8 +110,9 @@ function useRobots(): { robots: Robot[]; isPending: boolean; error: unknown } {
         method: "get",
       });
       return response.data.value;
+    } else {
+      return [];
     }
-    return [];
   }, [config, hasPermissions]);
 
   return { robots, isPending, error };
@@ -209,8 +211,9 @@ function toType(type: string) {
     ["Decimal", "Double"].includes(typeName)
   ) {
     return "number";
+  } else {
+    throw new BusinessError(`Unsupported input type: ${type}`);
   }
-  throw new BusinessError(`Unsupported input type: ${type}`);
 }
 
 export function releaseSchema(release: Release): Schema {

--- a/src/devTools/Editor.tsx
+++ b/src/devTools/Editor.tsx
@@ -132,8 +132,9 @@ const Editor: React.FunctionComponent = () => {
           showSupport={() => setShowChat(true)}
         />
       );
+    } else {
+      return <WelcomePane showSupport={() => setShowChat(true)} />;
     }
-    return <WelcomePane showSupport={() => setShowChat(true)} />;
   }, [
     beta,
     cancelInsert,

--- a/src/devTools/Editor.tsx
+++ b/src/devTools/Editor.tsx
@@ -132,9 +132,8 @@ const Editor: React.FunctionComponent = () => {
           showSupport={() => setShowChat(true)}
         />
       );
-    } else {
-      return <WelcomePane showSupport={() => setShowChat(true)} />;
     }
+    return <WelcomePane showSupport={() => setShowChat(true)} />;
   }, [
     beta,
     cancelInsert,

--- a/src/devTools/Panel.tsx
+++ b/src/devTools/Panel.tsx
@@ -70,9 +70,8 @@ const RequireScope: React.FunctionComponent<{ scope: string | null }> = ({
 
   if (mode !== "local" && (scope === "" || !scope)) {
     return <ScopeSettings />;
-  } else {
-    return <>{children}</>;
   }
+  return <>{children}</>;
 };
 
 const Panel: React.FunctionComponent = () => {

--- a/src/devTools/Panel.tsx
+++ b/src/devTools/Panel.tsx
@@ -70,8 +70,9 @@ const RequireScope: React.FunctionComponent<{ scope: string | null }> = ({
 
   if (mode !== "local" && (scope === "" || !scope)) {
     return <ScopeSettings />;
+  } else {
+    return <>{children}</>;
   }
-  return <>{children}</>;
 };
 
 const Panel: React.FunctionComponent = () => {

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -58,13 +58,12 @@ async function makeRequestConfig(
       method: "put",
       headers: { Authorization: `Token ${await getExtensionToken()}` },
     };
-  } else {
-    return {
-      url: await makeURL("api/bricks/"),
-      method: "post",
-      headers: { Authorization: `Token ${await getExtensionToken()}` },
-    };
   }
+  return {
+    url: await makeURL("api/bricks/"),
+    method: "post",
+    headers: { Authorization: `Token ${await getExtensionToken()}` },
+  };
 }
 
 function selectErrorMessage(error: unknown): string {

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -58,12 +58,13 @@ async function makeRequestConfig(
       method: "put",
       headers: { Authorization: `Token ${await getExtensionToken()}` },
     };
+  } else {
+    return {
+      url: await makeURL("api/bricks/"),
+      method: "post",
+      headers: { Authorization: `Token ${await getExtensionToken()}` },
+    };
   }
-  return {
-    url: await makeURL("api/bricks/"),
-    method: "post",
-    headers: { Authorization: `Token ${await getExtensionToken()}` },
-  };
 }
 
 function selectErrorMessage(error: unknown): string {

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -55,13 +55,12 @@ async function makeRequestConfig(
       method: "put",
       headers: { Authorization: `Token ${await getExtensionToken()}` },
     };
-  } else {
-    return {
-      url: await makeURL("api/bricks/"),
-      method: "post",
-      headers: { Authorization: `Token ${await getExtensionToken()}` },
-    };
   }
+  return {
+    url: await makeURL("api/bricks/"),
+    method: "post",
+    headers: { Authorization: `Token ${await getExtensionToken()}` },
+  };
 }
 
 function selectErrorMessage(error: unknown): string {

--- a/src/devTools/editor/hooks/useInstallState.ts
+++ b/src/devTools/editor/hooks/useInstallState.ts
@@ -45,9 +45,8 @@ function useInstallState(
   const [installedIds] = useAsyncState(async () => {
     if (meta) {
       return getInstalledExtensionPointIds(port);
-    } else {
-      return [];
     }
+    return [];
   }, [port, navSequence, meta]);
 
   const [availableDynamicIds] = useAsyncState(async () => {
@@ -62,9 +61,8 @@ function useInstallState(
           .filter(([, available]) => available)
           .map(([extension]) => extension.uuid)
       );
-    } else {
-      return new Set<string>();
     }
+    return new Set<string>();
   }, [
     port,
     meta,
@@ -83,12 +81,10 @@ function useInstallState(
         return installed.filter(
           (x) => !installedIds.includes(x.extensionPointId)
         ).length;
-      } else {
-        return null;
       }
-    } else {
-      return installed?.length;
+      return null;
     }
+    return installed?.length;
   }, [installed, installedIds, meta]);
 
   return { installedIds, availableDynamicIds, unavailableCount };

--- a/src/devTools/editor/hooks/useInstallState.ts
+++ b/src/devTools/editor/hooks/useInstallState.ts
@@ -45,8 +45,9 @@ function useInstallState(
   const [installedIds] = useAsyncState(async () => {
     if (meta) {
       return getInstalledExtensionPointIds(port);
+    } else {
+      return [];
     }
-    return [];
   }, [port, navSequence, meta]);
 
   const [availableDynamicIds] = useAsyncState(async () => {
@@ -61,8 +62,9 @@ function useInstallState(
           .filter(([, available]) => available)
           .map(([extension]) => extension.uuid)
       );
+    } else {
+      return new Set<string>();
     }
-    return new Set<string>();
   }, [
     port,
     meta,
@@ -81,10 +83,12 @@ function useInstallState(
         return installed.filter(
           (x) => !installedIds.includes(x.extensionPointId)
         ).length;
+      } else {
+        return null;
       }
-      return null;
+    } else {
+      return installed?.length;
     }
-    return installed?.length;
   }, [installed, installedIds, meta]);
 
   return { installedIds, availableDynamicIds, unavailableCount };

--- a/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
@@ -97,9 +97,8 @@ export const ReaderBlockForm: React.FunctionComponent<{
   const searchResults = useMemo(() => {
     if (debouncedQuery === "" || output == null) {
       return output;
-    } else {
-      return searchData(query, output);
     }
+    return searchData(query, output);
   }, [debouncedQuery, output]);
 
   const copyData = useCallback(() => {

--- a/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
@@ -97,8 +97,9 @@ export const ReaderBlockForm: React.FunctionComponent<{
   const searchResults = useMemo(() => {
     if (debouncedQuery === "" || output == null) {
       return output;
+    } else {
+      return searchData(query, output);
     }
-    return searchData(query, output);
   }, [debouncedQuery, output]);
 
   const copyData = useCallback(() => {

--- a/src/devTools/editor/tabs/reader/ReaderConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderConfig.tsx
@@ -318,9 +318,8 @@ const ReaderConfig: React.FunctionComponent<{
   const searchResults = useMemo(() => {
     if (debouncedQuery === "" || output == null) {
       return output;
-    } else {
-      return searchData(query, output);
     }
+    return searchData(query, output);
   }, [debouncedQuery, output]);
 
   if (locked) {

--- a/src/devTools/editor/tabs/reader/ReaderConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderConfig.tsx
@@ -318,8 +318,9 @@ const ReaderConfig: React.FunctionComponent<{
   const searchResults = useMemo(() => {
     if (debouncedQuery === "" || output == null) {
       return output;
+    } else {
+      return searchData(query, output);
     }
-    return searchData(query, output);
   }, [debouncedQuery, output]);
 
   if (locked) {

--- a/src/devTools/editor/tabs/reader/ReaderConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderConfig.tsx
@@ -322,9 +322,8 @@ const ReaderConfig: React.FunctionComponent<{
   const searchResults = useMemo(() => {
     if (debouncedQuery === "" || output == null) {
       return output;
-    } else {
-      return searchData(debouncedQuery, output);
     }
+    return searchData(debouncedQuery, output);
   }, [debouncedQuery, output]);
 
   if (locked) {

--- a/src/devTools/editor/toolbar/ReloadToolbar.tsx
+++ b/src/devTools/editor/toolbar/ReloadToolbar.tsx
@@ -95,25 +95,24 @@ const ReloadToolbar: React.FunctionComponent<{
 
   if (automaticUpdate) {
     return null;
-  } else {
-    return (
-      <>
-        <label className="AutoRun my-auto mr-1">
-          {isPanel ? "Auto-Render" : "Auto-Run"}
-        </label>
-        <ToggleField name="autoReload" />
-        <Button
-          className="mx-2"
-          disabled={disabled}
-          size="sm"
-          variant="info"
-          onClick={run}
-        >
-          {isPanel ? "Render Panel" : "Run Trigger"}
-        </Button>
-      </>
-    );
   }
+  return (
+    <>
+      <label className="AutoRun my-auto mr-1">
+        {isPanel ? "Auto-Render" : "Auto-Run"}
+      </label>
+      <ToggleField name="autoReload" />
+      <Button
+        className="mx-2"
+        disabled={disabled}
+        size="sm"
+        variant="info"
+        onClick={run}
+      >
+        {isPanel ? "Render Panel" : "Run Trigger"}
+      </Button>
+    </>
+  );
 };
 
 export default ReloadToolbar;

--- a/src/devTools/editor/toolbar/ReloadToolbar.tsx
+++ b/src/devTools/editor/toolbar/ReloadToolbar.tsx
@@ -94,25 +94,24 @@ const ReloadToolbar: React.FunctionComponent<{
 
   if (automaticUpdate) {
     return null;
-  } else {
-    return (
-      <>
-        <label className="AutoRun my-auto mr-1">
-          {isPanel ? "Auto-Render" : "Auto-Run"}
-        </label>
-        <ToggleField name="autoReload" />
-        <Button
-          className="mx-2"
-          disabled={disabled}
-          size="sm"
-          variant="info"
-          onClick={run}
-        >
-          {isPanel ? "Render Panel" : "Run Trigger"}
-        </Button>
-      </>
-    );
   }
+  return (
+    <>
+      <label className="AutoRun my-auto mr-1">
+        {isPanel ? "Auto-Render" : "Auto-Run"}
+      </label>
+      <ToggleField name="autoReload" />
+      <Button
+        className="mx-2"
+        disabled={disabled}
+        size="sm"
+        variant="info"
+        onClick={run}
+      >
+        {isPanel ? "Render Panel" : "Run Trigger"}
+      </Button>
+    </>
+  );
 };
 
 export default ReloadToolbar;

--- a/src/devTools/editor/toolbar/ReloadToolbar.tsx
+++ b/src/devTools/editor/toolbar/ReloadToolbar.tsx
@@ -94,24 +94,25 @@ const ReloadToolbar: React.FunctionComponent<{
 
   if (automaticUpdate) {
     return null;
+  } else {
+    return (
+      <>
+        <label className="AutoRun my-auto mr-1">
+          {isPanel ? "Auto-Render" : "Auto-Run"}
+        </label>
+        <ToggleField name="autoReload" />
+        <Button
+          className="mx-2"
+          disabled={disabled}
+          size="sm"
+          variant="info"
+          onClick={run}
+        >
+          {isPanel ? "Render Panel" : "Run Trigger"}
+        </Button>
+      </>
+    );
   }
-  return (
-    <>
-      <label className="AutoRun my-auto mr-1">
-        {isPanel ? "Auto-Render" : "Auto-Run"}
-      </label>
-      <ToggleField name="autoReload" />
-      <Button
-        className="mx-2"
-        disabled={disabled}
-        size="sm"
-        variant="info"
-        onClick={run}
-      >
-        {isPanel ? "Render Panel" : "Run Trigger"}
-      </Button>
-    </>
-  );
 };
 
 export default ReloadToolbar;

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -79,12 +79,10 @@ function guessSelectedElement(): HTMLElement | null {
     const node = getCommonAncestor(start, end);
     if (node instanceof HTMLElement) {
       return node;
-    } else {
-      return null;
     }
-  } else {
     return null;
   }
+  return null;
 }
 
 function installMouseHandlerOnce(): void {

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -79,10 +79,12 @@ function guessSelectedElement(): HTMLElement | null {
     const node = getCommonAncestor(start, end);
     if (node instanceof HTMLElement) {
       return node;
+    } else {
+      return null;
     }
+  } else {
     return null;
   }
-  return null;
 }
 
 function installMouseHandlerOnce(): void {

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -174,8 +174,9 @@ function _initialize(
 ): [Promise<JQuery<HTMLElement | Document>>, () => void] {
   if (isNativeCssSelector(selector)) {
     return mutationSelector(selector, target);
+  } else {
+    return pollSelector(selector, target, waitMillis);
   }
-  return pollSelector(selector, target, waitMillis);
 }
 
 /**
@@ -228,8 +229,9 @@ export function awaitElementOnce(
     ];
   } else if (rest.length === 0) {
     return [Promise.resolve($element), noop];
+  } else {
+    return awaitElementOnce(rest, $element);
   }
-  return awaitElementOnce(rest, $element);
 }
 
 /**

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -174,9 +174,8 @@ function _initialize(
 ): [Promise<JQuery<HTMLElement | Document>>, () => void] {
   if (isNativeCssSelector(selector)) {
     return mutationSelector(selector, target);
-  } else {
-    return pollSelector(selector, target, waitMillis);
   }
+  return pollSelector(selector, target, waitMillis);
 }
 
 /**
@@ -229,9 +228,8 @@ export function awaitElementOnce(
     ];
   } else if (rest.length === 0) {
     return [Promise.resolve($element), noop];
-  } else {
-    return awaitElementOnce(rest, $element);
   }
+  return awaitElementOnce(rest, $element);
 }
 
 /**

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -362,8 +362,9 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
             return acquireElement(element, this.id, () =>
               this.reacquire(menuUUID)
             );
+          } else {
+            existingCount++;
           }
-          existingCount++;
         })
         .get()
     );
@@ -780,8 +781,9 @@ class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
         throw new Error(`Found no elements for  reader selector: ${selector}`);
       }
       return $elt.get(0);
+    } else {
+      return document;
     }
-    return document;
   }
 
   defaultReader() {

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -362,9 +362,8 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
             return acquireElement(element, this.id, () =>
               this.reacquire(menuUUID)
             );
-          } else {
-            existingCount++;
           }
+          existingCount++;
         })
         .get()
     );
@@ -781,9 +780,8 @@ class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
         throw new Error(`Found no elements for  reader selector: ${selector}`);
       }
       return $elt.get(0);
-    } else {
-      return document;
     }
+    return document;
   }
 
   defaultReader() {

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -362,9 +362,8 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
             return acquireElement(element, this.id, async () =>
               this.reacquire(menuUUID)
             );
-          } else {
-            existingCount++;
           }
+          existingCount++;
         })
         .get()
     );
@@ -783,9 +782,8 @@ class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
         throw new Error(`Found no elements for  reader selector: ${selector}`);
       }
       return $elt.get(0);
-    } else {
-      return document;
     }
+    return document;
   }
 
   async defaultReader() {

--- a/src/frameworks/contrib/ember.ts
+++ b/src/frameworks/contrib/ember.ts
@@ -71,9 +71,8 @@ export function getEmberApplication(): EmberApplication {
     return namespaces.find(
       (namespace) => namespace instanceof (Ember.Application as any)
     ) as EmberApplication;
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 export function getEmberComponentById(componentId: string): EmberObject {
@@ -114,13 +113,11 @@ export function getProp(value: any, prop: string | number): unknown {
       return getProp(value.content, prop);
     } else if (typeof prop === "string" && isGetter(value, prop)) {
       return value[prop]();
-    } else {
-      return value[prop];
     }
-  } else {
-    // ignore functions and symbols
-    return undefined;
+    return value[prop];
   }
+  // ignore functions and symbols
+  return undefined;
 }
 
 function pickExternalProps(obj: object): object {
@@ -158,13 +155,11 @@ export function readEmberValueFromCache(
     } else if (Array.isArray(value.content)) {
       // consider arrays a traverse because knowing the property name by itself isn't useful for anything
       return value.content.map(traverse);
-    } else {
-      return mapValues(pickExternalProps(value), recurse);
     }
-  } else {
-    // ignore functions and symbols
-    return undefined;
+    return mapValues(pickExternalProps(value), recurse);
   }
+  // ignore functions and symbols
+  return undefined;
 }
 
 function isManaged(node: Node): boolean {

--- a/src/frameworks/contrib/ember.ts
+++ b/src/frameworks/contrib/ember.ts
@@ -71,8 +71,9 @@ export function getEmberApplication(): EmberApplication {
     return namespaces.find(
       (namespace) => namespace instanceof (Ember.Application as any)
     ) as EmberApplication;
+  } else {
+    return undefined;
   }
-  return undefined;
 }
 
 export function getEmberComponentById(componentId: string): EmberObject {
@@ -113,11 +114,13 @@ export function getProp(value: any, prop: string | number): unknown {
       return getProp(value.content, prop);
     } else if (typeof prop === "string" && isGetter(value, prop)) {
       return value[prop]();
+    } else {
+      return value[prop];
     }
-    return value[prop];
+  } else {
+    // ignore functions and symbols
+    return undefined;
   }
-  // ignore functions and symbols
-  return undefined;
 }
 
 function pickExternalProps(obj: object): object {
@@ -155,11 +158,13 @@ export function readEmberValueFromCache(
     } else if (Array.isArray(value.content)) {
       // consider arrays a traverse because knowing the property name by itself isn't useful for anything
       return value.content.map(traverse);
+    } else {
+      return mapValues(pickExternalProps(value), recurse);
     }
-    return mapValues(pickExternalProps(value), recurse);
+  } else {
+    // ignore functions and symbols
+    return undefined;
   }
-  // ignore functions and symbols
-  return undefined;
 }
 
 function isManaged(node: Node): boolean {

--- a/src/frameworks/contrib/ember.ts
+++ b/src/frameworks/contrib/ember.ts
@@ -71,9 +71,8 @@ export function getEmberApplication(): EmberApplication {
     return namespaces.find(
       (namespace) => namespace instanceof (Ember.Application as any)
     ) as EmberApplication;
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 export function getEmberComponentById(componentId: string): EmberObject {
@@ -114,13 +113,11 @@ export function getProp(value: any, prop: string | number): unknown {
       return getProp(value.content, prop);
     } else if (typeof prop === "string" && isGetter(value, prop)) {
       return value[prop]();
-    } else {
-      return value[prop];
     }
-  } else {
-    // ignore functions and symbols
-    return undefined;
+    return value[prop];
   }
+  // ignore functions and symbols
+  return undefined;
 }
 
 function pickExternalProps(obj: object): object {
@@ -158,13 +155,11 @@ export function readEmberValueFromCache(
     } else if (Array.isArray(value.content)) {
       // consider arrays a traverse because knowing the property name by itself isn't useful for anything
       return value.content.map((x: any) => traverse(x));
-    } else {
-      return mapValues(pickExternalProps(value), recurse);
     }
-  } else {
-    // ignore functions and symbols
-    return undefined;
+    return mapValues(pickExternalProps(value), recurse);
   }
+  // ignore functions and symbols
+  return undefined;
 }
 
 function isManaged(node: Node): boolean {

--- a/src/frameworks/contrib/react.ts
+++ b/src/frameworks/contrib/react.ts
@@ -116,9 +116,8 @@ export function findReactComponent(node: Node, traverseUp = 0): Fiber {
     const owner = (x: LegacyInstance) => x._currentElement._owner;
     const fiber = traverse(owner, owner(domFiber), traverseUp);
     return fiber._instance as Fiber;
-  } else {
-    return traverse(getComponentFiber, getComponentFiber(domFiber), traverseUp);
   }
+  return traverse(getComponentFiber, getComponentFiber(domFiber), traverseUp);
 }
 
 export class ReactRootVisitor implements RootInstanceVisitor<RootInstance> {

--- a/src/frameworks/contrib/react.ts
+++ b/src/frameworks/contrib/react.ts
@@ -116,8 +116,9 @@ export function findReactComponent(node: Node, traverseUp = 0): Fiber {
     const owner = (x: LegacyInstance) => x._currentElement._owner;
     const fiber = traverse(owner, owner(domFiber), traverseUp);
     return fiber._instance as Fiber;
+  } else {
+    return traverse(getComponentFiber, getComponentFiber(domFiber), traverseUp);
   }
-  return traverse(getComponentFiber, getComponentFiber(domFiber), traverseUp);
 }
 
 export class ReactRootVisitor implements RootInstanceVisitor<RootInstance> {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -117,15 +117,12 @@ export function mapArgs(
         // if we're returning the root service context, return the service itself
         // @ts-ignore: not sure why the "in" check isn't working
         return prop.__service;
-      } else {
-        return prop;
       }
-    } else {
-      return render(config, ctxt);
+      return prop;
     }
-  } else {
-    return config;
+    return render(config, ctxt);
   }
+  return config;
 }
 
 /**
@@ -151,9 +148,8 @@ export function missingProperties(
 export function inputProperties(inputSchema: Schema): SchemaProperties {
   if (typeof inputSchema === "object" && "properties" in inputSchema) {
     return inputSchema.properties;
-  } else {
-    return inputSchema as SchemaProperties;
   }
+  return inputSchema as SchemaProperties;
 }
 
 export const isChrome =

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -117,12 +117,15 @@ export function mapArgs(
         // if we're returning the root service context, return the service itself
         // @ts-ignore: not sure why the "in" check isn't working
         return prop.__service;
+      } else {
+        return prop;
       }
-      return prop;
+    } else {
+      return render(config, ctxt);
     }
-    return render(config, ctxt);
+  } else {
+    return config;
   }
-  return config;
 }
 
 /**
@@ -148,8 +151,9 @@ export function missingProperties(
 export function inputProperties(inputSchema: Schema): SchemaProperties {
   if (typeof inputSchema === "object" && "properties" in inputSchema) {
     return inputSchema.properties;
+  } else {
+    return inputSchema as SchemaProperties;
   }
-  return inputSchema as SchemaProperties;
 }
 
 export const isChrome =

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -71,7 +71,6 @@ export async function getAuth(): Promise<AuthState> {
       extension: true,
       flags,
     };
-  } else {
-    return anonAuth;
   }
+  return anonAuth;
 }

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -71,6 +71,7 @@ export async function getAuth(): Promise<AuthState> {
       extension: true,
       flags,
     };
+  } else {
+    return anonAuth;
   }
-  return anonAuth;
 }

--- a/src/hooks/fetch.ts
+++ b/src/hooks/fetch.ts
@@ -66,10 +66,9 @@ export async function fetch<TData>(
       throw new Error(`Request error: ${statusText}`);
     }
     return data;
-  } else {
-    const { data } = await axios.get<TData>(url);
-    return data;
   }
+  const { data } = await axios.get<TData>(url);
+  return data;
 }
 
 /**

--- a/src/hooks/fetch.ts
+++ b/src/hooks/fetch.ts
@@ -66,9 +66,10 @@ export async function fetch<TData>(
       throw new Error(`Request error: ${statusText}`);
     }
     return data;
+  } else {
+    const { data } = await axios.get<TData>(url);
+    return data;
   }
-  const { data } = await axios.get<TData>(url);
-  return data;
 }
 
 /**

--- a/src/icons/IconSelector.tsx
+++ b/src/icons/IconSelector.tsx
@@ -56,9 +56,8 @@ const IconSelector: React.FunctionComponent<OwnProps> = ({
       return iconOptions.find(
         (x) => x.value.library === value.library && x.value.id === value.id
       );
-    } else {
-      return null;
     }
+    return null;
   }, [value]);
 
   return (

--- a/src/icons/IconSelector.tsx
+++ b/src/icons/IconSelector.tsx
@@ -56,8 +56,9 @@ const IconSelector: React.FunctionComponent<OwnProps> = ({
       return iconOptions.find(
         (x) => x.value.library === value.library && x.value.id === value.id
       );
+    } else {
+      return null;
     }
-    return null;
   }, [value]);
 
   return (

--- a/src/nativeEditor/dynamic.ts
+++ b/src/nativeEditor/dynamic.ts
@@ -88,8 +88,9 @@ async function buildSingleReader(config: ReaderLike): Promise<IReader> {
     return config;
   } else if (isCustomReader(config)) {
     return readerFactory(config);
+  } else {
+    return blockRegistry.lookup(config.metadata.id) as Promise<IReader>;
   }
-  return blockRegistry.lookup(config.metadata.id) as Promise<IReader>;
 }
 
 async function buildReaders(configs: ReaderLike[]): Promise<IReader> {

--- a/src/nativeEditor/dynamic.ts
+++ b/src/nativeEditor/dynamic.ts
@@ -88,9 +88,8 @@ async function buildSingleReader(config: ReaderLike): Promise<IReader> {
     return config;
   } else if (isCustomReader(config)) {
     return readerFactory(config);
-  } else {
-    return blockRegistry.lookup(config.metadata.id) as Promise<IReader>;
   }
+  return blockRegistry.lookup(config.metadata.id) as Promise<IReader>;
 }
 
 async function buildReaders(configs: ReaderLike[]): Promise<IReader> {

--- a/src/nativeEditor/frameworks.ts
+++ b/src/nativeEditor/frameworks.ts
@@ -75,8 +75,9 @@ export async function elementInfo(
           traverseUp - 1
         ),
       };
+    } else {
+      console.debug(`No component found for ${framework}`);
     }
-    console.debug(`No component found for ${framework}`);
   }
 
   return {

--- a/src/nativeEditor/frameworks.ts
+++ b/src/nativeEditor/frameworks.ts
@@ -75,9 +75,8 @@ export async function elementInfo(
           traverseUp - 1
         ),
       };
-    } else {
-      console.debug(`No component found for ${framework}`);
     }
+    console.debug(`No component found for ${framework}`);
   }
 
   return {

--- a/src/nativeEditor/infer.ts
+++ b/src/nativeEditor/infer.ts
@@ -171,19 +171,17 @@ function removeUnstyledLayout(node: Node): Node | null {
       nonEmptyChildren.length === 1
     ) {
       return removeUnstyledLayout(nonEmptyChildren[0]);
-    } else {
-      const clone = node.cloneNode(false) as Element;
-      for (const childNode of node.childNodes) {
-        const newChild = removeUnstyledLayout(childNode);
-        if (newChild != null) {
-          clone.append(newChild);
-        }
-      }
-      return clone;
     }
-  } else {
-    return node.cloneNode(false);
+    const clone = node.cloneNode(false) as Element;
+    for (const childNode of node.childNodes) {
+      const newChild = removeUnstyledLayout(childNode);
+      if (newChild != null) {
+        clone.append(newChild);
+      }
+    }
+    return clone;
   }
+  return node.cloneNode(false);
 }
 
 /**
@@ -214,9 +212,8 @@ function commonButtonStructure(
     if (error instanceof SkipElement) {
       // Shouldn't happen at the top level
       return [$(), currentCaptioned];
-    } else {
-      throw error;
     }
+    throw error;
   }
 
   // Heuristic that assumes elements match from the beginning
@@ -519,7 +516,6 @@ export function inferSelectors(
         root,
         error,
       });
-      return;
     }
   };
 
@@ -623,9 +619,8 @@ export function findContainer(
       container,
       selectors: inferSelectors(container),
     };
-  } else {
-    return findContainerForElement(elements[0]);
   }
+  return findContainerForElement(elements[0]);
 }
 
 /**
@@ -675,9 +670,8 @@ export function inferPanelHTML(
   if (selected.length > 1) {
     const children = containerChildren($container, selected);
     return commonPanelHTML(selected[0].tagName, $(children));
-  } else {
-    return inferSinglePanelHTML(container, selected[0]);
   }
+  return inferSinglePanelHTML(container, selected[0]);
 }
 
 export function inferButtonHTML(

--- a/src/nativeEditor/infer.ts
+++ b/src/nativeEditor/infer.ts
@@ -171,17 +171,19 @@ function removeUnstyledLayout(node: Node): Node | null {
       nonEmptyChildren.length === 1
     ) {
       return removeUnstyledLayout(nonEmptyChildren[0]);
-    }
-    const clone = node.cloneNode(false) as Element;
-    for (const childNode of node.childNodes) {
-      const newChild = removeUnstyledLayout(childNode);
-      if (newChild != null) {
-        clone.append(newChild);
+    } else {
+      const clone = node.cloneNode(false) as Element;
+      for (const childNode of node.childNodes) {
+        const newChild = removeUnstyledLayout(childNode);
+        if (newChild != null) {
+          clone.append(newChild);
+        }
       }
+      return clone;
     }
-    return clone;
+  } else {
+    return node.cloneNode(false);
   }
-  return node.cloneNode(false);
 }
 
 /**
@@ -212,8 +214,9 @@ function commonButtonStructure(
     if (error instanceof SkipElement) {
       // Shouldn't happen at the top level
       return [$(), currentCaptioned];
+    } else {
+      throw error;
     }
-    throw error;
   }
 
   // Heuristic that assumes elements match from the beginning
@@ -516,6 +519,7 @@ export function inferSelectors(
         root,
         error,
       });
+      return;
     }
   };
 
@@ -619,8 +623,9 @@ export function findContainer(
       container,
       selectors: inferSelectors(container),
     };
+  } else {
+    return findContainerForElement(elements[0]);
   }
-  return findContainerForElement(elements[0]);
 }
 
 /**
@@ -670,8 +675,9 @@ export function inferPanelHTML(
   if (selected.length > 1) {
     const children = containerChildren($container, selected);
     return commonPanelHTML(selected[0].tagName, $(children));
+  } else {
+    return inferSinglePanelHTML(container, selected[0]);
   }
-  return inferSinglePanelHTML(container, selected[0]);
 }
 
 export function inferButtonHTML(

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -68,9 +68,8 @@ const RequireInstall: React.FunctionComponent = ({ children }) => {
   }
   if (mode === "remote" && !token) {
     return <SetupPage />;
-  } else {
-    return <>{children}</>;
   }
+  return <>{children}</>;
 };
 
 const Layout = () => {

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -68,8 +68,9 @@ const RequireInstall: React.FunctionComponent = ({ children }) => {
   }
   if (mode === "remote" && !token) {
     return <SetupPage />;
+  } else {
+    return <>{children}</>;
   }
-  return <>{children}</>;
 };
 
 const Layout = () => {

--- a/src/options/pages/InstalledPage.tsx
+++ b/src/options/pages/InstalledPage.tsx
@@ -193,12 +193,13 @@ const ExtensionRow: React.FunctionComponent<{
           <FontAwesomeIcon icon={faCheck} /> Active
         </span>
       );
+    } else {
+      return (
+        <Button variant="info" size="sm" onClick={requestPermissions}>
+          Grant Permissions
+        </Button>
+      );
     }
-    return (
-      <Button variant="info" size="sm" onClick={requestPermissions}>
-        Grant Permissions
-      </Button>
-    );
   }, [hasPermissions, requestPermissions, validation]);
 
   return (

--- a/src/options/pages/InstalledPage.tsx
+++ b/src/options/pages/InstalledPage.tsx
@@ -193,13 +193,12 @@ const ExtensionRow: React.FunctionComponent<{
           <FontAwesomeIcon icon={faCheck} /> Active
         </span>
       );
-    } else {
-      return (
-        <Button variant="info" size="sm" onClick={requestPermissions}>
-          Grant Permissions
-        </Button>
-      );
     }
+    return (
+      <Button variant="info" size="sm" onClick={requestPermissions}>
+        Grant Permissions
+      </Button>
+    );
   }, [hasPermissions, requestPermissions, validation]);
 
   return (

--- a/src/options/pages/brickEditor/EditPage.tsx
+++ b/src/options/pages/brickEditor/EditPage.tsx
@@ -68,8 +68,9 @@ function useParseBrick(config: string | null): ParsedBrickInfo {
         ),
         config: configJSON,
       };
+    } else {
+      return { isBlueprint: false, isInstalled: false, config: configJSON };
     }
-    return { isBlueprint: false, isInstalled: false, config: configJSON };
   }, [config, extensions]);
 }
 

--- a/src/options/pages/brickEditor/EditPage.tsx
+++ b/src/options/pages/brickEditor/EditPage.tsx
@@ -68,9 +68,8 @@ function useParseBrick(config: string | null): ParsedBrickInfo {
         ),
         config: configJSON,
       };
-    } else {
-      return { isBlueprint: false, isInstalled: false, config: configJSON };
     }
+    return { isBlueprint: false, isInstalled: false, config: configJSON };
   }, [config, extensions]);
 }
 

--- a/src/options/pages/brickEditor/Editor.tsx
+++ b/src/options/pages/brickEditor/Editor.tsx
@@ -52,8 +52,9 @@ const SharingIcon: React.FunctionComponent<{
     return <FontAwesomeIcon icon={faGlobe} />;
   } else if (organizations) {
     return <FontAwesomeIcon icon={faBuilding} />;
+  } else {
+    return <FontAwesomeIcon icon={faEyeSlash} />;
   }
-  return <FontAwesomeIcon icon={faEyeSlash} />;
 };
 
 export interface EditorValues {

--- a/src/options/pages/brickEditor/Editor.tsx
+++ b/src/options/pages/brickEditor/Editor.tsx
@@ -52,9 +52,8 @@ const SharingIcon: React.FunctionComponent<{
     return <FontAwesomeIcon icon={faGlobe} />;
   } else if (organizations) {
     return <FontAwesomeIcon icon={faBuilding} />;
-  } else {
-    return <FontAwesomeIcon icon={faEyeSlash} />;
   }
+  return <FontAwesomeIcon icon={faEyeSlash} />;
 };
 
 export interface EditorValues {

--- a/src/options/pages/brickEditor/validate.ts
+++ b/src/options/pages/brickEditor/validate.ts
@@ -65,7 +65,6 @@ export async function validateSchema(value: string): Promise<any> {
     return {
       config: validation.errors.map((x) => `${x.instanceLocation}: ${x.error}`),
     };
-  } else {
-    return {};
   }
+  return {};
 }

--- a/src/options/pages/brickEditor/validate.ts
+++ b/src/options/pages/brickEditor/validate.ts
@@ -65,6 +65,7 @@ export async function validateSchema(value: string): Promise<any> {
     return {
       config: validation.errors.map((x) => `${x.instanceLocation}: ${x.error}`),
     };
+  } else {
+    return {};
   }
-  return {};
 }

--- a/src/options/pages/deployments/DeploymentBanner.tsx
+++ b/src/options/pages/deployments/DeploymentBanner.tsx
@@ -92,8 +92,9 @@ function useEnsurePermissions(deployments: Deployment[]) {
         autoDismiss: true,
       });
       return false;
+    } else {
+      return true;
     }
-    return true;
   }, [permissions, setEnabled]);
 
   const groupedPermissions = useMemo(() => {

--- a/src/options/pages/deployments/DeploymentBanner.tsx
+++ b/src/options/pages/deployments/DeploymentBanner.tsx
@@ -92,9 +92,8 @@ function useEnsurePermissions(deployments: Deployment[]) {
         autoDismiss: true,
       });
       return false;
-    } else {
-      return true;
     }
+    return true;
   }, [permissions, setEnabled]);
 
   const groupedPermissions = useMemo(() => {

--- a/src/options/pages/deployments/hooks.ts
+++ b/src/options/pages/deployments/hooks.ts
@@ -86,8 +86,9 @@ export function useEnsurePermissions(deployments: Deployment[]) {
         autoDismiss: true,
       });
       return false;
+    } else {
+      return true;
     }
-    return true;
   }, [permissions, setEnabled]);
 
   const groupedPermissions = useMemo(() => {

--- a/src/options/pages/deployments/hooks.ts
+++ b/src/options/pages/deployments/hooks.ts
@@ -86,9 +86,8 @@ export function useEnsurePermissions(deployments: Deployment[]) {
         autoDismiss: true,
       });
       return false;
-    } else {
-      return true;
     }
+    return true;
   }, [permissions, setEnabled]);
 
   const groupedPermissions = useMemo(() => {

--- a/src/options/pages/extensionEditor/DataSourceCard.tsx
+++ b/src/options/pages/extensionEditor/DataSourceCard.tsx
@@ -88,13 +88,14 @@ const ArrayEntry: React.FunctionComponent<{
         )}
       </ListGroup.Item>
     );
+  } else {
+    return (
+      <ListGroup.Item>
+        <span>{prop}</span>
+        <span className="type">: array of {itemType ?? "unknown"}</span>
+      </ListGroup.Item>
+    );
   }
-  return (
-    <ListGroup.Item>
-      <span>{prop}</span>
-      <span className="type">: array of {itemType ?? "unknown"}</span>
-    </ListGroup.Item>
-  );
 };
 
 const PrimitiveEntry: React.FunctionComponent<{
@@ -148,14 +149,15 @@ export const SchemaTree: React.FunctionComponent<{ schema: Schema }> = ({
                 key={prop}
               />
             );
+          } else {
+            return (
+              <PrimitiveEntry
+                prop={prop}
+                definition={schemaDefinition}
+                key={prop}
+              />
+            );
           }
-          return (
-            <PrimitiveEntry
-              prop={prop}
-              definition={schemaDefinition}
-              key={prop}
-            />
-          );
         })}
     </ListGroup>
   );
@@ -176,8 +178,9 @@ const DataSourceCard: React.FunctionComponent<{
       return <Card.Body>{error.toString()}</Card.Body>;
     } else if (isEmpty(outputSchema)) {
       return <Card.Body>No schema available</Card.Body>;
+    } else {
+      return <SchemaTree schema={outputSchema} />;
     }
-    return <SchemaTree schema={outputSchema} />;
   }, [error, outputSchema, isPending]);
 
   return <div className="DataSourceCard">{body}</div>;

--- a/src/options/pages/extensionEditor/DataSourceCard.tsx
+++ b/src/options/pages/extensionEditor/DataSourceCard.tsx
@@ -88,14 +88,13 @@ const ArrayEntry: React.FunctionComponent<{
         )}
       </ListGroup.Item>
     );
-  } else {
-    return (
-      <ListGroup.Item>
-        <span>{prop}</span>
-        <span className="type">: array of {itemType ?? "unknown"}</span>
-      </ListGroup.Item>
-    );
   }
+  return (
+    <ListGroup.Item>
+      <span>{prop}</span>
+      <span className="type">: array of {itemType ?? "unknown"}</span>
+    </ListGroup.Item>
+  );
 };
 
 const PrimitiveEntry: React.FunctionComponent<{
@@ -149,15 +148,14 @@ export const SchemaTree: React.FunctionComponent<{ schema: Schema }> = ({
                 key={prop}
               />
             );
-          } else {
-            return (
-              <PrimitiveEntry
-                prop={prop}
-                definition={schemaDefinition}
-                key={prop}
-              />
-            );
           }
+          return (
+            <PrimitiveEntry
+              prop={prop}
+              definition={schemaDefinition}
+              key={prop}
+            />
+          );
         })}
     </ListGroup>
   );
@@ -178,9 +176,8 @@ const DataSourceCard: React.FunctionComponent<{
       return <Card.Body>{error.toString()}</Card.Body>;
     } else if (isEmpty(outputSchema)) {
       return <Card.Body>No schema available</Card.Body>;
-    } else {
-      return <SchemaTree schema={outputSchema} />;
     }
+    return <SchemaTree schema={outputSchema} />;
   }, [error, outputSchema, isPending]);
 
   return <div className="DataSourceCard">{body}</div>;

--- a/src/options/pages/extensionEditor/ExtensionEditor.tsx
+++ b/src/options/pages/extensionEditor/ExtensionEditor.tsx
@@ -106,21 +106,20 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
     return <GridLoader />;
   } else if (!extensionPoint) {
     return <WorkshopPage navigate={navigate} />;
-  } else {
-    return (
-      <ExtensionPointDetail
-        initialValue={{
-          label: extensionConfig?.label,
-          config: extensionConfig?.config,
-          services: extensionConfig?.services ?? [],
-          optionsArgs: extensionConfig?.optionsArgs ?? {},
-        }}
-        extensionId={extensionId}
-        extensionPoint={extensionPoint}
-        onSave={save}
-      />
-    );
   }
+  return (
+    <ExtensionPointDetail
+      initialValue={{
+        label: extensionConfig?.label,
+        config: extensionConfig?.config,
+        services: extensionConfig?.services ?? [],
+        optionsArgs: extensionConfig?.optionsArgs ?? {},
+      }}
+      extensionId={extensionId}
+      extensionPoint={extensionPoint}
+      onSave={save}
+    />
+  );
 };
 
 const mapStateToProps: null = undefined;

--- a/src/options/pages/extensionEditor/ExtensionEditor.tsx
+++ b/src/options/pages/extensionEditor/ExtensionEditor.tsx
@@ -106,20 +106,21 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
     return <GridLoader />;
   } else if (!extensionPoint) {
     return <WorkshopPage navigate={navigate} />;
+  } else {
+    return (
+      <ExtensionPointDetail
+        initialValue={{
+          label: extensionConfig?.label,
+          config: extensionConfig?.config,
+          services: extensionConfig?.services ?? [],
+          optionsArgs: extensionConfig?.optionsArgs ?? {},
+        }}
+        extensionId={extensionId}
+        extensionPoint={extensionPoint}
+        onSave={save}
+      />
+    );
   }
-  return (
-    <ExtensionPointDetail
-      initialValue={{
-        label: extensionConfig?.label,
-        config: extensionConfig?.config,
-        services: extensionConfig?.services ?? [],
-        optionsArgs: extensionConfig?.optionsArgs ?? {},
-      }}
-      extensionId={extensionId}
-      extensionPoint={extensionPoint}
-      onSave={save}
-    />
-  );
 };
 
 const mapStateToProps: null = undefined;

--- a/src/options/pages/marketplace/ActivateBody.tsx
+++ b/src/options/pages/marketplace/ActivateBody.tsx
@@ -91,9 +91,8 @@ export function useEnsurePermissions(
         autoDismiss: true,
       });
       return false;
-    } else {
-      return true;
     }
+    return true;
   }, [permissions, addToast]);
 
   const activate = useCallback(() => {
@@ -105,12 +104,11 @@ export function useEnsurePermissions(
           extensions: extensions.map((x) => x.label),
         });
         return submitForm();
-      } else {
-        reportEvent("MarketplaceRejectPermissions", {
-          blueprintId: blueprint.metadata.id,
-          extensions: extensions.map((x) => x.label),
-        });
       }
+      reportEvent("MarketplaceRejectPermissions", {
+        blueprintId: blueprint.metadata.id,
+        extensions: extensions.map((x) => x.label),
+      });
     });
   }, [extensions, request, submitForm, blueprint.metadata]);
 

--- a/src/options/pages/marketplace/ActivateBody.tsx
+++ b/src/options/pages/marketplace/ActivateBody.tsx
@@ -91,8 +91,9 @@ export function useEnsurePermissions(
         autoDismiss: true,
       });
       return false;
+    } else {
+      return true;
     }
-    return true;
   }, [permissions, addToast]);
 
   const activate = useCallback(() => {
@@ -104,11 +105,12 @@ export function useEnsurePermissions(
           extensions: extensions.map((x) => x.label),
         });
         return submitForm();
+      } else {
+        reportEvent("MarketplaceRejectPermissions", {
+          blueprintId: blueprint.metadata.id,
+          extensions: extensions.map((x) => x.label),
+        });
       }
-      reportEvent("MarketplaceRejectPermissions", {
-        blueprintId: blueprint.metadata.id,
-        extensions: extensions.map((x) => x.label),
-      });
     });
   }, [extensions, request, submitForm, blueprint.metadata]);
 

--- a/src/options/pages/marketplace/ActivatePage.tsx
+++ b/src/options/pages/marketplace/ActivatePage.tsx
@@ -109,9 +109,8 @@ const ActivatePage: React.FunctionComponent = () => {
           </Card.Body>
         </Card>
       );
-    } else {
-      return <GridLoader />;
     }
+    return <GridLoader />;
   }, [blueprintId, blueprint, sourcePage]);
 
   return (

--- a/src/options/pages/marketplace/ActivatePage.tsx
+++ b/src/options/pages/marketplace/ActivatePage.tsx
@@ -109,8 +109,9 @@ const ActivatePage: React.FunctionComponent = () => {
           </Card.Body>
         </Card>
       );
+    } else {
+      return <GridLoader />;
     }
-    return <GridLoader />;
   }, [blueprintId, blueprint, sourcePage]);
 
   return (

--- a/src/options/pages/marketplace/ServicesBody.tsx
+++ b/src/options/pages/marketplace/ServicesBody.tsx
@@ -170,14 +170,13 @@ const ServiceDescriptor: React.FunctionComponent<{
         <code className="small p-0">{serviceId}</code>
       </div>
     );
-  } else {
-    return (
-      <div>
-        {config && <span>{config.metadata.name}</span>}
-        <code className="p-0">{serviceId}</code>
-      </div>
-    );
   }
+  return (
+    <div>
+      {config && <span>{config.metadata.name}</span>}
+      <code className="p-0">{serviceId}</code>
+    </div>
+  );
 };
 
 const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {

--- a/src/options/pages/marketplace/ServicesBody.tsx
+++ b/src/options/pages/marketplace/ServicesBody.tsx
@@ -170,13 +170,14 @@ const ServiceDescriptor: React.FunctionComponent<{
         <code className="small p-0">{serviceId}</code>
       </div>
     );
+  } else {
+    return (
+      <div>
+        {config && <span>{config.metadata.name}</span>}
+        <code className="p-0">{serviceId}</code>
+      </div>
+    );
   }
-  return (
-    <div>
-      {config && <span>{config.metadata.name}</span>}
-      <code className="p-0">{serviceId}</code>
-    </div>
-  );
 };
 
 const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {

--- a/src/options/pages/services/ServiceEditorModal.tsx
+++ b/src/options/pages/services/ServiceEditorModal.tsx
@@ -61,8 +61,9 @@ const ServiceEditorModal: React.FunctionComponent<OwnProps> = ({
   const Editor = useMemo(() => {
     if (optionsRegistry.has(service.id)) {
       return optionsRegistry.get(service.id);
+    } else {
+      return genericOptionsFactory(service.schema);
     }
-    return genericOptionsFactory(service.schema);
   }, [service]);
 
   const schemaPromise = useMemo(

--- a/src/options/pages/services/ServiceEditorModal.tsx
+++ b/src/options/pages/services/ServiceEditorModal.tsx
@@ -61,9 +61,8 @@ const ServiceEditorModal: React.FunctionComponent<OwnProps> = ({
   const Editor = useMemo(() => {
     if (optionsRegistry.has(service.id)) {
       return optionsRegistry.get(service.id);
-    } else {
-      return genericOptionsFactory(service.schema);
     }
+    return genericOptionsFactory(service.schema);
   }, [service]);
 
   const schemaPromise = useMemo(

--- a/src/pages/marketplace/MarketplacePage.tsx
+++ b/src/pages/marketplace/MarketplacePage.tsx
@@ -57,13 +57,12 @@ const Entry: React.FunctionComponent<
           Add
         </Button>
       );
-    } else {
-      return (
-        <Button size="sm" variant="info" {...buttonProps} disabled>
-          Added
-        </Button>
-      );
     }
+    return (
+      <Button size="sm" variant="info" {...buttonProps} disabled>
+        Added
+      </Button>
+    );
   }, [onInstall, installed]);
 
   return (

--- a/src/pages/marketplace/MarketplacePage.tsx
+++ b/src/pages/marketplace/MarketplacePage.tsx
@@ -57,12 +57,13 @@ const Entry: React.FunctionComponent<
           Add
         </Button>
       );
+    } else {
+      return (
+        <Button size="sm" variant="info" {...buttonProps} disabled>
+          Added
+        </Button>
+      );
     }
-    return (
-      <Button size="sm" variant="info" {...buttonProps} disabled>
-        Added
-      </Button>
-    );
   }, [onInstall, installed]);
 
   return (

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -118,10 +118,11 @@ export async function serviceOriginPermissions(
     // Don't need permissions to access the pixiebrix API proxy server because they're already granted on
     // extension install. The proxy server will check isAvailable when making request
     return { origins: [] };
+  } else {
+    const service = await registry.lookup(dependency.id);
+    const matchPatterns = service.getOrigins(localConfig.config);
+    return { origins: matchPatterns };
   }
-  const service = await registry.lookup(dependency.id);
-  const matchPatterns = service.getOrigins(localConfig.config);
-  return { origins: matchPatterns };
 }
 
 /**

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -118,11 +118,10 @@ export async function serviceOriginPermissions(
     // Don't need permissions to access the pixiebrix API proxy server because they're already granted on
     // extension install. The proxy server will check isAvailable when making request
     return { origins: [] };
-  } else {
-    const service = await registry.lookup(dependency.id);
-    const matchPatterns = service.getOrigins(localConfig.config);
-    return { origins: matchPatterns };
   }
+  const service = await registry.lookup(dependency.id);
+  const matchPatterns = service.getOrigins(localConfig.config);
+  return { origins: matchPatterns };
 }
 
 /**

--- a/src/script.ts
+++ b/src/script.ts
@@ -183,9 +183,8 @@ async function read<TComponent>(
     });
     if (optional) {
       return {};
-    } else {
-      throw error;
     }
+    throw error;
   }
 
   let component: TComponent;

--- a/src/script.ts
+++ b/src/script.ts
@@ -178,9 +178,8 @@ async function read<TComponent>(
     });
     if (optional) {
       return {};
-    } else {
-      throw error;
     }
+    throw error;
   }
 
   let component: TComponent;

--- a/src/script.ts
+++ b/src/script.ts
@@ -178,8 +178,9 @@ async function read<TComponent>(
     });
     if (optional) {
       return {};
+    } else {
+      throw error;
     }
-    throw error;
   }
 
   let component: TComponent;

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -37,8 +37,9 @@ export async function getBaseURL(): Promise<string> {
     return withoutTrailingSlash(
       isEmpty(configured) ? DEFAULT_SERVICE_URL : configured
     );
+  } else {
+    return withoutTrailingSlash(DEFAULT_SERVICE_URL);
   }
-  return withoutTrailingSlash(DEFAULT_SERVICE_URL);
 }
 
 export async function setBaseURL(serviceURL: string): Promise<void> {

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -37,9 +37,8 @@ export async function getBaseURL(): Promise<string> {
     return withoutTrailingSlash(
       isEmpty(configured) ? DEFAULT_SERVICE_URL : configured
     );
-  } else {
-    return withoutTrailingSlash(DEFAULT_SERVICE_URL);
   }
+  return withoutTrailingSlash(DEFAULT_SERVICE_URL);
 }
 
 export async function setBaseURL(serviceURL: string): Promise<void> {

--- a/src/services/factory.ts
+++ b/src/services/factory.ts
@@ -135,9 +135,8 @@ class LocalDefinedService<
         .authentication as TokenAuthenticationDefinition).token;
       // console.debug("token context", { definition, serviceConfig });
       return mapArgs<TokenContext>(definition, serviceConfig);
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 
   getOAuth2Context(serviceConfig: ServiceConfig): OAuth2Context {
@@ -146,9 +145,8 @@ class LocalDefinedService<
         .authentication as OAuth2AuthenticationDefinition).oauth2;
       console.debug("getOAuth2Context", { definition, serviceConfig });
       return mapArgs<OAuth2Context>(definition, serviceConfig);
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 
   /**

--- a/src/services/factory.ts
+++ b/src/services/factory.ts
@@ -135,8 +135,9 @@ class LocalDefinedService<
         .authentication as TokenAuthenticationDefinition).token;
       // console.debug("token context", { definition, serviceConfig });
       return mapArgs<TokenContext>(definition, serviceConfig);
+    } else {
+      return undefined;
     }
-    return undefined;
   }
 
   getOAuth2Context(serviceConfig: ServiceConfig): OAuth2Context {
@@ -145,8 +146,9 @@ class LocalDefinedService<
         .authentication as OAuth2AuthenticationDefinition).oauth2;
       console.debug("getOAuth2Context", { definition, serviceConfig });
       return mapArgs<OAuth2Context>(definition, serviceConfig);
+    } else {
+      return undefined;
     }
-    return undefined;
   }
 
   /**

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -64,8 +64,9 @@ export function useDependency(
       );
       const service = await registry.lookup(dependency.id);
       return { localConfig: localConfig, service };
+    } else {
+      throw new Error("No integration selected");
     }
-    throw new Error("No integration selected");
   }, [dependency?.config]);
 
   const origins = useMemo(() => {
@@ -77,8 +78,9 @@ export function useDependency(
   const [hasPermissions] = useAsyncState(async () => {
     if (origins != null) {
       return checkPermissions([{ origins }]);
+    } else {
+      return false;
     }
-    return false;
   }, [origins]);
 
   useEffect(() => {

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -64,9 +64,8 @@ export function useDependency(
       );
       const service = await registry.lookup(dependency.id);
       return { localConfig: localConfig, service };
-    } else {
-      throw new Error("No integration selected");
     }
+    throw new Error("No integration selected");
   }, [dependency?.config]);
 
   const origins = useMemo(() => {
@@ -78,9 +77,8 @@ export function useDependency(
   const [hasPermissions] = useAsyncState(async () => {
     if (origins != null) {
       return checkPermissions([{ origins }]);
-    } else {
-      return false;
     }
+    return false;
   }, [origins]);
 
   useEffect(() => {

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -82,8 +82,9 @@ export function toLogArgument(error: unknown): LogArgument {
   } else if (typeof error === "object") {
     // the custom data or error object
     return error;
+  } else {
+    return error.toString();
   }
-  return error.toString();
 }
 
 export async function updateAuth({

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -82,9 +82,8 @@ export function toLogArgument(error: unknown): LogArgument {
   } else if (typeof error === "object") {
     // the custom data or error object
     return error;
-  } else {
-    return error.toString();
   }
+  return error.toString();
 }
 
 export async function updateAuth({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,8 +135,9 @@ export function removeUndefined(obj: unknown): unknown {
       pickBy(obj, (x) => x !== undefined),
       (x) => removeUndefined(x)
     );
+  } else {
+    return obj;
   }
-  return obj;
 }
 
 export function boolean(value: unknown): boolean {
@@ -203,8 +204,9 @@ export function cleanValue(value: unknown, maxDepth = 5, depth = 0): unknown {
     return mapValues(value, recurse);
   } else if (typeof value === "function" || typeof value === "symbol") {
     return undefined;
+  } else {
+    return value;
   }
-  return value;
 }
 
 /**
@@ -273,8 +275,9 @@ export function getPropByPath(
     if (value == null) {
       if (coalesce || index === rawParts.length - 1) {
         return null;
+      } else {
+        throw new InvalidPathError(`${path} undefined (missing ${part})`, path);
       }
-      throw new InvalidPathError(`${path} undefined (missing ${part})`, path);
     }
 
     if (typeof value === "function") {
@@ -294,8 +297,9 @@ export function isNullOrBlank(value: unknown): boolean {
     return true;
   } else if (typeof value === "string" && value.trim() === "") {
     return true;
+  } else {
+    return false;
   }
-  return false;
 }
 
 export class PromiseCancelled extends Error {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,9 +135,8 @@ export function removeUndefined(obj: unknown): unknown {
       pickBy(obj, (x) => x !== undefined),
       (x) => removeUndefined(x)
     );
-  } else {
-    return obj;
   }
+  return obj;
 }
 
 export function boolean(value: unknown): boolean {
@@ -204,9 +203,8 @@ export function cleanValue(value: unknown, maxDepth = 5, depth = 0): unknown {
     return mapValues(value, recurse);
   } else if (typeof value === "function" || typeof value === "symbol") {
     return undefined;
-  } else {
-    return value;
   }
+  return value;
 }
 
 /**
@@ -275,9 +273,8 @@ export function getPropByPath(
     if (value == null) {
       if (coalesce || index === rawParts.length - 1) {
         return null;
-      } else {
-        throw new InvalidPathError(`${path} undefined (missing ${part})`, path);
       }
+      throw new InvalidPathError(`${path} undefined (missing ${part})`, path);
     }
 
     if (typeof value === "function") {
@@ -297,9 +294,8 @@ export function isNullOrBlank(value: unknown): boolean {
     return true;
   } else if (typeof value === "string" && value.trim() === "") {
     return true;
-  } else {
-    return false;
   }
+  return false;
 }
 
 export class PromiseCancelled extends Error {

--- a/src/validators/validation.ts
+++ b/src/validators/validation.ts
@@ -91,60 +91,57 @@ export function configSchemaFactory(
     return Yup.lazy((val) => {
       if (isPlainObject(val)) {
         return Yup.lazy(blockSchemaFactory);
-      } else {
-        return Yup.array().of(Yup.lazy(blockSchemaFactory)).min(1);
       }
+      return Yup.array().of(Yup.lazy(blockSchemaFactory)).min(1);
     });
-  } else
-    switch (schema.type) {
-      case "object": {
-        return Yup.lazy((val) => {
-          if (isPlainObject(val)) {
-            return Yup.object().shape(
-              mapValues(schema.properties, (definition, prop) => {
-                if (typeof definition === "boolean") {
-                  return wrapRequired(Yup.string());
-                } else {
-                  return configSchemaFactory(definition, {
-                    required: (schema.required ?? []).includes(prop),
-                  });
-                }
-              })
-            );
-          } else {
-            return Yup.string();
-          }
-        });
-      }
-      case "array": {
-        if (typeof schema.items === "boolean") {
-          throw new TypeError(
-            "Expected schema definition for items, not boolean"
-          );
-        } else if (Array.isArray(schema.items)) {
-          // TODO: implement support for tuples
-          // https://github.com/jquense/yup/issues/528
-          return Yup.lazy((x) =>
-            Array.isArray(x)
-              ? wrapRequired(Yup.array())
-              : wrapRequired(Yup.string())
-          );
-        } else {
-          const items = schema.items as Schema;
-          return Yup.lazy((x) =>
-            Array.isArray(x)
-              ? wrapRequired(Yup.array().of(configSchemaFactory(items)))
-              : wrapRequired(Yup.string())
+  }
+  switch (schema.type) {
+    case "object": {
+      return Yup.lazy((val) => {
+        if (isPlainObject(val)) {
+          return Yup.object().shape(
+            mapValues(schema.properties, (definition, prop) => {
+              if (typeof definition === "boolean") {
+                return wrapRequired(Yup.string());
+              }
+              return configSchemaFactory(definition, {
+                required: (schema.required ?? []).includes(prop),
+              });
+            })
           );
         }
-      }
-      case "boolean": {
-        return Yup.bool();
-      }
-      default: {
-        return wrapRequired(Yup.string());
+        return Yup.string();
+      });
+    }
+    case "array": {
+      if (typeof schema.items === "boolean") {
+        throw new TypeError(
+          "Expected schema definition for items, not boolean"
+        );
+      } else if (Array.isArray(schema.items)) {
+        // TODO: implement support for tuples
+        // https://github.com/jquense/yup/issues/528
+        return Yup.lazy((x) =>
+          Array.isArray(x)
+            ? wrapRequired(Yup.array())
+            : wrapRequired(Yup.string())
+        );
+      } else {
+        const items = schema.items as Schema;
+        return Yup.lazy((x) =>
+          Array.isArray(x)
+            ? wrapRequired(Yup.array().of(configSchemaFactory(items)))
+            : wrapRequired(Yup.string())
+        );
       }
     }
+    case "boolean": {
+      return Yup.bool();
+    }
+    default: {
+      return wrapRequired(Yup.string());
+    }
+  }
 }
 
 function serviceSchemaFactory(): Yup.Schema<unknown> {
@@ -192,11 +189,10 @@ function serviceSchemaFactory(): Yup.Schema<unknown> {
                 return this.createError({
                   message: "Configuration no longer available",
                 });
-              } else {
-                console.exception(
-                  `An error occurred validating service: ${this.parent.id}`
-                );
               }
+              console.exception(
+                `An error occurred validating service: ${this.parent.id}`
+              );
             }
             return true;
           }

--- a/src/validators/validation.ts
+++ b/src/validators/validation.ts
@@ -91,57 +91,60 @@ export function configSchemaFactory(
     return Yup.lazy((val) => {
       if (isPlainObject(val)) {
         return Yup.lazy(blockSchemaFactory);
+      } else {
+        return Yup.array().of(Yup.lazy(blockSchemaFactory)).min(1);
       }
-      return Yup.array().of(Yup.lazy(blockSchemaFactory)).min(1);
     });
-  }
-  switch (schema.type) {
-    case "object": {
-      return Yup.lazy((val) => {
-        if (isPlainObject(val)) {
-          return Yup.object().shape(
-            mapValues(schema.properties, (definition, prop) => {
-              if (typeof definition === "boolean") {
-                return wrapRequired(Yup.string());
-              }
-              return configSchemaFactory(definition, {
-                required: (schema.required ?? []).includes(prop),
-              });
-            })
+  } else
+    switch (schema.type) {
+      case "object": {
+        return Yup.lazy((val) => {
+          if (isPlainObject(val)) {
+            return Yup.object().shape(
+              mapValues(schema.properties, (definition, prop) => {
+                if (typeof definition === "boolean") {
+                  return wrapRequired(Yup.string());
+                } else {
+                  return configSchemaFactory(definition, {
+                    required: (schema.required ?? []).includes(prop),
+                  });
+                }
+              })
+            );
+          } else {
+            return Yup.string();
+          }
+        });
+      }
+      case "array": {
+        if (typeof schema.items === "boolean") {
+          throw new TypeError(
+            "Expected schema definition for items, not boolean"
+          );
+        } else if (Array.isArray(schema.items)) {
+          // TODO: implement support for tuples
+          // https://github.com/jquense/yup/issues/528
+          return Yup.lazy((x) =>
+            Array.isArray(x)
+              ? wrapRequired(Yup.array())
+              : wrapRequired(Yup.string())
+          );
+        } else {
+          const items = schema.items as Schema;
+          return Yup.lazy((x) =>
+            Array.isArray(x)
+              ? wrapRequired(Yup.array().of(configSchemaFactory(items)))
+              : wrapRequired(Yup.string())
           );
         }
-        return Yup.string();
-      });
-    }
-    case "array": {
-      if (typeof schema.items === "boolean") {
-        throw new TypeError(
-          "Expected schema definition for items, not boolean"
-        );
-      } else if (Array.isArray(schema.items)) {
-        // TODO: implement support for tuples
-        // https://github.com/jquense/yup/issues/528
-        return Yup.lazy((x) =>
-          Array.isArray(x)
-            ? wrapRequired(Yup.array())
-            : wrapRequired(Yup.string())
-        );
-      } else {
-        const items = schema.items as Schema;
-        return Yup.lazy((x) =>
-          Array.isArray(x)
-            ? wrapRequired(Yup.array().of(configSchemaFactory(items)))
-            : wrapRequired(Yup.string())
-        );
+      }
+      case "boolean": {
+        return Yup.bool();
+      }
+      default: {
+        return wrapRequired(Yup.string());
       }
     }
-    case "boolean": {
-      return Yup.bool();
-    }
-    default: {
-      return wrapRequired(Yup.string());
-    }
-  }
 }
 
 function serviceSchemaFactory(): Yup.Schema<unknown> {
@@ -189,10 +192,11 @@ function serviceSchemaFactory(): Yup.Schema<unknown> {
                 return this.createError({
                   message: "Configuration no longer available",
                 });
+              } else {
+                console.exception(
+                  `An error occurred validating service: ${this.parent.id}`
+                );
               }
-              console.exception(
-                `An error occurred validating service: ${this.parent.id}`
-              );
             }
             return true;
           }


### PR DESCRIPTION
- Based on https://github.com/pixiebrix/pixiebrix-extension/pull/761

It's best to merge that one first.



This is essentially a whitespace-only lint change around else/if/return, no functional changes were made to the code. It felt like an easy fix to reduce indentation.

**PR diff best looked at without whitespace changes.**

- https://eslint.org/docs/rules/no-else-return <-- most common
- https://eslint.org/docs/rules/no-useless-return
- https://eslint.org/docs/rules/no-lonely-if
- https://eslint.org/docs/rules/no-negated-condition (not autofixable, so I just soft-enabled it)

In short, it turns else/if cascades:

```js
if (something) {
	return 1;
} else if (somethingElse) {
	return 2;
}
```

into in early returns:


```js
if (something) {
	return 1;
}

if (somethingElse) {
	return 2;
}
```