### PR TITLE
Don't upload extension artifacts for non-main CI builds

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,7 +39,7 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.STAGE_GOOGLE_API_KEY }}
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.STAGE_GOOGLE_OAUTH_CLIENT_ID }}
       - uses: actions/upload-artifact@v2
-        if: contains(github.ref, "release/") || startsWith(github.ref, "refs/tags")
+        if: contains(github.ref, 'release/') || startsWith(github.ref, 'refs/tags')
         with:
           name: build-staging
           path: dist

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,6 +39,7 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.STAGE_GOOGLE_API_KEY }}
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.STAGE_GOOGLE_OAUTH_CLIENT_ID }}
       - uses: actions/upload-artifact@v2
+        if: contains(github.ref, "release/") || startsWith(github.ref, "refs/tags")
         with:
           name: build-staging
           path: dist


### PR DESCRIPTION
- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/1063

I left the other upload as it's not on a slow path