### PR TITLE
#2010: add `!defer` expression

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -138,7 +138,9 @@ export type TemplateEngine =
 export type ExpressionType =
   | TemplateEngine
   // BlockPipeline with deferred execution
-  | "pipeline";
+  | "pipeline"
+  // Raw section with deferred rendering (rendered by the brick that executes it)
+  | "defer";
 
 /**
  * The JSON/JS representation of an explicit template/variable expression (e.g., mustache, var, etc.)

--- a/src/runtime/brickYaml.test.ts
+++ b/src/runtime/brickYaml.test.ts
@@ -45,6 +45,22 @@ describe("loadYaml", () => {
       },
     });
   });
+
+  test("deserialize defer", async () => {
+    expect(
+      loadBrickYaml("foo: !defer\n  bar: !mustache '{{ @element }}'")
+    ).toEqual({
+      foo: {
+        __type__: "defer",
+        __value__: {
+          bar: {
+            __type__: "mustache",
+            __value__: "{{ @element }}",
+          },
+        },
+      },
+    });
+  });
 });
 
 describe("dumpYaml", () => {
@@ -68,6 +84,17 @@ describe("dumpYaml", () => {
     });
 
     expect(dumped).toBe("foo: !pipeline \n  - id: '@pixiebrix/confetti'\n");
+  });
+
+  test("serialize defer", () => {
+    const dumped = dumpBrickYaml({
+      foo: {
+        __type__: "defer",
+        __value__: { bar: 42 },
+      },
+    });
+
+    expect(dumped).toBe("foo: !defer \n  bar: 42\n");
   });
 
   test("strips sharing information", () => {

--- a/src/runtime/mapArgs.test.ts
+++ b/src/runtime/mapArgs.test.ts
@@ -89,6 +89,33 @@ describe("handlebars", () => {
   });
 });
 
+describe("defer", () => {
+  test("render !defer stops at defer", async () => {
+    const config = {
+      foo: {
+        __type__: "var",
+        __value__: "foo",
+      },
+    };
+
+    const rendered = await renderExplicit(
+      {
+        foo: {
+          __type__: "defer",
+          __value__: config,
+        },
+        bar: config,
+      },
+      { foo: 42 }
+    );
+
+    expect(rendered).toEqual({
+      foo: config,
+      bar: { foo: 42 },
+    });
+  });
+});
+
 describe("pipeline", () => {
   test("render !pipeline", async () => {
     const rendered = await renderExplicit(

--- a/src/runtime/mapArgs.ts
+++ b/src/runtime/mapArgs.ts
@@ -31,7 +31,11 @@ const templateTypes: TemplateEngine[] = [
   "var",
 ];
 
-const expressionTypes: ExpressionType[] = [...templateTypes, "pipeline"];
+const expressionTypes: ExpressionType[] = [
+  ...templateTypes,
+  "pipeline",
+  "defer",
+];
 
 type Args = string | UnknownObject | UnknownObject[];
 
@@ -83,7 +87,7 @@ export async function renderExplicit(
     return render(config.__value__, ctxt);
   }
 
-  if (isExpression(config) && config.__type__ === "pipeline") {
+  if (isExpression(config) && ["pipeline", "defer"].includes(config.__type__)) {
     // Pipelines are passed through directly
     return config.__value__;
   }

--- a/src/runtime/pipelineTests/deferExpression.test.ts
+++ b/src/runtime/pipelineTests/deferExpression.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import blockRegistry from "@/blocks/registry";
+import { reducePipeline } from "@/runtime/reducePipeline";
+import { deferBlock, simpleInput, testOptions } from "./pipelineTestHelpers";
+
+// Mock the recordX trace methods. Otherwise they'll fail and Jest will have unhandledrejection errors since we call
+// them with `void` instead of awaiting them in the reducePipeline methods
+import * as logging from "@/background/logging";
+
+jest.mock("@/background/trace");
+(logging.getLoggingConfig as any) = jest.fn().mockResolvedValue({
+  logValues: true,
+});
+
+beforeEach(() => {
+  blockRegistry.clear();
+  blockRegistry.register(deferBlock);
+});
+
+describe("apiVersion: v3", () => {
+  test("run block with defer arg", async () => {
+    const pipeline = {
+      id: deferBlock.id,
+      config: {
+        array: [1, 2],
+        element: {
+          immediate: {
+            __type__: "mustache",
+            __value__: "{{ @element }} - {{ @input.value }}",
+          },
+          deferred: {
+            __type__: "defer",
+            __value__: {
+              __type__: "mustache",
+              __value__: "{{ @element }} - {{ @input.value }}",
+            },
+          },
+        },
+      },
+    };
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({ value: 42 }),
+      testOptions("v3")
+    );
+    expect(result).toStrictEqual([
+      { immediate: " - 42", deferred: "1 - 42" },
+      { immediate: " - 42", deferred: "2 - 42" },
+    ]);
+  });
+});

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -6,6 +6,7 @@ import { InitialValues } from "@/runtime/reducePipeline";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { BusinessError } from "@/errors";
 import { BlockPipeline } from "@/blocks/types";
+import { mapArgs } from "@/runtime/mapArgs";
 
 const logger = new ConsoleLogger();
 
@@ -125,6 +126,55 @@ class PipelineBlock extends Block {
   }
 }
 
+/**
+ * Test block that renders an array of elements with a deferred expression
+ */
+class DeferBlock extends Block {
+  constructor() {
+    super("test/defer", "Defer Block");
+  }
+
+  inputSchema = propertiesToSchema(
+    {
+      array: {
+        type: "array",
+      },
+      elementKey: {
+        type: "string",
+        default: "element",
+      },
+      element: {
+        type: "object",
+        additionalProperties: true,
+      },
+    },
+    ["array", "element"]
+  );
+
+  async run(
+    {
+      element,
+      array = [],
+      elementKey = "element",
+    }: BlockArg<{
+      element: UnknownObject;
+      array: unknown[];
+      elementKey?: string;
+    }>,
+    { ctxt }: BlockOptions
+  ) {
+    return Promise.all(
+      array.map(async (data) => {
+        const elementContext = {
+          ...ctxt,
+          [`@${elementKey}`]: data,
+        };
+        return mapArgs(element, elementContext, { implicitRender: null });
+      })
+    );
+  }
+}
+
 export const echoBlock = new EchoBlock();
 export const contextBlock = new ContextBlock();
 export const identityBlock = new IdentityBlock();
@@ -132,6 +182,7 @@ export const throwBlock = new ThrowBlock();
 export const teapotBlock = new TeapotBlock();
 export const arrayBlock = new ArrayBlock();
 export const pipelineBlock = new PipelineBlock();
+export const deferBlock = new DeferBlock();
 
 /**
  * Helper method to pass only `input` to reducePipeline.


### PR DESCRIPTION
Closes #2010

- This adds support for a `!defer` expression to the runtime. Config/mappings underneath the expression is left as-is
- @BALEHOK See the [deferBlock](http://github.com/pixiebrix/pixiebrix-extension/blob/7d1c1df7de6602c578c31298d0d240482b7aa695/src/runtime/pipelineTests/pipelineTestHelpers.ts#L132-L132) tests to see how this might be used in our document renderer for repeated elements
