### PR TITLE
Use Messenger for ModalForm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "webext-content-scripts": "^0.9.0",
         "webext-detect-page": "^3.0.2",
         "webext-dynamic-content-scripts": "^8.0.0",
-        "webext-messenger": "^0.6.1",
+        "webext-messenger": "^0.7.0",
         "webext-patterns": "^1.1.1",
         "webext-polyfill-kinda": "^0.1.0",
         "webextension-polyfill-ts": "^0.26.0"
@@ -44055,9 +44055,9 @@
       }
     },
     "node_modules/webext-messenger": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.6.1.tgz",
-      "integrity": "sha512-eIR7F6zxNGcia5wLHItuOEXMndLzNNBofNRgk9Gcc6LmRbym2epuBBfWiOyTWoTo1EW1uN1f6wVZJTrA51BqZA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.7.0.tgz",
+      "integrity": "sha512-m1GDI4xoiDkVRX580D6GwqLEgriHUaGnw0O+Ym5tTeLALqs+79ynWFzn8rjLxAyrvTVJ+ToHQ9BVur8ssg+ApA==",
       "dependencies": {
         "serialize-error": "^8.1.0",
         "webext-detect-page": "^3.0.2",
@@ -79285,9 +79285,9 @@
       }
     },
     "webext-messenger": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.6.1.tgz",
-      "integrity": "sha512-eIR7F6zxNGcia5wLHItuOEXMndLzNNBofNRgk9Gcc6LmRbym2epuBBfWiOyTWoTo1EW1uN1f6wVZJTrA51BqZA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.7.0.tgz",
+      "integrity": "sha512-m1GDI4xoiDkVRX580D6GwqLEgriHUaGnw0O+Ym5tTeLALqs+79ynWFzn8rjLxAyrvTVJ+ToHQ9BVur8ssg+ApA==",
       "requires": {
         "serialize-error": "^8.1.0",
         "webext-detect-page": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "webext-content-scripts": "^0.9.0",
     "webext-detect-page": "^3.0.2",
     "webext-dynamic-content-scripts": "^8.0.0",
-    "webext-messenger": "^0.6.1",
+    "webext-messenger": "^0.7.0",
     "webext-patterns": "^1.1.1",
     "webext-polyfill-kinda": "^0.1.0",
     "webextension-polyfill-ts": "^0.26.0"

--- a/src/blocks/transformers/modalForm/formTypes.ts
+++ b/src/blocks/transformers/modalForm/formTypes.ts
@@ -23,7 +23,3 @@ export type FormDefinition = {
   cancelable: boolean;
   submitCaption: string;
 };
-
-export const FORM_GET_DEFINITION = "@@forms/GET_FORM_DEFINITION";
-export const FORM_RESOLVE = "@@forms/FORM_RESOLVE";
-export const FORM_CANCEL = "@@forms/FORM_CANCEL";

--- a/src/blocks/transformers/modalForm/modal.tsx
+++ b/src/blocks/transformers/modalForm/modal.tsx
@@ -101,7 +101,10 @@ export class ModalTransformer extends Transformer {
 
     const frameSrc = new URL(browser.runtime.getURL("modalForm.html"));
     frameSrc.searchParams.set("nonce", nonce);
-    frameSrc.searchParams.set("frameId", String(tab.frameId));
+    frameSrc.searchParams.set(
+      "opener",
+      JSON.stringify({ tabId: tab.tab.id, frameId: tab.frameId })
+    );
 
     // By setting the modal-content 100vh, the iframe form content can expand to fit the available vertical size as
     // needed. Otherwise, we'd need to have the form message the content script with a requested vertical height.

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -30,7 +30,6 @@ import "@/contentScript/browserAction";
 import addContentScriptListener from "@/contentScript/backgroundProtocol";
 import { handleNavigate } from "@/contentScript/lifecycle";
 import addExecutorListener from "@/contentScript/executor";
-import { initFormListener } from "@/contentScript/modalForms";
 import "@/messaging/external";
 import "@/contentScript/script";
 import "@/vendors/notify";
@@ -59,7 +58,6 @@ async function init(): Promise<void> {
   addContentScriptListener();
   addExecutorListener();
   initTelemetry();
-  initFormListener();
 
   const sender = await whoAmI();
 

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -27,6 +27,9 @@ if (isContentScript()) {
   );
 }
 
+export const getFormDefinition = getContentScriptMethod("FORM_GET_DEFINITION");
+export const resolveForm = getContentScriptMethod("FORM_RESOLVE");
+export const cancelForm = getContentScriptMethod("FORM_CANCEL");
 export const queueReactivateTab = getContentScriptMethod(
   "QUEUE_REACTIVATE_TAB"
 );

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -20,6 +20,11 @@ import { registerMethods } from "webext-messenger";
 import { browser } from "webextension-polyfill-ts";
 import { expectContext } from "@/utils/expectContext";
 import { queueReactivateTab, reactivateTab } from "@/contentScript/lifecycle";
+import {
+  getFormDefinition,
+  resolveForm,
+  cancelForm,
+} from "@/contentScript/modalForms";
 
 expectContext("contentScript");
 
@@ -28,12 +33,18 @@ expectContext("contentScript");
 
 declare global {
   interface MessengerMethods {
+    FORM_GET_DEFINITION: typeof getFormDefinition;
+    FORM_RESOLVE: typeof resolveForm;
+    FORM_CANCEL: typeof cancelForm;
     QUEUE_REACTIVATE_TAB: typeof queueReactivateTab;
     REACTIVATE_TAB: typeof reactivateTab;
   }
 }
 
 registerMethods({
+  FORM_GET_DEFINITION: getFormDefinition,
+  FORM_RESOLVE: resolveForm,
+  FORM_CANCEL: cancelForm,
   QUEUE_REACTIVATE_TAB: queueReactivateTab,
   REACTIVATE_TAB: reactivateTab,
 });


### PR DESCRIPTION
### Intent

- Use new messenger to replace some raw sendMessage calls

### Testing

- The code was summarily tested, the modal opened and the next step was executed

### Other improvements

- the frame SRC includes the whole opener information: frame **and** tab, so no extra `whoAmI` call
- https://github.com/pixiebrix/webext-messenger/pull/15