### PR TITLE
#1078: reshape redux state for options/extensions state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Check if the bug has already been reported by searching on GitHub under [Issues]
   When possible, add a comment with any additional context that's not already covered in the discussion.
 
 - If you're not able to find an existing issue, [open a new issue](https://github.com/pixiebrix/pixiebrix-extension/issues/new).
-  Provide information about the what you were trying to do, the expected behavior, and the actual behavior.
+  Provide information about what you were trying to do, the expected behavior, and the actual behavior.
 
 ## Feature Pull Requests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,6 +187,7 @@
         "jest-environment-jsdom": "^27.0.6",
         "jest-raw-loader": "^1.0.1",
         "jest-webextension-mock": "^3.7.17",
+        "madge": "^5.0.1",
         "min-document": "^2.19.0",
         "mini-css-extract-plugin": "~2.0.0",
         "node-polyfill-webpack-plugin": "^1.1.4",
@@ -12993,6 +12994,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
+      "dev": true
+    },
     "node_modules/app-root-dir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
@@ -13266,6 +13273,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ast-module-types": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-2.7.1.tgz",
+      "integrity": "sha512-Rnnx/4Dus6fn7fTqdeLEAn5vUll5w7/vts0RN608yFa6si/rDOUonlIIiwugHBFWjylHjxm9owoSZn71KwG4gw==",
+      "dev": true
     },
     "node_modules/ast-types": {
       "version": "0.14.2",
@@ -14122,6 +14135,41 @@
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bluebird": {
@@ -15079,6 +15127,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
+      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-table3": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
@@ -15104,6 +15176,15 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clone-deep": {
@@ -17293,6 +17374,19 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/decomment": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/decomment/-/decomment-0.9.4.tgz",
+      "integrity": "sha512-8eNlhyI5cSU4UbBlrtagWpR03dqXcE5IR9zpe7PnO6UzReXDskucsD8usgrzUmQ6qJ3N82aws/p/mu/jqbURWw==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "4.0.1"
+      },
+      "engines": {
+        "node": ">=6.4",
+        "npm": ">=2.15"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -17318,6 +17412,15 @@
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
       "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -17336,6 +17439,15 @@
       "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
       }
     },
     "node_modules/define-properties": {
@@ -17385,6 +17497,44 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/dependency-tree": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-8.1.1.tgz",
+      "integrity": "sha512-bl5U16VQpaYxD0xvcnCH/dTctCiWnsVWymh9dNjbm4T00Hm21flu1VLnNueKCj7+3uusbcJhKKKtiWrpU0I+Nw==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.20.3",
+        "debug": "^4.3.1",
+        "filing-cabinet": "^3.0.0",
+        "precinct": "^8.0.0",
+        "typescript": "^3.9.7"
+      },
+      "bin": {
+        "dependency-tree": "bin/cli.js"
+      },
+      "engines": {
+        "node": "^10.13 || ^12 || >=14"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/dependency-tree/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/dequal": {
@@ -17510,6 +17660,175 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "node_modules/detective-amd": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-3.1.0.tgz",
+      "integrity": "sha512-G7wGWT6f0VErjUkE2utCm7IUshT7nBh7aBBH2VBOiY9Dqy2DMens5iiOvYCuhstoIxRKLrnOvVAz4/EyPIAjnw==",
+      "dev": true,
+      "dependencies": {
+        "ast-module-types": "^2.7.0",
+        "escodegen": "^2.0.0",
+        "get-amd-module-type": "^3.0.0",
+        "node-source-walk": "^4.0.0"
+      },
+      "bin": {
+        "detective-amd": "bin/detective-amd.js"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/detective-cjs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-3.1.1.tgz",
+      "integrity": "sha512-JQtNTBgFY6h8uT6pgph5QpV3IyxDv+z3qPk/FZRDT9TlFfm5dnRtpH39WtQEr1khqsUxVqXzKjZHpdoQvQbllg==",
+      "dev": true,
+      "dependencies": {
+        "ast-module-types": "^2.4.0",
+        "node-source-walk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/detective-es6": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-2.2.0.tgz",
+      "integrity": "sha512-fSpNY0SLER7/sVgQZ1NxJPwmc9uCTzNgdkQDhAaj8NPYwr7Qji9QBcmbNvtMCnuuOGMuKn3O7jv0An+/WRWJZQ==",
+      "dev": true,
+      "dependencies": {
+        "node-source-walk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/detective-less": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/detective-less/-/detective-less-1.0.2.tgz",
+      "integrity": "sha512-Rps1xDkEEBSq3kLdsdnHZL1x2S4NGDcbrjmd4q+PykK5aJwDdP5MBgrJw1Xo+kyUHuv3JEzPqxr+Dj9ryeDRTA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.0.0",
+        "gonzales-pe": "^4.2.3",
+        "node-source-walk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/detective-postcss": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-5.0.0.tgz",
+      "integrity": "sha512-IBmim4GTEmZJDBOAoNFBskzNryTmYpBq+CQGghKnSGkoGWascE8iEo98yA+ZM4N5slwGjCr/NxCm+Kzg+q3tZg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "is-url": "^1.2.4",
+        "postcss": "^8.2.13",
+        "postcss-values-parser": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/detective-postcss/node_modules/postcss": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+      "dev": true,
+      "dependencies": {
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.23",
+        "source-map-js": "^0.6.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/detective-postcss/node_modules/postcss-values-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-5.0.0.tgz",
+      "integrity": "sha512-2viDDjMMrt21W2izbeiJxl3kFuD/+asgB0CBwPEgSyhCmBnDIa/y+pLaoyX+q3I3DHH0oPPL3cgjVTQvlS1Maw==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "is-url-superb": "^4.0.0",
+        "quote-unquote": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/detective-sass": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-3.0.1.tgz",
+      "integrity": "sha512-oSbrBozRjJ+QFF4WJFbjPQKeakoaY1GiR380NPqwdbWYd5wfl5cLWv0l6LsJVqrgWfFN1bjFqSeo32Nxza8Lbw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "gonzales-pe": "^4.2.3",
+        "node-source-walk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/detective-scss": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-2.0.1.tgz",
+      "integrity": "sha512-VveyXW4WQE04s05KlJ8K0bG34jtHQVgTc9InspqoQxvnelj/rdgSAy7i2DXAazyQNFKlWSWbS+Ro2DWKFOKTPQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "gonzales-pe": "^4.2.3",
+        "node-source-walk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/detective-stylus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-1.0.0.tgz",
+      "integrity": "sha1-UK7n24uruZA4HwEMY/q7pbWOVM0=",
+      "dev": true
+    },
+    "node_modules/detective-typescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-7.0.0.tgz",
+      "integrity": "sha512-y/Ev98AleGvl43YKTNcA2Q+lyFmsmCfTTNWy4cjEJxoLkbobcXtRS0Kvx06daCgr2GdtlwLfNzL553BkktfJoA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "^4.8.2",
+        "ast-module-types": "^2.7.1",
+        "node-source-walk": "^4.2.0",
+        "typescript": "^3.9.7"
+      },
+      "engines": {
+        "node": "^10.13 || >=12.0.0"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
     "node_modules/diff-match-patch": {
       "version": "1.0.5",
@@ -17968,6 +18287,19 @@
         "dedent": "^0.7.0",
         "fast-json-parse": "^1.0.3",
         "objectorarray": "^1.0.5"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
+      "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/enquirer": {
@@ -19931,6 +20263,52 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/filing-cabinet": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-3.0.0.tgz",
+      "integrity": "sha512-o8Qac5qxZ1uVidR4Sd7ZQbbqObFZlqXU4xu1suAYg9PQPcQFNTzOmxQa/MehIDMgIvXHTb42mWPNV9l3eHBPSw==",
+      "dev": true,
+      "dependencies": {
+        "app-module-path": "^2.2.0",
+        "commander": "^2.20.3",
+        "debug": "^4.3.1",
+        "decomment": "^0.9.3",
+        "enhanced-resolve": "^5.3.2",
+        "is-relative-path": "^1.0.2",
+        "module-definition": "^3.3.1",
+        "module-lookup-amd": "^7.0.0",
+        "resolve": "^1.19.0",
+        "resolve-dependency-path": "^2.0.0",
+        "sass-lookup": "^3.0.0",
+        "stylus-lookup": "^3.0.1",
+        "typescript": "^3.9.7"
+      },
+      "bin": {
+        "filing-cabinet": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/filing-cabinet/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/filing-cabinet/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -20119,6 +20497,13 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+      "dev": true
+    },
+    "node_modules/flatten": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
+      "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
+      "deprecated": "flatten is deprecated in favor of utility frameworks such as lodash.",
       "dev": true
     },
     "node_modules/flush-write-stream": {
@@ -20808,6 +21193,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-amd-module-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-3.0.0.tgz",
+      "integrity": "sha512-99Q7COuACPfVt18zH9N4VAMyb81S6TUgJm2NgV6ERtkh9VIkAaByZkW530wl3lLN5KTtSrK9jVLxYsoP5hQKsw==",
+      "dev": true,
+      "dependencies": {
+        "ast-module-types": "^2.3.2",
+        "node-source-walk": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -20830,6 +21228,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
@@ -21104,11 +21508,38 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/gonzales-pe": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "gonzales": "bin/gonzales.js"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
+    },
+    "node_modules/graphviz": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.9.tgz",
+      "integrity": "sha512-SmoY2pOtcikmMCqCSy2NO1YsRfu9OO0wpTlOYW++giGjfX1a6gax/m1Fo8IdUd0/3H15cTOfR1SMKwohj4LKsg==",
+      "dev": true,
+      "dependencies": {
+        "temp": "~0.4.0"
+      },
+      "engines": {
+        "node": ">=0.6.8"
+      }
     },
     "node_modules/growly": {
       "version": "1.3.0",
@@ -22117,6 +22548,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
     "node_modules/infer-owner": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
@@ -22545,6 +22982,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
@@ -22603,6 +23049,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
@@ -22659,6 +23114,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-relative-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-1.0.2.tgz",
+      "integrity": "sha1-CRtGoNZ8HtD+hfH4z93gBrslHUY=",
+      "dev": true
     },
     "node_modules/is-resolvable": {
       "version": "1.1.0",
@@ -22747,6 +23217,36 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true
+    },
+    "node_modules/is-url-superb": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-what": {
       "version": "3.14.1",
@@ -26742,6 +27242,74 @@
       "resolved": "https://registry.npmjs.org/lodash.xor/-/lodash.xor-4.5.0.tgz",
       "integrity": "sha1-TUjtfpgJWwYyWCunFNP/iuj7HbY="
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -26783,6 +27351,120 @@
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/madge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/madge/-/madge-5.0.1.tgz",
+      "integrity": "sha512-krmSWL9Hkgub74bOjnjWRoFPAJvPwSG6Dbta06qhWOq6X/n/FPzO3ESZvbFYVIvG2g4UHXvCJN1b+RZLaSs9nA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.1",
+        "commander": "^7.2.0",
+        "commondir": "^1.0.1",
+        "debug": "^4.3.1",
+        "dependency-tree": "^8.1.1",
+        "detective-amd": "^3.1.0",
+        "detective-cjs": "^3.1.1",
+        "detective-es6": "^2.2.0",
+        "detective-less": "^1.0.2",
+        "detective-postcss": "^5.0.0",
+        "detective-sass": "^3.0.1",
+        "detective-scss": "^2.0.1",
+        "detective-stylus": "^1.0.0",
+        "detective-typescript": "^7.0.0",
+        "graphviz": "0.0.9",
+        "ora": "^5.4.1",
+        "pluralize": "^8.0.0",
+        "precinct": "^8.1.0",
+        "pretty-ms": "^7.0.1",
+        "rc": "^1.2.7",
+        "typescript": "^3.9.5",
+        "walkdir": "^0.4.1"
+      },
+      "bin": {
+        "madge": "bin/cli.js"
+      },
+      "engines": {
+        "node": "^10.13 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/pahen"
+      }
+    },
+    "node_modules/madge/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/madge/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/madge/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/madge/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/madge/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/madge/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/make-dir": {
@@ -27448,6 +28130,47 @@
         "node": ">=10"
       }
     },
+    "node_modules/module-definition": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-3.3.1.tgz",
+      "integrity": "sha512-kLidGPwQ2yq484nSD+D3JoJp4Etc0Ox9P0L34Pu/cU4X4HcG7k7p62XI5BBuvURWMRX3RPyuhOcBHbKus+UH4A==",
+      "dev": true,
+      "dependencies": {
+        "ast-module-types": "^2.7.1",
+        "node-source-walk": "^4.0.0"
+      },
+      "bin": {
+        "module-definition": "bin/module-definition.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/module-lookup-amd": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-7.0.1.tgz",
+      "integrity": "sha512-w9mCNlj0S8qviuHzpakaLVc+/7q50jl9a/kmJ/n8bmXQZgDPkQHnPBb8MUOYh3WpAYkXuNc2c+khsozhIp/amQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.8.1",
+        "debug": "^4.1.0",
+        "glob": "^7.1.6",
+        "requirejs": "^2.3.5",
+        "requirejs-config-file": "^4.0.0"
+      },
+      "bin": {
+        "lookup-amd": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/module-lookup-amd/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -28056,6 +28779,18 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/node-source-walk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-4.2.0.tgz",
+      "integrity": "sha512-hPs/QMe6zS94f5+jG3kk9E7TNm4P2SulrKiLWMzKszBfNZvL/V6wseHlTd7IvfW0NZWqPtK3+9yYNr+3USGteA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -28634,6 +29369,81 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -28928,6 +29738,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/parse-node-version": {
@@ -29568,6 +30387,20 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
+    "node_modules/postcss-values-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+      "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
+      "dev": true,
+      "dependencies": {
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.14.4"
+      }
+    },
     "node_modules/postcss/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -29587,6 +30420,72 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/precinct": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-8.1.0.tgz",
+      "integrity": "sha512-oeZBR9IdER42Ef6Rz11z1oOUqicsI5J1Qffj6tYghKLhxN2UnHy7uE1axxNr0VZRevPK2HWkROk36uXrbJwHFA==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.20.3",
+        "debug": "^4.3.1",
+        "detective-amd": "^3.0.1",
+        "detective-cjs": "^3.1.1",
+        "detective-es6": "^2.2.0",
+        "detective-less": "^1.0.2",
+        "detective-postcss": "^4.0.0",
+        "detective-sass": "^3.0.1",
+        "detective-scss": "^2.0.1",
+        "detective-stylus": "^1.0.0",
+        "detective-typescript": "^7.0.0",
+        "module-definition": "^3.3.1",
+        "node-source-walk": "^4.2.0"
+      },
+      "bin": {
+        "precinct": "bin/cli.js"
+      },
+      "engines": {
+        "node": "^10.13 || ^12 || >=14"
+      }
+    },
+    "node_modules/precinct/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/precinct/node_modules/detective-postcss": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-4.0.0.tgz",
+      "integrity": "sha512-Fwc/g9VcrowODIAeKRWZfVA/EufxYL7XfuqJQFroBKGikKX83d2G7NFw6kDlSYGG3LNQIyVa+eWv1mqre+v4+A==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "is-url": "^1.2.4",
+        "postcss": "^8.1.7",
+        "postcss-values-parser": "^2.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/precinct/node_modules/postcss": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+      "dev": true,
+      "dependencies": {
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.23",
+        "source-map-js": "^0.6.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/prelude-ls": {
@@ -29663,6 +30562,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "dev": true,
+      "dependencies": {
+        "parse-ms": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/primeicons": {
@@ -29961,6 +30875,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/quote-unquote": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
+      "integrity": "sha1-Z6mncUjv/q+BpNQoQEpxC6qsigs=",
+      "dev": true
+    },
     "node_modules/raf-schd": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
@@ -30060,6 +30980,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -31679,6 +32623,32 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "node_modules/requirejs": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "dev": true,
+      "bin": {
+        "r_js": "bin/r.js",
+        "r.js": "bin/r.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/requirejs-config-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/requirejs-config-file/-/requirejs-config-file-4.0.0.tgz",
+      "integrity": "sha512-jnIre8cbWOyvr8a5F2KuqBnY+SDA4NXr/hzEZJG79Mxm2WiFQz2dzhC8ibtPJS7zkmBEl1mxSwp5HhC1W4qpxw==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.0",
+        "stringify-object": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
@@ -31714,6 +32684,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-dependency-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-2.0.0.tgz",
+      "integrity": "sha512-DIgu+0Dv+6v2XwRaNWnumKu7GPufBBOr5I1gRPJHkvghrfCGOooJODFvgFimX/KRxk9j0whD2MnKHzM1jYvk9w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -31734,6 +32713,19 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ret": {
       "version": "0.1.15",
@@ -32465,6 +33457,27 @@
           "optional": true
         }
       }
+    },
+    "node_modules/sass-lookup": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-3.0.0.tgz",
+      "integrity": "sha512-TTsus8CfFRn1N44bvdEai1no6PqdmDiQUiqW5DlpmtT+tYnIt1tXtDIph5KA1efC+LmioJXSnCtUVpcK9gaKIg==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.16.0"
+      },
+      "bin": {
+        "sass-lookup": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/sass-lookup/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/sax": {
       "version": "1.2.4",
@@ -33729,6 +34742,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "dependencies": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -33838,6 +34865,28 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/stylus-lookup": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-3.0.2.tgz",
+      "integrity": "sha512-oEQGHSjg/AMaWlKe7gqsnYzan8DLcGIHe0dUaFkucZZ14z4zjENRlQMCHT4FNsiWnJf17YN9OvrCfCoi7VvOyg==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.8.1",
+        "debug": "^4.1.0"
+      },
+      "bin": {
+        "stylus-lookup": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/stylus-lookup/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/stylus/node_modules/debug": {
       "version": "3.1.0",
@@ -34151,6 +35200,15 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/temp": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
+      "integrity": "sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=",
+      "dev": true,
+      "engines": [
+        "node >=0.4.0"
+      ]
     },
     "node_modules/term-size": {
       "version": "2.2.1",
@@ -34678,19 +35736,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ts-loader/node_modules/enhanced-resolve": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-      "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/ts-loader/node_modules/has-flag": {
@@ -35805,6 +36850,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/walkdir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -36151,6 +37205,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/web-namespaces": {
@@ -36677,19 +37740,6 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^8"
-      }
-    },
-    "node_modules/webpack/node_modules/enhanced-resolve": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-      "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/webpack/node_modules/schema-utils": {
@@ -47066,6 +48116,12 @@
         "picomatch": "^2.0.4"
       }
     },
