### PR TITLE
Add Options menu item in the extension dropdown in Firefox

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -44,7 +44,7 @@ import initNavigation from "@/background/navigation";
 import initExecutor from "@/background/executor";
 import preload from "@/background/preload";
 import initDeploymentUpdater from "@/background/deployment";
-import initFirefoxCompat from "@/background/firefox-compat";
+import initFirefoxCompat from "@/background/firefoxCompat";
 
 initNavigation();
 initExecutor();

--- a/src/background.ts
+++ b/src/background.ts
@@ -52,4 +52,4 @@ initGoogle();
 initFrames();
 preload();
 initDeploymentUpdater();
-initFirefoxCompat();
+void initFirefoxCompat();

--- a/src/background.ts
+++ b/src/background.ts
@@ -44,6 +44,7 @@ import initNavigation from "@/background/navigation";
 import initExecutor from "@/background/executor";
 import preload from "@/background/preload";
 import initDeploymentUpdater from "@/background/deployment";
+import initFirefoxCompat from "@/background/firefox-compat";
 
 initNavigation();
 initExecutor();
@@ -51,3 +52,4 @@ initGoogle();
 initFrames();
 preload();
 initDeploymentUpdater();
+initFirefoxCompat();

--- a/src/background/firefox-compat.ts
+++ b/src/background/firefox-compat.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { isFirefox } from "@/helpers";
+import { browser } from "webextension-polyfill-ts";
+import { expectBackgroundPage } from "@/utils/expectContext";
+
+const FIREFOX_OPTIONS_MENU_ID = "PIXIEBRIX_FIREFOX_OPTIONS";
+
+function onContextMenuClick({ menuItemId }: browser.contextMenus.OnClickData) {
+  console.log("YO");
+  if (menuItemId === FIREFOX_OPTIONS_MENU_ID) {
+    void browser.runtime.openOptionsPage();
+  }
+}
+
+export default async function initFirefoxCompat(): Promise<void> {
+  expectBackgroundPage();
+  if (!isFirefox) {
+    return;
+  }
+
+  await browser.contextMenus.create({
+    id: FIREFOX_OPTIONS_MENU_ID,
+    title: "Options",
+    contexts: ["browser_action"],
+  });
+
+  browser.contextMenus.onClicked.addListener(onContextMenuClick);
+}

--- a/src/background/firefoxCompat.ts
+++ b/src/background/firefoxCompat.ts
@@ -22,7 +22,6 @@ import { expectBackgroundPage } from "@/utils/expectContext";
 const FIREFOX_OPTIONS_MENU_ID = "PIXIEBRIX_FIREFOX_OPTIONS";
 
 function onContextMenuClick({ menuItemId }: browser.contextMenus.OnClickData) {
-  console.log("YO");
   if (menuItemId === FIREFOX_OPTIONS_MENU_ID) {
     void browser.runtime.openOptionsPage();
   }
@@ -34,11 +33,10 @@ export default async function initFirefoxCompat(): Promise<void> {
     return;
   }
 
+  browser.contextMenus.onClicked.addListener(onContextMenuClick);
   await browser.contextMenus.create({
     id: FIREFOX_OPTIONS_MENU_ID,
     title: "Options",
     contexts: ["browser_action"],
   });
-
-  browser.contextMenus.onClicked.addListener(onContextMenuClick);
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -169,6 +169,10 @@ export const isChrome =
   typeof navigator === "object" &&
   navigator.userAgent.toLowerCase().includes("chrome");
 
+export const isFirefox =
+  typeof navigator === "object" &&
+  navigator.userAgent.toLowerCase().includes("firefox");
+
 /**
  * True if the script is executing in a web browser context.
  */


### PR DESCRIPTION
There are a few behaviors in Firefox that don't match Chrome’s. I wanted to add more here but I think I'll just open multiple PRs.


## This PR


To open the extension’s options page you have to:

1. Right click on the icon
2. Click **Manage Extension**
2. Open the tiny hamburger menu
3. Click Preferences 🤦‍♂️ 

<img width="295" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/126060791-60685da3-ebab-449a-be8b-edbd8f707955.png">


Whereas in Chrome:

<img width="353" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/126060785-ba0092f5-3ea7-496c-852f-79c8ac3f4be3.png">

And now also in Firefox:

https://user-images.githubusercontent.com/1402241/126060811-53bf3a62-a414-45e9-8724-a49c286dff75.mov

It's been implemented as its own file for now as it can be extracted into its own module later, like `webext-consistent-behavior` or something like that.