### PR TITLE
#1861: SchemaField data type toggle tests

### DIFF
--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
@@ -180,6 +180,7 @@ const TemplateToggleWidget: React.FC<TemplateToggleWidgetProps> = ({
         variant="link"
         onSelect={onModeChange}
         className={styles.dropdown}
+        data-testid={`toggle-${name}`}
       >
         {inputModeOptions.map((option) => (
           <Dropdown.Item

--- a/src/components/formBuilder/FormEditor.test.tsx
+++ b/src/components/formBuilder/FormEditor.test.tsx
@@ -213,12 +213,9 @@ describe("FormEditor", () => {
       );
       await fireFormSubmit();
 
-      expect(onSubmitMock).toHaveBeenCalledWith(
-        {
-          [RJSF_SCHEMA_PROPERTY_NAME]: expectedSchema,
-        },
-        expect.any(Object)
-      );
+      expect(onSubmitMock).toHaveBeenCalledWith({
+        [RJSF_SCHEMA_PROPERTY_NAME]: expectedSchema,
+      });
     }
   );
 
@@ -285,12 +282,9 @@ describe("FormEditor", () => {
 
       await fireFormSubmit();
 
-      expect(onSubmitMock).toHaveBeenCalledWith(
-        {
-          [RJSF_SCHEMA_PROPERTY_NAME]: expectedSchema,
-        },
-        expect.any(Object)
-      );
+      expect(onSubmitMock).toHaveBeenCalledWith({
+        [RJSF_SCHEMA_PROPERTY_NAME]: expectedSchema,
+      });
     }
   );
 

--- a/src/devTools/editor/tabs/effect/v3/__snapshots__/BlockConfiguration.test.tsx.snap
+++ b/src/devTools/editor/tabs/effect/v3/__snapshots__/BlockConfiguration.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`renders 1`] = `
               </div>
               <div
                 class="dropdown dropdown"
+                data-testid="toggle-extension.blockPipeline[0].config.message"
               >
                 <button
                   aria-expanded="false"

--- a/src/tests/formHelpers.tsx
+++ b/src/tests/formHelpers.tsx
@@ -27,7 +27,10 @@ export const createFormikTemplate = (
   onSubmit = jest.fn()
 ) => {
   const FormikTemplate = ({ children }: PropsWithChildren<unknown>) => (
-    <Formik initialValues={initialValues} onSubmit={onSubmit}>
+    <Formik
+      initialValues={initialValues}
+      onSubmit={(values) => onSubmit(values)}
+    >
       <Form>
         {children}
         <button type="submit">Submit</button>


### PR DESCRIPTION
Closes #1861 

This sets up simple toggle cases for field toggles. These will be fleshed out and more cases will be added once we have more smart behavior around inferring template type, preserving current input value when toggling, etc.