### PR TITLE
#866: add additional logging to deployment permission check

### DIFF
--- a/src/options/pages/deployments/DeploymentBanner.tsx
+++ b/src/options/pages/deployments/DeploymentBanner.tsx
@@ -76,9 +76,9 @@ function useEnsurePermissions(deployments: Deployment[]) {
     let accepted = false;
 
     try {
+      console.debug("Ensuring permissions for deployments", { permissions });
       accepted = await ensureAllPermissions(permissions);
     } catch (error: unknown) {
-      console.error(error);
       reportError(error);
       addToast(`Error granting permissions: ${error}`, {
         appearance: "error",
@@ -88,7 +88,7 @@ function useEnsurePermissions(deployments: Deployment[]) {
     }
 
     if (!accepted) {
-      addToast(`You declined the permissions`, {
+      addToast("You declined the permissions", {
         appearance: "error",
         autoDismiss: true,
       });

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -96,7 +96,7 @@ export async function requestPermissions(
   }
 
   // TODO: This only works in the Dev Tools; We should query the current or front-most window
-  // when this is missing in order to make it work in other contexts as well
+  //  when this is missing in order to make it work in other contexts as well
   const tabId = browser.devtools.inspectedWindow.tabId;
   await openPopupPrompt(tabId, page.toString());
   return containsPermissions(permissions);


### PR DESCRIPTION
I can't reproduce #866, so add logging to try to replicate it on client machines after next release