### PR TITLE
#1414: Add `AsyncIcon` component to load single FontAwesome icon

### DIFF
--- a/src/components/AsyncIcon.tsx
+++ b/src/components/AsyncIcon.tsx
@@ -5,49 +5,57 @@ export type FortAwesomeLibrary = "fas" | "fab" | "far";
 
 async function handleIconImport(
   moduleImport: Promise<{ definition: IconProp }>
-): Promise<IconProp | void> {
+): Promise<IconProp> {
   try {
     const { definition } = await moduleImport;
     return definition;
-  } catch {
-    // Icon not found, ignore error for now
+  } catch (error: unknown) {
+    console.warn("Error importing FontAwesome icon library module", { error });
+    throw error;
   }
 }
 
 /**
+ * Asynchronously fetch a FortAwesome icon definition
+ * @param library the FontAwesome library code ("fas", "fab", "far")
  * @param icon Must be in "fa-my-icon" format
  */
 export async function fetchFortAwesomeIcon(
   library: FortAwesomeLibrary,
   icon: string
-): Promise<IconProp | void> {
+): Promise<IconProp> {
   switch (library) {
     // For the dynamic imports to work correctly with Webpack, they must be as explicit as possible
-    case "fas":
+    case "fas": {
       return handleIconImport(
         import(
           /* webpackChunkName: "free-solid-svg-icons/[request]" */
           `@fortawesome/free-solid-svg-icons/${camelCase(icon)}.js`
         )
       );
+    }
 
-    case "fab":
+    case "fab": {
       return handleIconImport(
         import(
           /* webpackChunkName: "free-brands-svg-icons/[request]" */
           `@fortawesome/free-brands-svg-icons/${camelCase(icon)}.js`
         )
       );
+    }
 
-    case "far":
+    case "far": {
       return handleIconImport(
         import(
           /* webpackChunkName: "free-regular-svg-icons/[request]" */
           `@fortawesome/free-regular-svg-icons/${camelCase(icon)}.js`
         )
       );
+    }
 
-    default:
-    // Library not found
+    default: {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for `never`
+      throw new Error(`Unknown FontAwesome library: ${library}`);
+    }
   }
 }

--- a/src/components/AsyncIcon.tsx
+++ b/src/components/AsyncIcon.tsx
@@ -1,0 +1,53 @@
+import { IconProp } from "@fortawesome/fontawesome-svg-core";
+import { camelCase } from "lodash";
+
+export type FortAwesomeLibrary = "fas" | "fab" | "far";
+
+async function handleIconImport(
+  moduleImport: Promise<{ definition: IconProp }>
+): Promise<IconProp | void> {
+  try {
+    const { definition } = await moduleImport;
+    return definition;
+  } catch {
+    // Icon not found, ignore error for now
+  }
+}
+
+/**
+ * @param icon Must be in "fa-my-icon" format
+ */
+export async function fetchFortAwesomeIcon(
+  library: FortAwesomeLibrary,
+  icon: string
+): Promise<IconProp | void> {
+  switch (library) {
+    // For the dynamic imports to work correctly with Webpack, they must be as explicit as possible
+    case "fas":
+      return handleIconImport(
+        import(
+          /* webpackChunkName: "free-solid-svg-icons/[request]" */
+          `@fortawesome/free-solid-svg-icons/${camelCase(icon)}.js`
+        )
+      );
+
+    case "fab":
+      return handleIconImport(
+        import(
+          /* webpackChunkName: "free-brands-svg-icons/[request]" */
+          `@fortawesome/free-brands-svg-icons/${camelCase(icon)}.js`
+        )
+      );
+
+    case "far":
+      return handleIconImport(
+        import(
+          /* webpackChunkName: "free-regular-svg-icons/[request]" */
+          `@fortawesome/free-regular-svg-icons/${camelCase(icon)}.js`
+        )
+      );
+
+    default:
+    // Library not found
+  }
+}

