### PR TITLE
#1321: expose framework reader as a brick

### DIFF
--- a/src/blocks/readers/frameworkReader.ts
+++ b/src/blocks/readers/frameworkReader.ts
@@ -21,11 +21,11 @@ import { ReaderOutput, ReaderRoot } from "@/core";
 import { castArray, compact } from "lodash";
 import { getComponentData, ReadPayload } from "@/pageScript/protocol";
 
-type FrameworkConfig = ReadPayload & {
+export type FrameworkConfig = ReadPayload & {
   /**
    * @deprecated Legacy emberjs reader config. Use patchSpec instead
    */
-  attrs: string | string[];
+  attrs?: string | string[];
 };
 
 function isHTMLElement(root: ReaderRoot): root is HTMLElement {

--- a/src/blocks/renderers/propertyTable.tsx
+++ b/src/blocks/renderers/propertyTable.tsx
@@ -112,10 +112,18 @@ export class PropertyTableRenderer extends Renderer {
     );
   }
 
-  inputSchema = propertiesToSchema({});
+  inputSchema = propertiesToSchema(
+    {
+      data: {
+        description:
+          "The data to show in the table, or null/blank to show the implicit data",
+      },
+    },
+    []
+  );
 
   async render(
-    inputs: BlockArg,
+    { data }: BlockArg,
     { ctxt }: BlockOptions
   ): Promise<RenderedHTML> {
     const PropertyTree = (
@@ -128,7 +136,7 @@ export class PropertyTableRenderer extends Renderer {
     return {
       Component: PropertyTree,
       props: {
-        value: shapeData(ctxt),
+        value: shapeData(data ?? ctxt),
       },
     } as any;
   }

--- a/src/blocks/transformers/component/ComponentReader.ts
+++ b/src/blocks/transformers/component/ComponentReader.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Transformer } from "@/types";
+import { BlockArg, BlockOptions, Schema } from "@/core";
+import { frameworkReadFactory } from "@/blocks/readers/frameworkReader";
+import { KNOWN_READERS } from "@/messaging/constants";
+import { validateRegistryId } from "@/types/helpers";
+
+export const COMPONENT_READER_ID = validateRegistryId(
+  "@pixiebrix/component-reader"
+);
+
+export class ComponentReader extends Transformer {
+  constructor() {
+    super(
+      COMPONENT_READER_ID,
+      "Component Reader",
+      "Extract data from a front-end component (e.g., React, Vue, Ember, etc.)"
+    );
+  }
+
+  defaultOutputKey = "data";
+
+  inputSchema: Schema = {
+    type: "object",
+    required: ["framework", "selector"],
+    properties: {
+      framework: {
+        type: "string",
+        enum: KNOWN_READERS.filter((x) => x !== "jquery"),
+      },
+      selector: {
+        type: "string",
+        format: "selector",
+        description:
+          "CSS/JQuery selector to select the HTML element that corresponds to the component",
+      },
+      optional: {
+        type: "boolean",
+        default: false,
+        description: "Whether or not the selector is always available",
+      },
+      traverseUp: {
+        type: "number",
+        description: "Traverse non-visible framework elements",
+      },
+    },
+  };
+
+  async isPure(): Promise<boolean> {
+    return true;
+  }
+
+  async transform(
+    { framework, selector }: BlockArg,
+    { root }: BlockOptions
+  ): Promise<unknown> {
+    return frameworkReadFactory(framework)({ framework, selector }, root);
+  }
+}

--- a/src/blocks/transformers/component/ComponentReaderOptions.tsx
+++ b/src/blocks/transformers/component/ComponentReaderOptions.tsx
@@ -1,0 +1,105 @@
+import React, { useContext, useEffect, useMemo } from "react";
+import { BlockOptionProps } from "@/components/fields/schemaFields/genericOptionsFactory";
+import { DevToolsContext } from "@/devTools/context";
+import { useField } from "formik";
+import { compact } from "lodash";
+import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
+import SelectWidget from "@/components/form/widgets/SelectWidget";
+import { Framework, FrameworkMeta } from "@/messaging/constants";
+import SelectorSelectorWidget from "@/devTools/editor/fields/SelectorSelectorWidget";
+
+type FrameworkOption = {
+  value: Framework;
+  label: string;
+  detected?: FrameworkMeta;
+};
+
+export const readerOptions: FrameworkOption[] = [
+  { value: "react", label: "React" },
+  {
+    value: "angularjs",
+    label: "AngularJS",
+  },
+  { value: "emberjs", label: "Ember.js" },
+  {
+    // XXX: check if this needs to be vue or vuejs
+    value: "vue",
+    label: "Vue.js",
+  },
+];
+
+function useFrameworkOptions(frameworks: FrameworkMeta[]): FrameworkOption[] {
+  return useMemo(
+    () =>
+      readerOptions.map((option) => {
+        const detected = frameworks.find(({ id }) => option.value === id);
+        return {
+          ...option,
+          detected,
+          label:
+            option.value === "jquery"
+              ? option.label
+              : `${option.label} - ${
+                  detected
+                    ? detected.version ?? "Unknown Version"
+                    : "Not detected"
+                }`,
+        };
+      }),
+    [frameworks]
+  );
+}
+
+const ComponentReaderOptions: React.FunctionComponent<BlockOptionProps> = ({
+  name,
+  configKey,
+}) => {
+  const configFieldName = compact([name, configKey]).join(".");
+  const frameworkFieldName = [configFieldName, "framework"].join(".");
+
+  const {
+    tabState: { meta },
+  } = useContext(DevToolsContext);
+
+  const [{ value: framework }, , helpers] = useField<Framework>(
+    frameworkFieldName
+  );
+
+  const frameworkOptions = useFrameworkOptions(meta.frameworks);
+
+  useEffect(() => {
+    if (!framework) {
+      helpers.setValue(
+        meta.frameworks.find((x) => x.version)?.id ?? meta.frameworks[0].id
+      );
+    }
+  }, [framework, helpers, meta.frameworks]);
+
+  return (
+    <>
+      <ConnectedFieldTemplate
+        name={frameworkFieldName}
+        label="Framework"
+        description="Select the front-end framework (auto-detected)"
+        as={SelectWidget}
+        options={frameworkOptions}
+      />
+
+      <ConnectedFieldTemplate
+        name={[configFieldName, "selector"].join(".")}
+        label="Component Selector"
+        description="A CSS/JQuery selector for an element corresponding to the component"
+        as={SelectorSelectorWidget}
+      />
+
+      <ConnectedFieldTemplate
+        name={[configFieldName, "optional"].join(".")}
+        label="Optional"
+        description="Toggle to produce null/undefined if a component is not found (instead of raising an error)"
+        layout="switch"
+      />
+    </>
+  );
+};
+
+export default ComponentReaderOptions;

--- a/src/blocks/transformers/registerTransformers.ts
+++ b/src/blocks/transformers/registerTransformers.ts
@@ -17,7 +17,6 @@
 
 import { registerBlock } from "@/blocks/registry";
 
-import { JQueryReader } from "@/blocks/transformers/jquery/JQueryReader";
 import { JQTransformer } from "./jq";
 import { JSONPathTransformer } from "./jsonPath";
 import { GetAPITransformer } from "./httpGet";
@@ -33,6 +32,8 @@ import { ModalTransformer } from "./modalForm/modal";
 import { Base64Decode, Base64Encode } from "./encode";
 import { TemplateTransformer } from "./template";
 import { UrlParams } from "./url";
+import { ComponentReader } from "./component/ComponentReader";
+import { JQueryReader } from "./jquery/JQueryReader";
 
 function registerTransformers() {
   registerBlock(new JQTransformer());
@@ -52,6 +53,7 @@ function registerTransformers() {
   registerBlock(new TemplateTransformer());
   registerBlock(new UrlParams());
   registerBlock(new JQueryReader());
+  registerBlock(new ComponentReader());
 }
 
 export default registerTransformers;

--- a/src/contrib/editors.ts
+++ b/src/contrib/editors.ts
@@ -35,6 +35,8 @@ import FormModalOptions, {
 import FormRendererOptions, {
   FORM_RENDERER_ID,
 } from "@/devTools/editor/fields/FormRendererOptions";
+import { COMPONENT_READER_ID } from "@/blocks/transformers/component/ComponentReader";
+import ComponentReaderOptions from "@/blocks/transformers/component/ComponentReaderOptions";
 
 optionsRegistry.set(SERVICE_GOOGLE_SHEET_ID, SheetServiceOptions);
 optionsRegistry.set(ZAPIER_ID, PushOptions);
@@ -44,3 +46,4 @@ optionsRegistry.set(GOOGLE_SHEETS_API_ID, AppendSpreadsheetOptions);
 optionsRegistry.set(AUTOMATION_ANYWHERE_RUN_BOT_ID, BotOptions);
 optionsRegistry.set(FORM_MODAL_ID, FormModalOptions);
 optionsRegistry.set(FORM_RENDERER_ID, FormRendererOptions);
+optionsRegistry.set(COMPONENT_READER_ID, ComponentReaderOptions);

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import blockRegistry from "@/blocks/registry";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 76;
+const EXPECTED_HEADER_COUNT = 77;
 
 // Import for side-effects (these modules register the blocks)
 // NOTE: we don't need to also include extensionPoints because we got rid of all the legacy hard-coded extension points


### PR DESCRIPTION
- #1321: Exposes a separate framework ComponentReader brick
- Adds support for passing a variable to the PropertyTable renderer

TODO: 
- [ ] Test (on React, and Vue)
- [ ] Fix the "optional" toggle. It comes through as an array of on/off right now...
- [ ] Upload headers to app.pixiebrix.com so it's available in search