### PR TITLE
#1408: Show remove text on button below the column breakpoint

### DIFF
--- a/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
+++ b/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
@@ -33,5 +33,9 @@
 .removeText {
   @media (max-width: 1460px) {
     display: none;
+
+    @media (max-width: 1200px) {
+      display: inline;
+    }
   }
 }


### PR DESCRIPTION
Restore the full button text when below the bootstrap xl breakpoint for the columns (1200px)

![image](https://user-images.githubusercontent.com/2801308/134599807-b07d3424-a3d3-4d05-8c50-d7cd81334de4.png)
