### PR TITLE
Feature/1366 improve brick modal

### DIFF
--- a/src/components/brickModal/BrickDetail.tsx
+++ b/src/components/brickModal/BrickDetail.tsx
@@ -50,19 +50,19 @@ const BrickDetail: React.FunctionComponent<{
     <Col xs={12}>
       {"inputSchema" in brick && (
         <>
-          <h5 className="my-3">Input Schema</h5>
+          <h6 className="my-3">Input Schema</h6>
           <SchemaTree schema={brick.inputSchema} />
         </>
       )}
       {"outputSchema" in brick && (
         <>
-          <h5 className="my-3">Output Schema</h5>
+          <h6 className="my-3">Output Schema</h6>
           <SchemaTree schema={brick.outputSchema} />
         </>
       )}
       {"schema" in brick && (
         <>
-          <h5 className="my-3">Schema</h5>
+          <h6 className="my-3">Schema</h6>
           <SchemaTree schema={brick.schema} />
         </>
       )}

--- a/src/components/brickModal/BrickDetail.tsx
+++ b/src/components/brickModal/BrickDetail.tsx
@@ -15,7 +15,7 @@ const BrickDetail: React.FunctionComponent<{
   selectCaption?: React.ReactNode;
 }> = ({ brick, selectCaption = "Select", listing, onSelect }) => (
   <Row>
-    <Col xs={12} className="d-flex justify-content-between">
+    <Col xs={12} className="d-flex justify-content-between mb-3">
       <div>
         <h4>
           {brick.name} <BrickIcon brick={brick} />

--- a/src/components/brickModal/BrickDetail.tsx
+++ b/src/components/brickModal/BrickDetail.tsx
@@ -4,7 +4,7 @@ import { MarketplaceListing } from "@/types/contract";
 import { Button, Col, Row } from "react-bootstrap";
 import BrickIcon from "@/components/BrickIcon";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+import { faExternalLinkAlt, faPlus } from "@fortawesome/free-solid-svg-icons";
 import SchemaTree from "@/components/schemaTree/SchemaTree";
 import "./BrickModal.scss";
 
@@ -35,8 +35,14 @@ const BrickDetail: React.FunctionComponent<{
         )}
       </div>
       <div>
-        <Button variant="primary mr-1 text-nowrap" onClick={onSelect}>
-          {selectCaption}
+        <Button variant="primary mr-1 text-nowrap" size="lg" onClick={onSelect}>
+          {selectCaption ? (
+            selectCaption
+          ) : (
+            <>
+              <FontAwesomeIcon icon={faPlus} className="mr-1" /> Add
+            </>
+          )}
         </Button>
       </div>
     </Col>

--- a/src/components/brickModal/BrickModal.scss
+++ b/src/components/brickModal/BrickModal.scss
@@ -60,10 +60,6 @@
         padding-left: 0;
         padding-right: 0;
       }
-
-      &:hover {
-        background-color: #ececff;
-      }
     }
   }
 }

--- a/src/components/brickModal/BrickModal.scss
+++ b/src/components/brickModal/BrickModal.scss
@@ -62,8 +62,7 @@
       }
 
       &:hover {
-        color: #fff;
-        background-color: #b66dff;
+        background-color: #ececff;
       }
     }
   }

--- a/src/components/brickModal/BrickModal.scss
+++ b/src/components/brickModal/BrickModal.scss
@@ -61,6 +61,10 @@
         padding-right: 0;
       }
     }
+
+    .table {
+      font-size: 0.8rem;
+    }
   }
 }
 

--- a/src/components/brickModal/BrickModal.tsx
+++ b/src/components/brickModal/BrickModal.tsx
@@ -109,6 +109,7 @@ type ItemType = {
   selectCaption?: React.ReactNode;
   onSelect: (brick: IBrick) => void;
   close: () => void;
+  activeBrick: IBrick | null;
 };
 
 // The item renderer must be it's own separate component to react-window from re-mounting the results
