### PR TITLE
#1871 metadata.sharing section is being saved on server when performing "Update Blueprint"

### DIFF
--- a/src/devTools/editor/panes/save/saveHelpers.test.ts
+++ b/src/devTools/editor/panes/save/saveHelpers.test.ts
@@ -98,7 +98,6 @@ describe("replaceRecipeExtension round trip", () => {
         // `services` gets normalized from undefined to {}
         draft.extensionPoints[0].services = {};
         draft.extensionPoints[0].label = "New Label";
-        delete draft.sharing;
       })
     );
   });
@@ -145,7 +144,6 @@ describe("replaceRecipeExtension round trip", () => {
         // `services` gets normalized from undefined to {}
         draft.extensionPoints[0].services = {};
         draft.extensionPoints[0].label = "New Label";
-        delete draft.sharing;
       })
     );
   });
@@ -193,7 +191,6 @@ describe("replaceRecipeExtension round trip", () => {
         // `services` gets normalized from undefined to {}
         draft.extensionPoints[0].services = {};
         draft.extensionPoints[0].label = "New Label";
-        delete draft.sharing;
       })
     );
   });
@@ -255,7 +252,6 @@ describe("replaceRecipeExtension round trip", () => {
         // `services` gets normalized from undefined to {}
         draft.extensionPoints[0].services = {};
         draft.extensionPoints[0].label = "New Label";
-        delete draft.sharing;
       })
     );
   });
@@ -308,7 +304,6 @@ describe("replaceRecipeExtension round trip", () => {
         // `services` gets normalized from undefined to {}
         draft.extensionPoints[0].services = {};
         draft.extensionPoints[0].label = "New Label";
-        delete draft.sharing;
       })
     );
   });

--- a/src/devTools/editor/panes/save/saveHelpers.ts
+++ b/src/devTools/editor/panes/save/saveHelpers.ts
@@ -131,7 +131,6 @@ export function replaceRecipeExtension(
 
   return produce(sourceRecipe, (draft) => {
     draft.metadata = metadata;
-    delete draft.sharing;
 
     const index = findRecipeIndex(sourceRecipe, installedExtension);
 

--- a/src/runtime/brickYaml.test.ts
+++ b/src/runtime/brickYaml.test.ts
@@ -47,4 +47,20 @@ describe("dumpYaml", () => {
 
     expect(dumped).toBe("foo: !var a.b.c\n");
   });
+
+  test("strips sharing information", () => {
+    const dumped = dumpBrickYaml({
+      metadata: {
+        id: "test/brick",
+        sharing: {
+          foo: 42,
+        },
+      },
+      sharing: {
+        foo: 42,
+      },
+    });
+
+    expect(dumped).toBe("metadata:\n  id: test/brick\n");
+  });
 });

--- a/src/runtime/brickYaml.ts
+++ b/src/runtime/brickYaml.ts
@@ -52,19 +52,17 @@ const RUNTIME_SCHEMA = yaml.DEFAULT_SCHEMA.extend([
 ]);
 
 function stripNonSchemaProps(brick: any) {
-  const readyForSerialization = produce(brick, (draft: any) => {
+  return produce(brick, (draft: any) => {
     if ("sharing" in draft) {
       delete draft.sharing;
     }
 
-    if (typeof draft.metadata !== "undefined" && "sharing" in draft.metadata) {
+    if (typeof draft.metadata === "object" && "sharing" in draft.metadata) {
       delete draft.metadata.sharing;
     }
 
     return draft;
   });
-
-  return readyForSerialization;
 }
 
 /**

--- a/src/runtime/brickYaml.ts
+++ b/src/runtime/brickYaml.ts
@@ -17,6 +17,7 @@
 
 import yaml from "js-yaml";
 import { UnknownObject } from "@/types";
+import { produce } from "immer";
 
 /**
  * @param tag the tag name, without the leading `!`
@@ -50,6 +51,22 @@ const RUNTIME_SCHEMA = yaml.DEFAULT_SCHEMA.extend([
   createExpression("nunjucks"),
 ]);
 
+function stripNonSchemaProps(brick: any) {
+  const readyForSerialization = produce(brick, (draft: any) => {
+    if ("sharing" in draft) {
+      delete draft.sharing;
+    }
+
+    if (typeof draft.metadata !== "undefined" && "sharing" in draft.metadata) {
+      delete draft.metadata.sharing;
+    }
+
+    return draft;
+  });
+
+  return readyForSerialization;
+}
+
 /**
  * Load brick YAML, with support for the custom tags for expressions.
  * @param config
@@ -59,8 +76,11 @@ export function loadBrickYaml(config: string): unknown {
 }
 
 export function dumpBrickYaml(
-  obj: unknown,
+  brick: unknown,
   options: yaml.DumpOptions = {}
 ): string {
-  return yaml.dump(obj, { ...options, schema: RUNTIME_SCHEMA });
+  return yaml.dump(stripNonSchemaProps(brick), {
+    ...options,
+    schema: RUNTIME_SCHEMA,
+  });
 }


### PR DESCRIPTION
Fixes #1871 

`sharing` is a valid part of a recipe object, hence removing it only on the serialization phase.