### PR TITLE
Avoid duplicate type annotations on CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: CI
 
 on: [push]
 
@@ -25,7 +25,7 @@ jobs:
           node-version: "16"
           cache: npm
       - run: npm ci
-      - run: npm run build
+      - run: npm run build:webpack
         env:
           ENVIRONMENT: staging
           EXTERNALLY_CONNECTABLE: ${{ secrets.STAGING_SERVICE_URL }}*,http://127.0.0.1/*


### PR DESCRIPTION
The `build` script includes type-checking too, but on CI that's already part of its own job (#1061)

<img width="641" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/129465612-5c8f3588-9ca3-4ee7-838d-e0dbe0187932.png">
