### PR TITLE
Further webpack config fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/lcov.info
 
-  stage:
+  build:
     runs-on: ubuntu-latest
     env:
       # Uploads sourcemaps to S3, if it's a public release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: push
 
 env:
   # Creates and uploads sourcemaps to Rollbar, and save the built extension as an artifact
-  PUBLIC_RELEASE: ${{ github.ref == 'refs/heads/main' || true }}
+  PUBLIC_RELEASE: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/lcov.info
 
-  build:
+  build-stage:
     runs-on: ubuntu-latest
     env:
       # Uploads sourcemaps to S3, if it's a public release

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -3,7 +3,7 @@ name: Storybook
 on: [push]
 
 jobs:
-  stage:
+  storybook:
     runs-on: ubuntu-latest
 
     steps:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -367,12 +367,6 @@ module.exports = (env, options) =>
           "static",
         ],
       }),
-
-      produceSourcemap &&
-        new webpack.SourceMapDevToolPlugin({
-          publicPath: sourceMapPublicUrl,
-          filename: "[file].map[query]", // Without this it won't output anything
-        }),
     ]),
     module: {
       rules: [


### PR DESCRIPTION
To make for speedier reviews, I left out these small changes I had made in

- https://github.com/pixiebrix/pixiebrix-extension/pull/1071

Also in the future (or now) we can pre-zip the extension to speed up uploading because it takes as long as the build itself. Apparently this is due to the large number of files (the icons) that GHA uploads 2 at a time…

<img width="637" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/130278462-d8fd09cf-7771-4709-b14e-d43bbc59f3e8.png">
