### PR TITLE
UI Quick Hit: Expand certain nodes in the data panel by default

### DIFF
--- a/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -17,7 +17,7 @@
 
 import React, { useContext, useMemo } from "react";
 import { UUID } from "@/core";
-import { isEmpty, pickBy } from "lodash";
+import { isEmpty, pickBy, startsWith } from "lodash";
 import { useField, useFormikContext } from "formik";
 import formBuilderSelectors from "@/devTools/editor/slices/formBuilderSelectors";
 import { actions } from "@/devTools/editor/slices/formBuilderSlice";
@@ -167,7 +167,14 @@ const DataPanel: React.FC<{
       </Nav>
       <Tab.Content>
         <DataTab eventKey="context" isTraceEmpty={!record}>
-          <JsonTree data={relevantContext} copyable searchable />
+          <JsonTree
+            data={relevantContext}
+            copyable
+            searchable
+            shouldExpandNode={(keyPath) =>
+              keyPath.length === 1 && startsWith(keyPath[0].toString(), "@")
+            }
+          />
         </DataTab>
         {showDeveloperTabs && (
           <>
@@ -203,7 +210,17 @@ const DataPanel: React.FC<{
           isTraceOptional={previewInfo?.traceOptional}
         >
           {outputObj && (
-            <JsonTree data={outputObj} copyable searchable label="Data" />
+            <JsonTree
+              data={outputObj}
+              copyable
+              searchable
+              label="Data"
+              shouldExpandNode={(keyPath) =>
+                keyPath.length === 1 &&
+                "outputKey" in record &&
+                keyPath[0] === `@${record.outputKey}`
+              }
+            />
           )}
           {record && "error" in record && (
             <JsonTree data={record.error} label="Error" />

--- a/src/devTools/editor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
@@ -106,6 +106,9 @@ const FoundationDataPanel: React.FC<{
               copyable
               searchable
               label="Data"
+              shouldExpandNode={(keyPath) =>
+                keyPath.length === 1 && keyPath[0] === "@input"
+              }
             />
           ) : (
             <div className="text-muted">

--- a/src/devTools/editor/tabs/effect/BlockPreview.tsx
+++ b/src/devTools/editor/tabs/effect/BlockPreview.tsx
@@ -96,6 +96,7 @@ const BlockPreview: React.FunctionComponent<{
 
   const [isRunning, setIsRunning] = useState(false);
   const [output, setOutput] = useState<unknown | undefined>();
+  const [outputKey, setOutputKey] = useState<string>(blockConfig.outputKey);
 
   const [blockInfo, blockLoading, blockError] = usePreviewInfo(blockConfig.id);
 
@@ -108,6 +109,7 @@ const BlockPreview: React.FunctionComponent<{
           args,
         });
         const { outputKey } = blockConfig;
+        setOutputKey(outputKey);
         setOutput(outputKey ? { [`@${outputKey}`]: result } : result);
       } catch (error: unknown) {
         setOutput(error);
@@ -185,7 +187,14 @@ const BlockPreview: React.FunctionComponent<{
       )}
 
       {output && !isError && !isEmpty(output) && (
-        <JsonTree data={output} searchable copyable />
+        <JsonTree
+          data={output}
+          searchable
+          copyable
+          shouldExpandNode={(keyPath) =>
+            keyPath.length === 1 && keyPath[0] === `@${outputKey}`
+          }
+        />
       )}
 
       {output && !isError && isEmpty(output) && (


### PR DESCRIPTION
Related to #1540 

This makes certain nodes expand by default in the data panel so they don't need to be clicked every time the panel refreshes/changes.