### PR TITLE
#904: isolate CSS in devtools

### DIFF
--- a/src/action.tsx
+++ b/src/action.tsx
@@ -30,8 +30,8 @@ import "@/actionPanel/protocol";
 
 // Keep in order so precedence is preserved
 import "@/vendors/theme/app/app.scss";
-import "./action.scss";
 import "@/vendors/overrides.scss";
+import "./action.scss";
 
 const url = new URL(location.href);
 const nonce = url.searchParams.get("nonce");

--- a/src/devTools/Panel.scss
+++ b/src/devTools/Panel.scss
@@ -15,6 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Copied from `overrides.scss`, but I didn't want to grab the whole theme
+span.page-title-icon {
+  line-height: 36px;
+}
+
 .DevToolsContainer.container-fluid {
   padding-left: 0;
   padding-right: 0;

--- a/src/devtoolsPanel.tsx
+++ b/src/devtoolsPanel.tsx
@@ -21,7 +21,6 @@ import React from "react";
 import Panel from "@/devTools/Panel";
 
 import "bootstrap/dist/css/bootstrap.min.css";
-import "@/vendors/overrides.scss";
 import "@/devTools/Panel.scss";
 import { reportError } from "@/telemetry/logging";
 


### PR DESCRIPTION
PR #976 imported the theme in overrides, which then cause the theme to flow into the devtools.

This PR removes the overrides import from the devtools and puts the one rule that was in there in the devtools SCSS file