### PR TITLE
#1433: don't pass empty values from Formik state to PixieBrix

### DIFF
--- a/src/devTools/editor/extensionPoints/actionPanel.tsx
+++ b/src/devTools/editor/extensionPoints/actionPanel.tsx
@@ -25,6 +25,7 @@ import {
   makeExtensionReaders,
   makeIsAvailable,
   makeReaderFormState,
+  removeEmptyValues,
   selectIsAvailable,
   withInstanceIds,
   WizardStep,
@@ -110,21 +111,21 @@ function selectExtensionPoint(
   const {
     definition: { isAvailable },
   } = extensionPoint;
-  return {
+  return removeEmptyValues({
     ...baseSelectExtensionPoint(formState),
     definition: {
       type: "actionPanel",
       reader: readers.map((x) => x.metadata.id),
       isAvailable: pickBy(isAvailable, identity),
     },
-  };
+  });
 }
 
 function selectExtension(
   { uuid, label, extensionPoint, extension, services }: ActionPanelFormState,
   options: { includeInstanceIds?: boolean } = {}
 ): IExtension<ActionPanelConfig> {
-  return {
+  return removeEmptyValues({
     id: uuid,
     extensionPointId: extensionPoint.metadata.id,
     _recipe: null,
@@ -133,7 +134,7 @@ function selectExtension(
     config: options.includeInstanceIds
       ? extension
       : excludeInstanceIds(extension, "body"),
-  };
+  });
 }
 
 function asDynamicElement(element: ActionPanelFormState): DynamicDefinition {

--- a/src/devTools/editor/extensionPoints/base.test.ts
+++ b/src/devTools/editor/extensionPoints/base.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { removeEmptyValues } from "./base";
+
+test("can remove empty values", () => {
+  expect(
+    removeEmptyValues({ foo: "", bar: undefined, baz: null })
+  ).toStrictEqual({ baz: null });
+});
+
+test("can remove empty nested values", () => {
+  expect(
+    removeEmptyValues({
+      extension: {
+        action: [{ id: "@pixiebrix/jq", config: { data: "", filter: "." } }],
+      },
+    })
+  ).toStrictEqual({
+    extension: {
+      action: [{ id: "@pixiebrix/jq", config: { filter: "." } }],
+    },
+  });
+});

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -46,7 +46,7 @@ import {
 import { Except } from "type-fest";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { BlockPipeline } from "@/blocks/types";
-import { freshIdentifier, removeUndefined } from "@/utils";
+import { deepPickBy, freshIdentifier } from "@/utils";
 
 export interface WizardStep {
   step: string;
@@ -346,8 +346,8 @@ export function removeEmptyValues<T extends object>(obj: T): T {
   // Technically the return type is Partial<T> (with recursive partials). However, we'll trust that the PageEditor
   // requires the user to set values that actually need to be set. (They'll also get caught by input validation in
   // when the bricks are run.
-  return removeUndefined(
+  return deepPickBy(
     obj,
-    (x: unknown) => typeof x === "undefined" || x === ""
+    (x: unknown) => typeof x !== "undefined" && x !== ""
   ) as T;
 }

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -46,7 +46,7 @@ import {
 import { Except } from "type-fest";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { BlockPipeline } from "@/blocks/types";
-import { freshIdentifier } from "@/utils";
+import { freshIdentifier, removeUndefined } from "@/utils";
 
 export interface WizardStep {
   step: string;
@@ -333,4 +333,21 @@ export function extensionWithInnerDefinitions(
   }
 
   return extension;
+}
+
+/**
+ * Remove object entries undefined and empty-string values.
+ *
+ * - Formik/React need real blank values in order to control `input` tag components.
+ * - PixieBrix does not want those because it treats an empty string as "", not null/undefined
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types -- support interfaces that don't have index types
+export function removeEmptyValues<T extends object>(obj: T): T {
+  // Technically the return type is Partial<T> (with recursive partials). However, we'll trust that the PageEditor
+  // requires the user to set values that actually need to be set. (They'll also get caught by input validation in
+  // when the bricks are run.
+  return removeUndefined(
+    obj,
+    (x: unknown) => typeof x === "undefined" || x === ""
+  ) as T;
 }

--- a/src/devTools/editor/extensionPoints/contextMenu.tsx
+++ b/src/devTools/editor/extensionPoints/contextMenu.tsx
@@ -25,6 +25,7 @@ import {
   makeExtensionReaders,
   makeIsAvailable,
   makeReaderFormState,
+  removeEmptyValues,
   selectIsAvailable,
   withInstanceIds,
   WizardStep,
@@ -123,7 +124,7 @@ function selectExtensionPoint(
   const {
     definition: { isAvailable, documentUrlPatterns, contexts = ["all"] },
   } = extensionPoint;
-  return {
+  return removeEmptyValues({
     ...baseSelectExtensionPoint(formState),
     definition: {
       type: "contextMenu",
@@ -132,14 +133,14 @@ function selectExtensionPoint(
       reader: readers.map((x) => x.metadata.id),
       isAvailable: pickBy(isAvailable, identity),
     },
-  };
+  });
 }
 
 function selectExtension(
   { uuid, label, extensionPoint, extension, services }: ContextMenuFormState,
   options: { includeInstanceIds?: boolean } = {}
 ): IExtension<ContextMenuConfig> {
-  return {
+  return removeEmptyValues({
     id: uuid,
     extensionPointId: extensionPoint.metadata.id,
     _recipe: null,
@@ -148,7 +149,7 @@ function selectExtension(
     config: options.includeInstanceIds
       ? extension
       : excludeInstanceIds(extension, "action"),
-  };
+  });
 }
 
 async function fromExtension(

--- a/src/devTools/editor/extensionPoints/menuItem.ts
+++ b/src/devTools/editor/extensionPoints/menuItem.ts
@@ -29,6 +29,7 @@ import {
   makeExtensionReaders,
   makeIsAvailable,
   makeReaderFormState,
+  removeEmptyValues,
   selectIsAvailable,
   withInstanceIds,
   WizardStep,
@@ -132,7 +133,7 @@ function selectExtensionPoint(
   const {
     definition: { isAvailable, position, template, containerSelector },
   } = extensionPoint;
-  return {
+  return removeEmptyValues({
     ...baseSelectExtensionPoint(formState),
     definition: {
       type: "menuItem",
@@ -142,14 +143,14 @@ function selectExtensionPoint(
       position,
       template,
     },
-  };
+  });
 }
 
 function selectExtension(
   { uuid, label, extensionPoint, extension, services }: ActionFormState,
   options: { includeInstanceIds?: boolean } = {}
 ): IExtension<MenuItemExtensionConfig> {
-  return {
+  return removeEmptyValues({
     id: uuid,
     extensionPointId: extensionPoint.metadata.id,
     _recipe: null,
@@ -158,7 +159,7 @@ function selectExtension(
     config: options.includeInstanceIds
       ? extension
       : excludeInstanceIds(extension, "action"),
-  };
+  });
 }
 
 async function fromExtensionPoint(

--- a/src/devTools/editor/extensionPoints/panel.ts
+++ b/src/devTools/editor/extensionPoints/panel.ts
@@ -25,6 +25,7 @@ import {
   makeExtensionReaders,
   makeIsAvailable,
   makeReaderFormState,
+  removeEmptyValues,
   selectIsAvailable,
   withInstanceIds,
   WizardStep,
@@ -137,7 +138,7 @@ function selectExtensionPoint(
     definition: { isAvailable, position, template, containerSelector },
   } = extensionPoint;
 
-  return {
+  return removeEmptyValues({
     ...baseSelectExtensionPoint(formState),
     definition: {
       type: "panel",
@@ -147,14 +148,14 @@ function selectExtensionPoint(
       position,
       template,
     },
-  };
+  });
 }
 
 function selectExtension(
   { uuid, label, extensionPoint, extension, services }: PanelFormState,
   options: { includeInstanceIds?: boolean } = {}
 ): IExtension<PanelConfig> {
-  return {
+  return removeEmptyValues({
     id: uuid,
     extensionPointId: extensionPoint.metadata.id,
     _recipe: null,
@@ -163,7 +164,7 @@ function selectExtension(
     config: options.includeInstanceIds
       ? extension
       : excludeInstanceIds(extension, "body"),
-  };
+  });
 }
 
 function asDynamicElement(element: PanelFormState): DynamicDefinition {

--- a/src/devTools/editor/extensionPoints/trigger.tsx
+++ b/src/devTools/editor/extensionPoints/trigger.tsx
@@ -25,6 +25,7 @@ import {
   makeExtensionReaders,
   makeIsAvailable,
   makeReaderFormState,
+  removeEmptyValues,
   selectIsAvailable,
   withInstanceIds,
   WizardStep,
@@ -110,7 +111,7 @@ function selectExtensionPoint(
   const {
     definition: { isAvailable, rootSelector, trigger },
   } = extensionPoint;
-  return {
+  return removeEmptyValues({
     ...baseSelectExtensionPoint(formState),
     definition: {
       type: "trigger",
@@ -119,14 +120,14 @@ function selectExtensionPoint(
       trigger,
       rootSelector,
     },
-  };
+  });
 }
 
 function selectExtension(
   { uuid, label, extensionPoint, extension, services }: TriggerFormState,
   options: { includeInstanceIds?: boolean } = {}
 ): IExtension<TriggerConfig> {
-  return {
+  return removeEmptyValues({
     id: uuid,
     extensionPointId: extensionPoint.metadata.id,
     _recipe: null,
@@ -135,7 +136,7 @@ function selectExtension(
     config: options.includeInstanceIds
       ? extension
       : excludeInstanceIds(extension, "action"),
-  };
+  });
 }
 
 function asDynamicElement(element: TriggerFormState): DynamicDefinition {

--- a/src/devTools/editor/tabs/effect/BlockPreview.tsx
+++ b/src/devTools/editor/tabs/effect/BlockPreview.tsx
@@ -32,6 +32,7 @@ import JsonTree from "@/components/jsonTree/JsonTree";
 import { isEmpty } from "lodash";
 import { TraceRecord } from "@/telemetry/trace";
 import { getType } from "@/blocks/util";
+import { removeEmptyValues } from "@/devTools/editor/extensionPoints/base";
 
 const BlockPreview: React.FunctionComponent<{
   traceRecord: TraceRecord;
@@ -56,7 +57,10 @@ const BlockPreview: React.FunctionComponent<{
     async (blockConfig: BlockConfig, args: Record<string, unknown>) => {
       setIsRunning(true);
       try {
-        const result = await runBlock(port, { blockConfig, args });
+        const result = await runBlock(port, {
+          blockConfig: removeEmptyValues(blockConfig),
+          args,
+        });
         setOutput(result);
       } catch (error: unknown) {
         setOutput(error);

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { freshIdentifier, getPropByPath } from "@/utils";
+import { freshIdentifier, getPropByPath, removeUndefined } from "@/utils";
 import type { SafeString } from "@/core";
 
 test("can get array element by index", () => {
@@ -45,4 +45,17 @@ test("can generate fresh identifier", () => {
   ).toBe("field0");
   expect(freshIdentifier(root, ["field"])).toBe("field2");
   expect(freshIdentifier(root, ["foo", "bar"])).toBe("field");
+});
+
+describe("removeUndefined", () => {
+  test("remove top-level undefined", () => {
+    expect(removeUndefined({ foo: undefined, bar: null })).toStrictEqual({
+      bar: null,
+    });
+  });
+  test("remove nested undefined", () => {
+    expect(removeUndefined({ foo: { bar: undefined } })).toStrictEqual({
+      foo: {},
+    });
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,7 +163,17 @@ export function isPrimitive(val: unknown): val is Primitive {
   return typeof val !== "function";
 }
 
-export function removeUndefined(obj: unknown): unknown {
+const isUndefined = (value: unknown) => typeof value === "undefined";
+
+/**
+ * Recursively exclude properties that have undefined values
+ * @param obj an object
+ * @param predicate predicate returning true if value is undefined
+ */
+export function removeUndefined(
+  obj: unknown,
+  predicate: (value: unknown) => boolean = isUndefined
+): unknown {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null
   // `typeof null === "object"`, so have to check for it before the "object" check below
   if (obj == null) {
@@ -171,13 +181,13 @@ export function removeUndefined(obj: unknown): unknown {
   }
 
   if (Array.isArray(obj)) {
-    return obj.map((x) => removeUndefined(x));
+    return obj.map((item) => removeUndefined(item, predicate));
   }
 
   if (typeof obj === "object") {
     return mapValues(
-      pickBy(obj, (x) => x !== undefined),
-      (x) => removeUndefined(x)
+      pickBy(obj, (value) => !predicate(value)),
+      (value) => removeUndefined(value, predicate)
     );
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,16 +163,15 @@ export function isPrimitive(val: unknown): val is Primitive {
   return typeof val !== "function";
 }
 
-const isUndefined = (value: unknown) => typeof value === "undefined";
-
 /**
- * Recursively exclude properties that have undefined values
+ * Recursively pick entries that match property
  * @param obj an object
- * @param predicate predicate returning true if value is undefined
+ * @param predicate predicate returns true to include an entry
+ * @see pickBy
  */
-export function removeUndefined(
+export function deepPickBy(
   obj: unknown,
-  predicate: (value: unknown) => boolean = isUndefined
+  predicate: (value: unknown) => boolean
 ): unknown {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null
   // `typeof null === "object"`, so have to check for it before the "object" check below
@@ -181,17 +180,21 @@ export function removeUndefined(
   }
 
   if (Array.isArray(obj)) {
-    return obj.map((item) => removeUndefined(item, predicate));
+    return obj.map((item) => deepPickBy(item, predicate));
   }
 
   if (typeof obj === "object") {
     return mapValues(
-      pickBy(obj, (value) => !predicate(value)),
-      (value) => removeUndefined(value, predicate)
+      pickBy(obj, (value) => predicate(value)),
+      (value) => deepPickBy(value, predicate)
     );
   }
 
   return obj;
+}
+
+export function removeUndefined(obj: unknown): unknown {
+  return deepPickBy(obj, (value: unknown) => typeof value !== "undefined");
 }
 
 export function boolean(value: unknown): boolean {


### PR DESCRIPTION
Closes #1433

- Removes object entries that are `undefined` or `""` before passing them to PixieBrix