### PR TITLE
#1866: quick bar POC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "json-schema-ref-parser": "^9.0.9",
         "jsonpath-plus": "^6.0.1",
         "jsonschema": "^1.4.0",
+        "kbar": "^0.1.0-beta.23",
         "lodash-es": "^4.17.21",
         "marked": "^4.0.3",
         "mustache": "^4.2.0",
@@ -4495,6 +4496,38 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@reach/observe-rect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
+      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
+    },
+    "node_modules/@reach/portal": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
+      "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
+      "dependencies": {
+        "@reach/utils": "0.16.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/utils": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
+      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
+      "dependencies": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -19634,6 +19667,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-equals": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+      "integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
+    },
     "node_modules/fast-glob": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
@@ -26124,6 +26162,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/kbar": {
+      "version": "0.1.0-beta.23",
+      "resolved": "https://registry.npmjs.org/kbar/-/kbar-0.1.0-beta.23.tgz",
+      "integrity": "sha512-incORLzU/VwmSLiRnvTk3Figxs0iAXoeuBU8ul0457AlMZtqqCu3KrKLiQwmtFe/wooy6Br6MiYOBGXA44aAJQ==",
+      "dependencies": {
+        "@reach/portal": "^0.16.0",
+        "fast-equals": "^2.0.3",
+        "match-sorter": "^6.3.0",
+        "react-virtual": "^2.8.2",
+        "tiny-invariant": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
@@ -26615,6 +26669,15 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
       }
     },
     "node_modules/md5.js": {
@@ -30930,6 +30993,20 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-virtual": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.10.0.tgz",
+      "integrity": "sha512-Mgy//1Ty0YMcELTooFq5mMrEb4dLRzS9PbPrgDbpdgGRgG9RuQrXBxgPCm1vNBonoiNZjbsGSEPLuJ7MuHLvLg==",
+      "funding": [
+        "https://github.com/sponsors/tannerlinsley"
+      ],
+      "dependencies": {
+        "@reach/observe-rect": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.3 || ^17.0.0"
+      }
+    },
     "node_modules/react-virtualized": {
       "version": "9.22.3",
       "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
@@ -31568,6 +31645,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
     },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
@@ -40401,6 +40483,30 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.0.tgz",
       "integrity": "sha512-zrsUxjLOKAzdewIDRWy9nsV1GQsKBCWaGwsZQlCgr6/q+vjyZhFgqedLfFBuI9anTPEUT4APq9Mu0SZBTzIcGQ=="
+    },
+    "@reach/observe-rect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
+      "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
+    },
+    "@reach/portal": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.16.2.tgz",
+      "integrity": "sha512-9ur/yxNkuVYTIjAcfi46LdKUvH0uYZPfEp4usWcpt6PIp+WDF57F/5deMe/uGi/B/nfDweQu8VVwuMVrCb97JQ==",
+      "requires": {
+        "@reach/utils": "0.16.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@reach/utils": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.16.0.tgz",
+      "integrity": "sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==",
+      "requires": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      }
     },
     "@reduxjs/toolkit": {
       "version": "1.6.2",
@@ -52333,6 +52439,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "fast-equals": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.4.tgz",
+      "integrity": "sha512-caj/ZmjHljPrZtbzJ3kfH5ia/k4mTJe/qSiXAGzxZWRZgsgDV0cvNaQULqUX8t0/JVlzzEdYOwCN5DmzTxoD4w=="
+    },
     "fast-glob": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
@@ -57308,6 +57419,18 @@
       "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
       "dev": true
     },
+    "kbar": {
+      "version": "0.1.0-beta.23",
+      "resolved": "https://registry.npmjs.org/kbar/-/kbar-0.1.0-beta.23.tgz",
+      "integrity": "sha512-incORLzU/VwmSLiRnvTk3Figxs0iAXoeuBU8ul0457AlMZtqqCu3KrKLiQwmtFe/wooy6Br6MiYOBGXA44aAJQ==",
+      "requires": {
+        "@reach/portal": "^0.16.0",
+        "fast-equals": "^2.0.3",
+        "match-sorter": "^6.3.0",
+        "react-virtual": "^2.8.2",
+        "tiny-invariant": "^1.2.0"
+      }
+    },
     "keyv": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.4.tgz",
@@ -57707,6 +57830,15 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.5.tgz",
       "integrity": "sha512-eUToMA5d5lunnipkCN7zFD0RiunCF2Uo6bImEt/Qx8LZMW7oPXTw7R+f+M5V3eS7164HjEDPfW8/TrefuFhDfw=="
+    },
+    "match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -61142,6 +61274,14 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-virtual": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/react-virtual/-/react-virtual-2.10.0.tgz",
+      "integrity": "sha512-Mgy//1Ty0YMcELTooFq5mMrEb4dLRzS9PbPrgDbpdgGRgG9RuQrXBxgPCm1vNBonoiNZjbsGSEPLuJ7MuHLvLg==",
+      "requires": {
+        "@reach/observe-rect": "^1.1.0"
+      }
+    },
     "react-virtualized": {
       "version": "9.22.3",
       "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
@@ -61642,6 +61782,11 @@
       "requires": {
         "mdast-squeeze-paragraphs": "^4.0.0"
       }
+    },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "json-schema-ref-parser": "^9.0.9",
     "jsonpath-plus": "^6.0.1",
     "jsonschema": "^1.4.0",
+    "kbar": "^0.1.0-beta.23",
     "lodash-es": "^4.17.21",
     "marked": "^4.0.3",
     "mustache": "^4.2.0",

