### PR TITLE
#1124: fix log table story; fix SCSS warnings

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -34,9 +34,11 @@ module.exports = {
       "@contrib": path.resolve(rootDir, "contrib"),
       "@schemas": path.resolve(rootDir, "schemas"),
       vendors: path.resolve(rootDir, "src/vendors"),
+      "webextension-polyfill-ts": path.resolve(
+        rootDir,
+        "src/__mocks__/browserMocks.ts"
+      ),
     };
-
-    config.pl;
 
     config.module.rules.push({
       test: /\.scss$/,
@@ -44,7 +46,14 @@ module.exports = {
         // style-loader loads the css into the DOM
         "style-loader",
         "css-loader",
-        { loader: "sass-loader", options: { sourceMap: true } },
+        {
+          loader: "sass-loader",
+          options: {
+            sourceMap: true,
+            // Due to warnings in dart-sass https://github.com/pixiebrix/pixiebrix-extension/pull/1070
+            implementation: require("node-sass"),
+          },
+        },
       ],
     });
 

--- a/src/__mocks__/browserMocks.ts
+++ b/src/__mocks__/browserMocks.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Mock for "webextension-polyfill-ts"
+
+import type { Browser } from "webextension-polyfill-ts";
+
+export const browser: Partial<Browser> = {};

--- a/src/components/logViewer/EntryRow.tsx
+++ b/src/components/logViewer/EntryRow.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useMemo, useState } from "react";
-import { LogEntry } from "@/background/logging";
+import type { LogEntry } from "@/background/logging";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCaretDown, faCaretRight } from "@fortawesome/free-solid-svg-icons";
 import { ErrorObject } from "serialize-error";

--- a/src/components/logViewer/LogContext.tsx
+++ b/src/components/logViewer/LogContext.tsx
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState, useMemo, useCallback } from "react";
-import { LogEntry } from "@/background/logging";
+import React, { useState, useMemo, useCallback, createContext } from "react";
+import type { LogEntry } from "@/background/logging";
 import { isEqual, noop } from "lodash";
 
 type Refresh = () => Promise<void>;
@@ -40,9 +40,10 @@ const defaultValue: LogContextShape = {
 };
 
 /**
- * @deprecated This component introduces an anti-pattern of inversion of control. Should be using Redux store here?
+ * @deprecated This component introduces an anti-pattern of returning `safeSetUnread` and `safeSetRefresh`. In the
+ *  future, we should probably be using the Redux store here. Should be using Redux store here?
  */
-const LogContext = React.createContext(defaultValue);
+const LogContext = createContext(defaultValue);
 
 export const LogContextWrapper: React.FunctionComponent = ({ children }) => {
   const [unread, setUnread] = useState<LogEntry[]>([]);

--- a/src/components/logViewer/LogTable.stories.tsx
+++ b/src/components/logViewer/LogTable.stories.tsx
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+Object.assign(global, { chrome: { runtime: { id: 42 } } });
+
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { validateRegistryId, uuidv4 } from "@/types/helpers";
@@ -24,10 +26,10 @@ import { Card } from "react-bootstrap";
 import { ContextError } from "@/errors";
 import { InputValidationError } from "@/blocks/errors";
 import { Schema } from "@/core";
-import { LogEntry } from "@/background/logging";
+import type { LogEntry } from "@/background/logging";
 
 export default {
-  title: "Common/LogTable",
+  title: "Editor/LogTable",
   component: LogTable,
 } as ComponentMeta<typeof LogTable>;
 

--- a/src/components/logViewer/LogTable.tsx
+++ b/src/components/logViewer/LogTable.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { Table } from "react-bootstrap";
-import { LogEntry } from "@/background/logging";
+import type { LogEntry } from "@/background/logging";
 import EntryRow from "@/components/logViewer/EntryRow";
 
 const LogTable: React.FunctionComponent<{

--- a/src/components/logViewer/LogToolbar.tsx
+++ b/src/components/logViewer/LogToolbar.tsx
@@ -16,7 +16,7 @@
  */
 
 import { Form, Pagination } from "react-bootstrap";
-import { MessageLevel } from "@/background/logging";
+import type { MessageLevel } from "@/background/logging";
 import { range } from "lodash";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSync, faTrash } from "@fortawesome/free-solid-svg-icons";


### PR DESCRIPTION
Closes #1124 

- Mocks http://github.com/pixiebrix/pixiebrix-extension/blob/5137e9e0922ebbf65490af8efbc1c9da962946cd/src/__mocks__/browserMocks.ts#L21-L21 so the LogTable story can run
- Applies the fix from out main webpack config to prevent Storybook's webpack from spitting out warnings about bad css: http://github.com/pixiebrix/pixiebrix-extension/blob/5137e9e0922ebbf65490af8efbc1c9da962946cd/.storybook/main.js#L53-L53