### PR TITLE
#1098: revert mini-css-extract-plugin version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -188,7 +188,7 @@
         "jest-raw-loader": "^1.0.1",
         "jest-webextension-mock": "^3.7.17",
         "min-document": "^2.19.0",
-        "mini-css-extract-plugin": "~2.2.0",
+        "mini-css-extract-plugin": "~2.0.0",
         "node-polyfill-webpack-plugin": "^1.1.4",
         "node-sass": "^6.0.1",
         "raw-loader": "^4.0.1",
@@ -29634,12 +29634,12 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.2.0.tgz",
-      "integrity": "sha512-91HeVHbq7PUJ4TwOuMTlFWfVWrLqf3SF0PlEDPV+wtgsfxrMebN9LLzflyQqdKLp4/H3PexRB1WLKsCqpWKkxQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.0.0.tgz",
+      "integrity": "sha512-LzJaninAMkfVAUDldZ4lUidAeS8GD0w8tSUbZLscYXWmdTOjYuEoiIhwKvwHX6+42D2cRAl35pA9DHtvAv71JQ==",
       "dev": true,
       "dependencies": {
-        "schema-utils": "^3.1.0"
+        "schema-utils": "^3.0.0"
       },
       "engines": {
         "node": ">= 12.13.0"
@@ -62255,12 +62255,12 @@
       }
     },
     "mini-css-extract-plugin": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.2.0.tgz",
-      "integrity": "sha512-91HeVHbq7PUJ4TwOuMTlFWfVWrLqf3SF0PlEDPV+wtgsfxrMebN9LLzflyQqdKLp4/H3PexRB1WLKsCqpWKkxQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.0.0.tgz",
+      "integrity": "sha512-LzJaninAMkfVAUDldZ4lUidAeS8GD0w8tSUbZLscYXWmdTOjYuEoiIhwKvwHX6+42D2cRAl35pA9DHtvAv71JQ==",
       "dev": true,
       "requires": {
-        "schema-utils": "^3.1.0"
+        "schema-utils": "^3.0.0"
       },
       "dependencies": {
         "schema-utils": {

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "jest-raw-loader": "^1.0.1",
     "jest-webextension-mock": "^3.7.17",
     "min-document": "^2.19.0",
-    "mini-css-extract-plugin": "~2.2.0",
+    "mini-css-extract-plugin": "~2.0.0",
     "node-polyfill-webpack-plugin": "^1.1.4",
     "node-sass": "^6.0.1",
     "raw-loader": "^4.0.1",


### PR DESCRIPTION
Closes #1098 