### PR TITLE
Start using event pages as background

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -65,7 +65,8 @@
     }
   },
   "background": {
-    "scripts": ["grayIconWhileLoading.js", "vendors.js", "background.js"]
+    "scripts": ["grayIconWhileLoading.js", "vendors.js", "background.js"],
+    "persistent": false
   },
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
To prepare for MV3, we can already start using event pages. They're not service workers like MV3, but they are unloaded like them, thus exposing some issues we'll encounter with MV3. One such example is:

- https://github.com/fregante/content-scripts-register-polyfill/issues/48

This PR can't be merged yet, we definitely have bugs, but I opened it to possibly start a discussion around it and the possibility of merging it in the very near term.

I'll be testing this next week.