### PR TITLE
#1323: Stale data warnings on data tab

### DIFF
--- a/src/blocks/combinators.ts
+++ b/src/blocks/combinators.ts
@@ -236,6 +236,7 @@ export async function runStage(
       timestamp: new Date().toISOString(),
       templateContext: argContext as JsonObject,
       renderedArgs: blockArgs,
+      blockConfig: stage,
     });
   }
 

--- a/src/components/formBuilder/FormBuilder.tsx
+++ b/src/components/formBuilder/FormBuilder.tsx
@@ -19,11 +19,14 @@ import React, { useState } from "react";
 import FormEditor from "./FormEditor";
 import FormPreview from "./FormPreview";
 import styles from "./FormBuilder.module.scss";
+import { useField } from "formik";
+import { RJSFSchema } from "@/components/formBuilder/formBuilderTypes";
 
 const FormBuilder: React.FC<{
   name: string;
 }> = ({ name }) => {
   const [activeField, setActiveField] = useState<string>();
+  const [{ value: rjsfSchema }] = useField<RJSFSchema>(name);
 
   return (
     <div className={styles.root}>
@@ -36,7 +39,7 @@ const FormBuilder: React.FC<{
       </div>
       <div className={styles.column}>
         <FormPreview
-          name={name}
+          rjsfSchema={rjsfSchema}
           activeField={activeField}
           setActiveField={setActiveField}
         />

--- a/src/components/formBuilder/FormPreview.test.tsx
+++ b/src/components/formBuilder/FormPreview.test.tsx
@@ -18,16 +18,11 @@
 import { Schema, UiSchema } from "@/core";
 import testItRenders, { ItRendersOptions } from "@/tests/testItRenders";
 import { Except } from "type-fest";
-import {
-  createFormikTemplate,
-  RJSF_SCHEMA_PROPERTY_NAME,
-} from "./formBuilderTestHelpers";
-import { RJSFSchema } from "./formBuilderTypes";
 import FormPreview, { FormPreviewProps } from "./FormPreview";
 
 describe("FormPreview", () => {
   const defaultProps: Except<FormPreviewProps, "activeField"> = {
-    name: RJSF_SCHEMA_PROPERTY_NAME,
+    rjsfSchema: { schema: {}, uiSchema: {} },
     setActiveField: jest.fn(),
   };
 
@@ -35,7 +30,6 @@ describe("FormPreview", () => {
     testName: "it renders empty schema",
     Component: FormPreview,
     props: defaultProps,
-    TemplateComponent: createFormikTemplate({} as RJSFSchema),
   });
 
   testItRenders(() => {
@@ -62,18 +56,15 @@ describe("FormPreview", () => {
     const uiSchema: UiSchema = {};
 
     const props: FormPreviewProps = {
-      ...defaultProps,
+      rjsfSchema: { schema, uiSchema },
       activeField: "firstName",
+      setActiveField: defaultProps.setActiveField,
     };
 
     const options: ItRendersOptions<FormPreviewProps> = {
       testName: "it renders simple schema",
       Component: FormPreview,
       props,
-      TemplateComponent: createFormikTemplate({
-        schema,
-        uiSchema,
-      } as RJSFSchema),
     };
 
     return options;

--- a/src/components/formBuilder/FormPreview.tsx
+++ b/src/components/formBuilder/FormPreview.tsx
@@ -21,7 +21,6 @@ import JsonSchemaForm from "@rjsf/bootstrap-4";
 import { FieldProps, IChangeEvent } from "@rjsf/core";
 import { RJSFSchema, SetActiveField } from "./formBuilderTypes";
 import FormPreviewStringField from "./FormPreviewStringField";
-import { useField } from "formik";
 import { UI_ORDER, UI_SCHEMA_ACTIVE } from "./schemaFieldNames";
 import { produce } from "immer";
 import FormPreviewBooleanField from "./FormPreviewBooleanField";

--- a/src/components/formBuilder/FormPreview.tsx
+++ b/src/components/formBuilder/FormPreview.tsx
@@ -27,18 +27,16 @@ import { produce } from "immer";
 import FormPreviewBooleanField from "./FormPreviewBooleanField";
 
 export type FormPreviewProps = {
-  name: string;
+  rjsfSchema: RJSFSchema;
   activeField?: string;
   setActiveField: SetActiveField;
 };
 
 const FormPreview: React.FC<FormPreviewProps> = ({
-  name,
+  rjsfSchema,
   activeField,
   setActiveField,
 }) => {
-  const [{ value: rjsfSchema }] = useField<RJSFSchema>(name);
-
   const [data, setData] = useState(null);
   const onDataChanged = ({ formData }: IChangeEvent<unknown>) => {
     setData(formData);

--- a/src/components/formBuilder/__snapshots__/FormPreview.test.tsx.snap
+++ b/src/components/formBuilder/__snapshots__/FormPreview.test.tsx.snap
@@ -2,164 +2,151 @@
 
 exports[`FormPreview it renders empty schema 1`] = `
 <DocumentFragment>
-  <form
-    action="#"
+  <div
+    class="rjsf"
   >
-    <button
-      type="submit"
-    >
-      Submit
-    </button>
-  </form>
+    <div />
+  </div>
 </DocumentFragment>
 `;
 
 exports[`FormPreview it renders simple schema 1`] = `
 <DocumentFragment>
-  <form
-    action="#"
+  <div
+    class="rjsf"
   >
     <div
-      class="rjsf"
+      class="form-group"
     >
       <div
-        class="form-group"
+        class="my-1"
+      >
+        <h5>
+          A form
+        </h5>
+        <hr
+          class="border-0 bg-secondary"
+          style="height: 1px;"
+        />
+      </div>
+      <div>
+        <div
+          class="mb-3"
+        >
+          A form example.
+        </div>
+      </div>
+      <div
+        class="p-0 container-fluid"
       >
         <div
-          class="my-1"
+          class="row"
+          style="margin-bottom: 10px;"
         >
-          <h5>
-            A form
-          </h5>
-          <hr
-            class="border-0 bg-secondary"
-            style="height: 1px;"
-          />
-        </div>
-        <div>
           <div
-            class="mb-3"
+            class="col-12"
           >
-            A form example.
+             
+            <div
+              class="form-group"
+            >
+              <div
+                class="root root isActive"
+                role="group"
+              >
+                <div
+                  class="mb-0 form-group"
+                >
+                  <label
+                    class="form-label"
+                  >
+                    First name
+                  </label>
+                  <input
+                    class="form-control"
+                    id="root_firstName"
+                    placeholder=""
+                    type="text"
+                    value="Chuck"
+                  />
+                </div>
+              </div>
+            </div>
           </div>
         </div>
         <div
-          class="p-0 container-fluid"
+          class="row"
+          style="margin-bottom: 10px;"
         >
           <div
-            class="row"
-            style="margin-bottom: 10px;"
+            class="col-12"
           >
+             
             <div
-              class="col-12"
+              class="form-group"
             >
-               
               <div
-                class="form-group"
+                class="root root"
+                role="group"
               >
                 <div
-                  class="root root isActive"
-                  role="group"
+                  class="mb-0 form-group"
                 >
-                  <div
-                    class="mb-0 form-group"
+                  <label
+                    class="form-label"
                   >
-                    <label
-                      class="form-label"
-                    >
-                      First name
-                    </label>
-                    <input
-                      class="form-control"
-                      id="root_firstName"
-                      placeholder=""
-                      type="text"
-                      value="Chuck"
-                    />
-                  </div>
+                    Age
+                  </label>
+                  <input
+                    class="form-control"
+                    id="root_age"
+                    placeholder=""
+                    type="number"
+                    value=""
+                  />
                 </div>
               </div>
             </div>
           </div>
+        </div>
+        <div
+          class="row"
+          style="margin-bottom: 10px;"
+        >
           <div
-            class="row"
-            style="margin-bottom: 10px;"
+            class="col-12"
           >
+             
             <div
-              class="col-12"
+              class="form-group"
             >
-               
               <div
-                class="form-group"
+                class="root root"
+                role="group"
               >
                 <div
-                  class="root root"
-                  role="group"
+                  class="mb-0 form-group"
                 >
-                  <div
-                    class="mb-0 form-group"
+                  <label
+                    class="form-label"
                   >
-                    <label
-                      class="form-label"
-                    >
-                      Age
-                    </label>
-                    <input
-                      class="form-control"
-                      id="root_age"
-                      placeholder=""
-                      type="number"
-                      value=""
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="row"
-            style="margin-bottom: 10px;"
-          >
-            <div
-              class="col-12"
-            >
-               
-              <div
-                class="form-group"
-              >
-                <div
-                  class="root root"
-                  role="group"
-                >
-                  <div
-                    class="mb-0 form-group"
-                  >
-                    <label
-                      class="form-label"
-                    >
-                      Telephone
-                    </label>
-                    <input
-                      class="form-control"
-                      id="root_telephone"
-                      placeholder=""
-                      type="text"
-                      value=""
-                    />
-                  </div>
+                    Telephone
+                  </label>
+                  <input
+                    class="form-control"
+                    id="root_telephone"
+                    placeholder=""
+                    type="text"
+                    value=""
+                  />
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-      <div />
     </div>
-    <button
-      type="submit"
-    >
-      Submit
-    </button>
-  </form>
+    <div />
+  </div>
 </DocumentFragment>
 `;

--- a/src/devTools/editor/tabs/editTab/EditTab.tsx
+++ b/src/devTools/editor/tabs/editTab/EditTab.tsx
@@ -268,7 +268,8 @@ const EditTab: React.FC<{
           ) : (
             <DataPanel
               key={blockInstanceId}
-              blockFieldName={blockFieldName}
+              blockPipelineFieldName={pipelineFieldName}
+              blockPipelineIndex={activeNodeIndex - 1}
               instanceId={blockInstanceId}
             />
           )}

--- a/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -17,11 +17,11 @@
 
 import React, { useContext, useMemo } from "react";
 import { UUID } from "@/core";
-import { isEmpty, pickBy, startsWith } from "lodash";
-import { useField, useFormikContext } from "formik";
+import { get, isEmpty, isEqual, pickBy, startsWith } from "lodash";
+import { useFormikContext } from "formik";
 import formBuilderSelectors from "@/devTools/editor/slices/formBuilderSelectors";
 import { actions } from "@/devTools/editor/slices/formBuilderSlice";
-import { Nav, Tab, TabPaneProps } from "react-bootstrap";
+import { Alert, Nav, Tab, TabPaneProps } from "react-bootstrap";
 import JsonTree from "@/components/jsonTree/JsonTree";
 import styles from "./DataPanel.module.scss";
 import FormPreview from "@/components/formBuilder/FormPreview";
@@ -31,13 +31,17 @@ import BlockPreview, {
 } from "@/devTools/editor/tabs/effect/BlockPreview";
 import { BlockConfig } from "@/blocks/types";
 import useReduxState from "@/hooks/useReduxState";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import {
+  faExclamationTriangle,
+  faInfoCircle,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FormState } from "@/devTools/editor/slices/editorSlice";
 import AuthContext from "@/auth/AuthContext";
 import { useSelector } from "react-redux";
-import { makeSelectBlockTrace } from "@/devTools/editor/slices/runtimeSelectors";
+import { selectExtensionTrace } from "@/devTools/editor/slices/runtimeSelectors";
 import { JsonObject } from "type-fest";
+import { RJSFSchema } from "@/components/formBuilder/formBuilderTypes";
 
 /**
  * Exclude irrelevant top-level keys.
@@ -100,23 +104,58 @@ const DataTab: React.FC<TabPaneProps & TabStateProps> = ({
 };
 
 const DataPanel: React.FC<{
-  blockFieldName: string;
+  blockPipelineFieldName: string;
+  blockPipelineIndex: number;
   instanceId: UUID;
-}> = ({ blockFieldName, instanceId }) => {
+}> = ({ blockPipelineFieldName, blockPipelineIndex, instanceId }) => {
   const { flags } = useContext(AuthContext);
 
   const showDeveloperTabs = flags.includes("page-editor-developer");
 
   const { values: formState } = useFormikContext<FormState>();
 
-  const { record } = useSelector(makeSelectBlockTrace(instanceId));
+  const blockPipeline: BlockConfig[] = get(formState, blockPipelineFieldName);
+  // eslint-disable-next-line security/detect-object-injection
+  const block = blockPipeline[blockPipelineIndex];
+
+  const traces = useSelector(selectExtensionTrace);
+  const record = traces.find((t) => t.blockInstanceId === instanceId);
+
+  const isInputStale = useMemo(() => {
+    if (record === undefined) {
+      return false;
+    }
+
+    if (traces.length !== blockPipeline.length) {
+      return true;
+    }
+
+    const currentInput = blockPipeline.slice(0, blockPipelineIndex);
+    const tracedInput = currentInput.map(
+      (block) =>
+        traces.find((t) => t.blockInstanceId === block.instanceId).blockConfig
+    );
+
+    return !isEqual(currentInput, tracedInput);
+  }, [blockPipeline, blockPipelineIndex, record, traces]);
+
+  const isCurrentStale = useMemo(() => {
+    if (isInputStale) {
+      return true;
+    }
+
+    if (record === undefined) {
+      return false;
+    }
+
+    return !isEqual(record.blockConfig, block);
+  }, [isInputStale, record, block]);
 
   const relevantContext = useMemo(
     () => pickBy(record?.templateContext ?? {}, contextFilter),
     [record?.templateContext]
   );
-  const blockFieldConfigName = `${blockFieldName}.config`;
-  const [{ value: configValue }] = useField(blockFieldConfigName);
+
   const [formBuilderActiveField, setFormBuilderActiveField] = useReduxState(
     formBuilderSelectors.activeField,
     actions.setActiveField
@@ -129,13 +168,10 @@ const DataPanel: React.FC<{
         : record.output
       : null;
 
-  const [{ value: blockConfig }] = useField<BlockConfig>(blockFieldName);
+  const [previewInfo] = usePreviewInfo(block?.id);
 
-  const [previewInfo] = usePreviewInfo(blockConfig?.id);
-
-  const showFormPreview = configValue?.schema && configValue?.uiSchema;
-  const showBlockPreview =
-    (record && blockConfig) || previewInfo?.traceOptional;
+  const showFormPreview = block.config?.schema && block.config?.uiSchema;
+  const showBlockPreview = record || previewInfo?.traceOptional;
 
   const defaultKey = showFormPreview ? "preview" : "output";
 
@@ -167,6 +203,12 @@ const DataPanel: React.FC<{
       </Nav>
       <Tab.Content>
         <DataTab eventKey="context" isTraceEmpty={!record}>
+          {isInputStale && (
+            <Alert variant="warning">
+              <FontAwesomeIcon icon={faExclamationTriangle} /> A previous block
+              has changed, input context may be out of date
+            </Alert>
+          )}
           <JsonTree
             data={relevantContext}
             copyable
@@ -190,18 +232,26 @@ const DataPanel: React.FC<{
                 <FontAwesomeIcon icon={faInfoCircle} /> This tab is only visible
                 to developers
               </div>
-              <JsonTree data={blockConfig ?? {}} />
+              <JsonTree data={block ?? {}} />
             </DataTab>
           </>
         )}
         <DataTab eventKey="rendered" isTraceEmpty={!record}>
           {record && (
-            <JsonTree
-              data={record.renderedArgs}
-              copyable
-              searchable
-              label="Rendered Inputs"
-            />
+            <>
+              {isInputStale && (
+                <Alert variant="warning">
+                  <FontAwesomeIcon icon={faExclamationTriangle} /> A previous
+                  block has changed, input context may be out of date
+                </Alert>
+              )}
+              <JsonTree
+                data={record.renderedArgs}
+                copyable
+                searchable
+                label="Rendered Inputs"
+              />
+            </>
           )}
         </DataTab>
         <DataTab
@@ -210,17 +260,25 @@ const DataPanel: React.FC<{
           isTraceOptional={previewInfo?.traceOptional}
         >
           {outputObj && (
-            <JsonTree
-              data={outputObj}
-              copyable
-              searchable
-              label="Data"
-              shouldExpandNode={(keyPath) =>
-                keyPath.length === 1 &&
-                "outputKey" in record &&
-                keyPath[0] === `@${record.outputKey}`
-              }
-            />
+            <>
+              {isCurrentStale && (
+                <Alert variant="warning">
+                  <FontAwesomeIcon icon={faExclamationTriangle} /> This or a
+                  previous block has changed, output may be out of date
+                </Alert>
+              )}
+              <JsonTree
+                data={outputObj}
+                copyable
+                searchable
+                label="Data"
+                shouldExpandNode={(keyPath) =>
+                  keyPath.length === 1 &&
+                  "outputKey" in record &&
+                  keyPath[0] === `@${record.outputKey}`
+                }
+              />
+            </>
           )}
           {record && "error" in record && (
             <JsonTree data={record.error} label="Error" />
@@ -236,7 +294,7 @@ const DataPanel: React.FC<{
           {showFormPreview ? (
             <ErrorBoundary>
               <FormPreview
-                name={blockFieldConfigName}
+                rjsfSchema={block.config as RJSFSchema}
                 activeField={formBuilderActiveField}
                 setActiveField={setFormBuilderActiveField}
               />
@@ -244,7 +302,7 @@ const DataPanel: React.FC<{
           ) : // eslint-disable-next-line unicorn/no-nested-ternary -- pre-commit removes the parens
           showBlockPreview ? (
             <ErrorBoundary>
-              <BlockPreview traceRecord={record} blockConfig={blockConfig} />
+              <BlockPreview traceRecord={record} blockConfig={block} />
             </ErrorBoundary>
           ) : (
             <div className="text-muted">

--- a/src/telemetry/trace.ts
+++ b/src/telemetry/trace.ts
@@ -19,6 +19,7 @@ import { RegistryId, RenderedArgs, UUID } from "@/core";
 import { JsonObject } from "type-fest";
 import { DBSchema, openDB } from "idb/with-async-ittr";
 import { sortBy } from "lodash";
+import { BlockConfig } from "@/blocks/types";
 
 const STORAGE_KEY = "TRACE";
 const ENTRY_OBJECT_STORE = "traces";
@@ -76,6 +77,8 @@ export type TraceEntryData = TraceRecordMeta & {
   templateContext: JsonObject;
 
   renderedArgs: RenderedArgs;
+
+  blockConfig: BlockConfig;
 };
 
 export type TraceExitData = TraceRecordMeta & (Output | ErrorOutput);


### PR DESCRIPTION
Implement warnings when stale data is detected in block pipeline configs.


This warning is shown on the `Context` and `Rendered` tabs:
![image](https://user-images.githubusercontent.com/2801308/135542012-c5cee1f2-e738-4b18-83cc-c5ff8f2727ad.png)

This warning is shown on the `Output` tab:
![image](https://user-images.githubusercontent.com/2801308/135542116-cb3a7e4d-c851-40b8-8d3a-4b358f9686a2.png)
