### PR TITLE
#1111 - Fix "Add Property" button for object brick options

### DIFF
--- a/src/components/fields/FieldTable.tsx
+++ b/src/components/fields/FieldTable.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useContext, useMemo } from "react";
+import React, {useCallback, useContext, useMemo, useRef} from "react";
 import { Form, Button, Table } from "react-bootstrap";
 import { Schema } from "@/core";
 import { FieldProps } from "@/components/fields/propTypes";
@@ -217,7 +217,8 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
   const { setFieldValue } = useFormikContext();
 
   // UseRef indirection layer so the callbacks below don't re-calculate on every change
-  // const fieldRef = useRef(field);
+  const value = useRef(field.value);
+  value.current = field.value;
 
   const [properties, declaredProperties] = useMemo(() => {
     const declared = schema.properties ?? {};
@@ -233,20 +234,20 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
     (property: string) => {
       setFieldValue(
         name,
-        produce(field.value, draft => {
+        produce(value.current, draft => {
           if (draft != null) {
             delete draft[property];
           }
         })
       );
     },
-    [name, setFieldValue, field.value]
+    [name, setFieldValue, value]
   );
 
   const onRename = useCallback(
     (oldProp: string, newProp: string) => {
       if (oldProp !== newProp) {
-        const previousValue: ObjectValue = field.value ?? {};
+        const previousValue: ObjectValue = value.current ?? {};
 
         console.debug("Renaming property", {
           newProp,
@@ -263,17 +264,17 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
         );
       }
     },
-    [name, setFieldValue, field.value]
+    [name, setFieldValue, value]
   );
 
   const addProperty = useCallback(() => {
     setFieldValue(
       name,
-      produce(field.value, draft => {
+      produce(value.current, draft => {
         draft[freshPropertyName(draft)] = "";
       })
     );
-  }, [name, setFieldValue, field.value]);
+  }, [name, setFieldValue, value]);
 
   return (
     <Form.Group controlId={field.name}>

--- a/src/components/fields/FieldTable.tsx
+++ b/src/components/fields/FieldTable.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useContext, useMemo, useRef } from "react";
+import React, { useCallback, useContext, useMemo } from "react";
 import { Form, Button, Table } from "react-bootstrap";
 import { Schema } from "@/core";
 import { FieldProps } from "@/components/fields/propTypes";
@@ -213,11 +213,11 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
 
   // Helpers.setValue changes on every render, so use setFieldValue instead
   // https://github.com/formium/formik/issues/2268
-  const [field] = useField(props);
+  const [field] = useField<ObjectValue>(props);
   const { setFieldValue } = useFormikContext();
 
   // UseRef indirection layer so the callbacks below don't re-calculate on every change
-  const fieldRef = useRef(field);
+  // const fieldRef = useRef(field);
 
   const [properties, declaredProperties] = useMemo(() => {
     const declared = schema.properties ?? {};
@@ -233,20 +233,20 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
     (property: string) => {
       setFieldValue(
         name,
-        produce(fieldRef.current.value, (draft: ObjectValue) => {
+        produce(field.value, draft => {
           if (draft != null) {
             delete draft[property];
           }
         })
       );
     },
-    [name, setFieldValue, fieldRef]
+    [name, setFieldValue, field.value]
   );
 
   const onRename = useCallback(
     (oldProp: string, newProp: string) => {
       if (oldProp !== newProp) {
-        const previousValue = fieldRef.current.value ?? {};
+        const previousValue: ObjectValue = field.value ?? {};
 
         console.debug("Renaming property", {
           newProp,
@@ -256,24 +256,24 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
 
         setFieldValue(
           name,
-          produce(previousValue, (draft: ObjectValue) => {
+          produce(previousValue, draft => {
             draft[newProp] = draft[oldProp] ?? "";
             delete draft[oldProp];
           })
         );
       }
     },
-    [name, setFieldValue, fieldRef]
+    [name, setFieldValue, field.value]
   );
 
   const addProperty = useCallback(() => {
     setFieldValue(
       name,
-      produce(fieldRef.current.value ?? {}, (draft: ObjectValue) => {
+      produce(field.value, draft => {
         draft[freshPropertyName(draft)] = "";
       })
     );
-  }, [name, setFieldValue, fieldRef]);
+  }, [name, setFieldValue, field.value]);
 
   return (
     <Form.Group controlId={field.name}>

--- a/src/components/fields/FieldTable.tsx
+++ b/src/components/fields/FieldTable.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {useCallback, useContext, useMemo, useRef} from "react";
+import React, { useCallback, useContext, useMemo, useRef } from "react";
 import { Form, Button, Table } from "react-bootstrap";
 import { Schema } from "@/core";
 import { FieldProps } from "@/components/fields/propTypes";
@@ -217,8 +217,8 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
   const { setFieldValue } = useFormikContext();
 
   // UseRef indirection layer so the callbacks below don't re-calculate on every change
-  const value = useRef(field.value);
-  value.current = field.value;
+  const valueRef = useRef(field.value);
+  valueRef.current = field.value ?? {};
 
   const [properties, declaredProperties] = useMemo(() => {
     const declared = schema.properties ?? {};
@@ -234,20 +234,20 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
     (property: string) => {
       setFieldValue(
         name,
-        produce(value.current, draft => {
+        produce(valueRef.current, draft => {
           if (draft != null) {
             delete draft[property];
           }
         })
       );
     },
-    [name, setFieldValue, value]
+    [name, setFieldValue, valueRef]
   );
 
   const onRename = useCallback(
     (oldProp: string, newProp: string) => {
       if (oldProp !== newProp) {
-        const previousValue: ObjectValue = value.current ?? {};
+        const previousValue: ObjectValue = valueRef.current;
 
         console.debug("Renaming property", {
           newProp,
@@ -264,17 +264,17 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
         );
       }
     },
-    [name, setFieldValue, value]
+    [name, setFieldValue, valueRef]
   );
 
   const addProperty = useCallback(() => {
     setFieldValue(
       name,
-      produce(value.current, draft => {
+      produce(valueRef.current, draft => {
         draft[freshPropertyName(draft)] = "";
       })
     );
-  }, [name, setFieldValue, value]);
+  }, [name, setFieldValue, valueRef]);
 
   return (
     <Form.Group controlId={field.name}>

--- a/src/components/fields/FieldTable.tsx
+++ b/src/components/fields/FieldTable.tsx
@@ -247,7 +247,7 @@ export const ObjectField: React.FunctionComponent<FieldProps<unknown>> = ({
   const onRename = useCallback(
     (oldProp: string, newProp: string) => {
       if (oldProp !== newProp) {
-        const previousValue: ObjectValue = valueRef.current;
+        const previousValue = valueRef.current;
 
         console.debug("Renaming property", {
           newProp,


### PR DESCRIPTION
Fixes #1111 

`useRef()` creates something akin to a local variable that persists its own value across renders in a functional component, but the input parameter is just a default value, there is no tracking/updating of the current value happening under the covers. The ref must have its current value updated manually in order to store a new value across renders.

This change updates the current ref value for `ObjectField` on each render.