### PR TITLE
#2048: add support for url patterns in `isAvailable`

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,6 +1,6 @@
 {
   "silent": true,
-  "testEnvironment": "jest-environment-jsdom",
+  "testEnvironment": "jest-environment-jsdom-global",
   "modulePaths": ["/src"],
   "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "yaml", "yml", "json"],
   "testPathIgnorePatterns": ["<rootDir>/src/vendors/", "<rootDir>/selenium/"],
@@ -11,7 +11,7 @@
     "^.+\\.txt$": "jest-raw-loader"
   },
   "transformIgnorePatterns": [
-    "node_modules/(?!@cfworker|idb|webext-|p-timeout|p-retry|p-defer|serialize-error)"
+    "node_modules/(?!@cfworker|idb|webext-|p-timeout|p-retry|p-defer|serialize-error|urlpattern-polyfill)"
   ],
   "setupFiles": [
     "<rootDir>/src/testEnv.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
         "slugify": "^1.6.0",
         "to-json-schema": "^0.2.5",
         "url-join": "^4.0.1",
+        "urlpattern-polyfill": "^1.0.0-rc1",
         "use-async-effect": "^2.2.3",
         "use-debounce": "^7.0.0",
         "use-immer": "^0.6.0",
@@ -35524,6 +35525,11 @@
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "1.0.0-rc1",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-1.0.0-rc1.tgz",
+      "integrity": "sha512-OOH7VgVY4ShouTrd+raK3L6CpplYa24DfHTDW0t1OCeW8cSS4jkM62gvkHdKM4HKvU74klciKAq1SJ9rGFWX1g=="
+    },
     "node_modules/use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -64764,6 +64770,11 @@
         "mime-types": "^2.1.27",
         "schema-utils": "^3.0.0"
       }
+    },
+    "urlpattern-polyfill": {
+      "version": "1.0.0-rc1",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-1.0.0-rc1.tgz",
+      "integrity": "sha512-OOH7VgVY4ShouTrd+raK3L6CpplYa24DfHTDW0t1OCeW8cSS4jkM62gvkHdKM4HKvU74klciKAq1SJ9rGFWX1g=="
     },
     "use": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -204,6 +204,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.0.6",
         "jest-environment-jsdom": "^27.0.6",
+        "jest-environment-jsdom-global": "^3.0.0",
         "jest-raw-loader": "^1.0.1",
         "jest-webextension-mock": "^3.7.17",
         "min-document": "^2.19.0",
@@ -23734,6 +23735,18 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom-global": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom-global/-/jest-environment-jsdom-global-3.0.0.tgz",
+      "integrity": "sha512-+7ZNxuB/35ybGug9vMaBYontqI7T8KhnUU55wtT5OYw6GRfDn2Vzak2YRvBwFjdm0so0Qz7KAL6NtEB0r+3x+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "jest-environment-jsdom": "22.x || 23.x || 24.x || 25.x || 26.x || 27.x"
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/@jest/types": {
@@ -55494,6 +55507,13 @@
           }
         }
       }
+    },
+    "jest-environment-jsdom-global": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom-global/-/jest-environment-jsdom-global-3.0.0.tgz",
+      "integrity": "sha512-+7ZNxuB/35ybGug9vMaBYontqI7T8KhnUU55wtT5OYw6GRfDn2Vzak2YRvBwFjdm0so0Qz7KAL6NtEB0r+3x+g==",
+      "dev": true,
+      "requires": {}
     },
     "jest-environment-node": {
       "version": "27.3.1",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "slugify": "^1.6.0",
     "to-json-schema": "^0.2.5",
     "url-join": "^4.0.1",
+    "urlpattern-polyfill": "^1.0.0-rc1",
     "use-async-effect": "^2.2.3",
     "use-debounce": "^7.0.0",
     "use-immer": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -226,6 +226,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.0.6",
     "jest-environment-jsdom": "^27.0.6",
+    "jest-environment-jsdom-global": "^3.0.0",
     "jest-raw-loader": "^1.0.1",
     "jest-webextension-mock": "^3.7.17",
     "min-document": "^2.19.0",

--- a/schemas/reader.json
+++ b/schemas/reader.json
@@ -19,6 +19,44 @@
         }
       ]
     },
