### PR TITLE
More consistent page editor button styles

### DIFF
--- a/src/devTools/editor/tabs/editTab/editorNode/EditorNode.module.scss
+++ b/src/devTools/editor/tabs/editTab/editorNode/EditorNode.module.scss
@@ -26,24 +26,22 @@
 .box {
   display: flex;
   flex-direction: column;
-  border: 2px solid black;
+  border: none;
   border-radius: 20%;
   width: 60px;
   height: 60px;
   align-items: center;
   justify-content: center;
+  background-color: #dedede;
 
   &:hover {
     cursor: pointer;
     color: #fff;
     background-color: #c58aff;
-    box-shadow: 4px 4px 2px gray;
-    border: 2px solid black !important;
+  }
 
-    &:active {
-      box-shadow: none;
-      background-color: #b66dff;
-    }
+  &:active {
+    background-color: #b66dff;
   }
 }
 

--- a/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.module.scss
+++ b/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.module.scss
@@ -37,12 +37,10 @@
 
   &:hover {
     color: #a462e6;
-    box-shadow: 1px 1px 1px gray;
+  }
 
-    &:active {
-      box-shadow: none;
-      color: #b66dff;
-    }
+  &:active {
+    color: #b66dff;
   }
 }
 


### PR DESCRIPTION
Shadows and thick borders don't quite fit the existing style

<table>
<tr valign=top>
	<td><img width="391" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/134889291-691ac920-a405-4674-94a3-26ceed74744a.png">
	<td><img width="396" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/134889280-dbcf6bc1-1327-4621-806c-77c9ecd36878.png">
</table>

In the future we might look at https://shadows.brumm.af to generate _sick_ shadows.