### PR TITLE
#2366: Cleanup ensureContentScript and neighboring code

### DIFF
--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -70,11 +70,7 @@ async function dispatchMenu(
     throw new TypeError(`Not a PixieBrix menu item: ${info.menuItemId}`);
   }
 
-  try {
-    reportEvent("ContextMenuClick", { extensionId: info.menuItemId });
-  } catch (error) {
-    console.warn("Error reporting ContextMenuClick event", { error });
-  }
+  reportEvent("ContextMenuClick", { extensionId: info.menuItemId });
 
   console.time("ensureContentScript");
 
@@ -82,7 +78,7 @@ async function dispatchMenu(
   await pTimeout(
     ensureContentScript(target),
     CONTEXT_SCRIPT_INSTALL_MS,
-    `contentScript for context menu handler not ready in ${CONTEXT_SCRIPT_INSTALL_MS}s`
+    `contentScript for context menu handler not ready in ${CONTEXT_SCRIPT_INSTALL_MS}ms`
   );
 
   console.timeEnd("ensureContentScript");

--- a/src/background/initBrowserCommands.ts
+++ b/src/background/initBrowserCommands.ts
@@ -18,16 +18,14 @@
 import { toggleQuickBar } from "@/contentScript/messenger/api";
 import { Target } from "@/types";
 import { expectContext } from "@/utils/expectContext";
-import browser from "webextension-polyfill";
+import { canReceiveContentScript } from "@/utils/permissions";
 import { ensureContentScript } from "./util";
 
-async function handleCommand(command: string): Promise<void> {
-  if (command !== "toggle-quick-bar") {
-    return;
-  }
-
-  const [tab] = await browser.tabs.query({ currentWindow: true, active: true });
-  if (!tab) {
+async function handleCommand(
+  command: string,
+  tab: chrome.tabs.Tab
+): Promise<void> {
+  if (command !== "toggle-quick-bar" || !canReceiveContentScript(tab.url)) {
     return;
   }
 
@@ -42,5 +40,5 @@ async function handleCommand(command: string): Promise<void> {
 
 export default function initBrowserCommands(): void {
   expectContext("background");
-  browser.commands.onCommand.addListener(handleCommand);
+  chrome.commands.onCommand.addListener(handleCommand);
 }

--- a/src/background/initBrowserCommands.ts
+++ b/src/background/initBrowserCommands.ts
@@ -40,5 +40,6 @@ async function handleCommand(
 
 export default function initBrowserCommands(): void {
   expectContext("background");
+  // TODO: Use browser.* when its types are fixed https://github.com/Lusito/webextension-polyfill-ts/issues/70
   chrome.commands.onCommand.addListener(handleCommand);
 }

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -41,7 +41,6 @@ export const containsPermissions = browser.permissions
 
 export const getAvailableVersion = getMethod("GET_AVAILABLE_VERSION", bg);
 export const ensureContentScript = getMethod("INJECT_SCRIPT", bg);
-export const checkTargetPermissions = getMethod("CHECK_TARGET_PERMISSIONS", bg);
 export const openPopupPrompt = getMethod("OPEN_POPUP_PROMPT", bg);
 export const whoAmI = getMethod("ECHO_SENDER", bg);
 export const waitForTargetByUrl = getMethod("WAIT_FOR_TARGET_BY_URL", bg);

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -47,7 +47,6 @@ import { preloadContextMenus } from "@/background/initContextMenus";
 import { getAvailableVersion } from "@/background/installer";
 import { locator, refreshServices } from "@/background/locator";
 import { reactivateEveryTab } from "@/background/navigation";
-import { canAccessTab } from "webext-tools";
 import {
   getLoggingConfig,
   recordError,
@@ -80,7 +79,6 @@ declare global {
 
     GET_AVAILABLE_VERSION: typeof getAvailableVersion;
     INJECT_SCRIPT: typeof ensureContentScript;
-    CHECK_TARGET_PERMISSIONS: typeof canAccessTab;
     CONTAINS_PERMISSIONS: typeof browser.permissions.contains;
     PRELOAD_CONTEXT_MENUS: typeof preloadContextMenus;
     UNINSTALL_CONTEXT_MENU: typeof uninstallContextMenu;
@@ -142,7 +140,6 @@ registerMethods({
 
   GET_AVAILABLE_VERSION: getAvailableVersion,
   INJECT_SCRIPT: ensureContentScript,
-  CHECK_TARGET_PERMISSIONS: canAccessTab,
   CONTAINS_PERMISSIONS: browser.permissions.contains,
 
   PRELOAD_CONTEXT_MENUS: preloadContextMenus,

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -58,7 +58,7 @@ class ErrorBoundary extends Component<Props, State> {
   render(): React.ReactNode {
     if (this.state.hasError) {
       return (
-        <div>
+        <div className="p-3">
           <h1>Something went wrong.</h1>
           {this.props.errorContext && <h2>{this.props.errorContext}</h2>}
           <div>
@@ -73,7 +73,7 @@ class ErrorBoundary extends Component<Props, State> {
               <FontAwesomeIcon icon={faRedo} /> Reload the Page
             </Button>
           </div>
-          <pre className="mt-2">
+          <pre className="mt-2 small text-secondary">
             {this.state.stack.replaceAll(
               `chrome-extension://${process.env.CHROME_EXTENSION_ID}/`,
               ""

--- a/src/devTools/Panel.tsx
+++ b/src/devTools/Panel.tsx
@@ -38,6 +38,7 @@ import { ModalProvider } from "@/components/ConfirmationModal";
 import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 import { getErrorMessage } from "@/errors";
+import browser from "webextension-polyfill";
 
 // Import custom options widgets/forms for the built-in bricks
 import "@/contrib/editors";
@@ -82,36 +83,33 @@ const Panel: React.FunctionComponent = () => {
     await blockRegistry.fetch();
   }, []);
 
-  if (authError) {
+  const error =
+    (authError && getErrorMessage(authError)) || context.tabState.error;
+  if (error) {
     return (
-      <Centered>
-        <div className="PaneTitle">Error authenticating account</div>
-        <div>{getErrorMessage(authError)}</div>
-        <Button
-          onClick={() => {
-            location.reload();
-          }}
-        >
-          Reload Editor
-        </Button>
-      </Centered>
-    );
-  }
-
-  if (context.tabState.error) {
-    return (
-      <Centered>
-        <div className="PaneTitle">
-          <b>An error occurred</b>
-        </div>
-        <div>{context.tabState?.error}</div>
+      <Centered vertically>
+        {authError && (
+          <div className="PaneTitle">Error authenticating account</div>
+        )}
+        <div>{error}</div>
         <div className="mt-2">
           <Button
+            onClick={() => {
+              void browser.tabs.reload(browser.devtools.inspectedWindow.tabId);
+            }}
+          >
+            Reload page
+          </Button>
+        </div>
+        <div className="mt-2">
+          <Button
+            size="sm"
+            variant="light"
             onClick={() => {
               location.reload();
             }}
           >
-            Reload Editor
+            Reload editor
           </Button>
         </div>
       </Centered>

--- a/src/devTools/Panel.tsx
+++ b/src/devTools/Panel.tsx
@@ -98,7 +98,7 @@ const Panel: React.FunctionComponent = () => {
               void browser.tabs.reload(browser.devtools.inspectedWindow.tabId);
             }}
           >
-            Reload page
+            Reload Page
           </Button>
         </div>
         <div className="mt-2">
@@ -109,7 +109,7 @@ const Panel: React.FunctionComponent = () => {
               location.reload();
             }}
           >
-            Reload editor
+            Reload Editor
           </Button>
         </div>
       </Centered>

--- a/src/devTools/context.ts
+++ b/src/devTools/context.ts
@@ -99,7 +99,7 @@ async function connectToFrame(): Promise<FrameMeta> {
     await pTimeout(
       ensureContentScript(thisTab),
       4000,
-      "contentScript not ready in 4s"
+      "The Page Editor could not establish a connection to the page"
     );
   } catch (error) {
     // If it's not a permission error, then throw error as is

--- a/src/devTools/context.ts
+++ b/src/devTools/context.ts
@@ -25,17 +25,13 @@ import { reportError } from "@/telemetry/logging";
 import { uuidv4 } from "@/types/helpers";
 import { useTabEventListener } from "@/hooks/events";
 import { getErrorMessage } from "@/errors";
-import { getCurrentURL, thisTab } from "@/devTools/utils";
+import { thisTab } from "@/devTools/utils";
 import { Except } from "type-fest";
 import { detectFrameworks } from "@/contentScript/messenger/api";
-import {
-  checkTargetPermissions,
-  ensureContentScript,
-} from "@/background/messenger/api";
-import { runInMillis } from "@/utils";
+import { ensureContentScript } from "@/background/messenger/api";
+import { canAccessTab } from "webext-tools";
 
 interface FrameMeta {
-  url: string;
   frameworks: FrameworkMeta[];
 }
 
@@ -98,39 +94,35 @@ class PermissionsError extends Error {
 }
 
 async function connectToFrame(): Promise<FrameMeta> {
-  // TODO: drop the next few lines and just let ensureScript throw
+  console.debug("connectToFrame: ensuring contentScript");
+  try {
+    await pTimeout(
+      ensureContentScript(thisTab),
+      4000,
+      "contentScript not ready in 4s"
+    );
+  } catch (error) {
+    // If it's not a permission error, then throw error as is
+    if (await canAccessTab(thisTab)) {
+      throw error;
+    }
 
-  const [hasPermissions, url] = await Promise.all([
-    checkTargetPermissions(thisTab),
-    getCurrentURL(),
-  ]);
-  if (!hasPermissions) {
-    console.debug(`connectToFrame: no access to ${url}`);
-    throw new PermissionsError(`No access to URL: ${url}`);
+    console.debug("connectToFrame: no access to host");
+    throw new PermissionsError("No access to URL");
   }
-
-  console.debug(`connectToFrame: ensuring contentScript for ${url}`);
-  await pTimeout(
-    ensureContentScript(thisTab),
-    4000,
-    "contentScript not ready in 4s"
-  );
 
   let frameworks: FrameworkMeta[] = [];
   try {
-    console.debug(`connectToFrame: detecting frameworks on ${url}`);
-    frameworks = await runInMillis(
-      async () => detectFrameworks(thisTab, null),
-      500
-    );
+    console.debug("connectToFrame: detecting frameworks");
+    frameworks = await pTimeout(detectFrameworks(thisTab, null), 500);
   } catch (error) {
-    console.debug(`connectToFrame: error detecting frameworks ${url}`, {
+    console.debug("connectToFrame: error detecting frameworks", {
       error,
     });
   }
 
-  console.debug(`connectToFrame: finished for ${url}`);
-  return { frameworks, url };
+  console.debug("connectToFrame: finished");
+  return { frameworks };
 }
 
 export function useDevConnection(): Context {
@@ -150,9 +142,7 @@ export function useDevConnection(): Context {
       console.debug(`useDevConnection.connect: connecting for ${uuid}`);
       setConnecting(true);
       const meta = await connectToFrame();
-      console.debug(
-        `useDevConnection.connect: replacing tabState for ${uuid}: ${meta.url}`
-      );
+      console.debug(`useDevConnection.connect: replacing tabState for ${uuid}`);
       setCurrent({
         ...common,
         hasPermissions: true,

--- a/src/devTools/editor/panes/PermissionsPane.tsx
+++ b/src/devTools/editor/panes/PermissionsPane.tsx
@@ -20,13 +20,15 @@ import { DevToolsContext } from "@/devTools/context";
 import Centered from "@/devTools/editor/components/Centered";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle, faShieldAlt } from "@fortawesome/free-solid-svg-icons";
-import { requestPermissions } from "@/utils/permissions";
+import {
+  canReceiveContentScript,
+  requestPermissions,
+} from "@/utils/permissions";
 import AsyncButton from "@/components/AsyncButton";
 import { getCurrentURL } from "@/devTools/utils";
 import { safeParseUrl } from "@/utils";
 import { parse as parseDomain } from "psl";
 import { useAsyncEffect } from "use-async-effect";
-import { isScriptableUrl } from "webext-content-scripts";
 
 const PermissionsPane: React.FunctionComponent = () => {
   const { connect } = useContext(DevToolsContext);
@@ -41,7 +43,7 @@ const PermissionsPane: React.FunctionComponent = () => {
     }
 
     const { hostname } = safeParseUrl(url);
-    setAllowed(url.startsWith("http") && isScriptableUrl(url));
+    setAllowed(canReceiveContentScript(url));
     const result = parseDomain(hostname);
     if ("domain" in result && result.domain) {
       setSiteLabel(result.domain);

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -21,6 +21,7 @@ import {
   containsPermissions,
   openPopupPrompt,
 } from "@/background/messenger/api";
+import { isScriptableUrl } from "webext-content-scripts";
 
 /** Filters out any permissions that are not part of `optional_permissions` */
 export function selectOptionalPermissions(
@@ -71,4 +72,12 @@ export async function requestPermissions(
   const { tabId } = browser.devtools.inspectedWindow;
   await openPopupPrompt(tabId, page.toString());
   return containsPermissions(permissions);
+}
+
+/**
+ * Determines whether a page can potentially execute a content script.
+ * This excludes non-http pages and extension gallery pages.
+ */
+export function canReceiveContentScript(url: string): boolean {
+  return url.startsWith("http") && isScriptableUrl(url);
 }


### PR DESCRIPTION
- Followup to https://github.com/pixiebrix/pixiebrix-extension/pull/2317

Purpose of this PR is described in the review


Tested and working, on domains with and without permissions:

- browser action (even double click, no duplicates)
- context menu
- command (browser shortcut)
- attemptTemporaryAccess in the dev tools via activeTab
- a combination of the above