### PR TITLE
#1547 Do not show active brick cards when there's no Resolved extensions

### DIFF
--- a/src/options/pages/installed/InstalledPage.test.tsx
+++ b/src/options/pages/installed/InstalledPage.test.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-disable filenames/match-exported */
-
 /*
  * Copyright (C) 2021 PixieBrix, Inc.
  *
@@ -16,13 +13,29 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
-const reactRedux = jest.createMockFromModule("react-redux");
+import React from "react";
 
-export const useDispatch = jest.fn(() => jest.fn());
-export const connect = jest.fn(() => jest.fn());
-export const useSelector = jest.fn();
+import { render } from "@testing-library/react";
+import { InstalledPage } from "./InstalledPage";
+import { StaticRouter } from "react-router-dom";
 
-export default reactRedux;
+describe("InstalledPage", () => {
+  afterAll(() => {
+    jest.resetAllMocks();
+  });
+
+  jest.mock("@/hooks/common", () => ({
+    useAsyncState: jest.fn().mockReturnValue([[], false, null, jest.fn()]),
+  }));
+
+  test("doesn't show ActiveBrick card when no extensions installed", () => {
+    const { container } = render(
+      <StaticRouter>
+        <InstalledPage extensions={[]} push={jest.fn()} onRemove={jest.fn()} />
+      </StaticRouter>
+    );
+    expect(container.querySelector(".ActiveBricksCard")).toBeNull();
+  });
+});

--- a/src/options/pages/installed/InstalledPage.tsx
+++ b/src/options/pages/installed/InstalledPage.tsx
@@ -50,7 +50,7 @@ import { selectShowLogsContext } from "./installedPageSelectors";
 
 const { removeExtension } = optionsSlice.actions;
 
-const InstalledPage: React.FunctionComponent<{
+export const InstalledPage: React.FunctionComponent<{
   extensions: IExtension[];
   push: (path: string) => void;
   onRemove: RemoveAction;
@@ -187,7 +187,7 @@ const InstalledPage: React.FunctionComponent<{
       </Row>
       {noExtensions && <NoExtensionsPage />}
 
-      {resolvedExtensions && (
+      {resolvedExtensions?.length > 0 && (
         <ActiveBricksCard
           extensions={resolvedExtensions}
           onRemove={onRemove}


### PR DESCRIPTION
Fixes #1547 