### PR TITLE
Keep select widget in viewport

### DIFF
--- a/src/components/form/widgets/SelectWidget.tsx
+++ b/src/components/form/widgets/SelectWidget.tsx
@@ -87,6 +87,7 @@ const SelectWidget = <TOption extends Option<TOption["value"]>>({
 
   return (
     <Select
+      menuPlacement="auto"
       inputId={id}
       name={name}
       isDisabled={disabled}


### PR DESCRIPTION
## Issue

Dropdowns always open downwards, even if there's no space below, so it causes the container to expand and it requires the user to scroll:

https://user-images.githubusercontent.com/1402241/145455350-0a0d3a9d-cd76-481e-ab53-72ae4b0bcfad.mov


## Solution

Thankfully `react-select` also has an option to behave correctly (your OS also does the same): Dropdowns open downwards only if there's enough space.

This PR only covers this specific select widget I found, but it could probably be applied to most `react-select` instances

https://user-images.githubusercontent.com/1402241/145455544-e64d41f5-cf25-43ee-a4d9-7806ad910f4d.mov