--- a/src/components/BrickIcon.tsx
+++ b/src/components/BrickIcon.tsx
@@ -39,7 +39,6 @@ import { ContextMenuExtensionPoint } from "@/extensionPoints/contextMenu";
 import { PanelExtensionPoint } from "@/extensionPoints/panelExtension";
 import { ActionPanelExtensionPoint } from "@/extensionPoints/actionPanelExtension";
 import { useGetMarketplaceListingsQuery } from "@/services/api";
-import cx from "classnames";
 import { useAsyncState } from "@/hooks/common";
 import { useAsyncEffect } from "use-async-effect";
 import { fetchFortAwesomeIcon } from "@/components/AsyncIcon";
@@ -140,7 +139,7 @@ const BrickIcon: React.FunctionComponent<{
         <FontAwesomeIcon
           icon={faIcon}
           color={listing?.icon_color}
-          className={cx(faIconClass, { "text-muted": !listing?.icon_color })}
+          className={faIconClass}
           size={size}
           fixedWidth
         />

--- a/src/devTools/editor/tabs/editTab/EditTab.tsx
+++ b/src/devTools/editor/tabs/editTab/EditTab.tsx
@@ -25,10 +25,9 @@ import { ADAPTERS } from "@/devTools/editor/extensionPoints/adapter";
 import { BlockType, defaultBlockConfig, getType } from "@/blocks/util";
 import { useAsyncState } from "@/hooks/common";
 import blockRegistry from "@/blocks/registry";
-import { compact, noop, zip } from "lodash";
+import { compact, zip } from "lodash";
 import { IBlock, OutputKey } from "@/core";
 import hash from "object-hash";
-import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { produce } from "immer";
 import EditorNodeConfigPanel from "@/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel";
 import styles from "./EditTab.module.scss";
@@ -154,8 +153,6 @@ const EditTab: React.FC<{
           }
         : {
             title: "Loading...",
-            icon: faSpinner,
-            onClick: noop,
           }
   );
 

--- a/src/devTools/editor/tabs/editTab/editorNode/EditorNode.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNode/EditorNode.tsx
@@ -24,8 +24,8 @@ import cx from "classnames";
 export type EditorNodeProps = {
   title: string;
   outputKey?: string;
-  icon: IconProp | React.ReactNode;
-  onClick: () => void;
+  icon?: IconProp | React.ReactNode;
+  onClick?: () => void;
   muted?: boolean | undefined;
   active?: boolean | undefined;
 };

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -31,6 +31,7 @@ import {
 
 import { components } from "@/types/swagger";
 import { Except } from "type-fest";
+import { FortAwesomeLibrary } from "@/components/AsyncIcon";
 
 export type Kind = "block" | "foundation" | "service" | "blueprint" | "reader";
 
@@ -89,7 +90,7 @@ export type CloudExtension<T extends Config = EmptyConfig> = Except<
 export type MarketplaceListing = {
   id: string;
   package: Record<string, unknown>;
-  fa_icon: string;
+  fa_icon: `${FortAwesomeLibrary} ${string}`;
   icon_color: string;
   image?: {
     url: string;


### PR DESCRIPTION
This fixes https://github.com/pixiebrix/pixiebrix-extension/issues/1414 specifically.

Future work:

- have a `<AsyncIcon>` component that can be used exactly like `FontAwesomeIcon`, except it's async. It could also support other libraries
- replace every icon import with `<AsyncIcon>` so that no icons are ever bundled (+ lint rule to never import `@fortawesome/*` directly)

I'm not sure I will be able to make those changes by the release since I'm preparing to move tomorrow.

## Demo

https://user-images.githubusercontent.com/1402241/135047425-01288030-4ffd-4526-bbdb-2ce7e3f6b370.mov

## Bundle

<img width="1237" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/135047450-2e658b2d-9c4e-4d45-a56a-86379a52e847.png">


