### PR TITLE
#578: [WIP/POC] messaging infrastructure

### DIFF
--- a/src/messaging/framework/BackgroundActor.ts
+++ b/src/messaging/framework/BackgroundActor.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  FORWARD_MESSAGE_TYPE,
+  isMessage,
+  Message,
+  Target,
+} from "@/messaging/framework/types";
+import { Actor, RoutedMessage } from "@/messaging/framework/actor";
+import MessageSender = browser.runtime.MessageSender;
+
+/**
+ * Background script actor
+ *
+ * - Connects via port to devtools
+ * - Connects via runtime or polyfill to script
+ * - Connects via runtime to extension pages
+ * - Forwards messages to script via content script
+ */
+class BackgroundActor extends Actor {
+  public get self(): { actor: "background" } {
+    return { actor: "background" };
+  }
+
+  protected route(target: Target, message: Message): RoutedMessage {
+    if (target.actor === "pageScript") {
+      return ({
+        target: {
+          ...target,
+          actor: "contentScript",
+        },
+        message: {
+          type: FORWARD_MESSAGE_TYPE,
+          payload: {
+            // sender: figure out how to include information about the original sender here
+            message,
+          },
+        },
+      } as unknown) as RoutedMessage;
+    }
+
+    return super.route(target, message);
+  }
+
+  public initialize() {
+    // Intentionally not using async so that we can return undefined to indicate the message was not handled
+    // eslint-disable-next-line @typescript-eslint/promise-function-async
+    browser.runtime.onMessage.addListener(
+      (message: unknown, sender: MessageSender) => {
+        if (isMessage(message)) {
+          return this.handle(
+            {
+              // FIXME: figure out how to pass around sender and immediate sender
+              sender: null,
+              immediateSender: {
+                tabId: sender.tab.id,
+                frameId: sender.frameId,
+                actor: null,
+              },
+            },
+            message
+          );
+        }
+      }
+    );
+  }
+
+  protected async send(routedMessage: RoutedMessage) {
+    const { target, message } = routedMessage;
+
+    if (target.actor === "background") {
+      console.warn(
+        "background script sent message to itself; call the method directly"
+      );
+      await this.handle(
+        { immediateSender: this.self, sender: this.self },
+        message
+      );
+    }
+
+    if (target.actor === "contentScript") {
+      if (target.tabId === "*") {
+        // See existing logic: http://github.com/pixiebrix/pixiebrix-extension/blob/11c65b538054706d15de4c07afb8a1996dd82618/src/contentScript/backgroundProtocol.ts#L125-L125
+        // return browser.runtime.sendMessage(, message, {frameId: 0});
+        throw new Error("broadcast not implemented");
+      }
+
+      // FIXME: handle error deserialization here?
+      return browser.tabs.sendMessage(target.tabId, message, {
+        frameId: target.frameId,
+      });
+    }
+
+    return super.send(routedMessage);
+  }
+}
+
+export default BackgroundActor;

