### PR TITLE
#837: don't show pixiebrix api for marketplace wizard integrations

### DIFF
--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -195,7 +195,7 @@ async function updateDeployments() {
     (x) => x.hasPermissions
   );
 
-  let automaticError = false;
+  let automaticError: unknown;
 
   if (automatic.length > 0) {
     console.debug(
@@ -216,12 +216,19 @@ async function updateDeployments() {
       );
     } catch (error: unknown) {
       reportError(error);
-      automaticError = true;
+      automaticError = error;
     }
   }
 
   // We only want to call openOptionsPage a single time
-  if (manual.length > 0 || automaticError) {
+  if (manual.length > 0 || automaticError != null) {
+    console.debug(
+      "Opening options page for user to manually activate updated deployment(s)",
+      {
+        manual,
+        automaticError,
+      }
+    );
     await browser.runtime.openOptionsPage();
   }
 }

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -302,10 +302,10 @@ const ActivateWizard: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
               activeKey={stepKey}
               onSelect={(step: string) => setStep(step)}
             >
-              {blueprintSteps.map((x, i) => (
-                <Nav.Item key={x.key} className="flex-grow-1">
-                  <Nav.Link eventKey={x.key}>
-                    {i + 1}. {x.label}
+              {blueprintSteps.map((step, index) => (
+                <Nav.Item key={step.key} className="flex-grow-1">
+                  <Nav.Link eventKey={step.key}>
+                    {index + 1}. {step.label}
                   </Nav.Link>
                 </Nav.Item>
               ))}

--- a/src/options/pages/marketplace/ServicesBody.tsx
+++ b/src/options/pages/marketplace/ServicesBody.tsx
@@ -35,7 +35,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useFetch } from "@/hooks/fetch";
 import ServiceEditorModal from "@/options/pages/services/ServiceEditorModal";
 import { useAsyncState } from "@/hooks/common";
-import registry from "@/services/registry";
+import registry, { PIXIEBRIX_SERVICE_ID } from "@/services/registry";
 import { RawServiceConfiguration } from "@/core";
 import { servicesSlice } from "@/options/slices";
 import { useDispatch } from "react-redux";
@@ -92,15 +92,8 @@ const AuthWidget: React.FunctionComponent<{
         autoDismiss: true,
       });
 
-      // Don't need to track changes locally - they'll automatically flow through via the redux selectors
-      // setCreated(draft => {
-      //     draft.push({
-      //         value: id,
-      //         serviceId: serviceId,
-      //         label: values.label ?? "New Configuration",
-      //         local: true,
-      //     })
-      // })
+      // Don't need to track changes locally via setCreated; the new auth automatically flows
+      // through via the redux selectors
 
       helpers.setValue(id);
 
@@ -187,8 +180,13 @@ const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
 
   const serviceConfigs = useFetch<ServiceDefinition[]>("/api/services/");
 
-  const services = useMemo(
-    () => uniq(selected.flatMap((x) => Object.values(x.services ?? {}))),
+  const serviceIds = useMemo(
+    // The PixieBrix service gets automatically configured, so don't need to show it. If the PixieBrix service is
+    // the only service, the wizard won't render the ServicesBody component at all
+    () =>
+      uniq(selected.flatMap((x) => Object.values(x.services ?? {}))).filter(
+        (serviceId) => serviceId !== PIXIEBRIX_SERVICE_ID
+      ),
     [selected]
   );
 
@@ -219,7 +217,7 @@ const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
           </tr>
         </thead>
         <tbody>
-          {services.map((serviceId) => (
+          {serviceIds.map((serviceId) => (
             <tr key={serviceId}>
               <td>
                 <ServiceDescriptor
@@ -232,7 +230,7 @@ const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
               </td>
             </tr>
           ))}
-          {services.length === 0 && (
+          {serviceIds.length === 0 && (
             <tr>
               <td colSpan={2}>No services to configure</td>
             </tr>

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -44,7 +44,7 @@ export function mergePermissions(
 
 /**
  * @deprecated The logic of grouping permissions by origin doesn't actually make sense
- * as we don't have any way to enforce this.
+ * as we don't currently have any way to enforce permissions on a per-origin basis.
  * https://github.com/pixiebrix/pixiebrix-extension/pull/828#discussion_r671703130
  */
 export function distinctPermissions(


### PR DESCRIPTION
Closes #837

- Simplifies updateDeployments
- Exclude pixiebrix API from calculation of service permissions since it's a required permission