### PR TITLE
Tighten `externalProtocol` messaging

### DIFF
--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -27,7 +27,6 @@ import "@/contentScript/contextMenus";
 import "@/contentScript/browserAction";
 import addContentScriptListener from "@/contentScript/backgroundProtocol";
 import { handleNavigate } from "@/contentScript/lifecycle";
-import addExternalListener from "@/contentScript/externalProtocol";
 import addExecutorListener, {
   notifyReady,
   whoAmI,
@@ -53,7 +52,6 @@ async function init(): Promise<void> {
   addErrorListeners();
 
   addContentScriptListener();
-  addExternalListener();
   addExecutorListener();
   initTelemetry();
 

--- a/src/messaging/external.ts
+++ b/src/messaging/external.ts
@@ -23,9 +23,9 @@ import { liftBackground } from "@/background/protocol";
 import { liftExternal } from "@/contentScript/externalProtocol";
 import { browser } from "webextension-polyfill-ts";
 import { reportEvent } from "@/telemetry/events";
-import { isChrome } from "@/helpers";
+import { isFirefox } from "webext-detect-page";
 
-const lift = isChrome ? liftBackground : liftExternal;
+const lift = isFirefox() ? liftExternal : liftBackground;
 
 export const connectPage = lift("CONNECT_PAGE", async () =>
   // `browser.runtimes`'s types don't include the whole manifest. Use the chrome namespace to get the full type

--- a/src/messaging/external.ts
+++ b/src/messaging/external.ts
@@ -23,9 +23,9 @@ import { liftBackground } from "@/background/protocol";
 import { liftExternal } from "@/contentScript/externalProtocol";
 import { browser } from "webextension-polyfill-ts";
 import { reportEvent } from "@/telemetry/events";
-import { isFirefox } from "webext-detect-page";
+import { isChrome } from "@/helpers";
 
-const lift = isFirefox() ? liftExternal : liftBackground;
+const lift = isChrome ? liftBackground : liftExternal;
 
 export const connectPage = lift("CONNECT_PAGE", async () =>
   // `browser.runtimes`'s types don't include the whole manifest. Use the chrome namespace to get the full type


### PR DESCRIPTION
Core changes:

- it ensures that the messages aren't just lost into the void: Every message has to ping back or else it will fail just like `chrome.runtime.sendMessage` does.
- avoids passing of serialized errors as described in https://github.com/pixiebrix/pixiebrix-extension/issues/580
- refactors the file to linearize the sequence of events: send, await response, return response/error

Interim solution to some issues described in:

- https://github.com/pixiebrix/pixiebrix-extension/issues/1015

Fixes:

- Fixes https://github.com/pixiebrix/pixiebrix-app/issues/334

<table>
<tr>
	<th>No extension
	<th>With extension
<tr>
	<td><img src="https://user-images.githubusercontent.com/1402241/128657290-56183934-843d-4c4a-8c9d-d403800fe271.gif">
	<td><img src="https://user-images.githubusercontent.com/1402241/128658867-83464222-aba2-446c-8844-854642b0e386.gif">
</table>





Replaces an old unmerged PR: https://github.com/pixiebrix/pixiebrix-extension/pull/950