### PR TITLE
Use Messenger for `executeInTarget`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
         "webext-content-scripts": "^0.10.1",
         "webext-detect-page": "^3.0.2",
         "webext-dynamic-content-scripts": "^8.0.1",
-        "webext-messenger": "^0.15.0-5",
+        "webext-messenger": "^0.15.1-0",
         "webext-patterns": "^1.1.1",
         "webext-polyfill-kinda": "^0.1.0",
         "webextension-polyfill": "^0.8.0",
@@ -36249,9 +36249,9 @@
       }
     },
     "node_modules/webext-messenger": {
-      "version": "0.15.0-5",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.15.0-5.tgz",
-      "integrity": "sha512-dkSCoxd+0K2wgL1Co7US/E9oBgvKysXgKPgBp1MZCv+iZ0reiE1MFIu3S4h3F1ZHjWaetpVz5/XokCJ1zQjTFw==",
+      "version": "0.15.1-0",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.15.1-0.tgz",
+      "integrity": "sha512-x7ecSz05pNNN8ukE+3ISZsJ5cpiM9q1V0frHWWL/dgVVHuVItwBGKl1T9z5U+vNw9uSYs5tQhas3HvgL97XWmQ==",
       "dependencies": {
         "p-retry": "^5.0.0",
         "serialize-error": "^9.0.0",
@@ -65373,9 +65373,9 @@
       }
     },
     "webext-messenger": {
-      "version": "0.15.0-5",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.15.0-5.tgz",
-      "integrity": "sha512-dkSCoxd+0K2wgL1Co7US/E9oBgvKysXgKPgBp1MZCv+iZ0reiE1MFIu3S4h3F1ZHjWaetpVz5/XokCJ1zQjTFw==",
+      "version": "0.15.1-0",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.15.1-0.tgz",
+      "integrity": "sha512-x7ecSz05pNNN8ukE+3ISZsJ5cpiM9q1V0frHWWL/dgVVHuVItwBGKl1T9z5U+vNw9uSYs5tQhas3HvgL97XWmQ==",
       "requires": {
         "p-retry": "^5.0.0",
         "serialize-error": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "webext-content-scripts": "^0.10.1",
     "webext-detect-page": "^3.0.2",
     "webext-dynamic-content-scripts": "^8.0.1",
-    "webext-messenger": "^0.15.0-5",
+    "webext-messenger": "^0.15.1-0",
     "webext-patterns": "^1.1.1",
     "webext-polyfill-kinda": "^0.1.0",
     "webextension-polyfill": "^0.8.0",

--- a/src/blocks/effects/redirectPage.ts
+++ b/src/blocks/effects/redirectPage.ts
@@ -24,6 +24,10 @@ import {
 } from "@/blocks/transformers/url";
 import { makeURL } from "@/utils";
 
+export const target = {
+  id: -1,
+};
+
 export class NavigateURLEffect extends Effect {
   constructor() {
     super(
@@ -62,7 +66,7 @@ export class OpenURLEffect extends Effect {
     params,
     spaceEncoding = URL_INPUT_SPACE_ENCODING_DEFAULT,
   }: BlockArg): Promise<void> {
-    await openTab({
+    target.id = await openTab({
       url: makeURL(url, params, spaceEncoding),
     });
   }

--- a/src/blocks/effects/wait.ts
+++ b/src/blocks/effects/wait.ts
@@ -34,7 +34,7 @@ export class WaitEffect extends Effect {
     type: "object",
     properties: {
       timeMillis: {
-        type: "integer",
+        type: "string",
         description:
           "Time in milliseconds. If value is less than or equal to zero, do not sleep",
       },

--- a/src/blocks/effects/wait.ts
+++ b/src/blocks/effects/wait.ts
@@ -34,7 +34,7 @@ export class WaitEffect extends Effect {
     type: "object",
     properties: {
       timeMillis: {
-        type: "string",
+        type: "integer",
         description:
           "Time in milliseconds. If value is less than or equal to zero, do not sleep",
       },

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -17,14 +17,6 @@
 
 /* Do not use `registerMethod` in this file */
 import { getMethod, getNotifier } from "webext-messenger";
-import { isContentScript } from "webext-detect-page";
-
-// TODO: This should be a hard error, but due to unknown dependency routes, it can't be enforced yet
-if (isContentScript() && process.env.DEBUG) {
-  console.warn(
-    "This should not have been imported in the content script. Use the API directly instead."
-  );
-}
 
 export const getFormDefinition = getMethod("FORM_GET_DEFINITION");
 export const resolveForm = getMethod("FORM_RESOLVE");

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -240,6 +240,8 @@ async function execute(
           isErrorObject(error) &&
           error.message.startsWith("Could not establish connection")
         ) {
+          // Either the target isn't receiving messages (due to lack of permissions or other errors)
+          // or it does not exist anymore
           throw new BusinessError("Sender tab has no target");
         }
       });


### PR DESCRIPTION
- Includes https://github.com/pixiebrix/webext-messenger/pull/55

## Tests done

### 200 Successful

1. brick: open tab
2. brick: alert in Target:target

### 404 Missing target

1. brick: alert in Target:target
	- it doesn't exist, so it will receive `BusinessError("Sender tab has no target")`

### 410 Outdated target

1. brick: open tab
2. brick: wait 2000 ms
3. manually close tab
3. brick: alert in Target:target
	- it no longer exists exist, so it will receive `BusinessError("Sender tab has no target")`
