### PR TITLE
#918: fix error root cause filtering

### DIFF
--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -206,9 +206,11 @@ export const recordError = liftBackground(
       const message = getErrorMessage(error);
 
       if (!(await _getDNT())) {
-        // Deserialize the error before passing it to rollbar, otherwise rollbar will assume the
-        // object is the custom payload data
-        // https://docs.rollbar.com/docs/rollbarjs-configuration-reference#rollbarlog
+        // Deserialize the error before passing it to rollbar, otherwise rollbar will assume the object is the custom
+        // payload data. WARNING: the prototype chain is lost during deserialization, so make sure any predicate you
+        // call here also handles deserialized errors properly.
+        // See https://docs.rollbar.com/docs/rollbarjs-configuration-reference#rollbarlog
+        // See https://github.com/sindresorhus/serialize-error/issues/48
         const errorObj = deserializeError(error);
 
         if (hasCancelRootCause(error)) {

--- a/src/blocks/effects/event.ts
+++ b/src/blocks/effects/event.ts
@@ -75,12 +75,15 @@ export class ElementEvent extends Effect {
     { selector, event }: BlockArg,
     { logger }: BlockOptions
   ): Promise<void> {
+    // eslint-disable-next-line unicorn/no-array-callback-reference -- false positive for JQuery
     const $element = $(document).find(selector);
 
     if ($element.length === 0) {
-      logger.debug(`Element not found for selector: ${selector}`);
+      logger.debug(`Element not found for selector: ${selector as string}`);
     } else if ($element.length > 1) {
-      logger.debug(`Multiple elements found for selector: ${selector}`);
+      logger.debug(
+        `Multiple elements found for selector: ${selector as string}`
+      );
     }
 
     // Triggers the event. NOTE: the event is not "trusted" as being a user action

--- a/src/blocks/errors.ts
+++ b/src/blocks/errors.ts
@@ -17,11 +17,11 @@
 
 import { castArray } from "lodash";
 import { MessageContext, Schema } from "@/core";
+import { BlockConfig, BlockPipeline } from "@/blocks/combinators";
 import { BusinessError } from "@/errors";
 import { OutputUnit } from "@cfworker/json-schema";
-import { BlockConfig, BlockPipeline } from "@/blocks/combinators";
 
-export class PipelineConfigurationError extends Error {
+export class PipelineConfigurationError extends BusinessError {
   readonly config: BlockPipeline;
 
   constructor(message: string, config: BlockConfig | BlockPipeline) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -15,8 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { MessageContext } from "@/core";
+import { MessageContext, SerializedError } from "@/core";
 import { ErrorObject } from "serialize-error";
+import { AxiosError } from "axios";
+
+const DEFAULT_ERROR_MESSAGE = "Unknown error";
 
 export class ValidationError extends Error {
   errors: unknown;
@@ -55,6 +58,29 @@ export class BusinessError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "BusinessError";
+  }
+}
+
+export class NoElementsFoundError extends BusinessError {
+  readonly selector: string;
+
+  constructor(selector: string, message = "No elements found for selector") {
+    super(message);
+    this.name = "NoElementsFoundError";
+    this.selector = selector;
+  }
+}
+
+export class MultipleElementsFoundError extends BusinessError {
+  readonly selector: string;
+
+  constructor(
+    selector: string,
+    message = "Multiple elements found for selector"
+  ) {
+    super(message);
+    this.name = "MultipleElementsFoundError";
+    this.selector = selector;
   }
 }
 
@@ -100,6 +126,10 @@ export function isErrorObject(error: unknown): error is ErrorObject {
  * @param error the error object
  */
 export function hasCancelRootCause(error: unknown): boolean {
+  if (error == null) {
+    return false;
+  }
+
   if (!isErrorObject(error)) {
     return false;
   }
@@ -108,27 +138,54 @@ export function hasCancelRootCause(error: unknown): boolean {
     return true;
   }
 
-  if (error instanceof ContextError) {
+  if (error instanceof ContextError || error.name === "ContextError") {
     return hasCancelRootCause(error.cause);
   }
 
   return false;
 }
 
+// Manually list subclasses because the prototype chain is lost in serialization/deserialization
+// See https://github.com/sindresorhus/serialize-error/issues/48
+const BUSINESS_ERROR_CLASSES = [
+  BusinessError,
+  NoElementsFoundError,
+  MultipleElementsFoundError,
+];
+// Name classes from other modules separately, because otherwise we'll get a circular dependency with this module
+const BUSINESS_ERROR_NAMES = new Set([
+  ...BUSINESS_ERROR_CLASSES.map((x) => x.name),
+  "InputValidationError",
+  "OutputValidationError",
+  "PipelineConfigurationError",
+]);
+
 /**
  * Returns true iff the root cause of the error was a BusinessError.
  * @param error the error object
  */
-export function hasBusinessRootCause(error: unknown): boolean {
+export function hasBusinessRootCause(
+  error: SerializedError | unknown
+): boolean {
+  if (error == null) {
+    return false;
+  }
+
   if (!isErrorObject(error)) {
     return false;
   }
 
-  if (error instanceof BusinessError || error.name === "BusinessError") {
+  for (const errorClass of BUSINESS_ERROR_CLASSES) {
+    if (error instanceof errorClass) {
+      return true;
+    }
+  }
+
+  if (BUSINESS_ERROR_NAMES.has(error.name)) {
     return true;
   }
 
-  if (error instanceof ContextError) {
+  if (error instanceof ContextError || error.name === "ContextError") {
     return hasBusinessRootCause(error.cause);
   }
 
@@ -154,18 +211,53 @@ function testConnectionErrorPatterns(message: string): boolean {
   return false;
 }
 
-function isPromiseRejectionEvent(
+export function isPromiseRejectionEvent(
   event: unknown
 ): event is PromiseRejectionEvent {
   return typeof event === "object" && "reason" in event;
 }
 
-function isErrorEvent(event: unknown): event is ErrorEvent {
-  return typeof event === "object" && "message" in event;
+export function selectPromiseRejectionError(
+  event: PromiseRejectionEvent
+): Error {
+  // Convert the project rejection to an error instance
+  if (event.reason instanceof Error) {
+    return event.reason;
+  }
+
+  if (typeof event.reason === "string") {
+    return new Error(event.reason);
+  }
+
+  return new Error(event.reason?.message ?? "Uncaught error in promise");
 }
 
 /**
- * Return true if the proximate of event is an messaging or port error.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent
+ */
+export function isErrorEvent(event: unknown): event is ErrorEvent {
+  // Need to check enough of the structure to make sure it's not mistaken for an error
+  return typeof event === "object" && "error" in event && "message" in event;
+}
+
+/**
+ * Return true iff the value is an AxiosError.
+ */
+export function isAxiosError(error: unknown): error is AxiosError {
+  return typeof error === "object" && (error as AxiosError).isAxiosError;
+}
+
+/**
+ * Return true iff the value is an AxiosError corresponding to a HTTP_400_BAD_REQUEST.
+ */
+export function isBadRequestError(
+  error: unknown
+): error is AxiosError & { response: { status: 400 } } {
+  return isAxiosError(error) && error.response.status === 400;
+}
+
+/**
+ * Return true if the proximate cause of event is an messaging or port error.
  *
  * NOTE: does not recursively identify the root cause of the error.
  */
@@ -200,13 +292,10 @@ export function isConnectionError(
  * Some pages are off-limits to extension. This function can find out if an error is due to this limitation.
  *
  * Example error messages:
- * Cannot access a chrome:// URL
- * Cannot access a chrome-extension:// URL of different extension
- * Cannot access contents of url "chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/options.html#/". Extension manifest must request permission to access this host.
- * The extensions gallery cannot be scripted.
- *
- * @param error
- * @returns
+ * - Cannot access a chrome:// URL
+ * - Cannot access a chrome-extension:// URL of different extension
+ * - Cannot access contents of url "chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/options.html#/". Extension manifest must request permission to access this host.
+ * - The extensions gallery cannot be scripted.
  */
 export function isPrivatePageError(error: unknown): boolean {
   return /cannot be scripted|(chrome|about|extension):\/\//.test(
@@ -214,10 +303,38 @@ export function isPrivatePageError(error: unknown): boolean {
   );
 }
 
+/**
+ * Return an error message corresponding to an error.
+ */
 export function getErrorMessage(error: unknown): string {
   if (isErrorObject(error)) {
+    // `error.message` known to be of type string, so don't need to default it
     return error.message;
   }
 
-  return String(error);
+  return String(error ?? DEFAULT_ERROR_MESSAGE);
+}
+
+/**
+ * Returns the error corresponding to error-like objects
+ *
+ * Current handled:
+ * - unhandled promise rejections
+ * - error events
+ */
+export function selectError(error: unknown): unknown {
+  if (error instanceof Error) {
+    // Check first to return directly if possible (in case our other type guards match too much)
+    return error;
+  }
+
+  if (isPromiseRejectionEvent(error)) {
+    return selectPromiseRejectionError(error);
+  }
+
+  if (isErrorEvent(error)) {
+    return error.error;
+  }
+
+  return error;
 }

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -51,7 +51,11 @@ import {
 import { propertiesToSchema } from "@/validators/generic";
 import { Permissions } from "webextension-polyfill-ts";
 import { reportEvent } from "@/telemetry/events";
-import { hasCancelRootCause } from "@/errors";
+import {
+  hasCancelRootCause,
+  MultipleElementsFoundError,
+  NoElementsFoundError,
+} from "@/errors";
 import {
   DEFAULT_ACTION_RESULTS,
   mergeConfig,
@@ -792,11 +796,15 @@ class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
 
       const $elt = $containerElement.parents(selector);
       if ($elt.length > 1) {
-        throw new Error(
-          `Found multiple elements for reader selector: ${selector}`
+        throw new MultipleElementsFoundError(
+          selector,
+          `Multiple elements found for reader selector`
         );
       } else if ($elt.length === 0) {
-        throw new Error(`Found no elements for  reader selector: ${selector}`);
+        throw new NoElementsFoundError(
+          selector,
+          `No elements found for reader selector`
+        );
       }
 
       return $elt.get(0);

--- a/src/nativeEditor/infer.ts
+++ b/src/nativeEditor/infer.ts
@@ -18,6 +18,7 @@
 import { uniq, compact, sortBy, unary, intersection } from "lodash";
 import getCssSelector, { css_selector_type } from "css-selector-generator";
 import { isNullOrBlank, mostCommonElement } from "@/utils";
+import { BusinessError } from "@/errors";
 
 const BUTTON_TAGS: string[] = ["li", "button", "a", "span", "input", "svg"];
 const BUTTON_SELECTORS: string[] = ["[role='button']"];
@@ -683,7 +684,9 @@ export function inferButtonHTML(
   const $container = $(container);
 
   if (selected.length === 0) {
-    throw new Error("one or more prototype button-like elements required");
+    throw new BusinessError(
+      "One or more prototype button-like elements required"
+    );
   } else if (selected.length > 1) {
     const children = containerChildren($container, selected);
     // Vote on the root tag
@@ -709,7 +712,7 @@ export function inferButtonHTML(
       }
     }
 
-    throw new Error(
+    throw new BusinessError(
       `Did not find any button-like tags in container ${container.tagName}`
     );
   }

--- a/src/nativeEditor/utils.ts
+++ b/src/nativeEditor/utils.ts
@@ -16,13 +16,21 @@
  */
 
 import jQuery from "jquery";
+import { MultipleElementsFoundError, NoElementsFoundError } from "@/errors";
 
+/**
+ * Returns exactly one HTMLElement corresponding to the given selector.
+ * @param selector the JQuery selector
+ * @throws NoElementsFoundError if not elements are found
+ * @throws MultipleElementsFoundError if multiple elements are found
+ */
 export function requireSingleElement(selector: string): HTMLElement {
+  // eslint-disable-next-line unicorn/no-array-callback-reference -- false positive for jquery
   const $elt = jQuery(document).find(selector);
   if ($elt.length === 0) {
-    throw new Error(`No elements found for selector: '${selector}'`);
+    throw new NoElementsFoundError(selector);
   } else if ($elt.length > 1) {
-    throw new Error(`Multiple elements found for selector: '${selector}'`);
+    throw new MultipleElementsFoundError(selector);
   }
 
   return $elt.get(0);

--- a/src/script.ts
+++ b/src/script.ts
@@ -31,18 +31,15 @@ declare global {
   }
 }
 
-// False positive: using constant symbol defined above
-// eslint-disable-next-line security/detect-object-injection
-if (!window[PAGESCRIPT_SYMBOL]) {
-  // False positive: using constant symbol defined above
-  // eslint-disable-next-line security/detect-object-injection
-  window[PAGESCRIPT_SYMBOL] = uuidv4();
-} else {
+// eslint-disable-next-line security/detect-object-injection -- using constant symbol defined above
+if (window[PAGESCRIPT_SYMBOL]) {
   throw new Error(
-    // False positive: using constant symbol defined above
-    // eslint-disable-next-line security/detect-object-injection
+    // eslint-disable-next-line security/detect-object-injection -- using constant symbol defined above
     `PixieBrix pageScript already installed: ${window[PAGESCRIPT_SYMBOL]}`
   );
+} else {
+  // eslint-disable-next-line security/detect-object-injection -- using constant symbol defined above
+  window[PAGESCRIPT_SYMBOL] = uuidv4();
 }
 
 import jQuery from "jquery";
@@ -81,21 +78,7 @@ import {
   WriteableComponentAdapter,
 } from "@/frameworks/component";
 import { elementInfo } from "@/nativeEditor/frameworks";
-import { BusinessError } from "@/errors";
-
-function requireSingleElement(selector: string): HTMLElement {
-  // eslint-disable-next-line unicorn/no-array-callback-reference -- False positive
-  const $elt = jQuery(document).find(selector);
-  if ($elt.length === 0) {
-    throw new BusinessError(`No elements found for selector: '${selector}'`);
-  } else if ($elt.length > 1) {
-    throw new BusinessError(
-      `Multiple elements found for selector: '${selector}'`
-    );
-  }
-
-  return $elt.get(0);
-}
+import { requireSingleElement } from "@/nativeEditor/utils";
 
 const attachListener = initialize();
 

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -18,6 +18,7 @@
 import Rollbar, { LogArgument } from "rollbar";
 import { isExtensionContext } from "webext-detect-page";
 import { getUID } from "@/background/telemetry";
+import { getErrorMessage } from "@/errors";
 
 const accessToken = process.env.ROLLBAR_BROWSER_ACCESS_TOKEN;
 
@@ -67,7 +68,7 @@ export const rollbar: Rollbar = Rollbar.init({
 /**
  * Convert a message or value into a rollbar logging argument.
  *
- * Convert functions/callbacks to `unknown` so they're ignored by rollbar.
+ * Convert functions/callbacks to `undefined` so they're ignored by rollbar.
  *
  * @see https://docs.rollbar.com/docs/rollbarjs-configuration-reference#rollbarlog
  */
@@ -83,7 +84,7 @@ export function toLogArgument(error: unknown): LogArgument {
     return error;
   }
 
-  return String(error);
+  return getErrorMessage(error);
 }
 
 export async function updateAuth({

--- a/src/tests/errors.test.ts
+++ b/src/tests/errors.test.ts
@@ -1,0 +1,145 @@
+import {
+  BusinessError,
+  CancelError,
+  ContextError,
+  getErrorMessage,
+  hasBusinessRootCause,
+  hasCancelRootCause,
+  isErrorObject,
+  MultipleElementsFoundError,
+  NoElementsFoundError,
+} from "@/errors";
+import { range } from "lodash";
+import { deserializeError, serializeError } from "serialize-error";
+import { InputValidationError, OutputValidationError } from "@/blocks/errors";
+
+const TEST_MESSAGE = "Test message";
+
+function nest(error: Error, level = 1): Error {
+  if (level === 0) {
+    return error;
+  }
+  return nest(new ContextError(error), level - 1);
+}
+
+describe("hasCancelRootCause", () => {
+  test("can detect cancel root cause", () => {
+    const error = new CancelError(TEST_MESSAGE);
+    for (const level of range(3)) {
+      expect(hasCancelRootCause(nest(error, level))).toBe(true);
+    }
+  });
+
+  test("do not detect other causes", () => {
+    const error = new Error(TEST_MESSAGE);
+    for (const level of range(3)) {
+      expect(hasCancelRootCause(nest(error, level))).toBe(false);
+    }
+  });
+
+  test("handles message", () => {
+    expect(hasCancelRootCause(TEST_MESSAGE)).toBe(false);
+  });
+
+  test("can detect cancel root cause in serialized error", () => {
+    const error = new CancelError(TEST_MESSAGE);
+    for (const level of range(3)) {
+      expect(hasCancelRootCause(serializeError(nest(error, level)))).toBe(true);
+    }
+  });
+
+  test("handles other serialized errors", () => {
+    const error = new Error(TEST_MESSAGE);
+    for (const level of range(3)) {
+      expect(hasCancelRootCause(serializeError(nest(error, level)))).toBe(
+        false
+      );
+    }
+  });
+});
+
+describe("hasBusinessRootCause", () => {
+  const errorTable = [
+    new BusinessError(TEST_MESSAGE),
+    new NoElementsFoundError("#test"),
+    new MultipleElementsFoundError("#test"),
+    new InputValidationError(TEST_MESSAGE, { type: "string" }, 42, []),
+    new OutputValidationError(TEST_MESSAGE, { type: "string" }, 42, []),
+  ].map((error) => ({ error, name: error.name }));
+
+  test("can detect business root cause", () => {
+    const error = new BusinessError(TEST_MESSAGE);
+    for (const level of range(3)) {
+      expect(hasBusinessRootCause(nest(error, level))).toBe(true);
+    }
+  });
+
+  test("do not detect other causes", () => {
+    const error = new Error(TEST_MESSAGE);
+    expect(hasBusinessRootCause(error)).toBe(false);
+    for (const level of range(3)) {
+      expect(hasBusinessRootCause(nest(error, level))).toBe(false);
+    }
+  });
+
+  test("handles message", () => {
+    expect(hasBusinessRootCause(TEST_MESSAGE)).toBe(false);
+  });
+
+  test.each(errorTable)("can detect subclass $name", ({ error }) => {
+    for (const level of range(3)) {
+      expect(hasBusinessRootCause(nest(error, level))).toBe(true);
+    }
+  });
+
+  test.each(errorTable)("can detect serialized error $name", ({ error }) => {
+    for (const level of range(3)) {
+      expect(hasBusinessRootCause(serializeError(nest(error, level)))).toBe(
+        true
+      );
+    }
+  });
+
+  test.each(errorTable)("can detect deserialized error $name", ({ error }) => {
+    for (const level of range(3)) {
+      const deserialized = deserializeError(serializeError(nest(error, level)));
+      expect(hasBusinessRootCause(deserialized)).toBe(true);
+    }
+  });
+
+  test("handles serialized errors", () => {
+    const error = new Error(TEST_MESSAGE);
+    for (const level of range(3)) {
+      expect(hasBusinessRootCause(serializeError(nest(error, level)))).toBe(
+        false
+      );
+    }
+  });
+});
+
+describe("getErrorMessage", () => {
+  test("handles string", () => {
+    expect(getErrorMessage(TEST_MESSAGE)).toBe(TEST_MESSAGE);
+  });
+
+  test("handles vanilla error", () => {
+    expect(getErrorMessage(new Error(TEST_MESSAGE))).toBe(TEST_MESSAGE);
+  });
+
+  test("handles null/undefined", () => {
+    expect(getErrorMessage(null)).toBe("Unknown error");
+    // eslint-disable-next-line unicorn/no-useless-undefined -- testing value since it comes from variable/expression in the wild
+    expect(getErrorMessage(undefined)).toBe("Unknown error");
+  });
+});
+
+describe("isErrorObject", () => {
+  test("handles error", () => {
+    expect(isErrorObject(new Error(TEST_MESSAGE))).toBe(true);
+  });
+
+  test("handles primitives", () => {
+    expect(isErrorObject(null)).toBe(false);
+    expect(isErrorObject(TEST_MESSAGE)).toBe(false);
+  });
+});

--- a/src/tests/errors.test.ts
+++ b/src/tests/errors.test.ts
@@ -19,6 +19,7 @@ function nest(error: Error, level = 1): Error {
   if (level === 0) {
     return error;
   }
+
   return nest(new ContextError(error), level - 1);
 }
 


### PR DESCRIPTION
Closes #918

- Fixes bug where nested ContextErrors weren't getting unrolled all the way to get the root cause
- Fixes handling of BusinessError subclasses
- Introduces `NoElementsFoundError` and `MultipleElementsFoundError` classes that take a selector (to keep the message in the error telemetry cleaner)