### PR TITLE
Avoid duplicate borders on sidebar

### DIFF
--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -97,7 +97,7 @@ function insertActionPanel(): string {
   const actionURL = browser.runtime.getURL("action.html");
 
   const $panelContainer = $(
-    `<div id="${PANEL_CONTAINER_ID}" data-nonce="${nonce}" style="height: 100%; margin: 0; padding: 0; border-radius: 0; width: ${SIDEBAR_WIDTH_PX}px; position: fixed; top: 0; right: 0; z-index: 2147483647; border: 1px solid lightgray; background-color: rgb(255, 255, 255); display: block;"></div>`
+    `<div id="${PANEL_CONTAINER_ID}" data-nonce="${nonce}" style="height: 100%; margin: 0; padding: 0; border-radius: 0; width: ${SIDEBAR_WIDTH_PX}px; position: fixed; top: 0; right: 0; z-index: 2147483647; border-left: 1px solid lightgray; background-color: rgb(255, 255, 255); display: block;"></div>`
   );
 
   // CSS approach not well supported? https://stackoverflow.com/questions/15494568/html-iframe-disable-scroll


### PR DESCRIPTION
Minor change, the sidebar had borders all around and they are not needed

# Detail


## Before

![Screen Shot 13](https://user-images.githubusercontent.com/1402241/127268373-d0124456-5d11-421d-925f-7e19f75114f9.png)

## After


![Screen Shot 12](https://user-images.githubusercontent.com/1402241/127268375-421f28d7-ee3c-4954-ab83-ba653a3c3ed6.png)


# Whole

## Before


<img width="405" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/127267884-dba84050-7969-4ea0-811e-8b96d6b4353c.png">


## After

<img width="404" alt="Screen Shot 8" src="https://user-images.githubusercontent.com/1402241/127267878-64d57ef3-d18a-459b-b413-722fa065fcdb.png">
