### PR TITLE
#996 - Keep sidebar on the left side at smaller widths

### DIFF
--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -67,7 +67,7 @@ const Sidebar: React.FunctionComponent = () => {
   const { flags } = useContext(AuthContext);
 
   return (
-    <nav className="sidebar sidebar-offcanvas" id="sidebar">
+    <nav className="sidebar sidebar-offcanvas sidebar-offcanvas-left" id="sidebar">
       <ul className="nav">
         <SidebarLink
           route="/installed"

--- a/src/options.scss
+++ b/src/options.scss
@@ -77,3 +77,12 @@ body {
     }
   }
 }
+
+.sidebar-offcanvas-left {
+  right: auto;
+  left: -$sidebar-width-lg;
+  &.active {
+    right: auto;
+    left: 0;
+  }
+}


### PR DESCRIPTION
This fixes #996 

Adds some css to override what bootstrap is doing to move the sidebar to the other side.