### PR TITLE
#1849: remove straggling references to templates page

### DIFF
--- a/src/actionPanel/DefaultActionPanel.test.tsx
+++ b/src/actionPanel/DefaultActionPanel.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { optionsSlice } from "@/options/slices";
+import { extensionFactory } from "@/tests/factories";
+import { ExtensionOptionsState } from "@/store/extensions";
+import { PersistedExtension } from "@/core";
+import DefaultActionPanel from "./DefaultActionPanel";
+
+jest.unmock("react-redux");
+
+function optionsStore(initialState?: ExtensionOptionsState) {
+  return configureStore({
+    reducer: { options: optionsSlice.reducer },
+    preloadedState: initialState ? { options: initialState } : undefined,
+  });
+}
+
+describe("renders DefaultActionPanel", () => {
+  it("renders no active extensions", () => {
+    render(
+      <Provider store={optionsStore()}>
+        <DefaultActionPanel />
+      </Provider>
+    );
+
+    expect(screen.queryByText("Activate an Official Blueprint")).not.toBeNull();
+  });
+
+  it("renders no available extensions", () => {
+    const state: ExtensionOptionsState = {
+      extensions: [extensionFactory() as PersistedExtension],
+    };
+
+    render(
+      <Provider store={optionsStore(state)}>
+        <DefaultActionPanel />
+      </Provider>
+    );
+
+    expect(
+      screen.queryByText("No panels activated for the page")
+    ).not.toBeNull();
+  });
+});

--- a/src/actionPanel/DefaultActionPanel.tsx
+++ b/src/actionPanel/DefaultActionPanel.tsx
@@ -19,29 +19,31 @@ import React from "react";
 import { useSelector } from "react-redux";
 import marketplaceImage from "@img/marketplace.svg";
 import workshopImage from "@img/workshop.svg";
