### PR TITLE
#1122: only report typescript coverage to appease codacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
       "fake-indexeddb/auto"
     ],
     "collectCoverageFrom": [
-      "src/**/*.{ts,tsx,js,jsx}",
+      "src/**/*.{ts,tsx}",
       "!**/__mocks__/**",
       "!**/node_modules/**",
       "!**/vendor/**"

--- a/package.json
+++ b/package.json
@@ -258,6 +258,7 @@
     ],
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}",
+      "!src/**/*.stories.tsx",
       "!**/__mocks__/**",
       "!**/node_modules/**",
       "!**/vendor/**"


### PR DESCRIPTION
Tells Jest to only collect coverage from TypeScript files since the Codacy coverage reported breaks if you send multiple languages at once

The alternative would be to figure out how to report them separately, but that's not worth it given our own code is 99% TypeScript

> When working with multiple languages on your repository, it would be ideal to send separate coverage reports, one for JavaScript and one for TypeScript but another possible workaround for this would be uploading the same file twice specifying -l JavaScript once and -l TypeScript on the second upload.
> 
> Could you try uploading the coverage reports separately or uploading the same file twice specifying the languages with the flag -l, together with --force-language. For example:
> 
> bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l TypeScript --force-language