### PR TITLE
Drop `readStorageWithMigration`

### DIFF
--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -19,11 +19,7 @@ import browser from "webextension-polyfill";
 import Cookies from "js-cookie";
 import { updateAuth as updateRollbarAuth } from "@/telemetry/rollbar";
 import { isEqual } from "lodash";
-import {
-  ManualStorageKey,
-  readStorageWithMigration,
-  setStorage,
-} from "@/chrome";
+import { ManualStorageKey, readStorage, setStorage } from "@/chrome";
 
 const STORAGE_EXTENSION_KEY = "extensionKey" as ManualStorageKey;
 
@@ -40,7 +36,7 @@ export interface AuthData extends UserData {
 }
 
 async function readAuthData(): Promise<AuthData | Partial<AuthData>> {
-  return readStorageWithMigration(STORAGE_EXTENSION_KEY, {});
+  return readStorage(STORAGE_EXTENSION_KEY, {});
 }
 
 export async function getExtensionToken(): Promise<string | undefined> {

--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -16,11 +16,7 @@
  */
 
 import axios, { AxiosResponse } from "axios";
-import {
-  ManualStorageKey,
-  readStorageWithMigration,
-  setStorage,
-} from "@/chrome";
+import { ManualStorageKey, readStorage, setStorage } from "@/chrome";
 import {
   IService,
   AuthData,
@@ -49,7 +45,7 @@ async function setCachedAuthData<TAuthData extends Partial<AuthData>>(
     "Only the background page can access oauth2 information"
   );
 
-  const current = await readStorageWithMigration<Record<UUID, TAuthData>>(
+  const current = await readStorage<Record<UUID, TAuthData>>(
     OAUTH2_STORAGE_KEY,
     {}
   );
@@ -67,7 +63,7 @@ export async function getCachedAuthData(
     "Only the background page can access oauth2 information"
   );
 
-  const current = await readStorageWithMigration<Record<UUID, AuthData>>(
+  const current = await readStorage<Record<UUID, AuthData>>(
     OAUTH2_STORAGE_KEY,
     {}
   );
@@ -83,7 +79,7 @@ export async function deleteCachedAuthData(serviceAuthId: UUID): Promise<void> {
     "Only the background page can access oauth2 information"
   );
 
-  const current = await readStorageWithMigration<Record<UUID, AuthData>>(
+  const current = await readStorage<Record<UUID, AuthData>>(
     OAUTH2_STORAGE_KEY,
     {}
   );

--- a/src/background/dataStore.ts
+++ b/src/background/dataStore.ts
@@ -15,21 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  ManualStorageKey,
-  readStorageWithMigration,
-  setStorage,
-} from "@/chrome";
+import { ManualStorageKey, readStorage, setStorage } from "@/chrome";
 import { JsonObject } from "type-fest";
 
 export const LOCAL_DATA_STORE = "LOCAL_DATA_STORE" as ManualStorageKey;
 export const KEY_PREFIX = "@@";
 
 export async function getRecord(primaryKey: string): Promise<unknown> {
-  const data = await readStorageWithMigration<Record<string, unknown>>(
-    LOCAL_DATA_STORE,
-    {}
-  );
+  const data = await readStorage<Record<string, unknown>>(LOCAL_DATA_STORE, {});
   return data[`${KEY_PREFIX}${primaryKey}`] ?? {};
 }
 
@@ -37,10 +30,7 @@ export async function setRecord(
   primaryKey: string,
   value: JsonObject
 ): Promise<void> {
-  const data = await readStorageWithMigration<Record<string, unknown>>(
-    LOCAL_DATA_STORE,
-    {}
-  );
+  const data = await readStorage<Record<string, unknown>>(LOCAL_DATA_STORE, {});
   data[`${KEY_PREFIX}${primaryKey}`] = value;
   await setStorage(LOCAL_DATA_STORE, data);
 }

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -25,11 +25,7 @@ import { DBSchema, openDB } from "idb/with-async-ittr";
 import { sortBy, isEmpty } from "lodash";
 import { _getDNT } from "@/background/telemetry";
 import { isContentScript } from "webext-detect-page";
-import {
-  ManualStorageKey,
-  readStorageWithMigration,
-  setStorage,
-} from "@/chrome";
+import { ManualStorageKey, readStorage, setStorage } from "@/chrome";
 import {
   hasBusinessRootCause,
   hasCancelRootCause,
@@ -332,7 +328,7 @@ export async function _getLoggingConfig(): Promise<LoggingConfig> {
     return _config;
   }
 
-  return readStorageWithMigration(LOG_CONFIG_STORAGE_KEY, {
+  return readStorage(LOG_CONFIG_STORAGE_KEY, {
     logValues: false,
   });
 }

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -119,38 +119,6 @@ export class RuntimeNotFoundError extends Error {
   }
 }
 
-/**
- * Read from `browser.storage.local`, updating the value to be stored as an object instead of a JSON-stringified value
- *
- * WARNING: this method will convert string numbers, e.g., "42" to the the corresponding number. So this method is
- * not safe to use with storage holding primitive user-defined data.
- *
- * @deprecated Use `readStorage` instead
- * @see readStorage
- */
-export async function readStorageWithMigration<T = unknown>(
-  storageKey: ManualStorageKey,
-  defaultValue: T
-): Promise<T | undefined> {
-  const storedValue = await readStorage<T>(storageKey, defaultValue);
-  if (typeof storedValue !== "string") {
-    // No migration necessary
-    return storedValue;
-  }
-
-  let parsedValue: T;
-
-  try {
-    parsedValue = JSON.parse(storedValue) as T;
-    await browser.storage.local.set({ [storageKey]: parsedValue });
-  } catch {
-    // If it's not a valid JSON-string we must be working with a value that's already been migrated
-    parsedValue = storedValue;
-  }
-
-  return parsedValue;
-}
-
 export async function readStorage<T = unknown>(
   storageKey: ManualStorageKey,
   defaultValue?: T


### PR DESCRIPTION
We added this migration 3+ months ago:

- https://github.com/pixiebrix/pixiebrix-extension/pull/1192

Is it time to drop it or is it too soon?