### PR TITLE
Function-style related lint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -82,11 +82,6 @@
     "unicorn/prefer-set-has": "off", // Not always worth the extra code
     "unicorn/require-post-message-target-origin": "off", // Incompatible https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1396
 
-    // Large diffs, autofix later together
-    "arrow-body-style": "off",
-    "prefer-arrow-callback": "off",
-    "padding-line-between-statements": "off",
-
     // Temporarily disable rules
     "no-await-in-loop": "warn",
     "no-negated-condition": "warn",

--- a/src/actionPanel/DefaultActionPanel.tsx
+++ b/src/actionPanel/DefaultActionPanel.tsx
@@ -28,70 +28,66 @@ import {
 import { openExtensionOptions } from "@/messaging/external";
 import { selectInstalledExtensions } from "@/options/selectors";
 
-const OnboardingContent: React.FunctionComponent = () => {
-  return (
-    <Container>
-      <Row className="mt-4">
-        <Col>
-          <h4 className="display-6">Activate an Official Template</h4>
-          <p>
-            <span className="text-primary">
-              The easiest way to start using PixieBrix!
-            </span>{" "}
-            Activate a pre-made template from the Templates page.
-          </p>
-          <Button onClick={async () => openExtensionOptions()} variant="info">
-            View Templates&nbsp;
-            <FontAwesomeIcon icon={faClipboardCheck} />
-          </Button>
-        </Col>
-      </Row>
+const OnboardingContent: React.FunctionComponent = () => (
+  <Container>
+    <Row className="mt-4">
+      <Col>
+        <h4 className="display-6">Activate an Official Template</h4>
+        <p>
+          <span className="text-primary">
+            The easiest way to start using PixieBrix!
+          </span>{" "}
+          Activate a pre-made template from the Templates page.
+        </p>
+        <Button onClick={async () => openExtensionOptions()} variant="info">
+          View Templates&nbsp;
+          <FontAwesomeIcon icon={faClipboardCheck} />
+        </Button>
+      </Col>
+    </Row>
 
-      <Row className="mt-4">
-        <Col>
-          <h4 className="display-6">Create your Own</h4>
-          <p>
-            Follow the Quickstart Guide in our documentation area to start
-            creating your own bricks in minutes.
-          </p>
-          <a
-            className="btn btn-info"
-            href="https://docs.pixiebrix.com/quick-start-guide"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Open Quickstart Guide&nbsp;
-            <FontAwesomeIcon icon={faExternalLinkAlt} />
-          </a>
-        </Col>
-      </Row>
+    <Row className="mt-4">
+      <Col>
+        <h4 className="display-6">Create your Own</h4>
+        <p>
+          Follow the Quickstart Guide in our documentation area to start
+          creating your own bricks in minutes.
+        </p>
+        <a
+          className="btn btn-info"
+          href="https://docs.pixiebrix.com/quick-start-guide"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Open Quickstart Guide&nbsp;
+          <FontAwesomeIcon icon={faExternalLinkAlt} />
+        </a>
+      </Col>
+    </Row>
 
-      <Row>
-        <Col className="text-center">
-          <img src={marketplaceImage} alt="Marketplace image" width={300} />
-        </Col>
-      </Row>
-    </Container>
-  );
-};
+    <Row>
+      <Col className="text-center">
+        <img src={marketplaceImage} alt="Marketplace image" width={300} />
+      </Col>
+    </Row>
+  </Container>
+);
 
-const NoAvailablePanelsContent: React.FunctionComponent = () => {
-  return (
-    <Container>
-      <Row className="mt-4">
-        <Col className="text-center">
-          <h4 className="display-6">No panels activated for the page</h4>
-        </Col>
-      </Row>
+const NoAvailablePanelsContent: React.FunctionComponent = () => (
+  <Container>
+    <Row className="mt-4">
+      <Col className="text-center">
+        <h4 className="display-6">No panels activated for the page</h4>
+      </Col>
+    </Row>
 
-      <Row>
-        <Col className="text-center">
-          <img src={workshopImage} alt="Workshop image" width={300} />
-        </Col>
-      </Row>
-    </Container>
-  );
-};
+    <Row>
+      <Col className="text-center">
+        <img src={workshopImage} alt="Workshop image" width={300} />
+      </Col>
+    </Row>
+  </Container>
+);
 
 const DefaultActionPanel: React.FunctionComponent = () => {
   const extensions = useSelector(selectInstalledExtensions);

--- a/src/actionPanel/PanelBody.tsx
+++ b/src/actionPanel/PanelBody.tsx
@@ -32,8 +32,8 @@ import { getErrorMessage } from "@/errors";
 
 const BodyComponent: React.FunctionComponent<{
   body: string | ComponentRef;
-}> = ({ body }) => {
-  return useMemo(() => {
+}> = ({ body }) =>
+  useMemo(() => {
     if (typeof body === "string") {
       return (
         <div
@@ -46,7 +46,6 @@ const BodyComponent: React.FunctionComponent<{
     const { Component, props } = body;
     return <Component {...props} />;
   }, [body]);
-};
 
 const PanelBody: React.FunctionComponent<{ panel: PanelEntry }> = ({
   panel,

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -150,6 +150,7 @@ export function toggleActionPanel(): string | null {
     hideActionPanel();
     return null;
   }
+
   return showActionPanel();
 }
 

--- a/src/actionPanel/protocol.tsx
+++ b/src/actionPanel/protocol.tsx
@@ -88,6 +88,7 @@ handlers.set(RENDER_PANELS_MESSAGE, async (message: RenderPanelsMessage) => {
     );
     return;
   }
+
   seqNumber = messageSeq;
 
   console.debug(

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -114,9 +114,11 @@ async function waitFrameId(tabId: number): Promise<number> {
           `Action frame not ready for tab ${tabId} after ${FORWARD_RETRY_MAX_WAIT_MILLIS}ms`
         );
       }
+
       await sleep(FORWARD_RETRY_INTERVAL_MILLIS);
     }
   } while (frameId == null);
+
   return frameId;
 }
 
@@ -199,6 +201,7 @@ async function forwardWhenReady(
       }
     }
   }
+
   throw new Error(
     `Action frame for tab ${tabId} not ready in ${FORWARD_RETRY_MAX_WAIT_MILLIS}ms`
   );

--- a/src/background/dataStore.ts
+++ b/src/background/dataStore.ts
@@ -40,9 +40,7 @@ async function _setRecord(uuid: string, value: JsonObject): Promise<void> {
 
 export const getRecord = liftBackground(
   "GET_DATA_STORE",
-  async (uuid: string) => {
-    return _getRecord(uuid);
-  }
+  async (uuid: string) => _getRecord(uuid)
 );
 
 export const setRecord = liftBackground(

--- a/src/background/devtools/protocol.ts
+++ b/src/background/devtools/protocol.ts
@@ -66,34 +66,25 @@ export const getTabInfo = liftBackground(
 
 export const ensureScript = liftBackground(
   "INJECT_SCRIPT",
-  (target: Target) => async () => {
-    return ensureContentScript(target);
-  }
+  (target: Target) => async () => ensureContentScript(target)
 );
 
 export const readSelectedElement = liftBackground(
   "READ_ELEMENT",
-  (target: Target) => async () => {
-    return contentScriptProtocol.readSelected(target);
-  }
+  (target: Target) => async () => contentScriptProtocol.readSelected(target)
 );
 
 export const detectFrameworks: (
   port: Runtime.Port
 ) => Promise<FrameworkMeta[]> = liftBackground(
   "DETECT_FRAMEWORKS",
-  (target: Target) => async () => {
-    return contentScriptProtocol.detectFrameworks(target) as Promise<
-      FrameworkMeta[]
-    >;
-  }
+  (target: Target) => async () =>
+    contentScriptProtocol.detectFrameworks(target) as Promise<FrameworkMeta[]>
 );
 
 export const cancelSelectElement = liftBackground(
   "CANCEL_SELECT_ELEMENT",
-  (target: Target) => async () => {
-    return nativeSelectionProtocol.cancelSelect(target);
-  }
+  (target: Target) => async () => nativeSelectionProtocol.cancelSelect(target)
 );
 
 export const selectElement = liftBackground(
@@ -125,48 +116,37 @@ export const selectElement = liftBackground(
 
 export const dragButton = liftBackground(
   "DRAG_BUTTON",
-  (target: Target) => async ({ uuid }: { uuid: string }) => {
-    return nativeEditorProtocol.dragButton(target, { uuid });
-  }
+  (target: Target) => async ({ uuid }: { uuid: string }) =>
+    nativeEditorProtocol.dragButton(target, { uuid })
 );
 
 export const insertButton = liftBackground(
   "INSERT_BUTTON",
-  (target: Target) => async () => {
-    return nativeEditorProtocol.insertButton(target);
-  }
+  (target: Target) => async () => nativeEditorProtocol.insertButton(target)
 );
 
 export const insertPanel: (
   port: Runtime.Port
 ) => Promise<PanelSelectionResult> = liftBackground(
   "INSERT_PANEL",
-  (target: Target) => async () => {
-    return nativeEditorProtocol.insertPanel(target);
-  }
+  (target: Target) => async () => nativeEditorProtocol.insertPanel(target)
 );
 
 export const showBrowserActionPanel = liftBackground(
   "SHOW_BROWSER_ACTION_PANEL",
-  (target: Target) => async () => {
-    return browserActionProtocol.showActionPanel(target);
-  }
+  (target: Target) => async () => browserActionProtocol.showActionPanel(target)
 );
 
 export const updateDynamicElement = liftBackground(
   "UPDATE_DYNAMIC_ELEMENT",
-  (target: Target) => async (
-    element: nativeEditorProtocol.DynamicDefinition
-  ) => {
-    return nativeEditorProtocol.updateDynamicElement(target, element);
-  }
+  (target: Target) => async (element: nativeEditorProtocol.DynamicDefinition) =>
+    nativeEditorProtocol.updateDynamicElement(target, element)
 );
 
 export const clearDynamicElements = liftBackground(
   "CLEAR_DYNAMIC",
-  (target: Target) => async ({ uuid }: { uuid?: string }) => {
-    return nativeEditorProtocol.clear(target, { uuid });
-  }
+  (target: Target) => async ({ uuid }: { uuid?: string }) =>
+    nativeEditorProtocol.clear(target, { uuid })
 );
 
 export const toggleOverlay = liftBackground(
@@ -177,12 +157,11 @@ export const toggleOverlay = liftBackground(
   }: {
     uuid: string;
     on: boolean;
-  }) => {
-    return nativeEditorProtocol.toggleOverlay(target, {
+  }) =>
+    nativeEditorProtocol.toggleOverlay(target, {
       selector: `[data-uuid="${uuid}"]`,
       on,
-    });
-  }
+    })
 );
 
 export const toggleSelector = liftBackground(
@@ -193,23 +172,19 @@ export const toggleSelector = liftBackground(
   }: {
     selector: string;
     on: boolean;
-  }) => {
-    return nativeEditorProtocol.toggleOverlay(target, { selector, on });
-  }
+  }) => nativeEditorProtocol.toggleOverlay(target, { selector, on })
 );
 
 export const getInstalledExtensionPointIds = liftBackground(
   "INSTALLED_EXTENSION_POINT_IDS",
-  (target: Target) => async () => {
-    return nativeEditorProtocol.getInstalledExtensionPointIds(target);
-  }
+  (target: Target) => async () =>
+    nativeEditorProtocol.getInstalledExtensionPointIds(target)
 );
 
 export const checkAvailable = liftBackground(
   "CHECK_AVAILABLE",
-  (target: Target) => async (availability: Availability) => {
-    return nativeEditorProtocol.checkAvailable(target, availability);
-  }
+  (target: Target) => async (availability: Availability) =>
+    nativeEditorProtocol.checkAvailable(target, availability)
 );
 
 export const searchWindow: (
@@ -217,9 +192,8 @@ export const searchWindow: (
   query: string
 ) => Promise<{ results: unknown[] }> = liftBackground(
   "SEARCH_WINDOW",
-  (target: Target) => async (query: string) => {
-    return contentScriptProtocol.searchWindow(target, query);
-  }
+  (target: Target) => async (query: string) =>
+    contentScriptProtocol.searchWindow(target, query)
 );
 
 export const runReaderBlock = liftBackground(
@@ -230,12 +204,11 @@ export const runReaderBlock = liftBackground(
   }: {
     id: string;
     rootSelector?: string;
-  }) => {
-    return contentScriptProtocol.runReaderBlock(target, {
+  }) =>
+    contentScriptProtocol.runReaderBlock(target, {
       id,
       rootSelector,
-    });
-  }
+    })
 );
 
 export const runReader = liftBackground(
@@ -246,42 +219,35 @@ export const runReader = liftBackground(
   }: {
     config: ReaderTypeConfig;
     rootSelector?: string;
-  }) => {
-    return contentScriptProtocol.runReader(target, {
+  }) =>
+    contentScriptProtocol.runReader(target, {
       config,
       rootSelector,
-    });
-  }
+    })
 );
 
 export const uninstallContextMenu = liftBackground(
   "UNINSTALL_CONTEXT_MENU",
   // False positive - it's the inner method that should be async
   // eslint-disable-next-line unicorn/consistent-function-scoping
-  () => async ({ extensionId }: { extensionId: string }) => {
-    return contextMenuProtocol.uninstall(extensionId);
-  }
+  () => async ({ extensionId }: { extensionId: string }) =>
+    contextMenuProtocol.uninstall(extensionId)
 );
 
 export const uninstallActionPanelPanel = liftBackground(
   "UNINSTALL_ACTION_PANEL_PANEL",
   // False positive - it's the inner method that should be async
   // eslint-disable-next-line unicorn/consistent-function-scoping
-  (target) => async ({ extensionId }: { extensionId: string }) => {
-    return browserActionProtocol.removeActionPanelPanel(target, extensionId);
-  }
+  (target) => async ({ extensionId }: { extensionId: string }) =>
+    browserActionProtocol.removeActionPanelPanel(target, extensionId)
 );
 
 export const initUiPathRobot = liftBackground(
   "UIPATH_INIT",
-  (target: Target) => async () => {
-    return robotProtocol.initRobot(target);
-  }
+  (target: Target) => async () => robotProtocol.initRobot(target)
 );
 
 export const getUiPathProcesses = liftBackground(
   "UIPATH_GET_PROCESSES",
-  (target: Target) => async () => {
-    return robotProtocol.getProcesses(target);
-  }
+  (target: Target) => async () => robotProtocol.getProcesses(target)
 );

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -177,8 +177,8 @@ handlers.set(
     });
 
     const results = await Promise.allSettled(
-      tabTargets.map(async ([tabId]) => {
-        return browser.tabs.sendMessage(
+      tabTargets.map(async ([tabId]) =>
+        browser.tabs.sendMessage(
           Number.parseInt(tabId, 10),
           {
             type: CONTENT_MESSAGE_RUN_BLOCK,
@@ -189,8 +189,8 @@ handlers.set(
           },
           // For now, only support top-level frame as opener
           { frameId: TOP_LEVEL_FRAME }
-        );
-      })
+        )
+      )
     );
     return results
       .filter((x) => x.status === "fulfilled")
@@ -261,9 +261,9 @@ handlers.set(MESSAGE_ACTIVATE_TAB, async (_, sender) => {
   });
 });
 