@@ -116,7 +117,14 @@ type ItemType = {
 const ItemRenderer = ({
   index,
   style,
-  data: { searchResults, setDetailBrick, selectCaption, onSelect, close },
+  data: {
+    searchResults,
+    setDetailBrick,
+    selectCaption,
+    onSelect,
+    close,
+    activeBrick,
+  },
 }: {
   index: number;
   style: CSSProperties;
@@ -136,6 +144,7 @@ const ItemRenderer = ({
           close();
         }}
         selectCaption={selectCaption}
+        active={activeBrick?.id === brick.id}
       />
     </div>
   );
@@ -246,6 +255,7 @@ function ActualModal<T extends IBrick>({
                             {
                               searchResults,
                               setDetailBrick,
+                              activeBrick: detailBrick,
                               selectCaption,
                               onSelect,
                               close,

--- a/src/components/brickModal/BrickResult.tsx
+++ b/src/components/brickModal/BrickResult.tsx
@@ -17,18 +17,21 @@
 
 import React from "react";
 import { IBrick } from "@/core";
-import { ListGroup } from "react-bootstrap";
+import { Button, ListGroup } from "react-bootstrap";
 import cx from "classnames";
 import styles from "@/options/pages/brickEditor/referenceTab/BlockResult.module.scss";
 import BrickIcon from "@/components/BrickIcon";
-import { truncate } from "lodash";
 import { OfficialBadge } from "@/components/OfficialBadge";
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const BrickResult: React.FunctionComponent<{
   brick: IBrick;
   onSelect: () => void;
-}> = ({ brick, onSelect }) => (
-  <ListGroup.Item onClick={onSelect} className={cx(styles.root)}>
+  onDetail: () => void;
+  selectCaption?: React.ReactNode;
+}> = ({ brick, onSelect, onDetail, selectCaption }) => (
+  <ListGroup.Item onClick={onDetail} className={cx(styles.root)}>
     <div className="d-flex">
       <div className="mr-2 text-muted">
         <BrickIcon brick={brick} />
@@ -37,17 +40,28 @@ const BrickResult: React.FunctionComponent<{
         <div className={styles.ellipsis}>{brick.name}</div>
         <code className={cx("small", styles.id)}>{brick.id}</code>
         <p className={cx("small mb-0", styles.ellipsis)}>
-          {/* FIXME: applying both truncate and the CSS ellipses style is redundant */}
           {/* Use a span if no description to ensure a consistent height for react-window */}
-          {brick.description ? (
-            truncate(brick.description, { length: 256 })
-          ) : (
-            <span>&nbsp;</span>
-          )}
+          {brick.description ? `${brick.description}` : <span>&nbsp;</span>}
         </p>
       </div>
-      <div className="flex-grow-0">
+      <div className={cx("flex-grow-0", styles.officialBadge)}>
         <OfficialBadge id={brick.id} />
+      </div>
+      <div
+        className={cx(
+          "align-items-center justify-content-end",
+          styles.actionButtons
+        )}
+      >
+        <Button variant="info" className="mb-1 text-nowrap" onClick={onSelect}>
+          {selectCaption ? (
+            selectCaption
+          ) : (
+            <>
+              <FontAwesomeIcon icon={faPlus} className="mr-1" /> Add
+            </>
+          )}
+        </Button>
       </div>
     </div>
   </ListGroup.Item>

--- a/src/components/brickModal/BrickResult.tsx
+++ b/src/components/brickModal/BrickResult.tsx
@@ -29,9 +29,13 @@ const BrickResult: React.FunctionComponent<{
   brick: IBrick;
   onSelect: () => void;
   onDetail: () => void;
+  active?: boolean;
   selectCaption?: React.ReactNode;
-}> = ({ brick, onSelect, onDetail, selectCaption }) => (
-  <ListGroup.Item onClick={onDetail} className={cx(styles.root)}>
+}> = ({ brick, onSelect, onDetail, selectCaption, active }) => (
+  <ListGroup.Item
+    onClick={onDetail}
+    className={cx(styles.root, { [styles.active]: active, active })}
+  >
     <div className="d-flex">
       <div className="mr-2 text-muted">
         <BrickIcon brick={brick} />

--- a/src/components/brickModal/QuickAdd.scss
+++ b/src/components/brickModal/QuickAdd.scss
@@ -26,6 +26,7 @@
     &:hover {
       cursor: pointer;
       background-color: #ececff;
+      border-color: #c7c7ff;
       transition: background-color 0.15s ease-in-out;
     }
 

--- a/src/components/brickModal/QuickAdd.scss
+++ b/src/components/brickModal/QuickAdd.scss
@@ -26,6 +26,7 @@
     &:hover {
       cursor: pointer;
       background-color: #ececff;
+      transition: background-color 0.15s ease-in-out;
     }
 
     &__image {

--- a/src/components/schemaTree/SchemaTree.tsx
+++ b/src/components/schemaTree/SchemaTree.tsx
@@ -17,7 +17,7 @@
 
 import React, { useMemo } from "react";
 import { Schema } from "@/core";
-import { ListGroup, Table } from "react-bootstrap";
+import { Table } from "react-bootstrap";
 import { isEmpty, sortBy } from "lodash";
 import { useTable, useExpanded, Row, Cell } from "react-table";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -119,7 +119,7 @@ const getFormattedType = (definition: Schema) => {
   }
 
   if (format) {
-    return `${format} ${type as string}`;
+    return `${format}`;
   }
 
   return type ? type : "unknown";
@@ -198,23 +198,15 @@ const SchemaTree: React.FunctionComponent<{ schema: Schema }> = ({
   } = useTable({ columns, data }, useExpanded);
 
   if (!schema) {
-    return (
-      <ListGroup variant="flush" className="SchemaTree">
-        <ListGroup.Item>No schema</ListGroup.Item>
-      </ListGroup>
-    );
+    return <div className="text-muted">No schema</div>;
   }
 
   if (isEmpty(schema.properties)) {
-    return (
-      <ListGroup variant="flush" className="SchemaTree">
-        <ListGroup.Item>No properties defined</ListGroup.Item>
-      </ListGroup>
-    );
+    return <div className="text-muted">No properties defined</div>;
   }
 
   return (
-    <Table {...getTableProps()}>
+    <Table {...getTableProps()} size="sm">
       <thead>
         {headerGroups.map((headerGroup) => {
           const {

--- a/src/components/schemaTree/SchemaTree.tsx
+++ b/src/components/schemaTree/SchemaTree.tsx
@@ -58,20 +58,16 @@ const ExpandableCell: React.FunctionComponent<{
         )}
       </>
     )}
-    <code>{cell.value}</code>
+    {cell.value}
   </span>
 );
-
-const CodeCell: React.FunctionComponent<{
-  cell: Cell;
-}> = ({ cell }) => <code>{cell.value}</code>;
 
 const RequiredCell: React.FunctionComponent<{
   row: Row & { values: SchemaTreeRow };
 }> = ({ row }) => (
   <span>
     {row.values.required && (
-      <FontAwesomeIcon icon={faCheck} className="text-success" />
+      <FontAwesomeIcon icon={faCheck} className="text-muted" />
     )}
   </span>
 );
@@ -147,10 +143,6 @@ const getFormattedData = (schema: Schema): SchemaTreeRow[] => {
     }) as SchemaTreeRow[];
 };
 
-const DescriptionCell: React.FunctionComponent<{
-  cell: Cell;
-}> = ({ cell }) => <p className="m-0">{cell.value}</p>;
-
 const SchemaTree: React.FunctionComponent<{ schema: Schema }> = ({
   schema,
 }) => {
@@ -178,12 +170,10 @@ const SchemaTree: React.FunctionComponent<{ schema: Schema }> = ({
       {
         Header: "Type",
         accessor: "type",
-        Cell: CodeCell,
       },
       {
         Header: "Description",
         accessor: "description",
-        Cell: DescriptionCell,
       },
     ],
     []

--- a/src/options/pages/brickEditor/referenceTab/BlockResult.module.scss
+++ b/src/options/pages/brickEditor/referenceTab/BlockResult.module.scss
@@ -27,9 +27,6 @@
 
     .actionButtons {
       display: flex;
-      button {
-        z-index: 2;
-      }
     }
     .officialBadge {
       display: none;
@@ -37,9 +34,9 @@
   }
 
   &:global(.list-group-item).active {
-    border-color: #e5d3ff;
+    border-color: #dedeff;
     color: black;
-    background-color: #f0e1ff;
+    background-color: #ececff;
   }
 }
 

--- a/src/options/pages/brickEditor/referenceTab/BlockResult.module.scss
+++ b/src/options/pages/brickEditor/referenceTab/BlockResult.module.scss
@@ -22,8 +22,18 @@
   text-align: left;
 
   &:hover {
-    color: #fff;
-    background-color: #b66dff;
+    background-color: #ececff;
+    transition: background-color 0.15s ease-in-out;
+
+    .actionButtons {
+      display: flex;
+      button {
+        z-index: 2;
+      }
+    }
+    .officialBadge {
+      display: none;
+    }
   }
 
   &:global(.list-group-item).active {
@@ -42,6 +52,14 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.actionButtons {
+  display: none;
+}
+
+.officialBadge {
+  display: block;
 }
 
 .id {

--- a/src/options/pages/brickEditor/referenceTab/BlockResult.module.scss
+++ b/src/options/pages/brickEditor/referenceTab/BlockResult.module.scss
@@ -23,7 +23,10 @@
 
   &:hover {
     background-color: #ececff;
+    border-color: #c7c7ff;
     transition: background-color 0.15s ease-in-out;
+    // Lifts brick result to expose all borders
+    z-index: 3;
 
     .actionButtons {
       display: flex;

--- a/src/options/pages/brickEditor/referenceTab/BlockResult.module.scss
+++ b/src/options/pages/brickEditor/referenceTab/BlockResult.module.scss
@@ -34,7 +34,7 @@
   }
 
   &:global(.list-group-item).active {
-    border-color: #dedeff;
+    border-color: #c7c7ff;
     color: black;
     background-color: #ececff;
   }

--- a/src/options/pages/brickEditor/referenceTab/BrickDetail.tsx
+++ b/src/options/pages/brickEditor/referenceTab/BrickDetail.tsx
@@ -100,7 +100,7 @@ const BrickDetail: React.FunctionComponent<{
           <div className="text-muted">No input schema provided</div>
         ) : (
           <div>
-            <Button className="p-0" variant="link" onClick={copyHandler}>
+            <Button className="p-0 mb-3" variant="link" onClick={copyHandler}>
               <FontAwesomeIcon icon={faClipboard} /> Copy Argument YAML
             </Button>
             <SchemaTree schema={schema} />


### PR DESCRIPTION
Closes #1366 

This adds improvements to the Brick Selector Modal UI. This includes adding an "Add" button to the Brick Result on hover, highlighting the Brick Result that is currently being viewed, auto-focusing search input upon opening the modal, and tweaking the input/output schema to appear less prominent in the Brick Detail pane.

<a href="https://www.loom.com/share/6a654ee34e994901bc53f3017b170a57">
    <p>Google Chrome - Site administration | Django site admin - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/6a654ee34e994901bc53f3017b170a57-with-play.gif">
  </a>