### PR TITLE
#1767: fix tracing; add tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -205,6 +205,7 @@
         "jest-webextension-mock": "^3.7.17",
         "min-document": "^2.19.0",
         "mini-css-extract-plugin": "^2.4.1",
+        "mockdate": "^3.0.5",
         "node-polyfill-webpack-plugin": "^1.1.4",
         "node-sass": "^6.0.1",
         "raw-loader": "^4.0.1",
@@ -32245,6 +32246,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "dev": true
     },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
@@ -66134,6 +66141,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
+    },
+    "mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
       "dev": true
     },
     "move-concurrently": {

--- a/package.json
+++ b/package.json
@@ -226,6 +226,7 @@
     "jest-webextension-mock": "^3.7.17",
     "min-document": "^2.19.0",
     "mini-css-extract-plugin": "^2.4.1",
+    "mockdate": "^3.0.5",
     "node-polyfill-webpack-plugin": "^1.1.4",
     "node-sass": "^6.0.1",
     "raw-loader": "^4.0.1",

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -4,6 +4,7 @@ import { propertiesToSchema } from "@/validators/generic";
 import { ApiVersion, BlockArg, BlockOptions } from "@/core";
 import { InitialValues } from "@/runtime/reducePipeline";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
+import { BusinessError } from "@/errors";
 
 const logger = new ConsoleLogger();
 
@@ -49,9 +50,26 @@ class IdentityBlock extends Block {
   }
 }
 
+class ThrowBlock extends Block {
+  constructor() {
+    super("test/throw", "Throw Block");
+  }
+
+  inputSchema = propertiesToSchema({
+    message: {
+      type: "string",
+    },
+  });
+
+  async run({ message }: BlockArg<{ message: string }>) {
+    throw new BusinessError(message);
+  }
+}
+
 export const echoBlock = new EchoBlock();
 export const contextBlock = new ContextBlock();
 export const identityBlock = new IdentityBlock();
