### PR TITLE
#1046: include pathSpec when previewing reader data

### DIFF
--- a/src/blocks/readers/frameworkReader.ts
+++ b/src/blocks/readers/frameworkReader.ts
@@ -22,7 +22,9 @@ import { castArray, fromPairs, compact } from "lodash";
 import { getComponentData, ReadPayload } from "@/pageScript/protocol";
 
 type FrameworkConfig = ReadPayload & {
-  // Legacy emberjs reader config; now handled via pathSpec
+  /**
+   * @deprecated Legacy emberjs reader config. Use patchSpec instead
+   */
   attrs: string | string[];
 };
 
@@ -57,7 +59,7 @@ function makeRead(framework: Framework): Read<FrameworkConfig> {
     } = reader;
 
     const rootSelector = isHTMLElement(root)
-      ? await asyncFastCssSelector(root as HTMLElement)
+      ? await asyncFastCssSelector(root)
       : null;
 
     return getComponentData({

--- a/src/devTools/editor/tabs/reader/ReaderConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderConfig.tsx
@@ -43,11 +43,16 @@ import { useLabelRenderer } from "@/devTools/editor/tabs/reader/hooks";
 import ToggleField from "@/devTools/editor/components/ToggleField";
 import { isCustomReader } from "@/devTools/editor/extensionPoints/elementConfig";
 import SchemaTree from "@/components/schemaTree/SchemaTree";
+import type { ReadOptions } from "@/pageScript/protocol";
+import { Primitive } from "type-fest";
 
-type ReaderSelector = (options: {
-  type: string;
-  [prop: string]: unknown;
-}) => ReaderTypeConfig;
+type ReaderSelector = (
+  options: ReadOptions & {
+    type: string;
+    // `selectors` is JQuery-reader only
+    selectors?: Record<string, string>;
+  }
+) => ReaderTypeConfig;
 
 type FrameworkOption = {
   value: Framework;
@@ -59,7 +64,17 @@ type FrameworkOption = {
 export const defaultSelector: ReaderSelector = partial(
   pick,
   partial.placeholder,
-  ["type", "selector", "traverseUp", "optional"]
+  // Should be kept in sync with ReadOptions, otherwise behavior will differ between running a brick in the devtools
+  // vs. running a brick in the normal application
+  [
+    "type",
+    "pathSpec",
+    "waitMillis",
+    "retryMillis",
+    "selector",
+    "traverseUp",
+    "optional",
+  ]
 ) as ReaderSelector;
 
 export const readerOptions: FrameworkOption[] = [
@@ -124,7 +139,7 @@ const FrameworkSelector: React.FunctionComponent<{
   );
 };
 
-function normalize(value: unknown): string {
+function normalize(value: Primitive): string {
   return value.toString().toLowerCase();
 }
 
@@ -152,7 +167,7 @@ export function searchData(query: string, data: unknown): unknown {
     return compact(data.map(partial(searchData, query)));
   }
 
-  return normalize(data).includes(normalized) ? data : undefined;
+  return normalize(data as Primitive).includes(normalized) ? data : undefined;
 }
 
 const FrameworkFields: React.FunctionComponent<{

--- a/src/pageScript/protocol.ts
+++ b/src/pageScript/protocol.ts
@@ -31,14 +31,14 @@ export type PathSpec =
   | string[]
   | Record<string, string | { path: string; args: unknown }>;
 
-export interface ReadOptions {
+export type ReadOptions = {
   pathSpec?: PathSpec;
   waitMillis?: number;
   retryMillis?: number;
   traverseUp?: number;
   rootProp?: string;
   optional?: boolean;
-}
+};
 
 export type ReadPayload = ReadOptions & {
   framework: Framework;


### PR DESCRIPTION
Fixes #1046 

Fixes bug where reader previews in the page editor weren't using the pathSpec because it wasn't being passed through (I didn't include the pathSpec field originally b/c the devtools configuration interface doesn't support configuring the pathSpec)