-import { Button, Col, Container, Row } from "react-bootstrap";
+import { Col, Container, Row } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faClipboardCheck,
-  faExternalLinkAlt,
-} from "@fortawesome/free-solid-svg-icons";
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { selectExtensions } from "@/options/selectors";
 
 const OnboardingContent: React.FunctionComponent = () => (
   <Container>
     <Row className="mt-4">
       <Col>
-        <h4 className="display-6">Activate an Official Template</h4>
+        <h4 className="display-6">Activate an Official Blueprint</h4>
         <p>
           <span className="text-primary">
             The easiest way to start using PixieBrix!
           </span>{" "}
-          Activate a pre-made template from the Templates page.
+          Activate a pre-made blueprint from the Public Marketplace.
         </p>
-        <Button href="/options.html#/templates" target="_blank" variant="info">
-          View Templates&nbsp;
-          <FontAwesomeIcon icon={faClipboardCheck} />
-        </Button>
+        <a
+          className="btn btn-info"
+          href="https://www.pixiebrix.com/marketplace/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Open Marketplace&nbsp;
+          <FontAwesomeIcon icon={faExternalLinkAlt} />
+        </a>
       </Col>
     </Row>
 
@@ -49,8 +51,8 @@ const OnboardingContent: React.FunctionComponent = () => (
       <Col>
         <h4 className="display-6">Create your Own</h4>
         <p>
-          Follow the Quickstart Guide in our documentation area to start
-          creating your own bricks in minutes.
+          Follow the Quickstart Guide to start creating your own bricks in
+          minutes.
         </p>
         <a
           className="btn btn-info"
@@ -93,7 +95,7 @@ const DefaultActionPanel: React.FunctionComponent = () => {
 
   return (
     <div>
-      {extensions?.length ? (
+      {extensions?.length > 0 ? (
         <NoAvailablePanelsContent />
       ) : (
         <OnboardingContent />

--- a/src/messaging/external.ts
+++ b/src/messaging/external.ts
@@ -85,23 +85,6 @@ const _openMarketplace = liftBackground(
   }
 );
 
-const _openTemplates = liftBackground(
-  "BACKGROUND_OPEN_TEMPLATES",
-  async ({ newTab = true }: OpenOptionsOptions) => {
-    const baseUrl = browser.runtime.getURL("options.html");
-
-    const url = `${baseUrl}#/templates`;
-
-    if (newTab) {
-      await browser.tabs.create({ url, active: true });
-    } else {
-      await browser.tabs.update({ url });
-    }
-
-    return true;
-  }
-);
-
 type ActivateBlueprintOptions = {
   /**
    * The blueprint to activate
@@ -117,24 +100,22 @@ type ActivateBlueprintOptions = {
    * The "source" page to associate with the activate. This affects the wording in the ActivateWizard
    * component
    */
-  pageSource?: "templates" | "marketplace";
+  pageSource?: "marketplace";
 };
 
 const _openActivate = liftBackground(
   "BACKGROUND_OPEN_ACTIVATE_BLUEPRINT",
-  async ({
-    blueprintId,
-    newTab = true,
-    pageSource = "templates",
-  }: ActivateBlueprintOptions) => {
+  async ({ blueprintId, newTab = true }: ActivateBlueprintOptions) => {
     const baseUrl = browser.runtime.getURL("options.html");
-    const url = `${baseUrl}#/${pageSource}/activate/${encodeURIComponent(
+    const url = `${baseUrl}#/marketplace/activate/${encodeURIComponent(
       blueprintId
     )}`;
 
     reportEvent("ExternalActivate", {
       blueprintId,
-      pageSource,
+      // We used to have multiple sources: template vs. marketplace. However we got rid of "templates" as a separate
+      // pageSource. Keep for now for analytics consistency
+      pageSource: "marketplace",
     });
 
     if (newTab) {
@@ -159,9 +140,4 @@ export const openExtensionOptions = lift("OPEN_OPTIONS", async () =>
 export const openMarketplace = lift(
   "OPEN_MARKETPLACE",
   async (options: OpenOptionsOptions = {}) => _openMarketplace(options)
-);
-
-export const openTemplates = lift(
-  "OPEN_TEMPLATES",
-  async (options: OpenOptionsOptions = {}) => _openTemplates(options)
 );

--- a/src/options/pages/deployments/DeploymentBanner.tsx
+++ b/src/options/pages/deployments/DeploymentBanner.tsx
@@ -47,7 +47,6 @@ const DeploymentBanner: React.FunctionComponent<{ className?: string }> = ({
   const matchRoot = useRouteMatch({ path: "/", exact: true });
   const matchInstalled = useRouteMatch({ path: "/installed", exact: true });
   const matchMarketplace = useRouteMatch({ path: "/blueprints", exact: true });
-  const matchTemplates = useRouteMatch({ path: "/templates", exact: true });
 
   const updateExtension = useCallback(async () => {
     await chromeP.runtime.requestUpdateCheck();
@@ -58,7 +57,7 @@ const DeploymentBanner: React.FunctionComponent<{ className?: string }> = ({
     return null;
   }
 
-  if (!(matchRoot || matchInstalled || matchMarketplace || matchTemplates)) {
+  if (!(matchRoot || matchInstalled || matchMarketplace)) {
     return null;
   }
 

--- a/src/options/pages/marketplace/ActivateBlueprintPage.tsx
+++ b/src/options/pages/marketplace/ActivateBlueprintPage.tsx
@@ -15,11 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { PageTitle } from "@/layout/Page";
-import {
-  faClipboardCheck,
-  faStoreAlt,
-} from "@fortawesome/free-solid-svg-icons";
+import Page from "@/layout/Page";
+import { faStoreAlt } from "@fortawesome/free-solid-svg-icons";
 import React, { useMemo } from "react";
 import { useParams } from "react-router";
 import { RecipeDefinition, SharingDefinition } from "@/types/definitions";
@@ -36,53 +33,17 @@ type BlueprintResponse = {
   sharing: SharingDefinition;
 };
 
-const TEMPLATES_PAGE_PART = "templates";
-
-const TemplateHeader: React.FunctionComponent<{
-  blueprint: BlueprintResponse;
-}> = ({ blueprint }) => (
-  <>
-    <PageTitle
-      icon={faClipboardCheck}
-      title={
-        blueprint
-          ? `Activate: ${blueprint.config.metadata.name}`
-          : "Activate Blueprint"
-      }
-    />
-    <div className="pb-4">
-      <p>Configure and activate a pre-made template</p>
-    </div>
-  </>
-);
-
-const MarketplaceHeader: React.FunctionComponent<{
-  blueprint: BlueprintResponse;
-}> = ({ blueprint }) => (
-  <>
-    <PageTitle
-      icon={faStoreAlt}
-      title={
-        blueprint
-          ? `Activate: ${blueprint.config.metadata.name}`
-          : "Activate Blueprint"
-      }
-    />
-    <div className="pb-4">
-      <p>Configure and activate a blueprint from the marketplace</p>
-    </div>
-  </>
-);
-
 const ActivateBlueprintPage: React.FunctionComponent = () => {
-  const { blueprintId, sourcePage } = useParams<{
+  const { blueprintId } = useParams<{
     blueprintId: string;
-    sourcePage: string;
   }>();
-  const { data: blueprint } = useFetch<BlueprintResponse>(
-    `/api/recipes/${blueprintId}`
-  );
+  const {
+    data: blueprint,
+    isLoading,
+    error: fetchError,
+  } = useFetch<BlueprintResponse>(`/api/recipes/${blueprintId}`);
 
+  // Reshape to recipe definition
   const recipe: RecipeDefinition = useMemo(
     () => ({
       ...blueprint?.config,
@@ -97,45 +58,42 @@ const ActivateBlueprintPage: React.FunctionComponent = () => {
     }
 
     if (blueprint != null) {
+      // There's nothing stopping someone from hitting the link with a non-blueprint (e.g., service, component). So
+      // show an error message if not a valid blueprint
       return (
         <Card>
           <Card.Header>Invalid Blueprint</Card.Header>
           <Card.Body>
             <p className="text-danger">
-              Error: {decodeURIComponent(blueprintId)} is not a blueprint.
+              Error: {decodeURIComponent(blueprintId)} is not a valid blueprint.
               Please verify the link you received to activate the blueprint
             </p>
 
-            {sourcePage === TEMPLATES_PAGE_PART ? (
-              <Link to={"/templates"} className="btn btn-info">
-                <FontAwesomeIcon icon={faClipboardCheck} /> Go to Templates
-              </Link>
-            ) : (
-              <Link to={"/marketplace"} className="btn btn-info">
-                <FontAwesomeIcon icon={faStoreAlt} /> Go to Marketplace
-              </Link>
-            )}
+            <Link to={"/marketplace"} className="btn btn-info">
+              <FontAwesomeIcon icon={faStoreAlt} /> Go to Marketplace
+            </Link>
           </Card.Body>
         </Card>
       );
     }
 
     return <GridLoader />;
-  }, [blueprintId, blueprint, sourcePage]);
+  }, [recipe, blueprint, blueprintId]);
 
   return (
-    <div>
-      {sourcePage === TEMPLATES_PAGE_PART ? (
-        <TemplateHeader blueprint={blueprint} />
-      ) : (
-        <MarketplaceHeader blueprint={blueprint} />
-      )}
+    <Page
+      title="Activate Blueprint"
+      icon={faStoreAlt}
+      description="Configure and activate a blueprint from the marketplace"
+      isPending={isLoading}
+      error={fetchError}
+    >
       <Row>
         <Col xl={8} lg={10} md={12}>
           <ErrorBoundary>{body}</ErrorBoundary>
         </Col>
       </Row>
-    </div>
+    </Page>
   );
 };
 

--- a/src/pages/marketplace/useInstall.ts
+++ b/src/pages/marketplace/useInstall.ts
@@ -18,7 +18,6 @@
 import { RecipeDefinition } from "@/types/definitions";
 import useNotifications from "@/hooks/useNotifications";
 import { useDispatch } from "react-redux";
-import { useParams } from "react-router";
 import { useCallback } from "react";
 import { FormikHelpers } from "formik";
 import { WizardValues } from "@/options/pages/marketplace/wizardTypes";
@@ -42,7 +41,6 @@ type InstallRecipe = (
 function useInstall(recipe: RecipeDefinition): InstallRecipe {
   const notify = useNotifications();
   const dispatch = useDispatch();
-  const { sourcePage } = useParams<{ sourcePage: string }>();
 
   return useCallback(
     async (values, { setSubmitting }: FormikHelpers<WizardValues>) => {
@@ -112,9 +110,7 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
 
         void reactivate();
 
-        dispatch(
-          push(sourcePage === "templates" ? "/templates" : "/installed")
-        );
+        dispatch(push("/installed"));
       } catch (error: unknown) {
         notify.error(`Error installing ${recipe.metadata.name}`, {
           error,
@@ -122,7 +118,7 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
         setSubmitting(false);
       }
     },
-    [notify, dispatch, sourcePage, recipe]
+    [notify, dispatch, recipe]
   );
 }
 


### PR DESCRIPTION
What does this PR do?
- Removes remaining references to the Templates screen that doesn't exist anymore. (There's only the My Blueprints page now)

TODO:
- [ ]  Add PR in app project to remove the reference to the external method