### PR TITLE
#1714: Support multi-line text inputs

### DIFF
--- a/__mocks__/fit-textarea.js
+++ b/__mocks__/fit-textarea.js
@@ -1,0 +1,22 @@
+/* eslint-disable unicorn/filename-case */
+
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export default {
+  watch: jest.fn(),
+};

--- a/jest.config.json
+++ b/jest.config.json
@@ -11,7 +11,7 @@
     "^.+\\.txt$": "jest-raw-loader"
   },
   "transformIgnorePatterns": [
-    "node_modules/(?!@cfworker|idb|webext-|p-timeout|p-retry|p-defer|serialize-error|fit-textarea)"
+    "node_modules/(?!@cfworker|idb|webext-|p-timeout|p-retry|p-defer|serialize-error)"
   ],
   "setupFiles": [
     "<rootDir>/src/testEnv.js",

--- a/jest.config.json
+++ b/jest.config.json
@@ -11,7 +11,7 @@
     "^.+\\.txt$": "jest-raw-loader"
   },
   "transformIgnorePatterns": [
-    "node_modules/(?!@cfworker|idb|webext-|p-timeout|p-retry|p-defer|serialize-error)"
+    "node_modules/(?!@cfworker|idb|webext-|p-timeout|p-retry|p-defer|serialize-error|fit-textarea)"
   ],
   "setupFiles": [
     "<rootDir>/src/testEnv.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pixiebrix/extension",
-  "version": "1.4.9-alpha.1",
+  "version": "1.4.10-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pixiebrix/extension",
-      "version": "1.4.9-alpha.1",
+      "version": "1.4.10-alpha.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cfworker/json-schema": "^1.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "exifreader": "^4.0.0",
         "export-to-csv": "^0.2.1",
         "file-saver": "^2.0.5",
+        "fit-textarea": "^3.0.0",
         "formik": "^2.2.9",
         "fuse.js": "^6.4.6",
         "generate-schema": "^2.6.0",
@@ -19987,6 +19988,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/fit-textarea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fit-textarea/-/fit-textarea-3.0.0.tgz",
+      "integrity": "sha512-27CNxgJ0bL+ATJbLZuOjtUGfAiwa99kT6omFscYTQ9P/u6Lawekkws6lylTu32VgzkQTnTEXbu+bRaHtwoN02Q=="
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
@@ -52585,6 +52591,11 @@
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "fit-textarea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fit-textarea/-/fit-textarea-3.0.0.tgz",
+      "integrity": "sha512-27CNxgJ0bL+ATJbLZuOjtUGfAiwa99kT6omFscYTQ9P/u6Lawekkws6lylTu32VgzkQTnTEXbu+bRaHtwoN02Q=="
     },
     "flat-cache": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pixiebrix/extension",
-  "version": "1.4.9-alpha.1",
+  "version": "1.4.10-alpha.1",
   "description": "PixieBrix Browser Extension",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "exifreader": "^4.0.0",
     "export-to-csv": "^0.2.1",
     "file-saver": "^2.0.5",
+    "fit-textarea": "^3.0.0",
     "formik": "^2.2.9",
     "fuse.js": "^6.4.6",
     "generate-schema": "^2.6.0",

--- a/src/components/fields/schemaFields/SchemaField.test.tsx
+++ b/src/components/fields/schemaFields/SchemaField.test.tsx
@@ -66,13 +66,11 @@ describe("SchemaField", () => {
       );
 
       // Renders text entry HTML element
-      expect(container.querySelector("input[type='text']")).not.toBeNull();
+      expect(container.querySelector("textarea")).not.toBeNull();
       expect(container.querySelector("button")).toBeNull();
     }
   );
-});
 
