### PR TITLE
#1976: adjust behavior of pipeline and defer in mapargs

### DIFF
--- a/src/components/documentBuilder/DocumentBuilder.stories.tsx
+++ b/src/components/documentBuilder/DocumentBuilder.stories.tsx
@@ -29,6 +29,7 @@ import {
 import { ToastProvider } from "react-toast-notifications";
 import DocumentEditor from "./edit/DocumentEditor";
 import DocumentPreview from "./preview/DocumentPreview";
+import { action } from "@storybook/addon-actions";
 
 const schemaShape: yup.ObjectSchema = yup.object().shape({
   body: yup.array(yup.object()).required(),
@@ -41,7 +42,7 @@ const DocumentBuilder: React.FC = () => {
     <Formik
       validationSchema={schemaShape}
       initialValues={{ body: [] }}
-      onSubmit={console.log}
+      onSubmit={action("onSubmit")}
     >
       {({ handleSubmit }) => (
         <BootstrapForm noValidate onSubmit={handleSubmit}>

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -102,11 +102,11 @@ describe("When rendered in panel", () => {
     };
     const { container } = renderDocument(config);
 
-    const element = container.querySelector("span");
+    const element = container.querySelector("div");
 
     expect(element).not.toBeNull();
     expect(element).toHaveTextContent(
-      "Unknown type: TheTypeForWhichAComponentIsNotDefined"
+      "Unknown component type: TheTypeForWhichAComponentIsNotDefined"
     );
   });
 

--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -32,6 +32,7 @@ import useNotifications from "@/hooks/useNotifications";
 import documentTreeStyles from "./documentTree.module.scss";
 import cx from "classnames";
 import ListElement from "@/components/documentBuilder/render/ListElement";
+import { BusinessError } from "@/errors";
 
 const headerComponents = {
   header_1: "h1",
@@ -47,7 +48,9 @@ const gridComponents = {
 
 const UnknownType: React.FC<{ componentType: string }> = ({
   componentType,
-}) => <span>Unknown type: {componentType}</span>;
+}) => (
+  <div className="text-danger">Unknown component type: {componentType}</div>
+);
 
 export function getComponentDefinition(
   element: DocumentElement
@@ -102,10 +105,20 @@ export function getComponentDefinition(
     }
 
     case "pipeline": {
+      const { pipeline } = config;
+
+      if (typeof pipeline !== "undefined" && !isPipelineExpression(pipeline)) {
+        console.debug("Expected pipeline expression for pipeline", {
+          componentType: "pipeline",
+          config,
+        });
+        throw new BusinessError("Expected pipeline expression for pipeline");
+      }
+
       return {
         Component: BlockPipeline,
         props: {
-          pipeline: config.pipeline,
+          pipeline: pipeline.__value__,
         },
       };
     }
@@ -113,7 +126,11 @@ export function getComponentDefinition(
     case "button": {
       const { title, onClick, ...props } = config;
       if (typeof onClick !== "undefined" && !isPipelineExpression(onClick)) {
-        throw new Error("Expected pipeline expression for onClick");
+        console.debug("Expected pipeline expression for onClick", {
+          componentType: "button",
+          config,
+        });
+        throw new BusinessError("Expected pipeline expression for onClick");
       }
 
       return {
@@ -318,9 +335,9 @@ export function getPreviewComponentDefinition(
 export const buildDocumentBranch: BuildDocumentBranch = (root) => {
   const componentDefinition = getComponentDefinition(root);
   if (root.children?.length > 0) {
-    componentDefinition.props.children = root.children.map((child, i) => {
+    componentDefinition.props.children = root.children.map((child, index) => {
       const { Component, props } = buildDocumentBranch(child);
-      return <Component key={i} {...props} />;
+      return <Component key={index} {...props} />;
     });
   }
 

--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from "react";
-import BlockPipeline from "@/components/documentBuilder/render/BlockElement";
+import BlockElement from "@/components/documentBuilder/render/BlockElement";
 import { isExpression, isPipelineExpression } from "@/runtime/mapArgs";
 import { UnknownObject } from "@/types";
 import { get } from "lodash";
@@ -116,7 +116,7 @@ export function getComponentDefinition(
       }
 
       return {
-        Component: BlockPipeline,
+        Component: BlockElement,
         props: {
           pipeline: pipeline.__value__,
         },

--- a/src/components/documentBuilder/render/BlockElement.tsx
+++ b/src/components/documentBuilder/render/BlockElement.tsx
@@ -56,13 +56,6 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline }) => {
     });
   }, [pipeline]);
 
-  console.log("BlockElement", {
-    pipeline,
-    ctxt,
-    payload,
-    error,
-  });
-
   if (isLoading) {
     return <PanelBody payload={null} />;
   }

--- a/src/components/documentBuilder/render/BlockElement.tsx
+++ b/src/components/documentBuilder/render/BlockElement.tsx
@@ -20,7 +20,7 @@ import { BlockPipeline } from "@/blocks/types";
 import { useAsyncState } from "@/hooks/common";
 import { getErrorMessage } from "@/errors";
 import DocumentContext from "@/components/documentBuilder/render/DocumentContext";
-import { runMapArgs, runRendererPipeline } from "@/contentScript/messenger/api";
+import { runRendererPipeline } from "@/contentScript/messenger/api";
 import { whoAmI } from "@/background/messenger/api";
 import { uuidv4 } from "@/types/helpers";
 import PanelBody from "@/actionPanel/PanelBody";
@@ -43,25 +43,16 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline }) => {
     error,
   ] = useAsyncState<RendererPayload>(async () => {
     const me = await whoAmI();
-    const target = { tabId: me.tab.id, frameId: 0 };
-
-    const resolvedPipeline = (await runMapArgs(
-      target,
-      // TODO: pass runtime version via DocumentContext instead of hardcoding it
-      {
-        config: pipeline,
-        context: ctxt,
-        options: apiVersionOptions("v3"),
-      }
-    )) as BlockPipeline;
-
-    console.log({ resolvedPipeline });
 
     // We currently only support associating the sidebar with the content script in the top-level frame (frameId: 0)
+    const target = { tabId: me.tab.id, frameId: 0 };
+
     return runRendererPipeline(target, {
       nonce: uuidv4(),
       context: ctxt,
-      pipeline: resolvedPipeline,
+      pipeline,
+      // TODO: pass runtime version via DocumentContext instead of hard-coding it. This will break for v4+
+      options: apiVersionOptions("v3"),
     });
   }, [pipeline]);
 

--- a/src/components/documentBuilder/render/ButtonElement.tsx
+++ b/src/components/documentBuilder/render/ButtonElement.tsx
@@ -23,6 +23,7 @@ import { runEffectPipeline } from "@/contentScript/messenger/api";
 import { uuidv4 } from "@/types/helpers";
 import DocumentContext from "@/components/documentBuilder/render/DocumentContext";
 import { Except } from "type-fest";
+import apiVersionOptions from "@/runtime/apiVersionOptions";
 
 type ButtonElementProps = Except<AsyncButtonProps, "onClick"> & {
   onClick: BlockPipeline;
@@ -43,6 +44,8 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
         nonce: uuidv4(),
         context: context.options.ctxt,
         pipeline: onClick,
+        // TODO: pass runtime version via DocumentContext instead of hard-coding it. This will break for v4+
+        options: apiVersionOptions("v3"),
       }
     );
   }, [onClick, context]);

--- a/src/contentScript/pipelineProtocol.ts
+++ b/src/contentScript/pipelineProtocol.ts
@@ -9,11 +9,13 @@ import { RendererPayload } from "@/runtime/runtimeTypes";
 import { Args, mapArgs, MapOptions } from "@/runtime/mapArgs";
 import { Except } from "type-fest";
 import { UnknownObject } from "@/types";
+import { ApiVersionOptions } from "@/runtime/apiVersionOptions";
 
 type RunPipelineParams = {
   nonce: UUID;
   pipeline: BlockPipeline;
   context: BlockArgContext;
+  options: ApiVersionOptions;
 };
 
 /**
@@ -23,11 +25,13 @@ type RunPipelineParams = {
  * @param nonce a nonce to help the caller correlate requests/responses. (This shouldn't be necessary in practice though
  *  because the messaging framework takes care of the correlation. In this case we're just using it as a key on
  *  RendererPayload
+ * @param options pipeline options to pass to reducePipeline
  */
 export async function runRendererPipeline({
   pipeline,
   context,
   nonce,
+  options,
 }: RunPipelineParams): Promise<RendererPayload> {
   expectContext("contentScript");
 
@@ -49,6 +53,7 @@ export async function runRendererPipeline({
       {
         logger: new ConsoleLogger(),
         headless: true,
+        ...options,
       }
     );
   } catch (error) {
@@ -70,6 +75,7 @@ export async function runRendererPipeline({
 export async function runEffectPipeline({
   pipeline,
   context,
+  options,
 }: RunPipelineParams): Promise<void> {
   expectContext("contentScript");
 
@@ -88,6 +94,7 @@ export async function runEffectPipeline({
       serviceContext: context as ServiceContext,
     },
     {
+      ...options,
       logger: new ConsoleLogger(),
       headless: true,
     }

--- a/src/runtime/mapArgs.test.ts
+++ b/src/runtime/mapArgs.test.ts
@@ -114,7 +114,10 @@ describe("defer", () => {
     );
 
     expect(rendered).toEqual({
-      foo: config,
+      foo: {
+        __type__: "defer",
+        __value__: config,
+      },
       bar: { foo: 42 },
     });
   });
@@ -122,19 +125,21 @@ describe("defer", () => {
 
 describe("pipeline", () => {
   test("render !pipeline", async () => {
+    const expression = {
+      __type__: "pipeline",
+      __value__: [{ id: "@pixiebrix/confetti" }],
+    };
+
     const rendered = await renderExplicit(
       {
-        foo: {
-          __type__: "pipeline",
-          __value__: [{ id: "@pixiebrix/confetti" }],
-        },
+        foo: expression,
       },
       { array: ["bar"] },
       { autoescape: false }
     );
 
     expect(rendered).toEqual({
-      foo: [{ id: "@pixiebrix/confetti" }],
+      foo: expression,
     });
   });
 
@@ -164,7 +169,10 @@ describe("pipeline", () => {
     );
 
     expect(rendered).toEqual({
-      foo: [{ id: "@pixiebrix/confetti", config }],
+      foo: {
+        __type__: "pipeline",
+        __value__: [{ id: "@pixiebrix/confetti", config }],
+      },
       bar: { foo: 42 },
     });
   });

--- a/src/runtime/mapArgs.ts
+++ b/src/runtime/mapArgs.ts
@@ -96,7 +96,7 @@ export async function renderExplicit(
     return render(config.__value__, ctxt);
   }
 
-  if (isExpression(config) && ["pipeline", "defer"].includes(config.__type__)) {
+  if (isPipelineExpression(config) || isDeferExpression(config)) {
     // Pipeline and defer are not rendered. The brick that consumes the configuration is responsible for rendering
     // the value. We keep the expression type so that the brick has enough information to determine the expression type
     return config;

--- a/src/runtime/mapArgs.ts
+++ b/src/runtime/mapArgs.ts
@@ -55,10 +55,18 @@ export function isExpression(value: unknown): value is Expression<unknown> {
   return false;
 }
 
+export type PipelineExpression = Expression<BlockPipeline, "pipeline">;
+
 export function isPipelineExpression(
   value: unknown
-): value is Expression<BlockPipeline, "pipeline"> {
+): value is PipelineExpression {
   return isExpression(value) && value.__type__ === "pipeline";
+}
+
+export type DeferExpression = Expression<UnknownObject, "defer">;
+
+export function isDeferExpression(value: unknown): value is DeferExpression {
+  return isExpression(value) && value.__type__ === "defer";
 }
 
 /**
@@ -89,8 +97,9 @@ export async function renderExplicit(
   }
 
   if (isExpression(config) && ["pipeline", "defer"].includes(config.__type__)) {
-    // Pipelines are passed through directly
-    return config.__value__;
+    // Pipeline and defer are not rendered. The brick that consumes the configuration is responsible for rendering
+    // the value. We keep the expression type so that the brick has enough information to determine the expression type
+    return config;
   }
 
   // Array.isArray must come before the object check because arrays are objects

--- a/src/runtime/pipelineTests/deferExpression.test.ts
+++ b/src/runtime/pipelineTests/deferExpression.test.ts
@@ -34,7 +34,36 @@ beforeEach(() => {
 });
 
 describe("apiVersion: v3", () => {
-  test("run block with defer arg", async () => {
+  const deferred = {
+    __type__: "defer",
+    __value__: {
+      __type__: "mustache",
+      __value__: "{{ @element }} - {{ @input.value }}",
+    },
+  };
+
+  test("deferBlock renders top-level deferred block", async () => {
+    const pipeline = {
+      id: deferBlock.id,
+      config: {
+        array: [1, 2],
+        element: deferred,
+      },
+    };
+
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({ value: 42 }),
+      testOptions("v3")
+    );
+    expect(result).toStrictEqual([
+      // The deferBlock is set up to look for !defer expression as the top level expression
+      "1 - 42",
+      "2 - 42",
+    ]);
+  });
+
+  test("deferBlock only renders top-level deferred block", async () => {
     const pipeline = {
       id: deferBlock.id,
       config: {
@@ -44,24 +73,20 @@ describe("apiVersion: v3", () => {
             __type__: "mustache",
             __value__: "{{ @element }} - {{ @input.value }}",
           },
-          deferred: {
-            __type__: "defer",
-            __value__: {
-              __type__: "mustache",
-              __value__: "{{ @element }} - {{ @input.value }}",
-            },
-          },
+          deferred,
         },
       },
     };
+
     const result = await reducePipeline(
       pipeline,
       simpleInput({ value: 42 }),
       testOptions("v3")
     );
     expect(result).toStrictEqual([
-      { immediate: " - 42", deferred: "1 - 42" },
-      { immediate: " - 42", deferred: "2 - 42" },
+      // The deferBlock is set up to look for !defer expression as the top level expression
+      { immediate: " - 42", deferred },
+      { immediate: " - 42", deferred },
     ]);
   });
 });

--- a/src/runtime/pipelineTests/pipelineExpression.test.ts
+++ b/src/runtime/pipelineTests/pipelineExpression.test.ts
@@ -17,9 +17,14 @@
 
 import blockRegistry from "@/blocks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
-import { pipelineBlock, simpleInput, testOptions } from "./pipelineTestHelpers";
+import {
+  identityBlock,
+  pipelineBlock,
+  simpleInput,
+  testOptions,
+} from "./pipelineTestHelpers";
 
-// Mock the recordX trace methods. Otherwise they'll fail and Jest will have unhandledrejection errors since we call
+// Mock the recordX trace methods. Otherwise, they'll fail and Jest will have unhandledrejection errors since we call
 // them with `void` instead of awaiting them in the reducePipeline methods
 import * as logging from "@/background/logging";
 
@@ -30,7 +35,7 @@ jest.mock("@/background/trace");
 
 beforeEach(() => {
   blockRegistry.clear();
-  blockRegistry.register(pipelineBlock);
+  blockRegistry.register(pipelineBlock, identityBlock);
 });
 
 describe("apiVersion: v3", () => {
@@ -50,5 +55,28 @@ describe("apiVersion: v3", () => {
       testOptions("v3")
     );
     expect(result).toStrictEqual({ length: 1 });
+  });
+
+  test("keep pipeline expression", async () => {
+    const pipeline = {
+      id: identityBlock.id,
+      config: {
+        data: {
+          __type__: "pipeline",
+          __value__: [{ id: "@pixiebrix/confetti" }],
+        },
+      },
+    };
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      testOptions("v3")
+    );
+    expect(result).toStrictEqual({
+      data: {
+        __type__: "pipeline",
+        __value__: [{ id: "@pixiebrix/confetti" }],
+      },
+    });
   });
 });

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -1,12 +1,15 @@
 import ConsoleLogger from "@/tests/ConsoleLogger";
 import { Block, UnknownObject } from "@/types";
 import { propertiesToSchema } from "@/validators/generic";
-import { ApiVersion, BlockArg, BlockOptions } from "@/core";
+import { ApiVersion, BlockArg, BlockOptions, Schema } from "@/core";
 import { InitialValues } from "@/runtime/reducePipeline";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { BusinessError } from "@/errors";
-import { BlockPipeline } from "@/blocks/types";
-import { mapArgs } from "@/runtime/mapArgs";
+import {
+  isDeferExpression,
+  mapArgs,
+  PipelineExpression,
+} from "@/runtime/mapArgs";
 
 const logger = new ConsoleLogger();
 
@@ -96,14 +99,15 @@ class ArrayBlock extends Block {
   }
 }
 
-class PipelineBlock extends Block {
-  constructor() {
-    super("test/pipeline", "Pipeline Block");
-  }
-
-  inputSchema = propertiesToSchema({
-    // TODO: write a schema in schemas directory. The one in component.json is incomplete
-    pipeline: {
+// TODO: write a schema in schemas directory. The one in component.json is incomplete
+const pipelineSchema: Schema = {
+  type: "object",
+  properties: {
+    __type__: {
+      type: "string",
+      const: "pipeline",
+    },
+    __value__: {
       type: "array",
       items: {
         properties: {
@@ -117,11 +121,21 @@ class PipelineBlock extends Block {
         required: ["id"],
       },
     },
+  },
+};
+
+class PipelineBlock extends Block {
+  constructor() {
+    super("test/pipeline", "Pipeline Block");
+  }
+
+  inputSchema = propertiesToSchema({
+    pipeline: pipelineSchema,
   });
 
-  async run({ pipeline }: BlockArg<{ pipeline: BlockPipeline }>) {
+  async run({ pipeline }: BlockArg<{ pipeline: PipelineExpression }>) {
     return {
-      length: pipeline.length,
+      length: pipeline.__value__.length,
     };
   }
 }
@@ -169,9 +183,14 @@ class DeferBlock extends Block {
           ...ctxt,
           [`@${elementKey}`]: data,
         };
-        return mapArgs(element, elementContext, {
-          ...apiVersionOptions("v3"),
-        });
+
+        if (isDeferExpression(element)) {
+          return mapArgs(element.__value__, elementContext, {
+            ...apiVersionOptions("v3"),
+          });
+        }
+
+        return element;
       })
     );
   }


### PR DESCRIPTION
NOTE: this is a PR against feature/1976-doc-builder-pipeline

What does this PR do?
- Changes the behavior of mapArgs to keep the defer and pipeline expressions. (Previously is returned the value). We have to keep the expressions around so that a block that receives the value knows what kind of value it is. (In the pipeline case, it would just receive an array)
- Removes the mapArgs step from BlockElement. This was breaking the use of outputKeys in the embedded pipeline. (The reducePipeline call in runRendererPipeline already handles calling mapArgs.)