### PR TITLE
#1922: support for pipeline expressions

### DIFF
--- a/src/components/fields/schemaFields/fieldInputMode.ts
+++ b/src/components/fields/schemaFields/fieldInputMode.ts
@@ -17,7 +17,7 @@
 
 import { TemplateEngine } from "@/core";
 import { UnknownObject } from "@/types";
-import { isExpression } from "@/runtime/mapArgs";
+import { isTemplateExpression } from "@/runtime/mapArgs";
 
 export type FieldInputMode =
   | "string"
@@ -46,7 +46,7 @@ export function inferInputMode(
   // eslint-disable-next-line security/detect-object-injection -- config field names
   const value = fieldConfig[fieldName];
 
-  if (isExpression(value)) {
+  if (isTemplateExpression(value)) {
     return value.__type__;
   }
 

--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
@@ -20,7 +20,7 @@ import { FieldInputMode } from "@/components/fields/schemaFields/fieldInputMode"
 import { Field } from "formik";
 import { Expression, TemplateEngine } from "@/core";
 import { Dropdown, DropdownButton, Form } from "react-bootstrap";
-import { isExpression } from "@/runtime/mapArgs";
+import { isTemplateExpression } from "@/runtime/mapArgs";
 import { UnknownObject } from "@/types";
 import {
   SchemaFieldComponent,
@@ -154,7 +154,7 @@ const TemplateToggleWidget: React.FC<TemplateToggleWidgetProps> = ({
   );
 
   const field = useMemo(() => {
-    if (isExpression(value)) {
+    if (isTemplateExpression(value)) {
       return (
         <Form.Control
           name={name}

--- a/src/core.ts
+++ b/src/core.ts
@@ -28,6 +28,7 @@ import { Permissions } from "webextension-polyfill";
 import { pick } from "lodash";
 
 export type TemplateEngine = "mustache" | "nunjucks" | "handlebars" | "var";
+export type ExpressionType = TemplateEngine | "pipeline";
 // Use our own name in the project so we can re-map/adjust the typing as necessary
 export type Schema = JSONSchema7;
 export type UiSchema = StandardUiSchema;
@@ -117,9 +118,12 @@ export interface Meta {
  * @see BlockConfig
  * @since 1.5.0
  */
-export type Expression<T extends string = string> = {
-  __type__: TemplateEngine;
-  __value__: T;
+export type Expression<
+  V = string,
+  T extends ExpressionType = ExpressionType
+> = {
+  __type__: T;
+  __value__: V;
 };
 
 /**

--- a/src/core.ts
+++ b/src/core.ts
@@ -27,8 +27,6 @@ import { ErrorObject } from "serialize-error";
 import { Permissions } from "webextension-polyfill";
 import { pick } from "lodash";
 
-export type TemplateEngine = "mustache" | "nunjucks" | "handlebars" | "var";
-export type ExpressionType = TemplateEngine | "pipeline";
 // Use our own name in the project so we can re-map/adjust the typing as necessary
 export type Schema = JSONSchema7;
 export type UiSchema = StandardUiSchema;
@@ -108,23 +106,62 @@ export type RegistryId = string & {
 };
 type ServiceId = RegistryId;
 
-export interface Meta {
-  nonce?: string;
-  [index: string]: unknown;
-}
+/**
+ * The tag of an available template engine for rendering an expression given a context.
+ * @see mapArgs
+ */
+export type TemplateEngine =
+  // https://mustache.github.io/
+  | "mustache"
+  // https://mozilla.github.io/nunjucks/
+  | "nunjucks"
+  // https://handlebarsjs.com/
+  | "handlebars"
+  // Variable, with support for ? operator
+  | "var";
+
+/**
+ * The tag of an expression type without the !-prefix that appears in YAML. These appear in YAML files as simple tags,
+ * e.g., !pipeline, and are converted into Expressions during deserialization
+ * @see Expression
+ * @see loadBrickYaml
+ * @see TemplateEngine
+ * @see BlockPipeline
+ */
+export type ExpressionType =
+  | TemplateEngine
+  // BlockPipeline with deferred execution
+  | "pipeline";
 
 /**
  * The JSON/JS representation of an explicit template/variable expression (e.g., mustache, var, etc.)
  * @see BlockConfig
+ * @see loadBrickYaml
  * @since 1.5.0
  */
 export type Expression<
-  V = string,
-  T extends ExpressionType = ExpressionType
+  // The value. TemplateEngine ExpressionTypes, this will be a string containing the template. For `pipeline`
+  // ExpressionType this will be a BlockPipeline. (The loadBrickYaml method will currently accept any array for
+  // pipeline at this time, though.
+  TTemplateOrPipeline = string,
+  // The type tag (without the !-prefix of the YAML simple tag)
+  TTypeTag extends ExpressionType = ExpressionType
 > = {
-  __type__: T;
-  __value__: V;
+  __type__: TTypeTag;
+  __value__: TTemplateOrPipeline;
 };
+
+/**
+ * The Meta section of a message (for message passing between extension components)
+ *
+ * Not to be mistaken with Metadata in brick definitions
+ *
+ * @see Message
+ */
+export interface Meta {
+  nonce?: string;
+  [index: string]: unknown;
+}
 
 /**
  * Standard message format for cross-context messaging.

--- a/src/runtime/brickYaml.test.ts
+++ b/src/runtime/brickYaml.test.ts
@@ -34,6 +34,17 @@ describe("loadYaml", () => {
       },
     });
   });
+
+  test("deserialize pipeline", async () => {
+    expect(
+      loadBrickYaml("foo: !pipeline\n  - id: '@pixiebrix/confetti'")
+    ).toEqual({
+      foo: {
+        __type__: "pipeline",
+        __value__: [{ id: "@pixiebrix/confetti" }],
+      },
+    });
+  });
 });
 
 describe("dumpYaml", () => {
@@ -46,6 +57,17 @@ describe("dumpYaml", () => {
     });
 
     expect(dumped).toBe("foo: !var a.b.c\n");
+  });
+
+  test("serialize pipeline", () => {
+    const dumped = dumpBrickYaml({
+      foo: {
+        __type__: "pipeline",
+        __value__: [{ id: "@pixiebrix/confetti" }],
+      },
+    });
+
+    expect(dumped).toBe("foo: !pipeline \n  - id: '@pixiebrix/confetti'\n");
   });
 
   test("strips sharing information", () => {

--- a/src/runtime/brickYaml.ts
+++ b/src/runtime/brickYaml.ts
@@ -44,11 +44,30 @@ function createExpression(tag: string): yaml.Type {
   });
 }
 
+const pipelineExpression = new yaml.Type("!pipeline", {
+  kind: "sequence",
+
+  resolve: (data) => Array.isArray(data),
+
+  construct: (data) => ({
+    __type__: "pipeline",
+    __value__: data,
+  }),
+
+  predicate: (data) =>
+    typeof data === "object" &&
+    "__type__" in data &&
+    (data as UnknownObject).__type__ === "pipeline",
+
+  represent: (data) => (data as UnknownObject).__value__,
+});
+
 const RUNTIME_SCHEMA = yaml.DEFAULT_SCHEMA.extend([
   createExpression("var"),
   createExpression("mustache"),
   createExpression("handlebars"),
   createExpression("nunjucks"),
+  pipelineExpression,
 ]);
 
 function stripNonSchemaProps(brick: any) {

--- a/src/runtime/mapArgs.test.ts
+++ b/src/runtime/mapArgs.test.ts
@@ -88,3 +88,51 @@ describe("handlebars", () => {
     });
   });
 });
+
+describe("pipeline", () => {
+  test("render !pipeline", async () => {
+    const rendered = await renderExplicit(
+      {
+        foo: {
+          __type__: "pipeline",
+          __value__: [{ id: "@pixiebrix/confetti" }],
+        },
+      },
+      { array: ["bar"] }
+    );
+
+    expect(rendered).toEqual({
+      foo: [{ id: "@pixiebrix/confetti" }],
+    });
+  });
+
+  test("render !pipeline stops at pipeline", async () => {
+    const config = {
+      foo: {
+        __type__: "var",
+        __value__: "foo",
+      },
+    };
+
+    const rendered = await renderExplicit(
+      {
+        foo: {
+          __type__: "pipeline",
+          __value__: [
+            {
+              id: "@pixiebrix/confetti",
+              config,
+            },
+          ],
+        },
+        bar: config,
+      },
+      { foo: 42 }
+    );
+
+    expect(rendered).toEqual({
+      foo: [{ id: "@pixiebrix/confetti", config }],
+      bar: { foo: 42 },
+    });
+  });
+});

--- a/src/runtime/mapArgs.ts
+++ b/src/runtime/mapArgs.ts
@@ -36,7 +36,7 @@ type Args = string | UnknownObject | UnknownObject[];
 
 /**
  * Returns true if value represents an explicit expression
- * @param value
+ * @see isTemplateExpression
  */
 export function isExpression(value: unknown): value is Expression<unknown> {
   if (
@@ -51,8 +51,8 @@ export function isExpression(value: unknown): value is Expression<unknown> {
 }
 
 /**
- * Returns true if value represents an explicit expression
- * @param value
+ * Returns true if value represents an explicit template engine expression
+ * @see isExpression
  */
 export function isTemplateExpression(
   value: unknown

--- a/src/runtime/mapArgs.ts
+++ b/src/runtime/mapArgs.ts
@@ -19,16 +19,18 @@ import { UnknownObject } from "@/types";
 import { Renderer, engineRenderer } from "./renderers";
 import { isPlainObject, mapValues, pickBy } from "lodash";
 import { getPropByPath, isSimplePath } from "./pathHelpers";
-import { Expression, TemplateEngine } from "@/core";
+import { Expression, ExpressionType, TemplateEngine } from "@/core";
 import { asyncMapValues } from "@/utils";
 import Mustache from "mustache";
 
-const rendererTypes: TemplateEngine[] = [
+const templateTypes: TemplateEngine[] = [
   "mustache",
   "nunjucks",
   "handlebars",
   "var",
 ];
+
+const expressionTypes: ExpressionType[] = [...templateTypes, "pipeline"];
 
 type Args = string | UnknownObject | UnknownObject[];
 
@@ -36,13 +38,33 @@ type Args = string | UnknownObject | UnknownObject[];
  * Returns true if value represents an explicit expression
  * @param value
  */
-export function isExpression(value: unknown): value is Expression {
+export function isExpression(value: unknown): value is Expression<unknown> {
   if (
     isPlainObject(value) &&
     typeof value === "object" &&
     "__type__" in value
   ) {
-    return rendererTypes.includes((value as Expression).__type__);
+    return expressionTypes.includes((value as Expression).__type__);
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if value represents an explicit expression
+ * @param value
+ */
+export function isTemplateExpression(
+  value: unknown
+): value is Expression<string, TemplateEngine> {
+  if (
+    isPlainObject(value) &&
+    typeof value === "object" &&
+    "__type__" in value
+  ) {
+    return templateTypes.includes(
+      (value as Expression).__type__ as TemplateEngine
+    );
   }
 
   return false;
@@ -56,9 +78,14 @@ export async function renderExplicit(
   config: Args,
   ctxt: UnknownObject
 ): Promise<unknown> {
-  if (isExpression(config)) {
+  if (isTemplateExpression(config)) {
     const render = await engineRenderer(config.__type__);
     return render(config.__value__, ctxt);
+  }
+
+  if (isExpression(config) && config.__type__ === "pipeline") {
+    // Pipelines are passed through directly
+    return config.__value__;
   }
 
   // Array.isArray must come before the object check because arrays are objects

--- a/src/runtime/pipelineTests/pipelineExpression.test.ts
+++ b/src/runtime/pipelineTests/pipelineExpression.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import blockRegistry from "@/blocks/registry";
+import { reducePipeline } from "@/runtime/reducePipeline";
+import { pipelineBlock, simpleInput, testOptions } from "./pipelineTestHelpers";
+
+// Mock the recordX trace methods. Otherwise they'll fail and Jest will have unhandledrejection errors since we call
+// them with `void` instead of awaiting them in the reducePipeline methods
+import * as logging from "@/background/logging";
+
+jest.mock("@/background/trace");
+(logging.getLoggingConfig as any) = jest.fn().mockResolvedValue({
+  logValues: true,
+});
+
+beforeEach(() => {
+  blockRegistry.clear();
+  blockRegistry.register(pipelineBlock);
+});
+
+describe("apiVersion: v3", () => {
+  test("run block with pipeline arg", async () => {
+    const pipeline = {
+      id: pipelineBlock.id,
+      config: {
+        pipeline: {
+          __type__: "pipeline",
+          __value__: [{ id: "@pixiebrix/confetti" }],
+        },
+      },
+    };
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      testOptions("v3")
+    );
+    expect(result).toStrictEqual({ length: 1 });
+  });
+});

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -5,6 +5,7 @@ import { ApiVersion, BlockArg, BlockOptions } from "@/core";
 import { InitialValues } from "@/runtime/reducePipeline";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { BusinessError } from "@/errors";
+import { BlockPipeline } from "@/blocks/types";
 
 const logger = new ConsoleLogger();
 
@@ -94,12 +95,43 @@ class ArrayBlock extends Block {
   }
 }
 
+class PipelineBlock extends Block {
+  constructor() {
+    super("test/pipeline", "Pipeline Block");
+  }
+
+  inputSchema = propertiesToSchema({
+    // TODO: write a schema in schemas directory. The one in component.json is incomplete
+    pipeline: {
+      type: "array",
+      items: {
+        properties: {
+          id: {
+            type: "string",
+          },
+          config: {
+            type: "object",
+          },
+        },
+        required: ["id"],
+      },
+    },
+  });
+
+  async run({ pipeline }: BlockArg<{ pipeline: BlockPipeline }>) {
+    return {
+      length: pipeline.length,
+    };
+  }
+}
+
 export const echoBlock = new EchoBlock();
 export const contextBlock = new ContextBlock();
 export const identityBlock = new IdentityBlock();
 export const throwBlock = new ThrowBlock();
 export const teapotBlock = new TeapotBlock();
 export const arrayBlock = new ArrayBlock();
+export const pipelineBlock = new PipelineBlock();
 
 /**
  * Helper method to pass only `input` to reducePipeline.
@@ -122,5 +154,3 @@ export function testOptions(version: ApiVersion) {
     ...apiVersionOptions(version),
   };
 }
-
-export const TEST_BLOCKS = [echoBlock, contextBlock];


### PR DESCRIPTION
Closes: #1924

Adds support for `!pipeline` expressions in YAML files and argument rendering

The !pipeline tag acts as a barrier to rendering so that the brick can make subsequent calls to reducePipeline