### PR TITLE
#1653 Allow saving an extension with errors

### DIFF
--- a/src/devTools/editor/ElementWizard.tsx
+++ b/src/devTools/editor/ElementWizard.tsx
@@ -110,9 +110,7 @@ const ElementWizard: React.FunctionComponent<{
     setStatus,
   } = useFormikContext<FormState>();
 
-  const { savingExtensionId, save } = useSavingWizard();
-
-  const isSubmitting = Boolean(savingExtensionId);
+  const { isSaving, save } = useSavingWizard();
 
   const onSave = async () => {
     try {
@@ -159,14 +157,14 @@ const ElementWizard: React.FunctionComponent<{
 
           <PermissionsToolbar
             element={element}
-            disabled={isSubmitting || !isValid}
+            disabled={isSaving || !isValid}
           />
 
-          <ReloadToolbar element={element} disabled={isSubmitting} />
+          <ReloadToolbar element={element} disabled={isSaving} />
 
           <ActionToolbar
             element={element}
-            disabled={isSubmitting}
+            disabled={isSaving}
             onSave={onSave}
           />
         </Nav>

--- a/src/devTools/editor/ElementWizard.tsx
+++ b/src/devTools/editor/ElementWizard.tsx
@@ -37,6 +37,7 @@ import styles from "./ElementWizard.module.scss";
 import { thisTab } from "@/devTools/utils";
 import { checkAvailable } from "@/contentScript/messenger/api";
 import EditTab from "@/devTools/editor/tabs/editTab/EditTab";
+import useSavingWizard from "./panes/save/useSavingWizard";
 
 const LOG_STEP_NAME = "Logs";
 
@@ -103,12 +104,23 @@ const ElementWizard: React.FunctionComponent<{
   );
 
   const {
-    isSubmitting,
     isValid,
     status,
-    handleSubmit,
     handleReset,
+    setStatus,
   } = useFormikContext<FormState>();
+
+  const { savingExtensionId, save } = useSavingWizard();
+
+  const isSubmitting = Boolean(savingExtensionId);
+
+  const onSave = async () => {
+    try {
+      await save();
+    } catch (error: unknown) {
+      setStatus(error);
+    }
+  };
 
   const selectTabHandler = useCallback(
     (step: string) => {
@@ -155,7 +167,7 @@ const ElementWizard: React.FunctionComponent<{
           <ActionToolbar
             element={element}
             disabled={isSubmitting}
-            onSave={handleSubmit}
+            onSave={onSave}
           />
         </Nav>
 

--- a/src/devTools/editor/panes/EditorPane.tsx
+++ b/src/devTools/editor/panes/EditorPane.tsx
@@ -42,7 +42,7 @@ const EditorPane: React.FunctionComponent<{
 }> = ({ selectedElement, selectionSeq }) => {
   const dispatch = useDispatch();
   const editable = useEditable();
-  const { isWizardOpen, save: saveElement } = useSavingWizard();
+  const { isWizardOpen } = useSavingWizard();
 
   // XXX: anti-pattern: callback to update the redux store based on the formik state
   const syncReduxState = useDebouncedCallback(
@@ -62,14 +62,10 @@ const EditorPane: React.FunctionComponent<{
         <Formik
           key={key}
           initialValues={selectedElement}
-          onSubmit={async (values, { setSubmitting, setStatus }) => {
-            try {
-              await saveElement();
-            } catch (error: unknown) {
-              setStatus(error);
-            } finally {
-              setSubmitting(false);
-            }
+          onSubmit={() => {
+            console.error(
+              "Formik's submit should not be called to save an extension. Use 'saveElement' from 'useSavingWizard' instead."
+            );
           }}
         >
           {({ values: element }) => (

--- a/src/devTools/editor/panes/save/SaveExtensionWizard.test.tsx
+++ b/src/devTools/editor/panes/save/SaveExtensionWizard.test.tsx
@@ -54,7 +54,7 @@ afterEach(() => {
 
 test("shows loading when saving is in progress", async () => {
   (useSavingWizardMock as jest.Mock).mockReturnValue({
-    savingExtensionId: "test/extension",
+    isSaving: true,
   });
 
   render(<SaveExtensionWizard />);
@@ -71,7 +71,7 @@ test.each([
   ["loading packages", false, true],
 ])("shows loader when %s", (testName, loadingRecipes, loadingPackages) => {
   (useSavingWizardMock as jest.Mock).mockReturnValue({
-    savingExtensionId: null,
+    isSaving: false,
   });
   (useGetRecipesQueryMock as jest.Mock).mockReturnValue({
     data: [],
@@ -95,7 +95,7 @@ test("calls Save as Personal extension", async () => {
   const saveElementAsPersonalExtensionMock = jest.fn();
   const metadata = metadataFactory();
   (useSavingWizardMock as jest.Mock).mockReturnValue({
-    savingExtensionId: null,
+    isSaving: false,
     element: formStateFactory({
       recipe: metadata,
     }),
@@ -122,7 +122,7 @@ test("calls Save as New Blueprint", async () => {
   const saveElementAndCreateNewRecipeMock = jest.fn();
   const metadata = metadataFactory();
   (useSavingWizardMock as jest.Mock).mockReturnValue({
-    savingExtensionId: null,
+    isSaving: false,
     element: formStateFactory({
       recipe: metadata,
     }),
@@ -164,7 +164,7 @@ test("calls Update Blueprint", async () => {
   const saveElementAndUpdateRecipeMock = jest.fn();
   const metadata = metadataFactory();
   (useSavingWizardMock as jest.Mock).mockReturnValue({
-    savingExtensionId: null,
+    isSaving: false,
     element: formStateFactory({
       recipe: metadata,
     }),

--- a/src/devTools/editor/panes/save/SaveExtensionWizard.tsx
+++ b/src/devTools/editor/panes/save/SaveExtensionWizard.tsx
@@ -33,7 +33,7 @@ import RecipeConfigurationModal, {
 
 const SaveExtensionWizard: React.FC = () => {
   const {
-    savingExtensionId,
+    isSaving,
     element,
     saveElementAsPersonalExtension,
     saveElementAndCreateNewRecipe,
@@ -53,7 +53,7 @@ const SaveExtensionWizard: React.FC = () => {
   const isNewRecipe = useRef(false);
   const newRecipeInitialValues = useRef<RecipeConfiguration>(null);
 
-  if (savingExtensionId) {
+  if (isSaving) {
     return <SavingInProgressModal />;
   }
 

--- a/src/devTools/editor/panes/save/savingExtensionSelectors.ts
+++ b/src/devTools/editor/panes/save/savingExtensionSelectors.ts
@@ -20,5 +20,5 @@ import { RootState } from "@/devTools/store";
 export const selectIsWizardOpen = ({ savingExtension }: RootState) =>
   savingExtension.isWizardOpen;
 
-export const selectSavingExtensionId = ({ savingExtension }: RootState) =>
-  savingExtension.savingExtensionId;
+export const selectIsSaving = ({ savingExtension }: RootState) =>
+  savingExtension.isSaving;

--- a/src/devTools/editor/panes/save/savingExtensionSlice.ts
+++ b/src/devTools/editor/panes/save/savingExtensionSlice.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { UUID } from "@/core";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 export type SavingExtensionState = {
@@ -26,16 +25,15 @@ export type SavingExtensionState = {
   isWizardOpen: boolean;
 
   /**
-   * Id of the extension being saved.
-   * Is set only when the saving process is actually in progress.
-   * When a modal with saving options is open this property is null.
+   * Is TRUE only when the saving is actually in progress.
+   * When a modal with saving options is open this property is FALSE.
    */
-  savingExtensionId: UUID | null;
+  isSaving: boolean;
 };
 
 const initialState: SavingExtensionState = {
   isWizardOpen: false,
-  savingExtensionId: null,
+  isSaving: false,
 };
 
 export const savingExtensionSlice = createSlice({
@@ -45,12 +43,15 @@ export const savingExtensionSlice = createSlice({
     openWizard: (state) => {
       state.isWizardOpen = true;
     },
-    setSavingExtension: (state, action: PayloadAction<UUID>) => {
-      state.savingExtensionId = action.payload;
+    setSavingInProgress: (state, action: PayloadAction<boolean>) => {
+      state.isSaving = true;
     },
+    /**
+     * Closes the Wizard and also disables isSaving flag
+     */
     closeWizard: (state) => {
       state.isWizardOpen = false;
-      state.savingExtensionId = null;
+      state.isSaving = false;
     },
   },
 });

--- a/src/devTools/editor/panes/save/savingExtensionSlice.ts
+++ b/src/devTools/editor/panes/save/savingExtensionSlice.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createSlice } from "@reduxjs/toolkit";
 
 export type SavingExtensionState = {
   /**
@@ -43,7 +43,7 @@ export const savingExtensionSlice = createSlice({
     openWizard: (state) => {
       state.isWizardOpen = true;
     },
-    setSavingInProgress: (state, action: PayloadAction<boolean>) => {
+    setSavingInProgress: (state) => {
       state.isSaving = true;
     },
     /**

--- a/src/devTools/editor/panes/save/useSavingWizard.test.tsx
+++ b/src/devTools/editor/panes/save/useSavingWizard.test.tsx
@@ -135,7 +135,7 @@ test("saves non recipe element", async () => {
     });
   });
 
-  expect(result.current.savingExtensionId).toBe(element.uuid);
+  expect(result.current.isSaving).toBe(true);
   expect(createMock).toHaveBeenCalledTimes(1);
   expect(createMock).toHaveBeenCalledWith(element);
 });
@@ -195,7 +195,7 @@ describe("saving a Recipe Extension", () => {
   };
 
   test("saves as personal extension", async () => {
-    const { store, element, recipe, createMock, resetMock } = setupMocks();
+    const { store, recipe, createMock, resetMock } = setupMocks();
 
     // Render hook
     const { result } = renderUseSavingWizard(store);
@@ -210,7 +210,7 @@ describe("saving a Recipe Extension", () => {
     });
 
     expect(result.current.isWizardOpen).toBe(true);
-    expect(result.current.savingExtensionId).toBeNull();
+    expect(result.current.isSaving).toBe(false);
 
     // Saving as personal extension
     const savingElementPromise = act(async () =>
@@ -219,8 +219,7 @@ describe("saving a Recipe Extension", () => {
 
     // Check wizard state
     expect(result.current.isWizardOpen).toBe(true);
-    expect(result.current.savingExtensionId).not.toBeNull();
-    expect(result.current.savingExtensionId).not.toBe(element.uuid);
+    expect(result.current.isSaving).toBe(true);
 
     // Check new element added
     const elements = selectElements(store.getState());
@@ -241,7 +240,7 @@ describe("saving a Recipe Extension", () => {
 
     await savingElementPromise;
     expect(result.current.isWizardOpen).toBe(false);
-    expect(result.current.savingExtensionId).toBeNull();
+    expect(result.current.isSaving).toBe(false);
   });
 
   test("saves as new recipe", async () => {
@@ -257,7 +256,7 @@ describe("saving a Recipe Extension", () => {
     });
 
     expect(result.current.isWizardOpen).toBe(true);
-    expect(result.current.savingExtensionId).toBeNull();
+    expect(result.current.isSaving).toBe(false);
 
     // Saving with a new Recipe
     const newRecipeMeta = metadataFactory();
@@ -267,7 +266,7 @@ describe("saving a Recipe Extension", () => {
 
     // Check wizard state
     expect(result.current.isWizardOpen).toBe(true);
-    expect(result.current.savingExtensionId).toBe(element.uuid);
+    expect(result.current.isSaving).toBe(true);
 
     await savingElementPromise;
 
@@ -283,7 +282,7 @@ describe("saving a Recipe Extension", () => {
 
     // Check the wizard is closed
     expect(result.current.isWizardOpen).toBe(false);
-    expect(result.current.savingExtensionId).toBeNull();
+    expect(result.current.isSaving).toBe(false);
   });
 
   test("doesn't update extensions if recipe creation fails", async () => {
@@ -319,7 +318,7 @@ describe("saving a Recipe Extension", () => {
 
     // Wizard closes on error
     expect(result.current.isWizardOpen).toBe(false);
-    expect(result.current.savingExtensionId).toBeNull();
+    expect(result.current.isSaving).toBe(false);
 
     // Check it tried to create a recipe
     expect(createRecipeMock).toHaveBeenCalledTimes(1);
@@ -347,7 +346,7 @@ describe("saving a Recipe Extension", () => {
     });
 
     expect(result.current.isWizardOpen).toBe(true);
-    expect(result.current.savingExtensionId).toBeNull();
+    expect(result.current.isSaving).toBe(false);
 
     // Saving with a new Recipe
     const newRecipeMeta = metadataFactory({ id: recipe.metadata.id });
@@ -357,7 +356,7 @@ describe("saving a Recipe Extension", () => {
 
     // Check wizard state
     expect(result.current.isWizardOpen).toBe(true);
-    expect(result.current.savingExtensionId).toBe(element.uuid);
+    expect(result.current.isSaving).toBe(true);
 
     await savingElementPromise;
 
@@ -372,7 +371,7 @@ describe("saving a Recipe Extension", () => {
     expect(createMock).toHaveBeenCalledTimes(1);
 
     expect(result.current.isWizardOpen).toBe(false);
-    expect(result.current.savingExtensionId).toBeNull();
+    expect(result.current.isSaving).toBe(false);
   });
 
   test("doesn't update extensions if recipe update fails", async () => {
@@ -408,7 +407,7 @@ describe("saving a Recipe Extension", () => {
 
     // Wizard closes on error
     expect(result.current.isWizardOpen).toBe(false);
-    expect(result.current.savingExtensionId).toBeNull();
+    expect(result.current.isSaving).toBe(false);
 
     // Check it tried to create a recipe
     expect(updateRecipeMock).toHaveBeenCalledTimes(1);

--- a/src/devTools/editor/panes/save/useSavingWizard.ts
+++ b/src/devTools/editor/panes/save/useSavingWizard.ts
@@ -17,10 +17,7 @@
 
 import { actions as savingExtensionActions } from "./savingExtensionSlice";
 import { useDispatch, useSelector } from "react-redux";
-import {
-  selectIsWizardOpen,
-  selectSavingExtensionId,
-} from "./savingExtensionSelectors";
+import { selectIsWizardOpen, selectIsSaving } from "./savingExtensionSelectors";
 import {
   selectActiveElement,
   selectElements,
@@ -61,7 +58,7 @@ const useSavingWizard = () => {
   const reset = useReset();
   const notify = useNotifications();
   const isWizardOpen = useSelector(selectIsWizardOpen);
-  const savingExtensionId = useSelector(selectSavingExtensionId);
+  const isSaving = useSelector(selectIsSaving);
   const extensions = useSelector(selectExtensions);
   const elements = useSelector(selectElements);
   const element = useSelector(selectActiveElement);
@@ -86,7 +83,7 @@ const useSavingWizard = () => {
    * Saves an extension that is not a part of a Recipe
    */
   const saveNonRecipeElement = async () => {
-    dispatch(savingExtensionActions.setSavingExtension(element.uuid));
+    dispatch(savingExtensionActions.setSavingInProgress());
     const error = await create(element);
     closeWizard(error);
   };
@@ -96,13 +93,12 @@ const useSavingWizard = () => {
    * It will not be a part of the Recipe
    */
   const saveElementAsPersonalExtension = async () => {
-    const newExtensionUuid = uuidv4();
-    dispatch(savingExtensionActions.setSavingExtension(newExtensionUuid));
+    dispatch(savingExtensionActions.setSavingInProgress());
 
     const { recipe, ...rest } = element;
     const personalElement: FormState = {
       ...rest,
-      uuid: newExtensionUuid,
+      uuid: uuidv4(),
       // Detach from the recipe
       recipe: undefined,
     };
@@ -121,7 +117,7 @@ const useSavingWizard = () => {
   const saveElementAndCreateNewRecipe = async (
     recipeMeta: RecipeConfiguration
   ) => {
-    dispatch(savingExtensionActions.setSavingExtension(element.uuid));
+    dispatch(savingExtensionActions.setSavingInProgress());
 
     const elementRecipeMeta = element.recipe;
     const recipe = recipes.find((x) => x.metadata.id === elementRecipeMeta.id);
@@ -192,7 +188,7 @@ const useSavingWizard = () => {
   const saveElementAndUpdateRecipe = async (
     recipeMeta: RecipeConfiguration
   ) => {
-    dispatch(savingExtensionActions.setSavingExtension(element.uuid));
+    dispatch(savingExtensionActions.setSavingInProgress());
 
     const elementRecipeMeta = element.recipe;
     const recipe = recipes.find((x) => x.metadata.id === elementRecipeMeta.id);
@@ -282,7 +278,7 @@ const useSavingWizard = () => {
 
   return {
     isWizardOpen,
-    savingExtensionId,
+    isSaving,
     element,
     save,
     saveElementAsPersonalExtension,

--- a/src/devTools/editor/toolbar/ActionToolbar.tsx
+++ b/src/devTools/editor/toolbar/ActionToolbar.tsx
@@ -17,7 +17,6 @@
 
 import React from "react";
 import { FormState } from "@/devTools/editor/slices/editorSlice";
-import { useFormikContext } from "formik";
 import { Button, ButtonGroup } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faHistory, faSave, faTrash } from "@fortawesome/free-solid-svg-icons";
@@ -31,14 +30,13 @@ const ActionToolbar: React.FunctionComponent<{
 }> = ({ element, disabled, onSave }) => {
   const remove = useRemove(element);
   const reset = useReset();
-  const { values } = useFormikContext<FormState>();
 
   return (
     <ButtonGroup className="ml-2">
       <Button disabled={disabled} size="sm" variant="primary" onClick={onSave}>
         <FontAwesomeIcon icon={faSave} /> Save
       </Button>
-      {values.installed && (
+      {element.installed && (
         <Button
           disabled={disabled}
           size="sm"


### PR DESCRIPTION
Closes #1653 

Formik prevents submitting the form with validation errors. We want to allow this. Saving the extension without involving Formik at all.