### PR TITLE
#2231: tab screenshot brick

### DIFF
--- a/src/background/capture.ts
+++ b/src/background/capture.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { MessengerMeta } from "webext-messenger";
+import browser from "webextension-polyfill";
+
+export async function captureTab(this: MessengerMeta): Promise<string> {
+  return browser.tabs.captureVisibleTab(this.trace[0].tab.windowId, {
+    format: "png",
+  });
+}

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -121,3 +121,5 @@ export const traces = {
 
 export const initTelemetry = getNotifier("INIT_TELEMETRY", bg);
 export const sendDeploymentAlert = getNotifier("SEND_DEPLOYMENT_ALERT", bg);
+
+export const captureTab = getMethod("CAPTURE_TAB", bg);

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -65,6 +65,7 @@ import {
   recordEvent,
   sendDeploymentAlert,
 } from "@/background/telemetry";
+import { captureTab } from "@/background/capture";
 
 expectContext("background");
 
@@ -126,6 +127,8 @@ declare global {
 
     INIT_TELEMETRY: typeof initTelemetry;
     SEND_DEPLOYMENT_ALERT: typeof sendDeploymentAlert;
+
+    CAPTURE_TAB: typeof captureTab;
   }
 }
 
@@ -187,4 +190,6 @@ registerMethods({
 
   INIT_TELEMETRY: initTelemetry,
   SEND_DEPLOYMENT_ALERT: sendDeploymentAlert,
+
+  CAPTURE_TAB: captureTab,
 });

--- a/src/blocks/transformers/captureTab.ts
+++ b/src/blocks/transformers/captureTab.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Transformer } from "@/types";
+import { Schema } from "@/core";
+import { captureTab } from "@/background/messenger/api";
+
+export class CaptureTab extends Transformer {
+  constructor() {
+    super(
+      "@pixiebrix/browser/capture-tab",
+      "Capture Tab",
+      "Capture the visible area of the current tab"
+    );
+  }
+
+  inputSchema: Schema = {
+    type: "object",
+    properties: {},
+  };
+
+  async transform(): Promise<string> {
+    return captureTab();
+  }
+}

--- a/src/blocks/transformers/registerTransformers.ts
+++ b/src/blocks/transformers/registerTransformers.ts
@@ -37,7 +37,7 @@ import { JQueryReader } from "./jquery/JQueryReader";
 import { ParseCsv } from "./parseCsv";
 import { ParseDataUrl } from "./parseDataUrl";
 import { ParseDate } from "@/blocks/transformers/parseDate";
-import { CaptureTab } from "@/blocks/transformers/captureTab";
+import { ScreenshotTab } from "@/blocks/transformers/screenshotTab";
 
 function registerTransformers() {
   registerBlock(new JQTransformer());
@@ -61,7 +61,7 @@ function registerTransformers() {
   registerBlock(new ParseCsv());
   registerBlock(new ParseDataUrl());
   registerBlock(new ParseDate());
-  registerBlock(new CaptureTab());
+  registerBlock(new ScreenshotTab());
 }
 
 export default registerTransformers;

--- a/src/blocks/transformers/registerTransformers.ts
+++ b/src/blocks/transformers/registerTransformers.ts
@@ -37,6 +37,7 @@ import { JQueryReader } from "./jquery/JQueryReader";
 import { ParseCsv } from "./parseCsv";
 import { ParseDataUrl } from "./parseDataUrl";
 import { ParseDate } from "@/blocks/transformers/parseDate";
+import { CaptureTab } from "@/blocks/transformers/captureTab";
 
 function registerTransformers() {
   registerBlock(new JQTransformer());
@@ -60,6 +61,7 @@ function registerTransformers() {
   registerBlock(new ParseCsv());
   registerBlock(new ParseDataUrl());
   registerBlock(new ParseDate());
+  registerBlock(new CaptureTab());
 }
 
 export default registerTransformers;

--- a/src/blocks/transformers/screenshotTab.ts
+++ b/src/blocks/transformers/screenshotTab.ts
@@ -20,12 +20,12 @@ import { Schema } from "@/core";
 import { captureTab } from "@/background/messenger/api";
 import { BusinessError, getErrorMessage } from "@/errors";
 
-export class CaptureTab extends Transformer {
+export class ScreenshotTab extends Transformer {
   constructor() {
     super(
-      "@pixiebrix/browser/capture-tab",
-      "Capture Tab",
-      "Capture the visible area of the current tab"
+      "@pixiebrix/browser/screenshot",
+      "Screenshot Tab",
+      "Take a screenshot/capture the visible area of the active tab"
     );
   }
 
@@ -34,9 +34,21 @@ export class CaptureTab extends Transformer {
     properties: {},
   };
 
-  async transform(): Promise<string> {
+  outputSchema: Schema = {
+    type: "object",
+    properties: {
+      data: {
+        type: "string",
+        description: "The PNG screenshot as a data URI",
+      },
+    },
+  };
+
+  async transform(): Promise<unknown> {
     try {
-      return await captureTab();
+      return {
+        data: await captureTab(),
+      };
     } catch (error) {
       if (getErrorMessage(error).includes("activeTab")) {
         // Event if PixieBrix has access to a host, PixieBrix needs activeTab. So the user must have done one of the
@@ -46,7 +58,7 @@ export class CaptureTab extends Transformer {
         // - Executing a context menu item
         // - Executing a keyboard shortcut from the commands API
         throw new BusinessError(
-          "The capture tab brick can only be triggered from the context menu or sidebar"
+          "The Screenshot Tab brick can only be run from the context menu or sidebar of the active tab"
         );
       }
 

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import blockRegistry from "@/blocks/registry";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 88;
+const EXPECTED_HEADER_COUNT = 89;
 
 // Import for side-effects (these modules register the blocks)
 // NOTE: we don't need to also include extensionPoints because we got rid of all the legacy hard-coded extension points


### PR DESCRIPTION
Gotchas:
- The extension needs `activeTab` for it to work. It errors out if the extension has access but not activeTab. 

That means that even if PixieBrix has access to the page, the user still has to:
- Executing a action
- Executing a context menu item
- Executing a keyboard shortcut from the commands API
