### PR TITLE
#1986: remove incorrect check for plain objects being passed to field

### DIFF
--- a/src/components/form/FieldTemplate.tsx
+++ b/src/components/form/FieldTemplate.tsx
@@ -104,18 +104,6 @@ const RenderedField: React.FC<FieldProps> = ({
     );
   }
 
-  if (AsControl != null && isPlainObject(AsControl)) {
-    console.debug(
-      "RenderedField received a plain object for 'as'. Are the test mocks configured correctly?",
-      {
-        as: AsControl,
-      }
-    );
-
-    // XXX: this breaks a lot of our tests, but should be a real precondition
-    //  throw new Error("RenderedField received a plain object for 'as'");
-  }
-
   // Note on `controlId` and Bootstrap FormGroup.
   // If we set `controlId` on the Bootstrap FormGroup, we must not set `id` on `FormLabel` and `FormControl`.
   // This makes it impossible to use a FormControl as a CustomWidget,


### PR DESCRIPTION
The check is bad because it also triggers for memoized React components

I've updated the testing wiki with how to avoid the problem this was originally checking: https://github.com/pixiebrix/pixiebrix-extension/wiki/Unit-tests#mocking-a-single-method-in-a-module
