### PR TITLE
#1008: support property paths in set-values brick

### DIFF
--- a/src/blocks/effects/vue.ts
+++ b/src/blocks/effects/vue.ts
@@ -35,9 +35,12 @@ export class SetVueValues extends Effect {
     properties: {
       component: {
         type: "string",
+        description: "JQuery selector for the Vue.js component",
       },
       values: {
         type: "object",
+        description:
+          "Mapping from property path to new value (see https://lodash.com/docs/4.17.15#set)",
         minProperties: 1,
         additionalProperties: true,
       },

--- a/src/blocks/transformers/jsonPath.ts
+++ b/src/blocks/transformers/jsonPath.ts
@@ -44,6 +44,7 @@ export class JSONPathTransformer extends Transformer {
     { path }: BlockArg,
     { ctxt }: BlockOptions
   ): Promise<unknown> {
+    // eslint-disable-next-line new-cap -- export from a library
     return JSONPath({ preventEval: true, path, json: ctxt });
   }
 }

--- a/src/frameworks/contrib/vue.ts
+++ b/src/frameworks/contrib/vue.ts
@@ -19,7 +19,7 @@
 // https://github.com/vuejs/vue-devtools/blob/6d8fee4d058716fe72825c9ae22cf831ef8f5172/packages/app-backend/src/index.js#L185
 // https://github.com/vuejs/vue-devtools/blob/dev/packages/app-backend/src/utils.js
 
-import { pickBy, isEmpty } from "lodash";
+import { pickBy, isEmpty, set } from "lodash";
 import { RootInstanceVisitor } from "@/frameworks/scanner";
 import { WriteableComponentAdapter } from "@/frameworks/component";
 
@@ -162,8 +162,8 @@ const adapter: WriteableComponentAdapter<Instance> = {
   hasData: (instance: Instance) => !isEmpty(instance),
   getData: readVueData,
   setData: (instance: Instance, data) => {
-    for (const [key, value] of Object.entries(data)) {
-      (instance as any)[key] = value;
+    for (const [path, value] of Object.entries(data)) {
+      set(instance, path, value);
     }
   },
 };


### PR DESCRIPTION
- Closes #1008: use lodash `set` to support setting nested properties in vue components
- Clean some lint