--- a/schemas/extensionPoint.json
+++ b/schemas/extensionPoint.json
@@ -49,7 +49,14 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["menuItem", "panel", "trigger", "contextMenu", "actionPanel"]
+          "enum": [
+            "menuItem",
+            "panel",
+            "trigger",
+            "contextMenu",
+            "actionPanel",
+            "quickBar"
+          ]
         },
         "reader": {
           "$ref": "#/definitions/readerDefinition"

--- a/src/components/quickBar/QuickBarApp.module.scss
+++ b/src/components/quickBar/QuickBarApp.module.scss
@@ -1,0 +1,50 @@
+/*!
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+$background: rgb(252, 252, 252);
+$foreground: rgb(28, 28, 29);
+$shadow: 0px 6px 20px rgba(0, 0, 0, 20%);
+$a1: rgba(0, 0, 0, 0.05);
+$a2: rgba(0, 0, 0, 0.1);
+
+.search {
+  padding: 12px 16px;
+  font-size: 16px;
+  width: 100%;
+  box-sizing: border-box;
+  outline: none;
+  border: none;
+  background: $background;
+  color: $foreground;
+}
+
+.animator {
+  max-width: 600px;
+  width: 100%;
+  background: $background;
+  color: $foreground;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: $shadow;
+}
+
+.group {
+  padding: 8px 16px;
+  font-size: 10px;
+  text-transform: uppercase;
+  opacity: 0.5;
+}

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+
+import {
+  KBarAnimator,
+  KBarPortal,
+  KBarPositioner,
+  KBarProvider,
+  KBarResults,
+  KBarSearch,
+  useMatches,
+} from "kbar";
+import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
+import { expectContext } from "@/utils/expectContext";
+import { once } from "lodash";
+
+const RenderResults: React.FC = () => {
+  const { results } = useMatches();
+
+  return (
+    <KBarResults
+      items={results}
+      onRender={({ item, active }) =>
+        typeof item === "string" ? (
+          <div>{item}</div>
+        ) : (
+          <div
+            style={{
+              background: active ? "#eee" : "transparent",
+            }}
+          >
+            {item.name}
+          </div>
+        )
+      }
+    />
+  );
+};
+
+const QuickBarApp: React.FC = () => (
+  <KBarProvider actions={quickBarRegistry.actions}>
+    <KBarPortal>
+      <KBarPositioner>
+        <KBarAnimator>
+          <KBarSearch />
+          <RenderResults />
+        </KBarAnimator>
+      </KBarPositioner>
+    </KBarPortal>
+  </KBarProvider>
+);
+
+export const initQuickBarApp = once(() => {
+  expectContext("contentScript");
+
+  const container = document.createElement("div");
+  document.body.prepend(container);
+  ReactDOM.render(<QuickBarApp />, container);
+  console.debug("Initialized Quick Bar");
+});

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -15,54 +15,216 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { forwardRef, useEffect } from "react";
 import ReactDOM from "react-dom";
-
 import {
+  Action,
+  ActionId,
+  ActionImpl,
   KBarAnimator,
   KBarPortal,
   KBarPositioner,
   KBarProvider,
   KBarResults,
   KBarSearch,
+  useKBar,
   useMatches,
 } from "kbar";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import { expectContext } from "@/utils/expectContext";
 import { once } from "lodash";
 
+const theme = {
+  background: "rgb(252, 252, 252)",
+  foreground: "rgb(28, 28, 29)",
+  shadow: "0px 6px 20px rgba(0, 0, 0, 20%)",
+  a1: "rgba(0, 0, 0, 0.05)",
+  a2: "rgba(0, 0, 0, 0.1)",
+};
+
+const searchStyle = {
+  padding: "12px 16px",
+  fontSize: "16px",
+  width: "100%",
+  boxSizing: "border-box" as React.CSSProperties["boxSizing"],
+  outline: "none",
+  border: "none",
+  background: theme.background,
+  color: theme.foreground,
+};
+
+const animatorStyle = {
+  maxWidth: "600px",
+  width: "100%",
+  background: theme.background,
+  color: theme.foreground,
+  borderRadius: "8px",
+  overflow: "hidden",
+  boxShadow: theme.shadow,
+  zIndex: "10000000",
+};
+
+const groupNameStyle = {
+  padding: "8px 16px",
+  fontSize: "10px",
+  textTransform: "uppercase" as const,
+  opacity: 0.5,
+};
+
+const ResultItem = forwardRef(
+  (
+    {
+      action,
+      active,
+      currentRootActionId,
+    }: {
+      action: ActionImpl;
+      active: boolean;
+      currentRootActionId: ActionId;
+    },
+    ref: React.Ref<HTMLDivElement>
+  ) => {
+    const ancestors = React.useMemo(() => {
+      if (!currentRootActionId) return action.ancestors;
+      const index = action.ancestors.findIndex(
+        (ancestor) => ancestor.id === currentRootActionId
+      );
+      // +1 removes the currentRootAction; e.g.
+      // if we are on the "Set theme" parent action,
+      // the UI should not display "Set theme… > Dark"
+      // but rather just "Dark"
+      return action.ancestors.slice(index + 1);
+    }, [action.ancestors, currentRootActionId]);
+
+    return (
+      <div
+        ref={ref}
+        style={{
+          padding: "12px 16px",
+          background: active ? theme.a1 : "transparent",
+          borderLeft: `2px solid ${active ? theme.foreground : "transparent"}`,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          cursor: "pointer",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            gap: "8px",
+            alignItems: "center",
+            fontSize: 14,
+          }}
+        >
+          {action.icon && action.icon}
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div>
+              {ancestors.length > 0 &&
+                ancestors.map((ancestor) => (
+                  <React.Fragment key={ancestor.id}>
+                    <span
+                      style={{
+                        opacity: 0.5,
+                        marginRight: 8,
+                      }}
+                    >
+                      {ancestor.name}
+                    </span>
+                    <span
+                      style={{
+                        marginRight: 8,
+                      }}
+                    >
+                      &rsaquo;
+                    </span>
+                  </React.Fragment>
+                ))}
+              <span>{action.name}</span>
+            </div>
+            {action.subtitle && (
+              <span style={{ fontSize: 12 }}>{action.subtitle}</span>
+            )}
+          </div>
+        </div>
+        {action.shortcut?.length ? (
+          <div
+            aria-hidden
+            style={{ display: "grid", gridAutoFlow: "column", gap: "4px" }}
+          >
+            {action.shortcut.map((sc: string) => (
+              <kbd
+                key={sc}
+                style={{
+                  padding: "4px 6px",
+                  background: "rgba(0 0 0 / .1)",
+                  borderRadius: "4px",
+                  fontSize: 14,
+                }}
+              >
+                {sc}
+              </kbd>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+);
+
+ResultItem.displayName = "ResultItem";
+
 const RenderResults: React.FC = () => {
-  const { results } = useMatches();
+  const { results, rootActionId } = useMatches();
 
   return (
     <KBarResults
       items={results}
       onRender={({ item, active }) =>
         typeof item === "string" ? (
-          <div>{item}</div>
+          <div style={groupNameStyle}>{item}</div>
         ) : (
-          <div
-            style={{
-              background: active ? "#eee" : "transparent",
-            }}
-          >
-            {item.name}
-          </div>
+          <ResultItem
+            action={item}
+            active={active}
+            currentRootActionId={rootActionId}
+          />
         )
       }
     />
   );
 };
 
+function useActions(): void {
+  const { query } = useKBar();
+
+  useEffect(() => {
+    const handler = (actions: Action[]) => {
+      query.registerActions(actions as any);
+    };
+
+    quickBarRegistry.addListener(handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount; query will be defined on initial mount
+  }, []);
+}
+
+const KBarComponent: React.FC = () => {
+  useActions();
+
+  return (
+    <KBarPositioner>
+      <KBarAnimator style={animatorStyle}>
+        <KBarSearch style={searchStyle} />
+        <RenderResults />
+      </KBarAnimator>
+    </KBarPositioner>
+  );
+};
+
 const QuickBarApp: React.FC = () => (
   <KBarProvider actions={quickBarRegistry.actions}>
     <KBarPortal>
-      <KBarPositioner>
-        <KBarAnimator>
-          <KBarSearch />
-          <RenderResults />
-        </KBarAnimator>
-      </KBarPositioner>
+      <KBarComponent />
     </KBarPortal>
   </KBarProvider>
 );
@@ -73,5 +235,5 @@ export const initQuickBarApp = once(() => {
   const container = document.createElement("div");
   document.body.prepend(container);
   ReactDOM.render(<QuickBarApp />, container);
-  console.debug("Initialized Quick Bar");
+  console.debug("Initialized quick bar");
 });

--- a/src/components/quickBar/quickBarRegistry.ts
+++ b/src/components/quickBar/quickBarRegistry.ts
@@ -17,32 +17,72 @@
 
 import { Action } from "kbar";
 
+export const DEFAULT_SERVICE_URL = process.env.SERVICE_URL;
+
 const defaultActions: Action[] = [
   {
-    id: "blog",
-    name: "Blog",
-    shortcut: ["b"],
-    keywords: "writing words",
+    id: "marketplace",
+    name: "Open PixieBrix Marketplace",
+    keywords: "marketplace",
     perform: () => {
-      window.location.pathname = "blog";
+      window.location.href = "https://www.pixiebrix.com/marketplace/";
+    },
+  },
+  {
+    id: "admin",
+    name: "Open PixieBrix Admin Console",
+    keywords: "admin",
+    perform: () => {
+      window.location.href = DEFAULT_SERVICE_URL;
+    },
+  },
+  {
+    id: "quick-start",
+    name: "Open PixieBrix Quick Start",
+    keywords: "quick start, tutorials",
+    perform: () => {
+      window.location.href = "https://docs.pixiebrix.com/quick-start-guide";
+    },
+  },
+  {
+    id: "documentation",
+    name: "Open PixieBrix Documentation",
+    keywords: "docs, tutorials, documentation, how to",
+    perform: () => {
+      window.location.href = "https://docs.pixiebrix.com/";
     },
   },
 ];
 
+type ChangeHandler = (actions: Action[]) => void;
+
 class QuickBarRegistry {
   private _actions: Action[];
+  private readonly listeners: ChangeHandler[] = [];
 
   constructor() {
     this._actions = defaultActions;
   }
 
+  private notifyListeners() {
+    for (const listener of this.listeners) {
+      listener(this._actions);
+    }
+  }
+
   add(action: Action): void {
     this._actions = this._actions.filter((x) => x.id !== action.id);
     this._actions.push(action);
+    this.notifyListeners();
   }
 
   remove(id: string): void {
     this._actions = this._actions.filter((x) => x.id !== id);
+  }
+
+  addListener(handler: ChangeHandler) {
+    this.listeners.push(handler);
+    this.notifyListeners();
   }
 
   public get actions(): Action[] {

--- a/src/components/quickBar/quickBarRegistry.ts
+++ b/src/components/quickBar/quickBarRegistry.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Action } from "kbar";
+
+const defaultActions: Action[] = [
+  {
+    id: "blog",
+    name: "Blog",
+    shortcut: ["b"],
+    keywords: "writing words",
+    perform: () => {
+      window.location.pathname = "blog";
+    },
+  },
+];
+
+class QuickBarRegistry {
+  private _actions: Action[];
+
+  constructor() {
+    this._actions = defaultActions;
+  }
+
+  add(action: Action): void {
+    this._actions = this._actions.filter((x) => x.id !== action.id);
+    this._actions.push(action);
+  }
+
+  remove(id: string): void {
+    this._actions = this._actions.filter((x) => x.id !== id);
+  }
+
+  public get actions(): Action[] {
+    return this._actions;
+  }
+}
+
+// Singleton registry
+const quickBarRegistry = new QuickBarRegistry();
+
+export default quickBarRegistry;

--- a/src/components/quickBar/quickBarRegistry.tsx
+++ b/src/components/quickBar/quickBarRegistry.tsx
@@ -15,39 +15,68 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import React from "react";
 import { Action } from "kbar";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faAppleAlt,
+  faInfoCircle,
+  faSeedling,
+  faStore,
+  faUsers,
+} from "@fortawesome/free-solid-svg-icons";
 
 export const DEFAULT_SERVICE_URL = process.env.SERVICE_URL;
+
+const PIXIEBRIX_SECTION = "PixieBrix";
 
 const defaultActions: Action[] = [
   {
     id: "marketplace",
-    name: "Open PixieBrix Marketplace",
+    name: "Open Marketplace",
     keywords: "marketplace",
+    icon: <FontAwesomeIcon icon={faStore} fixedWidth />,
+    section: PIXIEBRIX_SECTION,
     perform: () => {
       window.location.href = "https://www.pixiebrix.com/marketplace/";
     },
   },
   {
     id: "admin",
-    name: "Open PixieBrix Admin Console",
-    keywords: "admin",
+    name: "Open Admin Console",
+    keywords: "admin, admin console",
+    section: PIXIEBRIX_SECTION,
+    icon: <FontAwesomeIcon icon={faUsers} fixedWidth />,
     perform: () => {
       window.location.href = DEFAULT_SERVICE_URL;
     },
   },
   {
     id: "quick-start",
-    name: "Open PixieBrix Quick Start",
+    name: "Open Quick Start",
     keywords: "quick start, tutorials",
+    section: PIXIEBRIX_SECTION,
+    icon: <FontAwesomeIcon icon={faAppleAlt} fixedWidth />,
     perform: () => {
       window.location.href = "https://docs.pixiebrix.com/quick-start-guide";
     },
   },
   {
+    id: "community",
+    name: "Open Community",
+    keywords: "community, how to",
+    section: PIXIEBRIX_SECTION,
+    icon: <FontAwesomeIcon icon={faSeedling} fixedWidth />,
+    perform: () => {
+      window.location.href = "https://community.pixiebrix.com/";
+    },
+  },
+  {
     id: "documentation",
-    name: "Open PixieBrix Documentation",
+    name: "Open Documentation",
     keywords: "docs, tutorials, documentation, how to",
+    section: PIXIEBRIX_SECTION,
+    icon: <FontAwesomeIcon icon={faInfoCircle} fixedWidth />,
     perform: () => {
       window.location.href = "https://docs.pixiebrix.com/";
     },

--- a/src/devTools/editor/extensionPoints/adapter.ts
+++ b/src/devTools/editor/extensionPoints/adapter.ts
@@ -20,6 +20,7 @@ import { IExtension } from "@/core";
 import { registry } from "@/background/messenger/api";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import menuItemExtension from "@/devTools/editor/extensionPoints/menuItem";
+import quickBarExtension from "@/devTools/editor/extensionPoints/quickBar";
 import triggerExtension from "@/devTools/editor/extensionPoints/trigger";
 import panelExtension from "@/devTools/editor/extensionPoints/panel";
 import contextMenuExtension from "@/devTools/editor/extensionPoints/contextMenu";
@@ -36,6 +37,7 @@ export const ADAPTERS = new Map<ElementType, ElementConfig>([
   ["contextMenu", contextMenuExtension],
   ["actionPanel", actionPanelExtension],
   ["menuItem", menuItemExtension],
+  ["quickBar", quickBarExtension],
 ]);
 
 export async function selectType(extension: IExtension): Promise<ElementType> {

--- a/src/devTools/editor/extensionPoints/base.ts
+++ b/src/devTools/editor/extensionPoints/base.ts
@@ -366,7 +366,7 @@ export function getImplicitReader(type: ElementType): SingleLayerReaderConfig {
     ]);
   }
 
-  // NOTE: we don't need to provide "@pixiebrix/context-menu-data" here because it's automatically attached by the
+  // NOTE: we don't need to provide "@pixiebrix/context-menu-data" here because it's automatically attached by
   // the contextMenu extension point.
   return [validateRegistryId("@pixiebrix/document-metadata")];
 }

--- a/src/devTools/editor/extensionPoints/elementConfig.ts
+++ b/src/devTools/editor/extensionPoints/elementConfig.ts
@@ -37,7 +37,8 @@ export type ElementType =
   | "trigger"
   | "panel"
   | "contextMenu"
-  | "actionPanel";
+  | "actionPanel"
+  | "quickBar";
 
 /**
  * A simplified type for ReaderConfig to prevent TypeScript reporting problems with infinite type instantiation

--- a/src/devTools/editor/extensionPoints/quickBar.tsx
+++ b/src/devTools/editor/extensionPoints/quickBar.tsx
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* eslint-disable filenames/match-exported */
+import { IExtension, Metadata } from "@/core";
+import {
+  baseFromExtension,
+  baseSelectExtension,
+  baseSelectExtensionPoint,
+  cleanIsAvailable,
+  getImplicitReader,
+  lookupExtensionPoint,
+  makeInitialBaseState,
+  makeIsAvailable,
+  normalizePipeline,
+  omitEditorMetadata,
+  PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
+  removeEmptyValues,
+  selectIsAvailable,
+} from "@/devTools/editor/extensionPoints/base";
+import { uuidv4 } from "@/types/helpers";
+import { DynamicDefinition } from "@/nativeEditor/dynamic";
+import { ExtensionPointConfig } from "@/extensionPoints/types";
+import { getDomain } from "@/permissions/patterns";
+import { faThLarge } from "@fortawesome/free-solid-svg-icons";
+import {
+  BaseExtensionState,
+  BaseFormState,
+  ElementConfig,
+  SingleLayerReaderConfig,
+} from "@/devTools/editor/extensionPoints/elementConfig";
+import { Menus } from "webextension-polyfill";
+import { NormalizedAvailability } from "@/blocks/types";
+import React from "react";
+import { Except } from "type-fest";
+import {
+  QuickBarConfig,
+  QuickBarDefaultOptions,
+  QuickBarDefinition,
+  QuickBarExtensionPoint,
+  QuickBarTargetMode,
+} from "@/extensionPoints/quickBarExtension";
+import QuickBarConfiguration from "@/devTools/editor/tabs/quickBar/QuickBarConfiguration";
+
+type Extension = BaseExtensionState & Except<QuickBarConfig, "action">;
+
+export interface QuickBarFormState extends BaseFormState<Extension> {
+  type: "quickBar";
+
+  extensionPoint: {
+    metadata: Metadata;
+    definition: {
+      defaultOptions: QuickBarDefaultOptions;
+      documentUrlPatterns: string[];
+      contexts: Menus.ContextType[];
+      targetMode: QuickBarTargetMode;
+      reader: SingleLayerReaderConfig;
+      isAvailable: NormalizedAvailability;
+    };
+  };
+}
+
+function fromNativeElement(url: string, metadata: Metadata): QuickBarFormState {
+  const base = makeInitialBaseState();
+
+  const isAvailable = makeIsAvailable(url);
+
+  const title = "Quick bar item";
+
+  return {
+    type: "quickBar",
+    // To simplify the interface, this is kept in sync with the caption
+    label: title,
+    ...base,
+    extensionPoint: {
+      metadata,
+      definition: {
+        reader: getImplicitReader("quickBar"),
+        documentUrlPatterns: isAvailable.matchPatterns,
+        contexts: ["all"],
+        targetMode: "eventTarget",
+        defaultOptions: {},
+        isAvailable,
+      },
+    },
+    extension: {
+      title,
+      blockPipeline: [],
+    },
+  };
+}
+
+function selectExtensionPoint(
+  formState: QuickBarFormState
+): ExtensionPointConfig<QuickBarDefinition> {
+  const { extensionPoint } = formState;
+  const {
+    definition: {
+      isAvailable,
+      documentUrlPatterns,
+      reader,
+      targetMode,
+      contexts = ["all"],
+    },
+  } = extensionPoint;
+  return removeEmptyValues({
+    ...baseSelectExtensionPoint(formState),
+    definition: {
+      type: "quickBar",
+      documentUrlPatterns,
+      contexts,
+      targetMode,
+      reader,
+      isAvailable: cleanIsAvailable(isAvailable),
+    },
+  });
+}
+
+function selectExtension(
+  { extension, ...state }: QuickBarFormState,
+  options: { includeInstanceIds?: boolean } = {}
+): IExtension<QuickBarConfig> {
+  const config: QuickBarConfig = {
+    title: extension.title,
+    action: options.includeInstanceIds
+      ? extension.blockPipeline
+      : omitEditorMetadata(extension.blockPipeline),
+  };
+  return removeEmptyValues({
+    ...baseSelectExtension(state),
+    config,
+  });
+}
+
+async function fromExtension(
+  config: IExtension<QuickBarConfig>
+): Promise<QuickBarFormState> {
+  const extensionPoint = await lookupExtensionPoint<
+    QuickBarDefinition,
+    QuickBarConfig,
+    "quickBar"
+  >(config, "quickBar");
+  const extensionConfig = config.config;
+
+  const {
+    documentUrlPatterns,
+    defaultOptions,
+    contexts,
+    targetMode,
+    reader,
+  } = extensionPoint.definition;
+
+  return {
+    ...baseFromExtension(config, extensionPoint.definition.type),
+
+    extension: normalizePipeline(extensionConfig, "action"),
+
+    extensionPoint: {
+      metadata: extensionPoint.metadata,
+      definition: {
+        documentUrlPatterns,
+        defaultOptions,
+        targetMode,
+        contexts,
+        // See comment on SingleLayerReaderConfig
+        reader: reader as SingleLayerReaderConfig,
+        isAvailable: selectIsAvailable(extensionPoint),
+      },
+    },
+  };
+}
+
+async function fromExtensionPoint(
+  url: string,
+  extensionPoint: ExtensionPointConfig<QuickBarDefinition>
+): Promise<QuickBarFormState> {
+  if (extensionPoint.definition.type !== "quickBar") {
+    throw new Error("Expected quickBar extension point type");
+  }
+
+  const {
+    defaultOptions = {},
+    documentUrlPatterns = [],
+    targetMode = "eventTarget",
+    type,
+    reader,
+  } = extensionPoint.definition;
+
+  return {
+    uuid: uuidv4(),
+    apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
+    installed: true,
+    type,
+    label: `My ${getDomain(url)} quick bar item`,
+
+    services: [],
+    optionsArgs: {},
+
+    extension: {
+      title: defaultOptions.title ?? "Custom Action",
+      blockPipeline: [],
+    },
+
+    extensionPoint: {
+      metadata: extensionPoint.metadata,
+      definition: {
+        ...extensionPoint.definition,
+        defaultOptions,
+        documentUrlPatterns,
+        targetMode,
+        // See comment on SingleLayerReaderConfig
+        reader: reader as SingleLayerReaderConfig,
+        isAvailable: selectIsAvailable(extensionPoint),
+      },
+    },
+
+    recipe: undefined,
+  };
+}
+
+function asDynamicElement(element: QuickBarFormState): DynamicDefinition {
+  return {
+    type: "quickBar",
+    extension: selectExtension(element, { includeInstanceIds: true }),
+    extensionPoint: selectExtensionPoint(element),
+  };
+}
+
+const config: ElementConfig<undefined, QuickBarFormState> = {
+  displayOrder: 6,
+  elementType: "quickBar",
+  label: "Quick Bar",
+  baseClass: QuickBarExtensionPoint,
+  EditorNode: QuickBarConfiguration,
+  selectNativeElement: undefined,
+  icon: faThLarge,
+  fromNativeElement,
+  fromExtensionPoint,
+  asDynamicElement,
+  selectExtensionPoint,
+  selectExtension,
+  fromExtension,
+  insertModeHelp: (
+    <div>
+      <p>The quick bar can be triggered on any page by hitting cmd+k</p>
+    </div>
+  ),
+};
+
+export default config;

--- a/src/devTools/editor/extensionPoints/quickBar.tsx
+++ b/src/devTools/editor/extensionPoints/quickBar.tsx
@@ -136,6 +136,7 @@ function selectExtension(
 ): IExtension<QuickBarConfig> {
   const config: QuickBarConfig = {
     title: extension.title,
+    icon: extension.icon,
     action: options.includeInstanceIds
       ? extension.blockPipeline
       : omitEditorMetadata(extension.blockPipeline),

--- a/src/devTools/editor/extensionPoints/quickBar.tsx
+++ b/src/devTools/editor/extensionPoints/quickBar.tsx
@@ -241,7 +241,7 @@ function asDynamicElement(element: QuickBarFormState): DynamicDefinition {
 }
 
 const config: ElementConfig<undefined, QuickBarFormState> = {
-  displayOrder: 6,
+  displayOrder: 2,
   elementType: "quickBar",
   label: "Quick Bar",
   baseClass: QuickBarExtensionPoint,

--- a/src/devTools/editor/extensionPoints/quickBar.tsx
+++ b/src/devTools/editor/extensionPoints/quickBar.tsx
@@ -241,9 +241,10 @@ function asDynamicElement(element: QuickBarFormState): DynamicDefinition {
 }
 
 const config: ElementConfig<undefined, QuickBarFormState> = {
-  displayOrder: 2,
+  displayOrder: 1,
   elementType: "quickBar",
   label: "Quick Bar",
+  beta: true,
   baseClass: QuickBarExtensionPoint,
   EditorNode: QuickBarConfiguration,
   selectNativeElement: undefined,

--- a/src/devTools/editor/panes/insert/GenericInsertPane.tsx
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.tsx
@@ -15,9 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useContext } from "react";
+import React, { useCallback } from "react";
 import { useDispatch } from "react-redux";
-import { DevToolsContext } from "@/devTools/context";
 import useAvailableExtensionPoints from "@/devTools/editor/hooks/useAvailableExtensionPoints";
 import Centered from "@/devTools/editor/components/Centered";
 import { Button, Row } from "react-bootstrap";
@@ -45,7 +44,6 @@ const GenericInsertPane: React.FunctionComponent<{
 }> = ({ cancel, config }) => {
   const dispatch = useDispatch();
   const { addToast } = useToasts();
-  const { port } = useContext(DevToolsContext);
 
   const start = useCallback(
     async (state: FormState) => {
@@ -65,14 +63,15 @@ const GenericInsertPane: React.FunctionComponent<{
           void showActionPanel(thisTab);
         }
       } catch (error) {
+        console.warn("Error adding element", error);
         reportError(error);
-        addToast("Error adding element", {
+        addToast("Error adding element!!!", {
           autoDismiss: true,
           appearance: "error",
         });
       }
     },
-    [config, port, dispatch, addToast]
+    [config, dispatch, addToast]
   );
 
   const addExisting = useCallback(

--- a/src/devTools/editor/panes/insert/GenericInsertPane.tsx
+++ b/src/devTools/editor/panes/insert/GenericInsertPane.tsx
@@ -63,9 +63,9 @@ const GenericInsertPane: React.FunctionComponent<{
           void showActionPanel(thisTab);
         }
       } catch (error) {
-        console.warn("Error adding element", error);
+        // If you're looking for the error message, it's in the logs for the page editor, not the host page
         reportError(error);
-        addToast("Error adding element!!!", {
+        addToast("Error adding element", {
           autoDismiss: true,
           appearance: "error",
         });

--- a/src/devTools/editor/sidebar/Sidebar.tsx
+++ b/src/devTools/editor/sidebar/Sidebar.tsx
@@ -46,6 +46,7 @@ import {
 import { CSSTransition } from "react-transition-group";
 import cx from "classnames";
 import { CSSTransitionProps } from "react-transition-group/CSSTransition";
+import AuthContext from "@/auth/AuthContext";
 
 const DropdownEntry: React.FunctionComponent<{
   caption: string;
@@ -90,6 +91,10 @@ const SidebarExpanded: React.FunctionComponent<
   collapseSidebar,
 }) => {
   const context = useContext(DevToolsContext);
+
+  const { flags } = useContext(AuthContext);
+  const showBetaExtensionPoints = flags.includes("page-editor-beta");
+
   const {
     port,
     tabState: { hasPermissions },
@@ -157,8 +162,9 @@ const SidebarExpanded: React.FunctionComponent<
               id="add-extension-point"
               className="mr-2"
             >
-              {sortBy([...ADAPTERS.values()], (x) => x.displayOrder).map(
-                (element) => (
+              {sortBy([...ADAPTERS.values()], (x) => x.displayOrder)
+                .filter((element) => showBetaExtensionPoints || !element.beta)
+                .map((element) => (
                   <DropdownEntry
                     key={element.elementType}
                     caption={element.label}
@@ -168,8 +174,7 @@ const SidebarExpanded: React.FunctionComponent<
                       addElement(element);
                     }}
                   />
-                )
-              )}
+                ))}
             </DropdownButton>
           </div>
           <button

--- a/src/devTools/editor/tabs/quickBar/QuickBarConfiguration.tsx
+++ b/src/devTools/editor/tabs/quickBar/QuickBarConfiguration.tsx
@@ -24,6 +24,7 @@ import MultiSelectWidget from "@/devTools/editor/fields/MultiSelectWidget";
 import { makeLockableFieldProps } from "@/devTools/editor/fields/makeLockableFieldProps";
 import { contextOptions } from "@/devTools/editor/tabs/contextMenu/ContextMenuConfiguration";
 import { DEFAULT_SHORTCUTS } from "@/devTools/editor/components/UrlMatchPatternWidget";
+import IconWidget from "@/components/fields/IconWidget";
 
 const matchPatternShortcuts = [
   { caption: "None", getPattern: async () => "" },
@@ -62,6 +63,13 @@ const QuickBarConfiguration: React.FC<{
     </FieldSection>
 
     <FieldSection title="Advanced">
+      <ConnectedFieldTemplate
+        name="extension.icon"
+        label="Icon"
+        as={IconWidget}
+        description="Icon to show in the menu"
+      />
+
       <ConnectedFieldTemplate
         name="extensionPoint.definition.targetMode"
         as="select"

--- a/src/devTools/editor/tabs/quickBar/QuickBarConfiguration.tsx
+++ b/src/devTools/editor/tabs/quickBar/QuickBarConfiguration.tsx
@@ -20,53 +20,25 @@ import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import { Card } from "react-bootstrap";
 import FieldSection from "@/devTools/editor/fields/FieldSection";
 import UrlMatchPatternField from "@/devTools/editor/fields/UrlMatchPatternField";
-import TemplateWidget, {
-  Snippet,
-} from "@/devTools/editor/fields/TemplateWidget";
 import MultiSelectWidget from "@/devTools/editor/fields/MultiSelectWidget";
 import { makeLockableFieldProps } from "@/devTools/editor/fields/makeLockableFieldProps";
+import { contextOptions } from "@/devTools/editor/tabs/contextMenu/ContextMenuConfiguration";
 import { DEFAULT_SHORTCUTS } from "@/devTools/editor/components/UrlMatchPatternWidget";
-
-const menuSnippets: Snippet[] = [{ label: "selected text", value: "%s" }];
-
-export const contextOptions = [
-  "page",
-  "all",
-  "frame",
-  "selection",
-  "link",
-  "editable",
-  "image",
-  "video",
-  "audio",
-].map((value) => ({
-  value,
-  label: value,
-}));
 
 const matchPatternShortcuts = [
   { caption: "None", getPattern: async () => "" },
   ...DEFAULT_SHORTCUTS,
 ];
 
-const ContextMenuConfiguration: React.FC<{
+const QuickBarConfiguration: React.FC<{
   isLocked: boolean;
 }> = ({ isLocked = false }) => (
   <Card>
     <FieldSection title="Configuration">
       <ConnectedFieldTemplate
         name="extension.title"
-        label="Title"
-        as={TemplateWidget}
-        rows={1}
-        snippets={menuSnippets}
-        description={
-          <span>
-            The context menu item caption. Use the <code>%s</code> placeholder
-            to have the browser dynamically insert the current selection in the
-            menu caption
-          </span>
-        }
+        label="Action Title"
+        description="Quick Bar action title"
       />
 
       <ConnectedFieldTemplate
@@ -75,9 +47,9 @@ const ContextMenuConfiguration: React.FC<{
         options={contextOptions}
         description={
           <span>
-            One or more contexts to include the context menu item. For example,
-            use the <code>selection</code> context to show the menu item when
-            right-clicking selected text.
+            One or more contexts to include the quick bar item. For example, use
+            the <code>selection</code> context to show the action item when text
+            is selected.
           </span>
         }
         {...makeLockableFieldProps("Contexts", isLocked)}
@@ -94,7 +66,7 @@ const ContextMenuConfiguration: React.FC<{
         name="extensionPoint.definition.targetMode"
         as="select"
         title="Target Mode"
-        blankValue="legacy"
+        blankValue="eventTarget"
         description={
           <p>
             Use&nbsp;<code>eventTarget</code> to pass the target of the
@@ -106,7 +78,6 @@ const ContextMenuConfiguration: React.FC<{
       >
         <option value="eventTarget">eventTarget</option>
         <option value="document">document</option>
-        <option value="legacy">legacy</option>
       </ConnectedFieldTemplate>
 
       <UrlMatchPatternField
@@ -126,4 +97,4 @@ const ContextMenuConfiguration: React.FC<{
   </Card>
 );
 
-export default ContextMenuConfiguration;
+export default QuickBarConfiguration;

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -82,7 +82,7 @@ function setActiveElement(event: MouseEvent): void {
   }
 }
 
-function guessSelectedElement(): HTMLElement | null {
+export function guessSelectedElement(): HTMLElement | null {
   const selection = document.getSelection();
   if (selection?.rangeCount) {
     const start = selection.getRangeAt(0).startContainer.parentNode;

--- a/src/extensionPoints/factory.ts
+++ b/src/extensionPoints/factory.ts
@@ -20,6 +20,7 @@ import { fromJS as deserializeMenuItem } from "@/extensionPoints/menuItemExtensi
 import { fromJS as deserializeTrigger } from "@/extensionPoints/triggerExtension";
 import { fromJS as deserializeContextMenu } from "@/extensionPoints/contextMenu";
 import { fromJS as deserializeActionPanel } from "@/extensionPoints/actionPanelExtension";
+import { fromJS as deserializeQuickBar } from "@/extensionPoints/quickBarExtension";
 import { IExtensionPoint } from "@/core";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 
@@ -29,6 +30,7 @@ const TYPE_MAP = {
   trigger: deserializeTrigger,
   contextMenu: deserializeContextMenu,
   actionPanel: deserializeActionPanel,
+  quickBar: deserializeQuickBar,
 };
 
 export function fromJS(config: ExtensionPointConfig): IExtensionPoint {

--- a/src/extensionPoints/quickBarExtension.ts
+++ b/src/extensionPoints/quickBarExtension.ts
@@ -1,0 +1,329 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { InitialValues, reducePipeline } from "@/runtime/reducePipeline";
+import { ExtensionPoint } from "@/types";
+import {
+  IBlock,
+  IExtensionPoint,
+  IReader,
+  ResolvedExtension,
+  Schema,
+} from "@/core";
+import { propertiesToSchema } from "@/validators/generic";
+import { Manifest, Menus, Permissions } from "webextension-polyfill";
+import {
+  ExtensionPointConfig,
+  ExtensionPointDefinition,
+} from "@/extensionPoints/types";
+import { castArray, cloneDeep, isEmpty } from "lodash";
+import { checkAvailable } from "@/blocks/available";
+import { reportError } from "@/telemetry/logging";
+import { notifyError } from "@/contentScript/notify";
+import { reportEvent } from "@/telemetry/events";
+import { selectEventData } from "@/telemetry/deployments";
+import { selectExtensionContext } from "@/extensionPoints/helpers";
+import { BusinessError, isErrorObject } from "@/errors";
+import { BlockConfig, BlockPipeline } from "@/blocks/types";
+import apiVersionOptions from "@/runtime/apiVersionOptions";
+import { blockList } from "@/blocks/util";
+import { mergeReaders } from "@/blocks/readers/readerUtils";
+import { makeServiceContext } from "@/services/serviceUtils";
+import { guessSelectedElement } from "@/extensionPoints/contextMenu";
+import { initQuickBarApp } from "@/components/quickBar/QuickBarApp";
+import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
+
+export type QuickBarTargetMode = "document" | "eventTarget";
+
+export type QuickBarConfig = {
+  // TODO: shortcut
+  // TODO: keywords
+  title: string;
+  action: BlockConfig | BlockPipeline;
+};
+
+export abstract class QuickBarExtensionPoint extends ExtensionPoint<QuickBarConfig> {
+  protected constructor(
+    id: string,
+    name: string,
+    description?: string,
+    icon = "faMousePointer"
+  ) {
+    super(id, name, description, icon);
+  }
+
+  public get syncInstall() {
+    return true;
+  }
+
+  abstract get targetMode(): QuickBarTargetMode;
+
+  abstract getBaseReader(): Promise<IReader>;
+
+  abstract readonly documentUrlPatterns: Manifest.MatchPattern[];
+
+  abstract readonly contexts: Menus.ContextType[];
+
+  inputSchema: Schema = propertiesToSchema(
+    {
+      title: {
+        type: "string",
+        description:
+          "The text to display in the item. When the context is selection, use %s within the string to show the selected text.",
+      },
+      action: {
+        oneOf: [
+          { $ref: "https://app.pixiebrix.com/schemas/effect#" },
+          {
+            type: "array",
+            items: { $ref: "https://app.pixiebrix.com/schemas/block#" },
+          },
+        ],
+      },
+    },
+    ["title", "action"]
+  );
+
+  async getBlocks(
+    extension: ResolvedExtension<QuickBarConfig>
+  ): Promise<IBlock[]> {
+    return blockList(extension.config.action);
+  }
+
+  uninstall(): void {
+    for (const extension of this.extensions) {
+      quickBarRegistry.remove(extension.id);
+    }
+  }
+
+  removeExtensions(): void {
+    // Don't need to do any cleanup since context menu registration is handled globally
+  }
+
+  async install(): Promise<boolean> {
+    initQuickBarApp();
+    const available = await this.isAvailable();
+    await this.registerExtensions();
+    return available;
+  }
+
+  async defaultReader(): Promise<IReader> {
+    return this.getBaseReader();
+  }
+
+  private async registerExtensions(): Promise<void> {
+    const results = await Promise.allSettled(
+      this.extensions.map(async (extension) => {
+        try {
+          await this.registerExtension(extension);
+        } catch (error) {
+          reportError(error, {
+            deploymentId: extension._deployment?.id,
+            extensionPointId: extension.extensionPointId,
+            extensionId: extension.id,
+          });
+          throw error;
+        }
+      })
+    );
+
+    const numErrors = results.filter((x) => x.status === "rejected").length;
+    if (numErrors > 0) {
+      notifyError(`An error occurred adding ${numErrors} context menu item(s)`);
+    }
+  }
+
+  decideReaderRoot(target: HTMLElement | Document): HTMLElement | Document {
+    switch (this.targetMode) {
+      case "eventTarget":
+        return target;
+      case "document":
+        return document;
+      default:
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
+        throw new BusinessError(`Unknown targetMode: ${this.targetMode}`);
+    }
+  }
+
+  decidePipelineRoot(target: HTMLElement | Document): HTMLElement | Document {
+    switch (this.targetMode) {
+      case "eventTarget":
+        return target;
+      case "document":
+        return document;
+      default:
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
+        throw new BusinessError(`Unknown targetMode: ${this.targetMode}`);
+    }
+  }
+
+  private async registerExtension(
+    extension: ResolvedExtension<QuickBarConfig>
+  ): Promise<void> {
+    const { title: name, action: actionConfig } = extension.config;
+
+    quickBarRegistry.add({
+      id: extension.id,
+      name,
+      perform: async () => {
+        reportEvent("HandleQuickBar", selectEventData(extension));
+
+        try {
+          const reader = await this.getBaseReader();
+          const serviceContext = await makeServiceContext(extension.services);
+
+          const targetElement = guessSelectedElement() ?? document;
+
+          const input = {
+            ...(await reader.read(this.decideReaderRoot(targetElement))),
+            // Add some additional data that people will generally want
+            documentUrl: document.location.href,
+          };
+
+          const initialValues: InitialValues = {
+            input,
+            root: this.decidePipelineRoot(targetElement),
+            serviceContext,
+            optionsArgs: extension.optionsArgs,
+          };
+
+          await reducePipeline(actionConfig, initialValues, {
+            logger: extensionLogger,
+            ...apiVersionOptions(extension.apiVersion),
+          });
+        } catch (error) {
+          if (isErrorObject(error)) {
+            reportError(error);
+            extensionLogger.error(error);
+          } else {
+            extensionLogger.warn(error as any);
+          }
+
+          throw error;
+        }
+      },
+    });
+
+    const extensionLogger = this.logger.childLogger(
+      selectExtensionContext(extension)
+    );
+
+    console.debug(
+      "Register context menu handler for: %s (%s)",
+      extension.id,
+      extension.label ?? "No Label",
+      {
+        extension,
+      }
+    );
+  }
+
+  async run(): Promise<void> {
+    if (this.extensions.length === 0) {
+      console.debug(
+        `contextMenu extension point ${this.id} has no installed extensions`
+      );
+      return;
+    }
+
+    await this.registerExtensions();
+  }
+}
+
+export type QuickBarDefaultOptions = {
+  title?: string;
+  [key: string]: string | string[];
+};
+
+export interface QuickBarDefinition extends ExtensionPointDefinition {
+  documentUrlPatterns?: Manifest.MatchPattern[];
+  contexts: Menus.ContextType[];
+  targetMode: QuickBarTargetMode;
+  defaultOptions?: QuickBarDefaultOptions;
+}
+
+class RemoteQuickBarExtensionPoint extends QuickBarExtensionPoint {
+  private readonly _definition: QuickBarDefinition;
+
+  public readonly permissions: Permissions.Permissions;
+
+  public readonly documentUrlPatterns: Manifest.MatchPattern[];
+
+  public readonly contexts: Menus.ContextType[];
+
+  public readonly rawConfig: ExtensionPointConfig<QuickBarDefinition>;
+
+  constructor(config: ExtensionPointConfig<QuickBarDefinition>) {
+    // `cloneDeep` to ensure we have an isolated copy (since proxies could get revoked)
+    const cloned = cloneDeep(config);
+    const { id, name, description, icon } = cloned.metadata;
+    super(id, name, description, icon);
+    this._definition = cloned.definition;
+    this.rawConfig = cloned;
+    const { isAvailable, documentUrlPatterns, contexts } = cloned.definition;
+    // If documentUrlPatterns not specified show everywhere
+    this.documentUrlPatterns = castArray(documentUrlPatterns ?? ["*://*/*"]);
+    this.contexts = castArray(contexts);
+    this.permissions = {
+      origins: isAvailable?.matchPatterns
+        ? castArray(isAvailable.matchPatterns)
+        : [],
+    };
+  }
+
+  get targetMode(): QuickBarTargetMode {
+    return this._definition.targetMode ?? "eventTarget";
+  }
+
+  async isAvailable(): Promise<boolean> {
+    if (
+      !isEmpty(this._definition.isAvailable) &&
+      (await checkAvailable(this._definition.isAvailable))
+    ) {
+      return true;
+    }
+
+    return checkAvailable({
+      matchPatterns: this._definition.documentUrlPatterns,
+    });
+  }
+
+  async getBaseReader() {
+    return mergeReaders(this._definition.reader);
+  }
+
+  public get defaultOptions(): {
+    title: string;
+    [key: string]: string | string[];
+  } {
+    return {
+      title: "PixieBrix",
+      ...this._definition.defaultOptions,
+    };
+  }
+}
+
+export function fromJS(
+  config: ExtensionPointConfig<QuickBarDefinition>
+): IExtensionPoint {
+  const { type } = config.definition;
+  if (type !== "quickBar") {
+    throw new Error(`Expected type=quickBar, got ${type}`);
+  }
+
+  return new RemoteQuickBarExtensionPoint(config);
+}

--- a/src/extensionPoints/quickBarExtension.ts
+++ b/src/extensionPoints/quickBarExtension.ts
@@ -23,6 +23,7 @@ import {
   IReader,
   ResolvedExtension,
   Schema,
+  UUID,
 } from "@/core";
 import { propertiesToSchema } from "@/validators/generic";
 import { Manifest, Menus, Permissions } from "webextension-polyfill";
@@ -110,8 +111,10 @@ export abstract class QuickBarExtensionPoint extends ExtensionPoint<QuickBarConf
     }
   }
 
-  removeExtensions(): void {
-    // Don't need to do any cleanup since context menu registration is handled globally
+  removeExtensions(extensionIds: UUID[]): void {
+    for (const extensionId of extensionIds) {
+      quickBarRegistry.remove(extensionId);
+    }
   }
 
   async install(): Promise<boolean> {
@@ -143,7 +146,7 @@ export abstract class QuickBarExtensionPoint extends ExtensionPoint<QuickBarConf
 
     const numErrors = results.filter((x) => x.status === "rejected").length;
     if (numErrors > 0) {
-      notifyError(`An error occurred adding ${numErrors} context menu item(s)`);
+      notifyError(`An error occurred adding ${numErrors} quick bar items(s)`);
     }
   }
 
@@ -223,7 +226,7 @@ export abstract class QuickBarExtensionPoint extends ExtensionPoint<QuickBarConf
     );
 
     console.debug(
-      "Register context menu handler for: %s (%s)",
+      "Register quick back action handler for: %s (%s)",
       extension.id,
       extension.label ?? "No Label",
       {

--- a/src/extensionPoints/quickBarExtension.tsx
+++ b/src/extensionPoints/quickBarExtension.tsx
@@ -15,10 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import React from "react";
 import { InitialValues, reducePipeline } from "@/runtime/reducePipeline";
 import { ExtensionPoint } from "@/types";
 import {
   IBlock,
+  IconConfig,
   IExtensionPoint,
   IReader,
   ResolvedExtension,
@@ -47,13 +49,18 @@ import { makeServiceContext } from "@/services/serviceUtils";
 import { guessSelectedElement } from "@/extensionPoints/contextMenu";
 import { initQuickBarApp } from "@/components/quickBar/QuickBarApp";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
+import Icon from "@/icons/Icon";
 
 export type QuickBarTargetMode = "document" | "eventTarget";
 
 export type QuickBarConfig = {
-  // TODO: shortcut
-  // TODO: keywords
   title: string;
+
+  /**
+   * (Optional) the icon to supply to the icon in the extension point template
+   */
+  icon?: IconConfig;
+
   action: BlockConfig | BlockPipeline;
 };
 
@@ -177,11 +184,20 @@ export abstract class QuickBarExtensionPoint extends ExtensionPoint<QuickBarConf
   private async registerExtension(
     extension: ResolvedExtension<QuickBarConfig>
   ): Promise<void> {
-    const { title: name, action: actionConfig } = extension.config;
+    const {
+      title: name,
+      action: actionConfig,
+      icon: iconConfig,
+    } = extension.config;
+
+    const icon = iconConfig ? (
+      <Icon icon={iconConfig.id} library={iconConfig.library} />
+    ) : undefined;
 
     quickBarRegistry.add({
       id: extension.id,
       name,
+      icon,
       perform: async () => {
         reportEvent("HandleQuickBar", selectEventData(extension));
 

--- a/src/extensionPoints/types.ts
+++ b/src/extensionPoints/types.ts
@@ -23,7 +23,8 @@ type ExtensionPointType =
   | "menuItem"
   | "trigger"
   | "contextMenu"
-  | "actionPanel";
+  | "actionPanel"
+  | "quickBar";
 
 export interface ExtensionPointDefinition {
   type: ExtensionPointType;

--- a/src/icons/Icon.tsx
+++ b/src/icons/Icon.tsx
@@ -20,15 +20,16 @@ import { useAsyncEffect } from "use-async-effect";
 import { IconLibrary } from "@/core";
 import getSvgIcon from "@/icons/getSvgIcon";
 
-const Icon: React.FunctionComponent<{ icon: string; library: IconLibrary }> = ({
-  icon,
-  library,
-}) => {
+const Icon: React.FunctionComponent<{
+  icon: string;
+  library: IconLibrary;
+  size?: number;
+}> = ({ icon, library, size = 16 }) => {
   const [svg, setSvg] = useState("");
 
   useAsyncEffect(
     async (isMounted) => {
-      const svg = await getSvgIcon({ id: icon, library, size: 16 });
+      const svg = await getSvgIcon({ id: icon, library, size });
       if (!isMounted()) {
         return;
       }


### PR DESCRIPTION
_Experimental quick bar POC_

See the issue for more context, but the basics are: 1) placing buttons is sometimes hard, 2) the ergonomics of context menus are bad

Is currently behind the "page-editor-beta" feature flag

![recording](https://user-images.githubusercontent.com/1879821/145493617-8ff11b22-5743-499b-95f3-ecb413acd44d.gif)

Not implemented yet / decisions:
- [ ] Fix z-index (shows behind content on LinkedIn)
- [ ] Use scss for CSS (need to put in shadow root? But it's displayed in a portal. So which part is wrapped in the portal? Might need to isolate in an iframe? E.g., on salesforce it just appears transparent. The downside of an iframe is load time
- [ ] Use Chrome short cut to trigger? Current approach registers when first dynamic extension is added to the quickbar.  If we do this, should support documentUrlPatterns instead of isAvailable since the extensions don't need to declare permissions for the page?
- [ ] Support subtitles, icons, keywords, etc. 
