### PR TITLE
#867: uninstall context menus in deployment flow

### DIFF
--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -31,6 +31,7 @@ import { refreshRegistries } from "@/hooks/refresh";
 import { liftBackground } from "@/background/protocol";
 import * as contentScript from "@/contentScript/lifecycle";
 import { selectInstalledExtensions } from "@/options/selectors";
+import { uninstallContextMenu } from "@/background/contextMenus";
 
 const { reducer, actions } = optionsSlice;
 
@@ -83,13 +84,16 @@ function installDeployment(
 
   for (const extension of installed) {
     if (extension._recipe.id === deployment.package.package_id) {
-      returnState = reducer(
-        returnState,
-        actions.removeExtension({
-          extensionPointId: extension.extensionPointId,
-          extensionId: extension.id,
-        })
-      );
+      const identifier = {
+        extensionPointId: extension.extensionPointId,
+        extensionId: extension.id,
+      };
+
+      void uninstallContextMenu(identifier).catch((error) => {
+        reportError(error);
+      });
+
+      returnState = reducer(returnState, actions.removeExtension(identifier));
     }
   }
 

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -205,7 +205,11 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
     const extensions = this.extensions.splice(0, this.extensions.length);
     if (global) {
       for (const extension of extensions) {
-        void uninstallContextMenu({ extensionId: extension.id });
+        void uninstallContextMenu({ extensionId: extension.id }).catch(
+          (error) => {
+            reportError(error);
+          }
+        );
       }
     }
   }

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -19,13 +19,13 @@ import { recordEvent, initUID } from "@/background/telemetry";
 import { JsonObject } from "type-fest";
 
 export function reportEvent(event: string, data: JsonObject = {}): void {
-  recordEvent({ event, data }).catch((error: unknown) => {
+  void recordEvent({ event, data }).catch((error: unknown) => {
     console.warn("Error reporting event", { error });
   });
 }
 
 export function initTelemetry(): void {
-  initUID().catch((error: unknown) => {
+  void initUID().catch((error: unknown) => {
     console.warn("Error initializing uid", { error });
   });
 }


### PR DESCRIPTION
Closes #867

Removes context menus in the deployment flow
- When installed from banner
- When installed automatically via the background page

Fixes some lint:
- Missing react dependencies
- Promise calls without void or await

Other:
- There's a bunch of duplicate code related to deployment reinstall (3 different places) that needs to be combined in the future. The `deployments.ts` code is hard to refactor because it uses a hacky approach to reusing the reducers