### PR TITLE
Soft-enable most lint rules from strict configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,8 +17,8 @@
     }
   },
   "extends": [
-    "xo",
-    "xo-typescript",
+    "xo", // Full config: https://github.com/xojs/eslint-config-xo/blob/main/index.js
+    "xo-typescript", // Full config: https://github.com/xojs/eslint-config-xo-typescript/blob/main/index.js
     "prettier", // Disable style-related rules
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",

--- a/.eslintrc
+++ b/.eslintrc
@@ -48,6 +48,8 @@
         }
       }
     ],
+    // smart allows for != null. See: https://github.com/pixiebrix/pixiebrix-extension/pull/887#pullrequestreview-711873690
+    "eqeqeq": ["error", "smart"],
 
     // Soft-enable some rules, maybe enforce them later
     "@typescript-eslint/ban-types": "warn",
@@ -61,7 +63,8 @@
     "unicorn/prefer-switch": "warn",
 
     // Disable recommended rules
-    "no-eq-null": "off", // It's fine https://github.com/pixiebrix/pixiebrix-extension/pull/887#pullrequestreview-711873690
+    // It's fine because eqeqeq covers it. See https://github.com/pixiebrix/pixiebrix-extension/pull/887#pullrequestreview-711873690
+    "no-eq-null": "off",
     "import/named": "off", // TypeScript does this natively
     "react/prop-types": "off",
     "unicorn/filename-case": "off", // Contrasts with React
@@ -75,7 +78,6 @@
     "padding-line-between-statements": "off",
 
     // Temporarily disable rules
