### PR TITLE
#943: switch to lodash-es to avoid module import error

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "json-schema-ref-parser": "^9.0.9",
     "jsonpath-plus": "^6.0.1",
     "jsonschema": "^1.4.0",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "marked": "^2.0.1",
     "mustache": "^4.2.0",
     "notifyjs-browser": "^0.4.2",

--- a/resolve.config.js
+++ b/resolve.config.js
@@ -30,7 +30,9 @@ module.exports = {
       "@microsoft/applicationinsights-web": path.resolve(
         "src/contrib/uipath/quietLogger"
       ),
-
+      // `lodash-es` is a build of lodash using es6 modules. It also avoids an import error loading lodash methods we
+      // were seeing on https://www.cbssports.com/fantasy/football/players/2258303/aj-brown/
+      lodash: "lodash-es",
       // An existence check triggers webpack’s warnings https://github.com/handlebars-lang/handlebars.js/issues/953
       handlebars: "handlebars/dist/handlebars.js",
     },

--- a/resolve.config.js
+++ b/resolve.config.js
@@ -31,7 +31,7 @@ module.exports = {
         "src/contrib/uipath/quietLogger"
       ),
       // `lodash-es` is a build of lodash using es6 modules. It also avoids an import error loading lodash methods we
-      // were seeing on https://www.cbssports.com/fantasy/football/players/2258303/aj-brown/
+      // were seeing: https://github.com/pixiebrix/pixiebrix-extension/issues/943
       lodash: "lodash-es",
       // An existence check triggers webpack’s warnings https://github.com/handlebars-lang/handlebars.js/issues/953
       handlebars: "handlebars/dist/handlebars.js",

--- a/src/frameworks/contrib/ember.ts
+++ b/src/frameworks/contrib/ember.ts
@@ -18,7 +18,10 @@
 // Resources:
 // https://github.com/emberjs/ember-inspector/blob/d4f1fbb1ee30d178f81ce03bf8f037722bd4b166/ember_debug/object-inspector.js
 
-import { mapValues, partial, unary, fromPairs } from "lodash";
+import { mapValues, partial, fromPairs } from "lodash";
+// Destructured `lodash` imports seem to be broken on https://www.cbssports.com pages, e.g., https://www.cbssports.com/fantasy/football/players/2258303/aj-brown/
+// Import separately so the page script can load. We'll get an error though if any method that uses lodash is called
+import unary from "lodash/unary";
 import { getAllPropertyNames, isGetter, isPrimitive } from "@/utils";
 import { ReadableComponentAdapter } from "@/frameworks/component";
 import { FrameworkNotFound, ignoreNotFound } from "@/frameworks/errors";

--- a/src/frameworks/contrib/ember.ts
+++ b/src/frameworks/contrib/ember.ts
@@ -18,10 +18,7 @@
 // Resources:
 // https://github.com/emberjs/ember-inspector/blob/d4f1fbb1ee30d178f81ce03bf8f037722bd4b166/ember_debug/object-inspector.js
 
-import { mapValues, partial, fromPairs } from "lodash";
-// Destructured `lodash` imports seem to be broken on https://www.cbssports.com pages, e.g., https://www.cbssports.com/fantasy/football/players/2258303/aj-brown/
-// Import separately so the page script can load. We'll get an error though if any method that uses lodash is called
-import unary from "lodash/unary";
+import { mapValues, partial, unary, fromPairs } from "lodash";
 import { getAllPropertyNames, isGetter, isPrimitive } from "@/utils";
 import { ReadableComponentAdapter } from "@/frameworks/component";
 import { FrameworkNotFound, ignoreNotFound } from "@/frameworks/errors";


### PR DESCRIPTION
Resolves #943

**Attempt using normal lodash**

The import works if I import it directly. I then get the same error for "compact" when using the selector selection widget: https://www.loom.com/share/e4be13054532425db9064082fac1c708

**Switching to lodash-es**

`lodash-es` is a build of lodash using es6 modules. It works in the page script even using destructured import. It should also let us benefit from tree-shaking in lodash