### PR TITLE
Use existing components for brick and node lists in editor

### DIFF
--- a/src/devTools/editor/ElementWizard.tsx
+++ b/src/devTools/editor/ElementWizard.tsx
@@ -15,13 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useContext, useMemo, useState } from "react";
 import { useFormikContext } from "formik";
 import { groupBy } from "lodash";
 import { Badge, Form as BootstrapForm, Nav, Tab } from "react-bootstrap";
@@ -90,10 +84,6 @@ const ElementWizard: React.FunctionComponent<{
   editable: Set<string>;
 }> = ({ element, editable }) => {
   const [step, setStep] = useState(wizard[0].step);
-
-  useEffect(() => {
-    setStep(wizard[0].step);
-  }, [setStep]);
 
   const { refresh: refreshLogs } = useContext(LogContext);
 

--- a/src/devTools/editor/sidebar/DynamicEntry.tsx
+++ b/src/devTools/editor/sidebar/DynamicEntry.tsx
@@ -55,12 +55,12 @@ const DynamicEntry: React.FunctionComponent<{
 
   return (
     <ListGroup.Item
+      action
       active={item.uuid === activeElement}
       key={`dynamic-${item.uuid}`}
       onMouseEnter={async () => showOverlay(item.uuid)}
       onMouseLeave={async () => hideOverlay()}
       onClick={() => dispatch(actions.selectElement(item.uuid))}
-      style={{ cursor: "pointer" }}
     >
       <ExtensionIcon type={item.type} /> {getLabel(item)}
       {!available && (

--- a/src/devTools/editor/sidebar/InstalledEntry.tsx
+++ b/src/devTools/editor/sidebar/InstalledEntry.tsx
@@ -62,10 +62,10 @@ const InstalledEntry: React.FunctionComponent<{
 
   return (
     <ListGroup.Item
+      action
       active={extension.id === activeElement}
       key={`installed-${extension.id}`}
       onClick={async () => selectHandler(extension)}
-      style={{ cursor: "pointer" }}
     >
       <ExtensionIcon type={type} /> {extension.label ?? extension.id}
       {!available && (

--- a/src/devTools/editor/sidebar/Sidebar.tsx
+++ b/src/devTools/editor/sidebar/Sidebar.tsx
@@ -21,6 +21,7 @@ import { DevToolsContext } from "@/devTools/context";
 import { sortBy } from "lodash";
 import {
   Badge,
+  Button,
   Dropdown,
   DropdownButton,
   Form,
@@ -176,13 +177,14 @@ const SidebarExpanded: React.FunctionComponent<
                 ))}
             </DropdownButton>
           </div>
-          <button
-            className={cx("navbar-toggler", styles.toggle)}
+          <Button
+            variant="light"
+            className={cx(styles.toggle)}
             type="button"
             onClick={collapseSidebar}
           >
             <FontAwesomeIcon icon={faAngleDoubleLeft} />
-          </button>
+          </Button>
         </div>
 
         {unavailableCount ? (
@@ -232,14 +234,15 @@ const SidebarCollapsed: React.FunctionComponent<{
   expandSidebar: () => void;
 }> = ({ expandSidebar }) => (
   <div className={cx(styles.root, styles.collapsed)}>
-    <button
-      className={cx("navbar-toggler", styles.toggle)}
+    <Button
+      variant="light"
+      className={cx(styles.toggle)}
       type="button"
       onClick={expandSidebar}
     >
       <Logo />
       <FontAwesomeIcon icon={faAngleDoubleRight} />
-    </button>
+    </Button>
   </div>
 );
 

--- a/src/devTools/editor/tabs/editTab/editorNode/EditorNode.module.scss
+++ b/src/devTools/editor/tabs/editTab/editorNode/EditorNode.module.scss
@@ -20,15 +20,8 @@
   display: flex;
   align-items: center;
   font-size: 0.875rem;
-  border: solid 1px #ced4da;
-  border-width: $borderWidth 0;
-  margin-top: -$borderWidth; // Overlap borders
   padding: 20px 10px;
   padding-right: 0;
-}
-.activeNode {
-  background-color: var(--blue);
-  color: white;
 }
 
 .icon {

--- a/src/devTools/editor/tabs/editTab/editorNode/EditorNode.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNode/EditorNode.tsx
@@ -19,7 +19,7 @@ import React, { useEffect, useRef } from "react";
 import styles from "./EditorNode.module.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
-import cx from "classnames";
+import { ListGroup } from "react-bootstrap";
 import { faArrowDown, faArrowUp } from "@fortawesome/free-solid-svg-icons";
 import { NodeId } from "@/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout";
 
@@ -62,7 +62,7 @@ const EditorNode: React.FC<EditorNodeProps> = ({
   onClickMoveUp,
   onClickMoveDown,
 }) => {
-  const nodeRef = useRef<HTMLDivElement>(null);
+  const nodeRef = useRef<HTMLAnchorElement>(null);
   const outputName = outputKey ? `@${outputKey}` : "";
 
   const icon = isFontAwesomeIcon(iconProp) ? (
@@ -90,17 +90,13 @@ const EditorNode: React.FC<EditorNodeProps> = ({
       nodeRef.current?.focus();
     }
   }, [active]);
-
   return (
-    // Use our own custom style here, not bootstrap
-    <div
+    <ListGroup.Item
       ref={nodeRef}
-      tabIndex={0}
-      role="button"
+      action
       onClick={onClick}
-      className={cx(styles.root, {
-        [styles.activeNode]: active,
-      })}
+      active={active}
+      className={styles.root}
     >
       <div className={styles.icon}>
         {icon}
@@ -142,7 +138,7 @@ const EditorNode: React.FC<EditorNodeProps> = ({
           )}
         </div>
       )}
-    </div>
+    </ListGroup.Item>
   );
 };
 

--- a/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.module.scss
+++ b/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.module.scss
@@ -23,29 +23,28 @@
   gap: 0.2em;
 
   position: relative;
-  z-index: 1;
+  z-index: 3; // Above Bootstrap’s .list-item.active
 
   --size: 22px;
   button {
     display: block;
     border: none;
-    background: none;
-    color: inherit;
+    color: gray;
+    background-color: white;
+    border-radius: 50%;
     padding: 0;
     outline: none;
+    &:focus,
+    &:hover {
+      color: var(--blue);
+    }
   }
 
   svg {
     display: block;
     font-size: var(--size);
-    color: gray;
-    background-color: white;
     border: solid 3px white;
     border-radius: 50%;
-    &:focus,
-    &:hover {
-      color: var(--blue);
-    }
   }
 }
 

--- a/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
@@ -32,6 +32,7 @@ import useBrickRecommendations from "@/devTools/editor/tabs/editTab/useBrickReco
 import cx from "classnames";
 import TooltipIconButton from "@/components/TooltipIconButton";
 import useApiVersionAtLeast from "@/devTools/editor/hooks/useApiVersionAtLeast";
+import { ListGroup } from "react-bootstrap";
 
 const addBrickCaption = (
   <span>
@@ -69,7 +70,7 @@ const EditorNodeLayout: React.FC<{
   const finalIndex = nodes.length - 1;
 
   return (
-    <>
+    <ListGroup variant="flush">
       {nodes.length > 0 &&
         nodes.map((nodeProps, index) => {
           const { nodeId } = nodeProps;
@@ -146,7 +147,7 @@ const EditorNodeLayout: React.FC<{
             </React.Fragment>
           );
         })}
-    </>
+    </ListGroup>
   );
 };
 

--- a/src/devtoolsPanel.tsx
+++ b/src/devtoolsPanel.tsx
@@ -15,18 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import ReactDOM from "react-dom";
-import React from "react";
-
-import Panel from "@/devTools/Panel";
-
-import "@/development/darkMode";
-import "@/telemetry/reportUncaughtErrors";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "@/vendors/overrides.scss";
 import "@/devTools/Panel.scss";
 
+import "@/development/darkMode";
+import "@/telemetry/reportUncaughtErrors";
 import "@/devTools/messenger/registration";
+
+import ReactDOM from "react-dom";
+import React from "react";
+import Panel from "@/devTools/Panel";
 import { watchNavigation } from "@/devTools/protocol";
 import initGoogle from "@/contrib/google/initGoogle";
 


### PR DESCRIPTION
Visually this changes little, it only adds the `:hover` and `:active` states, but it reduces code and delegates more to Bootstrap for style and behavior consistency.

The ListGroup component could actually be used even further to manage the whole interface and skip onClick handlers too since they're all essentially nested [tabbed interfaces](https://react-bootstrap-v4.netlify.app/components/list-group/#tabbed-interfaces)

- extensions
	- edit
		- bricks
	- logs

## Before



https://user-images.githubusercontent.com/1402241/148351991-8b097772-340b-4cbf-a7ed-fe1f3074d596.mov


## After


https://user-images.githubusercontent.com/1402241/148351998-bfe735dd-0f6b-4911-ae89-55ac12e00325.mov


