### PR TITLE
Make `webext-detect-page` static in some cases

### DIFF
--- a/src/__mocks__/webextDetectPage.ts
+++ b/src/__mocks__/webextDetectPage.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* eslint-disable import/export -- These are overrides, it's on purpose */
+
+// The node_modules path is to avoid self-references due to webpack alias to this file
+export * from "../../node_modules/webext-detect-page";
+
+export function isExtensionContext() {
+  // Enables static analysis and removal of dead code
+  return true;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -244,7 +244,9 @@ module.exports = (env, options) =>
       alias: {
         ...mockHeavyDependencies(),
 
+        // Enables static analysis and removal of dead code
         "webext-detect-page": path.resolve("src/__mocks__/webextDetectPage"),
+
         // An existence check triggers webpack’s warnings https://github.com/handlebars-lang/handlebars.js/issues/953
         handlebars: "handlebars/dist/handlebars.js",
       },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -244,6 +244,7 @@ module.exports = (env, options) =>
       alias: {
         ...mockHeavyDependencies(),
 
+        "webext-detect-page": path.resolve("src/__mocks__/webextDetectPage"),
         // An existence check triggers webpack’s warnings https://github.com/handlebars-lang/handlebars.js/issues/953
         handlebars: "handlebars/dist/handlebars.js",
       },


### PR DESCRIPTION
Context:

- https://github.com/pixiebrix/pixiebrix-extension/issues/669#issuecomment-894785221


In a perfect/pure world this solution would be enough to solve/avoid that issue since Webpack would be able to just drop unrelated code.

---


This is a basic setup of that suggestion. This partial implementation doesn't affect us much, but it's also super simple so I thought I'd add it here. 

In the future it could be replaced by using `process.env` directly in my module, but I have to see how that affects non-webpack users first: https://github.com/fregante/webext-detect-page/issues/12

