### PR TITLE
#1773: reset QA data before running rainforest

### DIFF
--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -37,6 +37,12 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SOURCEMAP_USER_KEY }}
           AWS_DEFAULT_REGION: "us-east-2"
 
+      - name: Reset Test Account Data
+        run: |
+          curl -H "Authorization: Token $TOKEN" -X POST https://app.pixiebrix.com/api/tests/accounts/reset/
+        env:
+          TOKEN: ${{ secrets.TEST_ACCOUNT_KEY }}
+
       - name: Install Rainforest QA CLI
         run: |
           curl -sL $(curl -s https://api.github.com/repos/rainforestapp/rainforest-cli/releases/latest | jq -r '.assets[].browser_download_url | select(test("linux-amd64.tar.gz"))') | tar zxf - rainforest
@@ -44,8 +50,11 @@ jobs:
       # https://github.com/rainforestapp/rainforest-cli
       - name: Run Rainforest QA Extension Test Suite
         # Include hash on at end of the URL because Rainforest QA automatically appends a "/" to the end of custom URLs
+        # Can't pass abort for conflict because while we're generating a separate Rainforest QA environment for each run
+        #   they're all using the same server
+        # Use --fail-fast so that we're not using GitHub build minutes if not necessary
         run: |
-          ./rainforest run --fail-fast --description "CI automatic run" --run-group $RUN_GROUP --release "${{ github.sha }}" --custom-url "https://pixiebrix-extension-builds.s3.us-east-2.amazonaws.com/$BUILD_PATH"
+          ./rainforest run --fail-fast --description "CI automatic run" --run-group $RUN_GROUP --release "${{ github.sha }}" --conflict abort-all --custom-url "https://pixiebrix-extension-builds.s3.us-east-2.amazonaws.com/$BUILD_PATH"
         env:
           RAINFOREST_API_TOKEN: ${{ secrets.RAINFORESTQA_TOKEN }}
           # The run group for tests to run during CI


### PR DESCRIPTION
Closes #1773 

- Cancel any existing runs in Rainforest QA
- Reset test accounts before run