### PR TITLE
#2175: fix panel input

### DIFF
--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -263,7 +263,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
   }
 
   private async runExtension(
-    readerContext: ReaderOutput,
+    readerOutput: ReaderOutput,
     extension: ResolvedExtension<PanelConfig>
   ) {
     if (this.uninstalled) {
@@ -306,7 +306,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
     }
 
     const serviceContext = await makeServiceContext(extension.services);
-    const extensionContext = { ...readerContext, ...serviceContext };
+    const extensionContext = { ...readerOutput, ...serviceContext };
 
     const $panel = $(
       Mustache.render(this.getTemplate(), {
@@ -375,7 +375,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
         isBodyInstalled = true;
 
         const initialValues: InitialValues = {
-          input: extension.optionsArgs,
+          input: readerOutput,
           optionsArgs: extension.optionsArgs,
           serviceContext,
           root: document,

--- a/src/runtime/pipelineTests/component.test.ts
+++ b/src/runtime/pipelineTests/component.test.ts
@@ -40,31 +40,59 @@ beforeEach(() => {
   blockRegistry.register(echoBlock, contextBlock);
 });
 
-describe("component block", () => {
-  test("component block uses own declared runtime within the brick", async () => {
-    const componentBlock = fromJS({
-      apiVersion: "v1",
-      kind: "component",
-      metadata: {
-        id: "test/component",
-        name: "Component Block",
-        version: "1.0.0",
-        description: "Component block using v1 runtime",
-      },
-      inputSchema: {
-        message: {
-          type: "string",
-        },
-      },
-      pipeline: [
-        {
-          id: echoBlock.id,
-          // Implicit application of mustache template referencing input without @input
-          config: { message: "{{message}}" },
-        },
-      ],
-    });
+const componentBlock = fromJS({
+  apiVersion: "v1",
+  kind: "component",
+  metadata: {
+    id: "test/component",
+    name: "Component Block",
+    version: "1.0.0",
+    description: "Component block using v1 runtime",
+  },
+  inputSchema: {
+    message: {
+      type: "string",
+    },
+  },
+  pipeline: [
+    {
+      id: echoBlock.id,
+      // Implicit application of mustache template referencing input without @input
+      config: { message: "{{message}}" },
+    },
+  ],
+});
 
+describe("component block v1", () => {
+  test("v2 pipeline calling v1 block", async () => {
+    blockRegistry.register(componentBlock);
+
+    const pipeline = [
+      {
+        id: "test/component",
+        outputKey: "first",
+        config: {
+          message: "@input.inputArg",
+        },
+      },
+      {
+        id: echoBlock.id,
+        config: {
+          message: "{{@first.message}}",
+        },
+      },
+    ] as BlockPipeline;
+
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({ inputArg: "hello" }),
+      testOptions("v2")
+    );
+
+    expect(result).toStrictEqual({ message: "hello" });
+  });
+
+  test("v3 pipeline calling v1 block", async () => {
     blockRegistry.register(componentBlock);
 
     const pipeline = [


### PR DESCRIPTION
Closes #2175 

Fixed bug where options were being passed as input to the extension and reader output wasn't being passed at all

TODO:
- [x] Double-check the other extensions
- [ ] Investigate the issue Sam was seeing with services (which wasn't related to this bug, though they have the same symptom)