### PR TITLE
#1320: add support bricks with integration alternatives

### DIFF
--- a/src/components/fields/fieldUtils.ts
+++ b/src/components/fields/fieldUtils.ts
@@ -15,7 +15,36 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Schema, SchemaDefinition } from "@/core";
+
 export function fieldLabel(name: string): string {
   const parts = name.split(".");
   return parts[parts.length - 1];
+}
+
+type TypePredicate = (fieldDefinition: Schema) => boolean;
+
+export function createTypePredicate(predicate: TypePredicate): TypePredicate {
+  return (fieldDefinition: Schema) => {
+    if (predicate(fieldDefinition)) {
+      return true;
+    }
+
+    const matches = (x: SchemaDefinition) =>
+      typeof x !== "boolean" && predicate(x);
+
+    if ((fieldDefinition.oneOf ?? []).some((x) => matches(x))) {
+      return true;
+    }
+
+    if ((fieldDefinition.anyOf ?? []).some((x) => matches(x))) {
+      return true;
+    }
+
+    if ((fieldDefinition.allOf ?? []).some((x) => matches(x))) {
+      return true;
+    }
+
+    return false;
+  };
 }

--- a/src/components/fields/schemaFields/SchemaFieldContext.tsx
+++ b/src/components/fields/schemaFields/SchemaFieldContext.tsx
@@ -22,7 +22,7 @@ import {
   SchemaFieldProps,
 } from "@/components/fields/schemaFields/propTypes";
 import ServiceField, {
-  SERVICE_BASE_SCHEMA,
+  isServiceField,
 } from "@/components/fields/schemaFields/ServiceField";
 import {
   booleanPredicate,
@@ -73,7 +73,7 @@ function makeOneOfField(oneOf: Schema): FieldComponent {
 }
 
 export function getDefaultField(fieldSchema: Schema): FieldComponent {
-  if (fieldSchema.$ref?.startsWith(SERVICE_BASE_SCHEMA)) {
+  if (isServiceField(fieldSchema)) {
     return ServiceField;
   }
 

--- a/src/devTools/editor/fields/devtoolFieldOverrides.tsx
+++ b/src/devTools/editor/fields/devtoolFieldOverrides.tsx
@@ -18,31 +18,16 @@
 import React from "react";
 import SelectorSelectorField from "@/components/fields/schemaFields/SelectorSelectorField";
 import { CustomFieldDefinitions } from "@/components/fields/schemaFields/SchemaFieldContext";
-import { Schema, SchemaDefinition } from "@/core";
 import SelectorSelectorWidget from "@/devTools/editor/fields/SelectorSelectorWidget";
+import { createTypePredicate } from "@/components/fields/fieldUtils";
 
 export const ClearableSelectorWidget: React.FunctionComponent<{
   name: string;
 }> = ({ name }) => <SelectorSelectorWidget isClearable sort name={name} />;
 
-function isSelectorField(fieldSchema: Schema): boolean {
-  if (fieldSchema.type === "string" && fieldSchema.format === "selector") {
-    return true;
-  }
-
-  const isSelector = (x: SchemaDefinition) =>
-    typeof x !== "boolean" && isSelectorField(x);
-
-  if ((fieldSchema.oneOf ?? []).some((x) => isSelector(x))) {
-    return true;
-  }
-
-  if ((fieldSchema.anyOf ?? []).some((x) => isSelector(x))) {
-    return true;
-  }
-
-  return false;
-}
+const isSelectorField = createTypePredicate(
+  (x) => x.type === "string" && x.format === "selector"
+);
 
 const devtoolFieldOverrides: CustomFieldDefinitions = {
   customFields: [

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -24,6 +24,7 @@ import { useAsyncState } from "./common";
 import { readRawConfigurations } from "@/services/registry";
 import { useMemo, useCallback } from "react";
 import { useGetServiceAuthsQuery } from "@/services/api";
+import { sortBy } from "lodash";
 
 interface OrganizationResponse {
   readonly id: string;
@@ -107,21 +108,27 @@ export function useAuthOptions(): [AuthOption[], () => void] {
   } = useGetServiceAuthsQuery();
 
   const authOptions = useMemo(() => {
-    const localOptions = (configuredServices ?? []).map((x) => ({
-      value: x.id,
-      label: `${defaultLabel(x.label)} — Private`,
-      local: true,
-      serviceId: x.serviceId,
-    }));
+    const localOptions = sortBy(
+      (configuredServices ?? []).map((x) => ({
+        value: x.id,
+        label: `${defaultLabel(x.label)} — Private`,
+        local: true,
+        serviceId: x.serviceId,
+      })),
+      (x) => x.label
+    );
 
-    const sharedOptions = (remoteAuths ?? []).map((x) => ({
-      value: x.id,
-      label: `${defaultLabel(x.label)} — ${
-        x.organization?.name ?? "✨ Built-in"
-      }`,
-      local: false,
-      serviceId: x.service.config.metadata.id,
-    }));
+    const sharedOptions = sortBy(
+      (remoteAuths ?? []).map((x) => ({
+        value: x.id,
+        label: `${defaultLabel(x.label)} — ${
+          x.organization?.name ?? "✨ Built-in"
+        }`,
+        local: false,
+        serviceId: x.service.config.metadata.id,
+      })),
+      (x) => x.label
+    );
 
     return [...localOptions, ...sharedOptions];
   }, [remoteAuths, configuredServices]);


### PR DESCRIPTION
Part of #1320
- Adds support for bricks that accept alternative services ids

Out of Scope / TODO: 
- Clean up output keys generate when switching between auths