### PR TITLE
#1334: Open sidebar in new tab instead of showing error

### DIFF
--- a/src/action.scss
+++ b/src/action.scss
@@ -16,6 +16,8 @@
  */
 
 html {
+  // Keep in sync with `SIDEBAR_WIDTH_PX` in `contentScript/browserAction.ts`
+  --sidebar-width: 400px;
   font-size: 16px;
   max-height: 100vh;
   height: 100vh;
@@ -31,7 +33,9 @@ body {
 
 #container {
   height: 100%;
-  width: 100%;
+  width: var(--sidebar-width);
+  border-left: 1px solid lightgray;
+  margin-left: auto;
 
   .action-sidebar-loader {
     width: 100%;

--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -139,14 +139,21 @@ const ActionPanelApp: React.FunctionComponent = () => {
         <ToastProvider>
           <div className="d-flex flex-column" style={{ height: "100vh" }}>
             <div className="d-flex flex-row mb-2 p-2 justify-content-between align-content-center">
-              <Button
-                className="action-panel-button"
-                onClick={closeSidebar}
-                size="sm"
-                variant="link"
-              >
-                <FontAwesomeIcon icon={faAngleDoubleRight} className="fa-lg" />
-              </Button>
+              {
+                /* Only when iframed #1395 */ self === top || (
+                  <Button
+                    className="action-panel-button"
+                    onClick={closeSidebar}
+                    size="sm"
+                    variant="link"
+                  >
+                    <FontAwesomeIcon
+                      icon={faAngleDoubleRight}
+                      className="fa-lg"
+                    />
+                  </Button>
+                )
+              }
               <div className="align-self-center">
                 <img
                   src={logo}

--- a/src/actionPanel/native.tsx
+++ b/src/actionPanel/native.tsx
@@ -31,6 +31,7 @@ import { reportEvent } from "@/telemetry/events";
 import { expectContext } from "@/utils/expectContext";
 import { ExtensionRef } from "@/core";
 
+// Keep in sync with `--sidebar-width` in `actions.scss`
 const SIDEBAR_WIDTH_PX = 400;
 const PANEL_CONTAINER_ID = "pixiebrix-extension";
 const PANEL_CONTAINER_SELECTOR = "#" + PANEL_CONTAINER_ID;
@@ -93,7 +94,7 @@ function insertActionPanel(): string {
   const actionURL = browser.runtime.getURL("action.html");
 
   const $panelContainer = $(
-    `<div id="${PANEL_CONTAINER_ID}" data-nonce="${nonce}" style="height: 100%; margin: 0; padding: 0; border-radius: 0; width: ${SIDEBAR_WIDTH_PX}px; position: fixed; top: 0; right: 0; z-index: 2147483647; border-left: 1px solid lightgray; background-color: rgb(255, 255, 255); display: block;"></div>`
+    `<div id="${PANEL_CONTAINER_ID}" data-nonce="${nonce}" style="height: 100%; margin: 0; padding: 0; border-radius: 0; width: ${SIDEBAR_WIDTH_PX}px; position: fixed; top: 0; right: 0; z-index: 2147483647; background-color: rgb(255, 255, 255); display: block;"></div>`
   );
 
   // CSS approach not well supported? https://stackoverflow.com/questions/15494568/html-iframe-disable-scroll

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -51,10 +51,7 @@ const tabNonces = new Map<number, string>();
  */
 const tabFrames = new Map<number, number>();
 
-async function handleBrowserAction(
-  tab: browser.tabs.Tab,
-  fallback = true
-): Promise<void> {
+async function handleBrowserAction(tab: browser.tabs.Tab): Promise<void> {
   // We're either getting a new frame, or getting rid of the existing one. Forget the old frame
   // id so we're not sending messages to a dead frame
   tabFrames.delete(tab.id);
@@ -73,21 +70,13 @@ async function handleBrowserAction(
       tabId: tab.id,
       frameId: TOP_LEVEL_FRAME_ID,
     });
-  } catch (error: unknown) {
-    // Avoid loops, report error
-    if (!fallback) {
-      reportError(error);
-      return;
-    }
-
+  } catch {
     // The sidebar was not injected in the page, so we'll create a new tab instead
     // https://github.com/pixiebrix/pixiebrix-extension/issues/1334
-    const options = await browser.tabs.create({
-      url: browser.runtime.getURL("options.html"),
+    await browser.tabs.create({
+      url: browser.runtime.getURL("action.html"),
       openerTabId: tab.id,
     });
-    await sleep(2000);
-    await handleBrowserAction(options, false);
   }
 }
 


### PR DESCRIPTION
- Fixes #1334 

Also tested in Firefox

# Before

https://user-images.githubusercontent.com/1402241/134046916-66587f9e-90f0-40c4-bc09-8e3dca4b2145.mov

# After

https://user-images.githubusercontent.com/1402241/134047030-e64bbde1-2404-4b78-9b5f-c32e9270089a.mov



