### PR TITLE
Feature/846 validate dom nesting warning

### DIFF
--- a/.idea/GitLinkConfig.xml
+++ b/.idea/GitLinkConfig.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Preferences">
+    <option name="defaultBranchName" value="main" />
+  </component>
+</project>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -19,6 +19,7 @@ import "vendors/theme/app/app.scss";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faMusic } from "@fortawesome/free-solid-svg-icons";
 
+// https://github.com/storybookjs/storybook/issues/3798
 library.add(faMusic);
 
 export const parameters = {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -16,6 +16,10 @@
  */
 
 import "vendors/theme/app/app.scss";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faMusic } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faMusic);
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -16,6 +16,7 @@
  */
 
 import "vendors/theme/app/app.scss";
+import "@/vendors/overrides.scss";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faMusic } from "@fortawesome/free-solid-svg-icons";
 

--- a/src/components/AsyncButton.stories.tsx
+++ b/src/components/AsyncButton.stories.tsx
@@ -26,14 +26,14 @@ export default {
   argTypes: {
     onClick: { action: "clicked" },
     variant: {
+      options: ["primary", "secondary", "info", "warning", "danger"],
       control: {
-        options: ["primary", "secondary", "info", "warning", "danger"],
         type: "select",
       },
     },
     size: {
+      options: ["lg", "md", "sm"],
       control: {
-        options: ["lg", "md", "sm"],
         type: "select",
       },
     },

--- a/src/layout/Page.stories.tsx
+++ b/src/layout/Page.stories.tsx
@@ -18,14 +18,15 @@
 import React from "react";
 import Page from "@/layout/Page";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import "@/vendors/overrides.scss";
 
 export default {
   component: Page,
   title: "Layout/Page",
 } as ComponentMeta<typeof Page>;
 
-const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />;
+const Template: ComponentStory<typeof Page> = (args) => (
+  <Page {...args}>Hello world!</Page>
+);
 
 export const Default = Template.bind({});
 Default.args = {

--- a/src/layout/Page.stories.tsx
+++ b/src/layout/Page.stories.tsx
@@ -17,13 +17,14 @@
 
 import React from "react";
 import Page from "@/layout/Page";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 export default {
   component: Page,
   title: "Layout/Page",
-};
+} as ComponentMeta<typeof Page>;
 
-const Template = (args) => <Page {...args} />;
+const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/src/layout/Page.stories.tsx
+++ b/src/layout/Page.stories.tsx
@@ -17,7 +17,6 @@
 
 import React from "react";
 import Page from "@/layout/Page";
-import { faMusic } from "@fortawesome/free-solid-svg-icons";
 
 export default {
   component: Page,
@@ -28,7 +27,7 @@ const Template = (args) => <Page {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
-  icon: { faMusic },
+  icon: "music",
   title: "Example page",
   description: "Welcome to an example page! Have a look around.",
 };

--- a/src/layout/Page.stories.tsx
+++ b/src/layout/Page.stories.tsx
@@ -18,6 +18,7 @@
 import React from "react";
 import Page from "@/layout/Page";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
+import "@/vendors/overrides.scss";
 
 export default {
   component: Page,

--- a/src/layout/Page.stories.tsx
+++ b/src/layout/Page.stories.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import Page from "@/layout/Page";
+
+export default {
+  component: Page,
+  title: "Page",
+};
+
+const Template = (args) => <Page {...args} />;

--- a/src/layout/Page.stories.tsx
+++ b/src/layout/Page.stories.tsx
@@ -17,10 +17,18 @@
 
 import React from "react";
 import Page from "@/layout/Page";
+import { faMusic } from "@fortawesome/free-solid-svg-icons";
 
 export default {
   component: Page,
-  title: "Page",
+  title: "Layout/Page",
 };
 
 const Template = (args) => <Page {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  icon: { faMusic },
+  title: "Example page",
+  description: "Welcome to an example page! Have a look around.",
+};

--- a/src/layout/Page.tsx
+++ b/src/layout/Page.tsx
@@ -58,6 +58,7 @@ const Page: React.FunctionComponent<{
               ) : (
                 description
               ))}
+            {breadcrumb}
           </div>
         </div>
         {toolbar && <div>{toolbar}</div>}

--- a/src/layout/Page.tsx
+++ b/src/layout/Page.tsx
@@ -52,12 +52,11 @@ const Page: React.FunctionComponent<{
         <div className="flex-grow-1">
           <PageTitle icon={icon} title={title} />
           <div className="pb-4">
-            {description &&
-              (description instanceof String ? (
-                <p>{description}</p>
-              ) : (
-                description
-              ))}
+            {typeof description === "string" ? (
+              <p>{description}</p>
+            ) : (
+              description
+            )}
             {breadcrumb}
           </div>
         </div>

--- a/src/layout/Page.tsx
+++ b/src/layout/Page.tsx
@@ -52,8 +52,12 @@ const Page: React.FunctionComponent<{
         <div className="flex-grow-1">
           <PageTitle icon={icon} title={title} />
           <div className="pb-4">
-            {description && <p>{description}</p>}
-            {breadcrumb}
+            {description &&
+              (description instanceof String ? (
+                <p>{description}</p>
+              ) : (
+                description
+              ))}
           </div>
         </div>
         {toolbar && <div>{toolbar}</div>}


### PR DESCRIPTION
This fixes #846 by adding extra conditional rendering to a Page component description. Specifically, this will render the description wrapped in `<p>` tags if the description is a String object, otherwise it will render as-is.