### PR TITLE
Disable `filenames/match-exported` on stories

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -165,6 +165,12 @@
   ],
   "overrides": [
     {
+      "files": ["*.stories.tsx"],
+      "rules": {
+        "filenames/match-exported": "off"
+      }
+    },
+    {
       "files": ["*.js"],
       "rules": {
         "@typescript-eslint/no-implicit-any-catch": "off"


### PR DESCRIPTION
As reported by @BALEHOK on Slack.

```
Filename 'LogTable.stories' must match the exported name 'LogTable'. eslint(filenames/match-exported)
```

`.stories` files must have that special filename and there's no practical way to name variables with a period.