### PR TITLE
527: effect to attach an autocomplete to an input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@uipath/robot": "1.2.5",
         "@xobotyi/scrollbar-width": "^1.9.5",
         "ace-builds": "^1.4.12",
+        "autocompleter": "^6.1.2",
         "axios": "^0.24.0",
         "bootstrap": "^4.6.0",
         "bootstrap-icons": "^1.5.0",
@@ -18369,6 +18370,11 @@
       "engines": {
         "node": ">= 4.5.0"
       }
+    },
+    "node_modules/autocompleter": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-6.1.2.tgz",
+      "integrity": "sha512-DfEcgxBJOTJJwxkIRZLv/ggD3g5w/fqzZkdJsOcgk7hjxw36lH/nAfIEXzV7qDE55swnYEe43E/WhZPXmSFfsA=="
     },
     "node_modules/autoprefixer": {
       "version": "9.8.6",
@@ -55136,6 +55142,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "autocompleter": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-6.1.2.tgz",
+      "integrity": "sha512-DfEcgxBJOTJJwxkIRZLv/ggD3g5w/fqzZkdJsOcgk7hjxw36lH/nAfIEXzV7qDE55swnYEe43E/WhZPXmSFfsA=="
     },
     "autoprefixer": {
       "version": "9.8.6",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@uipath/robot": "1.2.5",
     "@xobotyi/scrollbar-width": "^1.9.5",
     "ace-builds": "^1.4.12",
+    "autocompleter": "^6.1.2",
     "axios": "^0.24.0",
     "bootstrap": "^4.6.0",
     "bootstrap-icons": "^1.5.0",

--- a/src/blocks/effects/attachAutocomplete.ts
+++ b/src/blocks/effects/attachAutocomplete.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2021 Pixie Brix, LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Effect } from "@/types";
+import { BlockArg, BlockOptions, Schema } from "@/core";
+import { propertiesToSchema } from "@/validators/generic";
+import { AutocompleteItem } from "autocompleter";
+
+import autocompleterStyleUrl from "autocompleter/autocomplete.css?loadAsUrl";
+import { attachStylesheet } from "@/blocks/util";
+
+export class AttachAutocomplete extends Effect {
+  constructor() {
+    super(
+      "@pixiebrix/forms/autocomplete",
+      "Attach Autocomplete",
+      "Attach autocomplete to an input"
+    );
+  }
+
+  inputSchema: Schema = propertiesToSchema(
+    {
+      selector: {
+        type: "string",
+        format: "selector",
+      },
+      options: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
+    },
+    ["selector", "options"]
+  );
+
+  async effect(
+    {
+      selector,
+      options,
+    }: BlockArg<{
+      selector: string;
+      options: string[];
+    }>,
+    { logger }: BlockOptions
+  ): Promise<void> {
+    const $elt = $(document).find(selector);
+
+    const inputs = $elt.toArray().filter((x) => x.tagName === "INPUT");
+
+    const { default: autocompleter } = await import("autocompleter");
+    // TODO: adjust style to hard-code font color so it works on dark themes that have a light font color by default
+    await attachStylesheet(autocompleterStyleUrl);
+
+    if (inputs.length === 0) {
+      logger.warn("No input elements found for selector");
+    }
+
+    for (const input of inputs) {
+      autocompleter({
+        input: input as HTMLInputElement,
+        onSelect: (item) => {
+          $elt.val(item.label);
+        },
+        fetch: (text: string, update: (items: AutocompleteItem[]) => void) => {
+          const normalized = text.toLowerCase();
+          update(
+            options
+              .filter((x) => x.toLowerCase().includes(normalized))
+              .map((label) => ({ label }))
+          );
+        },
+      });
+    }
+  }
+}

--- a/src/blocks/effects/registerEffects.ts
+++ b/src/blocks/effects/registerEffects.ts
@@ -36,6 +36,7 @@ import { ShowEffect } from "./show";
 import { TelemetryEffect } from "./telemetry";
 import { ConfettiEffect } from "./confetti";
 import { TourEffect } from "./tour";
+import { AttachAutocomplete } from "./attachAutocomplete";
 
 function registerEffects(): void {
   registerBlock(new LogEffect());
@@ -63,6 +64,7 @@ function registerEffects(): void {
   registerBlock(new TelemetryEffect());
   registerBlock(new ConfettiEffect());
   registerBlock(new TourEffect());
+  registerBlock(new AttachAutocomplete());
 }
 
 export default registerEffects;

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import blockRegistry from "@/blocks/registry";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 82;
+const EXPECTED_HEADER_COUNT = 83;
 
 // Import for side-effects (these modules register the blocks)
 // NOTE: we don't need to also include extensionPoints because we got rid of all the legacy hard-coded extension points


### PR DESCRIPTION
What does this PR do?
- Defines a brick for attaching an autocomplete input (useful for providing suggestions based on an API call, or acting as documentation for users)

Out of scope:
- Get font style working on dark themed sites