### PR TITLE
#914: validate brick output and log validation errors

### DIFF
--- a/schemas/component.json
+++ b/schemas/component.json
@@ -19,6 +19,9 @@
     "inputSchema": {
       "$ref": "http://json-schema.org/draft-07/schema#"
     },
+    "outputSchema": {
+      "$ref": "http://json-schema.org/draft-07/schema#"
+    },
     "services": {
       "type": "object",
       "description": "Optionally declare services to inject into the component",

--- a/src/blocks/errors.ts
+++ b/src/blocks/errors.ts
@@ -87,6 +87,9 @@ export class InputValidationError extends BusinessError {
 
 /**
  * Error indicating output elements of a block did not match the schema.
+ *
+ * In practice, this error should be logged, not thrown. Checking brick post-conditions is helpful for fault
+ * localization, but we optimistically try to proceed with brick execution.
  */
 export class OutputValidationError extends BusinessError {
   readonly schema: Schema;
@@ -98,13 +101,13 @@ export class OutputValidationError extends BusinessError {
   constructor(
     message: string,
     schema: Schema,
-    input: unknown,
+    instance: unknown,
     errors: OutputUnit[]
   ) {
     super(message);
     this.name = "OutputValidationError";
     this.schema = schema;
-    this.instance = input;
+    this.instance = instance;
     this.errors = errors;
   }
 }

--- a/src/blocks/errors.ts
+++ b/src/blocks/errors.ts
@@ -84,3 +84,27 @@ export class InputValidationError extends BusinessError {
     this.errors = errors;
   }
 }
+
+/**
+ * Error indicating output elements of a block did not match the schema.
+ */
+export class OutputValidationError extends BusinessError {
+  readonly schema: Schema;
+
+  readonly instance: unknown;
+
+  readonly errors: OutputUnit[];
+
+  constructor(
+    message: string,
+    schema: Schema,
+    input: unknown,
+    errors: OutputUnit[]
+  ) {
+    super(message);
+    this.name = "OutputValidationError";
+    this.schema = schema;
+    this.instance = input;
+    this.errors = errors;
+  }
+}

--- a/src/blocks/transformers/prompt.ts
+++ b/src/blocks/transformers/prompt.ts
@@ -19,6 +19,7 @@ import { Transformer } from "@/types";
 import { registerBlock } from "@/blocks/registry";
 import { BlockArg, Schema } from "@/core";
 import { propertiesToSchema } from "@/validators/generic";
+import { CancelError } from "@/errors";
 
 export class Prompt extends Transformer {
   constructor() {
@@ -45,10 +46,23 @@ export class Prompt extends Transformer {
     ["message"]
   );
 
+  outputSchema: Schema = propertiesToSchema({
+    value: {
+      type: "string",
+      description: "The user-provided value",
+    },
+  });
+
   async transform({ message, defaultValue }: BlockArg): Promise<unknown> {
+    // eslint-disable-next-line no-alert -- purpose of this brick is to show an alert
+    const value = window.prompt(message, defaultValue);
+
+    if (value == null) {
+      throw new CancelError("User cancelled the prompt");
+    }
+
     return {
-      // eslint-disable-next-line no-alert
-      value: window.prompt(message, defaultValue),
+      value,
     };
   }
 }

--- a/src/components/logViewer/EntryRow.tsx
+++ b/src/components/logViewer/EntryRow.tsx
@@ -21,12 +21,13 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCaretDown, faCaretRight } from "@fortawesome/free-solid-svg-icons";
 import { ErrorObject } from "serialize-error";
 import { ContextError, isErrorObject } from "@/errors";
-import { InputValidationError } from "@/blocks/errors";
+import { InputValidationError, OutputValidationError } from "@/blocks/errors";
 import { AxiosError } from "axios";
 import InputDetail from "@/components/logViewer/details/InputDetail";
 import InputValidationErrorDetail from "@/components/logViewer/details/InputValidationErrorDetail";
 import NetworkErrorDetail from "@/components/logViewer/details/NetworkErrorDetail";
 import OutputDetail from "@/components/logViewer/details/OutputDetail";
+import OutputValidationErrorDetail from "@/components/logViewer/details/OutputValidationErrorDetail";
 
 const dateFormat = new Intl.DateTimeFormat("en-US", {
   dateStyle: "short",
@@ -51,6 +52,14 @@ const ErrorDetail: React.FunctionComponent<{ entry: LogEntry }> = ({
         return (
           <InputValidationErrorDetail
             error={(rootCause as unknown) as InputValidationError}
+          />
+        );
+      }
+
+      if (rootCause.name === "OutputValidationError") {
+        return (
+          <OutputValidationErrorDetail
+            error={(rootCause as unknown) as OutputValidationError}
           />
         );
       }
@@ -89,12 +98,14 @@ const EntryRow: React.FunctionComponent<{ entry: LogEntry }> = ({ entry }) => {
     return null;
   }, [entry]);
 
-  const expandable = !!Detail;
+  const expandable = Boolean(Detail);
 
   return (
     <>
       <tr
-        onClick={() => setExpanded(!expanded)}
+        onClick={() => {
+          setExpanded(!expanded);
+        }}
         style={{ cursor: expandable ? "pointer" : "" }}
       >
         <td>

--- a/src/components/logViewer/details/OutputValidationErrorDetail.tsx
+++ b/src/components/logViewer/details/OutputValidationErrorDetail.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { OutputValidationError } from "@/blocks/errors";
+import { Col, Row } from "react-bootstrap";
+import JsonTree from "@/components/JsonTree";
+
+const OutputValidationErrorDetail: React.FunctionComponent<{
+  error: OutputValidationError;
+}> = ({ error }) => (
+  <Row>
+    <Col>
+      <span>Errors</span>
+      <ul>
+        {error.errors.map((x) => (
+          <li key={`${x.keywordLocation}-${x.error}`}>
+            {x.keywordLocation}: {x.error}
+          </li>
+        ))}
+      </ul>
+    </Col>
+    <Col>
+      <span>Output</span>
+      <JsonTree data={error.instance} />
+    </Col>
+    <Col>
+      <span>Schema</span>
+      <JsonTree data={error.schema} />
+    </Col>
+  </Row>
+);
+
+export default OutputValidationErrorDetail;

--- a/src/options/pages/brickEditor/validate.ts
+++ b/src/options/pages/brickEditor/validate.ts
@@ -18,6 +18,7 @@
 import yaml from "js-yaml";
 import { KIND_SCHEMAS, validateKind } from "@/validators/generic";
 import { ValidationResult } from "@cfworker/json-schema";
+import { getErrorMessage } from "@/errors";
 
 interface PartialSchema {
   kind?: string;
@@ -36,7 +37,7 @@ export async function validateSchema(value: string): Promise<any> {
     json = yaml.load(value) as PartialSchema;
   } catch (error: unknown) {
     return {
-      config: [`Invalid YAML: ${error}`],
+      config: [`Invalid YAML: ${getErrorMessage(error)}`],
     };
   }
 
@@ -52,7 +53,7 @@ export async function validateSchema(value: string): Promise<any> {
 
   try {
     validation = await validateKind(
-      json,
+      json as Record<string, unknown>,
       json.kind as keyof typeof KIND_SCHEMAS
     );
   } catch (error: unknown) {

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -50,18 +50,15 @@ export const rollbar: Rollbar = Rollbar.init({
     },
     environment: process.env.ENVIRONMENT,
   },
-  transform: function (payload: Payload) {
+  transform: (payload: Payload) => {
     // Standardize the origin across browsers so that they match the source map we uploaded to rollbar
     // https://docs.rollbar.com/docs/source-maps#section-using-source-maps-on-many-domains
-    const trace = payload.body.trace;
-    if (trace && trace.frames) {
-      for (const frame of trace.frames) {
-        if (frame.filename?.includes(process.env.CHROME_EXTENSION_ID)) {
-          frame.filename = frame.filename.replace(
-            location.origin,
-            process.env.ROLLBAR_PUBLIC_PATH
-          );
-        }
+    for (const frame of payload.body.trace?.frames ?? []) {
+      if (frame.filename?.includes(process.env.CHROME_EXTENSION_ID)) {
+        frame.filename = frame.filename.replace(
+          location.origin,
+          process.env.ROLLBAR_PUBLIC_PATH
+        );
       }
     }
   },
@@ -86,7 +83,7 @@ export function toLogArgument(error: unknown): LogArgument {
     return error;
   }
 
-  return error.toString();
+  return String(error);
 }
 
 export async function updateAuth({
@@ -112,7 +109,7 @@ export async function updateAuth({
       }
     } else {
       rollbar.configure({
-        payload: { person: { id: userId, organizationId: organizationId } },
+        payload: { person: { id: userId, organizationId } },
       });
     }
   }


### PR DESCRIPTION
Half of #914 

- Checks output against `outputSchema` if available, and logs validation errors
- Adding support for outputSchema in `kind: component` defined via YAML

Not included:
- Checking output of readers against their output schema
