### PR TITLE
Replace `react-spinners` with custom CSS spinner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,6 @@
         "react-select": "^4.3.1",
         "react-select-virtualized": "^3.5.0",
         "react-shadow-root": "^5.0.4",
-        "react-spinners": "0.9.0",
         "react-split-pane": "^0.1.92",
         "react-toast-notifications": "^2.4.4",
         "react-virtualized": "^9.22.3",
@@ -34563,18 +34562,6 @@
         "react-dom": "^0.14.0 || ^15.0.0-0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/react-spinners": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.9.0.tgz",
-      "integrity": "sha512-+x6eD8tn/aYLdxZjNW7fSR1uoAXLb9qq6TFYZR1dFweJvckcf/HfP8Pa/cy5HOvB/cvI4JgrYXTjh2Me3S6Now==",
-      "dependencies": {
-        "@emotion/core": "^10.0.15"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0",
-        "react-dom": "^16.0.0"
-      }
-    },
     "node_modules/react-split-pane": {
       "version": "0.1.92",
       "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.92.tgz",
@@ -67809,14 +67796,6 @@
         "invariant": "^2.2.4",
         "shallowequal": "^1.1.0",
         "throttle-debounce": "^3.0.1"
-      }
-    },
-    "react-spinners": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.9.0.tgz",
-      "integrity": "sha512-+x6eD8tn/aYLdxZjNW7fSR1uoAXLb9qq6TFYZR1dFweJvckcf/HfP8Pa/cy5HOvB/cvI4JgrYXTjh2Me3S6Now==",
-      "requires": {
-        "@emotion/core": "^10.0.15"
       }
     },
     "react-split-pane": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "react-select": "^4.3.1",
     "react-select-virtualized": "^3.5.0",
     "react-shadow-root": "^5.0.4",
-    "react-spinners": "0.9.0",
     "react-split-pane": "^0.1.92",
     "react-toast-notifications": "^2.4.4",
     "react-virtualized": "^9.22.3",

--- a/src/action.html
+++ b/src/action.html
@@ -24,8 +24,9 @@
   </head>
   <body>
     <div id="container">
-      <div class="action-sidebar-loader">
-        <div>Loading PixieBrix&nbsp;&nbsp;🚀</div>
+      <div class="pb-loader">
+        <div class="pb-loader-spinner"><i></i><i></i><i></i><i></i></div>
+        <p class="pb-loader-error"></p>
       </div>
     </div>
     <script src="vendors.js"></script>

