### PR TITLE
Page Editor - Move delete button back to step config panel

### DIFF
--- a/src/devTools/editor/tabs/editTab/EditTab.tsx
+++ b/src/devTools/editor/tabs/editTab/EditTab.tsx
@@ -136,9 +136,6 @@ const EditTab: React.FC<{
           onClick: () => {
             onSelectNode(index + 1);
           },
-          onRemove: () => {
-            removeBlock(index);
-          },
         }
       : {
           title: "Loading...",
@@ -213,6 +210,9 @@ const EditTab: React.FC<{
             <EditorNodeConfigPanel
               blockFieldName={blockFieldName}
               blockId={resolvedBlocks[activeNodeIndex - 1].id}
+              onRemoveNode={() => {
+                removeBlock(activeNodeIndex - 1);
+              }}
             />
           )}
         </div>

--- a/src/devTools/editor/tabs/editTab/editorNode/EditorNode.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNode/EditorNode.tsx
@@ -20,7 +20,6 @@ import styles from "./EditorNode.module.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import cx from "classnames";
-import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 
 export type EditorNodeProps = {
   title: string;
@@ -29,7 +28,6 @@ export type EditorNodeProps = {
   onClick: () => void;
   muted?: boolean | undefined;
   active?: boolean | undefined;
-  onRemove?: (() => void) | undefined;
 };
 
 const EditorNode: React.FC<EditorNodeProps> = ({
@@ -39,7 +37,6 @@ const EditorNode: React.FC<EditorNodeProps> = ({
   outputKey,
   muted,
   active,
-  onRemove,
 }) => {
   const outputName = outputKey ? `@${outputKey}` : "";
 
@@ -47,14 +44,6 @@ const EditorNode: React.FC<EditorNodeProps> = ({
     // Use our own custom style here, not bootstrap
     <div className={styles.root}>
       <div className={styles.outputKey}>{outputName}</div>
-      {onRemove && (
-        <FontAwesomeIcon
-          icon={faTimesCircle}
-          size="lg"
-          className={styles.remove}
-          onClick={onRemove}
-        />
-      )}
       <button
         type="button"
         onClick={onClick}

--- a/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
+++ b/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
@@ -20,3 +20,8 @@
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
 }
+
+.removeButton {
+  margin-bottom: 10px;
+  margin-left: auto;
+}

--- a/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from "react";
-import { Form, InputGroup } from "react-bootstrap";
+import { Button, Form, InputGroup } from "react-bootstrap";
 import { RegistryId } from "@/core";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import { CustomFieldWidget, FieldProps } from "@/components/form/FieldTemplate";
@@ -25,6 +25,9 @@ import { useAsyncState } from "@/hooks/common";
 import blockRegistry from "@/blocks/registry";
 import { getType } from "@/blocks/util";
 import { showOutputKey } from "@/devTools/editor/tabs/editTab/editHelpers";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import styles from "./EditorNodeConfigPanel.module.scss";
 
 const OutputKeyWidget: CustomFieldWidget = (props: FieldProps) => (
   <InputGroup>
@@ -38,7 +41,8 @@ const OutputKeyWidget: CustomFieldWidget = (props: FieldProps) => (
 const EditorNodeConfigPanel: React.FC<{
   blockFieldName: string;
   blockId: RegistryId;
-}> = ({ blockFieldName, blockId }) => {
+  onRemoveNode: () => void;
+}> = ({ blockFieldName, blockId, onRemoveNode }) => {
   const [blockInfo] = useAsyncState(async () => {
     const block = await blockRegistry.lookup(blockId);
     return {
@@ -80,6 +84,14 @@ const EditorNodeConfigPanel: React.FC<{
           description={<p>Effect and renderer bricks do not produce outputs</p>}
         />
       )}
+
+      <Button
+        variant="danger"
+        onClick={onRemoveNode}
+        className={styles.removeButton}
+      >
+        <FontAwesomeIcon icon={faTrash} /> Remove Node
+      </Button>
 
       <BlockConfiguration
         name={blockFieldName}


### PR DESCRIPTION
Quick fix to move the delete-node button back to a full button in the config panel rather that an X on each node.