+export const throwBlock = new ThrowBlock();
 
 /**
  * Helper method to pass only `input` to reducePipeline.

--- a/src/runtime/pipelineTests/trace.test.ts
+++ b/src/runtime/pipelineTests/trace.test.ts
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { OutputKey, RenderedArgs } from "@/core";
+import blockRegistry from "@/blocks/registry";
+import { reducePipeline } from "@/runtime/reducePipeline";
+import {
+  contextBlock,
+  echoBlock,
+  simpleInput,
+  testOptions,
+  throwBlock,
+} from "./pipelineTestHelpers";
+import { uuidv4 } from "@/types/helpers";
+
+// Mock the recordX trace methods. Otherwise they'll fail and Jest will have unhandledrejection errors since we call
+// them with `void` instead of awaiting them in the reducePipeline methods
+import * as logging from "@/background/logging";
+import * as trace from "@/background/trace";
+import {
+  TraceEntryData,
+  TraceExitData,
+  TraceRecordMeta,
+} from "@/telemetry/trace";
+import ConsoleLogger from "@/tests/ConsoleLogger";
+import MockDate from "mockdate";
+import { BlockPipeline } from "@/blocks/types";
+
+jest.mock("@/background/trace");
+(logging.getLoggingConfig as any) = jest.fn().mockResolvedValue({
+  logValues: true,
+});
+
+beforeEach(() => {
+  blockRegistry.clear();
+  blockRegistry.register(echoBlock, contextBlock, throwBlock);
+  (trace.recordTraceEntry as any).mockReset();
+  (trace.recordTraceExit as any).mockReset();
+});
+
+describe("Trace exceptional exit", () => {
+  test("trace entry and normal exit", async () => {
+    const instanceId = uuidv4();
+
+    const result = await reducePipeline(
+      {
+        id: echoBlock.id,
+        config: { message: "{{@input.inputArg}}" },
+        instanceId,
+      },
+      simpleInput({ inputArg: "hello" }),
+      testOptions("v3")
+    );
+    expect(result).toStrictEqual({ message: "{{@input.inputArg}}" });
+  });
+});
+
+describe("Trace normal execution", () => {
+  test("trace entry and normal exit", async () => {
+    const timestamp = new Date("10/31/2021");
+    MockDate.set(timestamp);
+
+    const instanceId = uuidv4();
+    const runId = uuidv4();
+    const extensionId = uuidv4();
+
+    const blockConfig = {
+      id: echoBlock.id,
+      config: { message: "{{@input.inputArg}}" },
+      instanceId,
+    };
+
+    const logger = new ConsoleLogger().childLogger({ extensionId });
+
+    await reducePipeline(blockConfig, simpleInput({ inputArg: "hello" }), {
+      ...testOptions("v2"),
+      runId,
+      logger,
+    });
+
+    const meta: TraceRecordMeta = {
+      extensionId,
+      runId,
+      blockInstanceId: instanceId,
+      blockId: echoBlock.id,
+    };
+
+    const expectedEntry: TraceEntryData = {
+      ...meta,
+      timestamp: timestamp.toISOString(),
+      blockConfig,
+      templateContext: { "@input": { inputArg: "hello" }, "@options": {} },
+      renderedArgs: ({ message: "hello" } as unknown) as RenderedArgs,
+    };
+
+    const expectedExit: TraceExitData = {
+      ...meta,
+      outputKey: undefined,
+      output: { message: "hello" },
+    };
+
+    expect(trace.recordTraceEntry).toHaveBeenCalledTimes(1);
+    expect(trace.recordTraceEntry).toHaveBeenCalledWith(expectedEntry);
+
+    expect(trace.recordTraceExit).toHaveBeenCalledTimes(1);
+    expect(trace.recordTraceExit).toHaveBeenCalledWith(expectedExit);
+  });
+
+  test("trace output key exit", async () => {
+    const timestamp = new Date("10/31/2021");
+    MockDate.set(timestamp);
+
+    const instanceId = uuidv4();
+    const runId = uuidv4();
+    const extensionId = uuidv4();
+    const outputKey = "echo" as OutputKey;
+
+    const blockConfig: BlockPipeline = [
+      {
+        id: echoBlock.id,
+        config: { message: "{{@input.inputArg}}" },
+        outputKey,
+        instanceId,
+      },
+      {
+        id: contextBlock.id,
+        config: {},
+        instanceId: uuidv4(),
+      },
+    ];
+
+    const logger = new ConsoleLogger().childLogger({ extensionId });
+
+    await reducePipeline(blockConfig, simpleInput({ inputArg: "hello" }), {
+      ...testOptions("v2"),
+      runId,
+      logger,
+    });
+
+    const meta: TraceRecordMeta = {
+      extensionId,
+      runId,
+      blockInstanceId: instanceId,
+      blockId: echoBlock.id,
+    };
+
+    const expectedExit: TraceExitData = {
+      ...meta,
+      outputKey,
+      output: { message: "hello" },
+    };
+
+    expect(trace.recordTraceExit).toHaveBeenCalledTimes(2);
+    expect(trace.recordTraceExit).toHaveBeenNthCalledWith(1, expectedExit);
+  });
+
+  test("trace exceptional exit", async () => {
+    const timestamp = new Date("10/31/2021");
+    MockDate.set(timestamp);
+
+    const instanceId = uuidv4();
+    const runId = uuidv4();
+    const extensionId = uuidv4();
+    const outputKey = "never" as OutputKey;
+
+    const blockConfig: BlockPipeline = [
+      {
+        id: throwBlock.id,
+        config: { message: "{{@input.inputArg}}" },
+        outputKey,
+        instanceId,
+      },
+      {
+        id: contextBlock.id,
+        config: {},
+        instanceId: uuidv4(),
+      },
+    ];
+
+    const logger = new ConsoleLogger().childLogger({ extensionId });
+
+    await expect(async () => {
+      await reducePipeline(blockConfig, simpleInput({ inputArg: "hello" }), {
+        ...testOptions("v2"),
+        runId,
+        logger,
+      });
+    }).rejects.toThrow();
+
+    const meta: TraceRecordMeta = {
+      extensionId,
+      runId,
+      blockInstanceId: instanceId,
+      blockId: throwBlock.id,
+    };
+
+    expect(trace.recordTraceExit).toHaveBeenCalledTimes(1);
+
+    // Can't use toHaveBeenNthCalledWith because we don't want to include the stack trace in the test
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test code
+    const args = (trace.recordTraceExit as any).mock.calls[0][0];
+    expect(args.runId).toBe(meta.runId);
+    expect(args.blockInstanceId).toBe(meta.blockInstanceId);
+    expect(args.error.name).toBe("BusinessError");
+    expect(args.error.message).toBe("hello");
+  });
+});

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -186,6 +186,9 @@ type TraceMetadata = {
 };
 
 type RunBlockOptions = CommonOptions & {
+  /**
+   * Additional context to record with the trace entry/exit records.
+   */
   trace?: TraceMetadata;
 };
 
