### PR TITLE
#2307 Add a 'no options' message when there are no Advanced Options to present for a brick

### DIFF
--- a/src/devTools/editor/tabs/effect/v3/BlockConfiguration.tsx
+++ b/src/devTools/editor/tabs/effect/v3/BlockConfiguration.tsx
@@ -91,22 +91,12 @@ const BlockConfiguration: React.FunctionComponent<{
     [configName]
   );
 
-  const showRootMode = useMemo(
-    () =>
-      // Only show if necessary. Currently, only the trigger extension point passes the
-      // element that triggered the event through for the reader root.
-      isRootAware && ["trigger", "contextMenu"].includes(context.values.type),
-    [context.values.type, isRootAware]
-  );
-
-  const showIfAndTarget = useMemo(() => blockType && blockType !== "renderer", [
-    blockType,
-  ]);
-
-  const noAdvancedOptions = useMemo(() => !showRootMode && !showIfAndTarget, [
-    showIfAndTarget,
-    showRootMode,
-  ]);
+  // Only show if necessary. Currently, only the trigger extension point passes the element
+  // that triggered the event through for the reader root
+  const showRootMode =
+    isRootAware && ["trigger", "contextMenu"].includes(context.values.type);
+  const showIfAndTarget = blockType && blockType !== "renderer";
+  const noAdvancedOptions = !showRootMode && !showIfAndTarget;
 
   return (
     <>

--- a/src/devTools/editor/tabs/effect/v3/BlockConfiguration.tsx
+++ b/src/devTools/editor/tabs/effect/v3/BlockConfiguration.tsx
@@ -91,6 +91,23 @@ const BlockConfiguration: React.FunctionComponent<{
     [configName]
   );
 
+  const showRootMode = useMemo(
+    () =>
+      // Only show if necessary. Currently, only the trigger extension point passes the
+      // element that triggered the event through for the reader root.
+      isRootAware && ["trigger", "contextMenu"].includes(context.values.type),
+    [context.values.type, isRootAware]
+  );
+
+  const showIfAndTarget = useMemo(() => blockType && blockType !== "renderer", [
+    blockType,
+  ]);
+
+  const noAdvancedOptions = useMemo(() => !showRootMode && !showIfAndTarget, [
+    showIfAndTarget,
+    showRootMode,
+  ]);
+
   return (
     <>
       <AdvancedLinks name={name} scrollToRef={advancedOptionsRef} />
@@ -121,23 +138,18 @@ const BlockConfiguration: React.FunctionComponent<{
           Advanced Options
         </Card.Header>
         <Card.Body ref={advancedOptionsRef}>
-          {
-            // Only show if necessary. Currently only the trigger extension point passes the element that triggered the
-            // event through for the reader root
-            isRootAware &&
-              ["trigger", "contextMenu"].includes(context.values.type) && (
-                <ConnectedFieldTemplate
-                  name={configName("rootMode")}
-                  label="Root Mode"
-                  as={SelectWidget}
-                  options={rootModeOptions}
-                  blankValue="inherit"
-                  description="The root mode controls which page element PixieBrix provides as the implicit element"
-                />
-              )
-          }
+          {showRootMode && (
+            <ConnectedFieldTemplate
+              name={configName("rootMode")}
+              label="Root Mode"
+              as={SelectWidget}
+              options={rootModeOptions}
+              blankValue="inherit"
+              description="The root mode controls which page element PixieBrix provides as the implicit element"
+            />
+          )}
 
-          {blockType && blockType !== "renderer" && (
+          {showIfAndTarget && (
             <>
               <SchemaField {...ifSchemaProps} />
 
@@ -150,6 +162,10 @@ const BlockConfiguration: React.FunctionComponent<{
                 description="Where to execute the brick."
               />
             </>
+          )}
+
+          {noAdvancedOptions && (
+            <small className="text-muted font-italic">No options to show</small>
           )}
         </Card.Body>
       </Card>

--- a/src/devTools/editor/tabs/effect/v3/__snapshots__/BlockConfiguration.test.tsx.snap
+++ b/src/devTools/editor/tabs/effect/v3/__snapshots__/BlockConfiguration.test.tsx.snap
@@ -76,7 +76,13 @@ exports[`renders 1`] = `
       </div>
       <div
         class="card-body"
-      />
+      >
+        <small
+          class="text-muted font-italic"
+        >
+          No options to show
+        </small>
+      </div>
     </div>
     <button
       type="submit"


### PR DESCRIPTION
Closes #2307 

Adds this message:

![image](https://user-images.githubusercontent.com/2801308/148870618-b9edfceb-535f-4a17-a090-39685b23453f.png)
