### PR TITLE
Avoid injection on extension pages; Avoid duplicates on app pages

### DIFF
--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -75,6 +75,7 @@ async function handleBrowserAction(tab: chrome.tabs.Tab): Promise<void> {
     // Firefox does not catch injection errors so we don't get a specific error message
     // https://github.com/pixiebrix/pixiebrix-extension/issues/579#issuecomment-866451242
     await showErrorInOptions("ERR_BROWSER_ACTION_TOGGLE", tab.index);
+    console.error(error);
 
     // Only report unknown-reason errors
     reportError(error);

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -132,6 +132,14 @@ export async function ensureContentScript(target: Target): Promise<void> {
       return;
     }
 
+    if (!result.url.startsWith("http")) {
+      console.warn(
+        "ensureContentScript: can’t be injected on this URL, #801",
+        result.url
+      );
+      return;
+    }
+
     if (result.installed || (await isContentScriptRegistered(result.url))) {
       console.debug(
         `ensureContentScript: already exists or will be injected automatically`,

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -98,6 +98,7 @@ export async function onReadyNotification(signal: AbortSignal): Promise<void> {
   }
 }
 
+// TODO: Use https://github.com/sindresorhus/p-memoize/issues/20 to avoid multiple concurrent calls for every target
 /**
  * Ensures that the contentScript is ready on the specified page, regardless of its status.
  * - If it's not expected to be injected automatically, it also injects it into the page.

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -24,6 +24,7 @@ import { ENSURE_CONTENT_SCRIPT_READY } from "@/messaging/constants";
 import { isRemoteProcedureCallRequest } from "@/messaging/protocol";
 import { expectBackgroundPage } from "@/utils/expectContext";
 import { evaluableFunction } from "@/utils";
+import pTimeout from "p-timeout";
 
 export type Target = {
   tabId: number;
@@ -158,7 +159,11 @@ export async function ensureContentScript(target: Target): Promise<void> {
       await Promise.all(loadingScripts);
     }
 
-    await readyNotificationPromise;
+    await pTimeout(
+      readyNotificationPromise,
+      4000,
+      "contentScript not ready in 4s"
+    );
     console.debug(`ensureContentScript: ready`, target);
   } finally {
     controller.abort();

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -44,7 +44,7 @@ export async function isContentScriptRegistered(url: string): Promise<boolean> {
   });
 
   // Do not replace the 2 calls above with `permissions.getAll` because it might also
-  //  include hosts that are permitted by the manifest but have no content script registered.
+  // include hosts that are permitted by the manifest but have no content script registered.
   return patternToRegex(...origins, ...manifestScriptsOrigins).test(url);
 }
 

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -159,8 +159,8 @@ export async function ensureContentScript(target: Target): Promise<void> {
     }
 
     await readyNotificationPromise;
-  } finally {
     console.debug(`ensureContentScript: ready`, target);
+  } finally {
     controller.abort();
   }
 }


### PR DESCRIPTION
- Fixes: https://github.com/pixiebrix/pixiebrix-extension/issues/694

I had some issues while debugging https://github.com/pixiebrix/pixiebrix-extension/issues/958 that were caused by this. The _fun part_ is that the extension was attempting to inject the content script **into the sidebar’s iframe** due to this, resulting in content script code running in an unexpected context.

Related:

- https://github.com/pixiebrix/pixiebrix-extension/issues/801
- https://github.com/pixiebrix/pixiebrix-extension/issues/575
- https://github.com/fregante/webext-detect-page/issues/9