### PR TITLE
#2195: don't truncate deeply nested values when using `var` expression engine

### DIFF
--- a/src/runtime/mapArgs.test.ts
+++ b/src/runtime/mapArgs.test.ts
@@ -92,6 +92,53 @@ describe("handlebars", () => {
   });
 });
 
+describe("identity - deep clone", () => {
+  const config = {
+    filter: {
+      operator: "and",
+      operands: [
+        {
+          operator: "or",
+          operands: [
+            {
+              operator: "substring",
+              field: "process",
+              value: "Email Proof of Funds",
+            },
+          ],
+        },
+      ],
+    },
+    sort: {
+      field: "id",
+      direction: "desc",
+    },
+    page: {
+      offset: 0,
+      length: 80,
+    },
+  };
+
+  test("deep clone object/arrays", async () => {
+    const rendered = await renderExplicit(config, {}, apiVersionOptions("v3"));
+
+    expect(rendered).toEqual(config);
+  });
+
+  test("deep clone complex var", async () => {
+    const rendered = await renderExplicit(
+      {
+        __type__: "var",
+        __value__: "@payload",
+      },
+      { "@payload": config },
+      apiVersionOptions("v3")
+    );
+
+    expect(rendered).toEqual(config);
+  });
+});
+
 describe("defer", () => {
   test("render !defer stops at defer", async () => {
     const config = {

--- a/src/runtime/pathHelpers.ts
+++ b/src/runtime/pathHelpers.ts
@@ -54,13 +54,31 @@ export const noopProxy: ReadProxy = {
   },
 };
 
+type GetPropOptions = {
+  /**
+   * Arguments to apply if path refers to a method.
+   */
+  args?: UnknownObject;
+  /**
+   * Proxy to navigate/traverse the object. (Default: noopProxy, which only traverses own properties)
+   * @see noopProxy
+   */
+  proxy?: ReadProxy;
+  /**
+   * Max depth of nested object returned (Used when reading data from stores/caches which have a lot of redundant
+   * data, e.g., the EmberJS component cache)
+   */
+  maxDepth?: number;
+};
+
 export function getPropByPath(
-  obj: Record<string, unknown>,
+  obj: UnknownObject,
   path: string,
   {
     args = {},
     proxy = noopProxy,
-  }: { args?: Record<string, unknown>; proxy?: ReadProxy } | undefined = {}
+    maxDepth = null,
+  }: GetPropOptions | undefined = {}
 ): unknown {
   // Consider using jsonpath syntax https://www.npmjs.com/package/jsonpath-plus
 
@@ -112,7 +130,7 @@ export function getPropByPath(
     }
   }
 
-  return cleanValue(toJS(value));
+  return cleanValue(toJS(value), maxDepth);
 }
 
 export function getFieldNamesFromPathString(

--- a/src/script.ts
+++ b/src/script.ts
@@ -76,10 +76,12 @@ import { requireSingleElement } from "@/nativeEditor/utils";
 import { getPropByPath, noopProxy, ReadProxy } from "@/runtime/pathHelpers";
 import { UnknownObject } from "@/types";
 
+const MAX_READ_DEPTH = 5;
+
 const attachListener = initialize();
 
 attachListener(SEARCH_WINDOW, ({ query }) => {
-  console.debug(`Searching window for query: ${query}`);
+  console.debug("Searching window for query: %s", query);
   return {
     results: globalSearch(window, query),
   };
@@ -113,11 +115,13 @@ function readPathSpec(
       values[key] = getPropByPath(obj as UnknownObject, path, {
         args: args as UnknownObject,
         proxy,
+        maxDepth: MAX_READ_DEPTH,
       });
     } else {
       // eslint-disable-next-line security/detect-object-injection -- key is coming from pathSpec
       values[key] = getPropByPath(obj as Record<string, unknown>, pathOrObj, {
         proxy,
+        maxDepth: MAX_READ_DEPTH,
       });
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -247,23 +247,27 @@ export function clearObject(obj: Record<string, unknown>): void {
  */
 export function cleanValue(
   value: unknown[],
-  maxDepth?: number,
+  maxDepth?: number | undefined,
   depth?: number
 ): unknown[];
 export function cleanValue(
   value: Record<string, unknown>,
-  maxDepth?: number,
+  maxDepth?: number | undefined,
   depth?: number
 ): Record<string, unknown>;
 export function cleanValue(
   value: unknown,
-  maxDepth?: number,
+  maxDepth?: number | undefined,
   depth?: number
 ): unknown;
-export function cleanValue(value: unknown, maxDepth = 5, depth = 0): unknown {
+export function cleanValue(
+  value: unknown,
+  maxDepth: number | undefined,
+  depth = 0
+): unknown {
   const recurse = partial(cleanValue, partial.placeholder, maxDepth, depth + 1);
 
-  if (depth > maxDepth) {
+  if (maxDepth != null && depth > maxDepth) {
     return undefined;
   }
 


### PR DESCRIPTION
Closes #2195 