-handlers.set(MESSAGE_CLOSE_TAB, async (_, sender) => {
-  return browser.tabs.remove(sender.tab.id);
-});
+handlers.set(MESSAGE_CLOSE_TAB, async (_, sender) =>
+  browser.tabs.remove(sender.tab.id)
+);
 
 handlers.set(MESSAGE_OPEN_TAB, async (request: OpenTabAction, sender) => {
   const tab = await browser.tabs.create(request.payload);

--- a/src/background/iframes.ts
+++ b/src/background/iframes.ts
@@ -29,33 +29,31 @@ type Request =
 
 function initFrames(): void {
   // Save data to pass along to iframes
-  chrome.runtime.onMessage.addListener(function (
-    request: Request,
-    sender: MessageSender,
-    sendResponse
-  ) {
-    // Messages from content scripts should have sender.tab set
-    switch (request.type) {
-      case FORWARD_FRAME_DATA: {
-        console.log("request", { request });
-        const { frameId, html } = request.payload;
-        frameHTML.set(frameId, html);
-        sendResponse({});
-        return true;
-      }
+  chrome.runtime.onMessage.addListener(
+    (request: Request, sender: MessageSender, sendResponse) => {
+      // Messages from content scripts should have sender.tab set
+      switch (request.type) {
+        case FORWARD_FRAME_DATA: {
+          console.log("request", { request });
+          const { frameId, html } = request.payload;
+          frameHTML.set(frameId, html);
+          sendResponse({});
+          return true;
+        }
 
-      case REQUEST_FRAME_DATA: {
-        const { id } = request.payload;
-        sendResponse({ html: frameHTML.get(id) });
-        frameHTML.delete(id);
-        return true;
-      }
+        case REQUEST_FRAME_DATA: {
+          const { id } = request.payload;
+          sendResponse({ html: frameHTML.get(id) });
+          frameHTML.delete(id);
+          return true;
+        }
 
-      default: {
-        return false;
+        default: {
+          return false;
+        }
       }
     }
-  });
+  );
 }
 
 export default initFrames;

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -60,12 +60,10 @@ export const hasAppAccount = liftBackground("CHECK_APP_ACCOUNT", async () => {
 
 export const getAvailableVersion = liftBackground(
   "GET_AVAILABLE_VERSION",
-  async () => {
-    return {
-      installed: browser.runtime.getManifest().version,
-      available: _availableVersion,
-    };
-  }
+  async () => ({
+    installed: browser.runtime.getManifest().version,
+    available: _availableVersion,
+  })
 );
 
 async function setUninstallURL(): Promise<void> {

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -109,6 +109,7 @@ async function getDB() {
           unique: false,
         });
       }
+
       // Create the joint index
       store.createIndex(
         "context",
@@ -335,16 +336,11 @@ export async function _setLoggingConfig(config: LoggingConfig): Promise<void> {
   _config = config;
 }
 
-export const getLoggingConfig = liftBackground(
-  "GET_LOGGING_CONFIG",
-  async () => {
-    return _getLoggingConfig();
-  }
+export const getLoggingConfig = liftBackground("GET_LOGGING_CONFIG", async () =>
+  _getLoggingConfig()
 );
 
 export const setLoggingConfig = liftBackground(
   "SET_LOGGING_CONFIG",
-  async (config: LoggingConfig) => {
-    return _setLoggingConfig(config);
-  }
+  async (config: LoggingConfig) => _setLoggingConfig(config)
 );

--- a/src/background/notifications.ts
+++ b/src/background/notifications.ts
@@ -20,8 +20,7 @@ import { browser, Notifications } from "webextension-polyfill-ts";
 
 export const createNotification = liftBackground(
   "CREATE_NOTIFICATION",
-  async (options: Notifications.CreateNotificationOptions) => {
+  async (options: Notifications.CreateNotificationOptions) =>
     // Generate id automatically
-    return browser.notifications.create(undefined, options);
-  }
+    browser.notifications.create(undefined, options)
 );

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -101,26 +101,18 @@ const debouncedFlush = debounce(flush, EVENT_BUFFER_DEBOUNCE_MS, {
   maxWait: EVENT_BUFFER_MAX_MS,
 });
 
-export const getDNT = liftBackground("GET_DNT", async () => {
-  return _getDNT();
-});
+export const getDNT = liftBackground("GET_DNT", async () => _getDNT());
 
-export const getUID = liftBackground("GET_UID", async () => {
-  return uid();
-});
+export const getUID = liftBackground("GET_UID", async () => uid());
 
 export const getExtensionVersion = liftBackground(
   "GET_EXTENSION_VERSION",
-  async () => {
-    return browser.runtime.getManifest().version;
-  }
+  async () => browser.runtime.getManifest().version
 );
 
 export const toggleDNT = liftBackground(
   "TOGGLE_DNT",
-  async (enabled: boolean) => {
-    return _toggleDNT(enabled);
-  }
+  async (enabled: boolean) => _toggleDNT(enabled)
 );
 
 async function userSummary() {

--- a/src/blocks/renderers/DataTableComponent.tsx
+++ b/src/blocks/renderers/DataTableComponent.tsx
@@ -30,24 +30,22 @@ const primereact = require("!!raw-loader!primereact/resources/primereact.min.css
 const DataTableComponent: React.FunctionComponent<{
   columns: ColumnProps[];
   rows: object[];
-}> = ({ columns, rows }) => {
-  return (
-    <React.Fragment>
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{ __html: theme.toString() }}
-      />
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{ __html: primereact.toString() }}
-      />
-      <RawDataTable value={rows}>
-        {columns.map((column) => (
-          <Column key={column.field} {...column} />
-        ))}
-      </RawDataTable>
-    </React.Fragment>
-  );
-};
+}> = ({ columns, rows }) => (
+  <React.Fragment>
+    <style
+      type="text/css"
+      dangerouslySetInnerHTML={{ __html: theme.toString() }}
+    />
+    <style
+      type="text/css"
+      dangerouslySetInnerHTML={{ __html: primereact.toString() }}
+    />
+    <RawDataTable value={rows}>
+      {columns.map((column) => (
+        <Column key={column.field} {...column} />
+      ))}
+    </RawDataTable>
+  </React.Fragment>
+);
 
 export default DataTableComponent;

--- a/src/blocks/renderers/PropertyTree.tsx
+++ b/src/blocks/renderers/PropertyTree.tsx
@@ -32,27 +32,25 @@ const primereact = require("!!raw-loader!primereact/resources/primereact.min.css
 const primeicons = require("!!raw-loader!primeicons/primeicons.css?esModule=false")
   .default;
 
-const PropertyTree: React.FunctionComponent<{ value: any }> = ({ value }) => {
-  return (
-    <React.Fragment>
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{ __html: theme.toString() }}
-      />
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{ __html: primereact.toString() }}
-      />
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{ __html: primeicons.toString() }}
-      />
-      <TreeTable value={value}>
-        <Column field="name" header="Property" expander />
-        <Column field="value" header="Value" />
-      </TreeTable>
-    </React.Fragment>
-  );
-};
+const PropertyTree: React.FunctionComponent<{ value: any }> = ({ value }) => (
+  <React.Fragment>
+    <style
+      type="text/css"
+      dangerouslySetInnerHTML={{ __html: theme.toString() }}
+    />
+    <style
+      type="text/css"
+      dangerouslySetInnerHTML={{ __html: primereact.toString() }}
+    />
+    <style
+      type="text/css"
+      dangerouslySetInnerHTML={{ __html: primeicons.toString() }}
+    />
+    <TreeTable value={value}>
+      <Column field="name" header="Property" expander />
+      <Column field="value" header="Value" />
+    </TreeTable>
+  </React.Fragment>
+);
 
 export default PropertyTree;

--- a/src/blocks/renderers/customForm.tsx
+++ b/src/blocks/renderers/customForm.tsx
@@ -38,34 +38,32 @@ const CustomFormComponent: React.FunctionComponent<{
   uiSchema: UiSchema;
   formData: JsonObject;
   onSubmit: (values: JsonObject) => Promise<void>;
-}> = ({ schema, uiSchema, formData, onSubmit }) => {
-  return (
-    <div className="CustomForm">
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{ __html: theme.toString() }}
-      />
-      <style
-        type="text/css"
-        dangerouslySetInnerHTML={{ __html: custom.toString() }}
-      />
-      <Form
-        schema={schema}
-        uiSchema={uiSchema}
-        formData={formData}
-        onSubmit={async ({ formData }) => {
-          await onSubmit(formData);
-        }}
-      >
-        <div>
-          <button className="btn btn-primary" type="submit">
-            Save
-          </button>
-        </div>
-      </Form>
-    </div>
-  );
-};
+}> = ({ schema, uiSchema, formData, onSubmit }) => (
+  <div className="CustomForm">
+    <style
+      type="text/css"
+      dangerouslySetInnerHTML={{ __html: theme.toString() }}
+    />
+    <style
+      type="text/css"
+      dangerouslySetInnerHTML={{ __html: custom.toString() }}
+    />
+    <Form
+      schema={schema}
+      uiSchema={uiSchema}
+      formData={formData}
+      onSubmit={async ({ formData }) => {
+        await onSubmit(formData);
+      }}
+    >
+      <div>
+        <button className="btn btn-primary" type="submit">
+          Save
+        </button>
+      </div>
+    </Form>
+  </div>
+);
 
 export class CustomForm extends Renderer {
   constructor() {

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -40,24 +40,22 @@ export const ModalContext = React.createContext<ModalContextProps>(
 
 const ConfirmationModal: React.FunctionComponent<
   ModalProps & { onCancel: () => void; onSubmit: () => void }
-> = ({ title, message, submitCaption, onCancel, onSubmit }) => {
-  return (
-    <Modal show onHide={onCancel} backdrop="static" keyboard={false}>
-      <Modal.Header closeButton>
-        <Modal.Title>{title ?? "Confirm?"}</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>{message}</Modal.Body>
-      <Modal.Footer>
-        <Button variant="secondary" onClick={onCancel}>
-          Cancel
-        </Button>
-        <Button variant="danger" onClick={onSubmit}>
-          {submitCaption ?? "Continue"}
-        </Button>
-      </Modal.Footer>
-    </Modal>
-  );
-};
+> = ({ title, message, submitCaption, onCancel, onSubmit }) => (
+  <Modal show onHide={onCancel} backdrop="static" keyboard={false}>
+    <Modal.Header closeButton>
+      <Modal.Title>{title ?? "Confirm?"}</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>{message}</Modal.Body>
+    <Modal.Footer>
+      <Button variant="secondary" onClick={onCancel}>
+        Cancel
+      </Button>
+      <Button variant="danger" onClick={onSubmit}>
+        {submitCaption ?? "Continue"}
+      </Button>
+    </Modal.Footer>
+  </Modal>
+);
 
 type Callback = (submit: boolean) => void;
 
@@ -67,11 +65,12 @@ export const ModalProvider: React.FunctionComponent<{
   const [modalProps, setModalProps] = useState<ModalProps>();
   const [callback, setCallback] = useState<Callback>();
 
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       callback?.(false);
-    };
-  }, [callback]);
+    },
+    [callback]
+  );
 
   const showConfirmation = useCallback(
     async (modalProps: ModalProps) => {

--- a/src/components/JsonTree.tsx
+++ b/src/components/JsonTree.tsx
@@ -21,8 +21,6 @@ import React from "react";
 
 const JsonTree: React.FunctionComponent<Partial<VendorJSONTree["props"]>> = (
   props
-) => {
-  return <VendorJSONTree hideRoot theme={theme} invertTheme {...props} />;
-};
+) => <VendorJSONTree hideRoot theme={theme} invertTheme {...props} />;
 
 export default JsonTree;

--- a/src/components/fields/ServiceModal.tsx
+++ b/src/components/fields/ServiceModal.tsx
@@ -39,35 +39,33 @@ import { ButtonVariant } from "react-bootstrap/types";
 const ServiceResult: React.FunctionComponent<{
   service: ServiceDefinition;
   onSelect: () => void;
-}> = ({ service: { metadata }, onSelect }) => {
-  return (
-    <ListGroup.Item onClick={onSelect}>
-      <div className="d-flex">
-        <div className="mr-2">
-          <FontAwesomeIcon icon={faCloud} />
+}> = ({ service: { metadata }, onSelect }) => (
+  <ListGroup.Item onClick={onSelect}>
+    <div className="d-flex">
+      <div className="mr-2">
+        <FontAwesomeIcon icon={faCloud} />
+      </div>
+      <div className="flex-grow-1">
+        <div className="d-flex BlockModal__title">
+          <div className="flex-grow-1">{metadata.name}</div>
+          <div className="flex-grow-0 BlockModal__badges">
+            {metadata.id.startsWith("@pixiebrix/") && (
+              <Badge variant="info">Official</Badge>
+            )}
+          </div>
         </div>
-        <div className="flex-grow-1">
-          <div className="d-flex BlockModal__title">
-            <div className="flex-grow-1">{metadata.name}</div>
-            <div className="flex-grow-0 BlockModal__badges">
-              {metadata.id.startsWith("@pixiebrix/") && (
-                <Badge variant="info">Official</Badge>
-              )}
-            </div>
-          </div>
-          <div className="BlockModal__id">
-            <code className="small">{metadata.id}</code>
-          </div>
-          <div>
-            <p className="mb-0 small">
-              {truncate(metadata.description, { length: 256 })}
-            </p>
-          </div>
+        <div className="BlockModal__id">
+          <code className="small">{metadata.id}</code>
+        </div>
+        <div>
+          <p className="mb-0 small">
+            {truncate(metadata.description, { length: 256 })}
+          </p>
         </div>
       </div>
-    </ListGroup.Item>
-  );
-};
+    </div>
+  </ListGroup.Item>
+);
 
 export type ModalToggle = React.FunctionComponent<{
   setShow: (show: boolean) => void;

--- a/src/components/logViewer/LogTable.tsx
+++ b/src/components/logViewer/LogTable.tsx
@@ -23,37 +23,35 @@ import EntryRow from "@/components/logViewer/EntryRow";
 const LogTable: React.FunctionComponent<{
   pageEntries: LogEntry[];
   hasEntries: boolean;
-}> = ({ pageEntries, hasEntries }) => {
-  return (
-    <Table responsive>
-      <thead>
+}> = ({ pageEntries, hasEntries }) => (
+  <Table responsive>
+    <thead>
+      <tr>
+        <th>&nbsp;</th>
+        <th>Timestamp</th>
+        <th>Level</th>
+        <th>Block/Service</th>
+        <th className="w-100">Message/Error</th>
+      </tr>
+    </thead>
+    <tbody>
+      {pageEntries.map((entry) => (
+        <EntryRow entry={entry} key={entry.uuid} />
+      ))}
+      {pageEntries.length === 0 && (
         <tr>
-          <th>&nbsp;</th>
-          <th>Timestamp</th>
-          <th>Level</th>
-          <th>Block/Service</th>
-          <th className="w-100">Message/Error</th>
+          <td>&nbsp;</td>
+          <td colSpan={4}>
+            {hasEntries ? (
+              <span>There are no log entries at this log level</span>
+            ) : (
+              <span>No log entries</span>
+            )}
+          </td>
         </tr>
-      </thead>
-      <tbody>
-        {pageEntries.map((entry) => (
-          <EntryRow entry={entry} key={entry.uuid} />
-        ))}
-        {pageEntries.length === 0 && (
-          <tr>
-            <td>&nbsp;</td>
-            <td colSpan={4}>
-              {hasEntries ? (
-                <span>There are no log entries at this log level</span>
-              ) : (
-                <span>No log entries</span>
-              )}
-            </td>
-          </tr>
-        )}
-      </tbody>
-    </Table>
-  );
-};
+      )}
+    </tbody>
+  </Table>
+);
 
 export default LogTable;

--- a/src/components/logViewer/details/InputDetail.tsx
+++ b/src/components/logViewer/details/InputDetail.tsx
@@ -22,23 +22,21 @@ import JsonTree from "@/components/JsonTree";
 
 const InputDetail: React.FunctionComponent<{ entry: LogEntry }> = ({
   entry,
-}) => {
-  return (
-    <Row>
-      <Col>
-        <span>Template</span>
-        <JsonTree data={entry.data.template} />
-      </Col>
-      <Col>
-        <span>Context</span>
-        <JsonTree data={entry.data.templateContext} />
-      </Col>
-      <Col>
-        <span>Rendered Args</span>
-        <JsonTree data={entry.data.renderedArgs} />
-      </Col>
-    </Row>
-  );
-};
+}) => (
+  <Row>
+    <Col>
+      <span>Template</span>
+      <JsonTree data={entry.data.template} />
+    </Col>
+    <Col>
+      <span>Context</span>
+      <JsonTree data={entry.data.templateContext} />
+    </Col>
+    <Col>
+      <span>Rendered Args</span>
+      <JsonTree data={entry.data.renderedArgs} />
+    </Col>
+  </Row>
+);
 
 export default InputDetail;

