### PR TITLE
#2314: Add table parser and brick

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,6 +163,7 @@
         "@types/js-beautify": "^1.13.2",
         "@types/js-cookie": "^3.0.0",
         "@types/js-yaml": "^4.0.2",
+        "@types/jsdom": "^16.2.14",
         "@types/json-schema": "^7.0.8",
         "@types/lodash": "^4.14.171",
         "@types/marked": "^4.0.0",
@@ -13007,6 +13008,17 @@
       "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
       "dev": true
     },
+    "node_modules/@types/jsdom": {
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.14.tgz",
+      "integrity": "sha512-6BAy1xXEmMuHeAJ4Fv4yXKwBDTGTOseExKE3OaHiNycdHdZw59KfYzrt0DkDluvwmik1HRt6QS7bImxUmpSy+w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/parse5": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -13399,6 +13411,12 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
+      "dev": true
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.2",
@@ -47503,6 +47521,17 @@
       "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
       "dev": true
     },
+    "@types/jsdom": {
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.14.tgz",
+      "integrity": "sha512-6BAy1xXEmMuHeAJ4Fv4yXKwBDTGTOseExKE3OaHiNycdHdZw59KfYzrt0DkDluvwmik1HRt6QS7bImxUmpSy+w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/parse5": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -47896,6 +47925,12 @@
       "requires": {
         "@types/jest": "*"
       }
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==",
+      "dev": true
     },
     "@types/trusted-types": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "@types/js-beautify": "^1.13.2",
     "@types/js-cookie": "^3.0.0",
     "@types/js-yaml": "^4.0.2",
+    "@types/jsdom": "^16.2.14",
     "@types/json-schema": "^7.0.8",
     "@types/lodash": "^4.14.171",
     "@types/marked": "^4.0.0",

--- a/src/blocks/transformers/component/TableReader.ts
+++ b/src/blocks/transformers/component/TableReader.ts
@@ -49,6 +49,26 @@ export class TableReader extends Transformer {
     },
   };
 
+  outputSchema: Schema = {
+    $schema: "https://json-schema.org/draft/2019-09/schema#",
+    type: "object",
+    properties: {
+      records: {
+        description:
+          "The records in the table (rows or columns, depending on orientation)",
+        type: "array",
+        items: { type: "object" },
+      },
+      fieldNames: {
+        description: "The field names in the table",
+        type: "array",
+        items: { type: "string" },
+      },
+    },
+    required: ["records", "fieldNames"],
+    additionalProperties: false,
+  };
+
   async isRootAware(): Promise<boolean> {
     return true;
   }

--- a/src/blocks/transformers/registerTransformers.ts
+++ b/src/blocks/transformers/registerTransformers.ts
@@ -38,6 +38,7 @@ import { ParseCsv } from "./parseCsv";
 import { ParseDataUrl } from "./parseDataUrl";
 import { ParseDate } from "@/blocks/transformers/parseDate";
 import { ScreenshotTab } from "@/blocks/transformers/screenshotTab";
