### PR TITLE
Always name dynamic imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,12 @@ module.exports = {
     "pixiebrix",
   ],
   rules: {
+    "import/dynamic-import-chunkname": [
+      "error",
+      {
+        webpackChunknameFormat: "[a-zA-Z0-57-9-/_\\[\\].]+",
+      },
+    ],
     "unicorn/prevent-abbreviations": [
       "error",
       {

--- a/src/Globals.d.ts
+++ b/src/Globals.d.ts
@@ -37,18 +37,7 @@ declare module "generate-schema" {
 
 // From https://github.com/mozilla/page-metadata-parser/issues/116#issuecomment-614882830
 declare module "page-metadata-parser" {
-  export interface IPageMetadata {
-    [k: string]: string | string[];
-    description?: string;
-    icon: string;
-    image?: string;
-    keywords?: string[];
-    title?: string;
-    language?: string;
-    type?: string;
-    url: string;
-    provider: string;
-  }
+  export type IPageMetadata = Record<string, string | string[]>;
 
   export type PageMetadataRule = [
     string,

--- a/src/Globals.d.ts
+++ b/src/Globals.d.ts
@@ -35,6 +35,33 @@ declare module "generate-schema" {
   const json: (title: string, obj: unknown) => UnknownObject;
 }
 
+// From https://github.com/mozilla/page-metadata-parser/issues/116#issuecomment-614882830
+declare module "page-metadata-parser" {
+  export interface IPageMetadata {
+    [k: string]: string | string[];
+    description?: string;
+    icon: string;
+    image?: string;
+    keywords?: string[];
+    title?: string;
+    language?: string;
+    type?: string;
+    url: string;
+    provider: string;
+  }
+
+  export type PageMetadataRule = [
+    string,
+    (element: HTMLElement) => string | null
+  ];
+
+  export function getMetadata(
+    doc: Document | HTMLElement,
+    url: string,
+    customRuleSets?: Record<string, PageMetadataRule>
+  ): IPageMetadata;
+}
+
 declare module "@/vendors/initialize" {
   /** Attach a MutationObserver specifically for a selector */
   const initialize: (

--- a/src/blocks/effects/attachAutocomplete.ts
+++ b/src/blocks/effects/attachAutocomplete.ts
@@ -63,7 +63,9 @@ export class AttachAutocomplete extends Effect {
 
     const inputs = $elt.toArray().filter((x) => x.tagName === "INPUT");
 
-    const { default: autocompleter } = await import("autocompleter");
+    const { default: autocompleter } = await import(
+      /* webpackChunkName: "autocompleter" */ "autocompleter"
+    );
     // TODO: adjust style to hard-code font color so it works on dark themes that have a light font color by default
     await attachStylesheet(autocompleterStyleUrl);
 

--- a/src/blocks/effects/confetti.ts
+++ b/src/blocks/effects/confetti.ts
@@ -29,13 +29,10 @@ export class ConfettiEffect extends Effect {
   };
 
   async effect(): Promise<void> {
-    const confetti = (
-      await import(
-        /* webpackChunkName: "confetti" */
-        // @ts-expect-error no existing definitions exist
-        "canvas-confetti"
-      )
-    ).default;
+    const {
+      default: confetti,
+      // @ts-expect-error no existing definitions exist
+    } = await import(/* webpackChunkName: "confetti" */ "canvas-confetti");
 
     // https://www.kirilv.com/canvas-confetti/
     confetti({

--- a/src/blocks/effects/exportCsv.ts
+++ b/src/blocks/effects/exportCsv.ts
@@ -58,7 +58,9 @@ export class ExportCsv extends Effect {
     { filename = "exported", useBOM = false, data }: BlockArg,
     { ctxt }: BlockOptions
   ): Promise<void> {
-    const { ExportToCsv } = await import("export-to-csv");
+    const { ExportToCsv } = await import(
+      /* webpackChunkName: "export-to-csv" */ "export-to-csv"
+    );
 
     const csvExporter = new ExportToCsv({
       useKeysAsHeaders: true,

--- a/src/blocks/effects/tour.ts
+++ b/src/blocks/effects/tour.ts
@@ -118,7 +118,9 @@ export class TourEffect extends Effect {
       stylesheetLink.remove();
     };
 
-    const { default: introJs } = await import("intro.js");
+    const { default: introJs } = await import(
+      /* webpackChunkName: "intro.js" */ "intro.js"
+    );
 
     return new Promise<void>((resolve, reject) => {
       if (tourInProgress) {

--- a/src/blocks/readers/ImageExifReader.ts
+++ b/src/blocks/readers/ImageExifReader.ts
@@ -67,7 +67,9 @@ export class ImageExifReader extends Reader {
   }
 
   async read(elementOrDocument: HTMLElement | Document) {
-    const ExifReader = await import("exifreader");
+    const ExifReader = await import(
+      /* webpackChunkName: "exifreader" */ "exifreader"
+    );
 
     const element = elementOrDocument as HTMLImageElement;
 

--- a/src/blocks/readers/PageMetadataReader.ts
+++ b/src/blocks/readers/PageMetadataReader.ts
@@ -39,8 +39,7 @@ export class PageMetadataReader extends Reader {
 
   async read() {
     const { getMetadata } = await import(
-      // @ts-expect-error no type definitions available
-      "page-metadata-parser"
+      /* webpackChunkName: "page-metadata-parser" */ "page-metadata-parser"
     );
     return getMetadata(document, location.href);
   }

--- a/src/blocks/readers/PageSemanticReader.ts
+++ b/src/blocks/readers/PageSemanticReader.ts
@@ -35,8 +35,8 @@ export class PageSemanticReader extends Reader {
 
   async read(): Promise<ReaderOutput> {
     const [{ Handler }, { Parser }] = await Promise.all([
-      import("htmlmetaparser"),
-      import("htmlparser2"),
+      import(/* webpackChunkName: "htmlmetaparser" */ "htmlmetaparser"),
+      import(/* webpackChunkName: "htmlparser2" */ "htmlparser2"),
     ]);
 
     return new Promise((resolve, reject) => {

--- a/src/blocks/readers/PageSemanticReader.ts
+++ b/src/blocks/readers/PageSemanticReader.ts
@@ -35,8 +35,8 @@ export class PageSemanticReader extends Reader {
 
   async read(): Promise<ReaderOutput> {
     const [{ Handler }, { Parser }] = await Promise.all([
-      import(/* webpackChunkName: "htmlmetaparser" */ "htmlmetaparser"),
-      import(/* webpackChunkName: "htmlparser2" */ "htmlparser2"),
+      import(/* webpackChunkName: "htmlparsers" */ "htmlmetaparser"),
+      import(/* webpackChunkName: "htmlparsers" */ "htmlparser2"),
     ]);
 
     return new Promise((resolve, reject) => {

--- a/src/blocks/readers/frameworkReader.ts
+++ b/src/blocks/readers/frameworkReader.ts
@@ -35,7 +35,9 @@ export function isHTMLElement(root: ReaderRoot): root is HTMLElement {
 async function asyncFastCssSelector(element: HTMLElement): Promise<string> {
   // Load async because css-selector-generator references the window variable which fails when
   // generating headers
-  const getCssSelector = (await import("css-selector-generator")).default;
+  const { default: getCssSelector } = await import(
+    /* webpackChunkName: "css-selector-generator" */ "css-selector-generator"
+  );
   return getCssSelector(element, {
     // Prefer speed over robust/readable selectors
     combineWithinSelector: false,

--- a/src/blocks/readers/frameworkReader.ts
+++ b/src/blocks/readers/frameworkReader.ts
@@ -18,6 +18,7 @@
 import { Read } from "@/blocks/readers/factory";
 import { Framework } from "@/messaging/constants";
 import { ReaderOutput, ReaderRoot } from "@/core";
+import { getCssSelector } from "css-selector-generator";
 import { castArray, compact } from "lodash";
 import { getComponentData, ReadPayload } from "@/pageScript/protocol";
 
@@ -33,11 +34,6 @@ export function isHTMLElement(root: ReaderRoot): root is HTMLElement {
 }
 
 async function asyncFastCssSelector(element: HTMLElement): Promise<string> {
-  // Load async because css-selector-generator references the window variable which fails when
-  // generating headers
-  const { default: getCssSelector } = await import(
-    /* webpackChunkName: "css-selector-generator" */ "css-selector-generator"
-  );
   return getCssSelector(element, {
     // Prefer speed over robust/readable selectors
     combineWithinSelector: false,

--- a/src/blocks/registry.ts
+++ b/src/blocks/registry.ts
@@ -40,7 +40,9 @@ export class BlocksRegistry extends BaseRegistry<RegistryId, IBlock> {
 
   private async inferAllTypes(): Promise<TypedBlockMap> {
     // Import here to avoid circular dependency between getType and the block registry
-    const { getType } = await import("@/blocks/util");
+    const { getType } = await import(
+      /* webpackChunkName: "blocks/util" */ "@/blocks/util"
+    );
     const typeCache: TypedBlockMap = new Map();
     const items = await this.all();
 

--- a/src/blocks/renderers/markdown.ts
+++ b/src/blocks/renderers/markdown.ts
@@ -41,7 +41,7 @@ export class MarkdownRenderer extends Renderer {
   );
 
   async render({ markdown }: BlockArg): Promise<SafeHTML> {
-    const { marked } = await import("marked");
+    const { marked } = await import(/* webpackChunkName: "marked" */ "marked");
     return sanitize(marked(markdown));
   }
 }

--- a/src/blocks/transformers/jq.ts
+++ b/src/blocks/transformers/jq.ts
@@ -56,13 +56,9 @@ export class JQTransformer extends Transformer {
   ): Promise<unknown> {
     const input = isNullOrBlank(data) ? ctxt : data;
 
-    const jq = (
-      await import(
-        /* webpackChunkName: "jq-web" */
-        // @ts-expect-error no existing definitions exist
-        "jq-web"
-      )
-    ).default;
+    const { default: jq } =
+      // @ts-expect-error no existing definitions exist
+      await import(/* webpackChunkName: "jq-web" */ "jq-web");
 
     logger.debug("Running jq transform", { filter, data, ctxt, input });
 

--- a/src/blocks/transformers/jsonPath.ts
+++ b/src/blocks/transformers/jsonPath.ts
@@ -46,7 +46,9 @@ export class JSONPathTransformer extends Transformer {
     { path }: BlockArg,
     { ctxt }: BlockOptions
   ): Promise<unknown> {
-    const { JSONPath } = await import("jsonpath-plus");
+    const { JSONPath } = await import(
+      /* webpackChunkName: "jsonpath-plus" */ "jsonpath-plus"
+    );
 
     // eslint-disable-next-line new-cap -- export from a library
     return JSONPath({ preventEval: true, path, json: ctxt });

--- a/src/blocks/transformers/parseCsv.ts
+++ b/src/blocks/transformers/parseCsv.ts
@@ -68,7 +68,9 @@ export class ParseCsv extends Transformer {
     { content }: BlockArg,
     { logger }: BlockOptions
   ): Promise<unknown> {
-    const { default: Papa } = await import("papaparse");
+    const { default: Papa } = await import(
+      /* webpackChunkName: "papaparse" */ "papaparse"
+    );
     const { data, errors } = Papa.parse(content);
 
     if (errors.length > 0) {

--- a/src/blocks/transformers/parseDate.ts
+++ b/src/blocks/transformers/parseDate.ts
@@ -112,7 +112,9 @@ export class ParseDate extends Transformer {
   };
 
   async transform({ date }: BlockArg): Promise<unknown> {
-    const { parseDate } = await import("chrono-node");
+    const { parseDate } = await import(
+      /* webpackChunkName: "chrono-node" */ "chrono-node"
+    );
 
     const parsed = parseDate(date);
     const millisPerMinute = 60 * 1000;

--- a/src/blocks/transformers/parseUrl.ts
+++ b/src/blocks/transformers/parseUrl.ts
@@ -91,7 +91,9 @@ export class UrlParser extends Transformer {
   };
 
   async transform({ url, base }: BlockArg): Promise<unknown> {
-    const { isValid, parse } = await import("psl");
+    const { isValid, parse } = await import(
+      /* webpackChunkName: "psl" */ "psl"
+    );
 
     const parsed = new URL(url, base);
 

--- a/src/permissions/patterns.ts
+++ b/src/permissions/patterns.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import psl, { ParsedDomain } from "psl";
+import { ParsedDomain, parse } from "psl";
 
 export const HTTPS_PATTERN = "https://*/*";
 
@@ -29,7 +29,7 @@ export const SITES_PATTERN = "*://*/*";
  */
 export function getDomain(url: string): string {
   const urlClass = new URL(url);
-  const { domain } = psl.parse(urlClass.hostname) as ParsedDomain;
+  const { domain } = parse(urlClass.hostname) as ParsedDomain;
   return domain;
 }
 

--- a/src/runtime/renderers.ts
+++ b/src/runtime/renderers.ts
@@ -26,7 +26,9 @@ const hyphenRegex = /-/gi;
 export type Renderer = (template: string, context: unknown) => unknown;
 
 const ensureNunjucks = once(async () => {
-  const { default: nunjucks } = await import("nunjucks");
+  const { default: nunjucks } = await import(
+    /* webpackChunkName: "nunjucks" */ "nunjucks"
+  );
   return nunjucks;
 });
 
@@ -71,7 +73,9 @@ export async function engineRenderer(
     }
 
     case "handlebars": {
-      const { default: handlebars } = await import("handlebars");
+      const { default: handlebars } = await import(
+        /* webpackChunkName: "handlebars" */ "handlebars"
+      );
       return (template, ctxt) => {
         const compiledTemplate = handlebars.compile(template, {
           noEscape: !autoescape,


### PR DESCRIPTION
Minor QoL improvement, also useful for dependency/bundle tracking in https://github.com/pixiebrix/pixiebrix-extension/issues/1623

You'd think that webpack would be able to name a named dependency, but it can't. I even tried messing with [chunkFileName](https://github.com/pixiebrix/pixiebrix-extension/blob/50d0d3a11877cd0702b15ed10a819d33b1532c8a/webpack.config.js#L240) but it did not recognize anything more than `[id]` and `[name]` (which defaults to `[id]`)

## Before
<img width="200" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/148025289-4ba1e05d-75fe-4520-bae1-65711ad282bc.png">



## After

There are still a few unnamed chunks, but it's possible that they're created/`import()`ed inside a dependency.

<img width="205" alt="Screen Shot 15" src="https://user-images.githubusercontent.com/1402241/148025274-66c9ef4e-4605-45de-98e5-8f52cbe91439.png">