@@ -423,19 +426,21 @@ export async function blockReducer(
 
   const resolvedConfig = await resolveBlockConfig(blockConfig);
 
-  const props: BlockProps = {
-    args: await renderBlockArg(resolvedConfig, state, options),
-    root: selectBlockRootElement(blockConfig, root),
-    context,
-  };
-
-  const output = await runBlock(resolvedConfig, props, {
+  const blockOptions = {
     ...options,
     trace: {
       runId,
       blockInstanceId: blockConfig.instanceId,
     },
-  });
+  };
+
+  const props: BlockProps = {
+    args: await renderBlockArg(resolvedConfig, state, blockOptions),
+    root: selectBlockRootElement(blockConfig, root),
+    context,
+  };
+
+  const output = await runBlock(resolvedConfig, props, blockOptions);
 
   if (logValues) {
     console.info(`Output for block #${index + 1}: ${blockConfig.id}`, {

--- a/src/telemetry/trace.ts
+++ b/src/telemetry/trace.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { RegistryId, RenderedArgs, UUID } from "@/core";
+import { OutputKey, RegistryId, RenderedArgs, UUID } from "@/core";
 import { JsonObject } from "type-fest";
 import { DBSchema, openDB } from "idb/with-async-ittr";
 import { sortBy } from "lodash";
@@ -50,7 +50,7 @@ export type TraceRecordMeta = {
 };
 
 type Output = {
-  outputKey: string | null;
+  outputKey: OutputKey | null;
 
   /**
    * Output of the block

--- a/src/tests/ConsoleLogger.ts
+++ b/src/tests/ConsoleLogger.ts
@@ -16,35 +16,41 @@
  */
 
 import { Logger, MessageContext } from "@/core";
+import { UnknownObject } from "@/types";
+import { getErrorMessage } from "@/errors";
 
 class ConsoleLogger implements Logger {
   readonly context: MessageContext = {};
 
-  childLogger(): Logger {
-    return new ConsoleLogger();
+  constructor(context: MessageContext = {}) {
+    this.context = { ...context };
   }
 
-  trace(msg: string, data?: Record<string, unknown>): void {
+  childLogger(context: MessageContext = {}): Logger {
+    return new ConsoleLogger({ ...this.context, ...context });
+  }
+
+  trace(msg: string, data?: UnknownObject): void {
     console.debug(msg, data);
   }
 
-  debug(msg: string, data: Record<string, unknown>): void {
+  debug(msg: string, data: UnknownObject): void {
     console.debug(msg, data);
   }
 
-  error(error: unknown, data: Record<string, unknown>): void {
-    console.debug(error.toString(), { error, data });
+  error(error: unknown, data: UnknownObject): void {
+    console.debug(getErrorMessage(error), { error, data });
   }
 
-  info(msg: string, data: Record<string, unknown>): void {
+  info(msg: string, data: UnknownObject): void {
     console.debug(msg, data);
   }
 
-  log(msg: string, data: Record<string, unknown>): void {
+  log(msg: string, data: UnknownObject): void {
     console.debug(msg, data);
   }
 
-  warn(msg: string, data: Record<string, unknown>): void {
+  warn(msg: string, data: UnknownObject): void {
     console.debug(msg, data);
   }
 }


### PR DESCRIPTION
Closes #1767 

What does this PR do?
- Adds test cases for tracing calls in the runtime
- Fixes bug introduced in runtime where trace records weren't being created because run/block instance data wasn't being passed in correctly

TODO (out of scope)
- Figure out how to type the mocks to avoid casting to any