### PR TITLE
Improve modals’ accessibility

### DIFF
--- a/src/components/AsyncButton.tsx
+++ b/src/components/AsyncButton.tsx
@@ -20,6 +20,7 @@ import Button, { ButtonProps } from "react-bootstrap/Button";
 
 interface ExtraProps {
   onClick: (() => Promise<void>) | (() => void);
+  autoFocus?: boolean;
 }
 
 const AsyncButton: React.FunctionComponent<ButtonProps & ExtraProps> = ({

--- a/src/layout/ErrorModal.tsx
+++ b/src/layout/ErrorModal.tsx
@@ -46,7 +46,7 @@ const ErrorModal: React.FunctionComponent = () => {
 
   if (message) {
     return (
-      <Modal show onHide={handleClose}>
+      <Modal show onHide={handleClose} animation={false}>
         <Modal.Header closeButton>
           <Modal.Title className="text-danger">
             <FontAwesomeIcon icon={faExclamationCircle} className="mr-1" />
@@ -57,7 +57,8 @@ const ErrorModal: React.FunctionComponent = () => {
           <p>{message}</p>
         </Modal.Body>
         <Modal.Footer>
-          <Button variant="primary" onClick={handleClose}>
+          {/* eslint-disable-next-line jsx-a11y/no-autofocus -- It's a modal, autofocus improves a11y */}
+          <Button variant="primary" onClick={handleClose} autoFocus>
             Close
           </Button>
         </Modal.Footer>

--- a/src/popups/PermissionsPopup.tsx
+++ b/src/popups/PermissionsPopup.tsx
@@ -82,7 +82,8 @@ const PermissionsPopup: React.FC = () => {
       </p>
 
       <p>
-        <AsyncButton onClick={request}>
+        {/* eslint-disable-next-line jsx-a11y/no-autofocus -- It's a modal, autofocus improves a11y */}
+        <AsyncButton onClick={request} autoFocus>
           <FontAwesomeIcon icon={faShieldAlt} /> Grant Permissions
         </AsyncButton>
       </p>


### PR DESCRIPTION
0. In Firefox, in the editor
1. Click "Grant Permanent Permission"
2. The button is not focused, so <kbd>Enter</kbd> won't work

---

0. Visit `about:blank`
1. Click the browser action
2. The modal can't be closed with <kbd>Enter</kbd> because it's not focused
