### PR TITLE
#794: copy to clipboard accepts numbers and bools

### DIFF
--- a/src/blocks/effects/alert.ts
+++ b/src/blocks/effects/alert.ts
@@ -32,14 +32,14 @@ export class AlertEffect extends Effect {
 
   inputSchema: Schema = propertiesToSchema({
     message: {
-      type: "string",
+      type: ["string", "number", "boolean"],
       description: "A string you want to display in the alert dialog",
     },
   });
 
   async effect({ message }: BlockArg): Promise<void> {
     // eslint-disable-next-line no-alert
-    window.alert(message);
+    window.alert(String(message));
   }
 }
 

--- a/src/blocks/effects/clipboard.ts
+++ b/src/blocks/effects/clipboard.ts
@@ -45,7 +45,7 @@ export class CopyToClipboard extends Effect {
   };
 
   async effect({ text }: BlockArg): Promise<void> {
-    copy(text);
+    copy(String(text));
   }
 }
 

--- a/src/blocks/effects/clipboard.ts
+++ b/src/blocks/effects/clipboard.ts
@@ -39,7 +39,7 @@ export class CopyToClipboard extends Effect {
     type: "object",
     properties: {
       text: {
-        type: "string",
+        type: ["string", "boolean"],
       },
     },
   };

--- a/src/blocks/effects/clipboard.ts
+++ b/src/blocks/effects/clipboard.ts
@@ -39,7 +39,7 @@ export class CopyToClipboard extends Effect {
     type: "object",
     properties: {
       text: {
-        type: ["string", "boolean"],
+        type: ["string", "boolean", "number"],
       },
     },
   };


### PR DESCRIPTION
Resolves #794 and also resolves #900

This adds additional boolean and number types to the JSON schema for Alert and CopyToClipboard blocks, to prevent unintentional type errors when building up actions.