-describe("SchemaField", () => {
   test("string field options", () => {
     const { container } = render(
       <Formik
@@ -91,7 +89,7 @@ describe("SchemaField", () => {
     );
 
     // Renders text entry HTML element
-    expect(container.querySelector("input[type='text']")).not.toBeNull();
+    expect(container.querySelector("textarea")).not.toBeNull();
 
     expectToggleOptions(container, [
       "string",
@@ -215,8 +213,8 @@ describe("SchemaField", () => {
       </FormikTemplate>
     );
 
-    // Should render text input for anything that includes text
-    expect(container.querySelector("input[type='text']")).not.toBeNull();
+    // Should render textarea for anything that includes text
+    expect(container.querySelector("textarea")).not.toBeNull();
   });
 
   test("v2 field type array shows text", () => {
@@ -230,7 +228,7 @@ describe("SchemaField", () => {
       </FormikTemplate>
     );
 
-    // Should render text input for anything that includes text
-    expect(container.querySelector("input[type='text']")).not.toBeNull();
+    // Should render textarea for anything that includes text
+    expect(container.querySelector("textarea")).not.toBeNull();
   });
 });

--- a/src/components/fields/schemaFields/widgets/TextWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TextWidget.tsx
@@ -15,13 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import { useField } from "formik";
 import Select, { OptionsType } from "react-select";
 import { sortBy, uniq } from "lodash";
 import Creatable from "react-select/creatable";
 import { Form, FormControlProps } from "react-bootstrap";
+import fitTextarea from "fit-textarea";
 
 const TextWidget: React.FC<SchemaFieldProps & FormControlProps> = ({
   name,
@@ -52,6 +53,15 @@ const TextWidget: React.FC<SchemaFieldProps & FormControlProps> = ({
         : [];
     return [schema?.enum == null, options];
   }, [schema.examples, schema.enum, created, value, schema.type]);
+
+  const textAreaRef = useRef<HTMLTextAreaElement>();
+
+  useEffect(() => {
+    if (textAreaRef.current) {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- not using fs.watch, false positive
+      fitTextarea.watch(textAreaRef.current);
+    }
+  }, []);
 
   if (options.length > 0 && creatable) {
     return (
@@ -88,25 +98,15 @@ const TextWidget: React.FC<SchemaFieldProps & FormControlProps> = ({
     return <div>Cannot edit object value as text</div>;
   }
 
-  if (schema.format === "markdown" || uiSchema?.["ui:widget"] === "textarea") {
-    return (
-      <Form.Control
-        as="textarea"
-        value={value ?? ""}
-        {...field}
-        {...restProps}
-        isInvalid={Boolean(meta.error)}
-      />
-    );
-  }
-
   return (
     <Form.Control
-      type="text"
+      as="textarea"
+      rows="1"
       value={value ?? ""}
       {...field}
       {...restProps}
       isInvalid={Boolean(meta.error)}
+      ref={textAreaRef}
     />
   );
 };

--- a/src/components/formBuilder/__snapshots__/FormEditor.test.tsx.snap
+++ b/src/components/formBuilder/__snapshots__/FormEditor.test.tsx.snap
@@ -17,12 +17,11 @@ exports[`FormEditor renders empty schema 1`] = `
       <div
         class="col-lg-9"
       >
-        <input
+        <textarea
           class="form-control"
           id="rjsfSchema.schema.title"
           name="rjsfSchema.schema.title"
-          type="text"
-          value=""
+          rows="1"
         />
       </div>
     </div>
@@ -38,12 +37,11 @@ exports[`FormEditor renders empty schema 1`] = `
       <div
         class="col-lg-9"
       >
-        <input
+        <textarea
           class="form-control"
           id="rjsfSchema.schema.description"
           name="rjsfSchema.schema.description"
-          type="text"
-          value=""
+          rows="1"
         />
       </div>
     </div>
@@ -123,13 +121,14 @@ exports[`FormEditor renders simple schema 1`] = `
       <div
         class="col-lg-9"
       >
-        <input
+        <textarea
           class="form-control"
           id="rjsfSchema.schema.title"
           name="rjsfSchema.schema.title"
-          type="text"
-          value="A form"
-        />
+          rows="1"
+        >
+          A form
+        </textarea>
       </div>
     </div>
     <div
@@ -144,13 +143,14 @@ exports[`FormEditor renders simple schema 1`] = `
       <div
         class="col-lg-9"
       >
-        <input
+        <textarea
           class="form-control"
           id="rjsfSchema.schema.description"
           name="rjsfSchema.schema.description"
-          type="text"
-          value="A form example."
-        />
+          rows="1"
+        >
+          A form example.
+        </textarea>
       </div>
     </div>
     <hr />
@@ -269,13 +269,14 @@ exports[`FormEditor renders simple schema 1`] = `
         <div
           class="col-lg-9"
         >
-          <input
+          <textarea
             class="form-control"
             id="rjsfSchema.schema.properties.firstName.title"
             name="rjsfSchema.schema.properties.firstName.title"
-            type="text"
-            value="First name"
-          />
+            rows="1"
+          >
+            First name
+          </textarea>
           <small
             class="text-muted form-text"
           >
@@ -295,12 +296,11 @@ exports[`FormEditor renders simple schema 1`] = `
         <div
           class="col-lg-9"
         >
-          <input
+          <textarea
             class="form-control"
             id="rjsfSchema.schema.properties.firstName.description"
             name="rjsfSchema.schema.properties.firstName.description"
-            type="text"
-            value=""
+            rows="1"
           />
           <small
             class="text-muted form-text"
@@ -411,13 +411,14 @@ exports[`FormEditor renders simple schema 1`] = `
         <div
           class="col-lg-9"
         >
-          <input
+          <textarea
             class="form-control"
             id="rjsfSchema.schema.properties.firstName.default"
             name="rjsfSchema.schema.properties.firstName.default"
-            type="text"
-            value="Chuck"
-          />
+            rows="1"
+          >
+            Chuck
+          </textarea>
         </div>
       </div>
       <div

--- a/src/components/jsonTree/JsonTree.tsx
+++ b/src/components/jsonTree/JsonTree.tsx
@@ -110,7 +110,15 @@ const JsonTree: React.FunctionComponent<JsonTreeProps> = ({
           data={searchResults}
           labelRenderer={copyable ? copyLabelRenderer : undefined}
           hideRoot
-          theme={theme}
+          theme={{
+            extend: theme,
+            value: ({ style }) => ({
+              style: {
+                ...style,
+                whiteSpace: "pre-wrap",
+              },
+            }),
+          }}
           invertTheme
           {...restProps}
         />

--- a/src/devTools/editor/tabs/effect/v1/__snapshots__/BlockConfiguration.test.tsx.snap
+++ b/src/devTools/editor/tabs/effect/v1/__snapshots__/BlockConfiguration.test.tsx.snap
@@ -28,12 +28,11 @@ exports[`renders 1`] = `
           <div
             class="col-lg-9"
           >
-            <input
+            <textarea
               class="form-control"
               id="extension.blockPipeline[0].config.message"
               name="extension.blockPipeline[0].config.message"
-              type="text"
-              value=""
+              rows="1"
             />
           </div>
         </div>

--- a/src/devTools/editor/tabs/effect/v3/__snapshots__/BlockConfiguration.test.tsx.snap
+++ b/src/devTools/editor/tabs/effect/v3/__snapshots__/BlockConfiguration.test.tsx.snap
@@ -34,12 +34,11 @@ exports[`renders 1`] = `
               <div
                 class="field"
               >
-                <input
+                <textarea
                   class="form-control"
                   id="extension.blockPipeline[0].config.message"
                   name="extension.blockPipeline[0].config.message"
-                  type="text"
-                  value=""
+                  rows="1"
                 />
               </div>
               <div

--- a/src/options/pages/marketplace/__snapshots__/OptionsBody.test.tsx.snap
+++ b/src/options/pages/marketplace/__snapshots__/OptionsBody.test.tsx.snap
@@ -26,12 +26,11 @@ exports[`Marketplace Activate Wizard OptionsBody renders text field 1`] = `
       <div
         class="col-lg-9"
       >
-        <input
+        <textarea
           class="form-control"
           id="optionsArgs.textField"
           name="optionsArgs.textField"
-          type="text"
-          value=""
+          rows="1"
         />
       </div>
     </div>


### PR DESCRIPTION
Closes #1714.

This uses @fregante 's `fit-textarea` library to make our `TextWidget` component expand and allow multiple lines.