### PR TITLE
#1427: fix ServiceField onChange; fix infinite re-render in generating recommendations

### DIFF
--- a/src/components/brickModal/QuickAdd.tsx
+++ b/src/components/brickModal/QuickAdd.tsx
@@ -27,7 +27,7 @@ type OwnProps<T extends IBrick = IBrick> = {
 };
 
 const QuickAdd: React.FunctionComponent<OwnProps> = ({
-  recommendations,
+  recommendations = [],
   onSelect,
 }) => (
   <div>

--- a/src/components/fields/schemaFields/ChildObjectField.tsx
+++ b/src/components/fields/schemaFields/ChildObjectField.tsx
@@ -27,6 +27,7 @@ import ObjectWidget from "@/components/fields/schemaFields/widgets/ObjectWidget"
 import { Schema } from "@/core";
 import { isEmpty } from "lodash";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
+import { UnknownObject } from "@/types";
 
 const FALLBACK_SCHEMA: Schema = {
   type: "object",
@@ -58,7 +59,7 @@ const ChildContainer: React.FC<{ heading: string }> = ({
 );
 
 const ChildObjectWidget: CustomFieldWidget<
-  SchemaFieldProps<Record<string, unknown>> & OwnProps
+  SchemaFieldProps<UnknownObject> & OwnProps
 > = ({ name, schema, schemaLoading, schemaError, heading }) => {
   if (schemaLoading) {
     return (
@@ -76,7 +77,7 @@ const ChildObjectWidget: CustomFieldWidget<
     );
   }
 
-  if (isEmpty(schema.properties)) {
+  if (isEmpty(schema?.properties)) {
     return (
       <ChildContainer heading={heading}>
         <span className="text-muted">No parameters</span>
@@ -105,14 +106,14 @@ const ChildObjectWidget: CustomFieldWidget<
 };
 
 const ChildObjectField: React.FunctionComponent<
-  SchemaFieldProps<Record<string, unknown>> & OwnProps
+  SchemaFieldProps<UnknownObject> & OwnProps
 > = (props) => (
   <ConnectedFieldTemplate
     {...props}
     description={
       props.schemaError
         ? getErrorMessage(props.schemaError)
-        : props.schema.description
+        : props.schema?.description
     }
     as={ChildObjectWidget}
   />

--- a/src/components/fields/schemaFields/ServiceField.tsx
+++ b/src/components/fields/schemaFields/ServiceField.tsx
@@ -39,7 +39,9 @@ import { freshIdentifier } from "@/utils";
 import { browser } from "webextension-polyfill-ts";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCloud } from "@fortawesome/free-solid-svg-icons";
-import SelectWidget from "@/components/form/widgets/SelectWidget";
+import SelectWidget, {
+  SelectWidgetOnChange,
+} from "@/components/form/widgets/SelectWidget";
 import { isEmpty } from "lodash";
 
 const DEFAULT_SERVICE_OUTPUT_KEY = "service" as OutputKey;
@@ -137,10 +139,12 @@ const ServiceField: React.FunctionComponent<
       : authOptions.find((x) => x.value === dependency.config);
   }, [root.services, authOptions, value]);
 
-  const onChange = useCallback(
-    (option: AuthOption) => {
+  const onChange: SelectWidgetOnChange<AuthOption> = useCallback(
+    ({ target: { value, options } }) => {
       // Key Assumption: only one service of each type is configured. If a user changes the auth for one brick,
       // it changes the auth for all the bricks.
+
+      const option = options.find((x) => x.value === value);
 
       let outputKey: OutputKey;
 
@@ -201,7 +205,9 @@ const ServiceField: React.FunctionComponent<
           helpers.setValue(keyToFieldValue(match.outputKey));
         } else if (options.length === 1) {
           // Try defaulting to the only option available
-          onChange(options[0]);
+          onChange({
+            target: { value: options[0].value, name: field.name, options },
+          });
         }
       }
     },
@@ -231,7 +237,6 @@ const ServiceField: React.FunctionComponent<
       as={SelectWidget}
       options={options}
       onChange={onChange}
-      value={option?.value}
     />
   );
 };

--- a/src/components/form/widgets/RemoteSelectWidget.tsx
+++ b/src/components/form/widgets/RemoteSelectWidget.tsx
@@ -33,6 +33,9 @@ type OwnProps = {
   loadingMessage?: string;
 };
 
+/**
+ * Widget for selecting values retrieved from a 3rd party API
+ */
 const RemoteSelectWidget: CustomFieldWidget<OwnProps> = ({
   config,
   optionsFactory,

--- a/src/components/form/widgets/SelectWidget.tsx
+++ b/src/components/form/widgets/SelectWidget.tsx
@@ -20,17 +20,22 @@ import { CustomFieldWidget } from "@/components/form/FieldTemplate";
 import Select from "react-select";
 import { getErrorMessage } from "@/errors";
 
-export type Option = {
+export type Option<TValue = unknown> = {
   label: string;
-  value: unknown;
+  value: TValue;
 };
 
-type OwnProps = {
+export type SelectWidgetOnChange<TOption extends Option = Option> = (event: {
+  target: { value: TOption["value"]; name: string; options: TOption[] };
+}) => void;
+
+type OwnProps<TOption extends Option = Option> = {
   isClearable?: boolean;
-  options: Option[];
+  options: TOption[];
   isLoading?: boolean;
   loadingMessage?: string;
   error?: unknown;
+  onChange?: SelectWidgetOnChange<TOption>;
 };
 
 const SelectWidget: CustomFieldWidget<OwnProps> = ({

--- a/src/components/form/widgets/SelectWidget.tsx
+++ b/src/components/form/widgets/SelectWidget.tsx
@@ -25,6 +25,8 @@ export type Option<TValue = unknown> = {
   value: TValue;
 };
 
+// The signature of onChange is dictated by the compatibility with Formik. for a Widget to be compatible with Formik
+// it should trigger onChange with an event, that has target and value
 export type SelectWidgetOnChange<TOption extends Option = Option> = (event: {
   target: { value: TOption["value"]; name: string; options: TOption[] };
 }) => void;

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -16,8 +16,8 @@
  */
 
 import React from "react";
+import { partial } from "lodash";
 import { BlockOptionProps } from "@/components/fields/schemaFields/genericOptionsFactory";
-import { compact } from "lodash";
 import { AUTOMATION_ANYWHERE_PROPERTIES } from "@/contrib/automationanywhere/run";
 import { SanitizedServiceConfiguration, Schema } from "@/core";
 import { useField } from "formik";
@@ -39,6 +39,7 @@ import { Option } from "@/components/form/widgets/SelectWidget";
 import ChildObjectField from "@/components/fields/schemaFields/ChildObjectField";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import RemoteSelectWidget from "@/components/form/widgets/RemoteSelectWidget";
+import { joinName } from "@/utils";
 
 const AUTOMATION_ANYWHERE_SERVICE_ID = validateRegistryId(
   "automation-anywhere/control-room"
@@ -78,12 +79,13 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
   name,
   configKey,
 }) => {
-  const basePath = compact([name, configKey]).join(".");
+  const configName = partial(joinName, name, configKey);
+
   const { hasPermissions, requestPermissions, config } = useDependency(
     AUTOMATION_ANYWHERE_SERVICE_ID
   );
 
-  const [{ value: fileId }] = useField<string>(`${basePath}.fileId`);
+  const [{ value: fileId }] = useField<string>(configName("fileId"));
 
   const [inputSchema, schemaPending, schemaError] = useAsyncState(async () => {
     if (hasPermissions && fileId) {
@@ -98,7 +100,7 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
   const serviceField = (
     <ServiceField
       label="Integration"
-      name={[basePath, "service"].join(".")}
+      name={configName("service")}
       schema={AUTOMATION_ANYWHERE_PROPERTIES.service as Schema}
     />
   );
@@ -128,8 +130,8 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
 
       <ConnectedFieldTemplate
         label="Bot"
-        name={`${basePath}.fileId`}
-        description="The file id of the bot"
+        name={configName("fileId")}
+        description="The Automation Anywhere bot"
         as={RemoteSelectWidget}
         optionsFactory={fetchBots}
         config={config}
@@ -137,7 +139,7 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
 
       <ConnectedFieldTemplate
         label="Device"
-        name={`${basePath}.deviceId`}
+        name={configName("deviceId")}
         description="The device to run the bot on"
         as={RemoteSelectWidget}
         optionsFactory={fetchDevices}
@@ -147,7 +149,7 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
       {fileId != null && (
         <ChildObjectField
           heading="Input Arguments"
-          name={compact([basePath, "data"]).join(".")}
+          name={configName("data")}
           schema={inputSchema}
           schemaError={schemaError}
           schemaLoading={schemaPending}

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -147,8 +147,8 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
       {fileId != null && (
         <ChildObjectField
           heading="Input Arguments"
-          schema={inputSchema}
           name={compact([basePath, "data"]).join(".")}
+          schema={inputSchema}
           schemaError={schemaError}
           schemaLoading={schemaPending}
         />

--- a/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
@@ -26,14 +26,9 @@ import {
   faPlus,
   faPlusCircle,
 } from "@fortawesome/free-solid-svg-icons";
-import { IBlock } from "@/core";
+import { IBlock, RegistryId } from "@/core";
 import BlockModal from "@/components/brickModal/BrickModal";
-import { useFormikContext } from "formik";
-import { FormState } from "@/devTools/editor/slices/editorSlice";
-import { getRecommendations } from "@/devTools/editor/tabs/editTab/recommendations";
-import { useAsyncState } from "@/hooks/common";
-import { collectRegistryIds } from "@/devTools/editor/tabs/editTab/editHelpers";
-import { useDebounce } from "use-debounce";
+import useBrickRecommendations from "@/devTools/editor/tabs/editTab/useBrickRecommendations";
 
 const renderAppend = ({ show }: { show: () => void }) => (
   <>
@@ -65,19 +60,7 @@ const EditorNodeLayout: React.FC<{
   addBlock,
   showAppend,
 }) => {
-  const { values } = useFormikContext<FormState>();
-
-  const { type } = values;
-
-  const debouncedValues = useDebounce(values, 750, {
-    leading: true,
-    trailing: true,
-  });
-
-  const [recommendations] = useAsyncState(
-    async () => getRecommendations(type, collectRegistryIds(values)),
-    [type, debouncedValues]
-  );
+  const recommendations: RegistryId[] = useBrickRecommendations();
 
   const renderInsert = useCallback(
     ({ show }) => (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,10 +32,28 @@ import {
   zip,
   pickBy,
   isPlainObject,
+  compact,
 } from "lodash";
 import { Primitive } from "type-fest";
 import { getErrorMessage } from "@/errors";
 import { SafeString } from "@/core";
+
+/**
+ * Create a Formik field name, validating the individual path parts.
+ * @param baseFieldName The base field name
+ * @param rest the other Formik field name path parts
+ * @throws Error if a path part is invalid
+ */
+export function joinName(
+  baseFieldName: string | null,
+  ...rest: string[]
+): string {
+  if (rest.some((x) => x.includes("."))) {
+    throw new Error("Formik path parts cannot contain periods");
+  }
+
+  return compact([baseFieldName, ...rest]).join(".");
+}
 
 export function mostCommonElement<T>(items: T[]): T {
   // https://stackoverflow.com/questions/49731282/the-most-frequent-item-of-an-array-using-lodash


### PR DESCRIPTION
Closes #1427: fixes inconsistent use of onChange in ServiceField

Fixes infinite re-render in  generating brick recommendations

TODO:
- RemoteSelectWidget is flaky. Sometimes it doesn't get values back, but is not showing an error message.  (Seen when testing the AA configuration options)