### PR TITLE
Cleanup browser detection

### DIFF
--- a/src/background/firefoxCompat.ts
+++ b/src/background/firefoxCompat.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isFirefox } from "@/helpers";
+import { isFirefox } from "webext-detect-page";
 import { browser } from "webextension-polyfill-ts";
 import { expectBackgroundPage } from "@/utils/expectContext";
 
@@ -29,7 +29,7 @@ function onContextMenuClick({ menuItemId }: browser.contextMenus.OnClickData) {
 
 export default async function initFirefoxCompat(): Promise<void> {
   expectBackgroundPage();
-  if (!isFirefox) {
+  if (!isFirefox()) {
     return;
   }
 

--- a/src/background/permissionPrompt.ts
+++ b/src/background/permissionPrompt.ts
@@ -16,8 +16,8 @@
  */
 
 import { browser, Tabs } from "webextension-polyfill-ts";
-import { isFirefox } from "@/helpers";
 import { liftBackground } from "@/background/protocol";
+import { isFirefox } from "webext-detect-page";
 
 const POPUP_WIDTH_PX = 400; // Makes the native prompt appear centered
 const POPUP_HEIGHT_PX = 215; // Includes titlebar height, must fit the content and error to avoid scrollbars
@@ -72,7 +72,7 @@ async function detectPopupSupport(
   // Firefox on Mac seems to be unable to handle popups in fullscreen mode, changing the macOS "space"
   // back to the desktop
   const isBuggy =
-    isFirefox &&
+    isFirefox() &&
     navigator.userAgent.includes("Macintosh") &&
     currentWindow.state === "fullscreen";
   return !isBuggy;

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -18,6 +18,7 @@
 import isEmpty from "lodash/isEmpty";
 import pDefer from "p-defer";
 import pTimeout from "p-timeout";
+import { isExtensionContext } from "webext-detect-page";
 import { browser, Runtime } from "webextension-polyfill-ts";
 import { forbidBackgroundPage } from "./utils/expectContext";
 
@@ -37,18 +38,7 @@ export class RequestError extends Error {
 }
 
 export function isBrowserActionPanel(): boolean {
-  const isExtensionContext =
-    typeof chrome === "object" &&
-    chrome &&
-    typeof chrome.extension === "object";
-
-  if (!isExtensionContext) {
-    return false;
-  }
-
-  const url = new URL("action.html", location.origin);
-
-  return url.pathname === location.pathname && url.origin === location.origin;
+  return isExtensionContext() && location.pathname === "/action.html";
 }
 
 export function setChromeExtensionId(extensionId: string): void {

--- a/src/contrib/google/initGoogle.ts
+++ b/src/contrib/google/initGoogle.ts
@@ -19,7 +19,7 @@ const API_KEY = process.env.GOOGLE_API_KEY;
 
 import { DISCOVERY_DOCS as SHEETS_DOCS } from "./sheets/handlers";
 import { DISCOVERY_DOCS as BIGQUERY_DOCS } from "./bigquery/handlers";
-import { isChrome } from "@/helpers";
+import { isChrome } from "webext-detect-page";
 
 declare global {
   interface Window {
@@ -39,7 +39,7 @@ async function onGAPILoad(): Promise<void> {
 }
 
 function initGoogle(): void {
-  if (!isChrome) {
+  if (!isChrome()) {
     // TODO: Use feature detection instead of sniffing the user agent
     console.info(
       "Google API not enabled because it's not supported by this browser"

--- a/src/development/autoreload.ts
+++ b/src/development/autoreload.ts
@@ -15,11 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isChrome } from "@/helpers";
+import { isChrome } from "webext-detect-page";
 
 // In Chrome, `web-ext run` reloads the extension without reloading the manifest.
 // This forces a full reload if the version hasn't changed since the last run.
-if (process.env.ENVIRONMENT === "development" && isChrome) {
+if (process.env.ENVIRONMENT === "development" && isChrome()) {
   const { version_name } = chrome.runtime.getManifest();
 
   if (localStorage.getItem("dev:last-version") === version_name) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -124,14 +124,6 @@ export function inputProperties(inputSchema: Schema): SchemaProperties {
   return inputSchema as SchemaProperties;
 }
 
-export const isChrome =
-  typeof navigator === "object" &&
-  navigator.userAgent.toLowerCase().includes("chrome");
-
-export const isFirefox =
-  typeof navigator === "object" &&
-  navigator.userAgent.toLowerCase().includes("firefox");
-
 /**
  * True if the script is executing in a web browser context.
  */

--- a/src/messaging/external.ts
+++ b/src/messaging/external.ts
@@ -22,10 +22,10 @@ import { AuthData, updateExtensionAuth } from "@/auth/token";
 import { liftBackground } from "@/background/protocol";
 import { liftExternal } from "@/contentScript/externalProtocol";
 import { browser } from "webextension-polyfill-ts";
+import { isFirefox } from "webext-detect-page";
 import { reportEvent } from "@/telemetry/events";
-import { isChrome } from "@/helpers";
 
-const lift = isChrome ? liftBackground : liftExternal;
+const lift = isFirefox() ? liftExternal : liftBackground;
 
 export const connectPage = lift("CONNECT_PAGE", async () =>
   // `browser.runtimes`'s types don't include the whole manifest. Use the chrome namespace to get the full type


### PR DESCRIPTION
Minor cleanup

- Use existing detections in `webext-detect-page`
- Ensure that browser exclusions are exact (`!isChrome` might not necessarily mean `=== firefox` in the future)