### PR TITLE
#2373: add manager user role

### DIFF
--- a/src/devTools/editor/fields/DatabaseCreateModal.tsx
+++ b/src/devTools/editor/fields/DatabaseCreateModal.tsx
@@ -69,7 +69,9 @@ const initialValues: DatabaseConfig = {
 
 function getOrganizationOptions(organizations: Organization[]) {
   const organizationOptions = (organizations ?? [])
-    .filter((organization) => organization.role === UserRole.admin)
+    .filter((organization) =>
+      [UserRole.admin, UserRole.manager].includes(organization.role)
+    )
     .map((organization) => ({
       label: organization.name,
       value: organization.id,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -130,7 +130,7 @@ export const appApi = createApi({
           // Mapping between the API response and the UI model because we need to know whether the user is an admin of
           // the organization
 
-          // Currently API returns all members only for the organization where the user is an admin,
+          // Currently, the API returns all members only for the organization where the user is an admin,
           // hence if the user is an admin, they will have role === UserRole.admin,
           // otherwise there will be no other members listed (no member with role === UserRole.admin).
 

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -47,6 +47,7 @@ export enum UserRole {
   admin = 2,
   developer = 3,
   restricted = 4,
+  manager = 5,
 }
 
 export type Organization = components["schemas"]["Organization"] & {


### PR DESCRIPTION
Closes #2373 

- [ ] TODO: determine impact of the logic in the API definition. (Managers get the whole user list from that endpoint. So maybe we just have to support passing that role through there?)