### PR TITLE
#1047: make new personal configuration immediately available in wizard

### DIFF
--- a/src/options/pages/marketplace/AuthWidget.tsx
+++ b/src/options/pages/marketplace/AuthWidget.tsx
@@ -23,7 +23,7 @@ import { useField } from "formik";
 import { useDispatch } from "react-redux";
 import { useAsyncState } from "@/hooks/common";
 import registry from "@/services/registry";
-import { RawServiceConfiguration, UUID } from "@/core";
+import { RawServiceConfiguration, RegistryId, UUID } from "@/core";
 import { uuidv4 } from "@/types/helpers";
 import { persistor } from "@/options/store";
 import { refresh as refreshBackgroundLocator } from "@/background/locator";
@@ -38,10 +38,21 @@ import useNotifications from "@/hooks/useNotifications";
 const { updateServiceConfig } = servicesSlice.actions;
 
 const AuthWidget: React.FunctionComponent<{
+  /**
+   * The field name. WARNING: do not use `serviceId`s as part of a field name because they can contain periods which
+   * break Formik's nested field naming.
+   */
   name: string;
+
+  serviceId: RegistryId;
+
   authOptions: AuthOption[];
-  serviceId: string;
-}> = ({ name, serviceId, authOptions }) => {
+
+  /**
+   * Optional callback to refresh the authOptions.
+   */
+  onRefresh?: () => Promise<void>;
+}> = ({ name, serviceId, authOptions, onRefresh }) => {
   const helpers = useField<UUID>(name)[2];
   const dispatch = useDispatch();
   const notify = useNotifications();
@@ -76,6 +87,10 @@ const AuthWidget: React.FunctionComponent<{
       // Also refresh the service locator on the background so the new auth works immediately
       await refreshBackgroundLocator({ remote: false, local: true });
 
+      if (onRefresh) {
+        await onRefresh();
+      }
+
       notify.success("Added configuration for integration");
 
       // Don't need to track changes locally via setCreated; the new auth automatically flows
@@ -85,7 +100,7 @@ const AuthWidget: React.FunctionComponent<{
 
       setShow(false);
     },
-    [helpers, notify, dispatch, setShow, serviceId]
+    [helpers, notify, dispatch, setShow, serviceId, onRefresh]
   );
 
   const CustomMenuList = useMemo(() => {

--- a/src/options/pages/marketplace/ServicesBody.tsx
+++ b/src/options/pages/marketplace/ServicesBody.tsx
@@ -36,7 +36,7 @@ interface OwnProps {
 }
 
 const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
-  const [authOptions] = useAuthOptions();
+  const [authOptions, refreshAuthOptions] = useAuthOptions();
 
   const [field] = useField<ServiceAuthPair[]>("services");
 
@@ -96,6 +96,7 @@ const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
                   authOptions={authOptions}
                   serviceId={serviceId}
                   name={[field.name, index, "config"].join(".")}
+                  onRefresh={refreshAuthOptions}
                 />
               </td>
             </tr>


### PR DESCRIPTION
Closes #1047

Also re-fetches the remote configurations. Probably unnecessary, but the quickest way to fix for now