### PR TITLE
#1860: Validate on blur and memoize some things

### DIFF
--- a/src/components/fields/schemaFields/widgets/ArrayWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/ArrayWidget.tsx
@@ -18,7 +18,7 @@
 import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import { FieldArray, useField } from "formik";
 import { Button } from "react-bootstrap";
-import React from "react";
+import React, { useMemo } from "react";
 import { Schema } from "@/core";
 import {
   booleanPredicate,
@@ -30,6 +30,7 @@ import { defaultBlockConfig } from "@/blocks/util";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { joinName } from "@/utils";
 import useApiVersionAtLeast from "@/devTools/editor/hooks/useApiVersionAtLeast";
+import { JSONSchema7 } from "json-schema";
 
 // Empty value for text fields for the Formik state
 const EMPTY_TEXT_VALUE = "";
@@ -71,7 +72,11 @@ const ArrayWidget: React.FC<SchemaFieldProps> = ({ schema, name }) => {
     throw new TypeError("Schema required for items");
   }
 
-  const schemaItems = schema.items ?? { additionalProperties: true };
+  const schemaItems = useMemo<JSONSchema7>(
+    // Cast is okay here since we've already checked for array/boolean types
+    () => (schema.items as JSONSchema7) ?? { additionalProperties: true },
+    [schema.items]
+  );
 
   const apiVersionAtLeastV3 = useApiVersionAtLeast("v3");
   // Show explicit remove button before v3

--- a/src/components/fields/schemaFields/widgets/ArrayWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/ArrayWidget.tsx
@@ -30,7 +30,6 @@ import { defaultBlockConfig } from "@/blocks/util";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { joinName } from "@/utils";
 import useApiVersionAtLeast from "@/devTools/editor/hooks/useApiVersionAtLeast";
-import { JSONSchema7 } from "json-schema";
 
 // Empty value for text fields for the Formik state
 const EMPTY_TEXT_VALUE = "";
@@ -72,9 +71,9 @@ const ArrayWidget: React.FC<SchemaFieldProps> = ({ schema, name }) => {
     throw new TypeError("Schema required for items");
   }
 
-  const schemaItems = useMemo<JSONSchema7>(
+  const schemaItems = useMemo<Schema>(
     // Cast is okay here since we've already checked for array/boolean types
-    () => (schema.items as JSONSchema7) ?? { additionalProperties: true },
+    () => (schema.items as Schema) ?? { additionalProperties: true },
     [schema.items]
   );
 

--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
@@ -196,4 +196,4 @@ const TemplateToggleWidget: React.FC<TemplateToggleWidgetProps> = ({
   );
 };
 
-export default TemplateToggleWidget;
+export default React.memo(TemplateToggleWidget);

--- a/src/components/form/FieldTemplate.tsx
+++ b/src/components/form/FieldTemplate.tsx
@@ -191,4 +191,4 @@ const FieldTemplate: React.FC<FieldProps> = ({ layout, ...restProps }) => {
   }
 };
 
-export default FieldTemplate;
+export default React.memo(FieldTemplate);

--- a/src/devTools/editor/fields/ApiVersionField.tsx
+++ b/src/devTools/editor/fields/ApiVersionField.tsx
@@ -30,4 +30,4 @@ const ApiVersionField: React.FC = () => (
   </ConnectedFieldTemplate>
 );
 
-export default ApiVersionField;
+export default React.memo(ApiVersionField);

--- a/src/devTools/editor/panes/EditorPane.tsx
+++ b/src/devTools/editor/panes/EditorPane.tsx
@@ -67,6 +67,12 @@ const EditorPane: React.FunctionComponent<{
               "Formik's submit should not be called to save an extension. Use 'saveElement' from 'useSavingWizard' instead."
             );
           }}
+          // We're validating on blur instead of on change as a stop-gap measure to improve typing
+          // performance in schema fields of block configs in dev builds of the extension.
+          // The long-term better solution is to split up our pipeline validation code to work
+          // on one block at a time, and then modify the usePipelineField hook to only validate
+          // one block at a time. Then we can re-enable change validation here once this doesn't
+          // cause re-rendering the entire form on every change.
           validateOnChange={false}
           validateOnBlur={true}
         >

--- a/src/devTools/editor/panes/EditorPane.tsx
+++ b/src/devTools/editor/panes/EditorPane.tsx
@@ -67,6 +67,8 @@ const EditorPane: React.FunctionComponent<{
               "Formik's submit should not be called to save an extension. Use 'saveElement' from 'useSavingWizard' instead."
             );
           }}
