### PR TITLE
#1720: use element selectMode for trigger

### DIFF
--- a/src/devTools/editor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/devTools/editor/tabs/trigger/TriggerConfiguration.tsx
@@ -66,7 +66,7 @@ const TriggerConfiguration: React.FC<{
           <ConnectedFieldTemplate
             name="extensionPoint.definition.rootSelector"
             as={LocationWidget}
-            selectionMode="element"
+            selectMode="element"
             description="An element to watch"
             {...makeLockableFieldProps("Element", isLocked)}
           />


### PR DESCRIPTION
Closes #1720 

Our field types don't protect against unexpected property names