--- a/src/messaging/framework/actor.ts
+++ b/src/messaging/framework/actor.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import objectHash from "object-hash";
+import {
+  FORWARD_MESSAGE_TYPE,
+  Message,
+  Target,
+  Handler,
+  Meta,
+  ExtensionSender,
+  ForwardMessage,
+  MessageOptions,
+  Contract,
+  ContractHandler,
+} from "@/messaging/framework/types";
+import { isConnectionError } from "@/errors";
+import { sleep } from "@/utils";
+
+const RECEIVER_READY_POLL_MILLIS = 250;
+
+export type MessagePromise = {
+  message: Message;
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+} & MessageOptions;
+
+export type RoutedMessage = {
+  // Enforce nominal typing
+  _routedMessageBrand: null;
+  target: Target;
+  message: Message;
+};
+
+export abstract class Actor {
+  // Future work?: support an idempotency header field: https://tools.ietf.org/id/draft-idempotency-header-01.html
+  // Not necessary now, but necessary if non-persistent background service worker in MV3 causes some background
+  // work to arbitrarily fail: (see https://github.com/w3c/webextensions/issues/16)
+
+  // Future work? https://en.wikipedia.org/wiki/Dead_letter_queue
+
+  /**
+   * If the target is not available yet (and there's a max wait time), queue the messages so that messages are
+   * sent deterministically based on the order in which sendMessage was called.
+   */
+  private readonly messageQueues = new Map<string, MessagePromise[]>();
+
+  private readonly activeQueues = new Set<string>();
+
+  private readonly handlers = new Map<string, Handler>();
+
+  /**
+   * Set up listeners for the different channels that that the actor sends/received messages on.
+   */
+  public abstract initialize(): void;
+
+  /**
+   * Returns the target for this actor
+   */
+  protected abstract get self(): ExtensionSender;
+
+  /**
+   * Transform the target/message prior to sending (if necessary):
+   * 1. Wrap the message in a FORWARD_MESSAGE_TYPE message
+   * 2. Change the target to the next hop that gets the message to its destination
+   */
+  protected route(target: Target, message: Message): RoutedMessage {
+    return {
+      target,
+      message,
+    } as RoutedMessage;
+  }
+
+  public addHandler<T extends Contract>(
+    type: T["type"],
+    handler: ContractHandler<T>
+  ): void {
+    if (this.handlers.get(type)) {
+      throw new Error(`Handler already set for ${type}`);
+    }
+
+    this.handlers.set(type, handler);
+  }
+
+  /**
+   * Send the message on the appropriate channel. Examples of channels include:
+   * - browser.tabs
+   * - browser.runtime
+   * - external connection polyfill
+   * - persistent ports
+   */
+  protected async send(_message: RoutedMessage): Promise<unknown> {
+    throw new Error("Send not implemented for target");
+  }
+
+  // Using undefined to distinguish between handled and unhandled messages
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  protected handle(meta: Meta, message: Message): Promise<unknown> | undefined {
+    // XXX: check the intended target here and drop if it's not valid (e.g., if the URL changed)
+
+    if (message.type === FORWARD_MESSAGE_TYPE) {
+      const forward = message as ForwardMessage;
+      const routed = this.route(
+        forward.payload.target,
+        forward.payload.message
+      );
+      return this.sendMessage(routed.target, routed.message);
+    }
+
+    const handler = this.handlers.get(message.type);
+    if (handler) {
+      return handler(message, meta);
+    }
+
+    return undefined;
+  }
+
+  private async queueMessage(
+    target: Target,
+    message: Message
+  ): Promise<unknown> {
+    const targetHash = objectHash(target);
+    if (!this.messageQueues.has(targetHash)) {
+      this.messageQueues.set(targetHash, []);
+    }
+
+    return new Promise((resolve, reject) => {
+      this.messageQueues.get(targetHash).push({
+        message,
+        resolve,
+        reject,
+      });
+
+      if (!this.activeQueues.has(targetHash)) {
+        void this.pollRetry(target);
+      }
+    });
+  }
+
+  private async sendSingleMessage(
+    target: Target,
+    { resolve, reject, message, retryMillis = 0, notification }: MessagePromise
+  ) {
+    // TODO: don't do dumb polling, instead support chatter between the actors so they know which targets are ready
+
+    const start = Date.now();
+
+    while (Date.now() - start < retryMillis) {
+      try {
+        // FIXME: handle notifications properly here: how do we wait for the ack without waiting for the value?
+        // eslint-disable-next-line no-await-in-loop -- intentionally blocking
+        resolve(await this.send({ target, message }));
+      } catch (error: unknown) {
+        if (isConnectionError(error)) {
+          // Wait and try again
+          // eslint-disable-next-line no-await-in-loop -- intentionally blocking
+          await sleep(RECEIVER_READY_POLL_MILLIS);
+        } else {
+          // FIXME: handle error serialization here?
+          reject(error);
+          return;
+        }
+      }
+    }
+
+    // XXX: improve this error message
+    reject(new Error("message not sent"));
+  }
+
+  /**
+   * Sends queued messages to target
+   * @param target
+   */
+  private async pollRetry(target: Target): Promise<void> {
+    const targetHash = objectHash(target);
+    this.activeQueues.add(targetHash);
+
+    const next = () => this.messageQueues.get(objectHash(target)).shift();
+
+    try {
+      for (let item = next(); item != null; item = next()) {
+        // eslint-disable-next-line no-await-in-loop -- intentionally blocking
+        await this.sendSingleMessage(target, item);
+      }
+    } finally {
+      this.activeQueues.delete(targetHash);
+    }
+  }
+
+  public async sendMessage(target: Target, message: Message): Promise<unknown> {
+    return this.queueMessage(target, message);
+  }
+}

