### PR TITLE
#1687 group active marketplace bricks by team

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -246,7 +246,6 @@ export interface Metadata {
   readonly name: string;
   readonly version?: string;
   readonly description?: string;
-  readonly sharing?: Sharing;
 
   /**
    * @deprecated experimental prop that will likely be removed in the future
@@ -267,11 +266,11 @@ export interface Metadata {
 
 export interface Sharing {
   readonly public: boolean;
-  readonly organizations: string[];
+  readonly organizations: UUID[];
 }
 
 export function selectMetadata(metadata: Metadata): Metadata {
-  return pick(metadata, ["id", "name", "version", "description", "sharing"]);
+  return pick(metadata, ["id", "name", "version", "description"]);
 }
 
 export type Config = Record<string, unknown>;
@@ -351,6 +350,17 @@ export type ExtensionRef = {
   extensionPointId: RegistryId;
 };
 
+/**
+ * Recipe with Sharing information.
+ * @see optionsSlice
+ * We created this type as an alternative to Metadata
+ * in order to include information about the origin of an
+ * extension, e.g. on the ActiveBricks page.
+ */
+export type RecipeMetadata = Metadata & {
+  sharing?: Sharing;
+};
+
 export type IExtension<T extends Config = EmptyConfig> = {
   /**
    * UUID of the extension.
@@ -378,7 +388,7 @@ export type IExtension<T extends Config = EmptyConfig> = {
    * Metadata about the recipe used to install the extension, or `undefined` if the user created this extension
    * directly.
    */
-  _recipe: Metadata | undefined;
+  _recipe: RecipeMetadata | undefined;
 
   /**
    * A human-readable label for the extension.

--- a/src/core.ts
+++ b/src/core.ts
@@ -246,6 +246,7 @@ export interface Metadata {
   readonly name: string;
   readonly version?: string;
   readonly description?: string;
+  readonly sharing?: Sharing;
 
   /**
    * @deprecated experimental prop that will likely be removed in the future
@@ -270,7 +271,7 @@ export interface Sharing {
 }
 
 export function selectMetadata(metadata: Metadata): Metadata {
-  return pick(metadata, ["id", "name", "version", "description"]);
+  return pick(metadata, ["id", "name", "version", "description", "sharing"]);
 }
 
 export type Config = Record<string, unknown>;

--- a/src/options/pages/brickEditor/referenceTab/BlockResult.tsx
+++ b/src/options/pages/brickEditor/referenceTab/BlockResult.tsx
@@ -31,7 +31,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { find } from "@/registry/localRegistry";
 import { useAsyncState } from "@/hooks/common";
 import { Organization } from "@/types/contract";
-import { Sharing } from "@/core";
+import { Sharing, UUID } from "@/core";
 
 export const SharingTag: React.FunctionComponent<{
   block: ReferenceEntry;
@@ -56,7 +56,9 @@ export const SharingTag: React.FunctionComponent<{
     }
 
     // If more than one sharing organization, use the first
-    return organizations.find((org) => sharing.organizations.includes(org.id));
+    return organizations.find((org) =>
+      sharing.organizations.includes(org.id as UUID)
+    );
   }, [organizations, sharing]);
 
   const label = useMemo(() => {

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -189,7 +189,7 @@ const ActiveBricksCard: React.FunctionComponent<{
 
               {otherExtensionGroups.length > 0 && (
                 <>
-                  <ExtensionGroupHeader label="Marketplace Bricks" />
+                  <ExtensionGroupHeader label="Marketplace Blueprints" />
                   {otherExtensionGroups.map((extensions) => {
                     const recipe = extensions[0]._recipe;
                     const messageContext: MessageContext = {
@@ -212,7 +212,7 @@ const ActiveBricksCard: React.FunctionComponent<{
 
               {marketplaceExtensionGroups.length > 0 && (
                 <>
-                  <ExtensionGroupHeader label="Public Marketplace Bricks" />
+                  <ExtensionGroupHeader label="Public Marketplace Blueprints" />
                   {marketplaceExtensionGroups.map((extensions) => {
                     const recipe = extensions[0]._recipe;
                     const messageContext: MessageContext = {
@@ -237,7 +237,9 @@ const ActiveBricksCard: React.FunctionComponent<{
                 <>
                   <ExtensionGroupHeader
                     key={index}
-                    label={`${getOrganizationName(team.organizationId)} Bricks`}
+                    label={`${getOrganizationName(
+                      team.organizationId
+                    )} Blueprints`}
                   />
                   {team.extensions.map((extensions) => {
                     const recipe = extensions[0]._recipe;

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -120,6 +120,8 @@ const ActiveBricksCard: React.FunctionComponent<{
 
   const deploymentExtensionGroups = groupByRecipe(sortedExtensions.deployment);
 
+  // Sharing was added to _recipe recently (see the RecipeMetadata type and optionsSlice)
+  // We still want to display extensions that do not have this information yet
   const otherExtensionGroups = groupByRecipe(sortedExtensions.other);
 
   return (

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -31,10 +31,9 @@ const groupByRecipe = (
 ): ResolvedExtension[][] =>
   Object.values(groupBy(extensions, (extension) => extension._recipe.id));
 
-// TODO: Figure out return type
 const groupByOrganizationId = (
   extensions: ResolvedExtension[]
-): ResolvedExtension[][] =>
+): Array<[string, ResolvedExtension[]]> =>
   Object.entries(
     groupBy(
       extensions,
@@ -47,7 +46,7 @@ const ActiveBricksCard: React.FunctionComponent<{
   onRemove: RemoveAction;
   onExportBlueprint: ExportBlueprintAction;
 }> = ({ extensions, onRemove, onExportBlueprint }) => {
-  const { data: organizations = [], isLoading } = useGetOrganizationsQuery();
+  const { data: organizations = [] } = useGetOrganizationsQuery();
 
   const personalExtensions = extensions.filter(
     (extension) => !extension._recipe && !extension._deployment
@@ -66,16 +65,18 @@ const ActiveBricksCard: React.FunctionComponent<{
     organizations.find((organization) => organization.id === organization_uuid)
       ?.name;
 
-  const teamExtensionGroups = useMemo(() => {
-    return groupByOrganizationId(
-      extensions.filter(
-        (extension) =>
-          extension._recipe &&
-          extension._recipe.sharing?.organizations.length > 0 &&
-          !extension._deployment
-      )
-    );
-  }, [extensions, organizations]);
+  const teamExtensionGroups = useMemo(
+    () =>
+      groupByOrganizationId(
+        extensions.filter(
+          (extension) =>
+            extension._recipe &&
+            extension._recipe.sharing?.organizations.length > 0 &&
+            !extension._deployment
+        )
+      ),
+    [extensions]
+  );
 
   const deploymentGroups = groupByRecipe(
     extensions.filter((extension) => extension._deployment)

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -51,6 +51,10 @@ const isPublic = (extension: ResolvedExtension) =>
 const hasOrganization = (extension: ResolvedExtension) =>
   extension._recipe?.sharing?.organizations.length > 0;
 
+const isPersonal = (extension: ResolvedExtension, scope: string) =>
+  extension._recipe?.id.includes(scope) ||
+  (!extension._recipe && !extension._deployment);
+
 const ActiveBricksCard: React.FunctionComponent<{
   extensions: ResolvedExtension[];
   onRemove: RemoveAction;
@@ -63,10 +67,6 @@ const ActiveBricksCard: React.FunctionComponent<{
     organizations.find((organization) => organization.id === organization_uuid)
       ?.name;
 
-  const isPersonal = (extension: ResolvedExtension) =>
-    extension._recipe?.id.includes(scope) ||
-    (!extension._recipe && !extension._deployment);
-
   const sortedExtensions = useMemo(() => {
     const personal = [];
     const marketplace = [];
@@ -75,7 +75,7 @@ const ActiveBricksCard: React.FunctionComponent<{
     const other = [];
 
     for (const extension of extensions) {
-      if (isPersonal(extension)) {
+      if (isPersonal(extension, scope)) {
         personal.push(extension);
         continue;
       }
@@ -99,8 +99,6 @@ const ActiveBricksCard: React.FunctionComponent<{
     }
 
     return { personal, marketplace, team, deployment, other };
-    // We specifically would like to re-render on scope change, not isPersonal
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [extensions, scope]);
 
   const personalExtensions = sortedExtensions.personal;

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -99,6 +99,8 @@ const ActiveBricksCard: React.FunctionComponent<{
     }
 
     return { personal, marketplace, team, deployment, other };
+    // We specifically would like to re-render on scope change, not isPersonal
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [extensions, scope]);
 
   const personalExtensions = sortedExtensions.personal;

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -52,7 +52,9 @@ const hasOrganization = (extension: ResolvedExtension) =>
   extension._recipe?.sharing?.organizations.length > 0;
 
 const isPersonal = (extension: ResolvedExtension, scope: string) =>
-  (scope && extension._recipe?.id.startsWith(scope)) ||
+  // FIXME: recipes that I own that I have not shared with anyone should go under their own heading and be grouped by
+  //  recipe. The "personal bricks" section should only include extensions that don't correspond to a versioned recipe
+  (scope && extension._recipe?.id.startsWith(scope + "/")) ||
   (!extension._recipe && !extension._deployment);
 
 const groupExtensions = (extensions: ResolvedExtension[], scope: string) => {

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -52,8 +52,6 @@ const hasOrganization = (extension: ResolvedExtension) =>
   extension._recipe?.sharing?.organizations.length > 0;
 
 const isPersonalBrick = (extension: ResolvedExtension) =>
-  // FIXME: recipes that I own that I have not shared with anyone should go under their own heading and be grouped by
-  //  recipe. The "personal bricks" section should only include extensions that don't correspond to a versioned recipe
   !extension._recipe && !extension._deployment;
 
 const isPersonalBlueprint = (extension: ResolvedExtension, scope: string) =>

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useMemo } from "react";
+import React, { useContext, useMemo } from "react";
 import { MessageContext, ResolvedExtension, UUID } from "@/core";
 import { ExportBlueprintAction, RemoveAction } from "./installedPageTypes";
 import { Card, Col, Row, Table } from "react-bootstrap";
@@ -25,6 +25,7 @@ import { groupBy } from "lodash";
 import ExtensionRows from "./ExtensionRows";
 import { isDeploymentActive } from "@/options/deploymentUtils";
 import { useGetOrganizationsQuery } from "@/services/api";
+import AuthContext from "@/auth/AuthContext";
 
 const groupByRecipe = (
   extensions: ResolvedExtension[]
@@ -33,16 +34,20 @@ const groupByRecipe = (
 
 const groupByOrganizationId = (
   extensions: ResolvedExtension[]
-): Array<[string, ResolvedExtension[]]> =>
-  Object.entries(
+): Array<[UUID, ResolvedExtension[]]> =>
+  (Object.entries(
     groupBy(
       extensions,
+      // For the uncommon scenario that a user would be a part of two or more organizations
+      // with which the recipe is shared, we arbitrarily choose the first one
       (extension) => extension._recipe.sharing.organizations[0]
     )
-  );
+    // Could not figure out nominal type for UUID
+  ) as unknown) as Array<[UUID, ResolvedExtension[]]>;
 
 const isPublic = (extension: ResolvedExtension) =>
   extension._recipe?.sharing?.public;
+
 const hasOrganization = (extension: ResolvedExtension) =>
   extension._recipe?.sharing?.organizations.length > 0;
 
@@ -52,42 +57,70 @@ const ActiveBricksCard: React.FunctionComponent<{
   onExportBlueprint: ExportBlueprintAction;
 }> = ({ extensions, onRemove, onExportBlueprint }) => {
   const { data: organizations = [] } = useGetOrganizationsQuery();
+  const { scope } = useContext(AuthContext);
 
   const getOrganizationName = (organization_uuid: UUID) =>
     organizations.find((organization) => organization.id === organization_uuid)
       ?.name;
 
-  const personalExtensions = extensions.filter(
-    (extension) =>
-      (!extension._recipe && !extension._deployment) ||
-      (!isPublic(extension) && !hasOrganization(extension))
-  );
+  const isPersonal = (extension: ResolvedExtension) =>
+    extension._recipe?.id.includes(scope) ||
+    (!extension._recipe && !extension._deployment);
+
+  const sortedExtensions = useMemo(() => {
+    const personal = [];
+    const marketplace = [];
+    const team = [];
+    const deployment = [];
+    const other = [];
+
+    for (const extension of extensions) {
+      if (isPersonal(extension)) {
+        personal.push(extension);
+        continue;
+      }
+
+      if (extension._deployment) {
+        deployment.push(extension);
+        continue;
+      }
+
+      if (isPublic(extension)) {
+        marketplace.push(extension);
+        continue;
+      }
+
+      if (hasOrganization(extension)) {
+        team.push(extension);
+        continue;
+      }
+
+      other.push(extension);
+    }
+
+    return { personal, marketplace, team, deployment, other };
+  }, [extensions, scope]);
+
+  const personalExtensions = sortedExtensions.personal;
 
   const marketplaceExtensionGroups = groupByRecipe(
-    extensions.filter(
-      (extension) => isPublic(extension) && !extension._deployment
-    )
+    sortedExtensions.marketplace
   );
 
   const teamExtensionGroups = useMemo(
     () =>
-      groupByOrganizationId(
-        extensions.filter(
-          (extension) =>
-            hasOrganization(extension) &&
-            !isPublic(extension) &&
-            !extension._deployment
-        )
-      ).map(([organization_uuid, extensions]) => ({
-        organization_uuid,
-        extensions: groupByRecipe(extensions),
-      })),
-    [extensions]
+      groupByOrganizationId(sortedExtensions.team).map(
+        ([organization_uuid, extensions]) => ({
+          organization_uuid,
+          extensions: groupByRecipe(extensions),
+        })
+      ),
+    [sortedExtensions]
   );
 
-  const deploymentGroups = groupByRecipe(
-    extensions.filter((extension) => extension._deployment)
-  );
+  const deploymentExtensionGroups = groupByRecipe(sortedExtensions.deployment);
+
+  const otherExtensionGroups = groupByRecipe(sortedExtensions.other);
 
   return (
     <Row>
@@ -104,6 +137,29 @@ const ActiveBricksCard: React.FunctionComponent<{
                     onRemove={onRemove}
                     onExportBlueprint={onExportBlueprint}
                   />
+                </>
+              )}
+
+              {otherExtensionGroups.length > 0 && (
+                <>
+                  <ExtensionGroupHeader label="Marketplace Bricks" />
+                  {otherExtensionGroups.map((extensions) => {
+                    const recipe = extensions[0]._recipe;
+                    const messageContext: MessageContext = {
+                      blueprintId: recipe.id,
+                    };
+
+                    return (
+                      <ExtensionGroup
+                        key={recipe.id}
+                        label={recipe.name}
+                        extensions={extensions}
+                        groupMessageContext={messageContext}
+                        onRemove={onRemove}
+                        onExportBlueprint={onExportBlueprint}
+                      />
+                    );
+                  })}
                 </>
               )}
 
@@ -135,7 +191,7 @@ const ActiveBricksCard: React.FunctionComponent<{
                   <ExtensionGroupHeader
                     key={index}
                     label={`${getOrganizationName(
-                      team.organization_uuid as UUID
+                      team.organization_uuid
                     )} Bricks`}
                   />
                   {team.extensions.map((extensions) => {
@@ -158,10 +214,10 @@ const ActiveBricksCard: React.FunctionComponent<{
                 </>
               ))}
 
-              {deploymentGroups.length > 0 && (
+              {deploymentExtensionGroups.length > 0 && (
                 <>
                   <ExtensionGroupHeader label="Automatic Team Deployments" />
-                  {deploymentGroups.map((extensions) => {
+                  {deploymentExtensionGroups.map((extensions) => {
                     const recipe = extensions[0]._recipe;
                     const deployment = extensions[0]._deployment;
                     const messageContext: MessageContext = {

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -89,8 +89,6 @@ const ActiveBricksCard: React.FunctionComponent<{
     extensions.filter((extension) => extension._deployment)
   );
 
-  console.log("Extensions:", extensions);
-
   return (
     <Row>
       <Col xl={9} lg={10} md={12}>

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -48,6 +48,10 @@ const ActiveBricksCard: React.FunctionComponent<{
 }> = ({ extensions, onRemove, onExportBlueprint }) => {
   const { data: organizations = [] } = useGetOrganizationsQuery();
 
+  const getOrganizationName = (organization_uuid: UUID) =>
+    organizations.find((organization) => organization.id === organization_uuid)
+      ?.name;
+
   const personalExtensions = extensions.filter(
     (extension) => !extension._recipe && !extension._deployment
   );
@@ -58,10 +62,6 @@ const ActiveBricksCard: React.FunctionComponent<{
         extension._recipe?.sharing?.public && !extension._deployment
     )
   );
-
-  const getOrganizationName = (organization_uuid: UUID) =>
-    organizations.find((organization) => organization.id === organization_uuid)
-      ?.name;
 
   const teamExtensionGroups = useMemo(
     () =>
@@ -78,8 +78,6 @@ const ActiveBricksCard: React.FunctionComponent<{
       })),
     [extensions]
   );
-
-  console.log("Extensions:", extensions);
 
   const deploymentGroups = groupByRecipe(
     extensions.filter((extension) => extension._deployment)

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -62,7 +62,6 @@ const groupExtensions = (extensions: ResolvedExtension[], scope: string) => {
   const marketplace = [];
   const team = [];
   const deployment = [];
-  // `other` is the users ad-hoc extensions that aren't part of a recipe/blueprint
   const other = [];
 
   for (const extension of extensions) {

--- a/src/options/pages/installed/ActiveBricksCard.tsx
+++ b/src/options/pages/installed/ActiveBricksCard.tsx
@@ -41,6 +41,11 @@ const groupByOrganizationId = (
     )
   );
 
+const isPublic = (extension: ResolvedExtension) =>
+  extension._recipe?.sharing?.public;
+const hasOrganization = (extension: ResolvedExtension) =>
+  extension._recipe?.sharing?.organizations.length > 0;
+
 const ActiveBricksCard: React.FunctionComponent<{
   extensions: ResolvedExtension[];
   onRemove: RemoveAction;
@@ -53,13 +58,14 @@ const ActiveBricksCard: React.FunctionComponent<{
       ?.name;
 
   const personalExtensions = extensions.filter(
-    (extension) => !extension._recipe && !extension._deployment
+    (extension) =>
+      (!extension._recipe && !extension._deployment) ||
+      (!isPublic(extension) && !hasOrganization(extension))
   );
 
   const marketplaceExtensionGroups = groupByRecipe(
     extensions.filter(
-      (extension) =>
-        extension._recipe?.sharing?.public && !extension._deployment
+      (extension) => isPublic(extension) && !extension._deployment
     )
   );
 
@@ -68,8 +74,8 @@ const ActiveBricksCard: React.FunctionComponent<{
       groupByOrganizationId(
         extensions.filter(
           (extension) =>
-            extension._recipe?.sharing?.organizations.length > 0 &&
-            !extension._recipe?.sharing?.public &&
+            hasOrganization(extension) &&
+            !isPublic(extension) &&
             !extension._deployment
         )
       ).map(([organization_uuid, extensions]) => ({
@@ -82,6 +88,8 @@ const ActiveBricksCard: React.FunctionComponent<{
   const deploymentGroups = groupByRecipe(
     extensions.filter((extension) => extension._deployment)
   );
+
+  console.log("Extensions:", extensions);
 
   return (
     <Row>

--- a/src/options/pages/marketplace/ActivateBlueprintPage.tsx
+++ b/src/options/pages/marketplace/ActivateBlueprintPage.tsx
@@ -91,8 +91,6 @@ const ActivateBlueprintPage: React.FunctionComponent = () => {
     [blueprint]
   );
 
-  console.log("BLUEPRINT:", blueprint);
-
   const body = useMemo(() => {
     if (blueprint?.config?.extensionPoints != null) {
       return <ActivateWizard blueprint={recipe} />;

--- a/src/options/pages/marketplace/ActivateBlueprintPage.tsx
+++ b/src/options/pages/marketplace/ActivateBlueprintPage.tsx
@@ -22,7 +22,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import React, { useMemo } from "react";
 import { useParams } from "react-router";
-import { RecipeDefinition } from "@/types/definitions";
+import { RecipeDefinition, SharingDefinition } from "@/types/definitions";
 import { Card, Col, Row } from "react-bootstrap";
 import GridLoader from "react-spinners/GridLoader";
 import ActivateWizard from "@/options/pages/marketplace/ActivateWizard";
@@ -33,6 +33,7 @@ import useFetch from "@/hooks/useFetch";
 
 type BlueprintResponse = {
   config: RecipeDefinition;
+  sharing: SharingDefinition;
 };
 
 const TEMPLATES_PAGE_PART = "templates";
@@ -82,9 +83,19 @@ const ActivateBlueprintPage: React.FunctionComponent = () => {
     `/api/recipes/${blueprintId}`
   );
 
+  const recipe: RecipeDefinition = useMemo(
+    () => ({
+      ...blueprint?.config,
+      sharing: blueprint?.sharing,
+    }),
+    [blueprint]
+  );
+
+  console.log("BLUEPRINT:", blueprint);
+
   const body = useMemo(() => {
     if (blueprint?.config?.extensionPoints != null) {
-      return <ActivateWizard blueprint={blueprint.config} />;
+      return <ActivateWizard blueprint={recipe} />;
     }
 
     if (blueprint != null) {

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -117,8 +117,6 @@ const ActivateWizard: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
   const [stepKey, setStep] = useState(blueprintSteps[0].key);
   const install = useInstall(blueprint);
 
-  console.log("BLUEPRINT IN ACTIVATE WIZARD:", blueprint);
-
   useTitle(`Activate ${truncate(blueprint.metadata.name, { length: 15 })}`);
 
   return (

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -117,6 +117,8 @@ const ActivateWizard: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
   const [stepKey, setStep] = useState(blueprintSteps[0].key);
   const install = useInstall(blueprint);
 
+  console.log("BLUEPRINT IN ACTIVATE WIZARD:", blueprint);
+
   useTitle(`Activate ${truncate(blueprint.metadata.name, { length: 15 })}`);
 
   return (

--- a/src/options/slices.ts
+++ b/src/options/slices.ts
@@ -256,8 +256,6 @@ export const optionsSlice = createSlice({
           throw new Error("extensionPointId is required");
         }
 
-        console.log("RECIPE IN USEINSTALL:", recipe);
-
         const extension: PersistedExtension = {
           id: extensionId,
           // Default to `v1` for backward compatability

--- a/src/options/slices.ts
+++ b/src/options/slices.ts
@@ -256,12 +256,20 @@ export const optionsSlice = createSlice({
           throw new Error("extensionPointId is required");
         }
 
+        console.log("RECIPE IN USEINSTALL:", recipe);
+
         const extension: PersistedExtension = {
           id: extensionId,
           // Default to `v1` for backward compatability
           apiVersion: recipe.apiVersion ?? "v1",
           _deployment: selectDeploymentContext(deployment),
-          _recipe: recipe.metadata,
+          _recipe: {
+            id: recipe.metadata.id,
+            version: recipe.metadata.version,
+            name: recipe.metadata.name,
+            description: recipe.metadata.description,
+            sharing: recipe.sharing,
+          },
           // Definitions are pushed down into the extensions. That's OK because `resolveDefinitions` determines
           // uniqueness based on the content of the definition. Therefore, bricks will be re-used as necessary
           definitions: recipe.definitions ?? {},

--- a/src/pages/marketplace/MarketplacePage.tsx
+++ b/src/pages/marketplace/MarketplacePage.tsx
@@ -24,7 +24,7 @@ import {
   faScroll,
   faUsers,
 } from "@fortawesome/free-solid-svg-icons";
-import { Metadata, Sharing } from "@/core";
+import { Metadata, Sharing, UUID } from "@/core";
 import { RecipeDefinition } from "@/types/definitions";
 import { Col, InputGroup, ListGroup, Row, Button, Form } from "react-bootstrap";
 import "./MarketplacePage.scss";
@@ -69,7 +69,9 @@ const Entry: React.FunctionComponent<
     }
 
     // If more than one sharing organization, use the first
-    return organizations.find((org) => sharing.organizations.includes(org.id));
+    return organizations.find((org) =>
+      sharing.organizations.includes(org.id as UUID)
+    );
   }, [organizations, sharing.organizations]);
 
   const installButton = useMemo(() => {


### PR DESCRIPTION
Closes #1687, and depends on https://github.com/pixiebrix/pixiebrix-app/pull/781

This adds Team sections to the Active Bricks page that further group Active Bricks by their respective teams, or by Public Marketplace if not associated with a team.

<img width="1440" alt="Screen Shot 2021-11-08 at 4 42 55 PM" src="https://user-images.githubusercontent.com/36575242/140841133-45b9250d-b73f-433f-88e9-b9838ccb052a.png">

