### PR TITLE
Increase minimum Firefox version to 91

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "extension@pixiebrix.com",
-      "strict_min_version": "89.0"
+      "strict_min_version": "91.0"
     }
   },
   "icons": {


### PR DESCRIPTION
<img width="729" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/128484932-0b2a36ad-4e70-4899-aeb7-3c541cdb2521.png">

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/845

Let's merge this **after August 10th** (Firefox 91 release) or else Firefox will not let me open it unless I install a beta.


In the meanwhile one can follow the instructions in:

- https://github.com/pixiebrix/pixiebrix-extension/issues/992