--- a/src/action.scss
+++ b/src/action.scss
@@ -32,13 +32,6 @@ body {
 #container {
   height: 100%;
   width: 100%;
-
-  .action-sidebar-loader {
-    width: 100%;
-    margin-top: 60px;
-    display: flex;
-    justify-content: center;
-  }
 }
 
 .action-panel-button {

--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -37,7 +37,7 @@ import DefaultActionPanel from "@/actionPanel/DefaultActionPanel";
 import { ToastProvider } from "react-toast-notifications";
 import store, { persistor } from "@/options/store";
 import { Provider } from "react-redux";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { PersistGate } from "redux-persist/integration/react";
 import { reportEvent } from "@/telemetry/events";
 import useExtensionMeta from "@/hooks/useExtensionMeta";
@@ -135,7 +135,7 @@ const ActionPanelApp: React.FunctionComponent = () => {
 
   return (
     <Provider store={store}>
-      <PersistGate loading={<GridLoader />} persistor={persistor}>
+      <PersistGate loading={<Spinner />} persistor={persistor}>
         <ToastProvider>
           <div className="d-flex flex-column" style={{ height: "100vh" }}>
             <div className="d-flex flex-row mb-2 p-2 justify-content-between align-content-center">

--- a/src/actionPanel/PanelBody.tsx
+++ b/src/actionPanel/PanelBody.tsx
@@ -18,7 +18,7 @@
 import { ComponentRef, PanelComponent } from "@/extensionPoints/dom";
 import React, { useMemo } from "react";
 import { PanelEntry } from "@/actionPanel/protocol";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import blockRegistry from "@/blocks/registry";
 import { useAsyncState } from "@/hooks/common";
 import ConsoleLogger from "@/tests/ConsoleLogger";
@@ -89,7 +89,7 @@ const PanelBody: React.FunctionComponent<{ panel: PanelEntry }> = ({
   }
 
   if (pending || component == null) {
-    return <GridLoader />;
+    return <Spinner />;
   }
 
   return component;

--- a/src/components/Spinner.scss
+++ b/src/components/Spinner.scss
@@ -1,0 +1,82 @@
+/*!
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.pb-loader {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  // Automatically center the loader in the window it's about to be replaced by React
+  #container > &:only-child {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    transform: translate(-50%, -50%);
+  }
+}
+
+.pb-loader-spinner {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  width: fit-content;
+
+  i {
+    color: #b66dff;
+    border-top: 5px solid;
+    border-left: 5px solid;
+    height: 20px;
+    width: 20px;
+    margin: 5px;
+    border-top-left-radius: 45%;
+    animation: spinner-fade 1s infinite both;
+  }
+  i:nth-child(2) {
+    transform: rotate(90deg);
+    animation-delay: 0.25s;
+  }
+  i:nth-child(3) {
+    transform: rotate(270deg);
+    animation-delay: 0.75s;
+  }
+  i:nth-child(4) {
+    transform: rotate(180deg);
+    animation-delay: 0.5s;
+  }
+}
+@keyframes spinner-fade {
+  0%,
+  30%,
+  100% {
+    opacity: 0.2;
+  }
+  65% {
+    opacity: 1;
+  }
+}
+.pb-loader-error:before {
+  content: "An error occurred while loading PixieBrix";
+  display: block;
+  margin-top: 1em;
+  animation: spinner-pop-in 0s 5s both;
+}
+
+@keyframes spinner-pop-in {
+  from {
+    visibility: hidden;
+  }
+}

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -15,25 +15,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useContext } from "react";
-import AuthContext from "@/auth/AuthContext";
-import { DevToolsContext } from "@/devTools/context";
-import Spinner from "@/components/Spinner";
+import React from "react";
 
-const Footer: React.FunctionComponent = () => {
-  const { scope } = useContext(AuthContext);
-  const { connecting } = useContext(DevToolsContext);
+import "./Spinner.scss";
 
-  return (
-    <div className="Sidebar__footer flex-grow-0">
-      <div className="d-flex">
-        <div className="flex-grow-1">
-          Scope: <code>{scope}</code>
-        </div>
-        <div>{connecting && <Spinner />}</div>
-      </div>
+const Spinner: React.FunctionComponent = () => (
+  <div className="pb-loader">
+    <div className="pb-loader-spinner">
+      <i></i>
+      <i></i>
+      <i></i>
+      <i></i>
     </div>
-  );
-};
+    <p className="pb-loader-error"></p>
+  </div>
+);
 
-export default Footer;
+export default Spinner;

--- a/src/components/fields/BlockField.tsx
+++ b/src/components/fields/BlockField.tsx
@@ -41,7 +41,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "./BlockField.scss";
 import Button from "react-bootstrap/Button";
 import { useAsyncEffect } from "use-async-effect";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { reportError } from "@/telemetry/logging";
 import BlockModal from "@/components/fields/BlockModal";
 import optionsRegistry from "@/components/fields/optionsRegistry";
@@ -160,7 +160,7 @@ const BlockCard: React.FunctionComponent<{
           ) : error ? (
             <div className="invalid-feedback d-block mb-4">{error}</div>
           ) : (
-            <GridLoader />
+            <Spinner />
           )}
 
           <div className="d-flex">

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -32,7 +32,7 @@ import { fieldLabel } from "@/components/fields/fieldUtils";
 import Select from "react-select";
 import { FieldProps } from "@/components/fields/propTypes";
 import { inputProperties } from "@/helpers";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import useDependency from "@/services/useDependency";
 import {
   Bot,
@@ -297,7 +297,7 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
               {inputSchema != null &&
                 isEmpty(inputSchema.properties) &&
                 !schemaPending && <span>Bot does not take any inputs</span>}
-              {schemaPending && <GridLoader />}
+              {schemaPending && <Spinner />}
               {schemaError && (
                 <span className="text-danger">
                   Error fetching schema: {getErrorMessage(schemaError)}

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -28,7 +28,7 @@ import { useAsyncState } from "@/hooks/common";
 import { APPEND_SCHEMA } from "@/contrib/google/sheets/append";
 import { DevToolsContext } from "@/devTools/context";
 import { ObjectField } from "@/components/fields/FieldTable";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { isNullOrBlank } from "@/utils";
 import { SheetMeta } from "@/contrib/google/sheets/types";
 import FileField from "@/contrib/google/sheets/FileField";
@@ -126,7 +126,7 @@ const PropertiesField: React.FunctionComponent<{
   }, [doc?.id, tabName]);
 
   if (schemaPending) {
-    return <GridLoader />;
+    return <Spinner />;
   }
 
   if (schemaError) {

--- a/src/devTools/Locator.tsx
+++ b/src/devTools/Locator.tsx
@@ -20,7 +20,7 @@ import { useAsyncState } from "@/hooks/common";
 import InputGroup from "react-bootstrap/InputGroup";
 import Form from "react-bootstrap/Form";
 import { useDebounce } from "use-debounce";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import Table from "react-bootstrap/Table";
 import { searchWindow, detectFrameworks } from "@/background/devtools";
 import { browser } from "webextension-polyfill-ts";
@@ -119,7 +119,7 @@ const Locator: React.FunctionComponent = () => {
           </tbody>
         </Table>
       ) : (
-        <GridLoader />
+        <Spinner />
       )}
     </div>
   );

--- a/src/devTools/Panel.tsx
+++ b/src/devTools/Panel.tsx
@@ -20,7 +20,7 @@ import { Button, Container } from "react-bootstrap";
 import { HashRouter as Router } from "react-router-dom";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { DevToolsContext, useDevConnection } from "@/devTools/context";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import Editor from "@/devTools/Editor";
 import store, { persistor, RootState } from "./store";
 import { PersistGate } from "redux-persist/integration/react";
@@ -54,7 +54,7 @@ const defaultState: AuthState = {
 const PersistLoader: React.FunctionComponent = () => (
   <Centered>
     <div className="d-flex justify-content-center">
-      <GridLoader />
+      <Spinner />
     </div>
   </Centered>
 );
@@ -122,7 +122,7 @@ const Panel: React.FunctionComponent = () => {
       <Centered>
         <p>Initializing connection...</p>
         <div className="d-flex justify-content-center">
-          <GridLoader />
+          <Spinner />
         </div>
       </Centered>
     );

--- a/src/devTools/editor/tabs/EffectTab.tsx
+++ b/src/devTools/editor/tabs/EffectTab.tsx
@@ -28,7 +28,7 @@ import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FieldArray, useField } from "formik";
 import hash from "object-hash";
 import Centered from "@/devTools/editor/components/Centered";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import BlockModal from "@/components/fields/BlockModal";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { BlockType, getType } from "@/blocks/util";
@@ -123,7 +123,7 @@ const EffectTab: React.FunctionComponent<{
     return (
       <Tab.Pane eventKey={eventKey} className="EffectTab h-100">
         <Centered>
-          <GridLoader />
+          <Spinner />
         </Centered>
       </Tab.Pane>
     );

--- a/src/devTools/editor/tabs/RunLogCard.tsx
+++ b/src/devTools/editor/tabs/RunLogCard.tsx
@@ -17,7 +17,7 @@
 
 import React, { useMemo, useState } from "react";
 import { MessageLevel } from "@/background/logging";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { Card } from "react-bootstrap";
 import LogTable from "@/components/logViewer/LogTable";
 import useLogEntries from "@/components/logViewer/useLogEntries";
@@ -58,7 +58,7 @@ const RunLogCard: React.FunctionComponent<OwnProps> = ({
   if (logs.isLoading) {
     return (
       <Card.Body>
-        <GridLoader />
+        <Spinner />
       </Card.Body>
     );
   }

--- a/src/devTools/editor/tabs/effect/BlockConfiguration.tsx
+++ b/src/devTools/editor/tabs/effect/BlockConfiguration.tsx
@@ -22,7 +22,7 @@ import { useBlockOptions } from "@/components/fields/BlockField";
 import { Card, Form } from "react-bootstrap";
 import { RendererContext } from "@/components/fields/blockOptions";
 import devtoolFields from "@/devTools/editor/fields/Fields";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 
 const BlockConfiguration: React.FunctionComponent<{
   name: string;
@@ -56,7 +56,7 @@ const BlockConfiguration: React.FunctionComponent<{
               ) : error ? (
                 <div className="invalid-feedback d-block mb-4">{error}</div>
               ) : (
-                <GridLoader />
+                <Spinner />
               )}
             </RendererContext.Provider>
           </div>

--- a/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderBlockConfig.tsx
@@ -20,7 +20,7 @@ import { FormState } from "@/devTools/editor/editorSlice";
 import { useFormikContext } from "formik";
 import { Alert, Col, Form, Row } from "react-bootstrap";
 import { useAsyncEffect } from "use-async-effect";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { jsonTreeTheme as theme } from "@/themes/light";
 import JSONTree from "react-json-tree";
 import { useDebounce } from "use-debounce";
@@ -199,7 +199,7 @@ export const ReaderBlockForm: React.FunctionComponent<{
                 </span>
               )}
               {searchResults === undefined ? (
-                <GridLoader />
+                <Spinner />
               ) : (
                 <JSONTree
                   data={searchResults}
@@ -239,7 +239,7 @@ const ReaderBlockConfig: React.FunctionComponent<{
   }, [readerIndex, values.readers]);
 
   if (!readerBlock) {
-    return <GridLoader />;
+    return <Spinner />;
   }
 
   return (

--- a/src/devTools/editor/tabs/reader/ReaderConfig.tsx
+++ b/src/devTools/editor/tabs/reader/ReaderConfig.tsx
@@ -25,7 +25,7 @@ import Select from "react-select";
 import { Framework, FrameworkMeta } from "@/messaging/constants";
 import SelectorSelectorField from "@/devTools/editor/fields/SelectorSelectorField";
 import { useAsyncEffect } from "use-async-effect";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { runReader } from "@/background/devtools";
 import { jsonTreeTheme as theme } from "@/themes/light";
 import JSONTree from "react-json-tree";
@@ -416,7 +416,7 @@ const ReaderConfig: React.FunctionComponent<{
                 </span>
               )}
               {searchResults === undefined ? (
-                <GridLoader />
+                <Spinner />
               ) : (
                 <JSONTree
                   data={searchResults}
@@ -528,7 +528,7 @@ const ReaderConfig: React.FunctionComponent<{
                   </span>
                 )}
                 {searchResults === undefined ? (
-                  <GridLoader />
+                  <Spinner />
                 ) : (
                   <JSONTree
                     data={searchResults}
@@ -545,7 +545,7 @@ const ReaderConfig: React.FunctionComponent<{
               <span>Inferred Schema</span>
               <div className="overflow-auto h-100 w-100">
                 {schema === undefined ? (
-                  <GridLoader />
+                  <Spinner />
                 ) : (
                   <SchemaTree schema={schema} />
                 )}

--- a/src/devtoolsPanel.html
+++ b/src/devtoolsPanel.html
@@ -15,42 +15,22 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <!DOCTYPE html>
-<html style="display: flex">
+<html>
   <head>
+    <meta charset="utf8" />
     <!--Uncomment this script tag to enable the React Dev Tools app-->
     <!--See https://github.com/pixiebrix/pixiebrix-extension/wiki/Local-build-setup#stand-alone -->
     <!--<script src="http://localhost:8097"></script>-->
-    <meta charset="utf8" />
-    <style>
-      html {
-        display: flex;
-        height: 100%;
-      }
-      body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        flex: 1;
-        display: flex;
-      }
-      #container {
-        display: flex;
-        flex: 1;
-        width: 100%;
-        height: 100vh;
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-      }
-    </style>
-
     <link rel="stylesheet" href="devtoolsPanel.css" />
   </head>
   <body>
     <!-- main react mount point -->
-    <div id="container">🚀 Loading PixieBrix devtools.</div>
+    <div id="container">
+      <div class="pb-loader">
+        <div class="pb-loader-spinner"><i></i><i></i><i></i><i></i></div>
+        <p class="pb-loader-error"></p>
+      </div>
+    </div>
     <script src="vendors.js"></script>
     <script src="devtoolsPanel.js"></script>
   </body>

--- a/src/layout/Page.tsx
+++ b/src/layout/Page.tsx
@@ -20,7 +20,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { useTitle } from "@/hooks/title";
 import { getErrorMessage } from "@/errors";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 
 export const PageTitle: React.FunctionComponent<{
   title: React.ReactNode;
@@ -76,7 +76,7 @@ const Page: React.FunctionComponent<{
 
   const body = useMemo(() => {
     if (isPending) {
-      return <GridLoader />;
+      return <Spinner />;
     }
 
     if (error) {

--- a/src/options.html
+++ b/src/options.html
@@ -24,8 +24,9 @@
   </head>
   <body>
     <div id="container">
-      <div class="options-loader">
-        <div>Loading PixieBrix Options 🚀</div>
+      <div class="pb-loader">
+        <div class="pb-loader-spinner"><i></i><i></i><i></i><i></i></div>
+        <p class="pb-loader-error"></p>
       </div>
     </div>
     <script src="vendors.js"></script>

--- a/src/options.scss
+++ b/src/options.scss
@@ -37,13 +37,6 @@ body {
   right: 0;
   bottom: 0;
   overflow-y: auto;
-
-  .options-loader {
-    width: 100%;
-    margin-top: 60px;
-    display: flex;
-    justify-content: center;
-  }
 }
 
 .modal-backdrop {

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -19,7 +19,7 @@ import React, { useEffect } from "react";
 import store, { hashHistory, persistor } from "./store";
 import { Provider, useSelector } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import Container from "react-bootstrap/Container";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import InstalledPage from "@/options/pages/installed/InstalledPage";
@@ -159,7 +159,7 @@ const App: React.FunctionComponent = () => {
 
   return (
     <Provider store={store}>
-      <PersistGate loading={<GridLoader />} persistor={persistor}>
+      <PersistGate loading={<Spinner />} persistor={persistor}>
         <AuthContext.Provider value={authState ?? defaultState}>
           <ConnectedRouter history={hashHistory}>
             <ModalProvider>

--- a/src/options/pages/SetupPage.tsx
+++ b/src/options/pages/SetupPage.tsx
@@ -25,7 +25,7 @@ import { browser } from "webextension-polyfill-ts";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import cx from "classnames";
 import { useAsyncState } from "@/hooks/common";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 
 import "./SetupPage.scss";
 import { useTitle } from "@/hooks/title";
@@ -84,7 +84,7 @@ const SetupPage: React.FunctionComponent = () => {
           <Card className="OnboardingCard">
             <Card.Header>PixieBrix Setup Steps</Card.Header>
             <Card.Body>
-              <GridLoader />
+              <Spinner />
             </Card.Body>
           </Card>
         </Col>

--- a/src/options/pages/brickEditor/BrickLogs.tsx
+++ b/src/options/pages/brickEditor/BrickLogs.tsx
@@ -17,7 +17,7 @@
 
 import React, { useState } from "react";
 import { MessageLevel } from "@/background/logging";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { Card } from "react-bootstrap";
 import { MessageContext } from "@/core";
 import LogTable from "@/components/logViewer/LogTable";
@@ -44,7 +44,7 @@ const BrickLogs: React.FunctionComponent<{
   if (logs.isLoading) {
     return (
       <Card.Body>
-        <GridLoader />
+        <Spinner />
       </Card.Body>
     );
   }

--- a/src/options/pages/brickEditor/EditPage.tsx
+++ b/src/options/pages/brickEditor/EditPage.tsx
@@ -23,7 +23,7 @@ import { Formik, useField } from "formik";
 import { useParams } from "react-router";
 import Editor from "./Editor";
 import { truncate } from "lodash";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import useSubmitBrick from "./useSubmitBrick";
 import yaml from "js-yaml";
 import BootstrapSwitchButton from "bootstrap-switch-button-react";
@@ -103,7 +103,7 @@ const LoadingBody: React.FunctionComponent = () => (
       </div>
     </div>
     <div>
-      <GridLoader />
+      <Spinner />
     </div>
   </>
 );

--- a/src/options/pages/brickEditor/referenceTab/BrickReference.tsx
+++ b/src/options/pages/brickEditor/referenceTab/BrickReference.tsx
@@ -28,7 +28,7 @@ import { IBlock, IService } from "@/core";
 import Fuse from "fuse.js";
 import { sortBy } from "lodash";
 import styles from "./BrickReference.module.scss";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import BrickDetail from "./BrickDetail";
 import { ReferenceEntry } from "../brickEditorTypes";
 import BlockResult from "./BlockResult";
@@ -134,7 +134,7 @@ const BrickReference: React.FunctionComponent<{
             />
           ) : (
             <div>
-              <GridLoader />
+              <Spinner />
             </div>
           )}
         </Col>

--- a/src/options/pages/installed/ExtensionRow.tsx
+++ b/src/options/pages/installed/ExtensionRow.tsx
@@ -21,7 +21,7 @@ import {
   ExtensionValidationResult,
   useExtensionValidator,
 } from "@/validators/generic";
-import { BeatLoader } from "react-spinners";
+import Spinner from "@/components/Spinner";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCheck,
@@ -80,7 +80,7 @@ const ExtensionRow: React.FunctionComponent<{
 
   const statusElt = useMemo(() => {
     if (hasPermissions == null || validation == null) {
-      return <BeatLoader />;
+      return <Spinner />;
     }
 
     if (validation && !validation.valid) {

--- a/src/options/pages/marketplace/ActivateBlueprintPage.tsx
+++ b/src/options/pages/marketplace/ActivateBlueprintPage.tsx
@@ -24,7 +24,7 @@ import React, { useMemo } from "react";
 import { useParams } from "react-router";
 import { RecipeDefinition } from "@/types/definitions";
 import { Card, Col, Row } from "react-bootstrap";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import ActivateWizard from "@/options/pages/marketplace/ActivateWizard";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { Link } from "react-router-dom";
@@ -111,7 +111,7 @@ const ActivateBlueprintPage: React.FunctionComponent = () => {
       );
     }
 
-    return <GridLoader />;
+    return <Spinner />;
   }, [blueprintId, blueprint, sourcePage]);
 
   return (

--- a/src/options/pages/marketplace/PermissionsBody.tsx
+++ b/src/options/pages/marketplace/PermissionsBody.tsx
@@ -18,7 +18,7 @@
 import React, { useMemo } from "react";
 import { uniq } from "lodash";
 import { selectOptionalPermissions } from "@/utils/permissions";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { Card, Table } from "react-bootstrap";
 import useReportError from "@/hooks/useReportError";
 import { Permissions } from "webextension-polyfill-ts";
@@ -46,7 +46,7 @@ const PermissionsBody: React.FunctionComponent<{
 
   const helpText = useMemo(() => {
     if (isPending) {
-      return <GridLoader />;
+      return <Spinner />;
     }
 
     if (error) {

--- a/src/options/pages/services/ServicesEditor.tsx
+++ b/src/options/pages/services/ServicesEditor.tsx
@@ -31,7 +31,7 @@ import { persistor, RootState } from "../../store";
 import { RawServiceConfiguration } from "@/core";
 import { SanitizedAuth } from "@/types/contract";
 import { refresh as refreshBackgroundAuths } from "@/background/locator";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import ZapierModal from "@/options/pages/services/ZapierModal";
 import AuthContext from "@/auth/AuthContext";
 import { useTitle } from "@/hooks/title";
@@ -138,7 +138,7 @@ const ServicesEditor: React.FunctionComponent<OwnProps> = ({
         </div>
         <Row>
           <Col>
-            <GridLoader />
+            <Spinner />
           </Col>
         </Row>
       </div>

--- a/src/options/pages/services/SharedServicesCard.tsx
+++ b/src/options/pages/services/SharedServicesCard.tsx
@@ -21,7 +21,7 @@ import React from "react";
 import { useAsyncState } from "@/hooks/common";
 import { getBaseURL } from "@/services/baseService";
 import urljoin from "url-join";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { SanitizedAuth } from "@/types/contract";
 import { faUsers } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -71,7 +71,7 @@ const SharedServicesCard: React.FunctionComponent<OwnProps> = ({
         </Table>
       ) : (
         <Card.Body>
-          <GridLoader />
+          <Spinner />
         </Card.Body>
       )}
       <Card.Footer>

--- a/src/options/pages/settings/LoggingSettings.tsx
+++ b/src/options/pages/settings/LoggingSettings.tsx
@@ -22,7 +22,7 @@ import { Button, Card, Form } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import BootstrapSwitchButton from "bootstrap-switch-button-react";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { clearLogs } from "@/background/logging";
 import { reportError } from "@/telemetry/logging";
 import { getErrorMessage } from "@/errors";
@@ -63,7 +63,7 @@ const LoggingSettings: React.FunctionComponent = () => {
             </Form.Group>
           </Form>
         ) : (
-          <GridLoader />
+          <Spinner />
         )}
       </Card.Body>
       <Card.Footer>

--- a/src/options/pages/templates/TemplatesPage.tsx
+++ b/src/options/pages/templates/TemplatesPage.tsx
@@ -46,7 +46,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import cx from "classnames";
 import "./TemplatesPage.scss";
 import AuthContext from "@/auth/AuthContext";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { useTitle } from "@/hooks/title";
 import { RegistryId } from "@/core";
 import { selectExtensions } from "@/options/selectors";
@@ -267,7 +267,7 @@ const SharedTemplates: React.FunctionComponent<{
     return (
       <Row className="mt-3">
         <Col xl={9} lg={10} md={10} sm={12}>
-          <GridLoader />
+          <Spinner />
         </Col>
       </Row>
     );

--- a/src/pages/marketplace/MarketplacePage.tsx
+++ b/src/pages/marketplace/MarketplacePage.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useMemo, useState } from "react";
-import GridLoader from "react-spinners/GridLoader";
+import Spinner from "@/components/Spinner";
 import { PageTitle } from "@/layout/Page";
 import sortBy from "lodash/sortBy";
 import { faStoreAlt } from "@fortawesome/free-solid-svg-icons";
@@ -167,7 +167,7 @@ const MarketplacePage: React.FunctionComponent<MarketplaceProps> = ({
       <Row>
         <Col xl={8} lg={10} md={12}>
           {rawRecipes == null ? (
-            <GridLoader />
+            <Spinner />
           ) : (
             <RecipeList
               installedRecipes={installedRecipes}

--- a/src/permissionsPopup.html
+++ b/src/permissionsPopup.html
@@ -26,8 +26,9 @@
   </head>
   <body>
     <div id="container">
-      <div class="options-loader">
-        <div>Loading PixieBrix Permissions Dialog 🚀</div>
+      <div class="pb-loader">
+        <div class="pb-loader-spinner"><i></i><i></i><i></i><i></i></div>
+        <p class="pb-loader-error"></p>
       </div>
     </div>
   </body>

--- a/src/permissionsPopup.tsx
+++ b/src/permissionsPopup.tsx
@@ -25,5 +25,6 @@ import ReactDOM from "react-dom";
 import React from "react";
 
 import "bootstrap/dist/css/bootstrap.min.css";
+import "@/components/Spinner.scss";
 
 ReactDOM.render(<PermissionsPopup />, document.querySelector("#container"));


### PR DESCRIPTION
- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/1004
- Part of https://github.com/pixiebrix/pixiebrix-extension/issues/480
- Permanently fixes #755 

# Firefox permission dialog

Refer to this for the spinner/text spacing

<img width="512" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/131396640-791b6f56-7da9-4af9-9924-2635815888a9.png">

# Sidebar

<img width="1106" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/131396714-54b389df-f8a3-436a-a78c-239e57730c56.png">

# Editor

<img width="1112" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/131396745-619d2cad-9388-4ce4-baa9-ff741cecf900.png">

# Options

<img width="857" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/131396757-06a5bcaf-733d-4267-8e1b-34c61ee4ee6e.png">