+    "app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
+      "dev": true
+    },
     "app-root-dir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
@@ -47288,6 +48344,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "ast-module-types": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-2.7.1.tgz",
+      "integrity": "sha512-Rnnx/4Dus6fn7fTqdeLEAn5vUll5w7/vts0RN608yFa6si/rDOUonlIIiwugHBFWjylHjxm9owoSZn71KwG4gw==",
       "dev": true
     },
     "ast-types": {
@@ -47952,6 +49014,29 @@
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
       }
     },
     "bluebird": {
@@ -48700,6 +49785,21 @@
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
       "dev": true
     },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-spinners": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
+      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
+      "dev": true
+    },
     "cli-table3": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
@@ -48721,6 +49821,12 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -50382,6 +51488,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "decomment": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/decomment/-/decomment-0.9.4.tgz",
+      "integrity": "sha512-8eNlhyI5cSU4UbBlrtagWpR03dqXcE5IR9zpe7PnO6UzReXDskucsD8usgrzUmQ6qJ3N82aws/p/mu/jqbURWw==",
+      "dev": true,
+      "requires": {
+        "esprima": "4.0.1"
+      }
+    },
     "decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -50404,6 +51519,12 @@
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
       "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -50420,6 +51541,15 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
       "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -50457,6 +51587,33 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
+    },
+    "dependency-tree": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-8.1.1.tgz",
+      "integrity": "sha512-bl5U16VQpaYxD0xvcnCH/dTctCiWnsVWymh9dNjbm4T00Hm21flu1VLnNueKCj7+3uusbcJhKKKtiWrpU0I+Nw==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.3",
+        "debug": "^4.3.1",
+        "filing-cabinet": "^3.0.0",
+        "precinct": "^8.0.0",
+        "typescript": "^3.9.7"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+          "dev": true
+        }
+      }
     },
     "dequal": {
       "version": "2.0.2",
@@ -50552,6 +51709,132 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "detective-amd": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-3.1.0.tgz",
+      "integrity": "sha512-G7wGWT6f0VErjUkE2utCm7IUshT7nBh7aBBH2VBOiY9Dqy2DMens5iiOvYCuhstoIxRKLrnOvVAz4/EyPIAjnw==",
+      "dev": true,
+      "requires": {
+        "ast-module-types": "^2.7.0",
+        "escodegen": "^2.0.0",
+        "get-amd-module-type": "^3.0.0",
+        "node-source-walk": "^4.0.0"
+      }
+    },
+    "detective-cjs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-3.1.1.tgz",
+      "integrity": "sha512-JQtNTBgFY6h8uT6pgph5QpV3IyxDv+z3qPk/FZRDT9TlFfm5dnRtpH39WtQEr1khqsUxVqXzKjZHpdoQvQbllg==",
+      "dev": true,
+      "requires": {
+        "ast-module-types": "^2.4.0",
+        "node-source-walk": "^4.0.0"
+      }
+    },
+    "detective-es6": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-2.2.0.tgz",
+      "integrity": "sha512-fSpNY0SLER7/sVgQZ1NxJPwmc9uCTzNgdkQDhAaj8NPYwr7Qji9QBcmbNvtMCnuuOGMuKn3O7jv0An+/WRWJZQ==",
+      "dev": true,
+      "requires": {
+        "node-source-walk": "^4.0.0"
+      }
+    },
+    "detective-less": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/detective-less/-/detective-less-1.0.2.tgz",
+      "integrity": "sha512-Rps1xDkEEBSq3kLdsdnHZL1x2S4NGDcbrjmd4q+PykK5aJwDdP5MBgrJw1Xo+kyUHuv3JEzPqxr+Dj9ryeDRTA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.0.0",
+        "gonzales-pe": "^4.2.3",
+        "node-source-walk": "^4.0.0"
+      }
+    },
+    "detective-postcss": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-5.0.0.tgz",
+      "integrity": "sha512-IBmim4GTEmZJDBOAoNFBskzNryTmYpBq+CQGghKnSGkoGWascE8iEo98yA+ZM4N5slwGjCr/NxCm+Kzg+q3tZg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.1",
+        "is-url": "^1.2.4",
+        "postcss": "^8.2.13",
+        "postcss-values-parser": "^5.0.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+          "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+          "dev": true,
+          "requires": {
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
+          }
+        },
+        "postcss-values-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-5.0.0.tgz",
+          "integrity": "sha512-2viDDjMMrt21W2izbeiJxl3kFuD/+asgB0CBwPEgSyhCmBnDIa/y+pLaoyX+q3I3DHH0oPPL3cgjVTQvlS1Maw==",
+          "dev": true,
+          "requires": {
+            "color-name": "^1.1.4",
+            "is-url-superb": "^4.0.0",
+            "quote-unquote": "^1.0.0"
+          }
+        }
+      }
+    },
+    "detective-sass": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-3.0.1.tgz",
+      "integrity": "sha512-oSbrBozRjJ+QFF4WJFbjPQKeakoaY1GiR380NPqwdbWYd5wfl5cLWv0l6LsJVqrgWfFN1bjFqSeo32Nxza8Lbw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "gonzales-pe": "^4.2.3",
+        "node-source-walk": "^4.0.0"
+      }
+    },
+    "detective-scss": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-2.0.1.tgz",
+      "integrity": "sha512-VveyXW4WQE04s05KlJ8K0bG34jtHQVgTc9InspqoQxvnelj/rdgSAy7i2DXAazyQNFKlWSWbS+Ro2DWKFOKTPQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "gonzales-pe": "^4.2.3",
+        "node-source-walk": "^4.0.0"
+      }
+    },
+    "detective-stylus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-1.0.0.tgz",
+      "integrity": "sha1-UK7n24uruZA4HwEMY/q7pbWOVM0=",
+      "dev": true
+    },
+    "detective-typescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-7.0.0.tgz",
+      "integrity": "sha512-y/Ev98AleGvl43YKTNcA2Q+lyFmsmCfTTNWy4cjEJxoLkbobcXtRS0Kvx06daCgr2GdtlwLfNzL553BkktfJoA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "^4.8.2",
+        "ast-module-types": "^2.7.1",
+        "node-source-walk": "^4.2.0",
+        "typescript": "^3.9.7"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
           "dev": true
         }
       }
@@ -50953,6 +52236,16 @@
         "dedent": "^0.7.0",
         "fast-json-parse": "^1.0.3",
         "objectorarray": "^1.0.5"
+      }
+    },
+    "enhanced-resolve": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
+      "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
       }
     },
     "enquirer": {
@@ -52491,6 +53784,41 @@
       "integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==",
       "dev": true
     },
+    "filing-cabinet": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-3.0.0.tgz",
+      "integrity": "sha512-o8Qac5qxZ1uVidR4Sd7ZQbbqObFZlqXU4xu1suAYg9PQPcQFNTzOmxQa/MehIDMgIvXHTb42mWPNV9l3eHBPSw==",
+      "dev": true,
+      "requires": {
+        "app-module-path": "^2.2.0",
+        "commander": "^2.20.3",
+        "debug": "^4.3.1",
+        "decomment": "^0.9.3",
+        "enhanced-resolve": "^5.3.2",
+        "is-relative-path": "^1.0.2",
+        "module-definition": "^3.3.1",
+        "module-lookup-amd": "^7.0.0",
+        "resolve": "^1.19.0",
+        "resolve-dependency-path": "^2.0.0",
+        "sass-lookup": "^3.0.0",
+        "stylus-lookup": "^3.0.1",
+        "typescript": "^3.9.7"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+          "dev": true
+        }
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -52641,6 +53969,12 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+      "dev": true
+    },
+    "flatten": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
+      "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
       "dev": true
     },
     "flush-write-stream": {
@@ -53210,6 +54544,16 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
+    "get-amd-module-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-3.0.0.tgz",
+      "integrity": "sha512-99Q7COuACPfVt18zH9N4VAMyb81S6TUgJm2NgV6ERtkh9VIkAaByZkW530wl3lLN5KTtSrK9jVLxYsoP5hQKsw==",
+      "dev": true,
+      "requires": {
+        "ast-module-types": "^2.3.2",
+        "node-source-walk": "^4.0.0"
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -53226,6 +54570,12 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -53439,11 +54789,29 @@
         "minimatch": "~3.0.2"
       }
     },
+    "gonzales-pe": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
+    },
+    "graphviz": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.9.tgz",
+      "integrity": "sha512-SmoY2pOtcikmMCqCSy2NO1YsRfu9OO0wpTlOYW++giGjfX1a6gax/m1Fo8IdUd0/3H15cTOfR1SMKwohj4LKsg==",
+      "dev": true,
+      "requires": {
+        "temp": "~0.4.0"
+      }
     },
     "growly": {
       "version": "1.3.0",
@@ -54213,6 +55581,12 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
     "infer-owner": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
@@ -54517,6 +55891,12 @@
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "dev": true
     },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
     "is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
@@ -54549,6 +55929,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
       "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
     "is-object": {
@@ -54592,6 +55978,18 @@
         "call-bind": "^1.0.2",
         "has-symbols": "^1.0.2"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
+    "is-relative-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-1.0.2.tgz",
+      "integrity": "sha1-CRtGoNZ8HtD+hfH4z93gBrslHUY=",
+      "dev": true
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -54649,6 +56047,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true
+    },
+    "is-url-superb": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
       "dev": true
     },
     "is-what": {
@@ -57752,6 +59168,52 @@
       "resolved": "https://registry.npmjs.org/lodash.xor/-/lodash.xor-4.5.0.tgz",
       "integrity": "sha1-TUjtfpgJWwYyWCunFNP/iuj7HbY="
     },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -57786,6 +59248,84 @@
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "madge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/madge/-/madge-5.0.1.tgz",
+      "integrity": "sha512-krmSWL9Hkgub74bOjnjWRoFPAJvPwSG6Dbta06qhWOq6X/n/FPzO3ESZvbFYVIvG2g4UHXvCJN1b+RZLaSs9nA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.1",
+        "commander": "^7.2.0",
+        "commondir": "^1.0.1",
+        "debug": "^4.3.1",
+        "dependency-tree": "^8.1.1",
+        "detective-amd": "^3.1.0",
+        "detective-cjs": "^3.1.1",
+        "detective-es6": "^2.2.0",
+        "detective-less": "^1.0.2",
+        "detective-postcss": "^5.0.0",
+        "detective-sass": "^3.0.1",
+        "detective-scss": "^2.0.1",
+        "detective-stylus": "^1.0.0",
+        "detective-typescript": "^7.0.0",
+        "graphviz": "0.0.9",
+        "ora": "^5.4.1",
+        "pluralize": "^8.0.0",
+        "precinct": "^8.1.0",
+        "pretty-ms": "^7.0.1",
+        "rc": "^1.2.7",
+        "typescript": "^3.9.5",
+        "walkdir": "^0.4.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+          "dev": true
+        }
       }
     },
     "make-dir": {
@@ -58293,6 +59833,37 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
+    },
+    "module-definition": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-3.3.1.tgz",
+      "integrity": "sha512-kLidGPwQ2yq484nSD+D3JoJp4Etc0Ox9P0L34Pu/cU4X4HcG7k7p62XI5BBuvURWMRX3RPyuhOcBHbKus+UH4A==",
+      "dev": true,
+      "requires": {
+        "ast-module-types": "^2.7.1",
+        "node-source-walk": "^4.0.0"
+      }
+    },
+    "module-lookup-amd": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-7.0.1.tgz",
+      "integrity": "sha512-w9mCNlj0S8qviuHzpakaLVc+/7q50jl9a/kmJ/n8bmXQZgDPkQHnPBb8MUOYh3WpAYkXuNc2c+khsozhIp/amQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.8.1",
+        "debug": "^4.1.0",
+        "glob": "^7.1.6",
+        "requirejs": "^2.3.5",
+        "requirejs-config-file": "^4.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        }
+      }
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -58824,6 +60395,15 @@
         }
       }
     },
+    "node-source-walk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-4.2.0.tgz",
+      "integrity": "sha512-hPs/QMe6zS94f5+jG3kk9E7TNm4P2SulrKiLWMzKszBfNZvL/V6wseHlTd7IvfW0NZWqPtK3+9yYNr+3USGteA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.0.0"
+      }
+    },
     "nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -59246,6 +60826,59 @@
         }
       }
     },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -59476,6 +61109,12 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "dev": true
     },
     "parse-node-version": {
       "version": "1.0.1",
@@ -59983,6 +61622,69 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
+    "postcss-values-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+      "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
+      "dev": true,
+      "requires": {
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "precinct": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-8.1.0.tgz",
+      "integrity": "sha512-oeZBR9IdER42Ef6Rz11z1oOUqicsI5J1Qffj6tYghKLhxN2UnHy7uE1axxNr0VZRevPK2HWkROk36uXrbJwHFA==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.3",
+        "debug": "^4.3.1",
+        "detective-amd": "^3.0.1",
+        "detective-cjs": "^3.1.1",
+        "detective-es6": "^2.2.0",
+        "detective-less": "^1.0.2",
+        "detective-postcss": "^4.0.0",
+        "detective-sass": "^3.0.1",
+        "detective-scss": "^2.0.1",
+        "detective-stylus": "^1.0.0",
+        "detective-typescript": "^7.0.0",
+        "module-definition": "^3.3.1",
+        "node-source-walk": "^4.2.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "detective-postcss": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-4.0.0.tgz",
+          "integrity": "sha512-Fwc/g9VcrowODIAeKRWZfVA/EufxYL7XfuqJQFroBKGikKX83d2G7NFw6kDlSYGG3LNQIyVa+eWv1mqre+v4+A==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "is-url": "^1.2.4",
+            "postcss": "^8.1.7",
+            "postcss-values-parser": "^2.0.1"
+          }
+        },
+        "postcss": {
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+          "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+          "dev": true,
+          "requires": {
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
+          }
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -60039,6 +61741,15 @@
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
+    },
+    "pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "dev": true,
+      "requires": {
+        "parse-ms": "^2.1.0"
+      }
     },
     "primeicons": {
       "version": "4.1.0",
@@ -60273,6 +61984,12 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
+    "quote-unquote": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
+      "integrity": "sha1-Z6mncUjv/q+BpNQoQEpxC6qsigs=",
+      "dev": true
+    },
     "raf-schd": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
@@ -60349,6 +62066,26 @@
             "ajv": "^6.12.5",
             "ajv-keywords": "^3.5.2"
           }
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
         }
       }
     },
@@ -61633,6 +63370,22 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "requirejs": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "dev": true
+    },
+    "requirejs-config-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/requirejs-config-file/-/requirejs-config-file-4.0.0.tgz",
+      "integrity": "sha512-jnIre8cbWOyvr8a5F2KuqBnY+SDA4NXr/hzEZJG79Mxm2WiFQz2dzhC8ibtPJS7zkmBEl1mxSwp5HhC1W4qpxw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.0",
+        "stringify-object": "^3.2.1"
+      }
+    },
     "reselect": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
@@ -61662,6 +63415,12 @@
         "resolve-from": "^5.0.0"
       }
     },
