### PR TITLE
Don't inject contentScript into the options page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31686,9 +31686,9 @@
       }
     },
     "webext-patterns": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/webext-patterns/-/webext-patterns-1.1.0.tgz",
-      "integrity": "sha512-u2xQUdengcXxBFaSy2CF89RmlQCv3SRWNW6J2+EKZPRvnRARf+UyzwVZZJJogUCgqzNhn5mswOYchnHCfh/nmA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webext-patterns/-/webext-patterns-1.1.1.tgz",
+      "integrity": "sha512-mrOzbthOHKYX6T40jo6PGxFRcnKPnsF4/SFBtnRn5CmfEA79Z7jWZyn7/RzasloKT9hh1ISGoH9ZHU22f7/fag=="
     },
     "webext-polyfill-kinda": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "webext-content-scripts": "^0.9.0",
     "webext-detect-page": "^2.0.6",
     "webext-dynamic-content-scripts": "^8.0.0",
-    "webext-patterns": "^1.1.0",
+    "webext-patterns": "^1.1.1",
     "webext-polyfill-kinda": "^0.1.0",
     "webextension-polyfill-ts": "^0.26.0"
   },

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -19,7 +19,10 @@ import pDefer from "p-defer";
 import { browser } from "webextension-polyfill-ts";
 import { injectContentScript } from "webext-content-scripts";
 import { getAdditionalPermissions } from "webext-additional-permissions";
-import { patternToRegex } from "webext-patterns";
+import {
+  patternToRegex,
+  allStarsRegex as acceptableOriginsRegex,
+} from "webext-patterns";
 import { ENSURE_CONTENT_SCRIPT_READY } from "@/messaging/constants";
 import { isRemoteProcedureCallRequest } from "@/messaging/protocol";
 import { expectBackgroundPage } from "@/utils/expectContext";
@@ -121,6 +124,15 @@ export async function ensureContentScript(target: Target): Promise<void> {
 
     if (result.ready) {
       console.debug(`ensureContentScript: already exists and is ready`, target);
+      return;
+    }
+
+    if (!acceptableOriginsRegex.test(result.url)) {
+      console.debug(
+        "ensureContentScript: not allowed on this page",
+        result.url,
+        target
+      );
       return;
     }
 


### PR DESCRIPTION
1. Open the options page
2. Open the devtools
3. See `Error: This code can only run in the content script`

This is tricky because:

- https://github.com/fregante/webext-detect-page/issues/9

I'd like to fix this because the error is confusing (`contentScripts` appears as the "background script" in Firefox).

However this PR breaks PixieBrix on the options page (because it appears as "with permission") but now it cannot communicate with it because the content script is no longer injected.

The UI and code just does not expect this situation.

![gif](https://user-images.githubusercontent.com/1402241/126864933-ec1e8fed-f900-4aaa-ac31-dd83c974d53f.gif)
