### PR TITLE
Use JavaScript for ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,50 +1,50 @@
-{
-  "root": true,
-  "extends": [
+module.exports = {
+  root: true,
+  extends: [
     // Full config: https://github.com/fregante/eslint-config-pixiebrix/blob/main/index.js
-    "pixiebrix"
+    "pixiebrix",
   ],
-  "rules": {
+  rules: {
     "unicorn/prevent-abbreviations": [
       "error",
       {
-        "replacements": {
-          "acc": false,
-          "arg": false,
-          "args": false,
-          "db": false,
-          "dev": false,
-          "doc": false,
-          "docs": false,
-          "env": false,
-          "err": false,
-          "ev": false,
-          "evt": false,
-          "ext": false,
-          "exts": false,
-          "fn": false,
-          "func": {
-            "fn": true,
-            "function": false
+        replacements: {
+          acc: false,
+          arg: false,
+          args: false,
+          db: false,
+          dev: false,
+          doc: false,
+          docs: false,
+          env: false,
+          err: false,
+          ev: false,
+          evt: false,
+          ext: false,
+          exts: false,
+          fn: false,
+          func: {
+            fn: true,
+            function: false,
           },
-          "i": false,
-          "j": false,
-          "num": false,
-          "obj": false,
-          "param": false,
-          "params": false,
-          "prev": false,
-          "prod": false,
-          "prop": false,
-          "props": false,
-          "ref": false,
-          "refs": false,
-          "str": false,
-          "var": false,
-          "vars": false
+          i: false,
+          j: false,
+          num: false,
+          obj: false,
+          param: false,
+          params: false,
+          prev: false,
+          prod: false,
+          prop: false,
+          props: false,
+          ref: false,
+          refs: false,
+          str: false,
+          var: false,
+          vars: false,
         },
-        "ignore": ["semVer", "SemVer"]
-      }
+        ignore: ["semVer", "SemVer"],
+      },
     ],
 
     // Incorrectly suggests to use `runtime.sendMessage` instead of `browser.runtime.sendMessage`
@@ -69,9 +69,9 @@
     "jsx-a11y/no-static-element-interactions": "warn",
     "jsx-a11y/anchor-is-valid": "warn",
     "jsx-a11y/interactive-supports-focus": "warn",
-    "jsx-a11y/iframe-has-title": "warn"
+    "jsx-a11y/iframe-has-title": "warn",
   },
-  "ignorePatterns": [
+  ignorePatterns: [
     "node_modules",
     ".idea",
     "dist",
@@ -80,28 +80,28 @@
     "src/vendors",
     "src/types/swagger.ts",
     "src/nativeEditor/Overlay.tsx",
-    "selenium"
+    "selenium",
   ],
-  "overrides": [
+  overrides: [
     {
-      "files": ["*.stories.tsx"],
-      "rules": {
-        "filenames/match-exported": "off"
-      }
+      files: ["*.stories.tsx"],
+      rules: {
+        "filenames/match-exported": "off",
+      },
     },
     {
-      "files": [
+      files: [
         "webpack.*.js",
         "*.config.js",
         "test-env.js",
         "**/__mocks__/**",
-        "*.test.js"
+        "*.test.js",
       ],
-      "env": {
-        "node": true,
-        "jest": true
+      env: {
+        node: true,
+        jest: true,
       },
-      "extends": ["pixiebrix/server"]
-    }
-  ]
-}
+      extends: ["pixiebrix/server"],
+    },
+  ],
+};


### PR DESCRIPTION
[Our shared config](https://github.com/pixiebrix/eslint-config-pixiebrix/blob/main/index.js) is in JavaScript because it allows generating custom rules based on the folder and importing other configurations. It makes sense to allow the same here, also to simplify moving the config between these two locations.