### PR TITLE
#865: remove property panel as default

### DIFF
--- a/src/actionPanel/PanelBody.tsx
+++ b/src/actionPanel/PanelBody.tsx
@@ -59,7 +59,9 @@ const PanelBody: React.FunctionComponent<{ panel: PanelEntry }> = ({
 
     if ("error" in panel.payload) {
       const { error } = panel.payload;
-      return <div className="text-danger">Error running panel: {error}</div>;
+      return (
+        <div className="text-danger p-3">Error running panel: {error}</div>
+      );
     }
 
     const { blockId, ctxt, args } = panel.payload;

--- a/src/blocks/renderers/common.ts
+++ b/src/blocks/renderers/common.ts
@@ -18,13 +18,38 @@
 import { Logger } from "@/core";
 import { PanelComponent } from "@/extensionPoints/dom";
 
+function isRendererOutput(value: unknown): boolean {
+  if (typeof value === "string") {
+    return true;
+  }
+
+  if (value != null && typeof value === "object") {
+    const keys = Object.keys(value);
+    return (
+      keys.length > 0 &&
+      keys.every((key) => ["Component", "props"].includes(key))
+    );
+  }
+
+  return false;
+}
+
 /** An error boundary for renderers */
 export async function errorBoundary(
   renderPromise: Promise<PanelComponent>,
   logger: Logger
 ): Promise<PanelComponent> {
   try {
-    return await renderPromise;
+    const value = await renderPromise;
+
+    if (!isRendererOutput(value)) {
+      logger.warn("Expected a renderer brick");
+      return `<div style="color: red;">Expected a renderer brick</div>`;
+    }
+
+    // TODO: validate the shape of the value returned
+    return value;
+
     // eslint-disable-next-line @typescript-eslint/no-implicit-any-catch
   } catch (error) {
     logger.error(error);

--- a/src/devTools/editor/extensionPoints/actionPanel.tsx
+++ b/src/devTools/editor/extensionPoints/actionPanel.tsx
@@ -24,7 +24,6 @@ import {
   makeExtensionReaders,
   makeIsAvailable,
   makeReaderFormState,
-  PROPERTY_TABLE_BODY,
   selectIsAvailable,
   WizardStep,
 } from "@/devTools/editor/extensionPoints/base";
@@ -110,7 +109,7 @@ function fromNativeElement(
     },
     extension: {
       heading,
-      body: PROPERTY_TABLE_BODY,
+      body: [],
     },
   };
 }
@@ -178,7 +177,7 @@ export async function fromExtensionPoint(
 
     extension: {
       heading: heading,
-      body: PROPERTY_TABLE_BODY,
+      body: [],
     },
 
     extensionPoint: {

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -241,13 +241,6 @@ export async function makeReaderFormState(
   );
 }
 
-export const PROPERTY_TABLE_BODY = [
-  {
-    id: "@pixiebrix/property-table",
-    config: {},
-  },
-];
-
 /**
  * Availability with single matchPattern and selector.
  * The page editor UI currently doesn't support multiple patterns/selectors

--- a/src/devTools/editor/extensionPoints/panel.ts
+++ b/src/devTools/editor/extensionPoints/panel.ts
@@ -23,7 +23,6 @@ import {
   makeIsAvailable,
   makeReaderFormState,
   WizardStep,
-  PROPERTY_TABLE_BODY,
   selectIsAvailable,
   lookupExtensionPoint,
   baseSelectExtensionPoint,
@@ -140,7 +139,7 @@ function fromNativeElement(
       heading: panel.panel.heading,
       collapsible: panel.panel.collapsible ?? false,
       shadowDOM: panel.panel.shadowDOM ?? true,
-      body: PROPERTY_TABLE_BODY,
+      body: [],
     },
   };
 }
@@ -214,7 +213,7 @@ async function fromExtensionPoint(
     extension: {
       heading,
       collapsible: boolean(collapsible ?? false),
-      body: PROPERTY_TABLE_BODY,
+      body: [],
     },
 
     // There's no containerInfo for the page because the user did not select it during the session

--- a/src/devTools/editor/tabs/effect/QuickAdd.tsx
+++ b/src/devTools/editor/tabs/effect/QuickAdd.tsx
@@ -29,7 +29,6 @@ import {
   faHighlighter,
   faKeyboard,
   faListOl,
-  faTable,
   faWindowRestore,
 } from "@fortawesome/free-solid-svg-icons";
 import { ElementType } from "@/devTools/editor/extensionPoints/elementConfig";

--- a/src/devTools/editor/tabs/effect/QuickAdd.tsx
+++ b/src/devTools/editor/tabs/effect/QuickAdd.tsx
@@ -25,6 +25,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconDefinition } from "@fortawesome/fontawesome-common-types";
 import {
   faCloud,
+  faGlobe,
   faHighlighter,
   faKeyboard,
   faListOl,
@@ -70,7 +71,7 @@ const RECOMMENDED_BRICKS = new Map<ElementType, Recommendation[]>([
     "panel",
     [
       { id: "@pixiebrix/property-table", icon: faListOl },
-      { id: "@pixiebrix/table", icon: faTable },
+      { id: "@pixiebrix/iframe", icon: faGlobe },
       { id: "@pixiebrix/get", icon: faCloud },
     ],
   ],
@@ -78,7 +79,7 @@ const RECOMMENDED_BRICKS = new Map<ElementType, Recommendation[]>([
     "actionPanel",
     [
       { id: "@pixiebrix/property-table", icon: faListOl },
-      { id: "@pixiebrix/table", icon: faTable },
+      { id: "@pixiebrix/iframe", icon: faGlobe },
       { id: "@pixiebrix/get", icon: faCloud },
     ],
   ],

--- a/src/extensionPoints/actionPanelExtension.ts
+++ b/src/extensionPoints/actionPanelExtension.ts
@@ -130,7 +130,7 @@ export abstract class ActionPanelExtensionPoint extends ExtensionPoint<ActionPan
       });
       // We're expecting a HeadlessModeError (or other error) to be thrown in the line above
       // noinspection ExceptionCaughtLocallyJS
-      throw new BusinessError("No renderer attached to body");
+      throw new BusinessError("No renderer brick attached to body");
     } catch (error: unknown) {
       if (error instanceof HeadlessModeError) {
         upsertPanel(


### PR DESCRIPTION
Closes #865

- Don't show property tree by default when using page editor to add a panel
- Add iframe to the list of recommended bricks