### PR TITLE
#1878: schema field fixes for integrations page and activation wizard

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -49,8 +49,14 @@ module.exports = {
       ...[
         {
           test: /\.ya?ml$/,
+          resourceQuery: { not: [/loadAsText/] },
           type: "json",
           use: "yaml-loader",
+        },
+        {
+          test: /\.ya?ml$/,
+          resourceQuery: /loadAsText/,
+          use: "raw-loader",
         },
         {
           test: /\.scss$/,

--- a/package.json
+++ b/package.json
@@ -277,6 +277,7 @@
     "transform": {
       "^.+\\.[jt]sx?$": "babel-jest",
       "^.+\\.ya?ml$": "yaml-jest-transform",
+      "^.+\\.ya?ml\\?loadAsText$": "jest-raw-loader",
       "^.+\\.txt$": "jest-raw-loader"
     },
     "transformIgnorePatterns": [
@@ -302,7 +303,7 @@
       "^@/icons/list$": "<rootDir>/src/__mocks__/iconsListMock",
       "^@/(.*)$": "<rootDir>/src/$1",
       "^vendors/(.*)$": "<rootDir>/src/vendors/$1",
-      "^@contrib/(.*)$": "<rootDir>/contrib/$1",
+      "^@contrib/(.*?)(\\?loadAsText)?$": "<rootDir>/contrib/$1",
       "^@schemas/(.*)$": "<rootDir>/schemas/$1",
       "\\.(css|less|scss)$": "<rootDir>/src/__mocks__/styleMock.js",
       "\\.(gif|ttf|eot|svg)$": "<rootDir>/src/__mocks__/fileMock.js"

--- a/src/components/AsyncButton.tsx
+++ b/src/components/AsyncButton.tsx
@@ -18,12 +18,12 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Button, ButtonProps } from "react-bootstrap";
 
-interface ExtraProps {
+export type AsyncButtonProps = ButtonProps & {
   onClick: (() => Promise<void>) | (() => void);
   autoFocus?: boolean;
-}
+};
 
-const AsyncButton: React.FunctionComponent<ButtonProps & ExtraProps> = ({
+const AsyncButton: React.FunctionComponent<AsyncButtonProps> = ({
   onClick,
   children,
   disabled: manualDisabled = false,

--- a/src/components/fields/schemaFields/FieldRuntimeContext.ts
+++ b/src/components/fields/schemaFields/FieldRuntimeContext.ts
@@ -15,28 +15,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// https://stackoverflow.com/questions/43638454/webpack-typescript-image-import
-declare module "*.svg" {
-  const CONTENT: string;
-  export default CONTENT;
-}
+import React from "react";
+import { ApiVersion } from "@/core";
 
-declare module "*?loadAsUrl" {
-  const CONTENT: string;
-  export default CONTENT;
-}
+export type RuntimeContext = {
+  apiVersion: ApiVersion;
+};
 
-declare module "*?loadAsText" {
-  const CONTENT: string;
-  export default CONTENT;
-}
+const defaultValue: RuntimeContext = {
+  apiVersion: "v2",
+};
 
-declare module "*.txt" {
-  const CONTENT: string;
-  export default CONTENT;
-}
+/**
+ * A context to control whether v1 or v3 schema widgets. Introduced to that apiVersion doesn't have to be
+ * tracked explicitly on the Formik form as a top-level field.
+ * @see useApiVersionAtLeast
+ */
+const FieldRuntimeContext = React.createContext<RuntimeContext>(defaultValue);
 
-declare module "*.yaml" {
-  const CONTENT: Record<string, unknown>;
-  export default CONTENT;
-}
+export default FieldRuntimeContext;

--- a/src/components/fields/schemaFields/FieldRuntimeContext.ts
+++ b/src/components/fields/schemaFields/FieldRuntimeContext.ts
@@ -27,9 +27,10 @@ const defaultValue: RuntimeContext = {
 };
 
 /**
- * A context to control whether v1 or v3 schema widgets. Introduced to that apiVersion doesn't have to be
+ * A context to control whether v1 or v3 SchemaField. Introduced to that apiVersion doesn't have to be
  * tracked explicitly on the Formik form as a top-level field.
  * @see useApiVersionAtLeast
+ * @see SchemaField
  */
 const FieldRuntimeContext = React.createContext<RuntimeContext>(defaultValue);
 

--- a/src/components/fields/schemaFields/SchemaField.tsx
+++ b/src/components/fields/schemaFields/SchemaField.tsx
@@ -22,7 +22,7 @@ import SchemaFieldV1 from "@/components/fields/schemaFields/v1/SchemaField";
 import SchemaFieldV3 from "@/components/fields/schemaFields/v3/SchemaField";
 
 /**
- * A schema-based field that automatically determines it's layout/widget based on the schema and uiSchema.
+ * A schema-based field that automatically determines its layout/widget based on the schema and uiSchema.
  *
  * @see SchemaFieldContext
  * @see getDefaultField

--- a/src/devTools/editor/hooks/useApiVersionAtLeast.tsx
+++ b/src/devTools/editor/hooks/useApiVersionAtLeast.tsx
@@ -18,10 +18,15 @@
 import { ApiVersion } from "@/core";
 import { useField } from "formik";
 import { isApiVersionAtLeast } from "@/utils";
+import { useContext } from "react";
+import FieldRuntimeContext from "@/components/fields/schemaFields/FieldRuntimeContext";
 
 function useApiVersionAtLeast(atLeast: ApiVersion): boolean {
-  const { value: apiVersion } = useField<ApiVersion>("apiVersion")[0];
-  return isApiVersionAtLeast(apiVersion, atLeast);
+  const [{ value: formValuesApiVersion }] = useField<ApiVersion>("apiVersion");
+  const { apiVersion: contextApiVersion } = useContext(FieldRuntimeContext);
+  // Prefer the version on the form
+  const effectiveVersion = formValuesApiVersion ?? contextApiVersion;
+  return isApiVersionAtLeast(effectiveVersion, atLeast);
 }
 
 export default useApiVersionAtLeast;

--- a/src/layout/Page.stories.tsx
+++ b/src/layout/Page.stories.tsx
@@ -34,3 +34,19 @@ Default.args = {
   title: "Example page",
   description: "Welcome to an example page! Have a look around.",
 };
+
+export const Loading = Template.bind({});
+Loading.args = {
+  icon: "music",
+  title: "Example page",
+  isPending: true,
+  description: "Welcome to an example page! Have a look around.",
+};
+
+export const LoadError = Template.bind({});
+LoadError.args = {
+  icon: "music",
+  title: "Example page",
+  error: new Error("Error loading page"),
+  description: "Welcome to an example page! Have a look around.",
+};

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -49,7 +49,15 @@ type Step = {
 
 const STEPS: Step[] = [
   { key: "review", label: "Select Bricks", Component: ConfigureBody },
-  { key: "options", label: "Personalize", Component: OptionsBody },
+  // OptionsBody takes only a slice of the RecipeDefinition, however the types aren't set up in a way for Typescript
+  // to realize it's OK to pass in a whole RecipeDefinition for something that just needs the options prop
+  {
+    key: "options",
+    label: "Personalize",
+    Component: OptionsBody as React.FunctionComponent<{
+      blueprint: RecipeDefinition;
+    }>,
+  },
   { key: "services", label: "Select Integrations", Component: ServicesBody },
   { key: "activate", label: "Review & Activate", Component: ActivateBody },
 ];

--- a/src/options/pages/marketplace/OptionsBody.stories.tsx
+++ b/src/options/pages/marketplace/OptionsBody.stories.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import OptionsBody from "./OptionsBody";
+import { MemoryRouter } from "react-router";
+import { action } from "@storybook/addon-actions";
+import { Formik } from "formik";
+
+export default {
+  title: "ActivateWizard/OptionsBody",
+  component: OptionsBody,
+} as ComponentMeta<typeof OptionsBody>;
+
+const Template: ComponentStory<typeof OptionsBody> = (args) => (
+  <MemoryRouter>
+    <Formik initialValues={{ optionsArgs: {} }} onSubmit={action("onSubmit")}>
+      <OptionsBody {...args} />
+    </Formik>
+  </MemoryRouter>
+);
+
+export const TextField = Template.bind({});
+TextField.args = {
+  blueprint: {
+    options: {
+      schema: {
+        properties: {
+          textField: {
+            title: "Text Field",
+            type: "string",
+            description: "This is a basic required text field.",
+          },
+        },
+        required: ["textField"],
+      },
+    },
+  },
+};

--- a/src/options/pages/marketplace/OptionsBody.test.tsx
+++ b/src/options/pages/marketplace/OptionsBody.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import OptionsBody from "@/options/pages/marketplace/OptionsBody";
+import { MemoryRouter } from "react-router";
+import { Formik } from "formik";
+
+describe("Marketplace Activate Wizard OptionsBody", () => {
+  test("renders text field", async () => {
+    const rendered = render(
+      <MemoryRouter>
+        <Formik initialValues={{ optionsArgs: {} }} onSubmit={jest.fn()}>
+          <OptionsBody
+            blueprint={{
+              options: {
+                schema: {
+                  properties: {
+                    textField: {
+                      title: "Text Field",
+                      type: "string",
+                    },
+                  },
+                },
+              },
+            }}
+          />
+        </Formik>
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Text Field")).not.toBeNull();
+
+    expect(rendered.asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/options/pages/marketplace/OptionsBody.tsx
+++ b/src/options/pages/marketplace/OptionsBody.tsx
@@ -19,15 +19,23 @@ import React, { useMemo } from "react";
 import { Card } from "react-bootstrap";
 import { RecipeDefinition } from "@/types/definitions";
 import genericOptionsFactory from "@/components/fields/schemaFields/genericOptionsFactory";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCubes, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
-import { Link } from "react-router-dom";
+import FieldRuntimeContext, {
+  RuntimeContext,
+} from "@/components/fields/schemaFields/FieldRuntimeContext";
 
-interface OwnProps {
-  blueprint: RecipeDefinition;
+// Use "v2" because the service configuration form expects literal values for everything. (I.e., expressions are not
+// supports). But we still want to get our SchemaField support for enums, etc.
+const OPTIONS_FIELD_RUNTIME_CONTEXT: RuntimeContext = {
+  apiVersion: "v2",
+};
+
+export interface OptionsBodyProps {
+  blueprint: Pick<RecipeDefinition, "options">;
 }
 
-const OptionsBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
+const OptionsBody: React.FunctionComponent<OptionsBodyProps> = ({
+  blueprint,
+}) => {
   const OptionsGroup = useMemo(
     () =>
       genericOptionsFactory(
@@ -40,19 +48,11 @@ const OptionsBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
     <>
       <Card.Body className="px-3 py-3">
         <Card.Title>Personalize Blueprint</Card.Title>
-        <p className="text-info">
-          <FontAwesomeIcon icon={faInfoCircle} /> After activating this
-          blueprint, you can configure it at any time on the{" "}
-          <Link to="/installed">
-            <u>
-              <FontAwesomeIcon icon={faCubes} />
-              {"  "}Active Bricks page
-            </u>
-          </Link>
-        </p>
       </Card.Body>
       <Card.Body className="OptionsBody p-3">
-        <OptionsGroup name="optionsArgs" />
+        <FieldRuntimeContext.Provider value={OPTIONS_FIELD_RUNTIME_CONTEXT}>
+          <OptionsGroup name="optionsArgs" />
+        </FieldRuntimeContext.Provider>
       </Card.Body>
     </>
   );

--- a/src/options/pages/marketplace/__snapshots__/OptionsBody.test.tsx.snap
+++ b/src/options/pages/marketplace/__snapshots__/OptionsBody.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Marketplace Activate Wizard OptionsBody renders text field 1`] = `
+<DocumentFragment>
+  <div
+    class="px-3 py-3 card-body"
+  >
+    <div
+      class="card-title h5"
+    >
+      Personalize Blueprint
+    </div>
+  </div>
+  <div
+    class="OptionsBody p-3 card-body"
+  >
+    <div
+      class="horizontalFormGroup form-group row"
+    >
+      <label
+        class="horizontalLabel form-label col-form-label col-lg-3"
+        for="optionsArgs.textField"
+      >
+        Text Field
+      </label>
+      <div
+        class="col-lg-9"
+      >
+        <input
+          class="form-control"
+          name="optionsArgs.textField"
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/options/pages/services/ServiceEditorModal.stories.tsx
+++ b/src/options/pages/services/ServiceEditorModal.stories.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { ComponentProps } from "react";
+import { ComponentMeta, Story } from "@storybook/react";
+import ServiceEditorModal from "./ServiceEditorModal";
+import { action } from "@storybook/addon-actions";
+import { fromJS } from "@/services/factory";
+import { loadBrickYaml } from "@/runtime/brickYaml";
+import { ServiceDefinition } from "@/types/definitions";
+
+import pipedriveYaml from "@contrib/services/pipedrive.yaml?loadAsText";
+import automationAnywhereYaml from "@contrib/services/automation-anywhere.yaml?loadAsText";
+
+const FIXTURES = {
+  pipedrive: pipedriveYaml,
+  automationAnywhere: automationAnywhereYaml,
+};
+
+type StoryType = ComponentProps<typeof ServiceEditorModal> & {
+  fixture: keyof typeof FIXTURES;
+};
+
+export default {
+  title: "Options/ServiceEditorModal",
+  component: ServiceEditorModal,
+} as ComponentMeta<typeof ServiceEditorModal>;
+
+const Template: Story<StoryType> = ({ fixture, ...args }) => {
+  // eslint-disable-next-line security/detect-object-injection -- type checked from fixture object
+  const service = fromJS(loadBrickYaml(FIXTURES[fixture]) as ServiceDefinition);
+
+  return <ServiceEditorModal {...args} service={service} />;
+};
+
+// FIXME: the modals get rendered behind their own overlay so you can't interact with them on the page
+
+export const Pipedrive = Template.bind({});
+Pipedrive.args = {
+  fixture: "pipedrive",
+  onDelete: action("onDelete"),
+  onClose: action("onClose"),
+  onSave: async () => {
+    action("onSave");
+  },
+};
+
+export const AutomationAnywhere = Template.bind({});
+AutomationAnywhere.args = {
+  fixture: "automationAnywhere",
+  onDelete: action("onDelete"),
+  onClose: action("onClose"),
+  onSave: async () => {
+    action("onSave");
+  },
+};

--- a/src/options/pages/services/ServiceEditorModal.test.tsx
+++ b/src/options/pages/services/ServiceEditorModal.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { fromJS } from "@/services/factory";
+import ServiceEditorModal from "@/options/pages/services/ServiceEditorModal";
+import { render, screen } from "@testing-library/react";
+import { waitForEffect } from "@/tests/testHelpers";
+
+// FIXME: this is coming through as a module with default being a JSON object. (yaml-jest-transform is being applied)
+import pipedriveYaml from "@contrib/services/pipedrive.yaml?loadAsText";
+import { RawServiceConfiguration } from "@/core";
+
+describe("ServiceEditorModal", () => {
+  test("Can render Pipedrive configuration modal without existing configuration", async () => {
+    const service = fromJS(pipedriveYaml as any);
+
+    const rendered = render(
+      <ServiceEditorModal
+        configuration={{ label: "" } as RawServiceConfiguration}
+        onDelete={jest.fn()}
+        onSave={jest.fn()}
+        onClose={jest.fn()}
+        service={service}
+      />
+    );
+
+    await waitForEffect();
+
+    expect(screen.getByDisplayValue("pipedrive/api")).not.toBeNull();
+    expect(screen.getByText("Save")).not.toBeNull();
+    expect(screen.getByText("Delete")).not.toBeNull();
+    expect(screen.getByText("Close")).not.toBeNull();
+
+    expect(rendered.asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/options/pages/services/ServiceEditorModal.tsx
+++ b/src/options/pages/services/ServiceEditorModal.tsx
@@ -32,14 +32,21 @@ import { useTitle } from "@/hooks/title";
 import FormTheme, { ThemeProps } from "@/components/form/FormTheme";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import FieldTemplate from "@/components/form/FieldTemplate";
+import FieldRuntimeContext, {
+  RuntimeContext,
+} from "@/components/fields/schemaFields/FieldRuntimeContext";
 
-interface OwnProps {
+export type OwnProps = {
   configuration: RawServiceConfiguration;
   service: IService;
   onClose: () => void;
   onDelete?: (id: UUID) => void;
   onSave: (config: RawServiceConfiguration) => Promise<void>;
-}
+};
+
+// Use "v2" because the service configuration form expects literal values for everything. (I.e., expressions are not
+// supports). But we still want to get our SchemaField support for enums, etc.
+const FORM_RUNTIME_CONTEXT: RuntimeContext = { apiVersion: "v2" };
 
 const formTheme: ThemeProps = {
   layout: "vertical",
@@ -131,23 +138,25 @@ const ServiceEditorModal: React.FunctionComponent<OwnProps> = ({
         {({ handleSubmit, isValid, isSubmitting }) => (
           <Form noValidate onSubmit={handleSubmit}>
             <Modal.Body>
-              <FormTheme.Provider value={formTheme}>
-                <ConnectedFieldTemplate
-                  name="label"
-                  label="Label"
-                  description="A label to help identify this integration"
-                  blankValue=""
-                />
-                <FieldTemplate
-                  label="Integration"
-                  name="service"
-                  type="text"
-                  plaintext
-                  readOnly
-                  value={service.id}
-                />
-                <Editor name="config" />
-              </FormTheme.Provider>
+              <FieldRuntimeContext.Provider value={FORM_RUNTIME_CONTEXT}>
+                <FormTheme.Provider value={formTheme}>
+                  <ConnectedFieldTemplate
+                    name="label"
+                    label="Label"
+                    description="A label to help identify this integration"
+                    blankValue=""
+                  />
+                  <FieldTemplate
+                    label="Integration"
+                    name="service"
+                    type="text"
+                    plaintext
+                    readOnly
+                    value={service.id}
+                  />
+                  <Editor name="config" />
+                </FormTheme.Provider>
+              </FieldRuntimeContext.Provider>
             </Modal.Body>
             <Modal.Footer>
               <div className="d-flex w-100">

--- a/src/options/pages/services/__snapshots__/ServiceEditorModal.test.tsx.snap
+++ b/src/options/pages/services/__snapshots__/ServiceEditorModal.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ServiceEditorModal Can render Pipedrive configuration modal without existing configuration 1`] = `<DocumentFragment />`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,9 +65,9 @@ export abstract class Service<
 
   abstract hasAuth: boolean;
 
-  abstract isOAuth2: boolean;
+  abstract get isOAuth2(): boolean;
 
-  abstract isToken: boolean;
+  abstract get isToken(): boolean;
 
   protected constructor(
     id: RegistryId,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -15,7 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { freshIdentifier, isApiVersionAtLeast, removeUndefined } from "@/utils";
+import {
+  freshIdentifier,
+  isApiVersionAtLeast,
+  joinName,
+  removeUndefined,
+} from "@/utils";
 import type { SafeString } from "@/core";
 
 test("can generate fresh identifier", () => {
@@ -56,5 +61,28 @@ describe("isApiVersionAtLeast()", () => {
   });
   test("v1 is not at least v2", () => {
     expect(isApiVersionAtLeast("v1", "v2")).toStrictEqual(false);
+  });
+});
+
+describe("joinName", () => {
+  test("rejects no paths", () => {
+    expect(() => joinName("foo")).toThrow("Expected one or more field names");
+  });
+
+  test("compacts paths", () => {
+    expect(joinName("foo", null, "bar")).toBe("foo.bar");
+  });
+
+  test("rejects path part with period", () => {
+    expect(() => joinName("foo", "bar.baz")).toThrow("cannot contain periods");
+  });
+
+  test("accepts base path part with period", () => {
+    expect(joinName("foo.bar", "baz")).toBe("foo.bar.baz");
+  });
+
+  test("accepts null/undefined base path part", () => {
+    expect(joinName(null, "foo")).toBe("foo");
+    expect(joinName(undefined, "foo")).toBe("foo");
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,17 +46,19 @@ export function joinName(
   baseFieldName: string | null,
   ...rest: string[]
 ): string {
-  if (rest.length === 0) {
+  const fieldNames = compact(rest);
+
+  if (fieldNames.length === 0) {
     throw new Error(
       "Expected one or more field names to join with the main path"
     );
   }
 
-  if (rest.some((x) => x.includes("."))) {
+  if (fieldNames.some((x) => x.includes("."))) {
     throw new Error("Formik path parts cannot contain periods");
   }
 
-  return compact([baseFieldName, ...rest]).join(".");
+  return compact([baseFieldName, ...fieldNames]).join(".");
 }
 
 export function mostCommonElement<T>(items: T[]): T {


### PR DESCRIPTION
What does this PR do?
- The error is caused by SchemaField being used in a couple places where there's no `apiVersion` on the form: the ServiceEditorModal and the OptionsBody (for configuring blueprint options during install)
- Adds a FieldRuntimeContext for passing apiVersion down to uses of `useApiVersionAtLeast`
- Modifies useApiVersionAtLeast to check the version from FieldRuntimeContext. But it prefers the version from `apiVersion` on the form root
- Removes some inaccurate documentation from the OptionsBody card
- Closes #1878 

TODO: 
- [x] Add ServiceEditorModal to Storybook
- [x] Add smoke jest test for ServiceEditorModal
- [x] Add OptionsBody to Storybook
- [x] Add OptionsBody Jest test

Things I couldn't quite get working but aren't important right now:
- `?loadAsText` query string with Jest. (Fine for now since the tests aren't over the authentication section which is where expressions are allowed
- In Storybook the ServiceEditorModal is under the overlay so you can't interact with it. However, you can at least see what fields it renders