### PR TITLE
#1341: instantiate block configs with defaults

### DIFF
--- a/src/blocks/types.ts
+++ b/src/blocks/types.ts
@@ -16,6 +16,7 @@
  */
 
 import { OutputKey, RegistryId, TemplateEngine, UUID } from "@/core";
+import { UnknownObject } from "@/types";
 
 export interface Availability {
   matchPatterns?: string | string[];
@@ -65,7 +66,7 @@ export interface BlockConfig {
    */
   templateEngine?: TemplateEngine;
 
-  config: Record<string, unknown>;
+  config: UnknownObject;
 
   /**
    * A unique id for the configured block, used to correlate traces across runs when using the Page Editor.

--- a/src/components/fields/schemaFields/propTypes.ts
+++ b/src/components/fields/schemaFields/propTypes.ts
@@ -45,7 +45,7 @@ export interface SchemaFieldProps<TValue> {
    * A label for the field. If not provided, the label is automatically generated from the field name/schema.
    * @see fieldLabel
    */
-  label?: string;
+  label?: React.ReactNode;
 
   /**
    * Description to override the description from the schema

--- a/src/devTools/editor/tabs/editTab/EditTab.tsx
+++ b/src/devTools/editor/tabs/editTab/EditTab.tsx
@@ -22,7 +22,7 @@ import { useField, useFormikContext } from "formik";
 import { BlockPipeline } from "@/blocks/types";
 import { EditorNodeProps } from "@/devTools/editor/tabs/editTab/editorNode/EditorNode";
 import { ADAPTERS } from "@/devTools/editor/extensionPoints/adapter";
-import { BlockType, getType } from "@/blocks/util";
+import { BlockType, defaultBlockConfig, getType } from "@/blocks/util";
 import { useAsyncState } from "@/hooks/common";
 import blockRegistry from "@/blocks/registry";
 import { compact, noop, zip } from "lodash";
@@ -42,6 +42,7 @@ import { isNullOrBlank } from "@/utils";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import DataPanel from "@/devTools/editor/tabs/editTab/dataPanel/DataPanel";
 import { isInnerExtensionPoint } from "@/devTools/editor/extensionPoints/base";
+import { getExampleBlockConfig } from "@/devTools/editor/tabs/editTab/exampleBlockConfigs";
 
 async function filterBlocks(
   blocks: IBlock[],
@@ -181,7 +182,8 @@ const EditTab: React.FC<{
           ])
         ),
         instanceId: uuidv4(),
-        config: {},
+        config:
+          getExampleBlockConfig(block) ?? defaultBlockConfig(block.inputSchema),
       };
       pipelineFieldHelpers.setValue([...prev, newBlock, ...next]);
       onSelectNode(nodeIndex);

--- a/src/devTools/editor/tabs/editTab/exampleBlockConfigs.ts
+++ b/src/devTools/editor/tabs/editTab/exampleBlockConfigs.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { UnknownObject } from "@/types";
+import { IBlock } from "@/core";
+
+export function getExampleBlockConfig(block: IBlock): UnknownObject | null {
+  if (block.id === "@pixiebrix/form-modal") {
+    return {
+      schema: {
+        title: "Example Form",
+        type: "object",
+        properties: {
+          example: {
+            title: "Example Field",
+            type: "string",
+            description: "An example form field",
+          },
+        },
+      },
+      uiSchema: {},
+      cancelable: true,
+      submitCaption: "Submit",
+    };
+  }
+
+  if (block.id === "@pixiebrix/form") {
+    return {
+      schema: {
+        title: "Example Form",
+        type: "object",
+        properties: {
+          notes: {
+            title: "Example Notes Field",
+            type: "string",
+            description: "An example notes field",
+          },
+        },
+      },
+      uiSchema: {
+        notes: {
+          "ui:widget": "textarea",
+        },
+      },
+    };
+  }
+}

--- a/src/devTools/editor/tabs/editTab/useBrickRecommendations.ts
+++ b/src/devTools/editor/tabs/editTab/useBrickRecommendations.ts
@@ -33,6 +33,7 @@ const typeRecommendations = new Map<ElementType, RegistryId[]>([
   [
     "menuItem",
     [
+      "@pixiebrix/form-modal",
       "@pixiebrix/browser/open-tab",
       "@pixiebrix/zapier/push-data",
       "@pixiebrix/forms/set",
@@ -49,6 +50,7 @@ const typeRecommendations = new Map<ElementType, RegistryId[]>([
   [
     "contextMenu",
     [
+      "@pixiebrix/form-modal",
       "@pixiebrix/browser/open-tab",
       "@pixiebrix/zapier/push-data",
       "slack/simple-message",

--- a/src/devTools/editor/tabs/effect/BlockConfiguration.tsx
+++ b/src/devTools/editor/tabs/effect/BlockConfiguration.tsx
@@ -96,7 +96,6 @@ const BlockConfiguration: React.FunctionComponent<{
         <Card.Body ref={templateEngineRef}>
           <ConnectedFieldTemplate
             name={templateEngineFieldName}
-            layout="vertical"
             label="Template engine"
             as="select"
             description={


### PR DESCRIPTION
Closes #1341

- [x] Defines example data for the bricks using forms
- [x] Modifies form builder to activate the first field by default
- [x] Instantiate new bricks with defaults
- [x] Instantiate new bricks with defaults when using ArrayField
