### PR TITLE
Additional engine/template tests

### DIFF
--- a/src/blocks/transformers/blockFactory.ts
+++ b/src/blocks/transformers/blockFactory.ts
@@ -132,7 +132,7 @@ class ExternalBlock extends Block {
     const initialValues: InitialValues = {
       input: arg,
       // OptionsArgs are set at the blueprint level. For composite bricks, the options should be passed in
-      // at part of the brick inputs
+      // as part of the brick inputs
       optionsArgs: undefined,
       // Services are passed as inputs to the brick
       serviceContext: undefined,
@@ -142,6 +142,8 @@ class ExternalBlock extends Block {
     return reducePipeline(this.component.pipeline, initialValues, {
       logger: options.logger,
       headless: options.headless,
+      // The component uses its declared version of the runtime API, regardless of what version of the runtime
+      // is used to call the the component
       ...apiVersionOptions(this.component.apiVersion),
     });
   }

--- a/src/runtime/mapArgs.test.ts
+++ b/src/runtime/mapArgs.test.ts
@@ -17,6 +17,7 @@
 
 import { renderExplicit, renderImplicit } from "@/runtime/mapArgs";
 import Mustache from "mustache";
+import { engineRenderer } from "@/runtime/renderers";
 
 describe("renderExplicit", () => {
   test("render var path", async () => {
@@ -56,6 +57,34 @@ describe("renderImplicit", () => {
       renderImplicit({ foo: "array.0" }, { otherVar: ["bar"] }, Mustache.render)
     ).toEqual({
       foo: "array.0",
+    });
+  });
+});
+
+describe("handlebars", () => {
+  test("render array item", async () => {
+    expect(
+      renderImplicit(
+        { foo: "{{ obj.prop }}" },
+        { obj: { prop: 42 } },
+        await engineRenderer("handlebars")
+      )
+    ).toEqual({
+      foo: "42",
+    });
+  });
+
+  // NOTE: Handlebars doesn't work with @-prefixed variable because it uses @ to denote data variables
+  // see: https://handlebarsjs.com/api-reference/data-variables.html
+  test("cannot render @-prefixed variable", async () => {
+    expect(
+      renderImplicit(
+        { foo: "{{ obj.prop }}" },
+        { "@obj": { prop: 42 } },
+        await engineRenderer("handlebars")
+      )
+    ).toEqual({
+      foo: "",
     });
   });
 });

--- a/src/runtime/pipelineTests/component.test.ts
+++ b/src/runtime/pipelineTests/component.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import blockRegistry from "@/blocks/registry";
+import { reducePipeline } from "@/runtime/reducePipeline";
+import { BlockPipeline } from "@/blocks/types";
+import {
+  contextBlock,
+  echoBlock,
+  simpleInput,
+  testOptions,
+} from "./pipelineTestHelpers";
+
+// Mock the recordX trace methods. Otherwise they'll fail and Jest will have unhandledrejection errors since we call
+// them with `void` instead of awaiting them in the reducePipeline methods
+import * as logging from "@/background/logging";
+import { fromJS } from "@/blocks/transformers/blockFactory";
+jest.mock("@/background/trace");
+(logging.getLoggingConfig as any) = jest.fn().mockResolvedValue({
+  logValues: true,
+});
+
+beforeEach(() => {
+  blockRegistry.clear();
+  blockRegistry.register(echoBlock, contextBlock);
+});
+
+describe("component block", () => {
+  test("component block uses own declared runtime within the brick", async () => {
+    const componentBlock = fromJS({
+      apiVersion: "v1",
+      kind: "component",
+      metadata: {
+        id: "test/component",
+        name: "Component Block",
+        version: "1.0.0",
+        description: "Component block using v1 runtime",
+      },
+      inputSchema: {
+        message: {
+          type: "string",
+        },
+      },
+      pipeline: [
+        {
+          id: echoBlock.id,
+          // Implicit application of mustache template referencing input without @input
+          config: { message: "{{message}}" },
+        },
+      ],
+    });
+
+    blockRegistry.register(componentBlock);
+
+    const pipeline = [
+      {
+        id: "test/component",
+        outputKey: "first",
+        config: {
+          message: {
+            __type__: "var",
+            __value__: "@input.inputArg",
+          },
+        },
+      },
+      {
+        id: echoBlock.id,
+        config: {
+          message: {
+            __type__: "mustache",
+            __value__: "{{@first.message}}",
+          },
+        },
+      },
+    ] as BlockPipeline;
+
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({ inputArg: "hello" }),
+      testOptions("v3")
+    );
+
+    expect(result).toStrictEqual({ message: "hello" });
+  });
+});

--- a/src/runtime/pipelineTests/serviceContext.test.ts
+++ b/src/runtime/pipelineTests/serviceContext.test.ts
@@ -15,7 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ApiVersion, ServiceDependency } from "@/core";
+import {
+  ApiVersion,
+  SanitizedServiceConfiguration,
+  ServiceDependency,
+} from "@/core";
 import blockRegistry from "@/blocks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import {
@@ -28,17 +32,17 @@ import {
 import { makeServiceContext } from "@/services/serviceUtils";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
+import { pixieServiceFactory } from "@/services/locator";
 
 // Mock the recordX trace methods. Otherwise they'll fail and Jest will have unhandledrejection errors since we call
 // them with `void` instead of awaiting them in the reducePipeline methods
 import * as logging from "@/background/logging";
+import * as locator from "@/background/locator";
+import { uuidv4, validateRegistryId } from "@/types/helpers";
 jest.mock("@/background/trace");
 (logging.getLoggingConfig as any) = jest.fn().mockResolvedValue({
   logValues: true,
 });
-import * as locator from "@/background/locator";
-import { pixieServiceFactory } from "@/services/locator";
-(locator.locate as any) = jest.fn().mockResolvedValue(pixieServiceFactory());
 
 beforeEach(() => {
   blockRegistry.clear();
@@ -49,6 +53,10 @@ describe.each([["v1"], ["v2"], ["v3"]])(
   "apiVersion: %s",
   (apiVersion: ApiVersion) => {
     test("pass services in context with __service", async () => {
+      (locator.locate as any) = jest
+        .fn()
+        .mockResolvedValue(pixieServiceFactory());
+
       const dependencies: ServiceDependency[] = [
         { id: PIXIEBRIX_SERVICE_ID, outputKey: validateOutputKey("pixiebrix") },
       ];
@@ -77,6 +85,10 @@ describe.each([["v1"], ["v2"], ["v3"]])(
 
 describe.each([["v1"], ["v2"]])("apiVersion: %s", (apiVersion: ApiVersion) => {
   test("pass services for var without __service", async () => {
+    (locator.locate as any) = jest
+      .fn()
+      .mockResolvedValue(pixieServiceFactory());
+
     const dependencies: ServiceDependency[] = [
       { id: PIXIEBRIX_SERVICE_ID, outputKey: validateOutputKey("pixiebrix") },
     ];
@@ -96,10 +108,47 @@ describe.each([["v1"], ["v2"]])("apiVersion: %s", (apiVersion: ApiVersion) => {
       data: await pixieServiceFactory(),
     });
   });
+
+  test("reference sanitized configuration variable", async () => {
+    const authId = uuidv4();
+    const serviceId = validateRegistryId("test/api");
+
+    (locator.locate as any) = jest.fn().mockResolvedValue(({
+      id: authId,
+      serviceId,
+      proxy: false,
+      config: {
+        prop: "abc123",
+      },
+    } as unknown) as SanitizedServiceConfiguration);
+
+    const dependencies: ServiceDependency[] = [
+      { id: serviceId, outputKey: validateOutputKey("service") },
+    ];
+
+    const result = await reducePipeline(
+      {
+        id: identityBlock.id,
+        config: { data: "@service.prop" },
+      },
+      {
+        ...simpleInput({}),
+        serviceContext: await makeServiceContext(dependencies),
+      },
+      testOptions(apiVersion)
+    );
+    expect(result).toStrictEqual({
+      data: "abc123",
+    });
+  });
 });
 
 describe.each([["v3"]])("apiVersion: %s", (apiVersion: ApiVersion) => {
   test("pass services for var without __service", async () => {
+    (locator.locate as any) = jest
+      .fn()
+      .mockResolvedValue(pixieServiceFactory());
+
     const dependencies: ServiceDependency[] = [
       { id: PIXIEBRIX_SERVICE_ID, outputKey: validateOutputKey("pixiebrix") },
     ];
@@ -122,6 +171,89 @@ describe.each([["v3"]])("apiVersion: %s", (apiVersion: ApiVersion) => {
     );
     expect(result).toStrictEqual({
       data: await pixieServiceFactory(),
+    });
+  });
+
+  test("reference sanitized configuration variable", async () => {
+    const authId = uuidv4();
+    const serviceId = validateRegistryId("test/api");
+
+    (locator.locate as any) = jest.fn().mockResolvedValue(({
+      id: authId,
+      serviceId,
+      proxy: false,
+      config: {
+        prop: "abc123",
+      },
+    } as unknown) as SanitizedServiceConfiguration);
+
+    const dependencies: ServiceDependency[] = [
+      { id: serviceId, outputKey: validateOutputKey("service") },
+    ];
+
+    const result = await reducePipeline(
+      {
+        id: identityBlock.id,
+        config: {
+          data: {
+            __type__: "var",
+            __value__: "@service.prop",
+          },
+        },
+      },
+      {
+        ...simpleInput({}),
+        serviceContext: await makeServiceContext(dependencies),
+      },
+      testOptions(apiVersion)
+    );
+    expect(result).toStrictEqual({
+      data: "abc123",
+    });
+  });
+
+  describe.each([
+    // NOTE: Handlebars doesn't work with @-prefixed variable because it uses @ to denote data variables
+    // see: https://handlebarsjs.com/api-reference/data-variables.html
+    ["mustache"],
+    ["nunjucks"],
+  ])("templateEngine: %s", (templateEngine) => {
+    test("reference sanitized configuration variable via template", async () => {
+      const authId = uuidv4();
+      const serviceId = validateRegistryId("test/api");
+
+      (locator.locate as any) = jest.fn().mockResolvedValue(({
+        id: authId,
+        serviceId,
+        proxy: false,
+        config: {
+          prop: "abc123",
+        },
+      } as unknown) as SanitizedServiceConfiguration);
+
+      const dependencies: ServiceDependency[] = [
+        { id: serviceId, outputKey: validateOutputKey("service") },
+      ];
+
+      const result = await reducePipeline(
+        {
+          id: identityBlock.id,
+          config: {
+            data: {
+              __type__: templateEngine,
+              __value__: "{{ @service.prop }}",
+            },
+          },
+        },
+        {
+          ...simpleInput({}),
+          serviceContext: await makeServiceContext(dependencies),
+        },
+        testOptions(apiVersion)
+      );
+      expect(result).toStrictEqual({
+        data: "abc123",
+      });
     });
   });
 });


### PR DESCRIPTION
- Adds test for component runtime isolation
- Adds tests to demonstrate handlebars behavior (handlebars doesn't work with v2/v3 of the runtime because variables can't be prefixed with @, because handlebars tries to treat those as "data" variables