### PR TITLE
Exclude `redux-logger` from production build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -215,6 +215,19 @@ function mockHeavyDependencies() {
   }
 }
 
+/**
+ * Ensure that a dependency is never included in a production build.
+ * May cause runtime errors if this isn't *also* handled in the code,
+ * for example by checking ENV === 'production'
+ */
+function devDependenciesOnly(options, ...dependencyName) {
+  if (isProd(options)) {
+    return Object.fromEntries(dependencyName.map((dep) => [dep, false]));
+  }
+
+  return {};
+}
+
 module.exports = (env, options) =>
   mergeWithShared({
     node: {
@@ -272,6 +285,7 @@ module.exports = (env, options) =>
     resolve: {
       alias: {
         ...mockHeavyDependencies(),
+        ...devDependenciesOnly(options, "redux-logger"),
 
         // Enables static analysis and removal of dead code
         "webext-detect-page": path.resolve("src/__mocks__/webextDetectPage"),


### PR DESCRIPTION
Related to

- https://github.com/pixiebrix/pixiebrix-extension/pull/617#issuecomment-869160489
- https://github.com/pixiebrix/pixiebrix-extension/issues/480#issuecomment-869167118

# Before


<img width="402" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/131415175-f02dd944-bad7-4a68-b64e-3f9ecb94f3ef.png">

# After

<img width="329" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/131415190-aad68c4a-0835-4b29-b4ee-5a83888c9126.png">
