### PR TITLE
Show error message for custom widgets

### DIFF
--- a/src/components/form/FieldTemplate.module.scss
+++ b/src/components/form/FieldTemplate.module.scss
@@ -23,3 +23,10 @@
   padding-bottom: 0.25rem;
   width: 100%;
 }
+
+.invalidMessage {
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 80%;
+  color: #dc3545;
+}

--- a/src/components/form/FieldTemplate.tsx
+++ b/src/components/form/FieldTemplate.tsx
@@ -78,9 +78,7 @@ const renderHorizontal: (props: FieldRenderProps) => ReactElement = ({
           </BootstrapForm.Text>
         )}
         {isInvalid && (
-          <BootstrapForm.Control.Feedback type="invalid">
-            {getErrorMessage(error)}
-          </BootstrapForm.Control.Feedback>
+          <div className={styles.invalidMessage}>{getErrorMessage(error)}</div>
         )}
       </Col>
     </BootstrapForm.Group>


### PR DESCRIPTION
`BootstrapForm.Control.Feedback` shows an error message only if there's an element with class `is-invalid` next to it. This creates a not-so-obvious requirement for authoring widgets and makes the `FieldTemplate` depend on a widget implementation.
Making the login simpler giving the full responsibility of the errors to `FieldTemplate`.