### PR TITLE
#893: consolidate IExtension variant types

### DIFF
--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ExtensionOptions, loadOptions, saveOptions } from "@/options/loader";
+import { loadOptions, saveOptions } from "@/options/loader";
 import { Deployment } from "@/types/contract";
 import { browser } from "webextension-polyfill-ts";
 import { fromPairs, partition, uniqBy } from "lodash";
@@ -33,6 +33,7 @@ import { selectInstalledExtensions } from "@/options/selectors";
 import { uninstallContextMenu } from "@/background/contextMenus";
 import { containsPermissions } from "@/utils/permissions";
 import { deploymentPermissions } from "@/permissions";
+import { IExtension } from "@/core";
 
 const { reducer, actions } = optionsSlice;
 
@@ -45,7 +46,7 @@ type ActiveDeployment = {
 };
 
 export function activeDeployments(
-  extensions: Array<Pick<ExtensionOptions, "_deployment" | "_recipe">>
+  extensions: Array<Pick<IExtension, "_deployment" | "_recipe">>
 ): ActiveDeployment[] {
   return uniqBy(
     extensions
@@ -110,7 +111,7 @@ function installDeployment(
   return returnState;
 }
 
-function makeDeploymentTimestampLookup(extensions: ExtensionOptions[]) {
+function makeDeploymentTimestampLookup(extensions: IExtension[]) {
   const timestamps = new Map<string, Date>();
 
   for (const extension of extensions) {
@@ -133,7 +134,7 @@ async function updateDeployments() {
   }
 
   const { extensions: extensionPointConfigs } = await loadOptions();
-  const extensions: ExtensionOptions[] = Object.entries(
+  const extensions: IExtension[] = Object.entries(
     extensionPointConfigs
   ).flatMap(([, xs]) => Object.values(xs));
 

--- a/src/background/devtools/protocol.ts
+++ b/src/background/devtools/protocol.ts
@@ -33,6 +33,7 @@ import { ensureContentScript } from "@/background/util";
 import { isEmpty } from "lodash";
 import * as contextMenuProtocol from "@/background/contextMenus";
 import { Target } from "@/background/devtools/contract";
+import { DynamicDefinition } from "@/nativeEditor/dynamic";
 
 export const registerPort = liftBackground(
   "REGISTER_PORT",
@@ -131,7 +132,7 @@ export const showBrowserActionPanel = liftBackground(
 
 export const updateDynamicElement = liftBackground(
   "UPDATE_DYNAMIC_ELEMENT",
-  (target: Target) => async (element: nativeEditorProtocol.DynamicDefinition) =>
+  (target: Target) => async (element: DynamicDefinition) =>
     nativeEditorProtocol.updateDynamicElement(target, element)
 );
 
@@ -155,8 +156,7 @@ export const enableSelectorOverlay = liftBackground(
 
 export const disableOverlay = liftBackground(
   "DISABLE_ELEMENT",
-  (target: Target) => async () =>
-    nativeEditorProtocol.disableOverlay(target)
+  (target: Target) => async () => nativeEditorProtocol.disableOverlay(target)
 );
 
 export const getInstalledExtensionPointIds = liftBackground(

--- a/src/background/preload.ts
+++ b/src/background/preload.ts
@@ -24,11 +24,11 @@ import {
 import { reportError } from "@/telemetry/logging";
 import { loadOptions } from "@/options/loader";
 
-interface PreloadOptions<TConfig = Record<string, unknown>> {
+type PreloadOptions<TConfig = object> = {
   id: string;
   extensionPointId: string;
   config: TConfig;
-}
+};
 
 async function preload(extensions: PreloadOptions[]): Promise<void> {
   for (const definition of extensions) {

--- a/src/background/preload.ts
+++ b/src/background/preload.ts
@@ -56,9 +56,9 @@ export const preloadMenus = liftBackground(
 
 export async function preloadAllMenus(): Promise<void> {
   const { extensions: extensionPointConfigs } = await loadOptions();
-  const extensions: PreloadOptions[] = Object.entries(extensionPointConfigs)
-    .flatMap(([, xs]) => Object.values(xs))
-    .filter((x) => x.active);
+  const extensions: PreloadOptions[] = Object.entries(
+    extensionPointConfigs
+  ).flatMap(([, xs]) => Object.values(xs));
   await preload(extensions);
 }
 

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -18,14 +18,15 @@
 import { liftBackground } from "@/background/protocol";
 import { JsonObject } from "type-fest";
 import { v4 as uuidv4 } from "uuid";
-import { debounce, uniq, throttle } from "lodash";
+import { debounce, uniq, throttle, compact } from "lodash";
 import { browser } from "webextension-polyfill-ts";
 import { readStorage, setStorage } from "@/chrome";
 import { getExtensionToken } from "@/auth/token";
 import axios from "axios";
 import { getBaseURL } from "@/services/baseService";
 import { boolean } from "@/utils";
-import { ExtensionOptions, loadOptions } from "@/options/loader";
+import { loadOptions } from "@/options/loader";
+import { IExtension } from "@/core";
 
 const EVENT_BUFFER_DEBOUNCE_MS = 2000;
 const EVENT_BUFFER_MAX_MS = 10_000;
@@ -125,13 +126,12 @@ async function userSummary() {
 
   try {
     const { extensions: extensionPointConfigs } = await loadOptions();
-    const extensions: ExtensionOptions[] = Object.entries(
+    const extensions: IExtension[] = Object.entries(
       extensionPointConfigs
     ).flatMap(([, xs]) => Object.values(xs));
     numActiveExtensions = extensions.length;
-    numActiveBlueprints = uniq(
-      extensions.filter((x) => x._recipeId).map((x) => x._recipeId)
-    ).length;
+    numActiveBlueprints = uniq(compact(extensions.map((x) => x._recipe?.id)))
+      .length;
     numActiveExtensionPoints = uniq(extensions.map((x) => x.extensionPointId))
       .length;
   } catch (error: unknown) {

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -28,7 +28,7 @@ import {
   isReader,
   isRendererBlock,
   Logger,
-  OptionsArgs,
+  UserOptions,
   ReaderRoot,
   RenderedArgs,
   SanitizedServiceConfiguration,
@@ -125,7 +125,7 @@ interface ReduceOptions {
   validate?: boolean;
   logValues?: boolean;
   headless?: boolean;
-  optionsArgs?: OptionsArgs;
+  optionsArgs?: UserOptions;
   serviceArgs?: RenderedArgs;
 }
 

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -185,12 +185,12 @@ async function loadExtensions() {
 
   const { extensions: extensionPointConfigs } = await loadOptions();
 
-  for (const [extensionPointId, extensions] of Object.entries(
+  for (const [extensionPointId, extensionMap] of Object.entries(
     extensionPointConfigs
   )) {
-    const activeExtensions = Object.values(extensions).filter((x) => x.active);
+    const extensions = Object.values(extensionMap);
 
-    if (activeExtensions.length === 0 && !previousIds.has(extensionPointId)) {
+    if (extensions.length === 0 && !previousIds.has(extensionPointId)) {
       // Ignore the case where we uninstalled the last extension, but the extension point was
       // not deleted from the state.
       //
@@ -204,9 +204,9 @@ async function loadExtensions() {
         extensionPointId
       );
 
-      extensionPoint.syncExtensions(activeExtensions);
+      extensionPoint.syncExtensions(extensions);
 
-      if (activeExtensions.length > 0) {
+      if (extensions.length > 0) {
         // Cleared out _extensionPoints before, so can just push w/o checking if it's already in the array
         _extensionPoints.push(extensionPoint);
       }

--- a/src/core.ts
+++ b/src/core.ts
@@ -126,9 +126,8 @@ export function selectMetadata(metadata: Metadata): Metadata {
   return pick(metadata, ["id", "name", "version", "description"]);
 }
 
-// Don't assume anything about the config, except that it's an object
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type EmptyConfig = {};
+// eslint-disable-next-line @typescript-eslint/ban-types -- don't assume any keys
+export type EmptyConfig = object;
 
 export interface ServiceDependency {
   id: string;

--- a/src/core.ts
+++ b/src/core.ts
@@ -126,6 +126,8 @@ export function selectMetadata(metadata: Metadata): Metadata {
   return pick(metadata, ["id", "name", "version", "description"]);
 }
 
+export type Config = Record<string, unknown>;
+
 export type EmptyConfig = Record<never, unknown>;
 
 export interface ServiceDependency {
@@ -161,7 +163,7 @@ export type ExtensionIdentifier = {
   extensionPointId: string;
 };
 
-export interface IExtension<T extends EmptyConfig = EmptyConfig> {
+export interface IExtension<T extends Config = EmptyConfig> {
   /**
    * UUID of the extension
    */
@@ -291,24 +293,32 @@ type ServiceId = string;
 export type KeyedConfig = Record<string, string | null>;
 
 export type SanitizedConfig = KeyedConfig & {
-  // Nominal typing to distinguish from ServiceConfig
+  /**
+   * Nominal typing to distinguish from `ServiceConfig`
+   * @see `ServiceConfig`
+   */
   _sanitizedConfigBrand: null;
 };
 
 export type ServiceConfig = KeyedConfig & {
-  // Nominal typing to distinguish from SanitizedConfig
+  /**
+   * Nominal typing to distinguish from SanitizedConfig
+   * @see `SanitizedConfig`
+   */
   _serviceConfigBrand: null;
 };
 
 export interface AuthData {
-  // Nominal typing to distinguish from SanitizedConfig and ServiceConfig
+  /**
+   * Nominal typing to distinguish from `SanitizedConfig` and `ServiceConfig`
+   */
   _oauthBrand: null;
   [key: string]: string | null;
 }
 
 export interface TokenContext {
   url: string;
-  data: Record<string, unknown>;
+  data: Config;
 }
 
 export interface OAuth2Context {

--- a/src/core.ts
+++ b/src/core.ts
@@ -126,8 +126,7 @@ export function selectMetadata(metadata: Metadata): Metadata {
   return pick(metadata, ["id", "name", "version", "description"]);
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types -- don't assume any keys
-export type EmptyConfig = object;
+export type EmptyConfig = Record<never, unknown>;
 
 export interface ServiceDependency {
   id: string;

--- a/src/devTools/editor/extensionPoints/actionPanel.tsx
+++ b/src/devTools/editor/extensionPoints/actionPanel.tsx
@@ -40,7 +40,7 @@ import PanelTab from "@/devTools/editor/tabs/actionPanel/PanelTab";
 import ServicesTab from "@/devTools/editor/tabs/ServicesTab";
 import AvailabilityTab from "@/devTools/editor/tabs/AvailabilityTab";
 import LogsTab from "@/devTools/editor/tabs/LogsTab";
-import { DynamicDefinition } from "@/nativeEditor";
+import { DynamicDefinition } from "@/nativeEditor/dynamic";
 import EffectTab from "@/devTools/editor/tabs/EffectTab";
 import MetaTab from "@/devTools/editor/tabs/MetaTab";
 import { v4 as uuidv4 } from "uuid";
@@ -141,6 +141,7 @@ function selectExtension({
   return {
     id: uuid,
     extensionPointId: extensionPoint.metadata.id,
+    _recipe: null,
     label,
     services,
     config: extension,

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { IExtension, Metadata, selectMetadata } from "@/core";
+import { EmptyConfig, IExtension, Metadata, selectMetadata } from "@/core";
 import { Framework, FrameworkMeta, KNOWN_READERS } from "@/messaging/constants";
 import { castArray, isPlainObject } from "lodash";
 import brickRegistry from "@/blocks/registry";
@@ -283,8 +283,7 @@ export function selectIsAvailable(
 
 export async function lookupExtensionPoint<
   TDefinition extends ExtensionPointDefinition,
-  // eslint-disable-next-line @typescript-eslint/ban-types -- don't assume anything about keys
-  TConfig extends object,
+  TConfig extends EmptyConfig,
   TType extends string
 >(
   config: IExtension<TConfig>,

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -37,6 +37,7 @@ import {
   ReaderFormState,
   ReaderReferenceFormState,
 } from "@/devTools/editor/extensionPoints/elementConfig";
+import { Except } from "type-fest";
 
 export interface WizardStep {
   step: string;
@@ -117,7 +118,7 @@ export function makeBaseState(
   defaultSelector: string | null,
   metadata: Metadata,
   frameworks: FrameworkMeta[]
-): Omit<BaseFormState, "type" | "label" | "extensionPoint"> {
+): Except<BaseFormState, "type" | "label" | "extensionPoint"> {
   return {
     uuid,
     services: [],
@@ -282,7 +283,8 @@ export function selectIsAvailable(
 
 export async function lookupExtensionPoint<
   TDefinition extends ExtensionPointDefinition,
-  TConfig,
+  // eslint-disable-next-line @typescript-eslint/ban-types -- don't assume anything about keys
+  TConfig extends object,
   TType extends string
 >(
   config: IExtension<TConfig>,
@@ -313,7 +315,7 @@ export async function lookupExtensionPoint<
 
 export function baseSelectExtensionPoint(
   formState: BaseFormState
-): Omit<ExtensionPointConfig, "definition"> {
+): Except<ExtensionPointConfig, "definition"> {
   const { metadata } = formState.extensionPoint;
 
   return {

--- a/src/devTools/editor/extensionPoints/contextMenu.tsx
+++ b/src/devTools/editor/extensionPoints/contextMenu.tsx
@@ -28,7 +28,7 @@ import {
   WizardStep,
 } from "@/devTools/editor/extensionPoints/base";
 import { v4 as uuidv4 } from "uuid";
-import { DynamicDefinition } from "@/nativeEditor";
+import { DynamicDefinition } from "@/nativeEditor/dynamic";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import { castArray, identity, pickBy } from "lodash";
 import ReaderTab from "@/devTools/editor/tabs/reader/ReaderTab";
@@ -148,6 +148,7 @@ function selectExtension({
   return {
     id: uuid,
     extensionPointId: extensionPoint.metadata.id,
+    _recipe: null,
     label,
     services,
     config: extension,

--- a/src/devTools/editor/extensionPoints/elementConfig.ts
+++ b/src/devTools/editor/extensionPoints/elementConfig.ts
@@ -19,7 +19,7 @@ import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { Runtime } from "webextension-polyfill-ts";
 import { IExtension, Metadata, Schema, ServiceDependency } from "@/core";
 import { FrameworkMeta } from "@/messaging/constants";
-import { DynamicDefinition } from "@/nativeEditor";
+import { DynamicDefinition } from "@/nativeEditor/dynamic";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import { WizardStep } from "@/devTools/editor/extensionPoints/base";
 

--- a/src/devTools/editor/extensionPoints/menuItem.ts
+++ b/src/devTools/editor/extensionPoints/menuItem.ts
@@ -166,6 +166,7 @@ function selectExtension({
   return {
     id: uuid,
     extensionPointId: extensionPoint.metadata.id,
+    _recipe: null,
     label,
     services,
     config: extension,

--- a/src/devTools/editor/extensionPoints/panel.ts
+++ b/src/devTools/editor/extensionPoints/panel.ts
@@ -40,7 +40,7 @@ import PanelTab from "@/devTools/editor/tabs/panel/PanelTab";
 import ServicesTab from "@/devTools/editor/tabs/ServicesTab";
 import AvailabilityTab from "@/devTools/editor/tabs/AvailabilityTab";
 import LogsTab from "@/devTools/editor/tabs/LogsTab";
-import { DynamicDefinition } from "@/nativeEditor";
+import { DynamicDefinition } from "@/nativeEditor/dynamic";
 import { PanelSelectionResult } from "@/nativeEditor/insertPanel";
 import EffectTab from "@/devTools/editor/tabs/EffectTab";
 import MetaTab from "@/devTools/editor/tabs/MetaTab";
@@ -175,6 +175,7 @@ function selectExtension({
   return {
     id: uuid,
     extensionPointId: extensionPoint.metadata.id,
+    _recipe: null,
     label,
     services,
     config: extension,

--- a/src/devTools/editor/extensionPoints/trigger.tsx
+++ b/src/devTools/editor/extensionPoints/trigger.tsx
@@ -34,7 +34,7 @@ import {
   TriggerDefinition,
   TriggerExtensionPoint,
 } from "@/extensionPoints/triggerExtension";
-import { DynamicDefinition } from "@/nativeEditor";
+import { DynamicDefinition } from "@/nativeEditor/dynamic";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import { castArray, identity, pickBy } from "lodash";
 import ReaderTab from "@/devTools/editor/tabs/reader/ReaderTab";
@@ -136,6 +136,7 @@ function selectExtension({
   return {
     id: uuid,
     extensionPointId: extensionPoint.metadata.id,
+    _recipe: null,
     label,
     services,
     config: extension,

--- a/src/extensionPoints/actionPanelExtension.ts
+++ b/src/extensionPoints/actionPanelExtension.ts
@@ -57,10 +57,10 @@ import { BusinessError, getErrorMessage } from "@/errors";
 import { HeadlessModeError } from "@/blocks/errors";
 import { selectExtensionContext } from "@/extensionPoints/helpers";
 
-export interface ActionPanelConfig {
+export type ActionPanelConfig = {
   heading: string;
   body: BlockConfig | BlockPipeline;
-}
+};
 
 export abstract class ActionPanelExtensionPoint extends ExtensionPoint<ActionPanelConfig> {
   readonly permissions: Permissions.Permissions = {};

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -55,10 +55,10 @@ import { selectEventData } from "@/telemetry/deployments";
 import { selectExtensionContext } from "@/extensionPoints/helpers";
 import { getErrorMessage, isErrorObject } from "@/errors";
 
-export interface ContextMenuConfig {
+export type ContextMenuConfig = {
   title: string;
   action: BlockConfig | BlockPipeline;
-}
+};
 
 let clickedElement: HTMLElement = null;
 let selectionHandlerInstalled = false;

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -19,7 +19,7 @@ import { castArray, noop, once } from "lodash";
 // @ts-ignore: no type definitions
 import initialize from "@/vendors/initialize";
 import { sleep, waitAnimationFrame } from "@/utils";
-import { IExtension, MessageContext, Metadata } from "@/core";
+import { IExtension, MessageContext } from "@/core";
 
 export const EXTENSION_POINT_DATA_ATTR = "data-pb-extension-point";
 
@@ -280,11 +280,7 @@ export function acquireElement(
   return onNodeRemoved(element, onRemove);
 }
 
-// FIXME: we have inconsistent typing of extensions, e.g., IExtension, InstalledExtension, ExtensionOptions. So handle
-//  common shape without referencing those modules: https://github.com/pixiebrix/pixiebrix-extension/issues/893
-type Extension = IExtension & { _recipe?: Metadata };
-
-export function selectExtensionContext(extension: Extension): MessageContext {
+export function selectExtensionContext(extension: IExtension): MessageContext {
   return {
     extensionId: extension.id,
     extensionPointId: extension.extensionPointId,

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -79,18 +79,44 @@ export const DATA_ATTR = "data-pb-uuid";
 
 const MENU_INSTALL_ERROR_DEBOUNCE_MS = 1000;
 
-export interface MenuItemExtensionConfig {
+export type MenuItemExtensionConfig = {
+  /**
+   * The button caption to supply to the `caption` in the extension point template.
+   * If `dynamicCaption` is true, can include template expressions.
+   */
   caption: string;
-  if?: BlockConfig | BlockPipeline;
-  dependencies?: string[];
-  action: BlockConfig | BlockPipeline;
+
+  /**
+   * (Optional) the icon to supply to the icon in the extension point template
+   */
   icon?: IconConfig;
+
+  /**
+   * The action to perform when the button is clicked
+   */
+  action: BlockConfig | BlockPipeline;
+
+  /**
+   * (Experimental) condition to determine whether or not to show the menu item
+   * @see if
+   */
+  if?: BlockConfig | BlockPipeline;
+
+  /**
+   * (Experimental) re-install the menu if an off the selectors change.
+   * @see if
+   */
+  dependencies?: string[];
+
+  /**
+   * True if caption is determined dynamically (using the reader and templating)
+   */
   dynamicCaption?: boolean;
 
   onError?: MessageConfig;
   onCancel?: MessageConfig;
   onSuccess?: MessageConfig;
-}
+};
 
 export const actionSchema: Schema = {
   oneOf: [

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -55,13 +55,13 @@ import { reportEvent } from "@/telemetry/events";
 import { notifyError } from "@/contentScript/notify";
 import iconAsSVG from "@/icons/svgIcons";
 
-export interface PanelConfig {
+export type PanelConfig = {
   heading?: string;
   body: BlockConfig | BlockPipeline;
   icon?: IconConfig;
   collapsible?: boolean;
   shadowDOM?: boolean;
-}
+};
 
 const RENDER_LOOP_THRESHOLD = 25;
 const RENDER_LOOP_WINDOW_MS = 500;

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -51,9 +51,9 @@ import { notifyError } from "@/contentScript/notify";
 // @ts-ignore: using for the EventHandler type below
 import JQuery from "jquery";
 
-export interface TriggerConfig {
+export type TriggerConfig = {
   action: BlockPipeline | BlockConfig;
-}
+};
 
 export type Trigger = "load" | "click" | "dblclick" | "mouseover" | "appear";
 

--- a/src/hooks/useDeployments.ts
+++ b/src/hooks/useDeployments.ts
@@ -23,10 +23,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { fromPairs } from "lodash";
 import { reportEvent } from "@/telemetry/events";
 import { optionsSlice } from "@/options/slices";
-import {
-  InstalledExtension,
-  selectInstalledExtensions,
-} from "@/options/selectors";
+import { selectInstalledExtensions } from "@/options/selectors";
 import { getErrorMessage } from "@/errors";
 import useNotifications from "@/hooks/useNotifications";
 import { getExtensionToken } from "@/auth/token";
@@ -38,6 +35,7 @@ import { refreshRegistries } from "@/hooks/useRefresh";
 import { Dispatch } from "redux";
 import { mergePermissions } from "@/utils/permissions";
 import { Permissions } from "webextension-polyfill-ts";
+import { IExtension } from "@/core";
 
 const { actions } = optionsSlice;
 
@@ -54,7 +52,7 @@ async function selectDeploymentPermissions(
 }
 
 async function fetchDeployments(
-  installedExtensions: InstalledExtension[]
+  installedExtensions: IExtension[]
 ): Promise<Deployment[]> {
   const token = await getExtensionToken();
   const { data: deployments } = await axios.post<Deployment[]>(
@@ -71,7 +69,7 @@ async function fetchDeployments(
   return deployments;
 }
 
-const makeUpdatedFilter = (installed: InstalledExtension[]) => (
+const makeUpdatedFilter = (installed: IExtension[]) => (
   deployment: Deployment
 ) => {
   const match = installed.find(
@@ -86,7 +84,7 @@ const makeUpdatedFilter = (installed: InstalledExtension[]) => (
 function activateDeployments(
   dispatch: Dispatch,
   deployments: Deployment[],
-  installed: InstalledExtension[]
+  installed: IExtension[]
 ) {
   for (const deployment of deployments) {
     // Clear existing installs of the blueprint

--- a/src/hooks/useExtensionMeta.ts
+++ b/src/hooks/useExtensionMeta.ts
@@ -16,13 +16,11 @@
  */
 
 import { useSelector } from "react-redux";
-import {
-  InstalledExtension,
-  selectInstalledExtensions,
-} from "@/options/selectors";
+import { selectInstalledExtensions } from "@/options/selectors";
 import { useMemo } from "react";
+import { IExtension } from "@/core";
 
-function useExtensionMeta(): { lookup: Map<string, InstalledExtension> } {
+function useExtensionMeta(): { lookup: Map<string, IExtension> } {
   const extensions = useSelector(selectInstalledExtensions);
   const lookup = useMemo(() => new Map(extensions.map((x) => [x.id, x])), [
     extensions,

--- a/src/nativeEditor/dynamic.ts
+++ b/src/nativeEditor/dynamic.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { IExtension, IExtensionPoint, IReader } from "@/core";
+import { EmptyConfig, IExtension, IExtensionPoint, IReader } from "@/core";
 import { liftContentScript } from "@/contentScript/backgroundProtocol";
 import {
   clearDynamic,
@@ -50,8 +50,7 @@ export type ElementType =
 
 export interface DynamicDefinition<
   TExtensionPoint extends ExtensionPointDefinition = ExtensionPointDefinition,
-  // eslint-disable-next-line @typescript-eslint/ban-types -- don't assume anything about keys
-  TExtension extends object = object,
+  TExtension extends EmptyConfig = EmptyConfig,
   TReader extends ReaderDefinition = ReaderDefinition
 > {
   type: ElementType;

--- a/src/nativeEditor/dynamic.ts
+++ b/src/nativeEditor/dynamic.ts
@@ -50,7 +50,8 @@ export type ElementType =
 
 export interface DynamicDefinition<
   TExtensionPoint extends ExtensionPointDefinition = ExtensionPointDefinition,
-  TExtension = unknown,
+  // eslint-disable-next-line @typescript-eslint/ban-types -- don't assume anything about keys
+  TExtension extends object = object,
   TReader extends ReaderDefinition = ReaderDefinition
 > {
   type: ElementType;
@@ -147,15 +148,12 @@ export const enableOverlay = liftContentScript(
   }
 );
 
-export const disableOverlay = liftContentScript(
-  "DISABLE_OVERLAY",
-  async () => {
-    if (_overlay != null) {
-      _overlay.remove();
-      _overlay = null;
-    }
+export const disableOverlay = liftContentScript("DISABLE_OVERLAY", async () => {
+  if (_overlay != null) {
+    _overlay.remove();
+    _overlay = null;
   }
-);
+});
 
 export const checkAvailable = liftContentScript(
   "CHECK_AVAILABLE",

--- a/src/nativeEditor/index.ts
+++ b/src/nativeEditor/index.ts
@@ -22,7 +22,6 @@ export {
   updateDynamicElement,
   checkAvailable,
   getInstalledExtensionPointIds,
-  DynamicDefinition,
 } from "./dynamic";
 export { insertButton, dragButton } from "./insertButton";
 export { insertPanel } from "./insertPanel";

--- a/src/options/loader.ts
+++ b/src/options/loader.ts
@@ -15,35 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Metadata, ServiceDependency } from "@/core";
-import { Permissions, browser } from "webextension-polyfill-ts";
-import { Primitive } from "type-fest";
+import { browser } from "webextension-polyfill-ts";
 
 const STORAGE_KEY = "persist:extensionOptions";
 const INITIAL_STATE = JSON.stringify({});
 
-export interface ExtensionOptions {
-  id: string;
-  _recipeId?: string;
-  _recipe: Metadata | null;
-  _deployment?: {
-    id: string;
-    timestamp: string;
-  };
-  extensionPointId: string;
-  active: boolean;
-  label: string;
-  permissions?: Permissions.Permissions;
-  services: ServiceDependency[];
-  optionsArgs?: Record<string, Primitive>;
-  config: { [prop: string]: unknown };
-}
-
-type ExtensionOptionState = {
-  extensions: Record<string, Record<string, ExtensionOptions>>;
+type State = {
+  extensions: Record<string, Record<string, unknown>>;
 };
 
 type JSONString = string;
+
 type RawOptionsState = Record<string, JSONString>;
 
 async function getOptionsState(): Promise<RawOptionsState> {
@@ -57,7 +39,7 @@ async function getOptionsState(): Promise<RawOptionsState> {
 /**
  * Read extension options from local storage
  */
-export async function loadOptions(): Promise<ExtensionOptionState> {
+export async function loadOptions(): Promise<State> {
   const base = await getOptionsState();
   // The redux persist layer persists the extensions value as as JSON-string
   return { extensions: JSON.parse(base.extensions) };
@@ -66,7 +48,7 @@ export async function loadOptions(): Promise<ExtensionOptionState> {
 /**
  * Save extension options to local storage
  */
-export async function saveOptions(state: ExtensionOptionState): Promise<void> {
+export async function saveOptions(state: State): Promise<void> {
   const base = await getOptionsState();
   await browser.storage.local.set({
     // The redux persist layer persists the extensions value as as JSON-string

--- a/src/options/loader.ts
+++ b/src/options/loader.ts
@@ -16,12 +16,13 @@
  */
 
 import { browser } from "webextension-polyfill-ts";
+import { IExtension } from "@/core";
 
 const STORAGE_KEY = "persist:extensionOptions";
 const INITIAL_STATE = JSON.stringify({});
 
 type State = {
-  extensions: Record<string, Record<string, unknown>>;
+  extensions: Record<string, Record<string, IExtension>>;
 };
 
 type JSONString = string;

--- a/src/options/pages/MarketplacePage.tsx
+++ b/src/options/pages/MarketplacePage.tsx
@@ -54,7 +54,7 @@ export default connect(
     installedRecipes: new Set(
       Object.values(options.extensions).flatMap((extensionPoint) =>
         Object.values(extensionPoint)
-          .map((x) => x._recipeId)
+          .map((x) => x._recipe?.id)
           .filter((x) => x)
       )
     ),

--- a/src/options/pages/brickEditor/EditPage.tsx
+++ b/src/options/pages/brickEditor/EditPage.tsx
@@ -66,7 +66,7 @@ function useParseBrick(config: string | null): ParsedBrickInfo {
       return {
         isBlueprint: true,
         isInstalled: extensions.some(
-          (x) => x._recipeId === configJSON.metadata?.id
+          (x) => x._recipe?.id === configJSON.metadata?.id
         ),
         config: configJSON,
       };

--- a/src/options/pages/extensionEditor/ExtensionEditor.tsx
+++ b/src/options/pages/extensionEditor/ExtensionEditor.tsx
@@ -115,7 +115,7 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
     <ExtensionPointDetail
       initialValue={{
         label: extensionConfig?.label,
-        config: extensionConfig?.config,
+        config: extensionConfig?.config as Record<string, unknown>,
         services: extensionConfig?.services ?? [],
         optionsArgs: extensionConfig?.optionsArgs ?? {},
       }}

--- a/src/options/pages/extensionEditor/ExtensionEditor.tsx
+++ b/src/options/pages/extensionEditor/ExtensionEditor.tsx
@@ -115,7 +115,7 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
     <ExtensionPointDetail
       initialValue={{
         label: extensionConfig?.label,
-        config: extensionConfig?.config as Record<string, unknown>,
+        config: extensionConfig?.config,
         services: extensionConfig?.services ?? [],
         optionsArgs: extensionConfig?.optionsArgs ?? {},
       }}

--- a/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
+++ b/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
@@ -24,17 +24,17 @@ import {
   faEdit,
   faTimesCircle,
 } from "@fortawesome/free-solid-svg-icons";
-import { Form, Row, Col, Card, Nav, Button } from "react-bootstrap";
+import { Button, Card, Col, Form, Nav, Row } from "react-bootstrap";
 import ServicesFormCard from "@/options/pages/extensionEditor/ServicesFormCard";
 import ExtensionConfigurationCard from "@/options/pages/extensionEditor/ExtensionConfigurationCard";
-import { IExtensionPoint, UserOptions, ServiceDependency } from "@/core";
+import { IExtensionPoint, ServiceDependency, UserOptions } from "@/core";
 import DataSourceCard from "@/options/pages/extensionEditor/DataSourceCard";
 import { Formik, FormikProps, getIn, useFormikContext } from "formik";
 import TextField from "@/components/fields/TextField";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { extensionValidatorFactory } from "@/validators/validation";
 import { SCHEMA_TYPE_TO_BLOCK_PROPERTY } from "@/components/fields/BlockField";
-import { castArray, isEmpty, fromPairs, truncate } from "lodash";
+import { castArray, fromPairs, isEmpty, truncate } from "lodash";
 import useAsyncEffect from "use-async-effect";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import RunLogCard from "@/options/pages/extensionEditor/RunLogCard";
@@ -43,14 +43,14 @@ import { useDispatch } from "react-redux";
 import { push as navigate } from "connected-react-router";
 import { useAsyncState } from "@/hooks/common";
 import { saveAs } from "file-saver";
-import { useToasts } from "react-toast-notifications";
-import { reportError } from "@/telemetry/logging";
 import { configToYaml } from "@/devTools/editor/hooks/useCreate";
 import OptionsArgsCard from "@/options/pages/extensionEditor/OptionsArgsCard";
 import { useTitle } from "@/hooks/title";
 import { HotKeys } from "react-hotkeys";
+import { getErrorMessage } from "@/errors";
+import useNotifications from "@/hooks/useNotifications";
 
-type TopConfig = { [prop: string]: unknown };
+type TopConfig = Record<string, unknown>;
 
 export interface Config {
   config: TopConfig;
@@ -79,7 +79,7 @@ const labelSchema = {
  * - Cast block $ref fields to arrays to they can support combinations.
  */
 function normalizeConfig(
-  config: TopConfig = {},
+  config: TopConfig,
   extensionPoint: IExtensionPoint
 ): TopConfig {
   const schema = extensionPoint.inputSchema;
@@ -172,7 +172,7 @@ const ExtensionForm: React.FunctionComponent<{
   extensionId,
 }) => {
   useTitle(
-    `Configure ${truncate(!isEmpty(values.label) ? values.label : "Brick", {
+    `Configure ${truncate(isEmpty(values.label) ? "Brick" : values.label, {
       length: 15,
     })}`
   );
@@ -183,7 +183,7 @@ const ExtensionForm: React.FunctionComponent<{
 
   const dispatch = useDispatch();
 
-  const { addToast } = useToasts();
+  const notify = useNotifications();
 
   useAsyncEffect(async () => {
     await validateForm();
@@ -193,13 +193,11 @@ const ExtensionForm: React.FunctionComponent<{
     try {
       exportBlueprint(values, extensionPoint);
     } catch (error: unknown) {
-      reportError(error);
-      addToast(`Error exporting as blueprint: ${error}`, {
-        appearance: "error",
-        autoDismiss: true,
+      notify.error(`Error exporting as blueprint: ${getErrorMessage(error)}`, {
+        error,
       });
     }
-  }, [addToast, values, extensionPoint]);
+  }, [notify, values, extensionPoint]);
 
   const hasOptions = !isEmpty(values.optionsArgs);
 

--- a/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
+++ b/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
@@ -27,7 +27,7 @@ import {
 import { Form, Row, Col, Card, Nav, Button } from "react-bootstrap";
 import ServicesFormCard from "@/options/pages/extensionEditor/ServicesFormCard";
 import ExtensionConfigurationCard from "@/options/pages/extensionEditor/ExtensionConfigurationCard";
-import { IExtensionPoint, OptionsArgs, ServiceDependency } from "@/core";
+import { IExtensionPoint, UserOptions, ServiceDependency } from "@/core";
 import DataSourceCard from "@/options/pages/extensionEditor/DataSourceCard";
 import { Formik, FormikProps, getIn, useFormikContext } from "formik";
 import TextField from "@/components/fields/TextField";
@@ -56,7 +56,7 @@ export interface Config {
   config: TopConfig;
   label: string;
   services: ServiceDependency[];
-  optionsArgs: OptionsArgs;
+  optionsArgs: UserOptions;
 }
 
 interface OwnProps {

--- a/src/options/pages/extensionEditor/OptionsArgsCard.tsx
+++ b/src/options/pages/extensionEditor/OptionsArgsCard.tsx
@@ -18,13 +18,13 @@
 import React from "react";
 
 import { useField } from "formik";
-import { OptionsArgs } from "@/core";
+import { UserOptions } from "@/core";
 import { Card, Table } from "react-bootstrap";
 
 const OptionsArgsCard: React.FunctionComponent<{
   name: string;
 }> = (props) => {
-  const [field] = useField<OptionsArgs>(props);
+  const [field] = useField<UserOptions>(props);
 
   return (
     <div className="OptionsArgsCard">

--- a/src/options/pages/installed/InstalledPage.tsx
+++ b/src/options/pages/installed/InstalledPage.tsx
@@ -23,7 +23,7 @@ import { PageTitle } from "@/layout/Page";
 import { faCubes } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 import { Card, Col, Row, Table } from "react-bootstrap";
-import { ExtensionIdentifier } from "@/core";
+import { ExtensionIdentifier, IExtension } from "@/core";
 import "./InstalledPage.scss";
 import { uninstallContextMenu } from "@/background/contextMenus";
 import { reportError } from "@/telemetry/logging";
@@ -31,10 +31,7 @@ import AuthContext from "@/auth/AuthContext";
 import { reportEvent } from "@/telemetry/events";
 import { reactivate } from "@/background/navigation";
 import { Dispatch } from "redux";
-import {
-  InstalledExtension,
-  selectInstalledExtensions,
-} from "@/options/selectors";
+import { selectInstalledExtensions } from "@/options/selectors";
 import { useTitle } from "@/hooks/title";
 import NoExtensionsPage from "@/options/pages/installed/NoExtensionsPage";
 import RecipeEntry from "@/options/pages/installed/RecipeEntry";
@@ -44,7 +41,7 @@ const { removeExtension } = optionsSlice.actions;
 type RemoveAction = (identifier: ExtensionIdentifier) => void;
 
 const InstalledTable: React.FunctionComponent<{
-  extensions: InstalledExtension[];
+  extensions: IExtension[];
   onRemove: RemoveAction;
 }> = ({ extensions, onRemove }) => {
   const recipeExtensions = useMemo(
@@ -86,7 +83,7 @@ const InstalledTable: React.FunctionComponent<{
 };
 
 const InstalledPage: React.FunctionComponent<{
-  extensions: InstalledExtension[];
+  extensions: IExtension[];
   onRemove: RemoveAction;
 }> = ({ extensions, onRemove }) => {
   useTitle("Active Bricks");

--- a/src/options/pages/installed/RecipeEntry.tsx
+++ b/src/options/pages/installed/RecipeEntry.tsx
@@ -16,7 +16,6 @@
  */
 
 import React, { useCallback, useMemo, useState } from "react";
-import { InstalledExtension } from "@/options/selectors";
 import { reportError } from "@/telemetry/logging";
 import { getErrorMessage } from "@/errors";
 import cx from "classnames";
@@ -27,7 +26,7 @@ import {
   faCheck,
 } from "@fortawesome/free-solid-svg-icons";
 import AsyncButton from "@/components/AsyncButton";
-import { ExtensionIdentifier } from "@/core";
+import { ExtensionIdentifier, IExtension } from "@/core";
 import ExtensionRow from "@/options/pages/installed/ExtensionRow";
 import useNotifications from "@/hooks/useNotifications";
 import useExtensionPermissions from "@/options/pages/installed/useExtensionPermissions";
@@ -36,7 +35,7 @@ type RemoveAction = (identifier: ExtensionIdentifier) => void;
 
 const RecipeEntry: React.FunctionComponent<{
   recipeId: string;
-  extensions: InstalledExtension[];
+  extensions: IExtension[];
   onRemove: RemoveAction;
 }> = ({ recipeId, extensions, onRemove }) => {
   const notify = useNotifications();
@@ -50,7 +49,7 @@ const RecipeEntry: React.FunctionComponent<{
   );
 
   const removeMany = useCallback(
-    async (extensions: InstalledExtension[], name: string) => {
+    async (extensions: IExtension[], name: string) => {
       try {
         for (const { id: extensionId, extensionPointId } of extensions) {
           onRemove({ extensionId, extensionPointId });

--- a/src/options/pages/templates/TemplatesPage.tsx
+++ b/src/options/pages/templates/TemplatesPage.tsx
@@ -407,7 +407,7 @@ export default connect(
     installedRecipes: new Set(
       Object.values(options.extensions).flatMap((extensionPoint) =>
         Object.values(extensionPoint)
-          .map((x) => x._recipeId)
+          .map((x) => x._recipe?.id)
           .filter((x) => x)
       )
     ),

--- a/src/options/selectors.ts
+++ b/src/options/selectors.ts
@@ -18,16 +18,11 @@
 import { OptionsState } from "@/options/slices";
 import { IExtension } from "@/core";
 
-export type RecipeContext = {
-  id: string;
-  name: string;
-};
-
 export function selectExtensions({
   options,
 }: {
   options: OptionsState;
-}): Array<IExtension<Record<string, unknown>>> {
+}): IExtension[] {
   return Object.values(options.extensions).flatMap((extensionPointOptions) =>
     Object.values(extensionPointOptions)
   );

--- a/src/options/selectors.ts
+++ b/src/options/selectors.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ExtensionOptions, OptionsState } from "@/options/slices";
+import { OptionsState } from "@/options/slices";
 import { IExtension } from "@/core";
 
 export type RecipeContext = {
@@ -23,18 +23,11 @@ export type RecipeContext = {
   name: string;
 };
 
-/**
- * Extension with additional metadata about how it was installed.
- */
-export interface InstalledExtension extends IExtension {
-  _recipe: RecipeContext | null;
-}
-
 export function selectExtensions({
   options,
 }: {
   options: OptionsState;
-}): ExtensionOptions[] {
+}): Array<IExtension<Record<string, unknown>>> {
   return Object.values(options.extensions).flatMap((extensionPointOptions) =>
     Object.values(extensionPointOptions)
   );
@@ -42,7 +35,7 @@ export function selectExtensions({
 
 export function selectInstalledExtensions(state: {
   options: OptionsState;
-}): InstalledExtension[] {
+}): IExtension[] {
   return Object.entries(state.options.extensions).flatMap(
     ([extensionPointId, pointExtensions]) =>
       Object.entries(pointExtensions).map(([extensionId, extension]) => ({

--- a/src/options/slices.ts
+++ b/src/options/slices.ts
@@ -17,17 +17,10 @@
 
 import { v4 as uuidv4 } from "uuid";
 import { createSlice } from "@reduxjs/toolkit";
-import {
-  DeploymentContext,
-  Metadata,
-  RawServiceConfiguration,
-  ServiceDependency,
-} from "@/core";
+import { IExtension, RawServiceConfiguration } from "@/core";
 import { orderBy } from "lodash";
-import { Permissions } from "webextension-polyfill-ts";
 import { reportEvent } from "@/telemetry/events";
 import { preloadMenus } from "@/background/preload";
-import { Primitive } from "type-fest";
 import { selectEventData } from "@/telemetry/deployments";
 
 type InstallMode = "local" | "remote";
@@ -58,27 +51,10 @@ const initialServicesState: ServicesState = {
   configured: {},
 };
 
-type BaseConfig = Record<string, unknown>;
-type UserOptions = Record<string, Primitive>;
-
-export interface ExtensionOptions<TConfig = BaseConfig> {
-  id: string;
-  _deployment?: DeploymentContext;
-  _recipeId?: string;
-  _recipe: Metadata | null;
-  extensionPointId: string;
-  active: boolean;
-  label: string;
-  optionsArgs?: UserOptions;
-  permissions?: Permissions.Permissions;
-  services: ServiceDependency[];
-  config: TConfig;
-}
-
 export interface OptionsState {
   extensions: {
     [extensionPointId: string]: {
-      [extensionId: string]: ExtensionOptions;
+      [extensionId: string]: IExtension;
     };
   };
 }
@@ -189,10 +165,6 @@ export const optionsSlice = createSlice({
     resetOptions(state) {
       state.extensions = {};
     },
-    toggleExtension(state, { payload }) {
-      const { extensionPointId, extensionId, active } = payload;
-      state.extensions[extensionPointId][extensionId].active = active;
-    },
     installRecipe(state, { payload }) {
       const {
         recipe,
@@ -216,7 +188,7 @@ export const optionsSlice = createSlice({
           state.extensions[extensionPointId] = {};
         }
 
-        const extensionConfig: ExtensionOptions = {
+        const extensionConfig: IExtension = {
           id: extensionId,
           _deployment: deployment
             ? {
@@ -224,7 +196,6 @@ export const optionsSlice = createSlice({
                 timestamp: deployment.updated_at,
               }
             : undefined,
-          _recipeId: recipe.metadata.id,
           _recipe: recipe.metadata,
           optionsArgs,
           services: Object.entries(services ?? {}).map(
@@ -236,7 +207,6 @@ export const optionsSlice = createSlice({
           ),
           label,
           extensionPointId,
-          active: true,
           config,
         };
 
@@ -275,7 +245,6 @@ export const optionsSlice = createSlice({
         label,
         optionsArgs,
         services,
-        active: true,
         config,
       };
     },

--- a/src/pages/marketplace/useReinstall.ts
+++ b/src/pages/marketplace/useReinstall.ts
@@ -20,8 +20,9 @@ import { useDispatch, useSelector } from "react-redux";
 import { selectExtensions } from "@/options/selectors";
 import { useCallback } from "react";
 import { uninstallContextMenu } from "@/background/contextMenus";
-import { ExtensionOptions, optionsSlice } from "@/options/slices";
+import { optionsSlice } from "@/options/slices";
 import { groupBy, uniq } from "lodash";
+import { IExtension } from "@/core";
 
 const { installRecipe, removeExtension } = optionsSlice.actions;
 
@@ -29,9 +30,7 @@ type Reinstall = (recipe: RecipeDefinition) => Promise<void>;
 
 type ServiceId = string;
 
-function selectAuths(
-  extensions: ExtensionOptions[]
-): Record<ServiceId, string> {
+function selectAuths(extensions: IExtension[]): Record<ServiceId, string> {
   const serviceAuths = groupBy(
     extensions.flatMap((x) => x.services),
     (x) => x.id
@@ -59,7 +58,7 @@ function useReinstall(): Reinstall {
   return useCallback(
     async (recipe: RecipeDefinition) => {
       const recipeExtensions = extensions.filter(
-        (x) => x._recipeId === recipe.metadata.id
+        (x) => x._recipe?.id === recipe.metadata.id
       );
 
       if (recipeExtensions.length === 0) {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -19,13 +19,12 @@ import { useMemo } from "react";
 import extensionPointRegistry from "@/extensionPoints/registry";
 import { useSelector } from "react-redux";
 import { RootState } from "@/options/store";
-import { IExtensionPoint } from "@/core";
-import { ExtensionOptions } from "@/options/slices";
+import { IExtension, IExtensionPoint } from "@/core";
 import { useAsyncState } from "@/hooks/common";
 
 interface ExtensionResult {
   extensionPoint: IExtensionPoint | null;
-  extensionConfig: ExtensionOptions;
+  extensionConfig: IExtension;
   isPending: boolean;
 }
 

--- a/src/telemetry/deployments.ts
+++ b/src/telemetry/deployments.ts
@@ -1,15 +1,11 @@
-import { IExtension, Metadata } from "@/core";
+import { IExtension } from "@/core";
 import { JsonObject } from "type-fest";
-
-// FIXME: we have inconsistent typing of extensions, e.g., IExtension, InstalledExtension, ExtensionOptions. So handle
-//  common shape without referencing those modules: https://github.com/pixiebrix/pixiebrix-extension/issues/893
-type Extension = IExtension & { _recipe?: Metadata };
 
 /**
  * Select data to report to the team admins for the deployment
  */
 export function selectEventData(
-  extension: Extension | null | undefined
+  extension: IExtension | null | undefined
 ): JsonObject {
   if (extension == null) {
     return {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@
  */
 
 import {
-  BaseExtensionConfig,
+  EmptyConfig,
   BlockArg,
   BlockIcon,
   BlockOptions,
@@ -89,7 +89,7 @@ export abstract class Service<
   ): AxiosRequestConfig;
 }
 
-export abstract class ExtensionPoint<TConfig extends BaseExtensionConfig>
+export abstract class ExtensionPoint<TConfig extends EmptyConfig>
   implements IExtensionPoint {
   public readonly id: string;
 


### PR DESCRIPTION
Changes:
- Consolidate IExtension variant types (removes ExtensionOptions and InstalledExtension)
- Drops a couple of unused fields: `active`, `_recipeId` on IExtension
- Improve default type for IExtension config

Also:
- Fixes TypeScript (or is it Webpack?) warning about DynamicEntry not being defined by not re-exporting it from index.ts. This should hopefully resolve the Webpack build notification bug

Thoughts:
- These types are still error-prone, as remembering to use `?.` on the `_recipe` field is tricky. More motivation for #775 