### PR TITLE
Remove temporary `browser` global and forbid it

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -11,7 +11,7 @@
     "^.+\\.txt$": "jest-raw-loader"
   },
   "transformIgnorePatterns": [
-    "node_modules/(?!@cfworker|idb|webext-|p-timeout|p-defer|serialize-error)"
+    "node_modules/(?!@cfworker|idb|webext-|p-timeout|p-retry|p-defer|serialize-error)"
   ],
   "setupFiles": [
     "<rootDir>/src/testEnv.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
         "webext-content-scripts": "^0.10.1",
         "webext-detect-page": "^3.0.2",
         "webext-dynamic-content-scripts": "^8.0.1",
-        "webext-messenger": "^0.14.0",
+        "webext-messenger": "^0.14.1",
         "webext-patterns": "^1.1.1",
         "webext-polyfill-kinda": "^0.1.0",
         "webextension-polyfill": "^0.8.0",
@@ -33025,15 +33025,18 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-      "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.0.0.tgz",
+      "integrity": "sha512-swGFiU6Y1Q3rBikAGHpaT0FHSbiO9H04fSsJRKVtWyEQMAe2Sb1uXeBcqE/RlZqt2prlq4W2HA/+MZAt3V2NkQ==",
       "dependencies": {
-        "@types/retry": "^0.12.0",
+        "@types/retry": "^0.12.1",
         "retry": "^0.13.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
@@ -38895,9 +38898,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.5.4.tgz",
-      "integrity": "sha512-zyPomVvb6u7+gJ/GPYUH6/nLDNiTtVOqXVUHtxFv5PmZQh6skgfeRtFYzWC01T5KeNWNIx5/0P111rKFLlkFvA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.6.0.tgz",
+      "integrity": "sha512-XN1FDGGtaSDA6CFsCW5iolTQqFsnJ+ZF6JqSz0SqXoh4F8GY0xqUv5RYnTilpmL+sOH8OH4FX8tf9YyAPM2LDA==",
       "engines": {
         "node": ">=12.20"
       },
@@ -40069,9 +40072,9 @@
       "integrity": "sha512-TTtitT7rgdaR2nx0+TZDIYHpZ5TXH9Ak8C2TaBaJT9qNeHXexKzde6uQ6cjdOK2G80C04r8fcx98Iy+PTCNN7Q=="
     },
     "node_modules/webext-detect-page": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-3.0.2.tgz",
-      "integrity": "sha512-CdU8W+6g05YAYrkdOfqUNrG9A4AybemgPGC+xeKnffRO4tbBrdYYy77qO0jlj7Udw9HXcE2xeFlEoW1ywjwTZw=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-3.1.0.tgz",
+      "integrity": "sha512-hJy1srJozdC1ZHWNIwPPvDJmTUoJo7kSvEikFcVWi2B+che4RElyAST1u336D0yKuqphRPe1OF2Ug2qCrO31pA=="
     },
     "node_modules/webext-dynamic-content-scripts": {
       "version": "8.0.2",
@@ -40086,40 +40089,15 @@
       }
     },
     "node_modules/webext-messenger": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.14.0.tgz",
-      "integrity": "sha512-Bvbf1sTX51/VyVhjkwxdPkZ7P7XcOyothv1a5L1lHAMlNAXIDjGAwKnok0a43wAANvF4BPWqNjgJw/F7v9zRrg==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.14.1.tgz",
+      "integrity": "sha512-IA2zvNFDuPsuCb7yazi+BFxcPbKro7LKPuYcZdbBeyyu4fM2C7PxEiFuCe4kFpE9JcjuJAcmyH9QFKGhcqhj6A==",
       "dependencies": {
-        "p-retry": "^4.6.1",
-        "serialize-error": "^8.1.0",
-        "type-fest": "^2.5.1",
-        "webext-detect-page": "^3.0.2",
+        "p-retry": "^5.0.0",
+        "serialize-error": "^9.0.0",
+        "type-fest": "^2.6.0",
+        "webext-detect-page": "^3.1.0",
         "webextension-polyfill": "^0.8.0"
-      }
-    },
-    "node_modules/webext-messenger/node_modules/serialize-error": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webext-messenger/node_modules/serialize-error/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/webext-patterns": {
@@ -66367,11 +66345,11 @@
       }
     },
     "p-retry": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-      "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.0.0.tgz",
