### PR TITLE
#1421: fix off by one error in data panel

### DIFF
--- a/src/devTools/editor/tabs/editTab/EditTab.tsx
+++ b/src/devTools/editor/tabs/editTab/EditTab.tsx
@@ -241,7 +241,7 @@ const EditTab: React.FC<{
           <DataPanel
             blockFieldName={blockFieldName}
             // eslint-disable-next-line security/detect-object-injection
-            instanceId={blockPipeline[activeNodeIndex]?.instanceId}
+            instanceId={blockPipeline[activeNodeIndex - 1]?.instanceId}
           />
         </div>
       </div>

--- a/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -122,7 +122,7 @@ const DataPanel: React.FC<{
     actions.setActiveField
   );
 
-  const { value: blockConfig } = useField<BlockConfig>(blockFieldName)[0];
+  const [{ value: blockConfig }] = useField<BlockConfig>(blockFieldName);
 
   const showFormPreview = configValue?.schema && configValue?.uiSchema;
   const showBlockPreview = record && blockConfig;


### PR DESCRIPTION
Part of #1421. In the switch to the DataTab, we lost the ability to view output data on the foundation (first node)