### PR TITLE
Add css class for fa icons in BrickIcon component

### DIFF
--- a/src/components/BrickIcon.tsx
+++ b/src/components/BrickIcon.tsx
@@ -96,6 +96,7 @@ const SIZE_REGEX = /^(?<size>\d)x$/i;
 const BrickIcon: React.FunctionComponent<{
   brick: IBrick;
   size?: "1x" | "2x";
+  // This prop sets a className only in cases where a <FontAwesomeIcon/> is used
   faIconClass?: string;
 }> = ({ brick, size = "1x", faIconClass = "" }) => {
   const [type] = useAsyncState(async () => getType(brick), [brick]);

--- a/src/components/BrickIcon.tsx
+++ b/src/components/BrickIcon.tsx
@@ -96,7 +96,8 @@ const SIZE_REGEX = /^(?<size>\d)x$/i;
 const BrickIcon: React.FunctionComponent<{
   brick: IBrick;
   size?: "1x" | "2x";
-}> = ({ brick, size = "1x" }) => {
+  faIconClass?: string;
+}> = ({ brick, size = "1x", faIconClass = "" }) => {
   const [type] = useAsyncState(async () => getType(brick), [brick]);
   const { data: listings = {} } = useGetMarketplaceListingsQuery();
 
@@ -123,7 +124,7 @@ const BrickIcon: React.FunctionComponent<{
         <FontAwesomeIcon
           icon={fa_icon}
           color={listing?.icon_color}
-          className={cx({ "text-muted": !listing?.icon_color })}
+          className={cx(faIconClass, { "text-muted": !listing?.icon_color })}
           size={size}
           fixedWidth
         />

--- a/src/devTools/editor/tabs/editTab/EditTab.module.scss
+++ b/src/devTools/editor/tabs/editTab/EditTab.module.scss
@@ -49,3 +49,7 @@
   padding: 10px;
   overflow: auto;
 }
+
+.brickFaIcon {
+  color: inherit;
+}

--- a/src/devTools/editor/tabs/editTab/EditTab.tsx
+++ b/src/devTools/editor/tabs/editTab/EditTab.tsx
@@ -132,7 +132,13 @@ const EditTab: React.FC<{
         ? {
             title: isNullOrBlank(action.label) ? block?.name : action.label,
             outputKey: action.outputKey,
-            icon: <BrickIcon brick={block} size="2x" />,
+            icon: (
+              <BrickIcon
+                brick={block}
+                size="2x"
+                faIconClass={styles.brickFaIcon}
+              />
+            ),
             onClick: () => {
               onSelectNode(index + 1);
             },

--- a/src/devTools/editor/tabs/editTab/EditTab.tsx
+++ b/src/devTools/editor/tabs/editTab/EditTab.tsx
@@ -136,6 +136,10 @@ const EditTab: React.FC<{
               <BrickIcon
                 brick={block}
                 size="2x"
+                // This makes brick icons that use basic font awesome icons
+                //   inherit the editor node layout color scheme.
+                // Customized SVG icons are unaffected and keep their branded
+                //   color schemes.
                 faIconClass={styles.brickFaIcon}
               />
             ),


### PR DESCRIPTION
This makes brick icons that use basic font awesome icons inherit the node color scheme in the editor node layout. Customized SVG icons are unaffected and keep their branded color schemes.

![image](https://user-images.githubusercontent.com/2801308/134719219-53176500-4c3b-4f27-b772-2d6abfd90470.png)
