### PR TITLE
#2190: Isolate kbar style via Shadow DOM

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -35,7 +35,7 @@
     "^@contrib/(.*?)(\\?loadAsText)?$": "<rootDir>/contrib/$1",
     "^@schemas/(.*)$": "<rootDir>/schemas/$1",
     "\\.(css|less|scss)$": "<rootDir>/src/__mocks__/styleMock.js",
-    "\\.(gif|ttf|eot|svg)$": "<rootDir>/src/__mocks__/fileMock.js",
+    "\\.(gif|ttf|eot|svg)$|\\?loadAsUrl$": "<rootDir>/src/__mocks__/fileMock.js",
     "\\.svg\\?loadAsComponent$": "<rootDir>/src/__mocks__/svgAsComponentMock.js"
   }
 }

--- a/scripts/webpack.scripts.js
+++ b/scripts/webpack.scripts.js
@@ -56,17 +56,10 @@ module.exports = mergeWithShared({
       NPM_PACKAGE_VERSION: process.env.npm_package_version,
     }),
     new webpack.DefinePlugin({
-      // Patch browser variable selectively to avoid environment misdetection in React
-      window: webpack.DefinePlugin.runtimeValue((ctx) =>
-        ctx.module.resource.includes("css-selector-generator")
-          ? "global"
-          : "window"
-      ),
-      self: webpack.DefinePlugin.runtimeValue((ctx) =>
-        ctx.module.resource.includes("css-selector-generator")
-          ? "global"
-          : "self"
-      ),
+      "window.CSSStyleSheet": "{}",
+      window: "globalThis.window",
+      document: "globalThis.document",
+      self: "globalThis.document",
     }),
     // Don't fail on import of styles.
     // Using an identity object instead of actual style sheet because styles are not needed for headers generations

--- a/scripts/webpack.scripts.js
+++ b/scripts/webpack.scripts.js
@@ -59,7 +59,7 @@ module.exports = mergeWithShared({
       "window.CSSStyleSheet": "{}",
       window: "globalThis.window",
       document: "globalThis.document",
-      self: "globalThis.document",
+      self: "globalThis.self",
     }),
     // Don't fail on import of styles.
     // Using an identity object instead of actual style sheet because styles are not needed for headers generations

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -240,9 +240,9 @@ const KBarComponent: React.FC = () => {
 const QuickBarApp: React.FC = () => (
   <div>
     <ReactShadowRoot>
+      <link rel="stylesheet" href={faStyleSheet} />
       <KBarProvider actions={quickBarRegistry.actions}>
         <KBarToggle>
-          <link rel="stylesheet" href={faStyleSheet} />
           <KBarComponent />
         </KBarToggle>
       </KBarProvider>

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -238,16 +238,14 @@ const KBarComponent: React.FC = () => {
 };
 
 const QuickBarApp: React.FC = () => (
-  <div>
-    <ReactShadowRoot>
-      <link rel="stylesheet" href={faStyleSheet} />
-      <KBarProvider actions={quickBarRegistry.actions}>
-        <KBarToggle>
-          <KBarComponent />
-        </KBarToggle>
-      </KBarProvider>
-    </ReactShadowRoot>
-  </div>
+  <ReactShadowRoot>
+    <link rel="stylesheet" href={faStyleSheet} />
+    <KBarProvider actions={quickBarRegistry.actions}>
+      <KBarToggle>
+        <KBarComponent />
+      </KBarToggle>
+    </KBarProvider>
+  </ReactShadowRoot>
 );
 
 export const initQuickBarApp = once(() => {

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -22,15 +22,17 @@ import {
   ActionId,
   ActionImpl,
   KBarAnimator,
-  KBarPortal,
   KBarPositioner,
   KBarProvider,
   KBarResults,
   KBarSearch,
   useKBar,
   useMatches,
+  VisualState,
 } from "kbar";
+import ReactShadowRoot from "react-shadow-root";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
+import faStyleSheet from "@fortawesome/fontawesome-svg-core/styles.css?loadAsUrl";
 import { expectContext } from "@/utils/expectContext";
 import { once } from "lodash";
 import { MAX_Z_INDEX } from "@/common";
@@ -196,6 +198,19 @@ const RenderResults: React.FC = () => {
   );
 };
 
+// Modeled around KBarPortal https://github.com/timc1/kbar/blob/a232f3d8976a61eeeb844152dea25a23a76ad368/src/KBarPortal.tsx
+const KBarToggle: React.FC = (props) => {
+  const { showing } = useKBar((state) => ({
+    showing: state.visualState !== VisualState.hidden,
+  }));
+
+  if (!showing) {
+    return null;
+  }
+
+  return <>{props.children}</>;
+};
+
 function useActions(): void {
   const { query } = useKBar();
 
@@ -223,11 +238,16 @@ const KBarComponent: React.FC = () => {
 };
 
 const QuickBarApp: React.FC = () => (
-  <KBarProvider actions={quickBarRegistry.actions}>
-    <KBarPortal>
-      <KBarComponent />
-    </KBarPortal>
-  </KBarProvider>
+  <div>
+    <ReactShadowRoot>
+      <KBarProvider actions={quickBarRegistry.actions}>
+        <KBarToggle>
+          <link rel="stylesheet" href={faStyleSheet} />
+          <KBarComponent />
+        </KBarToggle>
+      </KBarProvider>
+    </ReactShadowRoot>
+  </div>
 );
 
 export const initQuickBarApp = once(() => {


### PR DESCRIPTION
- Closes #2190 

The shadow DOM correctly isolates the styles (you can see that the input field does not have LinkedIn’s border here) but somewhere the margins are being miscalculated.

I tried looking into it but was unable to determine if this is kbar’s fault or ours. I also used a simple `attachShadow` on the React DOM root (instead of react-shadow-root), but the result is the same.



https://user-images.githubusercontent.com/1402241/147736308-c9d0155a-03c0-4ef6-98fa-583821de1950.mov



