### PR TITLE
#912 Improve layout/styling of close/options buttons at the top of the action panel

### DIFF
--- a/src/action.scss
+++ b/src/action.scss
@@ -41,22 +41,11 @@ body {
   }
 }
 
-.action-panel-close-button {
-  padding: 4px;
-  margin: 4px 12px 4px 12px;
+.action-panel-button {
   color: #6562aa;
 
-  svg:last-child {
-    margin-left: -3px;
-  }
-
   &:hover {
+    color: #4d4b8b;
     background-color: #d1c2d7;
-  }
-}
-
-.ActionPanelToolbar {
-  .btn {
-    border-radius: 0;
   }
 }

--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -21,9 +21,9 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import logo from "@img/logo.svg";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faPuzzlePiece,
+  faCog,
   faSpinner,
-  faChevronRight,
+  faAngleDoubleRight
 } from "@fortawesome/free-solid-svg-icons";
 import { getStore } from "@/actionPanel/native";
 import {
@@ -138,18 +138,18 @@ const ActionPanelApp: React.FunctionComponent = () => {
       <PersistGate loading={<GridLoader />} persistor={persistor}>
         <ToastProvider>
           <div className="d-flex flex-column" style={{ height: "100vh" }}>
-            <div className="d-flex mb-2" style={{ flex: "none" }}>
+            <div className="d-flex flex-row mb-2 p-2 justify-content-between align-content-center">
               <Button
-                className="action-panel-close-button"
+                className="action-panel-button"
                 onClick={closeSidebar}
                 size="sm"
                 variant="link"
               >
-                <FontAwesomeIcon icon={faChevronRight} />
-                <FontAwesomeIcon icon={faChevronRight} />
+                <FontAwesomeIcon
+                  icon={faAngleDoubleRight}
+                  className="fa-lg"
+                />
               </Button>
-              {/* spacer */}
-              <div className="flex-grow-1" />
               <div className="align-self-center">
                 <img
                   src={logo}
@@ -158,16 +158,15 @@ const ActionPanelApp: React.FunctionComponent = () => {
                   className="px-4"
                 />
               </div>
-              <div className="ActionPanelToolbar">
-                <Button
-                  href="/options.html"
-                  target="_blank"
-                  size="sm"
-                  variant="info"
-                >
-                  <FontAwesomeIcon icon={faPuzzlePiece} /> Open Extension
-                </Button>
-              </div>
+              <Button
+                href="/options.html"
+                target="_blank"
+                size="sm"
+                variant="link"
+                className="action-panel-button d-inline-flex align-items-center"
+              >
+                <span>Options  <FontAwesomeIcon icon={faCog} /></span>
+              </Button>
             </div>
 
             <DeploymentBanner className="flex-none" />


### PR DESCRIPTION
Closes #912 

This makes a few tweaks to the top layout of the action panel sidebar:
![image](https://user-images.githubusercontent.com/2801308/128242905-ba82a482-7425-43b1-8aee-30e1ff74c58c.png)



- Replace the two chevrons+css hack with just the angle-double-right fontawesome icon
before: ![image](https://user-images.githubusercontent.com/2801308/128241537-87235392-f4c1-43dc-b36d-610ab511a6e1.png) after: ![image](https://user-images.githubusercontent.com/2801308/128241591-029cd827-87bc-4bec-b93c-858b097cc031.png)


- Update the look & feel of the options button
before: ![image](https://user-images.githubusercontent.com/2801308/128241993-af1798b4-1c18-40f8-9f27-356276398a1a.png)
after: ![image](https://user-images.githubusercontent.com/2801308/128242037-df0c32e2-8c57-4250-96c1-43b7c46f383f.png)


- Switch the whole top div to use flexbox space-between as opposed to an empty "spacer" piece to separate items
![image](https://user-images.githubusercontent.com/2801308/128241909-f5b6928b-e24d-4e5e-a543-786c7cfbeb2a.png)


- Simplify the css for these buttons to make it re-usable between the close and options buttons, and also add a hover color as a darker purple to override the blue from react bootstrap link-style buttons
![image](https://user-images.githubusercontent.com/2801308/128242349-e4bee64e-a4ae-4c47-8085-02dcf19e7ba9.png)

close button hover:
![image](https://user-images.githubusercontent.com/2801308/128243278-7973edad-ab98-4897-98aa-15d31edb2143.png)

options button hover:
![image](https://user-images.githubusercontent.com/2801308/128243326-cf64bff5-4b3e-461d-a371-2144f027b437.png)
