### PR TITLE
Don't show unresponsive editor UI on special browser pages

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -86,4 +86,4 @@ jobs:
         run: |
           echo "::remove-matcher owner=eslint-compact::"
           echo "::remove-matcher owner=eslint-stylish::"
-          npm run lint
+          npm run lint -- --quiet

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -292,7 +292,7 @@ async function attemptTemporaryAccess({
 
     // Side note: Cross-origin iframes lose the `activeTab` after navigation
     // https://github.com/pixiebrix/pixiebrix-extension/pull/661#discussion_r661590847
-    if (getErrorMessage(error).startsWith("Cannot access")) {
+    if (/Cannot access|missing host permission/.test(getErrorMessage(error))) {
       console.debug(
         `Skipping attemptTemporaryAccess because no activeTab permissions`,
         { tabId, frameId, url }

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -135,11 +135,11 @@ export async function ensureContentScript(target: Target): Promise<void> {
     }
 
     if (!result.url.startsWith("http")) {
-      console.warn(
-        "ensureContentScript: can’t be injected on this URL, #801",
+      console.debug(
+        "ensureContentScript: PixieBrix can’t run on this page",
         result.url
       );
-      return;
+      throw new Error("PixieBrix can’t run on this page");
     }
 
     if (result.installed || (await isContentScriptRegistered(result.url))) {

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -51,7 +51,7 @@ export function isBrowserActionPanel(): boolean {
   return url.pathname === location.pathname && url.origin === location.origin;
 }
 
-export function isDevtoolsPage(): boolean {
+export function isDevtoolsPanel(): boolean {
   const isExtensionContext =
     typeof chrome === "object" &&
     chrome &&

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -51,27 +51,6 @@ export function isBrowserActionPanel(): boolean {
   return url.pathname === location.pathname && url.origin === location.origin;
 }
 
-export function isDevtoolsPanel(): boolean {
-  const isExtensionContext =
-    typeof chrome === "object" &&
-    chrome &&
-    typeof chrome.extension === "object";
-
-  if (!isExtensionContext || !chrome?.runtime?.getManifest) {
-    return false;
-  }
-
-  // Make sure dev tools are installed
-  const { devtools_page } = chrome.runtime.getManifest();
-  if (typeof devtools_page !== "string") {
-    return false;
-  }
-
-  const url = new URL("devtoolsPanel.html", location.origin);
-
-  return url.pathname === location.pathname && url.origin === location.origin;
-}
-
 export function setChromeExtensionId(extensionId: string): void {
   if (isEmpty(extensionId)) {
     localStorage.removeItem(CHROME_EXTENSION_STORAGE_KEY);

--- a/src/devTools/editor/hooks/useAddElement.ts
+++ b/src/devTools/editor/hooks/useAddElement.ts
@@ -22,11 +22,11 @@ import AuthContext from "@/auth/AuthContext";
 import { useToasts } from "react-toast-notifications";
 import { actions, FormState } from "@/devTools/editor/editorSlice";
 import * as nativeOperations from "@/background/devtools";
-import { getTabInfo } from "@/background/devtools";
 import { generateExtensionPointMetadata } from "@/devTools/editor/extensionPoints/base";
 import { reportError } from "@/telemetry/logging";
 import { ElementConfig } from "@/devTools/editor/extensionPoints/elementConfig";
 import { getErrorMessage } from "@/errors";
+import { getCurrentURL } from "@/devTools/utils";
 
 type AddElement = (config: ElementConfig) => void;
 
@@ -54,7 +54,7 @@ function useAddElement(reservedNames: string[]): AddElement {
 
       try {
         const element = await config.selectNativeElement(port);
-        const { url } = await getTabInfo(port);
+        const url = await getCurrentURL();
 
         const metadata = await generateExtensionPointMetadata(
           config.label,

--- a/src/devTools/editor/panes/PermissionsPane.tsx
+++ b/src/devTools/editor/panes/PermissionsPane.tsx
@@ -17,18 +17,18 @@
 
 import React, { useCallback, useContext } from "react";
 import { DevToolsContext } from "@/devTools/context";
-import { getTabInfo } from "@/background/devtools";
 import Centered from "@/devTools/editor/components/Centered";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle, faShieldAlt } from "@fortawesome/free-solid-svg-icons";
 import { requestPermissions } from "@/utils/permissions";
 import AsyncButton from "@/components/AsyncButton";
+import { getCurrentURL } from "@/devTools/utils";
 
 const PermissionsPane: React.FunctionComponent = () => {
   const { port, connect } = useContext(DevToolsContext);
 
   const onRequestPermission = useCallback(async () => {
-    const { url } = await getTabInfo(port);
+    const url = await getCurrentURL();
     if (await requestPermissions({ origins: [url] })) {
       await connect();
     }

--- a/src/devTools/editor/panes/insert/GenericInsertPane.tsx
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.tsx
@@ -18,7 +18,7 @@
 import React, { useCallback, useContext } from "react";
 import { useDispatch } from "react-redux";
 import { DevToolsContext } from "@/devTools/context";
-import { getTabInfo, showBrowserActionPanel } from "@/background/devtools";
+import { showBrowserActionPanel } from "@/background/devtools";
 import useAvailableExtensionPoints from "@/devTools/editor/hooks/useAvailableExtensionPoints";
 import Centered from "@/devTools/editor/components/Centered";
 import { Button } from "react-bootstrap";
@@ -33,6 +33,7 @@ import { reportEvent } from "@/telemetry/events";
 import * as nativeOperations from "@/background/devtools";
 import { useToasts } from "react-toast-notifications";
 import { reportError } from "@/telemetry/logging";
+import { getCurrentURL } from "@/devTools/utils";
 
 const { addElement } = editorSlice.actions;
 
@@ -80,7 +81,7 @@ const GenericInsertPane: React.FunctionComponent<{
   const addExisting = useCallback(
     async (extensionPoint) => {
       try {
-        const { url } = await getTabInfo(port);
+        const url = await getCurrentURL();
         await start(
           (await config.fromExtensionPoint(
             url,
@@ -100,7 +101,7 @@ const GenericInsertPane: React.FunctionComponent<{
 
   const addNew = useCallback(async () => {
     try {
-      const { url } = await getTabInfo(port);
+      const url = await getCurrentURL();
 
       const metadata = await generateExtensionPointMetadata(
         config.label,

--- a/src/devTools/editor/panes/insert/useAddExisting.ts
+++ b/src/devTools/editor/panes/insert/useAddExisting.ts
@@ -16,7 +16,6 @@
  */
 
 import { useCallback, useContext } from "react";
-import { getTabInfo } from "@/background/devtools";
 import { reportEvent } from "@/telemetry/events";
 import { reportError } from "@/telemetry/logging";
 import { useDispatch } from "react-redux";
@@ -25,6 +24,7 @@ import { DevToolsContext } from "@/devTools/context";
 import { editorSlice, FormState } from "@/devTools/editor/editorSlice";
 import { ElementConfig } from "@/devTools/editor/extensionPoints/elementConfig";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
+import { getCurrentURL } from "@/devTools/utils";
 
 const { addElement } = editorSlice.actions;
 
@@ -42,7 +42,7 @@ function useAddExisting<T extends { rawConfig: ExtensionPointConfig }>(
         // Cancel out of insert mode
         cancel();
 
-        const { url } = await getTabInfo(port);
+        const url = await getCurrentURL();
         const state = await config.fromExtensionPoint(
           url,
           extensionPoint.rawConfig

--- a/src/devTools/editor/tabs/AvailabilityTab.tsx
+++ b/src/devTools/editor/tabs/AvailabilityTab.tsx
@@ -15,26 +15,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useContext, useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Alert, Col, Form, Row, Tab } from "react-bootstrap";
 import { FastField, FieldInputProps, useFormikContext } from "formik";
 import SelectorSelectorField from "@/devTools/editor/fields/SelectorSelectorField";
 import { FormState } from "@/devTools/editor/editorSlice";
 import { openTab } from "@/background/executor";
-import { getTabInfo } from "@/background/devtools";
-import { DevToolsContext } from "@/devTools/context";
 import {
   createDomainPattern,
   createSitePattern,
   HTTPS_PATTERN,
   SITES_PATTERN,
 } from "@/permissions/patterns";
+import { getCurrentURL } from "@/devTools/utils";
 
 const AvailabilityTab: React.FunctionComponent<{
   eventKey?: string;
   editable: Set<string>;
 }> = ({ eventKey = "availability", editable }) => {
-  const { port } = useContext(DevToolsContext);
   const { values, getFieldHelpers } = useFormikContext<FormState>();
   const locked = useMemo(
     () => values.installed && !editable?.has(values.extensionPoint.metadata.id),
@@ -71,7 +69,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 className="mx-2"
                 role="button"
                 onClick={async () => {
-                  const url = (await getTabInfo(port)).url;
+                  const url = await getCurrentURL();
                   setMatchPattern(createSitePattern(url));
                 }}
               >
@@ -82,7 +80,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 className="mx-2"
                 role="button"
                 onClick={async () => {
-                  const url = (await getTabInfo(port)).url;
+                  const url = await getCurrentURL();
                   setMatchPattern(createDomainPattern(url));
                 }}
               >

--- a/src/devTools/editor/tabs/contextMenu/AvailabilityTab.tsx
+++ b/src/devTools/editor/tabs/contextMenu/AvailabilityTab.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useContext, useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Alert, Col, Form, Row, Tab } from "react-bootstrap";
 import {
   FastField,
@@ -24,8 +24,6 @@ import {
   useField,
   useFormikContext,
 } from "formik";
-import { getTabInfo } from "@/background/devtools";
-import { DevToolsContext } from "@/devTools/context";
 import { openTab } from "@/background/executor";
 import Select from "react-select";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -37,6 +35,7 @@ import {
   SITES_PATTERN,
 } from "@/permissions/patterns";
 import { ContextMenuFormState } from "@/devTools/editor/extensionPoints/contextMenu";
+import { getCurrentURL } from "@/devTools/utils";
 
 const CONTEXTS = [
   "page",
@@ -81,7 +80,6 @@ const AvailabilityTab: React.FunctionComponent<{
   editable: Set<string>;
 }> = ({ eventKey = "availability", editable }) => {
   const { values, getFieldHelpers } = useFormikContext<ContextMenuFormState>();
-  const { port } = useContext(DevToolsContext);
   const locked = useMemo(
     () => values.installed && !editable?.has(values.extensionPoint.metadata.id),
     [editable, values.installed, values.extensionPoint.metadata.id]
@@ -128,7 +126,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 className="mx-2"
                 role="button"
                 onClick={async () => {
-                  const url = (await getTabInfo(port)).url;
+                  const url = await getCurrentURL();
                   setDocumentPattern(createSitePattern(url));
                 }}
               >
@@ -139,7 +137,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 className="mx-2"
                 role="button"
                 onClick={async () => {
-                  const url = (await getTabInfo(port)).url;
+                  const url = await getCurrentURL();
                   setDocumentPattern(createDomainPattern(url));
                 }}
               >
@@ -262,7 +260,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 className="mx-2"
                 role="button"
                 onClick={async () => {
-                  const url = (await getTabInfo(port)).url;
+                  const url = await getCurrentURL();
                   setMatchPattern(createSitePattern(url));
                 }}
               >
@@ -273,7 +271,7 @@ const AvailabilityTab: React.FunctionComponent<{
                 className="mx-2"
                 role="button"
                 onClick={async () => {
-                  const url = (await getTabInfo(port)).url;
+                  const url = await getCurrentURL();
                   setMatchPattern(createDomainPattern(url));
                 }}
               >

--- a/src/devTools/utils.ts
+++ b/src/devTools/utils.ts
@@ -33,6 +33,10 @@ export async function getCurrentURL(): Promise<string> {
   const [response, error] = await browser.devtools.inspectedWindow.eval(
     "location.href"
   );
+
+  // Handle Dev Tools API error response
+  // https://developer.chrome.com/docs/extensions/reference/devtools_inspectedWindow/#method-eval
+  // https://github.com/pixiebrix/pixiebrix-extension/pull/999#discussion_r684370643
   if (!response && error?.isError) {
     throw new Error(printf(error.description, error.details));
   }

--- a/src/devTools/utils.ts
+++ b/src/devTools/utils.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { browser } from "webextension-polyfill-ts";
+
+function printf(string: string, arguments_: string[]): string {
+  // eslint-disable-next-line unicorn/no-array-reduce -- Short and already described by "printf"
+  return arguments_.reduce(
+    (message, part) => message.replace("%s", part),
+    string
+  );
+}
+
+export async function getCurrentURL(): Promise<string> {
+  if (!browser.devtools) {
+    throw new Error("getCurrentURL can only run in the developer tools");
+  }
+
+  const [response, error] = await browser.devtools.inspectedWindow.eval(
+    "location.href"
+  );
+  if (!response && error?.isError) {
+    throw new Error(printf(error.description, error.details));
+  }
+
+  return response;
+}


### PR DESCRIPTION
- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/801

I was investigating a heisenbug when I noticed `getTabInfo` was used mainly to get the URL of the current tab but doing so with multiple steps (devtools, background, content script and back)

It "kind of" fixes the mentioned issue in that the user is no longer presented with a broken UI, but instead it shows the permission denied error (this also makes it consistent with Firefox)

<img width="771" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/128504100-e837889b-a65b-4092-8fe0-dd324a07ed64.png">

Future improvements for UX described in https://github.com/pixiebrix/pixiebrix-extension/issues/801#issuecomment-890942445

> The solution here is to introduce a third permission state:
> 
> - has permission
> - no permission
> - cannot have permission or "it makes no sense" (i.e. show the editor on the extension pages)