### PR TITLE
Remove underline from Options button

### DIFF
--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -160,7 +160,7 @@ const ActionPanelApp: React.FunctionComponent = () => {
                 target="_blank"
                 size="sm"
                 variant="link"
-                className="action-panel-button d-inline-flex align-items-center"
+                className="action-panel-button d-inline-flex align-items-center text-decoration-none"
               >
                 <span>
                   Options <FontAwesomeIcon icon={faCog} />


### PR DESCRIPTION
"Buttons" should not also have an underline


### Before

![begif](https://user-images.githubusercontent.com/1402241/134063541-8fc9842e-3696-411c-b569-8d5721aa3b33.gif)

### After


![gif](https://user-images.githubusercontent.com/1402241/134063550-fd87dcf0-b9de-4336-86ec-0d0a94fc0641.gif)
