### PR TITLE
Add ability to reload the whole extension in the `ErrorBoundary`

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -70,6 +70,7 @@ class ErrorBoundary extends Component<Props, State> {
                 if (event.altKey) {
                   chrome.runtime.reload();
                 }
+
                 location.reload();
               }}
             >

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -66,7 +66,10 @@ class ErrorBoundary extends Component<Props, State> {
           </div>
           <div>
             <Button
-              onClick={() => {
+              onClick={(event) => {
+                if (event.altKey) {
+                  chrome.runtime.reload();
+                }
                 location.reload();
               }}
             >


### PR DESCRIPTION
Not yet tested, but sometimes when the background page fails to reload correctly I get this message and it won't go away until I refresh the extension.

Related:

- #1317 