### PR TITLE
#1947: support passing event target for context menu

### DIFF
--- a/src/blocks/readers/frameworkReader.ts
+++ b/src/blocks/readers/frameworkReader.ts
@@ -43,6 +43,12 @@ async function asyncFastCssSelector(element: HTMLElement): Promise<string> {
   });
 }
 
+function elementSelector(rootSelector: string | null, selector: string | null) {
+  const rawParts = compact([rootSelector, selector]);
+  const parts = rawParts.length > 0 ? rawParts : ["body"];
+  return compact(parts).join(" ");
+}
+
 export function frameworkReadFactory(
   framework: Framework
 ): Read<FrameworkConfig> {
@@ -60,13 +66,15 @@ export function frameworkReadFactory(
       pathSpec,
     } = reader;
 
+    // Selector to uniquely identify the root (because we can't pass the element itself between the content script
+    // and the page script)
     const rootSelector = isHTMLElement(root)
       ? await asyncFastCssSelector(root)
       : null;
 
     return getComponentData({
       framework,
-      selector: compact([rootSelector, selector]).join(" "),
+      selector: elementSelector(rootSelector, selector),
       rootProp,
       waitMillis,
       optional,

--- a/src/blocks/transformers/component/ComponentReader.ts
+++ b/src/blocks/transformers/component/ComponentReader.ts
@@ -41,7 +41,7 @@ export class ComponentReader extends Transformer {
 
   inputSchema: Schema = {
     type: "object",
-    required: ["framework", "selector"],
+    required: ["framework"],
     properties: {
       framework: {
         type: "string",
@@ -51,16 +51,17 @@ export class ComponentReader extends Transformer {
         type: "string",
         format: "selector",
         description:
-          "CSS/JQuery selector to select the HTML element that corresponds to the component",
+          "CSS/JQuery selector to select the HTML element that corresponds to the component. Or, leave blank to use root context.",
       },
       optional: {
         type: "boolean",
-        default: false,
         description: "Whether or not the selector is always available",
+        default: false,
       },
       traverseUp: {
         type: "number",
         description: "Traverse non-visible framework elements",
+        default: 0,
       },
     },
   };

--- a/src/devTools/editor/extensionPoints/contextMenu.tsx
+++ b/src/devTools/editor/extensionPoints/contextMenu.tsx
@@ -38,6 +38,7 @@ import { ExtensionPointConfig } from "@/extensionPoints/types";
 import {
   ContextMenuConfig,
   ContextMenuExtensionPoint,
+  ContextMenuRootMode,
   MenuDefaultOptions as ContextMenuDefaultOptions,
   MenuDefinition,
 } from "@/extensionPoints/contextMenu";
@@ -66,6 +67,7 @@ export interface ContextMenuFormState extends BaseFormState<Extension> {
       defaultOptions: ContextMenuDefaultOptions;
       documentUrlPatterns: string[];
       contexts: Menus.ContextType[];
+      rootMode: ContextMenuRootMode;
       reader: SingleLayerReaderConfig;
       isAvailable: NormalizedAvailability;
     };
@@ -93,6 +95,7 @@ function fromNativeElement(
         reader: getImplicitReader("contextMenu"),
         documentUrlPatterns: isAvailable.matchPatterns,
         contexts: ["all"],
+        rootMode: "target",
         defaultOptions: {},
         isAvailable,
       },
@@ -113,6 +116,7 @@ function selectExtensionPoint(
       isAvailable,
       documentUrlPatterns,
       reader,
+      rootMode,
       contexts = ["all"],
     },
   } = extensionPoint;
@@ -122,6 +126,7 @@ function selectExtensionPoint(
       type: "contextMenu",
       documentUrlPatterns,
       contexts,
+      rootMode,
       reader,
       isAvailable: cleanIsAvailable(isAvailable),
     },
@@ -158,6 +163,7 @@ async function fromExtension(
     documentUrlPatterns,
     defaultOptions,
     contexts,
+    rootMode,
     reader,
   } = extensionPoint.definition;
 
@@ -171,6 +177,7 @@ async function fromExtension(
       definition: {
         documentUrlPatterns,
         defaultOptions,
+        rootMode,
         contexts,
         // See comment on SingleLayerReaderConfig
         reader: reader as SingleLayerReaderConfig,
@@ -191,6 +198,7 @@ async function fromExtensionPoint(
   const {
     defaultOptions = {},
     documentUrlPatterns = [],
+    rootMode = "legacy",
     type,
     reader,
   } = extensionPoint.definition;
@@ -216,11 +224,13 @@ async function fromExtensionPoint(
         ...extensionPoint.definition,
         defaultOptions,
         documentUrlPatterns,
+        rootMode,
         // See comment on SingleLayerReaderConfig
         reader: reader as SingleLayerReaderConfig,
         isAvailable: selectIsAvailable(extensionPoint),
       },
     },
+
     recipe: undefined,
   };
 }

--- a/src/devTools/editor/tabs/contextMenu/ContextMenuConfiguration.tsx
+++ b/src/devTools/editor/tabs/contextMenu/ContextMenuConfiguration.tsx
@@ -90,6 +90,24 @@ const ContextMenuConfiguration: React.FC<{
     </FieldSection>
 
     <FieldSection title="Advanced">
+      <ConnectedFieldTemplate
+        name="extensionPoint.definition.rootMode"
+        as="select"
+        title="Root Mode"
+        description={
+          <p>
+            Use&nbsp;<code>target</code> to pass the target of the right-click
+            as the action root. Use&nbsp;
+            <code>document</code> to pass the document
+          </p>
+        }
+        {...makeLockableFieldProps("Root Mode", isLocked)}
+      >
+        <option value="target">target</option>
+        <option value="document">document</option>
+        <option value="legacy">legacy</option>
+      </ConnectedFieldTemplate>
+
       <UrlMatchPatternField
         name="extensionPoint.definition.isAvailable.matchPatterns[0]"
         shortcuts={matchPatternShortcuts}

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -45,7 +45,7 @@ import { notifyError } from "@/contentScript/notify";
 import { reportEvent } from "@/telemetry/events";
 import { selectEventData } from "@/telemetry/deployments";
 import { selectExtensionContext } from "@/extensionPoints/helpers";
-import { isErrorObject } from "@/errors";
+import { BusinessError, isErrorObject } from "@/errors";
 import { BlockConfig, BlockPipeline } from "@/blocks/types";
 import { isDeploymentActive } from "@/options/deploymentUtils";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
@@ -53,11 +53,18 @@ import { blockList } from "@/blocks/util";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
 import { makeServiceContext } from "@/services/serviceUtils";
 
+export type ContextMenuRootMode =
+  // In `legacy` mode, the target was passed to the readers but the document is passed to reducePipeline
+  "legacy" | "document" | "target";
+
 export type ContextMenuConfig = {
   title: string;
   action: BlockConfig | BlockPipeline;
 };
 
+/**
+ * The element the user right-clicked on to trigger the context menu
+ */
 let clickedElement: HTMLElement = null;
 let selectionHandlerInstalled = false;
 
@@ -68,6 +75,9 @@ function setActiveElement(event: MouseEvent): void {
   // useCapture: true to the event listener
   clickedElement = null;
   if (event?.button === BUTTON_SECONDARY) {
+    console.debug("Setting right-clicked element for contextMenu", {
+      target: event.target,
+    });
     clickedElement = event?.target as HTMLElement;
   }
 }
@@ -175,6 +185,8 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
   }
 
   abstract getBaseReader(): Promise<IReader>;
+
+  abstract get rootMode(): ContextMenuRootMode;
 
   abstract readonly documentUrlPatterns: Manifest.MatchPattern[];
 
@@ -285,6 +297,32 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
     }
   }
 
+  selectReaderElement(target: HTMLElement | Document): HTMLElement | Document {
+    switch (this.rootMode) {
+      case "legacy":
+      case "target":
+        return target;
+      case "document":
+        return document;
+      default:
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
+        throw new BusinessError(`Unknown rootMode: ${this.rootMode}`);
+    }
+  }
+
+  selectRootElement(target: HTMLElement | Document): HTMLElement | Document {
+    switch (this.rootMode) {
+      case "target":
+        return target;
+      case "legacy":
+      case "document":
+        return document;
+      default:
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
+        throw new BusinessError(`Unknown rootMode: ${this.rootMode}`);
+    }
+  }
+
   private async registerExtension(
     extension: ResolvedExtension<ContextMenuConfig>
   ): Promise<void> {
@@ -316,7 +354,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
           clickedElement ?? guessSelectedElement() ?? document;
 
         const input = {
-          ...(await reader.read(targetElement)),
+          ...(await reader.read(this.selectReaderElement(targetElement))),
           // ClickData provides the data from schema defined above in ContextMenuReader
           ...clickData,
           // Add some additional data that people will generally want
@@ -325,7 +363,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
 
         const initialValues: InitialValues = {
           input,
-          root: document,
+          root: this.selectRootElement(targetElement),
           serviceContext,
           optionsArgs: extension.optionsArgs,
         };
@@ -367,6 +405,7 @@ export interface MenuDefaultOptions {
 export interface MenuDefinition extends ExtensionPointDefinition {
   documentUrlPatterns?: Manifest.MatchPattern[];
   contexts: Menus.ContextType[];
+  rootMode: ContextMenuRootMode;
   defaultOptions?: MenuDefaultOptions;
 }
 
@@ -397,6 +436,11 @@ class RemoteContextMenuExtensionPoint extends ContextMenuExtensionPoint {
         ? castArray(isAvailable.matchPatterns)
         : [],
     };
+  }
+
+  get rootMode(): ContextMenuRootMode {
+    // Default to "document" to match the legacy behavior
+    return this._definition.rootMode ?? "legacy";
   }
 
   async isAvailable(): Promise<boolean> {

--- a/src/pageScript/protocol.ts
+++ b/src/pageScript/protocol.ts
@@ -42,7 +42,7 @@ export type ReadOptions = {
 
 export type ReadPayload = ReadOptions & {
   framework: Framework;
-  selector: string;
+  selector: string | null;
 };
 
 export interface WritePayload {


### PR DESCRIPTION
Closes #1947 

- Adds a rootMode field to contextMenu definitions
- Support passing a blank selector for component reader (to use the root)