### PR TITLE
#878, #877: side panel reliability and removal

### DIFF
--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -77,7 +77,7 @@ const ActionPanelTabs: React.FunctionComponent<{ panels: PanelEntry[] }> = ({
 };
 
 const ActionPanelApp: React.FunctionComponent = () => {
-  const [{ panels }, setStoreState] = useState<ActionPanelStore>(getStore());
+  const [{ panels }, setStoreState] = useState(getStore());
 
   const syncPanels = useCallback(
     (store: ActionPanelStore) => {

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -171,6 +171,15 @@ function renderPanels() {
   }
 }
 
+export function removeExtension(extensionId: string): void {
+  expectContentScript();
+
+  // `panels` is const, so replace the contents
+  const current = panels.splice(0, panels.length);
+  panels.push(...current.filter((x) => x.extensionId !== extensionId));
+  renderPanels();
+}
+
 export function removeExtensionPoint(extensionPointId: string): void {
   expectContentScript();
 

--- a/src/actionPanel/protocol.tsx
+++ b/src/actionPanel/protocol.tsx
@@ -24,6 +24,8 @@ export const MESSAGE_PREFIX = "@@pixiebrix/browserAction/";
 
 export const RENDER_PANELS_MESSAGE = `${MESSAGE_PREFIX}RENDER_PANELS`;
 
+let seqNumber = -1;
+
 /**
  * Information required to run a renderer
  */
@@ -48,6 +50,7 @@ export type PanelEntry = {
 
 type RenderPanelsMessage = {
   type: typeof RENDER_PANELS_MESSAGE;
+  meta: { $seq: number };
   payload: { panels: PanelEntry[] };
 };
 
@@ -57,25 +60,45 @@ export type ActionPanelStore = {
 
 type StoreListener = (store: ActionPanelStore) => void;
 
-let _listeners: StoreListener[] = [];
+const listeners: StoreListener[] = [];
 
 export function addListener(fn: StoreListener): void {
-  _listeners.push(fn);
+  if (!listeners.includes(fn)) {
+    listeners.push(fn);
+  } else {
+    console.warn("Listener already registered for action panel");
+  }
 }
 
 export function removeListener(fn: StoreListener): void {
-  _listeners = _listeners.filter((x) => x !== fn);
+  listeners.splice(0, listeners.length, ...listeners.filter((x) => x !== fn));
 }
 
 const handlers = new HandlerMap();
 
-handlers.set(RENDER_PANELS_MESSAGE, async (request: RenderPanelsMessage) => {
+handlers.set(RENDER_PANELS_MESSAGE, async (message: RenderPanelsMessage) => {
+  const messageSeq = message.meta.$seq;
+
+  if (messageSeq < seqNumber) {
+    console.debug(
+      `Skipping stale message (seq: %d, current: %d)`,
+      seqNumber,
+      messageSeq,
+      message
+    );
+    return;
+  }
+  seqNumber = messageSeq;
+
   console.debug(
-    `Running render panels listeners for ${_listeners.length} listeners`
+    `Running ${listeners.length} listener(s) for %s`,
+    RENDER_PANELS_MESSAGE,
+    { message }
   );
-  for (const listener of _listeners) {
+
+  for (const listener of listeners) {
     try {
-      listener(request.payload);
+      listener(message.payload);
     } catch (error: unknown) {
       reportError(error);
     }

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -35,6 +35,12 @@ export const HIDE_ACTION_FRAME = `${MESSAGE_PREFIX}/HIDE_ACTION_FRAME`;
 const TOP_LEVEL_FRAME_ID = 0;
 
 /**
+ * Mapping from tabId to the message sequence number for forwarding. Reset/delete whenever the panel is shown/hidden.
+ * Messages with a sequence number lower than the value are dropped/skipped.
+ */
+const tabSeqNumber = new Map<number, number>();
+
+/**
  * Mapping from tabId to the nonce for the browser action iframe
  */
 const tabNonces = new Map<number, string>();
@@ -48,6 +54,7 @@ async function handleBrowserAction(tab: chrome.tabs.Tab): Promise<void> {
   // We're either getting a new frame, or getting rid of the existing one. Forget the old frame
   // id so we're not sending messages to a dead frame
   tabFrames.delete(tab.id);
+  tabSeqNumber.delete(tab.id);
 
   try {
     await ensureContentScript({ tabId: tab.id, frameId: TOP_LEVEL_FRAME_ID });
@@ -81,6 +88,7 @@ type RegisterActionFrameMessage = {
 
 type ForwardActionFrameNotification = {
   type: typeof FORWARD_FRAME_NOTIFICATION;
+  meta: { $seq: number };
   payload: {
     type: string;
     meta?: JsonObject;
@@ -115,23 +123,70 @@ async function waitFrameId(tabId: number): Promise<number> {
 /**
  * Send a message to the action frame (sidebar) for a page when it's ready
  * @param tabId the tab containing the action frame
+ * @param seqNum sequence number of the message, to ensure they're sent in the correct order despite non-determinism
+ * in when waitFrameId and content script ready are resolved
  * @param message the serializable message
  */
 async function forwardWhenReady(
   tabId: number,
-  message: { type: string }
+  seqNum: number,
+  message: { type: string; meta?: JsonObject }
 ): Promise<void> {
+  // `waitFrameId` and the `browser.tabs.sendMessage` loop cause non-determinism is what order the promises are
+  // resolved. Therefore, we need to use a sequence number to ensure the messages get sent in the correct order.
+
+  // Key assumption we're making: we're just forwarding render panel messages, which are safe to drop because the panel
+  // should always just be showing the values of the latest message
+
   const frameId = await waitFrameId(tabId);
 
+  const curSeqNum = tabSeqNumber.get(tabId);
+  if (curSeqNum != null && curSeqNum > seqNum) {
+    console.warn(
+      "Skipping stale message (current: %d, message: %d)",
+      curSeqNum,
+      seqNum
+    );
+    return;
+  }
+
+  const messageWithSequenceNumber = {
+    ...message,
+    meta: { ...(message.meta ?? {}), $seq: seqNum },
+  };
+
   console.debug(
-    `Forwarding message %s to action frame for tab: ${tabId}`,
-    message.type
+    `Forwarding message %s to action frame for tab: %d (seq: %d)`,
+    message.type,
+    tabId,
+    seqNum
   );
 
   const start = Date.now();
   while (Date.now() - start < FORWARD_RETRY_MAX_WAIT_MILLIS) {
+    const curSeqNum = tabSeqNumber.get(tabId);
+    if (curSeqNum != null && curSeqNum > seqNum) {
+      console.warn(
+        "Skipping stale message (current: %d, message: %d)",
+        curSeqNum,
+        seqNum
+      );
+      return;
+    }
+
     try {
-      return await browser.tabs.sendMessage(tabId, message, { frameId });
+      await browser.tabs.sendMessage(tabId, messageWithSequenceNumber, {
+        frameId,
+      });
+      console.debug(
+        `Forwarded message %s to action frame for tab: %d (seq: %d)`,
+        message.type,
+        tabId,
+        seqNum
+      );
+      // Message successfully received, so record latest sequence number for tab
+      tabSeqNumber.set(tabId, seqNum);
+      return;
     } catch (error: unknown) {
       if (getErrorMessage(error).includes("Could not establish connection")) {
         await sleep(FORWARD_RETRY_INTERVAL_MILLIS);
@@ -164,6 +219,7 @@ handlers.set(
       frameId: sender.frameId,
     });
     tabFrames.set(tabId, sender.frameId);
+    tabSeqNumber.delete(tabId);
   }
 );
 
@@ -171,7 +227,11 @@ handlers.set(
   FORWARD_FRAME_NOTIFICATION,
   async (request: ForwardActionFrameNotification, sender) => {
     const tabId = sender.tab.id;
-    return forwardWhenReady(tabId, request.payload).catch(reportError);
+    return forwardWhenReady(
+      tabId,
+      request.meta.$seq,
+      request.payload
+    ).catch((error) => reportError(error));
   }
 );
 
@@ -184,6 +244,7 @@ handlers.set(SHOW_ACTION_FRAME, async (_, sender) => {
   });
   console.debug("Setting action frame nonce", { sender, nonce });
   tabNonces.set(tabId, nonce);
+  tabSeqNumber.delete(tabId);
 });
 
 handlers.set(HIDE_ACTION_FRAME, async (_, sender) => {
@@ -192,6 +253,7 @@ handlers.set(HIDE_ACTION_FRAME, async (_, sender) => {
   await contentScript.hideActionPanel({ tabId, frameId: TOP_LEVEL_FRAME_ID });
   console.debug("Clearing action frame nonce", { sender });
   tabNonces.delete(tabId);
+  tabSeqNumber.delete(tabId);
 });
 
 if (isBackgroundPage()) {

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -138,6 +138,10 @@ async function forwardWhenReady(
   // Key assumption we're making: we're just forwarding render panel messages, which are safe to drop because the panel
   // should always just be showing the values of the latest message
 
+  // We _might_ be able to have forwardWhenReady handle the seqNum itself instead of passing an internal value. However
+  // I'm worried there would still some non-determinism because the source method calling forward from the content
+  // script uses `void browser.runtime.sendMessage`, so the messages are not guaranteed to be ordered
+
   const frameId = await waitFrameId(tabId);
 
   const curSeqNum = tabSeqNumber.get(tabId);

--- a/src/background/devtools/protocol.ts
+++ b/src/background/devtools/protocol.ts
@@ -263,6 +263,15 @@ export const uninstallContextMenu = liftBackground(
   }
 );
 
+export const uninstallActionPanelPanel = liftBackground(
+  "UNINSTALL_ACTION_PANEL_PANEL",
+  // False positive - it's the inner method that should be async
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  (target) => async ({ extensionId }: { extensionId: string }) => {
+    return browserActionProtocol.removeActionPanelPanel(target, extensionId);
+  }
+);
+
 export const initUiPathRobot = liftBackground(
   "UIPATH_INIT",
   (target: Target) => async () => {

--- a/src/background/navigation.ts
+++ b/src/background/navigation.ts
@@ -40,6 +40,7 @@ function initNavigation(): void {
 export const reactivate = liftBackground(
   "REACTIVATE",
   async () => {
+    console.debug("contentScript.reactivate on all tabs");
     await contentScript.reactivate(null);
   },
   { asyncResponse: false }

--- a/src/contentScript/browserAction.ts
+++ b/src/contentScript/browserAction.ts
@@ -34,3 +34,8 @@ export const hideActionPanel = liftContentScript(
   "HIDE_ACTION_PANEL",
   async () => native.hideActionPanel()
 );
+
+export const removeActionPanelPanel = liftContentScript(
+  "REMOVE_ACTION_PANEL_PANEL",
+  async (extensionId: string) => native.removeExtension(extensionId)
+);

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -23,9 +23,11 @@ import {
   notifyContentScripts,
 } from "@/contentScript/backgroundProtocol";
 import * as context from "@/contentScript/context";
+import * as actionPanel from "@/actionPanel/native";
 import { PromiseCancelled, sleep } from "@/utils";
 import { NAVIGATION_RULES } from "@/contrib/navigationRules";
 import { testMatchPatterns } from "@/blocks/available";
+import { reportError } from "@/telemetry/logging";
 
 let _scriptPromise: Promise<void>;
 const _dynamic: Map<string, IExtensionPoint> = new Map();
@@ -116,25 +118,33 @@ function markUninstalled(id: string) {
  * NOTE: if the dynamic extension was taking the place of a "permanent" extension, call `reactivate` or a similar
  * method for the extension to be reloaded.
  *
- * @param uuid the uuid of the dynamic extension, or undefined to clear all dynamic extensions
+ * NOTE: this works by removing all extensions attached to the extension point. Call `reactivate` or a similar
+ * method to re-install the installed extensions.
+ *
+ * @param extensionId the uuid of the dynamic extension, or undefined to clear all dynamic extensions
  */
-export function clearDynamic(uuid?: string): void {
-  if (uuid) {
-    if (_dynamic.has(uuid)) {
-      console.debug(`clearDynamic: ${uuid}`);
-      const extensionPoint = _dynamic.get(uuid);
+export function clearDynamic(extensionId?: string): void {
+  if (extensionId) {
+    if (_dynamic.has(extensionId)) {
+      console.debug(`clearDynamic: ${extensionId}`);
+      const extensionPoint = _dynamic.get(extensionId);
       extensionPoint.uninstall({ global: true });
-      _dynamic.delete(uuid);
+      _dynamic.delete(extensionId);
+      actionPanel.removeExtension(extensionId);
       markUninstalled(extensionPoint.id);
     } else {
-      console.debug(`No dynamic extension exists for uuid: ${uuid}`);
+      console.debug(`No dynamic extension exists for uuid: ${extensionId}`);
     }
   } else {
     for (const extensionPoint of _dynamic.values()) {
-      extensionPoint.uninstall({ global: true });
-      markUninstalled(extensionPoint.id);
+      try {
+        extensionPoint.uninstall({ global: true });
+        actionPanel.removeExtensionPoint(extensionPoint.id);
+        markUninstalled(extensionPoint.id);
+      } catch (error: unknown) {
+        reportError(error);
+      }
     }
-
     _dynamic.clear();
   }
 }

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -243,10 +243,18 @@ export function useCreate(): CreateCallback {
           type: element.type,
         });
 
+        // Make sure the page has the latest blocks/etc. for when we reactivate below
+        await Promise.all([
+          blockRegistry.fetch(),
+          extensionPointRegistry.fetch(),
+        ]);
+
         try {
           dispatch(saveExtension(adapter.selectExtension(element)));
           dispatch(markSaved(element.uuid));
+
           void reactivate();
+
           addToast("Saved extension", {
             appearance: "success",
             autoDismiss: true,
@@ -255,11 +263,6 @@ export function useCreate(): CreateCallback {
           onStepError(error, "saving extension");
           return;
         }
-
-        await Promise.all([
-          blockRegistry.fetch(),
-          extensionPointRegistry.fetch(),
-        ]);
       } catch (error: unknown) {
         console.error("Error saving extension", { error });
         reportError(error);

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -121,7 +121,7 @@ async function ensurePermissions(element: FormState, addToast: AddToast) {
 
   if (!hasPermissions) {
     addToast(
-      `You declined the additional required permissions. This brick won't work on other tabs until you grant the permissions`,
+      "You declined the additional required permissions. This brick won't work on other tabs until you grant the permissions",
       {
         appearance: "warning",
         autoDismiss: true,
@@ -168,7 +168,7 @@ export function useCreate(): CreateCallback {
           reportError(error);
           console.error("Error checking/enabling permissions", { error });
           addToast(
-            `An error occurred checking/enabling permissions. Grant permissions on the Active Bricks page`,
+            "An error occurred checking/enabling permissions. Grant permissions on the Active Bricks page",
             {
               appearance: "warning",
               autoDismiss: true,

--- a/src/devTools/editor/hooks/useRemove.ts
+++ b/src/devTools/editor/hooks/useRemove.ts
@@ -22,7 +22,6 @@ import { useToasts } from "react-toast-notifications";
 import { useFormikContext } from "formik";
 import { useDispatch } from "react-redux";
 import { useModals } from "@/components/ConfirmationModal";
-import { uninstallContextMenu } from "@/background/devtools";
 import * as nativeOperations from "@/background/devtools";
 import { optionsSlice } from "@/options/slices";
 import { reportError } from "@/telemetry/logging";
@@ -63,13 +62,10 @@ function useRemove(element: FormState): () => void {
         dispatch(optionsSlice.actions.removeExtension(target));
       }
 
-      if (element.type === "contextMenu") {
-        try {
-          await uninstallContextMenu(port, target);
-        } catch (error: unknown) {
-          console.warn("Error uninstalling contextMenu", { error });
-        }
-      }
+      void Promise.allSettled([
+        nativeOperations.uninstallContextMenu(port, target),
+        nativeOperations.uninstallActionPanelPanel(port, target),
+      ]);
 
       // Remove from page editor
       dispatch(actions.removeElement(element.uuid));

--- a/src/extensionPoints/actionPanelExtension.ts
+++ b/src/extensionPoints/actionPanelExtension.ts
@@ -166,19 +166,23 @@ export abstract class ActionPanelExtensionPoint extends ExtensionPoint<ActionPan
 
     if (this.extensions.length === 0) {
       console.debug(
-        `actionPanel extension point ${this.id} has no installed extension`
+        `actionPanel extension point %s has no installed extensions`,
+        this.id
       );
       return;
     }
 
     if (!isActionPanelVisible()) {
-      console.debug(`actionPanel is not visible`);
+      console.debug(
+        `Skipping run for %s because actionPanel is not visible`,
+        this.id
+      );
       return;
     }
 
     reservePanels(
-      this.extensions.map((x) => ({
-        extensionId: x.id,
+      this.extensions.map((extension) => ({
+        extensionId: extension.id,
         extensionPointId: this.id,
       }))
     );

--- a/src/extensionPoints/actionPanelExtension.ts
+++ b/src/extensionPoints/actionPanelExtension.ts
@@ -103,6 +103,12 @@ export abstract class ActionPanelExtensionPoint extends ExtensionPoint<ActionPan
     this.extensions.splice(0, this.extensions.length);
   }
 
+  public uninstall(): void {
+    this.removeExtensions();
+    removeExtensionPoint(this.id);
+    removeShowCallback(this.showCallback);
+  }
+
   private async runExtension(
     readerContext: ReaderOutput,
     extension: IExtension<ActionPanelConfig>
@@ -132,36 +138,24 @@ export abstract class ActionPanelExtensionPoint extends ExtensionPoint<ActionPan
       // noinspection ExceptionCaughtLocallyJS
       throw new BusinessError("No renderer brick attached to body");
     } catch (error: unknown) {
+      const ref = { extensionId: extension.id, extensionPointId: this.id };
+
       if (error instanceof HeadlessModeError) {
-        upsertPanel(
-          { extensionId: extension.id, extensionPointId: this.id },
-          heading,
-          {
-            blockId: error.blockId,
-            key: uuidv4(),
-            ctxt: error.ctxt,
-            args: error.args,
-          }
-        );
+        upsertPanel(ref, heading, {
+          blockId: error.blockId,
+          key: uuidv4(),
+          ctxt: error.ctxt,
+          args: error.args,
+        });
       } else {
-        upsertPanel(
-          { extensionId: extension.id, extensionPointId: this.id },
-          heading,
-          {
-            key: uuidv4(),
-            error: getErrorMessage(error as Error),
-          }
-        );
+        upsertPanel(ref, heading, {
+          key: uuidv4(),
+          error: getErrorMessage(error as Error),
+        });
         reportError(error);
         throw error;
       }
     }
-  }
-
-  public uninstall(): void {
-    this.removeExtensions();
-    removeExtensionPoint(this.id);
-    removeShowCallback(this.showCallback);
   }
 
   async run(extensionIds?: string[]): Promise<void> {

--- a/src/options/pages/InstalledPage.tsx
+++ b/src/options/pages/InstalledPage.tsx
@@ -415,13 +415,13 @@ const mapStateToProps = (state: { options: OptionsState }) => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  onRemove: (identifier: ExtensionIdentifier) => {
+  onRemove: (ref: ExtensionIdentifier) => {
     reportEvent("ExtensionRemove", {
-      extensionId: identifier.extensionId,
+      extensionId: ref.extensionId,
     });
     // Remove from storage first so it doesn't get re-added in reactivate step below
-    dispatch(removeExtension(identifier));
-    void uninstallContextMenu(identifier).catch((error) => {
+    dispatch(removeExtension(ref));
+    void uninstallContextMenu(ref).catch((error) => {
       reportError(error);
     });
     void reactivate().catch((error: unknown) => {

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -19,8 +19,9 @@ import { recordEvent, initUID } from "@/background/telemetry";
 import { JsonObject } from "type-fest";
 
 export function reportEvent(event: string, data: JsonObject = {}): void {
+  console.debug(event);
   void recordEvent({ event, data }).catch((error: unknown) => {
-    console.warn("Error reporting event", { error });
+    console.warn("Error reporting event %s", event, { error });
   });
 }
 


### PR DESCRIPTION
* Closes #877 
* Closes #878 

TODO:
- [x] On removal in page editor, call the native remove method: http://github.com/pixiebrix/pixiebrix-extension/blob/1aba9c5c4fa0112d948ef52c69dcd00ae1dcdbb6/src/devTools/editor/hooks/useRemove.ts#L79-L79
- [X] Add logging around sequence of events in page load
- [X] Report sidebar open/close events in telemetry
- [X] Fix panel loading issue - happens on new tabs. This was caused by non-determinism in the forwardWhenReady method. Panel updates were being received out of sequence
- [X] Make useCreate order in page editor more explicit using awaits