### PR TITLE
#1881: Upload sourcemaps once (no Rollbar-specific upload needed)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,6 +56,9 @@ module.exports = {
     // Incorrectly suggests to use `runtime.sendMessage` instead of `browser.runtime.sendMessage`
     "import/no-named-as-default-member": "off",
 
+    // Sometimes it conflicts with Prettier
+    "unicorn/no-nested-ternary": "off",
+
     // Rules that depend on https://github.com/pixiebrix/pixiebrix-extension/issues/775
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/restrict-template-expressions": "warn",
@@ -65,7 +68,6 @@ module.exports = {
     "no-await-in-loop": "warn",
 
     "unicorn/no-useless-undefined": "warn", // Buggy with React
-    "unicorn/no-nested-ternary": "warn", // Sometimes it conflicts with Prettier
     "unicorn/consistent-function-scoping": "warn", // Complains about some of the lifted functions
     "unicorn/no-await-expression-member": "warn", // Annoying sometimes, let's try it
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -221,7 +221,6 @@
         "node-sass": "^7.0.0",
         "raw-loader": "^4.0.1",
         "react-select-event": "^5.3.0",
-        "rollbar-sourcemap-webpack-plugin": "^3.3.0",
         "sass-loader": "^12.1.0",
         "selenium-webdriver": "^4.0.0-beta.4",
         "style-loader": "^3.0.0",
@@ -26782,18 +26781,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
       "integrity": "sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA="
     },
-    "node_modules/lodash.isfunction": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
-      "dev": true
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "dev": true
-    },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -32255,36 +32242,6 @@
       },
       "optionalDependencies": {
         "decache": "^3.0.5"
-      }
-    },
-    "node_modules/rollbar-sourcemap-webpack-plugin": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/rollbar-sourcemap-webpack-plugin/-/rollbar-sourcemap-webpack-plugin-3.3.0.tgz",
-      "integrity": "sha512-rIA6NXivXYRCA4UVT2UZV53bj5fVCNijK9N+EqM8m+//nQYO9J5Tk8YVsQKKMY2za63cUmRAi6AczfCaopFf1A==",
-      "dev": true,
-      "dependencies": {
-        "form-data": "^4.0.0",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.isstring": "^4.0.1",
-        "node-fetch": "^2.6.1",
-        "verror": "^1.6.1"
-      },
-      "peerDependencies": {
-        "webpack": ">= 4"
-      }
-    },
-    "node_modules/rollbar-sourcemap-webpack-plugin/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/rollbar/node_modules/lru-cache": {
@@ -58049,18 +58006,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
       "integrity": "sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA="
     },
-    "lodash.isfunction": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
-      "dev": true
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "dev": true
-    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -62377,32 +62322,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
           "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