-    "eqeqeq": ["warn", "smart"],
     "no-await-in-loop": "warn",
     "no-negated-condition": "warn",
     "no-implicit-coercion": "warn",

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,7 @@
 {
   "root": true,
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "security", "unicorn"],
   "env": {
     "browser": true
-  },
-  "parserOptions": {
-    "project": "tsconfig.json"
   },
   "settings": {
     "import/resolver": {
@@ -22,11 +17,9 @@
     }
   },
   "extends": [
-    // TODO: replace the following 3 with the stricter xo-typescript config
-    "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
-
+    "xo",
+    "xo-typescript",
+    "prettier", // Disable style-related rules
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:import/recommended",
@@ -35,40 +28,7 @@
     "plugin:unicorn/recommended"
   ],
   "rules": {
-    // Enable a few more rules
-    "no-lonely-if": "error",
-    "no-else-return": [
-      "error",
-      {
-        "allowElseIf": false
-      }
-    ],
-    "no-negated-condition": "off",
-    "no-useless-return": "error",
-    "prefer-promise-reject-errors": "error",
-    "padding-line-between-statements": "error",
-    "@typescript-eslint/no-implicit-any-catch": "error",
-    "@typescript-eslint/lines-between-class-members": "error",
-
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      {
-        "vars": "all",
-        "args": "after-used",
-        "ignoreRestSiblings": true,
-        "argsIgnorePattern": "^_",
-        "caughtErrors": "all",
-        "caughtErrorsIgnorePattern": "^_$"
-      }
-    ],
-    "@typescript-eslint/ban-ts-comment": [
-      "error",
-      {
-        "ts-ignore": "allow-with-description",
-        "minimumDescriptionLength": 3
-      }
-    ],
-
+    // Customize some rules
     "import/no-unresolved": [
       "error",
       {
@@ -100,52 +60,75 @@
     "unicorn/prefer-prototype-methods": "warn", // Buggy with abstract classes
     "unicorn/prefer-switch": "warn",
 
-    // Config copied from https://github.com/xojs/eslint-config-xo-typescript/blob/7842d05deaadff1ced9a46f3e56d786e7b2922d2/index.js#L306
-    "@typescript-eslint/no-floating-promises": [
-      "warn",
-      {
-        "ignoreVoid": true, // Prepend a function call with `void` to mark it as not needing to be await'ed, which silences this rule.
-        "ignoreIIFE": true
-      }
-    ],
-
-    // Config copied from https://github.com/xojs/eslint-config-xo/blob/main/index.js#L275
-    "capitalized-comments": [
-      "error",
-      "always",
-      {
-        "ignorePattern": "pragma|ignore|prettier-ignore|webpack",
-        "ignoreInlineComments": true,
-        "ignoreConsecutiveComments": true
-      }
-    ],
-
-    "spaced-comment": [
-      "error",
-      "always",
-      {
-        "line": {
-          "exceptions": ["-", "+", "*"],
-          "markers": ["!", "/", "=>"]
-        },
-        "block": {
-          "exceptions": ["-", "+", "*"],
-          "markers": ["!", "*"],
-          "balanced": true
-        }
-      }
-    ],
-
     // Disable recommended rules
-    "@typescript-eslint/no-empty-function": "off",
     "import/named": "off", // TypeScript does this natively
     "react/prop-types": "off",
-    "unicorn/no-null": "off", // Maybe later
     "unicorn/filename-case": "off", // Contrasts with React
     "unicorn/prefer-node-protocol": "off", // Not fully supported by TS
     "unicorn/prefer-set-has": "off", // Not always worth the extra code
-    "unicorn/prefer-ternary": "off", // Maybe later
-    "unicorn/require-post-message-target-origin": "off" // Incompatible https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1396
+    "unicorn/require-post-message-target-origin": "off", // Incompatible https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1396
+
+    // Large diffs, autofix later together
+    "arrow-body-style": "off",
+    "prefer-arrow-callback": "off",
+    "padding-line-between-statements": "off",
+
+    // Temporarily disable rules
+    "eqeqeq": "warn",
+    "no-eq-null": "warn",
+    "no-await-in-loop": "warn",
+    "no-negated-condition": "warn",
+    "no-implicit-coercion": "warn",
+    "prefer-destructuring": "warn",
+    "object-shorthand": "warn",
+    "no-return-await": "warn",
+    "no-promise-executor-return": "warn",
+    "no-useless-concat": "warn",
+    "new-cap": "warn",
+    "prefer-object-spread": "warn",
+    "no-self-compare": "warn",
+
+    "@typescript-eslint/no-confusing-void-expression": "warn",
+    "@typescript-eslint/restrict-template-expressions": "warn",
+    "@typescript-eslint/consistent-indexed-object-style": "warn",
+    "@typescript-eslint/no-base-to-string": "warn",
+    "@typescript-eslint/no-unnecessary-type-arguments": "warn",
+    "@typescript-eslint/prefer-ts-expect-error": "warn",
+    "@typescript-eslint/dot-notation": "warn",
+    "@typescript-eslint/array-type": "warn",
+    "@typescript-eslint/non-nullable-type-assertion-style": "warn",
+    "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+    "@typescript-eslint/consistent-type-assertions": "warn",
+    "@typescript-eslint/no-require-imports": "warn",
+    "@typescript-eslint/no-dynamic-delete": "warn",
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": "warn",
+    "@typescript-eslint/await-thenable": "warn",
+    "@typescript-eslint/return-await": "warn",
+    "@typescript-eslint/prefer-readonly": "warn",
+    "@typescript-eslint/prefer-optional-chain": "warn",
+    "@typescript-eslint/class-literal-property-style": "warn",
+    "@typescript-eslint/triple-slash-reference": "warn",
+    "@typescript-eslint/prefer-string-starts-ends-with": "warn",
+    "@typescript-eslint/prefer-function-type": "warn",
+    "@typescript-eslint/no-redeclare": "warn",
+    "@typescript-eslint/no-misused-promises": "warn",
+    "@typescript-eslint/no-loop-func": "warn",
+    "@typescript-eslint/unified-signatures": "warn",
+    "@typescript-eslint/prefer-regexp-exec": "warn",
+    "@typescript-eslint/no-useless-constructor": "warn",
+    "@typescript-eslint/default-param-last": "warn",
+
+    // Too strict for now
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-return": "off",
+    "@typescript-eslint/no-unsafe-call": "off",
+
+    // Maybe later, opinionated
+    "unicorn/no-null": "off",
+    "unicorn/prefer-ternary": "off",
+    "@typescript-eslint/member-ordering": "off",
+    "@typescript-eslint/no-empty-function": "off"
   },
   "ignorePatterns": [
     "node_modules",

--- a/.eslintrc
+++ b/.eslintrc
@@ -61,6 +61,7 @@
     "unicorn/prefer-switch": "warn",
 
     // Disable recommended rules
+    "no-eq-null": "off", // It's fine https://github.com/pixiebrix/pixiebrix-extension/pull/887#pullrequestreview-711873690
     "import/named": "off", // TypeScript does this natively
     "react/prop-types": "off",
     "unicorn/filename-case": "off", // Contrasts with React
@@ -74,8 +75,7 @@
     "padding-line-between-statements": "off",
 
     // Temporarily disable rules
-    "eqeqeq": "warn",
-    "no-eq-null": "warn",
+    "eqeqeq": ["warn", "smart"],
     "no-await-in-loop": "warn",
     "no-negated-condition": "warn",
     "no-implicit-coercion": "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14348,6 +14348,12 @@
         "proto-list": "~1.2.1"
       }
     },
