### PR TITLE
Use Messenger from devTools -> background communication

### DIFF
--- a/src/background/devtools/protocol.ts
+++ b/src/background/devtools/protocol.ts
@@ -15,53 +15,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import browser, { Runtime } from "webextension-polyfill";
+import { Runtime } from "webextension-polyfill";
 import {
   liftBackground,
   registerPort as internalRegisterPort,
 } from "@/background/devtools/internal";
-import { ensureContentScript } from "@/background/util";
 import type { Target } from "@/types";
-import { UUID } from "@/core";
-import {
-  removeActionPanel,
-  showActionPanel,
-} from "@/contentScript/messenger/api";
 
 export const registerPort = liftBackground(
   "REGISTER_PORT",
   (target: Target, port: Runtime.Port) => async () => {
     internalRegisterPort(target.tabId, port);
   }
-);
-
-export const checkTargetPermissions = liftBackground(
-  "CHECK_TARGET_PERMISSIONS",
-  (target: Target) => async () => {
-    try {
-      await browser.tabs.executeScript(target.tabId, {
-        code: "true",
-        frameId: target.frameId,
-      });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-);
-
-export const ensureScript = liftBackground(
-  "INJECT_SCRIPT",
-  (target: Target) => async () => ensureContentScript(target)
-);
-
-export const showBrowserActionPanel = liftBackground(
-  "SHOW_BROWSER_ACTION_PANEL",
-  (target: Target) => async () => showActionPanel(target)
-);
-
-export const uninstallActionPanelPanel = liftBackground(
-  "UNINSTALL_ACTION_PANEL_PANEL",
-  (target) => async ({ extensionId }: { extensionId: UUID }) =>
-    removeActionPanel(target, extensionId)
 );

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -25,7 +25,7 @@ import browser from "webextension-polyfill";
 import { isBackgroundPage } from "webext-detect-page";
 
 // TODO: This should be a hard error, but due to unknown dependency routes, it can't be enforced yet
-if (isBackgroundPage()) {
+if (isBackgroundPage() && process.env.DEBUG) {
   console.warn(
     "This should not have been imported in the background page. Use the API directly instead."
   );
@@ -36,6 +36,8 @@ export const containsPermissions = browser.permissions
   ? browser.permissions.contains
   : getMethod("CONTAINS_PERMISSIONS", bg);
 
+export const ensureContentScript = getMethod("INJECT_SCRIPT", bg);
+export const checkTargetPermissions = getMethod("CHECK_TARGET_PERMISSIONS", bg);
 export const openPopupPrompt = getMethod("OPEN_POPUP_PROMPT", bg);
 export const whoAmI = getMethod("ECHO_SENDER", bg);
 export const activateTab = getMethod("ACTIVATE_TAB", bg);

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -34,6 +34,7 @@ import {
 } from "@/background/executor";
 import * as registry from "@/registry/localRegistry";
 import * as browserAction from "@/background/browserAction";
+import { checkTargetPermissions, ensureContentScript } from "@/background/util";
 
 expectContext("background");
 
@@ -49,10 +50,13 @@ declare global {
     GOOGLE_SHEETS_BATCH_UPDATE: typeof sheets.batchUpdate;
     GOOGLE_SHEETS_BATCH_GET: typeof sheets.batchGet;
 
+    INJECT_SCRIPT: typeof ensureContentScript;
+    CHECK_TARGET_PERMISSIONS: typeof checkTargetPermissions;
     CONTAINS_PERMISSIONS: typeof browser.permissions.contains;
     UNINSTALL_CONTEXT_MENU: typeof uninstallContextMenu;
     ENSURE_CONTEXT_MENU: typeof ensureContextMenu;
     OPEN_POPUP_PROMPT: typeof openPopupPrompt;
+
     ECHO_SENDER: typeof whoAmI;
     ACTIVATE_TAB: typeof activateTab;
     CLOSE_TAB: typeof closeTab;
@@ -77,10 +81,13 @@ registerMethods({
   GOOGLE_SHEETS_BATCH_UPDATE: sheets.batchUpdate,
   GOOGLE_SHEETS_BATCH_GET: sheets.batchGet,
 
+  CHECK_TARGET_PERMISSIONS: checkTargetPermissions,
+  INJECT_SCRIPT: ensureContentScript,
   CONTAINS_PERMISSIONS: browser.permissions.contains,
   UNINSTALL_CONTEXT_MENU: uninstallContextMenu,
   ENSURE_CONTEXT_MENU: ensureContextMenu,
   OPEN_POPUP_PROMPT: openPopupPrompt,
+
   ECHO_SENDER: whoAmI,
   ACTIVATE_TAB: activateTab,
   CLOSE_TAB: closeTab,

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -44,6 +44,18 @@ export async function isContentScriptRegistered(url: string): Promise<boolean> {
   return patternToRegex(...origins, ...manifestScriptsOrigins).test(url);
 }
 
+export async function checkTargetPermissions(target: Target) {
+  return browser.tabs
+    .executeScript(target.tabId, {
+      code: "true",
+      frameId: target.frameId,
+    })
+    .then(
+      () => true,
+      () => false
+    );
+}
+
 interface TargetState {
   url: string;
   installed: boolean;

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -44,7 +44,7 @@ export async function isContentScriptRegistered(url: string): Promise<boolean> {
   return patternToRegex(...origins, ...manifestScriptsOrigins).test(url);
 }
 
-export async function checkTargetPermissions(target: Target) {
+export async function checkTargetPermissions(target: Target): Promise<boolean> {
   return browser.tabs
     .executeScript(target.tabId, {
       code: "true",

--- a/src/background/util.ts
+++ b/src/background/util.ts
@@ -34,7 +34,7 @@ export async function isContentScriptRegistered(url: string): Promise<boolean> {
     .getManifest()
     .content_scripts.flatMap((script) => script.matches);
 
-  // Inejcted by `webext-dynamic-content-scripts`
+  // Injected by `webext-dynamic-content-scripts`
   const { origins } = await getAdditionalPermissions({
     strictOrigins: false,
   });

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -21,7 +21,7 @@ import browser from "webextension-polyfill";
 import { isContentScript } from "webext-detect-page";
 
 // TODO: This should be a hard error, but due to unknown dependency routes, it can't be enforced yet
-if (isContentScript()) {
+if (isContentScript() && process.env.DEBUG) {
   console.warn(
     "This should not have been imported in the content script. Use the API directly instead."
   );

--- a/src/devTools/editor/hooks/useRemove.ts
+++ b/src/devTools/editor/hooks/useRemove.ts
@@ -22,13 +22,15 @@ import { useToasts } from "react-toast-notifications";
 import { useFormikContext } from "formik";
 import { useDispatch } from "react-redux";
 import { useModals } from "@/components/ConfirmationModal";
-import * as nativeOperations from "@/background/devtools";
 import { optionsSlice } from "@/options/slices";
 import { reportError } from "@/telemetry/logging";
 import { getErrorMessage } from "@/errors";
 import { uninstallContextMenu } from "@/background/messenger/api";
 import { thisTab } from "@/devTools/utils";
-import { clearDynamicElements } from "@/contentScript/messenger/api";
+import {
+  clearDynamicElements,
+  removeActionPanel,
+} from "@/contentScript/messenger/api";
 
 /**
  * Remove the current element from the page and installed extensions
@@ -65,9 +67,9 @@ function useRemove(element: FormState): () => void {
         dispatch(optionsSlice.actions.removeExtension(ref));
       }
 
-      void Promise.allSettled([
+      await Promise.allSettled([
         uninstallContextMenu(ref),
-        nativeOperations.uninstallActionPanelPanel(port, ref),
+        removeActionPanel(thisTab, ref.extensionId),
       ]);
 
       // Remove from page editor

--- a/src/devTools/editor/panes/insert/GenericInsertPane.tsx
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.tsx
@@ -18,7 +18,6 @@
 import React, { useCallback, useContext } from "react";
 import { useDispatch } from "react-redux";
 import { DevToolsContext } from "@/devTools/context";
-import { showBrowserActionPanel } from "@/background/devtools";
 import useAvailableExtensionPoints from "@/devTools/editor/hooks/useAvailableExtensionPoints";
 import Centered from "@/devTools/editor/components/Centered";
 import { Button, Row } from "react-bootstrap";
@@ -33,7 +32,10 @@ import { useToasts } from "react-toast-notifications";
 import { reportError } from "@/telemetry/logging";
 import { getCurrentURL, thisTab } from "@/devTools/utils";
 import styles from "./GenericInsertPane.module.scss";
-import { updateDynamicElement } from "@/contentScript/messenger/api";
+import {
+  showActionPanel,
+  updateDynamicElement,
+} from "@/contentScript/messenger/api";
 
 const { addElement } = editorSlice.actions;
 
@@ -60,7 +62,7 @@ const GenericInsertPane: React.FunctionComponent<{
         if (config.elementType === "actionPanel") {
           // For convenience, open the side panel if it's not already open so that the user doesn't
           // have to manually toggle it
-          void showBrowserActionPanel(port);
+          void showActionPanel(thisTab);
         }
       } catch (error: unknown) {
         reportError(error);


### PR DESCRIPTION
After a messenger refactor+cooldown, I'm back to porting the last bits of communication to it.

## Testing report

- CHECK_TARGET_PERMISSIONS: works
- INJECT_SCRIPT: works
- SHOW_BROWSER_ACTION_PANEL: replaced by existing method, works
- UNINSTALL_ACTION_PANEL_PANEL: replaced by existing method, works