### PR TITLE
#989: Page editor add/insert panel updates

### DIFF
--- a/src/components/brickModal/BrickModal.tsx
+++ b/src/components/brickModal/BrickModal.tsx
@@ -211,11 +211,11 @@ function ActualModal<T extends IBrick>({
     );
   }, [recommendations, bricks]);
 
-  // If there's no recommendations, default to the first brick so the right side isn't blank
   useEffect(
     () => {
-      if (recommendations.length === 0) {
-        setDetailBrick(bricks[0]);
+      // If there's no recommendations, default to the first brick so the right side isn't blank
+      if (recommendations.length === 0 && searchResults.length > 0) {
+        setDetailBrick(searchResults[0].data);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- run on initial mount

--- a/src/devTools/editor/components/Centered.tsx
+++ b/src/devTools/editor/components/Centered.tsx
@@ -25,7 +25,7 @@ const Centered: React.FunctionComponent<{ isScrollable?: boolean }> = ({
 }) => (
   <Container fluid className={cx({ "h-100 pb-2 overflow-auto": isScrollable })}>
     <Row>
-      <Col className="mx-auto mt-4 text-center" md={8} lg={5} sm={11}>
+      <Col className="mx-auto mt-4 text-center" sm={11} md={9} lg={6} xl={5}>
         {children}
       </Col>
     </Row>

--- a/src/devTools/editor/extensionPoints/actionPanel.tsx
+++ b/src/devTools/editor/extensionPoints/actionPanel.tsx
@@ -243,12 +243,12 @@ const config: ElementConfig<never, ActionPanelFormState> = {
     <div>
       <p>
         A sidebar panel can be configured to appear in the PixieBrix sidebar on
-        pages you choose
+        pages you choose.
       </p>
 
       <p>
-        Use an existing foundation, or start from scratch to have full control
-        over when the panel appears
+        Search for an existing sidebar panel in the marketplace, or start from
+        scratch to have full control over when the panel appears.
       </p>
     </div>
   ),

--- a/src/devTools/editor/extensionPoints/contextMenu.tsx
+++ b/src/devTools/editor/extensionPoints/contextMenu.tsx
@@ -278,12 +278,12 @@ const config: ElementConfig<undefined, ContextMenuFormState> = {
     <div>
       <p>
         A context menu (also called a right-click menu) can be configured to
-        appear when you right click on a page, text selection, or other content
+        appear when you right click on a page, text selection, or other content.
       </p>
 
       <p>
-        Use an existing foundation, or start from scratch to have full control
-        over where the the menu item appears
+        Search for an existing context menu in the marketplace, or start from
+        scratch to have full control over how your context menu appears.
       </p>
     </div>
   ),

--- a/src/devTools/editor/extensionPoints/trigger.tsx
+++ b/src/devTools/editor/extensionPoints/trigger.tsx
@@ -257,8 +257,8 @@ const config: ElementConfig<undefined, TriggerFormState> = {
         etc.)
       </p>
       <p>
-        Use an existing foundation, or start from scratch to have full control
-        over when the trigger runs
+        Search for an existing trigger in the marketplace, or start from scratch
+        to have full control over when the trigger runs.
       </p>
     </div>
   ),

--- a/src/devTools/editor/panes/insert/GenericInsertPane.module.scss
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.module.scss
@@ -21,10 +21,10 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
+}
 
-  :last-child {
-    margin-top: 0.5rem;
-  }
+.searchButton {
+  margin-top: 0.5rem;
 }
 
 .cancelRow {

--- a/src/devTools/editor/panes/insert/GenericInsertPane.module.scss
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.module.scss
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.buttonRow {
+  padding-left: 6rem;
+  padding-right: 6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+
+  :last-child {
+    margin-top: 0.5rem;
+  }
+}
+
+.cancelRow {
+  justify-content: center;
+}

--- a/src/devTools/editor/panes/insert/GenericInsertPane.tsx
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.tsx
@@ -21,7 +21,7 @@ import { DevToolsContext } from "@/devTools/context";
 import { showBrowserActionPanel } from "@/background/devtools";
 import useAvailableExtensionPoints from "@/devTools/editor/hooks/useAvailableExtensionPoints";
 import Centered from "@/devTools/editor/components/Centered";
-import { Button, Col, Row } from "react-bootstrap";
+import { Button, Row } from "react-bootstrap";
 import BlockModal from "@/components/brickModal/BrickModal";
 import { editorSlice, FormState } from "@/devTools/editor/slices/editorSlice";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/devTools/editor/panes/insert/GenericInsertPane.tsx
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.tsx
@@ -21,11 +21,11 @@ import { DevToolsContext } from "@/devTools/context";
 import { showBrowserActionPanel } from "@/background/devtools";
 import useAvailableExtensionPoints from "@/devTools/editor/hooks/useAvailableExtensionPoints";
 import Centered from "@/devTools/editor/components/Centered";
-import { Button } from "react-bootstrap";
+import { Button, Col, Row } from "react-bootstrap";
 import BlockModal from "@/components/brickModal/BrickModal";
 import { editorSlice, FormState } from "@/devTools/editor/slices/editorSlice";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCube, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faCube, faExpand, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { internalExtensionPointMetaFactory } from "@/devTools/editor/extensionPoints/base";
 import { ElementConfig } from "@/devTools/editor/extensionPoints/elementConfig";
 import { reportEvent } from "@/telemetry/events";
@@ -118,32 +118,40 @@ const GenericInsertPane: React.FunctionComponent<{
 
   return (
     <Centered isScrollable>
-      <div className="PaneTitle">Add {config.label}</div>
+      <div className="PaneTitle">Build new {config.label} extension</div>
       <div className="text-left">{config.insertModeHelp}</div>
-      <div>
-        <BlockModal
-          bricks={extensionPoints ?? []}
-          caption={`Select ${config.label} Foundation`}
-          renderButton={({ show }) => (
-            <Button
-              variant="info"
-              onClick={show}
-              disabled={!extensionPoints?.length}
-            >
-              <FontAwesomeIcon icon={faCube} /> Use Existing {config.label}
-            </Button>
-          )}
-          onSelect={async (block) => addExisting(block)}
-        />
+      <Row>
+        <Col sm={3}>
+          <h6>Start with:</h6>
+        </Col>
+        <Col
+          sm={9}
+          className="text-left d-flex flex-column align-items-stretch px-5"
+        >
+          <BlockModal
+            bricks={extensionPoints ?? []}
+            renderButton={({ show }) => (
+              <Button
+                variant="info"
+                onClick={show}
+                disabled={!extensionPoints?.length}
+              >
+                <FontAwesomeIcon icon={faCube} /> Existing Foundation
+              </Button>
+            )}
+            onSelect={async (block) => addExisting(block)}
+          />
 
-        <Button variant="info" className="ml-2" onClick={addNew}>
-          <FontAwesomeIcon icon={faPlus} /> Create New
+          <Button variant="info" className="mt-2" onClick={addNew}>
+            <FontAwesomeIcon icon={faExpand} /> Empty {config.label}
+          </Button>
+        </Col>
+      </Row>
+      <Row>
+        <Button variant="outline-danger" className="m-3" onClick={cancel}>
+          <FontAwesomeIcon icon={faTimes} /> Cancel
         </Button>
-
-        <Button variant="danger" className="ml-2" onClick={cancel}>
-          Cancel Insert
-        </Button>
-      </div>
+      </Row>
     </Centered>
   );
 };

--- a/src/devTools/editor/panes/insert/GenericInsertPane.tsx
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.tsx
@@ -33,6 +33,7 @@ import * as nativeOperations from "@/background/devtools";
 import { useToasts } from "react-toast-notifications";
 import { reportError } from "@/telemetry/logging";
 import { getCurrentURL } from "@/devTools/utils";
+import styles from "./GenericInsertPane.module.scss";
 
 const { addElement } = editorSlice.actions;
 
@@ -120,35 +121,26 @@ const GenericInsertPane: React.FunctionComponent<{
     <Centered isScrollable>
       <div className="PaneTitle">Build new {config.label} extension</div>
       <div className="text-left">{config.insertModeHelp}</div>
-      <Row>
-        <Col sm={3}>
-          <h5>Start with:</h5>
-        </Col>
-        <Col
-          sm={9}
-          className="text-left d-flex flex-column align-items-stretch px-5"
-        >
-          <Button variant="primary" onClick={addNew}>
-            <FontAwesomeIcon icon={faExpand} /> Empty {config.label}
-          </Button>
+      <Row className={styles.buttonRow}>
+        <Button variant="primary" onClick={addNew}>
+          <FontAwesomeIcon icon={faExpand} /> Create new {config.label}
+        </Button>
 
-          <BlockModal
-            bricks={extensionPoints ?? []}
-            renderButton={({ show }) => (
-              <Button
-                variant="info"
-                onClick={show}
-                disabled={!extensionPoints?.length}
-                className="mt-2"
-              >
-                <FontAwesomeIcon icon={faSearch} /> Search Marketplace
-              </Button>
-            )}
-            onSelect={async (block) => addExisting(block)}
-          />
-        </Col>
+        <BlockModal
+          bricks={extensionPoints ?? []}
+          renderButton={({ show }) => (
+            <Button
+              variant="info"
+              onClick={show}
+              disabled={!extensionPoints?.length}
+            >
+              <FontAwesomeIcon icon={faSearch} /> Search Marketplace
+            </Button>
+          )}
+          onSelect={async (block) => addExisting(block)}
+        />
       </Row>
-      <Row>
+      <Row className={styles.cancelRow}>
         <Button variant="outline-danger" className="m-3" onClick={cancel}>
           <FontAwesomeIcon icon={faTimes} /> Cancel
         </Button>

--- a/src/devTools/editor/panes/insert/GenericInsertPane.tsx
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.tsx
@@ -133,6 +133,7 @@ const GenericInsertPane: React.FunctionComponent<{
               variant="info"
               onClick={show}
               disabled={!extensionPoints?.length}
+              className={styles.searchButton}
             >
               <FontAwesomeIcon icon={faSearch} /> Search Marketplace
             </Button>

--- a/src/devTools/editor/panes/insert/GenericInsertPane.tsx
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.tsx
@@ -25,7 +25,7 @@ import { Button, Row } from "react-bootstrap";
 import BlockModal from "@/components/brickModal/BrickModal";
 import { editorSlice, FormState } from "@/devTools/editor/slices/editorSlice";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faExpand, faSearch, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faSearch, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { internalExtensionPointMetaFactory } from "@/devTools/editor/extensionPoints/base";
 import { ElementConfig } from "@/devTools/editor/extensionPoints/elementConfig";
 import { reportEvent } from "@/telemetry/events";
@@ -123,7 +123,7 @@ const GenericInsertPane: React.FunctionComponent<{
       <div className="text-left">{config.insertModeHelp}</div>
       <Row className={styles.buttonRow}>
         <Button variant="primary" onClick={addNew}>
-          <FontAwesomeIcon icon={faExpand} /> Create new {config.label}
+          <FontAwesomeIcon icon={faPlus} /> Create new {config.label}
         </Button>
 
         <BlockModal
@@ -141,7 +141,7 @@ const GenericInsertPane: React.FunctionComponent<{
         />
       </Row>
       <Row className={styles.cancelRow}>
-        <Button variant="outline-danger" className="m-3" onClick={cancel}>
+        <Button variant="danger" className="m-3" onClick={cancel}>
           <FontAwesomeIcon icon={faTimes} /> Cancel
         </Button>
       </Row>

--- a/src/devTools/editor/panes/insert/GenericInsertPane.tsx
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.tsx
@@ -25,7 +25,7 @@ import { Button, Col, Row } from "react-bootstrap";
 import BlockModal from "@/components/brickModal/BrickModal";
 import { editorSlice, FormState } from "@/devTools/editor/slices/editorSlice";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCube, faExpand, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faExpand, faSearch, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { internalExtensionPointMetaFactory } from "@/devTools/editor/extensionPoints/base";
 import { ElementConfig } from "@/devTools/editor/extensionPoints/elementConfig";
 import { reportEvent } from "@/telemetry/events";
@@ -122,12 +122,16 @@ const GenericInsertPane: React.FunctionComponent<{
       <div className="text-left">{config.insertModeHelp}</div>
       <Row>
         <Col sm={3}>
-          <h6>Start with:</h6>
+          <h5>Start with:</h5>
         </Col>
         <Col
           sm={9}
           className="text-left d-flex flex-column align-items-stretch px-5"
         >
+          <Button variant="primary" onClick={addNew}>
+            <FontAwesomeIcon icon={faExpand} /> Empty {config.label}
+          </Button>
+
           <BlockModal
             bricks={extensionPoints ?? []}
             renderButton={({ show }) => (
@@ -135,16 +139,13 @@ const GenericInsertPane: React.FunctionComponent<{
                 variant="info"
                 onClick={show}
                 disabled={!extensionPoints?.length}
+                className="mt-2"
               >
-                <FontAwesomeIcon icon={faCube} /> Existing Foundation
+                <FontAwesomeIcon icon={faSearch} /> Search Marketplace
               </Button>
             )}
             onSelect={async (block) => addExisting(block)}
           />
-
-          <Button variant="info" className="mt-2" onClick={addNew}>
-            <FontAwesomeIcon icon={faExpand} /> Empty {config.label}
-          </Button>
         </Col>
       </Row>
       <Row>

--- a/src/devTools/editor/panes/insert/InsertMenuItemPane.tsx
+++ b/src/devTools/editor/panes/insert/InsertMenuItemPane.tsx
@@ -55,8 +55,8 @@ const InsertMenuItemPane: React.FunctionComponent<{ cancel: () => void }> = ({
       <div className="text-left">
         <p>
           <FontAwesomeIcon icon={faMousePointer} size="lg" /> Click on an
-          existing <code>button</code> or button-like element to add a button
-          that that button group. You can also select a menu item or nav link.
+          existing <code>button</code> or button-like element to add a button to
+          that button&apos;s group. You can also select a menu item or nav link.
         </p>
 
         <div>

--- a/src/devTools/editor/panes/insert/InsertMenuItemPane.tsx
+++ b/src/devTools/editor/panes/insert/InsertMenuItemPane.tsx
@@ -25,7 +25,12 @@ import {
 import Centered from "@/devTools/editor/components/Centered";
 import { Alert, Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faInfo, faSearch, faTimes } from "@fortawesome/free-solid-svg-icons";
+import {
+  faInfo,
+  faMousePointer,
+  faSearch,
+  faTimes,
+} from "@fortawesome/free-solid-svg-icons";
 import BlockModal from "@/components/brickModal/BrickModal";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import useAddExisting from "@/devTools/editor/panes/insert/useAddExisting";
@@ -49,9 +54,9 @@ const InsertMenuItemPane: React.FunctionComponent<{ cancel: () => void }> = ({
 
       <div className="text-left">
         <p>
-          Click on an existing <code>button</code> or button-like element to add
-          a button that that button group. You can also select a menu item or
-          nav link.
+          <FontAwesomeIcon icon={faMousePointer} size="lg" /> Click on an
+          existing <code>button</code> or button-like element to add a button
+          that that button group. You can also select a menu item or nav link.
         </p>
 
         <div>

--- a/src/devTools/editor/panes/insert/InsertMenuItemPane.tsx
+++ b/src/devTools/editor/panes/insert/InsertMenuItemPane.tsx
@@ -84,7 +84,7 @@ const InsertMenuItemPane: React.FunctionComponent<{ cancel: () => void }> = ({
           onSelect={async (block) => addExisting(block as MenuItemWithConfig)}
         />
 
-        <Button variant="outline-danger" className="ml-2" onClick={cancel}>
+        <Button variant="danger" className="ml-2" onClick={cancel}>
           <FontAwesomeIcon icon={faTimes} /> Cancel
         </Button>
       </div>

--- a/src/devTools/editor/panes/insert/InsertMenuItemPane.tsx
+++ b/src/devTools/editor/panes/insert/InsertMenuItemPane.tsx
@@ -25,7 +25,7 @@ import {
 import Centered from "@/devTools/editor/components/Centered";
 import { Alert, Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCube, faInfo } from "@fortawesome/free-solid-svg-icons";
+import { faInfo, faSearch, faTimes } from "@fortawesome/free-solid-svg-icons";
 import BlockModal from "@/components/brickModal/BrickModal";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import useAddExisting from "@/devTools/editor/panes/insert/useAddExisting";
@@ -73,14 +73,14 @@ const InsertMenuItemPane: React.FunctionComponent<{ cancel: () => void }> = ({
               onClick={show}
               disabled={!menuItemExtensionPoints?.length}
             >
-              <FontAwesomeIcon icon={faCube} /> Use Existing Button
+              <FontAwesomeIcon icon={faSearch} /> Search Marketplace
             </Button>
           )}
           onSelect={async (block) => addExisting(block as MenuItemWithConfig)}
         />
 
-        <Button variant="danger" className="ml-2" onClick={cancel}>
-          Cancel Insert
+        <Button variant="outline-danger" className="ml-2" onClick={cancel}>
+          <FontAwesomeIcon icon={faTimes} /> Cancel
         </Button>
       </div>
     </Centered>

--- a/src/devTools/editor/panes/insert/InsertPanelPane.tsx
+++ b/src/devTools/editor/panes/insert/InsertPanelPane.tsx
@@ -29,6 +29,7 @@ import config from "@/devTools/editor/extensionPoints/panel";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faExclamationTriangle,
+  faMousePointer,
   faSearch,
   faTimes,
 } from "@fortawesome/free-solid-svg-icons";
@@ -50,7 +51,8 @@ const InsertPanelPane: React.FunctionComponent<{
 
       <div className="text-left">
         <p>
-          Click on a container to insert a panel in that container. Or, click{" "}
+          <FontAwesomeIcon icon={faMousePointer} size="lg" /> Click on a
+          container to insert a panel in that container. Or, click{" "}
           <span className="text-info">Use Existing Panel</span> to use a panel
           foundation that already exists for the page
         </p>

--- a/src/devTools/editor/panes/insert/InsertPanelPane.tsx
+++ b/src/devTools/editor/panes/insert/InsertPanelPane.tsx
@@ -51,10 +51,10 @@ const InsertPanelPane: React.FunctionComponent<{
 
       <div className="text-left">
         <p>
-          <FontAwesomeIcon icon={faMousePointer} size="lg" /> Click on a
-          container to insert a panel in that container. Or, click{" "}
-          <span className="text-info">Use Existing Panel</span> to use a panel
-          foundation that already exists for the page
+          <FontAwesomeIcon icon={faMousePointer} size="lg" /> Click on an
+          existing <code>div</code> or container-like element to insert a panel
+          in that container. You may also search the{" "}
+          <span className="text-info">Marketplace</span> for existing panels.
         </p>
 
         <div>

--- a/src/devTools/editor/panes/insert/InsertPanelPane.tsx
+++ b/src/devTools/editor/panes/insert/InsertPanelPane.tsx
@@ -28,8 +28,9 @@ import { Alert, Button } from "react-bootstrap";
 import config from "@/devTools/editor/extensionPoints/panel";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faCube,
   faExclamationTriangle,
+  faSearch,
+  faTimes,
 } from "@fortawesome/free-solid-svg-icons";
 import useAddExisting from "@/devTools/editor/panes/insert/useAddExisting";
 
@@ -72,14 +73,14 @@ const InsertPanelPane: React.FunctionComponent<{
               onClick={show}
               disabled={!panelExtensionPoints?.length}
             >
-              <FontAwesomeIcon icon={faCube} /> Use Existing Panel
+              <FontAwesomeIcon icon={faSearch} /> Search Marketplace
             </Button>
           )}
           onSelect={async (block) => addExistingPanel(block as PanelWithConfig)}
         />
 
-        <Button className="ml-2" variant="danger" onClick={cancel}>
-          Cancel Insert
+        <Button className="ml-2" variant="outline-danger" onClick={cancel}>
+          <FontAwesomeIcon icon={faTimes} /> Cancel
         </Button>
       </div>
     </Centered>

--- a/src/devTools/editor/panes/insert/InsertPanelPane.tsx
+++ b/src/devTools/editor/panes/insert/InsertPanelPane.tsx
@@ -81,7 +81,7 @@ const InsertPanelPane: React.FunctionComponent<{
           onSelect={async (block) => addExistingPanel(block as PanelWithConfig)}
         />
 
-        <Button className="ml-2" variant="outline-danger" onClick={cancel}>
+        <Button className="ml-2" variant="danger" onClick={cancel}>
           <FontAwesomeIcon icon={faTimes} /> Cancel
         </Button>
       </div>


### PR DESCRIPTION
This updates some button text and tweaks styling in the add/insert extension panels in page editor.

**Generic Add New Panel:**
![image](https://user-images.githubusercontent.com/2801308/135346662-a6cec0fa-f911-40d2-b9eb-094c9725eef4.png)


**Insert Button:**
![image](https://user-images.githubusercontent.com/2801308/135346716-6af33bbd-e8de-442a-9f8a-ef5420dd137e.png)


**Insert Panel:**
![image](https://user-images.githubusercontent.com/2801308/135346749-12659998-3b28-4cba-8a1f-5b565394bdab.png)
