### PR TITLE
#811: lazy-load handlebars/nunjucks

### DIFF
--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -192,10 +192,13 @@ async function runStage(
     }
   } else {
     // HACK: hack to avoid applying a list to the config for blocks that pass a list to the next block
-    const renderer = await engineRenderer(stage.templateEngine);
 
     blockArgs = isPlainObject(args)
-      ? mapArgs(stageConfig, argContext, renderer)
+      ? mapArgs(
+          stageConfig,
+          argContext,
+          await engineRenderer(stage.templateEngine)
+        )
       : stageConfig;
 
     if (logValues) {

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -20,7 +20,6 @@ import { ExtensionPoint } from "@/types";
 import Mustache from "mustache";
 import { checkAvailable } from "@/blocks/available";
 import { castArray, compact, once, debounce } from "lodash";
-import { engineRenderer } from "@/helpers";
 import {
   reducePipeline,
   mergeReaders,
@@ -63,6 +62,7 @@ import { getNavigationId } from "@/contentScript/context";
 import { rejectOnCancelled, PromiseCancelled } from "@/utils";
 import { PanelDefinition } from "@/extensionPoints/panelExtension";
 import iconAsSVG from "@/icons/svgIcons";
+import { engineRenderer } from "@/utils/renderers";
 
 interface ShadowDOM {
   mode?: "open" | "closed";
@@ -426,7 +426,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
       icon = { id: "box", size: 18 },
     } = extension.config;
 
-    const renderTemplate = engineRenderer(extension.templateEngine);
+    const renderTemplate = await engineRenderer(extension.templateEngine);
 
     let html: string;
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -16,51 +16,10 @@
  */
 
 import Mustache from "mustache";
-import nunjucks from "nunjucks";
-import isPlainObject from "lodash/isPlainObject";
-import mapValues from "lodash/mapValues";
-import pickBy from "lodash/pickBy";
-import mapKeys from "lodash/mapKeys";
-import { TemplateEngine, Schema, SchemaProperties } from "@/core";
-import Handlebars from "handlebars";
+import { mapValues, pickBy, isPlainObject } from "lodash";
+import { Schema, SchemaProperties } from "@/core";
 import { getPropByPath } from "@/utils";
-
-nunjucks.configure({ autoescape: true });
-
-const hyphenRegex = /-/gi;
-
-type Renderer = (template: string, context: object) => string;
-
-export function engineRenderer(
-  templateEngine: TemplateEngine = "mustache"
-): Renderer | undefined {
-  switch (templateEngine.toLowerCase()) {
-    case "mustache": {
-      return Mustache.render;
-    }
-
-    case "nunjucks": {
-      // Convert top level data from kebab case to snake case in order to be valid identifiers
-      return (template, ctxt) => {
-        const snakeCased = mapKeys(ctxt, (value, key) =>
-          key.replace(hyphenRegex, "_")
-        );
-        return nunjucks.renderString(template, snakeCased);
-      };
-    }
-
-    case "handlebars": {
-      return (template, ctxt) => {
-        const compiledTemplate = Handlebars.compile(template);
-        return compiledTemplate(ctxt);
-      };
-    }
-
-    default: {
-      return undefined;
-    }
-  }
-}
+import { Renderer } from "@/utils/renderers";
 
 // First part of the path can be global context with a @
 const pathRegex = /^(@?[\w-]+\??)(\.[\w-]+\??)*$/;

--- a/src/utils/renderers.ts
+++ b/src/utils/renderers.ts
@@ -17,29 +17,18 @@
 
 import { TemplateEngine } from "@/core";
 import Mustache from "mustache";
-import mapKeys from "lodash/mapKeys";
+import { mapKeys, once } from "lodash";
 
 const hyphenRegex = /-/gi;
 
+// eslint-disable-next-line @typescript-eslint/ban-types -- we don't need key logic
 export type Renderer = (template: string, context: object) => string;
 
-let _nunjucks: any;
-let _handlebars: any;
-
-async function ensureNunjucks() {
-  if (_nunjucks == null) {
-    _nunjucks = (await import("nunjucks")).default;
-    _nunjucks.configure({ autoescape: true });
-  }
-  return _nunjucks;
-}
-
-async function ensureHandlebars() {
-  if (!_handlebars == null) {
-    _handlebars = (await import("handlebars")).default;
-  }
-  return _handlebars;
-}
+const ensureNunjucks = once(async () => {
+  const { default: nunjucks } = await import("nunjucks");
+  nunjucks.configure({ autoescape: true });
+  return nunjucks;
+});
 
 export async function engineRenderer(
   templateEngine: TemplateEngine = "mustache"
@@ -61,7 +50,7 @@ export async function engineRenderer(
     }
 
     case "handlebars": {
-      const handlebars = await ensureHandlebars();
+      const handlebars = (await import("handlebars")).default;
       return (template, ctxt) => {
         const compiledTemplate = handlebars.compile(template);
         return compiledTemplate(ctxt);

--- a/src/utils/renderers.ts
+++ b/src/utils/renderers.ts
@@ -27,7 +27,7 @@ let _nunjucks: any;
 let _handlebars: any;
 
 async function ensureNunjucks() {
-  if (!_nunjucks) {
+  if (_nunjucks == null) {
     _nunjucks = (await import("nunjucks")).default;
     _nunjucks.configure({ autoescape: true });
   }
@@ -35,7 +35,7 @@ async function ensureNunjucks() {
 }
 
 async function ensureHandlebars() {
-  if (_handlebars) {
+  if (!_handlebars == null) {
     _handlebars = (await import("handlebars")).default;
   }
   return _handlebars;

--- a/src/utils/renderers.ts
+++ b/src/utils/renderers.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TemplateEngine } from "@/core";
+import Mustache from "mustache";
+import mapKeys from "lodash/mapKeys";
+
+const hyphenRegex = /-/gi;
+
+export type Renderer = (template: string, context: object) => string;
+
+let _nunjucks: any;
+let _handlebars: any;
+
+async function ensureNunjucks() {
+  if (!_nunjucks) {
+    _nunjucks = (await import("nunjucks")).default;
+    _nunjucks.configure({ autoescape: true });
+  }
+  return _nunjucks;
+}
+
+async function ensureHandlebars() {
+  if (_handlebars) {
+    _handlebars = (await import("handlebars")).default;
+  }
+  return _handlebars;
+}
+
+export async function engineRenderer(
+  templateEngine: TemplateEngine = "mustache"
+): Promise<Renderer | undefined> {
+  switch (templateEngine.toLowerCase()) {
+    case "mustache": {
+      return Mustache.render;
+    }
+
+    case "nunjucks": {
+      const nunjucks = await ensureNunjucks();
+      return (template, ctxt) => {
+        // Convert top level data from kebab case to snake case in order to be valid identifiers
+        const snakeCased = mapKeys(ctxt, (value, key) =>
+          key.replace(hyphenRegex, "_")
+        );
+        return nunjucks.renderString(template, snakeCased);
+      };
+    }
+
+    case "handlebars": {
+      const handlebars = await ensureHandlebars();
+      return (template, ctxt) => {
+        const compiledTemplate = handlebars.compile(template);
+        return compiledTemplate(ctxt);
+      };
+    }
+
+    default: {
+      return undefined;
+    }
+  }
+}

--- a/src/utils/renderers.ts
+++ b/src/utils/renderers.ts
@@ -50,7 +50,7 @@ export async function engineRenderer(
     }
 
     case "handlebars": {
-      const handlebars = (await import("handlebars")).default;
+      const { default: handlebars } = await import("handlebars");
       return (template, ctxt) => {
         const compiledTemplate = handlebars.compile(template);
         return compiledTemplate(ctxt);


### PR DESCRIPTION
Closes #811

![image](https://user-images.githubusercontent.com/1879821/126411891-19e51361-1c13-4f47-a6ef-ec94a8a8f6ca.png)

Future work: 
- Refactor helpers.ts to separate mapArgs from the more generic content (e.g., `isChrome`) which is used by more of the bundles