### PR TITLE
Fix extension context detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31672,9 +31672,9 @@
       "integrity": "sha512-ZWu7Qzn7muMz8Ml+HAyvq3RApqqf++h7mMEjM69oXs8tk4tdcMtTLuYN8MF8Z5ncYVd5irVM0l4puRhWUbJOwg=="
     },
     "webext-detect-page": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-2.0.6.tgz",
-      "integrity": "sha512-IGpAHdsHz9mwpT8nHyzbdVz1ArUnsRf3PNGMprk3MgEtyN+jhcV4JqkOjNiKIb3k9sZ4WKY4lCxi5MtV1MuTYg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-3.0.1.tgz",
+      "integrity": "sha512-xKxdTP6I3/dTylKUJ8IRJJSF32vMFkhzYGi+v4bkCI/AUHF6ZXoX7gh0bRdzIevFdfxYsazDCn8Tz+rEZh9llg=="
     },
     "webext-dynamic-content-scripts": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "uuid": "^8.3.2",
     "webext-additional-permissions": "^2.0.1",
     "webext-content-scripts": "^0.9.0",
-    "webext-detect-page": "^2.0.6",
+    "webext-detect-page": "^3.0.1",
     "webext-dynamic-content-scripts": "^8.0.0",
     "webext-patterns": "^1.1.0",
     "webext-polyfill-kinda": "^0.1.0",

--- a/src/auth/AuthContext.ts
+++ b/src/auth/AuthContext.ts
@@ -18,7 +18,7 @@
 import React from "react";
 import axios from "axios";
 import Cookies from "js-cookie";
