### PR TITLE
#1466: rootMode on BlockConfiguration

### DIFF
--- a/src/blocks/readers/ArrayCompositeReader.ts
+++ b/src/blocks/readers/ArrayCompositeReader.ts
@@ -67,6 +67,13 @@ class ArrayCompositeReader extends Reader {
     return availability.every((x) => x);
   }
 
+  async isRootAware(): Promise<boolean> {
+    const awareness = await Promise.all(
+      this._readers.map(async (x) => x.isRootAware())
+    );
+    return awareness.some((x) => x);
+  }
+
   async read(root: HTMLElement | Document): Promise<ReaderOutput> {
     let result = {};
     const readResults = await Promise.all(

--- a/src/blocks/readers/BlankReader.ts
+++ b/src/blocks/readers/BlankReader.ts
@@ -34,6 +34,10 @@ export class BlankReader extends Reader {
     additionalProperties: false,
   };
 
+  async isRootAware(): Promise<boolean> {
+    return false;
+  }
+
   async isAvailable() {
     return true;
   }

--- a/src/blocks/readers/CompositeReader.ts
+++ b/src/blocks/readers/CompositeReader.ts
@@ -53,7 +53,7 @@ class CompositeReader extends Reader {
 
   async isRootAware(): Promise<boolean> {
     const readerArray = Object.values(this._readers);
-    // PERFORMANCE: could return quicker if any came back false using Promise.any
+    // PERFORMANCE: could return quicker if any came back true using Promise.any
     const awareness = await Promise.all(
       readerArray.map(async (x) => x.isRootAware())
     );

--- a/src/blocks/readers/CompositeReader.ts
+++ b/src/blocks/readers/CompositeReader.ts
@@ -51,6 +51,15 @@ class CompositeReader extends Reader {
     return purity.every((x) => x);
   }
 
+  async isRootAware(): Promise<boolean> {
+    const readerArray = Object.values(this._readers);
+    // PERFORMANCE: could return quicker if any came back false using Promise.any
+    const awareness = await Promise.all(
+      readerArray.map(async (x) => x.isRootAware())
+    );
+    return awareness.some((x) => x);
+  }
+
   async read(root: HTMLElement | Document): Promise<ReaderOutput> {
     const readOne = async (key: string, reader: IReader) => [
       key,

--- a/src/blocks/readers/PageMetadataReader.ts
+++ b/src/blocks/readers/PageMetadataReader.ts
@@ -33,6 +33,10 @@ export class PageMetadataReader extends Reader {
     return true;
   }
 
+  async isRootAware(): Promise<boolean> {
+    return false;
+  }
+
   async read() {
     const { getMetadata } = await import(
       // @ts-expect-error no type definitions available

--- a/src/blocks/readers/PageSemanticReader.ts
+++ b/src/blocks/readers/PageSemanticReader.ts
@@ -29,6 +29,10 @@ export class PageSemanticReader extends Reader {
     );
   }
 
+  async isRootAware(): Promise<boolean> {
+    return false;
+  }
+
   async read(): Promise<ReaderOutput> {
     const [{ Handler }, { Parser }] = await Promise.all([
       import("htmlmetaparser"),

--- a/src/blocks/readers/meta.ts
+++ b/src/blocks/readers/meta.ts
@@ -37,6 +37,10 @@ export class TimestampReader extends Reader {
     };
   }
 
+  async isRootAware(): Promise<boolean> {
+    return false;
+  }
+
   outputSchema: Schema = {
     $schema: "https://json-schema.org/draft/2019-09/schema#",
     type: "object",
@@ -73,6 +77,10 @@ export class PixieBrixSessionReader extends Reader {
       navigationTimestamp: session.navigationTimestamp.toISOString(),
       ...(await getExtensionAuth()),
     };
+  }
+
+  async isRootAware(): Promise<boolean> {
+    return false;
   }
 
   async isPure(): Promise<boolean> {
@@ -139,6 +147,10 @@ export class PixieBrixProfileReader extends Reader {
     return true;
   }
 
+  async isRootAware(): Promise<boolean> {
+    return false;
+  }
+
   outputSchema: Schema = {
     $schema: "https://json-schema.org/draft/2019-09/schema#",
     type: "object",
@@ -179,6 +191,10 @@ export class DocumentReader extends Reader {
     };
   }
 
+  async isRootAware(): Promise<boolean> {
+    return false;
+  }
+
   async isPure(): Promise<boolean> {
     return true;
   }
@@ -215,6 +231,10 @@ export class ManifestReader extends Reader {
       "Chrome manifest reader",
       "Read the Chrome extension manifest"
     );
+  }
+
+  async isRootAware(): Promise<boolean> {
+    return false;
   }
 
   async isAvailable() {

--- a/src/blocks/transformers/blockFactory.ts
+++ b/src/blocks/transformers/blockFactory.ts
@@ -123,6 +123,19 @@ class ExternalBlock extends Block {
     return purity.every((x) => x);
   }
 
+  async isRootAware(): Promise<boolean> {
+    const pipeline = castArray(this.component.pipeline);
+
+    const awareness = await Promise.all(
+      pipeline.map(async (blockConfig) => {
+        const resolvedBlock = await blockRegistry.lookup(blockConfig.id);
+        return resolvedBlock.isRootAware();
+      })
+    );
+
+    return awareness.some((x) => x);
+  }
+
   async inferType(): Promise<ComponentKind | null> {
     const pipeline = castArray(this.component.pipeline);
     const last = pipeline[pipeline.length - 1];

--- a/src/blocks/transformers/component/ComponentReader.ts
+++ b/src/blocks/transformers/component/ComponentReader.ts
@@ -65,6 +65,10 @@ export class ComponentReader extends Transformer {
     },
   };
 
+  async isRootAware(): Promise<boolean> {
+    return true;
+  }
+
   async isPure(): Promise<boolean> {
     return true;
   }

--- a/src/blocks/transformers/jquery/JQueryReader.ts
+++ b/src/blocks/transformers/jquery/JQueryReader.ts
@@ -83,6 +83,10 @@ export class JQueryReader extends Transformer {
     },
   };
 
+  async isRootAware(): Promise<boolean> {
+    return true;
+  }
+
   async isPure(): Promise<boolean> {
     return true;
   }

--- a/src/blocks/types.ts
+++ b/src/blocks/types.ts
@@ -38,25 +38,65 @@ export type ReaderConfig =
   | { [key: string]: ReaderConfig }
   | ReaderConfig[];
 
-export interface BlockConfig {
+/**
+ * A block configuration to be executed by the PixieBrix runtime.
+ * @see runStage
+ * @see reducePipeline
+ */
+export type BlockConfig = {
+  /**
+   * The registry id of the configured block
+   */
   id: RegistryId;
 
   /**
-   * (Optional) human-readable label for the step. Shown in the progress indicator
+   * The configuration of the block
+   */
+  config: UnknownObject;
+
+  /**
+   * (Optional) human-readable label for the step.
+   *
+   * Shown in the page editor, logs, and the progress indicator
+   * @see notifyProgress
    */
   label?: string;
 
   /**
-   * (Optional) indicate the step is being run in the interface
+   * (Optional) `true` to indicate on the host page that the step is being run
    */
   notifyProgress?: boolean;
 
+  /**
+   * (Optional) If the brick is being run in the context of a deployment, if an error occurs in this step an
+   * alert email is send to the admins for the deployment with the brick input.
+   *
+   * Used as a stopgap/recovery mechanism operations that aren't safe to retry. (For example, sending data to a
+   * UiPath queue for execution)
+   */
   onError?: {
     alert?: boolean;
   };
 
+  /**
+   * Where to execute the brick (default=`self`)
+   * - self: the current tab
+   * - opener: the tab that opened the current tab
+   * - target: the last tab that the current tab opened
+   * - broadcast: all tabs that PixieBrix has access to (the result is returned as an array)
+   * - remote: the server (currently only support identity, get, and http bricks)
+   */
   window?: "self" | "opener" | "target" | "broadcast" | "remote";
 
+  /**
+   * The output key (without the preceding "@") to assign the brick output to
+   *
+   * As of brick API `v2`, the outputKey is required except:
+   * - Effect bricks (because they don't produce an output)
+   * - The last brick in pipeline
+   *
+   * @see ApiVersionOptions.explicitDataFlow
+   */
   outputKey?: OutputKey;
 
   /**
@@ -66,16 +106,28 @@ export interface BlockConfig {
   if?: string | boolean | number;
 
   /**
-   * (Optional) root selector for reader
+   * (Optional) whether the block should inherit the current root element, or if it should use the document
+   * (default=`inherit`)
+   *
+   * @see root
+   * @since 1.4.0
+   */
+  rootMode?: "inherit" | "document";
+
+  /**
+   * (Optional) root JQuery/CSS selector. The selector is relative to the `root` that is passed to the pipeline/stage.
+   *
+   * An error is thrown at runtime if the selector doesn't match exactly one argument
+   * @see rootMode
    */
   root?: string;
 
   /**
-   * (Optional) template language to use for rendering the if and config properties. Default is mustache
+   * (Optional) template language to use for rendering the `if` and `config` properties (default=`mustache`)
+   * @see config
+   * @see if
    */
   templateEngine?: TemplateEngine;
-
-  config: UnknownObject;
 
   /**
    * A unique id for the configured block, used to correlate traces across runs when using the Page Editor.
@@ -83,6 +135,6 @@ export interface BlockConfig {
    * DO NOT SET: generated automatically by the Page Editor when configuring a dynamic element.
    */
   instanceId?: UUID;
-}
+};
 
 export type BlockPipeline = BlockConfig[];

--- a/src/core.ts
+++ b/src/core.ts
@@ -488,7 +488,7 @@ export interface IBlock extends Metadata {
    * Returns `true` if the block can use the reader root from the block options
    *
    * Defined as a promise to support blocks that refer to other blocks (and therefore need to look up the status of
-   * the other blocks to resolve their purity).
+   * the other blocks to resolve their isRootAware status).
    *
    * @see BlockOptions.root
    * @since 1.4.0

--- a/src/core.ts
+++ b/src/core.ts
@@ -485,11 +485,24 @@ export interface IBlock extends Metadata {
   isPure?: () => Promise<boolean>;
 
   /**
+   * Returns `true` if the block can use the reader root from the block options
+   *
+   * Defined as a promise to support blocks that refer to other blocks (and therefore need to look up the status of
+   * the other blocks to resolve their purity).
+   *
+   * @see BlockOptions.root
+   * @since 1.4.0
+   */
+  isRootAware?: () => Promise<boolean>;
+
+  /**
    * (Optional) default root output key to use when this block is added in the page editor.
    *
    * If not provided, the Page Editor will use a generic name, potentially based on the inferred type of the brick.
    *
    * For example, "foo" will produce: foo, foo2, foo3, foo4, etc.
+   *
+   * @since 1.3.2
    */
   defaultOutputKey?: string;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,6 +215,11 @@ export abstract class Block implements IBlock {
     return false;
   }
 
+  async isRootAware(): Promise<boolean> {
+    // Safe default
+    return true;
+  }
+
   protected constructor(
     id: string,
     name: string,
@@ -240,6 +245,11 @@ export abstract class Effect extends Block {
     super(id, name, description, icon);
   }
 
+  async isRootAware(): Promise<boolean> {
+    // Most transformers don't use the root, so have them opt-in
+    return false;
+  }
+
   abstract effect(inputs: BlockArg, env?: BlockOptions): Promise<void>;
 
   async run(value: BlockArg, options: BlockOptions): Promise<void> {
@@ -255,6 +265,11 @@ export abstract class Transformer extends Block {
     icon?: BlockIcon
   ) {
     super(id, name, description, icon);
+  }
+
+  async isRootAware(): Promise<boolean> {
+    // Most transformers don't use the root, so have them opt-in
+    return false;
   }
 
   abstract transform(value: BlockArg, options: BlockOptions): Promise<unknown>;
@@ -279,6 +294,11 @@ export abstract class Renderer extends Block {
     options: BlockOptions
   ): Promise<RenderedHTML>;
 
+  async isRootAware(): Promise<boolean> {
+    // Most renderers don't use the root, so have them opt-in
+    return false;
+  }
+
   async run(value: BlockArg, options: BlockOptions): Promise<RenderedHTML> {
     return this.render(value, options);
   }
@@ -296,6 +316,11 @@ export abstract class Reader extends Block implements IReader {
     icon?: BlockIcon
   ) {
     super(id, name, description, icon);
+  }
+
+  async isRootAware(): Promise<boolean> {
+    // Most readers use the root, so have them opt-out if they don't
+    return true;
   }
 
   abstract isAvailable($elt?: JQuery): Promise<boolean>;


### PR DESCRIPTION
Closes #1466

- Adds a `rootMode` property on the BlockConfiguration. Can be used to force the root element passed in for BlockOptions to be `document` instead of inherited from the pipeline/foundation
- Adds a `isRootAware` method to IBlock for native blocks to declare whether or not they use the root from BlockOptions
- Shows a rootMode configuration option in the PageEditor where applicable