-        }
-      }
-    },
-    "rollbar-sourcemap-webpack-plugin": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/rollbar-sourcemap-webpack-plugin/-/rollbar-sourcemap-webpack-plugin-3.3.0.tgz",
-      "integrity": "sha512-rIA6NXivXYRCA4UVT2UZV53bj5fVCNijK9N+EqM8m+//nQYO9J5Tk8YVsQKKMY2za63cUmRAi6AczfCaopFf1A==",
-      "dev": true,
-      "requires": {
-        "form-data": "^4.0.0",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.isstring": "^4.0.1",
-        "node-fetch": "^2.6.1",
-        "verror": "^1.6.1"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -244,7 +244,6 @@
     "node-sass": "^7.0.0",
     "raw-loader": "^4.0.1",
     "react-select-event": "^5.3.0",
-    "rollbar-sourcemap-webpack-plugin": "^3.3.0",
     "sass-loader": "^12.1.0",
     "selenium-webdriver": "^4.0.0-beta.4",
     "style-loader": "^3.0.0",

--- a/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -137,8 +137,7 @@ const DataPanel: React.FC<{
 
   const outputObj: JsonObject =
     record !== undefined && "output" in record
-      ? // eslint-disable-next-line unicorn/no-nested-ternary -- prettier disagrees
-        "outputKey" in record
+      ? "outputKey" in record
         ? { [`@${record.outputKey}`]: record.output }
         : record.output
       : null;
@@ -319,8 +318,7 @@ const DataPanel: React.FC<{
                   />
                 )}
               </ErrorBoundary>
-            ) : // eslint-disable-next-line unicorn/no-nested-ternary -- the style rule conflicts with prettier
-            showBlockPreview ? (
+            ) : showBlockPreview ? (
               <ErrorBoundary>
                 <BlockPreview traceRecord={record} blockConfig={block} />
               </ErrorBoundary>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,6 @@ const WebExtensionTarget = require("webpack-target-webextension");
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
 const WebpackBuildNotifierPlugin = require("webpack-build-notifier");
 const { ESBuildMinifyPlugin } = require("esbuild-loader");
-const RollbarSourceMapPlugin = require("rollbar-sourcemap-webpack-plugin");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const CopyPlugin = require("copy-webpack-plugin");
 const { uniq, compact } = require("lodash");
@@ -48,7 +47,8 @@ function parseEnv(value) {
   return Number.isNaN(Number(value)) ? value : Number(value);
 }
 
-// Include defaults required for webpack here. Add defaults for the extension bundle to EnvironmentPlugin
+// Default ENVs used by webpack
+// Note: Default ENVs used by the extension itself should be set in EnvironmentPlugin
 const defaults = {
   DEV_NOTIFY: "true",
   DEV_SLIM: "false",
@@ -72,6 +72,10 @@ for (const [env, defaultValue] of Object.entries(defaults)) {
 console.log("SOURCE_VERSION:", process.env.SOURCE_VERSION);
 console.log("SERVICE_URL:", process.env.SERVICE_URL);
 console.log("CHROME_EXTENSION_ID:", process.env.CHROME_EXTENSION_ID);
+console.log(
+  "ROLLBAR_BROWSER_ACCESS_TOKEN:",
+  process.env.ROLLBAR_BROWSER_ACCESS_TOKEN
+);
 
 if (!process.env.SOURCE_VERSION) {
   process.env.SOURCE_VERSION = require("child_process")
@@ -84,35 +88,14 @@ if (!process.env.SOURCE_VERSION) {
 // Disable sourcemaps on CI unless it's a PUBLIC_RELEASE
 const produceSourcemap =
   !parseEnv(process.env.CI) || parseEnv(process.env.PUBLIC_RELEASE);
-if (!produceSourcemap) {
-  console.log("No sourcemaps will be generated");
-}
 
 const sourceMapPublicUrl =
   parseEnv(process.env.PUBLIC_RELEASE) &&
   `https://pixiebrix-extension-source-maps.s3.amazonaws.com/${process.env.SOURCE_MAP_PATH}/`;
-if (sourceMapPublicUrl) {
-  console.log("Source maps will be available at", sourceMapPublicUrl);
-}
-
-// Setup Rollbar
-const rollbarPlugin =
-  produceSourcemap &&
-  parseEnv(process.env.ROLLBAR_BROWSER_ACCESS_TOKEN) &&
-  parseEnv(process.env.ROLLBAR_BROWSER_ACCESS_TOKEN) &&
-  new RollbarSourceMapPlugin({
-    accessToken: process.env.ROLLBAR_POST_SERVER_ITEM_TOKEN,
-    version: process.env.SOURCE_VERSION, // https://stackoverflow.com/a/43661131
-    publicPath: process.env.ROLLBAR_PUBLIC_PATH,
-  });
-if (rollbarPlugin) {
-  console.log(
-    "Rollbar was configured with",
-    process.env.ROLLBAR_BROWSER_ACCESS_TOKEN
-  );
-} else {
-  console.log("Rollbar was not configured");
-}
+console.log(
+  "Sourcemaps:",
+  sourceMapPublicUrl ? sourceMapPublicUrl : produceSourcemap ? "Local" : "No"
+);
 
 function getVersion() {
   // `manifest.json` only supports numbers in the version, so use the semver
@@ -315,8 +298,6 @@ module.exports = (env, options) =>
       maxAssetSize: 15_120_000,
     },
     plugins: compact([
-      rollbarPlugin,
-
       produceSourcemap &&
         new webpack.SourceMapDevToolPlugin({
           publicPath: sourceMapPublicUrl,


### PR DESCRIPTION
I was looking for a way to fix https://github.com/pixiebrix/pixiebrix-extension/issues/1881 but noticed this section in the Rollbar plugin’s docs: https://github.com/thredup/rollbar-sourcemap-webpack-plugin#webpack-sourcemap-configuration

It appears that Rollbar already does try to access the linked sourcemaps, we only needed this plugin because our source code is offline… but https://github.com/pixiebrix/pixiebrix-extension/pull/1071 made them available publicly, so we shouldn't need it anymore.

Since the build occasionally fails due to it, there's more more reason to exclude it.