+    "resolve-dependency-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-2.0.0.tgz",
+      "integrity": "sha512-DIgu+0Dv+6v2XwRaNWnumKu7GPufBBOr5I1gRPJHkvghrfCGOooJODFvgFimX/KRxk9j0whD2MnKHzM1jYvk9w==",
+      "dev": true
+    },
     "resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -61678,6 +63437,16 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
     },
     "ret": {
       "version": "0.1.15",
@@ -62246,6 +64015,23 @@
       "requires": {
         "klona": "^2.0.4",
         "neo-async": "^2.6.2"
+      }
+    },
+    "sass-lookup": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-3.0.0.tgz",
+      "integrity": "sha512-TTsus8CfFRn1N44bvdEai1no6PqdmDiQUiqW5DlpmtT+tYnIt1tXtDIph5KA1efC+LmioJXSnCtUVpcK9gaKIg==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.16.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        }
       }
     },
     "sax": {
@@ -63305,6 +65091,17 @@
         "define-properties": "^1.1.3"
       }
     },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -63398,6 +65195,24 @@
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
+    },
+    "stylus-lookup": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-3.0.2.tgz",
+      "integrity": "sha512-oEQGHSjg/AMaWlKe7gqsnYzan8DLcGIHe0dUaFkucZZ14z4zjENRlQMCHT4FNsiWnJf17YN9OvrCfCoi7VvOyg==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.8.1",
+        "debug": "^4.1.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         }
       }
@@ -63635,6 +65450,12 @@
           "dev": true
         }
       }
+    },
+    "temp": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
+      "integrity": "sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=",
+      "dev": true
     },
     "term-size": {
       "version": "2.2.1",
@@ -64049,16 +65870,6 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
-          }
-        },
-        "enhanced-resolve": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-          "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.4",
-            "tapable": "^2.2.0"
           }
         },
         "has-flag": {
@@ -64913,6 +66724,12 @@
         "xml-name-validator": "^3.0.0"
       }
     },
+    "walkdir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
+      "dev": true
+    },
     "walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -65217,6 +67034,15 @@
         }
       }
     },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
+    },
     "web-namespaces": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
@@ -65334,16 +67160,6 @@
           "integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
           "dev": true,
           "requires": {}
