### PR TITLE
#1076: nominal subtyping for ids

### DIFF
--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -17,7 +17,7 @@
 
 import { browser } from "webextension-polyfill-ts";
 import { reportError } from "@/telemetry/logging";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import {
   ActionPanelStore,
   PanelEntry,

--- a/src/background/devtools/external.ts
+++ b/src/background/devtools/external.ts
@@ -29,7 +29,7 @@ import {
   TabId,
 } from "@/background/devtools/contract";
 import { browser, Runtime, WebNavigation } from "webextension-polyfill-ts";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { SimpleEvent } from "@/hooks/events";
 import { forbidBackgroundPage } from "@/utils/expectContext";
 import { getErrorMessage } from "@/errors";

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -36,7 +36,7 @@ import {
 } from "@/background/devtools/contract";
 import { reportError } from "@/telemetry/logging";
 import { isBackgroundPage } from "webext-detect-page";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { callBackground } from "@/background/devtools/external";
 import { ensureContentScript } from "@/background/util";
 import * as nativeEditorProtocol from "@/nativeEditor";

--- a/src/background/locator.ts
+++ b/src/background/locator.ts
@@ -18,6 +18,7 @@
 import LazyLocatorFactory from "@/services/locator";
 import { liftBackground } from "@/background/protocol";
 import { isBackgroundPage } from "webext-detect-page";
+import { RegistryId, UUID } from "@/core";
 
 export const locator = new LazyLocatorFactory();
 
@@ -27,7 +28,8 @@ async function initLocator() {
 
 export const locate = liftBackground(
   "LOCATE_SERVICE",
-  async (serviceId: string, id: string | null) => locator.locate(serviceId, id)
+  async (serviceId: RegistryId, id: UUID | null) =>
+    locator.locate(serviceId, id)
 );
 
 type RefreshOptions = {

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { liftBackground } from "@/background/protocol";
 import { rollbar } from "@/telemetry/rollbar";
 import { MessageContext, Logger as ILogger, SerializedError } from "@/core";

--- a/src/background/preload.ts
+++ b/src/background/preload.ts
@@ -23,11 +23,11 @@ import {
 } from "@/extensionPoints/contextMenu";
 import { reportError } from "@/telemetry/logging";
 import { loadOptions } from "@/options/loader";
-import { EmptyConfig } from "@/core";
+import { EmptyConfig, RegistryId, UUID } from "@/core";
 
 type PreloadOptions<TConfig = EmptyConfig> = {
-  id: string;
-  extensionPointId: string;
+  id: UUID;
+  extensionPointId: RegistryId;
   config: TConfig;
 };
 

--- a/src/background/protocol.ts
+++ b/src/background/protocol.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { getChromeExtensionId, RuntimeNotFoundError } from "@/chrome";
 import { browser, Runtime } from "webextension-polyfill-ts";
 import { patternToRegex } from "webext-patterns";

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -17,7 +17,7 @@
 
 import { liftBackground } from "@/background/protocol";
 import { JsonObject } from "type-fest";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { debounce, uniq, throttle, compact } from "lodash";
 import { browser } from "webextension-polyfill-ts";
 import { readStorage, setStorage } from "@/chrome";

--- a/src/baseRegistry.ts
+++ b/src/baseRegistry.ts
@@ -104,7 +104,7 @@ export class Registry<TItem extends RegistryItem> {
    * @deprecated needed for header generation; will be removed in future versions
    */
   cached(): TItem[] {
-    return Object.values(this.cache);
+    return [...this.cache.values()];
   }
 
   /**
@@ -121,7 +121,7 @@ export class Registry<TItem extends RegistryItem> {
         }
       })
     );
-    return Object.values(this.cache);
+    return [...this.cache.values()];
   }
 
   register(...items: TItem[]): void {
@@ -173,7 +173,7 @@ export class Registry<TItem extends RegistryItem> {
 
       if (!this.kinds.has(item.kind)) {
         console.warn(
-          `Item ${item.metadata?.id ?? "<unknown>"} has kind ${
+          `Item ${item.metadata?.id ?? "[[unknown]]"} has kind ${
             item.kind
           }; expected: ${[...this.kinds.values()].join(", ")}`
         );

--- a/src/blocks/transformers/modal.tsx
+++ b/src/blocks/transformers/modal.tsx
@@ -21,7 +21,7 @@ import Form from "@rjsf/core";
 import { Transformer } from "@/types";
 import { BlockArg, Schema } from "@/core";
 import { registerBlock } from "@/blocks/registry";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { BusinessError, CancelError } from "@/errors";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, unicorn/prefer-module

--- a/src/blocks/types.ts
+++ b/src/blocks/types.ts
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const PACKAGE_REGEX = /^((?<scope>@[\da-z~-][\d._a-z~-]*)\/)?((?<collection>[\da-z~-][\d._a-z~-]*)\/)?(?<name>[\da-z~-][\d._a-z~-]*)$/;
-
 export interface Availability {
   matchPatterns?: string | string[];
   selectors?: string | string[];

--- a/src/components/logViewer/LogTable.stories.tsx
+++ b/src/components/logViewer/LogTable.stories.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import LogTable from "@/components/logViewer/LogTable";
 import { serializeError } from "serialize-error";
 import { Card } from "react-bootstrap";

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -15,9 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { uuidv4 } from "@/types/helpers";
+
 const start = Date.now();
 
-import { v4 as uuidv4 } from "uuid";
 import "@/extensionContext";
 import addErrorListeners from "@/contentScript/errors";
 import "@/blocks";

--- a/src/contentScript/context.ts
+++ b/src/contentScript/context.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 
 export const sessionId = uuidv4();
 export const sessionTimestamp = new Date();

--- a/src/contentScript/externalProtocol.ts
+++ b/src/contentScript/externalProtocol.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import {
   HandlerEntry,
   HandlerOptions,

--- a/src/contrib/uipath/embedApp.ts
+++ b/src/contrib/uipath/embedApp.ts
@@ -19,7 +19,7 @@ import { Renderer } from "@/types";
 import { registerBlock } from "@/blocks/registry";
 import { isEmpty } from "lodash";
 import { BlockArg, BlockOptions, Schema } from "@/core";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { browser, Permissions } from "webextension-polyfill-ts";
 import { executeForNonce } from "@/background/executor";
 

--- a/src/contrib/zapier/push.ts
+++ b/src/contrib/zapier/push.ts
@@ -24,7 +24,7 @@ import { getBaseURL } from "@/services/baseService";
 import { validateInput } from "@/validators/generic";
 import { Webhook } from "@/contrib/zapier/contract";
 import { Permissions } from "webextension-polyfill-ts";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { BusinessError } from "@/errors";
 
 export const ZAPIER_ID = "@pixiebrix/zapier/push-data";

--- a/src/devTools/context.ts
+++ b/src/devTools/context.ts
@@ -29,7 +29,7 @@ import useAsyncEffect from "use-async-effect";
 import { useAsyncState } from "@/hooks/common";
 import { FrameworkMeta } from "@/messaging/constants";
 import { reportError } from "@/telemetry/logging";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { useTabEventListener } from "@/hooks/events";
 import { sleep } from "@/utils";
 import { getErrorMessage } from "@/errors";

--- a/src/devTools/editor/extensionPoints/actionPanel.tsx
+++ b/src/devTools/editor/extensionPoints/actionPanel.tsx
@@ -44,7 +44,7 @@ import LogsTab from "@/devTools/editor/tabs/LogsTab";
 import { DynamicDefinition } from "@/nativeEditor/dynamic";
 import EffectTab from "@/devTools/editor/tabs/EffectTab";
 import MetaTab from "@/devTools/editor/tabs/MetaTab";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { getDomain } from "@/permissions/patterns";
 import { faColumns } from "@fortawesome/free-solid-svg-icons";
 import {

--- a/src/devTools/editor/extensionPoints/contextMenu.tsx
+++ b/src/devTools/editor/extensionPoints/contextMenu.tsx
@@ -28,7 +28,7 @@ import {
   selectIsAvailable,
   WizardStep,
 } from "@/devTools/editor/extensionPoints/base";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { DynamicDefinition } from "@/nativeEditor/dynamic";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import { castArray, identity, pickBy } from "lodash";

--- a/src/devTools/editor/extensionPoints/elementConfig.ts
+++ b/src/devTools/editor/extensionPoints/elementConfig.ts
@@ -17,7 +17,7 @@
 import React from "react";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { Runtime } from "webextension-polyfill-ts";
-import { IExtension, Metadata, Schema, ServiceDependency } from "@/core";
+import { IExtension, Metadata, Schema, ServiceDependency, UUID } from "@/core";
 import { FrameworkMeta } from "@/messaging/constants";
 import { DynamicDefinition } from "@/nativeEditor/dynamic";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
@@ -47,7 +47,7 @@ export interface ReaderFormState {
      */
     type: string | null;
     selector: string | null;
-    selectors: { [field: string]: string };
+    selectors: Record<string, string>;
     optional: boolean;
   };
 }
@@ -72,7 +72,7 @@ export interface BaseFormState {
   /**
    * The extension uuid
    */
-  readonly uuid: string;
+  readonly uuid: UUID;
 
   /**
    * The type of the extensionPoint

--- a/src/devTools/editor/extensionPoints/menuItem.ts
+++ b/src/devTools/editor/extensionPoints/menuItem.ts
@@ -48,7 +48,7 @@ import EffectTab from "@/devTools/editor/tabs/EffectTab";
 import LogsTab from "@/devTools/editor/tabs/LogsTab";
 import AvailabilityTab from "@/devTools/editor/tabs/AvailabilityTab";
 import MetaTab from "@/devTools/editor/tabs/MetaTab";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { getDomain } from "@/permissions/patterns";
 import { faMousePointer } from "@fortawesome/free-solid-svg-icons";
 import * as nativeOperations from "@/background/devtools";

--- a/src/devTools/editor/extensionPoints/panel.ts
+++ b/src/devTools/editor/extensionPoints/panel.ts
@@ -45,7 +45,7 @@ import { DynamicDefinition } from "@/nativeEditor/dynamic";
 import { PanelSelectionResult } from "@/nativeEditor/insertPanel";
 import EffectTab from "@/devTools/editor/tabs/EffectTab";
 import MetaTab from "@/devTools/editor/tabs/MetaTab";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { boolean } from "@/utils";
 import { getDomain } from "@/permissions/patterns";
 import { faWindowMaximize } from "@fortawesome/free-solid-svg-icons";

--- a/src/devTools/editor/extensionPoints/trigger.tsx
+++ b/src/devTools/editor/extensionPoints/trigger.tsx
@@ -28,7 +28,7 @@ import {
   selectIsAvailable,
   WizardStep,
 } from "@/devTools/editor/extensionPoints/base";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import {
   Trigger,
   TriggerConfig,

--- a/src/devTools/editor/tabs/ServicesTab.tsx
+++ b/src/devTools/editor/tabs/ServicesTab.tsx
@@ -24,7 +24,7 @@ import { useAuthOptions } from "@/options/pages/extensionEditor/ServiceAuthSelec
 import { head } from "lodash";
 import { ServiceDefinition } from "@/types/definitions";
 import ServiceModal from "@/components/fields/ServiceModal";
-import { PACKAGE_REGEX } from "@/blocks/types";
+import { PACKAGE_REGEX } from "@/types/helpers";
 import useFetch from "@/hooks/useFetch";
 import AsyncButton from "@/components/AsyncButton";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/extensionPoints/actionPanelExtension.ts
+++ b/src/extensionPoints/actionPanelExtension.ts
@@ -52,7 +52,7 @@ import {
 } from "@/actionPanel/native";
 import Mustache from "mustache";
 import { reportError } from "@/telemetry/logging";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { BusinessError, getErrorMessage } from "@/errors";
 import { HeadlessModeError } from "@/blocks/errors";
 import { selectExtensionContext } from "@/extensionPoints/helpers";

--- a/src/extensionPoints/factory.ts
+++ b/src/extensionPoints/factory.ts
@@ -33,6 +33,8 @@ const TYPE_MAP = {
 
 export function fromJS(config: ExtensionPointConfig): IExtensionPoint {
   if (config.kind !== "extensionPoint") {
+    // Is `never` due to check, but needed because this method is called dynamically
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     throw new Error(`Expected kind extensionPoint, got ${config.kind}`);
   }
 
@@ -42,5 +44,6 @@ export function fromJS(config: ExtensionPointConfig): IExtensionPoint {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- the factory methods perform validation
   return TYPE_MAP[config.definition.type](config as any);
 }

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { ExtensionPoint } from "@/types";
 import Mustache from "mustache";
 import { checkAvailable } from "@/blocks/available";

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { ExtensionPoint } from "@/types";
 import Mustache from "mustache";
 import { errorBoundary } from "@/blocks/renderers/common";

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -17,7 +17,10 @@
 
 import fs from "fs";
 import blockRegistry from "@/blocks/registry";
-import extensionPointRegistry from "@/extensionPoints/registry";
+
+// Import for side-effects (these modules register the blocks)
+// NOTE: we don't need to also include extensionPoints because we got rid of all the legacy hard-coded extension points
+// (e.g., the Pipedrive calendar extension point, and TechCrunch entity extension point)
 import "@/blocks";
 import "@/contrib";
 
@@ -40,39 +43,12 @@ const blockDefinitions = blockRegistry.cached().map((block) => ({
   outputSchema: block.outputSchema,
 }));
 
-console.log("got blockDefinitions:", blockDefinitions.length);
-
-const extensionPointDefinitions = extensionPointRegistry
-  .cached()
-  .map((block) => ({
-    apiVersion: "v1",
-    header: true,
-    kind: "extensionPoint",
-    metadata: {
-      id: block.id,
-      version: process.env.NPM_PACKAGE_VERSION,
-      name: block.name,
-      description: block.description,
-      author: block.author,
-    },
-    inputSchema: block.inputSchema,
-  }));
-
-console.log("got extensionPointDefinitions:", extensionPointDefinitions.length);
-
-const content = JSON.stringify([
-  ...blockDefinitions,
-  ...extensionPointDefinitions,
-]);
+console.log(`Number of block headers: ${blockDefinitions.length}`);
 
 if (blockDefinitions.length === 0) {
   throw new Error("No block definitions generated");
 }
 
-if (extensionPointDefinitions.length === 0) {
-  throw new Error("No extension point definitions generated");
-}
+fs.writeFileSync("headers.json", JSON.stringify(blockDefinitions));
 
-fs.writeFileSync("headers.json", content);
-
-console.log(`headers.json written to disk: ${content.length} bytes`);
+console.log("headers.json written to disk");

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -28,7 +28,7 @@ console.log(`version: ${process.env.NPM_PACKAGE_VERSION}`);
 const blockDefinitions = blockRegistry.cached().map((block) => ({
   apiVersion: "v1",
   header: true,
-  kind: (block as any).read ? "reader" : "component",
+  kind: "read" in block ? "reader" : "component",
   metadata: {
     id: block.id,
     version: process.env.NPM_PACKAGE_VERSION,
@@ -64,6 +64,15 @@ const content = JSON.stringify([
   ...blockDefinitions,
   ...extensionPointDefinitions,
 ]);
+
+if (blockDefinitions.length === 0) {
+  throw new Error("No block definitions generated");
+}
+
+if (extensionPointDefinitions.length === 0) {
+  throw new Error("No extension point definitions generated");
+}
+
 fs.writeFileSync("headers.json", content);
 
 console.log(`headers.json written to disk: ${content.length} bytes`);

--- a/src/nativeEditor/insertButton.tsx
+++ b/src/nativeEditor/insertButton.tsx
@@ -17,7 +17,7 @@
 
 // https://github.com/facebook/react/blob/7559722a865e89992f75ff38c1015a865660c3cd/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
 
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { liftContentScript } from "@/contentScript/backgroundProtocol";
 import { ElementInfo } from "./frameworks";
 import { userSelectElement } from "./selector";
@@ -31,6 +31,8 @@ import {
 import { html as beautifyHTML } from "js-beautify";
 import { DynamicDefinition } from "./dynamic";
 import dragula from "dragula";
+import { Except } from "type-fest";
+import { UUID } from "@/core";
 
 export const DEFAULT_ACTION_CAPTION = "Action";
 
@@ -39,18 +41,18 @@ export type ButtonDefinition = DynamicDefinition<
   MenuItemExtensionConfig
 >;
 
-export interface ButtonSelectionResult {
-  uuid: string;
-  menu: Omit<MenuDefinition, "defaultOptions" | "isAvailable" | "reader">;
+export type ButtonSelectionResult = {
+  uuid: UUID;
+  menu: Except<MenuDefinition, "defaultOptions" | "isAvailable" | "reader">;
   item: Pick<MenuItemExtensionConfig, "caption">;
   containerInfo: ElementInfo;
-}
+};
 
-export interface DragResult {
+export type DragResult = {
   target: ElementInfo;
   // Element to place the button before
   sibling: string[] | null;
-}
+};
 
 async function dragPromise(uuid: string): Promise<DragResult | null> {
   const drake = dragula({

--- a/src/nativeEditor/insertPanel.tsx
+++ b/src/nativeEditor/insertPanel.tsx
@@ -17,7 +17,7 @@
 
 // https://github.com/facebook/react/blob/7559722a865e89992f75ff38c1015a865660c3cd/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
 
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { liftContentScript } from "@/contentScript/backgroundProtocol";
 import { ElementInfo } from "./frameworks";
 import { userSelectElement } from "./selector";
@@ -25,18 +25,20 @@ import * as pageScript from "@/pageScript/protocol";
 import { findContainer, inferPanelHTML } from "./infer";
 import { html as beautifyHTML } from "js-beautify";
 import { PanelConfig, PanelDefinition } from "@/extensionPoints/panelExtension";
+import { Except } from "type-fest";
+import { UUID } from "@/core";
 
 const DEFAULT_PANEL_HEADING = "PixieBrix Panel";
 
-export interface PanelSelectionResult {
-  uuid: string;
-  foundation: Omit<
+export type PanelSelectionResult = {
+  uuid: UUID;
+  foundation: Except<
     PanelDefinition,
     "defaultOptions" | "isAvailable" | "reader"
   >;
-  panel: Omit<PanelConfig, "body">;
+  panel: Except<PanelConfig, "body">;
   containerInfo: ElementInfo;
-}
+};
 
 export const insertPanel = liftContentScript("INSERT_PANEL", async () => {
   const selected = await userSelectElement();

--- a/src/options/pages/extensionEditor/ExtensionEditor.tsx
+++ b/src/options/pages/extensionEditor/ExtensionEditor.tsx
@@ -17,7 +17,7 @@
 
 import React, { useCallback } from "react";
 import { useToasts } from "react-toast-notifications";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { connect } from "react-redux";
 import { optionsSlice } from "@/options/slices";
 import { push } from "connected-react-router";

--- a/src/options/pages/extensionEditor/ServicesFormCard.tsx
+++ b/src/options/pages/extensionEditor/ServicesFormCard.tsx
@@ -30,7 +30,7 @@ import ServiceAuthSelector, {
 import ServiceModal from "@/components/fields/ServiceModal";
 import { useFetch } from "@/hooks/fetch";
 import { ServiceDefinition } from "@/types/definitions";
-import { PACKAGE_REGEX } from "@/blocks/types";
+import { PACKAGE_REGEX } from "@/types/helpers";
 
 function defaultOutputKey(serviceId: string): string {
   const match = PACKAGE_REGEX.exec(serviceId);

--- a/src/options/pages/marketplace/ConfigureBody.tsx
+++ b/src/options/pages/marketplace/ConfigureBody.tsx
@@ -26,12 +26,15 @@ import { WizardValues } from "@/options/pages/marketplace/wizard";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCubes, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
-import { ServiceAuthPair } from "@/core";
+import { RegistryId, ServiceAuthPair, UUID } from "@/core";
 
 export function selectedAuths(values: WizardValues): ServiceAuthPair[] {
-  return Object.entries(values.services)
-    .filter(([, config]) => config)
-    .map(([id, config]) => ({ id, config }));
+  return (
+    Object.entries(values.services)
+      .filter(([, config]) => config)
+      // We lose type information when using Object.entries
+      .map(([id, config]) => ({ id: id as RegistryId, config: config as UUID }))
+  );
 }
 
 export function selectedExtensions(

--- a/src/options/pages/marketplace/ServicesBody.tsx
+++ b/src/options/pages/marketplace/ServicesBody.tsx
@@ -21,7 +21,7 @@ import ServiceAuthSelector, {
   useAuthOptions,
 } from "@/options/pages/extensionEditor/ServiceAuthSelector";
 import { uniq } from "lodash";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { Button, Card, Table } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { RecipeDefinition, ServiceDefinition } from "@/types/definitions";

--- a/src/options/pages/services/PrivateServicesCard.tsx
+++ b/src/options/pages/services/PrivateServicesCard.tsx
@@ -20,7 +20,7 @@ import { Card, Table, Button } from "react-bootstrap";
 import React, { useCallback, useContext } from "react";
 import { RawServiceConfiguration, IService, ServiceConfig } from "@/core";
 import { RootState } from "../../store";
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 import { ServiceDefinition } from "@/types/definitions";
 import ServiceModal from "@/components/fields/ServiceModal";
 import useFetch from "@/hooks/useFetch";

--- a/src/options/slices.ts
+++ b/src/options/slices.ts
@@ -15,13 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { v4 as uuidv4 } from "uuid";
 import { createSlice } from "@reduxjs/toolkit";
-import { IExtension, RawServiceConfiguration } from "@/core";
+import { IExtension, RawServiceConfiguration, RegistryId } from "@/core";
 import { orderBy } from "lodash";
 import { reportEvent } from "@/telemetry/events";
 import { preloadMenus } from "@/background/preload";
 import { selectEventData } from "@/telemetry/deployments";
+import { uuidv4 } from "@/types/helpers";
 
 type InstallMode = "local" | "remote";
 
@@ -199,7 +199,7 @@ export const optionsSlice = createSlice({
           _recipe: recipe.metadata,
           optionsArgs,
           services: Object.entries(services ?? {}).map(
-            ([outputKey, id]: [string, string]) => ({
+            ([outputKey, id]: [string, RegistryId]) => ({
               outputKey,
               config: auths[id],
               id,

--- a/src/pages/marketplace/useInstall.ts
+++ b/src/pages/marketplace/useInstall.ts
@@ -30,6 +30,7 @@ import { collectPermissions } from "@/permissions";
 import { reactivate } from "@/background/navigation";
 import { push } from "connected-react-router";
 import { optionsSlice } from "@/options/slices";
+import { RegistryId, UUID } from "@/core";
 
 const { installRecipe } = optionsSlice.actions;
 
@@ -61,8 +62,12 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
       );
 
       const configuredAuths = Object.entries(values.services)
-        .filter((x) => x[1])
-        .map(([id, config]) => ({ id, config }));
+        .filter(([, config]) => config)
+        // We lose type information when using Object.entries
+        .map(([id, config]) => ({
+          id: id as RegistryId,
+          config: config as UUID,
+        }));
 
       const enabled = await containsPermissions(
         await collectPermissions(selected, configuredAuths)

--- a/src/script.ts
+++ b/src/script.ts
@@ -19,7 +19,7 @@
  * The script that gets injected into the host page. Shares a JS context with the host page
  */
 
-import { v4 as uuidv4 } from "uuid";
+import { uuidv4 } from "@/types/helpers";
 
 const JQUERY_WINDOW_PROP = "$$jquery";
 const PAGESCRIPT_SYMBOL = Symbol.for("pixiebrix-page-script");

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -25,6 +25,8 @@ import {
   ServiceLocator,
   SanitizedConfig,
   KeyedConfig,
+  RegistryId,
+  UUID,
 } from "@/core";
 import { sortBy, isEmpty } from "lodash";
 import registry, {
@@ -37,6 +39,7 @@ import {
   NotConfiguredError,
 } from "@/services/errors";
 import { fetch } from "@/hooks/fetch";
+import { castRegistryId } from "@/types/helpers";
 
 const REF_SECRETS = [
   "https://app.pixiebrix.com/schemas/key#",
@@ -81,8 +84,8 @@ export async function pixieServiceFactory(): Promise<SanitizedServiceConfigurati
 }
 
 type Option = {
-  id: string;
-  serviceId: string;
+  id: UUID;
+  serviceId: RegistryId;
   level: ServiceLevel;
   local: boolean;
   config: ServiceConfig | SanitizedConfig;
@@ -156,7 +159,7 @@ class LazyLocatorFactory {
           ...x,
           level: x.organization ? ServiceLevel.Team : ServiceLevel.BuiltIn,
           local: false,
-          serviceId: x.service.name,
+          serviceId: castRegistryId(x.service.name),
         })),
       ],
       (x) => x.level
@@ -176,8 +179,8 @@ class LazyLocatorFactory {
   }
 
   async locate(
-    serviceId: string,
-    authId: string
+    serviceId: RegistryId,
+    authId: UUID
   ): Promise<SanitizedServiceConfiguration> {
     if (!this.initialized) {
       await this.refresh();

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -18,10 +18,13 @@
 import { readStorage } from "@/chrome";
 import BaseRegistry from "@/baseRegistry";
 import { fromJS } from "@/services/factory";
-import { RawServiceConfiguration } from "@/core";
+import { RawServiceConfiguration, RegistryId } from "@/core";
 import { Service } from "@/types";
+import { castRegistryId } from "@/types/helpers";
 
-export const PIXIEBRIX_SERVICE_ID = "@pixiebrix/api";
+export const PIXIEBRIX_SERVICE_ID: RegistryId = castRegistryId(
+  "@pixiebrix/api"
+);
 
 const storageKey = "persist:servicesOptions";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,11 +33,13 @@ import {
   Schema,
   TokenContext,
   KeyedConfig,
+  RegistryId,
 } from "./core";
 import { AxiosRequestConfig } from "axios";
 import { BackgroundLogger } from "@/background/logging";
 import { partition } from "lodash";
 import { Permissions } from "webextension-polyfill-ts";
+import { castRegistryId } from "@/types/helpers";
 
 type SanitizedBrand = { _sanitizedConfigBrand: null };
 type SecretBrand = { _serviceConfigBrand: null };
@@ -46,7 +48,7 @@ export abstract class Service<
   TConfig extends KeyedConfig = KeyedConfig,
   TOAuth extends AuthData = AuthData
 > implements IService<TConfig> {
-  id: string;
+  id: RegistryId;
 
   name: string;
 
@@ -63,7 +65,7 @@ export abstract class Service<
   abstract isToken: boolean;
 
   protected constructor(
-    id: string,
+    id: RegistryId,
     name: string,
     description?: string,
     icon?: BlockIcon
@@ -91,7 +93,7 @@ export abstract class Service<
 
 export abstract class ExtensionPoint<TConfig extends EmptyConfig>
   implements IExtensionPoint {
-  public readonly id: string;
+  public readonly id: RegistryId;
 
   public readonly name: string;
 
@@ -125,7 +127,7 @@ export abstract class ExtensionPoint<TConfig extends EmptyConfig>
     description?: string,
     icon?: BlockIcon
   ) {
-    this.id = id;
+    this.id = castRegistryId(id);
     this.name = name;
     this.description = description;
     this.icon = icon;
@@ -185,7 +187,7 @@ export abstract class ExtensionPoint<TConfig extends EmptyConfig>
 }
 
 export abstract class Block implements IBlock {
-  readonly id: string;
+  readonly id: RegistryId;
 
   readonly name: string;
 
@@ -207,7 +209,7 @@ export abstract class Block implements IBlock {
     description?: string,
     icon?: BlockIcon
   ) {
-    this.id = id;
+    this.id = castRegistryId(id);
     this.name = name;
     this.description = description;
     this.icon = icon;

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -19,7 +19,7 @@
  * Type contract between the backend and front-end.
  */
 import { RecipeDefinition } from "@/types/definitions";
-import { ServiceConfig, SanitizedConfig, Metadata } from "@/core";
+import { ServiceConfig, SanitizedConfig, Metadata, UUID } from "@/core";
 
 import { components } from "@/types/swagger";
 
@@ -36,7 +36,7 @@ export type Organization = components["schemas"]["Organization"];
 
 export type SanitizedAuth = components["schemas"]["SanitizedAuth"] & {
   // XXX: update serialize to required id in response type
-  id: string;
+  id: UUID;
   // Specialized to `SanitizedConfig` to get nominal typing
   config: SanitizedConfig;
   // XXX: update serializer to include proper metadata child serializer

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -15,15 +15,35 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Primitive } from "type-fest";
+import { validate, v4 as uuidFactory } from "uuid";
 import { RegistryId, UUID } from "@/core";
 
-export interface WizardValues {
-  extensions: Record<string, boolean>;
-  /**
-   * Mapping from service id to auth id
-   */
-  services: Record<RegistryId, UUID>;
-  optionsArgs: Record<string, Primitive>;
-  grantPermissions: boolean;
+export const PACKAGE_REGEX = /^((?<scope>@[\da-z~-][\d._a-z~-]*)\/)?((?<collection>[\da-z~-][\d._a-z~-]*)\/)?(?<name>[\da-z~-][\d._a-z~-]*)$/;
+
+export function uuidv4(): UUID {
+  return uuidFactory() as UUID;
+}
+
+export function isUUID(uuid: string): uuid is UUID {
+  return validate(uuid);
+}
+
+export function castUUID(uuid: string): UUID {
+  if (isUUID(uuid)) {
+    return uuid;
+  }
+
+  throw new Error("Invalid UUID");
+}
+
+export function isRegistryId(id: string): id is RegistryId {
+  return PACKAGE_REGEX.test(id);
+}
+
+export function castRegistryId(id: string): RegistryId {
+  if (isRegistryId(id)) {
+    return id;
+  }
+
+  throw new Error("Invalid registry id");
 }

--- a/src/validators/validation.ts
+++ b/src/validators/validation.ts
@@ -25,6 +25,7 @@ import { MissingConfigurationError } from "@/services/errors";
 import uniq from "lodash/uniq";
 import isPlainObject from "lodash/isPlainObject";
 import mapValues from "lodash/mapValues";
+import { isUUID } from "@/types/helpers";
 
 const IDENTIFIER_REGEX = /^[A-Z_a-z]\w*$/;
 
@@ -191,6 +192,12 @@ function serviceSchemaFactory(): Yup.Schema<unknown> {
             if (value == null) {
               return this.createError({
                 message: "Select a service configuration",
+              });
+            }
+
+            if (!isUUID(value)) {
+              return this.createError({
+                message: "Expected service configuration UUID",
               });
             }
 


### PR DESCRIPTION
Closes #1076 
Closes #1073

- Introduces nominal subtyping for UUID vs. RegistryIds
- Fixes brick generation: #1073 (🤦 TypeScript not blocking Object.values on Maps)
- Remove header generation code for extensionPoints, as we don't have any hard-coded extension points anymore
- Fail build if no headers are generated
