### PR TITLE
Add opt-in dark mode for devs

### DIFF
--- a/src/development/darkMode.js
+++ b/src/development/darkMode.js
@@ -2,29 +2,33 @@ if (process.env.ENVIRONMENT === "development") {
   // Enables highlighting/prettifying
   const html = ([x]) => x;
 
-  if (localStorage.getItem("dev:dark-mode")) {
-    document.head.insertAdjacentHTML(
-      "beforeend",
-      html`
-        <style id="pb-dark-mode">
-          @media (prefers-color-scheme: dark) {
-            html {
-              background: white;
-              filter: invert(1) hue-rotate(180deg) contrast(0.8);
-            }
+  document.head.insertAdjacentHTML(
+    "beforeend",
+    html`
+      <style id="pb-dark-mode" media="none">
+        @media (prefers-color-scheme: dark) {
+          html {
+            background: white;
+            filter: invert(1) hue-rotate(180deg) contrast(0.8);
           }
-        </style>
-      `
-    );
-  }
+        }
+      </style>
+    `
+  );
+
+  const update = (set = localStorage.getItem("dev:dark-mode")) => {
+    document.querySelector("#pb-dark-mode").media = set ? "all" : "none";
+  };
+
+  update();
 
   window.pbToggleDark = () => {
     if (localStorage.getItem("dev:dark-mode")) {
       localStorage.removeItem("dev:dark-mode");
+      update(false);
     } else {
       localStorage.setItem("dev:dark-mode", "yes");
+      update(true);
     }
-
-    location.reload();
   };
 }

--- a/src/development/darkMode.js
+++ b/src/development/darkMode.js
@@ -1,0 +1,30 @@
+if (process.env.ENVIRONMENT === "development") {
+  // Enables highlighting/prettifying
+  const html = ([x]) => x;
+
+  if (localStorage.getItem("dev:dark-mode")) {
+    document.head.insertAdjacentHTML(
+      "beforeend",
+      html`
+        <style id="pb-dark-mode">
+          @media (prefers-color-scheme: dark) {
+            html {
+              background: white;
+              filter: invert(1) hue-rotate(180deg) contrast(0.8);
+            }
+          }
+        </style>
+      `
+    );
+  }
+
+  window.pbToggleDark = () => {
+    if (localStorage.getItem("dev:dark-mode")) {
+      localStorage.removeItem("dev:dark-mode");
+    } else {
+      localStorage.setItem("dev:dark-mode", "yes");
+    }
+
+    location.reload();
+  };
+}

--- a/src/devtoolsPanel.tsx
+++ b/src/devtoolsPanel.tsx
@@ -20,6 +20,7 @@ import React from "react";
 
 import Panel from "@/devTools/Panel";
 
+import "@/development/darkMode";
 import "@/telemetry/reportUncaughtErrors";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "@/vendors/overrides.scss";

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -24,6 +24,7 @@ import { render } from "react-dom";
 import React from "react";
 import App from "@/options/App";
 import initGoogle from "@/contrib/google/initGoogle";
+import "@/development/darkMode";
 
 import "@/options.scss";
 import "@/vendors/overrides.scss";


### PR DESCRIPTION
Here's a quick and dirty QoL improvement for devs living in the dark. It will not be included in the production builds.

## How to enable it

Call `pbToggleDark()` in the console of the options or editor to toggle the mode in both pages. ~~A reload will happen automatically.~~ I'll document this in the wiki after merge.

## Demo

<img width="1222" alt="Screen Shot 23" src="https://user-images.githubusercontent.com/1402241/145199896-c39b79c3-7830-4386-abc1-b6c07c6b20b1.png">


<img width="1263" alt="Screen Shot 24" src="https://user-images.githubusercontent.com/1402241/145199864-f02f9851-c471-47fe-af53-09e3e703d07e.png">


## Future


I think that we can use this pattern for more developer tools in the future as well. At some point I'll add a dev-only "reload" button to the editor that will reload both the tab _and_ the editor in one go.

