### PR TITLE
Fix eslint deprecation warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20910,9 +20910,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.4.tgz",
-      "integrity": "sha512-xjDAPJRxKc1uoTkdW8MEk7Fq/2bzz3YoCADYniDV7+KITCUdu9c90fj1aKI7nEZFZxRrHlDo3wtma/C6QkhlXQ==",
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
+      "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -57166,9 +57166,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.4.tgz",
-      "integrity": "sha512-xjDAPJRxKc1uoTkdW8MEk7Fq/2bzz3YoCADYniDV7+KITCUdu9c90fj1aKI7nEZFZxRrHlDo3wtma/C6QkhlXQ==",
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
+      "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",


### PR DESCRIPTION
A sub-dependency is causing noise when linting, the fix is easy (lockfile only)

- https://github.com/ljharb/es-abstract/issues/133

```
❯ nr lint -- --quiet
(node:20287) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./2020/" in the "exports" field module resolution of the package at ./node_modules/es-abstract/package.json.
Update this package.json to use a subpath pattern like "./2020/*".
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:20287) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./helpers/" in the "exports" field module resolution of the package at ./node_modules/es-abstract/package.json.
Update this package.json to use a subpath pattern like "./helpers/*".
```

