### PR TITLE
Add proper permission for `pixiebrix.com`

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,7 +34,8 @@
     "identity",
     "tabs",
     "webNavigation",
-    "contextMenus"
+    "contextMenus",
+    "https://*.pixiebrix.com/*"
   ],
   "devtools_page": "devtools.html",
   "externally_connectable": {


### PR DESCRIPTION
- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/575

I verified that this change does not disable the extension using an unlisted extension:

1. Added a content script for `https://*.pixiebrix.com/*`
2. That triggered the expected request: ✅ 

<img width="695" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/135856118-216b0323-ece3-4a2b-af8d-b8bb4666a7ed.png">
<img width="695" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/135856132-4cd03864-a46b-4cd6-9c77-db1049e223d0.png">

3. Then I added `https://*.pixiebrix.com/*` to the `permissions` array
4. The extension was not disabled 🎉 