### PR TITLE
Improve styles of editor sidebar logo

### DIFF
--- a/src/devTools/Panel.scss
+++ b/src/devTools/Panel.scss
@@ -109,7 +109,7 @@
       .list-group-item {
         padding-left: 12px;
         padding-right: 12px;
-        border-radius: 0;
+        border-right: none;
         font-size: 0.875rem;
       }
     }
@@ -121,13 +121,10 @@
     }
 
     &__logo {
-      width: 31px;
-      cursor: pointer;
-      margin-right: 2px;
-
-      svg:hover {
-        filter: brightness(0.75);
-      }
+      background-color: #6462aa; // Make logo icon look square
+    }
+    &__logo:hover {
+      filter: brightness(0.75);
     }
 
     &__actions button {
@@ -261,7 +258,7 @@
     }
 
     .list-group-item {
-      border-radius: 0;
+      border-right: none;
       font-size: 0.8rem;
       padding-left: 5px;
       padding-right: 5px;

--- a/src/devTools/editor/sidebar/Sidebar.tsx
+++ b/src/devTools/editor/sidebar/Sidebar.tsx
@@ -126,7 +126,13 @@ const Sidebar: React.FunctionComponent<
             target="_blank"
             title="Open PixieBrix Options"
           >
-            <img src={logoUrl} alt="" width={31} height={31} />
+            <img
+              src={logoUrl}
+              alt=""
+              width={31}
+              height={31}
+              className="Sidebar__logo"
+            />
           </a>
           <DropdownButton
             disabled={Boolean(inserting) || !hasPermissions}


### PR DESCRIPTION
- Discussed in https://github.com/pixiebrix/pixiebrix-extension/pull/1330

Changes:

- drops extra border on the right of each extension
- restore hover state on logo
- drop rounded borders on logo to make its look more consistent
- drop some CSS left behind by an old PR




## Before:


<img width="370" alt="Screen Shot 14" src="https://user-images.githubusercontent.com/1402241/134048839-4f33a711-1274-4512-8187-5d29e7a09bf9.png">

## After


<img width="389" alt="Screen Shot 13" src="https://user-images.githubusercontent.com/1402241/134048647-c0a3137f-45af-4a77-bad9-56a95c0932c4.png">

Hover:


![begif](https://user-images.githubusercontent.com/1402241/134065983-b4bf82d6-f735-4f1a-8614-576e767712ff.gif)