### PR TITLE
Change "Effect" to "Action" in Page Editor for buttons

### DIFF
--- a/src/devTools/editor/extensionPoints/menuItem.ts
+++ b/src/devTools/editor/extensionPoints/menuItem.ts
@@ -65,7 +65,7 @@ const wizard: WizardStep[] = [
   { step: "Data", Component: ReaderTab },
   { step: "Menu Item", Component: MenuItemTab },
   { step: "Integrations", Component: ServicesTab },
-  { step: "Effect", Component: EffectTab },
+  { step: "Action", Component: EffectTab },
   { step: "Availability", Component: AvailabilityTab },
   { step: "Logs", Component: LogsTab },
 ];


### PR DESCRIPTION
Fixes #1045 

Update the effect tab name to "Action" for buttons, matching other extension types.