### PR TITLE
UI Quick Hit: Add output key to preview data tree and make it copyable

### DIFF
--- a/src/devTools/editor/tabs/effect/BlockPreview.tsx
+++ b/src/devTools/editor/tabs/effect/BlockPreview.tsx
@@ -107,7 +107,8 @@ const BlockPreview: React.FunctionComponent<{
           blockConfig: removeEmptyValues(blockConfig),
           args,
         });
-        setOutput(result);
+        const { outputKey } = blockConfig;
+        setOutput(outputKey ? { [`@${outputKey}`]: result } : result);
       } catch (error: unknown) {
         setOutput(error);
       } finally {
@@ -184,7 +185,7 @@ const BlockPreview: React.FunctionComponent<{
       )}
 
       {output && !isError && !isEmpty(output) && (
-        <JsonTree data={output} searchable />
+        <JsonTree data={output} searchable copyable />
       )}
 
       {output && !isError && isEmpty(output) && (


### PR DESCRIPTION
Similar to #1526 , this adds the output key to the data tree in the preview tab of the data panel, and makes the labels "copyable".