### PR TITLE
Sidebar animation and toggle improvements

### DIFF
--- a/src/devTools/editor/sidebar/Sidebar.module.scss
+++ b/src/devTools/editor/sidebar/Sidebar.module.scss
@@ -6,22 +6,33 @@ $logoSize: 31px;
   justify-content: flex-start;
   height: 100%;
   border-right: 2px solid #c6bfdb;
+  background: white;
 
   &.collapsed {
     flex: 0 0 $logoSize;
     align-items: center;
-    transition: transform 100ms;
+    z-index: 2000;
   }
   &.expanded {
     flex: 0 0 260px;
-    transition: transform 100ms;
+    width: 260px;
   }
 
-  &.hidden {
+  &.enter {
     transform: translate3d(-100%, 0, 0);
   }
-  &.hidden.showing {
+  &.enterActive {
     transform: none;
+    transition: transform 400ms;
+  }
+  &.exit {
+    transform: none;
+  }
+  &.exitActive {
+    position: absolute;
+    transform: translate3d(-100%, 0, 0);
+    transition: transform 400ms;
+    z-index: 1000;
   }
 
   label {
@@ -47,7 +58,7 @@ $logoSize: 31px;
   width: $logoSize;
   height: $logoSize;
 
-  &:hover {
+  :hover > & {
     filter: brightness(0.75);
   }
 }
@@ -72,17 +83,17 @@ $logoSize: 31px;
 }
 
 .toggle {
+  border: none !important;
   border-radius: 0 !important;
-  background-color: white !important;
+  width: $logoSize;
+  padding: 0 !important;
+
   &:hover {
     background-color: #e9ecef !important;
   }
 
-  .expanded & {
-    padding: 0 5px !important;
-  }
-  .collapsed & {
-    padding: 5px !important;
+  svg {
+    margin: 5px;
   }
 }
 

--- a/src/devTools/editor/sidebar/Sidebar.tsx
+++ b/src/devTools/editor/sidebar/Sidebar.tsx
@@ -46,6 +46,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { CSSTransition } from "react-transition-group";
 import cx from "classnames";
+import { CSSTransitionProps } from "react-transition-group/CSSTransition";
 
 const DropdownEntry: React.FunctionComponent<{
   caption: string;
@@ -223,26 +224,25 @@ const SidebarCollapsed: React.FunctionComponent<{
   expandSidebar: () => void;
 }> = ({ expandSidebar }) => (
   <div className={cx(styles.root, styles.collapsed)}>
-    <Logo />
     <button
       className={cx("navbar-toggler", styles.toggle)}
       type="button"
       onClick={expandSidebar}
     >
+      <Logo />
       <FontAwesomeIcon icon={faAngleDoubleRight} />
     </button>
   </div>
 );
 
-const transitionProps = {
+const transitionProps: CSSTransitionProps = {
   classNames: {
-    enter: styles.hidden,
-    enterActive: styles.showing,
+    enter: styles.enter,
+    enterActive: styles.enterActive,
+    exit: styles.exit,
+    exitActive: styles.exitActive,
   },
-  timeout: {
-    enter: 100,
-    exit: 0,
-  },
+  timeout: 5000,
   unmountOnExit: true,
   mountOnEnter: true,
 };


### PR DESCRIPTION
I saw some possible improvements around the sidebar:

- Clickable logo (it had a hover style but no action)
- Smoother animation (both bars were open at the same time, so you can see a little non-animated step at the beginning of the animation)
- There was a tiny white bar on the right of the toggle:
	<img src="https://user-images.githubusercontent.com/1402241/136269891-9c285134-9596-4cd2-acb1-8f862d278b0a.png">


## Before

https://user-images.githubusercontent.com/1402241/136270006-165cf160-ef0c-46f0-a31f-133fd0ee1023.mov

## After

https://user-images.githubusercontent.com/1402241/136270050-eaed31fb-defb-4b18-9d01-86b05891a992.mov
