### PR TITLE
#1103: Handle null icons in getSvgIcon

### DIFF
--- a/src/icons/getSvgIcon.ts
+++ b/src/icons/getSvgIcon.ts
@@ -22,7 +22,7 @@ export default async function getSvgIcon({
   id = "box",
   size = 14,
   color = "#ae87e8",
-}: IconConfig): Promise<string> {
+}: IconConfig = {}): Promise<string> {
   const { icons } = await import(
     /* webpackChunkName: "iconLibrary" */ "@/icons/list"
   );

--- a/src/icons/getSvgIcon.ts
+++ b/src/icons/getSvgIcon.ts
@@ -22,7 +22,7 @@ export default async function getSvgIcon({
   id = "box",
   size = 14,
   color = "#ae87e8",
-}: IconConfig = {}): Promise<string> {
+}: Partial<IconConfig> = {}): Promise<string> {
   const { icons } = await import(
     /* webpackChunkName: "iconLibrary" */ "@/icons/list"
   );


### PR DESCRIPTION
Full fix for https://github.com/pixiebrix/pixiebrix-extension/issues/1103

The defaults had gotten lost due to a confusion around the typing, now resolved with `Partial<>`