### PR TITLE
#1325: default output keys

### DIFF
--- a/src/blocks/readers/ElementReader.ts
+++ b/src/blocks/readers/ElementReader.ts
@@ -19,6 +19,8 @@ import { Reader } from "@/types";
 import { Schema } from "@/core";
 
 export class ElementReader extends Reader {
+  defaultOutputKey = "element";
+
   constructor() {
     super(
       "@pixiebrix/html/element",

--- a/src/blocks/readers/ImageExifReader.ts
+++ b/src/blocks/readers/ImageExifReader.ts
@@ -56,6 +56,8 @@ async function getData(img: HTMLImageElement): Promise<ArrayBuffer> {
 }
 
 export class ImageExifReader extends Reader {
+  defaultOutputKey = "image";
+
   constructor() {
     super(
       "@pixiebrix/image/exif",

--- a/src/blocks/readers/ImageReader.ts
+++ b/src/blocks/readers/ImageReader.ts
@@ -40,6 +40,8 @@ function getBase64Image(img: HTMLImageElement) {
 }
 
 export class ImageReader extends Reader {
+  defaultOutputKey = "image";
+
   constructor() {
     super(
       "@pixiebrix/image",

--- a/src/blocks/readers/PageMetadataReader.ts
+++ b/src/blocks/readers/PageMetadataReader.ts
@@ -19,6 +19,8 @@ import { Reader } from "@/types";
 import { Schema } from "@/core";
 
 export class PageMetadataReader extends Reader {
+  defaultOutputKey = "metadata";
+
   constructor() {
     super(
       "@pixiebrix/document-metadata",

--- a/src/blocks/readers/PageSemanticReader.ts
+++ b/src/blocks/readers/PageSemanticReader.ts
@@ -19,6 +19,8 @@ import { Reader } from "@/types";
 import { ReaderOutput, Schema } from "@/core";
 
 export class PageSemanticReader extends Reader {
+  defaultOutputKey = "metadata";
+
   constructor() {
     super(
       "@pixiebrix/document-semantic",

--- a/src/blocks/readers/meta.ts
+++ b/src/blocks/readers/meta.ts
@@ -21,6 +21,8 @@ import * as session from "@/contentScript/context";
 import { ReaderOutput, Schema } from "@/core";
 
 export class TimestampReader extends Reader {
+  defaultOutputKey = "instant";
+
   constructor() {
     super(
       "@pixiebrix/timestamp",
@@ -53,6 +55,8 @@ export class TimestampReader extends Reader {
 }
 
 export class PixieBrixSessionReader extends Reader {
+  defaultOutputKey = "session";
+
   constructor() {
     super(
       "@pixiebrix/session",
@@ -117,6 +121,8 @@ export class PixieBrixSessionReader extends Reader {
 }
 
 export class PixieBrixProfileReader extends Reader {
+  defaultOutputKey = "profile";
+
   constructor() {
     super(
       "@pixiebrix/profile",
@@ -156,6 +162,8 @@ export class PixieBrixProfileReader extends Reader {
 }
 
 export class DocumentReader extends Reader {
+  defaultOutputKey = "context";
+
   constructor() {
     super(
       "@pixiebrix/document-context",
@@ -199,6 +207,8 @@ export class DocumentReader extends Reader {
 }
 
 export class ManifestReader extends Reader {
+  defaultOutputKey = "manifest";
+
   constructor() {
     super(
       "@pixiebrix/chrome-extension-manifest",

--- a/src/blocks/transformers/FormData.ts
+++ b/src/blocks/transformers/FormData.ts
@@ -20,6 +20,8 @@ import { BlockArg, Schema } from "@/core";
 import { propertiesToSchema } from "@/validators/generic";
 
 export class FormData extends Transformer {
+  defaultOutputKey = "form";
+
   constructor() {
     super(
       "@pixiebrix/forms/data",

--- a/src/blocks/transformers/detect.ts
+++ b/src/blocks/transformers/detect.ts
@@ -20,6 +20,8 @@ import { BlockArg, Schema } from "@/core";
 import { propertiesToSchema } from "@/validators/generic";
 
 export class DetectElement extends Transformer {
+  defaultOutputKey = "match";
+
   constructor() {
     super(
       "@pixiebrix/dom/detect",

--- a/src/blocks/transformers/encode.ts
+++ b/src/blocks/transformers/encode.ts
@@ -20,6 +20,8 @@ import { BlockArg } from "@/core";
 import { propertiesToSchema } from "@/validators/generic";
 
 export class Base64Encode extends Transformer {
+  defaultOutputKey = "encoded";
+
   async isPure(): Promise<boolean> {
     return true;
   }
@@ -49,6 +51,8 @@ export class Base64Encode extends Transformer {
 }
 
 export class Base64Decode extends Transformer {
+  defaultOutputKey = "decoded";
+
   constructor() {
     super(
       "@pixiebrix/encode/atob",

--- a/src/blocks/transformers/httpGet.ts
+++ b/src/blocks/transformers/httpGet.ts
@@ -27,6 +27,8 @@ export class GetAPITransformer extends Transformer {
     super("@pixiebrix/get", "HTTP GET", "Fetch data from an API", "faCloud");
   }
 
+  defaultOutputKey = "response";
+
   inputSchema: Schema = propertiesToSchema(
     {
       url: {

--- a/src/blocks/transformers/jquery/JQueryReader.ts
+++ b/src/blocks/transformers/jquery/JQueryReader.ts
@@ -28,6 +28,8 @@ export class JQueryReader extends Transformer {
     );
   }
 
+  defaultOutputKey = "data";
+
   inputSchema: Schema = {
     type: "object",
     required: ["selectors"],

--- a/src/blocks/transformers/mapping.ts
+++ b/src/blocks/transformers/mapping.ts
@@ -20,6 +20,8 @@ import { BlockArg, Schema } from "@/core";
 import { BusinessError } from "@/errors";
 
 export class MappingTransformer extends Transformer {
+  defaultOutputKey = "value";
+
   async isPure(): Promise<boolean> {
     return true;
   }

--- a/src/blocks/transformers/modalForm/modal.tsx
+++ b/src/blocks/transformers/modalForm/modal.tsx
@@ -43,6 +43,8 @@ function getMaxZ() {
 }
 
 export class ModalTransformer extends Transformer {
+  defaultOutputKey = "form";
+
   constructor() {
     super(
       "@pixiebrix/form-modal",

--- a/src/blocks/transformers/parseUrl.ts
+++ b/src/blocks/transformers/parseUrl.ts
@@ -42,6 +42,8 @@ export class UrlParser extends Transformer {
     return true;
   }
 
+  defaultOutputKey = "parsedUrl";
+
   constructor() {
     super(
       "@pixiebrix/parse-url",

--- a/src/blocks/transformers/prompt.ts
+++ b/src/blocks/transformers/prompt.ts
@@ -30,6 +30,8 @@ export class Prompt extends Transformer {
     );
   }
 
+  defaultOutputKey = "userInput";
+
   inputSchema: Schema = propertiesToSchema(
     {
       message: {

--- a/src/blocks/transformers/regex.ts
+++ b/src/blocks/transformers/regex.ts
@@ -34,6 +34,8 @@ export class RegexTransformer extends Transformer {
     );
   }
 
+  defaultOutputKey = "extracted";
+
   inputSchema: Schema = propertiesToSchema(
     {
       regex: {

--- a/src/blocks/transformers/remoteMethod.ts
+++ b/src/blocks/transformers/remoteMethod.ts
@@ -30,6 +30,8 @@ export class RemoteMethod extends Transformer {
     );
   }
 
+  defaultOutputKey = "response";
+
   inputSchema: Schema = propertiesToSchema(
     {
       url: {

--- a/src/blocks/transformers/template.ts
+++ b/src/blocks/transformers/template.ts
@@ -25,6 +25,8 @@ import { BusinessError } from "@/errors";
  * Transformer that fills a template using the current context.
  */
 export class TemplateTransformer extends Transformer {
+  defaultOutputKey = "filled";
+
   async isPure(): Promise<boolean> {
     return true;
   }

--- a/src/blocks/transformers/url.ts
+++ b/src/blocks/transformers/url.ts
@@ -50,6 +50,8 @@ export class UrlParams extends Transformer {
     return true;
   }
 
+  defaultOutputKey = "url";
+
   constructor() {
     super(
       "@pixiebrix/url-params",

--- a/src/components/formBuilder/formBuilderHelpers.ts
+++ b/src/components/formBuilder/formBuilderHelpers.ts
@@ -15,9 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Schema, UiSchema } from "@/core";
+import { SafeString, Schema, UiSchema } from "@/core";
 import { SelectStringOption } from "./formBuilderTypes";
 import { UI_ORDER } from "./schemaFieldNames";
+import { freshIdentifier } from "@/utils";
 
 export const MINIMAL_SCHEMA: Schema = {
   type: "object",
@@ -83,19 +84,10 @@ export const replaceStringInArray = (
   return arr;
 };
 
-const fieldNameRegex = /^field(\d+)$/;
-export const generateNewPropertyName = (existingProperties: string[]) => {
-  const prefix = "field";
-  const fieldIndexesUsed = existingProperties
-    .map((property) => fieldNameRegex.exec(property))
-    .filter((matches) => matches?.length > 1)
-    .map((matches) => Number(matches[1]))
-    .sort((a, b) => b - a);
-
-  // FixMe: possible integer overflow
-  const fieldIndex = fieldIndexesUsed.length > 0 ? fieldIndexesUsed[0] + 1 : 1;
-  return `${prefix}${fieldIndex}`;
-};
+export const generateNewPropertyName = (existingProperties: string[]) =>
+  freshIdentifier("field" as SafeString, existingProperties, {
+    includeFirstNumber: true,
+  });
 
 export const moveStringInArray = (
   array: string[],

--- a/src/core.ts
+++ b/src/core.ts
@@ -36,6 +36,13 @@ export type ActionType = string;
 
 export type OutputKey = string;
 
+/**
+ * A string known not to not be tainted with user-generated input.
+ */
+export type SafeString = string & {
+  _safeStringBrand: never;
+};
+
 export type UUID = string & {
   // Nominal subtyping
   _uuidBrand: never;
@@ -399,6 +406,15 @@ export interface IBlock extends Metadata {
    * - Writing to the session state
    */
   isPure?: () => Promise<boolean>;
+
+  /**
+   * (Optional) default root output key to use when this block is added in the page editor.
+   *
+   * If not provided, the Page Editor will use a generic name, potentially based on the inferred type of the brick.
+   *
+   * For example, "foo" will produce: foo, foo2, foo3, foo4, etc.
+   */
+  defaultOutputKey?: string;
 
   run: (value: BlockArg, options: BlockOptions) => Promise<unknown>;
 }

--- a/src/devTools/editor/sidebar/Footer.tsx
+++ b/src/devTools/editor/sidebar/Footer.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useContext } from "react";
+import React, { useCallback, useContext, useEffect } from "react";
 import AuthContext from "@/auth/AuthContext";
 import { DevToolsContext } from "@/devTools/context";
 import BeatLoader from "react-spinners/BeatLoader";
@@ -38,6 +38,12 @@ const Footer: React.FunctionComponent = () => {
   const toggleBetaUI = useCallback(() => {
     dispatch(actions.setBetaUIEnabled(!isBetaUI));
   }, [isBetaUI, dispatch]);
+
+  useEffect(() => {
+    if (flags.includes("beta-auto")) {
+      dispatch(actions.setBetaUIEnabled(true));
+    }
+  }, [dispatch, flags]);
 
   return (
     <div className="Sidebar__footer flex-grow-0">

--- a/src/devTools/editor/tabs/editTab/editHelpers.ts
+++ b/src/devTools/editor/tabs/editTab/editHelpers.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { IBlock, SafeString } from "@/core";
+import { getType } from "@/blocks/util";
+import { freshIdentifier } from "@/utils";
+
+/**
+ * Generate a fresh outputKey for `block`
+ * @param block the block
+ * @param outputKeys existing outputKeys already being used
+ */
+export async function generateFreshOutputKey(
+  block: IBlock,
+  outputKeys: string[]
+): Promise<string> {
+  const root = block.defaultOutputKey ?? (await getType(block));
+
+  return freshIdentifier(root as SafeString, outputKeys);
+}

--- a/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -21,6 +21,8 @@ import { RegistryId } from "@/core";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import { CustomFieldWidget, FieldProps } from "@/components/form/FieldTemplate";
 import BlockConfiguration from "@/devTools/editor/tabs/effect/BlockConfiguration";
+import { useAsyncState } from "@/hooks/common";
+import blockRegistry from "@/blocks/registry";
 
 const OutputKeyWidget: CustomFieldWidget = (props: FieldProps) => (
   <InputGroup>
@@ -34,33 +36,40 @@ const OutputKeyWidget: CustomFieldWidget = (props: FieldProps) => (
 const EditorNodeConfigPanel: React.FC<{
   blockFieldName: string;
   blockId: RegistryId;
-}> = ({ blockFieldName, blockId }) => (
-  <>
-    <ConnectedFieldTemplate
-      name={`${blockFieldName}.label`}
-      layout="horizontal"
-      label="Step Name"
-    />
-    <ConnectedFieldTemplate
-      name={`${blockFieldName}.outputKey`}
-      layout="horizontal"
-      label="Output"
-      as={OutputKeyWidget}
-      description={
-        <p>
-          Provide a output key to refer to the outputs of this block later. For
-          example, if you provide the name <code>myOutput</code>, you can use
-          the output later with <code>@myOutput</code>.
-        </p>
-      }
-    />
+}> = ({ blockFieldName, blockId }) => {
+  const [block] = useAsyncState(async () => blockRegistry.lookup(blockId), [
+    blockId,
+  ]);
 
-    <BlockConfiguration
-      name={blockFieldName}
-      blockId={blockId}
-      showOutput={false}
-    />
-  </>
-);
+  return (
+    <>
+      <ConnectedFieldTemplate
+        name={`${blockFieldName}.label`}
+        layout="horizontal"
+        label="Step Name"
+        placeholder={block?.name}
+      />
+      <ConnectedFieldTemplate
+        name={`${blockFieldName}.outputKey`}
+        layout="horizontal"
+        label="Output"
+        as={OutputKeyWidget}
+        description={
+          <p>
+            Provide a output key to refer to the outputs of this block later.
+            For example, if you provide the name <code>myOutput</code>, you can
+            use the output later with <code>@myOutput</code>.
+          </p>
+        }
+      />
+
+      <BlockConfiguration
+        name={blockFieldName}
+        blockId={blockId}
+        showOutput={false}
+      />
+    </>
+  );
+};
 
 export default EditorNodeConfigPanel;

--- a/src/devTools/editor/tabs/effect/PreviewView.tsx
+++ b/src/devTools/editor/tabs/effect/PreviewView.tsx
@@ -31,6 +31,7 @@ import objectHash from "object-hash";
 import JsonTree from "@/components/JsonTree";
 import { isEmpty } from "lodash";
 import { TraceRecord } from "@/telemetry/trace";
+import { getType } from "@/blocks/util";
 
 const PreviewView: React.FunctionComponent<{
   traceRecord: TraceRecord;
@@ -47,6 +48,7 @@ const PreviewView: React.FunctionComponent<{
     return {
       block,
       isPure: await block.isPure(),
+      type: await getType(block),
     };
   }, [blockConfig.id]);
 
@@ -79,6 +81,14 @@ const PreviewView: React.FunctionComponent<{
     return (
       <div>
         <GridLoader />
+      </div>
+    );
+  }
+
+  if (blockInfo?.type === "renderer") {
+    return (
+      <div className="text-muted">
+        Output previews are not currently available for renderers
       </div>
     );
   }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -15,7 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getPropByPath } from "@/utils";
+import { freshIdentifier, getPropByPath } from "@/utils";
+import type { SafeString } from "@/core";
 
 test("can get array element by index", () => {
   expect(getPropByPath({ array: [1, 2, 3] }, "array.0")).toBe(1);
@@ -31,4 +32,17 @@ test("can get object path in array", () => {
 
 test("can apply null coalescing to array index", () => {
   expect(getPropByPath({ array: [{ key: "foo" }] }, "array.1?.key")).toBeNull();
+});
+
+test("can generate fresh identifier", () => {
+  const root = "field" as SafeString;
+  expect(freshIdentifier(root, [])).toBe("field");
+  expect(freshIdentifier(root, [], { includeFirstNumber: true })).toBe(
+    "field1"
+  );
+  expect(
+    freshIdentifier(root, [], { includeFirstNumber: true, startNumber: 0 })
+  ).toBe("field0");
+  expect(freshIdentifier(root, ["field"])).toBe("field2");
+  expect(freshIdentifier(root, ["foo", "bar"])).toBe("field");
 });


### PR DESCRIPTION
- Adds the brick name as a placeholder for step name
- Generates a fresh default output key when adding a note
- Switches to the new block when adding a block
- Refactors out the helper method for generating fresh identifiers
- Support a feature flag for automatically toggling the beta checkbox