### PR TITLE
#849: add close sidebar button

### DIFF
--- a/src/action.scss
+++ b/src/action.scss
@@ -41,6 +41,15 @@ body {
   }
 }
 
+.action-panel-close-button {
+  padding: 4px;
+  margin: 4px 12px 4px 12px;
+
+  &:hover {
+    background-color: #d1c2d7;
+  }
+}
+
 .ActionPanelToolbar {
   .btn {
     border-radius: 0;

--- a/src/action.scss
+++ b/src/action.scss
@@ -44,6 +44,7 @@ body {
 .action-panel-close-button {
   padding: 4px;
   margin: 4px 12px 4px 12px;
+  color: #6562aa;
 
   svg:last-child {
     margin-left: -3px;

--- a/src/action.scss
+++ b/src/action.scss
@@ -45,6 +45,10 @@ body {
   padding: 4px;
   margin: 4px 12px 4px 12px;
 
+  svg:last-child {
+    margin-left: -3px;
+  }
+
   &:hover {
     background-color: #d1c2d7;
   }

--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -21,7 +21,11 @@ import { openExtensionOptions } from "@/messaging/external";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import logo from "@img/logo.svg";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPuzzlePiece, faSpinner } from "@fortawesome/free-solid-svg-icons";
+import {
+  faPuzzlePiece,
+  faSpinner,
+  faChevronRight,
+} from "@fortawesome/free-solid-svg-icons";
 import { getStore } from "@/actionPanel/native";
 import {
   ActionPanelStore,
@@ -39,7 +43,6 @@ import GridLoader from "react-spinners/GridLoader";
 import { PersistGate } from "redux-persist/integration/react";
 import { browser } from "webextension-polyfill-ts";
 import { HIDE_ACTION_FRAME } from "@/background/browserAction";
-import doubleChevronRight from "bootstrap-icons/icons/chevron-double-right.svg";
 
 const closeSidebar = async () => {
   await browser.runtime.sendMessage({
@@ -114,35 +117,19 @@ const ActionPanelApp: React.FunctionComponent = () => {
                 variant="link"
                 style={{ color: "#6562aa" }}
               >
-                {/* <img src={doubleChevronRight}></img> */}
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="16"
-                  height="16"
-                  fill="currentColor"
-                  className="bi bi-chevron-double-right"
-                  viewBox="0 0 16 16"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    d="M3.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L9.293 8 3.646 2.354a.5.5 0 0 1 0-.708z"
-                  />
-                  <path
-                    fill-rule="evenodd"
-                    d="M7.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L13.293 8 7.646 2.354a.5.5 0 0 1 0-.708z"
-                  />
-                </svg>
+                <FontAwesomeIcon icon={faChevronRight} />
+                <FontAwesomeIcon icon={faChevronRight} />
               </Button>
+              {/* spacer */}
+              <div className="flex-grow-1" />
               <div className="align-self-center">
                 <img
                   src={logo}
                   alt="PixieBrix logo"
                   height={20}
-                  className="px-2"
+                  className="px-4"
                 />
               </div>
-              {/* spacer */}
-              <div className="flex-grow-1" />
               <div className="ActionPanelToolbar">
                 <Button
                   onClick={async () => openExtensionOptions()}

--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -21,7 +21,11 @@ import { openExtensionOptions } from "@/messaging/external";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import logo from "@img/logo.svg";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPuzzlePiece, faSpinner } from "@fortawesome/free-solid-svg-icons";
+import {
+  faPuzzlePiece,
+  faSpinner,
+  faChevronRight,
+} from "@fortawesome/free-solid-svg-icons";
 import { getStore } from "@/actionPanel/native";
 import {
   ActionPanelStore,
@@ -97,6 +101,10 @@ const ActionPanelApp: React.FunctionComponent = () => {
         <ToastProvider>
           <div className="d-flex flex-column" style={{ height: "100vh" }}>
             <div className="d-flex mb-2" style={{ flex: "none" }}>
+              <Button size="sm" variant="link" style={{ color: "#6562aa" }}>
+                <FontAwesomeIcon icon={faChevronRight} />
+                <FontAwesomeIcon icon={faChevronRight} />
+              </Button>
               <div className="align-self-center">
                 <img
                   src={logo}

--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -41,6 +41,15 @@ import store, { persistor } from "@/options/store";
 import { Provider } from "react-redux";
 import GridLoader from "react-spinners/GridLoader";
 import { PersistGate } from "redux-persist/integration/react";
+import { browser } from "webextension-polyfill-ts";
+import { HIDE_ACTION_FRAME } from "@/background/browserAction";
+
+const closeSidebar = async () => {
+  await browser.runtime.sendMessage({
+    type: HIDE_ACTION_FRAME,
+    payload: {},
+  });
+};
 
 const ActionPanelTabs: React.FunctionComponent<{ panels: PanelEntry[] }> = ({
   panels,
@@ -101,7 +110,12 @@ const ActionPanelApp: React.FunctionComponent = () => {
         <ToastProvider>
           <div className="d-flex flex-column" style={{ height: "100vh" }}>
             <div className="d-flex mb-2" style={{ flex: "none" }}>
-              <Button size="sm" variant="link" style={{ color: "#6562aa" }}>
+              <Button
+                onClick={closeSidebar}
+                size="sm"
+                variant="link"
+                style={{ color: "#6562aa" }}
+              >
                 <FontAwesomeIcon icon={faChevronRight} />
                 <FontAwesomeIcon icon={faChevronRight} />
               </Button>

--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -145,7 +145,6 @@ const ActionPanelApp: React.FunctionComponent = () => {
                 onClick={closeSidebar}
                 size="sm"
                 variant="link"
-                style={{ color: "#6562aa" }}
               >
                 <FontAwesomeIcon icon={faChevronRight} />
                 <FontAwesomeIcon icon={faChevronRight} />

--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -21,11 +21,7 @@ import { openExtensionOptions } from "@/messaging/external";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import logo from "@img/logo.svg";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faPuzzlePiece,
-  faSpinner,
-  faChevronRight,
-} from "@fortawesome/free-solid-svg-icons";
+import { faPuzzlePiece, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { getStore } from "@/actionPanel/native";
 import {
   ActionPanelStore,
@@ -43,6 +39,7 @@ import GridLoader from "react-spinners/GridLoader";
 import { PersistGate } from "redux-persist/integration/react";
 import { browser } from "webextension-polyfill-ts";
 import { HIDE_ACTION_FRAME } from "@/background/browserAction";
+import doubleChevronRight from "bootstrap-icons/icons/chevron-double-right.svg";
 
 const closeSidebar = async () => {
   await browser.runtime.sendMessage({
@@ -111,13 +108,30 @@ const ActionPanelApp: React.FunctionComponent = () => {
           <div className="d-flex flex-column" style={{ height: "100vh" }}>
             <div className="d-flex mb-2" style={{ flex: "none" }}>
               <Button
+                id="closeSidebarButton"
                 onClick={closeSidebar}
                 size="sm"
                 variant="link"
                 style={{ color: "#6562aa" }}
               >
-                <FontAwesomeIcon icon={faChevronRight} />
-                <FontAwesomeIcon icon={faChevronRight} />
+                {/* <img src={doubleChevronRight}></img> */}
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  fill="currentColor"
+                  className="bi bi-chevron-double-right"
+                  viewBox="0 0 16 16"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M3.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L9.293 8 3.646 2.354a.5.5 0 0 1 0-.708z"
+                  />
+                  <path
+                    fill-rule="evenodd"
+                    d="M7.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L13.293 8 7.646 2.354a.5.5 0 0 1 0-.708z"
+                  />
+                </svg>
               </Button>
               <div className="align-self-center">
                 <img

--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -108,7 +108,7 @@ const ActionPanelApp: React.FunctionComponent = () => {
           <div className="d-flex flex-column" style={{ height: "100vh" }}>
             <div className="d-flex mb-2" style={{ flex: "none" }}>
               <Button
-                id="closeSidebarButton"
+                className="action-panel-close-button"
                 onClick={closeSidebar}
                 size="sm"
                 variant="link"


### PR DESCRIPTION
This adds a close sidebar button to the PixieBrix sidebar, which resolves #849, like so:
<img width="400" alt="Screen Shot 2021-07-22 at 4 29 14 PM" src="https://user-images.githubusercontent.com/36575242/126721268-f8fe6552-5d2c-4a95-a9d2-05fff55d64da.png">


