### PR TITLE
Adjust sidebar sizing and spacing

### DIFF
--- a/src/action.html
+++ b/src/action.html
@@ -23,7 +23,7 @@
     <link rel="stylesheet" href="action.css" />
   </head>
   <body>
-    <div id="container">
+    <div id="container" class="full-height">
       <div class="action-sidebar-loader">
         <div>Loading PixieBrix&nbsp;&nbsp;🚀</div>
       </div>

--- a/src/action.scss
+++ b/src/action.scss
@@ -15,30 +15,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-html {
-  font-size: 16px;
-  max-height: 100vh;
-  height: 100vh;
-}
-
-body {
-  margin: 0;
-  padding: 0;
-  height: 100vh;
-  max-height: 100vh;
-  overflow-y: hidden;
-}
-
 #container {
-  height: 100%;
-  width: 100%;
+  height: 100vh;
+}
 
-  .action-sidebar-loader {
-    width: 100%;
-    margin-top: 60px;
-    display: flex;
-    justify-content: center;
-  }
+.tab-content {
+  border: none;
+}
+
+.action-sidebar-loader {
+  width: 100%;
+  margin-top: 60px;
+  display: flex;
+  justify-content: center;
 }
 
 .action-panel-button {
@@ -48,4 +37,27 @@ body {
     color: #4d4b8b;
     background-color: #d1c2d7;
   }
+}
+
+.center-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.full-height {
+  display: flex;
+  flex-direction: column;
+  & > :last-child {
+    flex-grow: 1;
+  }
+
+  .scrollable-area {
+    height: 0;
+    overflow-y: auto;
+  }
+}
+
+.tab-content > .active.full-height {
+  display: flex; /* Overrides Bootstrap’s "block"*/
 }

