### PR TITLE
Drop unused attemptTemporaryAccess

### DIFF
--- a/src/background/devtools/internal.ts
+++ b/src/background/devtools/internal.ts
@@ -38,7 +38,6 @@ import { isBackground } from "webext-detect-page";
 import { callBackground } from "@/background/devtools/external";
 import { reactivateEveryTab } from "@/background/messenger/api";
 import { expectContext, forbidContext } from "@/utils/expectContext";
-import { getErrorMessage, isPrivatePageError } from "@/errors";
 import { clearDynamicElements } from "@/contentScript/messenger/api";
 
 const TOP_LEVEL_FRAME_ID = 0;


### PR DESCRIPTION
- Follows https://github.com/pixiebrix/pixiebrix-extension/pull/2186

It seems that this piece of code is duplicate. Without it, these sequences still work:

1. Open editor 
2. Click browser action
3. The CS is injected via click listener: 
	https://github.com/pixiebrix/pixiebrix-extension/blob/325e7bd309060ed677f582244b2029396d9dfa5d/src/background/browserAction.ts#L33-L47
4. Refresh page
3. The CS is injected via webNavigation listener in the open devTools, via connectToFrame
	https://github.com/pixiebrix/pixiebrix-extension/blob/325e7bd309060ed677f582244b2029396d9dfa5d/src/devTools/context.ts#L114-L128
5. Refresh page
6. Close and reopen editor
7. The CS is injected via useDevConnection — this will change once we fully drop the `port` in a future (WIP) PR
	https://github.com/pixiebrix/pixiebrix-extension/blob/ec4cbfb0d8787c4ea3d7e7649dd5c3f4278d329f/src/devTools/context.ts#L202:L207