### PR TITLE
Avoid category card clipping in options page

### DIFF
--- a/src/options/pages/templates/TemplatesPage.scss
+++ b/src/options/pages/templates/TemplatesPage.scss
@@ -16,8 +16,8 @@
  */
 
 .CategoryCard {
-  height: 4rem;
   width: 150px;
+  align-self: stretch;
 
   &:not(:first-child) {
     margin-left: 1rem;
@@ -36,6 +36,9 @@
 
   .card-body {
     padding: 0.875rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
   }
 
   &__title {


### PR DESCRIPTION
As reported by @mnholtz. I thought I'd take a stab at it since I saw a common problematic pattern.

This PR is not meant to be a final solution but rather to ensure it never happens:

- fixed widths and heights are problematic
- if the intent is to normalize the sizes of multiple items, let's use `stretch`

I don't know which commit caused this issue, but this gives us a hint:

<img width="477" alt="Screen Shot 13" src="https://user-images.githubusercontent.com/1402241/128510322-f1bf4a0c-bcb3-40f4-896f-b8a3360db5a6.png">

My guess is that that `vendor/**/_cards.scss` file is being imported _after_ the TemplatesPage (apparently duplicate, too) and therefore it's overriding it.

## Before

<img width="709" alt="Screen Shot 12" src="https://user-images.githubusercontent.com/1402241/128510028-0c8a22fb-d7f9-4237-b7b0-94fc2b1c9ebf.png">

## After

<img width="687" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/128510023-9fde4cde-240e-48cd-858c-e8025cca4166.png">