### PR TITLE
Improve Jest compilation quality

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -1,0 +1,10 @@
+{
+  "sourceMaps": true,
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true
+    },
+    "target": "es2020"
+  }
+}


### PR DESCRIPTION
While debugging another PR, I noticed that `swc` defaults to targeting `es5` and apparently no sourcemaps. This fixes both.

After this I'll also open a PR on the app