### PR TITLE
Don't highlight margin in overlay

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -52,8 +52,12 @@ body.pixiebrix-modal-open {
 /* Overlay.tsx has no classes, so we target each layer by using its hardcoded values */
 [style="z-index: 10000000;"] [style*="rgba(120, 170, 210, 0.7)"],
 [style="z-index: 10000000;"] [style*="rgba(77, 200, 0, 0.3)"],
-[style="z-index: 10000000;"] [style*="rgba(255, 155, 0, 0.3)"],
 [style="z-index: 10000000;"] [style*="rgba(255, 200, 50, 0.3)"] {
   background: rgba(182, 109, 255, 0.1) !important;
   border-color: rgba(182, 109, 255, 0.1) !important;
+}
+
+/* Don't highlight `margin` */
+[style="z-index: 10000000;"] [style*="rgba(255, 155, 0, 0.3)"] {
+  border-color: transparent !important;
 }


### PR DESCRIPTION
Tiny change, but I thought highlighting the margin is confusing because it's not part of the target. Feel free to close if you disagree

## Before

<img width="311" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/140232021-af416e5b-57ec-47b2-9d4a-08a27fd60386.png">

## After

<img width="297" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/140232016-7e9f5ddc-5058-40a5-ac6e-cae64ef2099f.png">

