### PR TITLE
Open an example page on `web-ext run`

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,6 +257,11 @@
     "zip-dir": "^2.0.0"
   },
   "webExt": {
-    "sourceDir": "dist"
+    "sourceDir": "dist",
+    "run": {
+      "startUrl": [
+        "https://pixiebrix.github.io/playground/"
+      ]
+    }
   }
 }


### PR DESCRIPTION
I think it makes sense to set a starting page when running the extension via `web-ext run`. 

I set https://pixiebrix.github.io/playground/ because it's lightweight and hopefully pushes us to extend the project with more pages, like the ones listed in https://github.com/pixiebrix/playground/issues