### PR TITLE
Enable 4 more lint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,8 +44,6 @@
     "@typescript-eslint/no-implicit-any-catch": "error",
     "capitalized-comments": "error",
     "spaced-comment": "error",
-    "@typescript-eslint/lines-between-class-members": "error",
-    "padding-line-between-statements": "error",
 
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -42,6 +42,10 @@
     "no-useless-return": "error",
     "prefer-promise-reject-errors": "error",
     "@typescript-eslint/no-implicit-any-catch": "error",
+    "capitalized-comments": "error",
+    "spaced-comment": "error",
+    "@typescript-eslint/lines-between-class-members": "error",
+    "padding-line-between-statements": "error",
 
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -37,15 +37,18 @@
   "rules": {
     // Enable a few more rules
     "no-lonely-if": "error",
-    "no-else-return": "error",
-    "no-negated-condition": "warn",
+    "no-else-return": [
+      "error",
+      {
+        "allowElseIf": false
+      }
+    ],
+    "no-negated-condition": "off",
     "no-useless-return": "error",
     "prefer-promise-reject-errors": "error",
-    "@typescript-eslint/no-implicit-any-catch": "error",
-    "capitalized-comments": "error",
-    "spaced-comment": "error",
-    "@typescript-eslint/lines-between-class-members": "error",
     "padding-line-between-statements": "error",
+    "@typescript-eslint/no-implicit-any-catch": "error",
+    "@typescript-eslint/lines-between-class-members": "error",
 
     "@typescript-eslint/no-unused-vars": [
       "error",
@@ -103,6 +106,33 @@
       {
         "ignoreVoid": true, // Prepend a function call with `void` to mark it as not needing to be await'ed, which silences this rule.
         "ignoreIIFE": true
+      }
+    ],
+
+    // Config copied from https://github.com/xojs/eslint-config-xo/blob/main/index.js#L275
+    "capitalized-comments": [
+      "error",
+      "always",
+      {
+        "ignorePattern": "pragma|ignore|prettier-ignore|webpack",
+        "ignoreInlineComments": true,
+        "ignoreConsecutiveComments": true
+      }
+    ],
+
+    "spaced-comment": [
+      "error",
+      "always",
+      {
+        "line": {
+          "exceptions": ["-", "+", "*"],
+          "markers": ["!", "/", "=>"]
+        },
+        "block": {
+          "exceptions": ["-", "+", "*"],
+          "markers": ["!", "*"],
+          "balanced": true
+        }
       }
     ],
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -44,6 +44,8 @@
     "@typescript-eslint/no-implicit-any-catch": "error",
     "capitalized-comments": "error",
     "spaced-comment": "error",
+    "@typescript-eslint/lines-between-class-members": "error",
+    "padding-line-between-statements": "error",
 
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/src/action.tsx
+++ b/src/action.tsx
@@ -17,7 +17,7 @@
 
 import "@/extensionContext";
 
-// init rollbar early so we get error reporting on the other initialization
+// Init rollbar early so we get error reporting on the other initialization
 import "@/telemetry/rollbar";
 
 import App from "./actionPanel/ActionPanelApp";
@@ -28,7 +28,7 @@ import { browser } from "webextension-polyfill-ts";
 import { REGISTER_ACTION_FRAME } from "@/background/browserAction";
 import "@/actionPanel/protocol";
 
-// keep in order so precedence is preserved
+// Keep in order so precedence is preserved
 import "vendors/theme/app/app.scss";
 import "./action.scss";
 import "@/vendors/overrides.scss";

--- a/src/actionPanel/PanelBody.tsx
+++ b/src/actionPanel/PanelBody.tsx
@@ -26,7 +26,7 @@ import ConsoleLogger from "@/tests/ConsoleLogger";
 // @ts-ignore: no @types/react-shadow-root
 import ReactShadowRoot from "react-shadow-root";
 
-// import the built-in bricks
+// Import the built-in bricks
 import "@/blocks";
 import "@/contrib";
 import { getErrorMessage } from "@/errors";

--- a/src/actionPanel/PanelBody.tsx
+++ b/src/actionPanel/PanelBody.tsx
@@ -43,6 +43,7 @@ const BodyComponent: React.FunctionComponent<{
         />
       );
     }
+
     const { Component, props } = body;
     return <Component {...props} />;
   }, [body]);
@@ -55,10 +56,12 @@ const PanelBody: React.FunctionComponent<{ panel: PanelEntry }> = ({
     if (!panel.payload) {
       return null;
     }
+
     if ("error" in panel.payload) {
       const { error } = panel.payload;
       return <div className="text-danger">Error running panel: {error}</div>;
     }
+
     const { blockId, ctxt, args } = panel.payload;
     console.debug("Render panel body", panel.payload);
     const block = await blockRegistry.lookup(blockId);
@@ -83,9 +86,11 @@ const PanelBody: React.FunctionComponent<{ panel: PanelEntry }> = ({
       </div>
     );
   }
+
   if (pending || component == null) {
     return <GridLoader />;
   }
+
   return component;
 };
 

--- a/src/actionPanel/PanelBody.tsx
+++ b/src/actionPanel/PanelBody.tsx
@@ -54,7 +54,8 @@ const PanelBody: React.FunctionComponent<{ panel: PanelEntry }> = ({
   const [component, pending, error] = useAsyncState(async () => {
     if (!panel.payload) {
       return null;
-    } else if ("error" in panel.payload) {
+    }
+    if ("error" in panel.payload) {
       const { error } = panel.payload;
       return <div className="text-danger">Error running panel: {error}</div>;
     }
@@ -81,7 +82,8 @@ const PanelBody: React.FunctionComponent<{ panel: PanelEntry }> = ({
         Error rendering panel: {getErrorMessage(error as Error)}
       </div>
     );
-  } else if (pending || component == null) {
+  }
+  if (pending || component == null) {
     return <GridLoader />;
   }
   return component;

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -58,9 +58,11 @@ function getHTMLElement(): JQuery<HTMLElement> {
   // resolve html tag, which is more dominant than <body>
   if (document.documentElement) {
     return $(document.documentElement);
-  } else if (document.querySelector("html")) {
+  }
+  if (document.querySelector("html")) {
     return $(document.querySelector("html"));
-  } else if ($("html").length > -1) {
+  }
+  if ($("html").length > -1) {
     return $("html");
   }
   throw new Error("HTML node not found");

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -59,12 +59,15 @@ function getHTMLElement(): JQuery<HTMLElement> {
   if (document.documentElement) {
     return $(document.documentElement);
   }
+
   if (document.querySelector("html")) {
     return $(document.querySelector("html"));
   }
+
   if ($("html").length > -1) {
     return $("html");
   }
+
   throw new Error("HTML node not found");
 }
 
@@ -138,6 +141,7 @@ export function toggleActionPanel(): string | null {
     hideActionPanel();
     return null;
   }
+
   return showActionPanel();
 }
 
@@ -182,6 +186,7 @@ export function reservePanels(refs: ExtensionRef[]): void {
         });
       }
     }
+
     renderPanels();
   }
 }
@@ -205,6 +210,7 @@ export function upsertPanel(
   } else {
     panels.push({ extensionId, extensionPointId, heading, payload });
   }
+
   renderPanels();
 }
 

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -55,7 +55,7 @@ export function removeShowCallback(onShow: ShowCallback): void {
 }
 
 function getHTMLElement(): JQuery<HTMLElement> {
-  // resolve html tag, which is more dominant than <body>
+  // Resolve html tag, which is more dominant than <body>
   if (document.documentElement) {
     return $(document.documentElement);
   }

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -65,6 +65,7 @@ export async function getExtensionAuth(): Promise<UserData> {
     const { user, email, hostname } = JSON.parse(valueJSON as string);
     return { user, email, hostname };
   }
+
   return {};
 }
 
@@ -86,6 +87,7 @@ export async function updateExtensionAuth(auth: AuthData): Promise<boolean> {
     } catch {
       // Pass
     }
+
     console.debug(`Setting extension auth for ${auth.email}`, auth);
     await updateRollbarAuth({
       userId: auth.user,
@@ -95,5 +97,6 @@ export async function updateExtensionAuth(auth: AuthData): Promise<boolean> {
     await setStorage(STORAGE_EXTENSION_KEY, JSON.stringify(auth));
     return !equal(auth, previous);
   }
+
   return false;
 }

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -84,7 +84,7 @@ export async function updateExtensionAuth(auth: AuthData): Promise<boolean> {
       const valueJSON = await readStorage(STORAGE_EXTENSION_KEY);
       previous = JSON.parse(valueJSON as string);
     } catch {
-      // pass
+      // Pass
     }
     console.debug(`Setting extension auth for ${auth.email}`, auth);
     await updateRollbarAuth({

--- a/src/background.ts
+++ b/src/background.ts
@@ -19,7 +19,7 @@
 // ensure the webpack path is correct
 import "@/extensionContext";
 
-// init rollbar early so we get error reporting on the other initialization
+// Init rollbar early so we get error reporting on the other initialization
 import "@/telemetry/rollbar";
 
 import "webpack-target-webextension/lib/background";

--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -77,6 +77,7 @@ export async function deleteCachedAuthData(key: string): Promise<void> {
       `deleteCachedAuthData: No cached auth data exists for key: ${key}`
     );
   }
+
   // Replace with updated object
   await setStorage(OAUTH2_STORAGE_KEY, JSON.stringify(current));
 }
@@ -210,6 +211,7 @@ export async function launchOAuth2Flow(
   if (client_secret) {
     tokenBody.client_secret = client_secret;
   }
+
   if (code_verifier) {
     tokenBody.code_verifier = code_verifier;
   }
@@ -247,15 +249,18 @@ export async function launchOAuth2Flow(
         "Expected application/x-www-form-urlencoded data for response"
       );
     }
+
     if (parsed.get("error")) {
       throw new Error(parsed.get("error_description") ?? parsed.get("error"));
     }
+
     const json: Record<string, string> = {};
     for (const [key, value] of parsed.entries()) {
       // Coming from the URL search parameter so will be safe
       // eslint-disable-next-line security/detect-object-injection
       json[key] = value;
     }
+
     await setCachedAuthData(auth.id, json);
     return json as AuthData;
   } else if (typeof data === "object") {

--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -77,7 +77,7 @@ export async function deleteCachedAuthData(key: string): Promise<void> {
       `deleteCachedAuthData: No cached auth data exists for key: ${key}`
     );
   }
-  // replace with updated object
+  // Replace with updated object
   await setStorage(OAUTH2_STORAGE_KEY, JSON.stringify(current));
 }
 
@@ -114,7 +114,7 @@ export async function launchOAuth2Flow(
   service: IService,
   auth: RawServiceConfiguration
 ): Promise<AuthData> {
-  // reference: https://github.com/kylpo/salesforce-chrome-oauth/blob/master/index.js
+  // Reference: https://github.com/kylpo/salesforce-chrome-oauth/blob/master/index.js
   if (!service.isOAuth2) {
     throw new Error(`Service ${service.id} is not an OAuth2 service`);
   }
@@ -137,7 +137,7 @@ export async function launchOAuth2Flow(
 
   const redirect_uri = browser.identity.getRedirectURL("oauth2");
 
-  // console.debug("OAuth2 context", {redirect_uri, context: oauth2});
+  // Console.debug("OAuth2 context", {redirect_uri, context: oauth2});
 
   const authorizeURL = new URL(rawAuthorizeUrl);
   for (const [key, value] of Object.entries({
@@ -169,7 +169,7 @@ export async function launchOAuth2Flow(
     );
   }
 
-  // console.debug("OAuth2 context", {
+  // Console.debug("OAuth2 context", {
   //   authorizeURL,
   //   oauth2,
   // });
@@ -185,7 +185,7 @@ export async function launchOAuth2Flow(
 
   const authResponse = new URL(responseUrl);
 
-  // console.debug("OAuth authorize response", authResponse);
+  // Console.debug("OAuth authorize response", authResponse);
 
   const error = authResponse.searchParams.get("error");
   if (error) {

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -131,6 +131,7 @@ handlers.set(
         actual: request.payload.nonce,
       });
     }
+
     console.debug("Setting action frame metadata", {
       tabId,
       frameId: sender.frameId,

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -93,7 +93,7 @@ function installDeployment(
     }
   }
 
-  // install the blueprint with the service definition
+  // Install the blueprint with the service definition
   returnState = reducer(
     returnState,
     actions.installRecipe({
@@ -188,7 +188,7 @@ async function updateDeployments() {
         try {
           let currentOptions = await loadOptions();
           for (const { deployment } of automatic) {
-            // clear existing installs of the blueprint
+            // Clear existing installs of the blueprint
             currentOptions = installDeployment(currentOptions, deployment);
           }
           await saveOptions(currentOptions);

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -191,6 +191,7 @@ async function updateDeployments() {
             // Clear existing installs of the blueprint
             currentOptions = installDeployment(currentOptions, deployment);
           }
+
           await saveOptions(currentOptions);
           void queueReactivate();
           console.info(

--- a/src/background/devtools/external.ts
+++ b/src/background/devtools/external.ts
@@ -73,6 +73,7 @@ function devtoolsMessageListener(response: BackgroundResponse) {
     if (isErrorResponse(payload)) {
       reject(deserializeError(payload.$$error));
     }
+
     return resolve(payload);
   }
 }

--- a/src/background/devtools/external.ts
+++ b/src/background/devtools/external.ts
@@ -119,7 +119,7 @@ export async function callBackground(
 }
 
 export function installPortListeners(port: Runtime.Port): void {
-  // can't use isDevtoolsPage since this will be called from the pane and other places
+  // Can't use isDevtoolsPage since this will be called from the pane and other places
   forbidBackgroundPage(
     "installPortListeners should only be called from the devtools"
   );

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -107,6 +107,7 @@ function backgroundMessageListener(
             payload: value,
           });
         }
+
         responded = true;
       },
       (error) => {
@@ -117,6 +118,7 @@ function backgroundMessageListener(
             payload: toErrorResponse(type, error),
           });
         }
+
         responded = true;
       }
     );
@@ -135,6 +137,7 @@ function backgroundMessageListener(
           );
         }
       }
+
       responded = true;
     });
   } else {
@@ -182,6 +185,7 @@ export function liftBackground<R extends SerializableResponse>(
     if (!port) {
       throw new Error("Devtools port is required");
     }
+
     return callBackground(port, fullType, args, options) as Promise<R>;
   };
 }
@@ -198,6 +202,7 @@ async function resetTab(tabId: number): Promise<void> {
     });
     reportError(error);
   }
+
   console.info(`Removed dynamic elements for tab: %d`, tabId);
 
   // Re-activate the content script so any saved extensions are added to the page as "permanent" extensions
@@ -264,6 +269,7 @@ export function registerPort(tabId: TabId, port: Runtime.Port): void {
   if (connections.has(tabId) && connections.get(tabId) !== port) {
     console.warn(`Devtools connection already exists for tab: ${tabId}`);
   }
+
   connections.set(tabId, port);
 }
 

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -229,7 +229,7 @@ function connectDevtools(port: Runtime.Port): void {
   expectBackgroundPage();
 
   if (allowBackgroundSender(port.sender) && port.name === PORT_NAME) {
-    // sender.tab won't be available if we don't have permissions for it yet
+    // Sender.tab won't be available if we don't have permissions for it yet
     console.debug(
       `Adding devtools listeners for port ${port.name} for tab: ${
         port.sender.tab?.id ?? "[[no permissions for tab]]"
@@ -241,7 +241,7 @@ function connectDevtools(port: Runtime.Port): void {
       type: "DEVTOOLS_RUNTIME_CONNECTION_CONFIRMED",
     });
 
-    // add/cleanup listener
+    // Add/cleanup listener
     numOpenConnections++;
     port.onMessage.addListener(backgroundMessageListener);
     port.onDisconnect.addListener(() => {
@@ -260,7 +260,7 @@ function connectDevtools(port: Runtime.Port): void {
 }
 
 export function registerPort(tabId: TabId, port: Runtime.Port): void {
-  // can't register the port in connectDevtools because we might know the tab at that point
+  // Can't register the port in connectDevtools because we might know the tab at that point
   if (connections.has(tabId) && connections.get(tabId) !== port) {
     console.warn(`Devtools connection already exists for tab: ${tabId}`);
   }

--- a/src/background/devtools/protocol.ts
+++ b/src/background/devtools/protocol.ts
@@ -254,7 +254,7 @@ export const runReader = liftBackground(
 
 export const uninstallContextMenu = liftBackground(
   "UNINSTALL_CONTEXT_MENU",
-  // false positive - it's the inner method that should be async
+  // False positive - it's the inner method that should be async
   // eslint-disable-next-line unicorn/consistent-function-scoping
   () => async ({ extensionId }: { extensionId: string }) => {
     return contextMenuProtocol.uninstall(extensionId);

--- a/src/background/devtools/protocol.ts
+++ b/src/background/devtools/protocol.ts
@@ -51,6 +51,7 @@ export const getTabInfo = liftBackground(
         `getTabInfo called targeting non top-level frame: ${target.frameId}`
       );
     }
+
     const state = await getTargetState({
       ...target,
       frameId: TOP_LEVEL_FRAME,
@@ -117,6 +118,7 @@ export const selectElement = liftBackground(
     if (isEmpty(element)) {
       throw new Error("selectElement returned an empty element");
     }
+
     return element;
   }
 );

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -86,6 +86,7 @@ async function waitNonceReady(
     if (target == null) {
       return false;
     }
+
     const frameReady = tabReady[target.tabId]?.[target.frameId] != null;
     if (!frameReady) {
       return false;
@@ -101,6 +102,7 @@ async function waitNonceReady(
         { frameId: target.frameId }
       );
     }
+
     return true;
   };
 
@@ -110,8 +112,10 @@ async function waitNonceReady(
         `Nonce ${nonce} was not ready after ${maxWaitMillis}ms`
       );
     }
+
     await sleep(50);
   }
+
   return true;
 }
 
@@ -126,8 +130,10 @@ async function waitReady(
         `Tab ${tabId} was not ready after ${maxWaitMillis}ms`
       );
     }
+
     await sleep(50);
   }
+
   return true;
 }
 
@@ -288,6 +294,7 @@ handlers.set(MESSAGE_CONTENT_SCRIPT_READY, async (_, sender) => {
   if (!tabReady[tabId]) {
     tabReady[tabId] = {};
   }
+
   tabReady[tabId][frameId] = true;
   emitDevtools("ContentScriptReady", { tabId, frameId });
 });
@@ -381,6 +388,7 @@ export async function executeForNonce(
         throw error;
       }
     }
+
     retries++;
   }
 
@@ -419,6 +427,7 @@ export async function executeInTarget(
         throw error;
       }
     }
+
     retries++;
   }
 

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -151,7 +151,7 @@ handlers.set(
           ...request.payload,
         },
       },
-      // for now, only support top-level frame as opener
+      // For now, only support top-level frame as opener
       { frameId: TOP_LEVEL_FRAME }
     );
   }
@@ -181,7 +181,7 @@ handlers.set(
               ...request.payload,
             },
           },
-          // for now, only support top-level frame as opener
+          // For now, only support top-level frame as opener
           { frameId: TOP_LEVEL_FRAME }
         );
       })
@@ -230,7 +230,7 @@ handlers.set(
     }
 
     console.debug(`Waiting for target tab ${target} to be ready`);
-    // for now, only support top-level frame as target
+    // For now, only support top-level frame as target
     await waitReady({ tabId: target, frameId: 0 });
     console.debug(
       `Sending ${CONTENT_MESSAGE_RUN_BLOCK} to target tab ${target} (sender=${sender.tab.id})`

--- a/src/background/iframes.ts
+++ b/src/background/iframes.ts
@@ -43,12 +43,14 @@ function initFrames(): void {
         sendResponse({});
         return true;
       }
+
       case REQUEST_FRAME_DATA: {
         const { id } = request.payload;
         sendResponse({ html: frameHTML.get(id) });
         frameHTML.delete(id);
         return true;
       }
+
       default: {
         return false;
       }

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -163,7 +163,7 @@ function buildContext(
     const currentContext =
       typeof error.context === "object" ? error.context : {};
     const innerContext = buildContext(error.cause as SerializedError, context);
-    // prefer the inner context
+    // Prefer the inner context
     return { ...context, ...innerContext, ...currentContext };
   }
   return context;

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -152,6 +152,7 @@ export async function getLog(
       entries.push(cursor.value);
     }
   }
+
   return sortBy(reverse(entries), (x) => -Number.parseInt(x.timestamp, 10));
 }
 
@@ -166,6 +167,7 @@ function buildContext(
     // Prefer the inner context
     return { ...context, ...innerContext, ...currentContext };
   }
+
   return context;
 }
 
@@ -297,6 +299,7 @@ export async function _getLoggingConfig(): Promise<LoggingConfig> {
   if (_config != null) {
     return _config;
   }
+
   const raw = await readStorage<string>(LOG_CONFIG_STORAGE_KEY);
   _config = raw ? JSON.parse(raw) : {};
   return _config;

--- a/src/background/navigation.ts
+++ b/src/background/navigation.ts
@@ -33,7 +33,7 @@ async function historyListener(
 }
 
 function initNavigation(): void {
-  // updates from the history API
+  // Updates from the history API
   browser.webNavigation.onHistoryStateUpdated.addListener(historyListener);
 }
 

--- a/src/background/notifications.ts
+++ b/src/background/notifications.ts
@@ -21,7 +21,7 @@ import { browser, Notifications } from "webextension-polyfill-ts";
 export const createNotification = liftBackground(
   "CREATE_NOTIFICATION",
   async (options: Notifications.CreateNotificationOptions) => {
-    // generate id automatically
+    // Generate id automatically
     return browser.notifications.create(undefined, options);
   }
 );

--- a/src/background/popup.ts
+++ b/src/background/popup.ts
@@ -32,6 +32,7 @@ async function onTabClose(tabId: number): Promise<void> {
         resolve();
       }
     };
+
     browser.tabs.onRemoved.addListener(handlePossibleClosure);
   });
 }

--- a/src/background/popup.ts
+++ b/src/background/popup.ts
@@ -27,7 +27,7 @@ async function onTabClose(tabId: number): Promise<void> {
   return new Promise((resolve) => {
     const handlePossibleClosure = (closeTabId: number) => {
       if (closeTabId === tabId) {
-        // remove listener first to ensure it's removed even if resolve throws
+        // Remove listener first to ensure it's removed even if resolve throws
         browser.tabs.onRemoved.removeListener(handlePossibleClosure);
         resolve();
       }

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -147,7 +147,7 @@ export async function callBackground(
       throw error;
     }
 
-    // console.debug(
+    // Console.debug(
     //   `Content script received response for ${type} (nonce: ${nonce})`,
     //   response
     // );

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -56,6 +56,7 @@ export function allowBackgroundSender(
   if (sender == null) {
     return false;
   }
+
   const { externally_connectable } = chrome.runtime.getManifest();
   return (
     sender.id === browser.runtime.id ||
@@ -99,11 +100,13 @@ export function getExtensionId(): string {
   if (isContentScript() || isOptionsPage() || isBackgroundPage()) {
     return browser.runtime.id;
   }
+
   if (chrome.runtime == null) {
     throw new RuntimeNotFoundError(
       "Browser runtime is unavailable; is the extension externally connectable?"
     );
   }
+
   return getChromeExtensionId();
 }
 
@@ -155,6 +158,7 @@ export async function callBackground(
     if (isErrorResponse(response)) {
       throw deserializeError(response.$$error);
     }
+
     return response;
   }
 }
@@ -210,6 +214,7 @@ export function liftBackground<R extends SerializableResponse>(
       console.log(`Resolving ${type} immediately from background page`);
       return method(...args);
     }
+
     return callBackground(fullType, args, options) as R;
   };
 }

--- a/src/background/requests.test.ts
+++ b/src/background/requests.test.ts
@@ -17,7 +17,7 @@
 
 import { SanitizedServiceConfiguration, ServiceConfig } from "@/core";
 import serviceRegistry, { PIXIEBRIX_SERVICE_ID } from "@/services/registry";
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { isBackgroundPage } from "webext-detect-page";
 
@@ -32,7 +32,6 @@ jest.mock("@/auth/token");
 jest.mock("webext-detect-page");
 
 import * as token from "@/auth/token";
-import { AxiosRequestConfig } from "axios";
 
 import { proxyService } from "./requests";
 

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -142,14 +142,16 @@ async function authenticate(
       ({ apiKey } as unknown) as ServiceConfig,
       { ...request, url: absoluteURL }
     );
-  } else if (service.isOAuth2) {
+  }
+  if (service.isOAuth2) {
     const localConfig = await locator.getLocalConfig(config.id);
     let data = await getCachedAuthData(config.id);
     if (isEmpty(data)) {
       data = await launchOAuth2Flow(service, localConfig);
     }
     return service.authenticateRequest(localConfig.config, request, data);
-  } else if (service.isToken) {
+  }
+  if (service.isToken) {
     const localConfig = await locator.getLocalConfig(config.id);
     let data = await getCachedAuthData(config.id);
     if (isEmpty(data)) {

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -230,7 +230,7 @@ const _proxyService = liftBackground(
       // eslint-disable-next-line @typescript-eslint/no-implicit-any-catch
     } catch (error) {
       if (UNAUTHORIZED_STATUS_CODES.includes(error.response?.status)) {
-        // try again - have the user login again, or automatically try to get a new token
+        // Try again - have the user login again, or automatically try to get a new token
         const service = await serviceRegistry.lookup(serviceConfig.serviceId);
         if (service.isOAuth2 || service.isToken) {
           await deleteCachedAuthData(serviceConfig.id);
@@ -243,7 +243,7 @@ const _proxyService = liftBackground(
         "Error occurred when making a request from the background page",
         { error }
       );
-      // caught outside to add additional context to the exception
+      // Caught outside to add additional context to the exception
       // noinspection ExceptionCaughtLocallyJS
       throw error;
     }

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -66,6 +66,7 @@ function proxyResponseToAxiosResponse(data: ProxyResponseData) {
       statusText: data.reason ?? data.message,
     } as AxiosResponse;
   }
+
   return {
     data: data.json,
     status: data.status_code,
@@ -143,14 +144,17 @@ async function authenticate(
       { ...request, url: absoluteURL }
     );
   }
+
   if (service.isOAuth2) {
     const localConfig = await locator.getLocalConfig(config.id);
     let data = await getCachedAuthData(config.id);
     if (isEmpty(data)) {
       data = await launchOAuth2Flow(service, localConfig);
     }
+
     return service.authenticateRequest(localConfig.config, request, data);
   }
+
   if (service.isToken) {
     const localConfig = await locator.getLocalConfig(config.id);
     let data = await getCachedAuthData(config.id);
@@ -160,11 +164,14 @@ async function authenticate(
       );
       data = await getToken(service, localConfig);
     }
+
     if (isEmpty(data)) {
       throw new Error("No auth data found for token authentication");
     }
+
     return service.authenticateRequest(localConfig.config, request, data);
   }
+
   const localConfig = await locator.getLocalConfig(config.id);
   return service.authenticateRequest(localConfig.config, request);
 }
@@ -223,6 +230,7 @@ const _proxyService = liftBackground(
       // Service uses the PixieBrix remote proxy to perform authentication. Proxy the request.
       return proxyRequest(serviceConfig, requestConfig);
     }
+
     try {
       return await backgroundRequest(
         await authenticate(serviceConfig, requestConfig)
@@ -239,6 +247,7 @@ const _proxyService = liftBackground(
           );
         }
       }
+
       console.debug(
         "Error occurred when making a request from the background page",
         { error }

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -168,7 +168,7 @@ async function _init(): Promise<void> {
   }
 }
 
-// up to every 30 min
+// Up to every 30 min
 const throttledInit = throttle(_init, 30 * 60 * 1000, {
   leading: true,
   trailing: true,

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -51,11 +51,13 @@ async function uid(): Promise<string> {
   if (_uid != null) {
     return _uid;
   }
+
   let uuid: string = await readStorage<string>(UUID_STORAGE_KEY);
   if (!uuid || typeof uuid !== "string") {
     uuid = uuidv4();
     await setStorage(UUID_STORAGE_KEY, uuid);
   }
+
   _uid = uuid;
   return _uid;
 }
@@ -70,6 +72,7 @@ export async function _getDNT(): Promise<boolean> {
   if (_dnt != null) {
     return _dnt;
   }
+
   _dnt = boolean(
     (await readStorage<boolean | string>(DNT_STORAGE_KEY)) ?? process.env.DEBUG
   );
@@ -214,6 +217,7 @@ export const sendDeploymentAlert = liftBackground(
     if (!token) {
       throw new Error("Extension not linked to PixieBrix server");
     }
+
     await axios.post(url, data, {
       headers: { Authorization: `Token ${token}` },
     });

--- a/src/baseRegistry.ts
+++ b/src/baseRegistry.ts
@@ -42,9 +42,13 @@ export class DoesNotExistError extends Error {
 
 export class Registry<TItem extends RegistryItem> {
   private cache: { [key: string]: TItem };
+
   private remote: Set<string>;
+
   private readonly remoteResourcePath: string;
+
   public readonly kinds: Set<Kind>;
+
   private readonly deserialize: (raw: unknown) => TItem;
 
   constructor(

--- a/src/baseRegistry.ts
+++ b/src/baseRegistry.ts
@@ -114,6 +114,7 @@ export class Registry<TItem extends RegistryItem> {
         }
       }
     }
+
     return Object.values(this.cache);
   }
 
@@ -123,6 +124,7 @@ export class Registry<TItem extends RegistryItem> {
         console.warn(`Skipping item with no id`, item);
         continue;
       }
+
       this.cache[item.id] = item;
     }
   }

--- a/src/blocks/available.ts
+++ b/src/blocks/available.ts
@@ -68,10 +68,12 @@ export async function checkAvailable({
     // );
     return false;
   }
+
   if (selectors.length > 0 && !selectors.some(testSelector)) {
     // Console.debug("Page doesn't match any selectors", selectors);
     return false;
   }
+
   return true;
 }
 

--- a/src/blocks/available.ts
+++ b/src/blocks/available.ts
@@ -60,16 +60,16 @@ export async function checkAvailable({
   const matchPatterns = rawPatterns ? castArray(rawPatterns) : [];
   const selectors = rawSelectors ? castArray(rawSelectors) : [];
 
-  // check matchPatterns first b/c they'll be faster
+  // Check matchPatterns first b/c they'll be faster
   if (matchPatterns.length > 0 && !testMatchPatterns(matchPatterns)) {
-    // console.debug(
+    // Console.debug(
     //   `Location doesn't match any pattern: ${document.location.href}`,
     //   matchPatterns
     // );
     return false;
   }
   if (selectors.length > 0 && !selectors.some(testSelector)) {
-    // console.debug("Page doesn't match any selectors", selectors);
+    // Console.debug("Page doesn't match any selectors", selectors);
     return false;
   }
   return true;

--- a/src/blocks/combinators.test.ts
+++ b/src/blocks/combinators.test.ts
@@ -19,7 +19,7 @@ test("dummy test", async () => {
   console.warn("combinator tests are disabled");
 });
 
-// import {
+// Import {
 //   InputValidationError,
 //   reducePipeline,
 //   mergeReaders,

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -101,6 +101,7 @@ export async function blockList(
           config
         );
       }
+
       return blockRegistry.lookup(id);
     })
   );
@@ -120,6 +121,7 @@ function castSchema(schemaOrProperties: Schema | SchemaProperties): Schema {
   if (schemaOrProperties["type"] && schemaOrProperties["properties"]) {
     return schemaOrProperties as Schema;
   }
+
   return {
     type: "object",
     properties: schemaOrProperties as SchemaProperties,
@@ -133,6 +135,7 @@ function excludeUndefined(obj: unknown): unknown {
       excludeUndefined
     );
   }
+
   return obj;
 }
 
@@ -249,21 +252,25 @@ async function runStage(
         messageContext: logger.context,
       });
     }
+
     if (stage.window === "target") {
       return await executeInTarget(stage.id, blockArgs, {
         ctxt: args,
         messageContext: logger.context,
       });
     }
+
     if (stage.window === "broadcast") {
       return await executeInAll(stage.id, blockArgs, {
         ctxt: args,
         messageContext: logger.context,
       });
     }
+
     if (stage.window ?? "self" === "self") {
       return await block.run(blockArgs, { ctxt: args, logger, root, headless });
     }
+
     throw new BusinessError(`Unexpected stage window ${stage.window}`);
   } finally {
     progressCallbacks?.hide();
@@ -354,6 +361,7 @@ export async function reducePipeline(
         if (stage.outputKey) {
           logger.warn(`Ignoring output key for effect ${block.id}`);
         }
+
         if (output != null) {
           console.warn(`Effect ${block.id} produced an output`, { output });
           logger.warn(`Ignoring output produced by effect ${block.id}`);
@@ -384,6 +392,7 @@ export async function reducePipeline(
           console.warn("Can only send alert from deployment context");
         }
       }
+
       throw new ContextError(
         error,
         stageContext,
@@ -403,6 +412,7 @@ async function resolveObj<T>(
     // eslint-disable-next-line security/detect-object-injection -- safe because we're using Object.entries
     result[key] = await promise;
   }
+
   return result;
 }
 
@@ -413,16 +423,19 @@ export async function mergeReaders(
   if (typeof readerConfig === "string") {
     return blockRegistry.lookup(readerConfig) as Promise<IReader>;
   }
+
   if (Array.isArray(readerConfig)) {
     return new ArrayCompositeReader(
       await Promise.all(readerConfig.map(mergeReaders))
     );
   }
+
   if (isPlainObject(readerConfig)) {
     return new CompositeReader(
       await resolveObj(mapValues(readerConfig, mergeReaders))
     );
   }
+
   throw new BusinessError("Unexpected value for readerConfig");
 }
 
@@ -446,5 +459,6 @@ export async function makeServiceContext(
       __service: configuredService,
     };
   }
+
   return ctxt;
 }

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -248,17 +248,20 @@ async function runStage(
         ctxt: args,
         messageContext: logger.context,
       });
-    } else if (stage.window === "target") {
+    }
+    if (stage.window === "target") {
       return await executeInTarget(stage.id, blockArgs, {
         ctxt: args,
         messageContext: logger.context,
       });
-    } else if (stage.window === "broadcast") {
+    }
+    if (stage.window === "broadcast") {
       return await executeInAll(stage.id, blockArgs, {
         ctxt: args,
         messageContext: logger.context,
       });
-    } else if (stage.window ?? "self" === "self") {
+    }
+    if (stage.window ?? "self" === "self") {
       return await block.run(blockArgs, { ctxt: args, logger, root, headless });
     }
     throw new BusinessError(`Unexpected stage window ${stage.window}`);
@@ -409,11 +412,13 @@ export async function mergeReaders(
 ): Promise<IReader> {
   if (typeof readerConfig === "string") {
     return blockRegistry.lookup(readerConfig) as Promise<IReader>;
-  } else if (Array.isArray(readerConfig)) {
+  }
+  if (Array.isArray(readerConfig)) {
     return new ArrayCompositeReader(
       await Promise.all(readerConfig.map(mergeReaders))
     );
-  } else if (isPlainObject(readerConfig)) {
+  }
+  if (isPlainObject(readerConfig)) {
     return new CompositeReader(
       await resolveObj(mapValues(readerConfig, mergeReaders))
     );

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -212,7 +212,7 @@ async function runStage(
       excludeUndefined(blockArgs)
     );
     if (!validationResult.valid) {
-      // don't need to check logValues here because this is logging to the console, not the provided logger
+      // Don't need to check logValues here because this is logging to the console, not the provided logger
       // so the values won't be persisted
       console.debug("Invalid inputs for block", {
         errors: validationResult.errors,
@@ -441,7 +441,7 @@ export async function makeServiceContext(
   for (const dependency of dependencies) {
     const configuredService = await locate(dependency.id, dependency.config);
     ctxt[`@${dependency.outputKey}`] = {
-      // our JSON validator gets mad at undefined values
+      // Our JSON validator gets mad at undefined values
       ...pickBy(configuredService.config, (x) => x !== undefined),
       __service: configuredService,
     };

--- a/src/blocks/effects/forms.ts
+++ b/src/blocks/effects/forms.ts
@@ -148,6 +148,7 @@ export class FormFill extends Effect {
       if ($input.length === 0) {
         logger.warn(`Could not find input ${name} on the form`);
       }
+
       setValue($input, value, { dispatchEvent: true });
     }
 
@@ -158,6 +159,7 @@ export class FormFill extends Effect {
           `Could not find input with selector ${selector} on the form`
         );
       }
+
       setValue($input, value, { dispatchEvent: true });
     }
 
@@ -168,6 +170,7 @@ export class FormFill extends Effect {
             `Can only submit a form element, got tag ${$form.get(0).tagName}`
           );
         }
+
         $form.trigger("submit");
       }
     } else if (typeof submit === "string") {
@@ -179,6 +182,7 @@ export class FormFill extends Effect {
           `Found multiple elements for the submit selector ${submit} in the form`
         );
       }
+
       $submit.trigger("click");
     } else {
       throw new BusinessError("Unexpected argument for property submit");

--- a/src/blocks/effects/notification.ts
+++ b/src/blocks/effects/notification.ts
@@ -41,7 +41,7 @@ export class ShowNotificationEffect extends Effect {
       type: "string",
       description: "Main notification content.",
     },
-    // contextMessage: {
+    // ContextMessage: {
     //   type: "string",
     //   description: "Alternate notification content with a lower-weight font.",
     // },

--- a/src/blocks/effects/pageState.ts
+++ b/src/blocks/effects/pageState.ts
@@ -59,18 +59,22 @@ export class SetPageState extends Transformer {
         _pageState = cloned;
         break;
       }
+
       case "deep": {
         _pageState = merge(_pageState, cloned);
         break;
       }
+
       case "shallow": {
         _pageState = { ..._pageState, ...cloned };
         break;
       }
+
       default: {
         throw new BusinessError(`Unknown merge strategy: ${mergeStrategy}`);
       }
     }
+
     return _pageState;
   }
 }

--- a/src/blocks/effects/redirectPage.ts
+++ b/src/blocks/effects/redirectPage.ts
@@ -65,6 +65,7 @@ function makeURL(
   if (spaceEncoding === "plus" || result.search.length === 0) {
     return fullURL;
   }
+
   return fullURL.replace(
     result.search,
     result.search.replaceAll("+", SPACE_ENCODED_VALUE)

--- a/src/blocks/errors.ts
+++ b/src/blocks/errors.ts
@@ -39,8 +39,11 @@ export class PipelineConfigurationError extends Error {
  */
 export class HeadlessModeError extends Error {
   public readonly blockId: string;
+
   public readonly args: unknown;
+
   public readonly ctxt: unknown;
+
   public readonly loggerContext: MessageContext;
 
   constructor(
@@ -63,7 +66,9 @@ export class HeadlessModeError extends Error {
  */
 export class InputValidationError extends BusinessError {
   readonly schema: Schema;
+
   readonly input: unknown;
+
   readonly errors: OutputUnit[];
 
   constructor(

--- a/src/blocks/readers/ArrayCompositeReader.ts
+++ b/src/blocks/readers/ArrayCompositeReader.ts
@@ -68,6 +68,7 @@ class ArrayCompositeReader extends Reader {
       console.debug(`ArrayCompositeReader:${reader.name}`, readerResult);
       result = { ...result, ...readerResult };
     }
+
     return result;
   }
 }

--- a/src/blocks/readers/ArrayCompositeReader.ts
+++ b/src/blocks/readers/ArrayCompositeReader.ts
@@ -21,6 +21,7 @@ import { identity, zip } from "lodash";
 
 class ArrayCompositeReader extends Reader {
   public readonly outputSchema: Schema;
+
   private readonly _readers: IReader[];
 
   constructor(readers: IReader[]) {

--- a/src/blocks/readers/CompositeReader.ts
+++ b/src/blocks/readers/CompositeReader.ts
@@ -23,6 +23,7 @@ import fromPairs from "lodash/fromPairs";
 
 class CompositeReader extends Reader {
   public readonly outputSchema: Schema;
+
   private readonly _readers: { [key: string]: IReader };
 
   constructor(readers: { [key: string]: IReader }) {

--- a/src/blocks/readers/ImageEXIFReader.ts
+++ b/src/blocks/readers/ImageEXIFReader.ts
@@ -39,7 +39,8 @@ async function getData(img: HTMLImageElement): Promise<ArrayBuffer> {
   if (/^data:/i.test(img.src)) {
     // Data URI
     return base64ToArrayBuffer(img.src);
-  } else if (/^blob:/i.test(img.src)) {
+  }
+  if (/^blob:/i.test(img.src)) {
     // Object URL
     const blob = await fetch(img.src).then((r) => r.blob());
     return await blob.arrayBuffer();

--- a/src/blocks/readers/ImageEXIFReader.ts
+++ b/src/blocks/readers/ImageEXIFReader.ts
@@ -31,6 +31,7 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
   for (let i = 0; i < len; i++) {
     view[i] = binary.charCodeAt(i);
   }
+
   return buffer;
 }
 
@@ -40,15 +41,18 @@ async function getData(img: HTMLImageElement): Promise<ArrayBuffer> {
     // Data URI
     return base64ToArrayBuffer(img.src);
   }
+
   if (/^blob:/i.test(img.src)) {
     // Object URL
     const blob = await fetch(img.src).then((r) => r.blob());
     return await blob.arrayBuffer();
   }
+
   const response = await axios.get(img.src, { responseType: "arraybuffer" });
   if (response.status !== 200) {
     throw new Error(`Error fetching image ${img.src}: ${response.statusText}`);
   }
+
   return response.data;
 }
 
@@ -68,6 +72,7 @@ class ImageEXIFReader extends Reader {
       const buffer = await getData(element);
       return ExifReader.load(buffer);
     }
+
     throw new Error(
       `Expected an image element, got ${element.tagName ?? "document"}`
     );

--- a/src/blocks/readers/ImageEXIFReader.ts
+++ b/src/blocks/readers/ImageEXIFReader.ts
@@ -22,7 +22,7 @@ import axios from "axios";
 import * as ExifReader from "exifreader";
 
 function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  // adapted from https://github.com/exif-js/exif-js/blob/master/exif.js#L343
+  // Adapted from https://github.com/exif-js/exif-js/blob/master/exif.js#L343
   base64 = base64.replace(/^data:([^;]+);base64,/gim, "");
   const binary = atob(base64);
   const len = binary.length;
@@ -35,7 +35,7 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
 }
 
 async function getData(img: HTMLImageElement): Promise<ArrayBuffer> {
-  // adapted from https://github.com/exif-js/exif-js/blob/master/exif.js#L384
+  // Adapted from https://github.com/exif-js/exif-js/blob/master/exif.js#L384
   if (/^data:/i.test(img.src)) {
     // Data URI
     return base64ToArrayBuffer(img.src);

--- a/src/blocks/readers/ImageReader.ts
+++ b/src/blocks/readers/ImageReader.ts
@@ -59,6 +59,7 @@ class ImageReader extends Reader {
         img: getBase64Image(element as HTMLImageElement),
       };
     }
+
     throw new Error(`Expected an image, got ${element.tagName ?? "document"}`);
   }
 

--- a/src/blocks/readers/factory.ts
+++ b/src/blocks/readers/factory.ts
@@ -80,6 +80,7 @@ export function makeRead(
   if (!doRead) {
     throw new Error(`Reader type ${config.type} not implemented`);
   }
+
   return (root: ReaderRoot) => doRead(config, root);
 }
 
@@ -115,6 +116,7 @@ export function readerFactory(component: unknown): IReader {
       if (doRead) {
         return doRead(reader as any, root);
       }
+
       throw new Error(`Reader type ${reader.type} not implemented`);
     }
   }

--- a/src/blocks/readers/frameworkReader.ts
+++ b/src/blocks/readers/frameworkReader.ts
@@ -72,6 +72,7 @@ function makeRead(framework: Framework): Read<FrameworkConfig> {
         : pathSpec,
     });
   }
+
   return read;
 }
 

--- a/src/blocks/readers/frameworkReader.ts
+++ b/src/blocks/readers/frameworkReader.ts
@@ -35,7 +35,7 @@ async function asyncFastCssSelector(element: HTMLElement): Promise<string> {
   // generating headers
   const getCssSelector = (await import("css-selector-generator")).default;
   return getCssSelector(element, {
-    // prefer speed over robust/readable selectors
+    // Prefer speed over robust/readable selectors
     combineWithinSelector: false,
     combineBetweenSelectors: false,
   });

--- a/src/blocks/readers/index.ts
+++ b/src/blocks/readers/index.ts
@@ -23,7 +23,7 @@ import "./ImageReader";
 import "./ImageEXIFReader";
 import "./ElementReader";
 
-// generic readers
+// Generic readers
 import "./frameworkReader";
 export * from "./jquery";
 export * from "./window";

--- a/src/blocks/readers/jquery.ts
+++ b/src/blocks/readers/jquery.ts
@@ -185,7 +185,8 @@ async function select(
     }
 
     return normalizedSelector.multi ? [] : undefined;
-  } else if ($elt.length > 1 && !normalizedSelector.multi) {
+  }
+  if ($elt.length > 1 && !normalizedSelector.multi) {
     throw new BusinessError(
       `Multiple elements found for ${normalizedSelector.selector}. To return a list of values, supply multi=true`
     );

--- a/src/blocks/readers/jquery.ts
+++ b/src/blocks/readers/jquery.ts
@@ -104,6 +104,7 @@ function processElement($elt: JQuery<HTMLElement>, selector: SingleSelector) {
         "Invalid contents argument, must be either 'text' or 'comment'"
       );
     }
+
     // https://stackoverflow.com/questions/14248519/jquery-text-equivalent-that-converts-br-tags-to-whitespace
     value = cleanValue(
       $elt
@@ -125,6 +126,7 @@ function processElement($elt: JQuery<HTMLElement>, selector: SingleSelector) {
   } else {
     value = cleanValue($elt.text());
   }
+
   return castValue(value, selector.type);
 }
 
@@ -154,6 +156,7 @@ async function select(
           "'selector' required if not nested within a 'find' block"
         );
       }
+
       $elt = $(document).find(normalizedSelector.selector);
     }
 
@@ -186,6 +189,7 @@ async function select(
 
     return normalizedSelector.multi ? [] : undefined;
   }
+
   if ($elt.length > 1 && !normalizedSelector.multi) {
     throw new BusinessError(
       `Multiple elements found for ${normalizedSelector.selector}. To return a list of values, supply multi=true`
@@ -203,6 +207,7 @@ async function select(
     if ($elt === $(document)) {
       throw new Error("Cannot process document as an element");
     }
+
     const values = $elt
       .map(function () {
         return processElement(
@@ -224,6 +229,7 @@ async function read(
   if ($root.length === 0) {
     throw new Error("JQuery reader requires the document or element(s)");
   }
+
   return asyncMapValues(selectors, (selector) => select(selector, $root));
 }
 

--- a/src/blocks/readers/jquery.ts
+++ b/src/blocks/readers/jquery.ts
@@ -42,7 +42,7 @@ type CommonSelector = ChildrenSelector | SingleSelector;
 type Selector = CommonSelector & {
   selector?: string;
 
-  // block until the element is available
+  // Block until the element is available
   maxWaitMillis?: number;
 };
 

--- a/src/blocks/readers/meta.ts
+++ b/src/blocks/readers/meta.ts
@@ -41,6 +41,7 @@ class ChromeProfileReader extends Reader {
     if (!chrome.identity) {
       throw new Error("No access to the Chrome Identity API");
     }
+
     const userInfo = await chromeP.identity.getProfileUserInfo();
     return { ...userInfo };
   }

--- a/src/blocks/renderers/html.ts
+++ b/src/blocks/renderers/html.ts
@@ -43,6 +43,7 @@ export class Html extends Renderer {
     if (!this.DOMPurify) {
       this.DOMPurify = createDOMPurify(window);
     }
+
     return this.DOMPurify.sanitize(html);
   }
 }

--- a/src/blocks/renderers/iframe.ts
+++ b/src/blocks/renderers/iframe.ts
@@ -65,6 +65,7 @@ export class IFrameRenderer extends Renderer {
     if (safeMode) {
       return `<iframe src="${url}" title="${title}" height="${height}" width="${width}" style="border:none;" allowfullscreen="false" allowpaymentrequest="false"></iframe>`;
     }
+
     // https://transitory.technology/browser-extensions-and-csp-headers/
     const frameSrc = chrome.extension.getURL("frame.html");
     const src = `${frameSrc}?url=${encodeURIComponent(url)}`;

--- a/src/blocks/renderers/markdown.ts
+++ b/src/blocks/renderers/markdown.ts
@@ -48,6 +48,7 @@ export class Markdown extends Renderer {
     if (!this.DOMPurify) {
       this.DOMPurify = createDOMPurify(window);
     }
+
     return this.DOMPurify.sanitize(marked(markdown));
   }
 }

--- a/src/blocks/renderers/propertyTable.tsx
+++ b/src/blocks/renderers/propertyTable.tsx
@@ -48,6 +48,7 @@ function richValue(value: unknown): unknown {
       </a>
     );
   }
+
   return value;
 }
 
@@ -65,6 +66,7 @@ function shapeData(inputs: unknown, keyPrefix = "root"): Item[] {
           children: shapeData(value, key),
         };
       }
+
       return {
         key,
         data: { name, value: richValue(value) },
@@ -72,6 +74,7 @@ function shapeData(inputs: unknown, keyPrefix = "root"): Item[] {
       };
     });
   }
+
   if (Array.isArray(inputs)) {
     return inputs.map((value, index) => {
       const key = `${keyPrefix}-${index}`;
@@ -83,6 +86,7 @@ function shapeData(inputs: unknown, keyPrefix = "root"): Item[] {
           children: shapeData(value, key),
         };
       }
+
       return {
         key,
         data: { name: `${index}`, value: richValue(value) },
@@ -90,6 +94,7 @@ function shapeData(inputs: unknown, keyPrefix = "root"): Item[] {
       };
     });
   }
+
   return [
     {
       key: keyPrefix,

--- a/src/blocks/renderers/propertyTable.tsx
+++ b/src/blocks/renderers/propertyTable.tsx
@@ -71,7 +71,8 @@ function shapeData(inputs: unknown, keyPrefix = "root"): Item[] {
         children: [],
       };
     });
-  } else if (Array.isArray(inputs)) {
+  }
+  if (Array.isArray(inputs)) {
     return inputs.map((value, index) => {
       const key = `${keyPrefix}-${index}`;
 

--- a/src/blocks/renderers/table.tsx
+++ b/src/blocks/renderers/table.tsx
@@ -24,7 +24,7 @@ import { BusinessError } from "@/errors";
 import { mapArgs } from "@/helpers";
 import makeDataTable, { Row } from "@/blocks/renderers/dataTable";
 
-// type ColumnDefinition = {
+// Type ColumnDefinition = {
 //   label: string;
 //   property: string;
 //   href: string;
@@ -84,7 +84,7 @@ export class Table extends Renderer {
 
     return table(ctxt);
 
-    // const makeLinkTemplate = ({
+    // Const makeLinkTemplate = ({
     //   property,
     //   href,
     // }: {

--- a/src/blocks/transformers/blockFactory.ts
+++ b/src/blocks/transformers/blockFactory.ts
@@ -114,7 +114,7 @@ class ExternalBlock extends Block {
       options.root,
       {
         headless: options.headless,
-        // optionsArgs are set at the blueprint level. For composite bricks, they options should be passed in
+        // OptionsArgs are set at the blueprint level. For composite bricks, they options should be passed in
         // at part of the brick inputs
         optionsArgs: undefined,
       }

--- a/src/blocks/transformers/blockFactory.ts
+++ b/src/blocks/transformers/blockFactory.ts
@@ -71,7 +71,9 @@ function validateBlockDefinition(
 
 class ExternalBlock extends Block {
   private component: ComponentConfig;
+
   readonly inputSchema: Schema;
+
   readonly defaultOptions: { [key: string]: any };
 
   constructor(component: ComponentConfig) {

--- a/src/blocks/transformers/httpGet.ts
+++ b/src/blocks/transformers/httpGet.ts
@@ -65,6 +65,7 @@ export class GetAPITransformer extends Transformer {
         service
       );
     }
+
     const { data } = await proxyService(
       !isNullOrBlank(service) ? service : null,
       {

--- a/src/blocks/transformers/httpGet.ts
+++ b/src/blocks/transformers/httpGet.ts
@@ -33,7 +33,7 @@ export class GetAPITransformer extends Transformer {
       url: {
         type: "string",
         description: "The API URL",
-        // can't use uri here because we want to support relative URLs when the using a service with a base URL
+        // Can't use uri here because we want to support relative URLs when the using a service with a base URL
         format: "string",
       },
       service: {

--- a/src/blocks/transformers/jq.ts
+++ b/src/blocks/transformers/jq.ts
@@ -92,6 +92,7 @@ export class JQTransformer extends Transformer {
           );
         }
       }
+
       throw error;
     }
   }

--- a/src/blocks/transformers/mapping.ts
+++ b/src/blocks/transformers/mapping.ts
@@ -60,17 +60,21 @@ export class MappingTransformer extends Transformer {
     if (key == null || key === "") {
       return null;
     }
+
     if (Object.prototype.hasOwnProperty.call(mapping, key)) {
       // Checking for hasOwnProperty
       // eslint-disable-next-line security/detect-object-injection
       return mapping[key];
     }
+
     if (missing === "null" || missing === null) {
       return null;
     }
+
     if (missing === "ignore") {
       return key;
     }
+
     throw new BusinessError(`Key ${key} not found in the mapping`);
   }
 }

--- a/src/blocks/transformers/mapping.ts
+++ b/src/blocks/transformers/mapping.ts
@@ -59,13 +59,16 @@ export class MappingTransformer extends Transformer {
   }: BlockArg): Promise<unknown> {
     if (key == null || key === "") {
       return null;
-    } else if (Object.prototype.hasOwnProperty.call(mapping, key)) {
+    }
+    if (Object.prototype.hasOwnProperty.call(mapping, key)) {
       // checking for hasOwnProperty
       // eslint-disable-next-line security/detect-object-injection
       return mapping[key];
-    } else if (missing === "null" || missing === null) {
+    }
+    if (missing === "null" || missing === null) {
       return null;
-    } else if (missing === "ignore") {
+    }
+    if (missing === "ignore") {
       return key;
     }
     throw new BusinessError(`Key ${key} not found in the mapping`);

--- a/src/blocks/transformers/mapping.ts
+++ b/src/blocks/transformers/mapping.ts
@@ -61,7 +61,7 @@ export class MappingTransformer extends Transformer {
       return null;
     }
     if (Object.prototype.hasOwnProperty.call(mapping, key)) {
-      // checking for hasOwnProperty
+      // Checking for hasOwnProperty
       // eslint-disable-next-line security/detect-object-injection
       return mapping[key];
     }

--- a/src/blocks/transformers/modal.tsx
+++ b/src/blocks/transformers/modal.tsx
@@ -70,6 +70,7 @@ export class ModalTransformer extends Transformer {
         if (typeof value !== "string") {
           throw new BusinessError("Invalid containerAttr");
         }
+
         container.setAttribute(attr, value);
       }
     }

--- a/src/blocks/transformers/parseURL.ts
+++ b/src/blocks/transformers/parseURL.ts
@@ -77,7 +77,7 @@ export class UrlParser extends Transformer {
 
     const searchParams: Record<string, string> = {};
     for (const [key, value] of parsed.searchParams.entries()) {
-      // fine because value will always be a string
+      // Fine because value will always be a string
       // eslint-disable-next-line security/detect-object-injection
       searchParams[key] = value;
     }

--- a/src/blocks/transformers/regex.ts
+++ b/src/blocks/transformers/regex.ts
@@ -59,7 +59,7 @@ export class RegexTransformer extends Transformer {
         return null;
       }
       const match = compiled.exec(x);
-      // console.debug(`Search for ${regex} in ${x}`, match);
+      // Console.debug(`Search for ${regex} in ${x}`, match);
       return match?.groups ?? {};
     };
 

--- a/src/blocks/transformers/regex.ts
+++ b/src/blocks/transformers/regex.ts
@@ -58,6 +58,7 @@ export class RegexTransformer extends Transformer {
       if (x == null) {
         return null;
       }
+
       const match = compiled.exec(x);
       // Console.debug(`Search for ${regex} in ${x}`, match);
       return match?.groups ?? {};

--- a/src/blocks/transformers/remoteMethod.ts
+++ b/src/blocks/transformers/remoteMethod.ts
@@ -74,6 +74,7 @@ export class RemoteMethod extends Transformer {
         service
       );
     }
+
     const { data } = await proxyService(service, requestConfig);
     return data;
   }

--- a/src/blocks/transformers/template.ts
+++ b/src/blocks/transformers/template.ts
@@ -59,6 +59,7 @@ export class TemplateTransformer extends Transformer {
         "Only 'mustache' is currently supported for templateEngine"
       );
     }
+
     return Mustache.render(template, ctxt);
   }
 }

--- a/src/blocks/util.ts
+++ b/src/blocks/util.ts
@@ -24,13 +24,17 @@ export async function getType(
 ): Promise<BlockType | null> {
   if ("inferType" in block) {
     return await (block as any).inferType();
-  } else if ("read" in block) {
+  }
+  if ("read" in block) {
     return "reader";
-  } else if ("effect" in block) {
+  }
+  if ("effect" in block) {
     return "effect";
-  } else if ("transform" in block) {
+  }
+  if ("transform" in block) {
     return "transform";
-  } else if ("render" in block) {
+  }
+  if ("render" in block) {
     return "renderer";
   }
   return null;

--- a/src/blocks/util.ts
+++ b/src/blocks/util.ts
@@ -25,17 +25,22 @@ export async function getType(
   if ("inferType" in block) {
     return await (block as any).inferType();
   }
+
   if ("read" in block) {
     return "reader";
   }
+
   if ("effect" in block) {
     return "effect";
   }
+
   if ("transform" in block) {
     return "transform";
   }
+
   if ("render" in block) {
     return "renderer";
   }
+
   return null;
 }

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -66,7 +66,7 @@ export function isDevtoolsPage(): boolean {
     return false;
   }
 
-  // make sure dev tools are installed
+  // Make sure dev tools are installed
   const { devtools_page } = chrome.runtime.getManifest();
   if (typeof devtools_page !== "string") {
     return false;

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -165,5 +165,6 @@ export async function setStorage(
   if (typeof value !== "string") {
     throw new TypeError("Expected string value");
   }
+
   await browser.storage[storageType].set({ [storageKey]: value });
 }

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -22,7 +22,7 @@ import "./ChatWidget.scss";
 const ChatWidget: React.FunctionComponent = () => {
   const src = browser.runtime.getURL("/support.html");
 
-  // iframe dom definition doesn't support csp even though Chrome supports it as an attribute
+  // Iframe dom definition doesn't support csp even though Chrome supports it as an attribute
   const props: any = {
     csp:
       "default-src 'self' https://w.chatlio.com; style-src 'self' 'unsafe-inline' https://w.chatlio.com; script-src 'self' https://w.chatlio.com; connect-src 'self' https://api.chatlio.com https://api-cdn.chatlio.com wss://push.chatlio.com wss://ws.pusherapp.com; img-src 'self' data: https://w.chatlio.com https://avatars.slack-edge.com https://files.slack.com https://files-origin.slack.com https://secure.gravatar.com https://uploads-cdn.chatlio.com; object-src 'none';",

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -84,6 +84,7 @@ export const ModalProvider: React.FunctionComponent<{
           resolve(submit);
           setCallback(undefined);
         };
+
         setCallback((_prevState: Callback) => newCallback);
       });
     },

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -75,7 +75,7 @@ export const ModalProvider: React.FunctionComponent<{
 
   const showConfirmation = useCallback(
     async (modalProps: ModalProps) => {
-      // cancel any previous modal that was showing
+      // Cancel any previous modal that was showing
       callback?.(false);
       return new Promise<boolean>((resolve) => {
         setModalProps(modalProps);

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -63,6 +63,7 @@ class ErrorBoundary extends React.Component<{}, State> {
         </>
       );
     }
+
     return this.props.children;
   }
 }

--- a/src/components/fields/BlockField.tsx
+++ b/src/components/fields/BlockField.tsx
@@ -189,7 +189,7 @@ const BlockCard: React.FunctionComponent<{
 
 interface BlockConfig {
   id: string;
-  // optionally, a name to store the output to
+  // Optionally, a name to store the output to
   outputKey?: string;
   config: ConfigValue;
   templateEngine?: "mustache" | "handlebars" | "nunjucks";

--- a/src/components/fields/BlockField.tsx
+++ b/src/components/fields/BlockField.tsx
@@ -99,6 +99,7 @@ export function useBlockOptions(
         registered ?? genericOptionsFactory(inputProperties(block.inputSchema))
       );
     }
+
     return null;
   }, [block?.id, block?.inputSchema]);
 

--- a/src/components/fields/BlockModal.tsx
+++ b/src/components/fields/BlockModal.tsx
@@ -74,13 +74,17 @@ export function getIcon(block: IBlock | IService, type: BlockType): IconProp {
 
   if (block instanceof TriggerExtensionPoint) {
     return faBolt;
-  } else if (block instanceof MenuItemExtensionPoint) {
+  }
+  if (block instanceof MenuItemExtensionPoint) {
     return faMousePointer;
-  } else if (block instanceof ContextMenuExtensionPoint) {
+  }
+  if (block instanceof ContextMenuExtensionPoint) {
     return faBars;
-  } else if (block instanceof PanelExtensionPoint) {
+  }
+  if (block instanceof PanelExtensionPoint) {
     return faWindowMaximize;
-  } else if (block instanceof ActionPanelExtensionPoint) {
+  }
+  if (block instanceof ActionPanelExtensionPoint) {
     return faColumns;
   }
 

--- a/src/components/fields/BlockModal.tsx
+++ b/src/components/fields/BlockModal.tsx
@@ -75,15 +75,19 @@ export function getIcon(block: IBlock | IService, type: BlockType): IconProp {
   if (block instanceof TriggerExtensionPoint) {
     return faBolt;
   }
+
   if (block instanceof MenuItemExtensionPoint) {
     return faMousePointer;
   }
+
   if (block instanceof ContextMenuExtensionPoint) {
     return faBars;
   }
+
   if (block instanceof PanelExtensionPoint) {
     return faWindowMaximize;
   }
+
   if (block instanceof ActionPanelExtensionPoint) {
     return faColumns;
   }
@@ -147,6 +151,7 @@ function searchBlocks(query: string, options: BlockOption[]): BlockOption[] {
         (x.block.description ?? "").toLowerCase().includes(normalizedQuery)
     );
   }
+
   return sortBy(filtered, (x) => x.label);
 }
 

--- a/src/components/fields/BlockModal.tsx
+++ b/src/components/fields/BlockModal.tsx
@@ -225,7 +225,7 @@ const BlockModal: React.FunctionComponent<{
                           block={x.block}
                           onSelect={() => {
                             onSelect(x.block);
-                            // reset the query for the next time it opens
+                            // Reset the query for the next time it opens
                             setQuery("");
                             close();
                           }}

--- a/src/components/fields/FieldTable.tsx
+++ b/src/components/fields/FieldTable.tsx
@@ -200,15 +200,15 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
 }) => {
   const { name } = props;
 
-  // allow additional properties for empty schema (empty schema allows shape)
+  // Allow additional properties for empty schema (empty schema allows shape)
   const additionalProperties = isEmpty(schema) || schema.additionalProperties;
 
-  // helpers.setValue changes on every render, so use setFieldValue instead
+  // Helpers.setValue changes on every render, so use setFieldValue instead
   // https://github.com/formium/formik/issues/2268
   const [field] = useField(props);
   const { setFieldValue } = useFormikContext();
 
-  // useRef indirection layer so the callbacks below don't re-calculate on every change
+  // UseRef indirection layer so the callbacks below don't re-calculate on every change
   const fieldRef = useRef(field);
 
   const [properties, declaredProperties] = useMemo(() => {

--- a/src/components/fields/FieldTable.tsx
+++ b/src/components/fields/FieldTable.tsx
@@ -88,6 +88,7 @@ const ValuePropertyRow: React.FunctionComponent<PropertyRow> = ({
     if (isComplex) {
       return ComplexObjectValue;
     }
+
     const { Component } = customControls.find((x) => x.match(schema)) ?? {};
     return Component ?? SimpleValue;
   }, [isComplex, customControls, schema]);
@@ -133,6 +134,7 @@ function freshPropertyName(obj: { [key: string]: unknown }) {
   while (Object.prototype.hasOwnProperty.call(obj, `property${x}`)) {
     x++;
   }
+
   return `property${x}`;
 }
 

--- a/src/components/fields/IconField.tsx
+++ b/src/components/fields/IconField.tsx
@@ -68,6 +68,7 @@ const IconField: React.FunctionComponent<FieldProps<IconConfig>> = ({
       } else {
         helpers.setValue(null);
       }
+
       helpers.setError(undefined);
       helpers.setTouched(true);
     },

--- a/src/components/fields/ServiceModal.tsx
+++ b/src/components/fields/ServiceModal.tsx
@@ -115,6 +115,7 @@ const ServiceModal: React.FunctionComponent<{
         (x) => x.label
       );
     }
+
     return sortBy(serviceOptions, (x) => x.label);
   }, [serviceOptions, debouncedQuery]);
 

--- a/src/components/fields/ServiceModal.tsx
+++ b/src/components/fields/ServiceModal.tsx
@@ -178,7 +178,7 @@ const ServiceModal: React.FunctionComponent<{
                           service={x.service}
                           onSelect={() => {
                             onSelect(x.service);
-                            // reset the query for the next time it opens
+                            // Reset the query for the next time it opens
                             setQuery("");
                             close();
                           }}

--- a/src/components/fields/blockOptions.tsx
+++ b/src/components/fields/blockOptions.tsx
@@ -125,7 +125,8 @@ const TextField: React.FunctionComponent<FieldProps<string>> = ({
 function extractServiceIds(schema: Schema): string[] {
   if ("$ref" in schema) {
     return [schema.$ref.slice(SERVICE_BASE_SCHEMA.length)];
-  } else if ("anyOf" in schema) {
+  }
+  if ("anyOf" in schema) {
     return schema.anyOf
       .filter((x) => x != false)
       .flatMap((x) => extractServiceIds(x as Schema));
@@ -306,13 +307,17 @@ function findOneOf(schema: Schema, predicate: TypePredicate): Schema {
 function getDefaultArrayItem(schema: Schema): unknown {
   if (schema.default) {
     return schema.default;
-  } else if (textPredicate(schema)) {
+  }
+  if (textPredicate(schema)) {
     return "";
-  } else if (schema.type === "object") {
+  }
+  if (schema.type === "object") {
     return {};
-  } else if (findOneOf(schema, booleanPredicate)) {
+  }
+  if (findOneOf(schema, booleanPredicate)) {
     return false;
-  } else if (findOneOf(schema, textPredicate)) {
+  }
+  if (findOneOf(schema, textPredicate)) {
     return "";
   }
   return null;
@@ -321,21 +326,28 @@ function getDefaultArrayItem(schema: Schema): unknown {
 export function getDefaultField(fieldSchema: Schema): FieldComponent {
   if (fieldSchema.$ref?.startsWith(SERVICE_BASE_SCHEMA)) {
     return ServiceField;
-  } else if (fieldSchema.type === "array") {
+  }
+  if (fieldSchema.type === "array") {
     return ArrayField;
-  } else if (fieldSchema.type === "object") {
+  }
+  if (fieldSchema.type === "object") {
     return ObjectField;
-  } else if (booleanPredicate(fieldSchema)) {
+  }
+  if (booleanPredicate(fieldSchema)) {
     // Should this be a TextField so it can be dynamically determined?
     // see https://github.com/pixiebrix/pixiebrix-extension/issues/709
     return BooleanField;
-  } else if (textPredicate(fieldSchema)) {
+  }
+  if (textPredicate(fieldSchema)) {
     return TextField;
-  } else if (findOneOf(fieldSchema, booleanPredicate)) {
+  }
+  if (findOneOf(fieldSchema, booleanPredicate)) {
     return makeOneOfField(findOneOf(fieldSchema, booleanPredicate));
-  } else if (findOneOf(fieldSchema, textPredicate)) {
+  }
+  if (findOneOf(fieldSchema, textPredicate)) {
     return makeOneOfField(findOneOf(fieldSchema, textPredicate));
-  } else if (isEmpty(fieldSchema)) {
+  }
+  if (isEmpty(fieldSchema)) {
     // An empty field schema supports any value. For now, provide an object field since this just shows up
     // in the @pixiebrix/http brick.
     // https://github.com/pixiebrix/pixiebrix-extension/issues/709

--- a/src/components/fields/blockOptions.tsx
+++ b/src/components/fields/blockOptions.tsx
@@ -225,7 +225,7 @@ const BooleanField: React.FunctionComponent<FieldProps<boolean>> = ({
   );
 };
 
-// ok to use object here since we don't have any key-specific logic
+// Ok to use object here since we don't have any key-specific logic
 // eslint-disable-next-line @typescript-eslint/ban-types
 const ArrayField: React.FunctionComponent<FieldProps<object[]>> = ({
   schema,
@@ -353,7 +353,7 @@ export function getDefaultField(fieldSchema: Schema): FieldComponent {
     // https://github.com/pixiebrix/pixiebrix-extension/issues/709
     return ObjectField;
   }
-  // number, string, other primitives, etc.
+  // Number, string, other primitives, etc.
   return TextField;
 }
 
@@ -417,7 +417,7 @@ function genericOptionsFactory(
         if (typeof fieldSchema === "boolean") {
           throw new TypeError("Expected schema for input property type");
         }
-        // fine because coming from Object.entries for the schema
+        // Fine because coming from Object.entries for the schema
         // eslint-disable-next-line security/detect-object-injection
         const propUiSchema = uiSchema?.[prop];
         return (

--- a/src/components/fields/blockOptions.tsx
+++ b/src/components/fields/blockOptions.tsx
@@ -126,11 +126,13 @@ function extractServiceIds(schema: Schema): string[] {
   if ("$ref" in schema) {
     return [schema.$ref.slice(SERVICE_BASE_SCHEMA.length)];
   }
+
   if ("anyOf" in schema) {
     return schema.anyOf
       .filter((x) => x != false)
       .flatMap((x) => extractServiceIds(x as Schema));
   }
+
   throw new Error("Expected $ref or anyOf in schema for service");
 }
 
@@ -239,6 +241,7 @@ const ArrayField: React.FunctionComponent<FieldProps<object[]>> = ({
   } else if (typeof schema.items === "boolean") {
     throw new TypeError("Schema required for items");
   }
+
   const schemaItems = schema.items as Schema;
 
   return (
@@ -308,18 +311,23 @@ function getDefaultArrayItem(schema: Schema): unknown {
   if (schema.default) {
     return schema.default;
   }
+
   if (textPredicate(schema)) {
     return "";
   }
+
   if (schema.type === "object") {
     return {};
   }
+
   if (findOneOf(schema, booleanPredicate)) {
     return false;
   }
+
   if (findOneOf(schema, textPredicate)) {
     return "";
   }
+
   return null;
 }
 
@@ -327,32 +335,40 @@ export function getDefaultField(fieldSchema: Schema): FieldComponent {
   if (fieldSchema.$ref?.startsWith(SERVICE_BASE_SCHEMA)) {
     return ServiceField;
   }
+
   if (fieldSchema.type === "array") {
     return ArrayField;
   }
+
   if (fieldSchema.type === "object") {
     return ObjectField;
   }
+
   if (booleanPredicate(fieldSchema)) {
     // Should this be a TextField so it can be dynamically determined?
     // see https://github.com/pixiebrix/pixiebrix-extension/issues/709
     return BooleanField;
   }
+
   if (textPredicate(fieldSchema)) {
     return TextField;
   }
+
   if (findOneOf(fieldSchema, booleanPredicate)) {
     return makeOneOfField(findOneOf(fieldSchema, booleanPredicate));
   }
+
   if (findOneOf(fieldSchema, textPredicate)) {
     return makeOneOfField(findOneOf(fieldSchema, textPredicate));
   }
+
   if (isEmpty(fieldSchema)) {
     // An empty field schema supports any value. For now, provide an object field since this just shows up
     // in the @pixiebrix/http brick.
     // https://github.com/pixiebrix/pixiebrix-extension/issues/709
     return ObjectField;
   }
+
   // Number, string, other primitives, etc.
   return TextField;
 }
@@ -417,6 +433,7 @@ function genericOptionsFactory(
         if (typeof fieldSchema === "boolean") {
           throw new TypeError("Expected schema for input property type");
         }
+
         // Fine because coming from Object.entries for the schema
         // eslint-disable-next-line security/detect-object-injection
         const propUiSchema = uiSchema?.[prop];

--- a/src/components/logViewer/EntryRow.tsx
+++ b/src/components/logViewer/EntryRow.tsx
@@ -37,6 +37,7 @@ function getRootCause(error: ErrorObject): ErrorObject {
   if (error.name === "ContextError" && (error as ContextError).cause != null) {
     return getRootCause(error.cause as ErrorObject);
   }
+
   return error;
 }
 
@@ -53,13 +54,16 @@ const ErrorDetail: React.FunctionComponent<{ entry: LogEntry }> = ({
           />
         );
       }
+
       if (rootCause.isAxiosError) {
         return (
           <NetworkErrorDetail error={(rootCause as unknown) as AxiosError} />
         );
       }
+
       return entry.error.stack;
     }
+
     return entry.error.toString();
   }, [entry.error]);
 
@@ -73,12 +77,15 @@ const EntryRow: React.FunctionComponent<{ entry: LogEntry }> = ({ entry }) => {
     if (typeof entry.error === "object" && entry.error) {
       return ErrorDetail;
     }
+
     if (entry.data?.renderedArgs != null) {
       return InputDetail;
     }
+
     if (entry.data?.output != null) {
       return OutputDetail;
     }
+
     return null;
   }, [entry]);
 

--- a/src/components/logViewer/EntryRow.tsx
+++ b/src/components/logViewer/EntryRow.tsx
@@ -52,7 +52,8 @@ const ErrorDetail: React.FunctionComponent<{ entry: LogEntry }> = ({
             error={(rootCause as unknown) as InputValidationError}
           />
         );
-      } else if (rootCause.isAxiosError) {
+      }
+      if (rootCause.isAxiosError) {
         return (
           <NetworkErrorDetail error={(rootCause as unknown) as AxiosError} />
         );
@@ -71,9 +72,11 @@ const EntryRow: React.FunctionComponent<{ entry: LogEntry }> = ({ entry }) => {
   const Detail = useMemo(() => {
     if (typeof entry.error === "object" && entry.error) {
       return ErrorDetail;
-    } else if (entry.data?.renderedArgs != null) {
+    }
+    if (entry.data?.renderedArgs != null) {
       return InputDetail;
-    } else if (entry.data?.output != null) {
+    }
+    if (entry.data?.output != null) {
       return OutputDetail;
     }
     return null;

--- a/src/components/logViewer/LogContext.tsx
+++ b/src/components/logViewer/LogContext.tsx
@@ -53,7 +53,7 @@ export const LogContextWrapper: React.FunctionComponent = ({ children }) => {
       setUnread((prevState) => {
         const prevUUIDs = new Set(prevState.map((x) => x.uuid));
         const newUUIDs = new Set(newUnread.map((x) => x.uuid));
-        // maintain reference equality
+        // Maintain reference equality
         return isEqual(prevUUIDs, newUUIDs) ? prevState : newUnread;
       });
     },
@@ -63,7 +63,7 @@ export const LogContextWrapper: React.FunctionComponent = ({ children }) => {
   const safeSetRefresh = useCallback(
     (refreshHandler: Refresh) => {
       console.debug("Setting log refresh reference");
-      // wrap setRefresh here to take in a method
+      // Wrap setRefresh here to take in a method
       setRefresh((_prevState: Refresh) => refreshHandler);
     },
     [setRefresh]

--- a/src/components/logViewer/LogTable.stories.tsx
+++ b/src/components/logViewer/LogTable.stories.tsx
@@ -68,7 +68,7 @@ const ERROR_MESSAGE: LogEntry = {
   message: "Sample error running brick message",
   level: "error",
   context: {
-    // just the context that will show up in the table
+    // Just the context that will show up in the table
     blockId: "@pixiebrix/system/notification",
   },
   error: serializeError(new Error("Simple error")),
@@ -103,7 +103,7 @@ const CONTEXT_ERROR_MESSAGE: LogEntry = {
   message: "Invalid inputs for block",
   level: "error",
   context: {
-    // just the context that will show up in the table
+    // Just the context that will show up in the table
     blockId: "@pixiebrix/system/notification",
   },
   error: serializeError(

--- a/src/components/logViewer/details/NetworkErrorDetail.tsx
+++ b/src/components/logViewer/details/NetworkErrorDetail.tsx
@@ -80,7 +80,7 @@ const NetworkErrorDetail: React.FunctionComponent<{ error: AxiosError }> = ({
   const cleanResponse = useMemo(() => {
     if (error.response) {
       const { request, config, data, ...rest } = error.response;
-      // don't include request, since we're showing it the other column
+      // Don't include request, since we're showing it the other column
       return {
         ...rest,
         data: tryParse(data),

--- a/src/components/logViewer/details/NetworkErrorDetail.tsx
+++ b/src/components/logViewer/details/NetworkErrorDetail.tsx
@@ -43,6 +43,7 @@ function tryParse(value: unknown): unknown {
       // NOP
     }
   }
+
   return value;
 }
 

--- a/src/components/logViewer/useLogEntries.ts
+++ b/src/components/logViewer/useLogEntries.ts
@@ -73,6 +73,7 @@ export default function useLogEntries({
       if (!isMounted()) {
         return;
       }
+
       setLogState({ entries, isLoading: false });
       setNumNew(0);
       setUnread([]);
@@ -119,6 +120,7 @@ export default function useLogEntries({
       // Wait for the initial set of logs before starting to check for updates
       return;
     }
+
     const newEntries = await getLog(context);
     const filteredNewEntries = (newEntries ?? []).filter(
       // eslint-disable-next-line security/detect-object-injection -- level is from dropdown

--- a/src/components/logViewer/useLogEntries.ts
+++ b/src/components/logViewer/useLogEntries.ts
@@ -96,7 +96,7 @@ export default function useLogEntries({
   const filteredEntries = useMemo(
     () =>
       (entries ?? []).filter(
-        // level is coming from the dropdown
+        // Level is coming from the dropdown
         // eslint-disable-next-line security/detect-object-injection
         (entry) => LOG_LEVELS[entry.level] >= LOG_LEVELS[level]
       ),
@@ -116,7 +116,7 @@ export default function useLogEntries({
 
   const checkNewEntries = useCallback(async () => {
     if (!initialized) {
-      // wait for the initial set of logs before starting to check for updates
+      // Wait for the initial set of logs before starting to check for updates
       return;
     }
     const newEntries = await getLog(context);

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -72,7 +72,7 @@ async function init(): Promise<void> {
   }
 
   try {
-    // notify the background script know we're ready to execute remote actions
+    // Notify the background script know we're ready to execute remote actions
     await notifyReady();
     console.info(`contentScript ready in ${Date.now() - start}ms`);
   } catch (error: unknown) {

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -236,6 +236,7 @@ export function liftContentScript<R extends SerializableResponse>(
       if (isNotification(options)) {
         return;
       }
+
       throw error;
     }
 

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -98,7 +98,7 @@ export function notifyContentScripts(
   const fullType = `${MESSAGE_PREFIX}${type}`;
 
   if (isContentScript()) {
-    // addContentScriptListener logs to console when the handler is installed on the window. So it would be confusing
+    // AddContentScriptListener logs to console when the handler is installed on the window. So it would be confusing
     // to include a console.debug statement here
     handlers.set(fullType, {
       // HandlerEntry's Handler field has a return value, not void
@@ -184,7 +184,7 @@ export function liftContentScript<R extends SerializableResponse>(
   const fullType = `${MESSAGE_PREFIX}${type}`;
 
   if (isContentScript()) {
-    // addContentScriptListener logs to console when the handler is installed on the window. So it would be confusing
+    // AddContentScriptListener logs to console when the handler is installed on the window. So it would be confusing
     // to include a console.debug statement here
     handlers.set(fullType, { handler: method, options });
   }

--- a/src/contentScript/devTools.ts
+++ b/src/contentScript/devTools.ts
@@ -31,7 +31,7 @@ import {
   selectedElement,
 } from "@/devTools/getSelectedElement";
 
-// install handlers
+// Install handlers
 import "@/nativeEditor/insertButton";
 import "@/nativeEditor/insertPanel";
 import "@/nativeEditor/dynamic";

--- a/src/contentScript/devTools.ts
+++ b/src/contentScript/devTools.ts
@@ -52,6 +52,7 @@ async function read(factory: () => Promise<unknown>): Promise<unknown> {
     if (deserializeError(error).name === "ComponentNotFoundError") {
       return "Component not detected";
     }
+
     return { error };
   }
 }
@@ -94,11 +95,13 @@ export const runReaderBlock = liftContentScript(
           documentUrl: document.location.href,
         };
       }
+
       return {
         selectionText: window.getSelection().toString(),
         documentUrl: document.location.href,
       };
     }
+
     const reader = (await blockRegistry.lookup(id)) as IReader;
     return reader.read(root);
   }
@@ -140,8 +143,10 @@ export const readSelected = liftContentScript("READ_SELECTED", async () => {
         getComponentData({ framework: framework as Framework, selector })
       );
     }
+
     return base;
   }
+
   return {
     error: "No element selected",
   };

--- a/src/contentScript/externalProtocol.ts
+++ b/src/contentScript/externalProtocol.ts
@@ -120,6 +120,7 @@ function initExternalPageListener() {
         console.warn(`Ignoring message with unknown nonce: ${meta.nonce}`);
         return;
       }
+
       try {
         const response = isErrorResponse(payload)
           ? deserializeError(payload.$$error)
@@ -179,6 +180,7 @@ export function liftExternal<R extends SerializableResponse>(
     if (isExtensionContext()) {
       throw new ContentScriptActionError("Expected call from external page");
     }
+
     // Wait for the extension to load before sending the message
     if (!document.documentElement.hasAttribute(PIXIEBRIX_READY_ATTRIBUTE)) {
       await Promise.race([

--- a/src/contentScript/externalProtocol.ts
+++ b/src/contentScript/externalProtocol.ts
@@ -107,7 +107,7 @@ function initExternalPageListener() {
   window.addEventListener("message", function (event: MessageEvent) {
     const { type, meta, error, payload } = event.data;
     if (
-      // check isResponseType to make sure we're not handling the messages from the content script
+      // Check isResponseType to make sure we're not handling the messages from the content script
       event.source === document.defaultView &&
       isResponseType(type) &&
       meta?.nonce
@@ -168,7 +168,7 @@ export function liftExternal<R extends SerializableResponse>(
   const fullType = `${MESSAGE_PREFIX}${type}`;
 
   if (isContentScript()) {
-    // console.debug(`Installed content script handler for ${type}`);
+    // Console.debug(`Installed content script handler for ${type}`);
     contentScriptHandlers.set(fullType, { handler: method, options });
     return method;
   }

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -80,7 +80,8 @@ async function runExtensionPoint(
       `Skipping ${extensionPoint.id} because it was not installed on the page`
     );
     return;
-  } else if (isCancelled()) {
+  }
+  if (isCancelled()) {
     console.debug(
       `Skipping ${extensionPoint.id} because user navigated away from the page`
     );

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -54,6 +54,7 @@ async function installScriptOnce(): Promise<void> {
       });
     });
   }
+
   return _scriptPromise;
 }
 
@@ -72,6 +73,7 @@ async function runExtensionPoint(
       );
       return;
     }
+
     throw error;
   }
 
@@ -81,6 +83,7 @@ async function runExtensionPoint(
     );
     return;
   }
+
   if (isCancelled()) {
     console.debug(
       `Skipping ${extensionPoint.id} because user navigated away from the page`
@@ -115,6 +118,7 @@ export function clearDynamic(uuid?: string): void {
       _installedExtensionPoints.splice(index, 1);
     }
   };
+
   if (uuid) {
     if (_dynamic.has(uuid)) {
       console.debug(`clearDynamic: ${uuid}`);
@@ -130,6 +134,7 @@ export function clearDynamic(uuid?: string): void {
       extensionPoint.uninstall({ global: true });
       markUninstalled(extensionPoint.id);
     }
+
     _dynamic.clear();
   }
 }
@@ -151,6 +156,7 @@ export async function runDynamic(
   if (_dynamic.has(uuid)) {
     _dynamic.get(uuid).uninstall();
   }
+
   _dynamic.set(uuid, extensionPoint);
   await runExtensionPoint(extensionPoint, makeCancelOnNavigate());
 }
@@ -208,6 +214,7 @@ async function loadExtensionsOnce(): Promise<IExtensionPoint[]> {
     _reloadOnNextNavigate = false;
     await loadExtensions();
   }
+
   return _extensionPoints;
 }
 
@@ -231,6 +238,7 @@ async function waitLoaded(cancel: () => boolean): Promise<void> {
       if (cancel()) {
         return;
       }
+
       console.debug(
         `Custom navigation rule detected that page is still loading: ${url}`
       );

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -33,7 +33,7 @@ const _frameHref: Map<number, string> = new Map();
 let _extensionPoints: IExtensionPoint[];
 let _navSequence = 1;
 const _installedExtensionPoints: IExtensionPoint[] = [];
-// reload extension definitions on next navigation
+// Reload extension definitions on next navigation
 let _reloadOnNextNavigate = false;
 
 const WAIT_LOADED_INTERVAL_MS = 25;
@@ -320,6 +320,6 @@ export const queueReactivate = notifyContentScripts(
 
 export const reactivate = notifyContentScripts("REACTIVATE", async () => {
   await loadExtensions();
-  // force navigate event even though the href hasn't changed
+  // Force navigate event even though the href hasn't changed
   await handleNavigate({ force: true });
 });

--- a/src/contentScript/notify.ts
+++ b/src/contentScript/notify.ts
@@ -61,6 +61,7 @@ export function mergeConfig(
   if (custom == null) {
     return defaults;
   }
+
   return merge({}, defaults, custom);
 }
 

--- a/src/contentScript/notify.ts
+++ b/src/contentScript/notify.ts
@@ -69,7 +69,7 @@ export interface NotificationCallbacks {
 }
 
 export function notifyError(message: string): void {
-  // call getErrorMessage on err and include in the details
+  // Call getErrorMessage on err and include in the details
   $.notify(message, {
     className: "error",
   });

--- a/src/contentScript/uipath.ts
+++ b/src/contentScript/uipath.ts
@@ -70,6 +70,7 @@ export const getProcesses = liftContentScript(
     if (!_robot) {
       throw new Error("UiPath not initialized");
     }
+
     return _robot.getProcesses();
   }
 );

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -217,6 +217,7 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
       </div>
     );
   }
+
   if (!hasPermissions) {
     return (
       <div className="my-2">
@@ -261,6 +262,7 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
                         "Expected schema for input property type"
                       );
                     }
+
                     return (
                       <FieldRenderer
                         key={prop}

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -216,7 +216,8 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
         </p>
       </div>
     );
-  } else if (!hasPermissions) {
+  }
+  if (!hasPermissions) {
     return (
       <div className="my-2">
         <p>

--- a/src/contrib/google/auth.ts
+++ b/src/contrib/google/auth.ts
@@ -69,7 +69,8 @@ export async function handleRejection(
       "Cannot locate the Google drive resource. Have you been granted access?",
       status
     );
-  } else if ([403, 401].includes(status)) {
+  }
+  if ([403, 401].includes(status)) {
     await chromeP.identity.removeCachedAuthToken({ token });
     console.debug(
       "Bad Google OAuth token. Removed the auth token from the cache so the user can re-authenticate"

--- a/src/contrib/google/auth.ts
+++ b/src/contrib/google/auth.ts
@@ -70,6 +70,7 @@ export async function handleRejection(
       status
     );
   }
+
   if ([403, 401].includes(status)) {
     await chromeP.identity.removeCachedAuthToken({ token });
     console.debug(
@@ -82,5 +83,6 @@ export async function handleRejection(
       status
     );
   }
+
   return new Error(getErrorMessage(error.result.error ?? "Unknown error"));
 }

--- a/src/contrib/google/bigquery/query.ts
+++ b/src/contrib/google/bigquery/query.ts
@@ -184,7 +184,8 @@ export class GoogleBigQueryQuery extends Transformer {
           x.f.map(({ v }) => v)
         )
       );
-    } else if (totalRows === 0) {
+    }
+    if (totalRows === 0) {
       throw new Error("No results returned");
     }
     return zipObject(

--- a/src/contrib/google/bigquery/query.ts
+++ b/src/contrib/google/bigquery/query.ts
@@ -152,7 +152,7 @@ export class GoogleBigQueryQuery extends Transformer {
       useQueryCache: true,
       queryParameters: queryParameters.map(
         ({ name, parameterType, parameterValue }: ScalarParameter) => ({
-          // simplify passing scalar parameters for now
+          // Simplify passing scalar parameters for now
           name,
           parameterType: { type: parameterType },
           parameterValue: { value: parameterValue },

--- a/src/contrib/google/bigquery/query.ts
+++ b/src/contrib/google/bigquery/query.ts
@@ -178,6 +178,7 @@ export class GoogleBigQueryQuery extends Transformer {
       if (totalRows > result.rows.length) {
         throw new Error("Support for multi-page results not implemented");
       }
+
       return result.rows.map((x) =>
         zipObject(
           fieldNames,
@@ -185,9 +186,11 @@ export class GoogleBigQueryQuery extends Transformer {
         )
       );
     }
+
     if (totalRows === 0) {
       throw new Error("No results returned");
     }
+
     return zipObject(
       fieldNames,
       result.rows[0].f.map(({ v }) => v)

--- a/src/contrib/google/initGoogle.ts
+++ b/src/contrib/google/initGoogle.ts
@@ -46,6 +46,7 @@ function initGoogle(): void {
     );
     return;
   }
+
   if (!API_KEY) {
     console.info("Google API not enabled because the API key is not available");
     return;

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -44,6 +44,7 @@ const TabField: React.FunctionComponent<
     if (doc?.id && port) {
       return devtoolsProtocol.getTabNames(port, doc.id);
     }
+
     return [];
   }, [doc?.id, port]);
 
@@ -112,6 +113,7 @@ const PropertiesField: React.FunctionComponent<{
         ),
       } as Schema;
     }
+
     return {
       type: "object",
       additionalProperties: true,
@@ -121,9 +123,11 @@ const PropertiesField: React.FunctionComponent<{
   if (schemaPending) {
     return <GridLoader />;
   }
+
   if (schemaError) {
     return <span className="text-danger">Error fetching column headers</span>;
   }
+
   return <ObjectField label="Row Values" name={name} schema={sheetSchema} />;
 };
 

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -120,7 +120,8 @@ const PropertiesField: React.FunctionComponent<{
 
   if (schemaPending) {
     return <GridLoader />;
-  } else if (schemaError) {
+  }
+  if (schemaError) {
     return <span className="text-danger">Error fetching column headers</span>;
   }
   return <ObjectField label="Row Values" name={name} schema={sheetSchema} />;

--- a/src/contrib/google/sheets/FileField.tsx
+++ b/src/contrib/google/sheets/FileField.tsx
@@ -55,7 +55,7 @@ const FileField: React.FunctionComponent<
       const spreadsheetId = field.value;
 
       if (doc?.id === spreadsheetId) {
-        // already up to date
+        // Already up to date
         return;
       }
       try {

--- a/src/contrib/google/sheets/FileField.tsx
+++ b/src/contrib/google/sheets/FileField.tsx
@@ -58,6 +58,7 @@ const FileField: React.FunctionComponent<
         // Already up to date
         return;
       }
+
       try {
         if (!isNullOrBlank(field.value) && doc?.id !== spreadsheetId) {
           setSheetError(null);
@@ -122,6 +123,7 @@ const FileField: React.FunctionComponent<
             if (doc.mimeType !== "application/vnd.google-apps.spreadsheet") {
               throw new Error(`${doc.name} is not a spreadsheet`);
             }
+
             helpers.setValue(data.docs[0].id);
             onSelect(doc);
           }

--- a/src/contrib/google/sheets/append.ts
+++ b/src/contrib/google/sheets/append.ts
@@ -92,6 +92,7 @@ function makeValues(headerRow: string[], rowValues: RowValue[]): CellValue[] {
       row.push(null);
     }
   }
+
   const unmatched = rowValues
     .map((x) => x.header)
     .filter((x) => !matched.has(x));
@@ -100,6 +101,7 @@ function makeValues(headerRow: string[], rowValues: RowValue[]): CellValue[] {
       `${unmatched.length} field(s) were unmatched: ${unmatched.join(", ")}`
     );
   }
+
   return row;
 }
 
@@ -147,6 +149,7 @@ export class GoogleSheetsAppend extends Effect {
       if (isAuthError(error)) {
         throw error;
       }
+
       logger.info(`Creating tab ${tabName}`);
       await createTab(spreadsheetId, tabName);
     }

--- a/src/contrib/google/sheets/handlers.ts
+++ b/src/contrib/google/sheets/handlers.ts
@@ -134,6 +134,7 @@ function columnToLetter(column: number): string {
     letter = String.fromCharCode(temp + 65) + letter;
     column = (column - temp - 1) / 26;
   }
+
   return letter;
 }
 
@@ -162,12 +163,14 @@ export async function getSheetProperties(
             )
           );
         }
+
         resolve(r.result);
       })
     );
     if (!spreadsheet) {
       throw new Error("Unknown error fetching spreadsheet");
     }
+
     return spreadsheet.properties;
   } catch (error: unknown) {
     throw await handleRejection(token, error);
@@ -197,12 +200,14 @@ async function getTabNames(spreadsheetId: string): Promise<string[]> {
             )
           );
         }
+
         resolve(r.result);
       })
     );
     if (!spreadsheet) {
       throw new Error("Unknown error fetching spreadsheet");
     }
+
     return spreadsheet.sheets.map((x) => x.properties.title);
   } catch (error: unknown) {
     throw await handleRejection(token, error);

--- a/src/contrib/hubspot/upsert.ts
+++ b/src/contrib/hubspot/upsert.ts
@@ -121,6 +121,7 @@ export class AddUpdateContact extends Effect {
           "firstname and lastname are required if an email is not provided"
         );
       }
+
       // @ts-ignore: come back and define types for the hubspot API
       const { contacts } = await proxyHubspot({
         url: "https://api.hubapi.com/contacts/v1/search/query",

--- a/src/contrib/pipedrive/readers.ts
+++ b/src/contrib/pipedrive/readers.ts
@@ -33,9 +33,11 @@ export async function checkRoute(expectedRoute: string): Promise<boolean> {
 
 class PipedriveReader extends Reader {
   private readonly ROOT_PATH = "app.router.currentView.model.attributes";
+
   public readonly outputSchema: Schema;
 
   resourceType: string;
+
   pathSpec: PathSpec;
 
   constructor(resourceType: string, pathSpec: PathSpec) {

--- a/src/contrib/uipath/localProcessOptions.tsx
+++ b/src/contrib/uipath/localProcessOptions.tsx
@@ -172,7 +172,8 @@ const LocalProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
         </span>
       </div>
     );
-  } else if (!robotAvailable) {
+  }
+  if (!robotAvailable) {
     return (
       <div>
         <span className="text-danger">

--- a/src/contrib/uipath/localProcessOptions.tsx
+++ b/src/contrib/uipath/localProcessOptions.tsx
@@ -107,6 +107,7 @@ function useReleaseSchema(releaseKey: string) {
         return releaseSchema(release);
       }
     }
+
     return null;
   }, [releaseKey, releases]);
 
@@ -142,6 +143,7 @@ const LocalProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
       );
       return;
     }
+
     try {
       const { available, consentCode } = await initUiPathRobot(port);
       setConsentCode(consentCode);
@@ -157,6 +159,7 @@ const LocalProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
     if (robotAvailable) {
       return getUiPathProcesses(port);
     }
+
     return [];
   }, [robotAvailable]);
 
@@ -173,6 +176,7 @@ const LocalProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
       </div>
     );
   }
+
   if (!robotAvailable) {
     return (
       <div>

--- a/src/contrib/uipath/process.ts
+++ b/src/contrib/uipath/process.ts
@@ -138,6 +138,7 @@ export class RunProcess extends Transformer {
       if (startData.value.length > 1) {
         throw new Error("Awaiting response of multiple jobs not supported");
       }
+
       do {
         const { data: resultData } = await proxyService<JobsResponse>(uipath, {
           url: `/odata/Jobs?$filter=Id eq ${startData.value[0].Id}`,
@@ -152,12 +153,15 @@ export class RunProcess extends Transformer {
         if (resultData.value[0].State === "Successful") {
           return JSON.parse(resultData.value[0].OutputArguments);
         }
+
         if (resultData.value[0].State === "Faulted") {
           logger.error(`UiPath job failed: ${resultData.value[0].Info}`);
           throw new BusinessError("UiPath job failed");
         }
+
         await sleep(POLL_MILLIS);
       } while (Date.now() - start < MAX_WAIT_MILLIS);
+
       throw new BusinessError(
         `UiPath job did not finish in ${MAX_WAIT_MILLIS / 1000} seconds`
       );

--- a/src/contrib/uipath/process.ts
+++ b/src/contrib/uipath/process.ts
@@ -151,7 +151,8 @@ export class RunProcess extends Transformer {
 
         if (resultData.value[0].State === "Successful") {
           return JSON.parse(resultData.value[0].OutputArguments);
-        } else if (resultData.value[0].State === "Faulted") {
+        }
+        if (resultData.value[0].State === "Faulted") {
           logger.error(`UiPath job failed: ${resultData.value[0].Info}`);
           throw new BusinessError("UiPath job failed");
         }

--- a/src/contrib/uipath/processOptions.tsx
+++ b/src/contrib/uipath/processOptions.tsx
@@ -70,7 +70,7 @@ interface Release {
   Description: string;
   Name: string;
   Arguments: {
-    // serialized input dict
+    // Serialized input dict
     Input: string | null;
     Output: string | null;
   };

--- a/src/contrib/uipath/processOptions.tsx
+++ b/src/contrib/uipath/processOptions.tsx
@@ -92,6 +92,7 @@ export function useReleases(): {
       });
       return response.data.value;
     }
+
     return null;
   }, [config, hasPermissions]);
 
@@ -110,6 +111,7 @@ function useRobots(): { robots: Robot[]; isPending: boolean; error: unknown } {
       });
       return response.data.value;
     }
+
     return [];
   }, [config, hasPermissions]);
 
@@ -198,18 +200,22 @@ function toType(type: string) {
   if (namespace === "System" && typeName === "String") {
     return "string";
   }
+
   if (namespace === "System" && typeName === "Boolean") {
     return "boolean";
   }
+
   if (
     namespace === "System" &&
     ["Int64", "Int32", "Int16", "UInt64", "UInt32", "UInt16"].includes(typeName)
   ) {
     return "integer";
   }
+
   if (namespace === "System" && ["Decimal", "Double"].includes(typeName)) {
     return "number";
   }
+
   throw new BusinessError(`Unsupported input type: ${type}`);
 }
 
@@ -247,6 +253,7 @@ export const InputArgumentsField: React.FunctionComponent<
                     "Expected schema for input property type"
                   );
                 }
+
                 return (
                   <FieldRenderer
                     key={prop}

--- a/src/contrib/uipath/processOptions.tsx
+++ b/src/contrib/uipath/processOptions.tsx
@@ -197,17 +197,17 @@ function toType(type: string) {
   // https://docs.microsoft.com/en-us/dotnet/api/system.valuetype?view=net-5.0
   if (namespace === "System" && typeName === "String") {
     return "string";
-  } else if (namespace === "System" && typeName === "Boolean") {
+  }
+  if (namespace === "System" && typeName === "Boolean") {
     return "boolean";
-  } else if (
+  }
+  if (
     namespace === "System" &&
     ["Int64", "Int32", "Int16", "UInt64", "UInt32", "UInt16"].includes(typeName)
   ) {
     return "integer";
-  } else if (
-    namespace === "System" &&
-    ["Decimal", "Double"].includes(typeName)
-  ) {
+  }
+  if (namespace === "System" && ["Decimal", "Double"].includes(typeName)) {
     return "number";
   }
   throw new BusinessError(`Unsupported input type: ${type}`);

--- a/src/core.ts
+++ b/src/core.ts
@@ -187,7 +187,7 @@ export interface IExtensionPoint extends Metadata {
   isAvailable: () => Promise<boolean>;
 
   /**
-   * true iff the extension point must be installed before the page can be considered ready
+   * True iff the extension point must be installed before the page can be considered ready
    */
   syncInstall: boolean;
 
@@ -256,17 +256,17 @@ export interface KeyedConfig {
 }
 
 export interface SanitizedConfig extends KeyedConfig {
-  // nominal typing to distinguish from ServiceConfig
+  // Nominal typing to distinguish from ServiceConfig
   _sanitizedConfigBrand: null;
 }
 
 export interface ServiceConfig extends KeyedConfig {
-  // nominal typing to distinguish from SanitizedConfig
+  // Nominal typing to distinguish from SanitizedConfig
   _serviceConfigBrand: null;
 }
 
 export interface AuthData {
-  // nominal typing to distinguish from SanitizedConfig and ServiceConfig
+  // Nominal typing to distinguish from SanitizedConfig and ServiceConfig
   _oauth: null;
   [key: string]: string | null;
 }
@@ -287,7 +287,7 @@ export interface OAuth2Context {
 
 /** Service configuration provided by a user. */
 export interface RawServiceConfiguration {
-  // nominal typing to distinguish from SanitizedServiceConfiguration
+  // Nominal typing to distinguish from SanitizedServiceConfiguration
   _rawServiceConfigurationBrand: null;
 
   /**
@@ -306,7 +306,7 @@ export interface RawServiceConfiguration {
 }
 
 export interface SanitizedServiceConfiguration {
-  // nominal typing to distinguish from RawServiceConfiguration
+  // Nominal typing to distinguish from RawServiceConfiguration
   _sanitizedServiceConfigurationBrand: null;
 
   /**
@@ -322,7 +322,7 @@ export interface SanitizedServiceConfiguration {
   config: SanitizedConfig;
 
   /**
-   * true if the service must be proxied for remote configs, e.g., because it has a secret it needs
+   * True if the service must be proxied for remote configs, e.g., because it has a secret it needs
    * to use to authenticate.
    */
   proxy: boolean;

--- a/src/devTools/Editor.tsx
+++ b/src/devTools/Editor.tsx
@@ -85,9 +85,11 @@ const Editor: React.FunctionComponent = () => {
     if (tabState.hasPermissions === false) {
       return <PermissionsPane />;
     }
+
     if (error && beta) {
       return <BetaPane />;
     }
+
     if (inserting) {
       switch (inserting) {
         case "menuItem":

--- a/src/devTools/Editor.tsx
+++ b/src/devTools/Editor.tsx
@@ -84,9 +84,11 @@ const Editor: React.FunctionComponent = () => {
   const body = useMemo(() => {
     if (tabState.hasPermissions === false) {
       return <PermissionsPane />;
-    } else if (error && beta) {
+    }
+    if (error && beta) {
       return <BetaPane />;
-    } else if (inserting) {
+    }
+    if (inserting) {
       switch (inserting) {
         case "menuItem":
           return <InsertMenuItemPane cancel={cancelInsert} />;

--- a/src/devTools/Panel.tsx
+++ b/src/devTools/Panel.tsx
@@ -71,6 +71,7 @@ const RequireScope: React.FunctionComponent<{ scope: string | null }> = ({
   if (mode !== "local" && (scope === "" || !scope)) {
     return <ScopeSettings />;
   }
+
   return <>{children}</>;
 };
 
@@ -91,6 +92,7 @@ const Panel: React.FunctionComponent = () => {
       </Centered>
     );
   }
+
   if (context.portError || context.tabState.error) {
     return (
       <Centered>
@@ -104,6 +106,7 @@ const Panel: React.FunctionComponent = () => {
       </Centered>
     );
   }
+
   if (!context.port) {
     return (
       <Centered>

--- a/src/devTools/Panel.tsx
+++ b/src/devTools/Panel.tsx
@@ -90,7 +90,8 @@ const Panel: React.FunctionComponent = () => {
         <Button onClick={() => location.reload()}>Reload Editor</Button>
       </Centered>
     );
-  } else if (context.portError || context.tabState.error) {
+  }
+  if (context.portError || context.tabState.error) {
     return (
       <Centered>
         <div className="PaneTitle">
@@ -102,7 +103,8 @@ const Panel: React.FunctionComponent = () => {
         </div>
       </Centered>
     );
-  } else if (!context.port) {
+  }
+  if (!context.port) {
     return (
       <Centered>
         <p>Initializing connection...</p>

--- a/src/devTools/Reader.tsx
+++ b/src/devTools/Reader.tsx
@@ -23,7 +23,7 @@
 //   DEV_WATCH_READER,
 //   DEV_WATCH_READER_READ,
 // } from "@/messaging/constants";
-// // import  toJsonSchema from 'to-json-schema';
+/// import  toJsonSchema from 'to-json-schema';
 // import GenerateSchema from "generate-schema";
 // import ReactJson from "react-json-view";
 //

--- a/src/devTools/ScopeSettings.tsx
+++ b/src/devTools/ScopeSettings.tsx
@@ -112,10 +112,12 @@ const ScopeSettings: React.FunctionComponent = () => {
             });
             return;
           }
+
           case StatusCodes.BAD_REQUEST: {
             setErrors(mapValues(error.response.data, (xs) => castArray(xs)[0]));
             return;
           }
+
           default: {
             reportError(error);
             addToast("Error updating account alias", {
@@ -125,6 +127,7 @@ const ScopeSettings: React.FunctionComponent = () => {
           }
         }
       }
+
       location.reload();
     },
     [addToast]

--- a/src/devTools/context.ts
+++ b/src/devTools/context.ts
@@ -200,7 +200,7 @@ export function useDevConnection(): Context {
     setConnecting(false);
   }, [port, setCurrent]);
 
-  // automatically connect on when background port connected, and on future navigations
+  // Automatically connect on when background port connected, and on future navigations
   useAsyncEffect(async () => {
     if (port) {
       await connect();

--- a/src/devTools/context.ts
+++ b/src/devTools/context.ts
@@ -133,6 +133,7 @@ async function connectToFrame(port: Runtime.Port): Promise<FrameMeta> {
     console.debug(`connectToFrame: no access to ${url}`);
     throw new PermissionsError(`No access to URL: ${url}`);
   }
+
   console.debug(`connectToFrame: ensuring contentScript for ${url}`);
   await pTimeout(ensureScript(port), 4000, "contentScript not ready in 4s");
 
@@ -166,6 +167,7 @@ export function useDevConnection(): Context {
     if (!port) {
       throw new Error("background port not initialized");
     }
+
     const uuid = uuidv4();
     const common = { frameId: 0, navSequence: uuid };
     try {
@@ -197,6 +199,7 @@ export function useDevConnection(): Context {
         });
       }
     }
+
     setConnecting(false);
   }, [port, setCurrent]);
 

--- a/src/devTools/editor/ElementWizard.tsx
+++ b/src/devTools/editor/ElementWizard.tsx
@@ -49,6 +49,7 @@ const WizardNavItem: React.FunctionComponent<{
     if (step.step !== LOG_STEP_NAME) {
       return null;
     }
+
     const levels = groupBy(unread, (x) => x.level);
     for (const [level, variant] of [
       ["error", "danger"],
@@ -64,6 +65,7 @@ const WizardNavItem: React.FunctionComponent<{
         );
       }
     }
+
     return null;
   }, [step.step, unread]);
 

--- a/src/devTools/editor/components/Effect.tsx
+++ b/src/devTools/editor/components/Effect.tsx
@@ -49,7 +49,7 @@ const Effect: React.FunctionComponent<{
     [setPrev, debounced, onChange]
   );
 
-  // don't render a react node
+  // Don't render a react node
   return null;
 };
 

--- a/src/devTools/editor/editorSlice.ts
+++ b/src/devTools/editor/editorSlice.ts
@@ -124,7 +124,7 @@ export const editorSlice = createSlice({
         (x) => x.uuid === actions.payload.uuid
       );
       if (index >= 0) {
-        // safe because we're getting it from findIndex
+        // Safe because we're getting it from findIndex
         // eslint-disable-next-line security/detect-object-injection
         state.elements[index] = actions.payload;
       } else {
@@ -139,7 +139,7 @@ export const editorSlice = createSlice({
       const { uuid } = actions.payload;
       const index = state.elements.findIndex((x) => x.uuid === uuid);
       if (index >= 0) {
-        // safe because we're getting it from findIndex
+        // Safe because we're getting it from findIndex
         // eslint-disable-next-line security/detect-object-injection
         state.elements[index] = actions.payload;
       } else {
@@ -183,17 +183,17 @@ export const editorSlice = createSlice({
 
       element.installed = true;
       state.dirty[element.uuid] = false;
-      // force a reload so the _new flags are correct on the readers
+      // Force a reload so the _new flags are correct on the readers
       state.selectionSeq++;
     },
-    // sync the redux state with the form state
+    // Sync the redux state with the form state
     updateElement: (state, action: PayloadAction<FormState>) => {
       const { uuid } = action.payload;
       const index = state.elements.findIndex((x) => x.uuid === uuid);
       if (index < 0) {
         throw new Error(`Unknown dynamic element: ${uuid}`);
       }
-      // safe b/c generated from findIndex
+      // Safe b/c generated from findIndex
       // eslint-disable-next-line security/detect-object-injection
       state.elements[index] = action.payload;
       // eslint-disable-next-line security/detect-object-injection -- is uuid, and also using immer

--- a/src/devTools/editor/editorSlice.ts
+++ b/src/devTools/editor/editorSlice.ts
@@ -130,6 +130,7 @@ export const editorSlice = createSlice({
       } else {
         state.elements.push(actions.payload);
       }
+
       state.error = null;
       state.beta = null;
       state.activeElement = actions.payload.uuid;
@@ -145,6 +146,7 @@ export const editorSlice = createSlice({
       } else {
         state.elements.push(actions.payload);
       }
+
       // eslint-disable-next-line security/detect-object-injection -- is uuid, and also using immer
       state.dirty[uuid] = false;
       state.error = null;
@@ -156,6 +158,7 @@ export const editorSlice = createSlice({
       if (!state.elements.some((x) => action.payload === x.uuid)) {
         throw new Error(`Unknown dynamic element: ${action.payload}`);
       }
+
       state.error = null;
       state.beta = null;
       state.activeElement = action.payload;
@@ -166,6 +169,7 @@ export const editorSlice = createSlice({
       if (!element) {
         throw new Error(`Unknown dynamic element: ${action.payload}`);
       }
+
       if (!element.installed) {
         state.knownEditable.push(
           element.extensionPoint.metadata.id,
@@ -193,6 +197,7 @@ export const editorSlice = createSlice({
       if (index < 0) {
         throw new Error(`Unknown dynamic element: ${uuid}`);
       }
+
       // Safe b/c generated from findIndex
       // eslint-disable-next-line security/detect-object-injection
       state.elements[index] = action.payload;
@@ -204,6 +209,7 @@ export const editorSlice = createSlice({
       if (state.activeElement === uuid) {
         state.activeElement = null;
       }
+
       state.elements.splice(
         state.elements.findIndex((x) => x.uuid === uuid),
         1

--- a/src/devTools/editor/extensionPoints/adapter.ts
+++ b/src/devTools/editor/extensionPoints/adapter.ts
@@ -45,6 +45,7 @@ export async function selectType(extension: IExtension): Promise<ElementType> {
     });
     throw new Error("Cannot find extension point");
   }
+
   const extensionPoint = (brick.config as unknown) as ExtensionPointConfig;
   return extensionPoint.definition.type;
 }
@@ -59,6 +60,7 @@ export async function extensionToFormState(
       `Editing existing extensions not implemented for type: '${type}'`
     );
   }
+
   // FormState is the sum type of all the extension form states, so OK to cast
   return fromExtension(extension) as Promise<FormState>;
 }

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -72,12 +72,14 @@ export function makeReaderId(
   if (!excludeIds.includes(base)) {
     return base;
   }
+
   let num = 1;
   let id: string;
   do {
     num++;
     id = `${base}-${num}`;
   } while (excludeIds.includes(id));
+
   return id;
 }
 
@@ -143,6 +145,7 @@ export async function generateExtensionPointMetadata(
         return true;
       }
     }
+
     return false;
   };
 
@@ -164,6 +167,7 @@ export async function generateExtensionPointMetadata(
       };
     }
   }
+
   throw new Error("Could not find available id");
 }
 

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -139,7 +139,7 @@ export async function generateExtensionPointMetadata(
       try {
         await brickRegistry.lookup(id);
       } catch {
-        // name doesn't exist yet
+        // Name doesn't exist yet
         return true;
       }
     }

--- a/src/devTools/editor/extensionPoints/contextMenu.tsx
+++ b/src/devTools/editor/extensionPoints/contextMenu.tsx
@@ -91,7 +91,7 @@ function fromNativeElement(
   frameworks: FrameworkMeta[]
 ): ContextMenuFormState {
   const base = makeBaseState(uuidv4(), null, metadata, frameworks);
-  // don't include a reader since in most cases can't use a selection reader
+  // Don't include a reader since in most cases can't use a selection reader
   base.readers = [];
 
   const isAvailable = makeIsAvailable(url);
@@ -100,7 +100,7 @@ function fromNativeElement(
 
   return {
     type: "contextMenu",
-    // to simplify the interface, this is kept in sync with the caption
+    // To simplify the interface, this is kept in sync with the caption
     label: title,
     ...base,
     extensionPoint: {

--- a/src/devTools/editor/extensionPoints/menuItem.ts
+++ b/src/devTools/editor/extensionPoints/menuItem.ts
@@ -201,7 +201,7 @@ async function fromExtensionPoint(
     extensionPoint: {
       metadata: extensionPoint.metadata,
       traits: {
-        // we don't provide a way to set style anywhere yet so this doesn't apply yet
+        // We don't provide a way to set style anywhere yet so this doesn't apply yet
         style: { mode: "inherit" },
       },
       definition: {

--- a/src/devTools/editor/extensionPoints/panel.ts
+++ b/src/devTools/editor/extensionPoints/panel.ts
@@ -223,7 +223,7 @@ async function fromExtensionPoint(
     extensionPoint: {
       metadata: extensionPoint.metadata,
       traits: {
-        // we don't provide a way to set style anywhere yet so this doesn't apply yet
+        // We don't provide a way to set style anywhere yet so this doesn't apply yet
         style: { mode: "inherit" },
       },
       definition: {
@@ -263,7 +263,7 @@ async function fromExtension(
     extensionPoint: {
       metadata: extensionPoint.metadata,
       traits: {
-        // we don't provide a way to set style anywhere yet so this doesn't apply yet
+        // We don't provide a way to set style anywhere yet so this doesn't apply yet
         style: { mode: "inherit" },
       },
       definition: {

--- a/src/devTools/editor/fields/SelectorSelectorField.tsx
+++ b/src/devTools/editor/fields/SelectorSelectorField.tsx
@@ -81,6 +81,7 @@ function unrollValues(elementInfo: ElementInfo): OptionValue[] {
   if (!elementInfo) {
     return [];
   }
+
   return [
     ...(elementInfo.selectors ?? []).map((value) => ({ value, elementInfo })),
     ...compact([elementInfo.parent]).flatMap(unrollValues),

--- a/src/devTools/editor/hooks/useAvailableExtensionPoints.ts
+++ b/src/devTools/editor/hooks/useAvailableExtensionPoints.ts
@@ -26,7 +26,7 @@ import { zip } from "lodash";
 
 function useAvailableExtensionPoints<
   TConfig extends IExtensionPoint & { rawConfig: ExtensionPointConfig }
-  // we want Function to pass in the CTOR
+  // We want Function to pass in the CTOR
   // eslint-disable-next-line @typescript-eslint/ban-types
 >(ctor: Function): TConfig[] | null {
   const { port } = useContext(DevToolsContext);

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -85,6 +85,7 @@ function selectErrorMessage(error: unknown): string {
       "No response from PixieBrix server"
     );
   }
+
   return error.toString();
 }
 
@@ -106,6 +107,7 @@ async function ensureAllPermissionsFromDevTools(
   for (const origin of mergedPermissions.origins) {
     page.searchParams.append("origin", origin);
   }
+
   for (const origin of mergedPermissions.permissions) {
     page.searchParams.append("permission", origin);
   }

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -191,7 +191,7 @@ export function useCreate(): CreateCallback {
         try {
           await ensurePermissions(element, addToast);
         } catch (error: unknown) {
-          // continue to allow saving (because there's a workaround)
+          // Continue to allow saving (because there's a workaround)
           reportError(error);
           console.error("Error checking/enabling permissions", { error });
           addToast(
@@ -224,13 +224,13 @@ export function useCreate(): CreateCallback {
               element
             ).filter((reader) => isCustomReader(reader));
             for (const customReader of customReaders) {
-              // savedReaders is to handle case where save failed for the foundation, so subsequent saves needs
+              // SavedReaders is to handle case where save failed for the foundation, so subsequent saves needs
               // to update the reader
               const packageId =
                 element.installed ||
                 savedReaders.includes(customReader.metadata.id)
                   ? editablePackages.find(
-                      // bricks endpoint uses "name" instead of id
+                      // Bricks endpoint uses "name" instead of id
                       (x) => x.name === customReader.metadata.id
                     )?.id
                   : null;
@@ -250,7 +250,7 @@ export function useCreate(): CreateCallback {
             const extensionPointConfig = adapter.selectExtensionPoint(element);
             const packageId = element.installed
               ? editablePackages.find(
-                  // bricks endpoint uses "name" instead of id
+                  // Bricks endpoint uses "name" instead of id
                   (x) => x.name === extensionPointConfig.metadata.id
                 )?.id
               : null;

--- a/src/devTools/editor/hooks/useEditable.ts
+++ b/src/devTools/editor/hooks/useEditable.ts
@@ -45,6 +45,7 @@ function useEditable(): Set<string> {
     for (const x of knownEditable) {
       rv.add(x);
     }
+
     return rv;
   }, [initialEditable, knownEditable]);
 }

--- a/src/devTools/editor/hooks/useEditable.ts
+++ b/src/devTools/editor/hooks/useEditable.ts
@@ -40,7 +40,7 @@ function useEditable(): Set<string> {
   }, []);
 
   return useMemo<Set<string>>(() => {
-    // set union
+    // Set union
     const rv = new Set<string>(initialEditable ?? new Set());
     for (const x of knownEditable) {
       rv.add(x);

--- a/src/devTools/editor/hooks/useEscapeHandler.ts
+++ b/src/devTools/editor/hooks/useEscapeHandler.ts
@@ -28,6 +28,7 @@ export default function useEscapeHandler(
     } else {
       document.removeEventListener("keydown", escapeHandler);
     }
+
     return () => document.removeEventListener("keydown", escapeHandler);
   }, [active, cancel, escapeHandler]);
 }

--- a/src/devTools/editor/hooks/useInstallState.ts
+++ b/src/devTools/editor/hooks/useInstallState.ts
@@ -46,6 +46,7 @@ function useInstallState(
     if (meta) {
       return getInstalledExtensionPointIds(port);
     }
+
     return [];
   }, [port, navSequence, meta]);
 
@@ -62,6 +63,7 @@ function useInstallState(
           .map(([extension]) => extension.uuid)
       );
     }
+
     return new Set<string>();
   }, [
     port,
@@ -82,8 +84,10 @@ function useInstallState(
           (x) => !installedIds.includes(x.extensionPointId)
         ).length;
       }
+
       return null;
     }
+
     return installed?.length;
   }, [installed, installedIds, meta]);
 

--- a/src/devTools/editor/hooks/useRemove.ts
+++ b/src/devTools/editor/hooks/useRemove.ts
@@ -63,7 +63,7 @@ function useRemove(element: FormState): () => void {
           uuid: element.uuid,
         });
       } catch (error: unknown) {
-        // element might not be on the page anymore
+        // Element might not be on the page anymore
         console.info("Cannot clear dynamic element from page", { error });
       }
       if (values.installed) {

--- a/src/devTools/editor/hooks/useRemove.ts
+++ b/src/devTools/editor/hooks/useRemove.ts
@@ -58,6 +58,7 @@ function useRemove(element: FormState): () => void {
           console.info("Cannot unregister contextMenu", { error });
         }
       }
+
       try {
         await nativeOperations.clearDynamicElements(port, {
           uuid: element.uuid,
@@ -66,6 +67,7 @@ function useRemove(element: FormState): () => void {
         // Element might not be on the page anymore
         console.info("Cannot clear dynamic element from page", { error });
       }
+
       if (values.installed) {
         dispatch(
           optionsSlice.actions.removeExtension({
@@ -74,6 +76,7 @@ function useRemove(element: FormState): () => void {
           })
         );
       }
+
       dispatch(actions.removeElement(element.uuid));
     } catch (error: unknown) {
       reportError(error);

--- a/src/devTools/editor/panes/EditorPane.tsx
+++ b/src/devTools/editor/panes/EditorPane.tsx
@@ -54,7 +54,7 @@ const EditorPane: React.FunctionComponent<{
     { trailing: true, leading: false }
   );
 
-  // key to force reload of component when user selects a different element from the sidebar
+  // Key to force reload of component when user selects a different element from the sidebar
   const key = `${selectedElement.uuid}-${selectedElement.installed}-${selectionSeq}`;
 
   return (

--- a/src/devTools/editor/panes/PermissionsPane.tsx
+++ b/src/devTools/editor/panes/PermissionsPane.tsx
@@ -43,6 +43,7 @@ const PermissionsPane: React.FunctionComponent = () => {
       const tabId = browser.devtools.inspectedWindow.tabId;
       await openPopupPrompt(tabId, page.toString());
     }
+
     await sleep(500);
     await connect();
   }, [connect, port]);

--- a/src/devTools/editor/panes/insert/useAddExisting.ts
+++ b/src/devTools/editor/panes/insert/useAddExisting.ts
@@ -39,7 +39,7 @@ function useAddExisting<T extends { rawConfig: ExtensionPointConfig }>(
   return useCallback(
     async (extensionPoint: T) => {
       try {
-        // cancel out of insert mode
+        // Cancel out of insert mode
         cancel();
 
         const { url } = await getTabInfo(port);

--- a/src/devTools/editor/tabs/EffectTab.tsx
+++ b/src/devTools/editor/tabs/EffectTab.tsx
@@ -43,7 +43,7 @@ async function filterBlocks(
   { excludeTypes = [] }: { excludeTypes: BlockType[] }
 ): Promise<IBlock[]> {
   const types = await Promise.all(blocks.map(async (block) => getType(block)));
-  // exclude null to exclude foundations
+  // Exclude null to exclude foundations
   return zip(blocks, types)
     .filter(([, type]) => type != null && !excludeTypes.includes(type))
     .map(([block]) => block);

--- a/src/devTools/editor/tabs/ServicesTab.tsx
+++ b/src/devTools/editor/tabs/ServicesTab.tsx
@@ -88,7 +88,7 @@ const ServicesTab: React.FunctionComponent<{
                         )
                       )?.value,
                     });
-                    // reset value in dropdown
+                    // Reset value in dropdown
                     setKey((k) => k + 1);
                   }}
                 />

--- a/src/devTools/editor/tabs/menuItem/FoundationTab.tsx
+++ b/src/devTools/editor/tabs/menuItem/FoundationTab.tsx
@@ -71,7 +71,7 @@ const FoundationTab: React.FunctionComponent<{
         );
       }
     } catch (error: unknown) {
-      // can continue, because it won't have any effect on the form values, so the user can just try again
+      // Can continue, because it won't have any effect on the form values, so the user can just try again
       // noinspection ES6MissingAwait
       reportError(error);
     } finally {
@@ -207,21 +207,21 @@ const FoundationTab: React.FunctionComponent<{
         </Col>
       </Form.Group>
 
-      {/*<Form.Group as={Row} controlId="formStyle">*/}
-      {/*  <Form.Label column sm={2}>*/}
-      {/*    Style*/}
-      {/*  </Form.Label>*/}
-      {/*  <Col sm={10}>*/}
-      {/*    <Field name="extensionPoint.traits.style.mode">*/}
-      {/*      {({ field }: { field: FieldInputProps<string> }) => (*/}
-      {/*        <Form.Control as="select" {...field}>*/}
-      {/*          <option value="inherit">Inherit</option>*/}
-      {/*          <option value="default">Default</option>*/}
-      {/*        </Form.Control>*/}
-      {/*      )}*/}
-      {/*    </Field>*/}
-      {/*  </Col>*/}
-      {/*</Form.Group>*/}
+      {/* <Form.Group as={Row} controlId="formStyle"> */}
+      {/*  <Form.Label column sm={2}> */}
+      {/*    Style */}
+      {/*  </Form.Label> */}
+      {/*  <Col sm={10}> */}
+      {/*    <Field name="extensionPoint.traits.style.mode"> */}
+      {/*      {({ field }: { field: FieldInputProps<string> }) => ( */}
+      {/*        <Form.Control as="select" {...field}> */}
+      {/*          <option value="inherit">Inherit</option> */}
+      {/*          <option value="default">Default</option> */}
+      {/*        </Form.Control> */}
+      {/*      )} */}
+      {/*    </Field> */}
+      {/*  </Col> */}
+      {/* </Form.Group> */}
 
       <Form.Group as={Row} controlId="formTemplate" className="pb-4">
         <Form.Label column sm={2}>

--- a/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
@@ -98,6 +98,7 @@ export const ReaderBlockForm: React.FunctionComponent<{
     if (debouncedQuery === "" || output == null) {
       return output;
     }
+
     return searchData(debouncedQuery, output);
   }, [debouncedQuery, output]);
 

--- a/src/devTools/editor/tabs/reader/ReaderConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderConfig.tsx
@@ -91,7 +91,7 @@ const FrameworkSelector: React.FunctionComponent<{
   name: string;
   frameworks: FrameworkMeta[];
 }> = ({ name, frameworks = [] }) => {
-  // console.debug("Frameworks", { frameworks });
+  // Console.debug("Frameworks", { frameworks });
 
   const frameworkOptions: FrameworkOption[] = useMemo(
     () =>
@@ -244,7 +244,7 @@ const ReaderConfig: React.FunctionComponent<{
   const [query, setQuery] = useState("");
   const { values, setFieldValue } = useFormikContext<FormState>();
 
-  // console.debug("reader form state", { readerIndex, readers: values.readers });
+  // Console.debug("reader form state", { readerIndex, readers: values.readers });
 
   const [{ output, schema, error }, setSchema] = useState({
     output: undefined,

--- a/src/devTools/editor/tabs/reader/ReaderConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderConfig.tsx
@@ -131,6 +131,7 @@ export function searchData(query: string, data: unknown): unknown {
   if (data == null) {
     return null;
   }
+
   if (typeof data === "object") {
     const values = mapValues(data, (value, key) =>
       normalize(key).includes(query) ? value : searchData(query, value)
@@ -144,9 +145,11 @@ export function searchData(query: string, data: unknown): unknown {
       return keyMatch || valueMatch;
     });
   }
+
   if (Array.isArray(data)) {
     return compact(data.map(partial(searchData, query)));
   }
+
   return normalize(data).includes(normalized) ? data : undefined;
 }
 
@@ -287,6 +290,7 @@ const ReaderConfig: React.FunctionComponent<{
         });
         return;
       }
+
       const option = readerOptions.find((x) => x.value === type);
       let output;
       let schema;
@@ -325,6 +329,7 @@ const ReaderConfig: React.FunctionComponent<{
     if (debouncedQuery === "" || output == null) {
       return output;
     }
+
     return searchData(debouncedQuery, output);
   }, [debouncedQuery, output]);
 

--- a/src/devTools/editor/tabs/reader/ReaderConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderConfig.tsx
@@ -130,7 +130,8 @@ export function searchData(query: string, data: unknown): unknown {
   const normalized = normalize(query);
   if (data == null) {
     return null;
-  } else if (typeof data === "object") {
+  }
+  if (typeof data === "object") {
     const values = mapValues(data, (value, key) =>
       normalize(key).includes(query) ? value : searchData(query, value)
     );
@@ -142,7 +143,8 @@ export function searchData(query: string, data: unknown): unknown {
           : value != null;
       return keyMatch || valueMatch;
     });
-  } else if (Array.isArray(data)) {
+  }
+  if (Array.isArray(data)) {
     return compact(data.map(partial(searchData, query)));
   }
   return normalize(data).includes(normalized) ? data : undefined;

--- a/src/devTools/editor/toolbar/ReloadToolbar.tsx
+++ b/src/devTools/editor/toolbar/ReloadToolbar.tsx
@@ -83,11 +83,11 @@ const ReloadToolbar: React.FunctionComponent<{
 
   useAsyncEffect(async () => {
     if (disabled) {
-      // don't automatically re-run if in an invalid state
+      // Don't automatically re-run if in an invalid state
       return;
     }
     if (!automaticUpdate && !element.autoReload) {
-      // by default, don't automatically trigger (because it might be doing expensive
+      // By default, don't automatically trigger (because it might be doing expensive
       // operations such as hitting an API)
       return;
     }

--- a/src/devTools/editor/toolbar/ReloadToolbar.tsx
+++ b/src/devTools/editor/toolbar/ReloadToolbar.tsx
@@ -66,6 +66,7 @@ const ReloadToolbar: React.FunctionComponent<{
         element,
       });
     }
+
     await nativeOperations.updateDynamicElement(port, factory(element));
   }, [element, port, disabled]);
 
@@ -86,17 +87,20 @@ const ReloadToolbar: React.FunctionComponent<{
       // Don't automatically re-run if in an invalid state
       return;
     }
+
     if (!automaticUpdate && !element.autoReload) {
       // By default, don't automatically trigger (because it might be doing expensive
       // operations such as hitting an API)
       return;
     }
+
     await debouncedRun();
   }, [debouncedRun, port, automaticUpdate, element, disabled]);
 
   if (automaticUpdate) {
     return null;
   }
+
   return (
     <>
       <label className="AutoRun my-auto mr-1">

--- a/src/devTools/editor/toolbar/ReloadToolbar.tsx
+++ b/src/devTools/editor/toolbar/ReloadToolbar.tsx
@@ -85,7 +85,8 @@ const ReloadToolbar: React.FunctionComponent<{
     if (disabled) {
       // don't automatically re-run if in an invalid state
       return;
-    } else if (!automaticUpdate && !element.autoReload) {
+    }
+    if (!automaticUpdate && !element.autoReload) {
       // by default, don't automatically trigger (because it might be doing expensive
       // operations such as hitting an API)
       return;

--- a/src/devTools/store.ts
+++ b/src/devTools/store.ts
@@ -55,7 +55,7 @@ export interface RootState {
 
 const middleware = [];
 if (process.env.NODE_ENV === "development") {
-  // allow tree shaking of logger in production
+  // Allow tree shaking of logger in production
   // https://github.com/LogRocket/redux-logger/issues/6
   middleware.push(createLogger());
 }

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -73,7 +73,7 @@ async function initialize() {
   try {
     await ensureScript(port);
 
-    // clear out any dynamic stuff from any previous devtools sessions
+    // Clear out any dynamic stuff from any previous devtools sessions
     await clearDynamicElements(port, {}).catch((error: unknown) => {
       console.warn(
         "Error clearing dynamic elements from previous devtools sessions",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -103,9 +103,12 @@ export function hasCancelRootCause(error: unknown): boolean {
 
   if (error instanceof CancelError || error.name === "CancelError") {
     return true;
-  } else if (error instanceof ContextError) {
+  }
+
+  if (error instanceof ContextError) {
     return hasCancelRootCause(error.cause);
   }
+
   return false;
 }
 
@@ -120,9 +123,12 @@ export function hasBusinessRootCause(error: unknown): boolean {
 
   if (error instanceof BusinessError || error.name === "BusinessError") {
     return true;
-  } else if (error instanceof ContextError) {
+  }
+
+  if (error instanceof ContextError) {
     return hasBusinessRootCause(error.cause);
   }
+
   return false;
 }
 
@@ -135,11 +141,13 @@ function testConnectionErrorPatterns(message: string): boolean {
   if (typeof message !== "string") {
     return;
   }
+
   for (const pattern of CONNECTION_ERROR_PATTERNS) {
     if ((message ?? "").includes(pattern)) {
       return true;
     }
   }
+
   return false;
 }
 
@@ -163,18 +171,25 @@ export function isConnectionError(
 ): boolean {
   if (typeof event === "string") {
     return testConnectionErrorPatterns(event);
-  } else if (event instanceof ConnectionError) {
+  }
+
+  if (event instanceof ConnectionError) {
     return true;
-  } else if (event != null && typeof event === "object") {
+  }
+
+  if (event != null && typeof event === "object") {
     if (isPromiseRejectionEvent(event)) {
       return (
         event.reason instanceof ConnectionError ||
         testConnectionErrorPatterns(event.reason)
       );
-    } else if (isErrorEvent(event)) {
+    }
+
+    if (isErrorEvent(event)) {
       return testConnectionErrorPatterns(event.message);
     }
   }
+
   return false;
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -60,7 +60,9 @@ export class BusinessError extends Error {
 
 export class PropError extends Error {
   public readonly blockId: string;
+
   public readonly prop: string;
+
   public readonly value: unknown;
 
   constructor(message: string, blockId: string, prop: string, value: unknown) {
@@ -77,6 +79,7 @@ export class PropError extends Error {
  */
 export class ContextError extends Error {
   public readonly cause?: Error;
+
   public readonly context?: MessageContext;
 
   constructor(cause: Error, context?: MessageContext, message?: string) {

--- a/src/extensionPoints/actionPanelExtension.ts
+++ b/src/extensionPoints/actionPanelExtension.ts
@@ -228,6 +228,7 @@ export abstract class ActionPanelExtensionPoint extends ExtensionPoint<ActionPan
     } else {
       removeExtensionPoint(this.id);
     }
+
     return available;
   }
 }
@@ -261,5 +262,6 @@ export function fromJS(
   if (type !== "actionPanel") {
     throw new Error(`Expected type=actionPanel, got ${type}`);
   }
+
   return new RemotePanelExtensionPoint(config);
 }

--- a/src/extensionPoints/actionPanelExtension.ts
+++ b/src/extensionPoints/actionPanelExtension.ts
@@ -63,6 +63,7 @@ export interface ActionPanelConfig {
 
 export abstract class ActionPanelExtensionPoint extends ExtensionPoint<ActionPanelConfig> {
   readonly permissions: Permissions.Permissions = {};
+
   readonly showCallback: ShowCallback;
 
   protected constructor(
@@ -237,6 +238,7 @@ export type PanelDefinition = ExtensionPointDefinition;
 
 class RemotePanelExtensionPoint extends ActionPanelExtensionPoint {
   private readonly definition: PanelDefinition;
+
   public readonly rawConfig: ExtensionPointConfig<PanelDefinition>;
 
   constructor(config: ExtensionPointConfig<PanelDefinition>) {

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -90,9 +90,9 @@ function installMouseHandlerOnce(): void {
     selectionHandlerInstalled = true;
     // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
     document.addEventListener("mousedown", setActiveElement, {
-      // handle it first in case a target beneath it cancels the event
+      // Handle it first in case a target beneath it cancels the event
       capture: true,
-      // for performance, indicate we won't call preventDefault
+      // For performance, indicate we won't call preventDefault
       passive: true,
     });
   }
@@ -195,7 +195,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
   }
 
   uninstall({ global = false }: { global?: boolean }): void {
-    // don't uninstall the mouse handler because other context menus need it
+    // Don't uninstall the mouse handler because other context menus need it
     const extensions = this.extensions.splice(0, this.extensions.length);
     if (global) {
       for (const extension of extensions) {
@@ -209,7 +209,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
   }
 
   async install(): Promise<boolean> {
-    // always install the mouse handler in case a context menu is added later
+    // Always install the mouse handler in case a context menu is added later
     installMouseHandlerOnce();
     const available = await this.isAvailable();
     await this.registerExtensions();
@@ -283,9 +283,9 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
 
       const ctxt = {
         ...(await reader.read(targetElement)),
-        // clickData provides the data from schema defined above in ContextMenuReader
+        // ClickData provides the data from schema defined above in ContextMenuReader
         ...clickData,
-        // add some additional data that people will generally want
+        // Add some additional data that people will generally want
         documentUrl: document.location.href,
       };
 
@@ -332,7 +332,7 @@ class RemoteContextMenuExtensionPoint extends ContextMenuExtensionPoint {
     this._definition = config.definition;
     this.rawConfig = config;
     const { isAvailable, documentUrlPatterns, contexts } = config.definition;
-    // if documentUrlPatterns not specified show everywhere
+    // If documentUrlPatterns not specified show everywhere
     this.documentUrlPatterns = castArray(documentUrlPatterns ?? ["*://*/*"]);
     this.contexts = castArray(contexts);
     this.permissions = {

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -169,8 +169,11 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
   }
 
   public readonly syncInstall: boolean = true;
+
   abstract getBaseReader(): Promise<IReader>;
+
   abstract readonly documentUrlPatterns: Manifest.MatchPattern[];
+
   abstract readonly contexts: Menus.ContextType[];
 
   inputSchema: Schema = propertiesToSchema(
@@ -325,9 +328,13 @@ export interface MenuDefinition extends ExtensionPointDefinition {
 
 class RemoteContextMenuExtensionPoint extends ContextMenuExtensionPoint {
   private readonly _definition: MenuDefinition;
+
   public readonly permissions: Permissions.Permissions;
+
   public readonly documentUrlPatterns: Manifest.MatchPattern[];
+
   public readonly contexts: Menus.ContextType[];
+
   public readonly rawConfig: ExtensionPointConfig<MenuDefinition>;
 
   constructor(config: ExtensionPointConfig<MenuDefinition>) {

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -80,8 +80,10 @@ function guessSelectedElement(): HTMLElement | null {
     if (node instanceof HTMLElement) {
       return node;
     }
+
     return null;
   }
+
   return null;
 }
 
@@ -165,6 +167,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
   ) {
     super(id, name, description, icon);
   }
+
   public readonly syncInstall: boolean = true;
   abstract getBaseReader(): Promise<IReader>;
   abstract readonly documentUrlPatterns: Manifest.MatchPattern[];
@@ -304,6 +307,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
       );
       return;
     }
+
     await this.registerExtensions();
   }
 }
@@ -373,5 +377,6 @@ export function fromJS(
   if (type !== "contextMenu") {
     throw new Error(`Expected type=contextMenu, got ${type}`);
   }
+
   return new RemoteContextMenuExtensionPoint(config);
 }

--- a/src/extensionPoints/dom.tsx
+++ b/src/extensionPoints/dom.tsx
@@ -44,7 +44,7 @@ export function render(
       $(root).html(body);
     }
   } else {
-    // consider using https://github.com/Wildhoney/ReactShadow or similar if we have problems with events
+    // Consider using https://github.com/Wildhoney/ReactShadow or similar if we have problems with events
     const { Component, props } = body;
     if (shadowDOM) {
       const shadowRoot = root.attachShadow({ mode: "closed" });

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -226,7 +226,8 @@ export function awaitElementOnce(
         innerCancel();
       },
     ];
-  } else if (rest.length === 0) {
+  }
+  if (rest.length === 0) {
     return [Promise.resolve($element), noop];
   }
   return awaitElementOnce(rest, $element);

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -45,7 +45,7 @@ export function onNodeRemoved(node: Node, callback: () => void): () => void {
   const nodes = new WeakSet<Node>(ancestors);
   const observers = new Set<MutationObserver>();
 
-  // make sure we're only calling once
+  // Make sure we're only calling once
   const wrappedCallback = once(callback);
 
   // Observe the whole path to the node. A node is removed if any of its ancestors are removed. Observe individual
@@ -198,11 +198,11 @@ export function awaitElementOnce(
     return [Promise.resolve($root), noop];
   }
 
-  // console.debug("Awaiting selectors", selectors);
+  // Console.debug("Awaiting selectors", selectors);
 
   const [nextSelector, ...rest] = selectors;
 
-  // find immediately, or wait for it to be initialized
+  // Find immediately, or wait for it to be initialized
   const $element: JQuery<HTMLElement | Document> = $root.find(nextSelector);
 
   if ($element.length === 0) {

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -36,6 +36,7 @@ function getAncestors(node: Node): Node[] {
     ancestors.push(currentNode);
     currentNode = currentNode.parentNode;
   }
+
   return ancestors;
 }
 
@@ -65,6 +66,7 @@ export function onNodeRemoved(node: Node, callback: () => void): () => void {
                   console.warn("Error disconnecting mutation observer", error);
                 }
               }
+
               wrappedCallback();
               break;
             }
@@ -83,6 +85,7 @@ export function onNodeRemoved(node: Node, callback: () => void): () => void {
         console.warn("Error disconnecting mutation observer", error);
       }
     }
+
     observers.clear();
   };
 }
@@ -116,12 +119,15 @@ async function _wait<T>(
     if (isCancelled()) {
       throw new PromiseCancelled("Cancelled waiting for element");
     }
+
     if (waitMillis != null) {
       await sleep(waitMillis);
     }
+
     await waitAnimationFrame();
     value = factory();
   }
+
   return value;
 }
 
@@ -175,6 +181,7 @@ function _initialize(
   if (isNativeCssSelector(selector)) {
     return mutationSelector(selector, target);
   }
+
   return pollSelector(selector, target, waitMillis);
 }
 
@@ -227,9 +234,11 @@ export function awaitElementOnce(
       },
     ];
   }
+
   if (rest.length === 0) {
     return [Promise.resolve($element), noop];
   }
+
   return awaitElementOnce(rest, $element);
 }
 
@@ -252,10 +261,12 @@ export function acquireElement(
       );
       return null;
     }
+
     console.debug(
       `acquireElement: re-acquiring element for ${extensionPointId}`
     );
   }
+
   element.setAttribute(EXTENSION_POINT_DATA_ATTR, extensionPointId);
   return onNodeRemoved(element, onRemove);
 }

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -204,7 +204,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
       try {
         cancelObserver?.();
       } catch (error: unknown) {
-        // try to proceed as normal
+        // Try to proceed as normal
         reportError(error, this.logger.context);
       }
     }
@@ -217,7 +217,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
       this.id,
       { extensionIds }
     );
-    // can't use this.menus.values() here b/c because it may have already been cleared
+    // Can't use this.menus.values() here b/c because it may have already been cleared
     for (const extensionId of extensionIds) {
       const $item = $(document).find(`[${DATA_ATTR}="${extensionId}"]`);
       if ($item.length === 0) {
@@ -232,7 +232,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
 
     const menus = [...this.menus.values()];
 
-    // clear so they don't get re-added by the onNodeRemoved mechanism
+    // Clear so they don't get re-added by the onNodeRemoved mechanism
     const extensions = this.extensions.splice(0, this.extensions.length);
     this.menus.clear();
 
@@ -251,7 +251,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
     for (const element of menus) {
       try {
         this.removeExtensions(extensions.map((x) => x.id));
-        // release the menu element
+        // Release the menu element
         element.removeAttribute(EXTENSION_POINT_DATA_ATTR);
         // eslint-disable-next-line @typescript-eslint/no-implicit-any-catch
       } catch (error) {
@@ -425,7 +425,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
     let html: string;
 
     if (extension.config.if) {
-      // read latest state at the time of the action
+      // Read latest state at the time of the action
       const ctxt = await ctxtPromise;
       const serviceContext = await makeServiceContext(extension.services);
 
@@ -475,7 +475,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
       reportEvent("MenuItemClick", { extensionId: extension.id });
 
       try {
-        // read latest state at the time of the action
+        // Read latest state at the time of the action
         const reader = await this.defaultReader();
         const ctxt = await reader.read(this.getReaderRoot($menu));
         const serviceContext = await makeServiceContext(extension.services);
@@ -534,7 +534,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
   watchDependencies(extension: IExtension<MenuItemExtensionConfig>): void {
     const { dependencies = [] } = extension.config;
 
-    // clean up old observers
+    // Clean up old observers
     if (this.cancelDependencyObservers.has(extension.id)) {
       this.cancelDependencyObservers.get(extension.id)();
       this.cancelDependencyObservers.delete(extension.id);
@@ -690,7 +690,7 @@ export type MenuPosition =
   | "append"
   | "prepend"
   | {
-      // element to insert the menu item before, selector is relative to the container
+      // Element to insert the menu item before, selector is relative to the container
       sibling: string | null;
     };
 
@@ -746,18 +746,18 @@ class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
         } else if ($sibling.length === 1) {
           $sibling.before($menuItem);
         } else {
-          // didn't find the sibling, so just try inserting it at the end
+          // Didn't find the sibling, so just try inserting it at the end
           $menu.append($menuItem);
         }
       } else {
-        // no element to insert the item before, so insert it at the end.
+        // No element to insert the item before, so insert it at the end.
         $menu.append($menuItem);
       }
     } else {
       switch (position) {
         case "prepend":
         case "append": {
-          // safe because we're checking the value in the case statements
+          // Safe because we're checking the value in the case statements
           // eslint-disable-next-line security/detect-object-injection
           $menu[position]($menuItem);
           break;

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -713,7 +713,9 @@ export interface MenuDefinition extends ExtensionPointDefinition {
 
 class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
   private readonly _definition: MenuDefinition;
+
   public readonly permissions: Permissions.Permissions;
+
   public readonly rawConfig: ExtensionPointConfig<PanelDefinition>;
 
   public get defaultOptions(): {

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -208,6 +208,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
         reportError(error, this.logger.context);
       }
     }
+
     this.cancelPending.clear();
   }
 
@@ -223,6 +224,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
       if ($item.length === 0) {
         console.warn(`Item for ${extensionId} was not in the menu`);
       }
+
       $item.remove();
     }
   }
@@ -268,6 +270,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
           console.error("Error cancelling dependency observer");
         }
       }
+
       this.cancelDependencyObservers.delete(extension.id);
     }
   }
@@ -304,6 +307,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
       );
       return;
     }
+
     const alreadyRemoved = this.removed.has(uuid);
     this.removed.add(uuid);
     if (!alreadyRemoved) {
@@ -364,6 +368,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
               this.reacquire(menuUUID)
             );
           }
+
           existingCount++;
         })
         .get()
@@ -381,6 +386,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
     if (!isAvailable) {
       return false;
     }
+
     return this.installMenus();
   }
 
@@ -581,6 +587,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
         } catch (error: unknown) {
           console.error("Error cancelling mutation observer", error);
         }
+
         for (const cancel of cancellers) {
           try {
             cancel();
@@ -762,6 +769,7 @@ class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
           $menu[position]($menuItem);
           break;
         }
+
         default: {
           throw new Error(`Unexpected position ${position}`);
         }
@@ -775,6 +783,7 @@ class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
       if ($containerElement.length > 1) {
         console.warn("getReaderRoot called with multiple containerElements");
       }
+
       const $elt = $containerElement.parents(selector);
       if ($elt.length > 1) {
         throw new Error(
@@ -783,8 +792,10 @@ class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
       } else if ($elt.length === 0) {
         throw new Error(`Found no elements for  reader selector: ${selector}`);
       }
+
       return $elt.get(0);
     }
+
     return document;
   }
 
@@ -832,5 +843,6 @@ export function fromJS(
   if (type !== "menuItem") {
     throw new Error(`Expected type=menuItem, got ${type}`);
   }
+
   return new RemoteMenuItemExtensionPoint(config);
 }

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -182,6 +182,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
       if ($item.length === 0) {
         console.debug(`Panel for ${extension.id} was not in the menu`);
       }
+
       $item.remove();
     }
 
@@ -214,6 +215,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
     if (this.$container.length === 0) {
       return false;
     }
+
     if (this.$container.length > 1) {
       console.error(`Multiple containers found for selector: ${selector}`);
       this.logger.error(`Multiple containers found: ${this.$container.length}`);
@@ -318,6 +320,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
       if (this.cancelRemovalMonitor.get(extension.id) != null) {
         throw new Error("Removal monitor still attached for panel");
       }
+
       console.debug(`Replacing existing panel for ${extension.id}`);
       $existingPanel.replaceWith($panel);
     } else {
@@ -522,6 +525,7 @@ class RemotePanelExtensionPoint extends PanelExtensionPoint {
         this.$container[position]($panel);
         break;
       }
+
       default: {
         throw new Error(`Unexpected position: ${position}`);
       }
@@ -549,5 +553,6 @@ export function fromJS(
   if (type !== "panel") {
     throw new Error(`Expected type=panel, got ${type}`);
   }
+
   return new RemotePanelExtensionPoint(config);
 }

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -213,7 +213,8 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
 
     if (this.$container.length === 0) {
       return false;
-    } else if (this.$container.length > 1) {
+    }
+    if (this.$container.length > 1) {
       console.error(`Multiple containers found for selector: ${selector}`);
       this.logger.error(`Multiple containers found: ${this.$container.length}`);
       return false;

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -90,10 +90,15 @@ function detectLoop(timestamps: Date[]): void {
  */
 export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
   protected template?: string;
+
   protected $container: JQuery;
+
   private readonly collapsedExtensions: { [key: string]: boolean };
+
   private readonly cancelPending: Set<() => void>;
+
   private uninstalled = false;
+
   private readonly cancelRemovalMonitor: Map<string, () => void>;
 
   private readonly renderTimestamps: Map<string, Date[]>;
@@ -480,7 +485,9 @@ export interface PanelDefinition extends ExtensionPointDefinition {
 
 class RemotePanelExtensionPoint extends PanelExtensionPoint {
   private readonly _definition: PanelDefinition;
+
   public readonly permissions: Permissions.Permissions;
+
   public readonly rawConfig: ExtensionPointConfig<PanelDefinition>;
 
   constructor(config: ExtensionPointConfig<PanelDefinition>) {

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -248,7 +248,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
       throw new Error("panelExtension has already been destroyed");
     }
 
-    // initialize render timestamps for extension
+    // Initialize render timestamps for extension
     let renderTimestamps = this.renderTimestamps.get(extension.id);
     if (renderTimestamps == null) {
       this.renderTimestamps.set(extension.id, []);
@@ -279,7 +279,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
     const collapsible = boolean(rawCollapsible);
     const shadowDOM = boolean(rawShadowDOM);
 
-    // start collapsed
+    // Start collapsed
     if (collapsible && cnt == 1) {
       this.collapsedExtensions[extension.id] = true;
     }
@@ -290,7 +290,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
     const $panel = $(
       Mustache.render(this.getTemplate(), {
         heading: Mustache.render(heading, extensionContext),
-        // render a placeholder body that we'll fill in async
+        // Render a placeholder body that we'll fill in async
         body: `<div id="${bodyUUID}"></div>`,
         icon: await iconAsSVG?.(icon),
         bodyUUID,
@@ -303,7 +303,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
       `[${PIXIEBRIX_DATA_ATTR}="${extension.id}"]`
     );
 
-    // clean up removal monitor, otherwise it will be re-triggered during replaceWith
+    // Clean up removal monitor, otherwise it will be re-triggered during replaceWith
     const cancelCurrent = this.cancelRemovalMonitor.get(extension.id);
     if (cancelCurrent) {
       console.debug(`Cancelling removal monitor for ${extension.id}`);
@@ -464,7 +464,7 @@ type PanelPosition =
   | "append"
   | "prepend"
   | {
-      // element to insert the panel item before, selector is relative to the container
+      // Element to insert the panel item before, selector is relative to the container
       sibling: string | null;
     };
 
@@ -517,7 +517,7 @@ class RemotePanelExtensionPoint extends PanelExtensionPoint {
     switch (position) {
       case "prepend":
       case "append": {
-        // safe because we're casing the method name
+        // Safe because we're casing the method name
         // eslint-disable-next-line security/detect-object-injection
         this.$container[position]($panel);
         break;

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -149,6 +149,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
           void reportError(error, extensionLogger.context);
           return error;
         }
+
         reportEvent("TriggerRun", {
           extensionId: extension.id,
         });
@@ -245,6 +246,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
         ]);
         TriggerExtensionPoint.notifyErrors(compact(promises));
       };
+
       this.$installedRoot = $root;
       this.installedEvents.add(this.trigger);
 
@@ -315,5 +317,6 @@ export function fromJS(
   if (type !== "trigger") {
     throw new Error(`Expected type=trigger, got ${type}`);
   }
+
   return new RemoteTriggerExtensionPoint(config);
 }

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -178,7 +178,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     let $root = await rootPromise;
 
     if (rootSelector) {
-      // awaitElementOnce doesn't work with multiple elements. Get what's currently on the page
+      // AwaitElementOnce doesn't work with multiple elements. Get what's currently on the page
       // eslint-disable-next-line unicorn/no-array-callback-reference -- false positive for JQuery
       $root = $(document).find(rootSelector);
     }
@@ -215,7 +215,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
         },
         {
           root: null,
-          // rootMargin: "0px",
+          // RootMargin: "0px",
           threshold: 0.2,
         }
       );

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -58,8 +58,11 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
   abstract get trigger(): Trigger;
 
   private handler: JQuery.EventHandler<unknown> | undefined;
+
   private observer: IntersectionObserver | undefined;
+
   private $installedRoot: JQuery<HTMLElement | Document> | undefined;
+
   private installedEvents: Set<string> = new Set();
 
   protected constructor(
@@ -272,7 +275,9 @@ export interface TriggerDefinition extends ExtensionPointDefinition {
 
 class RemoteTriggerExtensionPoint extends TriggerExtensionPoint {
   private readonly _definition: TriggerDefinition;
+
   public readonly permissions: Permissions.Permissions;
+
   public readonly rawConfig: ExtensionPointConfig<TriggerDefinition>;
 
   public get defaultOptions(): {

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -31,7 +31,7 @@ const iframe = document.createElement("iframe");
 iframe.src = url.toString();
 document.body.append(iframe);
 
-// import {REQUEST_FRAME_DATA} from "@/messaging/constants";
+// Import {REQUEST_FRAME_DATA} from "@/messaging/constants";
 // import {sendMessage} from "@/chrome";
 //
 // const id = new URLSearchParams(window.location.search).get('id');

--- a/src/frameworks/component.ts
+++ b/src/frameworks/component.ts
@@ -31,7 +31,7 @@ export function traverse<T = unknown>(
   return current;
 }
 
-// object required for WeakSet
+// Object required for WeakSet
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function traverseUntil<T extends object>(
   src: T,
@@ -40,7 +40,7 @@ export function traverseUntil<T extends object>(
   maxTraverse?: number
 ): T | null {
   let current = src;
-  // detect cycles
+  // Detect cycles
   const visited = new WeakSet<T>();
   let cnt = 0;
   while (

--- a/src/frameworks/component.ts
+++ b/src/frameworks/component.ts
@@ -28,6 +28,7 @@ export function traverse<T = unknown>(
   for (let i = 0; i < count && current; i++) {
     current = next(current);
   }
+
   return current;
 }
 
@@ -53,6 +54,7 @@ export function traverseUntil<T extends object>(
     current = next(current);
     cnt++;
   }
+
   return current;
 }
 

--- a/src/frameworks/contrib/angularjs.ts
+++ b/src/frameworks/contrib/angularjs.ts
@@ -58,6 +58,7 @@ export function getComponent(node: Node): AngularElement | null {
   if (!window.angular) {
     throw new FrameworkNotFound("Angular not found");
   }
+
   return window.angular.element(node);
 }
 

--- a/src/frameworks/contrib/ember.ts
+++ b/src/frameworks/contrib/ember.ts
@@ -99,19 +99,24 @@ function isMutableCell(cell: unknown): cell is MutableCell {
 export function getProp(value: any, prop: string | number): unknown {
   if (isPrimitive(value)) {
     return undefined;
-  } else if (Array.isArray(value)) {
+  }
+  if (Array.isArray(value)) {
     if (typeof prop !== "number") {
       throw new TypeError("Expected number for prop for array value");
     }
     return value[prop];
-  } else if (typeof value === "object") {
+  }
+  if (typeof value === "object") {
     if (isMutableCell(value) && "value" in value) {
       return getProp(value.value, prop);
-    } else if ("_cache" in value) {
+    }
+    if ("_cache" in value) {
       return getProp(value._cache, prop);
-    } else if (Array.isArray(value.content)) {
+    }
+    if (Array.isArray(value.content)) {
       return getProp(value.content, prop);
-    } else if (typeof prop === "string" && isGetter(value, prop)) {
+    }
+    if (typeof prop === "string" && isGetter(value, prop)) {
       return value[prop]();
     }
     return value[prop];
@@ -142,17 +147,22 @@ export function readEmberValueFromCache(
 
   if (depth >= maxDepth) {
     return undefined;
-  } else if (isPrimitive(value)) {
+  }
+  if (isPrimitive(value)) {
     return value;
-  } else if (Array.isArray(value)) {
+  }
+  if (Array.isArray(value)) {
     // must come before typeof value === "object" check because arrays are objects
     return value.map((x) => traverse(x));
-  } else if (typeof value === "object") {
+  }
+  if (typeof value === "object") {
     if (isMutableCell(value) && "value" in value) {
       return traverse(value.value);
-    } else if ("_cache" in value) {
+    }
+    if ("_cache" in value) {
       return traverse(value._cache);
-    } else if (Array.isArray(value.content)) {
+    }
+    if (Array.isArray(value.content)) {
       // consider arrays a traverse because knowing the property name by itself isn't useful for anything
       return value.content.map((x: any) => traverse(x));
     }

--- a/src/frameworks/contrib/ember.ts
+++ b/src/frameworks/contrib/ember.ts
@@ -126,7 +126,7 @@ export function getProp(value: any, prop: string | number): unknown {
 }
 
 function pickExternalProps(obj: object): object {
-  // lodash's pickby was having issues with some getters
+  // Lodash's pickby was having issues with some getters
   return fromPairs(
     Object.entries(obj).filter(([key]) => !EMBER_INTERNAL_PROPS.has(key))
   );
@@ -152,7 +152,7 @@ export function readEmberValueFromCache(
     return value;
   }
   if (Array.isArray(value)) {
-    // must come before typeof value === "object" check because arrays are objects
+    // Must come before typeof value === "object" check because arrays are objects
     return value.map((x) => traverse(x));
   }
   if (typeof value === "object") {
@@ -163,7 +163,7 @@ export function readEmberValueFromCache(
       return traverse(value._cache);
     }
     if (Array.isArray(value.content)) {
-      // consider arrays a traverse because knowing the property name by itself isn't useful for anything
+      // Consider arrays a traverse because knowing the property name by itself isn't useful for anything
       return value.content.map((x: any) => traverse(x));
     }
     return mapValues(pickExternalProps(value), recurse);
@@ -221,7 +221,7 @@ const adapter: ReadableComponentAdapter<EmberObject> = {
     const props = getAllPropertyNames(target).filter(
       (prop) => !prop.startsWith("_") && !EMBER_INTERNAL_PROPS.has(prop)
     );
-    // safe because the prop names are coming from getAllPropertyNames
+    // Safe because the prop names are coming from getAllPropertyNames
     // eslint-disable-next-line security/detect-object-injection
     return fromPairs(props.map((x) => [x, target[x]]));
   },

--- a/src/frameworks/contrib/ember.ts
+++ b/src/frameworks/contrib/ember.ts
@@ -72,6 +72,7 @@ export function getEmberApplication(): EmberApplication {
       (namespace) => namespace instanceof (Ember.Application as any)
     ) as EmberApplication;
   }
+
   return undefined;
 }
 
@@ -80,6 +81,7 @@ export function getEmberComponentById(componentId: string): EmberObject {
   if (!app) {
     throw new FrameworkNotFound("Ember application not found");
   }
+
   return app.__container__.lookup("-view-registry:main")[componentId];
 }
 
@@ -100,27 +102,35 @@ export function getProp(value: any, prop: string | number): unknown {
   if (isPrimitive(value)) {
     return undefined;
   }
+
   if (Array.isArray(value)) {
     if (typeof prop !== "number") {
       throw new TypeError("Expected number for prop for array value");
     }
+
     return value[prop];
   }
+
   if (typeof value === "object") {
     if (isMutableCell(value) && "value" in value) {
       return getProp(value.value, prop);
     }
+
     if ("_cache" in value) {
       return getProp(value._cache, prop);
     }
+
     if (Array.isArray(value.content)) {
       return getProp(value.content, prop);
     }
+
     if (typeof prop === "string" && isGetter(value, prop)) {
       return value[prop]();
     }
+
     return value[prop];
   }
+
   // ignore functions and symbols
   return undefined;
 }
@@ -148,26 +158,33 @@ export function readEmberValueFromCache(
   if (depth >= maxDepth) {
     return undefined;
   }
+
   if (isPrimitive(value)) {
     return value;
   }
+
   if (Array.isArray(value)) {
     // Must come before typeof value === "object" check because arrays are objects
     return value.map((x) => traverse(x));
   }
+
   if (typeof value === "object") {
     if (isMutableCell(value) && "value" in value) {
       return traverse(value.value);
     }
+
     if ("_cache" in value) {
       return traverse(value._cache);
     }
+
     if (Array.isArray(value.content)) {
       // Consider arrays a traverse because knowing the property name by itself isn't useful for anything
       return value.content.map((x: any) => traverse(x));
     }
+
     return mapValues(pickExternalProps(value), recurse);
   }
+
   // ignore functions and symbols
   return undefined;
 }
@@ -177,6 +194,7 @@ function isManaged(node: Node): boolean {
   if (!elt) {
     throw new Error("Could not get DOM HTMLElement for node");
   }
+
   return !!ignoreNotFound(() => getEmberComponentById(elt.id));
 }
 
@@ -206,6 +224,7 @@ const adapter: ReadableComponentAdapter<EmberObject> = {
     if (!elt) {
       throw new Error("No DOM HTMLElement for node");
     }
+
     return ignoreNotFound(() => getEmberComponentById(elt.id));
   },
   getParent: (instance) => instance.parentView,

--- a/src/frameworks/contrib/react.ts
+++ b/src/frameworks/contrib/react.ts
@@ -96,6 +96,7 @@ function getComponentFiber(fiber: Fiber): Fiber {
     // String for HTML nodes, so traverse
     parentFiber = parentFiber.return;
   }
+
   return parentFiber;
 }
 
@@ -117,6 +118,7 @@ export function findReactComponent(node: Node, traverseUp = 0): Fiber {
     const fiber = traverse(owner, owner(domFiber), traverseUp);
     return fiber._instance as Fiber;
   }
+
   return traverse(getComponentFiber, getComponentFiber(domFiber), traverseUp);
 }
 
@@ -127,6 +129,7 @@ export class ReactRootVisitor implements RootInstanceVisitor<RootInstance> {
       this.rootInstances.push(node);
       return false;
     }
+
     return true;
   }
 }

--- a/src/frameworks/contrib/react.ts
+++ b/src/frameworks/contrib/react.ts
@@ -90,10 +90,10 @@ export function readReactProps(fiber: Fiber): { [prop: string]: unknown } {
 }
 
 function getComponentFiber(fiber: Fiber): Fiber {
-  // return fiber._debugOwner; // this also works, but is __DEV__ only
+  // Return fiber._debugOwner; // this also works, but is __DEV__ only
   let parentFiber = fiber.return;
   while (typeof parentFiber.type === "string") {
-    // string for HTML nodes, so traverse
+    // String for HTML nodes, so traverse
     parentFiber = parentFiber.return;
   }
   return parentFiber;

--- a/src/frameworks/contrib/react.ts
+++ b/src/frameworks/contrib/react.ts
@@ -124,6 +124,7 @@ export function findReactComponent(node: Node, traverseUp = 0): Fiber {
 
 export class ReactRootVisitor implements RootInstanceVisitor<RootInstance> {
   public rootInstances: RootInstance[] = [];
+
   visit(node: Element | Node): boolean {
     if ("_reactRootContainer" in node) {
       this.rootInstances.push(node);

--- a/src/frameworks/contrib/vue.ts
+++ b/src/frameworks/contrib/vue.ts
@@ -78,7 +78,9 @@ interface VueHTMLElement {
 
 export class VueRootVisitor implements RootInstanceVisitor<Instance> {
   public rootInstances: Instance[] = [];
+
   private inFragment = false;
+
   private currentFragment: Instance = null;
 
   private processInstance(instance: Instance): boolean {

--- a/src/frameworks/contrib/vue.ts
+++ b/src/frameworks/contrib/vue.ts
@@ -86,19 +86,24 @@ export class VueRootVisitor implements RootInstanceVisitor<Instance> {
       if (!this.rootInstances.includes(instance.$root)) {
         instance = instance.$root;
       }
+
       if (instance._isFragment) {
         this.inFragment = true;
         this.currentFragment = instance;
       }
+
       let baseVue = instance.constructor;
       while (baseVue.super) {
         baseVue = baseVue.super;
       }
+
       if (baseVue.config) {
         this.rootInstances.push(instance);
       }
+
       return true;
     }
+
     return false;
   }
 
@@ -108,8 +113,10 @@ export class VueRootVisitor implements RootInstanceVisitor<Instance> {
         this.inFragment = false;
         this.currentFragment = null;
       }
+
       return true;
     }
+
     const instance = (node as any).__vue__;
     return this.processInstance(instance);
   }
@@ -130,6 +137,7 @@ export function findRelatedComponent(el: HTMLElement): Instance | null {
   while (!isManaged(el) && el.parentElement) {
     el = el.parentElement;
   }
+
   return isManaged(el) ? el.__vue__ : null;
 }
 

--- a/src/frameworks/contrib/vue.ts
+++ b/src/frameworks/contrib/vue.ts
@@ -71,7 +71,7 @@ interface VueHTMLElement {
   __vue__: Instance;
 }
 
-// interface VNode {
+// Interface VNode {
 //   _isVue: boolean;
 //   $el: HTMLElement;
 // }

--- a/src/frameworks/dom.ts
+++ b/src/frameworks/dom.ts
@@ -24,8 +24,10 @@ export function findElement(node: Node): Element | null {
   while (current && !(current instanceof Element)) {
     current = current.parentNode;
   }
+
   if (current instanceof Element) {
     return current;
   }
+
   return null;
 }

--- a/src/frameworks/errors.ts
+++ b/src/frameworks/errors.ts
@@ -39,6 +39,7 @@ export function ignoreNotFound<T>(factory: () => T): T | null {
     ) {
       return null;
     }
+
     throw error;
   }
 }

--- a/src/frameworks/scanner.ts
+++ b/src/frameworks/scanner.ts
@@ -39,6 +39,7 @@ export function walk(node: Node | Element, visitor: Visitor): void {
       }
     }
   }
+
   // Also walk shadow DOM
   if (node instanceof Element && node.shadowRoot) {
     walk(node.shadowRoot, visitor);

--- a/src/frameworks/scanner.ts
+++ b/src/frameworks/scanner.ts
@@ -39,7 +39,7 @@ export function walk(node: Node | Element, visitor: Visitor): void {
       }
     }
   }
-  // also walk shadow DOM
+  // Also walk shadow DOM
   if (node instanceof Element && node.shadowRoot) {
     walk(node.shadowRoot, visitor);
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -103,14 +103,16 @@ export function mapArgs(
 ): unknown {
   if (Array.isArray(config)) {
     return config.map((x) => mapArgs(x, ctxt, render));
-  } else if (isPlainObject(config)) {
+  }
+  if (isPlainObject(config)) {
     return pickBy(
       mapValues(config as object, (subConfig) =>
         mapArgs(subConfig, ctxt, render)
       ),
       (x) => x != null
     );
-  } else if (typeof config === "string") {
+  }
+  if (typeof config === "string") {
     if (isSimplePath(config, ctxt)) {
       const prop = getPropByPath(ctxt as { [prop: string]: unknown }, config);
       if (prop && typeof prop === "object" && "__service" in prop) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -38,6 +38,7 @@ export function engineRenderer(
     case "mustache": {
       return Mustache.render;
     }
+
     case "nunjucks": {
       // Convert top level data from kebab case to snake case in order to be valid identifiers
       return (template, ctxt) => {
@@ -47,12 +48,14 @@ export function engineRenderer(
         return nunjucks.renderString(template, snakeCased);
       };
     }
+
     case "handlebars": {
       return (template, ctxt) => {
         const compiledTemplate = Handlebars.compile(template);
         return compiledTemplate(ctxt);
       };
     }
+
     default: {
       return undefined;
     }
@@ -71,6 +74,7 @@ export function isSimplePath(maybePath: string, ctxt: object): boolean {
   if (!pathRegex.test(maybePath)) {
     return false;
   }
+
   const [head] = maybePath.split(".");
   const path = head.endsWith("?") ? head.slice(0, -1) : head;
   return ctxt ? Object.prototype.hasOwnProperty.call(ctxt, path) : false;
@@ -104,6 +108,7 @@ export function mapArgs(
   if (Array.isArray(config)) {
     return config.map((x) => mapArgs(x, ctxt, render));
   }
+
   if (isPlainObject(config)) {
     return pickBy(
       mapValues(config as object, (subConfig) =>
@@ -112,6 +117,7 @@ export function mapArgs(
       (x) => x != null
     );
   }
+
   if (typeof config === "string") {
     if (isSimplePath(config, ctxt)) {
       const prop = getPropByPath(ctxt as { [prop: string]: unknown }, config);
@@ -120,10 +126,13 @@ export function mapArgs(
         // @ts-ignore: not sure why the "in" check isn't working
         return prop.__service;
       }
+
       return prop;
     }
+
     return render(config, ctxt);
   }
+
   return config;
 }
 
@@ -144,6 +153,7 @@ export function missingProperties(
       }
     }
   }
+
   return acc;
 }
 
@@ -151,6 +161,7 @@ export function inputProperties(inputSchema: Schema): SchemaProperties {
   if (typeof inputSchema === "object" && "properties" in inputSchema) {
     return inputSchema.properties;
   }
+
   return inputSchema as SchemaProperties;
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -39,7 +39,7 @@ export function engineRenderer(
       return Mustache.render;
     }
     case "nunjucks": {
-      // convert top level data from kebab case to snake case in order to be valid identifiers
+      // Convert top level data from kebab case to snake case in order to be valid identifiers
       return (template, ctxt) => {
         const snakeCased = mapKeys(ctxt, (value, key) =>
           key.replace(hyphenRegex, "_")
@@ -59,7 +59,7 @@ export function engineRenderer(
   }
 }
 
-// first part of the path can be global context with a @
+// First part of the path can be global context with a @
 const pathRegex = /^(@?[\w-]+\??)(\.[\w-]+\??)*$/;
 
 /**
@@ -116,7 +116,7 @@ export function mapArgs(
     if (isSimplePath(config, ctxt)) {
       const prop = getPropByPath(ctxt as { [prop: string]: unknown }, config);
       if (prop && typeof prop === "object" && "__service" in prop) {
-        // if we're returning the root service context, return the service itself
+        // If we're returning the root service context, return the service itself
         // @ts-ignore: not sure why the "in" check isn't working
         return prop.__service;
       }

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -72,5 +72,6 @@ export async function getAuth(): Promise<AuthState> {
       flags,
     };
   }
+
   return anonAuth;
 }

--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -33,6 +33,7 @@ export class SimpleEvent<TValue> implements TabEvent<TValue> {
     if (!this.listeners.has(tabId)) {
       this.listeners.set(tabId, []);
     }
+
     this.listeners.get(tabId).push(handler);
   }
 

--- a/src/hooks/fetch.ts
+++ b/src/hooks/fetch.ts
@@ -65,8 +65,10 @@ export async function fetch<TData>(
     } else if (status >= 300) {
       throw new Error(`Request error: ${statusText}`);
     }
+
     return data;
   }
+
   const { data } = await axios.get<TData>(url);
   return data;
 }

--- a/src/hooks/logging.ts
+++ b/src/hooks/logging.ts
@@ -35,6 +35,7 @@ export function useLoggingConfig(): [
       if (!isMounted()) {
         return;
       }
+
       setConfig(config);
     },
     [setConfig]

--- a/src/hooks/refresh.ts
+++ b/src/hooks/refresh.ts
@@ -47,6 +47,7 @@ export function useRefresh(
         if (!isMounted()) {
           return;
         }
+
         addToast(`Error refreshing bricks from server: ${error}`, {
           appearance: "error",
           autoDismiss: true,

--- a/src/hooks/registry.ts
+++ b/src/hooks/registry.ts
@@ -30,6 +30,7 @@ export function useRegistry<T extends RegistryItem>(
       if (!isMounted) {
         return;
       }
+
       setResult(result);
     },
     [registry, id]

--- a/src/hooks/useSVG.ts
+++ b/src/hooks/useSVG.ts
@@ -28,6 +28,7 @@ function useSVG(logoUrl: string): string {
       if (!isMounted()) {
         return;
       }
+
       setLogo($icon.get(0).outerHTML);
     },
     [setLogo]

--- a/src/icons/Icon.tsx
+++ b/src/icons/Icon.tsx
@@ -32,6 +32,7 @@ const Icon: React.FunctionComponent<{ icon: string; library: IconLibrary }> = ({
       if (!isMounted()) {
         return;
       }
+
       setSvg($icon);
     },
     [icon, library, setSvg]

--- a/src/icons/IconSelector.tsx
+++ b/src/icons/IconSelector.tsx
@@ -66,7 +66,7 @@ const IconSelector: React.FunctionComponent<OwnProps> = ({
       value={selectedOption}
       options={iconOptions}
       onChange={onChange}
-      // react-select-virtualized doesn't support styling the elements in the dropdown, so can't show
+      // React-select-virtualized doesn't support styling the elements in the dropdown, so can't show
       // the icons in the actual dropdown
       components={{ SingleValue: customSingleValue }}
     />

--- a/src/icons/IconSelector.tsx
+++ b/src/icons/IconSelector.tsx
@@ -57,6 +57,7 @@ const IconSelector: React.FunctionComponent<OwnProps> = ({
         (x) => x.value.library === value.library && x.value.id === value.id
       );
     }
+
     return null;
   }, [value]);
 

--- a/src/icons/svgElementFromUrl.ts
+++ b/src/icons/svgElementFromUrl.ts
@@ -26,6 +26,7 @@ export default async function fetchSVG(
       "fetchSVG can only be used to fetch icons bundled with the extension"
     );
   }
+
   const response = await fetch(src);
   const svg = await response.text();
   // There might also be comment nodes, so they need to be filtered out

--- a/src/layout/ErrorBanner.tsx
+++ b/src/layout/ErrorBanner.tsx
@@ -33,6 +33,7 @@ const ErrorBanner: React.FunctionComponent = () => {
   if (message) {
     return <div className="error-banner w-100">{message}</div>;
   }
+
   return null;
 };
 

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -94,7 +94,7 @@ const Sidebar: React.FunctionComponent = () => {
         {flags.includes("workshop") && (
           <SidebarLink route="/workshop" title="Workshop" icon={faHammer} />
         )}
-        {/*<ConnectedNavLink route="build" title="Build Brick" icon={faTools} />*/}
+        {/* <ConnectedNavLink route="build" title="Build Brick" icon={faTools} /> */}
         <SidebarLink route="/services" title="Integrations" icon={faCloud} />
         <SidebarLink route="/settings" title="Settings" icon={faCogs} />
         <li className={cx("nav-item")}>

--- a/src/messaging/chrome.ts
+++ b/src/messaging/chrome.ts
@@ -52,7 +52,7 @@ export function createSendScriptMessage<TReturn = unknown, TPayload = unknown>(
       const callback = callbacks.get(id);
 
       if (callback != null) {
-        // clean up callbacks
+        // Clean up callbacks
         fulfillmentCallbacks.delete(id);
         rejectionCallbacks.delete(id);
 

--- a/src/messaging/chrome.ts
+++ b/src/messaging/chrome.ts
@@ -46,6 +46,7 @@ export function createSendScriptMessage<TReturn = unknown, TPayload = unknown>(
           `Handler for ${type} did not provide a detail property`
         );
       }
+
       const { id } = event.detail;
       // This listener also receives it's own FULFILLED/REJECTED messages it sends back to the content
       // script. So if you add any logging outside of the if, the logs are confusing.

--- a/src/messaging/external.ts
+++ b/src/messaging/external.ts
@@ -48,6 +48,7 @@ export const setExtensionAuth = lift(
         await _reload();
       }, 100);
     }
+
     return updated;
   }
 );

--- a/src/messaging/external.ts
+++ b/src/messaging/external.ts
@@ -36,7 +36,7 @@ const _reload = liftBackground("BACKGROUND_RELOAD", async () => {
   browser.runtime.reload();
 });
 
-// called by PixieBrix app
+// Called by PixieBrix app
 export const setExtensionAuth = lift(
   "SET_EXTENSION_AUTH",
   async (auth: AuthData) => {
@@ -52,7 +52,7 @@ export const setExtensionAuth = lift(
   }
 );
 
-// chrome.runtime.openOptionsPage only available from the background page
+// Chrome.runtime.openOptionsPage only available from the background page
 const _openOptions = liftBackground("BACKGROUND_OPEN_OPTIONS", async () => {
   await browser.runtime.openOptionsPage();
   return true;

--- a/src/messaging/protocol.ts
+++ b/src/messaging/protocol.ts
@@ -98,6 +98,7 @@ export class HandlerMap {
     if (this.handlers.has(actionType)) {
       throw new Error(`Handler for ${actionType} already defined`);
     }
+
     this.handlers.set(actionType, handler);
     return this;
   }
@@ -111,6 +112,7 @@ export class HandlerMap {
       if (!allowSender(sender)) {
         return;
       }
+
       const handler = this.handlers.get(request.type);
       if (handler) {
         console.trace("Handling message: %s", request.type);
@@ -120,6 +122,7 @@ export class HandlerMap {
             `Expected promise response from handler ${request.type}`
           );
         }
+
         return promise;
       }
     };

--- a/src/nativeEditor/Overlay.tsx
+++ b/src/nativeEditor/Overlay.tsx
@@ -171,7 +171,6 @@ function findTipPos(dims: any, bounds: any, tipSize: any) {
   if (dims.left < bounds.left) {
     left = bounds.left + margin;
   }
-
   if (dims.left + tipWidth > bounds.left + bounds.width) {
     left = bounds.left + bounds.width - tipWidth - margin;
   }
@@ -241,11 +240,11 @@ export default class Overlay {
 
   constructor() {
     // Find the root window, because overlays are positioned relative to it.
-    const currentWindow = window; // Window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
+    const currentWindow = window; // window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
     this.window = window;
 
     // When opened in shells/dev, the tooltip should be bound by the app iframe, not by the topmost window.
-    const tipBoundsWindow = window; // Window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
+    const tipBoundsWindow = window; // window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
     this.tipBoundsWindow = tipBoundsWindow;
 
     const doc = currentWindow.document;
@@ -263,7 +262,6 @@ export default class Overlay {
     for (const rect of this.rects) {
       rect.remove();
     }
-
     this.rects.length = 0;
     if (this.container.parentNode) {
       this.container.remove();
@@ -281,7 +279,6 @@ export default class Overlay {
       const rect = this.rects.pop();
       rect.remove();
     }
-
     if (elements.length === 0) {
       return;
     }
@@ -318,7 +315,7 @@ export default class Overlay {
 
     if (!name) {
       name = elements[0].nodeName.toLowerCase();
-      // Const ownerName = getOwnerDisplayName(elements[0]);
+      // const ownerName = getOwnerDisplayName(elements[0]);
       // if (ownerName) {
       //     name += ' (in ' + ownerName + ')';
       // }
@@ -411,7 +408,6 @@ function getNestedBoundingClientRect(
       if (onlyOneMore) {
         break;
       }
-
       // We don't want to calculate iframe offsets upwards beyond
       // the iframe containing the boundaryWindow, but we
       // need to calculate the offset relative to the boundaryWindow.
@@ -421,9 +417,9 @@ function getNestedBoundingClientRect(
     }
 
     return mergeRectOffsets(rects);
+  } else {
+    return node.getBoundingClientRect();
   }
-
-  return node.getBoundingClientRect();
 }
 
 // Get the window object for the document that a node belongs to,
@@ -433,7 +429,6 @@ function getOwnerWindow(node: HTMLElement): typeof window | null {
   if (!node.ownerDocument) {
     return null;
   }
-
   return node.ownerDocument.defaultView;
 }
 
@@ -444,6 +439,5 @@ function getOwnerIframe(node: HTMLElement): HTMLElement | null {
   if (nodeWindow) {
     return nodeWindow.frameElement as HTMLElement;
   }
-
   return null;
 }

--- a/src/nativeEditor/Overlay.tsx
+++ b/src/nativeEditor/Overlay.tsx
@@ -417,9 +417,8 @@ function getNestedBoundingClientRect(
     }
 
     return mergeRectOffsets(rects);
-  } else {
-    return node.getBoundingClientRect();
   }
+  return node.getBoundingClientRect();
 }
 
 // Get the window object for the document that a node belongs to,

--- a/src/nativeEditor/Overlay.tsx
+++ b/src/nativeEditor/Overlay.tsx
@@ -240,11 +240,11 @@ export default class Overlay {
 
   constructor() {
     // Find the root window, because overlays are positioned relative to it.
-    const currentWindow = window; // window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
+    const currentWindow = window; // Window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
     this.window = window;
 
     // When opened in shells/dev, the tooltip should be bound by the app iframe, not by the topmost window.
-    const tipBoundsWindow = window; // window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
+    const tipBoundsWindow = window; // Window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
     this.tipBoundsWindow = tipBoundsWindow;
 
     const doc = currentWindow.document;
@@ -315,7 +315,7 @@ export default class Overlay {
 
     if (!name) {
       name = elements[0].nodeName.toLowerCase();
-      // const ownerName = getOwnerDisplayName(elements[0]);
+      // Const ownerName = getOwnerDisplayName(elements[0]);
       // if (ownerName) {
       //     name += ' (in ' + ownerName + ')';
       // }

--- a/src/nativeEditor/Overlay.tsx
+++ b/src/nativeEditor/Overlay.tsx
@@ -171,6 +171,7 @@ function findTipPos(dims: any, bounds: any, tipSize: any) {
   if (dims.left < bounds.left) {
     left = bounds.left + margin;
   }
+
   if (dims.left + tipWidth > bounds.left + bounds.width) {
     left = bounds.left + bounds.width - tipWidth - margin;
   }
@@ -262,6 +263,7 @@ export default class Overlay {
     for (const rect of this.rects) {
       rect.remove();
     }
+
     this.rects.length = 0;
     if (this.container.parentNode) {
       this.container.remove();
@@ -279,6 +281,7 @@ export default class Overlay {
       const rect = this.rects.pop();
       rect.remove();
     }
+
     if (elements.length === 0) {
       return;
     }
@@ -408,6 +411,7 @@ function getNestedBoundingClientRect(
       if (onlyOneMore) {
         break;
       }
+
       // We don't want to calculate iframe offsets upwards beyond
       // the iframe containing the boundaryWindow, but we
       // need to calculate the offset relative to the boundaryWindow.
@@ -418,6 +422,7 @@ function getNestedBoundingClientRect(
 
     return mergeRectOffsets(rects);
   }
+
   return node.getBoundingClientRect();
 }
 
@@ -428,6 +433,7 @@ function getOwnerWindow(node: HTMLElement): typeof window | null {
   if (!node.ownerDocument) {
     return null;
   }
+
   return node.ownerDocument.defaultView;
 }
 
@@ -438,5 +444,6 @@ function getOwnerIframe(node: HTMLElement): HTMLElement | null {
   if (nodeWindow) {
     return nodeWindow.frameElement as HTMLElement;
   }
+
   return null;
 }

--- a/src/nativeEditor/dynamic.ts
+++ b/src/nativeEditor/dynamic.ts
@@ -87,9 +87,11 @@ async function buildSingleReader(config: ReaderLike): Promise<IReader> {
   if (config instanceof Reader) {
     return config;
   }
+
   if (isCustomReader(config)) {
     return readerFactory(config);
   }
+
   return blockRegistry.lookup(config.metadata.id) as Promise<IReader>;
 }
 
@@ -137,6 +139,7 @@ export const toggleOverlay = liftContentScript(
       if (_overlay == null) {
         _overlay = new Overlay();
       }
+
       // eslint-disable-next-line unicorn/no-array-callback-reference -- false positive on JQuery method
       const $elt = $(document).find(selector);
       _overlay.inspect($elt.toArray(), null);

--- a/src/nativeEditor/dynamic.ts
+++ b/src/nativeEditor/dynamic.ts
@@ -86,7 +86,8 @@ type ReaderLike = ReaderConfig | ReaderReference | Reader;
 async function buildSingleReader(config: ReaderLike): Promise<IReader> {
   if (config instanceof Reader) {
     return config;
-  } else if (isCustomReader(config)) {
+  }
+  if (isCustomReader(config)) {
     return readerFactory(config);
   }
   return blockRegistry.lookup(config.metadata.id) as Promise<IReader>;

--- a/src/nativeEditor/frameworks.ts
+++ b/src/nativeEditor/frameworks.ts
@@ -76,6 +76,7 @@ export async function elementInfo(
         ),
       };
     }
+
     console.debug(`No component found for ${framework}`);
   }
 

--- a/src/nativeEditor/infer.ts
+++ b/src/nativeEditor/infer.ts
@@ -160,6 +160,7 @@ function removeUnstyledLayout(node: Node): Node | null {
   if ([Node.COMMENT_NODE, Node.CDATA_SECTION_NODE].includes(node.nodeType)) {
     return null;
   }
+
   if (node.nodeType === Node.ELEMENT_NODE) {
     const element = node as HTMLElement;
     const nonEmptyChildren = [...node.childNodes].filter(
@@ -173,6 +174,7 @@ function removeUnstyledLayout(node: Node): Node | null {
     ) {
       return removeUnstyledLayout(nonEmptyChildren[0]);
     }
+
     const clone = node.cloneNode(false) as Element;
     for (const childNode of node.childNodes) {
       const newChild = removeUnstyledLayout(childNode);
@@ -180,8 +182,10 @@ function removeUnstyledLayout(node: Node): Node | null {
         clone.append(newChild);
       }
     }
+
     return clone;
   }
+
   return node.cloneNode(false);
 }
 
@@ -214,6 +218,7 @@ function commonButtonStructure(
       // Shouldn't happen at the top level
       return [$(), currentCaptioned];
     }
+
     throw error;
   }
 
@@ -455,6 +460,7 @@ function commonPanelHTML(tag: string, $items: JQuery<HTMLElement>): string {
   if (!bodyInserted) {
     console.warn("No body detected for panel");
   }
+
   if (!headingInserted) {
     console.warn("No heading detected for panel");
   }
@@ -554,6 +560,7 @@ export function getCommonAncestor(...args: Node[]): Node {
     if (otherNodes.every((x) => currentNode.contains(x))) {
       return currentNode;
     }
+
     currentNode = currentNode?.parentNode;
   }
 
@@ -616,11 +623,13 @@ export function findContainer(
     if (!container) {
       throw new Error("Selected elements have no common ancestors");
     }
+
     return {
       container,
       selectors: inferSelectors(container),
     };
   }
+
   return findContainerForElement(elements[0]);
 }
 
@@ -672,6 +681,7 @@ export function inferPanelHTML(
     const children = containerChildren($container, selected);
     return commonPanelHTML(selected[0].tagName, $(children));
   }
+
   return inferSinglePanelHTML(container, selected[0]);
 }
 
@@ -703,6 +713,7 @@ export function inferButtonHTML(
             : commonType;
           return `<input type="${inputType}" value="{{{ caption }}}" />`;
         }
+
         return commonButtonHTML(buttonTag, $items);
       }
     }

--- a/src/nativeEditor/infer.ts
+++ b/src/nativeEditor/infer.ts
@@ -122,7 +122,7 @@ function setCommonAttrs(
 
   // Find the common attributes between the elements
   for (const attrIndex in Object.keys(attributes)) {
-    // safe because we're getting from Object.keys
+    // Safe because we're getting from Object.keys
     // eslint-disable-next-line security/detect-object-injection
     const attrName = attributes[attrIndex].name;
 
@@ -487,7 +487,7 @@ export function safeCssSelector(
     selectors: selectors ?? DEFAULT_SELECTOR_PRIORITIES,
     combineWithinSelector: true,
     combineBetweenSelectors: true,
-    // convert null to undefined, because getCssSelector bails otherwise
+    // Convert null to undefined, because getCssSelector bails otherwise
     root: root ?? undefined,
   });
 
@@ -685,7 +685,7 @@ export function inferButtonHTML(
     throw new Error("one or more prototype button-like elements required");
   } else if (selected.length > 1) {
     const children = containerChildren($container, selected);
-    // vote on the root tag
+    // Vote on the root tag
     const tag = mostCommonElement(selected.map((x) => x.tagName)).toLowerCase();
     return commonButtonHTML(tag, $(children));
   } else {

--- a/src/nativeEditor/infer.ts
+++ b/src/nativeEditor/infer.ts
@@ -159,7 +159,8 @@ function ignoreDivChildNode(node: Node): boolean {
 function removeUnstyledLayout(node: Node): Node | null {
   if ([Node.COMMENT_NODE, Node.CDATA_SECTION_NODE].includes(node.nodeType)) {
     return null;
-  } else if (node.nodeType === Node.ELEMENT_NODE) {
+  }
+  if (node.nodeType === Node.ELEMENT_NODE) {
     const element = node as HTMLElement;
     const nonEmptyChildren = [...node.childNodes].filter(
       (x) => !ignoreDivChildNode(x)

--- a/src/nativeEditor/insertButton.tsx
+++ b/src/nativeEditor/insertButton.tsx
@@ -69,6 +69,7 @@ function dragPromise(uuid: string): Promise<DragResult | null> {
       if (!resolved) {
         resolve(null);
       }
+
       drake.destroy();
     });
 

--- a/src/nativeEditor/insertButton.tsx
+++ b/src/nativeEditor/insertButton.tsx
@@ -48,7 +48,7 @@ export interface ButtonSelectionResult {
 
 export interface DragResult {
   target: ElementInfo;
-  // element to place the button before
+  // Element to place the button before
   sibling: string[] | null;
 }
 
@@ -114,7 +114,7 @@ export const dragButton = liftContentScript(
 export const insertButton = liftContentScript("INSERT_BUTTON", async () => {
   let selected = await userSelectElement();
 
-  // anchor is an inline element, so if the structure in a > span, the user has no way of
+  // Anchor is an inline element, so if the structure in a > span, the user has no way of
   // selecting the outer anchor unless there's padding/margin involved.
   //
   // if the parent is BUTTON, the user probably just selected the wrong thing

--- a/src/nativeEditor/selector.ts
+++ b/src/nativeEditor/selector.ts
@@ -74,6 +74,7 @@ export function userSelectElement(root?: HTMLElement): Promise<HTMLElement[]> {
                 "One or more selected elements are not contained with the root container"
               );
             }
+
             resolve(result);
           }
         } finally {
@@ -179,6 +180,7 @@ export const selectElement = liftContentScript(
         if (root) {
           throw new Error(`root selector not implemented for mode: ${mode}`);
         }
+
         const { selectors } = findContainer(elements);
 
         requireSingleElement(selectors[0]);
@@ -189,6 +191,7 @@ export const selectElement = liftContentScript(
           traverseUp,
         });
       }
+
       case "element": {
         const selector = safeCssSelector(elements[0], [], rootElement);
 
@@ -203,6 +206,7 @@ export const selectElement = liftContentScript(
           traverseUp,
         });
       }
+
       default: {
         throw new Error(`Unexpected mode: ${mode}`);
       }

--- a/src/nativeEditor/selector.ts
+++ b/src/nativeEditor/selector.ts
@@ -142,7 +142,7 @@ export function userSelectElement(root?: HTMLElement): Promise<HTMLElement[]> {
 
 export type SelectMode = "element" | "container";
 
-// export const findComponent = liftContentScript(
+// Export const findComponent = liftContentScript(
 //     "SELECT_COMPONENT",
 //     async ({ selector, framework }: { selector: string, framework: Framework }) => {
 //     }
@@ -194,7 +194,7 @@ export const selectElement = liftContentScript(
 
         console.debug(`Generated selector: ${selector}`);
 
-        // double-check we have a valid selector
+        // Double-check we have a valid selector
         requireSingleElement(selector);
 
         return pageScript.getElementInfo({

--- a/src/nativeEditor/utils.ts
+++ b/src/nativeEditor/utils.ts
@@ -24,5 +24,6 @@ export function requireSingleElement(selector: string): HTMLElement {
   } else if ($elt.length > 1) {
     throw new Error(`Multiple elements found for selector: '${selector}'`);
   }
+
   return $elt.get(0);
 }

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -17,7 +17,7 @@
 
 import "@/extensionContext";
 
-// init rollbar early so we get error reporting on the other initialization
+// Init rollbar early so we get error reporting on the other initialization
 import "@/telemetry/rollbar";
 
 import ReactDOM from "react-dom";

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -66,9 +66,11 @@ const RequireInstall: React.FunctionComponent = ({ children }) => {
   if (isPending && mode === "remote") {
     return null;
   }
+
   if (mode === "remote" && !token) {
     return <SetupPage />;
   }
+
   return <>{children}</>;
 };
 

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -52,7 +52,7 @@ import { initTelemetry } from "@/telemetry/events";
 import DeploymentBanner from "@/options/pages/deployments/DeploymentBanner";
 import UpdateBanner from "@/options/pages/UpdateBanner";
 
-// import the built-in bricks
+// Import the built-in bricks
 import "@/blocks";
 import "@/contrib";
 import "@/contrib/editors";

--- a/src/options/loader.ts
+++ b/src/options/loader.ts
@@ -16,9 +16,8 @@
  */
 
 import { Metadata, ServiceDependency } from "@/core";
-import { Permissions } from "webextension-polyfill-ts";
+import { Permissions, browser } from "webextension-polyfill-ts";
 import { Primitive } from "type-fest";
-import { browser } from "webextension-polyfill-ts";
 
 const STORAGE_KEY = "persist:extensionOptions";
 const INITIAL_STATE = JSON.stringify({});

--- a/src/options/pages/InstalledPage.tsx
+++ b/src/options/pages/InstalledPage.tsx
@@ -180,14 +180,16 @@ const ExtensionRow: React.FunctionComponent<{
   const statusElt = useMemo(() => {
     if (hasPermissions == null || validation == null) {
       return <BeatLoader />;
-    } else if (validation && !validation.valid) {
+    }
+    if (validation && !validation.valid) {
       return (
         <span className="text-danger text-wrap">
           <FontAwesomeIcon icon={faExclamation} />{" "}
           {validationMessage(validation)}
         </span>
       );
-    } else if (hasPermissions) {
+    }
+    if (hasPermissions) {
       return (
         <span>
           <FontAwesomeIcon icon={faCheck} /> Active

--- a/src/options/pages/InstalledPage.tsx
+++ b/src/options/pages/InstalledPage.tsx
@@ -209,7 +209,7 @@ const ExtensionRow: React.FunctionComponent<{
       <td>
         <Link to={`/workshop/extensions/${id}`}>{label ?? id}</Link>
       </td>
-      {/*<td>2 weeks</td>*/}
+      {/* <td>2 weeks</td> */}
       <td className="text-wrap">{statusElt}</td>
       <td>
         <Button
@@ -251,7 +251,7 @@ const InstalledTable: React.FunctionComponent<{
               <tr>
                 <th>&nbsp;</th>
                 <th>Name</th>
-                {/*<th>Last Used</th>*/}
+                {/* <th>Last Used</th> */}
                 <th>Status</th>
                 <th>Uninstall</th>
               </tr>
@@ -410,7 +410,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     // Remove from storage first so it doesn't get re-added in reactivate step below
     dispatch(removeExtension(identifier));
     uninstallContextMenu(identifier).catch(() => {
-      // noop because this is expected to error for non-context menus
+      // Noop because this is expected to error for non-context menus
     });
     reactivate().catch((error: unknown) => {
       console.warn("Error re-activating content scripts", { error });

--- a/src/options/pages/InstalledPage.tsx
+++ b/src/options/pages/InstalledPage.tsx
@@ -79,6 +79,7 @@ function validationMessage(validation: ExtensionValidationResult) {
   } else {
     console.debug("Validation result", validation);
   }
+
   return message;
 }
 
@@ -98,6 +99,7 @@ const RecipeEntry: React.FunctionComponent<{
         for (const { id: extensionId, extensionPointId } of extensions) {
           onRemove({ extensionId, extensionPointId });
         }
+
         addToast(`Uninstalled ${name}`, {
           appearance: "success",
           autoDismiss: true,
@@ -181,6 +183,7 @@ const ExtensionRow: React.FunctionComponent<{
     if (hasPermissions == null || validation == null) {
       return <BeatLoader />;
     }
+
     if (validation && !validation.valid) {
       return (
         <span className="text-danger text-wrap">
@@ -189,6 +192,7 @@ const ExtensionRow: React.FunctionComponent<{
         </span>
       );
     }
+
     if (hasPermissions) {
       return (
         <span>
@@ -196,6 +200,7 @@ const ExtensionRow: React.FunctionComponent<{
         </span>
       );
     }
+
     return (
       <Button variant="info" size="sm" onClick={requestPermissions}>
         Grant Permissions

--- a/src/options/pages/SetupPage.tsx
+++ b/src/options/pages/SetupPage.tsx
@@ -86,7 +86,7 @@ const SetupPage: React.FunctionComponent = () => {
     window.close();
   }, [accountTab]);
 
-  // try to automatically open the web app to sync the credentials so that the user doesn't
+  // Try to automatically open the web app to sync the credentials so that the user doesn't
   // have to click the button
   useAsyncState(async () => {
     if (accountTab) {

--- a/src/options/pages/SetupPage.tsx
+++ b/src/options/pages/SetupPage.tsx
@@ -82,6 +82,7 @@ const SetupPage: React.FunctionComponent = () => {
         active: true,
       });
     }
+
     // Close the browser extension tab
     window.close();
   }, [accountTab]);

--- a/src/options/pages/brickEditor/BrickReference.tsx
+++ b/src/options/pages/brickEditor/BrickReference.tsx
@@ -68,16 +68,19 @@ function makeArgumentYaml(schema: Schema): string {
             result += `# ${line} \n`;
           }
         }
+
         if (value.enum) {
           result += "# valid values:\n";
           for (const line of value.enum) {
             result += `# - ${line} \n`;
           }
         }
+
         result += `# ${prop.includes(" ") ? `"${prop}"` : prop}: \n`;
       }
     }
   }
+
   return result;
 }
 

--- a/src/options/pages/brickEditor/BrickReference.tsx
+++ b/src/options/pages/brickEditor/BrickReference.tsx
@@ -207,7 +207,7 @@ const BrickReference: React.FunctionComponent<{
 
   const fuse: Fuse<IBlock | IService> = useMemo(() => {
     return new Fuse(sortedBlocks, {
-      // prefer name, then id
+      // Prefer name, then id
       keys: ["name", "id"],
     });
   }, [sortedBlocks]);
@@ -218,7 +218,7 @@ const BrickReference: React.FunctionComponent<{
         ? sortedBlocks
         : fuse.search(query).map((x) => x.item);
 
-    // if a brick is selected, have it show up at the top of the list
+    // If a brick is selected, have it show up at the top of the list
     if (selected && selected.id === initialSelected?.id) {
       matches = [selected, ...matches.filter((x) => x.id !== selected.id)];
     }

--- a/src/options/pages/brickEditor/CodeEditor.tsx
+++ b/src/options/pages/brickEditor/CodeEditor.tsx
@@ -119,8 +119,8 @@ const CodeEditor: React.FunctionComponent<OwnProps> = ({
           editorProps={{ $blockScrolling: true }}
           commands={[
             {
-              name: "save", //name for the key binding.
-              bindKey: { win: "Ctrl-S", mac: "Command-S" }, //key combination used for the command.
+              name: "save", // Name for the key binding.
+              bindKey: { win: "Ctrl-S", mac: "Command-S" }, // Key combination used for the command.
               exec: () => {
                 void submitForm();
               },

--- a/src/options/pages/brickEditor/EditPage.tsx
+++ b/src/options/pages/brickEditor/EditPage.tsx
@@ -58,6 +58,7 @@ function useParseBrick(config: string | null): ParsedBrickInfo {
     if (config == null) {
       return { isBlueprint: false, isInstalled: false, config: undefined };
     }
+
     const configJSON = yaml.load(config) as RawConfig;
     const isBlueprint = configJSON.kind === "recipe";
     if (isBlueprint) {
@@ -69,6 +70,7 @@ function useParseBrick(config: string | null): ParsedBrickInfo {
         config: configJSON,
       };
     }
+
     return { isBlueprint: false, isInstalled: false, config: configJSON };
   }, [config, extensions]);
 }
@@ -106,17 +108,21 @@ function useLogContext(config: string | null): MessageContext | null {
         case "service": {
           return { serviceId: json.metadata.id };
         }
+
         case "extensionPoint": {
           return { extensionPointId: json.metadata.id };
         }
+
         case "component":
         case "reader": {
           return { blockId: json.metadata.id };
         }
+
         case "recipe": {
           const extensionId = blueprintMap.get(json.metadata.id);
           return extensionId ? { extensionId } : null;
         }
+
         default: {
           return null;
         }

--- a/src/options/pages/brickEditor/Editor.tsx
+++ b/src/options/pages/brickEditor/Editor.tsx
@@ -50,7 +50,8 @@ const SharingIcon: React.FunctionComponent<{
 }> = ({ isPublic, organizations }) => {
   if (isPublic) {
     return <FontAwesomeIcon icon={faGlobe} />;
-  } else if (organizations) {
+  }
+  if (organizations) {
     return <FontAwesomeIcon icon={faBuilding} />;
   }
   return <FontAwesomeIcon icon={faEyeSlash} />;

--- a/src/options/pages/brickEditor/Editor.tsx
+++ b/src/options/pages/brickEditor/Editor.tsx
@@ -51,9 +51,11 @@ const SharingIcon: React.FunctionComponent<{
   if (isPublic) {
     return <FontAwesomeIcon icon={faGlobe} />;
   }
+
   if (organizations) {
     return <FontAwesomeIcon icon={faBuilding} />;
   }
+
   return <FontAwesomeIcon icon={faEyeSlash} />;
 };
 

--- a/src/options/pages/brickEditor/useSubmitBrick.tsx
+++ b/src/options/pages/brickEditor/useSubmitBrick.tsx
@@ -123,7 +123,7 @@ function useSubmitBrick({
             });
           });
 
-        // reset initial values of the form so dirty=false
+        // Reset initial values of the form so dirty=false
         resetForm({ values });
 
         if (create) {

--- a/src/options/pages/brickEditor/useSubmitBrick.tsx
+++ b/src/options/pages/brickEditor/useSubmitBrick.tsx
@@ -76,6 +76,7 @@ function useSubmitBrick({
       });
       return;
     }
+
     addToast("Deleted brick", {
       appearance: "success",
       autoDismiss: true,

--- a/src/options/pages/brickEditor/validate.ts
+++ b/src/options/pages/brickEditor/validate.ts
@@ -66,5 +66,6 @@ export async function validateSchema(value: string): Promise<any> {
       config: validation.errors.map((x) => `${x.instanceLocation}: ${x.error}`),
     };
   }
+
   return {};
 }

--- a/src/options/pages/deployments/DeploymentBanner.tsx
+++ b/src/options/pages/deployments/DeploymentBanner.tsx
@@ -139,11 +139,11 @@ function useDeployments() {
   const { request } = useEnsurePermissions(updated);
 
   const update = useCallback(() => {
-    // can't use async here because Firefox loses track of trusted UX event
+    // Can't use async here because Firefox loses track of trusted UX event
     request().then((accepted: boolean) => {
       if (accepted) {
         for (const deployment of deployments) {
-          // clear existing installs of the blueprint
+          // Clear existing installs of the blueprint
           for (const extension of installed) {
             if (
               extension._recipe != null &&

--- a/src/options/pages/deployments/DeploymentBanner.tsx
+++ b/src/options/pages/deployments/DeploymentBanner.tsx
@@ -93,6 +93,7 @@ function useEnsurePermissions(deployments: Deployment[]) {
       });
       return false;
     }
+
     return true;
   }, [permissions, setEnabled]);
 
@@ -173,6 +174,7 @@ function useDeployments() {
             deployment: deployment.id,
           });
         }
+
         void queueReactivate();
         addToast("Activated team bricks", {
           appearance: "success",

--- a/src/options/pages/deployments/hooks.ts
+++ b/src/options/pages/deployments/hooks.ts
@@ -87,6 +87,7 @@ export function useEnsurePermissions(deployments: Deployment[]) {
       });
       return false;
     }
+
     return true;
   }, [permissions, setEnabled]);
 
@@ -149,6 +150,7 @@ export function useDeployments() {
             deployment: deployment.id,
           });
         }
+
         addToast("Activated team bricks", {
           appearance: "success",
           autoDismiss: true,

--- a/src/options/pages/deployments/hooks.ts
+++ b/src/options/pages/deployments/hooks.ts
@@ -118,11 +118,11 @@ export function useDeployments() {
   const { request } = useEnsurePermissions(updated);
 
   const update = useCallback(() => {
-    // can't use async here because Firefox loses track of trusted UX event
+    // Can't use async here because Firefox loses track of trusted UX event
     request().then((accepted: boolean) => {
       if (accepted) {
         for (const deployment of deployments) {
-          // clear existing installs of the blueprint
+          // Clear existing installs of the blueprint
           for (const extension of installed) {
             if (extension._recipe.id === deployment.package.package_id) {
               dispatch(
@@ -134,7 +134,7 @@ export function useDeployments() {
             }
           }
 
-          // install the blueprint with the service definition
+          // Install the blueprint with the service definition
           dispatch(
             actions.installRecipe({
               recipe: deployment.package.config,

--- a/src/options/pages/extensionEditor/DataSourceCard.tsx
+++ b/src/options/pages/extensionEditor/DataSourceCard.tsx
@@ -140,7 +140,8 @@ export const SchemaTree: React.FunctionComponent<{ schema: Schema }> = ({
                 key={prop}
               />
             );
-          } else if (type === "array") {
+          }
+          if (type === "array") {
             return (
               <ArrayEntry
                 prop={prop}
@@ -172,9 +173,11 @@ const DataSourceCard: React.FunctionComponent<{
   const body = useMemo(() => {
     if (isPending) {
       return <GridLoader />;
-    } else if (error) {
+    }
+    if (error) {
       return <Card.Body>{error.toString()}</Card.Body>;
-    } else if (isEmpty(outputSchema)) {
+    }
+    if (isEmpty(outputSchema)) {
       return <Card.Body>No schema available</Card.Body>;
     }
     return <SchemaTree schema={outputSchema} />;

--- a/src/options/pages/extensionEditor/DataSourceCard.tsx
+++ b/src/options/pages/extensionEditor/DataSourceCard.tsx
@@ -89,6 +89,7 @@ const ArrayEntry: React.FunctionComponent<{
       </ListGroup.Item>
     );
   }
+
   return (
     <ListGroup.Item>
       <span>{prop}</span>
@@ -141,6 +142,7 @@ export const SchemaTree: React.FunctionComponent<{ schema: Schema }> = ({
               />
             );
           }
+
           if (type === "array") {
             return (
               <ArrayEntry
@@ -150,6 +152,7 @@ export const SchemaTree: React.FunctionComponent<{ schema: Schema }> = ({
               />
             );
           }
+
           return (
             <PrimitiveEntry
               prop={prop}
@@ -174,12 +177,15 @@ const DataSourceCard: React.FunctionComponent<{
     if (isPending) {
       return <GridLoader />;
     }
+
     if (error) {
       return <Card.Body>{error.toString()}</Card.Body>;
     }
+
     if (isEmpty(outputSchema)) {
       return <Card.Body>No schema available</Card.Body>;
     }
+
     return <SchemaTree schema={outputSchema} />;
   }, [error, outputSchema, isPending]);
 

--- a/src/options/pages/extensionEditor/ExtensionEditor.tsx
+++ b/src/options/pages/extensionEditor/ExtensionEditor.tsx
@@ -69,6 +69,7 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
       if (!extensionPoint) {
         return;
       }
+
       try {
         const isNew = !extensionConfig?.id;
         const extensionId = extensionConfig?.id ?? uuidv4();
@@ -105,9 +106,11 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
   if (isPending) {
     return <GridLoader />;
   }
+
   if (!extensionPoint) {
     return <WorkshopPage navigate={navigate} />;
   }
+
   return (
     <ExtensionPointDetail
       initialValue={{

--- a/src/options/pages/extensionEditor/ExtensionEditor.tsx
+++ b/src/options/pages/extensionEditor/ExtensionEditor.tsx
@@ -104,7 +104,8 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
 
   if (isPending) {
     return <GridLoader />;
-  } else if (!extensionPoint) {
+  }
+  if (!extensionPoint) {
     return <WorkshopPage navigate={navigate} />;
   }
   return (

--- a/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
+++ b/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
@@ -103,6 +103,7 @@ function normalizeConfig(
     }
     /* eslint-enable security/detect-object-injection */
   }
+
   return result;
 }
 

--- a/src/options/pages/extensionEditor/ServiceAuthSelector.tsx
+++ b/src/options/pages/extensionEditor/ServiceAuthSelector.tsx
@@ -81,7 +81,7 @@ export function useAuthOptions(): [AuthOption[], () => Promise<void>] {
   return [authOptions, refresh];
 }
 
-// customStyles.js
+// CustomStyles.js
 const colors = {
   error: "#dc3545",
   divider: "#ebedf2",

--- a/src/options/pages/extensionEditor/WorkshopPage.tsx
+++ b/src/options/pages/extensionEditor/WorkshopPage.tsx
@@ -279,6 +279,7 @@ const KindIcon: React.FunctionComponent<{ brick: EnhancedBrick }> = ({
   } else if (kind === "Blueprint") {
     icon = faStoreAlt;
   }
+
   return <FontAwesomeIcon icon={icon} fixedWidth />;
 };
 

--- a/src/options/pages/extensionEditor/WorkshopPage.tsx
+++ b/src/options/pages/extensionEditor/WorkshopPage.tsx
@@ -96,7 +96,7 @@ function useEnrichBricks(bricks: Brick[]): EnhancedBrick[] {
           timestamp: recent.get(brick.id),
         };
       }),
-      // show recently accessed first
+      // Show recently accessed first
       [(x) => x.timestamp ?? -1, (x) => x.verbose_name],
       ["desc", "asc"]
     );

--- a/src/options/pages/extensionEditor/fieldRenderer.tsx
+++ b/src/options/pages/extensionEditor/fieldRenderer.tsx
@@ -55,19 +55,26 @@ export function defaultFieldRenderer(
 ): React.FunctionComponent<FieldProps<unknown>> {
   if (booleanPredicate(schema)) {
     return BooleanField;
-  } else if (textPredicate(schema)) {
+  }
+  if (textPredicate(schema)) {
     return TextField;
-  } else if (blockPredicate(schema)) {
+  }
+  if (blockPredicate(schema)) {
     return BlockField;
-  } else if (schema["$ref"] === "https://app.pixiebrix.com/schemas/icon#") {
+  }
+  if (schema["$ref"] === "https://app.pixiebrix.com/schemas/icon#") {
     return IconField;
-  } else if (findOneOf(schema, blockPredicate)) {
+  }
+  if (findOneOf(schema, blockPredicate)) {
     return BlockField;
-  } else if (findOneOf(schema, textPredicate)) {
+  }
+  if (findOneOf(schema, textPredicate)) {
     return makeOneOfField(findOneOf(schema, textPredicate));
-  } else if (findOneOf(schema, booleanPredicate)) {
+  }
+  if (findOneOf(schema, booleanPredicate)) {
     return makeOneOfField(findOneOf(schema, booleanPredicate));
-  } else if (schema["$ref"] && !schema.type) {
+  }
+  if (schema["$ref"] && !schema.type) {
     throw new Error(`Unexpected $ref ${schema["$ref"]}`);
   } else {
     // Not using reportError here because we generally know about this, and it generates an error every render

--- a/src/options/pages/extensionEditor/fieldRenderer.tsx
+++ b/src/options/pages/extensionEditor/fieldRenderer.tsx
@@ -56,24 +56,31 @@ export function defaultFieldRenderer(
   if (booleanPredicate(schema)) {
     return BooleanField;
   }
+
   if (textPredicate(schema)) {
     return TextField;
   }
+
   if (blockPredicate(schema)) {
     return BlockField;
   }
+
   if (schema["$ref"] === "https://app.pixiebrix.com/schemas/icon#") {
     return IconField;
   }
+
   if (findOneOf(schema, blockPredicate)) {
     return BlockField;
   }
+
   if (findOneOf(schema, textPredicate)) {
     return makeOneOfField(findOneOf(schema, textPredicate));
   }
+
   if (findOneOf(schema, booleanPredicate)) {
     return makeOneOfField(findOneOf(schema, booleanPredicate));
   }
+
   if (schema["$ref"] && !schema.type) {
     throw new Error(`Unexpected $ref ${schema["$ref"]}`);
   } else {

--- a/src/options/pages/marketplace/ActivateBody.tsx
+++ b/src/options/pages/marketplace/ActivateBody.tsx
@@ -96,7 +96,7 @@ export function useEnsurePermissions(
   }, [permissions, addToast]);
 
   const activate = useCallback(() => {
-    // can't use async here because Firefox loses track of trusted UX event
+    // Can't use async here because Firefox loses track of trusted UX event
     request().then((accepted: boolean) => {
       if (accepted) {
         reportEvent("MarketplaceActivate", {

--- a/src/options/pages/marketplace/ActivateBody.tsx
+++ b/src/options/pages/marketplace/ActivateBody.tsx
@@ -92,6 +92,7 @@ export function useEnsurePermissions(
       });
       return false;
     }
+
     return true;
   }, [permissions, addToast]);
 
@@ -105,6 +106,7 @@ export function useEnsurePermissions(
         });
         return submitForm();
       }
+
       reportEvent("MarketplaceRejectPermissions", {
         blueprintId: blueprint.metadata.id,
         extensions: extensions.map((x) => x.label),

--- a/src/options/pages/marketplace/ActivatePage.tsx
+++ b/src/options/pages/marketplace/ActivatePage.tsx
@@ -88,6 +88,7 @@ const ActivatePage: React.FunctionComponent = () => {
     if (blueprint?.config?.extensionPoints != null) {
       return <ActivateWizard blueprint={blueprint.config} />;
     }
+
     if (blueprint != null) {
       return (
         <Card>
@@ -111,6 +112,7 @@ const ActivatePage: React.FunctionComponent = () => {
         </Card>
       );
     }
+
     return <GridLoader />;
   }, [blueprintId, blueprint, sourcePage]);
 

--- a/src/options/pages/marketplace/ActivatePage.tsx
+++ b/src/options/pages/marketplace/ActivatePage.tsx
@@ -87,7 +87,8 @@ const ActivatePage: React.FunctionComponent = () => {
   const body = useMemo(() => {
     if (blueprint?.config?.extensionPoints != null) {
       return <ActivateWizard blueprint={blueprint.config} />;
-    } else if (blueprint != null) {
+    }
+    if (blueprint != null) {
       return (
         <Card>
           <Card.Header>Invalid Blueprint</Card.Header>

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -150,7 +150,8 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
         });
         setSubmitting(false);
         return;
-      } else if (missingServiceIds.length > 0) {
+      }
+      if (missingServiceIds.length > 0) {
         addToast(
           `You must select a configuration for each service: ${missingServiceIds.join(
             ", "
@@ -162,7 +163,8 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
         );
         setSubmitting(false);
         return;
-      } else if (!enabled) {
+      }
+      if (!enabled) {
         addToast("You must grant browser permissions for the selected bricks", {
           appearance: "error",
           autoDismiss: true,

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -66,9 +66,11 @@ function selectAuths(
     } else if (configs.length > 1) {
       throw new Error(`Service ${id} has multiple configurations`);
     }
+
     // eslint-disable-next-line security/detect-object-injection -- safe because it's from Object.entries
     result[id] = configs[0];
   }
+
   return result;
 }
 
@@ -151,6 +153,7 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
         setSubmitting(false);
         return;
       }
+
       if (missingServiceIds.length > 0) {
         addToast(
           `You must select a configuration for each service: ${missingServiceIds.join(
@@ -164,6 +167,7 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
         setSubmitting(false);
         return;
       }
+
       if (!enabled) {
         addToast("You must grant browser permissions for the selected bricks", {
           appearance: "error",
@@ -257,9 +261,11 @@ function useWizard(blueprint: RecipeDefinition): [Step[], WizardValues] {
             (serviceId) => serviceId !== PIXIEBRIX_SERVICE_ID
           );
         }
+
         case "options": {
           return !isEmpty(blueprint.options?.schema);
         }
+
         default: {
           return true;
         }

--- a/src/options/pages/marketplace/ConfigureBody.tsx
+++ b/src/options/pages/marketplace/ConfigureBody.tsx
@@ -89,9 +89,9 @@ const ConfigureRow: React.FunctionComponent<{
           <span className="text-muted">Ignore</span>
         )}
       </td>
-      {/*<td>*/}
-      {/*  <code className="pl-0">{definition.id}</code>*/}
-      {/*</td>*/}
+      {/* <td> */}
+      {/*  <code className="pl-0">{definition.id}</code> */}
+      {/* </td> */}
       <td>{definition.label ?? "No label provided"}</td>
     </tr>
   );
@@ -136,7 +136,7 @@ const ConfigureBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
         <thead>
           <tr>
             <th colSpan={2}>Selected?</th>
-            {/*<th>Foundation</th>*/}
+            {/* <th>Foundation</th> */}
             <th className="w-100">Name/Description</th>
           </tr>
         </thead>

--- a/src/options/pages/marketplace/ServicesBody.tsx
+++ b/src/options/pages/marketplace/ServicesBody.tsx
@@ -171,6 +171,7 @@ const ServiceDescriptor: React.FunctionComponent<{
       </div>
     );
   }
+
   return (
     <div>
       {config && <span>{config.metadata.name}</span>}

--- a/src/options/pages/services/PrivateServicesCard.tsx
+++ b/src/options/pages/services/PrivateServicesCard.tsx
@@ -132,6 +132,7 @@ const PrivateServicesCard: React.FunctionComponent<OwnProps> = ({
             if (!service) {
               throw new Error(`Unknown service ${configuredService.serviceId}`);
             }
+
             return (
               <tr
                 key={`${configuredService.serviceId}-${configuredService.id}`}

--- a/src/options/pages/services/ServiceEditorModal.tsx
+++ b/src/options/pages/services/ServiceEditorModal.tsx
@@ -62,6 +62,7 @@ const ServiceEditorModal: React.FunctionComponent<OwnProps> = ({
     if (optionsRegistry.has(service.id)) {
       return optionsRegistry.get(service.id);
     }
+
     return genericOptionsFactory(service.schema);
   }, [service]);
 
@@ -89,6 +90,7 @@ const ServiceEditorModal: React.FunctionComponent<OwnProps> = ({
     if (!schema) {
       return Yup.object();
     }
+
     try {
       return buildYup(schema, {});
     } catch (error: unknown) {

--- a/src/options/pages/services/ServicesEditor.tsx
+++ b/src/options/pages/services/ServicesEditor.tsx
@@ -85,7 +85,7 @@ const ServicesEditor: React.FunctionComponent<OwnProps> = ({
         autoDismiss: true,
       });
 
-      // wait 1000ms to allow changes to propagate to storage (via redux persist)
+      // Wait 1000ms to allow changes to propagate to storage (via redux persist)
       void sleep(1000).then(async () => {
         try {
           await refreshServices();
@@ -115,7 +115,7 @@ const ServicesEditor: React.FunctionComponent<OwnProps> = ({
         autoDismiss: true,
       });
 
-      // don't need to wait before navigating, as this window has the updated state immediately
+      // Don't need to wait before navigating, as this window has the updated state immediately
       void sleep(1000).then(async () => {
         try {
           await refreshServices();

--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -65,6 +65,7 @@ const AdvancedSettings: React.FunctionComponent = () => {
       if (newURL === serviceURL || (isEmpty(newURL) && isEmpty(serviceURL))) {
         return;
       }
+
       await setServiceURL(newURL);
       addToast("Updated the service URL", {
         appearance: "success",

--- a/src/options/slices.ts
+++ b/src/options/slices.ts
@@ -256,7 +256,7 @@ export const optionsSlice = createSlice({
         optionsArgs,
         services,
       } = payload;
-      // support both extensionId and id to keep the API consistent with the shape of the stored extension
+      // Support both extensionId and id to keep the API consistent with the shape of the stored extension
       if (extensionId == null && id == null) {
         throw new Error("extensionId is required");
       } else if (extensionPointId == null) {
@@ -280,7 +280,7 @@ export const optionsSlice = createSlice({
       const { extensionPointId, extensionId } = payload;
       const extensions = state.extensions[extensionPointId] ?? {};
       if (!extensions[extensionId]) {
-        // it's already removed
+        // It's already removed
         console.debug(
           `Extension id ${extensionId} does not exist for extension point ${extensionPointId}`
         );

--- a/src/options/slices.ts
+++ b/src/options/slices.ts
@@ -162,6 +162,7 @@ export const servicesSlice = createSlice({
       if (!state.configured[id]) {
         throw new Error(`Service configuration ${id} does not exist`);
       }
+
       delete state.configured[id];
       return state;
     },
@@ -209,9 +210,11 @@ export const optionsSlice = createSlice({
         if (extensionPointId == null) {
           throw new Error("extensionPointId is required");
         }
+
         if (state.extensions[extensionPointId] == null) {
           state.extensions[extensionPointId] = {};
         }
+
         reportEvent("ExtensionActivate", {
           extensionId,
           blueprintId: recipe.metadata.id,
@@ -262,9 +265,11 @@ export const optionsSlice = createSlice({
       } else if (extensionPointId == null) {
         throw new Error("extensionPointId is required");
       }
+
       if (state.extensions[extensionPointId] == null) {
         state.extensions[extensionPointId] = {};
       }
+
       state.extensions[extensionPointId][extensionId ?? id] = {
         id: extensionId ?? id,
         extensionPointId,

--- a/src/options/store.ts
+++ b/src/options/store.ts
@@ -61,7 +61,7 @@ export interface RootState {
 
 const middleware = [routerMiddleware(hashHistory)];
 if (process.env.NODE_ENV === "development") {
-  // allow tree shaking of logger in production
+  // Allow tree shaking of logger in production
   // https://github.com/LogRocket/redux-logger/issues/6
   middleware.push(createLogger());
 }

--- a/src/pages/marketplace/MarketplacePage.tsx
+++ b/src/pages/marketplace/MarketplacePage.tsx
@@ -51,7 +51,8 @@ const Entry: React.FunctionComponent<
   const installButton = useMemo(() => {
     if (!onInstall) {
       return null;
-    } else if (!installed) {
+    }
+    if (!installed) {
       return (
         <Button size="sm" variant="info" {...buttonProps} onClick={onInstall}>
           Add

--- a/src/pages/marketplace/MarketplacePage.tsx
+++ b/src/pages/marketplace/MarketplacePage.tsx
@@ -52,6 +52,7 @@ const Entry: React.FunctionComponent<
     if (!onInstall) {
       return null;
     }
+
     if (!installed) {
       return (
         <Button size="sm" variant="info" {...buttonProps} onClick={onInstall}>
@@ -59,6 +60,7 @@ const Entry: React.FunctionComponent<
         </Button>
       );
     }
+
     return (
       <Button size="sm" variant="info" {...buttonProps} disabled>
         Added

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -94,7 +94,7 @@ export async function collectPermissions(
   const permissions = await Promise.all(
     extensionPoints.map(
       async ({ id, permissions = {} }: ExtensionPointDefinition) => {
-        // console.debug(`Extra permissions for ${id}`, permissions);
+        // Console.debug(`Extra permissions for ${id}`, permissions);
         const extensionPoint = await extensionRegistry.lookup(id);
         return mergePermissions(
           [extensionPoint.permissions, permissions].map((x) => normalize(x))

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -119,6 +119,7 @@ export async function serviceOriginPermissions(
     // extension install. The proxy server will check isAvailable when making request
     return { origins: [] };
   }
+
   const service = await registry.lookup(dependency.id);
   const matchPatterns = service.getOrigins(localConfig.config);
   return { origins: matchPatterns };

--- a/src/permissionsPopup.tsx
+++ b/src/permissionsPopup.tsx
@@ -17,7 +17,7 @@
 
 import "@/extensionContext";
 
-// init rollbar early so we get error reporting on the other initialization
+// Init rollbar early so we get error reporting on the other initialization
 import "@/telemetry/rollbar";
 import PermissionsPopup from "@/popups/PermissionsPopup";
 

--- a/src/registry/localRegistry.ts
+++ b/src/registry/localRegistry.ts
@@ -155,6 +155,7 @@ export const find = liftBackground("REGISTRY_FIND", async (id: string) => {
     console.error(`REGISTRY_FIND received invalid id argument`, { id });
     throw new Error("invalid brick id");
   }
+
   const db = await getBrickDB();
   const versions = await db.getAllFromIndex(BRICK_STORE, "id", id);
   return latestVersion(versions);

--- a/src/script.ts
+++ b/src/script.ts
@@ -93,6 +93,7 @@ function requireSingleElement(selector: string): HTMLElement {
       `Multiple elements found for selector: '${selector}'`
     );
   }
+
   return $elt.get(0);
 }
 
@@ -145,6 +146,7 @@ function readPathSpec(
       );
     }
   }
+
   return values;
 }
 
@@ -155,6 +157,7 @@ attachListener(READ_WINDOW, async ({ pathSpec, waitMillis }) => {
       ? undefined
       : values;
   };
+
   return awaitValue(factory, { waitMillis });
 });
 
@@ -184,6 +187,7 @@ async function read<TComponent>(
     if (optional) {
       return {};
     }
+
     throw error;
   }
 
@@ -202,6 +206,7 @@ async function read<TComponent>(
       );
       return {};
     }
+
     throw error;
   }
 
@@ -243,6 +248,7 @@ attachListener(
     if (!adapter) {
       throw new Error(`No read adapter available for framework: ${framework}`);
     }
+
     return read(adapter, selector, options);
   }
 );
@@ -259,6 +265,7 @@ attachListener(
     if (!adapter?.setData) {
       throw new Error(`No write adapter available for ${framework}`);
     }
+
     const element = requireSingleElement(selector);
     const component = adapter.getComponent(element);
     adapter.setData(component, valueMap);

--- a/src/script.ts
+++ b/src/script.ts
@@ -31,15 +31,15 @@ declare global {
   }
 }
 
-// false positive: using constant symbol defined above
+// False positive: using constant symbol defined above
 // eslint-disable-next-line security/detect-object-injection
 if (!window[PAGESCRIPT_SYMBOL]) {
-  // false positive: using constant symbol defined above
+  // False positive: using constant symbol defined above
   // eslint-disable-next-line security/detect-object-injection
   window[PAGESCRIPT_SYMBOL] = uuidv4();
 } else {
   throw new Error(
-    // false positive: using constant symbol defined above
+    // False positive: using constant symbol defined above
     // eslint-disable-next-line security/detect-object-injection
     `PixieBrix pageScript already installed: ${window[PAGESCRIPT_SYMBOL]}`
   );
@@ -213,7 +213,7 @@ async function read<TComponent>(
     adapter.proxy
   );
 
-  // if (process.env.DEBUG) {
+  // If (process.env.DEBUG) {
   //   const clonedData = cloneDeep(readData);
   //   console.debug(`Read ${selector}`, {
   //     target,
@@ -276,7 +276,7 @@ attachListener(
     framework?: Framework;
 
     /**
-     * traverseUp controls how many ancestor elements to also return
+     * TraverseUp controls how many ancestor elements to also return
      */
     traverseUp: number;
   }) => {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -42,7 +42,8 @@ export function useExtension(
 
     if (!extensionId) {
       return null;
-    } else if (extensionPointId) {
+    }
+    if (extensionPointId) {
       config = options.extensions[extensionPointId][extensionId];
     } else {
       for (const pointExtensions of Object.values(options.extensions)) {
@@ -66,7 +67,8 @@ export function useExtension(
   const [extensionPoint, isPending] = useAsyncState(async () => {
     if (extensionConfig) {
       return extensionPointRegistry.lookup(extensionConfig.extensionPointId);
-    } else if (extensionPointId) {
+    }
+    if (extensionPointId) {
       return extensionPointRegistry.lookup(extensionPointId);
     }
     return null;

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -43,6 +43,7 @@ export function useExtension(
     if (!extensionId) {
       return null;
     }
+
     if (extensionPointId) {
       config = options.extensions[extensionPointId][extensionId];
     } else {
@@ -54,6 +55,7 @@ export function useExtension(
         }
       }
     }
+
     if (!config) {
       throw new Error(
         `Could not locate configuration for extension ${extensionId} (extension point: ${
@@ -61,6 +63,7 @@ export function useExtension(
         })`
       );
     }
+
     return config;
   }, [options, extensionId, extensionPointId]);
 
@@ -68,9 +71,11 @@ export function useExtension(
     if (extensionConfig) {
       return extensionPointRegistry.lookup(extensionConfig.extensionPointId);
     }
+
     if (extensionPointId) {
       return extensionPointRegistry.lookup(extensionPointId);
     }
+
     return null;
   }, [extensionPointRegistry, extensionConfig, extensionPointId]);
 

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -38,6 +38,7 @@ export async function getBaseURL(): Promise<string> {
       isEmpty(configured) ? DEFAULT_SERVICE_URL : configured
     );
   }
+
   return withoutTrailingSlash(DEFAULT_SERVICE_URL);
 }
 

--- a/src/services/errors.ts
+++ b/src/services/errors.ts
@@ -26,6 +26,7 @@ export class IncompatibleServiceError extends Error {
 
 export class MissingConfigurationError extends Error {
   serviceId: string;
+
   id: string;
 
   constructor(message: string, serviceId: string, id?: string) {
@@ -38,6 +39,7 @@ export class MissingConfigurationError extends Error {
 
 export class NotConfiguredError extends Error {
   serviceId: string;
+
   missingProperties: string[];
 
   constructor(

--- a/src/services/factory.ts
+++ b/src/services/factory.ts
@@ -50,7 +50,9 @@ class LocalDefinedService<
   TDefinition extends ServiceDefinition = ServiceDefinition
 > extends Service {
   private readonly _definition: TDefinition;
+
   public readonly schema: Schema;
+
   public readonly hasAuth: boolean;
 
   constructor(definition: TDefinition) {

--- a/src/services/factory.ts
+++ b/src/services/factory.ts
@@ -136,6 +136,7 @@ class LocalDefinedService<
       // Console.debug("token context", { definition, serviceConfig });
       return mapArgs<TokenContext>(definition, serviceConfig);
     }
+
     return undefined;
   }
 
@@ -146,6 +147,7 @@ class LocalDefinedService<
       console.debug("getOAuth2Context", { definition, serviceConfig });
       return mapArgs<OAuth2Context>(definition, serviceConfig);
     }
+
     return undefined;
   }
 
@@ -178,6 +180,7 @@ class LocalDefinedService<
         `Service ${this.id} cannot be used to authenticate requests to ${requestConfig.url}`
       );
     }
+
     const {
       baseURL,
       headers = {},

--- a/src/services/factory.ts
+++ b/src/services/factory.ts
@@ -104,7 +104,7 @@ class LocalDefinedService<
       this._definition.authentication != null &&
       "baseURL" in this._definition.authentication
     ) {
-      // convert into a real match pattern: https://developer.chrome.com/docs/extensions/mv3/match_patterns/
+      // Convert into a real match pattern: https://developer.chrome.com/docs/extensions/mv3/match_patterns/
       const baseUrlTemplate = this._definition.authentication.baseURL;
       const baseUrl = mapArgs(baseUrlTemplate, serviceConfig);
       patterns.push(baseUrl + (baseUrl.endsWith("/") ? "*" : "/*"));
@@ -133,7 +133,7 @@ class LocalDefinedService<
     if (this.isToken) {
       const definition: TokenContext = (this._definition
         .authentication as TokenAuthenticationDefinition).token;
-      // console.debug("token context", { definition, serviceConfig });
+      // Console.debug("token context", { definition, serviceConfig });
       return mapArgs<TokenContext>(definition, serviceConfig);
     }
     return undefined;

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -53,6 +53,7 @@ export function useDependency(
     if (configuredServices.length > 1) {
       throw new Error("Multiple matching services configured");
     }
+
     return head(configuredServices);
   }, [values.services]);
 
@@ -65,6 +66,7 @@ export function useDependency(
       const service = await registry.lookup(dependency.id);
       return { localConfig: localConfig, service };
     }
+
     throw new Error("No integration selected");
   }, [dependency?.config]);
 
@@ -78,6 +80,7 @@ export function useDependency(
     if (origins != null) {
       return checkPermissions([{ origins }]);
     }
+
     return false;
   }, [origins]);
 

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -56,7 +56,7 @@ export function excludeSecrets(
   for (const [key, type] of Object.entries(inputProperties(service.schema))) {
     // @ts-ignore: ts doesn't think $ref can be on SchemaDefinition
     if (!REF_SECRETS.includes(type["$ref"])) {
-      // safe because we're getting from Object.entries
+      // Safe because we're getting from Object.entries
       // eslint-disable-next-line security/detect-object-injection
       result[key] = config[key];
     }
@@ -69,7 +69,7 @@ export async function pixieServiceFactory(): Promise<SanitizedServiceConfigurati
     _sanitizedServiceConfigurationBrand: undefined,
     id: undefined,
     serviceId: PIXIEBRIX_SERVICE_ID,
-    // don't need to proxy requests to our own service
+    // Don't need to proxy requests to our own service
     proxy: false,
     config: {} as SanitizedConfig,
   };

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -88,10 +88,15 @@ let wasInitialized = false;
 
 class LazyLocatorFactory {
   private remote: ConfigurableAuth[] = [];
+
   private local: RawServiceConfiguration[] = [];
+
   private options: Option[];
+
   private _initialized = false;
+
   private _refreshPromise: Promise<void>;
+
   private updateTimestamp: number = undefined;
 
   constructor() {

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -174,7 +174,8 @@ class LazyLocatorFactory {
     if (serviceId === PIXIEBRIX_SERVICE_ID) {
       // HACK: for now use the separate storage for the extension key
       return pixieServiceFactory();
-    } else if (!authId) {
+    }
+    if (!authId) {
       throw new NotConfiguredError(
         `No configuration selected for ${serviceId}`,
         serviceId

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -61,6 +61,7 @@ export function excludeSecrets(
       result[key] = config[key];
     }
   }
+
   return result;
 }
 
@@ -97,6 +98,7 @@ class LazyLocatorFactory {
     if (wasInitialized) {
       throw new Error("LazyLocatorFactory is a singleton class");
     }
+
     wasInitialized = true;
   }
 
@@ -160,6 +162,7 @@ class LazyLocatorFactory {
     if (!this.initialized) {
       await this.refresh();
     }
+
     return this.local.find((x) => x.id === authId);
   }
 
@@ -175,6 +178,7 @@ class LazyLocatorFactory {
       // HACK: for now use the separate storage for the extension key
       return pixieServiceFactory();
     }
+
     if (!authId) {
       throw new NotConfiguredError(
         `No configuration selected for ${serviceId}`,

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -24,7 +24,7 @@ import { isBackgroundPage } from "webext-detect-page";
 
 function selectError(error: unknown): SerializedError {
   if (error instanceof PromiseRejectionEvent) {
-    // convert the project rejection to an error instance
+    // Convert the project rejection to an error instance
     if (error.reason instanceof Error) {
       error = error.reason;
     } else if (typeof error.reason === "string") {
@@ -41,10 +41,7 @@ function selectError(error: unknown): SerializedError {
  * @param error the error object
  * @param context optional context for error telemetry
  */
-export function reportError(
-  error: unknown,
-  context?: MessageContext
-): void {
+export function reportError(error: unknown, context?: MessageContext): void {
   void _reportError(error, context).catch((reportingError: unknown) => {
     console.error("An error occurred when reporting an error", {
       originalError: error,

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -33,6 +33,7 @@ function selectError(error: unknown): SerializedError {
       error = new Error(error.reason?.message ?? "Uncaught error in promise");
     }
   }
+
   return serializeError(error);
 }
 

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -79,7 +79,8 @@ export function toLogArgument(error: unknown): LogArgument {
     // the function argument for rollbar.log is a callback to call once the error has been reported, drop
     // these prevent accidentally calling the callback
     return undefined;
-  } else if (typeof error === "object") {
+  }
+  if (typeof error === "object") {
     // the custom data or error object
     return error;
   }

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -76,12 +76,12 @@ export const rollbar: Rollbar = Rollbar.init({
  */
 export function toLogArgument(error: unknown): LogArgument {
   if (typeof error === "function") {
-    // the function argument for rollbar.log is a callback to call once the error has been reported, drop
+    // The function argument for rollbar.log is a callback to call once the error has been reported, drop
     // these prevent accidentally calling the callback
     return undefined;
   }
   if (typeof error === "object") {
-    // the custom data or error object
+    // The custom data or error object
     return error;
   }
   return error.toString();

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -80,10 +80,12 @@ export function toLogArgument(error: unknown): LogArgument {
     // these prevent accidentally calling the callback
     return undefined;
   }
+
   if (typeof error === "object") {
     // The custom data or error object
     return error;
   }
+
   return error.toString();
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,12 +47,19 @@ export abstract class Service<
   TOAuth extends AuthData = AuthData
 > implements IService<TConfig> {
   id: string;
+
   name: string;
+
   description?: string;
+
   icon?: BlockIcon;
+
   abstract schema: Schema;
+
   abstract hasAuth: boolean;
+
   abstract isOAuth2: boolean;
+
   abstract isToken: boolean;
 
   protected constructor(
@@ -85,13 +92,21 @@ export abstract class Service<
 export abstract class ExtensionPoint<TConfig extends BaseExtensionConfig>
   implements IExtensionPoint {
   public readonly id: string;
+
   public readonly name: string;
+
   public readonly description: string;
+
   public readonly icon: BlockIcon;
+
   protected readonly extensions: IExtension<TConfig>[] = [];
+
   protected readonly template?: string;
+
   public abstract readonly inputSchema: Schema;
+
   protected readonly logger: Logger;
+
   public readonly syncInstall: boolean = false;
 
   /**
@@ -171,14 +186,19 @@ export abstract class ExtensionPoint<TConfig extends BaseExtensionConfig>
 
 export abstract class Block implements IBlock {
   readonly id: string;
+
   readonly name: string;
+
   readonly description: string;
+
   readonly icon: BlockIcon;
 
   abstract readonly inputSchema: Schema;
+
   readonly outputSchema?: Schema = undefined;
 
   readonly permissions = {};
+
   readonly defaultOptions = {};
 
   protected constructor(

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,7 +129,7 @@ export abstract class ExtensionPoint<TConfig extends BaseExtensionConfig>
     );
     this.removeExtensions(removed.map((x) => x.id));
 
-    // clear extensions and re-populate with updated extensions
+    // Clear extensions and re-populate with updated extensions
     this.extensions.splice(0, this.extensions.length);
     this.extensions.push(...extensions);
 
@@ -146,7 +146,7 @@ export abstract class ExtensionPoint<TConfig extends BaseExtensionConfig>
       console.warn(
         `Extension ${extension.id} already registered for the extension point ${this.id}`
       );
-      // index is guaranteed to be a number, and this.extensions is an array
+      // Index is guaranteed to be a number, and this.extensions is an array
       // eslint-disable-next-line security/detect-object-injection
       this.extensions[index] = extension;
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,8 +54,10 @@ export function getAllPropertyNames(obj: object): string[] {
     for (const name of Object.getOwnPropertyNames(current)) {
       props.add(name);
     }
+
     current = Object.getPrototypeOf(current);
   }
+
   return [...props.values()];
 }
 
@@ -111,6 +113,7 @@ export async function awaitValue<T>(
     if (predicate(value)) {
       return value;
     }
+
     await sleep(retryMillis);
   } while (Date.now() - start < waitMillis);
 
@@ -121,6 +124,7 @@ export function isPrimitive(val: unknown): val is Primitive {
   if (typeof val === "object") {
     return val === null;
   }
+
   return typeof val !== "function";
 }
 
@@ -128,15 +132,18 @@ export function removeUndefined(obj: unknown): unknown {
   if (obj === undefined) {
     return null;
   }
+
   if (Array.isArray(obj)) {
     return obj.map((x) => removeUndefined(x));
   }
+
   if (typeof obj === "object") {
     return mapValues(
       pickBy(obj, (x) => x !== undefined),
       (x) => removeUndefined(x)
     );
   }
+
   return obj;
 }
 
@@ -146,12 +153,15 @@ export function boolean(value: unknown): boolean {
       value.trim().toLowerCase()
     );
   }
+
   if (typeof value === "number") {
     return value !== 0;
   }
+
   if (typeof value === "boolean") {
     return value;
   }
+
   return false;
 }
 
@@ -201,15 +211,19 @@ export function cleanValue(value: unknown, maxDepth = 5, depth = 0): unknown {
   if (depth > maxDepth) {
     return undefined;
   }
+
   if (Array.isArray(value)) {
     return value.map(recurse);
   }
+
   if (typeof value === "object" && value != null) {
     return mapValues(value, recurse);
   }
+
   if (typeof value === "function" || typeof value === "symbol") {
     return undefined;
   }
+
   return value;
 }
 
@@ -280,6 +294,7 @@ export function getPropByPath(
       if (coalesce || index === rawParts.length - 1) {
         return null;
       }
+
       throw new InvalidPathError(`${path} undefined (missing ${part})`, path);
     }
 
@@ -299,9 +314,11 @@ export function isNullOrBlank(value: unknown): boolean {
   if (value == null) {
     return true;
   }
+
   if (typeof value === "string" && value.trim() === "") {
     return true;
   }
+
   return false;
 }
 
@@ -327,11 +344,14 @@ export async function rejectOnCancelled<T>(
     if (isCancelled()) {
       throw new PromiseCancelled("Promise was cancelled");
     }
+
     throw error;
   }
+
   if (isCancelled()) {
     throw new PromiseCancelled("Promise was cancelled");
   }
+
   return rv;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,9 +127,11 @@ export function isPrimitive(val: unknown): val is Primitive {
 export function removeUndefined(obj: unknown): unknown {
   if (obj === undefined) {
     return null;
-  } else if (Array.isArray(obj)) {
+  }
+  if (Array.isArray(obj)) {
     return obj.map((x) => removeUndefined(x));
-  } else if (typeof obj === "object") {
+  }
+  if (typeof obj === "object") {
     return mapValues(
       pickBy(obj, (x) => x !== undefined),
       (x) => removeUndefined(x)
@@ -143,9 +145,11 @@ export function boolean(value: unknown): boolean {
     return ["true", "t", "yes", "y", "on", "1"].includes(
       value.trim().toLowerCase()
     );
-  } else if (typeof value === "number") {
+  }
+  if (typeof value === "number") {
     return value !== 0;
-  } else if (typeof value === "boolean") {
+  }
+  if (typeof value === "boolean") {
     return value;
   }
   return false;
@@ -196,11 +200,14 @@ export function cleanValue(value: unknown, maxDepth = 5, depth = 0): unknown {
 
   if (depth > maxDepth) {
     return undefined;
-  } else if (Array.isArray(value)) {
+  }
+  if (Array.isArray(value)) {
     return value.map(recurse);
-  } else if (typeof value === "object" && value != null) {
+  }
+  if (typeof value === "object" && value != null) {
     return mapValues(value, recurse);
-  } else if (typeof value === "function" || typeof value === "symbol") {
+  }
+  if (typeof value === "function" || typeof value === "symbol") {
     return undefined;
   }
   return value;
@@ -291,7 +298,8 @@ export function getPropByPath(
 export function isNullOrBlank(value: unknown): boolean {
   if (value == null) {
     return true;
-  } else if (typeof value === "string" && value.trim() === "") {
+  }
+  if (typeof value === "string" && value.trim() === "") {
     return true;
   }
   return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -232,6 +232,7 @@ export function cleanValue(value: unknown, maxDepth = 5, depth = 0): unknown {
  */
 export class InvalidPathError extends Error {
   public readonly path: string;
+
   readonly input: unknown;
 
   constructor(message: string, path: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -245,7 +245,7 @@ export function getPropByPath(
     proxy = noopProxy,
   }: { args?: object; proxy?: ReadProxy } | undefined = {}
 ): unknown {
-  // consider using jsonpath syntax https://www.npmjs.com/package/jsonpath-plus
+  // Consider using jsonpath syntax https://www.npmjs.com/package/jsonpath-plus
 
   const { toJS = noopProxy.toJS, get = noopProxy.get } = proxy;
 
@@ -255,7 +255,7 @@ export function getPropByPath(
   for (const [index, rawPart] of rawParts.entries()) {
     const previous = value;
 
-    // handle null coalescing syntax
+    // Handle null coalescing syntax
     let part: string | number = rawPart;
     let coalesce = false;
     let numeric = false;

--- a/src/validators/generic.ts
+++ b/src/validators/generic.ts
@@ -206,7 +206,7 @@ export function useExtensionValidator(
   return useAsyncState(validationPromise);
 }
 
-// const PIXIEBRIX_SCHEMA = /^https:\/\/app.pixiebrix\.com\/schemas\//i;
+// Const PIXIEBRIX_SCHEMA = /^https:\/\/app.pixiebrix\.com\/schemas\//i;
 
 const pixieResolver: ResolverOptions = {
   order: 1,

--- a/src/validators/generic.ts
+++ b/src/validators/generic.ts
@@ -215,6 +215,7 @@ const pixieResolver: ResolverOptions = {
     if (SCHEMA_URLS[file.url]) {
       return SCHEMA_URLS[file.url] as any;
     }
+
     throw new Error(`Unknown file ${file.url}`);
   },
 };

--- a/src/validators/validation.ts
+++ b/src/validators/validation.ts
@@ -177,7 +177,8 @@ function serviceSchemaFactory(): Yup.Schema<unknown> {
                 });
               }
               return true;
-            } else if (value == null) {
+            }
+            if (value == null) {
               return this.createError({
                 message: "Select a service configuration",
               });

--- a/src/validators/validation.ts
+++ b/src/validators/validation.ts
@@ -92,9 +92,11 @@ export function configSchemaFactory(
       if (isPlainObject(val)) {
         return Yup.lazy(blockSchemaFactory);
       }
+
       return Yup.array().of(Yup.lazy(blockSchemaFactory)).min(1);
     });
   }
+
   switch (schema.type) {
     case "object": {
       return Yup.lazy((val) => {
@@ -104,15 +106,18 @@ export function configSchemaFactory(
               if (typeof definition === "boolean") {
                 return wrapRequired(Yup.string());
               }
+
               return configSchemaFactory(definition, {
                 required: (schema.required ?? []).includes(prop),
               });
             })
           );
         }
+
         return Yup.string();
       });
     }
+
     case "array": {
       if (typeof schema.items === "boolean") {
         throw new TypeError(
@@ -135,9 +140,11 @@ export function configSchemaFactory(
         );
       }
     }
+
     case "boolean": {
       return Yup.bool();
     }
+
     default: {
       return wrapRequired(Yup.string());
     }
@@ -159,6 +166,7 @@ function serviceSchemaFactory(): Yup.Schema<unknown> {
                 return false;
               }
             }
+
             return true;
           }
         ),
@@ -176,13 +184,16 @@ function serviceSchemaFactory(): Yup.Schema<unknown> {
                   message: "PixieBrix service configuration should be blank",
                 });
               }
+
               return true;
             }
+
             if (value == null) {
               return this.createError({
                 message: "Select a service configuration",
               });
             }
+
             try {
               await locate(this.parent.id, value);
             } catch (error: unknown) {
@@ -191,10 +202,12 @@ function serviceSchemaFactory(): Yup.Schema<unknown> {
                   message: "Configuration no longer available",
                 });
               }
+
               console.error(
                 `An error occurred validating service: ${this.parent.id}`
               );
             }
+
             return true;
           }
         ),

--- a/src/vendors/globalSearch.ts
+++ b/src/vendors/globalSearch.ts
@@ -24,6 +24,7 @@ export function globalSearch(
       if (returnFirstResult) {
         return [{ path: address, value }];
       }
+
       found.push({ path: address, value });
     }
 
@@ -47,5 +48,6 @@ export function globalSearch(
       searched.push(obj);
     }
   }
+
   return Array.from(found);
 }

--- a/src/vendors/globalSearch.ts
+++ b/src/vendors/globalSearch.ts
@@ -3,7 +3,7 @@ export function globalSearch(
   value: unknown,
   returnFirstResult = false
 ): unknown[] {
-  // adapted from: https://stackoverflow.com/a/12103127/402560
+  // Adapted from: https://stackoverflow.com/a/12103127/402560
   if (startObject == null) {
     throw Error("startObject cannot be null");
   }

--- a/src/vendors/initialize.js
+++ b/src/vendors/initialize.js
@@ -10,7 +10,7 @@ var combinators = [" ", ">", "+", "~"]; // https://developer.mozilla.org/en-US/d
 var fraternisers = ["+", "~"]; // These combinators involve siblings.
 var complexTypes = ["ATTR", "PSEUDO", "ID", "CLASS"]; // These selectors are based upon attributes.
 
-//Check if browser supports "matches" function
+// Check if browser supports "matches" function
 if (typeof Element !== "undefined" && !Element.prototype.matches) {
   Element.prototype.matches =
     Element.prototype.matchesSelector ||

--- a/src/vendors/libraryDetector/detect.ts
+++ b/src/vendors/libraryDetector/detect.ts
@@ -39,6 +39,7 @@ async function detectLibraries(): Promise<Library[]> {
       );
     }
   }
+
   return detectedLibraries;
 }
 

--- a/src/vendors/libraryDetector/libraries.js
+++ b/src/vendors/libraryDetector/libraries.js
@@ -55,6 +55,7 @@ export default {
 
         return { version: gwtVersion };
       }
+
       return false;
     },
   },
@@ -67,6 +68,7 @@ export default {
       if (win.Ink && win.Ink.createModule) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -79,6 +81,7 @@ export default {
       if (win.vaadin && win.vaadin.registerWidgetset) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -121,6 +124,7 @@ export default {
               return true;
               // Bootstrap >= 2.0.0 and <= 3.1.0 detection
             }
+
             if (
               new RegExp(RE_PREFIX_V3 + component).test(
                 win.$.fn[component].toString()
@@ -130,6 +134,7 @@ export default {
               return true;
               // Bootstrap < 3.1.0 detection
             }
+
             if (
               new RegExp(RE_PREFIX_V2 + component).test(
                 win.$.fn[component].toString()
@@ -161,6 +166,7 @@ export default {
       if (win.Foundation && win.Foundation.Toggler) {
         return { version: win.Foundation.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -174,6 +180,7 @@ export default {
       if (win.Polymer && win.Polymer.dom) {
         return { version: win.Polymer.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -191,6 +198,7 @@ export default {
         );
         return { version: versions[versions.length - 1] };
       }
+
       return false;
     },
   },
@@ -204,6 +212,7 @@ export default {
       if (win.Highcharts && win.Highcharts.Point) {
         return { version: win.Highcharts.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -216,6 +225,7 @@ export default {
       if (win.$jit && win.$jit.PieChart) {
         return { version: win.$jit.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -229,6 +239,7 @@ export default {
       if (win.$ && win.$.plot) {
         return { version: win.$.plot.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -242,6 +253,7 @@ export default {
       if (win.createjs && win.createjs.promote) {
         return { version: UNKNOWN_VERSION }; // No version info available
       }
+
       return false;
     },
   },
@@ -254,6 +266,7 @@ export default {
       if (win.google && win.google.maps) {
         return { version: win.google.maps.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -270,6 +283,7 @@ export default {
           version: jq.fn.jquery.replace(/[^\d+\.+]/g, "") || UNKNOWN_VERSION,
         };
       }
+
       return false;
     },
   },
@@ -284,6 +298,7 @@ export default {
       if (jq && jq.fn) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -306,11 +321,13 @@ export default {
               plugins[i].substr(0, 1).toUpperCase() + plugins[i].substr(1)
             );
         }
+
         return {
           version: jq.ui.version || UNKNOWN_VERSION,
           details: concat.length ? "Plugins used: " + concat.join(",") : "",
         };
       }
+
       return false;
     },
   },
@@ -330,6 +347,7 @@ export default {
           details: "Details: " + (win.dijit ? "Uses Dijit" : "none"),
         };
       }
+
       return false;
     },
   },
@@ -342,6 +360,7 @@ export default {
       if (win.Prototype && win.Prototype.BrowserFeatures) {
         return { version: win.Prototype.Version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -354,6 +373,7 @@ export default {
       if (win.Scriptaculous && win.Scriptaculous.load) {
         return { version: win.Scriptaculous.Version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -366,6 +386,7 @@ export default {
       if (win.MooTools && win.MooTools.build) {
         return { version: win.MooTools.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -378,6 +399,7 @@ export default {
       if (win.Spry && win.Spry.Data) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -390,6 +412,7 @@ export default {
       if (win.YAHOO && win.YAHOO.util) {
         return { version: win.YAHOO.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -403,6 +426,7 @@ export default {
       if (win.YUI && win.YUI.Env) {
         return { version: win.YUI.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -416,6 +440,7 @@ export default {
       if (win.qx && win.qx.Bootstrap) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -428,9 +453,11 @@ export default {
       if (win.Ext && win.Ext.versions) {
         return { version: win.Ext.versions.core.version };
       }
+
       if (win.Ext) {
         return { version: win.Ext.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -443,6 +470,7 @@ export default {
       if (win.base2 && win.base2.dom) {
         return { version: win.base2.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -456,6 +484,7 @@ export default {
       if (win.goog && win.goog.provide) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -468,6 +497,7 @@ export default {
       if (win.Raphael && win.Raphael.circle) {
         return { version: win.Raphael.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -481,11 +511,13 @@ export default {
       function isMatch(node) {
         return node != null && node._reactRootContainer != null;
       }
+
       function nodeFilter(node) {
         return isMatch(node)
           ? NodeFilter.FILTER_ACCEPT
           : NodeFilter.FILTER_SKIP;
       }
+
       var reactRoot = document.getElementById("react-root");
       var altHasReact = document.querySelector("*[data-reactroot]");
       var bodyReactRoot =
@@ -503,6 +535,7 @@ export default {
       ) {
         return { version: (win.React && win.React.version) || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -516,6 +549,7 @@ export default {
       function isMatch(node) {
         return node != null && node._reactRootContainer != null;
       }
+
       var reactRoot = document.getElementById("react-root");
       var altHasReact = document.querySelector("*[data-reactroot]");
       var hasReactRoot =
@@ -523,6 +557,7 @@ export default {
       if (hasReactRoot || reactRoot || altHasReact || win.React) {
         return { version: (win.React && win.React.version) || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -538,6 +573,7 @@ export default {
           version: (window.next && window.next.version) || UNKNOWN_VERSION,
         };
       }
+
       return false;
     },
   },
@@ -551,6 +587,7 @@ export default {
       if (win.__NEXT_DATA__) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -567,20 +604,24 @@ export default {
         if ("__k" in node && "props" in node.__k && "type" in node.__k) {
           return true;
         }
+
         return (
           "_component" in node ||
           "__preactattr_" in node ||
           (expando && node[expando] != null)
         );
       }
+
       function getMatch(node) {
         return node != null && isMatch(node) && node;
       }
+
       function nodeFilter(node) {
         return isMatch(node)
           ? NodeFilter.FILTER_ACCEPT
           : NodeFilter.FILTER_SKIP;
       }
+
       var preactRoot =
         getMatch(document.body) || getMatch(document.body.firstElementChild);
       if (!preactRoot) {
@@ -588,21 +629,26 @@ export default {
           .createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, nodeFilter)
           .nextNode();
       }
+
       if (preactRoot || win.preact) {
         var version = UNKNOWN_VERSION;
         if (preactRoot) {
           if ("__k" in preactRoot) {
             version = "10";
           }
+
           if ("__preactattr_" in preactRoot) {
             version = "8";
           }
+
           if (expando && preactRoot[expando] != null) {
             version = "7";
           }
         }
+
         return { version: version };
       }
+
       return false;
     },
   },
@@ -619,16 +665,20 @@ export default {
           version = "10";
           return true;
         }
+
         return node._component != null || node.__preactattr_ != null;
       }
+
       function getMatch(node) {
         return node != null && isMatch(node);
       }
+
       var preactRoot =
         getMatch(document.body) || getMatch(document.body.firstElementChild);
       if (preactRoot || win.preact) {
         return { version: version };
       }
+
       return false;
     },
   },
@@ -642,6 +692,7 @@ export default {
       if (win.Modernizr && win.Modernizr.addTest) {
         return { version: win.Modernizr._version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -655,6 +706,7 @@ export default {
       if (win.Processing && win.Processing.box) {
         return { version: Processing.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -668,6 +720,7 @@ export default {
       if (win.Backbone && win.Backbone.Model.extend) {
         return { version: win.Backbone.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -682,6 +735,7 @@ export default {
       if (win.L && win.L.GeoJSON && (win.L.marker || win.L.Marker)) {
         return { version: win.L.version || win.L.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -695,6 +749,7 @@ export default {
       if (win.L && win.L.mapbox && win.L.mapbox.geocoder) {
         return { version: win.L.mapbox.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -718,6 +773,7 @@ export default {
       if (_ && wrapper.__wrapped__) {
         return { version: _.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -737,6 +793,7 @@ export default {
       ) {
         return { version: win._.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -749,6 +806,7 @@ export default {
       if (win.Sammy && win.Sammy.Application.curry) {
         return { version: win.Sammy.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -761,6 +819,7 @@ export default {
       if (win.Rico && window.Rico.checkIfComplete) {
         return { version: win.Rico.Version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -773,6 +832,7 @@ export default {
       if (win.MochiKit && win.MochiKit.Base.module) {
         return { version: MochiKit.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -785,6 +845,7 @@ export default {
       if (win.Raphael && win.Raphael.fn.g) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -797,12 +858,15 @@ export default {
       if (win.gloader && win.gloader.getRequests) {
         return { version: UNKNOWN_VERSION };
       }
+
       if (win.glow && win.glow.dom) {
         return { version: win.glow.VERSION || UNKNOWN_VERSION };
       }
+
       if (win.Glow) {
         return { version: win.Glow.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -817,6 +881,7 @@ export default {
       if (win.io && (win.io.sockets || win.io.Socket)) {
         return { version: win.io.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -830,6 +895,7 @@ export default {
       if (win.Mustache && win.Mustache.to_html) {
         return { version: win.Mustache.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -843,6 +909,7 @@ export default {
       if (win.fabric && win.fabric.util) {
         return { version: win.fabric.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -856,6 +923,7 @@ export default {
       if (win.Fuse) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -869,6 +937,7 @@ export default {
       if (win.TWEEN && win.TWEEN.Easing) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -881,6 +950,7 @@ export default {
       if (win.SC && win.SC.Application) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -894,6 +964,7 @@ export default {
       if (win.Zepto && win.Zepto.fn) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -907,9 +978,11 @@ export default {
       if (win.THREE && win.THREE.REVISION) {
         return { version: "r" + win.THREE.REVISION };
       }
+
       if (win.THREE) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -923,6 +996,7 @@ export default {
       if (win.PhiloGL && win.PhiloGL.Camera) {
         return { version: win.PhiloGL.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -936,9 +1010,11 @@ export default {
       if (win.Caman && win.Caman.version) {
         return { version: win.Caman.version.release };
       }
+
       if (win.Caman) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -951,6 +1027,7 @@ export default {
       if (win.yepnope && win.yepnope.injectJs) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -963,6 +1040,7 @@ export default {
       if (win.$LAB && win.$LAB.setOptions) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -976,6 +1054,7 @@ export default {
       if (win.head && win.head.js) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -988,6 +1067,7 @@ export default {
       if (win.CJS && win.CJS.start) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1009,6 +1089,7 @@ export default {
       ) {
         return { version: req.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1021,6 +1102,7 @@ export default {
       if (win.RightJS && win.RightJS.isNode) {
         return { version: win.RightJS.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1034,6 +1116,7 @@ export default {
       if (jq && jq.tools) {
         return { version: jq.tools.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1047,6 +1130,7 @@ export default {
       if (win.Pusher && win.Pusher.Channel) {
         return { version: win.Pusher.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1060,6 +1144,7 @@ export default {
       if (win.paper && win.paper.Point) {
         return { version: win.paper.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1072,6 +1157,7 @@ export default {
       if (win.swiffy && win.swiffy.Stage) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1085,6 +1171,7 @@ export default {
       if (win.move && win.move.compile) {
         return { version: win.move.version() || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1098,6 +1185,7 @@ export default {
       if (win.amplify && win.amplify.publish) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1110,6 +1198,7 @@ export default {
       if (win.Popcorn && win.Popcorn.Events) {
         return { version: win.Popcorn.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1123,6 +1212,7 @@ export default {
       if (win.d3 && win.d3.select) {
         return { version: win.d3.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1136,6 +1226,7 @@ export default {
       if (win.Handlebars && win.Handlebars.compile) {
         return { version: win.Handlebars.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1149,6 +1240,7 @@ export default {
       if (win.ko && win.ko.applyBindings) {
         return { version: win.ko.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1161,6 +1253,7 @@ export default {
       if (win.Spine && win.Spine.Controller) {
         return { version: win.Spine.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1175,6 +1268,7 @@ export default {
       if (jq && jq.fn && jq.fn.jquery && jq.mobile) {
         return { version: jq.mobile.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1188,6 +1282,7 @@ export default {
       if (win.WebFont && win.WebFont.load) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1204,9 +1299,11 @@ export default {
           version: ngVersion.getAttribute("ng-version") || UNKNOWN_VERSION,
         };
       }
+
       if (win.ng && win.ng.probe instanceof Function) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1221,9 +1318,11 @@ export default {
       if (ng && ng.version && ng.version.full) {
         return { version: ng.version.full };
       }
+
       if (ng) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1238,6 +1337,7 @@ export default {
       if (ember && ember.GUID_KEY) {
         return { version: ember.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1252,6 +1352,7 @@ export default {
         // Hammer.VERSION available in 1.0.10+
         return { version: win.Hammer.VERSION || "&lt; 1.0.10" };
       }
+
       return false;
     },
   },
@@ -1265,6 +1366,7 @@ export default {
       if (win.Visibility && win.Visibility.every) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1288,9 +1390,11 @@ export default {
             velocity.version.patch,
         };
       }
+
       if (velocity && velocity.RegisterEffect) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1305,6 +1409,7 @@ export default {
       if (iv && iv.__ceGUID === "ifvisible.object.event.identifier") {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1319,6 +1424,7 @@ export default {
         // Version 4.4.3 returns simply "4.4.3"; version 1.5.2 returns "v1.5.2"
         return { version: px.VERSION.replace("v", "") || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1332,6 +1438,7 @@ export default {
       if (dc && dc.registerChart) {
         return { version: dc.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1344,6 +1451,7 @@ export default {
       if (win.TweenMax && win.TweenMax.pauseAll) {
         return { version: win.TweenMax.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1356,6 +1464,7 @@ export default {
       if (win.FastClick && win.FastClick.notNeeded) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1368,6 +1477,7 @@ export default {
       if (win.Isotope || (win.$ != null && win.$.Isotope)) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1380,6 +1490,7 @@ export default {
       if (win.Marionette && win.Marionette.Application) {
         return { version: win.Marionette.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1392,6 +1503,7 @@ export default {
       if (win.can && win.can.Construct) {
         return { version: win.can.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1406,6 +1518,7 @@ export default {
           ? NodeFilter.FILTER_ACCEPT
           : NodeFilter.FILTER_SKIP;
       }
+
       var hasVueNode =
         document
           .createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, isVueNode)
@@ -1413,6 +1526,7 @@ export default {
       if (hasVueNode || win.Vue) {
         return { version: (win.Vue && win.Vue.version) || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1425,6 +1539,7 @@ export default {
       if (win.Vue) {
         return { version: (win.Vue && win.Vue.version) || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1437,6 +1552,7 @@ export default {
       if ((win.__NUXT__ && win.__NUXT__.data != null) || win.$nuxt) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1449,6 +1565,7 @@ export default {
       if (win.__NUXT__ || win.$nuxt) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1461,6 +1578,7 @@ export default {
       if (win.Two && win.Two.Utils) {
         return { version: win.Two.Version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1473,6 +1591,7 @@ export default {
       if (win.BREWSER && win.BREWSER.ua) {
         return { version: BREWSER.VERSION || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1485,6 +1604,7 @@ export default {
       if (win.componentHandler && win.componentHandler.upgradeElement) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1497,6 +1617,7 @@ export default {
       if (win.kendo && win.kendo.View && win.kendo.View.extend) {
         return { version: win.kendo.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1509,6 +1630,7 @@ export default {
       if (win.Matter && win.Matter.Engine) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1521,6 +1643,7 @@ export default {
       if (win.riot && win.riot.mixin) {
         return { version: win.riot.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1533,6 +1656,7 @@ export default {
       if (win.seajs && win.seajs.use) {
         return { version: win.seajs.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1546,6 +1670,7 @@ export default {
         // Version 1.0.0 has neither "isMoment" nor "version"
         return { version: win.moment.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1558,6 +1683,7 @@ export default {
       if (win.moment && win.moment.tz) {
         return { version: win.moment.tz.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1570,6 +1696,7 @@ export default {
       if (win.ScrollMagic && win.ScrollMagic.Controller) {
         return { version: ScrollMagic.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1582,10 +1709,12 @@ export default {
         // 2.x - exact version only for 2.3
         return { version: win.swfobject.version || UNKNOWN_VERSION };
       }
+
       if (win.deconcept && win.deconcept.SWFObject) {
         // 1.x
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1599,6 +1728,7 @@ export default {
       if (jq && jq.fn && jq.fn.jquery && jq.flexslider) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1611,6 +1741,7 @@ export default {
       if (win.spf && win.spf.init) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1623,6 +1754,7 @@ export default {
       if (win.numeral && win.isNumeral) {
         return { version: win.numeral.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1635,6 +1767,7 @@ export default {
       if (win.BOOMR && win.BOOMR.utils && win.BOOMR.init) {
         return { version: win.BOOMR.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1647,6 +1780,7 @@ export default {
       if (win.Framer && win.Framer.Layer) {
         return { version: win.Framer.Version.build || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1661,6 +1795,7 @@ export default {
       if (markoElement) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1683,6 +1818,7 @@ export default {
       if (document.getElementById("___gatsby")) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1695,6 +1831,7 @@ export default {
       if (win.Shopify && win.Shopify.shop) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1749,6 +1886,7 @@ export default {
       if (win.wixBiSession) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1794,8 +1932,10 @@ export default {
                 ) {
                   version = matches[1];
                 }
+
                 return { version: version };
               }
+
               return false;
             });
         });
@@ -1819,6 +1959,7 @@ export default {
       if (win.WIZ_global_data) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1831,6 +1972,7 @@ export default {
       if (document.__wizdispatcher) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1852,9 +1994,11 @@ export default {
             : UNKNOWN_VERSION,
         };
       }
+
       if (core) {
         return { version: core.version || UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -1952,6 +2096,7 @@ export default {
       if (win.__GUESS__ && win.__GUESS__.guess) {
         return { version: UNKNOWN_VERSION };
       }
+
       return false;
     },
   },
@@ -2006,6 +2151,7 @@ export default {
           version: generatorMeta.getAttribute("content").replace(/^\w+\s/, ""),
         };
       }
+
       if (win.Joomla || hasJoomlaBootstrap) {
         return { version: UNKNOWN_VERSION };
       }

--- a/src/vendors/libraryDetector/libraries.js
+++ b/src/vendors/libraryDetector/libraries.js
@@ -8,7 +8,7 @@ export default {
     icon: "gwt",
     url: "http://www.gwtproject.org/",
     test: function (win) {
-      // pretty complicated, many possible tell tales
+      // Pretty complicated, many possible tell tales
       var doc = win.document,
         hasHistFrame = doc.getElementById("__gwt_historyFrame"),
         hasGwtUid = doc.gwt_uid,
@@ -21,7 +21,7 @@ export default {
           win.__gwt_stylesLoaded ||
           win.__gwt_activeModules;
 
-      // use the many possible indicators
+      // Use the many possible indicators
       if (
         hasHistFrame ||
         hasGwtUid ||
@@ -31,13 +31,13 @@ export default {
         hasJsonP ||
         hasRootWinApp
       ) {
-        // carefully look at frames, but only if certain is GWT frame
+        // Carefully look at frames, but only if certain is GWT frame
         var frames = doc.getElementsByTagName("iframe"),
           gwtVersion = UNKNOWN_VERSION;
         for (var n = 0; n < frames.length; n++) {
-          // catch security access errors
+          // Catch security access errors
           try {
-            var hasNegativeTabIndex = frames[n].tabIndex < 0; // on for GWT
+            var hasNegativeTabIndex = frames[n].tabIndex < 0; // On for GWT
             if (
               hasNegativeTabIndex &&
               frames[n].contentWindow &&
@@ -88,7 +88,7 @@ export default {
     icon: "bootstrap",
     url: "http://getbootstrap.com/",
     npm: "bootstrap",
-    // look for a function Boostrap has added to jQuery - regex for BS 2 & 3
+    // Look for a function Boostrap has added to jQuery - regex for BS 2 & 3
     test: function (win) {
       var jQueryAvailable = win.$ && win.$.fn,
         RE_PREFIX_V2 = "\\$this\\.data\\((?:'|\")",
@@ -240,7 +240,7 @@ export default {
     npm: "createjs",
     test: function (win) {
       if (win.createjs && win.createjs.promote) {
-        return { version: UNKNOWN_VERSION }; // no version info available
+        return { version: UNKNOWN_VERSION }; // No version info available
       }
       return false;
     },
@@ -809,11 +809,11 @@ export default {
 
   "Socket.IO": {
     id: "socketio",
-    icon: "socketio", // currently has no icon
+    icon: "socketio", // Currently has no icon
     url: "https://socket.io/",
     npm: "socket.io",
     test: function (win) {
-      // version 0.6.2 uses only io.Socket; more recent versions also have io.sockets
+      // Version 0.6.2 uses only io.Socket; more recent versions also have io.sockets
       if (win.io && (win.io.sockets || win.io.Socket)) {
         return { version: win.io.version || UNKNOWN_VERSION };
       }
@@ -836,7 +836,7 @@ export default {
 
   "Fabric.js": {
     id: "fabricjs",
-    icon: "icon38", // currently has no icon
+    icon: "icon38", // Currently has no icon
     url: "http://fabricjs.com/",
     npm: "fabric",
     test: function (win) {
@@ -862,7 +862,7 @@ export default {
 
   "Tween.js": {
     id: "tweenjs",
-    icon: "icon38", // currently has no icon
+    icon: "icon38", // Currently has no icon
     url: "https://github.com/tweenjs/tween.js",
     npm: "tween.js",
     test: function (win) {
@@ -900,7 +900,7 @@ export default {
 
   "three.js": {
     id: "threejs",
-    icon: "icon38", // currently has no icon
+    icon: "icon38", // Currently has no icon
     url: "https://threejs.org/",
     npm: "three",
     test: function (win) {
@@ -1316,7 +1316,7 @@ export default {
     test: function (win) {
       var px = win.PIXI;
       if (px && px.WebGLRenderer && px.VERSION) {
-        // version 4.4.3 returns simply "4.4.3"; version 1.5.2 returns "v1.5.2"
+        // Version 4.4.3 returns simply "4.4.3"; version 1.5.2 returns "v1.5.2"
         return { version: px.VERSION.replace("v", "") || UNKNOWN_VERSION };
       }
       return false;
@@ -1543,7 +1543,7 @@ export default {
     npm: "moment",
     test: function (win) {
       if (win.moment && (win.moment.isMoment || win.moment.lang)) {
-        // version 1.0.0 has neither "isMoment" nor "version"
+        // Version 1.0.0 has neither "isMoment" nor "version"
         return { version: win.moment.version || UNKNOWN_VERSION };
       }
       return false;
@@ -1575,7 +1575,7 @@ export default {
   },
   SWFObject: {
     id: "swfobject",
-    icon: "icon38", // currently has no icon
+    icon: "icon38", // Currently has no icon
     url: "https://github.com/swfobject/swfobject",
     test: function (win) {
       if (win.swfobject && win.swfobject.embedSWF) {
@@ -1591,7 +1591,7 @@ export default {
   },
   FlexSlider: {
     id: "flexslider",
-    icon: "icon38", // currently has no icon
+    icon: "icon38", // Currently has no icon
     url: "https://woocommerce.com/flexslider/",
     npm: "flexslider",
     test: function (win) {
@@ -1604,7 +1604,7 @@ export default {
   },
   SPF: {
     id: "spf",
-    icon: "icon38", // currently has no icon
+    icon: "icon38", // Currently has no icon
     url: "https://youtube.github.io/spfjs/",
     npm: "spf",
     test: function (win) {
@@ -1616,7 +1616,7 @@ export default {
   },
   "Numeral.js": {
     id: "numeraljs",
-    icon: "icon38", // currently has no icon
+    icon: "icon38", // Currently has no icon
     url: "http://numeraljs.com/",
     npm: "numeraljs",
     test: function (win) {
@@ -1628,7 +1628,7 @@ export default {
   },
   "boomerang.js": {
     id: "boomerangjs",
-    icon: "icon38", // currently has no icon
+    icon: "icon38", // Currently has no icon
     url: "https://soasta.github.io/boomerang/",
     npm: "boomerangjs",
     test: function (win) {

--- a/src/vendors/libraryDetector/libraries.js
+++ b/src/vendors/libraryDetector/libraries.js
@@ -8,7 +8,7 @@ export default {
     icon: "gwt",
     url: "http://www.gwtproject.org/",
     test: function (win) {
-      // Pretty complicated, many possible tell tales
+      // pretty complicated, many possible tell tales
       var doc = win.document,
         hasHistFrame = doc.getElementById("__gwt_historyFrame"),
         hasGwtUid = doc.gwt_uid,
@@ -21,7 +21,7 @@ export default {
           win.__gwt_stylesLoaded ||
           win.__gwt_activeModules;
 
-      // Use the many possible indicators
+      // use the many possible indicators
       if (
         hasHistFrame ||
         hasGwtUid ||
@@ -31,13 +31,13 @@ export default {
         hasJsonP ||
         hasRootWinApp
       ) {
-        // Carefully look at frames, but only if certain is GWT frame
+        // carefully look at frames, but only if certain is GWT frame
         var frames = doc.getElementsByTagName("iframe"),
           gwtVersion = UNKNOWN_VERSION;
         for (var n = 0; n < frames.length; n++) {
-          // Catch security access errors
+          // catch security access errors
           try {
-            var hasNegativeTabIndex = frames[n].tabIndex < 0; // On for GWT
+            var hasNegativeTabIndex = frames[n].tabIndex < 0; // on for GWT
             if (
               hasNegativeTabIndex &&
               frames[n].contentWindow &&
@@ -55,7 +55,6 @@ export default {
 
         return { version: gwtVersion };
       }
-
       return false;
     },
   },
@@ -68,7 +67,6 @@ export default {
       if (win.Ink && win.Ink.createModule) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -81,7 +79,6 @@ export default {
       if (win.vaadin && win.vaadin.registerWidgetset) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -91,7 +88,7 @@ export default {
     icon: "bootstrap",
     url: "http://getbootstrap.com/",
     npm: "bootstrap",
-    // Look for a function Boostrap has added to jQuery - regex for BS 2 & 3
+    // look for a function Boostrap has added to jQuery - regex for BS 2 & 3
     test: function (win) {
       var jQueryAvailable = win.$ && win.$.fn,
         RE_PREFIX_V2 = "\\$this\\.data\\((?:'|\")",
@@ -123,9 +120,7 @@ export default {
               bootstrapVersion = win.$.fn[component].Constructor.VERSION;
               return true;
               // Bootstrap >= 2.0.0 and <= 3.1.0 detection
-            }
-
-            if (
+            } else if (
               new RegExp(RE_PREFIX_V3 + component).test(
                 win.$.fn[component].toString()
               )
@@ -133,9 +128,7 @@ export default {
               bootstrapVersion = ">= 3.0.0 & <= 3.1.1";
               return true;
               // Bootstrap < 3.1.0 detection
-            }
-
-            if (
+            } else if (
               new RegExp(RE_PREFIX_V2 + component).test(
                 win.$.fn[component].toString()
               )
@@ -166,7 +159,6 @@ export default {
       if (win.Foundation && win.Foundation.Toggler) {
         return { version: win.Foundation.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -180,7 +172,6 @@ export default {
       if (win.Polymer && win.Polymer.dom) {
         return { version: win.Polymer.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -198,7 +189,6 @@ export default {
         );
         return { version: versions[versions.length - 1] };
       }
-
       return false;
     },
   },
@@ -212,7 +202,6 @@ export default {
       if (win.Highcharts && win.Highcharts.Point) {
         return { version: win.Highcharts.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -225,7 +214,6 @@ export default {
       if (win.$jit && win.$jit.PieChart) {
         return { version: win.$jit.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -239,7 +227,6 @@ export default {
       if (win.$ && win.$.plot) {
         return { version: win.$.plot.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -251,9 +238,8 @@ export default {
     npm: "createjs",
     test: function (win) {
       if (win.createjs && win.createjs.promote) {
-        return { version: UNKNOWN_VERSION }; // No version info available
+        return { version: UNKNOWN_VERSION }; // no version info available
       }
-
       return false;
     },
   },
@@ -266,7 +252,6 @@ export default {
       if (win.google && win.google.maps) {
         return { version: win.google.maps.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -283,7 +268,6 @@ export default {
           version: jq.fn.jquery.replace(/[^\d+\.+]/g, "") || UNKNOWN_VERSION,
         };
       }
-
       return false;
     },
   },
@@ -298,7 +282,6 @@ export default {
       if (jq && jq.fn) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -321,13 +304,11 @@ export default {
               plugins[i].substr(0, 1).toUpperCase() + plugins[i].substr(1)
             );
         }
-
         return {
           version: jq.ui.version || UNKNOWN_VERSION,
           details: concat.length ? "Plugins used: " + concat.join(",") : "",
         };
       }
-
       return false;
     },
   },
@@ -347,7 +328,6 @@ export default {
           details: "Details: " + (win.dijit ? "Uses Dijit" : "none"),
         };
       }
-
       return false;
     },
   },
@@ -360,7 +340,6 @@ export default {
       if (win.Prototype && win.Prototype.BrowserFeatures) {
         return { version: win.Prototype.Version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -373,7 +352,6 @@ export default {
       if (win.Scriptaculous && win.Scriptaculous.load) {
         return { version: win.Scriptaculous.Version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -386,7 +364,6 @@ export default {
       if (win.MooTools && win.MooTools.build) {
         return { version: win.MooTools.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -399,7 +376,6 @@ export default {
       if (win.Spry && win.Spry.Data) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -412,7 +388,6 @@ export default {
       if (win.YAHOO && win.YAHOO.util) {
         return { version: win.YAHOO.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -426,7 +401,6 @@ export default {
       if (win.YUI && win.YUI.Env) {
         return { version: win.YUI.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -440,7 +414,6 @@ export default {
       if (win.qx && win.qx.Bootstrap) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -452,12 +425,9 @@ export default {
     test: function (win) {
       if (win.Ext && win.Ext.versions) {
         return { version: win.Ext.versions.core.version };
-      }
-
-      if (win.Ext) {
+      } else if (win.Ext) {
         return { version: win.Ext.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -470,7 +440,6 @@ export default {
       if (win.base2 && win.base2.dom) {
         return { version: win.base2.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -484,7 +453,6 @@ export default {
       if (win.goog && win.goog.provide) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -497,7 +465,6 @@ export default {
       if (win.Raphael && win.Raphael.circle) {
         return { version: win.Raphael.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -511,13 +478,11 @@ export default {
       function isMatch(node) {
         return node != null && node._reactRootContainer != null;
       }
-
       function nodeFilter(node) {
         return isMatch(node)
           ? NodeFilter.FILTER_ACCEPT
           : NodeFilter.FILTER_SKIP;
       }
-
       var reactRoot = document.getElementById("react-root");
       var altHasReact = document.querySelector("*[data-reactroot]");
       var bodyReactRoot =
@@ -535,7 +500,6 @@ export default {
       ) {
         return { version: (win.React && win.React.version) || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -549,7 +513,6 @@ export default {
       function isMatch(node) {
         return node != null && node._reactRootContainer != null;
       }
-
       var reactRoot = document.getElementById("react-root");
       var altHasReact = document.querySelector("*[data-reactroot]");
       var hasReactRoot =
@@ -557,7 +520,6 @@ export default {
       if (hasReactRoot || reactRoot || altHasReact || win.React) {
         return { version: (win.React && win.React.version) || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -573,7 +535,6 @@ export default {
           version: (window.next && window.next.version) || UNKNOWN_VERSION,
         };
       }
-
       return false;
     },
   },
@@ -587,7 +548,6 @@ export default {
       if (win.__NEXT_DATA__) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -604,24 +564,20 @@ export default {
         if ("__k" in node && "props" in node.__k && "type" in node.__k) {
           return true;
         }
-
         return (
           "_component" in node ||
           "__preactattr_" in node ||
           (expando && node[expando] != null)
         );
       }
-
       function getMatch(node) {
         return node != null && isMatch(node) && node;
       }
-
       function nodeFilter(node) {
         return isMatch(node)
           ? NodeFilter.FILTER_ACCEPT
           : NodeFilter.FILTER_SKIP;
       }
-
       var preactRoot =
         getMatch(document.body) || getMatch(document.body.firstElementChild);
       if (!preactRoot) {
@@ -629,26 +585,21 @@ export default {
           .createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, nodeFilter)
           .nextNode();
       }
-
       if (preactRoot || win.preact) {
         var version = UNKNOWN_VERSION;
         if (preactRoot) {
           if ("__k" in preactRoot) {
             version = "10";
           }
-
           if ("__preactattr_" in preactRoot) {
             version = "8";
           }
-
           if (expando && preactRoot[expando] != null) {
             version = "7";
           }
         }
-
         return { version: version };
       }
-
       return false;
     },
   },
@@ -665,20 +616,16 @@ export default {
           version = "10";
           return true;
         }
-
         return node._component != null || node.__preactattr_ != null;
       }
-
       function getMatch(node) {
         return node != null && isMatch(node);
       }
-
       var preactRoot =
         getMatch(document.body) || getMatch(document.body.firstElementChild);
       if (preactRoot || win.preact) {
         return { version: version };
       }
-
       return false;
     },
   },
@@ -692,7 +639,6 @@ export default {
       if (win.Modernizr && win.Modernizr.addTest) {
         return { version: win.Modernizr._version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -706,7 +652,6 @@ export default {
       if (win.Processing && win.Processing.box) {
         return { version: Processing.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -720,7 +665,6 @@ export default {
       if (win.Backbone && win.Backbone.Model.extend) {
         return { version: win.Backbone.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -735,7 +679,6 @@ export default {
       if (win.L && win.L.GeoJSON && (win.L.marker || win.L.Marker)) {
         return { version: win.L.version || win.L.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -749,7 +692,6 @@ export default {
       if (win.L && win.L.mapbox && win.L.mapbox.geocoder) {
         return { version: win.L.mapbox.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -773,7 +715,6 @@ export default {
       if (_ && wrapper.__wrapped__) {
         return { version: _.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -793,7 +734,6 @@ export default {
       ) {
         return { version: win._.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -806,7 +746,6 @@ export default {
       if (win.Sammy && win.Sammy.Application.curry) {
         return { version: win.Sammy.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -819,7 +758,6 @@ export default {
       if (win.Rico && window.Rico.checkIfComplete) {
         return { version: win.Rico.Version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -832,7 +770,6 @@ export default {
       if (win.MochiKit && win.MochiKit.Base.module) {
         return { version: MochiKit.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -845,7 +782,6 @@ export default {
       if (win.Raphael && win.Raphael.fn.g) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -857,31 +793,25 @@ export default {
     test: function (win) {
       if (win.gloader && win.gloader.getRequests) {
         return { version: UNKNOWN_VERSION };
-      }
-
-      if (win.glow && win.glow.dom) {
+      } else if (win.glow && win.glow.dom) {
         return { version: win.glow.VERSION || UNKNOWN_VERSION };
-      }
-
-      if (win.Glow) {
+      } else if (win.Glow) {
         return { version: win.Glow.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
 
   "Socket.IO": {
     id: "socketio",
-    icon: "socketio", // Currently has no icon
+    icon: "socketio", // currently has no icon
     url: "https://socket.io/",
     npm: "socket.io",
     test: function (win) {
-      // Version 0.6.2 uses only io.Socket; more recent versions also have io.sockets
+      // version 0.6.2 uses only io.Socket; more recent versions also have io.sockets
       if (win.io && (win.io.sockets || win.io.Socket)) {
         return { version: win.io.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -895,21 +825,19 @@ export default {
       if (win.Mustache && win.Mustache.to_html) {
         return { version: win.Mustache.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
 
   "Fabric.js": {
     id: "fabricjs",
-    icon: "icon38", // Currently has no icon
+    icon: "icon38", // currently has no icon
     url: "http://fabricjs.com/",
     npm: "fabric",
     test: function (win) {
       if (win.fabric && win.fabric.util) {
         return { version: win.fabric.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -923,21 +851,19 @@ export default {
       if (win.Fuse) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
 
   "Tween.js": {
     id: "tweenjs",
-    icon: "icon38", // Currently has no icon
+    icon: "icon38", // currently has no icon
     url: "https://github.com/tweenjs/tween.js",
     npm: "tween.js",
     test: function (win) {
       if (win.TWEEN && win.TWEEN.Easing) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -950,7 +876,6 @@ export default {
       if (win.SC && win.SC.Application) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -964,25 +889,21 @@ export default {
       if (win.Zepto && win.Zepto.fn) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
 
   "three.js": {
     id: "threejs",
-    icon: "icon38", // Currently has no icon
+    icon: "icon38", // currently has no icon
     url: "https://threejs.org/",
     npm: "three",
     test: function (win) {
       if (win.THREE && win.THREE.REVISION) {
         return { version: "r" + win.THREE.REVISION };
-      }
-
-      if (win.THREE) {
+      } else if (win.THREE) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -996,7 +917,6 @@ export default {
       if (win.PhiloGL && win.PhiloGL.Camera) {
         return { version: win.PhiloGL.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1009,12 +929,9 @@ export default {
     test: function (win) {
       if (win.Caman && win.Caman.version) {
         return { version: win.Caman.version.release };
-      }
-
-      if (win.Caman) {
+      } else if (win.Caman) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1027,7 +944,6 @@ export default {
       if (win.yepnope && win.yepnope.injectJs) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1040,7 +956,6 @@ export default {
       if (win.$LAB && win.$LAB.setOptions) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1054,7 +969,6 @@ export default {
       if (win.head && win.head.js) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1067,7 +981,6 @@ export default {
       if (win.CJS && win.CJS.start) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1089,7 +1002,6 @@ export default {
       ) {
         return { version: req.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1102,7 +1014,6 @@ export default {
       if (win.RightJS && win.RightJS.isNode) {
         return { version: win.RightJS.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1116,7 +1027,6 @@ export default {
       if (jq && jq.tools) {
         return { version: jq.tools.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1130,7 +1040,6 @@ export default {
       if (win.Pusher && win.Pusher.Channel) {
         return { version: win.Pusher.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1144,7 +1053,6 @@ export default {
       if (win.paper && win.paper.Point) {
         return { version: win.paper.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1157,7 +1065,6 @@ export default {
       if (win.swiffy && win.swiffy.Stage) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1171,7 +1078,6 @@ export default {
       if (win.move && win.move.compile) {
         return { version: win.move.version() || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1185,7 +1091,6 @@ export default {
       if (win.amplify && win.amplify.publish) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1198,7 +1103,6 @@ export default {
       if (win.Popcorn && win.Popcorn.Events) {
         return { version: win.Popcorn.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1212,7 +1116,6 @@ export default {
       if (win.d3 && win.d3.select) {
         return { version: win.d3.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1226,7 +1129,6 @@ export default {
       if (win.Handlebars && win.Handlebars.compile) {
         return { version: win.Handlebars.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1240,7 +1142,6 @@ export default {
       if (win.ko && win.ko.applyBindings) {
         return { version: win.ko.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1253,7 +1154,6 @@ export default {
       if (win.Spine && win.Spine.Controller) {
         return { version: win.Spine.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1268,7 +1168,6 @@ export default {
       if (jq && jq.fn && jq.fn.jquery && jq.mobile) {
         return { version: jq.mobile.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1282,7 +1181,6 @@ export default {
       if (win.WebFont && win.WebFont.load) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1298,12 +1196,9 @@ export default {
         return {
           version: ngVersion.getAttribute("ng-version") || UNKNOWN_VERSION,
         };
-      }
-
-      if (win.ng && win.ng.probe instanceof Function) {
+      } else if (win.ng && win.ng.probe instanceof Function) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1317,12 +1212,9 @@ export default {
       var ng = win.angular;
       if (ng && ng.version && ng.version.full) {
         return { version: ng.version.full };
-      }
-
-      if (ng) {
+      } else if (ng) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1337,7 +1229,6 @@ export default {
       if (ember && ember.GUID_KEY) {
         return { version: ember.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1352,7 +1243,6 @@ export default {
         // Hammer.VERSION available in 1.0.10+
         return { version: win.Hammer.VERSION || "&lt; 1.0.10" };
       }
-
       return false;
     },
   },
@@ -1366,7 +1256,6 @@ export default {
       if (win.Visibility && win.Visibility.every) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1389,12 +1278,9 @@ export default {
             "." +
             velocity.version.patch,
         };
-      }
-
-      if (velocity && velocity.RegisterEffect) {
+      } else if (velocity && velocity.RegisterEffect) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1409,7 +1295,6 @@ export default {
       if (iv && iv.__ceGUID === "ifvisible.object.event.identifier") {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1421,10 +1306,9 @@ export default {
     test: function (win) {
       var px = win.PIXI;
       if (px && px.WebGLRenderer && px.VERSION) {
-        // Version 4.4.3 returns simply "4.4.3"; version 1.5.2 returns "v1.5.2"
+        // version 4.4.3 returns simply "4.4.3"; version 1.5.2 returns "v1.5.2"
         return { version: px.VERSION.replace("v", "") || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1438,7 +1322,6 @@ export default {
       if (dc && dc.registerChart) {
         return { version: dc.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1451,7 +1334,6 @@ export default {
       if (win.TweenMax && win.TweenMax.pauseAll) {
         return { version: win.TweenMax.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1464,7 +1346,6 @@ export default {
       if (win.FastClick && win.FastClick.notNeeded) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1477,7 +1358,6 @@ export default {
       if (win.Isotope || (win.$ != null && win.$.Isotope)) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1490,7 +1370,6 @@ export default {
       if (win.Marionette && win.Marionette.Application) {
         return { version: win.Marionette.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1503,7 +1382,6 @@ export default {
       if (win.can && win.can.Construct) {
         return { version: win.can.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1518,7 +1396,6 @@ export default {
           ? NodeFilter.FILTER_ACCEPT
           : NodeFilter.FILTER_SKIP;
       }
-
       var hasVueNode =
         document
           .createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, isVueNode)
@@ -1526,7 +1403,6 @@ export default {
       if (hasVueNode || win.Vue) {
         return { version: (win.Vue && win.Vue.version) || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1539,7 +1415,6 @@ export default {
       if (win.Vue) {
         return { version: (win.Vue && win.Vue.version) || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1552,7 +1427,6 @@ export default {
       if ((win.__NUXT__ && win.__NUXT__.data != null) || win.$nuxt) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1565,7 +1439,6 @@ export default {
       if (win.__NUXT__ || win.$nuxt) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1578,7 +1451,6 @@ export default {
       if (win.Two && win.Two.Utils) {
         return { version: win.Two.Version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1591,7 +1463,6 @@ export default {
       if (win.BREWSER && win.BREWSER.ua) {
         return { version: BREWSER.VERSION || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1604,7 +1475,6 @@ export default {
       if (win.componentHandler && win.componentHandler.upgradeElement) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1617,7 +1487,6 @@ export default {
       if (win.kendo && win.kendo.View && win.kendo.View.extend) {
         return { version: win.kendo.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1630,7 +1499,6 @@ export default {
       if (win.Matter && win.Matter.Engine) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1643,7 +1511,6 @@ export default {
       if (win.riot && win.riot.mixin) {
         return { version: win.riot.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1656,7 +1523,6 @@ export default {
       if (win.seajs && win.seajs.use) {
         return { version: win.seajs.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1667,10 +1533,9 @@ export default {
     npm: "moment",
     test: function (win) {
       if (win.moment && (win.moment.isMoment || win.moment.lang)) {
-        // Version 1.0.0 has neither "isMoment" nor "version"
+        // version 1.0.0 has neither "isMoment" nor "version"
         return { version: win.moment.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1683,7 +1548,6 @@ export default {
       if (win.moment && win.moment.tz) {
         return { version: win.moment.tz.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1696,31 +1560,27 @@ export default {
       if (win.ScrollMagic && win.ScrollMagic.Controller) {
         return { version: ScrollMagic.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
   SWFObject: {
     id: "swfobject",
-    icon: "icon38", // Currently has no icon
+    icon: "icon38", // currently has no icon
     url: "https://github.com/swfobject/swfobject",
     test: function (win) {
       if (win.swfobject && win.swfobject.embedSWF) {
         // 2.x - exact version only for 2.3
         return { version: win.swfobject.version || UNKNOWN_VERSION };
-      }
-
-      if (win.deconcept && win.deconcept.SWFObject) {
+      } else if (win.deconcept && win.deconcept.SWFObject) {
         // 1.x
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
   FlexSlider: {
     id: "flexslider",
-    icon: "icon38", // Currently has no icon
+    icon: "icon38", // currently has no icon
     url: "https://woocommerce.com/flexslider/",
     npm: "flexslider",
     test: function (win) {
@@ -1728,46 +1588,42 @@ export default {
       if (jq && jq.fn && jq.fn.jquery && jq.flexslider) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
   SPF: {
     id: "spf",
-    icon: "icon38", // Currently has no icon
+    icon: "icon38", // currently has no icon
     url: "https://youtube.github.io/spfjs/",
     npm: "spf",
     test: function (win) {
       if (win.spf && win.spf.init) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
   "Numeral.js": {
     id: "numeraljs",
-    icon: "icon38", // Currently has no icon
+    icon: "icon38", // currently has no icon
     url: "http://numeraljs.com/",
     npm: "numeraljs",
     test: function (win) {
       if (win.numeral && win.isNumeral) {
         return { version: win.numeral.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
   "boomerang.js": {
     id: "boomerangjs",
-    icon: "icon38", // Currently has no icon
+    icon: "icon38", // currently has no icon
     url: "https://soasta.github.io/boomerang/",
     npm: "boomerangjs",
     test: function (win) {
       if (win.BOOMR && win.BOOMR.utils && win.BOOMR.init) {
         return { version: win.BOOMR.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1780,7 +1636,6 @@ export default {
       if (win.Framer && win.Framer.Layer) {
         return { version: win.Framer.Version.build || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1795,7 +1650,6 @@ export default {
       if (markoElement) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1818,7 +1672,6 @@ export default {
       if (document.getElementById("___gatsby")) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1831,7 +1684,6 @@ export default {
       if (win.Shopify && win.Shopify.shop) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1886,7 +1738,6 @@ export default {
       if (win.wixBiSession) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1932,10 +1783,8 @@ export default {
                 ) {
                   version = matches[1];
                 }
-
                 return { version: version };
               }
-
               return false;
             });
         });
@@ -1959,7 +1808,6 @@ export default {
       if (win.WIZ_global_data) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1972,7 +1820,6 @@ export default {
       if (document.__wizdispatcher) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -1993,12 +1840,9 @@ export default {
                 .join("; ")
             : UNKNOWN_VERSION,
         };
-      }
-
-      if (core) {
+      } else if (core) {
         return { version: core.version || UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -2096,7 +1940,6 @@ export default {
       if (win.__GUESS__ && win.__GUESS__.guess) {
         return { version: UNKNOWN_VERSION };
       }
-
       return false;
     },
   },
@@ -2150,9 +1993,7 @@ export default {
         return {
           version: generatorMeta.getAttribute("content").replace(/^\w+\s/, ""),
         };
-      }
-
-      if (win.Joomla || hasJoomlaBootstrap) {
+      } else if (win.Joomla || hasJoomlaBootstrap) {
         return { version: UNKNOWN_VERSION };
       }
 

--- a/src/vendors/libraryDetector/libraries.js
+++ b/src/vendors/libraryDetector/libraries.js
@@ -120,7 +120,8 @@ export default {
               bootstrapVersion = win.$.fn[component].Constructor.VERSION;
               return true;
               // Bootstrap >= 2.0.0 and <= 3.1.0 detection
-            } else if (
+            }
+            if (
               new RegExp(RE_PREFIX_V3 + component).test(
                 win.$.fn[component].toString()
               )
@@ -128,7 +129,8 @@ export default {
               bootstrapVersion = ">= 3.0.0 & <= 3.1.1";
               return true;
               // Bootstrap < 3.1.0 detection
-            } else if (
+            }
+            if (
               new RegExp(RE_PREFIX_V2 + component).test(
                 win.$.fn[component].toString()
               )
@@ -425,7 +427,8 @@ export default {
     test: function (win) {
       if (win.Ext && win.Ext.versions) {
         return { version: win.Ext.versions.core.version };
-      } else if (win.Ext) {
+      }
+      if (win.Ext) {
         return { version: win.Ext.version || UNKNOWN_VERSION };
       }
       return false;
@@ -793,9 +796,11 @@ export default {
     test: function (win) {
       if (win.gloader && win.gloader.getRequests) {
         return { version: UNKNOWN_VERSION };
-      } else if (win.glow && win.glow.dom) {
+      }
+      if (win.glow && win.glow.dom) {
         return { version: win.glow.VERSION || UNKNOWN_VERSION };
-      } else if (win.Glow) {
+      }
+      if (win.Glow) {
         return { version: win.Glow.version || UNKNOWN_VERSION };
       }
       return false;
@@ -901,7 +906,8 @@ export default {
     test: function (win) {
       if (win.THREE && win.THREE.REVISION) {
         return { version: "r" + win.THREE.REVISION };
-      } else if (win.THREE) {
+      }
+      if (win.THREE) {
         return { version: UNKNOWN_VERSION };
       }
       return false;
@@ -929,7 +935,8 @@ export default {
     test: function (win) {
       if (win.Caman && win.Caman.version) {
         return { version: win.Caman.version.release };
-      } else if (win.Caman) {
+      }
+      if (win.Caman) {
         return { version: UNKNOWN_VERSION };
       }
       return false;
@@ -1196,7 +1203,8 @@ export default {
         return {
           version: ngVersion.getAttribute("ng-version") || UNKNOWN_VERSION,
         };
-      } else if (win.ng && win.ng.probe instanceof Function) {
+      }
+      if (win.ng && win.ng.probe instanceof Function) {
         return { version: UNKNOWN_VERSION };
       }
       return false;
@@ -1212,7 +1220,8 @@ export default {
       var ng = win.angular;
       if (ng && ng.version && ng.version.full) {
         return { version: ng.version.full };
-      } else if (ng) {
+      }
+      if (ng) {
         return { version: UNKNOWN_VERSION };
       }
       return false;
@@ -1278,7 +1287,8 @@ export default {
             "." +
             velocity.version.patch,
         };
-      } else if (velocity && velocity.RegisterEffect) {
+      }
+      if (velocity && velocity.RegisterEffect) {
         return { version: UNKNOWN_VERSION };
       }
       return false;
@@ -1571,7 +1581,8 @@ export default {
       if (win.swfobject && win.swfobject.embedSWF) {
         // 2.x - exact version only for 2.3
         return { version: win.swfobject.version || UNKNOWN_VERSION };
-      } else if (win.deconcept && win.deconcept.SWFObject) {
+      }
+      if (win.deconcept && win.deconcept.SWFObject) {
         // 1.x
         return { version: UNKNOWN_VERSION };
       }
@@ -1840,7 +1851,8 @@ export default {
                 .join("; ")
             : UNKNOWN_VERSION,
         };
-      } else if (core) {
+      }
+      if (core) {
         return { version: core.version || UNKNOWN_VERSION };
       }
       return false;
@@ -1993,7 +2005,8 @@ export default {
         return {
           version: generatorMeta.getAttribute("content").replace(/^\w+\s/, ""),
         };
-      } else if (win.Joomla || hasJoomlaBootstrap) {
+      }
+      if (win.Joomla || hasJoomlaBootstrap) {
         return { version: UNKNOWN_VERSION };
       }
 

--- a/src/vendors/notify.js
+++ b/src/vendors/notify.js
@@ -182,9 +182,8 @@ function init($) {
   var find = function (elem, selector) {
     if (elem.is(selector)) {
       return elem;
-    } else {
-      return elem.find(selector);
     }
+    return elem.find(selector);
   };
 
   var pluginOptions = {
@@ -263,9 +262,11 @@ function init($) {
   var realign = function (alignment, inner, outer) {
     if (alignment === "l" || alignment === "t") {
       return 0;
-    } else if (alignment === "c" || alignment === "m") {
+    }
+    if (alignment === "c" || alignment === "m") {
       return outer / 2 - inner / 2;
-    } else if (alignment === "r" || alignment === "b") {
+    }
+    if (alignment === "r" || alignment === "b") {
       return outer - inner;
     }
     throw "Invalid alignment";
@@ -543,7 +544,8 @@ function init($) {
     if (this.container && !data) {
       this.show(false);
       return;
-    } else if (!this.container && !data) {
+    }
+    if (!this.container && !data) {
       return;
     }
     datas = {};

--- a/src/vendors/notify.js
+++ b/src/vendors/notify.js
@@ -9,6 +9,7 @@ function init($) {
           return i;
         }
       }
+
       return -1;
     };
 
@@ -95,6 +96,7 @@ function init($) {
     if (!name) {
       throw "Missing Style name";
     }
+
     if (styles[name]) {
       delete styles[name];
     }
@@ -104,20 +106,25 @@ function init($) {
     if (!name) {
       throw "Missing Style name";
     }
+
     if (!def) {
       throw "Missing Style definition";
     }
+
     if (!def.html) {
       throw "Missing Style HTML";
     }
+
     // Remove existing style
     var existing = styles[name];
     if (existing && existing.cssElem) {
       if (window.console) {
         console.warn(pluginName + ": overwriting style '" + name + "'");
       }
+
       styles[name].cssElem.remove();
     }
+
     def.name = name;
     styles[name] = def;
     var cssText = "";
@@ -131,18 +138,22 @@ function init($) {
               return (cssText += "	" + prefix + name + ": " + val + ";\n");
             });
           }
+
           return (cssText += "	" + name + ": " + val + ";\n");
         });
         return (cssText += "}\n");
       });
     }
+
     if (def.css) {
       cssText += "/* styles for " + def.name + " */\n" + def.css;
     }
+
     if (cssText) {
       def.cssElem = insertCSS(cssText);
       def.cssElem.attr("id", "notify-" + def.name);
     }
+
     var fields = {};
     var elem = $(def.html);
     findFields("html", elem, fields);
@@ -160,6 +171,7 @@ function init($) {
     } catch {
       elem[0].styleSheet.cssText = cssText;
     }
+
     return elem;
   };
 
@@ -168,6 +180,7 @@ function init($) {
     if (type !== "html") {
       type = "text";
     }
+
     attr = "data-notify-" + type;
     return find(elem, "[" + attr + "]").each(function () {
       var name;
@@ -175,6 +188,7 @@ function init($) {
       if (!name) {
         name = blankFieldName;
       }
+
       fields[name] = type;
     });
   };
@@ -183,6 +197,7 @@ function init($) {
     if (elem.is(selector)) {
       return elem;
     }
+
     return elem.find(selector);
   };
 
@@ -232,6 +247,7 @@ function init($) {
         });
       element = radios.first();
     }
+
     return element;
   };
 
@@ -242,20 +258,24 @@ function init($) {
     } else if (typeof val !== "number") {
       return;
     }
+
     if (isNaN(val)) {
       return;
     }
+
     opp = positions[opposites[pos.charAt(0)]];
     temp = pos;
     if (obj[opp] !== undefined) {
       pos = positions[opp.charAt(0)];
       val = -val;
     }
+
     if (obj[pos] === undefined) {
       obj[pos] = val;
     } else {
       obj[pos] += val;
     }
+
     return null;
   };
 
@@ -263,12 +283,15 @@ function init($) {
     if (alignment === "l" || alignment === "t") {
       return 0;
     }
+
     if (alignment === "c" || alignment === "m") {
       return outer / 2 - inner / 2;
     }
+
     if (alignment === "r" || alignment === "b") {
       return outer - inner;
     }
+
     throw "Invalid alignment";
   };
 
@@ -283,6 +306,7 @@ function init($) {
         className: options,
       };
     }
+
     this.options = inherit(
       pluginOptions,
       $.isPlainObject(options) ? options : {}
@@ -292,6 +316,7 @@ function init($) {
     if (this.options.clickToHide) {
       this.wrapper.addClass(pluginClassName + "-hidable");
     }
+
     this.wrapper.data(pluginClassName, this);
     this.arrow = this.wrapper.find("." + pluginClassName + "-arrow");
     this.container = this.wrapper.find("." + pluginClassName + "-container");
@@ -303,6 +328,7 @@ function init($) {
       this.elem.data(pluginClassName, this);
       this.elem.before(this.wrapper);
     }
+
     this.container.hide();
     this.run(data);
   }
@@ -321,6 +347,7 @@ function init($) {
         if (!show && !_this.elem) {
           _this.destroy();
         }
+
         if (userCallback) {
           return userCallback();
         }
@@ -342,6 +369,7 @@ function init($) {
     } else {
       return callback();
     }
+
     args.push(callback);
     return elems[fn].apply(elems, args);
   };
@@ -365,9 +393,11 @@ function init($) {
       } else {
         css[align] = 0;
       }
+
       anchor.css(css).addClass(pluginClassName + "-corner");
       $("body").append(anchor);
     }
+
     return anchor.prepend(this.wrapper);
   };
 
@@ -428,6 +458,7 @@ function init($) {
         incr(css, pos, margin);
       }
     }
+
     gap = Math.max(
       0,
       this.options.gap - (this.options.arrowShow ? arrowSize : 0)
@@ -449,14 +480,17 @@ function init($) {
         if (pos === opp) {
           continue;
         }
+
         color = posFull === mainFull ? arrowColor : "transparent";
         arrowCss["border-" + posFull] = arrowSize + "px solid " + color;
       }
+
       incr(css, positions[opp], arrowSize);
       if (indexOf.call(mainPositions, pAlign) >= 0) {
         incr(arrowCss, positions[pAlign], arrowSize * 2);
       }
     }
+
     if (indexOf.call(vAligns, pMain) >= 0) {
       incr(css, "left", realign(pAlign, contW, elemW));
       if (arrowCss) {
@@ -468,9 +502,11 @@ function init($) {
         incr(arrowCss, "top", realign(pAlign, arrowSize, elemIH));
       }
     }
+
     if (this.container.is(":visible")) {
       css.display = "block";
     }
+
     this.container.removeAttr("style").css(css);
     if (arrowCss) {
       return this.arrow.removeAttr("style").css(arrowCss);
@@ -486,9 +522,11 @@ function init($) {
     if (pos.length === 0) {
       pos[0] = "b";
     }
+
     if (((ref = pos[0]), indexOf.call(mainPositions, ref) < 0)) {
       throw "Must be one of [" + mainPositions + "]";
     }
+
     if (
       pos.length === 1 ||
       (((ref1 = pos[0]), indexOf.call(vAligns, ref1) >= 0) &&
@@ -498,9 +536,11 @@ function init($) {
     ) {
       pos[1] = ((ref5 = pos[0]), indexOf.call(hAligns, ref5) >= 0) ? "m" : "l";
     }
+
     if (pos.length === 2) {
       pos[2] = pos[1];
     }
+
     return pos;
   };
 
@@ -509,13 +549,16 @@ function init($) {
     if (!name) {
       name = this.options.style;
     }
+
     if (!name) {
       name = "default";
     }
+
     style = styles[name];
     if (!style) {
       throw "Missing style: " + name;
     }
+
     return style;
   };
 
@@ -527,6 +570,7 @@ function init($) {
     } else if (this.options.className) {
       classes.push(this.options.className);
     }
+
     style = this.getStyle();
     classes = $.map(classes, function (n) {
       return pluginClassName + "-" + style.name + "-" + n;
@@ -541,40 +585,48 @@ function init($) {
     } else if ($.type(options) === "string") {
       this.options.className = options;
     }
+
     if (this.container && !data) {
       this.show(false);
       return;
     }
+
     if (!this.container && !data) {
       return;
     }
+
     datas = {};
     if ($.isPlainObject(data)) {
       datas = data;
     } else {
       datas[blankFieldName] = data;
     }
+
     for (name in datas) {
       d = datas[name];
       type = this.userFields[name];
       if (!type) {
         continue;
       }
+
       if (type === "text") {
         d = encode(d);
         if (this.options.breakNewLines) {
           d = d.replace(/\n/g, "<br/>");
         }
       }
+
       value = name === blankFieldName ? "" : "=" + name;
       find(this.userContainer, "[data-notify-" + type + value + "]").html(d);
     }
+
     this.updateClasses();
     if (this.elem) {
       this.setElementPosition();
     } else {
       this.setGlobalPosition();
     }
+
     this.show(true);
     if (this.options.autoHide) {
       clearTimeout(this.autohideTimer);
@@ -599,6 +651,7 @@ function init($) {
       const notification = new Notification(null, data, options);
       return notification.wrapper;
     }
+
     return elem;
   };
 
@@ -608,6 +661,7 @@ function init($) {
       if (prev) {
         prev.destroy();
       }
+
       var curr = new Notification($(this), data, options);
     });
     return this;

--- a/src/vendors/notify.js
+++ b/src/vendors/notify.js
@@ -1,6 +1,6 @@
 /* Notify.js - http://notifyjs.com/ Copyright (c) 2015 MIT */
 function init($) {
-  //IE8 indexOf polyfill
+  // IE8 indexOf polyfill
   var indexOf =
     [].indexOf ||
     function (item) {
@@ -110,7 +110,7 @@ function init($) {
     if (!def.html) {
       throw "Missing Style HTML";
     }
-    //remove existing style
+    // Remove existing style
     var existing = styles[name];
     if (existing && existing.cssElem) {
       if (window.console) {
@@ -622,7 +622,7 @@ function init($) {
     insertCSS: insertCSS,
   });
 
-  //always include the default bootstrap style
+  // Always include the default bootstrap style
   addStyle("bootstrap", {
     html: "<div>\n<span data-notify-text></span>\n</div>",
     classes: {

--- a/src/vendors/notify.js
+++ b/src/vendors/notify.js
@@ -1,6 +1,6 @@
 /* Notify.js - http://notifyjs.com/ Copyright (c) 2015 MIT */
 function init($) {
-  // IE8 indexOf polyfill
+  //IE8 indexOf polyfill
   var indexOf =
     [].indexOf ||
     function (item) {
@@ -9,7 +9,6 @@ function init($) {
           return i;
         }
       }
-
       return -1;
     };
 
@@ -96,7 +95,6 @@ function init($) {
     if (!name) {
       throw "Missing Style name";
     }
-
     if (styles[name]) {
       delete styles[name];
     }
@@ -106,25 +104,20 @@ function init($) {
     if (!name) {
       throw "Missing Style name";
     }
-
     if (!def) {
       throw "Missing Style definition";
     }
-
     if (!def.html) {
       throw "Missing Style HTML";
     }
-
-    // Remove existing style
+    //remove existing style
     var existing = styles[name];
     if (existing && existing.cssElem) {
       if (window.console) {
         console.warn(pluginName + ": overwriting style '" + name + "'");
       }
-
       styles[name].cssElem.remove();
     }
-
     def.name = name;
     styles[name] = def;
     var cssText = "";
@@ -138,22 +131,18 @@ function init($) {
               return (cssText += "	" + prefix + name + ": " + val + ";\n");
             });
           }
-
           return (cssText += "	" + name + ": " + val + ";\n");
         });
         return (cssText += "}\n");
       });
     }
-
     if (def.css) {
       cssText += "/* styles for " + def.name + " */\n" + def.css;
     }
-
     if (cssText) {
       def.cssElem = insertCSS(cssText);
       def.cssElem.attr("id", "notify-" + def.name);
     }
-
     var fields = {};
     var elem = $(def.html);
     findFields("html", elem, fields);
@@ -171,7 +160,6 @@ function init($) {
     } catch {
       elem[0].styleSheet.cssText = cssText;
     }
-
     return elem;
   };
 
@@ -180,7 +168,6 @@ function init($) {
     if (type !== "html") {
       type = "text";
     }
-
     attr = "data-notify-" + type;
     return find(elem, "[" + attr + "]").each(function () {
       var name;
@@ -188,7 +175,6 @@ function init($) {
       if (!name) {
         name = blankFieldName;
       }
-
       fields[name] = type;
     });
   };
@@ -196,9 +182,9 @@ function init($) {
   var find = function (elem, selector) {
     if (elem.is(selector)) {
       return elem;
+    } else {
+      return elem.find(selector);
     }
-
-    return elem.find(selector);
   };
 
   var pluginOptions = {
@@ -247,7 +233,6 @@ function init($) {
         });
       element = radios.first();
     }
-
     return element;
   };
 
@@ -258,40 +243,31 @@ function init($) {
     } else if (typeof val !== "number") {
       return;
     }
-
     if (isNaN(val)) {
       return;
     }
-
     opp = positions[opposites[pos.charAt(0)]];
     temp = pos;
     if (obj[opp] !== undefined) {
       pos = positions[opp.charAt(0)];
       val = -val;
     }
-
     if (obj[pos] === undefined) {
       obj[pos] = val;
     } else {
       obj[pos] += val;
     }
-
     return null;
   };
 
   var realign = function (alignment, inner, outer) {
     if (alignment === "l" || alignment === "t") {
       return 0;
-    }
-
-    if (alignment === "c" || alignment === "m") {
+    } else if (alignment === "c" || alignment === "m") {
       return outer / 2 - inner / 2;
-    }
-
-    if (alignment === "r" || alignment === "b") {
+    } else if (alignment === "r" || alignment === "b") {
       return outer - inner;
     }
-
     throw "Invalid alignment";
   };
 
@@ -306,7 +282,6 @@ function init($) {
         className: options,
       };
     }
-
     this.options = inherit(
       pluginOptions,
       $.isPlainObject(options) ? options : {}
@@ -316,7 +291,6 @@ function init($) {
     if (this.options.clickToHide) {
       this.wrapper.addClass(pluginClassName + "-hidable");
     }
-
     this.wrapper.data(pluginClassName, this);
     this.arrow = this.wrapper.find("." + pluginClassName + "-arrow");
     this.container = this.wrapper.find("." + pluginClassName + "-container");
@@ -328,7 +302,6 @@ function init($) {
       this.elem.data(pluginClassName, this);
       this.elem.before(this.wrapper);
     }
-
     this.container.hide();
     this.run(data);
   }
@@ -347,7 +320,6 @@ function init($) {
         if (!show && !_this.elem) {
           _this.destroy();
         }
-
         if (userCallback) {
           return userCallback();
         }
@@ -369,7 +341,6 @@ function init($) {
     } else {
       return callback();
     }
-
     args.push(callback);
     return elems[fn].apply(elems, args);
   };
@@ -393,11 +364,9 @@ function init($) {
       } else {
         css[align] = 0;
       }
-
       anchor.css(css).addClass(pluginClassName + "-corner");
       $("body").append(anchor);
     }
-
     return anchor.prepend(this.wrapper);
   };
 
@@ -458,7 +427,6 @@ function init($) {
         incr(css, pos, margin);
       }
     }
-
     gap = Math.max(
       0,
       this.options.gap - (this.options.arrowShow ? arrowSize : 0)
@@ -480,17 +448,14 @@ function init($) {
         if (pos === opp) {
           continue;
         }
-
         color = posFull === mainFull ? arrowColor : "transparent";
         arrowCss["border-" + posFull] = arrowSize + "px solid " + color;
       }
-
       incr(css, positions[opp], arrowSize);
       if (indexOf.call(mainPositions, pAlign) >= 0) {
         incr(arrowCss, positions[pAlign], arrowSize * 2);
       }
     }
-
     if (indexOf.call(vAligns, pMain) >= 0) {
       incr(css, "left", realign(pAlign, contW, elemW));
       if (arrowCss) {
@@ -502,11 +467,9 @@ function init($) {
         incr(arrowCss, "top", realign(pAlign, arrowSize, elemIH));
       }
     }
-
     if (this.container.is(":visible")) {
       css.display = "block";
     }
-
     this.container.removeAttr("style").css(css);
     if (arrowCss) {
       return this.arrow.removeAttr("style").css(arrowCss);
@@ -522,11 +485,9 @@ function init($) {
     if (pos.length === 0) {
       pos[0] = "b";
     }
-
     if (((ref = pos[0]), indexOf.call(mainPositions, ref) < 0)) {
       throw "Must be one of [" + mainPositions + "]";
     }
-
     if (
       pos.length === 1 ||
       (((ref1 = pos[0]), indexOf.call(vAligns, ref1) >= 0) &&
@@ -536,11 +497,9 @@ function init($) {
     ) {
       pos[1] = ((ref5 = pos[0]), indexOf.call(hAligns, ref5) >= 0) ? "m" : "l";
     }
-
     if (pos.length === 2) {
       pos[2] = pos[1];
     }
-
     return pos;
   };
 
@@ -549,16 +508,13 @@ function init($) {
     if (!name) {
       name = this.options.style;
     }
-
     if (!name) {
       name = "default";
     }
-
     style = styles[name];
     if (!style) {
       throw "Missing style: " + name;
     }
-
     return style;
   };
 
@@ -570,7 +526,6 @@ function init($) {
     } else if (this.options.className) {
       classes.push(this.options.className);
     }
-
     style = this.getStyle();
     classes = $.map(classes, function (n) {
       return pluginClassName + "-" + style.name + "-" + n;
@@ -585,48 +540,39 @@ function init($) {
     } else if ($.type(options) === "string") {
       this.options.className = options;
     }
-
     if (this.container && !data) {
       this.show(false);
       return;
-    }
-
-    if (!this.container && !data) {
+    } else if (!this.container && !data) {
       return;
     }
-
     datas = {};
     if ($.isPlainObject(data)) {
       datas = data;
     } else {
       datas[blankFieldName] = data;
     }
-
     for (name in datas) {
       d = datas[name];
       type = this.userFields[name];
       if (!type) {
         continue;
       }
-
       if (type === "text") {
         d = encode(d);
         if (this.options.breakNewLines) {
           d = d.replace(/\n/g, "<br/>");
         }
       }
-
       value = name === blankFieldName ? "" : "=" + name;
       find(this.userContainer, "[data-notify-" + type + value + "]").html(d);
     }
-
     this.updateClasses();
     if (this.elem) {
       this.setElementPosition();
     } else {
       this.setGlobalPosition();
     }
-
     this.show(true);
     if (this.options.autoHide) {
       clearTimeout(this.autohideTimer);
@@ -651,7 +597,6 @@ function init($) {
       const notification = new Notification(null, data, options);
       return notification.wrapper;
     }
-
     return elem;
   };
 
@@ -661,7 +606,6 @@ function init($) {
       if (prev) {
         prev.destroy();
       }
-
       var curr = new Notification($(this), data, options);
     });
     return this;
@@ -676,7 +620,7 @@ function init($) {
     insertCSS: insertCSS,
   });
 
-  // Always include the default bootstrap style
+  //always include the default bootstrap style
   addStyle("bootstrap", {
     html: "<div>\n<span data-notify-text></span>\n</div>",
     classes: {

--- a/src/vendors/pkce.ts
+++ b/src/vendors/pkce.ts
@@ -16,13 +16,13 @@ export const MIN_VERIFIER_LENGTH = 43;
 export const MAX_VERIFIER_LENGTH = 128;
 export const DEFAULT_CODE_CHALLENGE_METHOD = "S256";
 
-// converts a string to base64 (url/filename safe variant)
+// Converts a string to base64 (url/filename safe variant)
 export function stringToBase64Url(str: string): string {
   var b64 = btoa(str);
   return base64ToBase64Url(b64);
 }
 
-// converts a standard base64-encoded string to a "url/filename safe" variant
+// Converts a standard base64-encoded string to a "url/filename safe" variant
 export function base64ToBase64Url(b64: string): string {
   return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
@@ -53,7 +53,7 @@ export function computeChallenge(str: string): PromiseLike<any> {
     var hash = String.fromCharCode.apply(null, [
       ...new Uint8Array(arrayBuffer),
     ]);
-    var b64u = stringToBase64Url(hash); // url-safe base64 variant
+    var b64u = stringToBase64Url(hash); // Url-safe base64 variant
     return b64u;
   });
 }

--- a/src/vendors/pkce.ts
+++ b/src/vendors/pkce.ts
@@ -44,6 +44,7 @@ export function generateVerifier(prefix?: string): string {
     verifier =
       verifier + getRandomString(MIN_VERIFIER_LENGTH - verifier.length);
   }
+
   return encodeURIComponent(verifier).slice(0, MAX_VERIFIER_LENGTH);
 }
 

--- a/src/vendors/pkce.ts
+++ b/src/vendors/pkce.ts
@@ -16,13 +16,13 @@ export const MIN_VERIFIER_LENGTH = 43;
 export const MAX_VERIFIER_LENGTH = 128;
 export const DEFAULT_CODE_CHALLENGE_METHOD = "S256";
 
-// Converts a string to base64 (url/filename safe variant)
+// converts a string to base64 (url/filename safe variant)
 export function stringToBase64Url(str: string): string {
   var b64 = btoa(str);
   return base64ToBase64Url(b64);
 }
 
-// Converts a standard base64-encoded string to a "url/filename safe" variant
+// converts a standard base64-encoded string to a "url/filename safe" variant
 export function base64ToBase64Url(b64: string): string {
   return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
@@ -44,7 +44,6 @@ export function generateVerifier(prefix?: string): string {
     verifier =
       verifier + getRandomString(MIN_VERIFIER_LENGTH - verifier.length);
   }
-
   return encodeURIComponent(verifier).slice(0, MAX_VERIFIER_LENGTH);
 }
 
@@ -54,7 +53,7 @@ export function computeChallenge(str: string): PromiseLike<any> {
     var hash = String.fromCharCode.apply(null, [
       ...new Uint8Array(arrayBuffer),
     ]);
-    var b64u = stringToBase64Url(hash); // Url-safe base64 variant
+    var b64u = stringToBase64Url(hash); // url-safe base64 variant
     return b64u;
   });
 }


### PR DESCRIPTION
This is part of the gradual linting that eventually will let us enable a [shared configuration](https://github.com/xojs/eslint-config-xo-typescript) and drop most of our lint config. Future PR:

- [ ] Enable `eslint-config-xo` and just _disable_ the rules we can't enable yet, so we don't have to import complex config for each rule

---

A few more stylistic rules enabled, basically just spacing.

- spaced-comment
- @typescript-eslint/lines-between-class-members
- padding-line-between-statements
- no-else-return (#770) again
	- The configuration was not just supposed to be `"error"`: https://github.com/xojs/eslint-config-xo/blob/e5c4861e31f8f7febb8b1864a104850fd5cabd89/index.js#L125-L130
- capitalized-comments: This is a bit "annoying" because it capitalizes commented code, there are 3 solutions:
	  1. Don't commit commented code
	  2. Prepend a line explaining why the code is still there (only the first line is capitalized)
	  3. If it's just a word, use Markdown: ``// `permission` does blah blah`` so `permission` doesn't get capitalized