+      "integrity": "sha512-swGFiU6Y1Q3rBikAGHpaT0FHSbiO9H04fSsJRKVtWyEQMAe2Sb1uXeBcqE/RlZqt2prlq4W2HA/+MZAt3V2NkQ==",
       "requires": {
-        "@types/retry": "^0.12.0",
+        "@types/retry": "^0.12.1",
         "retry": "^0.13.1"
       }
     },
@@ -71032,9 +71010,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.5.4.tgz",
-      "integrity": "sha512-zyPomVvb6u7+gJ/GPYUH6/nLDNiTtVOqXVUHtxFv5PmZQh6skgfeRtFYzWC01T5KeNWNIx5/0P111rKFLlkFvA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.6.0.tgz",
+      "integrity": "sha512-XN1FDGGtaSDA6CFsCW5iolTQqFsnJ+ZF6JqSz0SqXoh4F8GY0xqUv5RYnTilpmL+sOH8OH4FX8tf9YyAPM2LDA=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -71955,9 +71933,9 @@
       }
     },
     "webext-detect-page": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-3.0.2.tgz",
-      "integrity": "sha512-CdU8W+6g05YAYrkdOfqUNrG9A4AybemgPGC+xeKnffRO4tbBrdYYy77qO0jlj7Udw9HXcE2xeFlEoW1ywjwTZw=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-3.1.0.tgz",
+      "integrity": "sha512-hJy1srJozdC1ZHWNIwPPvDJmTUoJo7kSvEikFcVWi2B+che4RElyAST1u336D0yKuqphRPe1OF2Ug2qCrO31pA=="
     },
     "webext-dynamic-content-scripts": {
       "version": "8.0.2",
@@ -71969,32 +71947,15 @@
       }
     },
     "webext-messenger": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.14.0.tgz",
-      "integrity": "sha512-Bvbf1sTX51/VyVhjkwxdPkZ7P7XcOyothv1a5L1lHAMlNAXIDjGAwKnok0a43wAANvF4BPWqNjgJw/F7v9zRrg==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.14.1.tgz",
+      "integrity": "sha512-IA2zvNFDuPsuCb7yazi+BFxcPbKro7LKPuYcZdbBeyyu4fM2C7PxEiFuCe4kFpE9JcjuJAcmyH9QFKGhcqhj6A==",
       "requires": {
-        "p-retry": "^4.6.1",
-        "serialize-error": "^8.1.0",
-        "type-fest": "^2.5.1",
-        "webext-detect-page": "^3.0.2",
+        "p-retry": "^5.0.0",
+        "serialize-error": "^9.0.0",
+        "type-fest": "^2.6.0",
+        "webext-detect-page": "^3.1.0",
         "webextension-polyfill": "^0.8.0"
-      },
-      "dependencies": {
-        "serialize-error": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
-          "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
-          "requires": {
-            "type-fest": "^0.20.2"
-          },
-          "dependencies": {
-            "type-fest": {
-              "version": "0.20.2",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-              "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
-            }
-          }
-        }
       }
     },
     "webext-patterns": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "webext-content-scripts": "^0.10.1",
     "webext-detect-page": "^3.0.2",
     "webext-dynamic-content-scripts": "^8.0.1",
-    "webext-messenger": "^0.14.0",
+    "webext-messenger": "^0.14.1",
     "webext-patterns": "^1.1.1",
     "webext-polyfill-kinda": "^0.1.0",
     "webextension-polyfill": "^0.8.0",

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -73,6 +73,3 @@ export const registry = {
   syncRemote: getMethod("REGISTRY_SYNC", bg),
   find: getMethod("REGISTRY_FIND", bg),
 };
