### PR TITLE
#1334: Don't show error when the user clicks on browserAction

### DIFF
--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -63,7 +63,7 @@ async function handleBrowserAction(tab: browser.tabs.Tab): Promise<void> {
     return;
   }
 
-  if (!hostname || !protocol.startsWith("http")) {
+  if (!protocol.startsWith("http")) {
     // Page not supported. Open the options page instead
     void browser.runtime.openOptionsPage();
     return;

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -58,7 +58,6 @@ const tabFrames = new Map<number, number>();
 const webstores = ["chrome.google.com", "addons.mozilla.org"];
 async function handleBrowserAction(tab: browser.tabs.Tab): Promise<void> {
   const { protocol, hostname } = safeParseUrl(tab.url);
-  console.log(tab.url, hostname);
   if (webstores.includes(hostname)) {
     void showErrorInOptions("ERR_BROWSER_ACTION_TOGGLE_WEBSTORE", tab.index);
     return;

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -58,12 +58,14 @@ const tabFrames = new Map<number, number>();
 const webstores = ["chrome.google.com", "addons.mozilla.org"];
 async function handleBrowserAction(tab: browser.tabs.Tab): Promise<void> {
   const { protocol, hostname } = safeParseUrl(tab.url);
-  if (
-    !hostname ||
-    !protocol.startsWith("http") ||
-    webstores.includes(hostname)
-  ) {
-    // Page not supported/allowed. Just open the options page instead
+  console.log(tab.url, hostname);
+  if (webstores.includes(hostname)) {
+    void showErrorInOptions("ERR_BROWSER_ACTION_TOGGLE_WEBSTORE", tab.index);
+    return;
+  }
+
+  if (!hostname || !protocol.startsWith("http")) {
+    // Page not supported. Open the options page instead
     void browser.runtime.openOptionsPage();
     return;
   }

--- a/src/layout/ErrorModal.tsx
+++ b/src/layout/ErrorModal.tsx
@@ -23,7 +23,14 @@ import { useHistory, useLocation } from "react-router";
 
 // Hardcoded list of error messages to avoid using user-provided strings in the options page
 const errorMessages = new Map([
+  // Unknown reason
   ["ERR_BROWSER_ACTION_TOGGLE", "PixieBrix could not run on the page"],
+
+  // Standard message for extensions being blocked by the browser
+  [
+    "ERR_BROWSER_ACTION_TOGGLE_WEBSTORE",
+    "The extensions gallery cannot be scripted",
+  ],
 ]);
 
 const ErrorModal: React.FunctionComponent = () => {

--- a/src/layout/ErrorModal.tsx
+++ b/src/layout/ErrorModal.tsx
@@ -21,11 +21,8 @@ import React, { useCallback, useMemo } from "react";
 import { Button, Modal } from "react-bootstrap";
 import { useHistory, useLocation } from "react-router";
 
+// Hardcoded list of error messages to avoid using user-provided strings in the options page
 const errorMessages = new Map([
-  [
-    "ERR_BROWSER_ACTION_TOGGLE_SPECIAL_PAGE",
-    "PixieBrix can’t run on internal browser pages",
-  ],
   ["ERR_BROWSER_ACTION_TOGGLE", "PixieBrix could not run on the page"],
 ]);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -528,3 +528,12 @@ export function freshIdentifier(
 
   return `${root}${next}`;
 }
+
+/** Like `new URL(url)` except it never throws and always returns an URL object, empty if the url is invalid */
+export function safeParseUrl(url: string): URL {
+  try {
+    return new URL(url);
+  } catch {
+    return new URL("invalid-url://");
+  }
+}


### PR DESCRIPTION
- Replaces https://github.com/pixiebrix/pixiebrix-extension/pull/1395
- Fixes #1334 

## Video showing an error on the extension gallery and no error on other browser pages

https://user-images.githubusercontent.com/1402241/134939098-668a8509-ba15-40d2-a101-9ce7975e5e35.mov
