### PR TITLE
#1169: fix use of null coalescing operator in saveExtension

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,7 +37,8 @@
         // Customize the defaults to force being explicit about use of null-coalescing operator because its precedence
         // is unintuitive. See: https://eslint.org/docs/rules/no-mixed-operators
         "groups": [
-          ["+", "-", "*", "/", "%", "**", "??"],
+          // Conflicts with Prettier: https://github.com/prettier/prettier/issues/3968
+          // ["+", "-", "*", "/", "%", "**", "??"],
           ["&", "|", "^", "~", "<<", ">>", ">>>", "??"],
           ["==", "!=", "===", "!==", ">", ">=", "<", "<=", "??"],
           ["&&", "||", "??"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,21 @@
     // Enable extra rules
     "filenames/match-exported": "error",
 
+    "no-mixed-operators": [
+      "error",
+      {
+        // Customize the defaults to force being explicit about use of null-coalescing operator because its precedence
+        // is unintuitive. See: https://eslint.org/docs/rules/no-mixed-operators
+        "groups": [
+          ["+", "-", "*", "/", "%", "**", "??"],
+          ["&", "|", "^", "~", "<<", ">>", ">>>", "??"],
+          ["==", "!=", "===", "!==", ">", ">=", "<", "<=", "??"],
+          ["&&", "||", "??"],
+          ["in", "instanceof", "??"]
+        ]
+      }
+    ],
+
     // Customize some rules
     "import/no-unresolved": [
       "error",

--- a/src/options/slices.ts
+++ b/src/options/slices.ts
@@ -294,20 +294,20 @@ export const optionsSlice = createSlice({
         _deployment,
         createTimestamp = timestamp,
       } = payload;
+
+      const persistedId = extensionId ?? id;
+
       // Support both extensionId and id to keep the API consistent with the shape of the stored extension
-      if (extensionId == null && id == null) {
+      if (persistedId) {
         throw new Error("id or extensionId is required");
       } else if (extensionPointId == null) {
         throw new Error("extensionPointId is required");
       }
 
-      const index = state.extensions.findIndex(
-        (x) => x.id === extensionId ?? id
-      );
-
       const extension: PersistedExtension = {
-        id: extensionId ?? id,
+        id: persistedId,
         extensionPointId,
+        // If the user updates an extension, detach it from the recipe -- it's now a personal extension
         _recipe: null,
         label,
         optionsArgs,
@@ -322,6 +322,8 @@ export const optionsSlice = createSlice({
         // In the future, we'll want to make the Redux action async. For now, just fail silently in the interface
         void saveUserExtension(extension).catch(reportError);
       }
+
+      const index = state.extensions.findIndex((x) => x.id === persistedId);
 
       if (index >= 0) {
         // eslint-disable-next-line security/detect-object-injection -- array index from findIndex


### PR DESCRIPTION
Should fix half of #1169 

Additional:
- Turns on the no-mixed-operators rule and forces explicit parens around `??` expressions
- For arithmetic, I could enable the rule b/c it conflicts with prettier's behavior. (Prettier has its own point of view of what's confusing). It's possible we might hit incompatibility with the other rules. IMO it's safer to enable for now and tweak as we go. The alternative is to leave it enabled and force the developer to assign subexpressions to variables to avoid the confusing code