### PR TITLE
Use real links wherever possible + use Messenger for `sendTab`

### DIFF
--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -51,6 +51,8 @@ interface Target {
 
 const tabToOpener = new Map<number, number>();
 const tabToTarget = new Map<number, number>();
+// TODO: One tab could have multiple targets, but `tabToTarget` currenly only supports one at a time
+
 // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- Record<> doesn't allow labelled keys
 const tabReady: { [tabId: string]: { [frameId: string]: boolean } } = {};
 const nonceToTarget = new Map<string, Target>();

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -43,6 +43,7 @@ export const markTabAsReady = getMethod("MARK_TAB_AS_READY");
  */
 export const uninstallContextMenu = getMethod("UNINSTALL_CONTEXT_MENU");
 export const ensureContextMenu = getMethod("ENSURE_CONTEXT_MENU");
+export const openTab = getMethod("OPEN_TAB");
 
 // Temporary, webext-messenger depends on this global
 (globalThis as any).browser = browser;

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -29,6 +29,7 @@ import {
   closeTab,
   markTabAsReady,
   whoAmI,
+  openTab,
 } from "@/background/executor";
 
 expectContext("background");
@@ -43,6 +44,7 @@ declare global {
     ACTIVATE_TAB: typeof activateTab;
     CLOSE_TAB: typeof closeTab;
     MARK_TAB_AS_READY: typeof markTabAsReady;
+    OPEN_TAB: typeof openTab;
   }
 }
 
@@ -55,6 +57,7 @@ registerMethods({
   ACTIVATE_TAB: activateTab,
   CLOSE_TAB: closeTab,
   MARK_TAB_AS_READY: markTabAsReady,
+  OPEN_TAB: openTab,
 });
 
 // Temporary, webext-messenger depends on this global

--- a/src/blocks/effects/redirectPage.ts
+++ b/src/blocks/effects/redirectPage.ts
@@ -17,7 +17,7 @@
 
 import { Effect } from "@/types";
 import { BlockArg } from "@/core";
-import { openTab } from "@/background/executor";
+import { openTab } from "@/background/messenger/api";
 import {
   URL_INPUT_SPACE_ENCODING_DEFAULT,
   URL_INPUT_SPEC,
@@ -64,7 +64,6 @@ export class OpenURLEffect extends Effect {
   }: BlockArg): Promise<void> {
     await openTab({
       url: makeURL(url, params, spaceEncoding),
-      active: true,
     });
   }
 }

--- a/src/devTools/editor/panes/NoExtensionsPane.tsx
+++ b/src/devTools/editor/panes/NoExtensionsPane.tsx
@@ -17,7 +17,6 @@
 
 import React from "react";
 import Centered from "@/devTools/editor/components/Centered";
-import { openTab } from "@/background/executor";
 import { Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCommentAlt, faPhone } from "@fortawesome/free-solid-svg-icons";
