### PR TITLE
#1472: fix race condition in trace update check

### DIFF
--- a/src/devTools/editor/slices/runtimeSelectors.ts
+++ b/src/devTools/editor/slices/runtimeSelectors.ts
@@ -30,7 +30,7 @@ type EditorSelector<T> = (state: RootState) => T;
  */
 export const selectTraceError: EditorSelector<TraceError> = (state) => {
   const records = selectExtensionTrace(state);
-  return (records ?? []).find((x) => "error" in x && x.error) as TraceError;
+  return records.find((x) => "error" in x && x.error) as TraceError;
 };
 
 const EMPTY_TRACE: TraceRecord[] = Object.freeze([]) as TraceRecord[];

--- a/src/devTools/editor/slices/runtimeSlice.ts
+++ b/src/devTools/editor/slices/runtimeSlice.ts
@@ -30,10 +30,6 @@ const initialState: RuntimeState = {
   extensionTraces: {},
 };
 
-export function selectRunId(records: TraceRecord[]): UUID {
-  return (records ?? [])[0]?.runId;
-}
-
 const runtimeSlice = createSlice({
   name: "runtime",
   initialState,
@@ -43,14 +39,8 @@ const runtimeSlice = createSlice({
       { payload }: PayloadAction<{ extensionId: UUID; records: TraceRecord[] }>
     ) {
       const { extensionId, records } = payload;
-
-      // @ts-expect-error -- why does this cause infinite typing issues? Probably related to partial over sum type
-      const previousRunId = selectRunId(state.extensionTraces[extensionId]);
-      const currentRunId = selectRunId(records);
-
-      if (previousRunId !== currentRunId) {
-        state.extensionTraces[extensionId] = records;
-      }
+      // @ts-expect-error -- infinite type warning caused by Partial over Output and Error states in TraceRecord?
+      state.extensionTraces[extensionId] = records;
     },
   },
 });

--- a/src/telemetry/trace.ts
+++ b/src/telemetry/trace.ts
@@ -82,6 +82,7 @@ export type TraceExitData = TraceRecordMeta & (Output | ErrorOutput);
 
 export type TraceRecord = TraceEntryData & Partial<TraceExitData>;
 
+export type TraceSuccess = TraceEntryData & Output;
 export type TraceError = TraceEntryData & ErrorOutput;
 
 const indexKeys: Array<


### PR DESCRIPTION
Solves trace data update for #1472 

Formik errors not working because the the error  gets set, but then theres a follow on render event where the error is no longer in there. Will have to look into it

