### PR TITLE
#1451: cleanup unused service dependency entries

### DIFF
--- a/src/components/fields/schemaFields/ServiceField.tsx
+++ b/src/components/fields/schemaFields/ServiceField.tsx
@@ -137,7 +137,6 @@ export function produceExcludeUnusedDependencies<
   T extends ServiceSlice = ServiceSlice
 >(state: T): T {
   const used = selectTopLevelVars(state);
-  console.debug("produceExcludeUnusedDependencies", { used });
   return produce(state, (draft) => {
     draft.services = draft.services.filter((x) =>
       used.has(keyToFieldValue(x.outputKey))
@@ -193,8 +192,6 @@ function produceServiceAuths(
         config: option.value,
       });
     }
-
-    console.debug("Setting field value", { fieldName });
   });
 
   // Update field value before calling produceExcludeUnusedDependencies, otherwise it will see the stale service var

--- a/src/components/fields/schemaFields/ServiceField.tsx
+++ b/src/components/fields/schemaFields/ServiceField.tsx
@@ -17,14 +17,14 @@
 
 import React, { useCallback, useEffect, useMemo } from "react";
 import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
-import { useField, useFormikContext } from "formik";
+import { setIn, useField, useFormikContext } from "formik";
 import {
   OutputKey,
   RegistryId,
   SafeString,
-  Schema,
   ServiceDependency,
   ServiceKeyVar,
+  UUID,
 } from "@/core";
 import {
   createTypePredicate,
@@ -41,20 +41,23 @@ import { faCloud } from "@fortawesome/free-solid-svg-icons";
 import SelectWidget, {
   SelectWidgetOnChange,
 } from "@/components/form/widgets/SelectWidget";
-import { isEmpty } from "lodash";
+import { castArray, isEmpty } from "lodash";
 import FieldTemplate from "@/components/form/FieldTemplate";
+import {
+  extractServiceIds,
+  SERVICE_BASE_SCHEMA,
+  SERVICE_FIELD_REFS,
+} from "@/services/serviceUtils";
+import { FormState } from "@/devTools/editor/slices/editorSlice";
+import { UnknownObject } from "@/types";
+import { BlockPipeline } from "@/blocks/types";
 
 const DEFAULT_SERVICE_OUTPUT_KEY = "service" as OutputKey;
 
-export const SERVICE_FIELD_REFS = [
-  "https://app.pixiebrix.com/schemas/service#/definitions/configuredServiceOrVar",
-  "https://app.pixiebrix.com/schemas/service#/definitions/configuredService",
-];
-
-export const SERVICE_BASE_SCHEMA =
-  "https://app.pixiebrix.com/schemas/services/";
-
-const SERVICE_ID_REGEX = /^https:\/\/app\.pixiebrix\.com\/schemas\/services\/(?<id>\S+)$/;
+/**
+ * Regex matching identifiers generated via defaultOutputKey
+ */
+const SERVICE_VAR_REGEX = /^@\w+$/;
 
 export const isServiceField = createTypePredicate(
   (x) =>
@@ -81,23 +84,126 @@ function defaultOutputKey(
   ) as OutputKey;
 }
 
-export function extractServiceIds(schema: Schema): RegistryId[] {
-  if ("$ref" in schema) {
-    const match = SERVICE_ID_REGEX.exec(schema.$ref ?? "");
-    return match ? [match.groups.id as RegistryId] : [];
-  }
-
-  if ("anyOf" in schema) {
-    return schema.anyOf
-      .filter((x) => x !== false)
-      .flatMap((x) => extractServiceIds(x as Schema));
-  }
-
-  throw new Error("Expected $ref or anyOf in schema for service");
-}
-
 function keyToFieldValue(key: OutputKey): ServiceKeyVar {
   return key == null ? null : (`@${key}` as ServiceKeyVar);
+}
+
+type ServiceSlice = Pick<FormState, "services" | "extension">;
+
+/**
+ * Return the auth id corresponding to a service variable usage
+ * @see AuthOption.value
+ * @see ServiceDependency.config
+ */
+function lookupAuthId(
+  dependencies: ServiceDependency[],
+  authOptions: AuthOption[],
+  value: ServiceKeyVar
+): UUID {
+  const dependency =
+    value == null
+      ? null
+      : dependencies.find((x) => keyToFieldValue(x.outputKey) === value);
+
+  return dependency == null
+    ? null
+    : authOptions.find((x) => x.value === dependency.config)?.value;
+}
+
+const PIPELINE_PROPERTIES = ["action", "body"];
+
+function selectTopLevelVars(state: Pick<FormState, "extension">): Set<string> {
+  const extensionConfig = state.extension as UnknownObject;
+
+  const identifiers = PIPELINE_PROPERTIES.flatMap((prop) => {
+    // eslint-disable-next-line security/detect-object-injection -- prop is constant
+    const pipeline = castArray(extensionConfig[prop] ?? []) as BlockPipeline;
+    return pipeline.flatMap((blockConfig) => {
+      const values = Object.values(blockConfig.config).filter(
+        (x) => typeof x === "string"
+      ) as string[];
+      return values.filter((value) => SERVICE_VAR_REGEX.test(value));
+    });
+  });
+
+  return new Set(identifiers);
+}
+
+/**
+ * Return a new copy of state with unused dependencies excluded
+ * @param state the form state
+ */
+export function produceExcludeUnusedDependencies<
+  T extends ServiceSlice = ServiceSlice
+>(state: T): T {
+  const used = selectTopLevelVars(state);
+  console.debug("produceExcludeUnusedDependencies", { used });
+  return produce(state, (draft) => {
+    draft.services = draft.services.filter((x) =>
+      used.has(keyToFieldValue(x.outputKey))
+    );
+  });
+}
+
+/**
+ * Key assumptions/limitations:
+ * - We're only supporting one service of each type at this time. If you change one of the auths for a service, it will
+ * change the other auths for that service too
+ */
+// eslint-disable-next-line max-params -- internal method where all the arguments have different types
+function produceServiceAuths(
+  state: ServiceSlice,
+  fieldName: string,
+  serviceId: UUID,
+  serviceIds: RegistryId[],
+  options: AuthOption[]
+) {
+  const option = options.find((x) => x.value === serviceId);
+
+  let outputKey: OutputKey;
+
+  let nextState = produce(state, (draft) => {
+    // Some bricks support alternative service ids, so need to check all of them
+    const match = draft.services.find((dependency) =>
+      serviceIds.includes(dependency.id)
+    );
+
+    if (match) {
+      console.debug(
+        "Dependency already exists for %s, switching service auth",
+        option.serviceId,
+        { state }
+      );
+      match.id = option.serviceId;
+      match.config = option.value;
+      outputKey = match.outputKey;
+    } else {
+      console.debug(
+        "Dependency does not exist for %s, creating dependency",
+        option.serviceId,
+        { state }
+      );
+      outputKey = defaultOutputKey(
+        option.serviceId,
+        draft.services.map((x) => x.outputKey)
+      );
+      draft.services.push({
+        id: option.serviceId,
+        outputKey,
+        config: option.value,
+      });
+    }
+
+    console.debug("Setting field value", { fieldName });
+  });
+
+  // Update field value before calling produceExcludeUnusedDependencies, otherwise it will see the stale service var
+  nextState = setIn(nextState, fieldName, keyToFieldValue(outputKey));
+
+  // Perform cleanup of the service dependencies
+  nextState = produceExcludeUnusedDependencies(nextState);
+
+  return nextState;
 }
 
 /**
@@ -111,12 +217,11 @@ const ServiceField: React.FunctionComponent<
   }
 > = ({ label, detectDefault = true, schema, ...props }) => {
   const [authOptions] = useAuthOptions();
-
+  const {
+    values: root,
+    setValues: setRootValues,
+  } = useFormikContext<ServiceSlice>();
   const [{ value, ...field }, meta, helpers] = useField<ServiceKeyVar>(props);
-
-  const { values: root, setValues } = useFormikContext<{
-    services: ServiceDependency[];
-  }>();
 
   const { serviceIds, options } = useMemo(() => {
     const serviceIds = extractServiceIds(schema);
@@ -128,64 +233,13 @@ const ServiceField: React.FunctionComponent<
     };
   }, [authOptions, schema]);
 
-  const selectedOption = useMemo(() => {
-    const dependency =
-      value == null
-        ? null
-        : root.services.find((x) => keyToFieldValue(x.outputKey) === value);
-
-    return dependency == null
-      ? null
-      : authOptions.find((x) => x.value === dependency.config);
-  }, [root.services, authOptions, value]);
-
   const onChange: SelectWidgetOnChange<AuthOption> = useCallback(
     ({ target: { value, options } }) => {
-      // Key Assumption: only one service of each type is configured. If a user changes the auth for one brick,
-      // it changes the auth for all the bricks.
-
-      const option = options.find((x) => x.value === value);
-
-      let outputKey: OutputKey;
-
-      setValues(
-        produce(root, (draft) => {
-          // Some bricks support alternative service ids, so need to check all of them
-          const match = draft.services.find((dependency) =>
-            serviceIds.includes(dependency.id)
-          );
-          if (match) {
-            console.debug(
-              "Dependency already exists for %s, switching service auth",
-              option.serviceId,
-              { root }
-            );
-            match.id = option.serviceId;
-            match.config = option.value;
-            outputKey = match.outputKey;
-          } else {
-            console.debug(
-              "Dependency does not exist for %s, creating dependency",
-              option.serviceId,
-              { root }
-            );
-            outputKey = defaultOutputKey(
-              option.serviceId,
-              draft.services.map((x) => x.outputKey)
-            );
-            draft.services.push({
-              id: option.serviceId,
-              outputKey,
-              config: option.value,
-            });
-          }
-        })
+      setRootValues(
+        produceServiceAuths(root, field.name, value, serviceIds, options)
       );
-
-      console.debug("Setting value to %s", outputKey);
-      helpers.setValue(keyToFieldValue(outputKey));
     },
-    [root, helpers, setValues, serviceIds]
+    [root, setRootValues, serviceIds, field.name]
   );
 
   useEffect(
@@ -243,7 +297,7 @@ const ServiceField: React.FunctionComponent<
       blankValue={null}
       options={options}
       // The SelectWidget re-looks up the option based on the value
-      value={selectedOption?.value}
+      value={lookupAuthId(root.services, authOptions, value)}
       onChange={onChange}
       error={meta.error}
       touched={meta.touched}

--- a/src/contrib/RequireServiceConfig.tsx
+++ b/src/contrib/RequireServiceConfig.tsx
@@ -18,10 +18,9 @@
 import React from "react";
 import { SanitizedServiceConfiguration, Schema } from "@/core";
 import useDependency from "@/services/useDependency";
-import ServiceField, {
-  extractServiceIds,
-} from "@/components/fields/schemaFields/ServiceField";
+import ServiceField from "@/components/fields/schemaFields/ServiceField";
 import { Button } from "react-bootstrap";
+import { extractServiceIds } from "@/services/serviceUtils";
 
 type ConfigProps = {
   serviceSchema: Schema;

--- a/src/services/serviceUtils.ts
+++ b/src/services/serviceUtils.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { RegistryId, Schema } from "@/core";
+
+export const SERVICE_FIELD_REFS = [
+  "https://app.pixiebrix.com/schemas/service#/definitions/configuredServiceOrVar",
+  "https://app.pixiebrix.com/schemas/service#/definitions/configuredService",
+];
+
+export const SERVICE_BASE_SCHEMA =
+  "https://app.pixiebrix.com/schemas/services/";
+
+const SERVICE_ID_REGEX = /^https:\/\/app\.pixiebrix\.com\/schemas\/services\/(?<id>\S+)$/;
+
+/**
+ * Return the registry ids of services supported by a JSON Schema field definition
+ * @param schema
+ */
+export function extractServiceIds(schema: Schema): RegistryId[] {
+  if ("$ref" in schema) {
+    const match = SERVICE_ID_REGEX.exec(schema.$ref ?? "");
+    return match ? [match.groups.id as RegistryId] : [];
+  }
+
+  if ("anyOf" in schema) {
+    return schema.anyOf
+      .filter((x) => x !== false)
+      .flatMap((x) => extractServiceIds(x as Schema));
+  }
+
+  throw new Error("Expected $ref or anyOf in schema for service");
+}


### PR DESCRIPTION
Closes #1451 

Future work / Out of Scope: 
- Share dependencies when possible for the `get` and `http` bricks which don't declare which services they use
- Handle rapidapi cases where multiple different services are using the same integration