### PR TITLE
Use native ESM support in Jest

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -16,9 +16,5 @@
  */
 
 module.exports = {
-  presets: [
-    ["@babel/preset-env", { targets: { node: "current" } }],
-    "@babel/preset-react",
-    "@babel/preset-typescript",
-  ],
+  presets: ["@babel/preset-react", "@babel/preset-typescript"],
 };

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,18 +1,16 @@
 {
   "silent": true,
-  "testEnvironment": "jest-environment-jsdom",
+  "testEnvironment": "jsdom",
   "modulePaths": ["/src"],
   "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "yaml", "yml", "json"],
   "testPathIgnorePatterns": ["<rootDir>/src/vendors/", "<rootDir>/selenium/"],
+  "extensionsToTreatAsEsm": [".ts", ".tsx"],
   "transform": {
     "^.+\\.[jt]sx?$": "babel-jest",
     "^.+\\.ya?ml$": "yaml-jest-transform",
     "^.+\\.ya?ml\\?loadAsText$": "jest-raw-loader",
     "^.+\\.txt$": "jest-raw-loader"
   },
-  "transformIgnorePatterns": [
-    "node_modules/(?!@cfworker|idb|webext-|p-timeout|p-defer|serialize-error)"
-  ],
   "setupFiles": [
     "<rootDir>/src/testEnv.js",
     "jest-webextension-mock",
@@ -27,6 +25,7 @@
     "!**/vendor/**"
   ],
   "moduleNameMapper": {
+    "^lodash$": "lodash-es",
     "\\.module.(css|scss)$": "identity-obj-proxy",
     "^@/icons/list$": "<rootDir>/src/__mocks__/iconsListMock",
     "^@/telemetry/logging$": "<rootDir>/src/__mocks__/logging.ts",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "@pixiebrix/extension",
   "version": "1.4.9-alpha.1",
   "description": "PixieBrix Browser Extension",
+  "type": "module",
   "scripts": {
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "jest --watchAll",
     "test:selenium": "jest --config selenium/jest.config.js",
     "test:selenium:local": "BROWSERSTACK_USERNAME= jest --config selenium/jest.config.js",

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -21,7 +21,7 @@ import { rollbar } from "@/telemetry/rollbar";
 import { MessageContext, Logger as ILogger, SerializedError } from "@/core";
 import { Except, JsonObject } from "type-fest";
 import { deserializeError, serializeError } from "serialize-error";
-import { DBSchema, openDB } from "idb/with-async-ittr";
+import { DBSchema, openDB } from "idb/with-async-ittr-cjs";
 import { sortBy, isEmpty } from "lodash";
 import { _getDNT } from "@/background/telemetry";
 import { isContentScript } from "webext-detect-page";

--- a/src/registry/localRegistry.ts
+++ b/src/registry/localRegistry.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DBSchema, openDB } from "idb/with-async-ittr";
+import { DBSchema, openDB } from "idb/with-async-ittr-cjs";
 import { sortBy, groupBy } from "lodash";
 
 const STORAGE_KEY = "BRICK_REGISTRY";

--- a/src/telemetry/trace.ts
+++ b/src/telemetry/trace.ts
@@ -17,7 +17,7 @@
 
 import { OutputKey, RegistryId, RenderedArgs, UUID } from "@/core";
 import { JsonObject } from "type-fest";
-import { DBSchema, openDB } from "idb/with-async-ittr";
+import { DBSchema, openDB } from "idb/with-async-ittr-cjs";
 import { sortBy } from "lodash";
 import { BlockConfig } from "@/blocks/types";
 


### PR DESCRIPTION
Attempt at closing https://github.com/pixiebrix/pixiebrix-extension/issues/684

The benefit here is that Jest wouldn't have to transform modules and therefore debugging tests would be easier. 

The issue is that this is basically impossible at this point because it'd mean loading some npm packages as _real_ ES modules — and that'd mean making this codebase compliant with native Node ES modules. 

One example: we rely on TypeScript’s `esModuleInterop` to allow `import {something} from X` even if `X` is a CJS module and does _not_ technically have an export named `something`. CJS modules only export one thing, that may be an object.

Bundlers/babel are flexible on this, Node isn't.

---

In short, too much work, not worth it at this point. 