### PR TITLE
Lint: Enforce double quotes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "pixiebrix"
   ],
   "rules": {
+    "quotes": ["error", "double", { "avoidEscape": true }],
     // Rules that depend on https://github.com/pixiebrix/pixiebrix-extension/issues/775
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-confusing-void-expression": "warn",
@@ -56,6 +57,7 @@
     "src/support.js",
     "selenium"
   ],
+
   "overrides": [
     {
       "files": ["*.stories.tsx"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -57,7 +57,6 @@
     "src/support.js",
     "selenium"
   ],
-
   "overrides": [
     {
       "files": ["*.stories.tsx"],

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -245,7 +245,7 @@ export function updateHeading(extensionId: string, heading: string): void {
     renderPanels();
   } else {
     console.warn(
-      `updateHeading: No panel exists for extension %s`,
+      "updateHeading: No panel exists for extension %s",
       extensionId
     );
   }

--- a/src/actionPanel/protocol.tsx
+++ b/src/actionPanel/protocol.tsx
@@ -82,7 +82,7 @@ handlers.set(RENDER_PANELS_MESSAGE, async (message: RenderPanelsMessage) => {
 
   if (messageSeq < seqNumber) {
     console.debug(
-      `Skipping stale message (seq: %d, current: %d)`,
+      "Skipping stale message (seq: %d, current: %d)",
       seqNumber,
       messageSeq,
       message

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -170,7 +170,7 @@ async function forwardWhenReady(
   };
 
   console.debug(
-    `Forwarding message %s to action frame for tab: %d (seq: %d)`,
+    "Forwarding message %s to action frame for tab: %d (seq: %d)",
     message.type,
     tabId,
     seqNum
@@ -193,7 +193,7 @@ async function forwardWhenReady(
         frameId,
       });
       console.debug(
-        `Forwarded message %s to action frame for tab: %d (seq: %d)`,
+        "Forwarded message %s to action frame for tab: %d (seq: %d)",
         message.type,
         tabId,
         seqNum

--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -137,7 +137,7 @@ export async function uninstallContextMenu({
   } catch (error: unknown) {
     // Will throw if extensionId doesn't refer to a context menu. The callers don't have an easy way to check the type
     // without having to resolve the extensionPointId. So instead we'll just expect some of the calls to fail.
-    console.debug(`Could not uninstall context menu %s`, extensionId, {
+    console.debug("Could not uninstall context menu %s", extensionId, {
       error,
     });
     return false;

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -67,7 +67,7 @@ function backgroundMessageListener(
 
   if (!allowBackgroundSender(port.sender)) {
     console.debug(
-      `Ignoring devtools message to background page from unknown sender`,
+      "Ignoring devtools message to background page from unknown sender",
       port.sender
     );
   } else if (handler) {
@@ -189,18 +189,18 @@ async function resetTab(tabId: number): Promise<void> {
       {}
     );
   } catch (error: unknown) {
-    console.warn(`Error clearing dynamic elements for tab: %d`, tabId, {
+    console.warn("Error clearing dynamic elements for tab: %d", tabId, {
       error,
     });
     reportError(error);
   }
 
-  console.info(`Removed dynamic elements for tab: %d`, tabId);
+  console.info("Removed dynamic elements for tab: %d", tabId);
 
   // Re-activate the content script so any saved extensions are added to the page as "permanent" extensions
   await reactivate();
 
-  console.info(`Re-activated extensions for tab: %d`, tabId);
+  console.info("Re-activated extensions for tab: %d", tabId);
 }
 
 function deleteStaleConnections(port: Runtime.Port) {
@@ -215,7 +215,7 @@ function deleteStaleConnections(port: Runtime.Port) {
         const listeners = permissionsListeners.get(tabId);
         permissionsListeners.delete(tabId);
         for (const [, reject] of listeners) {
-          reject(new Error(`Cleaning up stale connection`));
+          reject(new Error("Cleaning up stale connection"));
         }
       }
     }
@@ -279,7 +279,7 @@ async function attemptTemporaryAccess({
     return;
   }
 
-  console.debug(`attemptTemporaryAccess:`, { tabId, frameId, url });
+  console.debug("attemptTemporaryAccess:", { tabId, frameId, url });
 
   try {
     await ensureContentScript({ tabId, frameId });
@@ -292,7 +292,7 @@ async function attemptTemporaryAccess({
     // https://github.com/pixiebrix/pixiebrix-extension/pull/661#discussion_r661590847
     if (/Cannot access|missing host permission/.test(getErrorMessage(error))) {
       console.debug(
-        `Skipping attemptTemporaryAccess because no activeTab permissions`,
+        "Skipping attemptTemporaryAccess because no activeTab permissions",
         { tabId, frameId, url }
       );
       return;

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -304,7 +304,7 @@ export class BackgroundLogger implements ILogger {
   }
 
   async error(error: unknown, data: JsonObject): Promise<void> {
-    console.error(`An error occurred: %s`, getErrorMessage(error), {
+    console.error("An error occurred: %s", getErrorMessage(error), {
       error,
       context: this.context,
       data,

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -107,7 +107,7 @@ export async function onReadyNotification(signal: AbortSignal): Promise<void> {
 export async function ensureContentScript(target: Target): Promise<void> {
   expectContext("background");
 
-  console.debug(`ensureContentScript: requested`, target);
+  console.debug("ensureContentScript: requested", target);
 
   const controller = new AbortController();
 
@@ -123,14 +123,14 @@ export async function ensureContentScript(target: Target): Promise<void> {
 
     if (!result) {
       console.debug(
-        `ensureContentScript: script messaged us back while waiting`,
+        "ensureContentScript: script messaged us back while waiting",
         target
       );
       return;
     }
 
     if (result.ready) {
-      console.debug(`ensureContentScript: already exists and is ready`, target);
+      console.debug("ensureContentScript: already exists and is ready", target);
       return;
     }
 
@@ -144,11 +144,11 @@ export async function ensureContentScript(target: Target): Promise<void> {
 
     if (result.installed || (await isContentScriptRegistered(result.url))) {
       console.debug(
-        `ensureContentScript: already exists or will be injected automatically`,
+        "ensureContentScript: already exists or will be injected automatically",
         target
       );
     } else {
-      console.debug(`ensureContentScript: injecting`, target);
+      console.debug("ensureContentScript: injecting", target);
       const loadingScripts = chrome.runtime
         .getManifest()
         .content_scripts.map(async (script) => {
@@ -165,7 +165,7 @@ export async function ensureContentScript(target: Target): Promise<void> {
       4000,
       "contentScript not ready in 4s"
     );
-    console.debug(`ensureContentScript: ready`, target);
+    console.debug("ensureContentScript: ready", target);
   } finally {
     controller.abort();
   }

--- a/src/baseRegistry.ts
+++ b/src/baseRegistry.ts
@@ -151,7 +151,7 @@ export class Registry<
       return this.deserialize(raw);
     } catch (error: unknown) {
       console.warn(
-        `Error de-serializing item: %s`,
+        "Error de-serializing item: %s",
         getErrorMessage(error),
         raw
       );

--- a/src/blocks/readers/ElementReader.ts
+++ b/src/blocks/readers/ElementReader.ts
@@ -31,7 +31,7 @@ export class ElementReader extends Reader {
     const element = elementOrDocument as HTMLElement;
 
     if (!element?.tagName) {
-      throw new Error(`Expected an HTML Element`);
+      throw new Error("Expected an HTML Element");
     }
 
     const $element = $(element);

--- a/src/blocks/readers/factory.ts
+++ b/src/blocks/readers/factory.ts
@@ -58,7 +58,7 @@ function validateReaderDefinition(
   );
   const result = validator.validate(component);
   if (!result.valid) {
-    console.warn(`Invalid reader configuration`, result);
+    console.warn("Invalid reader configuration", result);
     throw new ValidationError("Invalid reader configuration", result.errors);
   }
 }

--- a/src/blocks/readers/jquery.ts
+++ b/src/blocks/readers/jquery.ts
@@ -197,7 +197,7 @@ async function select(
   if ($elt.length > 1 && !normalizedSelector.multi) {
     throw new MultipleElementsFoundError(
       normalizedSelector.selector,
-      `Multiple elements found for selector. To return a list of values, supply multi=true`
+      "Multiple elements found for selector. To return a list of values, supply multi=true"
     );
   } else if ("find" in normalizedSelector) {
     const values = await Promise.all(

--- a/src/blocks/renderers/common.ts
+++ b/src/blocks/renderers/common.ts
@@ -44,7 +44,7 @@ export async function errorBoundary(
 
     if (!isRendererOutput(value)) {
       logger.warn("Expected a renderer brick");
-      return `<div style="color: red;">Expected a renderer brick</div>`;
+      return '<div style="color: red;">Expected a renderer brick</div>';
     }
 
     // TODO: validate the shape of the value returned

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -76,7 +76,7 @@ handlers.set(MESSAGE_RUN_BLOCK, async (request: RunBlockAction) => {
   } catch (error: unknown) {
     // Provide extra logging on the tab because `handlers` doesn't report errors. It's also nice to log here because
     // we still have the original (non-serialized) error
-    console.info(`Error running remote block on tab`, {
+    console.info("Error running remote block on tab", {
       request,
       error,
     });

--- a/src/contrib/automationanywhere/run.ts
+++ b/src/contrib/automationanywhere/run.ts
@@ -70,7 +70,7 @@ export class RunBot extends Effect {
     options: BlockOptions
   ): Promise<void> {
     const { data: responseData } = await proxyService<DeployResponse>(service, {
-      url: `/v2/automations/deploy`,
+      url: "/v2/automations/deploy",
       method: "post",
       data: {
         fileId,

--- a/src/contrib/google/auth.ts
+++ b/src/contrib/google/auth.ts
@@ -40,7 +40,7 @@ export async function ensureAuth(
     throw new Error(`Cannot get Chrome OAuth token: ${getErrorMessage(error)}`);
   }
 
-  throw new Error(`Cannot get Chrome OAuth token`);
+  throw new Error("Cannot get Chrome OAuth token");
 }
 
 class PermissionsError extends Error {

--- a/src/contrib/hubspot/upsert.ts
+++ b/src/contrib/hubspot/upsert.ts
@@ -137,7 +137,7 @@ export class AddUpdateContact extends Effect {
         throw new BusinessError("Multiple Hubspot contacts found");
       } else {
         await proxyHubspot({
-          url: `https://api.hubapi.com/contacts/v1/contact/`,
+          url: "https://api.hubapi.com/contacts/v1/contact/",
           method: "post",
           data: { properties },
         });

--- a/src/contrib/uipath/localProcess.ts
+++ b/src/contrib/uipath/localProcess.ts
@@ -72,7 +72,7 @@ export class RunLocalProcess extends Transformer {
         if (!process) {
           // `releaseKey`'s type is checked in the inputSchema
           logger.error(`Cannot find UiPath release: ${releaseKey as string}`);
-          throw new BusinessError(`Cannot find UiPath release`);
+          throw new BusinessError("Cannot find UiPath release");
         }
 
         console.debug("Running local UiPath process", { releaseKey });

--- a/src/contrib/uipath/process.ts
+++ b/src/contrib/uipath/process.ts
@@ -124,7 +124,7 @@ export class RunProcess extends Transformer {
     { logger }: BlockOptions
   ): Promise<unknown> {
     const { data: startData } = await proxyService<JobsResponse>(uipath, {
-      url: `/odata/Jobs/UiPath.Server.Configuration.OData.StartJobs`,
+      url: "/odata/Jobs/UiPath.Server.Configuration.OData.StartJobs",
       method: "post",
       data: {
         startInfo: {

--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -136,7 +136,7 @@ export function useCreate(): CreateCallback {
       const onStepError = (error: unknown, step: string) => {
         const message = selectErrorMessage(error);
         reportError(error);
-        console.warn(`Error %s: %s`, step, message, { error });
+        console.warn("Error %s: %s", step, message, { error });
         setStatus(`Error ${step}: ${message}`);
         addToast(`Error ${step}: ${message}`, {
           appearance: "error",

--- a/src/extensionPoints/actionPanelExtension.ts
+++ b/src/extensionPoints/actionPanelExtension.ts
@@ -166,7 +166,7 @@ export abstract class ActionPanelExtensionPoint extends ExtensionPoint<ActionPan
 
     if (this.extensions.length === 0) {
       console.debug(
-        `actionPanel extension point %s has no installed extensions`,
+        "actionPanel extension point %s has no installed extensions",
         this.id
       );
       return;
@@ -174,7 +174,7 @@ export abstract class ActionPanelExtensionPoint extends ExtensionPoint<ActionPan
 
     if (!isActionPanelVisible()) {
       console.debug(
-        `Skipping run for %s because actionPanel is not visible`,
+        "Skipping run for %s because actionPanel is not visible",
         this.id
       );
       return;

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -366,11 +366,11 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
    */
   private async installMenus(): Promise<boolean> {
     if (this.uninstalled) {
-      console.error(`Menu item extension point is uninstalled`, {
+      console.error("Menu item extension point is uninstalled", {
         extensionId: this.instanceId,
       });
       throw new Error(
-        `Cannot install menu item because extension point was uninstalled`
+        "Cannot install menu item because extension point was uninstalled"
       );
     }
 
@@ -509,7 +509,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
       e.preventDefault();
       e.stopPropagation();
 
-      console.debug(`Run menu item`, this.logger.context);
+      console.debug("Run menu item", this.logger.context);
 
       reportEvent("MenuItemClick", selectEventData(extension));
 
@@ -825,12 +825,12 @@ class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
       if ($elt.length > 1) {
         throw new MultipleElementsFoundError(
           selector,
-          `Multiple elements found for reader selector`
+          "Multiple elements found for reader selector"
         );
       } else if ($elt.length === 0) {
         throw new NoElementsFoundError(
           selector,
-          `No elements found for reader selector`
+          "No elements found for reader selector"
         );
       }
 

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -82,10 +82,10 @@ function detectLoop(timestamps: Date[]): void {
     const diffs = timestamps.map((x) =>
       Math.abs(current.getTime() - x.getTime())
     );
-    console.error(`Panel is stuck in a render loop`, {
+    console.error("Panel is stuck in a render loop", {
       diffs,
     });
-    throw new Error(`Panel is stuck in a render loop`);
+    throw new Error("Panel is stuck in a render loop");
   }
 }
 
@@ -535,7 +535,7 @@ class RemotePanelExtensionPoint extends PanelExtensionPoint {
     const { position = "append" } = this._definition;
 
     if (typeof position !== "string") {
-      throw new TypeError(`Expected string for panel position`);
+      throw new TypeError("Expected string for panel position");
     }
 
     switch (position) {

--- a/src/layout/Banner.tsx
+++ b/src/layout/Banner.tsx
@@ -52,7 +52,7 @@ const EnvironmentBanner: React.FunctionComponent = () => {
 
   const syncText = hostname
     ? `synced with ${hostname}`
-    : `not synced with server`;
+    : "not synced with server";
 
   return (
     <div

--- a/src/nativeEditor/infer.ts
+++ b/src/nativeEditor/infer.ts
@@ -194,7 +194,7 @@ function commonButtonStructure(
   if (ICON_TAGS.includes(proto.tagName.toLowerCase())) {
     // TODO: need to provide a way of adding additional classes to the button. E.g. some classes
     //  may provide for the margin, etc.
-    return [$(document.createTextNode(`{{{ icon }}}`)), currentCaptioned];
+    return [$(document.createTextNode("{{{ icon }}}")), currentCaptioned];
   }
 
   const $common = $(`<${proto.tagName.toLowerCase()}>`);
@@ -419,7 +419,7 @@ export function buildSinglePanelElement(
 
 function commonButtonHTML(tag: string, $items: JQuery): string {
   if ($items.length === 0) {
-    throw new Error(`No items provided`);
+    throw new Error("No items provided");
   }
 
   const elements = compact(
@@ -438,7 +438,7 @@ function commonButtonHTML(tag: string, $items: JQuery): string {
 
 function commonPanelHTML(tag: string, $items: JQuery): string {
   if ($items.length === 0) {
-    throw new Error(`No items provided`);
+    throw new Error("No items provided");
   }
 
   const [$common, { bodyInserted, headingInserted }] = commonPanelStructure(

--- a/src/options/pages/brickEditor/EditPage.tsx
+++ b/src/options/pages/brickEditor/EditPage.tsx
@@ -115,7 +115,7 @@ const keyMap = {
 function useTouchBrick(id: string): void {
   const dispatch = useDispatch();
   useEffect(() => {
-    console.debug(`Marking brick as touched: %s`, id);
+    console.debug("Marking brick as touched: %s", id);
     dispatch(touchBrick({ id }));
   }, [dispatch, id]);
 }

--- a/src/options/pages/services/PrivateServicesCard.tsx
+++ b/src/options/pages/services/PrivateServicesCard.tsx
@@ -112,7 +112,7 @@ const PrivateServicesCard: React.FunctionComponent<OwnProps> = ({
                   variant="info"
                   size="sm"
                   onClick={() => {
-                    navigate(`/services/zapier/`);
+                    navigate("/services/zapier/");
                   }}
                 >
                   View Key

--- a/src/options/pages/services/ServicesEditor.tsx
+++ b/src/options/pages/services/ServicesEditor.tsx
@@ -90,7 +90,7 @@ const ServicesEditor: React.FunctionComponent<OwnProps> = ({
         await refreshBackgroundAuths();
       } catch (error: unknown) {
         notify.warning(
-          `Error refreshing service configurations, restart the PixieBrix extension`,
+          "Error refreshing service configurations, restart the PixieBrix extension",
           {
             error,
           }
@@ -114,7 +114,7 @@ const ServicesEditor: React.FunctionComponent<OwnProps> = ({
         await refreshBackgroundAuths();
       } catch (error: unknown) {
         notify.warning(
-          `Error refreshing service configurations, restart the PixieBrix extension`,
+          "Error refreshing service configurations, restart the PixieBrix extension",
           {
             error,
           }

--- a/src/options/pages/workshop/WorkshopPage.tsx
+++ b/src/options/pages/workshop/WorkshopPage.tsx
@@ -394,7 +394,7 @@ const WorkshopPage: React.FunctionComponent<OwnProps> = ({ navigate }) => {
               <Button
                 variant="info"
                 onClick={() => {
-                  navigate(`/workshop/create/`);
+                  navigate("/workshop/create/");
                 }}
               >
                 <FontAwesomeIcon icon={faPlus} /> Create New Brick

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -122,7 +122,7 @@ export async function collectPermissions(
           }
         );
       } catch (error: unknown) {
-        console.warn(`Error getting blocks for extensionPoint %s`, id, {
+        console.warn("Error getting blocks for extensionPoint %s", id, {
           error,
           config,
         });

--- a/src/registry/internal.ts
+++ b/src/registry/internal.ts
@@ -199,7 +199,7 @@ export async function resolveDefinitions(
     return extension as ResolvedExtension;
   }
 
-  console.debug(`Resolving definitions for extension: %s`, extension.id, {
+  console.debug("Resolving definitions for extension: %s", extension.id, {
     extension,
   });
 

--- a/src/registry/localRegistry.ts
+++ b/src/registry/localRegistry.ts
@@ -152,7 +152,7 @@ export const find = liftBackground("REGISTRY_FIND", async (id: string) => {
   if (id == null) {
     throw new Error("id is required");
   } else if (typeof id !== "string") {
-    console.error(`REGISTRY_FIND received invalid id argument`, { id });
+    console.error("REGISTRY_FIND received invalid id argument", { id });
     throw new Error("invalid brick id");
   }
 

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -162,7 +162,7 @@ class LazyLocatorFactory {
     this.makeOptions();
     this._initialized = true;
     this.updateTimestamp = timestamp;
-    console.debug(`Refreshed service configuration locator`, {
+    console.debug("Refreshed service configuration locator", {
       updateTimestamp: this.updateTimestamp,
     });
   }

--- a/src/telemetry/trace.ts
+++ b/src/telemetry/trace.ts
@@ -192,7 +192,7 @@ export async function clearExtensionTraces(extensionId: UUID): Promise<void> {
     }
   }
 
-  console.debug(`Cleared %d trace entries for extension %s`, cnt, extensionId);
+  console.debug("Cleared %d trace entries for extension %s", cnt, extensionId);
 }
 
 export async function getByInstanceId(

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,7 @@ export abstract class ExtensionPoint<TConfig extends EmptyConfig>
     this.extensions.splice(0, this.extensions.length);
     this.extensions.push(...extensions);
 
-    console.debug(`syncExtensions for extension point %s`, this.id, {
+    console.debug("syncExtensions for extension point %s", this.id, {
       before,
       after: extensions.map((x) => x.id),
       removed: removed.map((x) => x.id),


### PR DESCRIPTION
It turns out Prettier does not enforce `"` over <code>`</code> (because "it would change the AST") so I see this inconsistency in the code.

This PR restores the ESLint rule that takes care of quotes (disabled by `eslint-config-prettier`)

The changes here are the result of autofix. If conflicts arise I can rebase and call `npm run lint -- --quiet --fix`