--- a/src/messaging/framework/examples.ts
+++ b/src/messaging/framework/examples.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import BackgroundActor from "@/messaging/framework/BackgroundActor";
+import {
+  ActionCreator,
+  Message,
+  Contract,
+  Payload,
+} from "@/messaging/framework/types";
+
+// The type contract we can put in a shared protocol file. (The
+const MESSAGE_TYPE = "EXAMPLE";
+type Example = {
+  type: typeof MESSAGE_TYPE;
+  method: (args: { foo: number }) => Promise<number>;
+};
+
+// Example of adding a handler. Ideally it would reference the ExampleMethod. We'll have to replicate the message
+// type 2x, it would be nice to figure how to not repeat it 3 times
+const exampleHandler: Example["method"] = async (message: { foo: number }) =>
+  message.foo;
+const backgroundActor = new BackgroundActor();
+
+// Type checks
+backgroundActor.addHandler<Example>(MESSAGE_TYPE, exampleHandler);
+backgroundActor.addHandler(MESSAGE_TYPE, exampleHandler);
+
+// Does not type check
+// backgroundActor.addHandler<Example>(MESSAGE_TYPE, ({bar}: {bar: string}) => 42);
+// backgroundActor.addHandler(MESSAGE_TYPE, ({bar}: {bar: string}) => 42);
+// backgroundActor.addHandler("NOTHINGTOSEEHERE", ({bar}: {bar: string}) => 42);
+
+// Creating the caller/operation
+
+// A "dumb" action creator method to perform type checking
+function createAction<T extends Contract>(
+  type: T["type"],
+  payload: Payload<T["method"]>
+): Message<string, Payload<T["method"]>> {
+  return {
+    type,
+    payload,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const create: ActionCreator<Example> = (foo: number) => ({
+  type: MESSAGE_TYPE,
+  payload: { foo },
+});
+
+// const doesNotTypeCheck: ActionCreator<Example> = (bar: number) => ({
+//   type: MESSAGE_TYPE,
+//   payload: {bar}
+// })
+
+// const doesNotTypeCheck: ActionCreator<Example> = (bar: string) => ({
+//   type: MESSAGE_TYPE,
+//   payload: {bar}
+// })
+
+// Doesn't type check
+// const doesNotTypeCheck = createAction<Example>(MESSAGE_TYPE, {bar: 32});
+
+// Type checks
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const action = createAction<Example>(MESSAGE_TYPE, { foo: 32 });

--- a/src/messaging/framework/examples.ts
+++ b/src/messaging/framework/examples.ts
@@ -47,17 +47,6 @@ backgroundActor.addHandler(MESSAGE_TYPE, exampleHandler);
 
 // Creating the caller/operation
 
-// A "dumb" action creator method to perform type checking
-function createAction<T extends Contract>(
-  type: T["type"],
-  payload: Payload<T["method"]>
-): Message<string, Payload<T["method"]>> {
-  return {
-    type,
-    payload,
-  };
-}
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const create: ActionCreator<Example> = (foo: number) => ({
   type: MESSAGE_TYPE,
@@ -78,5 +67,16 @@ const create: ActionCreator<Example> = (foo: number) => ({
 // const doesNotTypeCheck = createAction<Example>(MESSAGE_TYPE, {bar: 32});
 
 // Type checks
+// A "dumb" action creator method so call don't have to use the string
+function createAction<T extends Contract>(
+  type: T["type"]
+): ActionCreator<Contract> {
+  return (payload: Payload<T["method"]>) => ({
+    type,
+    payload,
+  });
+}
+
+const actionFactory = createAction<Example>(MESSAGE_TYPE);
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const action = createAction<Example>(MESSAGE_TYPE, { foo: 32 });
+const action = actionFactory({ foo: 32 });

--- a/src/messaging/framework/types.ts
+++ b/src/messaging/framework/types.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type BaseActionType = string;
+export type BasePayload = Record<string, unknown>;
+
+export type Method<T extends BasePayload = BasePayload> = (
+  arg: T
+) => Promise<unknown>;
+
+export type Message<
+  T extends BaseActionType = BaseActionType,
+  P extends BasePayload = BasePayload
+> = {
+  type: T;
+  payload: P;
+};
+
+export function isMessage(value: unknown): value is Message {
+  return (
+    typeof value === "object" &&
+    typeof (value as any).type === "string" &&
+    typeof (value as any).message === "object"
+  );
+}
+
+export const FORWARD_MESSAGE_TYPE = "@@/forward";
+
+/**
+ * See Runtime.MessageSender
+ */
+export type ExtensionSender =
+  | { actor: "background" }
+  | {
+      tabId: number;
+      frameId: number;
+      actor: Exclude<
+        ActorType,
+        "background" | "devtools" | "external" | "contentScript"
+      >;
+    }
+  | {
+      tabId: number;
+      frameId: number;
+      url: string;
+      actor: Exclude<ActorType, "background" | "devtools"> | string;
+    };
+
+export type ForwardMessage = {
+  type: typeof FORWARD_MESSAGE_TYPE;
+  payload: {
+    /**
+     * The original target of the message
+     */
+    target: Target;
+
+    /**
+     * The original message
+     */
+    sender: ExtensionSender;
+
+    /**
+     * The original message
+     */
+    message: Message;
+  };
+};
+
+export type Meta = {
+  /**
+   * The original sender of the message.
+   */
+  sender: ExtensionSender;
+
+  /**
+   * The sender that sent the last hop of the message.
+   */
+  immediateSender: ExtensionSender;
+};
+
+export type Handler<
+  T extends BaseActionType = string,
+  P extends BasePayload = BasePayload,
+  M extends Method<P> = Method
+> = (payload: Message<T, P>["payload"], meta: Meta) => ReturnType<M>;
+
+type ActorType =
+  | "background"
+  | "extension"
+  | "contentScript"
+  | "devtools"
+  | "external"
+  | "pageScript";
+
+export type Target =
+  | { actor: "background" }
+  | { tabId: number; actor: "extension" }
+  | { tabId: "*"; actor: "contentScript" | "external" }
+  | {
+      tabId: number;
+      frameId: number;
+      actor: Exclude<ActorType, "background" | "extension"> | string;
+      /**
+       * Optional provide a URL to match for the message to be accepted
+       */
+      url?: string;
+    };
+
+export type Contract<
+  T extends BaseActionType = BaseActionType,
+  M extends Method = Method
+> = {
+  type: T;
+  method: M;
+};
+
+export type Payload<T extends Method> = Parameters<T>[0];
+
+export type ContractHandler<T extends Contract> = (
+  payload: Payload<T["method"]>,
+  meta: Meta
+) => ReturnType<T["method"]>;
+
+/**
+ * Type for passing arg-style operations
+ */
+export type ActionCreator<T extends Contract> = (
+  ...args: unknown[]
+) => Message<T["type"], Payload<T["method"]>>;
+
+export type MessageOptions = {
+  /**
+   * True iff the message is a notification. For notification, the promise resolves when the message is successfully
+   * acknowledged, not when the response is received.
+   */
+  notification?: boolean;
+
+  /**
+   * Maximum amount of time to try resend the message (in milliseconds)
+   */
+  retryMillis?: number;
+};


### PR DESCRIPTION
Some high-level architecture ideas for messaging

**Key Ideas**
* Each context (background page, content script, externally connectable page, etc.) has an actor that listens for and sends messages
* Each actor knows how to listen/send on channels. They can take advantage of persistent connections (e.g., with a port with the devtools)
* Each actor can act as a relay for sending other messages (e.g., content script will relay messages to the page script)
* When sending a message, the sender include the _final_ target, and sends the message to the first hop along the away (in most cases, that will be the background page)

**Files**
* `examples.ts`: examples of shared contract, and ergonomics in the sender and handler
* `types.ts`: the types
* `actor.ts`: class that tries to consolidate what we've learned about 1) retries, 1) deterministic send order, 3) retaining sender information in messages
* `BackgroundActor.ts`: an partially-implemented instance of `actor.ts` that hooks up to runtime to listen for messages, and decides what channels to send messages on


**Open Questions/TODO**
- [ ] Figure API for passing information about the sender
- [ ] Implement error serialization logic
- [ ] Which actors are responsible for determining how to route the message? Currently each actor is responsible for figuring out the next hop given the final destination
- [ ] Should notifications resolve on ACK? Or once we're pretty sure the message has been sent?
- [ ] Its probably not OK to block on messages b/c no messages will send if the handler on the other side doesn't return. Considerations: 1) if we have a port we can ack the message, 2) maybe we only ensure order that we send messages in once the target becomes ready? The forwarding sequence number context is here: http://github.com/pixiebrix/pixiebrix-extension/blob/85682b371b8ff77eec06fda06baf7695fcb5672d/src/background/browserAction.ts#L145-L145
- [ ] Where should certain meta data live (e.g., the original sender)? The meta of certain messages? Or passed along separately
- [ ] How do the types need to change to support broadcast (which returns an array)? Does it just involve
- [ ] Should we support special tab types here or have the caller maintain? (e.g., "opener" would correspond to the tab which opened the current tab, "sidebar" would correspond to our sidebar on the current page

**Next Steps**
- Get high-level feedback from @fregante (a live sessions probably works best?)
- Split out into a separate repository?
- As an implementation strategy, we'll incrementally replace certain actions and test as opposed to a rip and replace of the current lift infrastructure
