### PR TITLE
#904: move options navbar css to options css file

### DIFF
--- a/src/devTools/Panel.scss
+++ b/src/devTools/Panel.scss
@@ -15,11 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Copied from `overrides.scss`, but I didn't want to grab the whole theme
-span.page-title-icon {
-  line-height: 36px;
-}
-
 .DevToolsContainer.container-fluid {
   padding-left: 0;
   padding-right: 0;

--- a/src/devtoolsPanel.tsx
+++ b/src/devtoolsPanel.tsx
@@ -21,6 +21,7 @@ import React from "react";
 import Panel from "@/devTools/Panel";
 
 import "bootstrap/dist/css/bootstrap.min.css";
+import "@/vendors/overrides.scss";
 import "@/devTools/Panel.scss";
 import { reportError } from "@/telemetry/logging";
 

--- a/src/options.scss
+++ b/src/options.scss
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@import "vendors/theme/app/app";
 
 html {
   display: flex;
@@ -48,4 +49,31 @@ body {
 .modal-backdrop {
   // keep behind services modal of 999
   z-index: 998;
+}
+
+.navbar {
+  .navbar-toggler {
+    // move down slightly to align better with logo
+    margin-top: 5px;
+  }
+  .navbar-menu-wrapper {
+    @media (min-width: 992px) {
+      padding-left: 0;
+    }
+  }
+  .navbar-brand-wrapper {
+    &.navbar-toggler-wrapper {
+      @media (max-width: 991px) {
+        width: 100px;
+      }
+    }
+    .navbar-toggler {
+      color: $navbar-menu-color;
+      height: $navbar-height;
+      padding-left: 0;
+      @media (min-width: 992px) {
+        display: none;
+      }
+    }
+  }
 }

--- a/src/vendors/overrides.scss
+++ b/src/vendors/overrides.scss
@@ -14,34 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-@import "theme/app/app";
 
 span.page-title-icon {
   line-height: 36px;
-}
-
-.navbar {
-  .navbar-toggler {
-    margin-top: 5px;
-  }
-  .navbar-menu-wrapper {
-    @media (min-width: 992px) {
-      padding-left: 0;
-    }
-  }
-  .navbar-brand-wrapper {
-    &.navbar-toggler-wrapper {
-      @media (max-width: 991px) {
-        width: 100px;
-      }
-    }
-    .navbar-toggler {
-      color: $navbar-menu-color;
-      height: $navbar-height;
-      padding-left: 0;
-      @media (min-width: 992px) {
-        display: none;
-      }
-    }
-  }
 }


### PR DESCRIPTION
This moves css added in PR #976 to the css file specific to only the options page (`options.scss`). This separates it from affecting the dev tools panel and the action panel. Also keeps the `vendors/overrides.scss` file clean from the options page navbar customizations so it can still be referenced everywhere.