### PR TITLE
#2008: Show text input for v2 bricks if the oneOf schema includes text

### DIFF
--- a/src/components/fields/schemaFields/SchemaField.test.tsx
+++ b/src/components/fields/schemaFields/SchemaField.test.tsx
@@ -19,7 +19,7 @@ import React from "react";
 import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { Formik } from "formik";
-import { ApiVersion, Expression, TemplateEngine } from "@/core";
+import { ApiVersion, Expression, Schema, TemplateEngine } from "@/core";
 import { createFormikTemplate } from "@/tests/formHelpers";
 import { waitForEffect } from "@/tests/testHelpers";
 import userEvent from "@testing-library/user-event";
@@ -202,5 +202,35 @@ describe("SchemaField", () => {
       "nunjucks",
       "omit",
     ]);
+  });
+
+  test("v2 field oneOf type priority shows text", () => {
+    const FormikTemplate = createFormikTemplate({ apiVersion: "v2" });
+    const schema: Schema = {
+      oneOf: [{ type: "boolean" }, { type: "string" }, { type: "number" }],
+    };
+    const { container } = render(
+      <FormikTemplate>
+        <SchemaField name="myField" schema={schema} />
+      </FormikTemplate>
+    );
+
+    // Should render text input for anything that includes text
+    expect(container.querySelector("input[type='text']")).not.toBeNull();
+  });
+
+  test("v2 field type array shows text", () => {
+    const FormikTemplate = createFormikTemplate({ apiVersion: "v2" });
+    const schema: Schema = {
+      type: ["boolean", "number", "string"],
+    };
+    const { container } = render(
+      <FormikTemplate>
+        <SchemaField name="myField" schema={schema} />
+      </FormikTemplate>
+    );
+
+    // Should render text input for anything that includes text
+    expect(container.querySelector("input[type='text']")).not.toBeNull();
   });
 });

--- a/src/components/fields/schemaFields/SchemaFieldContext.tsx
+++ b/src/components/fields/schemaFields/SchemaFieldContext.tsx
@@ -97,12 +97,12 @@ export function getDefaultField(fieldSchema: Schema): SchemaFieldComponent {
     return TextField;
   }
 
-  if (findOneOf(fieldSchema, booleanPredicate)) {
-    return makeOneOfField(findOneOf(fieldSchema, booleanPredicate));
-  }
-
   if (findOneOf(fieldSchema, textPredicate)) {
     return makeOneOfField(findOneOf(fieldSchema, textPredicate));
+  }
+
+  if (findOneOf(fieldSchema, booleanPredicate)) {
+    return makeOneOfField(findOneOf(fieldSchema, booleanPredicate));
   }
 
   if (isEmpty(fieldSchema)) {


### PR DESCRIPTION
Fixes #2008 

In page editor v2, When a config schema field allows multiple types, we need to give priority to text input if `text` is included in the types