### PR TITLE
Use tsconfig preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,7 @@
         "@babel/preset-env": "^7.15.0",
         "@babel/preset-react": "^7.14.5",
         "@babel/preset-typescript": "^7.15.0",
+        "@sindresorhus/tsconfig": "^1.0.2",
         "@storybook/addon-actions": "^6.3.4",
         "@storybook/addon-essentials": "^6.3.6",
         "@storybook/addon-links": "^6.3.4",
@@ -4329,6 +4330,15 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sindresorhus/tsconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-6N3TkxwK6XuRCH/IRQXvp4PwTrRxktE4NpmeFczA283W6rJjcorJKNbjSmgCNVKkofNoawPF9OmCqDVzDv5UPg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -43174,6 +43184,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
       "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==",
+      "dev": true
+    },
+    "@sindresorhus/tsconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-6N3TkxwK6XuRCH/IRQXvp4PwTrRxktE4NpmeFczA283W6rJjcorJKNbjSmgCNVKkofNoawPF9OmCqDVzDv5UPg==",
       "dev": true
     },
     "@sinonjs/commons": {

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.15.0",
+    "@sindresorhus/tsconfig": "^1.0.2",
     "@storybook/addon-actions": "^6.3.4",
     "@storybook/addon-essentials": "^6.3.6",
     "@storybook/addon-links": "^6.3.4",

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -171,8 +171,8 @@ function mutationSelector(
   const promise = new Promise<JQuery>((resolve) => {
     observer = initialize(
       selector,
-      function () {
-        resolve($(this));
+      (i: number, element: HTMLElement) => {
+        resolve($(element));
       },
       { target: target ?? document }
     );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,22 @@
 {
+  // You can see the full details at https://github.com/sindresorhus/tsconfig/blob/main/tsconfig.json
+  // Note: `strict: true` enables many flags that aren’t explicitly listed in that file
+  "extends": "@sindresorhus/tsconfig/tsconfig.json",
   "compilerOptions": {
     "sourceMap": true,
-    "noImplicitAny": true,
-    "module": "es2020",
     "target": "es2020",
-    "jsx": "react",
-    "allowJs": false,
-    "strictBindCallApply": true,
-    "resolveJsonModule": true,
-    "moduleResolution": "Node",
-    "noUnusedLocals": true,
-    "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "downlevelIteration": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "baseUrl": ".",
+
+    // TODO: Drop these lines to make TS stricter https://github.com/pixiebrix/pixiebrix-extension/issues/775
+    "strictNullChecks": false,
+    "strictFunctionTypes": false,
+    "noPropertyAccessFromIndexSignature": false,
+    "noImplicitReturns": false,
+    "noUnusedParameters": false,
+    "useDefineForClassFields": false,
     "paths": {
       "@/*": ["src/*"],
       "@img/*": ["img/*"],


### PR DESCRIPTION
Related to:

- https://github.com/pixiebrix/pixiebrix-extension/issues/775
- https://github.com/pixiebrix/pixiebrix-app/issues/362
- https://github.com/pixiebrix/pixiebrix-extension/pull/887

Pros:

- shorter config to manually handle (eventually)
- clear view of rules that we want to enable over time

Strictness isn't affected by this PR except for a `this`-related rule I fixed in `jquery.initialize`.

Side note: `extension-messaging` is taking a while so I'm taking a break with some lighter PRs while starting with a stricter config in that repo.