### PR TITLE
Increase dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20


### PR DESCRIPTION
I think the weekly cadence has worked well for us, we don't get barraged by PRs every day and I think we can increase the number of PRs since they're relatively easy to review and merge in batch