+    "urlPattern": {
+      "description": " A URL pattern: https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "properties": {
+            "baseURL": {
+              "type": "string"
+            },
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "protocol": {
+              "type": "string"
+            },
+            "hostname": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            },
+            "pathname": {
+              "type": "string"
+            },
+            "search": {
+              "type": "string"
+            },
+            "hash": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
     "frameworkReader": {
       "type": "object",
       "properties": {
@@ -187,6 +225,20 @@
           "properties": {
             "matchPatterns": {
               "$ref": "#/definitions/stringArray"
+            },
+            "urlPatterns": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/urlPattern"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/urlPattern"
+                  },
+                  "minItems": 1
+                }
+              ]
             },
             "selectors": {
               "$ref": "#/definitions/stringArray"

--- a/src/Globals.d.ts
+++ b/src/Globals.d.ts
@@ -48,3 +48,8 @@ declare module "@/vendors/initialize" {
 interface HTMLDialogElement extends HTMLElement {
   showModal(): void;
 }
+
+// Made available via: "jest-environment-jsdom-global" for jest tests
+declare const jsdom: {
+  reconfigure: (options: { url: string }) => void;
+};

--- a/src/blocks/available.test.ts
+++ b/src/blocks/available.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { checkAvailable } from "@/blocks/available";
+
+describe("isAvailable.urlPatterns", () => {
+  test("can match hash", async () => {
+    // @ts-expect-error -- made available via "jest-environment-jsdom-global"
+    jsdom.reconfigure({ url: "https://www.example.com/#/foo/42" });
+    expect(await checkAvailable({ urlPatterns: { hash: "/foo/:id" } })).toBe(
+      true
+    );
+  });
+
+  test("can reject hash", async () => {
+    // @ts-expect-error -- made available via "jest-environment-jsdom-global"
+    jsdom.reconfigure({ url: "https://www.example.com/#/MISMATCH/42" });
+    expect(await checkAvailable({ urlPatterns: { hash: "/foo/:id" } })).toBe(
+      false
+    );
+  });
+});
+
+describe("isAvailable.matchPatterns", () => {
+  test("can match pattern", async () => {
+    // @ts-expect-error -- made available via "jest-environment-jsdom-global"
+    jsdom.reconfigure({ url: "https://www.example.com/foo/bar/baz/" });
+    expect(
+      await checkAvailable({ matchPatterns: "https://www.example.com/*" })
+    ).toBe(true);
+  });
+});
+
+describe("isAvailable.matchPatterns", () => {
+  test("require urlPattern and matchPattern", async () => {
+    // @ts-expect-error -- made available via "jest-environment-jsdom-global"
+    jsdom.reconfigure({ url: "https://www.example.com/#/MISMATCH/42" });
+    expect(
+      await checkAvailable({
+        matchPatterns: "https://www.example.com/*",
+        urlPatterns: { hash: "/foo/:id" },
+      })
+    ).toBe(false);
+  });
+});

--- a/src/blocks/available.test.ts
+++ b/src/blocks/available.test.ts
@@ -19,15 +19,20 @@ import { checkAvailable } from "@/blocks/available";
 
 describe("isAvailable.urlPatterns", () => {
   test("can match hash", async () => {
-    // @ts-expect-error -- made available via "jest-environment-jsdom-global"
     jsdom.reconfigure({ url: "https://www.example.com/#/foo/42" });
     expect(await checkAvailable({ urlPatterns: { hash: "/foo/:id" } })).toBe(
       true
     );
   });
 
+  test("invalid baseURL", async () => {
+    jsdom.reconfigure({ url: "https://www.example.com/#/foo/42" });
+    await expect(
+      checkAvailable({ urlPatterns: { baseURL: "NOTAREALURL" } })
+    ).rejects.toThrow("Pattern for baseURL not recognized");
+  });
+
   test("can reject hash", async () => {
-    // @ts-expect-error -- made available via "jest-environment-jsdom-global"
     jsdom.reconfigure({ url: "https://www.example.com/#/MISMATCH/42" });
     expect(await checkAvailable({ urlPatterns: { hash: "/foo/:id" } })).toBe(
       false
@@ -37,7 +42,6 @@ describe("isAvailable.urlPatterns", () => {
 
 describe("isAvailable.matchPatterns", () => {
   test("can match pattern", async () => {
-    // @ts-expect-error -- made available via "jest-environment-jsdom-global"
     jsdom.reconfigure({ url: "https://www.example.com/foo/bar/baz/" });
     expect(
       await checkAvailable({ matchPatterns: "https://www.example.com/*" })
@@ -47,7 +51,6 @@ describe("isAvailable.matchPatterns", () => {
 
 describe("isAvailable.matchPatterns", () => {
   test("require urlPattern and matchPattern", async () => {
-    // @ts-expect-error -- made available via "jest-environment-jsdom-global"
     jsdom.reconfigure({ url: "https://www.example.com/#/MISMATCH/42" });
     expect(
       await checkAvailable({

--- a/src/blocks/available.ts
+++ b/src/blocks/available.ts
@@ -87,14 +87,33 @@ function testSelector(selector: string): boolean {
   return $safeFind(selector).length > 0;
 }
 
-export async function checkAvailable({
-  matchPatterns: rawMatchPatterns = [],
-  urlPatterns: rawUrlPatterns = [],
-  selectors: rawSelectors = [],
-}: Availability): Promise<boolean> {
+export async function checkAvailable(
+  availability: Availability
+): Promise<boolean> {
+  const {
+    matchPatterns: rawMatchPatterns = [],
+    urlPatterns: rawUrlPatterns = [],
+    selectors: rawSelectors = [],
+  } = availability;
+
   const matchPatterns = rawMatchPatterns ? castArray(rawMatchPatterns) : [];
   const urlPatterns = rawUrlPatterns ? castArray(rawUrlPatterns) : [];
   const selectors = rawSelectors ? castArray(rawSelectors) : [];
+
+  if (process.env.DEBUG) {
+    const result = {
+      matchPatterns:
+        matchPatterns.length === 0 || testMatchPatterns(matchPatterns),
+      urlPatterns:
+        urlPatterns.length === 0 ||
+        urlPatterns.some((pattern) => testUrlPattern(pattern)),
+      selectors:
+        selectors.length === 0 ||
+        selectors.some((selector) => testSelector(selector)),
+    };
+
+    console.debug("Availability test for", availability, "had result", result);
+  }
 
   // Check matchPatterns and urlPatterns first b/c they're faster than searching selectors
 
@@ -113,7 +132,6 @@ export async function checkAvailable({
     selectors.length > 0 &&
     !selectors.some((selector) => testSelector(selector))
   ) {
-    // Console.debug("Page doesn't match any selectors", selectors);
     return false;
   }
 

--- a/src/blocks/available.ts
+++ b/src/blocks/available.ts
@@ -48,7 +48,10 @@ export function testMatchPatterns(
   return re.test(url);
 }
 
-function testUrlPattern(pattern: string | URLPatternInit): boolean {
+function testUrlPattern(
+  pattern: string | URLPatternInit,
+  url: string = document.location.href
+): boolean {
   let compiled;
 
   try {
@@ -77,7 +80,7 @@ function testUrlPattern(pattern: string | URLPatternInit): boolean {
     );
   }
 
-  return compiled.test(location.href);
+  return compiled.test(url);
 }
 
 function testSelector(selector: string): boolean {

--- a/src/blocks/available.ts
+++ b/src/blocks/available.ts
@@ -66,9 +66,7 @@ function testUrlPattern(
           void new URLPattern({ [key]: entry });
         } catch {
           throw new BusinessError(
-            `Pattern for ${key} not recognized as a valid url pattern: ${
-              entry as string
-            }`
+            `Pattern for ${key} not recognized as a valid url pattern: ${entry}`
           );
         }
       }

--- a/src/blocks/available.ts
+++ b/src/blocks/available.ts
@@ -112,7 +112,14 @@ export async function checkAvailable(
         selectors.some((selector) => testSelector(selector)),
     };
 
-    console.debug("Availability test for", availability, "had result", result);
+    console.debug(
+      "Availability test for",
+      document.location.href,
+      "vs.",
+      availability,
+      "had result",
+      result
+    );
   }
 
   // Check matchPatterns and urlPatterns first b/c they're faster than searching selectors

--- a/src/blocks/effects/reactivate.ts
+++ b/src/blocks/effects/reactivate.ts
@@ -18,6 +18,7 @@
 import { Effect, UnknownObject } from "@/types";
 import { BlockArg, BlockOptions, Schema } from "@/core";
 import { reactivateTab } from "@/contentScript/lifecycle";
+import { expectContext } from "@/utils/expectContext";
 
 export class ReactivateEffect extends Effect {
   constructor() {
@@ -37,7 +38,9 @@ export class ReactivateEffect extends Effect {
     arg: BlockArg<UnknownObject>,
     { logger }: BlockOptions
   ): Promise<void> {
-    logger.debug("Sending navigation signal");
+    expectContext("contentScript");
+    console.debug("Sending reactivateTab signal");
+    logger.debug("Sending reactivateTab signal");
     await reactivateTab();
   }
 }

--- a/src/blocks/effects/reactivate.ts
+++ b/src/blocks/effects/reactivate.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Effect, UnknownObject } from "@/types";
+import { BlockArg, BlockOptions, Schema } from "@/core";
+import { reactivateTab } from "@/contentScript/lifecycle";
+
+export class ReactivateEffect extends Effect {
+  constructor() {
+    super(
+      "@pixiebrix/reactivate",
+      "Reactivate All",
+      "Reactivate PixieBrix enhancements, e.g., because page content has changed without a navigation event"
+    );
+  }
+
+  inputSchema: Schema = {
+    type: "object",
+    properties: {},
+  };
+
+  async effect(
+    arg: BlockArg<UnknownObject>,
+    { logger }: BlockOptions
+  ): Promise<void> {
+    logger.debug("Sending navigation signal");
+    await reactivateTab();
+  }
+}

--- a/src/blocks/effects/registerEffects.ts
+++ b/src/blocks/effects/registerEffects.ts
@@ -37,6 +37,7 @@ import { TelemetryEffect } from "./telemetry";
 import { ConfettiEffect } from "./confetti";
 import { TourEffect } from "./tour";
 import { AttachAutocomplete } from "./attachAutocomplete";
+import { ReactivateEffect } from "@/blocks/effects/reactivate";
 
 function registerEffects(): void {
   registerBlock(new LogEffect());
@@ -66,6 +67,7 @@ function registerEffects(): void {
   registerBlock(new ConfettiEffect());
   registerBlock(new TourEffect());
   registerBlock(new AttachAutocomplete());
+  registerBlock(new ReactivateEffect());
 }
 
 export default registerEffects;

--- a/src/blocks/types.ts
+++ b/src/blocks/types.ts
@@ -23,18 +23,50 @@ import {
   UUID,
 } from "@/core";
 import { UnknownObject } from "@/types";
+import { URLPatternInit } from "urlpattern-polyfill/dist/url-pattern.interfaces";
 
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API
+ * @since 1.4.10
+ */
+export type URLPattern = string | URLPatternInit;
+
+/**
+ * An availability rule. For a rule to match, there must be match from each of the provided entries.
+ *
+ * An empty value (null, empty array, etc.) matches any site.
+ *
+ * @see checkAvailable
+ */
 export type Availability = {
+  /**
+   * Used to request permissions from the browser
+   */
   matchPatterns?: string | string[];
+  /**
+   * NOTE: the urlPatterns must be a subset of matchPatterns (i.e., more restrictive). If not, PixieBrix may not have
+   * access to the page
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API
+   * @since 1.4.10
+   */
+  urlPatterns?: URLPattern | URLPattern[];
+  /**
+   * A selector that must be available on the page in order for the extension to be run.
+   *
+   * NOTE: the selector must be available at the time the contentScript is installed. While the contentScript is loaded
+   * on document_idle, for SPAs this may lead to races between the selector check and rendering of the front-end.
+   */
   selectors?: string | string[];
 };
 
 /**
- * Availability with consistent shape
+ * Availability with consistent shape (i.e., all fields are arrays if provded)
  * @see Availability
  */
 export type NormalizedAvailability = {
   matchPatterns?: string[];
+  urlPatterns?: URLPattern[];
   selectors?: string[];
 };
 

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -25,7 +25,7 @@ import {
   SafeString,
   UUID,
 } from "@/core";
-import { castArray, cloneDeep, omit } from "lodash";
+import { castArray, cloneDeep, isEmpty, omit } from "lodash";
 import {
   assertExtensionPointConfig,
   ExtensionPointConfig,
@@ -82,6 +82,7 @@ export function isInnerExtensionPoint(
 export function makeIsAvailable(url: string): NormalizedAvailability {
   return {
     matchPatterns: [createSitePattern(url)],
+    urlPatterns: [],
     selectors: [],
   };
 }
@@ -194,10 +195,12 @@ export function selectIsAvailable(
 
   const { isAvailable } = extensionPoint.definition;
   const matchPatterns = castArray(isAvailable.matchPatterns ?? []);
+  const urlPatterns = castArray(isAvailable.urlPatterns ?? []);
   const selectors = castArray(isAvailable.selectors ?? []);
 
   return {
     matchPatterns,
+    urlPatterns,
     selectors,
   };
 }
@@ -206,16 +209,18 @@ export function selectIsAvailable(
  * Exclude malformed matchPatterns and selectors from an isAvailable section that may have found their way over from the
  * Page Editor.
  *
- * Currently excludes:
+ * Currently, excludes:
  * - Null values
  * - Blank values
  */
 export function cleanIsAvailable({
   matchPatterns = [],
+  urlPatterns = [],
   selectors = [],
 }: NormalizedAvailability): NormalizedAvailability {
   return {
     matchPatterns: matchPatterns.filter((x) => !isNullOrBlank(x)),
+    urlPatterns: urlPatterns.filter((x) => isEmpty(x)),
     selectors: selectors.filter((x) => !isNullOrBlank(x)),
   };
 }

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -527,7 +527,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
       reportEvent("MenuItemClick", selectEventData(extension));
 
       try {
-        // Read latest state at the time of the action
+        // Read the latest state at the time of the action
         const reader = await this.defaultReader();
 
         const initialValues: InitialValues = {

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import blockRegistry from "@/blocks/registry";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 85;
+const EXPECTED_HEADER_COUNT = 86;
 
 // Import for side-effects (these modules register the blocks)
 // NOTE: we don't need to also include extensionPoints because we got rid of all the legacy hard-coded extension points

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -52,6 +52,12 @@ export function inputProperties(inputSchema: Schema): SchemaProperties {
 export const IS_BROWSER =
   typeof window !== "undefined" && typeof window.document !== "undefined";
 
+/**
+ * Find an element(s) by its JQuery selector. A safe alternative to $(selector), which constructs an element it it's
+ * passed HTML.
+ * @param selector a JQuery selector
+ * @param parent parent element to search (default=document)
+ */
 export function $safeFind(
   selector: string,
   parent: Document | Element | JQuery<HTMLElement | Document> = document

--- a/src/tests/factories.ts
+++ b/src/tests/factories.ts
@@ -283,6 +283,7 @@ export const innerExtensionPointRecipeFactory = ({
           type: "menuItem",
           isAvailable: {
             matchPatterns: ["https://*/*"],
+            urlPatterns: [],
             selectors: [],
           },
           reader: validateRegistryId("@pixiebrix/document-context"),


### PR DESCRIPTION
What does this PR do?
- Adds support for urlPatterns in isAvailable of extension points
- Closes #2048 
- Adds a ReactivateEffect which causes extensions to be reinstalled on the page. (Useful in conjunction with triggers for handling sites SPAs that don't issue navigation events)
