### PR TITLE
#2165: Fix "SVG Marketplace Icons broken in brick selection modal"

### DIFF
--- a/src/components/BrickIcon.tsx
+++ b/src/components/BrickIcon.tsx
@@ -147,7 +147,12 @@ const BrickIcon: React.FunctionComponent<{
   const cssSize = `${sizeMultiplier}em`;
 
   return listing?.image ? (
-    <img width={cssSize} height={cssSize} src={listing.image.url} alt="Icon" />
+    // Don't use the `width`/`height` attributes because they don't work with `em`
+    <img
+      src={listing.image.url}
+      alt="Icon"
+      style={{ width: cssSize, height: cssSize }}
+    />
   ) : (
     <FontAwesomeIcon
       icon={listingFaIcon ?? getDefaultBrickIcon(brick, type)}


### PR DESCRIPTION
- Fixes #2165

<img width="182" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/146442175-e8a9fcf4-b857-43df-90cc-f351401d1096.png">
