### PR TITLE
Document builder. Reset active element on changing a node

### DIFF
--- a/src/components/formBuilder/FormEditor.tsx
+++ b/src/components/formBuilder/FormEditor.tsx
@@ -74,13 +74,17 @@ const FormEditor: React.FC<FormEditorProps> = ({
   useEffect(
     () => {
       const firstInOrder = uiSchema?.[UI_ORDER]?.[0];
-      if (firstInOrder && firstInOrder !== "*") {
+      if (
+        firstInOrder &&
+        firstInOrder !== "*" &&
+        firstInOrder !== activeField
+      ) {
         setActiveField(firstInOrder);
         return;
       }
 
       const firstInProperties = Object.keys(schema?.properties || {})[0];
-      if (firstInProperties) {
+      if (firstInProperties && firstInProperties !== activeField) {
         setActiveField(firstInProperties);
       }
     },

--- a/src/devTools/editor/fields/DocumentOptions.tsx
+++ b/src/devTools/editor/fields/DocumentOptions.tsx
@@ -17,7 +17,6 @@
 
 import React, { useEffect } from "react";
 import { validateRegistryId } from "@/types/helpers";
-import { isPlainObject } from "lodash";
 import { joinName } from "@/utils";
 import { useField } from "formik";
 import DocumentEditor from "@/components/documentBuilder/DocumentEditor";
@@ -25,6 +24,7 @@ import useReduxState from "@/hooks/useReduxState";
 import { actions as documentBuilderActions } from "@/devTools/editor/slices/documentBuilderSlice";
 import documentBuilderSelectors from "@/devTools/editor/slices/documentBuilderSelectors";
 import { DocumentElement } from "@/components/documentBuilder/documentBuilderTypes";
+import ConfigErrorBoundary from "@/devTools/editor/fields/ConfigErrorBoundary";
 
 export const DOCUMENT_ID = validateRegistryId("@pixiebrix/document");
 
@@ -40,24 +40,27 @@ const DocumentOptions: React.FC<{
   const bodyName = joinName(name, configKey, "body");
   const [{ value }, , { setValue }] = useField<DocumentElement[]>(bodyName);
 
-  useEffect(() => {
-    setActiveElement(null);
-  }, []);
+  useEffect(
+    () => () => {
+      // Clean up selected element on destroy
+      setActiveElement(null);
+    },
+    [bodyName]
+  );
+
   useEffect(() => {
     if (!Array.isArray(value)) {
       setValue([]);
     }
   }, [value]);
 
-  if (isPlainObject(value)) {
-    return <div>Edit in the workshop</div>;
-  }
-
   return (
-    <DocumentEditor
-      activeElement={activeElement}
-      setActiveElement={setActiveElement}
-    />
+    <ConfigErrorBoundary>
+      <DocumentEditor
+        activeElement={activeElement}
+        setActiveElement={setActiveElement}
+      />
+    </ConfigErrorBoundary>
   );
 };
 

--- a/src/devTools/editor/fields/FormModalOptions.tsx
+++ b/src/devTools/editor/fields/FormModalOptions.tsx
@@ -17,7 +17,7 @@
 
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { Schema } from "@/core";
-import React from "react";
+import React, { useEffect } from "react";
 import { validateRegistryId } from "@/types/helpers";
 import { actions as formBuilderActions } from "@/devTools/editor/slices/formBuilderSlice";
 import formBuilderSelectors from "@/devTools/editor/slices/formBuilderSelectors";
@@ -56,6 +56,14 @@ const FormModalOptions: React.FC<{
   );
 
   const configName = `${name}.${configKey}`;
+
+  useEffect(
+    () => () => {
+      // Clean up selected field on destroy
+      setActiveField(null);
+    },
+    [configName]
+  );
 
   return (
     <div>

--- a/src/devTools/editor/fields/FormRendererOptions.tsx
+++ b/src/devTools/editor/fields/FormRendererOptions.tsx
@@ -17,7 +17,7 @@
 
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { Schema } from "@/core";
-import React from "react";
+import React, { useEffect } from "react";
 import { validateRegistryId } from "@/types/helpers";
 import FormEditor from "@/components/formBuilder/FormEditor";
 import { actions as elementWizardActions } from "@/devTools/editor/slices/formBuilderSlice";
@@ -42,6 +42,14 @@ const FormRendererOptions: React.FC<{
   );
 
   const configName = `${name}.${configKey}`;
+
+  useEffect(
+    () => () => {
+      // Clean up selected field on destroy
+      setActiveField(null);
+    },
+    [configName]
+  );
 
   return (
     <div>


### PR DESCRIPTION
Related to #1976 

Steps to reproduce an issue on Edit Page:
1. Select a Document Builder node
2. Select an element in Document Builder preview
3. Switch to a different node with Document Builder

Expected result: Document Builder for another node is shown.
Actual result: an error is thrown and displayed on the Edit Page.