### PR TITLE
#2284 Show message and block editing in page editor for v1 bricks/extensions

### DIFF
--- a/src/devTools/editor/tabs/editTab/EditTab.tsx
+++ b/src/devTools/editor/tabs/editTab/EditTab.tsx
@@ -47,6 +47,8 @@ import { selectActiveNodeId } from "@/devTools/editor/uiState/uiState";
 import AuthContext from "@/auth/AuthContext";
 import ApiVersionField from "@/devTools/editor/fields/ApiVersionField";
 import useBlockPipelineActions from "@/devTools/editor/tabs/editTab/useBlockPipelineActions";
+import useApiVersionAtLeast from "@/devTools/editor/hooks/useApiVersionAtLeast";
+import UnsupportedApiVersionV1 from "@/devTools/editor/tabs/editTab/editorNodeConfigPanel/UnsupportedApiVersionV1";
 
 const blockConfigTheme: ThemeProps = {
   layout: "horizontal",
@@ -66,10 +68,13 @@ const EditTab: React.FC<{
     [extensionPoint.metadata.id]
   );
 
-  const { label, icon, EditorNode: FoundationNode } = useMemo(
-    () => ADAPTERS.get(elementType),
-    [elementType]
-  );
+  const isApiAtLeastV2 = useApiVersionAtLeast("v2");
+
+  const { label, icon, EditorNode } = useMemo(() => ADAPTERS.get(elementType), [
+    elementType,
+  ]);
+
+  const FoundationNode = isApiAtLeastV2 ? EditorNode : UnsupportedApiVersionV1;
 
   const [allBlocks] = useAsyncState<TypedBlockMap>(
     async () => blockRegistry.allTyped(),
@@ -266,7 +271,7 @@ const EditTab: React.FC<{
                   {showVersionField && <ApiVersionField />}
                   <FoundationNode isLocked={isLocked} />
                 </Col>
-              ) : (
+              ) : isApiAtLeastV2 ? (
                 <EditorNodeConfigPanel
                   key={activeNodeId}
                   blockFieldName={blockFieldName}
@@ -281,6 +286,8 @@ const EditTab: React.FC<{
                     copyBlock(activeNodeId);
                   }}
                 />
+              ) : (
+                <UnsupportedApiVersionV1 />
               )}
             </FormTheme.Provider>
           </ErrorBoundary>

--- a/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/UnsupportedApiVersionV1.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/UnsupportedApiVersionV1.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React from "react";
+import { Alert, Card } from "react-bootstrap";
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+
+const UnsupportedApiVersionV1: React.FC = () => (
+  <Card>
+    <Card.Header>Unsupported API Version</Card.Header>
+    <Card.Body>
+      <Alert variant="warning">
+        <FontAwesomeIcon icon={faExclamationTriangle} />
+        {"  "}Bricks created with the runtime API v1 are no longer supported in
+        the Page Editor.
+      </Alert>
+      <p>
+        Use the Workshop to edit this brick/extension.{" "}
+        <a
+          href="https://docs.pixiebrix.com/runtime"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Read more about this change here.
+        </a>
+      </p>
+    </Card.Body>
+  </Card>
+);
+
+export default UnsupportedApiVersionV1;

--- a/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/UnsupportedApiVersionV1.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNodeConfigPanel/UnsupportedApiVersionV1.tsx
@@ -22,7 +22,7 @@ import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 
 const UnsupportedApiVersionV1: React.FC = () => (
   <Card>
-    <Card.Header>Unsupported API Version</Card.Header>
+    <Card.Header>Unsupported Extension Runtime Version</Card.Header>
     <Card.Body>
       <Alert variant="warning">
         <FontAwesomeIcon icon={faExclamationTriangle} />

--- a/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
@@ -31,6 +31,7 @@ import BlockModal from "@/components/brickModal/BrickModal";
 import useBrickRecommendations from "@/devTools/editor/tabs/editTab/useBrickRecommendations";
 import cx from "classnames";
 import TooltipIconButton from "@/components/TooltipIconButton";
+import useApiVersionAtLeast from "@/devTools/editor/hooks/useApiVersionAtLeast";
 
 const addBrickCaption = (
   <span>
@@ -62,6 +63,7 @@ const EditorNodeLayout: React.FC<{
   pasteBlock,
 }) => {
   const recommendations: RegistryId[] = useBrickRecommendations();
+  const isApiAtLeastV2 = useApiVersionAtLeast("v2");
 
   const canMoveAnything = nodes.length > 2;
   const finalIndex = nodes.length - 1;
@@ -87,9 +89,11 @@ const EditorNodeLayout: React.FC<{
             };
           }
 
-          const showAddBlock = index < finalIndex || showAppend;
+          const showAddBlock =
+            isApiAtLeastV2 && (index < finalIndex || showAppend);
           const isFinal = index === finalIndex;
           const showAddMessage = showAddBlock && isFinal;
+          const showPaste = pasteBlock && isApiAtLeastV2;
 
           return (
             <React.Fragment key={nodeId}>
@@ -121,7 +125,7 @@ const EditorNodeLayout: React.FC<{
                     }}
                   />
                 )}
-                {pasteBlock && (
+                {showPaste && (
                   <TooltipIconButton
                     name={`paste-brick-${index}`}
                     icon={faPaste}


### PR DESCRIPTION
If an extension is loaded in the page editor, instead of showing config options, show this message now:

![image](https://user-images.githubusercontent.com/2801308/148115436-2dd12302-209e-4499-90b6-12021bdc6f64.png)

![image](https://user-images.githubusercontent.com/2801308/148115457-56a9c73d-d65b-4768-8ec9-a83d4a7584a1.png)


The only option left in is changing the extension name (and selecting api version for those on the internal feature flag). Reasoning here is that people may still want to rename an extension, like add `(v1)` on the name or something like that so it's easy to identify when they go to pull it up in the workshop, or so they know the difference in the page editor. Can easily remove the option to edit the name if we don't think it's needed.