### PR TITLE
#1801: include previous output in context of next step

### DIFF
--- a/src/runtime/pipelineTests/implicitDataFlow.test.ts
+++ b/src/runtime/pipelineTests/implicitDataFlow.test.ts
@@ -60,6 +60,29 @@ describe("apiVersion: v1", () => {
     );
     expect(result).toStrictEqual({ message: "hello, bar" });
   });
+
+  test("pass block output in context to next block", async () => {
+    const pipeline: BlockPipeline = [
+      {
+        id: echoBlock.id,
+        config: { message: "{{inputArg}}" },
+      },
+      {
+        id: contextBlock.id,
+        config: {},
+      },
+    ];
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({ inputArg: "bar" }),
+      testOptions("v1")
+    );
+    expect(result).toStrictEqual({
+      "@input": { inputArg: "bar" },
+      "@options": {},
+      message: "bar",
+    });
+  });
 });
 
 describe.each([["v2"], ["v3"]])("apiVersion: %s", (apiVersion: ApiVersion) => {

--- a/src/runtime/pipelineTests/implicitDataFlow.test.ts
+++ b/src/runtime/pipelineTests/implicitDataFlow.test.ts
@@ -24,6 +24,7 @@ import {
   contextBlock,
   echoBlock,
   simpleInput,
+  teapotBlock,
   testOptions,
 } from "./pipelineTestHelpers";
 import { UnknownObject } from "@/types";
@@ -38,7 +39,7 @@ jest.mock("@/background/trace");
 
 beforeEach(() => {
   blockRegistry.clear();
-  blockRegistry.register(echoBlock, contextBlock);
+  blockRegistry.register(echoBlock, contextBlock, teapotBlock);
 });
 
 describe("apiVersion: v1", () => {
@@ -81,6 +82,38 @@ describe("apiVersion: v1", () => {
       "@input": { inputArg: "bar" },
       "@options": {},
       message: "bar",
+    });
+  });
+
+  test("pass block output only single block", async () => {
+    // The outputs from blocks is not accumulated, it's only passed a single step
+    // See: https://github.com/pixiebrix/pixiebrix-extension/blob/release/1.4.4/src/blocks/combinators.ts#L455
+    // See: https://github.com/pixiebrix/pixiebrix-extension/blob/release/1.4.4/src/blocks/combinators.ts#L175
+
+    const pipeline: BlockPipeline = [
+      {
+        id: echoBlock.id,
+        config: { message: "{{inputArg}}" },
+      },
+      {
+        id: teapotBlock.id,
+        config: {},
+      },
+      {
+        id: contextBlock.id,
+        config: {},
+      },
+    ];
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({ inputArg: "bar" }),
+      testOptions("v1")
+    );
+    expect(result).toStrictEqual({
+      "@input": { inputArg: "bar" },
+      "@options": {},
+      // `message` is not in the context because it's only passed a single step
+      prop: "I'm a teapot",
     });
   });
 });

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -36,6 +36,22 @@ class EchoBlock extends Block {
   }
 }
 
+/**
+ * A block that returns a `prop` 🫖
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418
+ */
+class TeapotBlock extends Block {
+  constructor() {
+    super("test/teapot", "Teapot Block");
+  }
+
+  inputSchema = propertiesToSchema({});
+
+  async run() {
+    return { prop: "I'm a teapot" };
+  }
+}
+
 class IdentityBlock extends Block {
   constructor() {
     super("test/identity", "Identity Block");
@@ -70,6 +86,7 @@ export const echoBlock = new EchoBlock();
 export const contextBlock = new ContextBlock();
 export const identityBlock = new IdentityBlock();
 export const throwBlock = new ThrowBlock();
+export const teapotBlock = new TeapotBlock();
 
 /**
  * Helper method to pass only `input` to reducePipeline.

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -413,12 +413,14 @@ export async function blockReducer(
   const { runId, explicitDataFlow, logValues, logger } = options;
 
   // Match the override behavior in v1, where the output from previous block would override anything in the context
-  const ctxt =
+  const contextWithPreviousOutput =
     explicitDataFlow || !isPlainObject(previousOutput)
       ? context
       : { ...context, ...(previousOutput as UnknownObject) };
 
-  if (!(await shouldRunBlock(blockConfig, ctxt, options))) {
+  if (
+    !(await shouldRunBlock(blockConfig, contextWithPreviousOutput, options))
+  ) {
     logger.debug(`Skipping stage ${blockConfig.id} because condition not met`);
 
     return { output: previousOutput, context };
@@ -437,7 +439,7 @@ export async function blockReducer(
   const props: BlockProps = {
     args: await renderBlockArg(resolvedConfig, state, blockOptions),
     root: selectBlockRootElement(blockConfig, root),
-    context,
+    context: contextWithPreviousOutput,
   };
 
   const output = await runBlock(resolvedConfig, props, blockOptions);


### PR DESCRIPTION
Closes #1801

Fixes runtime "v1" bug where the output of the previous block was not being included in the context of the next block