### PR TITLE
#881: add `DEV_SLIM` environment option

### DIFF
--- a/src/__mocks__/iconsMock.ts
+++ b/src/__mocks__/iconsMock.ts
@@ -15,23 +15,39 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { IconConfig } from "@/core";
+
 export type IconLibrary = "bootstrap" | "simple-icons";
 
-export interface IconConfig {
-  id: string;
-  library?: IconLibrary;
-  size?: number;
-}
+const DEFAULT_ICON_CONFIG: IconConfig = { library: "bootstrap", id: "box" };
 
 export interface IconOption {
   value: { id: string; library: IconLibrary };
   label: string;
 }
 
-export const iconOptions: IconOption[] = [];
+export const iconOptions: IconOption[] = [
+  {
+    value: { id: "exclamation-triangle", library: "bootstrap" },
+    label: "No Icons - Slim Build",
+  },
+];
 
-async function iconAsSVG(): Promise<string> {
-  return "<svg></svg>";
+// https://raw.githubusercontent.com/twbs/icons/main/icons/exclamation-triangle.svg -- bootstrap icon triangle
+const icon =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-triangle" viewBox="0 0 16 16">\n' +
+  '  <path d="M7.938 2.016A.13.13 0 0 1 8.002 2a.13.13 0 0 1 .063.016.146.146 0 0 1 .054.057l6.857 11.667c.036.06.035.124.002.183a.163.163 0 0 1-.054.06.116.116 0 0 1-.066.017H1.146a.115.115 0 0 1-.066-.017.163.163 0 0 1-.054-.06.176.176 0 0 1 .002-.183L7.884 2.073a.147.147 0 0 1 .054-.057zm1.044-.45a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566z"/>\n' +
+  '  <path d="M7.002 12a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 5.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995z"/>\n' +
+  "</svg>";
+
+async function iconAsSVG(
+  config: IconConfig = DEFAULT_ICON_CONFIG
+): Promise<string> {
+  const $elt = $(icon);
+  $elt.attr("width", config.size ?? 14);
+  $elt.attr("height", config.size ?? 14);
+  $elt.attr("fill", config.color ?? "#ae87e8");
+  return $elt.get(0).outerHTML;
 }
 
 export default iconAsSVG;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,10 @@ for (const [env, defaultValue] of Object.entries(defaults)) {
 
 if (true) {
   console.warn("Mocking icons for development build");
-  resolve.alias["@/icons/svgIcons"] = path.resolve("src/__mocks__/iconsMock");
+  resolve.alias = {
+    "@/icons/svgIcons": path.resolve("src/__mocks__/iconsMock"),
+    ...resolve.alias,
+  };
   console.info(resolve.alias);
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,7 @@ const { resolve } = require("./resolve.config.js");
 // Include defaults required for webpack here. Add defaults for the extension bundle to EnvironmentPlugin
 const defaults = {
   DEV_NOTIFY: "true",
+  DEV_SLIM: "false",
   CHROME_EXTENSION_ID: "mpjjildhmpddojocokjkgmlkkkfjnepo",
   ROLLBAR_PUBLIC_PATH: "extension://dynamichost",
 
@@ -49,15 +50,6 @@ for (const [env, defaultValue] of Object.entries(defaults)) {
   if (isEmpty(process.env[env])) {
     process.env[env] = defaultValue;
   }
-}
-
-if (true) {
-  console.warn("Mocking icons for development build");
-  resolve.alias = {
-    "@/icons/svgIcons": path.resolve("src/__mocks__/iconsMock"),
-    ...resolve.alias,
-  };
-  console.info(resolve.alias);
 }
 
 console.log("SOURCE_VERSION:", process.env.SOURCE_VERSION);
@@ -187,6 +179,18 @@ function customizeManifest(manifest, isProduction) {
       scopes: [""],
     };
   }
+}
+
+if (process.env.DEV_SLIM.toLowerCase() === "true") {
+  console.warn(
+    "Mocking dependencies for development build: svgIcons, uipath/robot"
+  );
+  resolve.alias = {
+    // Webpack resolves aliases in order, so our overrides need to be first
+    "@/icons/svgIcons": path.resolve("src/__mocks__/iconsMock"),
+    "@uipath/robot": path.resolve("src/__mocks__/robotMock"),
+    ...resolve.alias,
+  };
 }
 
 module.exports = (env, options) => ({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,12 @@ for (const [env, defaultValue] of Object.entries(defaults)) {
   }
 }
 
+if (true) {
+  console.warn("Mocking icons for development build");
+  resolve.alias["@/icons/svgIcons"] = path.resolve("src/__mocks__/iconsMock");
+  console.info(resolve.alias);
+}
+
 console.log("SOURCE_VERSION:", process.env.SOURCE_VERSION);
 console.log("SERVICE_URL:", process.env.SERVICE_URL);
 console.log("CHROME_EXTENSION_ID:", process.env.CHROME_EXTENSION_ID);


### PR DESCRIPTION
@fregante any idea of what might be causing webpack to still bundle the icon assets? 

I'm trying to alias to our existing mock for Jest

```
resolve.alias["@/icons/svgIcons"] = path.resolve("src/__mocks__/iconsMock");
```

But Webpack is still creating the icon directories:

```
Mocking icons for development build
{
  '@': '/Users/tschiller/projects/pixiebrix-extension/src',
  '@img': '/Users/tschiller/projects/pixiebrix-extension/img',
  '@contrib': '/Users/tschiller/projects/pixiebrix-extension/contrib',
  '@schemas': '/Users/tschiller/projects/pixiebrix-extension/schemas',
  vendors: '/Users/tschiller/projects/pixiebrix-extension/src/vendors',
  '@microsoft/applicationinsights-web': '/Users/tschiller/projects/pixiebrix-extension/src/contrib/uipath/quietLogger',
  handlebars: 'handlebars/dist/handlebars.js',
  '@/icons/svgIcons': '/Users/tschiller/projects/pixiebrix-extension/src/__mocks__/iconsMock'
}
SOURCE_VERSION: undefined
SERVICE_URL: http://127.0.0.1:8000
CHROME_EXTENSION_ID: mpjjildhmpddojocokjkgmlkkkfjnepo
assets by path user-icons/simple-icons/*.svg 2.92 MiB 1972 assets
assets by path user-icons/bootstrap-icons/*.svg 739 KiB 1370 assets
```