### PR TITLE
Set up react-devtools for use as a global npm dependency

### DIFF
--- a/src/devtoolsPanel.html
+++ b/src/devtoolsPanel.html
@@ -17,7 +17,8 @@
 <!DOCTYPE html>
 <html style="display: flex">
   <head>
-    <!--Uncomment this to enable the React Dev Tools app-->
+    <!--Uncomment this script tag to enable the React Dev Tools app-->
+    <!--See https://github.com/pixiebrix/pixiebrix-extension/wiki/Local-build-setup#stand-alone -->
     <!--<script src="http://localhost:8097"></script>-->
     <meta charset="utf8" />
     <style>

--- a/src/devtoolsPanel.html
+++ b/src/devtoolsPanel.html
@@ -17,6 +17,8 @@
 <!DOCTYPE html>
 <html style="display: flex">
   <head>
+    <!--Uncomment this to enable the React Dev Tools app-->
+    <!--<script src="http://localhost:8097"></script>-->
     <meta charset="utf8" />
     <style>
       html {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,6 +163,12 @@ function customizeManifest(manifest, isProduction) {
     policy.add("connect-src", "ws://localhost:9090/ http://127.0.0.1:8000");
   }
 
+  // React Dev Tools app
+  if (!isProduction) {
+    policy.add("script-src", "http://localhost:8097")
+    policy.add("connect-src", "ws://localhost:8097/")
+  }
+
   manifest.content_security_policy = policy.toString();
 
   if (process.env.EXTERNALLY_CONNECTABLE) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,10 +163,10 @@ function customizeManifest(manifest, isProduction) {
     policy.add("connect-src", "ws://localhost:9090/ http://127.0.0.1:8000");
   }
 
-  // React Dev Tools app
   if (!isProduction) {
-    policy.add("script-src", "http://localhost:8097")
-    policy.add("connect-src", "ws://localhost:8097/")
+    // React Dev Tools app. See https://github.com/pixiebrix/pixiebrix-extension/wiki/Local-build-setup#stand-alone
+    policy.add("script-src", "http://localhost:8097");
+    policy.add("connect-src", "ws://localhost:8097/");
   }
 
   manifest.content_security_policy = policy.toString();


### PR DESCRIPTION
These changes enable `react-devtools` to run against our Page Editor app in the Chrome dev tools panel.

In order to run this, you'll need to install react-devtools first:
```
npm i -g react-devtools
```

Then, uncomment the script injection in `devtoolsPanel.html` to let the app connect.


Example:
![image](https://user-images.githubusercontent.com/2801308/130299768-a265ebec-50b4-4673-9585-912c15932f55.png)