-import { isExtensionContext } from "@/chrome";
+import { isExtensionContext } from "webext-detect-page";
 import { AuthState } from "@/core";
 
 if (!isExtensionContext()) {

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -16,15 +16,12 @@
  */
 
 import { v4 as uuidv4 } from "uuid";
-import {
-  getChromeExtensionId,
-  isExtensionContext,
-  RuntimeNotFoundError,
-} from "@/chrome";
+import { getChromeExtensionId, RuntimeNotFoundError } from "@/chrome";
 import { browser, Runtime } from "webextension-polyfill-ts";
 import { patternToRegex } from "webext-patterns";
 import chromeP from "webext-polyfill-kinda";
 import {
+  isExtensionContext,
   isBackgroundPage,
   isContentScript,
   isOptionsPage,
@@ -118,6 +115,7 @@ export async function callBackground(
   const nonce = uuidv4();
   const message = { type, payload: args, meta: { nonce } };
 
+  console.log("isExtensionContext()", isExtensionContext());
   // `browser.*` APIs are not polyfilled outside the extension context (`externally_connectable` pages)
   // https://github.com/mozilla/webextension-polyfill/issues/326
   const sendMessage = isExtensionContext()
@@ -211,7 +209,7 @@ export function liftBackground<R extends SerializableResponse>(
 
   return async (...args: unknown[]) => {
     if (isBackgroundPage()) {
-      console.log(`Resolving ${type} immediately from background page`);
+      console.trace(`Resolving ${type} immediately from background page`);
       return method(...args);
     }
 
@@ -223,6 +221,7 @@ function backgroundListener(
   request: RemoteProcedureCallRequest,
   sender: Runtime.MessageSender
 ): Promise<unknown> | void {
+  console.log("got request", request);
   // Returning "undefined" indicates the message has not been handled
   // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
   // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -115,7 +115,6 @@ export async function callBackground(
   const nonce = uuidv4();
   const message = { type, payload: args, meta: { nonce } };
 
-  console.log("isExtensionContext()", isExtensionContext());
   // `browser.*` APIs are not polyfilled outside the extension context (`externally_connectable` pages)
   // https://github.com/mozilla/webextension-polyfill/issues/326
   const sendMessage = isExtensionContext()
@@ -209,7 +208,7 @@ export function liftBackground<R extends SerializableResponse>(
 
   return async (...args: unknown[]) => {
     if (isBackgroundPage()) {
-      console.trace(`Resolving ${type} immediately from background page`);
+      console.log(`Resolving ${type} immediately from background page`);
       return method(...args);
     }
 
@@ -221,7 +220,6 @@ function backgroundListener(
   request: RemoteProcedureCallRequest,
   sender: Runtime.MessageSender
 ): Promise<unknown> | void {
-  console.log("got request", request);
   // Returning "undefined" indicates the message has not been handled
   // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
   // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -19,11 +19,6 @@ import isEmpty from "lodash/isEmpty";
 import pDefer from "p-defer";
 import pTimeout from "p-timeout";
 import { browser, Runtime } from "webextension-polyfill-ts";
-import {
-  isBackgroundPage,
-  isContentScript,
-  isOptionsPage,
-} from "webext-detect-page";
 import { forbidBackgroundPage } from "./utils/expectContext";
 
 export const CHROME_EXTENSION_STORAGE_KEY = "chrome_extension_id";
@@ -75,15 +70,6 @@ export function isDevtoolsPage(): boolean {
   const url = new URL("devtoolsPanel.html", location.origin);
 
   return url.pathname === location.pathname && url.origin === location.origin;
-}
-
-export function isExtensionContext(): boolean {
-  return (
-    isContentScript() ||
-    isOptionsPage() ||
-    isBackgroundPage() ||
-    isDevtoolsPage()
-  );
 }
 
 export function setChromeExtensionId(extensionId: string): void {

--- a/src/contentScript/externalProtocol.ts
+++ b/src/contentScript/externalProtocol.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isExtensionContext } from "webext-detect-page";
 import { v4 as uuidv4 } from "uuid";
 import {
   HandlerEntry,
@@ -25,7 +24,7 @@ import {
   toErrorResponse,
 } from "@/messaging/protocol";
 import oneMutation from "one-mutation";
-import { isContentScript } from "webext-detect-page";
+import { isContentScript, isExtensionContext } from "webext-detect-page";
 import { deserializeError } from "serialize-error";
 import { ContentScriptActionError } from "@/contentScript/backgroundProtocol";
 import { PIXIEBRIX_READY_ATTRIBUTE } from "@/contentScript/context";

--- a/src/contentScript/externalProtocol.ts
+++ b/src/contentScript/externalProtocol.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isExtensionContext } from "@/chrome";
+import { isExtensionContext } from "webext-detect-page";
 import { v4 as uuidv4 } from "uuid";
 import {
   HandlerEntry,

--- a/src/hooks/fetch.ts
+++ b/src/hooks/fetch.ts
@@ -21,7 +21,7 @@ import axios from "axios";
 import { getBaseURL } from "@/services/baseService";
 import { useAsyncState } from "@/hooks/common";
 import { useToasts } from "react-toast-notifications";
-import { isExtensionContext } from "@/chrome";
+import { isExtensionContext } from "webext-detect-page";
 import { getExtensionToken } from "@/auth/token";
 
 export function isAbsoluteURL(url: string): boolean {

--- a/src/layout/Banner.tsx
+++ b/src/layout/Banner.tsx
@@ -20,7 +20,7 @@ import cx from "classnames";
 import "./Banner.scss";
 import { getExtensionAuth } from "@/auth/token";
 import AuthContext from "@/auth/AuthContext";
-import { isExtensionContext } from "@/chrome";
+import { isExtensionContext } from "webext-detect-page";
 import { connectPage } from "@/messaging/external";
 import { useAsyncState } from "@/hooks/common";
 

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -16,7 +16,8 @@
  */
 
 import isEmpty from "lodash/isEmpty";
-import { isExtensionContext, readStorage, setStorage } from "@/chrome";
+import { readStorage, setStorage } from "@/chrome";
+import { isExtensionContext } from "webext-detect-page";
 import useAsyncEffect from "use-async-effect";
 import { useState, useCallback } from "react";
 

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -19,7 +19,7 @@ import { recordError } from "@/background/logging";
 import { rollbar, toLogArgument } from "@/telemetry/rollbar";
 import { MessageContext, SerializedError } from "@/core";
 import { serializeError } from "serialize-error";
-import { isExtensionContext } from "@/chrome";
+import { isExtensionContext } from "webext-detect-page";
 import { isBackgroundPage } from "webext-detect-page";
 
 function selectError(error: unknown): SerializedError {

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -19,8 +19,7 @@ import { recordError } from "@/background/logging";
 import { rollbar, toLogArgument } from "@/telemetry/rollbar";
 import { MessageContext, SerializedError } from "@/core";
 import { serializeError } from "serialize-error";
-import { isExtensionContext } from "webext-detect-page";
-import { isBackgroundPage } from "webext-detect-page";
+import { isExtensionContext, isBackgroundPage } from "webext-detect-page";
 
 function selectError(error: unknown): SerializedError {
   if (error instanceof PromiseRejectionEvent) {

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -16,7 +16,7 @@
  */
 
 import Rollbar, { LogArgument } from "rollbar";
-import { isExtensionContext } from "@/chrome";
+import { isExtensionContext } from "webext-detect-page";
 import { getUID } from "@/background/telemetry";
 
 const accessToken = process.env.ROLLBAR_BROWSER_ACCESS_TOKEN;


### PR DESCRIPTION
Currently the detection is:

https://github.com/pixiebrix/pixiebrix-extension/blob/ede30e8e08065622ce659d1119fc296b8ac771b3/src/chrome.ts#L80-L87

But that does not include the sidebar. This line has been at the [base of `webext-detect-page`](https://github.com/fregante/webext-detect-page/blob/1eb24e148d0d773225ba5d2b6f7cb984c3989054/index.ts#L1) for a while:

```js
typeof globalThis.chrome?.extension === 'object'
```


## TODO

- [x] Clean (there are extra logs)
- [ ] ~Test~
- [x] Self-review