### PR TITLE
Restore GitHub Actions annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,13 +123,7 @@ jobs:
           node-version: "16"
           cache: npm
       - run: npm ci
-        # Run eslint without GitHub Actions annotations
-        # https://stackoverflow.com/a/65964721/288906
-      - name: npm run lint
-        run: |
-          echo "::remove-matcher owner=eslint-compact::"
-          echo "::remove-matcher owner=eslint-stylish::"
-          npm run lint -- --quiet
+      - run: npm run lint -- --quiet
 
   # https://pre-commit.com/#usage-in-continuous-integration
   prettier:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "baseUrl": ".",
+    "skipLibCheck": false,
 
     // TODO: Drop these lines to make TS stricter https://github.com/pixiebrix/pixiebrix-extension/issues/775
     "strictNullChecks": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "baseUrl": ".",
-    "skipLibCheck": false,
 
     // TODO: Drop these lines to make TS stricter https://github.com/pixiebrix/pixiebrix-extension/issues/775
     "strictNullChecks": false,


### PR DESCRIPTION
… since Codacy is hit or miss: https://github.com/pixiebrix/pixiebrix-extension/pull/1241#pullrequestreview-746068548

And also because annotations always appear immediately.


Annotation example:

<img width="300" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/132007585-cbbc5865-7fba-4c4b-a3b1-468ab25ca2f6.png">
