### PR TITLE
Drop webpack node_modules exclusion

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -238,11 +238,6 @@ module.exports = (env, options) =>
     // Explicitly handled by `SourceMapDevToolPlugin` below
     devtool: false,
 
-    // https://webpack.js.org/configuration/watch/#saving-in-webstorm
-    watchOptions: {
-      ignored: /node_modules/,
-    },
-
     output: {
       path: path.resolve("dist"),
       globalObject: "window",


### PR DESCRIPTION
This setting makes webpack not watch the node_modules folder, so if you change files in it or install updates, you'll have to restart the `watch` script.

I'm not sure why this was enabled, but it doesn't match the comment that precedes it:  https://webpack.js.org/configuration/watch/#saving-in-webstorm