### PR TITLE
Disable `filenames/match-exported` in files where we ignore it

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,9 @@
     "plugin:jsx-a11y/recommended"
   ],
   "rules": {
-    "filenames/match-exported": "warn",
+    // Enable extra rules
+    "filenames/match-exported": "error",
+
     // Customize some rules
     "import/no-unresolved": [
       "error",

--- a/src/__mocks__/iconsMock.ts
+++ b/src/__mocks__/iconsMock.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/background/firefoxCompat.ts
+++ b/src/background/firefoxCompat.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/background/iframes.ts
+++ b/src/background/iframes.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/background/navigation.ts
+++ b/src/background/navigation.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/baseRegistry.ts
+++ b/src/baseRegistry.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/blocks/renderers/dataTable.ts
+++ b/src/blocks/renderers/dataTable.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/components/fields/UnknownField.tsx
+++ b/src/components/fields/UnknownField.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/components/fields/blockOptions.tsx
+++ b/src/components/fields/blockOptions.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/contentScript/backgroundProtocol.ts
+++ b/src/contentScript/backgroundProtocol.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/contentScript/errors.ts
+++ b/src/contentScript/errors.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/contrib/zapier/pushOptions.tsx
+++ b/src/contrib/zapier/pushOptions.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/devTools/editor/extensionPoints/actionPanel.tsx
+++ b/src/devTools/editor/extensionPoints/actionPanel.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/devTools/editor/extensionPoints/contextMenu.tsx
+++ b/src/devTools/editor/extensionPoints/contextMenu.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/devTools/editor/extensionPoints/menuItem.ts
+++ b/src/devTools/editor/extensionPoints/menuItem.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/devTools/editor/extensionPoints/panel.ts
+++ b/src/devTools/editor/extensionPoints/panel.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/devTools/editor/extensionPoints/trigger.tsx
+++ b/src/devTools/editor/extensionPoints/trigger.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/devTools/editor/fields/Fields.tsx
+++ b/src/devTools/editor/fields/Fields.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/devTools/editor/panes/NoExtensionsSelectedPane.tsx
+++ b/src/devTools/editor/panes/NoExtensionsSelectedPane.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/devTools/editor/tabs/panel/PanelTab.tsx
+++ b/src/devTools/editor/tabs/panel/PanelTab.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/frameworks/adapters.ts
+++ b/src/frameworks/adapters.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/frameworks/contrib/angularjs.ts
+++ b/src/frameworks/contrib/angularjs.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/frameworks/contrib/ember.ts
+++ b/src/frameworks/contrib/ember.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/frameworks/contrib/react.ts
+++ b/src/frameworks/contrib/react.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/frameworks/contrib/vue.ts
+++ b/src/frameworks/contrib/vue.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/icons/svgElementFromUrl.ts
+++ b/src/icons/svgElementFromUrl.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/icons/svgIcons.ts
+++ b/src/icons/svgIcons.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/options/pages/brickEditor/Sharing.tsx
+++ b/src/options/pages/brickEditor/Sharing.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -1,3 +1,4 @@
+/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *


### PR DESCRIPTION
Follows:

- #899 

If we're going to keep the rule, then we should just disable it where it's not used and enforce it elsewhere.

Current output:

```
src/__mocks__/iconsMock.ts
  18:1  warning  Filename 'iconsMock' must match the exported name 'iconAsSVG'  filenames/match-exported

src/background/deployment.ts
  18:1  warning  Filename 'deployment' must match the exported name 'initDeploymentUpdater'  filenames/match-exported

src/background/firefoxCompat.ts
  18:1  warning  Filename 'firefoxCompat' must match the exported name 'initFirefoxCompat'  filenames/match-exported

src/background/iframes.ts
  18:1  warning  Filename 'iframes' must match the exported name 'initFrames'  filenames/match-exported

src/background/navigation.ts
  18:1  warning  Filename 'navigation' must match the exported name 'initNavigation'  filenames/match-exported

src/baseRegistry.ts
  18:1  warning  Filename 'baseRegistry' must match the exported name 'Registry'  filenames/match-exported

src/blocks/renderers/dataTable.ts
  18:1  warning  Filename 'dataTable' must match the exported name 'makeDataTable'  filenames/match-exported

src/components/fields/UnknownField.tsx
  18:1  warning  Filename 'UnknownField' must match the exported name 'UnsupportedField'  filenames/match-exported

src/components/fields/blockOptions.tsx
  18:1  warning  Filename 'blockOptions' must match the exported name 'genericOptionsFactory'  filenames/match-exported

src/contentScript/backgroundProtocol.ts
  18:1  warning  Filename 'backgroundProtocol' must match the exported name 'addContentScriptListener'  filenames/match-exported

src/contentScript/errors.ts
  18:1  warning  Filename 'errors' must match the exported name 'addErrorListeners'  filenames/match-exported

src/contentScript/executor.ts
  18:1  warning  Filename 'executor' must match the exported name 'addExecutorListener'  filenames/match-exported

src/contrib/zapier/pushOptions.tsx
  18:1  warning  Filename 'pushOptions' must match the exported name 'PushOptions'  filenames/match-exported

src/devTools/editor/extensionPoints/actionPanel.tsx
  18:1  warning  Filename 'actionPanel' must match the exported name 'config'  filenames/match-exported

src/devTools/editor/extensionPoints/contextMenu.tsx
  18:1  warning  Filename 'contextMenu' must match the exported name 'config'  filenames/match-exported

src/devTools/editor/extensionPoints/menuItem.ts
  18:1  warning  Filename 'menuItem' must match the exported name 'config'  filenames/match-exported

src/devTools/editor/extensionPoints/panel.ts
  18:1  warning  Filename 'panel' must match the exported name 'config'  filenames/match-exported

src/devTools/editor/extensionPoints/trigger.tsx
  18:1  warning  Filename 'trigger' must match the exported name 'config'  filenames/match-exported

src/devTools/editor/fields/Fields.tsx
  18:1  warning  Filename 'Fields' must match the exported name 'devtoolFields'  filenames/match-exported

src/devTools/editor/panes/NoExtensionsSelectedPane.tsx
  18:1  warning  Filename 'NoExtensionsSelectedPane' must match the exported name 'NoExtensionSelectedPane'  filenames/match-exported

src/devTools/editor/tabs/panel/PanelTab.tsx
  18:1  warning  Filename 'PanelTab' must match the exported name 'PanelTeb'  filenames/match-exported

src/frameworks/adapters.ts
  18:1  warning  Filename 'adapters' must match the exported name 'FRAMEWORK_ADAPTERS'  filenames/match-exported

src/frameworks/contrib/angularjs.ts
  21:1  warning  Filename 'angularjs' must match the exported name 'adapter'  filenames/match-exported

src/frameworks/contrib/ember.ts
  21:1  warning  Filename 'ember' must match the exported name 'adapter'  filenames/match-exported

src/frameworks/contrib/react.ts
  18:1  warning  Filename 'react' must match the exported name 'adapter'  filenames/match-exported

src/frameworks/contrib/vue.ts
  22:1  warning  Filename 'vue' must match the exported name 'adapter'  filenames/match-exported

src/icons/svgElementFromUrl.ts
  18:1  warning  Filename 'svgElementFromUrl' must match the exported name 'fetchSVG'  filenames/match-exported

src/icons/svgIcons.ts
  18:1  warning  Filename 'svgIcons' must match the exported name 'iconAsSVG'  filenames/match-exported

src/options/pages/brickEditor/Sharing.tsx
  18:1  warning  Filename 'Sharing' must match the exported name 'SharingTable'  filenames/match-exported

src/services/locator.ts
  18:1  warning  Filename 'locator' must match the exported name 'LazyLocatorFactory'  filenames/match-exported
```