+          validateOnChange={false}
+          validateOnBlur={true}
         >
           {({ values: element }) => (
             <>

--- a/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { useMemo } from "react";
 import { Button, Col, Form, InputGroup, Row } from "react-bootstrap";
 import { RegistryId } from "@/core";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
@@ -74,6 +74,11 @@ const EditorNodeConfigPanel: React.FC<{
     ? "Effect and renderer bricks do not produce outputs"
     : "Provide an output key to refer to the outputs of this block later.";
 
+  const outputKeyLabel = useMemo(
+    () => <PopoverOutputLabel description={outputDescription} />,
+    [outputDescription]
+  );
+
   return (
     <>
       {blockError && (
@@ -92,7 +97,7 @@ const EditorNodeConfigPanel: React.FC<{
         <Col xl>
           <ConnectedFieldTemplate
             name={`${blockFieldName}.outputKey`}
-            label={<PopoverOutputLabel description={outputDescription} />}
+            label={outputKeyLabel}
             disabled={isOutputDisabled}
             as={OutputKeyWidget}
           />

--- a/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
@@ -155,4 +155,4 @@ const EditorNodeLayout: React.FC<{
   );
 };
 
-export default EditorNodeLayout;
+export default React.memo(EditorNodeLayout);

--- a/src/devTools/editor/tabs/effect/BlockConfiguration.tsx
+++ b/src/devTools/editor/tabs/effect/BlockConfiguration.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef } from "react";
+import React, { useMemo, useRef } from "react";
 import { RegistryId, TemplateEngine } from "@/core";
 import { getIn, useFormikContext } from "formik";
 import { useBlockOptions } from "@/hooks/useBlockOptions";
@@ -58,6 +58,56 @@ const BlockConfiguration: React.FunctionComponent<{
 
   const advancedOptionsRef = useRef<HTMLDivElement>();
 
+  const templateEngineOptions = useMemo<Array<Option<TemplateEngine>>>(
+    () => [
+      { label: "Mustache", value: "mustache" },
+      { label: "Handlebars", value: "handlebars" },
+      { label: "Nunjucks", value: "nunjucks" },
+    ],
+    []
+  );
+
+  const templateEngineDescription = useMemo(
+    () => (
+      <p>
+        The template engine controls how PixieBrix fills in{" "}
+        <code>{"{{variables}}"}</code> in the inputs.
+      </p>
+    ),
+    []
+  );
+
+  const rootModeOptions = useMemo(
+    () => [
+      { label: "Inherit", value: "inherit" },
+      { label: "Document", value: "document" },
+    ],
+    []
+  );
+
+  const ifConditionDescription = useMemo(
+    () => (
+      <p>
+        Condition determining whether or not to execute the brick. Truthy string
+        values are&nbsp;
+        <code>true</code>, <code>t</code>, <code>yes</code>, <code>y</code>,{" "}
+        <code>on</code>, and <code>1</code> (case-insensitive)
+      </p>
+    ),
+    []
+  );
+
+  const targetOptions = useMemo<Array<Option<BlockWindow>>>(
+    () => [
+      { label: "Current Tab (self)", value: "self" },
+      { label: "Opener Tab (opener)", value: "opener" },
+      { label: "Target Tab (target)", value: "target" },
+      { label: "All Tabs (broadcast)", value: "broadcast" },
+      { label: "Server (remote)", value: "remote" },
+    ],
+    []
+  );
+
   return (
     <>
       <AdvancedLinks name={name} scrollToRef={advancedOptionsRef} />
@@ -92,20 +142,9 @@ const BlockConfiguration: React.FunctionComponent<{
             name={configName("templateEngine")}
             label="Template engine"
             as={SelectWidget}
-            options={
-              [
-                { label: "Mustache", value: "mustache" },
-                { label: "Handlebars", value: "handlebars" },
-                { label: "Nunjucks", value: "nunjucks" },
-              ] as Array<Option<TemplateEngine>>
-            }
+            options={templateEngineOptions}
             blankValue={DEFAULT_TEMPLATE_ENGINE_VALUE}
-            description={
-              <p>
-                The template engine controls how PixieBrix fills in{" "}
-                <code>{"{{variables}}"}</code> in the inputs.
-              </p>
-            }
+            description={templateEngineDescription}
           />
 
           {
@@ -116,10 +155,7 @@ const BlockConfiguration: React.FunctionComponent<{
                 name={configName("rootMode")}
                 label="Root Mode"
                 as={SelectWidget}
-                options={[
-                  { label: "Inherit", value: "inherit" },
-                  { label: "Document", value: "document" },
-                ]}
+                options={rootModeOptions}
                 blankValue="inherit"
                 description="The root mode controls which page element PixieBrix provides as the implicit element"
               />
@@ -131,30 +167,14 @@ const BlockConfiguration: React.FunctionComponent<{
               <ConnectedFieldTemplate
                 name={configName("if")}
                 label="Condition"
-                description={
-                  <p>
-                    Condition determining whether or not to execute the brick.
-                    Truthy string values are&nbsp;
-                    <code>true</code>, <code>t</code>, <code>yes</code>,{" "}
-                    <code>y</code>, <code>on</code>, and <code>1</code>{" "}
-                    (case-insensitive)
-                  </p>
-                }
+                description={ifConditionDescription}
               />
 
               <ConnectedFieldTemplate
                 name={configName("window")}
                 label="Target"
                 as={SelectWidget}
-                options={
-                  [
-                    { label: "Current Tab (self)", value: "self" },
-                    { label: "Opener Tab (opener)", value: "opener" },
-                    { label: "Target Tab (target)", value: "target" },
-                    { label: "All Tabs (broadcast)", value: "broadcast" },
-                    { label: "Server (remote)", value: "remote" },
-                  ] as Array<Option<BlockWindow>>
-                }
+                options={targetOptions}
                 blankValue={DEFAULT_WINDOW_VALUE}
                 description="Where to execute the brick."
               />


### PR DESCRIPTION
Fixes #1860 

The biggest change here is to changer our Formik setup so that we're validating inputs on blur events instead of on change events. This was, by a long shot, the most effective change I made that helped typing speed in inputs in dev builds of the page editor. I also memo-ized a few components and tried to make sure that their props were being memo-ized properly.