### PR TITLE
#1506: apiVersion 2 with explicit data flow

### DIFF
--- a/schemas/component.json
+++ b/schemas/component.json
@@ -7,7 +7,7 @@
   "properties": {
     "apiVersion": {
       "type": "string",
-      "enum": ["v1"]
+      "enum": ["v1", "v2"]
     },
     "kind": {
       "type": "string",

--- a/schemas/effect.json
+++ b/schemas/effect.json
@@ -7,7 +7,7 @@
   "properties": {
     "apiVersion": {
       "type": "string",
-      "enum": ["v1"]
+      "enum": ["v1", "v2"]
     },
     "kind": {
       "type": "string",

--- a/schemas/extensionPoint.json
+++ b/schemas/extensionPoint.json
@@ -37,7 +37,7 @@
   "properties": {
     "apiVersion": {
       "type": "string",
-      "enum": ["v1"]
+      "enum": ["v1", "v2"]
     },
     "kind": {
       "type": "string",

--- a/schemas/reader.json
+++ b/schemas/reader.json
@@ -154,7 +154,7 @@
   "properties": {
     "apiVersion": {
       "type": "string",
-      "enum": ["v1"]
+      "enum": ["v1", "v2"]
     },
     "kind": {
       "type": "string",

--- a/schemas/recipe.json
+++ b/schemas/recipe.json
@@ -7,7 +7,7 @@
   "properties": {
     "apiVersion": {
       "type": "string",
-      "enum": ["v1"]
+      "enum": ["v1", "v2"]
     },
     "kind": {
       "type": "string",

--- a/schemas/renderer.json
+++ b/schemas/renderer.json
@@ -7,7 +7,7 @@
   "properties": {
     "apiVersion": {
       "type": "string",
-      "enum": ["v1"]
+      "enum": ["v1", "v2"]
     },
     "kind": {
       "type": "string",

--- a/schemas/service.json
+++ b/schemas/service.json
@@ -34,7 +34,7 @@
   "properties": {
     "apiVersion": {
       "type": "string",
-      "enum": ["v1"]
+      "enum": ["v1", "v2"]
     },
     "kind": {
       "type": "string",

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -499,6 +499,11 @@ export async function reducePipeline(
         extraContext[`@${stage.outputKey}`] = output;
       } else if (isFinalStage || !explicitDataFlow) {
         currentArgs = output as any;
+      } else if (explicitDataFlow) {
+        // Force correct use of outputKey in `apiVersion: v2` usage
+        throw new BusinessError(
+          "outputKey is required for blocks that return data"
+        );
       }
       // eslint-disable-next-line @typescript-eslint/no-implicit-any-catch
     } catch (error) {

--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -21,6 +21,7 @@ import ArrayCompositeReader from "@/blocks/readers/ArrayCompositeReader";
 import CompositeReader from "@/blocks/readers/CompositeReader";
 import { locate } from "@/background/locator";
 import {
+  ApiVersion,
   BlockArg,
   IBlock,
   IReader,
@@ -84,14 +85,46 @@ export async function blockList(
   );
 }
 
-interface ReduceOptions {
+/**
+ * Options controlled by the apiVersion directive in brick definitions.
+ * @see ApiVersion
+ */
+type ApiVersionOptions = {
+  /**
+   * If set to `true`, data only flows via output keys. The last output of the last stage is returned.
+   * @since apiVersion 2
+   */
+  explicitDataFlow?: boolean;
+};
+
+type ReduceOptions = ApiVersionOptions & {
+  /**
+   * `true` to throw an error if JSON Schema validation fails against the inputSchema for a brick. Logs a warning
+   * if the errors don't match the outputSchema (if an outputSchema is provided)
+   */
   validate?: boolean;
+  /**
+   * `true` to log all inputs to the extension logger. The user toggles this setting on the Settings page
+   */
   logValues?: boolean;
+  /**
+   * `true` to throw an error if a renderer is encountered. Used to abort execution in the contentScript to pass
+   * data over to be rendered in a PixieBrix sidebar actionPanel.
+   */
   headless?: boolean;
+  /**
+   * Option values provided by the user during activation of an extension
+   */
   optionsArgs?: UserOptions;
+  /**
+   * Service credentials provided by the user during activation of an extension
+   */
   serviceArgs?: RenderedArgs;
+  /**
+   * A UUID to correlate trace records for a brick
+   */
   runId?: UUID;
-}
+};
 
 type SchemaProperties = Record<string, Schema>;
 
@@ -301,12 +334,32 @@ function arraySchema(itemSchema: Schema): Schema {
   };
 }
 
+/**
+ * Return reducePipeline option settings based on the PixieBrix brick definition API version
+ * @see ReduceOptions
+ * @see ApiVersionOptions
+ */
+export function apiVersionOptions(
+  version: ApiVersion = "v1"
+): ApiVersionOptions {
+  switch (version) {
+    case "v2": {
+      return { explicitDataFlow: true };
+    }
+
+    case "v1":
+    default: {
+      return { explicitDataFlow: false };
+    }
+  }
+}
+
 /** Execute a pipeline of blocks and return the result. */
 export async function reducePipeline(
   pipeline: BlockConfig | BlockPipeline,
   renderedArgs: RenderedArgs,
   logger: Logger,
-  root: HTMLElement | Document = null,
+  root: ReaderRoot = null,
   {
     validate = true,
     // Don't default `logValues`, will set async below using `getLoggingConfig` if not provided
@@ -314,6 +367,8 @@ export async function reducePipeline(
     headless = false,
     optionsArgs = {},
     serviceArgs = {},
+    // Default to the `apiVersion: v1` data flow behavior
+    explicitDataFlow = false,
     runId = uuidv4(),
   }: ReduceOptions = {}
 ): Promise<unknown> {
@@ -328,9 +383,13 @@ export async function reducePipeline(
     logValues = (await getLoggingConfig()).logValues ?? false;
   }
 
-  let currentArgs: RenderedArgs = renderedArgs;
+  // When using explicit data flow, the arguments come from `@input`
+  let currentArgs: RenderedArgs = explicitDataFlow ? {} : renderedArgs;
 
-  for (const [index, stage] of castArray(pipeline).entries()) {
+  const pipelineArray = castArray(pipeline);
+
+  for (const [index, stage] of pipelineArray.entries()) {
+    const isFinalStage = index === pipelineArray.length - 1;
     const stageContext: MessageContext = {
       blockId: stage.id,
       label: stage.label,
@@ -438,7 +497,7 @@ export async function reducePipeline(
         }
       } else if (stage.outputKey) {
         extraContext[`@${stage.outputKey}`] = output;
-      } else {
+      } else if (isFinalStage || !explicitDataFlow) {
         currentArgs = output as any;
       }
       // eslint-disable-next-line @typescript-eslint/no-implicit-any-catch

--- a/src/blocks/readers/factory.ts
+++ b/src/blocks/readers/factory.ts
@@ -18,7 +18,14 @@
 import { Reader } from "@/types";
 import { checkAvailable } from "@/blocks/available";
 import { ValidationError } from "@/errors";
-import { Metadata, IReader, Schema, ReaderOutput, ReaderRoot } from "@/core";
+import {
+  Metadata,
+  IReader,
+  Schema,
+  ReaderOutput,
+  ReaderRoot,
+  ApiVersion,
+} from "@/core";
 import { Availability } from "@/blocks/types";
 import { Validator } from "@cfworker/json-schema";
 import { dereference } from "@/validators/generic";
@@ -39,7 +46,7 @@ export interface ReaderDefinition {
 export interface ReaderConfig<
   TDefinition extends ReaderDefinition = ReaderDefinition
 > {
-  apiVersion?: "v1";
+  apiVersion?: ApiVersion;
   metadata: Metadata;
   outputSchema: Schema;
   kind: "reader";

--- a/src/blocks/transformers/blockFactory.ts
+++ b/src/blocks/transformers/blockFactory.ts
@@ -20,8 +20,9 @@ import { readerFactory } from "@/blocks/readers/factory";
 import { Validator, Schema as ValidatorSchema } from "@cfworker/json-schema";
 import { ValidationError } from "@/errors";
 import { castArray } from "lodash";
-import { reducePipeline } from "@/blocks/combinators";
+import { apiVersionOptions, reducePipeline } from "@/blocks/combinators";
 import {
+  ApiVersion,
   BlockArg,
   BlockOptions,
   Config,
@@ -49,6 +50,7 @@ const METHOD_MAP: Map<ComponentKind, string> = new Map([
 ]);
 
 interface ComponentConfig {
+  apiVersion?: ApiVersion;
   kind: ComponentKind;
   metadata: Metadata;
   defaultOptions: Record<string, string>;
@@ -78,6 +80,8 @@ function validateBlockDefinition(
 class ExternalBlock extends Block {
   public readonly component: ComponentConfig;
 
+  readonly apiVersion: ApiVersion;
+
   readonly inputSchema: Schema;
 
   readonly outputSchema: Schema;
@@ -87,6 +91,7 @@ class ExternalBlock extends Block {
   constructor(component: ComponentConfig) {
     const { id, name, description, icon } = component.metadata;
     super(id, name, description, icon);
+    this.apiVersion = component.apiVersion ?? "v1";
     this.component = component;
     this.inputSchema = this.component.inputSchema;
     this.outputSchema = this.component.outputSchema;
@@ -145,6 +150,7 @@ class ExternalBlock extends Block {
         // OptionsArgs are set at the blueprint level. For composite bricks, they options should be passed in
         // at part of the brick inputs
         optionsArgs: undefined,
+        ...apiVersionOptions(this.component.apiVersion),
       }
     );
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -35,6 +35,16 @@ export type SchemaDefinition = JSONSchema7Definition;
 export type SchemaProperties = Record<string, SchemaDefinition>;
 export type SchemaPropertyType = JSONSchema7TypeName;
 
+/**
+ * The PixieBrix brick definition API. Controls how the PixieBrix runtime interprets brick definitions.
+ *
+ * Incremented whenever backward-incompatible changes are made.
+ *
+ * - v1: original, implicit templating and dataflow
+ * - v2: introduces explicitDataFlow
+ */
+export type ApiVersion = "v1" | "v2";
+
 export type RenderedHTML = string;
 
 export type ActionType = string;
@@ -245,6 +255,12 @@ export type IExtension<T extends Config = EmptyConfig> = {
    * UUID of the extension.
    */
   id: UUID;
+
+  /**
+   * The PixieBrix brick definition API version, controlling how the runtime interprets configuration values.
+   * @see ApiVersion
+   */
+  apiVersion: ApiVersion;
 
   /**
    * Registry id of the extension point, or a reference to the definitions section.

--- a/src/devTools/editor/extensionPoints/actionPanel.tsx
+++ b/src/devTools/editor/extensionPoints/actionPanel.tsx
@@ -24,6 +24,7 @@ import {
   lookupExtensionPoint,
   makeInitialBaseState,
   makeIsAvailable,
+  PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
   readerHack,
   removeEmptyValues,
   selectIsAvailable,
@@ -122,11 +123,19 @@ function selectExtensionPoint(
 }
 
 function selectExtension(
-  { uuid, label, extensionPoint, extension, services }: ActionPanelFormState,
+  {
+    uuid,
+    label,
+    extensionPoint,
+    extension,
+    services,
+    apiVersion,
+  }: ActionPanelFormState,
   options: { includeInstanceIds?: boolean } = {}
 ): IExtension<ActionPanelConfig> {
   return removeEmptyValues({
     id: uuid,
+    apiVersion,
     extensionPointId: extensionPoint.metadata.id,
     _recipe: null,
     label,
@@ -157,6 +166,7 @@ export async function fromExtensionPoint(
 
   return {
     uuid: uuidv4(),
+    apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
     installed: true,
     type: extensionPoint.definition.type,
     label: heading,
@@ -190,6 +200,7 @@ async function fromExtension(
 
   return {
     uuid: config.id,
+    apiVersion: config.apiVersion,
     installed: true,
     type: extensionPoint.definition.type,
     label: config.label,

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  ApiVersion,
   Config,
   EmptyConfig,
   IExtension,
@@ -57,6 +58,15 @@ export interface WizardStep {
   extraProps?: Record<string, unknown>;
 }
 
+/**
+ * Brick definition API controlling how the PixieBrix runtime interprets brick configurations
+ * @see ApiVersion
+ */
+export const PAGE_EDITOR_DEFAULT_BRICK_API_VERSION: ApiVersion = "v2";
+
+/**
+ * Default definition entry for the inner definition of the extensionPoint for the extension
+ */
 const DEFAULT_EXTENSION_POINT_VAR = "extensionPoint";
 
 const INNER_SCOPE = "@internal";
@@ -105,6 +115,7 @@ export function makeInitialBaseState(
 ): Except<BaseFormState, "type" | "label" | "extensionPoint"> {
   return {
     uuid,
+    apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
     services: [],
     extension: {},
   };
@@ -174,7 +185,7 @@ export async function lookupExtensionPoint<
       definition
     );
     const innerExtensionPoint = ({
-      apiVersion: "v1",
+      apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
       kind: "extensionPoint",
       metadata: internalExtensionPointMetaFactory(),
       ...definition,
@@ -209,7 +220,7 @@ export function baseSelectExtensionPoint(
   const { metadata } = formState.extensionPoint;
 
   return {
-    apiVersion: "v1",
+    apiVersion: formState.apiVersion,
     kind: "extensionPoint",
     metadata: {
       id: metadata.id,

--- a/src/devTools/editor/extensionPoints/contextMenu.tsx
+++ b/src/devTools/editor/extensionPoints/contextMenu.tsx
@@ -24,6 +24,7 @@ import {
   lookupExtensionPoint,
   makeInitialBaseState,
   makeIsAvailable,
+  PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
   removeEmptyValues,
   selectIsAvailable,
   withInstanceIds,
@@ -139,11 +140,19 @@ function selectExtensionPoint(
 }
 
 function selectExtension(
-  { uuid, label, extensionPoint, extension, services }: ContextMenuFormState,
+  {
+    uuid,
+    apiVersion,
+    label,
+    extensionPoint,
+    extension,
+    services,
+  }: ContextMenuFormState,
   options: { includeInstanceIds?: boolean } = {}
 ): IExtension<ContextMenuConfig> {
   return removeEmptyValues({
     id: uuid,
+    apiVersion,
     extensionPointId: extensionPoint.metadata.id,
     _recipe: null,
     label,
@@ -173,6 +182,7 @@ async function fromExtension(
 
   return {
     uuid: config.id,
+    apiVersion: config.apiVersion,
     installed: true,
     type: "contextMenu",
     label: config.label,
@@ -215,6 +225,7 @@ async function fromExtensionPoint(
 
   return {
     uuid: uuidv4(),
+    apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
     installed: true,
     type,
     label: `My ${getDomain(url)} context menu`,

--- a/src/devTools/editor/extensionPoints/elementConfig.ts
+++ b/src/devTools/editor/extensionPoints/elementConfig.ts
@@ -18,6 +18,7 @@ import React from "react";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { Runtime } from "webextension-polyfill-ts";
 import {
+  ApiVersion,
   IExtension,
   Metadata,
   RegistryId,
@@ -56,6 +57,12 @@ export interface BaseExtensionPointState {
 }
 
 export interface BaseFormState {
+  /**
+   * The apiVersion of the brick definition, controlling how PixieBrix interprets brick definitions
+   * @see ApiVersion
+   */
+  readonly apiVersion: ApiVersion;
+
   /**
    * The extension uuid
    */

--- a/src/devTools/editor/extensionPoints/menuItem.ts
+++ b/src/devTools/editor/extensionPoints/menuItem.ts
@@ -28,6 +28,7 @@ import {
   lookupExtensionPoint,
   makeInitialBaseState,
   makeIsAvailable,
+  PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
   readerHack,
   removeEmptyValues,
   selectIsAvailable,
@@ -147,11 +148,19 @@ function selectExtensionPoint(
 }
 
 function selectExtension(
-  { uuid, label, extensionPoint, extension, services }: ActionFormState,
+  {
+    uuid,
+    apiVersion,
+    label,
+    extensionPoint,
+    extension,
+    services,
+  }: ActionFormState,
   options: { includeInstanceIds?: boolean } = {}
 ): IExtension<MenuItemExtensionConfig> {
   return removeEmptyValues({
     id: uuid,
+    apiVersion,
     extensionPointId: extensionPoint.metadata.id,
     _recipe: null,
     label,
@@ -172,6 +181,7 @@ async function fromExtensionPoint(
 
   return {
     uuid: uuidv4(),
+    apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
     installed: true,
     type: extensionPoint.definition.type,
     label: `My ${getDomain(url)} button`,
@@ -213,6 +223,7 @@ export async function fromExtension(
 
   return {
     uuid: config.id,
+    apiVersion: config.apiVersion,
     installed: true,
     type: extensionPoint.definition.type,
     label: config.label,

--- a/src/devTools/editor/extensionPoints/panel.ts
+++ b/src/devTools/editor/extensionPoints/panel.ts
@@ -24,6 +24,7 @@ import {
   lookupExtensionPoint,
   makeInitialBaseState,
   makeIsAvailable,
+  PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
   readerHack,
   removeEmptyValues,
   selectIsAvailable,
@@ -152,11 +153,19 @@ function selectExtensionPoint(
 }
 
 function selectExtension(
-  { uuid, label, extensionPoint, extension, services }: PanelFormState,
+  {
+    uuid,
+    apiVersion,
+    label,
+    extensionPoint,
+    extension,
+    services,
+  }: PanelFormState,
   options: { includeInstanceIds?: boolean } = {}
 ): IExtension<PanelConfig> {
   return removeEmptyValues({
     id: uuid,
+    apiVersion,
     extensionPointId: extensionPoint.metadata.id,
     _recipe: null,
     label,
@@ -188,6 +197,7 @@ async function fromExtensionPoint(
 
   return {
     uuid: uuidv4(),
+    apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
     installed: true,
     type: "panel",
     label: `My ${getDomain(url)} panel`,
@@ -229,6 +239,7 @@ async function fromExtension(
 
   return {
     uuid: config.id,
+    apiVersion: config.apiVersion,
     installed: true,
     type: extensionPoint.definition.type,
     label: config.label,

--- a/src/devTools/editor/extensionPoints/trigger.tsx
+++ b/src/devTools/editor/extensionPoints/trigger.tsx
@@ -24,6 +24,7 @@ import {
   lookupExtensionPoint,
   makeInitialBaseState,
   makeIsAvailable,
+  PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
   readerHack,
   removeEmptyValues,
   selectIsAvailable,
@@ -124,11 +125,19 @@ function selectExtensionPoint(
 }
 
 function selectExtension(
-  { uuid, label, extensionPoint, extension, services }: TriggerFormState,
+  {
+    uuid,
+    apiVersion,
+    label,
+    extensionPoint,
+    extension,
+    services,
+  }: TriggerFormState,
   options: { includeInstanceIds?: boolean } = {}
 ): IExtension<TriggerConfig> {
   return removeEmptyValues({
     id: uuid,
+    apiVersion,
     extensionPointId: extensionPoint.metadata.id,
     _recipe: null,
     label,
@@ -164,6 +173,7 @@ async function fromExtensionPoint(
 
   return {
     uuid: uuidv4(),
+    apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
     installed: true,
     type,
     label: `My ${getDomain(url)} ${trigger} trigger`,
@@ -200,6 +210,7 @@ async function fromExtension(
 
   return {
     uuid: config.id,
+    apiVersion: config.apiVersion,
     installed: true,
     type: extensionPoint.definition.type,
     label: config.label,

--- a/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -54,11 +54,10 @@ function useLatestTraceRecord(instanceId: UUID) {
   }, [instanceId]);
 }
 
+/**
+ * Exclude irrelevant top-level keys.
+ */
 const contextFilter = (value: unknown, key: string) => {
-  if (!key.startsWith("@")) {
-    return false;
-  }
-
   // `@options` comes from marketplace-installed extensions. There's a chance the user might add a brick that has
   // @options as an output key. In that case, we'd expect values to flow into it. So just checking to see if there's
   // any data is a good compromise even though we miss the corner-case where @options is user-defined but empty
@@ -66,6 +65,8 @@ const contextFilter = (value: unknown, key: string) => {
     return false;
   }
 
+  // At one point, we also excluded keys that weren't prefixed with "@" as a stop-gap for encouraging the use of output
+  // keys. With the introduction of ApiVersion v2, we removed that filter
   return true;
 };
 

--- a/src/extensionPoints/actionPanelExtension.ts
+++ b/src/extensionPoints/actionPanelExtension.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  apiVersionOptions,
   blockList,
   makeServiceContext,
   mergeReaders,
@@ -135,6 +136,7 @@ export abstract class ActionPanelExtensionPoint extends ExtensionPoint<ActionPan
         serviceArgs: serviceContext,
         optionsArgs: extension.optionsArgs,
         headless: true,
+        ...apiVersionOptions(extension.apiVersion),
       });
       // We're expecting a HeadlessModeError (or other error) to be thrown in the line above
       // noinspection ExceptionCaughtLocallyJS

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  apiVersionOptions,
   blockList,
   makeServiceContext,
   mergeReaders,
@@ -310,6 +311,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
           validate: true,
           serviceArgs: serviceContext,
           optionsArgs: extension.optionsArgs,
+          ...apiVersionOptions(extension.apiVersion),
         });
       } catch (error: unknown) {
         if (isErrorObject(error)) {

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -25,6 +25,7 @@ import {
   mergeReaders,
   blockList,
   makeServiceContext,
+  apiVersionOptions,
 } from "@/blocks/combinators";
 import { reportError } from "@/telemetry/logging";
 import {
@@ -479,6 +480,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
           validate: true,
           serviceArgs: serviceContext,
           optionsArgs: extension.optionsArgs,
+          ...apiVersionOptions(extension.apiVersion),
         }
       );
 
@@ -523,6 +525,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
           validate: true,
           serviceArgs: serviceContext,
           optionsArgs: extension.optionsArgs,
+          ...apiVersionOptions(extension.apiVersion),
         });
 
         extensionLogger.info("Successfully ran menu action");

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -26,6 +26,7 @@ import {
   mergeReaders,
   blockList,
   makeServiceContext,
+  apiVersionOptions,
 } from "@/blocks/combinators";
 import { boolean } from "@/utils";
 import {
@@ -383,6 +384,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
             validate: true,
             serviceArgs: serviceContext,
             optionsArgs: extension.optionsArgs,
+            ...apiVersionOptions(extension.apiVersion),
           }
         ) as Promise<PanelComponent>;
 

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -17,6 +17,7 @@
 
 import { ExtensionPoint } from "@/types";
 import {
+  apiVersionOptions,
   blockList,
   makeServiceContext,
   mergeReaders,
@@ -140,6 +141,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
         validate: true,
         serviceArgs: serviceContext,
         optionsArgs: extension.optionsArgs,
+        ...apiVersionOptions(extension.apiVersion),
       });
       extensionLogger.info("Successfully ran trigger");
       // eslint-disable-next-line @typescript-eslint/no-implicit-any-catch

--- a/src/extensionPoints/types.ts
+++ b/src/extensionPoints/types.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Metadata } from "@/core";
+import { ApiVersion, Metadata } from "@/core";
 import { Availability, ReaderConfig } from "@/blocks/types";
 
 type ExtensionPointType =
@@ -34,7 +34,7 @@ export interface ExtensionPointDefinition {
 export interface ExtensionPointConfig<
   T extends ExtensionPointDefinition = ExtensionPointDefinition
 > {
-  apiVersion?: "v1";
+  apiVersion?: ApiVersion;
   metadata: Metadata;
   definition: T;
   kind: "extensionPoint";

--- a/src/options/slices.ts
+++ b/src/options/slices.ts
@@ -228,6 +228,7 @@ export const optionsSlice = createSlice({
         extensionPoints,
         deployment,
       } = payload;
+
       for (const {
         id: extensionPointId,
         label,
@@ -244,6 +245,8 @@ export const optionsSlice = createSlice({
 
         const extension: PersistedExtension = {
           id: extensionId,
+          // Default to `v1` for backward compatability
+          apiVersion: recipe.apiVersion ?? "v1",
           _deployment: deployment
             ? {
                 id: deployment.id,
@@ -298,6 +301,7 @@ export const optionsSlice = createSlice({
 
       const {
         id,
+        apiVersion,
         extensionId,
         extensionPointId,
         config,
@@ -320,6 +324,7 @@ export const optionsSlice = createSlice({
 
       const extension: PersistedExtension = {
         id: persistedId,
+        apiVersion,
         extensionPointId,
         // If the user updates an extension, detach it from the recipe -- it's now a personal extension
         _recipe: null,

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -51,6 +51,7 @@ export const extensionFactory: (
   extensionProps?: Partial<IExtension>
 ) => IExtension = (extensionProps) => ({
   id: randomWords() as UUID,
+  apiVersion: "v1",
   extensionPointId: randomWords() as RegistryId,
   _deployment: null,
   _recipe: null,

--- a/src/types/definitions.ts
+++ b/src/types/definitions.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  ApiVersion,
   Config,
   InnerDefinitionRef,
   InnerDefinitions,
@@ -81,7 +82,7 @@ type Kind = "recipe" | "service" | "reader" | "component";
  * A PixieBrix brick or extension point definition
  */
 export interface Definition {
-  apiVersion: "v1";
+  apiVersion: ApiVersion;
   kind: Kind;
   metadata: Metadata;
 }


### PR DESCRIPTION
Closes #1506

- [x] Update meta JSON Schema for bricks to support "v2"
- [x] Introduce an `explicitDataFlow` flag on runStage that's controlled by the apiVersion of the extension/composite brick
- [x] Default page editor to create bricks with v2 
- [x] Default to v1 behavior if the apiVersion is not specified

TODO:
- [ ] Update schema definitions in the API project