### PR TITLE
#1751: Allow setting a specific value of boxes

### DIFF
--- a/src/blocks/effects/forms.ts
+++ b/src/blocks/effects/forms.ts
@@ -20,15 +20,19 @@ import { BlockArg, BlockOptions, Logger, Schema } from "@/core";
 import { BusinessError } from "@/errors";
 import { boolean } from "@/utils";
 import { requireSingleElement } from "@/nativeEditor/utils";
+import { RequireExactlyOne } from "type-fest";
 
-type SetValueData = {
-  form?: HTMLElement | Document;
-  selector?: string;
-  name?: string;
-  value: unknown;
-  dispatchEvent?: boolean;
-  logger: Logger;
-};
+type SetValueData = RequireExactlyOne<
+  {
+    form?: HTMLElement | Document;
+    value: unknown;
+    selector?: string;
+    name?: string;
+    dispatchEvent?: boolean;
+    logger: Logger;
+  },
+  "selector" | "name"
+>;
 
 const optionFields = ["checkbox", "radio"];
 

--- a/src/blocks/effects/forms.ts
+++ b/src/blocks/effects/forms.ts
@@ -44,25 +44,24 @@ function setValue({
   dispatchEvent = true,
 }: SetValueData) {
   const isNameBased = Boolean(name);
-  const fields = [
-    ...form.querySelectorAll<
-      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-    >(selector),
-  ].filter((element) => {
-    const isField =
-      element.isContentEditable ||
-      element instanceof HTMLInputElement ||
-      element instanceof HTMLTextAreaElement ||
-      element instanceof HTMLSelectElement;
-    if (!isField) {
-      logger.warn(
-        "The selected element is not an input field nor an editable element",
-        { element }
-      );
-    }
+  const fields = $(form)
+    .find<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>(selector)
+    .toArray()
+    .filter((element) => {
+      const isField =
+        element.isContentEditable ||
+        element instanceof HTMLInputElement ||
+        element instanceof HTMLTextAreaElement ||
+        element instanceof HTMLSelectElement;
+      if (!isField) {
+        logger.warn(
+          "The selected element is not an input field nor an editable element",
+          { element }
+        );
+      }
 
-    return isField;
-  });
+      return isField;
+    });
 
   if (fields.length === 0) {
     if (isNameBased) {

--- a/src/blocks/effects/forms.ts
+++ b/src/blocks/effects/forms.ts
@@ -112,8 +112,24 @@ function setValue({
     }
 
     if (dispatchEvent) {
-      field.dispatchEvent(new Event("change", { bubbles: true }));
-      field.dispatchEvent(new InputEvent("input", { bubbles: true }));
+      if (
+        !(
+          optionFields.includes(field.type) ||
+          field instanceof HTMLSelectElement
+        )
+      ) {
+        // Browsers normally fire these text events while typing
+        field.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true }));
+        field.dispatchEvent(new KeyboardEvent("keypress", { bubbles: true }));
+        field.dispatchEvent(
+          new CompositionEvent("textInput", { bubbles: true })
+        );
+        field.dispatchEvent(new InputEvent("input", { bubbles: true }));
+        field.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
+      }
+
+      // Browsers normally fire this on `blur` if it's a text field, otherwise immediately
+      field.dispatchEvent(new KeyboardEvent("change", { bubbles: true }));
     }
   }
 }


### PR DESCRIPTION
- Closes #1751

### Changes

- moves `querySelector` and warnings to the setValue function to avoid duplication
- handles a selection of multiple elements as a single entity — if `name` was used.
	
	Using the name `size` and value `M` the right radio will be `checked`:
	```html
	<input type="radio" name="size" value="S">
	<input type="radio" name="size" value="M">
	<input type="radio" name="size" value="L">
	```

	 When the exact value isn't found, the previous behavior will be used (`value` is set as a boolean on all the matching elements)
- adds support for `select` elements by value


Tested on https://pixiebrix.github.io/playground/example/