+    "confusing-browser-globals": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+      "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
+      "dev": true
+    },
     "connected-react-router": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.9.1.tgz",
@@ -16319,6 +16325,30 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true
+    },
+    "eslint-config-xo": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.37.0.tgz",
+      "integrity": "sha512-aOCZ4fDELnhdojORvV5GcyxrjOzDH75UMkRlRD5/eGVekA5PfTiQjW0/E3Tqa4zCnEgB77PO7JCRWhB8dEv7xg==",
+      "dev": true,
+      "requires": {
+        "confusing-browser-globals": "1.0.10"
+      }
+    },
+    "eslint-config-xo-typescript": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.43.0.tgz",
+      "integrity": "sha512-8T4O7Dy4c5/TeOPxBOTw7DI8fgS+u5ni0xA6alcJDyiMCuBq7O+FUMsOkz2vAOQ3C3HMkYmkpAXA/gZFX4QUrg==",
+      "dev": true,
+      "requires": {
+        "typescript": ">=4.3"
       }
     },
     "eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watchAll",
-    "lint": "eslint src",
+    "lint": "eslint src --ext js,jsx,ts,tsx",
     "watch": "ENV_FILE='.env.development' webpack --mode development --watch",
     "build": "NODE_OPTIONS=--max_old_space_size=8192 webpack --mode production",
     "build:scripts": "webpack --mode production --config scripts/webpack.scripts.js",
@@ -179,6 +179,9 @@
     "css-minimizer-webpack-plugin": "^3.0.2",
     "dotenv": "^10.0.0",
     "eslint": "^7.30.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-config-xo": "^0.37.0",
+    "eslint-config-xo-typescript": "^0.43.0",
     "eslint-import-resolver-webpack": "^0.13.1",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-react": "^7.24.0",

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -181,7 +181,7 @@ export const initUID = liftBackground(
   "INIT_UID",
   async (): Promise<void> => {
     if (!(await _getDNT())) {
-      throttledInit();
+      void throttledInit();
     }
   },
   { asyncResponse: false }
@@ -203,7 +203,7 @@ export const recordEvent = liftBackground(
         timestamp: Date.now(),
         data,
       });
-      debouncedFlush();
+      void debouncedFlush();
     }
   },
   { asyncResponse: false }

--- a/src/blocks/effects/alert.ts
+++ b/src/blocks/effects/alert.ts
@@ -38,6 +38,7 @@ export class AlertEffect extends Effect {
   });
 
   async effect({ message }: BlockArg): Promise<void> {
+    // eslint-disable-next-line no-alert
     window.alert(message);
   }
 }