-        },
-        "enhanced-resolve": {
-          "version": "5.8.2",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-          "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.4",
-            "tapable": "^2.2.0"
-          }
         },
         "schema-utils": {
           "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:scripts": "webpack --config scripts/webpack.scripts.js",
     "generate:headers": "NODE_OPTIONS=--stack-trace-limit=100 node scripts/bin/headers.js",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "madge:circular": "madge --extensions js,ts,tsx --circular src/** --ts-config tsconfig.json"
   },
   "engine-strict": true,
   "engines": {
@@ -204,6 +205,7 @@
     "jest-environment-jsdom": "^27.0.6",
     "jest-raw-loader": "^1.0.1",
     "jest-webextension-mock": "^3.7.17",
+    "madge": "^5.0.1",
     "min-document": "^2.19.0",
     "mini-css-extract-plugin": "~2.0.0",
     "node-polyfill-webpack-plugin": "^1.1.4",

--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -23,7 +23,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCog,
   faSpinner,
-  faAngleDoubleRight
+  faAngleDoubleRight,
 } from "@fortawesome/free-solid-svg-icons";
 import { getStore } from "@/actionPanel/native";
 import {
@@ -45,6 +45,7 @@ import useExtensionMeta from "@/hooks/useExtensionMeta";
 import { selectEventData } from "@/telemetry/deployments";
 import { browser } from "webextension-polyfill-ts";
 import { HIDE_ACTION_FRAME } from "@/background/browserAction";
+import { UUID } from "@/core";
 
 const closeSidebar = async () => {
   await browser.runtime.sendMessage({
@@ -61,7 +62,7 @@ const ActionPanelTabs: React.FunctionComponent<{ panels: PanelEntry[] }> = ({
   const { lookup } = useExtensionMeta();
 
   const onSelect = useCallback(
-    (extensionId: string) => {
+    (extensionId: UUID) => {
       reportEvent("ViewSidePanelPanel", {
         ...selectEventData(lookup.get(extensionId)),
         initialLoad: false,
@@ -145,10 +146,7 @@ const ActionPanelApp: React.FunctionComponent = () => {
                 size="sm"
                 variant="link"
               >
-                <FontAwesomeIcon
-                  icon={faAngleDoubleRight}
-                  className="fa-lg"
-                />
+                <FontAwesomeIcon icon={faAngleDoubleRight} className="fa-lg" />
               </Button>
               <div className="align-self-center">
                 <img
@@ -165,7 +163,9 @@ const ActionPanelApp: React.FunctionComponent = () => {
                 variant="link"
                 className="action-panel-button d-inline-flex align-items-center"
               >
-                <span>Options  <FontAwesomeIcon icon={faCog} /></span>
+                <span>
+                  Options <FontAwesomeIcon icon={faCog} />
+                </span>
               </Button>
             </div>
 

--- a/src/actionPanel/DefaultActionPanel.tsx
+++ b/src/actionPanel/DefaultActionPanel.tsx
@@ -25,7 +25,7 @@ import {
   faClipboardCheck,
   faExternalLinkAlt,
 } from "@fortawesome/free-solid-svg-icons";
-import { selectInstalledExtensions } from "@/options/selectors";
+import { selectExtensions } from "@/options/selectors";
 
 const OnboardingContent: React.FunctionComponent = () => (
   <Container>
@@ -89,7 +89,7 @@ const NoAvailablePanelsContent: React.FunctionComponent = () => (
 );
 
 const DefaultActionPanel: React.FunctionComponent = () => {
-  const extensions = useSelector(selectInstalledExtensions);
+  const extensions = useSelector(selectExtensions);
 
   return (
     <div>

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -29,17 +29,13 @@ import { FORWARD_FRAME_NOTIFICATION } from "@/background/browserAction";
 import { isBrowser } from "@/helpers";
 import { reportEvent } from "@/telemetry/events";
 import { expectContentScript } from "@/utils/expectContext";
+import { ExtensionRef } from "@/core";
 
 const SIDEBAR_WIDTH_PX = 400;
 const PANEL_CONTAINER_ID = "pixiebrix-extension";
 const PANEL_CONTAINER_SELECTOR = "#" + PANEL_CONTAINER_ID;
 
 let renderSequenceNumber = 0;
-
-type ExtensionRef = {
-  extensionId: string;
-  extensionPointId: string;
-};
 
 export type ShowCallback = () => void;
 

--- a/src/actionPanel/protocol.tsx
+++ b/src/actionPanel/protocol.tsx
@@ -19,6 +19,7 @@ import { browser } from "webextension-polyfill-ts";
 import { isBrowserActionPanel } from "@/chrome";
 import { HandlerMap } from "@/messaging/protocol";
 import { reportError } from "@/telemetry/logging";
+import { RegistryId, UUID } from "@/core";
 
 export const MESSAGE_PREFIX = "@@pixiebrix/browserAction/";
 
@@ -30,7 +31,7 @@ let seqNumber = -1;
  * Information required to run a renderer
  */
 export type RendererPayload = {
-  blockId: string;
+  blockId: RegistryId;
   key: string;
   args: unknown;
   ctxt: unknown;
@@ -42,8 +43,8 @@ export type RendererError = {
 };
 
 export type PanelEntry = {
-  extensionId: string;
-  extensionPointId: string;
+  extensionId: UUID;
+  extensionPointId: RegistryId;
   heading: string;
   payload: RendererPayload | RendererError | null;
 };

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -34,6 +34,9 @@ export interface AuthData extends UserData {
   token: string;
 }
 
+/**
+ * @deprecated will be moved into the app project since it's not used directly by the extension
+ */
 export function readAuthFromWebsite(): AuthData {
   const container = document.querySelector<HTMLElement>("#container");
   const {
@@ -87,9 +90,11 @@ export async function clearExtensionAuth(): Promise<void> {
 }
 
 /**
- * Refresh the Chrome extensions auth (user, email, token, hostname), and return true if it was updated.
+ * Refresh the Chrome extensions auth (user, email, token, API hostname), and return true if it was updated.
  */
-export async function updateExtensionAuth(auth: AuthData): Promise<boolean> {
+export async function updateExtensionAuth(
+  auth: AuthData & { browserId: string }
+): Promise<boolean> {
   if (!auth) {
     return false;
   }
@@ -98,6 +103,7 @@ export async function updateExtensionAuth(auth: AuthData): Promise<boolean> {
     userId: auth.user,
     email: auth.email,
     organizationId: auth.telemetryOrganizationId ?? auth.organizationId,
+    browserId: auth.browserId,
   });
 
   // Note: `auth` is a `Object.create(null)` object, which for some `isEqual` implementations

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -25,7 +25,7 @@ import axios from "axios";
 import { getBaseURL } from "@/services/baseService";
 import { getExtensionVersion, getUID } from "@/background/telemetry";
 import { getExtensionToken } from "@/auth/token";
-import { ExtensionsOptionsState, optionsSlice } from "@/options/slices";
+import { optionsSlice } from "@/options/slices";
 import { reportEvent } from "@/telemetry/events";
 import { refreshRegistries } from "@/hooks/useRefresh";
 import { liftBackground } from "@/background/protocol";
@@ -35,6 +35,7 @@ import { uninstallContextMenu } from "@/background/contextMenus";
 import { containsPermissions } from "@/utils/permissions";
 import { deploymentPermissions } from "@/permissions";
 import { IExtension } from "@/core";
+import { ExtensionsOptionsState } from "@/store/extensions";
 
 const { reducer, actions } = optionsSlice;
 

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -25,12 +25,12 @@ import axios from "axios";
 import { getBaseURL } from "@/services/baseService";
 import { getExtensionVersion, getUID } from "@/background/telemetry";
 import { getExtensionToken } from "@/auth/token";
-import { optionsSlice, OptionsState } from "@/options/slices";
+import { ExtensionsOptionsState, optionsSlice } from "@/options/slices";
 import { reportEvent } from "@/telemetry/events";
 import { refreshRegistries } from "@/hooks/useRefresh";
 import { liftBackground } from "@/background/protocol";
 import * as contentScript from "@/contentScript/lifecycle";
-import { selectInstalledExtensions } from "@/options/selectors";
+import { selectExtensions } from "@/options/selectors";
 import { uninstallContextMenu } from "@/background/contextMenus";
 import { containsPermissions } from "@/utils/permissions";
 import { deploymentPermissions } from "@/permissions";
@@ -70,11 +70,11 @@ export const queueReactivate = liftBackground(
 );
 
 function installDeployment(
-  state: OptionsState,
+  state: ExtensionsOptionsState,
   deployment: Deployment
-): OptionsState {
+): ExtensionsOptionsState {
   let returnState = state;
-  const installed = selectInstalledExtensions({ options: state });
+  const installed = selectExtensions({ options: state });
 
   for (const extension of installed) {
     if (extension._recipe.id === deployment.package.package_id) {
@@ -134,10 +134,7 @@ async function updateDeployments() {
     return;
   }
 
-  const { extensions: extensionPointConfigs } = await loadOptions();
-  const extensions: IExtension[] = Object.entries(
-    extensionPointConfigs
-  ).flatMap(([, xs]) => Object.values(xs));
+  const { extensions } = await loadOptions();
 
   if (!extensions.some((x) => x._deployment?.id)) {
     console.debug("No deployments installed");

--- a/src/background/devtools/protocol.ts
+++ b/src/background/devtools/protocol.ts
@@ -34,6 +34,7 @@ import { isEmpty } from "lodash";
 import * as contextMenuProtocol from "@/background/contextMenus";
 import { Target } from "@/background/devtools/contract";
 import { DynamicDefinition } from "@/nativeEditor/dynamic";
+import { RegistryId, UUID } from "@/core";
 
 export const registerPort = liftBackground(
   "REGISTER_PORT",
@@ -138,13 +139,13 @@ export const updateDynamicElement = liftBackground(
 
 export const clearDynamicElements = liftBackground(
   "CLEAR_DYNAMIC",
-  (target: Target) => async ({ uuid }: { uuid?: string }) =>
+  (target: Target) => async ({ uuid }: { uuid?: UUID }) =>
     nativeEditorProtocol.clear(target, { uuid })
 );
 
 export const enableDataOverlay = liftBackground(
   "ENABLE_ELEMENT",
-  (target: Target) => async (uuid: string) =>
+  (target: Target) => async (uuid: UUID) =>
     nativeEditorProtocol.enableOverlay(target, `[data-uuid="${uuid}"]`)
 );
 
@@ -186,7 +187,7 @@ export const runReaderBlock = liftBackground(
     id,
     rootSelector,
   }: {
-    id: string;
+    id: RegistryId;
     rootSelector?: string;
   }) =>
     contentScriptProtocol.runReaderBlock(target, {
@@ -214,15 +215,14 @@ export const uninstallContextMenu = liftBackground(
   "UNINSTALL_CONTEXT_MENU",
   // False positive - it's the inner method that should be async
   // eslint-disable-next-line unicorn/consistent-function-scoping
-  () => async ({ extensionId }: { extensionId: string }) =>
+  () => async ({ extensionId }: { extensionId: UUID }) =>
     contextMenuProtocol.uninstall(extensionId)
 );
 
 export const uninstallActionPanelPanel = liftBackground(
   "UNINSTALL_ACTION_PANEL_PANEL",
   // False positive - it's the inner method that should be async
-  // eslint-disable-next-line unicorn/consistent-function-scoping
-  (target) => async ({ extensionId }: { extensionId: string }) =>
+  (target) => async ({ extensionId }: { extensionId: UUID }) =>
     browserActionProtocol.removeActionPanelPanel(target, extensionId)
 );
 

--- a/src/background/preload.ts
+++ b/src/background/preload.ts
@@ -58,10 +58,7 @@ export const preloadMenus = liftBackground(
 );
 
 export async function preloadAllMenus(): Promise<void> {
-  const { extensions: extensionPointConfigs } = await loadOptions();
-  const extensions: PreloadOptions[] = Object.entries(
-    extensionPointConfigs
-  ).flatMap(([, xs]) => Object.values(xs));
+  const { extensions } = await loadOptions();
   await preload(extensions);
 }
 

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -303,7 +303,7 @@ export async function proxyService<TData>(
     // eslint-disable-next-line @typescript-eslint/no-implicit-any-catch
   } catch (error) {
     throw new ContextError(error, {
-      serviceId: serviceConfig.id,
+      serviceId: serviceConfig.serviceId,
       authId: serviceConfig.id,
     });
   }

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -23,10 +23,10 @@ import { browser } from "webextension-polyfill-ts";
 import { readStorage, setStorage } from "@/chrome";
 import { getExtensionToken } from "@/auth/token";
 import axios from "axios";
+import { Data } from "@/core";
 import { getBaseURL } from "@/services/baseService";
 import { boolean } from "@/utils";
 import { loadOptions } from "@/options/loader";
-import { IExtension } from "@/core";
 
 const EVENT_BUFFER_DEBOUNCE_MS = 2000;
 const EVENT_BUFFER_MAX_MS = 10_000;
@@ -125,10 +125,7 @@ async function userSummary() {
   let numActiveBlueprints: number = null;
 
   try {
-    const { extensions: extensionPointConfigs } = await loadOptions();
-    const extensions: IExtension[] = Object.entries(
-      extensionPointConfigs
-    ).flatMap(([, xs]) => Object.values(xs));
+    const { extensions } = await loadOptions();
     numActiveExtensions = extensions.length;
     numActiveBlueprints = uniq(compact(extensions.map((x) => x._recipe?.id)))
       .length;
@@ -203,7 +200,7 @@ export const recordEvent = liftBackground(
 
 export const sendDeploymentAlert = liftBackground(
   "SEND_DEPLOYMENT_ALERT",
-  async ({ deploymentId, data }: { deploymentId: string; data: object }) => {
+  async ({ deploymentId, data }: { deploymentId: string; data: Data }) => {
     const url = `${await getBaseURL()}/api/deployments/${deploymentId}/alerts/`;
     const token = await getExtensionToken();
     if (!token) {

--- a/src/baseRegistry.ts
+++ b/src/baseRegistry.ts
@@ -27,9 +27,10 @@ import {
 import { groupBy } from "lodash";
 import { RegistryPackage } from "@/types/contract";
 import { getErrorMessage } from "@/errors";
+import { RegistryId } from "@/core";
 
-export interface RegistryItem {
-  id: string;
+export interface RegistryItem<T extends RegistryId = RegistryId> {
+  id: T;
 }
 
 export class DoesNotExistError extends Error {
@@ -42,33 +43,38 @@ export class DoesNotExistError extends Error {
   }
 }
 
-export class Registry<TItem extends RegistryItem> {
-  private readonly cache = new Map<string, TItem>();
+export class Registry<
+  Id extends RegistryId = RegistryId,
+  Item extends RegistryItem<Id> = RegistryItem<Id>
+> {
+  // Use RegistryId for `cache` and `remote` because they come from the external service
 
-  private readonly remote: Set<string>;
+  private readonly cache = new Map<RegistryId, Item>();
+
+  private readonly remote: Set<RegistryId>;
 
   private readonly remoteResourcePath: string;
 
   public readonly kinds: Set<Kind>;
 
-  private readonly deserialize: (raw: unknown) => TItem;
+  private readonly deserialize: (raw: unknown) => Item;
 
   constructor(
     kinds: Kind[],
     remoteResourcePath: string,
-    deserialize: (raw: unknown) => TItem
+    deserialize: (raw: unknown) => Item
   ) {
-    this.remote = new Set<string>();
+    this.remote = new Set<Id>();
     this.kinds = new Set(kinds);
     this.remoteResourcePath = remoteResourcePath;
     this.deserialize = deserialize;
   }
 
-  async exists(id: string): Promise<boolean> {
+  async exists(id: Id): Promise<boolean> {
     return this.cache.has(id) || (await find(id)) != null;
   }
 
-  async lookup(id: string): Promise<TItem> {
+  async lookup(id: Id): Promise<Item> {
     if (!id) {
       throw new Error("id is required");
     }
@@ -82,7 +88,9 @@ export class Registry<TItem extends RegistryItem> {
     const raw = await find(id);
 
     if (!raw) {
-      console.debug(`Cannot find ${id} in registry ${this.remoteResourcePath}`);
+      console.debug(
+        `Cannot find ${id as string} in registry ${this.remoteResourcePath}`
+      );
       throw new DoesNotExistError(id);
     }
 
@@ -103,14 +111,14 @@ export class Registry<TItem extends RegistryItem> {
   /**
    * @deprecated needed for header generation; will be removed in future versions
    */
-  cached(): TItem[] {
+  cached(): Item[] {
     return [...this.cache.values()];
   }
 
   /**
    * @deprecated requires all data to be parsed
    */
-  async all(): Promise<TItem[]> {
+  async all(): Promise<Item[]> {
     await Promise.allSettled(
       [...this.kinds.values()].map(async (kind) => {
         for (const raw of await getKind(kind)) {
@@ -124,7 +132,7 @@ export class Registry<TItem extends RegistryItem> {
     return [...this.cache.values()];
   }
 
-  register(...items: TItem[]): void {
+  register(...items: Item[]): void {
     for (const item of items) {
       if (item.id == null) {
         console.warn("Skipping item with no id", item);
@@ -135,7 +143,7 @@ export class Registry<TItem extends RegistryItem> {
     }
   }
 
-  private parse(raw: unknown): TItem | undefined {
+  private parse(raw: unknown): Item | undefined {
     try {
       return this.deserialize(raw);
     } catch (error: unknown) {

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -35,6 +35,7 @@ import {
   Schema,
   ServiceDependency,
   TemplateEngine,
+  RegistryId,
 } from "@/core";
 import { validateInput, validateOutput } from "@/validators/generic";
 import {
@@ -65,19 +66,23 @@ import {
 import { engineRenderer } from "@/utils/renderers";
 
 export type ReaderConfig =
-  | string
+  | RegistryId
   // Can't use Record syntax because generics can't reference themselves
   // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
   | { [key: string]: ReaderConfig }
   | ReaderConfig[];
 
 export interface BlockConfig {
-  id: string;
+  id: RegistryId;
 
-  // (Optional) human-readable label for the step. Shown in the progress indicator
+  /**
+   * (Optional) human-readable label for the step. Shown in the progress indicator
+   */
   label?: string;
 
-  // (Optional) indicate the step is being run in the interface
+  /**
+   * (Optional) indicate the step is being run in the interface
+   */
   notifyProgress?: boolean;
 
   onError?: {
@@ -88,14 +93,20 @@ export interface BlockConfig {
 
   outputKey?: string;
 
-  // (Optional) condition expression written in templateEngine for deciding if the step should be run. If not
-  // provided, the step is run unconditionally.
+  /**
+   * (Optional) condition expression written in templateEngine for deciding if the step should be run. If not
+   * provided, the step is run unconditionally.
+   */
   if?: string | boolean | number;
 
-  // (Optional) root selector for reader
+  /**
+   * (Optional) root selector for reader
+   */
   root?: string;
 
-  // (Optional) template language to use for rendering the if and config properties. Default is mustache
+  /**
+   * (Optional) template language to use for rendering the if and config properties. Default is mustache
+   */
   templateEngine?: TemplateEngine;
 
   config: Record<string, unknown>;

--- a/src/blocks/errors.ts
+++ b/src/blocks/errors.ts
@@ -16,7 +16,7 @@
  */
 
 import { castArray } from "lodash";
-import { MessageContext, Schema } from "@/core";
+import { MessageContext, RegistryId, Schema } from "@/core";
 import { BlockConfig, BlockPipeline } from "@/blocks/combinators";
 import { BusinessError } from "@/errors";
 import { OutputUnit } from "@cfworker/json-schema";
@@ -38,7 +38,7 @@ export class PipelineConfigurationError extends BusinessError {
  * different browser context (e.g., the PixieBrix sidebar)
  */
 export class HeadlessModeError extends Error {
-  public readonly blockId: string;
+  public readonly blockId: RegistryId;
 
   public readonly args: unknown;
 
@@ -47,7 +47,7 @@ export class HeadlessModeError extends Error {
   public readonly loggerContext: MessageContext;
 
   constructor(
-    blockId: string,
+    blockId: RegistryId,
     args: unknown,
     ctxt: unknown,
     loggerContext: MessageContext

--- a/src/blocks/registry.ts
+++ b/src/blocks/registry.ts
@@ -17,9 +17,9 @@
 
 import BaseRegistry from "@/baseRegistry";
 import { fromJS } from "@/blocks/transformers/blockFactory";
-import { IBlock } from "@/core";
+import { IBlock, RegistryId } from "@/core";
 
-const registry = new BaseRegistry<IBlock>(
+const registry = new BaseRegistry<RegistryId, IBlock>(
   ["block", "component", "effect", "reader"],
   "blocks",
   fromJS

--- a/src/components/fields/BlockField.tsx
+++ b/src/components/fields/BlockField.tsx
@@ -22,7 +22,7 @@ import { Form, Row, Col } from "react-bootstrap";
 import { castArray, isEmpty } from "lodash";
 import { FieldProps } from "@/components/fields/propTypes";
 import { inputProperties } from "@/helpers";
-import { IBlock } from "@/core";
+import { IBlock, RegistryId } from "@/core";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import {
   FieldArray,
@@ -40,13 +40,13 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import "./BlockField.scss";
 import Button from "react-bootstrap/Button";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import GridLoader from "react-spinners/GridLoader";
 import { reportError } from "@/telemetry/logging";
 import BlockModal from "@/components/fields/BlockModal";
 import optionsRegistry from "@/components/fields/optionsRegistry";
 
-export const SCHEMA_TYPE_TO_BLOCK_PROPERTY: { [key: string]: string } = {
+export const SCHEMA_TYPE_TO_BLOCK_PROPERTY: Record<string, string> = {
   "#/definitions/renderer": "render",
   "#/definitions/effect": "effect",
   "#/definitions/reader": "read",
@@ -61,7 +61,7 @@ export const SCHEMA_TYPE_TO_BLOCK_PROPERTY: { [key: string]: string } = {
   "https://app.pixiebrix.com/schemas/transformer": "transform",
 };
 
-type ConfigValue = { [key: string]: string };
+type ConfigValue = Record<string, string>;
 
 interface BlockState {
   block?: IBlock | null;
@@ -69,7 +69,7 @@ interface BlockState {
 }
 
 export function useBlockOptions(
-  id: string
+  id: RegistryId
 ): [BlockState, React.FunctionComponent<BlockOptionProps>] {
   const [{ block, error }, setBlock] = useState<BlockState>({
     block: null,
@@ -93,7 +93,7 @@ export function useBlockOptions(
   );
 
   const BlockOptions = useMemo(() => {
-    if (block) {
+    if (block?.id) {
       const registered = optionsRegistry.get(block.id);
       return (
         registered ?? genericOptionsFactory(inputProperties(block.inputSchema))
@@ -191,8 +191,10 @@ const BlockCard: React.FunctionComponent<{
 };
 
 interface BlockConfig {
-  id: string;
-  // Optionally, a name to store the output to
+  id: RegistryId;
+  /**
+   * (Optional) a name to store the output to (excluding a "@")
+   */
   outputKey?: string;
   config: ConfigValue;
   templateEngine?: "mustache" | "handlebars" | "nunjucks";

--- a/src/components/fields/BlockModal.tsx
+++ b/src/components/fields/BlockModal.tsx
@@ -44,7 +44,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { BlockType, getType } from "@/blocks/util";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { useDebounce } from "use-debounce";
 
 import "./BlockModal.scss";

--- a/src/components/logViewer/LogTable.stories.tsx
+++ b/src/components/logViewer/LogTable.stories.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { uuidv4 } from "@/types/helpers";
+import { castRegistryId, uuidv4 } from "@/types/helpers";
 import LogTable from "@/components/logViewer/LogTable";
 import { serializeError } from "serialize-error";
 import { Card } from "react-bootstrap";
@@ -52,13 +52,15 @@ NoEntriesForLevel.args = {
   pageEntries: [],
 };
 
+const blockId = castRegistryId("@pixiebrix/system/notification");
+
 const DEBUG_MESSAGE: LogEntry = {
   uuid: uuidv4(),
   timestamp: Date.now().toString(),
   message: "Sample debug message",
   level: "debug",
   context: {
-    blockId: "@pixiebrix/system/notification",
+    blockId,
   },
 };
 
@@ -69,7 +71,7 @@ const ERROR_MESSAGE: LogEntry = {
   level: "error",
   context: {
     // Just the context that will show up in the table
-    blockId: "@pixiebrix/system/notification",
+    blockId,
   },
   error: serializeError(new Error("Simple error")),
 };
@@ -104,11 +106,11 @@ const CONTEXT_ERROR_MESSAGE: LogEntry = {
   level: "error",
   context: {
     // Just the context that will show up in the table
-    blockId: "@pixiebrix/system/notification",
+    blockId,
   },
   error: serializeError(
     new ContextError(validationError, {
-      blockId: "@pixiebrix/system/notification",
+      blockId,
     })
   ),
 };

--- a/src/components/logViewer/useLogEntries.ts
+++ b/src/components/logViewer/useLogEntries.ts
@@ -24,7 +24,7 @@ import {
   MessageLevel,
 } from "@/background/logging";
 import { stubTrue } from "lodash";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { MessageContext } from "@/core";
 import LogContext from "@/components/logViewer/LogContext";
 

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -19,7 +19,7 @@
 import { browser, Runtime } from "webextension-polyfill-ts";
 import blockRegistry from "@/blocks/registry";
 import { BackgroundLogger } from "@/background/logging";
-import { MessageContext } from "@/core";
+import { MessageContext, RegistryId, RenderedArgs } from "@/core";
 import {
   liftContentScript,
   MESSAGE_PREFIX,
@@ -56,8 +56,8 @@ export interface RunBlockAction {
   payload: {
     sourceTabId?: number;
     nonce?: string;
-    blockId: string;
-    blockArgs: Record<string, unknown>;
+    blockId: RegistryId;
+    blockArgs: RenderedArgs;
     options: RemoteBlockOptions;
   };
 }

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -17,7 +17,7 @@
 
 import { loadOptions } from "@/options/loader";
 import extensionPointRegistry from "@/extensionPoints/registry";
-import { IExtensionPoint, RegistryId } from "@/core";
+import { IExtension, IExtensionPoint, RegistryId, UUID } from "@/core";
 import {
   liftContentScript,
   notifyContentScripts,
@@ -29,9 +29,10 @@ import { NAVIGATION_RULES } from "@/contrib/navigationRules";
 import { testMatchPatterns } from "@/blocks/available";
 import { reportError } from "@/telemetry/logging";
 import { browser } from "webextension-polyfill-ts";
+import { groupBy } from "lodash";
 
 let _scriptPromise: Promise<void> | undefined;
-const _dynamic: Map<string, IExtensionPoint> = new Map();
+const _dynamic: Map<UUID, IExtensionPoint> = new Map();
 const _frameHref: Map<number, string> = new Map();
 let _extensionPoints: IExtensionPoint[];
 let _navSequence = 1;
@@ -100,11 +101,11 @@ async function runExtensionPoint(
   await extensionPoint.run();
 }
 
-export function getInstalledIds(): string[] {
+export function getInstalledIds(): RegistryId[] {
   return _installedExtensionPoints.map((x) => x.id);
 }
 
-function markUninstalled(id: string) {
+function markUninstalled(id: RegistryId) {
   // Remove from _installedExtensionPoints so they'll be re-added on a call to loadExtensions
   const index = _installedExtensionPoints.findIndex((x) => x.id === id);
   if (index >= 0) {
@@ -124,7 +125,7 @@ function markUninstalled(id: string) {
  *
  * @param extensionId the uuid of the dynamic extension, or undefined to clear all dynamic extensions
  */
-export function clearDynamic(extensionId?: string): void {
+export function clearDynamic(extensionId?: UUID): void {
   if (extensionId) {
     if (_dynamic.has(extensionId)) {
       console.debug(`clearDynamic: ${extensionId}`);
@@ -161,7 +162,7 @@ function makeCancelOnNavigate(): () => boolean {
 }
 
 export async function runDynamic(
-  uuid: string,
+  uuid: UUID,
   extensionPoint: IExtensionPoint
 ): Promise<void> {
   // Uninstall the previous extension point instance (in favor of the updated extensionPoint)
@@ -185,42 +186,43 @@ async function loadExtensions() {
 
   _extensionPoints = [];
 
-  const { extensions: extensionPointConfigs } = await loadOptions();
+  const options = await loadOptions();
 
-  for (const [extensionPointId, extensionMap] of Object.entries(
-    extensionPointConfigs
-  )) {
-    const extensions = Object.values(extensionMap);
+  const extensionMap = groupBy(options.extensions, (x) => x.extensionPointId);
 
-    if (
-      extensions.length === 0 &&
-      !previousIds.has(extensionPointId as RegistryId)
-    ) {
-      // Ignore the case where we uninstalled the last extension, but the extension point was
-      // not deleted from the state.
-      //
-      // But for updates (i.e., re-activation flow) we need to include to so that when we run
-      // syncExtensions their elements are removed from the page
-      continue;
-    }
+  await Promise.all(
+    Object.entries(extensionMap).map(
+      async ([extensionPointId, extensions]: [RegistryId, IExtension[]]) => {
+        // Object.entries loses the type information
 
-    try {
-      const extensionPoint = await extensionPointRegistry.lookup(
-        extensionPointId
-      );
+        if (extensions.length === 0 && !previousIds.has(extensionPointId)) {
+          // Ignore the case where we uninstalled the last extension, but the extension point was
+          // not deleted from the state.
+          //
+          // But for updates (i.e., re-activation flow) we need to include to so that when we run
+          // syncExtensions their elements are removed from the page
+          return;
+        }
 
-      extensionPoint.syncExtensions(extensions);
+        try {
+          const extensionPoint = await extensionPointRegistry.lookup(
+            extensionPointId
+          );
 
-      if (extensions.length > 0) {
-        // Cleared out _extensionPoints before, so can just push w/o checking if it's already in the array
-        _extensionPoints.push(extensionPoint);
+          extensionPoint.syncExtensions(extensions);
+
+          if (extensions.length > 0) {
+            // We cleared _extensionPoints prior to the loop, so we can just push w/o checking if it's already in the array
+            _extensionPoints.push(extensionPoint);
+          }
+        } catch (error: unknown) {
+          console.warn(`Error adding extension point: ${extensionPointId}`, {
+            error,
+          });
+        }
       }
-    } catch (error: unknown) {
-      console.warn(`Error adding extension point: ${extensionPointId}`, {
-        error,
-      });
-    }
-  }
+    )
+  );
 }
 
 /**
@@ -260,6 +262,7 @@ async function waitLoaded(cancel: () => boolean): Promise<void> {
       console.debug(
         `Custom navigation rule detected that page is still loading: ${url}`
       );
+      // eslint-disable-next-line no-await-in-loop -- looping to allow for sleep
       await sleep(WAIT_LOADED_INTERVAL_MS);
     }
   }
@@ -311,21 +314,24 @@ export async function handleNavigate({
 
     await waitLoaded(cancel);
 
-    for (const extensionPoint of extensionPoints) {
-      // Don't await each extension point since the extension point may never appear. For example, an
-      // extension point that runs on the contact information page on LinkedIn
-      const runPromise = runExtensionPoint(extensionPoint, cancel).catch(
-        (error: unknown) => {
-          console.error(`Error installing/running: ${extensionPoint.id}`, {
-            error,
-          });
-        }
-      );
+    // Safe to use Promise.all since the inner method can't throw
+    await Promise.all(
+      extensionPoints.map(async (extensionPoint) => {
+        // Don't await each extension point since the extension point may never appear. For example, an
+        // extension point that runs on the contact information modal on LinkedIn
+        const runPromise = runExtensionPoint(extensionPoint, cancel).catch(
+          (error: unknown) => {
+            console.error(`Error installing/running: ${extensionPoint.id}`, {
+              error,
+            });
+          }
+        );
 
-      if (extensionPoint.syncInstall) {
-        await runPromise;
-      }
-    }
+        if (extensionPoint.syncInstall) {
+          await runPromise;
+        }
+      })
+    );
   }
 }
 

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -42,8 +42,11 @@ import {
   ListResponse,
 } from "@/contrib/automationanywhere/contract";
 import { getErrorMessage } from "@/errors";
+import { castRegistryId } from "@/types/helpers";
 
-const AUTOMATION_ANYWHERE_SERVICE_ID = "automation-anywhere/control-room";
+const AUTOMATION_ANYWHERE_SERVICE_ID = castRegistryId(
+  "automation-anywhere/control-room"
+);
 
 const OUTPUT_KEY_SCHEMA: Schema = {
   type: "string",

--- a/src/contrib/google/sheets/FileField.tsx
+++ b/src/contrib/google/sheets/FileField.tsx
@@ -19,21 +19,21 @@ import React, { useCallback, useContext, useState } from "react";
 import { FieldProps } from "@/components/fields/propTypes";
 import { Data, SheetMeta } from "@/contrib/google/sheets/types";
 import { DevToolsContext } from "@/devTools/context";
-import { useToasts } from "react-toast-notifications";
 import { useField } from "formik";
 import { useAsyncEffect } from "use-async-effect";
 import { isNullOrBlank } from "@/utils";
+import * as sheetHandlers from "@/contrib/google/sheets/handlers";
 import {
   devtoolsProtocol,
   GOOGLE_SHEETS_SCOPES,
 } from "@/contrib/google/sheets/handlers";
-import * as sheetHandlers from "@/contrib/google/sheets/handlers";
-import { reportError } from "@/telemetry/logging";
 import { ensureAuth } from "@/contrib/google/auth";
 import { partial } from "lodash";
 import { isOptionsPage } from "webext-detect-page";
 import { browser } from "webextension-polyfill-ts";
 import { Button, Form, InputGroup } from "react-bootstrap";
+import useNotifications from "@/hooks/useNotifications";
+import { getErrorMessage } from "@/errors";
 
 const API_KEY = process.env.GOOGLE_API_KEY;
 const APP_ID = process.env.GOOGLE_APP_ID;
@@ -45,7 +45,7 @@ const FileField: React.FunctionComponent<
   }
 > = ({ name, onSelect, doc }) => {
   const { port } = useContext(DevToolsContext);
-  const { addToast } = useToasts();
+  const notify = useNotifications();
 
   const [field, meta, helpers] = useField<string>(name);
   const [sheetError, setSheetError] = useState(null);
@@ -76,11 +76,9 @@ const FileField: React.FunctionComponent<
       } catch (error: unknown) {
         if (!isMounted()) return;
         onSelect(null);
-        reportError(error);
         setSheetError(error);
-        addToast("Error retrieving sheet information", {
-          appearance: "error",
-          autoDismiss: true,
+        notify.error("Error retrieving sheet information", {
+          error,
         });
       }
     },
@@ -136,12 +134,11 @@ const FileField: React.FunctionComponent<
         .build();
       picker.setVisible(true);
     } catch (error: unknown) {
-      addToast(`Error loading file picker: ${error}`, {
-        appearance: "error",
-        autoDismiss: true,
+      notify.error(`Error loading file picker: ${getErrorMessage(error)}`, {
+        error,
       });
     }
-  }, [addToast, helpers, onSelect]);
+  }, [notify, helpers, onSelect]);
 
   return (
     <Form.Group>

--- a/src/contrib/google/sheets/FileField.tsx
+++ b/src/contrib/google/sheets/FileField.tsx
@@ -21,7 +21,7 @@ import { Data, SheetMeta } from "@/contrib/google/sheets/types";
 import { DevToolsContext } from "@/devTools/context";
 import { useToasts } from "react-toast-notifications";
 import { useField } from "formik";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { isNullOrBlank } from "@/utils";
 import {
   devtoolsProtocol,

--- a/src/contrib/uipath/process.ts
+++ b/src/contrib/uipath/process.ts
@@ -18,16 +18,23 @@
 import { proxyService } from "@/background/requests";
 import { Transformer } from "@/types";
 import { registerBlock } from "@/blocks/registry";
-import { BlockArg, BlockOptions, Schema, SchemaProperties } from "@/core";
+import {
+  BlockArg,
+  BlockOptions,
+  RegistryId,
+  Schema,
+  SchemaProperties,
+} from "@/core";
 import { sleep } from "@/utils";
 import { BusinessError } from "@/errors";
+import { castRegistryId } from "@/types/helpers";
 
-export const UIPATH_SERVICE_IDS = [
+export const UIPATH_SERVICE_IDS: RegistryId[] = [
   "uipath/cloud",
   "uipath/cloud-oauth",
   "uipath/orchestrator",
-];
-export const UIPATH_ID = "@pixiebrix/uipath/process";
+].map((x) => castRegistryId(x));
+export const UIPATH_ID = castRegistryId("@pixiebrix/uipath/process");
 
 const MAX_WAIT_MILLIS = 20_000;
 const POLL_MILLIS = 1000;
@@ -140,6 +147,7 @@ export class RunProcess extends Transformer {
       }
 
       do {
+        // eslint-disable-next-line no-await-in-loop -- polling for response
         const { data: resultData } = await proxyService<JobsResponse>(uipath, {
           url: `/odata/Jobs?$filter=Id eq ${startData.value[0].Id}`,
           method: "get",
@@ -159,6 +167,7 @@ export class RunProcess extends Transformer {
           throw new BusinessError("UiPath job failed");
         }
 
+        // eslint-disable-next-line no-await-in-loop -- polling for response
         await sleep(POLL_MILLIS);
       } while (Date.now() - start < MAX_WAIT_MILLIS);
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -72,16 +72,18 @@ export interface Message<
  * @see Logger
  */
 export interface MessageContext {
-  readonly deploymentId?: string;
-  readonly blueprintId?: string;
-  readonly extensionPointId?: string;
-  readonly blockId?: string;
-  readonly extensionId?: string;
-  readonly serviceId?: string;
-  readonly authId?: string;
+  readonly deploymentId?: UUID;
+  readonly blueprintId?: RegistryId;
+  readonly extensionPointId?: RegistryId;
+  readonly blockId?: RegistryId;
+  readonly extensionId?: UUID;
+  readonly serviceId?: RegistryId;
+  readonly authId?: UUID;
 }
 
 export type SerializedError = Primitive | ErrorObject;
+
+export type Data = Record<string, unknown>;
 
 export interface Logger {
   readonly context: MessageContext;
@@ -89,15 +91,12 @@ export interface Logger {
    * Return a child logger with additional message context
    */
   childLogger: (additionalContext: MessageContext) => Logger;
-  trace: (msg: string, data?: Record<string, unknown>) => void;
-  warn: (msg: string, data?: Record<string, unknown>) => void;
-  debug: (msg: string, data?: Record<string, unknown>) => void;
-  log: (msg: string, data?: Record<string, unknown>) => void;
-  info: (msg: string, data?: Record<string, unknown>) => void;
-  error: (
-    error: SerializedError | Error,
-    data?: Record<string, unknown>
-  ) => void;
+  trace: (msg: string, data?: Data) => void;
+  warn: (msg: string, data?: Data) => void;
+  debug: (msg: string, data?: Data) => void;
+  log: (msg: string, data?: Data) => void;
+  info: (msg: string, data?: Data) => void;
+  error: (error: unknown, data?: Data) => void;
 }
 
 export type ReaderRoot = HTMLElement | Document;
@@ -185,7 +184,7 @@ export interface DeploymentContext {
   timestamp: string;
 }
 
-export type ExtensionIdentifier = {
+export type ExtensionRef = {
   /**
    * UUID of the extension.
    */
@@ -199,12 +198,12 @@ export type ExtensionIdentifier = {
 
 export interface IExtension<T extends Config = EmptyConfig> {
   /**
-   * UUID of the extension
+   * UUID of the extension.
    */
   id: UUID;
 
   /**
-   * Registry id of the extension point
+   * Registry id of the extension point.
    */
   extensionPointId: RegistryId;
 
@@ -215,7 +214,8 @@ export interface IExtension<T extends Config = EmptyConfig> {
   _deployment?: DeploymentContext;
 
   /**
-   * Metadata about the recipe used to install the extension, or `undefined` if the user created this extension directly
+   * Metadata about the recipe used to install the extension, or `undefined` if the user created this extension
+   * directly.
    */
   _recipe: Metadata | undefined;
 
@@ -235,7 +235,12 @@ export interface IExtension<T extends Config = EmptyConfig> {
   permissions?: Permissions.Permissions;
 
   /**
-   * Inner/anonymous component/reader/extensionPoint definitions.
+   * Inner/anonymous definitions used by the extension.
+   *
+   * Supported definitions:
+   * - extension points
+   * - components
+   * - readers
    */
   definitions?: InnerDefinitions;
 

--- a/src/devTools/Editor.tsx
+++ b/src/devTools/Editor.tsx
@@ -22,7 +22,7 @@ import { RootState } from "@/devTools/store";
 import SplitPane from "react-split-pane";
 import { cancelSelectElement } from "@/background/devtools";
 import { DevToolsContext } from "@/devTools/context";
-import { selectInstalledExtensions } from "@/options/selectors";
+import { selectExtensions } from "@/options/selectors";
 import PermissionsPane from "@/devTools/editor/panes/PermissionsPane";
 import BetaPane from "@/devTools/editor/panes/BetaPane";
 import SupportWidget from "@/devTools/editor/panes/SupportWidget";
@@ -45,7 +45,7 @@ const DEFAULT_SIDEBAR_WIDTH_PX = 260;
 
 const Editor: React.FunctionComponent = () => {
   const { tabState, port, connecting } = useContext(DevToolsContext);
-  const installed = useSelector(selectInstalledExtensions);
+  const installed = useSelector(selectExtensions);
   const dispatch = useDispatch();
 
   const [showChat, setShowChat] = useState<boolean>(false);

--- a/src/devTools/Locator.tsx
+++ b/src/devTools/Locator.tsx
@@ -25,7 +25,7 @@ import Table from "react-bootstrap/Table";
 import { searchWindow, detectFrameworks } from "@/background/devtools";
 import { browser } from "webextension-polyfill-ts";
 import { DevToolsContext } from "@/devTools/context";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { isEmpty } from "lodash";
 
 function useSearchWindow(query: string) {

--- a/src/devTools/Panel.tsx
+++ b/src/devTools/Panel.tsx
@@ -30,7 +30,7 @@ import { useAsyncState } from "@/hooks/common";
 import { getAuth } from "@/hooks/auth";
 import AuthContext from "@/auth/AuthContext";
 import { ToastProvider } from "react-toast-notifications";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import blockRegistry from "@/blocks/registry";
 import ScopeSettings from "@/devTools/ScopeSettings";
 import { AuthState } from "@/core";

--- a/src/devTools/context.ts
+++ b/src/devTools/context.ts
@@ -25,7 +25,7 @@ import {
   ensureScript,
   navigationEvent,
 } from "@/background/devtools/index";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { useAsyncState } from "@/hooks/common";
 import { FrameworkMeta } from "@/messaging/constants";
 import { reportError } from "@/telemetry/logging";

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -158,9 +158,8 @@ export async function generateExtensionPointMetadata(
     return false;
   };
 
-  const collection = `${scope ?? "@local"}/${domain}/`;
-
   // Find next available foundation id
+  const collection = `${scope ?? "@local"}/${domain}`;
   for (let index = 1; index < 1000; index++) {
     const id = castRegistryId(
       [collection, index === 1 ? "foundation" : `foundation-${index}`].join("/")

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -145,7 +145,7 @@ export async function generateExtensionPointMetadata(
 
   await brickRegistry.fetch();
 
-  const allowId = async (id: string) => {
+  const allowId = async (id: RegistryId) => {
     if (!reservedNames.includes(id)) {
       try {
         await brickRegistry.lookup(id);
@@ -158,12 +158,13 @@ export async function generateExtensionPointMetadata(
     return false;
   };
 
+  const collection = `${scope ?? "@local"}/${domain}/`;
+
   // Find next available foundation id
   for (let index = 1; index < 1000; index++) {
-    const id =
-      index === 1
-        ? `${scope ?? "@local"}/${domain}/foundation`
-        : `${scope ?? "@local"}/${domain}/foundation-${index}`;
+    const id = castRegistryId(
+      [collection, index === 1 ? "foundation" : `foundation-${index}`].join("/")
+    );
 
     // Can't parallelize loop because we're looking for first alternative
     const ok = (await Promise.all([allowId(id), allowId(makeReaderId(id))])) // eslint-disable-line no-await-in-loop
@@ -214,14 +215,14 @@ export async function makeReaderFormState(
 ): Promise<Array<ReaderFormState | ReaderReferenceFormState>> {
   const readerId = extensionPoint.definition.reader;
 
-  let readerIds: string[];
+  let readerIds: RegistryId[];
 
   if (isPlainObject(readerId)) {
     throw new Error("Key-based composite readers not supported");
   } else if (typeof readerId === "string") {
     readerIds = [readerId];
   } else if (Array.isArray(readerId)) {
-    readerIds = readerId as string[];
+    readerIds = readerId as RegistryId[];
   } else {
     throw new TypeError("Unexpected reader configuration");
   }

--- a/src/devTools/editor/panes/EditorPane.tsx
+++ b/src/devTools/editor/panes/EditorPane.tsx
@@ -19,7 +19,7 @@ import React from "react";
 import { editorSlice, FormState } from "@/devTools/editor/editorSlice";
 import { useCreate } from "@/devTools/editor/hooks/useCreate";
 import { useDispatch, useSelector } from "react-redux";
-import { selectInstalledExtensions } from "@/options/selectors";
+import { selectExtensions } from "@/options/selectors";
 import { useDebouncedCallback } from "use-debounce";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { Formik } from "formik";
@@ -42,7 +42,7 @@ const EditorPane: React.FunctionComponent<{
 }> = ({ selectedElement, toggleChat, selectionSeq }) => {
   const create = useCreate();
   const dispatch = useDispatch();
-  const installed = useSelector(selectInstalledExtensions);
+  const installed = useSelector(selectExtensions);
   const editable = useEditable();
 
   // XXX: anti-pattern: callback to update the redux store based on the formik state

--- a/src/devTools/editor/sidebar/DynamicEntry.tsx
+++ b/src/devTools/editor/sidebar/DynamicEntry.tsx
@@ -28,6 +28,7 @@ import {
   NotAvailableIcon,
   UnsavedChangesIcon,
 } from "@/devTools/editor/sidebar/ExtensionIcons";
+import { UUID } from "@/core";
 
 /**
  * A sidebar menu entry corresponding to an extension that is new or is currently being edited.
@@ -46,18 +47,15 @@ const DynamicEntry: React.FunctionComponent<{
   );
 
   const showOverlay = useCallback(
-    async (uuid: string) => {
+    async (uuid: UUID) => {
       await enableDataOverlay(port, uuid);
     },
     [port]
   );
 
-  const hideOverlay = useCallback(
-    async () => {
-      await disableOverlay(port);
-    },
-    [port]
-  )
+  const hideOverlay = useCallback(async () => {
+    await disableOverlay(port);
+  }, [port]);
 
   return (
     <ListGroup.Item

--- a/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
@@ -20,7 +20,7 @@ import { FormState } from "@/devTools/editor/editorSlice";
 import { useFormikContext } from "formik";
 import { Alert, Col, Form, Row } from "react-bootstrap";
 import { SchemaTree } from "@/options/pages/extensionEditor/DataSourceCard";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import GridLoader from "react-spinners/GridLoader";
 import { jsonTreeTheme as theme } from "@/themes/light";
 import JSONTree from "react-json-tree";
@@ -193,7 +193,7 @@ export const ReaderBlockForm: React.FunctionComponent<{
             </div>
 
             <div className="overflow-auto h-100 w-100">
-              {available === false && (
+              {!available && (
                 <span className="text-danger">
                   Extension not available on page
                 </span>

--- a/src/devTools/editor/tabs/reader/ReaderConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderConfig.tsx
@@ -25,7 +25,7 @@ import Select from "react-select";
 import { Framework, FrameworkMeta } from "@/messaging/constants";
 import SelectorSelectorField from "@/devTools/editor/fields/SelectorSelectorField";
 import { SchemaTree } from "@/options/pages/extensionEditor/DataSourceCard";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import GridLoader from "react-spinners/GridLoader";
 import { runReader } from "@/background/devtools";
 import { jsonTreeTheme as theme } from "@/themes/light";

--- a/src/devTools/editor/toolbar/PermissionsToolbar.tsx
+++ b/src/devTools/editor/toolbar/PermissionsToolbar.tsx
@@ -24,7 +24,7 @@ import { ADAPTERS } from "@/devTools/editor/extensionPoints/adapter";
 import { ensureAllPermissions, extensionPermissions } from "@/permissions";
 import { fromJS as extensionPointFactory } from "@/extensionPoints/factory";
 import { Permissions } from "webextension-polyfill-ts";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { useDebounce } from "use-debounce";
 import { useToasts } from "react-toast-notifications";
 import { containsPermissions } from "@/utils/permissions";

--- a/src/devTools/editor/toolbar/ReloadToolbar.tsx
+++ b/src/devTools/editor/toolbar/ReloadToolbar.tsx
@@ -21,7 +21,7 @@ import { DevToolsContext } from "@/devTools/context";
 import { useDebouncedCallback } from "use-debounce";
 import { ADAPTERS } from "@/devTools/editor/extensionPoints/adapter";
 import * as nativeOperations from "@/background/devtools";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import ToggleField from "@/devTools/editor/components/ToggleField";
 import { Button } from "react-bootstrap";
 import { TriggerFormState } from "@/devTools/editor/extensionPoints/trigger";

--- a/src/devTools/store.ts
+++ b/src/devTools/store.ts
@@ -20,7 +20,6 @@ import { persistStore, persistReducer } from "redux-persist";
 import { localStorage } from "redux-persist-webextension-storage";
 import {
   optionsSlice,
-  OptionsState,
   servicesSlice,
   settingsSlice,
   SettingsState,
@@ -29,7 +28,7 @@ import {
 import { editorSlice, EditorState } from "@/devTools/editor/editorSlice";
 import { createLogger } from "redux-logger";
 import { boolean } from "@/utils";
-import { persistOptionsConfig } from "@/store/extensions";
+import { OptionsState, persistOptionsConfig } from "@/store/extensions";
 import { persistServicesConfig } from "@/store/services";
 
 const REDUX_DEV_TOOLS: boolean = boolean(process.env.REDUX_DEV_TOOLS);

--- a/src/devTools/store.ts
+++ b/src/devTools/store.ts
@@ -29,18 +29,10 @@ import {
 import { editorSlice, EditorState } from "@/devTools/editor/editorSlice";
 import { createLogger } from "redux-logger";
 import { boolean } from "@/utils";
+import { persistOptionsConfig } from "@/store/extensions";
+import { persistServicesConfig } from "@/store/services";
 
 const REDUX_DEV_TOOLS: boolean = boolean(process.env.REDUX_DEV_TOOLS);
-
-const persistOptionsConfig = {
-  key: "extensionOptions",
-  storage: localStorage,
-};
-
-const persistServicesConfig = {
-  key: "servicesOptions",
-  storage: localStorage,
-};
 
 const persistSettingsConfig = {
   key: "settings",

--- a/src/extensionPoints/registry.ts
+++ b/src/extensionPoints/registry.ts
@@ -18,9 +18,9 @@
 import { sortBy } from "lodash";
 import { fromJS } from "@/extensionPoints/factory";
 import BaseRegistry from "@/baseRegistry";
-import { IExtensionPoint, IOption } from "@/core";
+import { IExtensionPoint, IOption, RegistryId } from "@/core";
 
-const registry = new BaseRegistry<IExtensionPoint>(
+const registry = new BaseRegistry<RegistryId, IExtensionPoint>(
   ["foundation", "extensionPoint"],
   "extension-points",
   fromJS

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -18,6 +18,7 @@
 import { fetch } from "@/hooks/fetch";
 import { AuthState } from "@/core";
 import { updateAuth as updateRollbarAuth } from "@/telemetry/rollbar";
+import { getUID } from "@/background/telemetry";
 
 interface OrganizationResponse {
   readonly id: string;
@@ -60,6 +61,7 @@ export async function getAuth(): Promise<AuthState> {
       userId: id,
       email,
       organizationId: telemetryOrganization?.id ?? organization?.id,
+      browserId: await getUID(),
     });
     return {
       userId: id,

--- a/src/hooks/common.ts
+++ b/src/hooks/common.ts
@@ -16,7 +16,7 @@
  */
 
 import { useCallback, useState } from "react";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 
 type StateFactory<T> = Promise<T> | (() => Promise<T>);
 

--- a/src/hooks/fetch.ts
+++ b/src/hooks/fetch.ts
@@ -16,7 +16,7 @@
  */
 
 import { useState } from "react";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import axios from "axios";
 import { getBaseURL } from "@/services/baseService";
 import { useAsyncState } from "@/hooks/common";

--- a/src/hooks/logging.ts
+++ b/src/hooks/logging.ts
@@ -16,7 +16,7 @@
  */
 
 import { useCallback, useState } from "react";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import {
   getLoggingConfig,
   LoggingConfig,

--- a/src/hooks/registry.ts
+++ b/src/hooks/registry.ts
@@ -15,13 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Registry, { RegistryItem } from "@/baseRegistry";
+import { Registry, RegistryItem } from "@/baseRegistry";
 import { useState } from "react";
 import { useAsyncEffect } from "use-async-effect";
+import { RegistryId } from "@/core";
 
-export function useRegistry<T extends RegistryItem>(
-  registry: Registry<T>,
-  id: string
+export function useRegistry<Id extends RegistryId, T extends RegistryItem<Id>>(
+  registry: Registry<Id, T>,
+  id: Id
 ): T {
   const [result, setResult] = useState<T>();
   useAsyncEffect(

--- a/src/hooks/useDeployments.ts
+++ b/src/hooks/useDeployments.ts
@@ -23,7 +23,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { fromPairs } from "lodash";
 import { reportEvent } from "@/telemetry/events";
 import { optionsSlice } from "@/options/slices";
-import { selectInstalledExtensions } from "@/options/selectors";
+import { selectExtensions } from "@/options/selectors";
 import { getErrorMessage } from "@/errors";
 import useNotifications from "@/hooks/useNotifications";
 import { getExtensionToken } from "@/auth/token";
@@ -126,7 +126,7 @@ type DeploymentState = {
 function useDeployments(): DeploymentState {
   const notify = useNotifications();
   const dispatch = useDispatch();
-  const installed = useSelector(selectInstalledExtensions);
+  const installed = useSelector(selectExtensions);
 
   const [deployments] = useAsyncState(async () => fetchDeployments(installed), [
     installed,

--- a/src/hooks/useExtensionMeta.ts
+++ b/src/hooks/useExtensionMeta.ts
@@ -16,12 +16,12 @@
  */
 
 import { useSelector } from "react-redux";
-import { selectInstalledExtensions } from "@/options/selectors";
+import { selectExtensions } from "@/options/selectors";
 import { useMemo } from "react";
 import { IExtension } from "@/core";
 
 function useExtensionMeta(): { lookup: Map<string, IExtension> } {
-  const extensions = useSelector(selectInstalledExtensions);
+  const extensions = useSelector(selectExtensions);
   const lookup = useMemo(() => new Map(extensions.map((x) => [x.id, x])), [
     extensions,
   ]);

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -19,7 +19,7 @@ import { useAsyncState } from "@/hooks/common";
 import { getBaseURL } from "@/services/baseService";
 import { useToasts } from "react-toast-notifications";
 import { useCallback, useState } from "react";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { fetch } from "@/hooks/fetch";
 
 type FetchState<TData> = {

--- a/src/hooks/useRefresh.ts
+++ b/src/hooks/useRefresh.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { useToasts } from "react-toast-notifications";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import extensionPointRegistry from "@/extensionPoints/registry";
 import blockRegistry from "@/blocks/registry";
 import serviceRegistry from "@/services/registry";

--- a/src/icons/Icon.tsx
+++ b/src/icons/Icon.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useState } from "react";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { IconLibrary } from "@/core";
 import iconAsSVG from "@/icons/svgIcons";
 

--- a/src/messaging/external.ts
+++ b/src/messaging/external.ts
@@ -24,6 +24,7 @@ import { liftExternal } from "@/contentScript/externalProtocol";
 import { browser } from "webextension-polyfill-ts";
 import { isFirefox } from "webext-detect-page";
 import { reportEvent } from "@/telemetry/events";
+import { getUID } from "@/background/telemetry";
 
 const lift = isFirefox() ? liftExternal : liftBackground;
 
@@ -40,7 +41,8 @@ const _reload = liftBackground("BACKGROUND_RELOAD", async () => {
 export const setExtensionAuth = lift(
   "SET_EXTENSION_AUTH",
   async (auth: AuthData) => {
-    const updated = await updateExtensionAuth(auth);
+    const browserId = await getUID();
+    const updated = await updateExtensionAuth({ ...auth, browserId });
     if (updated) {
       // A hack to ensure the SET_EXTENSION_AUTH response flows to the front-end before the backend
       // page is reloaded, causing the message port to close.

--- a/src/nativeEditor/dynamic.ts
+++ b/src/nativeEditor/dynamic.ts
@@ -15,7 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { EmptyConfig, IExtension, IExtensionPoint, IReader } from "@/core";
+import {
+  EmptyConfig,
+  IExtension,
+  IExtensionPoint,
+  IReader,
+  UUID,
+} from "@/core";
 import { liftContentScript } from "@/contentScript/backgroundProtocol";
 import {
   clearDynamic,
@@ -64,7 +70,7 @@ const _temporaryExtensions: Map<string, IExtensionPoint> = new Map();
 
 export const clear = liftContentScript(
   "CLEAR_DYNAMIC",
-  async ({ uuid }: { uuid?: string }) => {
+  async ({ uuid }: { uuid?: UUID }) => {
     clearDynamic(uuid);
     if (uuid) {
       _temporaryExtensions.delete(uuid);

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -20,7 +20,7 @@ import "@/extensionContext";
 // Init rollbar early so we get error reporting on the other initialization
 import "@/telemetry/rollbar";
 
-import ReactDOM from "react-dom";
+import { render } from "react-dom";
 import React from "react";
 import App from "@/options/App";
 import initGoogle from "@/contrib/google/initGoogle";
@@ -30,4 +30,4 @@ import "@/vendors/overrides.scss";
 
 initGoogle();
 
-ReactDOM.render(<App />, document.querySelector("#container"));
+render(<App />, document.querySelector("#container"));

--- a/src/options/loader.ts
+++ b/src/options/loader.ts
@@ -16,14 +16,10 @@
  */
 
 import { browser } from "webextension-polyfill-ts";
-import { IExtension } from "@/core";
+import { ExtensionsOptionsState, migrateOptionsState } from "@/options/slices";
 
 const STORAGE_KEY = "persist:extensionOptions";
 const INITIAL_STATE = JSON.stringify({});
-
-type State = {
-  extensions: Record<string, Record<string, IExtension>>;
-};
 
 type JSONString = string;
 
@@ -38,18 +34,21 @@ async function getOptionsState(): Promise<RawOptionsState> {
 }
 
 /**
- * Read extension options from local storage
+ * Read extension options from local storage (without going through redux-persistor).
  */
-export async function loadOptions(): Promise<State> {
+export async function loadOptions(): Promise<ExtensionsOptionsState> {
   const base = await getOptionsState();
-  // The redux persist layer persists the extensions value as as JSON-string
-  return { extensions: JSON.parse(base.extensions) };
+  // The redux persist layer persists the extensions value as as JSON-string.
+  // Also apply the upgradeExtensionsState migration here because the migration in store might not have run yet.
+  return migrateOptionsState({ extensions: JSON.parse(base.extensions) });
 }
 
 /**
- * Save extension options to local storage
+ * Save extension options to local storage (without going through redux-persistor).
  */
-export async function saveOptions(state: State): Promise<void> {
+export async function saveOptions(
+  state: ExtensionsOptionsState
+): Promise<void> {
   const base = await getOptionsState();
   await browser.storage.local.set({
     // The redux persist layer persists the extensions value as as JSON-string

--- a/src/options/loader.ts
+++ b/src/options/loader.ts
@@ -16,7 +16,10 @@
  */
 
 import { browser } from "webextension-polyfill-ts";
-import { ExtensionsOptionsState, migrateOptionsState } from "@/options/slices";
+import {
+  ExtensionsOptionsState,
+  migrateOptionsState,
+} from "@/store/extensions";
 
 const STORAGE_KEY = "persist:extensionOptions";
 const INITIAL_STATE = JSON.stringify({});

--- a/src/options/pages/MarketplacePage.tsx
+++ b/src/options/pages/MarketplacePage.tsx
@@ -17,14 +17,17 @@
 
 import React, { useCallback } from "react";
 import { connect } from "react-redux";
+import { compact } from "lodash";
 import { OptionsState } from "../slices";
 import GenericMarketplacePage from "@/pages/marketplace/MarketplacePage";
 import { push } from "connected-react-router";
 import { RecipeDefinition } from "@/types/definitions";
 import { useTitle } from "@/hooks/title";
+import { selectExtensions } from "@/options/selectors";
+import { RegistryId } from "@/core";
 
 export interface MarketplaceProps {
-  installedRecipes: Set<string>;
+  installedRecipes: Set<RegistryId>;
   navigate: (url: string) => void;
 }
 
@@ -50,13 +53,9 @@ const MarketplacePage: React.FunctionComponent<MarketplaceProps> = ({
 };
 
 export default connect(
-  ({ options }: { options: OptionsState }) => ({
+  (state: { options: OptionsState }) => ({
     installedRecipes: new Set(
-      Object.values(options.extensions).flatMap((extensionPoint) =>
-        Object.values(extensionPoint)
-          .map((x) => x._recipe?.id)
-          .filter((x) => x)
-      )
+      compact(selectExtensions(state).map((x) => x._recipe?.id))
     ),
   }),
   { navigate: push }

--- a/src/options/pages/MarketplacePage.tsx
+++ b/src/options/pages/MarketplacePage.tsx
@@ -18,13 +18,13 @@
 import React, { useCallback } from "react";
 import { connect } from "react-redux";
 import { compact } from "lodash";
-import { OptionsState } from "../slices";
 import GenericMarketplacePage from "@/pages/marketplace/MarketplacePage";
 import { push } from "connected-react-router";
 import { RecipeDefinition } from "@/types/definitions";
 import { useTitle } from "@/hooks/title";
 import { selectExtensions } from "@/options/selectors";
 import { RegistryId } from "@/core";
+import { OptionsState } from "@/store/extensions";
 
 export interface MarketplaceProps {
   installedRecipes: Set<RegistryId>;

--- a/src/options/pages/brickEditor/BrickReference.tsx
+++ b/src/options/pages/brickEditor/BrickReference.tsx
@@ -31,7 +31,7 @@ import Fuse from "fuse.js";
 import { isEmpty, sortBy } from "lodash";
 import copy from "copy-to-clipboard";
 import { BlockType, getType } from "@/blocks/util";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getIcon } from "@/components/fields/BlockModal";
 import cx from "classnames";

--- a/src/options/pages/brickEditor/useLogContext.ts
+++ b/src/options/pages/brickEditor/useLogContext.ts
@@ -19,7 +19,7 @@ import { useDebounce } from "use-debounce";
 import { useState } from "react";
 import yaml from "js-yaml";
 import { MessageContext, RawConfig } from "@/core";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 
 const LOG_MESSAGE_CONTEXT_DEBOUNCE_MS = 350;
 

--- a/src/options/pages/extensionEditor/ExtensionEditor.tsx
+++ b/src/options/pages/extensionEditor/ExtensionEditor.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { useToasts } from "react-toast-notifications";
 import { uuidv4 } from "@/types/helpers";
 import { connect } from "react-redux";
@@ -23,33 +23,32 @@ import { optionsSlice } from "@/options/slices";
 import { push } from "connected-react-router";
 import { useParams } from "react-router";
 import { useExtension } from "@/selectors";
-import ExtensionPointDetail, { Config } from "./ExtensionPointDetail";
+import ExtensionPointDetail from "./ExtensionPointDetail";
 import WorkshopPage from "@/options/pages/extensionEditor/WorkshopPage";
 import { reactivate } from "@/background/navigation";
 import GridLoader from "react-spinners/GridLoader";
 
 import "./ExtensionEditor.scss";
+import { RegistryId, UUID } from "@/core";
 
 const { saveExtension } = optionsSlice.actions;
 
 interface OwnProps {
   navigate: (target: string) => void;
-  saveExtension: (
-    config: Config & { extensionPointId: string; extensionId: string }
-  ) => void;
+  saveExtension: typeof saveExtension;
 }
 
-interface InstallRouteParams {
-  extensionId: null;
-  extensionPointId: string;
+type InstallRouteParams = {
+  extensionId: UUID;
+  extensionPointId: RegistryId;
   tab?: string;
-}
+};
 
-interface EditRouteParams {
-  extensionPointId: null;
-  extensionId: string;
+type EditRouteParams = {
+  extensionPointId: UUID;
+  extensionId: RegistryId;
   tab?: string;
-}
+};
 
 type RouteParams = InstallRouteParams | EditRouteParams;
 
@@ -58,10 +57,23 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
   navigate,
 }) => {
   const { addToast } = useToasts();
-  const { extensionPointId, extensionId } = useParams<RouteParams>();
+  const params = useParams<RouteParams>();
+
+  const parsed = useMemo(
+    () => ({
+      extensionPointId: params.extensionPointId
+        ? (decodeURIComponent(params.extensionPointId) as RegistryId)
+        : undefined,
+      extensionId: params.extensionId
+        ? (decodeURIComponent(params.extensionId) as UUID)
+        : undefined,
+    }),
+    [params]
+  );
+
   const { extensionPoint, extensionConfig, isPending } = useExtension(
-    extensionPointId ? decodeURIComponent(extensionPointId) : undefined,
-    extensionId ? decodeURIComponent(extensionId) : undefined
+    parsed.extensionPointId,
+    parsed.extensionId
   );
 
   const save = useCallback(
@@ -74,8 +86,9 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
         const isNew = !extensionConfig?.id;
         const extensionId = extensionConfig?.id ?? uuidv4();
         saveExtension({
-          extensionPointId: extensionPoint.id,
+          id: extensionId,
           extensionId,
+          extensionPointId: extensionPoint.id,
           config,
           services,
           label,
@@ -119,7 +132,7 @@ const ExtensionEditor: React.FunctionComponent<OwnProps> = ({
         services: extensionConfig?.services ?? [],
         optionsArgs: extensionConfig?.optionsArgs ?? {},
       }}
-      extensionId={extensionId}
+      extensionId={parsed.extensionId}
       extensionPoint={extensionPoint}
       onSave={save}
     />

--- a/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
+++ b/src/options/pages/extensionEditor/ExtensionPointDetail.tsx
@@ -27,7 +27,7 @@ import {
 import { Button, Card, Col, Form, Nav, Row } from "react-bootstrap";
 import ServicesFormCard from "@/options/pages/extensionEditor/ServicesFormCard";
 import ExtensionConfigurationCard from "@/options/pages/extensionEditor/ExtensionConfigurationCard";
-import { IExtensionPoint, ServiceDependency, UserOptions } from "@/core";
+import { IExtensionPoint, ServiceDependency, UserOptions, UUID } from "@/core";
 import DataSourceCard from "@/options/pages/extensionEditor/DataSourceCard";
 import { Formik, FormikProps, getIn, useFormikContext } from "formik";
 import TextField from "@/components/fields/TextField";
@@ -35,7 +35,7 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import { extensionValidatorFactory } from "@/validators/validation";
 import { SCHEMA_TYPE_TO_BLOCK_PROPERTY } from "@/components/fields/BlockField";
 import { castArray, fromPairs, isEmpty, truncate } from "lodash";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import RunLogCard from "@/options/pages/extensionEditor/RunLogCard";
 import { useParams } from "react-router";
@@ -61,7 +61,7 @@ export interface Config {
 
 interface OwnProps {
   extensionPoint: IExtensionPoint;
-  extensionId: string | null;
+  extensionId: UUID | null;
   initialValue: Config;
   onSave: (
     update: Config,
@@ -165,7 +165,7 @@ function exportBlueprint(
 const ExtensionForm: React.FunctionComponent<{
   formikProps: FormikProps<Config>;
   extensionPoint: IExtensionPoint;
-  extensionId: string | null;
+  extensionId: UUID | null;
 }> = ({
   formikProps: { handleSubmit, isSubmitting, isValid, validateForm, values },
   extensionPoint,

--- a/src/options/pages/extensionEditor/RunLogCard.tsx
+++ b/src/options/pages/extensionEditor/RunLogCard.tsx
@@ -22,11 +22,12 @@ import { Card } from "react-bootstrap";
 import LogTable from "@/components/logViewer/LogTable";
 import useLogEntries from "@/components/logViewer/useLogEntries";
 import LogToolbar from "@/components/logViewer/LogToolbar";
+import { RegistryId, UUID } from "@/core";
 
 type OwnProps = {
   initialLevel?: MessageLevel;
-  extensionPointId: string;
-  extensionId: string;
+  extensionPointId: RegistryId;
+  extensionId: UUID;
   perPage?: number;
   refreshInterval?: number;
 };

--- a/src/options/pages/installed/ExtensionRow.tsx
+++ b/src/options/pages/installed/ExtensionRow.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useMemo } from "react";
-import { ExtensionIdentifier, IExtension } from "@/core";
+import { ExtensionRef, IExtension } from "@/core";
 import { useToasts } from "react-toast-notifications";
 import {
   ExtensionValidationResult,
@@ -30,7 +30,7 @@ import { Link } from "react-router-dom";
 import AsyncButton from "@/components/AsyncButton";
 import useExtensionPermissions from "@/options/pages/installed/useExtensionPermissions";
 
-type RemoveAction = (identifier: ExtensionIdentifier) => void;
+type RemoveAction = (identifier: ExtensionRef) => void;
 
 function validationMessage(validation: ExtensionValidationResult) {
   let message = "Invalid Configuration";

--- a/src/options/pages/installed/InstalledPage.tsx
+++ b/src/options/pages/installed/InstalledPage.tsx
@@ -23,7 +23,7 @@ import { PageTitle } from "@/layout/Page";
 import { faCubes } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 import { Card, Col, Row, Table } from "react-bootstrap";
-import { ExtensionIdentifier, IExtension } from "@/core";
+import { ExtensionRef, IExtension } from "@/core";
 import "./InstalledPage.scss";
 import { uninstallContextMenu } from "@/background/contextMenus";
 import { reportError } from "@/telemetry/logging";
@@ -31,14 +31,14 @@ import AuthContext from "@/auth/AuthContext";
 import { reportEvent } from "@/telemetry/events";
 import { reactivate } from "@/background/navigation";
 import { Dispatch } from "redux";
-import { selectInstalledExtensions } from "@/options/selectors";
+import { selectExtensions } from "@/options/selectors";
 import { useTitle } from "@/hooks/title";
 import NoExtensionsPage from "@/options/pages/installed/NoExtensionsPage";
 import RecipeEntry from "@/options/pages/installed/RecipeEntry";
 
 const { removeExtension } = optionsSlice.actions;
 
-type RemoveAction = (identifier: ExtensionIdentifier) => void;
+type RemoveAction = (identifier: ExtensionRef) => void;
 
 const InstalledTable: React.FunctionComponent<{
   extensions: IExtension[];
@@ -140,11 +140,11 @@ const InstalledPage: React.FunctionComponent<{
 };
 
 const mapStateToProps = (state: { options: OptionsState }) => ({
-  extensions: selectInstalledExtensions(state),
+  extensions: selectExtensions(state),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  onRemove: (ref: ExtensionIdentifier) => {
+  onRemove: (ref: ExtensionRef) => {
     reportEvent("ExtensionRemove", {
       extensionId: ref.extensionId,
     });

--- a/src/options/pages/installed/InstalledPage.tsx
+++ b/src/options/pages/installed/InstalledPage.tsx
@@ -18,7 +18,7 @@
 import { connect } from "react-redux";
 import React, { useContext, useMemo } from "react";
 import { groupBy, isEmpty, sortBy } from "lodash";
-import { optionsSlice, OptionsState } from "@/options/slices";
+import { optionsSlice } from "@/options/slices";
 import { PageTitle } from "@/layout/Page";
 import { faCubes } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
@@ -35,6 +35,7 @@ import { selectExtensions } from "@/options/selectors";
 import { useTitle } from "@/hooks/title";
 import NoExtensionsPage from "@/options/pages/installed/NoExtensionsPage";
 import RecipeEntry from "@/options/pages/installed/RecipeEntry";
+import { OptionsState } from "@/store/extensions";
 
 const { removeExtension } = optionsSlice.actions;
 
@@ -139,9 +140,8 @@ const InstalledPage: React.FunctionComponent<{
   );
 };
 
-const mapStateToProps = (state: { options: OptionsState }) => ({
-  extensions: selectExtensions(state),
-});
+const mapStateToProps = (state: { options: OptionsState }) =>
+  selectExtensions(state);
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   onRemove: (ref: ExtensionRef) => {

--- a/src/options/pages/installed/RecipeEntry.tsx
+++ b/src/options/pages/installed/RecipeEntry.tsx
@@ -26,12 +26,12 @@ import {
   faCheck,
 } from "@fortawesome/free-solid-svg-icons";
 import AsyncButton from "@/components/AsyncButton";
-import { ExtensionIdentifier, IExtension } from "@/core";
+import { ExtensionRef, IExtension } from "@/core";
 import ExtensionRow from "@/options/pages/installed/ExtensionRow";
 import useNotifications from "@/hooks/useNotifications";
 import useExtensionPermissions from "@/options/pages/installed/useExtensionPermissions";
 
-type RemoveAction = (identifier: ExtensionIdentifier) => void;
+type RemoveAction = (identifier: ExtensionRef) => void;
 
 const RecipeEntry: React.FunctionComponent<{
   recipeId: string;

--- a/src/options/pages/services/ConnectExtensionCard.tsx
+++ b/src/options/pages/services/ConnectExtensionCard.tsx
@@ -18,7 +18,7 @@
 import React, { useState } from "react";
 import { useAsyncState } from "@/hooks/common";
 import { getBaseURL } from "@/services/baseService";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { getExtensionToken } from "@/auth/token";
 import Card from "react-bootstrap/Card";
 import urljoin from "url-join";

--- a/src/options/pages/settings/PermissionsSettings.tsx
+++ b/src/options/pages/settings/PermissionsSettings.tsx
@@ -20,7 +20,7 @@ import { useToasts } from "react-toast-notifications";
 import { getAdditionalPermissions } from "webext-additional-permissions";
 import { browser, Manifest } from "webextension-polyfill-ts";
 import { sortBy } from "lodash";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { Button, Card, ListGroup } from "react-bootstrap";
 type OptionalPermission = Manifest.OptionalPermission;
 type Permissions = chrome.permissions.Permissions;

--- a/src/options/pages/settings/PrivacySettings.tsx
+++ b/src/options/pages/settings/PrivacySettings.tsx
@@ -20,7 +20,7 @@ import { Card, Form } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import BootstrapSwitchButton from "bootstrap-switch-button-react";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { getDNT, toggleDNT } from "@/background/telemetry";
 
 function useDNT(): [boolean, (enabled: boolean) => Promise<void>] {

--- a/src/options/pages/templates/TemplatesPage.tsx
+++ b/src/options/pages/templates/TemplatesPage.tsx
@@ -42,7 +42,6 @@ import {
 } from "react-bootstrap";
 import { InstallRecipe, RecipeList } from "@/pages/marketplace/MarketplacePage";
 import { connect } from "react-redux";
-import { OptionsState } from "@/options/slices";
 import { push } from "connected-react-router";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import cx from "classnames";
@@ -53,6 +52,7 @@ import GridLoader from "react-spinners/GridLoader";
 import { useTitle } from "@/hooks/title";
 import { RegistryId } from "@/core";
 import { selectExtensions } from "@/options/selectors";
+import { OptionsState } from "@/store/extensions";
 
 export interface TemplatesProps {
   installedRecipes: Set<RegistryId>;

--- a/src/options/selectors.ts
+++ b/src/options/selectors.ts
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { OptionsState } from "@/options/slices";
 import { IExtension } from "@/core";
+import { OptionsState } from "@/store/extensions";
 
 export function selectExtensions({
   options,

--- a/src/options/selectors.ts
+++ b/src/options/selectors.ts
@@ -23,20 +23,12 @@ export function selectExtensions({
 }: {
   options: OptionsState;
 }): IExtension[] {
-  return Object.values(options.extensions).flatMap((extensionPointOptions) =>
-    Object.values(extensionPointOptions)
-  );
-}
+  if (!Array.isArray(options.extensions)) {
+    console.warn("state migration has not been applied yet", {
+      options,
+    });
+    throw new TypeError("state migration has not been applied yet");
+  }
 
-export function selectInstalledExtensions(state: {
-  options: OptionsState;
-}): IExtension[] {
-  return Object.entries(state.options.extensions).flatMap(
-    ([extensionPointId, pointExtensions]) =>
-      Object.entries(pointExtensions).map(([extensionId, extension]) => ({
-        id: extensionId,
-        extensionPointId,
-        ...extension,
-      }))
-  );
+  return options.extensions;
 }

--- a/src/options/slices.ts
+++ b/src/options/slices.ts
@@ -29,6 +29,7 @@ import { preloadMenus } from "@/background/preload";
 import { selectEventData } from "@/telemetry/deployments";
 import { uuidv4 } from "@/types/helpers";
 import { Except } from "type-fest";
+import { OptionsState } from "@/store/extensions";
 
 type InstallMode = "local" | "remote";
 
@@ -57,49 +58,6 @@ export interface ServicesState {
 const initialServicesState: ServicesState = {
   configured: {},
 };
-
-/**
- * @deprecated use ExtensionsState - this is only used in the migration
- */
-type LegacyExtensionsState = {
-  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- documentation
-  extensions: {
-    // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- documentation
-    [extensionPointId: string]: {
-      [extensionId: string]: IExtension;
-    };
-  };
-};
-
-export type ExtensionsOptionsState = {
-  extensions: IExtension[];
-};
-
-export function migrateOptionsState<T>(
-  state: T & (LegacyExtensionsState | ExtensionsOptionsState)
-): T & ExtensionsOptionsState {
-  if (state.extensions == null) {
-    console.info("Repairing redux state");
-    return { ...state, extensions: [] };
-  }
-
-  if (Array.isArray(state.extensions)) {
-    // Already migrated
-    console.debug("Redux state already up-to-date");
-    return state as T & ExtensionsOptionsState;
-  }
-
-  console.info("Migrating redux state");
-
-  return {
-    ...state,
-    extensions: Object.values(state.extensions).flatMap((extensionMap) =>
-      Object.values(extensionMap)
-    ),
-  };
-}
-
-export type OptionsState = LegacyExtensionsState | ExtensionsOptionsState;
 
 type RecentBrick = {
   id: string;

--- a/src/options/slices.ts
+++ b/src/options/slices.ts
@@ -15,13 +15,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { createSlice } from "@reduxjs/toolkit";
-import { IExtension, RawServiceConfiguration, RegistryId } from "@/core";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import {
+  ExtensionRef,
+  IExtension,
+  RawServiceConfiguration,
+  RegistryId,
+  UUID,
+} from "@/core";
 import { orderBy } from "lodash";
 import { reportEvent } from "@/telemetry/events";
 import { preloadMenus } from "@/background/preload";
 import { selectEventData } from "@/telemetry/deployments";
 import { uuidv4 } from "@/types/helpers";
+import { Except } from "type-fest";
 
 type InstallMode = "local" | "remote";
 
@@ -51,13 +58,48 @@ const initialServicesState: ServicesState = {
   configured: {},
 };
 
-export interface OptionsState {
+/**
+ * @deprecated use ExtensionsState - this is only used in the migration
+ */
+type LegacyExtensionsState = {
+  // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- documentation
   extensions: {
+    // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- documentation
     [extensionPointId: string]: {
       [extensionId: string]: IExtension;
     };
   };
+};
+
+export type ExtensionsOptionsState = {
+  extensions: IExtension[];
+};
+
+export function migrateOptionsState<T>(
+  state: T & (LegacyExtensionsState | ExtensionsOptionsState)
+): T & ExtensionsOptionsState {
+  if (state.extensions == null) {
+    console.info("Repairing redux state");
+    return { ...state, extensions: [] };
+  }
+
+  if (Array.isArray(state.extensions)) {
+    // Already migrated
+    console.debug("Redux state already up-to-date");
+    return state as T & ExtensionsOptionsState;
+  }
+
+  console.info("Migrating redux state");
+
+  return {
+    ...state,
+    extensions: Object.values(state.extensions).flatMap((extensionMap) =>
+      Object.values(extensionMap)
+    ),
+  };
 }
+
+export type OptionsState = LegacyExtensionsState | ExtensionsOptionsState;
 
 type RecentBrick = {
   id: string;
@@ -88,11 +130,8 @@ const initialWorkshopState: WorkshopState = {
 };
 
 const initialOptionsState: OptionsState = {
-  extensions: {},
+  extensions: [],
 };
-
-/* The object access in servicesSlice and optionsSlice should be safe because slice reducers use immer under the hood */
-/* eslint-disable security/detect-object-injection */
 
 export const workshopSlice = createSlice({
   name: "workshop",
@@ -132,30 +171,39 @@ export const workshopSlice = createSlice({
 });
 
 export const servicesSlice = createSlice({
+  /* The object access in servicesSlice and optionsSlice should be safe because type-checker enforced UUID */
+  /* eslint-disable security/detect-object-injection */
+
   name: "services",
   initialState: initialServicesState,
   reducers: {
-    deleteServiceConfig(state, { payload: { id } }) {
+    deleteServiceConfig(
+      state,
+      { payload: { id } }: PayloadAction<{ id: UUID }>
+    ) {
       if (!state.configured[id]) {
         throw new Error(`Service configuration ${id} does not exist`);
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- type-checked as UUID
       delete state.configured[id];
       return state;
     },
     updateServiceConfig(state, { payload: { id, serviceId, label, config } }) {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- branding with nominal type
       state.configured[id] = {
-        _rawServiceConfigurationBrand: undefined,
         id,
         serviceId,
         label,
         config,
-      };
+      } as RawServiceConfiguration;
     },
     resetServices(state) {
       state.configured = {};
     },
   },
+
+  /* eslint-enable security/detect-object-injection */
 });
 
 export const optionsSlice = createSlice({
@@ -163,7 +211,7 @@ export const optionsSlice = createSlice({
   initialState: initialOptionsState,
   reducers: {
     resetOptions(state) {
-      state.extensions = {};
+      state.extensions = [];
     },
     installRecipe(state, { payload }) {
       const {
@@ -184,11 +232,7 @@ export const optionsSlice = createSlice({
           throw new Error("extensionPointId is required");
         }
 
-        if (state.extensions[extensionPointId] == null) {
-          state.extensions[extensionPointId] = {};
-        }
-
-        const extensionConfig: IExtension = {
+        const extension: IExtension = {
           id: extensionId,
           _deployment: deployment
             ? {
@@ -201,6 +245,7 @@ export const optionsSlice = createSlice({
           services: Object.entries(services ?? {}).map(
             ([outputKey, id]: [string, RegistryId]) => ({
               outputKey,
+              // eslint-disable-next-line security/detect-object-injection -- type-checked as RegistryId
               config: auths[id],
               id,
             })
@@ -210,14 +255,20 @@ export const optionsSlice = createSlice({
           config,
         };
 
-        reportEvent("ExtensionActivate", selectEventData(extensionConfig));
+        reportEvent("ExtensionActivate", selectEventData(extension));
 
-        state.extensions[extensionPointId][extensionId] = extensionConfig;
+        state.extensions.push(extension);
 
-        void preloadMenus({ extensions: [extensionConfig] });
+        void preloadMenus({ extensions: [extension] });
       }
     },
-    saveExtension(state, { payload }) {
+    // XXX: why do we expose a `extensionId` in addition IExtension's `id` prop here?
+    saveExtension(
+      state,
+      {
+        payload,
+      }: PayloadAction<Except<IExtension, "_recipe"> & { extensionId?: UUID }>
+    ) {
       const {
         id,
         extensionId,
@@ -229,16 +280,16 @@ export const optionsSlice = createSlice({
       } = payload;
       // Support both extensionId and id to keep the API consistent with the shape of the stored extension
       if (extensionId == null && id == null) {
-        throw new Error("extensionId is required");
+        throw new Error("id or extensionId is required");
       } else if (extensionPointId == null) {
         throw new Error("extensionPointId is required");
       }
 
-      if (state.extensions[extensionPointId] == null) {
-        state.extensions[extensionPointId] = {};
-      }
+      const index = state.extensions.findIndex(
+        (x) => x.id === extensionId ?? id
+      );
 
-      state.extensions[extensionPointId][extensionId ?? id] = {
+      const extension: IExtension = {
         id: extensionId ?? id,
         extensionPointId,
         _recipe: null,
@@ -247,20 +298,19 @@ export const optionsSlice = createSlice({
         services,
         config,
       };
-    },
-    removeExtension(state, { payload }) {
-      const { extensionPointId, extensionId } = payload;
-      const extensions = state.extensions[extensionPointId] ?? {};
-      if (extensions[extensionId]) {
-        delete extensions[extensionId];
+
+      if (index >= 0) {
+        // eslint-disable-next-line security/detect-object-injection -- array index from findIndex
+        state.extensions[index] = extension;
       } else {
-        // It's already removed
-        console.debug(
-          `Extension id ${extensionId} does not exist for extension point ${extensionPointId}`
-        );
+        state.extensions.push(extension);
       }
+    },
+    removeExtension(
+      state,
+      { payload: { extensionId } }: PayloadAction<ExtensionRef>
+    ) {
+      state.extensions = state.extensions.filter((x) => x.id === extensionId);
     },
   },
 });
-
-/* eslint-enable security/detect-object-injection */

--- a/src/options/store.ts
+++ b/src/options/store.ts
@@ -20,7 +20,6 @@ import { persistReducer, persistStore } from "redux-persist";
 import { localStorage } from "redux-persist-webextension-storage";
 import {
   optionsSlice,
-  OptionsState,
   servicesSlice,
   ServicesState,
   settingsSlice,
@@ -32,7 +31,7 @@ import { createLogger } from "redux-logger";
 import { connectRouter, routerMiddleware } from "connected-react-router";
 import { createHashHistory } from "history";
 import { boolean } from "@/utils";
-import { persistOptionsConfig } from "@/store/extensions";
+import { OptionsState, persistOptionsConfig } from "@/store/extensions";
 import { persistServicesConfig } from "@/store/services";
 
 const REDUX_DEV_TOOLS: boolean = boolean(process.env.REDUX_DEV_TOOLS);

--- a/src/options/store.ts
+++ b/src/options/store.ts
@@ -16,7 +16,7 @@
  */
 
 import { configureStore } from "@reduxjs/toolkit";
-import { persistStore, persistReducer } from "redux-persist";
+import { persistReducer, persistStore } from "redux-persist";
 import { localStorage } from "redux-persist-webextension-storage";
 import {
   optionsSlice,
@@ -32,20 +32,12 @@ import { createLogger } from "redux-logger";
 import { connectRouter, routerMiddleware } from "connected-react-router";
 import { createHashHistory } from "history";
 import { boolean } from "@/utils";
+import { persistOptionsConfig } from "@/store/extensions";
+import { persistServicesConfig } from "@/store/services";
 
 const REDUX_DEV_TOOLS: boolean = boolean(process.env.REDUX_DEV_TOOLS);
 
-const persistOptionsConfig = {
-  key: "extensionOptions",
-  storage: localStorage,
-};
-
 export const hashHistory = createHashHistory({ hashType: "slash" });
-
-const persistServicesConfig = {
-  key: "servicesOptions",
-  storage: localStorage,
-};
 
 const persistSettingsConfig = {
   key: "settings",
@@ -71,6 +63,7 @@ const store = configureStore({
     router: connectRouter(hashHistory),
     options: persistReducer(persistOptionsConfig, optionsSlice.reducer),
     services: persistReducer(persistServicesConfig, servicesSlice.reducer),
+    // XXX: settings and workshop use the same persistor config?
     settings: persistReducer(persistSettingsConfig, settingsSlice.reducer),
     workshop: persistReducer(persistSettingsConfig, workshopSlice.reducer),
   },

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -18,7 +18,7 @@
 import isEmpty from "lodash/isEmpty";
 import { readStorage, setStorage } from "@/chrome";
 import { isExtensionContext } from "webext-detect-page";
-import useAsyncEffect from "use-async-effect";
+import { useAsyncEffect } from "use-async-effect";
 import { useState, useCallback } from "react";
 
 export const DEFAULT_SERVICE_URL = process.env.SERVICE_URL;

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -28,7 +28,11 @@ export const PIXIEBRIX_SERVICE_ID: RegistryId = castRegistryId(
 
 const storageKey = "persist:servicesOptions";
 
-const registry = new BaseRegistry<Service>(["service"], "services", fromJS);
+const registry = new BaseRegistry<RegistryId, Service>(
+  ["service"],
+  "services",
+  fromJS
+);
 
 export async function readRawConfigurations(): Promise<
   RawServiceConfiguration[]

--- a/src/services/useDependency.ts
+++ b/src/services/useDependency.ts
@@ -18,7 +18,11 @@
 import { useAsyncState } from "@/hooks/common";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useFormikContext } from "formik";
-import { SanitizedServiceConfiguration, ServiceDependency } from "@/core";
+import {
+  RegistryId,
+  SanitizedServiceConfiguration,
+  ServiceDependency,
+} from "@/core";
 import { castArray, head } from "lodash";
 import { locator } from "@/background/locator";
 import registry from "@/services/registry";
@@ -42,7 +46,7 @@ function listenerKey(dependency: ServiceDependency) {
   return `${dependency.id}:${dependency.config}`;
 }
 
-function useDependency(serviceId: string | string[]): Dependency {
+function useDependency(serviceId: RegistryId | RegistryId[]): Dependency {
   const notify = useNotifications();
   const { values } = useFormikContext<{ services: ServiceDependency[] }>();
   const [grantedPermissions, setGrantedPermissions] = useState(false);

--- a/src/store/extensions.ts
+++ b/src/store/extensions.ts
@@ -15,26 +15,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useState } from "react";
-import { useAsyncEffect } from "use-async-effect";
-import fetchSVG from "@/icons/svgElementFromUrl";
+import { MigrationManifest, PersistedState } from "redux-persist/es/types";
+import { migrateOptionsState, OptionsState } from "@/options/slices";
+import { localStorage } from "redux-persist-webextension-storage";
+import { createMigrate } from "redux-persist";
+import { boolean } from "@/utils";
 
-function useSvg(logoUrl: string): string {
-  const [logo, setLogo] = useState("");
+const migrations: MigrationManifest = {
+  1: (state: PersistedState & OptionsState) => migrateOptionsState(state),
+};
 
-  useAsyncEffect(
-    async (isMounted) => {
-      const $icon = await fetchSVG(logoUrl);
-      if (!isMounted()) {
-        return;
-      }
-
-      setLogo($icon.get(0).outerHTML);
-    },
-    [setLogo]
-  );
-
-  return logo;
-}
-
-export default useSvg;
+export const persistOptionsConfig = {
+  key: "extensionOptions",
+  storage: localStorage,
+  version: 1,
+  // https://github.com/rt2zz/redux-persist#migrations
+  migrate: createMigrate(migrations, { debug: boolean(process.env.DEBUG) }),
+};

--- a/src/store/services.ts
+++ b/src/store/services.ts
@@ -1,0 +1,6 @@
+import { localStorage } from "redux-persist-webextension-storage";
+
+export const persistServicesConfig = {
+  key: "servicesOptions",
+  storage: localStorage,
+};

--- a/src/store/services.ts
+++ b/src/store/services.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { localStorage } from "redux-persist-webextension-storage";
 
 export const persistServicesConfig = {

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -16,11 +16,22 @@
  */
 
 import Rollbar, { LogArgument } from "rollbar";
-import { isExtensionContext } from "webext-detect-page";
-import { getUID } from "@/background/telemetry";
 import { getErrorMessage } from "@/errors";
+import { isExtensionContext } from "webext-detect-page";
 
 const accessToken = process.env.ROLLBAR_BROWSER_ACCESS_TOKEN;
+
+type Frame = {
+  filename: string;
+};
+
+type Payload = {
+  body: {
+    trace: {
+      frames: Frame[];
+    };
+  };
+};
 
 /**
  *  @see https://docs.rollbar.com/docs/javascript
@@ -97,39 +108,31 @@ export async function updateAuth({
   userId,
   email,
   organizationId,
+  browserId,
 }: {
   userId: string;
   organizationId: string | null;
   email: string | null;
+  browserId: string | null;
 }): Promise<void> {
-  if (rollbar) {
-    if (isExtensionContext()) {
-      if (organizationId) {
-        // Enterprise accounts, use userId for telemetry
-        rollbar.configure({
-          payload: { person: { id: userId, email, organizationId } },
-        });
-      } else {
-        rollbar.configure({
-          payload: { person: { id: await getUID(), organizationId: null } },
-        });
-      }
+  if (!rollbar) {
+    return;
+  }
+
+  if (isExtensionContext()) {
+    if (organizationId) {
+      // Enterprise accounts, use userId for telemetry
+      rollbar.configure({
+        payload: { person: { id: userId, email, organizationId } },
+      });
     } else {
       rollbar.configure({
-        payload: { person: { id: userId, organizationId } },
+        payload: { person: { id: browserId, organizationId: null } },
       });
     }
+  } else {
+    rollbar.configure({
+      payload: { person: { id: userId, organizationId } },
+    });
   }
 }
-
-type Frame = {
-  filename: string;
-};
-
-type Payload = {
-  body: {
-    trace: {
-      frames: Frame[];
-    };
-  };
-};

--- a/src/types/definitions.ts
+++ b/src/types/definitions.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Metadata, Schema } from "@/core";
+import { Config, Metadata, RegistryId, Schema } from "@/core";
 import { Permissions } from "webextension-polyfill-ts";
 import { UiSchema } from "@rjsf/core";
 
@@ -23,7 +23,7 @@ export interface ExtensionPointConfig {
   /**
    * The id of the ExtensionPoint
    */
-  id: string;
+  id: RegistryId;
 
   label: string;
 
@@ -35,7 +35,7 @@ export interface ExtensionPointConfig {
 
   services?: Record<string, string>;
 
-  config: Record<string, unknown>;
+  config: Config;
 }
 
 export interface OptionsDefinition {
@@ -81,7 +81,7 @@ export interface OAuth2AuthenticationDefinition {
     authorizeUrl: string;
     tokenUrl: string;
   };
-  headers: { [header: string]: string };
+  headers: Record<string, string>;
 }
 
 export interface ServiceDefinition<

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -28,22 +28,22 @@ export function isUUID(uuid: string): uuid is UUID {
   return validate(uuid);
 }
 
-export function castUUID(uuid: string): UUID {
-  if (isUUID(uuid)) {
-    return uuid;
-  }
-
-  throw new Error("Invalid UUID");
-}
-
 export function isRegistryId(id: string): id is RegistryId {
   return PACKAGE_REGEX.test(id);
 }
 
 export function castRegistryId(id: string): RegistryId {
+  if (id == null) {
+    // We don't have strictNullChecks on, so null values will find there way here. We should pass them along. Eventually
+    // we can remove this check as strictNullChecks will check the callsite
+    return id as RegistryId;
+  }
+
   if (isRegistryId(id)) {
     return id;
   }
+
+  console.debug("Invalid registry id: %s", id);
 
   throw new Error("Invalid registry id");
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -181,13 +181,15 @@ export function boolean(value: unknown): boolean {
   return false;
 }
 
-export function clone<T extends {}>(object: T): T {
+export function clone<T extends Record<string, unknown>>(object: T): T {
   return Object.assign(Object.create(null), object);
 }
 
-export function clearObject(obj: { [key: string]: unknown }): void {
+export function clearObject(obj: Record<string, unknown>): void {
   for (const member in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, member)) {
+      // Checking to ensure own property
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete,security/detect-object-injection
       delete obj[member];
     }
   }
@@ -263,7 +265,16 @@ export interface ReadProxy {
 
 export const noopProxy: ReadProxy = {
   toJS: identity,
-  get: (value, prop) => (value as any)[prop],
+  get: (value, prop) => {
+    if (
+      typeof value === "object" &&
+      Object.prototype.hasOwnProperty.call(value, prop)
+    ) {
+      // Checking visibility of the property above
+      // eslint-disable-next-line security/detect-object-injection,@typescript-eslint/no-explicit-any
+      return (value as any)[prop];
+    }
+  },
 };
 
 export function getPropByPath(

--- a/src/validators/validation.ts
+++ b/src/validators/validation.ts
@@ -25,7 +25,7 @@ import { MissingConfigurationError } from "@/services/errors";
 import uniq from "lodash/uniq";
 import isPlainObject from "lodash/isPlainObject";
 import mapValues from "lodash/mapValues";
-import { isUUID } from "@/types/helpers";
+import { castRegistryId, isUUID } from "@/types/helpers";
 
 const IDENTIFIER_REGEX = /^[A-Z_a-z]\w*$/;
 
@@ -52,7 +52,7 @@ function blockSchemaFactory(): Yup.Schema<Record<string, unknown>> {
   return Yup.object().shape({
     id: Yup.string().test("is-block", "Block not found", async (id: string) =>
       // eslint-disable-next-line security/detect-non-literal-fs-filename -- false positive
-      blockRegistry.exists(id)
+      blockRegistry.exists(castRegistryId(id))
     ),
     templateEngine: Yup.string()
       .oneOf(["nunjucks", "mustache", "handlebars"])
@@ -161,7 +161,7 @@ function serviceSchemaFactory(): Yup.Schema<unknown> {
           "Unknown service",
           async (value) => {
             try {
-              await serviceRegistry.lookup(value);
+              await serviceRegistry.lookup(castRegistryId(value));
             } catch (error: unknown) {
               if (error instanceof DoesNotExistError) {
                 return false;


### PR DESCRIPTION
Closes #1078 

- Reshape redux state for extensions to a flat array
- Continue UUID and RegistryId type cleanup
- Adds Madge as a dev dependency, which reports 70 circular dependencies 😦 

TODO:
- [x] find/fix the circular dependency causing test/header generation errors