@@ -60,12 +59,8 @@ const NoExtensionsPane: React.FunctionComponent<{
         <Button
           className="ml-2"
           variant="info"
-          onClick={async () =>
-            openTab({
-              url: "https://calendly.com/pixiebrix-todd/live-support-session",
-              active: true,
-            })
-          }
+          href="https://calendly.com/pixiebrix-todd/live-support-session"
+          target="_blank"
         >
           <FontAwesomeIcon icon={faPhone} /> Schedule FREE Zoom Session
         </Button>

--- a/src/devTools/editor/panes/SupportWidget.tsx
+++ b/src/devTools/editor/panes/SupportWidget.tsx
@@ -22,7 +22,6 @@ import {
   faPhone,
   faTimes,
 } from "@fortawesome/free-solid-svg-icons";
-import { openTab } from "@/background/executor";
 import ChatWidget from "@/components/ChatWidget";
 
 const SupportWidget: React.FunctionComponent<{ onClose: () => void }> = ({
@@ -36,13 +35,9 @@ const SupportWidget: React.FunctionComponent<{ onClose: () => void }> = ({
             <FontAwesomeIcon icon={faPhone} />
           </span>{" "}
           <a
-            href="#"
-            onClick={async () =>
-              openTab({
-                url: "https://calendly.com/pixiebrix-todd/live-support-session",
-                active: true,
-              })
-            }
+            href="https://calendly.com/pixiebrix-todd/live-support-session"
+            target="_blank"
+            rel="noreferrer"
           >
             Schedule FREE Zoom session
           </a>
@@ -52,13 +47,9 @@ const SupportWidget: React.FunctionComponent<{ onClose: () => void }> = ({
             <FontAwesomeIcon icon={faExternalLinkAlt} />{" "}
           </span>
           <a
-            href="#"
-            onClick={async () =>
-              openTab({
-                url: "https://docs.pixiebrix.com/",
-                active: true,
-              })
-            }
+            href="https://docs.pixiebrix.com/"
+            target="_blank"
+            rel="noreferrer"
           >
             Open Documentation
           </a>

--- a/src/devTools/editor/panes/WelcomePane.tsx
+++ b/src/devTools/editor/panes/WelcomePane.tsx
@@ -17,7 +17,6 @@
 
 import React from "react";
 import Centered from "@/devTools/editor/components/Centered";
-import { openTab } from "@/background/executor";
 import { Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCommentAlt, faPhone } from "@fortawesome/free-solid-svg-icons";
@@ -34,13 +33,9 @@ const WelcomePane: React.FunctionComponent<{ showSupport: () => void }> = ({
       <p>
         Learn how to use the Page Editor in our{" "}
         <a
-          href="#"
-          onClick={async () =>
-            openTab({
-              url: "https://docs.pixiebrix.com/quick-start-guide",
-              active: true,
-            })
-          }
+          href="https://docs.pixiebrix.com/quick-start-guide"
+          target="_blank"
+          rel="noreferrer"
         >
           Quick Start Guide
         </a>
@@ -54,12 +49,8 @@ const WelcomePane: React.FunctionComponent<{ showSupport: () => void }> = ({
         <Button
           className="ml-2"
           variant="info"
-          onClick={async () =>
-            openTab({
-              url: "https://calendly.com/pixiebrix-todd/live-support-session",
-              active: true,
-            })
-          }
+          href="https://calendly.com/pixiebrix-todd/live-support-session"
+          target="_blank"
         >
           <FontAwesomeIcon icon={faPhone} /> Schedule FREE Zoom Session
         </Button>

--- a/src/devTools/editor/tabs/AvailabilityTab.tsx
+++ b/src/devTools/editor/tabs/AvailabilityTab.tsx
@@ -20,7 +20,6 @@ import { Alert, Col, Form, Row, Tab } from "react-bootstrap";
 import { FastField, FieldInputProps, useFormikContext } from "formik";
 import SelectorSelectorField from "@/devTools/editor/fields/SelectorSelectorField";
 import { FormState } from "@/devTools/editor/editorSlice";
-import { openTab } from "@/background/executor";
 import {
   createDomainPattern,
   createSitePattern,
@@ -116,14 +115,9 @@ const AvailabilityTab: React.FunctionComponent<{
           <Form.Text className="text-muted">
             URL match pattern for which pages to run the extension on. See{" "}
             <a
-              href="#"
-              onClick={async () =>
-                openTab({
-                  url:
-                    "https://developer.chrome.com/docs/extensions/mv2/match_patterns/",
-                  active: true,
-                })
-              }
+              href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/"
+              target="_blank"
+              rel="noreferrer"
             >
               Patterns Documentation
             </a>{" "}

--- a/src/devTools/editor/tabs/contextMenu/AvailabilityTab.tsx
+++ b/src/devTools/editor/tabs/contextMenu/AvailabilityTab.tsx
@@ -24,7 +24,6 @@ import {
   useField,
   useFormikContext,
 } from "formik";
-import { openTab } from "@/background/executor";
 import Select from "react-select";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
@@ -173,14 +172,9 @@ const AvailabilityTab: React.FunctionComponent<{
           <Form.Text className="text-muted">
             Show context menu on documents whose URL matches the pattern. See{" "}
             <a
-              href="#"
-              onClick={async () =>
-                openTab({
-                  url:
-                    "https://developer.chrome.com/docs/extensions/mv2/match_patterns/",
-                  active: true,
-                })
-              }
+              href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/"
+              target="_blank"
+              rel="noreferrer"
             >
               Patterns Documentation
             </a>{" "}


### PR DESCRIPTION
As I migrate the lifted functions to the messenger, I might refactor some code to skip the messenger altogether where possible. 


<img width="124" alt="diff" src="https://user-images.githubusercontent.com/1402241/133234603-1f53f9a8-5d7d-41a5-ad4e-5550c76e3631.png"> <img width="60" src="https://user-images.githubusercontent.com/1402241/133234821-10784f4e-f72a-4431-bae3-a240bb401584.png">



Related:

- https://github.com/pixiebrix/pixiebrix-extension/pull/907