--- a/src/blocks/readers/ImageEXIFReader.ts
+++ b/src/blocks/readers/ImageEXIFReader.ts
@@ -44,8 +44,8 @@ async function getData(img: HTMLImageElement): Promise<ArrayBuffer> {
 
   if (/^blob:/i.test(img.src)) {
     // Object URL
-    const blob = await fetch(img.src).then((r) => r.blob());
-    return await blob.arrayBuffer();
+    const blob = await fetch(img.src).then(async (r) => r.blob());
+    return blob.arrayBuffer();
   }
 
   const response = await axios.get(img.src, { responseType: "arraybuffer" });
@@ -68,7 +68,7 @@ class ImageEXIFReader extends Reader {
   async read(elementOrDocument: HTMLElement | Document) {
     const element = elementOrDocument as HTMLImageElement;
 
-    if (element?.tagName == "IMG") {
+    if (element?.tagName === "IMG") {
       const buffer = await getData(element);
       return ExifReader.load(buffer);
     }

--- a/src/blocks/readers/ImageReader.ts
+++ b/src/blocks/readers/ImageReader.ts
@@ -53,7 +53,7 @@ class ImageReader extends Reader {
   async read(elementOrDocument: HTMLElement | Document) {
     const element = elementOrDocument as HTMLImageElement;
 
-    if (element?.tagName == "IMG") {
+    if (element?.tagName === "IMG") {
       return {
         src: element.src,
         img: getBase64Image(element as HTMLImageElement),

--- a/src/blocks/renderers/dataTable.ts
+++ b/src/blocks/renderers/dataTable.ts
@@ -48,7 +48,7 @@ function renderRow<TRow extends Row>(
 function makeDataTable<TRow extends {}>(
   columns: ColumnDefinition<TRow>[]
 ): (ctxt: unknown) => string {
-  return function drawTable(ctxt: unknown): string {
+  return (ctxt: unknown): string => {
     if (!Array.isArray(ctxt)) {
       throw new BusinessError("makeDataTable expected an array of data");
     }

--- a/src/blocks/transformers/prompt.ts
+++ b/src/blocks/transformers/prompt.ts
@@ -47,6 +47,7 @@ export class Prompt extends Transformer {
 
   async transform({ message, defaultValue }: BlockArg): Promise<unknown> {
     return {
+      // eslint-disable-next-line no-alert
       value: window.prompt(message, defaultValue),
     };
   }

--- a/src/components/fields/BlockModal.tsx
+++ b/src/components/fields/BlockModal.tsx
@@ -142,7 +142,7 @@ type BlockOption = {
 
 function searchBlocks(query: string, options: BlockOption[]): BlockOption[] {
   let filtered = options;
-  if (query?.trim() != "") {
+  if (query?.trim() !== "") {
     const normalizedQuery = query.toLowerCase();
     filtered = options.filter(
       (x) =>

--- a/src/components/fields/ServiceModal.tsx
+++ b/src/components/fields/ServiceModal.tsx
@@ -102,7 +102,7 @@ const ServiceModal: React.FunctionComponent<{
   );
 
   const filteredOptions = useMemo(() => {
-    if (debouncedQuery.trim() != "") {
+    if (debouncedQuery.trim() !== "") {
       const normalQuery = debouncedQuery.toLowerCase();
       return sortBy(
         serviceOptions.filter(

--- a/src/components/fields/blockOptions.tsx
+++ b/src/components/fields/blockOptions.tsx
@@ -129,7 +129,7 @@ function extractServiceIds(schema: Schema): string[] {
 
   if ("anyOf" in schema) {
     return schema.anyOf
-      .filter((x) => x != false)
+      .filter((x) => x !== false)
       .flatMap((x) => extractServiceIds(x as Schema));
   }
 

--- a/src/contrib/google/sheets/handlers.ts
+++ b/src/contrib/google/sheets/handlers.ts
@@ -127,8 +127,8 @@ export const batchGet = liftBackground(
 
 function columnToLetter(column: number): string {
   // https://stackoverflow.com/a/21231012/402560
-  let temp,
-    letter = "";
+  let temp;
+  let letter = "";
   while (column > 0) {
     temp = (column - 1) % 26;
     letter = String.fromCharCode(temp + 65) + letter;

--- a/src/devTools/editor/sidebar/DynamicEntry.tsx
+++ b/src/devTools/editor/sidebar/DynamicEntry.tsx
@@ -54,7 +54,7 @@ const DynamicEntry: React.FunctionComponent<{
 
   return (
     <ListGroup.Item
-      active={item.uuid == activeElement}
+      active={item.uuid === activeElement}
       key={`dynamic-${item.uuid}`}
       onMouseEnter={async () => showOverlay(item.uuid, true)}
       onMouseLeave={async () => showOverlay(item.uuid, false)}

--- a/src/devTools/editor/sidebar/InstalledEntry.tsx
+++ b/src/devTools/editor/sidebar/InstalledEntry.tsx
@@ -61,7 +61,7 @@ const InstalledEntry: React.FunctionComponent<{
 
   return (
     <ListGroup.Item
-      active={extension.id == activeElement}
+      active={extension.id === activeElement}
       key={`installed-${extension.id}`}
       onClick={async () => selectInstalled(extension)}
       style={{ cursor: "pointer" }}

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -32,7 +32,7 @@ export function isHost(hostname: string): boolean {
 function getAncestors(node: Node): Node[] {
   const ancestors = [node];
   let currentNode: Node = node;
-  while (currentNode && currentNode != document) {
+  while (currentNode && currentNode !== document) {
     ancestors.push(currentNode);
     currentNode = currentNode.parentNode;
   }

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -358,6 +358,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
 
     const cancelObservers = compact(
       $menuContainers
+        // eslint-disable-next-line array-callback-return -- `compact()` takes care of undefined items
         .map((index, element) => {
           // Only acquire new menu items, otherwise we end up with duplicate entries in this.menus which causes
           // repeat evaluation of menus in this.run

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -287,7 +287,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
     const shadowDOM = boolean(rawShadowDOM);
 
     // Start collapsed
-    if (collapsible && cnt == 1) {
+    if (collapsible && cnt === 1) {
       this.collapsedExtensions[extension.id] = true;
     }
 

--- a/src/frameworks/component.ts
+++ b/src/frameworks/component.ts
@@ -40,6 +40,10 @@ export function traverseUntil<T extends object>(
   next: (current: T) => T | null,
   maxTraverse?: number
 ): T | null {
+  if (maxTraverse == null) {
+    return src;
+  }
+
   let current = src;
   // Detect cycles
   const visited = new WeakSet<T>();
@@ -48,7 +52,7 @@ export function traverseUntil<T extends object>(
     current != null &&
     !match(current) &&
     !visited.has(current) &&
-    (maxTraverse == null || cnt <= maxTraverse)
+    cnt <= maxTraverse
   ) {
     visited.add(current);
     current = next(current);

--- a/src/frameworks/component.ts
+++ b/src/frameworks/component.ts
@@ -38,12 +38,8 @@ export function traverseUntil<T extends object>(
   src: T,
   match: (element: T) => boolean,
   next: (current: T) => T | null,
-  maxTraverse?: number
+  maxTraverse: number = Number.POSITIVE_INFINITY
 ): T | null {
-  if (maxTraverse == null) {
-    return src;
-  }
-
   let current = src;
   // Detect cycles
   const visited = new WeakSet<T>();

--- a/src/nativeEditor/infer.ts
+++ b/src/nativeEditor/infer.ts
@@ -58,11 +58,7 @@ const VALUE_EXCLUDE_PATTERNS = new Map<string, RegExp[]>([
   ["class", [/^ember-view$/]],
 ]);
 
-class SkipElement extends Error {
-  constructor(msg: string) {
-    super(msg);
-  }
-}
+class SkipElement extends Error {}
 
 function outerHTML($element: JQuery<HTMLElement | Text>): string {
   // Trick to get the HTML of the actual element
@@ -116,9 +112,7 @@ function setCommonAttrs(
   $common: JQuery<HTMLElement>,
   $items: JQuery<HTMLElement>
 ) {
-  const proto = $items.get(0);
-
-  const attributes = proto.attributes;
+  const { attributes } = $items.get(0);
 
   // Find the common attributes between the elements
   for (const { name } of attributes) {
@@ -540,6 +534,7 @@ export function inferSelectors(
  * Returns true if selector uniquely identifies an element on the page
  */
 function isUniqueSelector(selector: string): boolean {
+  // eslint-disable-next-line unicorn/no-array-callback-reference -- false positive for jquery
   return $(document).find(selector).length === 1;
 }
 
@@ -585,7 +580,7 @@ export function findContainerForElement(
   const extra: string[] = [];
 
   if (container !== element) {
-    const descendent = level == 1 ? ">" : "> * >";
+    const descendent = level === 1 ? ">" : "> * >";
 
     if (element.tagName === "INPUT") {
       extra.push(
@@ -605,7 +600,7 @@ export function findContainerForElement(
   return {
     container,
     selectors: uniq([
-      ...extra.filter(isUniqueSelector),
+      ...extra.filter((selector) => isUniqueSelector(selector)),
       ...inferSelectors(container),
     ]),
   };

--- a/src/nativeEditor/infer.ts
+++ b/src/nativeEditor/infer.ts
@@ -121,16 +121,12 @@ function setCommonAttrs(
   const attributes = proto.attributes;
 
   // Find the common attributes between the elements
-  for (const attrIndex in Object.keys(attributes)) {
-    // Safe because we're getting from Object.keys
-    // eslint-disable-next-line security/detect-object-injection
-    const attrName = attributes[attrIndex].name;
-
-    if (ATTR_EXCLUDE_PATTERNS.some((x) => x.test(attrName))) {
+  for (const { name } of attributes) {
+    if (ATTR_EXCLUDE_PATTERNS.some((x) => x.test(name))) {
       continue;
     }
 
-    const value = commonAttr($items, attrName);
+    const value = commonAttr($items, name);
     if (value != null) {
       if (
         value
@@ -144,7 +140,7 @@ function setCommonAttrs(
         );
       }
 
-      $common.attr(attrName, value);
+      $common.attr(name, value);
     }
   }
 }

--- a/src/options/pages/brickEditor/useSubmitBrick.tsx
+++ b/src/options/pages/brickEditor/useSubmitBrick.tsx
@@ -134,12 +134,12 @@ function useSubmitBrick({
       } catch (error) {
         console.debug("Got validation error", error);
         if (isPlainObject(error.response?.data)) {
-          castArray(error.response.data.__all__ ?? []).map((message) => {
+          for (const message of castArray(error.response.data.__all__ ?? [])) {
             addToast(`Error: ${message} `, {
               appearance: "error",
               autoDismiss: true,
             });
-          });
+          }
           setErrors(error.response.data);
         } else {
           addToast(error.toString(), {

--- a/src/options/pages/deployments/hooks.ts
+++ b/src/options/pages/deployments/hooks.ts
@@ -120,7 +120,7 @@ export function useDeployments() {
 
   const update = useCallback(() => {
     // Can't use async here because Firefox loses track of trusted UX event
-    request().then((accepted: boolean) => {
+    void request().then((accepted: boolean) => {
       if (accepted) {
         for (const deployment of deployments) {
           // Clear existing installs of the blueprint

--- a/src/options/pages/marketplace/ActivateBody.tsx
+++ b/src/options/pages/marketplace/ActivateBody.tsx
@@ -98,7 +98,7 @@ export function useEnsurePermissions(
 
   const activate = useCallback(() => {
     // Can't use async here because Firefox loses track of trusted UX event
-    request().then((accepted: boolean) => {
+    void request().then((accepted: boolean) => {
       if (accepted) {
         reportEvent("MarketplaceActivate", {
           blueprintId: blueprint.metadata.id,

--- a/src/registry/localRegistry.ts
+++ b/src/registry/localRegistry.ts
@@ -131,13 +131,13 @@ export const syncRemote = liftBackground(
     let deleteCnt = 0;
     for (const obj of current) {
       if (obj.kind === kind && obj.scope !== LOCAL_SCOPE) {
-        tx.store.delete(getKey(obj));
+        void tx.store.delete(getKey(obj));
         deleteCnt++;
       }
     }
 
     for (const obj of objs) {
-      tx.store.put(obj);
+      void tx.store.put(obj);
     }
 
     await tx.done;

--- a/src/test-env.js
+++ b/src/test-env.js
@@ -17,6 +17,7 @@
 
 import $ from "jquery";
 
-global.$ = global.jQuery = $;
+global.$ = $;
+global.jQuery = $;
 
 process.env.SERVICE_URL = "https://app.pixiebrix.com";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -281,7 +281,7 @@ export function getPropByPath(
     }
 
     if (/^\d+$/.test(part) && Array.isArray(value)) {
-      part = Number.parseInt(part, 0);
+      part = Number.parseInt(part, 10);
       numeric = true;
     }
 

--- a/src/validators/validation.ts
+++ b/src/validators/validation.ts
@@ -178,7 +178,7 @@ function serviceSchemaFactory(): Yup.Schema<unknown> {
           "is-config",
           "Invalid service configuration",
           async function (value) {
-            if (this.parent.id == PIXIEBRIX_SERVICE_ID) {
+            if (this.parent.id === PIXIEBRIX_SERVICE_ID) {
               if (value != null) {
                 return this.createError({
                   message: "PixieBrix service configuration should be blank",


### PR DESCRIPTION
In this PR:

- drop most custom configuration since it's covered by xo presets
- soft-enable more rules

This PR lets us:

- more easily enable rules over time because the eslint config just requires deleting a line rather than adding config

## Next

- progressively enable rules or disable some rules permanently with a reason
- enable the strict rules that are completely disabled
- also use a shared tsconfig https://github.com/sindresorhus/tsconfig

## For the reviewer

- First and last commits are for configuration
- other commits enable

## Number of occurrences of soft-enabled rules

Some of these are soft-enabled by the preset itself, like max-params, but most aren't

 139 [eqeqeq](https://eslint.org/docs/rules/eqeqeq)
 127 [no-eq-null](https://eslint.org/docs/rules/no-eq-null)
 111 [@typescript-eslint/no-confusing-void-expression](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-confusing-void-expression.md)
  95 [@typescript-eslint/restrict-template-expressions](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/restrict-template-expressions.md)
  74 [@typescript-eslint/no-explicit-any](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-explicit-any.md)
  63 [@typescript-eslint/consistent-indexed-object-style](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md)
  46 [@typescript-eslint/ban-types](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-types.md)
  40 security/detect-object-injection
  40 [@typescript-eslint/no-base-to-string](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-base-to-string.md)
  39 [no-warning-comments](https://eslint.org/docs/rules/no-warning-comments)
  38 [no-await-in-loop](https://eslint.org/docs/rules/no-await-in-loop)
  32 [@typescript-eslint/promise-function-async](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/promise-function-async.md)
  31 unicorn/no-array-callback-reference
  27 [no-negated-condition](https://eslint.org/docs/rules/no-negated-condition)
  27 [@typescript-eslint/no-unnecessary-type-arguments](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md)
  24 [@typescript-eslint/prefer-ts-expect-error](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.md)
  21 [no-implicit-coercion](https://eslint.org/docs/rules/no-implicit-coercion)
  19 [prefer-destructuring](https://eslint.org/docs/rules/prefer-destructuring)
  19 [@typescript-eslint/dot-notation](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/dot-notation.md)
  19 [@typescript-eslint/array-type](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md)
  18 [object-shorthand](https://eslint.org/docs/rules/object-shorthand)
  16 [@typescript-eslint/non-nullable-type-assertion-style](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/non-nullable-type-assertion-style.md)
  16 [@typescript-eslint/no-unnecessary-type-assertion](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md)
  13 react-hooks/exhaustive-deps
  13 [@typescript-eslint/consistent-type-assertions](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-assertions.md)
  11 unicorn/no-useless-undefined
   9 [@typescript-eslint/await-thenable](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/await-thenable.md)
   8 [@typescript-eslint/no-require-imports](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-require-imports.md)
   8 [@typescript-eslint/no-dynamic-delete](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-dynamic-delete.md)
   7 [@typescript-eslint/no-unnecessary-boolean-literal-compare](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md)
   6 [no-return-await](https://eslint.org/docs/rules/no-return-await)
   6 [no-promise-executor-return](https://eslint.org/docs/rules/no-promise-executor-return)
   5 unicorn/consistent-function-scoping
   5 [@typescript-eslint/return-await](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/return-await.md)
   4 security/detect-unsafe-regex
   4 [complexity](https://eslint.org/docs/rules/complexity)
   4 [@typescript-eslint/prefer-readonly](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-readonly.md)
   3 [no-useless-concat](https://eslint.org/docs/rules/no-useless-concat)
   3 [new-cap](https://eslint.org/docs/rules/new-cap)
   3 [max-depth](https://eslint.org/docs/rules/max-depth)
   3 [@typescript-eslint/prefer-optional-chain](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-optional-chain.md)
   3 [@typescript-eslint/class-literal-property-style](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/class-literal-property-style.md)
   2 unicorn/no-nested-ternary
   2 [prefer-object-spread](https://eslint.org/docs/rules/prefer-object-spread)
   2 [no-self-compare](https://eslint.org/docs/rules/no-self-compare)
   2 import/no-named-as-default
   2 [@typescript-eslint/triple-slash-reference](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/triple-slash-reference.md)
   2 [@typescript-eslint/prefer-string-starts-ends-with](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-string-starts-ends-with.md)
   2 [@typescript-eslint/prefer-function-type](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-function-type.md)
   2 [@typescript-eslint/no-redeclare](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-redeclare.md)
   2 [@typescript-eslint/no-misused-promises](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-promises.md)
   2 [@typescript-eslint/no-loop-func](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-loop-func.md)
   1 unicorn/prefer-switch
   1 security/detect-non-literal-regexp
   1 max-params
   1 [@typescript-eslint/unified-signatures](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/unified-signatures.md)
   1 [@typescript-eslint/prefer-regexp-exec](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-regexp-exec.md)
   1 [@typescript-eslint/no-useless-constructor](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-useless-constructor.md)
   1 [@typescript-eslint/no-empty-function](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-empty-function.md)
   1 [@typescript-eslint/default-param-last](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/default-param-last.md)