+import { TableReader } from "./component/TableReader";
 
 function registerTransformers() {
   registerBlock(new JQTransformer());
@@ -58,6 +59,7 @@ function registerTransformers() {
   registerBlock(new UrlParams());
   registerBlock(new JQueryReader());
   registerBlock(new ComponentReader());
+  registerBlock(new TableReader());
   registerBlock(new ParseCsv());
   registerBlock(new ParseDataUrl());
   registerBlock(new ParseDate());

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import blockRegistry from "@/blocks/registry";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 90;
+const EXPECTED_HEADER_COUNT = 91;
 
 // Import for side-effects (these modules register the blocks)
 // NOTE: we don't need to also include extensionPoints because we got rid of all the legacy hard-coded extension points

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -58,9 +58,9 @@ export const IS_BROWSER =
  * @param selector a JQuery selector
  * @param parent parent element to search (default=document)
  */
-export function $safeFind(
+export function $safeFind<Element extends HTMLElement>(
   selector: string,
-  parent: Document | Element | JQuery<HTMLElement | Document> = document
-): JQuery {
-  return $(parent).find(selector);
+  parent: Document | HTMLElement | JQuery<HTMLElement | Document> = document
+): JQuery<Element> {
+  return $(parent).find<Element>(selector);
 }

--- a/src/utils/parseDomTable.test.ts
+++ b/src/utils/parseDomTable.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import parseDomTable from "./parseDomTable";
+import { JSDOM } from "jsdom";
+
+function getTable(html: string): HTMLTableElement {
+  return JSDOM.fragment("<table>" + html).firstElementChild as HTMLTableElement;
+}
+
+describe("parseDomTable", () => {
+  test("parse simple table", () => {
+    const table = getTable(`
+      <tr><th>Name<th>Age
+      <tr><td>Mario<td>42
+      <tr><td>Luigi<td>39
+    `);
+
+    const expected = [
+      { Name: "Mario", Age: "42" },
+      { Name: "Luigi", Age: "39" },
+    ];
+
+    const actual = parseDomTable(table);
+
+    expect(actual).toStrictEqual(expected);
+  });
+
+  test("parse header-less table", () => {
+    const table = getTable(`
+      <tr><td>Mario<td>42
+      <tr><td>Luigi<td>39
+    `);
+
+    const expected = [
+      { 0: "Mario", 1: "42" },
+      { 0: "Luigi", 1: "39" },
+    ];
+
+    const actual = parseDomTable(table);
+
+    expect(actual).toStrictEqual(expected);
+  });
+
+  test("parse table with incomplete header", () => {
+    const table = getTable(`
+      <tr><th>Name<td>Age
+      <tr><td>Mario<td>42
+      <tr><td>Luigi<td>39
+    `);
+
+    const expected = [
+      { Name: "Mario", Age: "42" },
+      { Name: "Luigi", Age: "39" },
+    ];
+
+    const actual = parseDomTable(table);
+
+    expect(actual).toStrictEqual(expected);
+  });
+});

--- a/src/utils/parseDomTable.test.ts
+++ b/src/utils/parseDomTable.test.ts
@@ -30,10 +30,13 @@ describe("parseDomTable", () => {
       <tr><td>Luigi<td>39
     `);
 
-    const expected = [
-      { Name: "Mario", Age: "42" },
-      { Name: "Luigi", Age: "39" },
-    ];
+    const expected = {
+      fieldNames: ["Name", "Age"],
+      records: [
+        { Name: "Mario", Age: "42" },
+        { Name: "Luigi", Age: "39" },
+      ],
+    };
 
     const actual = parseDomTable(table);
 
@@ -46,10 +49,13 @@ describe("parseDomTable", () => {
       <tr><td>Luigi<td>39
     `);
 
-    const expected = [
-      { 0: "Mario", 1: "42" },
-      { 0: "Luigi", 1: "39" },
-    ];
+    const expected = {
+      fieldNames: [0, 1],
+      records: [
+        { 0: "Mario", 1: "42" },
+        { 0: "Luigi", 1: "39" },
+      ],
+    };
 
     const actual = parseDomTable(table);
 
@@ -63,10 +69,13 @@ describe("parseDomTable", () => {
       <tr><th>Height<td>5' 6"<td>5' 8"
     `);
 
-    const expected = [
-      { Name: "Mario", Age: "42", Height: "5' 6\"" },
-      { Name: "Luigi", Age: "39", Height: "5' 8\"" },
-    ];
+    const expected = {
+      fieldNames: ["Name", "Age", "Height"],
+      records: [
+        { Name: "Mario", Age: "42", Height: "5' 6\"" },
+        { Name: "Luigi", Age: "39", Height: "5' 8\"" },
+      ],
+    };
 
     const actual = parseDomTable(table);
 

--- a/src/utils/parseDomTable.test.ts
+++ b/src/utils/parseDomTable.test.ts
@@ -56,16 +56,16 @@ describe("parseDomTable", () => {
     expect(actual).toStrictEqual(expected);
   });
 
-  test("parse table with incomplete header", () => {
+  test("parse horizontal table", () => {
     const table = getTable(`
-      <tr><th>Name<td>Age
-      <tr><td>Mario<td>42
-      <tr><td>Luigi<td>39
+      <tr><th>Name<td>Mario<td>Luigi
+      <tr><th>Age<td>42<td>39
+      <tr><th>Height<td>5' 6"<td>5' 8"
     `);
 
     const expected = [
-      { Name: "Mario", Age: "42" },
-      { Name: "Luigi", Age: "39" },
+      { Name: "Mario", Age: "42", Height: "5' 6\"" },
+      { Name: "Luigi", Age: "39", Height: "5' 8\"" },
     ];
 
     const actual = parseDomTable(table);

--- a/src/utils/parseDomTable.ts
+++ b/src/utils/parseDomTable.ts
@@ -53,20 +53,23 @@ function getList(
   direction: ParsingOptions["direction"]
 ): List {
   if (direction === "columns") {
-    // Transpose table
+    // Transpose table so we only deal with one direction
     table = zip(...table);
   }
 
+  // Carefully deal with cells because the "table" could just be an empty array
   const [firstRow] = table;
   const lastCell = firstRow?.[firstRow.length - 1];
   const hasHeader = lastCell?.type === "header";
+
   const textTable = table.map((row) => row.map((cell) => cell.value));
   if (hasHeader) {
     const [headers, ...body] = textTable;
     return { headers, body };
   }
 
-  return { headers: [...firstRow.keys()], body: textTable };
+  // If it has no headers, use a 0-based index as header
+  return { headers: [...(firstRow ?? []).keys()], body: textTable };
 }
 
 export default function parseDomTable(
@@ -77,12 +80,6 @@ export default function parseDomTable(
     normalizeTable(table),
     direction ?? guessDirection(table)
   );
-  const values: Array<Record<number | string, string>> = [];
-  for (const row of body) {
-    // Create record for current row
-    const cells = row.map((cell) => cell);
-    values.push(zipObject(headers, cells));
-  }
 
-  return values;
+  return body.map((row) => zipObject(headers, row));
 }

--- a/src/utils/parseDomTable.ts
+++ b/src/utils/parseDomTable.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { zipObject } from "lodash";
+
+export default function parseDomTable(
+  table: HTMLTableElement
+): Array<Record<string, string>> {
+  let headers: Array<number | string>;
+  const values: Array<Record<number | string, string>> = [];
+  for (const [index, row] of [...table.rows].entries()) {
+    if (index === 0) {
+      // If there's at least one `th` in the first row, treat it as headers
+      const isHeader = row.querySelector("th");
+
+      // Parse every column header; use the index if it's not a header
+      headers = [...row.cells].map((header, column) =>
+        isHeader ? header.textContent.trim() : column
+      );
+
+      if (isHeader) {
+        continue;
+      }
+    }
+
+    // Create record for current row
+    const cells = [...row.cells].map((cell) => cell.textContent.trim());
+    values.push(zipObject(headers, cells));
+  }
+
+  return values;
+}

--- a/src/utils/parseDomTable.ts
+++ b/src/utils/parseDomTable.ts
@@ -18,7 +18,7 @@
 import { zip, zipObject } from "lodash";
 
 interface ParsingOptions {
-  direction?: "rows" | "columns";
+  orientation?: "vertical" | "horizontal" | "infer";
 }
 type Headers = Array<number | string>;
 
@@ -31,11 +31,13 @@ type NormalizedTable = Cell[][];
 
 type Table = Array<Record<string, string>>;
 
-function guessDirection(table: HTMLTableElement): ParsingOptions["direction"] {
+function guessDirection(
+  table: HTMLTableElement
+): ParsingOptions["orientation"] {
   const labelRatio =
     table.rows[0].querySelectorAll("th").length /
     table.querySelectorAll("th").length;
-  return labelRatio < 0.5 ? "columns" : "rows";
+  return labelRatio < 0.5 ? "horizontal" : "vertical";
 }
 
 // TODO: Normalize rowspan and colspan in here as well
@@ -50,10 +52,10 @@ function normalizeTable(table: HTMLTableElement): NormalizedTable {
 
 function getList(
   table: NormalizedTable,
-  direction: ParsingOptions["direction"]
+  orientation: ParsingOptions["orientation"]
 ): List {
-  if (direction === "columns") {
-    // Transpose table so we only deal with one direction
+  if (orientation === "horizontal") {
+    // Transpose table so we only deal with one orientation
     table = zip(...table);
   }
 
@@ -74,11 +76,11 @@ function getList(
 
 export default function parseDomTable(
   table: HTMLTableElement,
-  { direction }: ParsingOptions = {}
+  { orientation = "infer" }: ParsingOptions = {}
 ): Table {
   const { headers, body } = getList(
     normalizeTable(table),
-    direction ?? guessDirection(table)
+    orientation === "infer" ? guessDirection(table) : orientation
   );
 
   return body.map((row) => zipObject(headers, row));


### PR DESCRIPTION
- For https://github.com/pixiebrix/pixiebrix-extension/issues/2314

Let me know what inputs/options you'd like. There's a lot of guessing at the moment but I suppose it could be replaced by plain options in the editor, for example:

- headers: 
	- [x] first row
	- [ ] custom: ________
- direction:
	- [x] rows
	- [ ] columns

Possible improvements:

- is "direction" ok? There must be a better word for "in which axis are the records added?"

Next:

- in the brick itself you can add a simple "html parser" anywhere if necessary and then pass the `<table>` element to this function.