### PR TITLE
Avoid overflow on setup page

### DIFF
--- a/src/options/pages/SetupPage.scss
+++ b/src/options/pages/SetupPage.scss
@@ -29,7 +29,6 @@
     > div {
       padding-top: 10px;
       padding-bottom: 10px;
-      height: 115px;
     }
 
     &.current {


### PR DESCRIPTION
1. Install extension
2. Resize window to about 1000px

## Before

<img width="1003" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/126859628-1e7d8222-71d9-4b74-98a4-c1dce347ab33.png">

## After

<img width="1002" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/126859660-fc775a9a-49d9-40f2-80ac-6e7dd9f0155b.png">


<img width="50" src="https://user-images.githubusercontent.com/1402241/126859634-4792c0e8-9de1-46a1-a97c-e5fb594db2f4.jpg">
