### PR TITLE
Change active tab to preview for form builder nodes

### DIFF
--- a/src/devTools/editor/tabs/editTab/EditTab.tsx
+++ b/src/devTools/editor/tabs/editTab/EditTab.tsx
@@ -237,8 +237,8 @@ const EditTab: React.FC<{
         </div>
         <div className={styles.dataPanel}>
           <DataPanel
+            key={activeNodeIndex}
             blockFieldName={blockFieldName}
-            // eslint-disable-next-line security/detect-object-injection
             instanceId={blockPipeline[activeNodeIndex - 1]?.instanceId}
           />
         </div>

--- a/src/devTools/editor/tabs/editTab/EditTab.tsx
+++ b/src/devTools/editor/tabs/editTab/EditTab.tsx
@@ -191,6 +191,8 @@ const EditTab: React.FC<{
     [onSelectNode, pipelineFieldHelpers, blockPipeline]
   );
 
+  const blockInstanceId = blockPipeline[activeNodeIndex - 1]?.instanceId;
+
   return (
     <Tab.Pane eventKey={eventKey} className={styles.tabPane}>
       <div className={styles.paneContent}>
@@ -237,9 +239,9 @@ const EditTab: React.FC<{
         </div>
         <div className={styles.dataPanel}>
           <DataPanel
-            key={activeNodeIndex}
+            key={blockInstanceId}
             blockFieldName={blockFieldName}
-            instanceId={blockPipeline[activeNodeIndex - 1]?.instanceId}
+            instanceId={blockInstanceId}
           />
         </div>
       </div>

--- a/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useContext, useMemo, useState } from "react";
+import React, { useContext, useMemo } from "react";
 import { UUID } from "@/core";
 import useInterval from "@/hooks/useInterval";
 import { isEmpty, pickBy, sortBy } from "lodash";
@@ -143,16 +143,9 @@ const DataPanel: React.FC<{
   const showBlockPreview = record && blockConfig;
 
   const defaultKey = showFormPreview ? "preview" : "output";
-  const [activeTabKey, setActiveTabKey] = useState<string>(defaultKey);
-  const handleSelect = useCallback(
-    (eventKey: string) => {
-      setActiveTabKey(eventKey);
-    },
-    [setActiveTabKey]
-  );
 
   return (
-    <Tab.Container activeKey={activeTabKey} onSelect={handleSelect}>
+    <Tab.Container defaultActiveKey={defaultKey}>
       <Nav variant="tabs">
         <Nav.Item className={styles.tabNav}>
           <Nav.Link eventKey="context">Context</Nav.Link>


### PR DESCRIPTION
This re-sets the default active tab when the active node changes, so that form nodes will show the preview data tab.