### PR TITLE
Drop `tabReady` from in-frame brick execution

### DIFF
--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -23,7 +23,7 @@ import { expectContext } from "@/utils/expectContext";
 import { asyncLoop } from "@/utils";
 import { getLinkedApiClient } from "@/services/apiClient";
 import { JsonObject } from "type-fest";
-import { MessengerMeta, Sender } from "webext-messenger";
+import { MessengerMeta } from "webext-messenger";
 import { linkChildTab, runBrick } from "@/contentScript/messenger/api";
 import { Target } from "@/types";
 import { TabId } from "@/background/devtools/contract";
@@ -33,26 +33,6 @@ import pDefer from "p-defer";
 const tabToOpener = new Map<number, number>();
 const tabToTarget = new Map<number, number>();
 // TODO: One tab could have multiple targets, but `tabToTarget` currenly only supports one at a time
-
-export const eventManager = new EventTarget();
-interface MessengerEvent {
-  sender: Sender;
-  eventName: string;
-  args: unknown[];
-}
-export async function triggerBackgroundEvent(
-  this: MessengerMeta,
-  eventName: string,
-  ...args: unknown[]
-): Promise<void> {
-  const sender = this.trace[0];
-  const event: MessengerEvent = { sender, eventName, args };
-  eventManager.dispatchEvent(
-    new CustomEvent(eventName, {
-      detail: event,
-    })
-  );
-}
 
 export async function waitForTargetByUrl(url: string): Promise<Target> {
   const { promise, resolve } = pDefer<Target>();

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -18,92 +18,58 @@
 
 import { RunBlock } from "@/contentScript/executor";
 import browser, { Runtime, Tabs } from "webextension-polyfill";
-import { Availability } from "@/blocks/types";
 import { BusinessError } from "@/errors";
 import { expectContext } from "@/utils/expectContext";
-import { asyncLoop, sleep } from "@/utils";
+import { asyncLoop } from "@/utils";
 import { getLinkedApiClient } from "@/services/apiClient";
 import { JsonObject } from "type-fest";
-import { MessengerMeta } from "webext-messenger";
-import {
-  checkAvailable,
-  linkChildTab,
-  runBrick,
-} from "@/contentScript/messenger/api";
+import { MessengerMeta, Sender } from "webext-messenger";
+import { linkChildTab, runBrick } from "@/contentScript/messenger/api";
 import { Target } from "@/types";
 import { TabId } from "@/background/devtools/contract";
 import { RemoteExecutionError } from "@/blocks/errors";
+import pDefer from "p-defer";
 
 const tabToOpener = new Map<number, number>();
 const tabToTarget = new Map<number, number>();
 // TODO: One tab could have multiple targets, but `tabToTarget` currenly only supports one at a time
 
-// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- Record<> doesn't allow labelled keys
-const tabReady: { [tabId: string]: { [frameId: string]: boolean } } = {};
-const nonceToTarget = new Map<string, Target>();
-
-interface WaitOptions {
-  maxWaitMillis?: number;
-  isAvailable?: Availability;
+export const eventManager = new EventTarget();
+interface MessengerEvent {
+  sender: Sender;
+  eventName: string;
+  args: unknown[];
+}
+export async function triggerBackgroundEvent(
+  this: MessengerMeta,
+  eventName: string,
+  ...args: unknown[]
+): Promise<void> {
+  const sender = this.trace[0];
+  const event: MessengerEvent = { sender, eventName, args };
+  eventManager.dispatchEvent(
+    new CustomEvent(eventName, {
+      detail: event,
+    })
+  );
 }
 
-async function waitNonceReady(
-  nonce: string,
-  { maxWaitMillis = 10_000, isAvailable }: WaitOptions = {}
-) {
-  console.debug(`Waiting for frame with nonce ${nonce} to be ready`);
-  const startTime = Date.now();
-
-  const isReady = async () => {
-    const target = nonceToTarget.get(nonce);
-    if (target == null) {
-      return false;
+export async function waitForTargetByUrl(url: string): Promise<Target> {
+  const { promise, resolve } = pDefer<Target>();
+  browser.webNavigation.onCommitted.addListener(
+    function wait({ tabId, frameId }): void {
+      resolve({ tabId, frameId });
+      browser.webNavigation.onCommitted.removeListener(wait);
+    },
+    {
+      url: [
+        {
+          urlMatches: url,
+        },
+      ],
     }
-
-    const frameReady = tabReady[target.tabId]?.[target.frameId] != null;
-    if (!frameReady) {
-      return false;
-    }
-
-    if (isAvailable) {
-      return checkAvailable(target, isAvailable);
-    }
-
-    return true;
-  };
-
-  // eslint-disable-next-line no-await-in-loop -- retry loop
-  while (!(await isReady())) {
-    if (Date.now() - startTime > maxWaitMillis) {
-      throw new BusinessError(
-        `Nonce ${nonce} was not ready after ${maxWaitMillis}ms`
-      );
-    }
-
-    // eslint-disable-next-line no-await-in-loop -- retry loop
-    await sleep(50);
-  }
-
-  return true;
-}
-
-async function waitReady(
-  { tabId, frameId }: Target,
-  { maxWaitMillis = 10_000 }: WaitOptions = {}
-): Promise<boolean> {
-  const startTime = Date.now();
-  while (tabReady[tabId]?.[frameId] == null) {
-    if (Date.now() - startTime > maxWaitMillis) {
-      throw new BusinessError(
-        `Tab ${tabId} was not ready after ${maxWaitMillis}ms`
-      );
-    }
-
-    // eslint-disable-next-line no-await-in-loop -- retry loop
-    await sleep(50);
-  }
-
-  return true;
+  );
+  return promise;
 }
 
 export async function requestRunInOpener(
@@ -156,21 +122,6 @@ export async function requestRunInBroadcast(
   return [...fulfilled].map(([, value]) => value);
 }
 
-export async function requestRunInFrameNonce(
-  this: MessengerMeta,
-  { nonce, ...request }: RunBlock
-): Promise<unknown> {
-  const sourceTabId = this.trace[0].tab.id;
-
-  await waitNonceReady(nonce, {
-    isAvailable: request.options.isAvailable,
-  });
-
-  const target = nonceToTarget.get(nonce);
-  const subRequest = { ...request, sourceTabId };
-  return runBrick(target, subRequest);
-}
-
 export async function requestRunInTarget(
   this: MessengerMeta,
   request: RunBlock
@@ -181,10 +132,6 @@ export async function requestRunInTarget(
   if (!target) {
     throw new BusinessError("Sender tab has no target");
   }
-
-  // For now, only support top-level frame as target
-  console.debug(`Waiting for target tab ${target} to be ready`);
-  await waitReady({ tabId: target, frameId: 0 });
 
   const subRequest = { ...request, sourceTabId };
   return runBrick({ tabId: target }, subRequest);
@@ -201,33 +148,6 @@ export async function openTab(
   // FIXME: include frame information here
   tabToTarget.set(openerTabId, tab.id);
   tabToOpener.set(tab.id, openerTabId);
-}
-
-export async function markTabAsReady(this: MessengerMeta) {
-  const sender = this.trace[0];
-  const tabId = sender.tab.id;
-  const { frameId } = sender;
-  console.debug(`Marked tab ${tabId} (frame: ${frameId}) as ready`, {
-    sender,
-  });
-
-  const url = new URL(sender.url);
-  const nonce = url.searchParams.get("_pb");
-
-  if (nonce) {
-    console.debug(`Marking nonce as ready: ${nonce}`, {
-      nonce,
-      tabId,
-      frameId,
-    });
-    nonceToTarget.set(nonce, { tabId, frameId });
-  }
-
-  if (!tabReady[tabId]) {
-    tabReady[tabId] = {};
-  }
-
-  tabReady[tabId][frameId] = true;
 }
 
 async function linkTabListener(tab: Tabs.Tab): Promise<void> {

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -36,20 +36,17 @@ const tabToTarget = new Map<number, number>();
 
 export async function waitForTargetByUrl(url: string): Promise<Target> {
   const { promise, resolve } = pDefer<Target>();
-  browser.webNavigation.onCommitted.addListener(
-    function wait({ tabId, frameId }): void {
-      resolve({ tabId, frameId });
-      browser.webNavigation.onCommitted.removeListener(wait);
-    },
-    {
-      url: [
-        {
-          // This uses RE2, which is a regex-like syntax
-          urlMatches: url.replaceAll("?", "\\?"),
-        },
-      ],
-    }
-  );
+
+  // This uses RE2, which is a regex-like syntax
+  const urlMatches = url.replaceAll("?", "\\?");
+  function wait({ tabId, frameId }: Target): void {
+    resolve({ tabId, frameId });
+    browser.webNavigation.onCommitted.removeListener(wait);
+  }
+
+  browser.webNavigation.onCommitted.addListener(wait, {
+    url: [{ urlMatches }],
+  });
   return promise;
 }
 

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -44,7 +44,8 @@ export async function waitForTargetByUrl(url: string): Promise<Target> {
     {
       url: [
         {
-          urlMatches: url,
+          // This uses RE2, which is a regex-like syntax
+          urlMatches: url.replaceAll("?", "\\?"),
         },
       ],
     }

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -45,10 +45,6 @@ export const checkTargetPermissions = getMethod("CHECK_TARGET_PERMISSIONS", bg);
 export const openPopupPrompt = getMethod("OPEN_POPUP_PROMPT", bg);
 export const whoAmI = getMethod("ECHO_SENDER", bg);
 export const waitForTargetByUrl = getMethod("WAIT_FOR_TARGET_BY_URL", bg);
-export const triggerBackgroundEvent = getNotifier(
-  "TRIGGER_BACKGROUND_EVENT",
-  bg
-);
 
 export const activateTab = getMethod("ACTIVATE_TAB", bg);
 export const reactivateEveryTab = getNotifier("REACTIVATE_EVERY_TAB", bg);

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -44,12 +44,16 @@ export const ensureContentScript = getMethod("INJECT_SCRIPT", bg);
 export const checkTargetPermissions = getMethod("CHECK_TARGET_PERMISSIONS", bg);
 export const openPopupPrompt = getMethod("OPEN_POPUP_PROMPT", bg);
 export const whoAmI = getMethod("ECHO_SENDER", bg);
+export const waitForTargetByUrl = getMethod("WAIT_FOR_TARGET_BY_URL", bg);
+export const triggerBackgroundEvent = getNotifier(
+  "TRIGGER_BACKGROUND_EVENT",
+  bg
+);
 
 export const activateTab = getMethod("ACTIVATE_TAB", bg);
 export const reactivateEveryTab = getNotifier("REACTIVATE_EVERY_TAB", bg);
 
 export const closeTab = getMethod("CLOSE_TAB", bg);
-export const markTabAsReady = getMethod("MARK_TAB_AS_READY", bg);
 export const deleteCachedAuthData = getMethod("DELETE_CACHED_AUTH", bg);
 export const clearServiceCache = getMethod("CLEAR_SERVICE_CACHE", bg);
 export const readGoogleBigQuery = getMethod("GOOGLE_BIGQUERY_READ", bg);
@@ -86,7 +90,6 @@ export const requestRun = {
   onServer: getMethod("REQUEST_RUN_ON_SERVER", bg),
   inOpener: getMethod("REQUEST_RUN_IN_OPENER", bg),
   inTarget: getMethod("REQUEST_RUN_IN_TARGET", bg),
-  inFrame: getMethod("REQUEST_RUN_IN_FRAME_NONCE", bg),
   inAll: getMethod("REQUEST_RUN_IN_ALL", bg),
 };
 

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -28,14 +28,14 @@ import { openPopupPrompt } from "@/background/permissionPrompt";
 import {
   activateTab,
   closeTab,
-  markTabAsReady,
+  triggerBackgroundEvent,
   whoAmI,
   openTab,
   requestRunOnServer,
   requestRunInOpener,
   requestRunInTarget,
   requestRunInBroadcast,
-  requestRunInFrameNonce,
+  waitForTargetByUrl,
 } from "@/background/executor";
 import * as registry from "@/registry/localRegistry";
 import { ensureContentScript } from "@/background/util";
@@ -88,10 +88,12 @@ declare global {
     OPEN_POPUP_PROMPT: typeof openPopupPrompt;
 
     ECHO_SENDER: typeof whoAmI;
+    WAIT_FOR_TARGET_BY_URL: typeof waitForTargetByUrl;
+    TRIGGER_BACKGROUND_EVENT: typeof triggerBackgroundEvent;
+
     ACTIVATE_TAB: typeof activateTab;
     REACTIVATE_EVERY_TAB: typeof reactivateEveryTab;
     CLOSE_TAB: typeof closeTab;
-    MARK_TAB_AS_READY: typeof markTabAsReady;
     OPEN_TAB: typeof openTab;
     REGISTRY_GET_KIND: typeof registry.getKind;
     REGISTRY_SYNC: typeof registry.syncRemote;
@@ -103,7 +105,6 @@ declare global {
     REQUEST_RUN_IN_OPENER: typeof requestRunInOpener;
     REQUEST_RUN_IN_TARGET: typeof requestRunInTarget;
     REQUEST_RUN_IN_ALL: typeof requestRunInBroadcast;
-    REQUEST_RUN_IN_FRAME_NONCE: typeof requestRunInFrameNonce;
 
     HTTP_REQUEST: typeof doCleanAxiosRequest;
     DELETE_CACHED_AUTH: typeof deleteCachedAuthData;
@@ -149,10 +150,12 @@ registerMethods({
   OPEN_POPUP_PROMPT: openPopupPrompt,
 
   ECHO_SENDER: whoAmI,
+  WAIT_FOR_TARGET_BY_URL: waitForTargetByUrl,
+  TRIGGER_BACKGROUND_EVENT: triggerBackgroundEvent,
+
   ACTIVATE_TAB: activateTab,
   REACTIVATE_EVERY_TAB: reactivateEveryTab,
   CLOSE_TAB: closeTab,
-  MARK_TAB_AS_READY: markTabAsReady,
   OPEN_TAB: openTab,
   REGISTRY_GET_KIND: registry.getKind,
   REGISTRY_SYNC: registry.syncRemote,
@@ -164,7 +167,6 @@ registerMethods({
   REQUEST_RUN_IN_OPENER: requestRunInOpener,
   REQUEST_RUN_IN_TARGET: requestRunInTarget,
   REQUEST_RUN_IN_ALL: requestRunInBroadcast,
-  REQUEST_RUN_IN_FRAME_NONCE: requestRunInFrameNonce,
 
   HTTP_REQUEST: doCleanAxiosRequest,
   DELETE_CACHED_AUTH: deleteCachedAuthData,

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -28,7 +28,6 @@ import { openPopupPrompt } from "@/background/permissionPrompt";
 import {
   activateTab,
   closeTab,
-  triggerBackgroundEvent,
   whoAmI,
   openTab,
   requestRunOnServer,
@@ -89,7 +88,6 @@ declare global {
 
     ECHO_SENDER: typeof whoAmI;
     WAIT_FOR_TARGET_BY_URL: typeof waitForTargetByUrl;
-    TRIGGER_BACKGROUND_EVENT: typeof triggerBackgroundEvent;
 
     ACTIVATE_TAB: typeof activateTab;
     REACTIVATE_EVERY_TAB: typeof reactivateEveryTab;
@@ -151,7 +149,6 @@ registerMethods({
 
   ECHO_SENDER: whoAmI,
   WAIT_FOR_TARGET_BY_URL: waitForTargetByUrl,
-  TRIGGER_BACKGROUND_EVENT: triggerBackgroundEvent,
 
   ACTIVATE_TAB: activateTab,
   REACTIVATE_EVERY_TAB: reactivateEveryTab,

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -28,11 +28,7 @@ import registerContribBlocks from "@/contrib/registerContribBlocks";
 import { handleNavigate } from "@/contentScript/lifecycle";
 import "@/messaging/external";
 import { markReady, updateTabInfo } from "@/contentScript/context";
-import {
-  whoAmI,
-  initTelemetry,
-  triggerBackgroundEvent,
-} from "@/background/messenger/api";
+import { whoAmI, initTelemetry } from "@/background/messenger/api";
 import { showConnectionLost } from "@/contentScript/connection";
 import { isConnectionError } from "@/errors";
 import { ENSURE_CONTENT_SCRIPT_READY } from "@/messaging/constants";
@@ -84,12 +80,6 @@ async function init(): Promise<void> {
 
   // Inform the external website
   markReady();
-
-  // Inform the background page (and any content scripts listening)
-  triggerBackgroundEvent(
-    "registration",
-    new URLSearchParams(location.search).get("_pb")
-  );
 
   // Inform `ensureContentScript`
   void browser.runtime.sendMessage({ type: ENSURE_CONTENT_SCRIPT_READY });

--- a/src/contentScript.ts
+++ b/src/contentScript.ts
@@ -29,9 +29,9 @@ import { handleNavigate } from "@/contentScript/lifecycle";
 import "@/messaging/external";
 import { markReady, updateTabInfo } from "@/contentScript/context";
 import {
-  markTabAsReady,
   whoAmI,
   initTelemetry,
+  triggerBackgroundEvent,
 } from "@/background/messenger/api";
 import { showConnectionLost } from "@/contentScript/connection";
 import { isConnectionError } from "@/errors";
@@ -82,20 +82,19 @@ async function init(): Promise<void> {
     throw error;
   }
 
-  try {
-    // Notify the background script know we're ready to execute remote actions
-    markReady();
+  // Inform the external website
+  markReady();
 
-    // Inform `ensureContentScript` that the content script has loaded, if it's listening
-    void browser.runtime.sendMessage({ type: ENSURE_CONTENT_SCRIPT_READY });
+  // Inform the background page (and any content scripts listening)
+  triggerBackgroundEvent(
+    "registration",
+    new URLSearchParams(location.search).get("_pb")
+  );
 
-    // Informs the standard background listener to track this tab
-    await markTabAsReady();
-    console.info(`contentScript ready in ${Date.now() - start}ms`);
-  } catch (error) {
-    console.error("Error pinging the background script", error);
-    throw error;
-  }
+  // Inform `ensureContentScript`
+  void browser.runtime.sendMessage({ type: ENSURE_CONTENT_SCRIPT_READY });
+
+  console.info(`contentScript ready in ${Date.now() - start}ms`);
 }
 
 // Make sure we don't install the content script multiple times

--- a/src/contentScript/context.ts
+++ b/src/contentScript/context.ts
@@ -26,7 +26,14 @@ export let navigationTimestamp = new Date();
 export let tabId: number;
 export let frameId: number;
 
+const PIXIEBRIX_READY_SYMBOL = Symbol.for("pixiebrix-content-script-ready");
 export const PIXIEBRIX_READY_ATTRIBUTE = "data-pb-ready";
+
+declare global {
+  interface Window {
+    [PIXIEBRIX_READY_SYMBOL]?: true;
+  }
+}
 
 /**
  * Set a unique id and timestamp for current navigation event.
@@ -44,6 +51,9 @@ export function getNavigationId(): string {
 }
 
 export function markReady(): void {
+  // eslint-disable-next-line security/detect-object-injection -- Static symbol
+  window[PIXIEBRIX_READY_SYMBOL] = true;
+
   document.documentElement.setAttribute(PIXIEBRIX_READY_ATTRIBUTE, "");
 }
 

--- a/src/contentScript/context.ts
+++ b/src/contentScript/context.ts
@@ -26,14 +26,7 @@ export let navigationTimestamp = new Date();
 export let tabId: number;
 export let frameId: number;
 
-const PIXIEBRIX_READY_SYMBOL = Symbol.for("pixiebrix-content-script-ready");
 export const PIXIEBRIX_READY_ATTRIBUTE = "data-pb-ready";
-
-declare global {
-  interface Window {
-    [PIXIEBRIX_READY_SYMBOL]?: true;
-  }
-}
 
 /**
  * Set a unique id and timestamp for current navigation event.
@@ -51,9 +44,6 @@ export function getNavigationId(): string {
 }
 
 export function markReady(): void {
-  // eslint-disable-next-line security/detect-object-injection -- Static symbol
-  window[PIXIEBRIX_READY_SYMBOL] = true;
-
   document.documentElement.setAttribute(PIXIEBRIX_READY_ATTRIBUTE, "");
 }
 

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -17,14 +17,6 @@
 
 /* Do not use `registerMethod` in this file */
 import { getMethod, getNotifier } from "webext-messenger";
-import { isContentScript } from "webext-detect-page";
-
-// TODO: This should be a hard error, but due to unknown dependency routes, it can't be enforced yet
-if (isContentScript() && process.env.DEBUG) {
-  console.warn(
-    "This should not have been imported in the content script. Use the API directly instead."
-  );
-}
 
 export const getFormDefinition = getMethod("FORM_GET_DEFINITION");
 export const resolveForm = getMethod("FORM_RESOLVE");

--- a/src/frame.html
+++ b/src/frame.html
@@ -19,4 +19,4 @@
 <meta charset="utf-8" />
 <title>PixieBrix Frame</title>
 <link rel="stylesheet" href="frame.css" />
-<script src="frame.js"></script>
+<script defer src="frame.js"></script>

--- a/src/frame.html
+++ b/src/frame.html
@@ -16,14 +16,7 @@
   -->
 
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>PixieBrix Frame</title>
-    <link rel="stylesheet" href="frame.css" />
-  </head>
-  <body>
-    <script src="vendors.js"></script>
-    <script src="frame.js"></script>
-  </body>
-</html>
+<meta charset="utf-8" />
+<title>PixieBrix Frame</title>
+<link rel="stylesheet" href="frame.css" />
+<script src="frame.js"></script>

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -18,22 +18,8 @@
 // https://transitory.technology/browser-extensions-and-csp-headers/
 // Load the passed URL into an another iframe to get around the parent page's CSP headers
 
-const params = new URLSearchParams(window.location.search);
-
-const rawURL = params.get("url");
-
-console.debug("Initializing indirect frame", {
-  url: rawURL,
-  nonce: params.get("nonce"),
-});
-
-const url = new URL(rawURL);
-const nonce = params.get("nonce");
-
-if (nonce) {
-  url.searchParams.set("_pb", nonce);
-}
+const frameUrl = new URLSearchParams(window.location.search).get("url");
 
 const iframe = document.createElement("iframe");
-iframe.src = url.href;
+iframe.src = frameUrl;
 document.body.append(iframe);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -249,7 +249,6 @@ module.exports = (env, options) =>
           "background",
           "contentScript",
           "devtoolsPanel",
-          "frame",
           "ephemeralForm",
           "options",
           "action",
@@ -272,7 +271,8 @@ module.exports = (env, options) =>
         "@fortawesome/free-solid-svg-icons",
       ],
 
-      // This is a one-line file without imports
+      // Tiny files without imports, no vendors needed
+      frame: "./src/frame",
       devtools: "./src/devtools",
 
       // The script that gets injected into the host page should not have a vendor chunk


### PR DESCRIPTION
- Follows https://github.com/pixiebrix/pixiebrix-extension/pull/2215#issuecomment-997925457
- Related to https://github.com/pixiebrix/pixiebrix-extension/pull/2106

## Before

Read these from top to bottom, as a sequence of events

<table>
<tr>
	<th>CS
	<th>Frame
	<th>Background
<tr>
	<td>Asks BG to message iframe with `nonce`
	<td>
	<td>
<tr>
	<td>
	<td>
	<td>Waits for `nonce` iframe to register itself, via local polling
<tr>
	<td>
	<td>Registers itself with BG
	<td>
<tr>
	<td>
	<td>
	<td>Forwards brick to frame
<tr>
	<td>
	<td>Iframe handles brick and responds to BG
	<td>
<tr>
	<td>
	<td>
	<td>Forwards response to CS
</table>

## After

<table>
<tr>
	<th>CS
	<th>Frame
	<th>Background
<tr>
	<td>Asks BG to wait for specific URL to appear
	<td>
	<td>
<tr>
	<td>
	<td>
	<td>Waits for new URL to starts loading
<tr>
	<td>
	<td>
	<td>Responds with `{tabId, frameId}` when it finds it
<tr>
	<td>Messages frame "directly" (forwarding is handled by the messenger)
	<td>
	<td>
<tr>
	<td>
	<td>Iframe handles brick and responds to CS
	<td>
</table>