### PR TITLE
#1408: Add output key to output in data panel so that the copy label includes the output key

### DIFF
--- a/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -37,6 +37,7 @@ import { FormState } from "@/devTools/editor/slices/editorSlice";
 import AuthContext from "@/auth/AuthContext";
 import { useSelector } from "react-redux";
 import { makeSelectBlockTrace } from "@/devTools/editor/slices/runtimeSelectors";
+import { JsonObject } from "type-fest";
 
 /**
  * Exclude irrelevant top-level keys.
@@ -122,6 +123,13 @@ const DataPanel: React.FC<{
     actions.setActiveField
   );
 
+  const outputObj: JsonObject =
+    record !== undefined && "output" in record
+      ? "outputKey" in record
+        ? { [`@${record.outputKey}`]: record.output }
+        : record.output
+      : null;
+
   const [{ value: blockConfig }] = useField<BlockConfig>(blockFieldName);
 
   const [previewInfo] = usePreviewInfo(blockConfig?.id);
@@ -190,8 +198,8 @@ const DataPanel: React.FC<{
           isTraceEmpty={!record}
           isTraceOptional={previewInfo?.traceOptional}
         >
-          {record && "output" in record && (
-            <JsonTree data={record.output} copyable searchable label="Data" />
+          {outputObj && (
+            <JsonTree data={outputObj} copyable searchable label="Data" />
           )}
           {record && "error" in record && (
             <JsonTree data={record.error} label="Error" />


### PR DESCRIPTION
This adds the output key to the Output tab data on the data panel. This makes the copy functionality on the json tree include the output key when copying a value.

![image](https://user-images.githubusercontent.com/2801308/135125934-bc8c55c4-3d17-4c01-9beb-fb42921221ff.png)