--- a/src/actionPanel/ActionPanelApp.tsx
+++ b/src/actionPanel/ActionPanelApp.tsx
@@ -78,8 +78,8 @@ const ActionPanelApp: React.FunctionComponent = () => {
     <Provider store={store}>
       <PersistGate loading={<GridLoader />} persistor={persistor}>
         <ToastProvider>
-          <div className="d-flex flex-column" style={{ height: "100vh" }}>
-            <div className="d-flex flex-row mb-2 p-2 justify-content-between align-content-center">
+          <div className="full-height">
+            <div className="d-flex p-2 justify-content-between align-content-center">
               <Button
                 className="action-panel-button"
                 onClick={async () => {
@@ -112,7 +112,7 @@ const ActionPanelApp: React.FunctionComponent = () => {
               </Button>
             </div>
 
-            <div className="mt-2" style={{ minHeight: 1, flex: "1 1 auto" }}>
+            <div className="full-height">
               {state.panels?.length || state.forms?.length ? (
                 <ActionPanelTabs
                   {...state}

--- a/src/actionPanel/ActionPanelTabs.tsx
+++ b/src/actionPanel/ActionPanelTabs.tsx
@@ -71,7 +71,7 @@ const ActionPanelTabs: React.FunctionComponent<ActionPanelTabsProps> = ({
       defaultActiveKey={activeKey}
       activeKey={activeKey}
     >
-      <Card className="h-100">
+      <Card>
         <Card.Header>
           <Nav variant="tabs" onSelect={onSelect}>
             {panels.map((panel) => (
@@ -92,14 +92,13 @@ const ActionPanelTabs: React.FunctionComponent<ActionPanelTabsProps> = ({
             ))}
           </Nav>
         </Card.Header>
-        <Card.Body className="p-0 flex-grow-1" style={{ overflowY: "auto" }}>
-          <Tab.Content className="p-0 h-100">
+        <Card.Body className="p-0 scrollable-area full-height">
+          <Tab.Content className="p-0 full-height">
             {panels.map((panel: PanelEntry) => (
               <Tab.Pane
-                className="h-100"
+                className="full-height"
                 key={panel.extensionId}
                 eventKey={mapTabEventKey("panel", panel)}
-                style={{ minHeight: "1px" }}
               >
                 <ErrorBoundary>
                   <PanelBody payload={panel.payload} />
@@ -108,10 +107,9 @@ const ActionPanelTabs: React.FunctionComponent<ActionPanelTabsProps> = ({
             ))}
             {forms.map((form) => (
               <Tab.Pane
-                className="h-100"
+                className="full-height"
                 key={form.nonce}
                 eventKey={mapTabEventKey("form", form)}
-                style={{ minHeight: "1px" }}
               >
                 <ErrorBoundary>
                   <FormBody form={form} />

--- a/src/actionPanel/ActionPanelTabs.tsx
+++ b/src/actionPanel/ActionPanelTabs.tsx
@@ -96,7 +96,7 @@ const ActionPanelTabs: React.FunctionComponent<ActionPanelTabsProps> = ({
           <Tab.Content className="p-0 full-height">
             {panels.map((panel: PanelEntry) => (
               <Tab.Pane
-                className="full-height"
+                className="full-height flex-grow"
                 key={panel.extensionId}
                 eventKey={mapTabEventKey("panel", panel)}
               >
@@ -107,7 +107,7 @@ const ActionPanelTabs: React.FunctionComponent<ActionPanelTabsProps> = ({
             ))}
             {forms.map((form) => (
               <Tab.Pane
-                className="full-height"
+                className="full-height flex-grow"
                 key={form.nonce}
                 eventKey={mapTabEventKey("form", form)}
               >

--- a/src/actionPanel/PanelBody.tsx
+++ b/src/actionPanel/PanelBody.tsx
@@ -51,7 +51,7 @@ const PanelBody: React.FunctionComponent<{ payload: PanelPayload }> = ({
       logger: new ConsoleLogger({ blockId }),
     });
     return (
-      <div className="h-100" data-block-id={blockId}>
+      <div className="full-height" data-block-id={blockId}>
         <ReactShadowRoot>
           <RendererComponent body={body as RendererOutput} />
         </ReactShadowRoot>

--- a/src/blocks/renderers/customForm.tsx
+++ b/src/blocks/renderers/customForm.tsx
@@ -33,7 +33,7 @@ const CustomFormComponent: React.FunctionComponent<{
   formData: JsonObject;
   onSubmit: (values: JsonObject) => Promise<void>;
 }> = ({ schema, uiSchema, formData, onSubmit }) => (
-  <div className="CustomForm">
+  <div className="CustomForm p-3">
     <BootstrapStylesheet />
     <link rel="stylesheet" href={custom} />
     <JsonSchemaForm

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -324,6 +324,6 @@ config:
       `[data-block-id="${blockId}"]`
     );
     expect(blockContainer).not.toBeNull();
-    expect(blockContainer).toHaveClass("h-100");
+    expect(blockContainer).toHaveClass("full-height");
   }
 });


### PR DESCRIPTION
Should fix:

- https://www.loom.com/share/fccdd5c9e6d448bbaa1606bfc6929da7

I can't replicate that issue because it probably depends on the content, but this PR revisits the usage of `height: 100%` (i.e. drops most of it) and just lets flexbox takes care of "filling the container".

I think the pattern I found is simple and flexible:

1. Sets 100vh only on the page container
2. Set `full-height` on every child just like you would with `h-100`
3. If `full-height` has multiple children, only the last one fills the frame
	- This automatically supports fixed-height headers
3. If you want an area to scroll, use `scrollable-area`

Also this PR resolves several other visual issues I found in the sidebar, mainly around spacing (or lack thereof) and extra borders.

Related:

- https://github.com/pixiebrix/pixiebrix-extension/issues/1234


## Before

<img width="432" alt="Screen Shot 16" src="https://user-images.githubusercontent.com/1402241/146640946-cccee123-3376-45f4-8b36-1104b1fff446.png">

## After

<img width="431" alt="Screen Shot 15" src="https://user-images.githubusercontent.com/1402241/146640954-bd747e3c-5404-418d-be72-f067b8454e3d.png">

