### PR TITLE
#2343: Avoid nesting `button` in editor

### DIFF
--- a/src/devTools/editor/tabs/editTab/editorNode/EditorNode.module.scss
+++ b/src/devTools/editor/tabs/editTab/editorNode/EditorNode.module.scss
@@ -16,12 +16,12 @@
  */
 
 .root {
-  $borderWidth: 1px;
   display: flex;
   align-items: center;
   font-size: 0.875rem;
   padding: 20px 10px;
   padding-right: 0;
+  cursor: pointer;
 }
 
 .icon {

--- a/src/devTools/editor/tabs/editTab/editorNode/EditorNode.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNode/EditorNode.tsx
@@ -94,7 +94,7 @@ const EditorNode: React.FC<EditorNodeProps> = ({
   return (
     <ListGroup.Item
       ref={nodeRef}
-      tabIndex={0}
+      tabIndex={0} // Avoid using `button` because this item includes more buttons #2343
       onClick={onClick}
       active={active}
       className={cx(styles.root, "list-group-item-action")}

--- a/src/devTools/editor/tabs/editTab/editorNode/EditorNode.tsx
+++ b/src/devTools/editor/tabs/editTab/editorNode/EditorNode.tsx
@@ -22,6 +22,7 @@ import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { ListGroup } from "react-bootstrap";
 import { faArrowDown, faArrowUp } from "@fortawesome/free-solid-svg-icons";
 import { NodeId } from "@/devTools/editor/tabs/editTab/editorNodeLayout/EditorNodeLayout";
+import cx from "classnames";
 
 export type EditorNodeProps = {
   nodeId?: NodeId;
@@ -93,10 +94,10 @@ const EditorNode: React.FC<EditorNodeProps> = ({
   return (
     <ListGroup.Item
       ref={nodeRef}
-      action
+      tabIndex={0}
       onClick={onClick}
       active={active}
-      className={styles.root}
+      className={cx(styles.root, "list-group-item-action")}
     >
       <div className={styles.icon}>
         {icon}


### PR DESCRIPTION
- closes #2343

Technically this does not solve the error but just silences it by reverting to a plain `<div tabindex>`, which react-dom does not detect (this could change in the future I suppose)

The actual solution would be to move the up/down buttons outside the `<ListGroup.Item>`, but styling it correctly requires more (fragile) code than you'd probably like.

I think it's just better to implement draggability instead and revert this PR later.