### PR TITLE
Drop port connection and data viewer panel from `devtools.html`

### DIFF
--- a/src/devtools.html
+++ b/src/devtools.html
@@ -15,12 +15,5 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-  </head>
-  <body>
-    <script src="vendors.js"></script>
-    <script src="devtools.js"></script>
-  </body>
-</html>
+<meta charset="utf-8" />
+<script src="devtools.js"></script>

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -63,10 +63,6 @@ const connectSidebarPane = once(async () => {
 
 if (browser.devtools.inspectedWindow.tabId) {
   // Add panel and sidebar as early as possible so they appear quickly
-  void browser.devtools.panels.create(
-    "PixieBrix",
-    "",
-    `devtoolsPanel.html?tabId=${browser.devtools.inspectedWindow.tabId}`
-  );
+  void browser.devtools.panels.create("PixieBrix", "", "devtoolsPanel.html");
   void connectSidebarPane();
 }

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -15,54 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// This context does not import rollbar because it only creates the devtool tab.
-// If it ends up becoming more complex, import "@/telemetry/reportUncaughtErrors"
-import browser from "webextension-polyfill";
-import { updateSelectedElement } from "@/devTools/getSelectedElement";
-import { once } from "lodash";
-import { serializeError } from "serialize-error";
-import { readSelected } from "@/contentScript/messenger/api";
-
-const { onSelectionChanged } = browser.devtools.panels.elements;
-
-async function updateElementProperties(): Promise<void> {
-  // This call is instant because sidebar and port has connected earlier
-  const sidebar = await connectSidebarPane();
-  void sidebar.setObject({ state: "loading..." });
-  try {
-    await updateSelectedElement();
-    await sidebar.setObject(
-      await readSelected({ tabId: browser.devtools.inspectedWindow.tabId })
-    );
-  } catch (error) {
-    await sidebar.setObject({ error: serializeError(error) });
-  }
-}
-
-function onSidebarShow() {
-  onSelectionChanged.addListener(updateElementProperties);
-  void updateElementProperties();
-}
-
-function onSidebarHide() {
-  onSelectionChanged.removeListener(updateElementProperties);
-}
-
-// This only ever needs to run once per devtools load. Sidebar and port will be constant throughout
-const connectSidebarPane = once(async () => {
-  const sidebar = await browser.devtools.panels.elements.createSidebarPane(
-    "PixieBrix Data Viewer"
-  );
-
-  sidebar.onShown.addListener(onSidebarShow);
-  sidebar.onHidden.addListener(onSidebarHide);
-
-  console.debug("DevTools sidebar ready");
-  return sidebar;
-});
-
-if (browser.devtools.inspectedWindow.tabId) {
-  // Add panel and sidebar as early as possible so they appear quickly
-  void browser.devtools.panels.create("PixieBrix", "", "devtoolsPanel.html");
-  void connectSidebarPane();
+if (chrome.devtools.inspectedWindow.tabId) {
+  chrome.devtools.panels.create("PixieBrix", "", "devtoolsPanel.html");
 }

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -15,26 +15,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// https://developer.chrome.com/extensions/devtools
-
-import "@/telemetry/reportUncaughtErrors";
+// This context does not import rollbar because it only creates the devtool tab.
+// If it ends up becoming more complex, import "@/telemetry/reportUncaughtErrors"
 import browser from "webextension-polyfill";
-import { connectDevtools } from "@/devTools/protocol";
 import { updateSelectedElement } from "@/devTools/getSelectedElement";
 import { once } from "lodash";
 import { serializeError } from "serialize-error";
 import { readSelected } from "@/contentScript/messenger/api";
-import { thisTab } from "@/devTools/utils";
 
 const { onSelectionChanged } = browser.devtools.panels.elements;
 
 async function updateElementProperties(): Promise<void> {
   // This call is instant because sidebar and port has connected earlier
-  const { sidebar } = await connectSidebarPane();
+  const sidebar = await connectSidebarPane();
   void sidebar.setObject({ state: "loading..." });
   try {
     await updateSelectedElement();
-    await sidebar.setObject(await readSelected(thisTab));
+    await sidebar.setObject(
+      await readSelected({ tabId: browser.devtools.inspectedWindow.tabId })
+    );
   } catch (error) {
     await sidebar.setObject({ error: serializeError(error) });
   }
@@ -51,20 +50,23 @@ function onSidebarHide() {
 
 // This only ever needs to run once per devtools load. Sidebar and port will be constant throughout
 const connectSidebarPane = once(async () => {
-  const [sidebar, port] = await Promise.all([
-    browser.devtools.panels.elements.createSidebarPane("PixieBrix Data Viewer"),
-    connectDevtools(),
-  ]);
+  const sidebar = await browser.devtools.panels.elements.createSidebarPane(
+    "PixieBrix Data Viewer"
+  );
 
   sidebar.onShown.addListener(onSidebarShow);
   sidebar.onHidden.addListener(onSidebarHide);
 
   console.debug("DevTools sidebar ready");
-  return { sidebar, port };
+  return sidebar;
 });
 
 if (browser.devtools.inspectedWindow.tabId) {
   // Add panel and sidebar as early as possible so they appear quickly
-  void browser.devtools.panels.create("PixieBrix", "", "devtoolsPanel.html");
+  void browser.devtools.panels.create(
+    "PixieBrix",
+    "",
+    `devtoolsPanel.html?tabId=${browser.devtools.inspectedWindow.tabId}`
+  );
   void connectSidebarPane();
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -248,7 +248,6 @@ module.exports = (env, options) =>
         [
           "background",
           "contentScript",
-          "devtools",
           "devtoolsPanel",
           "frame",
           "ephemeralForm",
@@ -272,6 +271,10 @@ module.exports = (env, options) =>
         "css-selector-generator",
         "@fortawesome/free-solid-svg-icons",
       ],
+
+      // This is a one-line file without imports
+      devtools: "./src/devtools",
+
       // The script that gets injected into the host page should not have a vendor chunk
       script: "./src/script",
     },


### PR DESCRIPTION
Related:

- #2184 

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/910

This context is only needed to create the dev tools tab, it doesn't need/use the port and it doesn't need to weigh 1.22MB. This change brings it down to 0.34MB and drops the unused port overhead.


If [the "sidebar panel" is not working](https://github.com/pixiebrix/pixiebrix-extension/issues/910) for you either and is completely unused, we can drop/archive it and just leave one line of code in this file.