### PR TITLE
#1267: fix read storage calls

### DIFF
--- a/src/background/dataStore.ts
+++ b/src/background/dataStore.ts
@@ -24,7 +24,10 @@ export const LOCAL_DATA_STORE = "LOCAL_DATA_STORE";
 export const KEY_PREFIX = "@@";
 
 async function _getRecord(primaryKey: string): Promise<unknown> {
-  const data = await readStorageWithMigration(LOCAL_DATA_STORE, {});
+  const data = await readStorageWithMigration<Record<string, unknown>>(
+    LOCAL_DATA_STORE,
+    {}
+  );
   return data[`${KEY_PREFIX}${primaryKey}`] ?? {};
 }
 
@@ -32,7 +35,10 @@ async function _setRecord(
   primaryKey: string,
   value: JsonObject
 ): Promise<void> {
-  const data = await readStorageWithMigration(LOCAL_DATA_STORE, {});
+  const data = await readStorageWithMigration<Record<string, unknown>>(
+    LOCAL_DATA_STORE,
+    {}
+  );
   data[`${KEY_PREFIX}${primaryKey}`] = value;
   await setStorage(LOCAL_DATA_STORE, data);
 }

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -328,7 +328,9 @@ export async function _getLoggingConfig(): Promise<LoggingConfig> {
     return _config;
   }
 
-  return readStorageWithMigration(LOG_CONFIG_STORAGE_KEY, {});
+  return readStorageWithMigration(LOG_CONFIG_STORAGE_KEY, {
+    logValues: false,
+  });
 }
 
 export async function _setLoggingConfig(config: LoggingConfig): Promise<void> {

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -22,7 +22,7 @@ import { compact, debounce, throttle, uniq } from "lodash";
 import { browser } from "webextension-polyfill-ts";
 import { readStorage, setStorage } from "@/chrome";
 import { isLinked } from "@/auth/token";
-import { Data } from "@/core";
+import { Data, UUID } from "@/core";
 import { boolean } from "@/utils";
 import { loadOptions } from "@/options/loader";
 import {
@@ -43,21 +43,25 @@ interface UserEvent {
 export const DNT_STORAGE_KEY = "DNT";
 const UUID_STORAGE_KEY = "USER_UUID";
 
-let _uid: string = null;
+let _uid: UUID = null;
 let _dnt: boolean;
 const buffer: UserEvent[] = [];
 
 /**
  * Return a random ID for this browser profile.
  */
-async function uid(): Promise<string> {
+async function uid(): Promise<UUID> {
   if (_uid != null) {
     return _uid;
   }
 
-  let uuid = await readStorage<boolean | string>(UUID_STORAGE_KEY);
+  let uuid = await readStorage<UUID>(UUID_STORAGE_KEY);
+
+  console.debug("Current browser UID", { uuid });
+
   if (!uuid || typeof uuid !== "string") {
     uuid = uuidv4();
+    console.debug("Generating UID for browser", { uuid });
     await setStorage(UUID_STORAGE_KEY, uuid);
   }
 

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -109,13 +109,15 @@ export class RuntimeNotFoundError extends Error {
  */
 export async function readStorageWithMigration<
   T extends Record<string, unknown>
->(storageKey: string, defaultValue?: Partial<T>): Promise<T | undefined> {
+>(storageKey: string, defaultValue?: T): Promise<T | undefined> {
   const storedValue = await readStorage<T>(storageKey, defaultValue);
   if (typeof storedValue !== "string") {
     // No migration necessary
     return storedValue;
   }
 
+  // If storedValue is another string (e.g., a UUID, it will be returned as-is), so readStorageWithMigration is
+  // safe to use with string values
   const parsedValue = JSON.parse(storedValue) as T;
   await browser.storage.local.set({ [storageKey]: parsedValue });
   return parsedValue;
@@ -123,20 +125,26 @@ export async function readStorageWithMigration<
 
 export async function readStorage<T = unknown>(
   storageKey: string,
-  defaultValue?: Partial<T>
+  defaultValue?: T
 ): Promise<T | undefined> {
-  const result = await browser.storage.local.get({
-    [storageKey]: defaultValue,
-  });
+  // `browser.storage.local` is supposed to have a signature that takes an object that includes default values.
+  // On Chrome 93.0.4577.63 that signature appears to return the defaultValue even when the value is set?
+  const result = await browser.storage.local.get(storageKey);
+
+  console.debug("readStorage for key %s", storageKey, result);
+
   if (Object.prototype.hasOwnProperty.call(result, storageKey)) {
-    // eslint-disable-next-line security/detect-object-injection -- Just checked with `in`
+    // eslint-disable-next-line security/detect-object-injection -- Just checked with hasOwnProperty
     return result[storageKey];
   }
+
+  return defaultValue;
 }
 
 export async function setStorage(
   storageKey: string,
   value: unknown
 ): Promise<void> {
+  console.debug("setStorage for key %s", storageKey, { value });
   await browser.storage.local.set({ [storageKey]: value });
 }

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -144,6 +144,5 @@ export async function setStorage(
   storageKey: string,
   value: unknown
 ): Promise<void> {
-  console.debug("setStorage for key %s", storageKey, { value });
   await browser.storage.local.set({ [storageKey]: value });
 }

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -107,9 +107,10 @@ export class RuntimeNotFoundError extends Error {
  * @deprecated Use `readStorage` instead
  * @see readStorage
  */
-export async function readStorageWithMigration<
-  T extends Record<string, unknown>
->(storageKey: string, defaultValue?: T): Promise<T | undefined> {
+export async function readStorageWithMigration<T = unknown>(
+  storageKey: string,
+  defaultValue?: T
+): Promise<T | undefined> {
   const storedValue = await readStorage<T>(storageKey, defaultValue);
   if (typeof storedValue !== "string") {
     // No migration necessary
@@ -130,8 +131,6 @@ export async function readStorage<T = unknown>(
   // `browser.storage.local` is supposed to have a signature that takes an object that includes default values.
   // On Chrome 93.0.4577.63 that signature appears to return the defaultValue even when the value is set?
   const result = await browser.storage.local.get(storageKey);
-
-  console.debug("readStorage for key %s", storageKey, result);
 
   if (Object.prototype.hasOwnProperty.call(result, storageKey)) {
     // eslint-disable-next-line security/detect-object-injection -- Just checked with hasOwnProperty

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -29,10 +29,19 @@ const registry = new BaseRegistry<RegistryId, Service>(
   fromJS
 );
 
+// See the ServicesState slice
+type PersistedServicesState = {
+  // XXX: in practice, only one of these should be true. Need to better understand/document how redux-persist stores
+  // each leave of state
+  configured: string | Record<string, RawServiceConfiguration>;
+};
+
 export async function readRawConfigurations(): Promise<
   RawServiceConfiguration[]
 > {
-  const base = await readStorageWithMigration(storageKey);
+  const base = await readStorageWithMigration<PersistedServicesState>(
+    storageKey
+  );
   if (!base?.configured) {
     return [];
   }


### PR DESCRIPTION
Fixes #1267 

- Fixes type signatures of readStorage and readStorageWithMigration (the default, if provided, must be a valid value to store)
- Fixes form of the browser.storage.local.get to work on chrome