### PR TITLE
#1408: Vertical align labels to top row of inputs

### DIFF
--- a/src/components/form/FieldTemplate.module.scss
+++ b/src/components/form/FieldTemplate.module.scss
@@ -29,6 +29,10 @@
   align-items: center;
 }
 
+.horizontalLabel {
+  align-self: stretch;
+}
+
 .invalidMessage {
   width: 100%;
   margin-top: 0.25rem;

--- a/src/components/form/FieldTemplate.tsx
+++ b/src/components/form/FieldTemplate.tsx
@@ -95,7 +95,7 @@ const RenderedField: React.FC<FieldProps> = ({
       className={styles.horizontalFormGroup}
     >
       {label && (
-        <BootstrapForm.Label column lg="3">
+        <BootstrapForm.Label column lg="3" className={styles.horizontalLabel}>
           {label}
         </BootstrapForm.Label>
       )}


### PR DESCRIPTION
Stretches the label to full height and keeps the text aligned to the top.

![image](https://user-images.githubusercontent.com/2801308/134597068-ac71f415-4168-4b4e-832f-c1f83a74d9b1.png)
