### PR TITLE
Listen to navigation events from dev tools (instead of the background)

### DIFF
--- a/src/background/devtools/contract.ts
+++ b/src/background/devtools/contract.ts
@@ -30,27 +30,13 @@ export type PromiseHandler = [
   (value: unknown) => void
 ];
 
-export type BackgroundEventType =
-  | "HistoryStateUpdate"
-  | "DOMContentLoaded"
-  | "ContentScriptReady";
+export type BackgroundEventType = "HistoryStateUpdate";
 
-export type BackgroundEvent =
-  | {
-      type: "HistoryStateUpdate";
-      meta: Meta;
-      payload: WebNavigation.OnHistoryStateUpdatedDetailsType;
-    }
-  | {
-      type: "DOMContentLoaded";
-      meta: Meta;
-      payload: WebNavigation.OnDOMContentLoadedDetailsType;
-    }
-  | {
-      type: "ContentScriptReady";
-      meta: Meta;
-      payload: { frameId: number; tabId: TabId };
-    };
+export type BackgroundEvent = {
+  type: "HistoryStateUpdate";
+  meta: Meta;
+  payload: WebNavigation.OnHistoryStateUpdatedDetailsType;
+};
 
 export interface BackgroundResponse {
   type: string;

--- a/src/background/devtools/external.ts
+++ b/src/background/devtools/external.ts
@@ -26,7 +26,6 @@ import {
   BackgroundResponse,
   Nonce,
   PromiseHandler,
-  TabId,
 } from "@/background/devtools/contract";
 import browser, { Runtime, WebNavigation } from "webextension-polyfill";
 import { uuidv4 } from "@/types/helpers";
@@ -36,24 +35,14 @@ import { getErrorMessage } from "@/errors";
 
 const devtoolsHandlers = new Map<Nonce, PromiseHandler>();
 
-type NavigationDetails = WebNavigation.OnHistoryStateUpdatedDetailsType &
-  WebNavigation.OnDOMContentLoadedDetailsType;
+type NavigationDetails = WebNavigation.OnHistoryStateUpdatedDetailsType;
 
 export const navigationEvent = new SimpleEvent<NavigationDetails>();
-export const contentScriptReady = new SimpleEvent<{
-  tabId: TabId;
-  frameId: number;
-}>();
 
 function devtoolsEventListener(event: BackgroundEvent) {
   console.debug(`devtools port message: ${event.type}`, event);
-  if (
-    event.type === "DOMContentLoaded" ||
-    event.type === "HistoryStateUpdate"
-  ) {
-    navigationEvent.emit(event.payload.tabId, event.payload);
-  } else if (event.type === "ContentScriptReady") {
-    contentScriptReady.emit(event.payload.tabId, event.payload);
+  if (event.type === "HistoryStateUpdate") {
+    navigationEvent.emit(event.payload.tabId);
   }
 }
 

--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -317,13 +317,7 @@ export function emitDevtools(
 if (isBackground()) {
   console.debug("Adding devtools connection listener");
   browser.runtime.onConnect.addListener(connectDevtools);
-
-  browser.webNavigation.onHistoryStateUpdated.addListener((details) => {
-    emitDevtools("HistoryStateUpdate", details);
-  });
-
   browser.webNavigation.onDOMContentLoaded.addListener((details) => {
-    emitDevtools("DOMContentLoaded", details);
     void attemptTemporaryAccess(details);
   });
 }

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -18,7 +18,6 @@
 
 import { RunBlock } from "@/contentScript/executor";
 import browser, { Runtime, Tabs } from "webextension-polyfill";
-import { emitDevtools } from "@/background/devtools/internal";
 import { Availability } from "@/blocks/types";
 import { BusinessError } from "@/errors";
 import { expectContext } from "@/utils/expectContext";
@@ -232,7 +231,6 @@ export async function markTabAsReady(this: MessengerMeta) {
   }
 
   tabReady[tabId][frameId] = true;
-  emitDevtools("ContentScriptReady", { tabId, frameId });
 }
 
 async function linkTabListener(tab: Tabs.Tab): Promise<void> {

--- a/src/devTools/protocol.ts
+++ b/src/devTools/protocol.ts
@@ -18,7 +18,10 @@
 import browser, { Runtime } from "webextension-polyfill";
 import { registerPort } from "@/background/devtools";
 import { PORT_NAME } from "@/background/devtools/contract";
-import { installPortListeners } from "@/background/devtools/external";
+import {
+  installPortListeners,
+  navigationEvent,
+} from "@/background/devtools/external";
 import { runtimeConnect } from "@/chrome";
 
 let _cachedPort: Runtime.Port | null = null;
@@ -57,4 +60,13 @@ export async function connectDevtools(): Promise<Runtime.Port> {
 
   _cachedPort = port;
   return port;
+}
+
+function onNavigation(): void {
+  navigationEvent.emit(browser.devtools.inspectedWindow.tabId);
+}
+
+export function watchNavigation(): void {
+  browser.webNavigation.onHistoryStateUpdated.addListener(onNavigation);
+  browser.webNavigation.onDOMContentLoaded.addListener(onNavigation);
 }

--- a/src/devTools/protocol.ts
+++ b/src/devTools/protocol.ts
@@ -80,4 +80,13 @@ function onNavigation(
 export function watchNavigation(): void {
   browser.webNavigation.onHistoryStateUpdated.addListener(onNavigation);
   browser.webNavigation.onDOMContentLoaded.addListener(onNavigation);
+
+  if (process.env.DEBUG)
+    browser.webNavigation.onTabReplaced.addListener(
+      ({ replacedTabId, tabId }) => {
+        console.warn(
+          `The tab ID was updated by the browser from ${replacedTabId} to ${tabId}. Did this cause any issues? https://stackoverflow.com/q/17756258/288906`
+        );
+      }
+    );
 }

--- a/src/devTools/protocol.ts
+++ b/src/devTools/protocol.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import browser, { Runtime } from "webextension-polyfill";
+import browser, { Runtime, WebNavigation } from "webextension-polyfill";
 import { registerPort } from "@/background/devtools";
 import { PORT_NAME } from "@/background/devtools/contract";
 import {
@@ -62,8 +62,14 @@ export async function connectDevtools(): Promise<Runtime.Port> {
   return port;
 }
 
-function onNavigation(): void {
-  navigationEvent.emit(browser.devtools.inspectedWindow.tabId);
+function onNavigation(
+  details:
+    | WebNavigation.OnHistoryStateUpdatedDetailsType
+    | WebNavigation.OnDOMContentLoadedDetailsType
+): void {
+  if (details.tabId === browser.devtools.inspectedWindow.tabId) {
+    navigationEvent.emit(browser.devtools.inspectedWindow.tabId);
+  }
 }
 
 export function watchNavigation(): void {

--- a/src/devTools/protocol.ts
+++ b/src/devTools/protocol.ts
@@ -24,6 +24,8 @@ import {
 } from "@/background/devtools/external";
 import { runtimeConnect } from "@/chrome";
 
+const TOP_LEVEL_FRAME_ID = 0;
+
 let _cachedPort: Runtime.Port | null = null;
 
 export async function connectDevtools(): Promise<Runtime.Port> {
@@ -67,7 +69,10 @@ function onNavigation(
     | WebNavigation.OnHistoryStateUpdatedDetailsType
     | WebNavigation.OnDOMContentLoadedDetailsType
 ): void {
-  if (details.tabId === browser.devtools.inspectedWindow.tabId) {
+  if (
+    details.frameId === TOP_LEVEL_FRAME_ID &&
+    details.tabId === browser.devtools.inspectedWindow.tabId
+  ) {
     navigationEvent.emit(browser.devtools.inspectedWindow.tabId);
   }
 }

--- a/src/devtoolsPanel.tsx
+++ b/src/devtoolsPanel.tsx
@@ -26,8 +26,10 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import "@/vendors/overrides.scss";
 import "@/devTools/Panel.scss";
 
+import { watchNavigation } from "@/devTools/protocol";
 import initGoogle from "@/contrib/google/initGoogle";
 
 initGoogle();
+watchNavigation();
 
 ReactDOM.render(<Panel />, document.querySelector("#container"));

--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -45,7 +45,7 @@ export class SimpleEvent<TValue> implements TabEvent<TValue> {
     }
   }
 
-  emit(tabId: number, value: TValue): void {
+  emit(tabId: number, value?: TValue): void {
     for (const listener of this.listeners.get(tabId) ?? []) {
       listener(value);
     }


### PR DESCRIPTION
## Context

- I'm porting the last pieces of the dev tools to the messenger
- These listeners don't need to be in the background page at all
- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/1277


## Demo

The video shows:

1. Start with host with permissions
2. Change to host without permissions
3. Detect `activeTab` permission (unchanged)

https://user-images.githubusercontent.com/1402241/146656035-fbe6b926-4513-4c36-9dde-438b2aae8844.mov


