### PR TITLE
#1271: fix manual access to persisted redux state

### DIFF
--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -19,9 +19,9 @@ import { browser } from "webextension-polyfill-ts";
 import Cookies from "js-cookie";
 import { updateAuth as updateRollbarAuth } from "@/telemetry/rollbar";
 import { isEqual } from "lodash";
-import { readStorageWithMigration, setStorage } from "@/chrome";
+import { RawStorageKey, readStorageWithMigration, setStorage } from "@/chrome";
 
-const STORAGE_EXTENSION_KEY = "extensionKey";
+const STORAGE_EXTENSION_KEY = "extensionKey" as RawStorageKey;
 
 interface UserData {
   email?: string;

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -19,9 +19,13 @@ import { browser } from "webextension-polyfill-ts";
 import Cookies from "js-cookie";
 import { updateAuth as updateRollbarAuth } from "@/telemetry/rollbar";
 import { isEqual } from "lodash";
-import { RawStorageKey, readStorageWithMigration, setStorage } from "@/chrome";
+import {
+  ManualStorageKey,
+  readStorageWithMigration,
+  setStorage,
+} from "@/chrome";
 
-const STORAGE_EXTENSION_KEY = "extensionKey" as RawStorageKey;
+const STORAGE_EXTENSION_KEY = "extensionKey" as ManualStorageKey;
 
 interface UserData {
   email?: string;

--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -16,7 +16,7 @@
  */
 
 import axios, { AxiosResponse } from "axios";
-import { readStorageWithMigration, setStorage } from "@/chrome";
+import { RawStorageKey, readStorageWithMigration, setStorage } from "@/chrome";
 import { IService, AuthData, RawServiceConfiguration, UUID } from "@/core";
 import { browser } from "webextension-polyfill-ts";
 import {
@@ -27,7 +27,7 @@ import {
 import { BusinessError, getErrorMessage } from "@/errors";
 import { expectContext } from "@/utils/expectContext";
 
-const OAUTH2_STORAGE_KEY = "OAUTH2";
+const OAUTH2_STORAGE_KEY = "OAUTH2" as RawStorageKey;
 
 async function setCachedAuthData<TAuthData extends Partial<AuthData>>(
   serviceAuthId: UUID,

--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -16,7 +16,11 @@
  */
 
 import axios, { AxiosResponse } from "axios";
-import { RawStorageKey, readStorageWithMigration, setStorage } from "@/chrome";
+import {
+  ManualStorageKey,
+  readStorageWithMigration,
+  setStorage,
+} from "@/chrome";
 import { IService, AuthData, RawServiceConfiguration, UUID } from "@/core";
 import { browser } from "webextension-polyfill-ts";
 import {
@@ -27,7 +31,7 @@ import {
 import { BusinessError, getErrorMessage } from "@/errors";
 import { expectContext } from "@/utils/expectContext";
 
-const OAUTH2_STORAGE_KEY = "OAUTH2" as RawStorageKey;
+const OAUTH2_STORAGE_KEY = "OAUTH2" as ManualStorageKey;
 
 async function setCachedAuthData<TAuthData extends Partial<AuthData>>(
   serviceAuthId: UUID,

--- a/src/background/dataStore.ts
+++ b/src/background/dataStore.ts
@@ -15,12 +15,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { RawStorageKey, readStorageWithMigration, setStorage } from "@/chrome";
+import {
+  ManualStorageKey,
+  readStorageWithMigration,
+  setStorage,
+} from "@/chrome";
 import { JsonObject } from "type-fest";
 import { liftBackground } from "./protocol";
 import { SerializableResponse } from "@/messaging/protocol";
 
-export const LOCAL_DATA_STORE = "LOCAL_DATA_STORE" as RawStorageKey;
+export const LOCAL_DATA_STORE = "LOCAL_DATA_STORE" as ManualStorageKey;
 export const KEY_PREFIX = "@@";
 
 async function _getRecord(primaryKey: string): Promise<unknown> {

--- a/src/background/dataStore.ts
+++ b/src/background/dataStore.ts
@@ -15,12 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { readStorageWithMigration, setStorage } from "@/chrome";
+import { RawStorageKey, readStorageWithMigration, setStorage } from "@/chrome";
 import { JsonObject } from "type-fest";
 import { liftBackground } from "./protocol";
 import { SerializableResponse } from "@/messaging/protocol";
 
-export const LOCAL_DATA_STORE = "LOCAL_DATA_STORE";
+export const LOCAL_DATA_STORE = "LOCAL_DATA_STORE" as RawStorageKey;
 export const KEY_PREFIX = "@@";
 
 async function _getRecord(primaryKey: string): Promise<unknown> {

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -25,7 +25,7 @@ import { DBSchema, openDB } from "idb/with-async-ittr";
 import { sortBy, isEmpty } from "lodash";
 import { _getDNT } from "@/background/telemetry";
 import { isContentScript } from "webext-detect-page";
-import { readStorageWithMigration, setStorage } from "@/chrome";
+import { RawStorageKey, readStorageWithMigration, setStorage } from "@/chrome";
 import {
   hasBusinessRootCause,
   hasCancelRootCause,
@@ -318,7 +318,7 @@ export type LoggingConfig = {
   logValues: boolean;
 };
 
-const LOG_CONFIG_STORAGE_KEY = "LOG_OPTIONS";
+const LOG_CONFIG_STORAGE_KEY = "LOG_OPTIONS" as RawStorageKey;
 let _config: LoggingConfig = null;
 
 export async function _getLoggingConfig(): Promise<LoggingConfig> {

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -25,7 +25,11 @@ import { DBSchema, openDB } from "idb/with-async-ittr";
 import { sortBy, isEmpty } from "lodash";
 import { _getDNT } from "@/background/telemetry";
 import { isContentScript } from "webext-detect-page";
-import { RawStorageKey, readStorageWithMigration, setStorage } from "@/chrome";
+import {
+  ManualStorageKey,
+  readStorageWithMigration,
+  setStorage,
+} from "@/chrome";
 import {
   hasBusinessRootCause,
   hasCancelRootCause,
@@ -318,7 +322,7 @@ export type LoggingConfig = {
   logValues: boolean;
 };
 
-const LOG_CONFIG_STORAGE_KEY = "LOG_OPTIONS" as RawStorageKey;
+const LOG_CONFIG_STORAGE_KEY = "LOG_OPTIONS" as ManualStorageKey;
 let _config: LoggingConfig = null;
 
 export async function _getLoggingConfig(): Promise<LoggingConfig> {

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -20,7 +20,7 @@ import { JsonObject } from "type-fest";
 import { uuidv4 } from "@/types/helpers";
 import { compact, debounce, throttle, uniq } from "lodash";
 import { browser } from "webextension-polyfill-ts";
-import { readStorage, setStorage } from "@/chrome";
+import { RawStorageKey, readStorage, setStorage } from "@/chrome";
 import { isLinked } from "@/auth/token";
 import { Data, UUID } from "@/core";
 import { boolean } from "@/utils";
@@ -40,8 +40,8 @@ interface UserEvent {
   data: JsonObject;
 }
 
-export const DNT_STORAGE_KEY = "DNT";
-const UUID_STORAGE_KEY = "USER_UUID";
+export const DNT_STORAGE_KEY = "DNT" as RawStorageKey;
+const UUID_STORAGE_KEY = "USER_UUID" as RawStorageKey;
 
 let _uid: UUID = null;
 let _dnt: boolean;

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -20,7 +20,7 @@ import { JsonObject } from "type-fest";
 import { uuidv4 } from "@/types/helpers";
 import { compact, debounce, throttle, uniq } from "lodash";
 import { browser } from "webextension-polyfill-ts";
-import { RawStorageKey, readStorage, setStorage } from "@/chrome";
+import { ManualStorageKey, readStorage, setStorage } from "@/chrome";
 import { isLinked } from "@/auth/token";
 import { Data, UUID } from "@/core";
 import { boolean } from "@/utils";
@@ -40,8 +40,8 @@ interface UserEvent {
   data: JsonObject;
 }
 
-export const DNT_STORAGE_KEY = "DNT" as RawStorageKey;
-const UUID_STORAGE_KEY = "USER_UUID" as RawStorageKey;
+export const DNT_STORAGE_KEY = "DNT" as ManualStorageKey;
+const UUID_STORAGE_KEY = "USER_UUID" as ManualStorageKey;
 
 let _uid: UUID = null;
 let _dnt: boolean;

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -20,10 +20,27 @@ import pTimeout from "p-timeout";
 import { isExtensionContext } from "webext-detect-page";
 import { browser, Runtime } from "webextension-polyfill-ts";
 import { forbidContext } from "./utils/expectContext";
+import { JsonValue } from "type-fest";
 
 // eslint-disable-next-line prefer-destructuring -- It breaks EnvironmentPlugin
 const CHROME_EXTENSION_ID = process.env.CHROME_EXTENSION_ID;
 const CHROME_EXTENSION_STORAGE_KEY = "chrome_extension_id";
+
+/**
+ * A storage key managed manually (i.e., not using redux-persist).
+ * @see ReduxStorageKey
+ */
+export type RawStorageKey = string & {
+  _rawStorageKeyBrand: never;
+};
+
+/**
+ * A storage key managed by redux-persist.
+ * @see RawStorageKey
+ */
+export type ReduxStorageKey = string & {
+  _reduxStorageKeyBrand: never;
+};
 
 export class RequestError extends Error {
   readonly response: unknown;
@@ -108,7 +125,7 @@ export class RuntimeNotFoundError extends Error {
  * @see readStorage
  */
 export async function readStorageWithMigration<T = unknown>(
-  storageKey: string,
+  storageKey: RawStorageKey,
   defaultValue?: T
 ): Promise<T | undefined> {
   const storedValue = await readStorage<T>(storageKey, defaultValue);
@@ -125,7 +142,7 @@ export async function readStorageWithMigration<T = unknown>(
 }
 
 export async function readStorage<T = unknown>(
-  storageKey: string,
+  storageKey: RawStorageKey,
   defaultValue?: T
 ): Promise<T | undefined> {
   // `browser.storage.local` is supposed to have a signature that takes an object that includes default values.
@@ -140,9 +157,41 @@ export async function readStorage<T = unknown>(
   return defaultValue;
 }
 
+export async function readReduxStorage<T extends JsonValue = JsonValue>(
+  storageKey: ReduxStorageKey,
+  defaultValue?: T
+): Promise<T | undefined> {
+  // `browser.storage.local` is supposed to have a signature that takes an object that includes default values.
+  // On Chrome 93.0.4577.63 that signature appears to return the defaultValue even when the value is set?
+  const result = await browser.storage.local.get(storageKey);
+
+  if (Object.prototype.hasOwnProperty.call(result, storageKey)) {
+    // eslint-disable-next-line security/detect-object-injection -- Just checked with hasOwnProperty
+    const value = result[storageKey];
+    if (typeof value === "string") {
+      return JSON.parse(value);
+    }
+
+    if (value !== undefined) {
+      console.warn("Expected stringified value for key %s", storageKey, {
+        value,
+      });
+    }
+  }
+
+  return defaultValue;
+}
+
 export async function setStorage(
-  storageKey: string,
+  storageKey: RawStorageKey,
   value: unknown
 ): Promise<void> {
   await browser.storage.local.set({ [storageKey]: value });
+}
+
+export async function setReduxStorage<T extends JsonValue = JsonValue>(
+  storageKey: ReduxStorageKey,
+  value: T
+): Promise<void> {
+  await browser.storage.local.set({ [storageKey]: JSON.stringify(value) });
 }

--- a/src/options/loader.ts
+++ b/src/options/loader.ts
@@ -53,7 +53,7 @@ export async function saveOptions(state: ExtensionOptionsState): Promise<void> {
   const base = await getOptionsState();
   await setReduxStorage(STORAGE_KEY, {
     ...base,
-    // The redux persist layer persists the extensions value as as JSON-string
+    // The redux persist layer persists the extensions value as a JSON-string
     extensions: JSON.stringify(state.extensions),
   });
 }

--- a/src/options/loader.ts
+++ b/src/options/loader.ts
@@ -20,17 +20,16 @@ import {
   migrateActiveExtensions,
   ExtensionOptionsState,
 } from "@/store/extensions";
-import { readStorageWithMigration, setStorage } from "@/chrome";
+import { readReduxStorage, ReduxStorageKey, setReduxStorage } from "@/chrome";
 
-const STORAGE_KEY = "persist:extensionOptions";
-const INITIAL_STATE = {};
+const STORAGE_KEY = "persist:extensionOptions" as ReduxStorageKey;
 
 type JSONString = string;
 
-type RawOptionsState = Record<string, JSONString>;
+type PersistedOptionsState = Record<string, JSONString>;
 
-async function getOptionsState(): Promise<RawOptionsState> {
-  return readStorageWithMigration(STORAGE_KEY, INITIAL_STATE);
+async function getOptionsState(): Promise<PersistedOptionsState> {
+  return readReduxStorage(STORAGE_KEY, {});
 }
 
 /**
@@ -52,7 +51,7 @@ export async function loadOptions(): Promise<ExtensionOptionsState> {
  */
 export async function saveOptions(state: ExtensionOptionsState): Promise<void> {
   const base = await getOptionsState();
-  await setStorage(STORAGE_KEY, {
+  await setReduxStorage(STORAGE_KEY, {
     ...base,
     // The redux persist layer persists the extensions value as as JSON-string
     extensions: JSON.stringify(state.extensions),

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -16,13 +16,13 @@
  */
 
 import { isEmpty } from "lodash";
-import { readStorage, setStorage } from "@/chrome";
+import { RawStorageKey, readStorage, setStorage } from "@/chrome";
 import { isExtensionContext } from "webext-detect-page";
 import { useAsyncEffect } from "use-async-effect";
 import { useCallback, useState } from "react";
 
 export const DEFAULT_SERVICE_URL = process.env.SERVICE_URL;
-export const SERVICE_STORAGE_KEY = "service-url";
+export const SERVICE_STORAGE_KEY = "service-url" as RawStorageKey;
 
 type ConfiguredHost = string | null | undefined;
 

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -16,13 +16,13 @@
  */
 
 import { isEmpty } from "lodash";
-import { RawStorageKey, readStorage, setStorage } from "@/chrome";
+import { ManualStorageKey, readStorage, setStorage } from "@/chrome";
 import { isExtensionContext } from "webext-detect-page";
 import { useAsyncEffect } from "use-async-effect";
 import { useCallback, useState } from "react";
 
 export const DEFAULT_SERVICE_URL = process.env.SERVICE_URL;
-export const SERVICE_STORAGE_KEY = "service-url" as RawStorageKey;
+export const SERVICE_STORAGE_KEY = "service-url" as ManualStorageKey;
 
 type ConfiguredHost = string | null | undefined;
 

--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -15,13 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { readStorageWithMigration } from "@/chrome";
+import { readReduxStorage, ReduxStorageKey } from "@/chrome";
 import BaseRegistry from "@/baseRegistry";
 import { fromJS } from "@/services/factory";
 import { RawServiceConfiguration, RegistryId } from "@/core";
 import { Service } from "@/types";
 
-const storageKey = "persist:servicesOptions";
+const storageKey = "persist:servicesOptions" as ReduxStorageKey;
 
 const registry = new BaseRegistry<RegistryId, Service>(
   ["service"],
@@ -39,16 +39,15 @@ type PersistedServicesState = {
 export async function readRawConfigurations(): Promise<
   RawServiceConfiguration[]
 > {
-  const base = await readStorageWithMigration<PersistedServicesState>(
-    storageKey
-  );
-  if (!base?.configured) {
-    return [];
-  }
+  const base = (await readReduxStorage(storageKey)) as PersistedServicesState;
 
-  if (typeof base.configured === "string") {
+  if (typeof base?.configured === "string") {
     // Not really sure why redux-persist stores the next level down as escaped JSON?
     return Object.values(JSON.parse(base.configured));
+  }
+
+  if (!base?.configured) {
+    return [];
   }
 
   return Object.values(base.configured);


### PR DESCRIPTION
Fixes #1271

- [x] Add nominal typing to storage keys to differentiate manually managed vs. redux managed storage
- [x] Fix and test use in loader.ts
- [x] Fix and test use in registry.ts