### PR TITLE
Clean up devtools init

### DIFF
--- a/src/devTools/getSelectedElement.ts
+++ b/src/devTools/getSelectedElement.ts
@@ -29,10 +29,10 @@ export function addListenerForUpdateSelectedElement(): void {
   });
 }
 
-export function updateSelectedElement(): void {
+export async function updateSelectedElement(): Promise<void> {
   let $0: Element; // Unused, type only, don't move it inside `evaluableFunction`
 
-  chrome.devtools.inspectedWindow.eval(
+  await browser.devtools.inspectedWindow.eval(
     evaluableFunction(() => {
       // This function does not have access outside its scope,
       // don't use the `GET_SELECTED_DEV_TOOLS_ELEMENT` constant

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -25,9 +25,14 @@ import { updateSelectedElement } from "./devTools/getSelectedElement";
 import { once } from "lodash";
 import { serializeError } from "serialize-error";
 
-// TODO: Ensure that reportError can handle ErrorEvent
-window.addEventListener("error", reportError);
-window.addEventListener("unhandledrejection", reportError);
+window.addEventListener("error", function (e) {
+  reportError(e);
+  return false;
+});
+
+window.addEventListener("unhandledrejection", function (e) {
+  reportError(e);
+});
 
 const { onSelectionChanged } = browser.devtools.panels.elements;
 


### PR DESCRIPTION
Until now, every time you open the console _a lot_ of code is run or attempts to run even if your intention is not to use PixieBrix.

This file has been refactored to:

- avoid running the element detection code unless the PB devtools sidebar is visible
- avoid content script injection attempts until the PB panel is selected
	- if we have permissions, the CS is already injected 
	- if we don't have permissions, the attempt will fail
	- if we have activeTab, the user is likely already on PB panel anyway, which is handled directly by `connectFrame` in the background (which could also benefit from similar changes)
	- this avoids console noise when I open the regular console
- actually show errors in the sidebar pane thanks to `serializeError`
	 
	<img width="564" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/126878484-3d1fdc2d-bc5a-4c6a-8eea-ce5006f9bb36.png">

- reduce but not completely avoid confusing console errors https://github.com/pixiebrix/pixiebrix-extension/pull/905