### PR TITLE
#1181: handle services with period in the name

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -259,7 +259,7 @@ export type IExtension<T extends Config = EmptyConfig> = {
   /**
    * Configured services/integrations for the extension.
    */
-  services: ServiceDependency[];
+  services?: ServiceDependency[];
 
   /**
    * Options the end-user has configured (i.e., during blueprint activation)

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -97,8 +97,10 @@ function useWizard(blueprint: RecipeDefinition): [Step[], WizardValues] {
       }
     });
     const initialValues: WizardValues = {
-      extensions: Object.fromEntries(extensionPoints.map((x, i) => [i, true])),
-      services: Object.fromEntries(serviceIds.map((x) => [x, undefined])),
+      extensions: Object.fromEntries(
+        extensionPoints.map((x, index) => [index, true])
+      ),
+      services: serviceIds.map((id) => ({ id, config: undefined })),
       optionsArgs: mapValues(
         blueprint.options?.schema ?? {},
         (x) => (x as any).default

--- a/src/options/pages/marketplace/AuthWidget.tsx
+++ b/src/options/pages/marketplace/AuthWidget.tsx
@@ -38,13 +38,11 @@ import useNotifications from "@/hooks/useNotifications";
 const { updateServiceConfig } = servicesSlice.actions;
 
 const AuthWidget: React.FunctionComponent<{
-  name?: string;
+  name: string;
   authOptions: AuthOption[];
   serviceId: string;
 }> = ({ name, serviceId, authOptions }) => {
-  const fieldName = name ?? `services.${serviceId}`;
-
-  const helpers = useField<UUID>(fieldName)[2];
+  const helpers = useField<UUID>(name)[2];
   const dispatch = useDispatch();
   const notify = useNotifications();
 
@@ -140,7 +138,7 @@ const AuthWidget: React.FunctionComponent<{
         {options.length > 0 && (
           <div style={{ minWidth: "300px" }} className="mr-2">
             <ServiceAuthSelector
-              name={fieldName}
+              name={name}
               serviceId={serviceId}
               authOptions={options}
               CustomMenuList={CustomMenuList}

--- a/src/options/pages/marketplace/ConfigureBody.tsx
+++ b/src/options/pages/marketplace/ConfigureBody.tsx
@@ -20,20 +20,15 @@ import { useField, useFormikContext } from "formik";
 import BootstrapSwitchButton from "bootstrap-switch-button-react";
 import { Card, Table } from "react-bootstrap";
 import { ExtensionPointConfig, RecipeDefinition } from "@/types/definitions";
-import { pickBy, identity } from "lodash";
+import { identity, pickBy } from "lodash";
 import { WizardValues } from "@/options/pages/marketplace/wizardTypes";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCubes, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
-import { RegistryId, ServiceAuthPair, UUID } from "@/core";
+import { ServiceAuthPair } from "@/core";
 
 export function selectedAuths(values: WizardValues): ServiceAuthPair[] {
-  return (
-    Object.entries(values.services)
-      .filter(([, config]) => config)
-      // We lose type information when using Object.entries
-      .map(([id, config]) => ({ id: id as RegistryId, config: config as UUID }))
-  );
+  return values.services.filter((x) => x.config);
 }
 
 export function selectedExtensions(
@@ -43,11 +38,7 @@ export function selectedExtensions(
   const indexes = Object.keys(pickBy(values.extensions, identity)).map((x) =>
     Number.parseInt(x, 10)
   );
-  console.debug("selected extensions", {
-    extensions: values.extensions,
-    indexes,
-  });
-  return extensions.filter((x, i) => indexes.includes(i));
+  return extensions.filter((_, index) => indexes.includes(index));
 }
 
 export function useSelectedAuths(): ServiceAuthPair[] {

--- a/src/options/pages/marketplace/PermissionsBody.tsx
+++ b/src/options/pages/marketplace/PermissionsBody.tsx
@@ -22,6 +22,7 @@ import GridLoader from "react-spinners/GridLoader";
 import { Card, Table } from "react-bootstrap";
 import useReportError from "@/hooks/useReportError";
 import { Permissions } from "webextension-polyfill-ts";
+import { getErrorMessage } from "@/errors";
 
 const PermissionsBody: React.FunctionComponent<{
   enabled: boolean;
@@ -51,7 +52,8 @@ const PermissionsBody: React.FunctionComponent<{
     if (error) {
       return (
         <Card.Text className="text-danger">
-          An error occurred determining additional permissions
+          An error occurred determining additional permissions:{" "}
+          {getErrorMessage(error)}
         </Card.Text>
       );
     }

--- a/src/options/pages/marketplace/ServicesBody.tsx
+++ b/src/options/pages/marketplace/ServicesBody.tsx
@@ -28,6 +28,8 @@ import useFetch from "@/hooks/useFetch";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import AuthWidget from "@/options/pages/marketplace/AuthWidget";
 import ServiceDescriptor from "@/options/pages/marketplace/ServiceDescriptor";
+import { useField } from "formik";
+import { ServiceAuthPair } from "@/core";
 
 interface OwnProps {
   blueprint: RecipeDefinition;
@@ -35,6 +37,8 @@ interface OwnProps {
 
 const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
   const [authOptions] = useAuthOptions();
+
+  const [field] = useField<ServiceAuthPair[]>("services");
 
   const selected = useSelectedExtensions(blueprint.extensionPoints);
 
@@ -79,7 +83,7 @@ const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
           </tr>
         </thead>
         <tbody>
-          {serviceIds.map((serviceId) => (
+          {field.value.map(({ id: serviceId }, index) => (
             <tr key={serviceId}>
               <td>
                 <ServiceDescriptor
@@ -88,7 +92,11 @@ const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
                 />
               </td>
               <td>
-                <AuthWidget authOptions={authOptions} serviceId={serviceId} />
+                <AuthWidget
+                  authOptions={authOptions}
+                  serviceId={serviceId}
+                  name={[field.name, index, "config"].join(".")}
+                />
               </td>
             </tr>
           ))}

--- a/src/options/pages/marketplace/wizardTypes.ts
+++ b/src/options/pages/marketplace/wizardTypes.ts
@@ -16,14 +16,22 @@
  */
 
 import { Primitive } from "type-fest";
-import { RegistryId, UUID } from "@/core";
+import { ServiceAuthPair } from "@/core";
 
-export interface WizardValues {
-  extensions: Record<string, boolean>;
+export type WizardValues = {
   /**
-   * Mapping from service id to auth id
+   * Mapping from extension index to whether or not it's toggled.
    */
-  services: Record<RegistryId, UUID>;
+  extensions: Record<string, boolean>;
+
+  // Use array instead of Record<RegistryId, UUID> because `RegistryId`s can contain periods which throw off Formik
+  /**
+   * Mapping from service id to auth id.
+   */
+  services: ServiceAuthPair[];
+
+  // XXX: optionsArgs can contain periods, which will throw off formik
   optionsArgs: Record<string, Primitive>;
+
   grantPermissions: boolean;
-}
+};


### PR DESCRIPTION
Closes #1181 

Also fixes bug/warning where extension permissions could not be calculated if a services section was not defined for all extensions in the blueprint