### PR TITLE
Immediately catch `activeTab` and update editor state

### DIFF
--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -24,6 +24,7 @@ import { sleep } from "@/utils";
 import { JsonObject, JsonValue } from "type-fest";
 import { HandlerMap } from "@/messaging/protocol";
 import { getErrorMessage, isPrivatePageError } from "@/errors";
+import { emitDevtools } from "@/background/devtools/internal";
 
 const MESSAGE_PREFIX = "@@pixiebrix/background/browserAction/";
 export const REGISTER_ACTION_FRAME = `${MESSAGE_PREFIX}/REGISTER_ACTION_FRAME`;
@@ -63,6 +64,12 @@ async function handleBrowserAction(tab: chrome.tabs.Tab): Promise<void> {
       frameId: TOP_LEVEL_FRAME_ID,
     });
     tabNonces.set(tab.id, nonce);
+
+    // Inform editor that it now has the ActiveTab permission, if it's open
+    emitDevtools("HistoryStateUpdate", {
+      tabId: tab.id,
+      frameId: TOP_LEVEL_FRAME_ID,
+    });
   } catch (error: unknown) {
     if (isPrivatePageError(error)) {
       void showErrorInOptions(

--- a/src/devTools/editor/panes/PermissionsPane.tsx
+++ b/src/devTools/editor/panes/PermissionsPane.tsx
@@ -44,14 +44,13 @@ const PermissionsPane: React.FunctionComponent = () => {
           <FontAwesomeIcon icon={faShieldAlt} /> Grant Permanent Access
         </AsyncButton>
       </p>
-      <p className="text-info">
-        <FontAwesomeIcon icon={faInfoCircle} /> You can revoke PixieBrix&apos;s
-        access to a site at any time on PixieBrix&apos;s Settings page
-      </p>
       <p>
-        Or, grant temporary access by 1) clicking on the PixieBrix extension
-        menu item in your browser&apos;s extensions dropdown, and 2) then
-        refreshing the page
+        Or grant temporary access by clicking on the PixieBrix extension menu
+        item in your browser&apos;s extensions dropdown.
+      </p>
+      <p className="text-info">
+        <FontAwesomeIcon icon={faInfoCircle} /> You can revoke access to a site
+        at any time on PixieBrix&apos;s Settings page
       </p>
     </Centered>
   );

--- a/src/popups/PermissionsPopup.tsx
+++ b/src/popups/PermissionsPopup.tsx
@@ -78,7 +78,7 @@ const PermissionsPopup: React.FC = () => {
     <Centered>
       <p>
         Additional permissions are required, the browser will prompt you to
-        accept permissions.
+        accept them.
       </p>
 
       <p>


### PR DESCRIPTION
- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/813
- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/812

In short, the `activeTab` permission is lost on refresh in Firefox, so the previous behavior was not possible. This is now documented in: https://github.com/pixiebrix/pixiebrix-extension/wiki/Web-Extensions-behaviors#activetab


# Firefox

https://user-images.githubusercontent.com/1402241/128483105-b78e539f-243d-43bf-af07-98b7e10bebb9.mov

# Chrome

https://user-images.githubusercontent.com/1402241/128483033-be2f0541-ebf3-4878-bb12-99c82a3fbf2d.mov


