### PR TITLE
Align editor sidebar

### DIFF
--- a/src/devTools/editor/sidebar/DynamicEntry.tsx
+++ b/src/devTools/editor/sidebar/DynamicEntry.tsx
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import styles from "./Entry.module.scss";
 import React, { useCallback } from "react";
 import { actions, FormState } from "@/devTools/editor/slices/editorSlice";
 import { useDispatch, useSelector } from "react-redux";
@@ -29,6 +30,7 @@ import {
 import { UUID } from "@/core";
 import { disableOverlay, enableOverlay } from "@/contentScript/messenger/api";
 import { thisTab } from "@/devTools/utils";
+import cx from "classnames";
 
 /**
  * A sidebar menu entry corresponding to an extension that is new or is currently being edited.
@@ -55,6 +57,7 @@ const DynamicEntry: React.FunctionComponent<{
 
   return (
     <ListGroup.Item
+      className={styles.root}
       action
       active={item.uuid === activeElement}
       key={`dynamic-${item.uuid}`}
@@ -62,14 +65,17 @@ const DynamicEntry: React.FunctionComponent<{
       onMouseLeave={async () => hideOverlay()}
       onClick={() => dispatch(actions.selectElement(item.uuid))}
     >
-      <ExtensionIcon type={item.type} /> {getLabel(item)}
+      <span className={styles.icon}>
+        <ExtensionIcon type={item.type} />
+      </span>
+      <span className={styles.name}>{getLabel(item)}</span>
       {!available && (
-        <span className="ml-2">
+        <span className={styles.icon}>
           <NotAvailableIcon />
         </span>
       )}
       {isDirty && (
-        <span className="text-danger ml-2">
+        <span className={cx(styles.icon, "text-danger")}>
           <UnsavedChangesIcon />
         </span>
       )}

--- a/src/devTools/editor/sidebar/Entry.module.scss
+++ b/src/devTools/editor/sidebar/Entry.module.scss
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.root {
+  display: flex;
+  gap: 0.5em;
+  padding: 0.8em 0.6em !important;
+}
+.icon {
+  width: 1.5em;
+  text-align: center;
+}
+.name {
+  flex-grow: 1;
+}

--- a/src/devTools/editor/sidebar/Entry.module.scss
+++ b/src/devTools/editor/sidebar/Entry.module.scss
@@ -23,6 +23,7 @@
 .icon {
   width: 1.5em;
   text-align: center;
+  flex-shrink: 0;
 }
 .name {
   flex-grow: 1;

--- a/src/devTools/editor/sidebar/Footer.module.scss
+++ b/src/devTools/editor/sidebar/Footer.module.scss
@@ -1,10 +1,14 @@
 .root {
   font-size: 0.875rem;
-  background-color: lightgray;
+  background-color: #c6bfdb;
   flex-grow: 0;
   display: flex;
 }
 
 .scope {
   flex: 1;
+  padding: 0 0.4em;
+  code {
+    color: inherit;
+  }
 }

--- a/src/devTools/editor/sidebar/InstalledEntry.tsx
+++ b/src/devTools/editor/sidebar/InstalledEntry.tsx
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import styles from "./Entry.module.scss";
 import React, { useCallback } from "react";
 import { IExtension, UUID } from "@/core";
 import { useDispatch } from "react-redux";
@@ -62,14 +63,18 @@ const InstalledEntry: React.FunctionComponent<{
 
   return (
     <ListGroup.Item
+      className={styles.root}
       action
       active={extension.id === activeElement}
       key={`installed-${extension.id}`}
       onClick={async () => selectHandler(extension)}
     >
-      <ExtensionIcon type={type} /> {extension.label ?? extension.id}
+      <span className={styles.icon}>
+        <ExtensionIcon type={type} />
+      </span>
+      <span className={styles.name}>{extension.label ?? extension.id}</span>
       {!available && (
-        <span className="ml-2">
+        <span className={styles.icon}>
           <NotAvailableIcon />
         </span>
       )}

--- a/src/devTools/editor/sidebar/Sidebar.tsx
+++ b/src/devTools/editor/sidebar/Sidebar.tsx
@@ -190,6 +190,7 @@ const SidebarExpanded: React.FunctionComponent<
         {unavailableCount ? (
           <div className={styles.unavailable}>
             <Form.Check
+              id="unavailable-extensions-checkbox"
               type="checkbox"
               label={`Show ${unavailableCount} unavailable`}
               defaultChecked={showAll}


### PR DESCRIPTION
### This PR fixes these issues

- the sidebar’s labels were not aligned as the icons have varying widths
- the extension names would wrap under the extension icon, together with the unsaved/hidden icons
- the "Show unavailable" label was not clickable, only the checkbox was
- the scope footer was so close to the corner that it was nearly clipped by the rounder corner



### Possible future improvements

- align, color or drop the "Show unavailable" checkbox
- avoid red icon on blue background <img width="24" valign=top alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/148677913-e5709f9c-a28d-4314-a88c-d59a1a88dc7e.png">



### Questions

- I was actually hoping to color the whole sidebar purple to improve its visual hierarchy, but purple unfortunately doesn't really fit with the rest of the color scheme in the editor. 
	- @twschiller how come the editor doesn't use the custom/purple bootstrap theme?


<table>
<tr>
	<th>Before
	<th>After
<tr>
<tr>
	<td><img width="327" alt="Screen Shot 8" src="https://user-images.githubusercontent.com/1402241/148677774-1c75139f-f6d4-417e-ac95-7cd92ad7075b.png">
	<td><img width="327" alt="Screen Shot 9" src="https://user-images.githubusercontent.com/1402241/148677776-acd852ea-d231-4ad4-9249-96978e8fbae8.png">
</table>

