### PR TITLE
#1466: [DO NOT MERGE] add `rootMode` property on readers

### DIFF
--- a/schemas/reader.json
+++ b/schemas/reader.json
@@ -26,6 +26,12 @@
           "type": "string",
           "enum": ["react", "angularjs", "vue", "emberjs"]
         },
+        "rootMode": {
+          "type": "string",
+          "description": "The root for selecting data. Either the document, or the element context from the foundation",
+          "enum": ["document", "element"],
+          "default": "element"
+        },
         "selector": {
           "type": "string",
           "description": "The selector for the framework argument"
@@ -109,6 +115,12 @@
         "type": {
           "type": "string",
           "const": "jquery"
+        },
+        "rootMode": {
+          "type": "string",
+          "description": "The root for selecting data. Either the document, or the element context from the foundation",
+          "enum": ["document", "element"],
+          "default": "element"
         },
         "selectors": {
           "type": "object",

--- a/src/blocks/readers/ElementReader.ts
+++ b/src/blocks/readers/ElementReader.ts
@@ -17,6 +17,7 @@
 
 import { Reader } from "@/types";
 import { Schema } from "@/core";
+import { isHTMLElement } from "@/blocks/readers/frameworkReader";
 
 export class ElementReader extends Reader {
   defaultOutputKey = "element";
@@ -30,12 +31,9 @@ export class ElementReader extends Reader {
   }
 
   async read(elementOrDocument: HTMLElement | Document) {
-    const element = elementOrDocument as HTMLElement;
-
-    if (!element?.tagName) {
-      throw new Error("Expected an HTML Element");
-    }
-
+    const element = isHTMLElement(elementOrDocument)
+      ? elementOrDocument
+      : document.body;
     const $element = $(element);
 
     return {
@@ -73,7 +71,7 @@ export class ElementReader extends Reader {
         additionalProperties: true,
       },
     },
-    required: ["tagName", "attrs", "data", "text"],
+    required: ["tagName", "text", "attrs", "data"],
     additionalProperties: false,
   };
 

--- a/src/blocks/readers/frameworkReader.ts
+++ b/src/blocks/readers/frameworkReader.ts
@@ -37,7 +37,7 @@ export type FrameworkConfig = ReadPayload & {
   attrs?: string | string[];
 };
 
-function isHTMLElement(root: ReaderRoot): root is HTMLElement {
+export function isHTMLElement(root: ReaderRoot): root is HTMLElement {
   return root !== document;
 }
 

--- a/src/blocks/readers/jquery.ts
+++ b/src/blocks/readers/jquery.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ReaderOutput } from "@/core";
+import { ReaderOutput, ReaderRootMode } from "@/core";
 import { asyncMapValues, sleep } from "@/utils";
 import { BusinessError, MultipleElementsFoundError } from "@/errors";
 
@@ -57,10 +57,11 @@ type Result =
   // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- can't use Record for recursive signature
   | { [key: string]: Result };
 
-export interface JQueryConfig {
+export type JQueryConfig = {
   type: "jquery";
+  rootMode: ReaderRootMode;
   selectors: SelectorMap;
-}
+};
 
 function cleanValue(value: string): string {
   return value.trim().replace(/\s+/g, " ");
@@ -224,9 +225,11 @@ async function select(
 
 export async function readJQuery(
   reader: JQueryConfig,
-  root: HTMLElement | Document
+  defaultRoot: HTMLElement | Document
 ): Promise<ReaderOutput> {
-  const { selectors } = reader;
+  const { selectors, rootMode } = reader;
+
+  const root = rootMode === "document" ? document : defaultRoot;
   const $root = $(root ?? document);
   if ($root.length === 0) {
     throw new Error("JQuery reader requires the document or element(s)");

--- a/src/blocks/transformers/component/ComponentReader.ts
+++ b/src/blocks/transformers/component/ComponentReader.ts
@@ -16,7 +16,7 @@
  */
 
 import { Transformer } from "@/types";
-import { BlockArg, BlockOptions, Schema } from "@/core";
+import { BlockOptions, Schema } from "@/core";
 import {
   FrameworkConfig,
   frameworkReadFactory,
@@ -47,6 +47,13 @@ export class ComponentReader extends Transformer {
         type: "string",
         enum: KNOWN_READERS.filter((x) => x !== "jquery"),
       },
+      rootMode: {
+        type: "string",
+        description:
+          "The root for selecting data. Either the document, or the element context from the foundation",
+        enum: ["document", "element"],
+        default: "document",
+      },
       selector: {
         type: "string",
         format: "selector",
@@ -69,7 +76,10 @@ export class ComponentReader extends Transformer {
     return true;
   }
 
-  async transform(args: BlockArg, { root }: BlockOptions): Promise<unknown> {
-    return frameworkReadFactory(args.framework)(args as FrameworkConfig, root);
+  async transform(
+    args: FrameworkConfig,
+    { root: defaultRoot }: BlockOptions
+  ): Promise<unknown> {
+    return frameworkReadFactory(args.framework)(args, defaultRoot);
   }
 }

--- a/src/blocks/transformers/jquery/JQueryReader.ts
+++ b/src/blocks/transformers/jquery/JQueryReader.ts
@@ -16,7 +16,7 @@
  */
 
 import { Transformer } from "@/types";
-import { BlockOptions, Schema } from "@/core";
+import { BlockOptions, ReaderRootMode, Schema } from "@/core";
 import { readJQuery, SelectorMap } from "@/blocks/readers/jquery";
 
 export class JQueryReader extends Transformer {
@@ -34,6 +34,13 @@ export class JQueryReader extends Transformer {
     type: "object",
     required: ["selectors"],
     properties: {
+      rootMode: {
+        type: "string",
+        description:
+          "The root for selecting data. Either the document, or the element context from the foundation",
+        enum: ["document", "element"],
+        default: "document",
+      },
       selectors: {
         type: "object",
         additionalProperties: {
@@ -88,9 +95,12 @@ export class JQueryReader extends Transformer {
   }
 
   async transform(
-    { selectors }: { selectors: SelectorMap },
-    { root }: BlockOptions
+    {
+      selectors,
+      rootMode = "document",
+    }: { selectors: SelectorMap; rootMode: ReaderRootMode },
+    { root: defaultRoot }: BlockOptions
   ): Promise<unknown> {
-    return readJQuery({ type: "jquery", selectors }, root);
+    return readJQuery({ type: "jquery", rootMode, selectors }, defaultRoot);
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -135,15 +135,41 @@ export interface Logger {
   error: (error: unknown, data?: Data) => void;
 }
 
+export type ReaderRootMode = "document" | "element";
+
 export type ReaderRoot = HTMLElement | Document;
 
 export interface BlockOptions {
   // Using "any" for now so that blocks don't have to assert/cast all their argument types. We're checking
   // the inputs using yup/jsonschema, so the types should match what's expected.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ctxt: Record<string, any>;
+  /**
+   * The full context for the stage. Should only be used for internal logging/observeability. For user-configurable
+   * behavior expose a property the user can pass data to.
+   * @see runStage
+   */
+  ctxt: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
   logger: Logger;
+
+  /**
+   * The DOM root to use for readers that use selectors.
+   *
+   * Necessary for providing support for extensionPoints that can attach to multiple DOM elements (e.g., trigger
+   * and menuItem).
+   *
+   * Expose a rootMode property on readers to enable the user ton
+   *
+   */
   root: ReaderRoot;
+
+  /**
+   * True to throw an error if a renderer brick is encountered.
+   *
+   * Used to short-circuit execution in the contentScript so that the output of the previous step can be passed toa
+   * PixieBrix sidebar panel (i.e., actionPanel)
+   *
+   * @see runStage
+   */
   headless?: boolean;
 }
 

--- a/src/devTools/editor/extensionPoints/actionPanel.tsx
+++ b/src/devTools/editor/extensionPoints/actionPanel.tsx
@@ -94,7 +94,7 @@ function fromNativeElement(
       metadata,
       definition: {
         isAvailable: makeIsAvailable(url),
-        reader: getImplicitReader(),
+        reader: getImplicitReader("actionPanel"),
       },
     },
     extension: {

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -36,6 +36,7 @@ import React from "react";
 import { createSitePattern } from "@/permissions/patterns";
 import {
   BaseFormState,
+  ElementType,
   SingleLayerReaderConfig,
 } from "@/devTools/editor/extensionPoints/elementConfig";
 import { Except } from "type-fest";
@@ -272,7 +273,18 @@ export function removeEmptyValues<T extends object>(obj: T): T {
 /**
  * Return a composite reader to automatically include in new extensions created with the Page Editor.
  */
-export function getImplicitReader(): SingleLayerReaderConfig {
+export function getImplicitReader(
+  elementType: ElementType
+): SingleLayerReaderConfig {
+  if (elementType === "trigger") {
+    return [
+      validateRegistryId("@pixiebrix/document-metadata"),
+      {
+        element: validateRegistryId("@pixiebrix/html/element"),
+      },
+    ] as SingleLayerReaderConfig;
+  }
+
   return [validateRegistryId("@pixiebrix/document-metadata")];
 }
 

--- a/src/devTools/editor/extensionPoints/contextMenu.tsx
+++ b/src/devTools/editor/extensionPoints/contextMenu.tsx
@@ -100,7 +100,7 @@ function fromNativeElement(
     extensionPoint: {
       metadata,
       definition: {
-        reader: getImplicitReader(),
+        reader: getImplicitReader("contextMenu"),
         documentUrlPatterns: isAvailable.matchPatterns,
         contexts: ["all"],
         defaultOptions: {},

--- a/src/devTools/editor/extensionPoints/menuItem.ts
+++ b/src/devTools/editor/extensionPoints/menuItem.ts
@@ -109,7 +109,7 @@ function fromNativeElement(
       metadata,
       definition: {
         ...button.menu,
-        reader: getImplicitReader(),
+        reader: getImplicitReader("menuItem"),
         isAvailable: makeIsAvailable(url),
       },
       traits: {

--- a/src/devTools/editor/extensionPoints/panel.ts
+++ b/src/devTools/editor/extensionPoints/panel.ts
@@ -116,7 +116,7 @@ function fromNativeElement(
       metadata,
       definition: {
         ...panel.foundation,
-        reader: getImplicitReader(),
+        reader: getImplicitReader("panel"),
         isAvailable: makeIsAvailable(url),
       },
       traits: DEFAULT_TRAITS,

--- a/src/devTools/editor/extensionPoints/trigger.tsx
+++ b/src/devTools/editor/extensionPoints/trigger.tsx
@@ -94,7 +94,7 @@ function fromNativeElement(
       definition: {
         rootSelector: null,
         trigger: "load",
-        reader: getImplicitReader(),
+        reader: getImplicitReader("trigger"),
         isAvailable: makeIsAvailable(url),
       },
     },

--- a/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -29,6 +29,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
 import styles from "./EditorNodeConfigPanel.module.scss";
 import PopoverInfoLabel from "@/components/form/popoverInfoLabel/PopoverInfoLabel";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const OutputKeyWidget: CustomFieldWidget = (props: FieldProps) => (
   <InputGroup>
@@ -103,7 +104,9 @@ const EditorNodeConfigPanel: React.FC<{
         </Col>
       </Row>
 
-      <BlockConfiguration name={blockFieldName} blockId={blockId} />
+      <ErrorBoundary>
+        <BlockConfiguration name={blockFieldName} blockId={blockId} />
+      </ErrorBoundary>
     </>
   );
 };

--- a/src/pageScript/protocol.ts
+++ b/src/pageScript/protocol.ts
@@ -31,13 +31,46 @@ export type PathSpec =
   | string[]
   | Record<string, string | { path: string; args: unknown }>;
 
+/**
+ * @see read (in script.ts)
+ */
 export type ReadOptions = {
-  pathSpec?: PathSpec;
+  /**
+   * If set/non-zero, attempt to re-read the component until a non-empty value is returned (default=0)
+   */
   waitMillis?: number;
+
+  /**
+   * When using waitMillis, the number of milliseconds to wait between retries
+   */
   retryMillis?: number;
+
+  /**
+   * The number of Framework components to traverse upward from the component selected with the selector (default=0)
+   *
+   * Used for when you want to read from a component for which there isn't a DOM element on the page. E.g., in React
+   * there will often be a non-DOM React Component with the interesting state that renders multiple presentation-only
+   * DOM elements as children
+   */
   traverseUp?: number;
-  rootProp?: string;
+
+  /**
+   * If true, do not throw an error if the component is not found (default=false)
+   */
   optional?: boolean;
+
+  /**
+   * An object specifying which properties to read from the component. If not provided, all properties are recursively
+   * read up to a hard-coded depth
+   *
+   * @see readPathSpec
+   */
+  pathSpec?: PathSpec;
+
+  /**
+   * The root component property for the pathSpec
+   */
+  rootProp?: string;
 };
 
 export type ReadPayload = ReadOptions & {


### PR DESCRIPTION
Closes #1466 

- [x] Exposes a `rootMode` property, which controls whether the document or the
- [x] In the page editor, an implicit element reader is automatically added for trigger extensions

**Update**
- The functionality is already provided by `BlockConfig.root`, so this issue it not urgent and that property needs to be eventually exposed in the page editor