--- a/src/components/logViewer/details/InputValidationErrorDetail.tsx
+++ b/src/components/logViewer/details/InputValidationErrorDetail.tsx
@@ -22,29 +22,27 @@ import JsonTree from "@/components/JsonTree";
 
 const InputValidationErrorDetail: React.FunctionComponent<{
   error: InputValidationError;
-}> = ({ error }) => {
-  return (
-    <Row>
-      <Col>
-        <span>Errors</span>
-        <ul>
-          {error.errors.map((x) => (
-            <li key={`${x.keywordLocation}-${x.error}`}>
-              {x.keywordLocation}: {x.error}
-            </li>
-          ))}
-        </ul>
-      </Col>
-      <Col>
-        <span>Rendered Args</span>
-        <JsonTree data={error.input} />
-      </Col>
-      <Col>
-        <span>Schema</span>
-        <JsonTree data={error.schema} />
-      </Col>
-    </Row>
-  );
-};
+}> = ({ error }) => (
+  <Row>
+    <Col>
+      <span>Errors</span>
+      <ul>
+        {error.errors.map((x) => (
+          <li key={`${x.keywordLocation}-${x.error}`}>
+            {x.keywordLocation}: {x.error}
+          </li>
+        ))}
+      </ul>
+    </Col>
+    <Col>
+      <span>Rendered Args</span>
+      <JsonTree data={error.input} />
+    </Col>
+    <Col>
+      <span>Schema</span>
+      <JsonTree data={error.schema} />
+    </Col>
+  </Row>
+);
 
 export default InputValidationErrorDetail;

--- a/src/components/logViewer/details/OutputDetail.tsx
+++ b/src/components/logViewer/details/OutputDetail.tsx
@@ -22,15 +22,13 @@ import JsonTree from "@/components/JsonTree";
 
 const OutputDetail: React.FunctionComponent<{ entry: LogEntry }> = ({
   entry,
-}) => {
-  return (
-    <Row>
-      <Col>
-        {entry.data.outputKey && <code>{entry.data.outputKey}</code>}
-        <JsonTree data={entry.data.output} />
-      </Col>
-    </Row>
-  );
-};
+}) => (
+  <Row>
+    <Col>
+      {entry.data.outputKey && <code>{entry.data.outputKey}</code>}
+      <JsonTree data={entry.data.output} />
+    </Col>
+  </Row>
+);
 
 export default OutputDetail;

--- a/src/components/logViewer/useLogEntries.ts
+++ b/src/components/logViewer/useLogEntries.ts
@@ -139,9 +139,7 @@ export default function useLogEntries({
     initialized,
   ]);
 