-
-// Temporary, webext-messenger depends on this global
-(globalThis as any).browser = browser;

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -38,8 +38,6 @@ import { checkTargetPermissions, ensureContentScript } from "@/background/util";
 
 expectContext("background");
 
-// Temporary, webext-messenger depends on this global
-(globalThis as any).browser = browser;
 declare global {
   interface MessengerMethods {
     GOOGLE_SHEETS_GET_TAB_NAMES: typeof sheets.getTabNames;

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -22,6 +22,7 @@ const start = Date.now();
 import "@/extensionContext";
 import { uncaughtErrorHandlers } from "@/telemetry/reportUncaughtErrors";
 import "@/contentScript/messenger/registration";
+import browser from "webextension-polyfill";
 import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 import { handleNavigate } from "@/contentScript/lifecycle";

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -17,7 +17,6 @@
 
 /* Do not use `registerMethod` in this file */
 import { getMethod, getNotifier } from "webext-messenger";
-import browser from "webextension-polyfill";
 import { isContentScript } from "webext-detect-page";
 
 // TODO: This should be a hard error, but due to unknown dependency routes, it can't be enforced yet
@@ -66,6 +65,3 @@ export const selectElement = getMethod("SELECT_ELEMENT");
 
 export const runRendererPipeline = getMethod("RUN_RENDERER_PIPELINE");
 export const runEffectPipeline = getMethod("RUN_EFFECT_PIPELINE");
-
-// Temporary, webext-messenger depends on this global
-(globalThis as any).browser = browser;

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -17,7 +17,6 @@
 
 /* Do not use `getMethod` in this file; Keep only registrations here, not implementations */
 import { registerMethods } from "webext-messenger";
-import browser from "webextension-polyfill";
 import { expectContext } from "@/utils/expectContext";
 import { handleMenuAction } from "@/contentScript/contextMenus";
 import {
@@ -67,9 +66,6 @@ import {
 } from "@/contentScript/pipelineProtocol";
 
 expectContext("contentScript");
-
-// Temporary, webext-messenger depends on this global
-(globalThis as any).browser = browser;
 
 declare global {
   interface MessengerMethods {

--- a/src/devTools/getSelectedElement.ts
+++ b/src/devTools/getSelectedElement.ts
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import browser from "webextension-polyfill";
 import { expectContext } from "@/utils/expectContext";
 import { evaluableFunction } from "@/utils";
 

--- a/src/devTools/utils.ts
+++ b/src/devTools/utils.ts
@@ -93,7 +93,7 @@ export function searchData(query: string, data: unknown): unknown {
  */
 export const thisTab: Target = {
   // This code might end up (unused) in non-dev bundles, so use `?.` to avoid errors from undefined values
-  tabId: globalThis.browser?.devtools?.inspectedWindow?.tabId ?? 0,
+  tabId: globalThis.chrome?.devtools?.inspectedWindow?.tabId ?? 0,
   // The top-level frame
   frameId: 0,
 };

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import browser from "webextension-polyfill";
 import React, { useMemo } from "react";
 import { isExtensionContext } from "webext-detect-page";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
       // Silently improve tree-shakeability and AMD-related errors like #943
       "lodash": ["node_modules/lodash-es"]
     },
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
     "plugins": [{ "name": "typescript-plugin-css-modules" }]
   },
   "exclude": ["venv", "dist", "node_modules"]


### PR DESCRIPTION
This is part of the effort to make `browser` types consistent and reliable. The `window.browser` type is defined due to a sub-dependency (so the build passed) but the global does **not** exist in Chrome, it only worked due to some patching.

This PR drops that patch and enforces usage via `import`

### Related 

- https://github.com/pixiebrix/webext-messenger/releases/tag/v0.14.1
- https://github.com/pixiebrix/webext-messenger/pull/44
- https://github.com/pixiebrix/pixiebrix-extension/pull/1763
- https://github.com/fregante/webext-polyfill-kinda/issues/2