### PR TITLE
#2180 Document builder UI improvement

### DIFF
--- a/src/components/documentBuilder/createNewElement.test.ts
+++ b/src/components/documentBuilder/createNewElement.test.ts
@@ -99,7 +99,7 @@ test("sets default config for block", () => {
 test("sets default config for button", () => {
   const confettiEffect = new ConfettiEffect();
   const expectedConfig = {
-    title: "Confetti",
+    title: "Action",
     onClick: {
       __type__: "pipeline",
       __value__: [

--- a/src/components/documentBuilder/createNewElement.ts
+++ b/src/components/documentBuilder/createNewElement.ts
@@ -74,7 +74,7 @@ export function createNewElement(elementType: DocumentElementType) {
     }
 
     case "button": {
-      element.config.title = "Confetti";
+      element.config.title = "Action";
 
       const confettiConfig: BlockConfig = {
         id: confettiEffect.id,

--- a/src/components/documentBuilder/preview/__snapshots__/ElementPreview.test.tsx.snap
+++ b/src/components/documentBuilder/preview/__snapshots__/ElementPreview.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`can preview default button 1`] = `
         class="btn btn-primary"
         type="button"
       >
-        Confetti
+        Action
       </button>
     </div>
   </div>

--- a/src/components/fields/schemaFields/v3/BasicSchemaField.test.tsx
+++ b/src/components/fields/schemaFields/v3/BasicSchemaField.test.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import BasicSchemaField from "@/components/fields/schemaFields/v3/BasicSchemaField";
+import { Schema } from "@/core";
+import { Formik } from "formik";
+import { fireTextInput } from "@/tests/formHelpers";
+import { waitForEffect } from "@/tests/testHelpers";
+
+describe("option mode switching", () => {
+  const renderSchemaField = (
+    name: string,
+    schema: Schema,
+    initialValues: any
+  ) =>
+    render(
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+        <BasicSchemaField name={name} schema={schema} />
+      </Formik>
+    );
+
+  const expectToggleMode = (container: HTMLElement, mode: string) => {
+    expect(
+      container.querySelector('[data-testid="toggle-test"]')
+    ).toHaveAttribute("data-test-selected", mode);
+  };
+
+  test("switches automatically from variable to text when @ removed", async () => {
+    const { container } = renderSchemaField(
+      "test",
+      { type: "string" },
+      {
+        test: {
+          __type__: "var",
+          __value__: "@data",
+        },
+      }
+    );
+
+    expectToggleMode(container, "Variable");
+
+    const inputElement = screen.getByLabelText("test");
+    fireTextInput(inputElement, "text");
+    await waitForEffect();
+
+    expectToggleMode(container, "Text");
+  });
+
+  test("doesn't automatically switch to Text in case of Select field", async () => {
+    const { container } = renderSchemaField(
+      "test",
+      { type: "string", enum: ["option 1", "option 2"] },
+      {
+        test: {
+          __type__: "var",
+          __value__: "@data",
+        },
+      }
+    );
+
+    expectToggleMode(container, "Variable");
+
+    const inputElement = screen.getByLabelText("test");
+    fireTextInput(inputElement, "text");
+    await waitForEffect();
+
+    expectToggleMode(container, "Variable");
+  });
+});

--- a/src/components/fields/schemaFields/v3/BasicSchemaField.tsx
+++ b/src/components/fields/schemaFields/v3/BasicSchemaField.tsx
@@ -359,7 +359,9 @@ export function schemaSupportsTemplates(schema: Schema): boolean {
     isObjectProperty: false,
     isArrayItem: false,
   });
-  return options.some((option) => option.value === "string");
+  return options.some(
+    (option) => option.value === "string" && option.label === "Text"
+  );
 }
 
 const BasicSchemaField: SchemaFieldComponent = (props) => {

--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
@@ -136,6 +136,7 @@ const TemplateToggleWidget: React.FC<TemplateToggleWidgetProps> = ({
         onSelect={onModeChange}
         className={styles.dropdown}
         data-testid={`toggle-${schemaFieldProps.name}`}
+        data-test-selected={selectedOption?.label ?? ""}
       >
         {inputModeOptions.map((option) => (
           <Dropdown.Item

--- a/src/devTools/editor/tabs/effect/v3/__snapshots__/BlockConfiguration.test.tsx.snap
+++ b/src/devTools/editor/tabs/effect/v3/__snapshots__/BlockConfiguration.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`renders 1`] = `
               </div>
               <div
                 class="dropdown dropdown"
+                data-test-selected="Text"
                 data-testid="toggle-extension.blockPipeline[0].config.message"
               >
                 <button


### PR DESCRIPTION
Related to #2180 

- Changing default button caption to "Action"
- Fixing automatic switching of the Schema Field mode to text in case of Select when text (or template) is not accepted.