-  const clear = useCallback(async () => {
-    return clearLog(context);
-  }, [context]);
+  const clear = useCallback(async () => clearLog(context), [context]);
 
   useEffect(() => {
     if (refreshInterval) {

--- a/src/contentScript/browserAction.ts
+++ b/src/contentScript/browserAction.ts
@@ -20,9 +20,7 @@ import * as native from "@/actionPanel/native";
 
 export const toggleActionPanel = liftContentScript(
   "TOGGLE_ACTION_PANEL",
-  async () => {
-    return native.toggleActionPanel();
-  }
+  async () => native.toggleActionPanel()
 );
 
 export const showActionPanel = liftContentScript(

--- a/src/contentScript/devTools.ts
+++ b/src/contentScript/devTools.ts
@@ -59,9 +59,7 @@ async function read(factory: () => Promise<unknown>): Promise<unknown> {
 
 export const detectFrameworks = liftContentScript(
   "DETECT_FRAMEWORKS",
-  async () => {
-    return withDetectFrameworkVersions(null);
-  }
+  async () => withDetectFrameworkVersions(null)
 );
 
 export const searchWindow: (
@@ -69,9 +67,7 @@ export const searchWindow: (
   query: string
 ) => Promise<{ results: unknown[] }> = liftContentScript(
   "SEARCH_WINDOW",
-  async (query: string) => {
-    return withSearchWindow({ query });
-  }
+  async (query: string) => withSearchWindow({ query })
 );
 
 export const runReaderBlock = liftContentScript(

--- a/src/contentScript/errors.ts
+++ b/src/contentScript/errors.ts
@@ -20,7 +20,7 @@ import { showConnectionLost } from "@/contentScript/connection";
 import { reportError } from "@/telemetry/logging";
 
 function addErrorListeners(): void {
-  window.addEventListener("error", function (error) {
+  window.addEventListener("error", (error) => {
     if (isConnectionError(error)) {
       showConnectionLost();
     } else {
@@ -29,7 +29,7 @@ function addErrorListeners(): void {
     }
   });
 
-  window.addEventListener("unhandledrejection", function (error) {
+  window.addEventListener("unhandledrejection", (error) => {
     if (isConnectionError(error)) {
       showConnectionLost();
     } else {

--- a/src/contentScript/externalProtocol.ts
+++ b/src/contentScript/externalProtocol.ts
@@ -47,64 +47,61 @@ const pageRejectedCallbacks = new Map<string, (response: unknown) => void>();
 function initContentScriptListener() {
   const targetOrigin = document.defaultView.origin;
 
-  document.defaultView.addEventListener(
-    "message",
-    function (event: MessageEvent) {
-      const { type, meta, payload } = event.data;
-      const { handler, options: { asyncResponse } = { asyncResponse: true } } =
-        contentScriptHandlers.get(type) ?? {};
+  document.defaultView.addEventListener("message", (event: MessageEvent) => {
+    const { type, meta, payload } = event.data;
+    const { handler, options: { asyncResponse } = { asyncResponse: true } } =
+      contentScriptHandlers.get(type) ?? {};
 
-      if (event.source === document.defaultView && handler) {
-        const handlerPromise = new Promise((resolve) =>
-          resolve(handler(...payload))
+    if (event.source === document.defaultView && handler) {
+      const handlerPromise = new Promise((resolve) =>
+        resolve(handler(...payload))
+      );
+
+      const send = (data: unknown, error = false) => {
+        document.defaultView.postMessage(
+          {
+            type: `${type}${error ? rejectedSuffix : fulfilledSuffix}`,
+            error,
+            meta: { nonce: meta.nonce },
+            payload: data,
+          },
+          targetOrigin
         );
+      };
 
-        const send = (data: unknown, error = false) => {
-          document.defaultView.postMessage(
-            {
-              type: `${type}${error ? rejectedSuffix : fulfilledSuffix}`,
-              error,
-              meta: { nonce: meta.nonce },
-              payload: data,
-            },
-            targetOrigin
-          );
-        };
-
-        handlerPromise
-          .then((response) => {
-            if (asyncResponse) {
-              console.debug(
-                `Handler returning success response for ${type} with nonce ${meta.nonce}`
-              );
-              send(response);
-            }
-          })
-          .catch((error: unknown) => {
-            if (asyncResponse) {
-              console.debug(
-                `Handler returning error response for ${type} with nonce ${meta.nonce}`
-              );
-              send(toErrorResponse(type, error), true);
-            } else {
-              console.warn(
-                "An error occurred while processing notification %s",
-                type,
-                error
-              );
-            }
-          });
-        return asyncResponse;
-      }
+      handlerPromise
+        .then((response) => {
+          if (asyncResponse) {
+            console.debug(
+              `Handler returning success response for ${type} with nonce ${meta.nonce}`
+            );
+            send(response);
+          }
+        })
+        .catch((error: unknown) => {
+          if (asyncResponse) {
+            console.debug(
+              `Handler returning error response for ${type} with nonce ${meta.nonce}`
+            );
+            send(toErrorResponse(type, error), true);
+          } else {
+            console.warn(
+              "An error occurred while processing notification %s",
+              type,
+              error
+            );
+          }
+        });
+      return asyncResponse;
     }
-  );
+  });
 }
 
 /**
  * Listener on the external webpage to listen for responses from the contentScript.
  */
 function initExternalPageListener() {
-  window.addEventListener("message", function (event: MessageEvent) {
+  window.addEventListener("message", (event: MessageEvent) => {
     const { type, meta, error, payload } = event.data;
     if (
       // Check isResponseType to make sure we're not handling the messages from the content script

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -49,7 +49,7 @@ async function installScriptOnce(): Promise<void> {
       const script = document.createElement("script");
       script.src = chrome.extension.getURL("script.js");
       (document.head || document.documentElement).append(script);
-      script.addEventListener("load", function () {
+      script.addEventListener("load", () => {
         script.remove();
         console.debug("Installed page script");
         resolve();
@@ -145,6 +145,7 @@ export function clearDynamic(extensionId?: string): void {
         reportError(error);
       }
     }
+
     _dynamic.clear();
   }
 }

--- a/src/contentScript/uipath.ts
+++ b/src/contentScript/uipath.ts
@@ -60,9 +60,9 @@ async function _initRobot(): Promise<InitResponse> {
   });
 }
 
-export const initRobot = liftContentScript("UIPATH_INIT", async () => {
-  return _initRobot();
-});
+export const initRobot = liftContentScript("UIPATH_INIT", async () =>
+  _initRobot()
+);
 
 export const getProcesses = liftContentScript(
   "UIPATH_GET_PROCESSES",

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -108,9 +108,10 @@ const RobotField: React.FunctionComponent<FieldProps<string>> = ({
 
   const { bots, error } = useBots();
 
-  const options = useMemo(() => {
-    return (bots ?? []).map((bot) => ({ value: bot.id, label: bot.name, bot }));
-  }, [bots]);
+  const options = useMemo(
+    () => (bots ?? []).map((bot) => ({ value: bot.id, label: bot.name, bot })),
+    [bots]
+  );
 
   return (
     <Form.Group>
@@ -149,13 +150,15 @@ const DeviceField: React.FunctionComponent<FieldProps<string>> = ({
 
   const { devices, error } = useDevices();
 
-  const options = useMemo(() => {
-    return (devices ?? []).map((device) => ({
-      value: device.id,
-      label: `${device.nickname} (${device.hostName})`,
-      device,
-    }));
-  }, [devices]);
+  const options = useMemo(
+    () =>
+      (devices ?? []).map((device) => ({
+        value: device.id,
+        label: `${device.nickname} (${device.hostName})`,
+        device,
+      })),
+    [devices]
+  );
 
   return (
     <Form.Group>

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -48,12 +48,14 @@ const TabField: React.FunctionComponent<
     return [];
   }, [doc?.id, port]);
 
-  const sheetOptions = useMemo(() => {
-    return uniq(compact([...(tabNames ?? []), field.value])).map((value) => ({
-      label: value,
-      value,
-    }));
-  }, [tabNames, field.value]);
+  const sheetOptions = useMemo(
+    () =>
+      uniq(compact([...(tabNames ?? []), field.value])).map((value) => ({
+        label: value,
+        value,
+      })),
+    [tabNames, field.value]
+  );
 
   return (
     <Form.Group>

--- a/src/contrib/google/sheets/handlers.ts
+++ b/src/contrib/google/sheets/handlers.ts
@@ -217,15 +217,11 @@ async function getTabNames(spreadsheetId: string): Promise<string[]> {
 export const devtoolsProtocol = {
   getTabNames: liftDevtools(
     "GET_TAB_NAMES",
-    () => async (spreadsheetId: string) => {
-      return getTabNames(spreadsheetId);
-    }
+    () => async (spreadsheetId: string) => getTabNames(spreadsheetId)
   ),
   getSheetProperties: liftDevtools(
     "GET_SHEET_PROPERTIES",
-    () => async (spreadsheetId: string) => {
-      return getSheetProperties(spreadsheetId);
-    }
+    () => async (spreadsheetId: string) => getSheetProperties(spreadsheetId)
   ),
   getHeaders: liftDevtools(
     "GET_HEADERS",
@@ -235,9 +231,7 @@ export const devtoolsProtocol = {
     }: {
       spreadsheetId: string;
       tabName: string;
-    }) => {
-      return getHeaders(spreadsheetId, tabName);
-    }
+    }) => getHeaders(spreadsheetId, tabName)
   ),
 };
 

--- a/src/contrib/uipath/localProcessOptions.tsx
+++ b/src/contrib/uipath/localProcessOptions.tsx
@@ -62,13 +62,15 @@ export const ProcessField: React.FunctionComponent<
 > = ({ label, schema, processes, fetchError, isPending, ...props }) => {
   const [{ value, ...field }, meta, helpers] = useField(props);
 
-  const options = useMemo(() => {
-    return (processes ?? []).map((x) => ({
-      value: x.id,
-      label: x.name,
-      process: x,
-    }));
-  }, [processes]);
+  const options = useMemo(
+    () =>
+      (processes ?? []).map((x) => ({
+        value: x.id,
+        label: x.name,
+        process: x,
+      })),
+    [processes]
+  );
 
   return (
     <Form.Group>
@@ -163,9 +165,10 @@ const LocalProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
     return [];
   }, [robotAvailable]);
 
-  const process = useMemo(() => {
-    return processes?.find((x) => x.id === releaseKey);
-  }, [processes, releaseKey]);
+  const process = useMemo(() => processes?.find((x) => x.id === releaseKey), [
+    processes,
+    releaseKey,
+  ]);
 
   if (!port) {
     return (

--- a/src/contrib/uipath/processOptions.tsx
+++ b/src/contrib/uipath/processOptions.tsx
@@ -127,9 +127,10 @@ const RobotsField: React.FunctionComponent<FieldProps<number[]>> = ({
 
   const { robots, error } = useRobots();
 
-  const options = useMemo(() => {
-    return (robots ?? []).map((x) => ({ value: x.Id, label: x.Id }));
-  }, [robots]);
+  const options = useMemo(
+    () => (robots ?? []).map((x) => ({ value: x.Id, label: x.Id })),
+    [robots]
+  );
 
   return (
     <Form.Group>
@@ -163,13 +164,15 @@ export const ReleaseField: React.FunctionComponent<
 > = ({ label, schema, releases, fetchError, ...props }) => {
   const [{ value, ...field }, meta, helpers] = useField(props);
 
-  const options = useMemo(() => {
-    return (releases ?? []).map((x) => ({
-      value: x.Key,
-      label: `${x.Name} - ${x.ProcessVersion}`,
-      release: x,
-    }));
-  }, [releases]);
+  const options = useMemo(
+    () =>
+      (releases ?? []).map((x) => ({
+        value: x.Key,
+        label: `${x.Name} - ${x.ProcessVersion}`,
+        release: x,
+      })),
+    [releases]
+  );
 
   return (
     <Form.Group>
@@ -238,36 +241,30 @@ export function releaseSchema(release: Release): Schema {
 
 export const InputArgumentsField: React.FunctionComponent<
   FieldProps<object>
-> = ({ name, schema, label }) => {
-  return (
-    <Form.Group>
-      <Form.Label>inputArguments</Form.Label>
-      <Card>
-        <Card.Header>{label}</Card.Header>
-        <Card.Body>
-          {schema &&
-            Object.entries(inputProperties(schema)).map(
-              ([prop, fieldSchema]) => {
-                if (typeof fieldSchema === "boolean") {
-                  throw new TypeError(
-                    "Expected schema for input property type"
-                  );
-                }
+> = ({ name, schema, label }) => (
+  <Form.Group>
+    <Form.Label>inputArguments</Form.Label>
+    <Card>
+      <Card.Header>{label}</Card.Header>
+      <Card.Body>
+        {schema &&
+          Object.entries(inputProperties(schema)).map(([prop, fieldSchema]) => {
+            if (typeof fieldSchema === "boolean") {
+              throw new TypeError("Expected schema for input property type");
+            }
 
-                return (
-                  <FieldRenderer
-                    key={prop}
-                    name={`${name}.${prop}`}
-                    schema={schema}
-                  />
-                );
-              }
-            )}
-        </Card.Body>
-      </Card>
-    </Form.Group>
-  );
-};
+            return (
+              <FieldRenderer
+                key={prop}
+                name={`${name}.${prop}`}
+                schema={schema}
+              />
+            );
+          })}
+      </Card.Body>
+    </Card>
+  </Form.Group>
+);
 
 const ProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
   name,

--- a/src/contrib/zapier/pushOptions.tsx
+++ b/src/contrib/zapier/pushOptions.tsx
@@ -64,13 +64,15 @@ export const ZapField: React.FunctionComponent<
 > = ({ label, schema, hooks, error, ...props }) => {
   const [{ value, ...field }, meta, helpers] = useField(props);
 
-  const options = useMemo(() => {
-    return (hooks ?? []).map((x) => ({
-      value: x.display_name,
-      label: x.display_name,
-      hook: x,
-    }));
-  }, [hooks]);
+  const options = useMemo(
+    () =>
+      (hooks ?? []).map((x) => ({
+        value: x.display_name,
+        label: x.display_name,
+        hook: x,
+      })),
+    [hooks]
+  );
 
   return (
     <Form.Group>
@@ -119,9 +121,10 @@ const PushOptions: React.FunctionComponent<BlockOptionProps> = ({
     setGrantedPermissions(result);
   }, [setGrantedPermissions]);
 
-  const hook = useMemo(() => {
-    return hooks?.find((x) => x.display_name === pushKey);
-  }, [hooks, pushKey]);
+  const hook = useMemo(() => hooks?.find((x) => x.display_name === pushKey), [
+    hooks,
+    pushKey,
+  ]);
 
   if (!(grantedPermissions || hasPermissions)) {
     return (

--- a/src/devTools/Panel.tsx
+++ b/src/devTools/Panel.tsx
@@ -52,15 +52,13 @@ const defaultState: AuthState = {
   flags: [],
 };
 
-const PersistLoader: React.FunctionComponent = () => {
-  return (
-    <Centered>
-      <div className="d-flex justify-content-center">
-        <GridLoader />
-      </div>
-    </Centered>
-  );
-};
+const PersistLoader: React.FunctionComponent = () => (
+  <Centered>
+    <div className="d-flex justify-content-center">
+      <GridLoader />
+    </div>
+  </Centered>
+);
 
 const RequireScope: React.FunctionComponent<{
   scope: string | null;

--- a/src/devTools/editor/components/Centered.tsx
+++ b/src/devTools/editor/components/Centered.tsx
@@ -18,16 +18,14 @@
 import React from "react";
 import { Col, Container, Row } from "react-bootstrap";
 
-const Centered: React.FunctionComponent = ({ children }) => {
-  return (
-    <Container fluid>
-      <Row>
-        <Col className="mx-auto mt-4 text-center" md={8} lg={5} sm={11}>
-          {children}
-        </Col>
-      </Row>
-    </Container>
-  );
-};
+const Centered: React.FunctionComponent = ({ children }) => (
+  <Container fluid>
+    <Row>
+      <Col className="mx-auto mt-4 text-center" md={8} lg={5} sm={11}>
+        {children}
+      </Col>
+    </Row>
+  </Container>
+);
 
 export default Centered;

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -84,6 +84,7 @@ function selectErrorMessage(error: unknown): string {
       "No response from PixieBrix server"
     );
   }
+
   return getErrorMessage(error);
 }
 

--- a/src/devTools/editor/panes/BetaPane.tsx
+++ b/src/devTools/editor/panes/BetaPane.tsx
@@ -18,26 +18,24 @@
 import Centered from "@/devTools/editor/components/Centered";
 import React from "react";
 
-const BetaPane: React.FunctionComponent = () => {
-  return (
-    <Centered>
-      <div className="PaneTitle">
-        This Page Editor feature is currently in private beta
-      </div>
+const BetaPane: React.FunctionComponent = () => (
+  <Centered>
+    <div className="PaneTitle">
+      This Page Editor feature is currently in private beta
+    </div>
 
-      <div className="text-left">
-        <p>
-          To request access, contact{" "}
-          <a href="mailto:support@pixiebrix.com">support@pixiebrix.com</a>
-        </p>
+    <div className="text-left">
+      <p>
+        To request access, contact{" "}
+        <a href="mailto:support@pixiebrix.com">support@pixiebrix.com</a>
+      </p>
 
-        <p>
-          In the meantime, you can create extensions that depend on this feature
-          in the Workshop.
-        </p>
-      </div>
-    </Centered>
-  );
-};
+      <p>
+        In the meantime, you can create extensions that depend on this feature
+        in the Workshop.
+      </p>
+    </div>
+  </Centered>
+);
 
 export default BetaPane;

--- a/src/devTools/editor/panes/NoExtensionsPane.tsx
+++ b/src/devTools/editor/panes/NoExtensionsPane.tsx
@@ -25,59 +25,57 @@ import { faCommentAlt, faPhone } from "@fortawesome/free-solid-svg-icons";
 const NoExtensionsPane: React.FunctionComponent<{
   unavailableCount: number;
   showSupport: () => void;
-}> = ({ unavailableCount, showSupport }) => {
-  return (
-    <Centered>
-      <div className="PaneTitle">No custom extensions on the page</div>
+}> = ({ unavailableCount, showSupport }) => (
+  <Centered>
+    <div className="PaneTitle">No custom extensions on the page</div>
 
-      <div className="text-left">
-        <p>
-          Click <span className="text-info">Add</span> in the sidebar to add an
-          element to the page.
-        </p>
+    <div className="text-left">
+      <p>
+        Click <span className="text-info">Add</span> in the sidebar to add an
+        element to the page.
+      </p>
 
-        <p>
-          Check the &ldquo;Show {unavailableCount ?? 1} unavailable&rdquo; box
-          to list extensions that are activated but aren&apos;t available on
-          this page.
-        </p>
+      <p>
+        Check the &ldquo;Show {unavailableCount ?? 1} unavailable&rdquo; box to
+        list extensions that are activated but aren&apos;t available on this
+        page.
+      </p>
 
-        <p>
-          Learn how to use the Page Editor in our{" "}
-          <a
-            href="#"
-            onClick={async () =>
-              openTab({
-                url: "https://docs.pixiebrix.com/quick-start-guide",
-                active: true,
-              })
-            }
-          >
-            Quick Start Guide
-          </a>
-        </p>
+      <p>
+        Learn how to use the Page Editor in our{" "}
+        <a
+          href="#"
+          onClick={async () =>
+            openTab({
+              url: "https://docs.pixiebrix.com/quick-start-guide",
+              active: true,
+            })
+          }
+        >
+          Quick Start Guide
+        </a>
+      </p>
 
-        <div className="text-center">
-          <Button variant="info" onClick={showSupport}>
-            <FontAwesomeIcon icon={faCommentAlt} /> Live Chat Support
-          </Button>
+      <div className="text-center">
+        <Button variant="info" onClick={showSupport}>
+          <FontAwesomeIcon icon={faCommentAlt} /> Live Chat Support
+        </Button>
 
-          <Button
-            className="ml-2"
-            variant="info"
-            onClick={async () =>
-              openTab({
-                url: "https://calendly.com/pixiebrix-todd/live-support-session",
-                active: true,
-              })
-            }
-          >
-            <FontAwesomeIcon icon={faPhone} /> Schedule FREE Zoom Session
-          </Button>
-        </div>
+        <Button
+          className="ml-2"
+          variant="info"
+          onClick={async () =>
+            openTab({
+              url: "https://calendly.com/pixiebrix-todd/live-support-session",
+              active: true,
+            })
+          }
+        >
+          <FontAwesomeIcon icon={faPhone} /> Schedule FREE Zoom Session
+        </Button>
       </div>
-    </Centered>
-  );
-};
+    </div>
+  </Centered>
+);
 
 export default NoExtensionsPane;

--- a/src/devTools/editor/panes/NoExtensionsSelectedPane.tsx
+++ b/src/devTools/editor/panes/NoExtensionsSelectedPane.tsx
@@ -18,20 +18,18 @@
 import Centered from "@/devTools/editor/components/Centered";
 import React from "react";
 
-const NoExtensionSelectedPane: React.FunctionComponent = () => {
-  return (
-    <Centered>
-      <div className="PaneTitle">No extension selected</div>
+const NoExtensionSelectedPane: React.FunctionComponent = () => (
+  <Centered>
+    <div className="PaneTitle">No extension selected</div>
 
-      <div className="text-left">
-        <p>Select an extension in the sidebar to edit</p>
-        <p>
-          Or, click the <span className="text-info">Add</span> button in the
-          sidebar to add an extension to the page.
-        </p>
-      </div>
-    </Centered>
-  );
-};
+    <div className="text-left">
+      <p>Select an extension in the sidebar to edit</p>
+      <p>
+        Or, click the <span className="text-info">Add</span> button in the
+        sidebar to add an extension to the page.
+      </p>
+    </div>
+  </Centered>
+);
 
 export default NoExtensionSelectedPane;

--- a/src/devTools/editor/panes/SupportWidget.tsx
+++ b/src/devTools/editor/panes/SupportWidget.tsx
@@ -27,56 +27,53 @@ import ChatWidget from "@/components/ChatWidget";
 
 const SupportWidget: React.FunctionComponent<{ onClose: () => void }> = ({
   onClose,
-}) => {
-  return (
-    <div className="d-flex flex-column h-100">
-      <div className="d-flex pl-2">
-        <div className="flex-grow-1">
-          <div className="small">
-            <span className="text-muted">
-              <FontAwesomeIcon icon={faPhone} />
-            </span>{" "}
-            <a
-              href="#"
-              onClick={async () =>
-                openTab({
-                  url:
-                    "https://calendly.com/pixiebrix-todd/live-support-session",
-                  active: true,
-                })
-              }
-            >
-              Schedule FREE Zoom session
-            </a>
-          </div>
-          <div className="small">
-            <span className="text-muted">
-              <FontAwesomeIcon icon={faExternalLinkAlt} />{" "}
-            </span>
-            <a
-              href="#"
-              onClick={async () =>
-                openTab({
-                  url: "https://docs.pixiebrix.com/",
-                  active: true,
-                })
-              }
-            >
-              Open Documentation
-            </a>
-          </div>
+}) => (
+  <div className="d-flex flex-column h-100">
+    <div className="d-flex pl-2">
+      <div className="flex-grow-1">
+        <div className="small">
+          <span className="text-muted">
+            <FontAwesomeIcon icon={faPhone} />
+          </span>{" "}
+          <a
+            href="#"
+            onClick={async () =>
+              openTab({
+                url: "https://calendly.com/pixiebrix-todd/live-support-session",
+                active: true,
+              })
+            }
+          >
+            Schedule FREE Zoom session
+          </a>
         </div>
-        <div className="pr-2 text-muted">
-          <span onClick={() => onClose()} role="button">
-            <FontAwesomeIcon icon={faTimes} />
+        <div className="small">
+          <span className="text-muted">
+            <FontAwesomeIcon icon={faExternalLinkAlt} />{" "}
           </span>
+          <a
+            href="#"
+            onClick={async () =>
+              openTab({
+                url: "https://docs.pixiebrix.com/",
+                active: true,
+              })
+            }
+          >
+            Open Documentation
+          </a>
         </div>
       </div>
-      <div className="flex-grow-1">
-        <ChatWidget />
+      <div className="pr-2 text-muted">
+        <span onClick={() => onClose()} role="button">
+          <FontAwesomeIcon icon={faTimes} />
+        </span>
       </div>
     </div>
-  );
-};
+    <div className="flex-grow-1">
+      <ChatWidget />
+    </div>
+  </div>
+);
 
 export default SupportWidget;

--- a/src/devTools/editor/panes/WelcomePane.tsx
+++ b/src/devTools/editor/panes/WelcomePane.tsx
@@ -24,50 +24,48 @@ import { faCommentAlt, faPhone } from "@fortawesome/free-solid-svg-icons";
 
 const WelcomePane: React.FunctionComponent<{ showSupport: () => void }> = ({
   showSupport,
-}) => {
-  return (
-    <Centered>
-      <div className="PaneTitle">Welcome to the PixieBrix Page Editor!</div>
+}) => (
+  <Centered>
+    <div className="PaneTitle">Welcome to the PixieBrix Page Editor!</div>
 
-      <div className="text-left">
-        <p>Click Add in the sidebar to add an element to the page.</p>
+    <div className="text-left">
+      <p>Click Add in the sidebar to add an element to the page.</p>
 
-        <p>
-          Learn how to use the Page Editor in our{" "}
-          <a
-            href="#"
-            onClick={async () =>
-              openTab({
-                url: "https://docs.pixiebrix.com/quick-start-guide",
-                active: true,
-              })
-            }
-          >
-            Quick Start Guide
-          </a>
-        </p>
+      <p>
+        Learn how to use the Page Editor in our{" "}
+        <a
+          href="#"
+          onClick={async () =>
+            openTab({
+              url: "https://docs.pixiebrix.com/quick-start-guide",
+              active: true,
+            })
+          }
+        >
+          Quick Start Guide
+        </a>
+      </p>
 
-        <div className="text-center">
-          <Button variant="info" onClick={showSupport}>
-            <FontAwesomeIcon icon={faCommentAlt} /> Live Chat Support
-          </Button>
+      <div className="text-center">
+        <Button variant="info" onClick={showSupport}>
+          <FontAwesomeIcon icon={faCommentAlt} /> Live Chat Support
+        </Button>
 
-          <Button
-            className="ml-2"
-            variant="info"
-            onClick={async () =>
-              openTab({
-                url: "https://calendly.com/pixiebrix-todd/live-support-session",
-                active: true,
-              })
-            }
-          >
-            <FontAwesomeIcon icon={faPhone} /> Schedule FREE Zoom Session
-          </Button>
-        </div>
+        <Button
+          className="ml-2"
+          variant="info"
+          onClick={async () =>
+            openTab({
+              url: "https://calendly.com/pixiebrix-todd/live-support-session",
+              active: true,
+            })
+          }
+        >
+          <FontAwesomeIcon icon={faPhone} /> Schedule FREE Zoom Session
+        </Button>
       </div>
-    </Centered>
-  );
-};
+    </div>
+  </Centered>
+);
 
 export default WelcomePane;

--- a/src/devTools/editor/sidebar/ExtensionIcons.tsx
+++ b/src/devTools/editor/sidebar/ExtensionIcons.tsx
@@ -27,9 +27,7 @@ import { ElementType } from "@/devTools/editor/extensionPoints/elementConfig";
 
 export const ExtensionIcon: React.FunctionComponent<{ type: ElementType }> = ({
   type,
-}) => {
-  return <FontAwesomeIcon icon={ADAPTERS.get(type)?.icon ?? faPuzzlePiece} />;
-};
+}) => <FontAwesomeIcon icon={ADAPTERS.get(type)?.icon ?? faPuzzlePiece} />;
 
 export const NotAvailableIcon: React.FunctionComponent = () => (
   <FontAwesomeIcon icon={faEyeSlash} title="Not available on page" />

--- a/src/devTools/editor/sidebar/Sidebar.tsx
+++ b/src/devTools/editor/sidebar/Sidebar.tsx
@@ -47,22 +47,20 @@ const DropdownEntry: React.FunctionComponent<{
   icon: IconProp;
   onClick: () => void;
   beta?: boolean;
-}> = ({ beta, icon, caption, onClick }) => {
-  return (
-    <Dropdown.Item onClick={onClick}>
-      <FontAwesomeIcon icon={icon} />
-      &nbsp;{caption}
-      {beta && (
-        <>
-          {" "}
-          <Badge variant="success" pill>
-            Beta
-          </Badge>
-        </>
-      )}
-    </Dropdown.Item>
-  );
-};
+}> = ({ beta, icon, caption, onClick }) => (
+  <Dropdown.Item onClick={onClick}>
+    <FontAwesomeIcon icon={icon} />
+    &nbsp;{caption}
+    {beta && (
+      <>
+        {" "}
+        <Badge variant="success" pill>
+          Beta
+        </Badge>
+      </>
+    )}
+  </Dropdown.Item>
+);
 
 const Sidebar: React.FunctionComponent<
   Omit<EditorState, "error" | "dirty" | "knownEditable" | "selectionSeq"> & {

--- a/src/devTools/editor/tabs/EffectTab.tsx
+++ b/src/devTools/editor/tabs/EffectTab.tsx
@@ -87,9 +87,7 @@ const EffectTab: React.FunctionComponent<{
     actions.length > 0 ? 0 : null
   );
 
-  const [blocks] = useAsyncState(async () => {
-    return blockRegistry.all();
-  }, []);
+  const [blocks] = useAsyncState(async () => blockRegistry.all(), []);
 
   const [relevantBlocks] = useAsyncState(async () => {
     const excludeTypes: BlockType[] = ["actionPanel", "panel"].includes(type)
@@ -100,11 +98,8 @@ const EffectTab: React.FunctionComponent<{
 
   const actionsHash = hash(actions.map((x) => x.id));
   const resolvedBlocks = useMemo(
-    () => {
-      return actions.map(({ id }) =>
-        (blocks ?? []).find((block) => block.id === id)
-      );
-    },
+    () =>
+      actions.map(({ id }) => (blocks ?? []).find((block) => block.id === id)),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- using actionsHash since we only use the actions ids
     [blocks, actionsHash]
   );

--- a/src/devTools/editor/tabs/LockedFoundationTab.tsx
+++ b/src/devTools/editor/tabs/LockedFoundationTab.tsx
@@ -20,26 +20,24 @@ import { Field, FieldInputProps } from "formik";
 
 const LockedFoundationTab: React.FunctionComponent<{
   eventKey?: string;
-}> = ({ eventKey }) => {
-  return (
-    <Tab.Pane eventKey={eventKey} className="h-100">
-      <Alert variant="info">
-        You do not have edit permissions for this foundation
-      </Alert>
-      <Form.Group as={Row} controlId="formExtensionPointId">
-        <Form.Label column sm={2}>
-          Foundation Id
-        </Form.Label>
-        <Col sm={10}>
-          <Field name="extensionPoint.metadata.id">
-            {({ field }: { field: FieldInputProps<string> }) => (
-              <Form.Control type="text" {...field} disabled />
-            )}
-          </Field>
-        </Col>
-      </Form.Group>
-    </Tab.Pane>
-  );
-};
+}> = ({ eventKey }) => (
+  <Tab.Pane eventKey={eventKey} className="h-100">
+    <Alert variant="info">
+      You do not have edit permissions for this foundation
+    </Alert>
+    <Form.Group as={Row} controlId="formExtensionPointId">
+      <Form.Label column sm={2}>
+        Foundation Id
+      </Form.Label>
+      <Col sm={10}>
+        <Field name="extensionPoint.metadata.id">
+          {({ field }: { field: FieldInputProps<string> }) => (
+            <Form.Control type="text" {...field} disabled />
+          )}
+        </Field>
+      </Col>
+    </Form.Group>
+  </Tab.Pane>
+);
 
 export default LockedFoundationTab;

--- a/src/devTools/editor/tabs/MetaTab.tsx
+++ b/src/devTools/editor/tabs/MetaTab.tsx
@@ -21,41 +21,39 @@ import { Field, FieldInputProps } from "formik";
 
 const MetaTab: React.FunctionComponent<{
   eventKey?: string;
-}> = ({ eventKey = "meta" }) => {
-  return (
-    <Tab.Pane eventKey={eventKey} className="h-100">
-      <Form.Group as={Row} controlId="extensionName">
-        <Form.Label column sm={2}>
-          Name
-        </Form.Label>
-        <Col sm={10}>
-          <Field name="label">
-            {({ field }: { field: FieldInputProps<string> }) => (
-              <Form.Control type="text" {...field} />
-            )}
-          </Field>
-          <Form.Text className="text-muted">
-            A name for this extension so that you can find it later
-          </Form.Text>
-        </Col>
-      </Form.Group>
-      <Form.Group as={Row} controlId="extensionId">
-        <Form.Label column sm={2}>
-          UUID
-        </Form.Label>
-        <Col sm={10}>
-          <Field name="uuid">
-            {({ field }: { field: FieldInputProps<string> }) => (
-              <Form.Control type="text" {...field} disabled />
-            )}
-          </Field>
-          <Form.Text className="text-muted">
-            An automatically generated unique identifier for this extension
-          </Form.Text>
-        </Col>
-      </Form.Group>
-    </Tab.Pane>
-  );
-};
+}> = ({ eventKey = "meta" }) => (
+  <Tab.Pane eventKey={eventKey} className="h-100">
+    <Form.Group as={Row} controlId="extensionName">
+      <Form.Label column sm={2}>
+        Name
+      </Form.Label>
+      <Col sm={10}>
+        <Field name="label">
+          {({ field }: { field: FieldInputProps<string> }) => (
+            <Form.Control type="text" {...field} />
+          )}
+        </Field>
+        <Form.Text className="text-muted">
+          A name for this extension so that you can find it later
+        </Form.Text>
+      </Col>
+    </Form.Group>
+    <Form.Group as={Row} controlId="extensionId">
+      <Form.Label column sm={2}>
+        UUID
+      </Form.Label>
+      <Col sm={10}>
+        <Field name="uuid">
+          {({ field }: { field: FieldInputProps<string> }) => (
+            <Form.Control type="text" {...field} disabled />
+          )}
+        </Field>
+        <Form.Text className="text-muted">
+          An automatically generated unique identifier for this extension
+        </Form.Text>
+      </Col>
+    </Form.Group>
+  </Tab.Pane>
+);
 
 export default MetaTab;

--- a/src/devTools/editor/tabs/ServicesTab.tsx
+++ b/src/devTools/editor/tabs/ServicesTab.tsx
@@ -52,9 +52,10 @@ const ServicesTab: React.FunctionComponent<{
     ServiceDefinition[]
   >("/api/services/");
 
-  const refresh = useCallback(async () => {
-    return Promise.all([refreshServices(), refreshAuths()]);
-  }, [refreshAuths, refreshServices]);
+  const refresh = useCallback(
+    async () => Promise.all([refreshServices(), refreshAuths()]),
+    [refreshAuths, refreshServices]
+  );
 
   return (
     <Tab.Pane eventKey={eventKey} className="h-100">

--- a/src/devTools/editor/tabs/actionPanel/PanelTab.tsx
+++ b/src/devTools/editor/tabs/actionPanel/PanelTab.tsx
@@ -21,23 +21,21 @@ import { Col, Form, Row, Tab } from "react-bootstrap";
 
 const PanelTab: React.FunctionComponent<{
   eventKey?: string;
-}> = ({ eventKey = "panelBody" }) => {
-  return (
-    <Tab.Pane eventKey={eventKey} className="h-100">
-      <Form.Group as={Row} controlId="formCaption">
-        <Form.Label column sm={2}>
-          Heading
-        </Form.Label>
-        <Col sm={10}>
-          <Field name="extension.heading">
-            {({ field }: { field: FieldInputProps<string> }) => (
-              <Form.Control type="text" {...field} />
-            )}
-          </Field>
-        </Col>
-      </Form.Group>
-    </Tab.Pane>
-  );
-};
+}> = ({ eventKey = "panelBody" }) => (
+  <Tab.Pane eventKey={eventKey} className="h-100">
+    <Form.Group as={Row} controlId="formCaption">
+      <Form.Label column sm={2}>
+        Heading
+      </Form.Label>
+      <Col sm={10}>
+        <Field name="extension.heading">
+          {({ field }: { field: FieldInputProps<string> }) => (
+            <Form.Control type="text" {...field} />
+          )}
+        </Field>
+      </Col>
+    </Form.Group>
+  </Tab.Pane>
+);
 
 export default PanelTab;

--- a/src/devTools/editor/tabs/menuItem/MenuItemTab.tsx
+++ b/src/devTools/editor/tabs/menuItem/MenuItemTab.tsx
@@ -23,42 +23,40 @@ import ToggleField from "@/devTools/editor/components/ToggleField";
 
 const MenuItemTab: React.FunctionComponent<{
   eventKey?: string;
-}> = ({ eventKey = "menuItem" }) => {
-  return (
-    <Tab.Pane eventKey={eventKey} className="h-100">
-      <Form.Group as={Row} controlId="formCaption">
-        <Form.Label column sm={2}>
-          Caption
-        </Form.Label>
-        <Col sm={10}>
-          <FastField name="extension.caption">
-            {({ field }: { field: FieldInputProps<string> }) => (
-              <Form.Control type="text" {...field} />
-            )}
-          </FastField>
-          <Form.Text className="text-muted">
-            The button caption, which can use data from the reader
-          </Form.Text>
-        </Col>
-      </Form.Group>
+}> = ({ eventKey = "menuItem" }) => (
+  <Tab.Pane eventKey={eventKey} className="h-100">
+    <Form.Group as={Row} controlId="formCaption">
+      <Form.Label column sm={2}>
+        Caption
+      </Form.Label>
+      <Col sm={10}>
+        <FastField name="extension.caption">
+          {({ field }: { field: FieldInputProps<string> }) => (
+            <Form.Control type="text" {...field} />
+          )}
+        </FastField>
+        <Form.Text className="text-muted">
+          The button caption, which can use data from the reader
+        </Form.Text>
+      </Col>
+    </Form.Group>
 
-      <Form.Group as={Row} controlId="formDynamicCaption">
-        <Form.Label column sm={2}>
-          Dynamic Caption
-        </Form.Label>
-        <Col sm={10}>
-          <ToggleField name="extension.dynamicCaption" />
-          <Form.Text className="text-muted">
-            Toggle on to enabling templates in the caption. Turning dynamic
-            captions on may slow down menu rendering if your menu reads a lot of
-            data
-          </Form.Text>
-        </Col>
-      </Form.Group>
+    <Form.Group as={Row} controlId="formDynamicCaption">
+      <Form.Label column sm={2}>
+        Dynamic Caption
+      </Form.Label>
+      <Col sm={10}>
+        <ToggleField name="extension.dynamicCaption" />
+        <Form.Text className="text-muted">
+          Toggle on to enabling templates in the caption. Turning dynamic
+          captions on may slow down menu rendering if your menu reads a lot of
+          data
+        </Form.Text>
+      </Col>
+    </Form.Group>
 
-      <IconField label="Icon" name="extension.icon" schema={iconSchema} />
-    </Tab.Pane>
-  );
-};
+    <IconField label="Icon" name="extension.icon" schema={iconSchema} />
+  </Tab.Pane>
+);
 
 export default MenuItemTab;

--- a/src/devTools/editor/tabs/panel/PanelTab.tsx
+++ b/src/devTools/editor/tabs/panel/PanelTab.tsx
@@ -22,41 +22,39 @@ import ToggleField from "@/devTools/editor/components/ToggleField";
 
 const PanelTeb: React.FunctionComponent<{
   eventKey?: string;
-}> = ({ eventKey = "panelBody" }) => {
-  return (
-    <Tab.Pane eventKey={eventKey} className="h-100">
-      <Form.Group as={Row} controlId="formCaption">
-        <Form.Label column sm={2}>
-          Heading
-        </Form.Label>
-        <Col sm={10}>
-          <Field name="extension.heading">
-            {({ field }: { field: FieldInputProps<string> }) => (
-              <Form.Control type="text" {...field} />
-            )}
-          </Field>
-        </Col>
-      </Form.Group>
+}> = ({ eventKey = "panelBody" }) => (
+  <Tab.Pane eventKey={eventKey} className="h-100">
+    <Form.Group as={Row} controlId="formCaption">
+      <Form.Label column sm={2}>
+        Heading
+      </Form.Label>
+      <Col sm={10}>
+        <Field name="extension.heading">
+          {({ field }: { field: FieldInputProps<string> }) => (
+            <Form.Control type="text" {...field} />
+          )}
+        </Field>
+      </Col>
+    </Form.Group>
 
-      <Form.Group as={Row} controlId="formCaption">
-        <Form.Label column sm={2}>
-          Collapsible
-        </Form.Label>
-        <Col sm={10}>
-          <ToggleField name="extension.collapsible" />
-        </Col>
-      </Form.Group>
+    <Form.Group as={Row} controlId="formCaption">
+      <Form.Label column sm={2}>
+        Collapsible
+      </Form.Label>
+      <Col sm={10}>
+        <ToggleField name="extension.collapsible" />
+      </Col>
+    </Form.Group>
 
-      <Form.Group as={Row} controlId="formCaption">
-        <Form.Label column sm={2}>
-          Shadow DOM
-        </Form.Label>
-        <Col sm={10}>
-          <ToggleField name="extension.shadowDOM" />
-        </Col>
-      </Form.Group>
-    </Tab.Pane>
-  );
-};
+    <Form.Group as={Row} controlId="formCaption">
+      <Form.Label column sm={2}>
+        Shadow DOM
+      </Form.Label>
+      <Col sm={10}>
+        <ToggleField name="extension.shadowDOM" />
+      </Col>
+    </Form.Group>
+  </Tab.Pane>
+);
 
 export default PanelTeb;

--- a/src/devTools/editor/tabs/reader/ReaderConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderConfig.tsx
@@ -156,53 +156,51 @@ export function searchData(query: string, data: unknown): unknown {
 const FrameworkFields: React.FunctionComponent<{
   name: string;
   element: FormState;
-}> = ({ element, name }) => {
-  return (
-    <>
-      <Form.Group as={Row} controlId="readerSelector">
-        <Form.Label column sm={2}>
-          Selector
-        </Form.Label>
-        <Col sm={10}>
-          <SelectorSelectorField
-            isClearable
-            name={`${name}.definition.selector`}
-            initialElement={
-              "containerInfo" in element ? element.containerInfo : null
-            }
-            traverseUp={5}
-          />
-        </Col>
-      </Form.Group>
-      <Form.Group as={Row} controlId="readerOptional">
-        <Form.Label column sm={2}>
-          Optional
-        </Form.Label>
-        <Col sm={10}>
-          <ToggleField name={`${name}.definition.optional`} />
-          <Form.Text className="text-muted">
-            Toggle on if the selector might not always be available
-          </Form.Text>
-        </Col>
-      </Form.Group>
-      <Form.Group as={Row} controlId="readerTraverseUp">
-        <Form.Label column sm={2}>
-          Traverse Up
-        </Form.Label>
-        <Col sm={10}>
-          <Field name={`${name}.definition.traverseUp`}>
-            {({ field }: { field: FieldInputProps<number> }) => (
-              <Form.Control type="number" {...field} min={0} max={10} />
-            )}
-          </Field>
-          <Form.Text className="text-muted">
-            Traverse non-visible framework elements
-          </Form.Text>
-        </Col>
-      </Form.Group>
-    </>
-  );
-};
+}> = ({ element, name }) => (
+  <>
+    <Form.Group as={Row} controlId="readerSelector">
+      <Form.Label column sm={2}>
+        Selector
+      </Form.Label>
+      <Col sm={10}>
+        <SelectorSelectorField
+          isClearable
+          name={`${name}.definition.selector`}
+          initialElement={
+            "containerInfo" in element ? element.containerInfo : null
+          }
+          traverseUp={5}
+        />
+      </Col>
+    </Form.Group>
+    <Form.Group as={Row} controlId="readerOptional">
+      <Form.Label column sm={2}>
+        Optional
+      </Form.Label>
+      <Col sm={10}>
+        <ToggleField name={`${name}.definition.optional`} />
+        <Form.Text className="text-muted">
+          Toggle on if the selector might not always be available
+        </Form.Text>
+      </Col>
+    </Form.Group>
+    <Form.Group as={Row} controlId="readerTraverseUp">
+      <Form.Label column sm={2}>
+        Traverse Up
+      </Form.Label>
+      <Col sm={10}>
+        <Field name={`${name}.definition.traverseUp`}>
+          {({ field }: { field: FieldInputProps<number> }) => (
+            <Form.Control type="number" {...field} min={0} max={10} />
+          )}
+        </Field>
+        <Form.Text className="text-muted">
+          Traverse non-visible framework elements
+        </Form.Text>
+      </Col>
+    </Form.Group>
+  </>
+);
 
 const JQUERY_FIELD_SCHEMA: Schema = {
   type: "object",

--- a/src/devTools/editor/tabs/reader/ReaderTab.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderTab.tsx
@@ -138,12 +138,10 @@ const ReaderTab: React.FunctionComponent<{
   const [blocks] = useAsyncState(async () => {
     const all = await blockRegistry.all();
     const annotated = await Promise.all(
-      all.map(async (block: IBlock) => {
-        return {
-          type: await getType(block),
-          block,
-        };
-      })
+      all.map(async (block: IBlock) => ({
+        type: await getType(block),
+        block,
+      }))
     );
     return annotated.filter((x) => x.type === "reader").map((x) => x.block);
   }, []);

--- a/src/devTools/editor/tabs/reader/hooks.tsx
+++ b/src/devTools/editor/tabs/reader/hooks.tsx
@@ -31,27 +31,25 @@ export function useLabelRenderer() {
       [key, ...rest]: (string | number)[],
       nodeType: string,
       expanded: boolean
-    ) => {
-      return (
-        <span>
-          <span>{key}</span>
-          {!expanded && ": "}
-          <span
-            className="ReaderTree__copy-path"
-            aria-label="copy path"
-            onClick={() => {
-              copy(reverse([key, ...rest]).join("."));
-              addToast("Copied property path to the clipboard", {
-                appearance: "info",
-                autoDismiss: true,
-              });
-            }}
-          >
-            <FontAwesomeIcon icon={faCopy} aria-hidden />
-          </span>
+    ) => (
+      <span>
+        <span>{key}</span>
+        {!expanded && ": "}
+        <span
+          className="ReaderTree__copy-path"
+          aria-label="copy path"
+          onClick={() => {
+            copy(reverse([key, ...rest]).join("."));
+            addToast("Copied property path to the clipboard", {
+              appearance: "info",
+              autoDismiss: true,
+            });
+          }}
+        >
+          <FontAwesomeIcon icon={faCopy} aria-hidden />
         </span>
-      );
-    },
+      </span>
+    ),
     [addToast]
   );
 }

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -27,12 +27,12 @@ import {
 import { reportError } from "@/telemetry/logging";
 import { updateSelectedElement } from "./devTools/getSelectedElement";
 
-window.addEventListener("error", function (e) {
+window.addEventListener("error", (e) => {
   reportError(e);
   return false;
 });
 
-window.addEventListener("unhandledrejection", function (e) {
+window.addEventListener("unhandledrejection", (e) => {
   reportError(e);
 });
 

--- a/src/devtoolsPanel.tsx
+++ b/src/devtoolsPanel.tsx
@@ -27,12 +27,12 @@ import { reportError } from "@/telemetry/logging";
 
 import initGoogle from "@/contrib/google/initGoogle";
 
-window.addEventListener("error", function (e) {
+window.addEventListener("error", (e) => {
   reportError(e);
   return false;
 });
 
-window.addEventListener("unhandledrejection", function (e) {
+window.addEventListener("unhandledrejection", (e) => {
   reportError(e);
 });
 

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -318,6 +318,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
         } else {
           extensionLogger.warn(getErrorMessage(error));
         }
+
         throw error;
       }
     });

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -775,6 +775,7 @@ class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
           $menu[position]($menuItem);
           break;
         }
+
         default: {
           throw new Error(`Unexpected position ${String(position)}`);
         }

--- a/src/frameworks/contrib/angularjs.ts
+++ b/src/frameworks/contrib/angularjs.ts
@@ -81,9 +81,7 @@ const adapter: ReadableComponentAdapter<AngularElement, Scope> = {
   getComponent: (node) => ignoreNotFound(() => getComponent(node)),
   getParent: (instance) => instance.parent(),
   getNode: (instance) => instance[0],
-  hasData: (instance) => {
-    return !isEmpty(getAngularData(instance));
-  },
+  hasData: (instance) => !isEmpty(getAngularData(instance)),
   getData: getAngularData,
 };
 

--- a/src/frameworks/contrib/vue.ts
+++ b/src/frameworks/contrib/vue.ts
@@ -159,9 +159,7 @@ const adapter: WriteableComponentAdapter<Instance> = {
   getComponent: findRelatedComponent,
   getNode: (instance: Instance) => instance.$el,
   getParent: (instance: Instance) => instance.$parent,
-  hasData: (instance: Instance) => {
-    return !isEmpty(instance);
-  },
+  hasData: (instance: Instance) => !isEmpty(instance),
   getData: readVueData,
   setData: (instance: Instance, data) => {
     for (const [key, value] of Object.entries(data)) {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -71,6 +71,7 @@ function useNotifications(): Notifications {
       if (event) {
         reportEvent(event);
       }
+
       addToast(content, {
         appearance: "success",
         autoDismiss: true,
@@ -103,9 +104,11 @@ function useNotifications(): Notifications {
       if (report) {
         reportError(error ?? content);
       }
+
       if (event) {
         reportEvent(event);
       }
+
       addToast(content, {
         appearance,
         autoDismiss,

--- a/src/layout/Banner.tsx
+++ b/src/layout/Banner.tsx
@@ -71,6 +71,7 @@ const Banner: React.FunctionComponent = () => {
   if (environment === "production") {
     return null;
   }
+
   return <EnvironmentBanner />;
 };
 

--- a/src/messaging/chrome.ts
+++ b/src/messaging/chrome.ts
@@ -40,7 +40,7 @@ export function createSendScriptMessage<TReturn = unknown, TPayload = unknown>(
     callbacks: CallbackMap,
     prop: "result" | "error"
   ) => {
-    document.addEventListener(type, function (event: CustomEvent) {
+    document.addEventListener(type, (event: CustomEvent) => {
       if (!event.detail) {
         throw new Error(
           `Handler for ${type} did not provide a detail property`

--- a/src/messaging/external.ts
+++ b/src/messaging/external.ts
@@ -27,10 +27,10 @@ import { isChrome } from "@/helpers";
 
 const lift = isChrome ? liftBackground : liftExternal;
 
-export const connectPage = lift("CONNECT_PAGE", async () => {
+export const connectPage = lift("CONNECT_PAGE", async () =>
   // `browser.runtimes`'s types don't include the whole manifest. Use the chrome namespace to get the full type
-  return chrome.runtime.getManifest();
-});
+  chrome.runtime.getManifest()
+);
 
 const _reload = liftBackground("BACKGROUND_RELOAD", async () => {
   browser.runtime.reload();
@@ -147,25 +147,19 @@ const _openActivate = liftBackground(
 
 export const openActivateBlueprint = lift(
   "OPEN_ACTIVATE_BLUEPRINT",
-  async (options: ActivateBlueprintOptions) => {
-    return _openActivate(options);
-  }
+  async (options: ActivateBlueprintOptions) => _openActivate(options)
 );
 
-export const openExtensionOptions = lift("OPEN_OPTIONS", async () => {
-  return _openOptions();
-});
+export const openExtensionOptions = lift("OPEN_OPTIONS", async () =>
+  _openOptions()
+);
 
 export const openMarketplace = lift(
   "OPEN_MARKETPLACE",
-  async (options: OpenOptionsOptions = {}) => {
-    return _openMarketplace(options);
-  }
+  async (options: OpenOptionsOptions = {}) => _openMarketplace(options)
 );
 
 export const openTemplates = lift(
   "OPEN_TEMPLATES",
-  async (options: OpenOptionsOptions = {}) => {
-    return _openTemplates(options);
-  }
+  async (options: OpenOptionsOptions = {}) => _openTemplates(options)
 );

--- a/src/nativeEditor/dynamic.ts
+++ b/src/nativeEditor/dynamic.ts
@@ -76,9 +76,7 @@ export const clear = liftContentScript(
 
 export const getInstalledExtensionPointIds = liftContentScript(
   "INSTALLED_EXTENSIONS",
-  async () => {
-    return getInstalledIds();
-  }
+  async () => getInstalledIds()
 );
 
 type ReaderLike = ReaderConfig | ReaderReference | Reader;

--- a/src/nativeEditor/insertButton.tsx
+++ b/src/nativeEditor/insertButton.tsx
@@ -54,12 +54,8 @@ export interface DragResult {
 
 function dragPromise(uuid: string): Promise<DragResult | null> {
   const drake = dragula({
-    isContainer: (el?: Element) => {
-      return ["DIV", "SECTION"].includes(el.tagName);
-    },
-    moves: (el?: Element) => {
-      return el.getAttribute(DATA_ATTR) === uuid;
-    },
+    isContainer: (el?: Element) => ["DIV", "SECTION"].includes(el.tagName),
+    moves: (el?: Element) => el.getAttribute(DATA_ATTR) === uuid,
   });
 
   let resolved = false;
@@ -107,9 +103,7 @@ function dragPromise(uuid: string): Promise<DragResult | null> {
 
 export const dragButton = liftContentScript(
   "DRAG_BUTTON",
-  async ({ uuid }: { uuid: string }) => {
-    return dragPromise(uuid);
-  }
+  async ({ uuid }: { uuid: string }) => dragPromise(uuid)
 );
 
 export const insertButton = liftContentScript("INSERT_BUTTON", async () => {

--- a/src/options/pages/SetupPage.tsx
+++ b/src/options/pages/SetupPage.tsx
@@ -38,23 +38,21 @@ const Step: React.FunctionComponent<{
   number: number;
   completed?: boolean;
   active?: boolean;
-}> = ({ number, completed, active, children }) => {
-  return (
-    <ListGroup.Item className={cx("OnboardingStep", { current: active })}>
-      <div className="d-flex">
-        <div className="OnboardingStep__status">
-          {completed && (
-            <span>
-              <FontAwesomeIcon icon={faCheck} />
-            </span>
-          )}
-        </div>
-        <div className="OnboardingStep__step">Step {number}</div>
-        <div className="OnboardingStep__content">{children}</div>
+}> = ({ number, completed, active, children }) => (
+  <ListGroup.Item className={cx("OnboardingStep", { current: active })}>
+    <div className="d-flex">
+      <div className="OnboardingStep__status">
+        {completed && (
+          <span>
+            <FontAwesomeIcon icon={faCheck} />
+          </span>
+        )}
       </div>
-    </ListGroup.Item>
-  );
-};
+      <div className="OnboardingStep__step">Step {number}</div>
+      <div className="OnboardingStep__content">{children}</div>
+    </div>
+  </ListGroup.Item>
+);
 
 const SetupPage: React.FunctionComponent = () => {
   useTitle("Setup");

--- a/src/options/pages/brickEditor/BrickReference.tsx
+++ b/src/options/pages/brickEditor/BrickReference.tsx
@@ -46,14 +46,12 @@ export type ReferenceEntry = IBlock | IExtensionPoint | IService;
 const DetailSection: React.FunctionComponent<{ title: string }> = ({
   title,
   children,
-}) => {
-  return (
-    <div className="my-4">
-      <div className="font-weight-bold">{title}</div>
-      <div className="py-2">{children}</div>
-    </div>
-  );
-};
+}) => (
+  <div className="my-4">
+    <div className="font-weight-bold">{title}</div>
+    <div className="py-2">{children}</div>
+  </div>
+);
 
 function makeArgumentYaml(schema: Schema): string {
   let result = "";
@@ -194,13 +192,15 @@ const BrickReference: React.FunctionComponent<{
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<ReferenceEntry>(initialSelected);
 
-  const sortedBlocks = useMemo(() => {
-    return sortBy(
-      blocks ?? [],
-      (x) => (isOfficial(x) ? 0 : 1),
-      (x) => x.name
-    );
-  }, [blocks]);
+  const sortedBlocks = useMemo(
+    () =>
+      sortBy(
+        blocks ?? [],
+        (x) => (isOfficial(x) ? 0 : 1),
+        (x) => x.name
+      ),
+    [blocks]
+  );
 
   useEffect(() => {
     if (sortedBlocks.length > 0 && selected == null) {
@@ -208,12 +208,14 @@ const BrickReference: React.FunctionComponent<{
     }
   }, [sortedBlocks, selected, setSelected]);
 
-  const fuse: Fuse<IBlock | IService> = useMemo(() => {
-    return new Fuse(sortedBlocks, {
-      // Prefer name, then id
-      keys: ["name", "id"],
-    });
-  }, [sortedBlocks]);
+  const fuse: Fuse<IBlock | IService> = useMemo(
+    () =>
+      new Fuse(sortedBlocks, {
+        // Prefer name, then id
+        keys: ["name", "id"],
+      }),
+    [sortedBlocks]
+  );
 
   const results = useMemo(() => {
     let matches =

--- a/src/options/pages/brickEditor/EditPage.tsx
+++ b/src/options/pages/brickEditor/EditPage.tsx
@@ -92,23 +92,21 @@ const ToggleField: React.FunctionComponent<{ name: string }> = ({ name }) => {
   );
 };
 
-const LoadingBody: React.FunctionComponent = () => {
-  return (
-    <>
-      <div className="d-flex">
-        <div className="flex-grow-1">
-          <PageTitle icon={faHammer} title="Edit Brick" />
-        </div>
-        <div className="flex-grow-1 text-right">
-          <Button disabled>Update Brick</Button>
-        </div>
+const LoadingBody: React.FunctionComponent = () => (
+  <>
+    <div className="d-flex">
+      <div className="flex-grow-1">
+        <PageTitle icon={faHammer} title="Edit Brick" />
       </div>
-      <div>
-        <GridLoader />
+      <div className="flex-grow-1 text-right">
+        <Button disabled>Update Brick</Button>
       </div>
-    </>
-  );
-};
+    </div>
+    <div>
+      <GridLoader />
+    </div>
+  </>
+);
 
 const keyMap = {
   SAVE: "command+s",

--- a/src/options/pages/brickEditor/useSubmitBrick.tsx
+++ b/src/options/pages/brickEditor/useSubmitBrick.tsx
@@ -140,6 +140,7 @@ function useSubmitBrick({
               autoDismiss: true,
             });
           }
+
           setErrors(error.response.data);
         } else {
           addToast(error.toString(), {

--- a/src/options/pages/extensionEditor/ExtensionConfigurationCard.tsx
+++ b/src/options/pages/extensionEditor/ExtensionConfigurationCard.tsx
@@ -31,25 +31,23 @@ const ExtensionConfigurationCard: React.FunctionComponent<OwnProps> = ({
   name,
   extensionPoint,
   blocks = [],
-}) => {
-  return (
-    <Card.Body>
-      {Object.entries(inputProperties(extensionPoint.inputSchema)).map(
-        ([property, schema]) => {
-          const Field = defaultFieldRenderer(schema as Schema);
-          return (
-            <Field
-              key={property}
-              name={name ? `${name}.${property}` : property}
-              schema={schema as Schema}
-              // @ts-ignore: need to type field props to allow extra types
-              blocks={blocks}
-            />
-          );
-        }
-      )}
-    </Card.Body>
-  );
-};
+}) => (
+  <Card.Body>
+    {Object.entries(inputProperties(extensionPoint.inputSchema)).map(
+      ([property, schema]) => {
+        const Field = defaultFieldRenderer(schema as Schema);
+        return (
+          <Field
+            key={property}
+            name={name ? `${name}.${property}` : property}
+            schema={schema as Schema}
+            // @ts-ignore: need to type field props to allow extra types
+            blocks={blocks}
+          />
+        );
+      }
+    )}
+  </Card.Body>
+);
 
 export default ExtensionConfigurationCard;

--- a/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
+++ b/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
@@ -341,9 +341,10 @@ const ExtensionPointDetail: React.FunctionComponent<OwnProps> = ({
     ]
   );
 
-  const validationSchema = useMemo(() => {
-    return extensionValidatorFactory(extensionPoint.inputSchema);
-  }, [extensionPoint]);
+  const validationSchema = useMemo(
+    () => extensionValidatorFactory(extensionPoint.inputSchema),
+    [extensionPoint]
+  );
 
   return (
     <HotKeys keyMap={keyMap}>

--- a/src/options/pages/extensionEditor/ServicesFormCard.tsx
+++ b/src/options/pages/extensionEditor/ServicesFormCard.tsx
@@ -43,56 +43,50 @@ export const DependencyRow: React.FunctionComponent<{
   dependency: ServiceDependency;
   index: number;
   remove: (x: number) => void;
-}> = ({ field, authOptions, index, remove, dependency }) => {
-  return (
-    <tr>
-      <td style={{ width: 250 }}>
-        <Field name={`${field.name}.${index}.outputKey`}>
-          {/* @ts-ignore: not sure what's going on with the type definition for this */}
-          {({ field, meta }) => (
-            <Form.Group>
-              <Form.Control
-                {...field}
-                size="default"
-                isInvalid={!!meta.error}
-              />
-              {meta.touched && meta.error && (
-                <Form.Control.Feedback type="invalid">
-                  {meta.error}
-                </Form.Control.Feedback>
-              )}
-            </Form.Group>
-          )}
-        </Field>
-      </td>
-      <td>
-        <Form.Group>
-          {/* TODO: indicate if the service no longer exists */}
-          <input
-            type="hidden"
-            name={`${field.name}.${index}.id`}
-            value={dependency.id}
-          />
-          <code>{dependency.id}</code>
-        </Form.Group>
-      </td>
-      <td style={{ width: 350 }}>
-        <ServiceAuthSelector
-          name={`${field.name}.${index}.config`}
-          serviceId={dependency.id}
-          authOptions={authOptions}
+}> = ({ field, authOptions, index, remove, dependency }) => (
+  <tr>
+    <td style={{ width: 250 }}>
+      <Field name={`${field.name}.${index}.outputKey`}>
+        {/* @ts-ignore: not sure what's going on with the type definition for this */}
+        {({ field, meta }) => (
+          <Form.Group>
+            <Form.Control {...field} size="default" isInvalid={!!meta.error} />
+            {meta.touched && meta.error && (
+              <Form.Control.Feedback type="invalid">
+                {meta.error}
+              </Form.Control.Feedback>
+            )}
+          </Form.Group>
+        )}
+      </Field>
+    </td>
+    <td>
+      <Form.Group>
+        {/* TODO: indicate if the service no longer exists */}
+        <input
+          type="hidden"
+          name={`${field.name}.${index}.id`}
+          value={dependency.id}
         />
-      </td>
-      <td>
-        <Form.Group>
-          <Button variant="danger" size="sm" onClick={() => remove(index)}>
-            <FontAwesomeIcon icon={faTrash} /> Remove
-          </Button>
-        </Form.Group>
-      </td>
-    </tr>
-  );
-};
+        <code>{dependency.id}</code>
+      </Form.Group>
+    </td>
+    <td style={{ width: 350 }}>
+      <ServiceAuthSelector
+        name={`${field.name}.${index}.config`}
+        serviceId={dependency.id}
+        authOptions={authOptions}
+      />
+    </td>
+    <td>
+      <Form.Group>
+        <Button variant="danger" size="sm" onClick={() => remove(index)}>
+          <FontAwesomeIcon icon={faTrash} /> Remove
+        </Button>
+      </Form.Group>
+    </td>
+  </tr>
+);
 
 const ServicesFormCard: React.FunctionComponent<{ name: string }> = ({
   ...props

--- a/src/options/pages/extensionEditor/WorkshopPage.tsx
+++ b/src/options/pages/extensionEditor/WorkshopPage.tsx
@@ -104,24 +104,32 @@ function useEnrichBricks(bricks: Brick[]): EnhancedBrick[] {
 }
 
 function useSearchOptions(bricks: EnhancedBrick[]) {
-  const scopeOptions = useMemo(() => {
-    return sortBy(uniq((bricks ?? []).map((x) => x.scope))).map((value) => ({
-      value,
-      label: value ?? "[No Scope]",
-    }));
-  }, [bricks]);
+  const scopeOptions = useMemo(
+    () =>
+      sortBy(uniq((bricks ?? []).map((x) => x.scope))).map((value) => ({
+        value,
+        label: value ?? "[No Scope]",
+      })),
+    [bricks]
+  );
 
-  const collectionOptions = useMemo(() => {
-    return sortBy(
-      uniq((bricks ?? []).map((x) => x.collection))
-    ).map((value) => ({ value, label: value ?? "[No Collection]" }));
-  }, [bricks]);
+  const collectionOptions = useMemo(
+    () =>
+      sortBy(uniq((bricks ?? []).map((x) => x.collection))).map((value) => ({
+        value,
+        label: value ?? "[No Collection]",
+      })),
+    [bricks]
+  );
 
-  const kindOptions = useMemo(() => {
-    return sortBy(
-      compact(uniq((bricks ?? []).map((x) => x.kind)))
-    ).map((value) => ({ value, label: value }));
-  }, [bricks]);
+  const kindOptions = useMemo(
+    () =>
+      sortBy(compact(uniq((bricks ?? []).map((x) => x.kind)))).map((value) => ({
+        value,
+        label: value,
+      })),
+    [bricks]
+  );
 
   return {
     scopeOptions,
@@ -146,11 +154,13 @@ const CustomBricksSection: React.FunctionComponent<OwnProps> = ({
 
   const filtered = !isEmpty(scopes) || !isEmpty(collections) || !isEmpty(kinds);
 
-  const fuse: Fuse<EnhancedBrick> = useMemo(() => {
-    return new Fuse(bricks, {
-      keys: ["verbose_name", "name"],
-    });
-  }, [bricks]);
+  const fuse: Fuse<EnhancedBrick> = useMemo(
+    () =>
+      new Fuse(bricks, {
+        keys: ["verbose_name", "name"],
+      }),
+    [bricks]
+  );
 
   const sortedBricks = useMemo(() => {
     const results =
@@ -285,55 +295,53 @@ const KindIcon: React.FunctionComponent<{ brick: EnhancedBrick }> = ({
 
 const CustomBricksCard: React.FunctionComponent<
   OwnProps & { bricks: EnhancedBrick[]; maxRows?: number }
-> = ({ navigate, bricks, maxRows = 10 }) => {
-  return (
-    <Card>
-      <Card.Header>Custom Bricks</Card.Header>
-      <Table className="WorkshopPage__BrickTable">
-        <thead>
-          <tr>
-            <th>&nbsp;</th>
-            <th>Name</th>
-            <th>Collection</th>
-            <th>Type</th>
-            <th>Version</th>
+> = ({ navigate, bricks, maxRows = 10 }) => (
+  <Card>
+    <Card.Header>Custom Bricks</Card.Header>
+    <Table className="WorkshopPage__BrickTable">
+      <thead>
+        <tr>
+          <th>&nbsp;</th>
+          <th>Name</th>
+          <th>Collection</th>
+          <th>Type</th>
+          <th>Version</th>
+        </tr>
+      </thead>
+      <tbody>
+        {bricks.slice(0, maxRows).map((brick) => (
+          <tr
+            key={brick.id}
+            onClick={() => navigate(`/workshop/bricks/${brick.id}`)}
+          >
+            <td className="text-right text-muted px-1">
+              <KindIcon brick={brick} />
+            </td>
+            <td>
+              <div>{brick.verbose_name}</div>
+              <div className="mt-1">
+                <code className="p-0" style={{ fontSize: "0.8rem" }}>
+                  {brick.name}
+                </code>
+              </div>
+            </td>
+            <td>{brick.collection}</td>
+            <td>{brick.kind}</td>
+            <td>{brick.version}</td>
           </tr>
-        </thead>
-        <tbody>
-          {bricks.slice(0, maxRows).map((brick) => (
-            <tr
-              key={brick.id}
-              onClick={() => navigate(`/workshop/bricks/${brick.id}`)}
-            >
-              <td className="text-right text-muted px-1">
-                <KindIcon brick={brick} />
-              </td>
-              <td>
-                <div>{brick.verbose_name}</div>
-                <div className="mt-1">
-                  <code className="p-0" style={{ fontSize: "0.8rem" }}>
-                    {brick.name}
-                  </code>
-                </div>
-              </td>
-              <td>{brick.collection}</td>
-              <td>{brick.kind}</td>
-              <td>{brick.version}</td>
-            </tr>
-          ))}
-          {bricks.length >= maxRows && (
-            <tr className="WorkshopPage__BrickTable__more">
-              <td colSpan={5} className="text-info text-center">
-                <FontAwesomeIcon icon={faInfoCircle} />{" "}
-                {bricks.length - maxRows} more entries not shown
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </Table>
-    </Card>
-  );
-};
+        ))}
+        {bricks.length >= maxRows && (
+          <tr className="WorkshopPage__BrickTable__more">
+            <td colSpan={5} className="text-info text-center">
+              <FontAwesomeIcon icon={faInfoCircle} /> {bricks.length - maxRows}{" "}
+              more entries not shown
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </Table>
+  </Card>
+);
 
 const WorkshopPage: React.FunctionComponent<OwnProps> = ({ navigate }) => {
   useTitle("Workshop");

--- a/src/options/pages/installed/InstalledPage.tsx
+++ b/src/options/pages/installed/InstalledPage.tsx
@@ -47,12 +47,14 @@ const InstalledTable: React.FunctionComponent<{
   extensions: InstalledExtension[];
   onRemove: RemoveAction;
 }> = ({ extensions, onRemove }) => {
-  const recipeExtensions = useMemo(() => {
-    return sortBy(
-      Object.entries(groupBy(extensions, (x) => x._recipe?.id ?? "")),
-      (x) => (x[0] === "" ? 0 : 1)
-    );
-  }, [extensions]);
+  const recipeExtensions = useMemo(
+    () =>
+      sortBy(
+        Object.entries(groupBy(extensions, (x) => x._recipe?.id ?? "")),
+        (x) => (x[0] === "" ? 0 : 1)
+      ),
+    [extensions]
+  );
 
   return (
     <Row>

--- a/src/options/pages/installed/NoExtensionsPage.tsx
+++ b/src/options/pages/installed/NoExtensionsPage.tsx
@@ -24,70 +24,68 @@ import {
   faExternalLinkAlt,
 } from "@fortawesome/free-solid-svg-icons";
 
-const NoExtensionsPage: React.FunctionComponent = () => {
-  return (
-    <>
-      <Row>
-        <Col className="VideoCard">
-          <Card>
-            <Card.Header>Activate Bricks</Card.Header>
-            <Card.Body>
-              <Row>
-                <Col>
-                  <h4>Activate an Official Template</h4>
-                  <p>
-                    <span className="text-primary">
-                      The easiest way to start using PixieBrix!
-                    </span>{" "}
-                    Activate a pre-made template from the Templates page.
-                  </p>
-                  <Link to={"/templates"} className="btn btn-info">
-                    View Templates&nbsp;
-                    <FontAwesomeIcon icon={faClipboardCheck} />
-                  </Link>
-                </Col>
-                <Col>
-                  <h4>Create your Own</h4>
-                  <p>
-                    Follow the Quickstart Guide in our documentation area to
-                    start creating your own bricks in minutes.
-                  </p>
-                  <a
-                    className="btn btn-info"
-                    href="https://docs.pixiebrix.com/quick-start-guide"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Open Quickstart Guide&nbsp;
-                    <FontAwesomeIcon icon={faExternalLinkAlt} />
-                  </a>
-                </Col>
-              </Row>
-            </Card.Body>
-          </Card>
-        </Col>
-      </Row>
-      <Row>
-        <Col className="VideoCard mt-3">
-          <Card>
-            <Card.Header>Video Tour</Card.Header>
-            <Card.Body className="mx-auto">
-              <div>
-                <iframe
-                  src="https://player.vimeo.com/video/514828533"
-                  width="640"
-                  height="400"
-                  frameBorder="0"
-                  allow="fullscreen; picture-in-picture"
-                  allowFullScreen
-                />
-              </div>
-            </Card.Body>
-          </Card>
-        </Col>
-      </Row>
-    </>
-  );
-};
+const NoExtensionsPage: React.FunctionComponent = () => (
+  <>
+    <Row>
+      <Col className="VideoCard">
+        <Card>
+          <Card.Header>Activate Bricks</Card.Header>
+          <Card.Body>
+            <Row>
+              <Col>
+                <h4>Activate an Official Template</h4>
+                <p>
+                  <span className="text-primary">
+                    The easiest way to start using PixieBrix!
+                  </span>{" "}
+                  Activate a pre-made template from the Templates page.
+                </p>
+                <Link to={"/templates"} className="btn btn-info">
+                  View Templates&nbsp;
+                  <FontAwesomeIcon icon={faClipboardCheck} />
+                </Link>
+              </Col>
+              <Col>
+                <h4>Create your Own</h4>
+                <p>
+                  Follow the Quickstart Guide in our documentation area to start
+                  creating your own bricks in minutes.
+                </p>
+                <a
+                  className="btn btn-info"
+                  href="https://docs.pixiebrix.com/quick-start-guide"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Open Quickstart Guide&nbsp;
+                  <FontAwesomeIcon icon={faExternalLinkAlt} />
+                </a>
+              </Col>
+            </Row>
+          </Card.Body>
+        </Card>
+      </Col>
+    </Row>
+    <Row>
+      <Col className="VideoCard mt-3">
+        <Card>
+          <Card.Header>Video Tour</Card.Header>
+          <Card.Body className="mx-auto">
+            <div>
+              <iframe
+                src="https://player.vimeo.com/video/514828533"
+                width="640"
+                height="400"
+                frameBorder="0"
+                allow="fullscreen; picture-in-picture"
+                allowFullScreen
+              />
+            </div>
+          </Card.Body>
+        </Card>
+      </Col>
+    </Row>
+  </>
+);
 
 export default NoExtensionsPage;

--- a/src/options/pages/installed/RecipeEntry.tsx
+++ b/src/options/pages/installed/RecipeEntry.tsx
@@ -55,6 +55,7 @@ const RecipeEntry: React.FunctionComponent<{
         for (const { id: extensionId, extensionPointId } of extensions) {
           onRemove({ extensionId, extensionPointId });
         }
+
         notify.success(`Uninstalled ${name}`);
       } catch (error: unknown) {
         reportError(error);

--- a/src/options/pages/marketplace/ActivatePage.tsx
+++ b/src/options/pages/marketplace/ActivatePage.tsx
@@ -39,43 +39,39 @@ const TEMPLATES_PAGE_PART = "templates";
 
 const TemplateHeader: React.FunctionComponent<{
   blueprint: BlueprintResponse;
-}> = ({ blueprint }) => {
-  return (
-    <>
-      <PageTitle
-        icon={faClipboardCheck}
-        title={
-          blueprint
-            ? `Activate: ${blueprint.config.metadata.name}`
-            : "Activate Blueprint"
-        }
-      />
-      <div className="pb-4">
-        <p>Configure and activate a pre-made template</p>
-      </div>
-    </>
-  );
-};
+}> = ({ blueprint }) => (
+  <>
+    <PageTitle
+      icon={faClipboardCheck}
+      title={
+        blueprint
+          ? `Activate: ${blueprint.config.metadata.name}`
+          : "Activate Blueprint"
+      }
+    />
+    <div className="pb-4">
+      <p>Configure and activate a pre-made template</p>
+    </div>
+  </>
+);
 
 const MarketplaceHeader: React.FunctionComponent<{
   blueprint: BlueprintResponse;
-}> = ({ blueprint }) => {
-  return (
-    <>
-      <PageTitle
-        icon={faStoreAlt}
-        title={
-          blueprint
-            ? `Activate: ${blueprint.config.metadata.name}`
-            : "Activate Blueprint"
-        }
-      />
-      <div className="pb-4">
-        <p>Configure and activate a blueprint from the marketplace</p>
-      </div>
-    </>
-  );
-};
+}> = ({ blueprint }) => (
+  <>
+    <PageTitle
+      icon={faStoreAlt}
+      title={
+        blueprint
+          ? `Activate: ${blueprint.config.metadata.name}`
+          : "Activate Blueprint"
+      }
+    />
+    <div className="pb-4">
+      <p>Configure and activate a blueprint from the marketplace</p>
+    </div>
+  </>
+);
 
 const ActivatePage: React.FunctionComponent = () => {
   const { blueprintId, sourcePage } = useParams<{

--- a/src/options/pages/marketplace/ConfigureBody.tsx
+++ b/src/options/pages/marketplace/ConfigureBody.tsx
@@ -97,52 +97,50 @@ interface OwnProps {
   blueprint: RecipeDefinition;
 }
 
-const ConfigureBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
-  return (
-    <>
-      <Card.Body className="p-3">
-        <h3 className="pb-1 mb-0">{blueprint.metadata.name}</h3>
-        <code className="p-0 small">{blueprint.metadata.id}</code>
-        <div className="pt-3">
-          <p>
-            {blueprint.metadata.description ?? (
-              <span>
-                <i>No description provided</i>
-              </span>
-            )}
-          </p>
-        </div>
-      </Card.Body>
-
-      <Card.Body className="px-3 py-0">
-        <p className="text-info">
-          <FontAwesomeIcon icon={faInfoCircle} /> Don&apos;t know which bricks
-          to select? Don&apos;t worry! &mdash; you can de-activate bricks at any
-          time on the{" "}
-          <Link to="/installed">
-            <u>
-              <FontAwesomeIcon icon={faCubes} />
-              {"  "}Active Bricks page
-            </u>
-          </Link>
+const ConfigureBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => (
+  <>
+    <Card.Body className="p-3">
+      <h3 className="pb-1 mb-0">{blueprint.metadata.name}</h3>
+      <code className="p-0 small">{blueprint.metadata.id}</code>
+      <div className="pt-3">
+        <p>
+          {blueprint.metadata.description ?? (
+            <span>
+              <i>No description provided</i>
+            </span>
+          )}
         </p>
-      </Card.Body>
+      </div>
+    </Card.Body>
 
-      <Table>
-        <thead>
-          <tr>
-            <th colSpan={2}>Selected?</th>
-            <th className="w-100">Name/Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          {blueprint.extensionPoints.map((x, i) => (
-            <ConfigureRow key={i} definition={x} name={`extensions.${i}`} />
-          ))}
-        </tbody>
-      </Table>
-    </>
-  );
-};
+    <Card.Body className="px-3 py-0">
+      <p className="text-info">
+        <FontAwesomeIcon icon={faInfoCircle} /> Don&apos;t know which bricks to
+        select? Don&apos;t worry! &mdash; you can de-activate bricks at any time
+        on the{" "}
+        <Link to="/installed">
+          <u>
+            <FontAwesomeIcon icon={faCubes} />
+            {"  "}Active Bricks page
+          </u>
+        </Link>
+      </p>
+    </Card.Body>
+
+    <Table>
+      <thead>
+        <tr>
+          <th colSpan={2}>Selected?</th>
+          <th className="w-100">Name/Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {blueprint.extensionPoints.map((x, i) => (
+          <ConfigureRow key={i} definition={x} name={`extensions.${i}`} />
+        ))}
+      </tbody>
+    </Table>
+  </>
+);
 
 export default ConfigureBody;

--- a/src/options/pages/marketplace/ServicesBody.tsx
+++ b/src/options/pages/marketplace/ServicesBody.tsx
@@ -60,9 +60,10 @@ const AuthWidget: React.FunctionComponent<{
 
   const [showModal, setShow] = useState(false);
 
-  const [serviceDefinition, isPending, error] = useAsyncState(async () => {
-    return (await registry.all()).find((x) => x.id === serviceId);
-  }, [serviceId]);
+  const [serviceDefinition, isPending, error] = useAsyncState(
+    async () => (await registry.all()).find((x) => x.id === serviceId),
+    [serviceId]
+  );
 
   const options = useMemo(
     () => authOptions.filter((x) => x.serviceId === serviceId),
@@ -102,13 +103,15 @@ const AuthWidget: React.FunctionComponent<{
     [helpers, addToast, dispatch, setShow, serviceId]
   );
 
-  const initialConfiguration: RawServiceConfiguration = useMemo(() => {
-    return {
-      serviceId,
-      label: "New Configuration",
-      config: {},
-    } as RawServiceConfiguration;
-  }, [serviceId]);
+  const initialConfiguration: RawServiceConfiguration = useMemo(
+    () =>
+      ({
+        serviceId,
+        label: "New Configuration",
+        config: {},
+      } as RawServiceConfiguration),
+    [serviceId]
+  );
 
   return (
     <>
@@ -152,9 +155,10 @@ const ServiceDescriptor: React.FunctionComponent<{
   serviceConfigs: ServiceDefinition[];
   serviceId: string;
 }> = ({ serviceId, serviceConfigs }) => {
-  const config = useMemo(() => {
-    return serviceConfigs?.find((x) => x.metadata.id === serviceId);
-  }, [serviceId, serviceConfigs]);
+  const config = useMemo(
+    () => serviceConfigs?.find((x) => x.metadata.id === serviceId),
+    [serviceId, serviceConfigs]
+  );
 
   if (config) {
     return (

--- a/src/options/pages/services/useServiceDefinitions.ts
+++ b/src/options/pages/services/useServiceDefinitions.ts
@@ -46,26 +46,32 @@ function useServiceDefinitions(): ServiceDefinitions {
 
   const showZapier = configurationId === ZAPIER_SLUG;
 
-  const [serviceDefinitions, isPending, error] = useAsyncState(async () => {
-    return sortBy(
-      (await registry.all()).filter((x) => x.id !== PIXIEBRIX_SERVICE_ID),
-      (x) => x.id
-    );
-  }, []);
+  const [serviceDefinitions, isPending, error] = useAsyncState(
+    async () =>
+      sortBy(
+        (await registry.all()).filter((x) => x.id !== PIXIEBRIX_SERVICE_ID),
+        (x) => x.id
+      ),
+    []
+  );
 
-  const activeConfiguration = useMemo(() => {
-    return configurationId && configurationId !== ZAPIER_SLUG
-      ? configuredServices.find((x) => x.id === configurationId)
-      : null;
-  }, [configuredServices, configurationId]);
+  const activeConfiguration = useMemo(
+    () =>
+      configurationId && configurationId !== ZAPIER_SLUG
+        ? configuredServices.find((x) => x.id === configurationId)
+        : null,
+    [configuredServices, configurationId]
+  );
 
-  const activeService = useMemo(() => {
-    return activeConfiguration
-      ? (serviceDefinitions ?? []).find(
-          (x) => x.id === activeConfiguration.serviceId
-        )
-      : null;
-  }, [serviceDefinitions, activeConfiguration]);
+  const activeService = useMemo(
+    () =>
+      activeConfiguration
+        ? (serviceDefinitions ?? []).find(
+            (x) => x.id === activeConfiguration.serviceId
+          )
+        : null,
+    [serviceDefinitions, activeConfiguration]
+  );
 
   if (error) {
     throw error;

--- a/src/options/pages/settings/PermissionsSettings.tsx
+++ b/src/options/pages/settings/PermissionsSettings.tsx
@@ -28,18 +28,16 @@ type Permissions = chrome.permissions.Permissions;
 const PermissionRow: React.FunctionComponent<{
   value: string;
   remove: (value: string) => void;
-}> = ({ value, remove }) => {
-  return (
-    <ListGroup.Item className="d-flex">
-      <div className="flex-grow-1 align-self-center">{value}</div>
-      <div className="align-self-center">
-        <Button variant="danger" size="sm" onClick={async () => remove(value)}>
-          Revoke
-        </Button>{" "}
-      </div>
-    </ListGroup.Item>
-  );
-};
+}> = ({ value, remove }) => (
+  <ListGroup.Item className="d-flex">
+    <div className="flex-grow-1 align-self-center">{value}</div>
+    <div className="align-self-center">
+      <Button variant="danger" size="sm" onClick={async () => remove(value)}>
+        Revoke
+      </Button>{" "}
+    </div>
+  </ListGroup.Item>
+);
 
 // `devtools` is actually a required permission that gets added automatically
 // https://github.com/fregante/webext-additional-permissions/issues/6
@@ -79,15 +77,17 @@ const PermissionsSettings: React.FunctionComponent = () => {
     [refresh, addToast]
   );
 
-  const origins = useMemo(() => {
-    return sortBy(permissions?.origins ?? []);
-  }, [permissions]);
+  const origins = useMemo(() => sortBy(permissions?.origins ?? []), [
+    permissions,
+  ]);
 
-  const extraPermissions = useMemo(() => {
-    return sortBy(permissions?.permissions ?? []).filter(
-      (x) => !HIDE_EXTRA_PERMISSIONS.includes(x)
-    );
-  }, [permissions]);
+  const extraPermissions = useMemo(
+    () =>
+      sortBy(permissions?.permissions ?? []).filter(
+        (x) => !HIDE_EXTRA_PERMISSIONS.includes(x)
+      ),
+    [permissions]
+  );
 
   useAsyncEffect(async () => refresh(), []);
 

--- a/src/options/pages/templates/TemplatesPage.tsx
+++ b/src/options/pages/templates/TemplatesPage.tsx
@@ -130,40 +130,36 @@ const TemplateGroup: React.FunctionComponent<GroupProps> = ({
 
 const TemplateEntry: React.FunctionComponent<
   FeaturedRecipeDefinition & { installed: boolean; onAdd: () => void }
-> = ({ feature, metadata, installed, onAdd }) => {
-  return (
-    <ListGroup.Item className="TemplateEntry">
-      <div className="d-flex align-items-center">
-        <div>
-          {installed ? (
-            <Button size="sm" variant="info" disabled>
-              Added
-            </Button>
-          ) : (
-            <Button size="sm" variant="info" onClick={onAdd}>
-              Add
-            </Button>
-          )}
-        </div>
-        <div className="ml-3">{feature.shortName ?? metadata.name}</div>
+> = ({ feature, metadata, installed, onAdd }) => (
+  <ListGroup.Item className="TemplateEntry">
+    <div className="d-flex align-items-center">
+      <div>
+        {installed ? (
+          <Button size="sm" variant="info" disabled>
+            Added
+          </Button>
+        ) : (
+          <Button size="sm" variant="info" onClick={onAdd}>
+            Add
+          </Button>
+        )}
       </div>
-    </ListGroup.Item>
-  );
-};
+      <div className="ml-3">{feature.shortName ?? metadata.name}</div>
+    </div>
+  </ListGroup.Item>
+);
 
 const SharedWithMe: React.FunctionComponent<{
   active?: boolean;
   onSelect: () => void;
-}> = ({ active, onSelect }) => {
-  return (
-    <Card className={cx("CategoryCard", { active })} onClick={onSelect}>
-      <Card.Body>
-        <div className="CategoryCard__title">Shared with Me</div>
-        <div className="CategoryCard__subtitle">Custom</div>
-      </Card.Body>
-    </Card>
-  );
-};
+}> = ({ active, onSelect }) => (
+  <Card className={cx("CategoryCard", { active })} onClick={onSelect}>
+    <Card.Body>
+      <div className="CategoryCard__title">Shared with Me</div>
+      <div className="CategoryCard__subtitle">Custom</div>
+    </Card.Body>
+  </Card>
+);
 
 const Category: React.FunctionComponent<{
   active?: boolean;
@@ -171,24 +167,22 @@ const Category: React.FunctionComponent<{
   title: string;
   subtitle: string;
   onSelect?: () => void;
-}> = ({ title, subtitle, active, inviteOnly, onSelect = noop }) => {
-  return (
-    <Card
-      className={cx("CategoryCard", { active, inviteOnly })}
-      onClick={onSelect}
-    >
-      <Card.Body>
-        {inviteOnly && (
-          <div className="ribbon">
-            <span>Invite-Only</span>
-          </div>
-        )}
-        <div className="CategoryCard__title">{title}</div>
-        <div className="CategoryCard__subtitle">{subtitle}</div>
-      </Card.Body>
-    </Card>
-  );
-};
+}> = ({ title, subtitle, active, inviteOnly, onSelect = noop }) => (
+  <Card
+    className={cx("CategoryCard", { active, inviteOnly })}
+    onClick={onSelect}
+  >
+    <Card.Body>
+      {inviteOnly && (
+        <div className="ribbon">
+          <span>Invite-Only</span>
+        </div>
+      )}
+      <div className="CategoryCard__title">{title}</div>
+      <div className="CategoryCard__subtitle">{subtitle}</div>
+    </Card.Body>
+  </Card>
+);
 
 const ContextMenuTemplates: React.FunctionComponent<{
   installedRecipes: Set<string>;

--- a/src/pages/marketplace/MarketplacePage.tsx
+++ b/src/pages/marketplace/MarketplacePage.tsx
@@ -95,28 +95,26 @@ export const RecipeList: React.FunctionComponent<
     buttonProps?: ButtonProps;
     recipes: RecipeDefinition[];
   }
-> = ({ buttonProps, recipes, installedRecipes, installRecipe }) => {
-  return (
-    <ListGroup>
-      {(recipes ?? []).slice(0, 10).map((x) => (
-        <Entry
-          {...x}
-          buttonProps={buttonProps}
-          key={x.metadata.id}
-          onInstall={() => installRecipe(x)}
-          installed={installedRecipes.has(x.metadata.id)}
-        />
-      ))}
-      {recipes.length >= 10 && (
-        <ListGroup.Item>
-          <span className="text-muted">
-            {recipes.length - 10} more result(s) not shown
-          </span>
-        </ListGroup.Item>
-      )}
-    </ListGroup>
-  );
-};
+> = ({ buttonProps, recipes, installedRecipes, installRecipe }) => (
+  <ListGroup>
+    {(recipes ?? []).slice(0, 10).map((x) => (
+      <Entry
+        {...x}
+        buttonProps={buttonProps}
+        key={x.metadata.id}
+        onInstall={() => installRecipe(x)}
+        installed={installedRecipes.has(x.metadata.id)}
+      />
+    ))}
+    {recipes.length >= 10 && (
+      <ListGroup.Item>
+        <span className="text-muted">
+          {recipes.length - 10} more result(s) not shown
+        </span>
+      </ListGroup.Item>
+    )}
+  </ListGroup>
+);
 
 const MarketplacePage: React.FunctionComponent<MarketplaceProps> = ({
   installRecipe,

--- a/src/pages/marketplace/useReinstall.ts
+++ b/src/pages/marketplace/useReinstall.ts
@@ -44,6 +44,7 @@ function selectAuths(
     } else if (configs.length > 1) {
       throw new Error(`Service ${id} has multiple configurations`);
     }
+
     // eslint-disable-next-line security/detect-object-injection -- safe because it's from Object.entries
     result[id] = configs[0];
   }

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -121,6 +121,7 @@ export async function collectPermissions(
           config,
         });
       }
+
       return mergePermissions([extensionPoint.permissions, permissions, inner]);
     }
   );

--- a/src/script.ts
+++ b/src/script.ts
@@ -106,9 +106,7 @@ attachListener(SEARCH_WINDOW, ({ query }) => {
   };
 });
 
-attachListener(DETECT_FRAMEWORK_VERSIONS, async () => {
-  return detectLibraries();
-});
+attachListener(DETECT_FRAMEWORK_VERSIONS, async () => detectLibraries());
 
 function readPathSpec(
   // eslint-disable-next-line @typescript-eslint/ban-types -- object because we need to pass in window
@@ -298,7 +296,7 @@ attachListener(
 console.debug(`DISPATCH: ${SCRIPT_LOADED} (Injected Script Run)`);
 document.dispatchEvent(new CustomEvent(SCRIPT_LOADED));
 
-setTimeout(function () {
+setTimeout(() => {
   document.dispatchEvent(new CustomEvent(CONNECT_EXTENSION, {}));
 }, 0);
 

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -70,11 +70,13 @@ export function useDependency(
     throw new Error("No integration selected");
   }, [dependency?.config]);
 
-  const origins = useMemo(() => {
-    return serviceResult?.service
-      ? serviceResult.service.getOrigins(serviceResult.localConfig.config)
-      : null;
-  }, [serviceResult.localConfig.config, serviceResult?.service]);
+  const origins = useMemo(
+    () =>
+      serviceResult?.service
+        ? serviceResult.service.getOrigins(serviceResult.localConfig.config)
+        : null,
+    [serviceResult.localConfig.config, serviceResult?.service]
+  );
 
   const [hasPermissions] = useAsyncState(async () => {
     if (origins != null) {
@@ -90,6 +92,7 @@ export function useDependency(
       const listener = () => {
         setGrantedPermissions(true);
       };
+
       permissionsListeners.set(key, [
         ...(permissionsListeners.get(key) ?? []),
         listener,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,9 +83,8 @@ export async function asyncMapValues<T, TResult>(
   ) as any;
 }
 
-export const sleep = (milliseconds: number): Promise<void> => {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds));
-};
+export const sleep = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
 
 export class TimeoutError extends Error {
   constructor(message: string) {

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -91,6 +91,7 @@ export async function requestPermissions(
   for (const origin of permissions.origins ?? []) {
     page.searchParams.append("origin", origin);
   }
+
   for (const permission of permissions.permissions ?? []) {
     page.searchParams.append("permission", permission);
   }

--- a/src/validators/validation.ts
+++ b/src/validators/validation.ts
@@ -213,9 +213,11 @@ function serviceSchemaFactory(): Yup.Schema<unknown> {
         ),
       })
     )
-    .test("unique-keys", "Services must have unique keys", function (value) {
-      return value.length === uniq(value.map((x) => x.outputKey)).length;
-    });
+    .test(
+      "unique-keys",
+      "Services must have unique keys",
+      (value) => value.length === uniq(value.map((x) => x.outputKey)).length
+    );
 }
 
 export function extensionValidatorFactory(schema: Schema): Yup.Schema<unknown> {


### PR DESCRIPTION
This covers 3 function-related rules that cause a large diff but make no functional Hiding whitespace changes while reviewing is best

- https://eslint.org/docs/rules/arrow-body-style
- https://eslint.org/docs/rules/prefer-arrow-callback
- https://eslint.org/docs/rules/padding-line-between-statements

There might be a few more similarly common-but-harmless rules that I might autofix soon. 
I think it's easier to auto-fix these 1 rule at a time (or a few, if they're related) and review it than lengthening PRs with several unrelated changes caused by IntelliJ’s autofix-on-save.