### PR TITLE
Logs and Traces performance

### DIFF
--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -36,7 +36,7 @@ import { expectContext } from "@/utils/expectContext";
 
 const STORAGE_KEY = "LOG";
 const ENTRY_OBJECT_STORE = "entries";
-const DB_VERSION_NUMBER = 5;
+const DB_VERSION_NUMBER = 3;
 
 export type MessageLevel = "trace" | "debug" | "info" | "warn" | "error";
 
@@ -169,8 +169,6 @@ export async function getLog(
 
   const match = makeMatchEntry(context);
   const matches = entries.filter((entry) => match(entry));
-
-  console.log("getLog", { context, entries, matches });
 
   // Use both reverse and sortBy because we want insertion order if there's a tie in the timestamp
   return sortBy(matches.reverse(), (x) => -Number.parseInt(x.timestamp, 10));

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -184,13 +184,6 @@ export async function getLog(
   const match = makeMatchEntry(context);
   const matches = entries.filter((entry) => match(entry));
 
-  console.log("getLog", {
-    context,
-    indexKey,
-    entries: entries.length,
-    matches: matches.length,
-  });
-
   // Use both reverse and sortBy because we want insertion order if there's a tie in the timestamp
   return sortBy(matches.reverse(), (x) => -Number.parseInt(x.timestamp, 10));
 }

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -148,8 +148,6 @@ export async function clearLog(context: MessageContext = {}): Promise<void> {
 export async function getLog(
   context: MessageContext = {}
 ): Promise<LogEntry[]> {
-  const start = performance.now();
-
   const db = await getDB();
   const objectStore = db
     .transaction(ENTRY_OBJECT_STORE, "readonly")
@@ -169,20 +167,8 @@ export async function getLog(
     entries = await objectStore.getAll();
   }
 
-  const entriesTime = performance.now();
-
   const match = makeMatchEntry(context);
   const matches = entries.filter((entry) => match(entry));
-
-  const end = performance.now();
-  console.log("getLog", {
-    context,
-    entries: entries.length,
-    matches: matches.length,
-    entriesTime: entriesTime - start,
-    matchingTime: end - entriesTime,
-    totalTime: end - start,
-  });
 
   // Use both reverse and sortBy because we want insertion order if there's a tie in the timestamp
   return sortBy(matches.reverse(), (x) => -Number.parseInt(x.timestamp, 10));

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -148,6 +148,8 @@ export async function clearLog(context: MessageContext = {}): Promise<void> {
 export async function getLog(
   context: MessageContext = {}
 ): Promise<LogEntry[]> {
+  const start = performance.now();
+
   const db = await getDB();
   const objectStore = db
     .transaction(ENTRY_OBJECT_STORE, "readonly")
@@ -163,12 +165,24 @@ export async function getLog(
       .index("blueprintId")
       .getAll(context.blueprintId);
   } else {
-    // This can lead to huge performance issues
+    // This can lead to performance issues
     entries = await objectStore.getAll();
   }
 
+  const entriesTime = performance.now();
+
   const match = makeMatchEntry(context);
   const matches = entries.filter((entry) => match(entry));
+
+  const end = performance.now();
+  console.log("getLog", {
+    context,
+    entries: entries.length,
+    matches: matches.length,
+    entriesTime: entriesTime - start,
+    matchingTime: end - entriesTime,
+    totalTime: end - start,
+  });
 
   // Use both reverse and sortBy because we want insertion order if there's a tie in the timestamp
   return sortBy(matches.reverse(), (x) => -Number.parseInt(x.timestamp, 10));

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -115,6 +115,7 @@ export const traces = {
   addEntry: getNotifier("ADD_TRACE_ENTRY", bg),
   addExit: getNotifier("ADD_TRACE_EXIT", bg),
   clear: getNotifier("CLEAR_TRACES", bg),
+  clearAll: getNotifier("CLEAR_ALL_TRACES", bg),
 };
 
 export const initTelemetry = getNotifier("INIT_TELEMETRY", bg);

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -57,6 +57,7 @@ import {
   addTraceEntry,
   addTraceExit,
   clearExtensionTraces,
+  clearTraces,
 } from "@/telemetry/trace";
 import {
   initTelemetry,
@@ -121,6 +122,7 @@ declare global {
     ADD_TRACE_ENTRY: typeof addTraceEntry;
     ADD_TRACE_EXIT: typeof addTraceExit;
     CLEAR_TRACES: typeof clearExtensionTraces;
+    CLEAR_ALL_TRACES: typeof clearTraces;
 
     INIT_TELEMETRY: typeof initTelemetry;
     SEND_DEPLOYMENT_ALERT: typeof sendDeploymentAlert;
@@ -183,6 +185,7 @@ registerMethods({
   ADD_TRACE_ENTRY: addTraceEntry,
   ADD_TRACE_EXIT: addTraceExit,
   CLEAR_TRACES: clearExtensionTraces,
+  CLEAR_ALL_TRACES: clearTraces,
 
   INIT_TELEMETRY: initTelemetry,
   SEND_DEPLOYMENT_ALERT: sendDeploymentAlert,

--- a/src/components/logViewer/useLogEntries.ts
+++ b/src/components/logViewer/useLogEntries.ts
@@ -116,11 +116,16 @@ export default function useLogEntries({
     return [pageEntries, Math.ceil(filteredEntries.length / perPage)];
   }, [perPage, page, filteredEntries]);
 
+  let checkingNewEntries = false;
   const checkNewEntries = useCallback(async () => {
-    if (!initialized) {
-      // Wait for the initial set of logs before starting to check for updates
+    if (!initialized || checkingNewEntries) {
+      // Wait for the initial set of logs or the previous check to complete
+      // before running another check for updates
       return;
     }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- we can neglect the loss of the value on re-render for the sake of simplicity
+    checkingNewEntries = true;
 
     const newEntries = await getLog(context);
     const filteredNewEntries = (newEntries ?? []).filter(
@@ -129,6 +134,7 @@ export default function useLogEntries({
     );
     setUnread(newEntries.filter((x) => Number(x.timestamp) > lastTimestamp));
     setNumNew(Math.max(0, filteredNewEntries.length - filteredEntries.length));
+    checkingNewEntries = false;
   }, [
     lastTimestamp,
     setUnread,

--- a/src/components/logViewer/useLogEntries.ts
+++ b/src/components/logViewer/useLogEntries.ts
@@ -131,7 +131,6 @@ export default function useLogEntries({
       return;
     }
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- we can neglect the loss of the value on re-render for the sake of simplicity
     checkingNewEntriesRef.current = true;
 
     const newEntries = await getLog(context);

--- a/src/components/logViewer/useLogEntries.ts
+++ b/src/components/logViewer/useLogEntries.ts
@@ -15,7 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   clearLog,
   getLog,
@@ -116,16 +123,16 @@ export default function useLogEntries({
     return [pageEntries, Math.ceil(filteredEntries.length / perPage)];
   }, [perPage, page, filteredEntries]);
 
-  let checkingNewEntries = false;
+  const checkingNewEntriesRef = useRef(false);
   const checkNewEntries = useCallback(async () => {
-    if (!initialized || checkingNewEntries) {
+    if (!initialized || checkingNewEntriesRef.current) {
       // Wait for the initial set of logs or the previous check to complete
       // before running another check for updates
       return;
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps -- we can neglect the loss of the value on re-render for the sake of simplicity
-    checkingNewEntries = true;
+    checkingNewEntriesRef.current = true;
 
     const newEntries = await getLog(context);
     const filteredNewEntries = (newEntries ?? []).filter(
@@ -134,7 +141,7 @@ export default function useLogEntries({
     );
     setUnread(newEntries.filter((x) => Number(x.timestamp) > lastTimestamp));
     setNumNew(Math.max(0, filteredNewEntries.length - filteredEntries.length));
-    checkingNewEntries = false;
+    checkingNewEntriesRef.current = false;
   }, [
     lastTimestamp,
     setUnread,

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -152,7 +152,7 @@ export function clearDynamic(
       traces.clear(extensionId);
     }
   } else {
-    for (const [, extensionPoint] of _dynamic.entries()) {
+    for (const extensionPoint of _dynamic.values()) {
       try {
         extensionPoint.uninstall({ global: true });
         actionPanel.removeExtensionPoint(extensionPoint.id);

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -152,11 +152,7 @@ export function clearDynamic(
       traces.clear(extensionId);
     }
   } else {
-    for (const [extensionId, extensionPoint] of _dynamic.entries()) {
-      if (clearTrace) {
-        traces.clear(extensionId);
-      }
-
+    for (const [, extensionPoint] of _dynamic.entries()) {
       try {
         extensionPoint.uninstall({ global: true });
         actionPanel.removeExtensionPoint(extensionPoint.id);
@@ -164,6 +160,10 @@ export function clearDynamic(
       } catch (error) {
         reportError(error);
       }
+    }
+
+    if (clearTrace) {
+      traces.clearAll();
     }
 
     _dynamic.clear();

--- a/src/devTools/editor/hooks/useExtensionTrace.ts
+++ b/src/devTools/editor/hooks/useExtensionTrace.ts
@@ -54,7 +54,13 @@ function useExtensionTrace() {
   const extensionId = useSelector(selectActiveExtensionId);
   const extensionTrace = useSelector(selectExtensionTrace);
 
+  let checkingNewEntries = false;
   const refreshTrace = async () => {
+    if (checkingNewEntries) {
+      return;
+    }
+
+    checkingNewEntries = true;
     const lastRun = await getLatestRunByExtensionId(extensionId);
     // Keep the Redux log clean. Don't setExtensionTrace unless we have to
     if (
@@ -65,6 +71,8 @@ function useExtensionTrace() {
     ) {
       dispatch(setExtensionTrace({ extensionId, records: lastRun }));
     }
+
+    checkingNewEntries = false;
   };
 
   useInterval(refreshTrace, TRACE_RELOAD_MILLIS);

--- a/src/devTools/editor/hooks/useExtensionTrace.ts
+++ b/src/devTools/editor/hooks/useExtensionTrace.ts
@@ -27,6 +27,7 @@ import runtimeSlice from "@/devTools/editor/slices/runtimeSlice";
 import { selectActiveExtensionId } from "@/devTools/editor/slices/editorSelectors";
 import { selectExtensionTrace } from "@/devTools/editor/slices/runtimeSelectors";
 import { isEqual } from "lodash";
+import { useRef } from "react";
 
 const { setExtensionTrace } = runtimeSlice.actions;
 
@@ -54,13 +55,13 @@ function useExtensionTrace() {
   const extensionId = useSelector(selectActiveExtensionId);
   const extensionTrace = useSelector(selectExtensionTrace);
 
-  let checkingNewEntries = false;
+  const checkingNewEntriesRef = useRef(false);
   const refreshTrace = async () => {
-    if (checkingNewEntries) {
+    if (checkingNewEntriesRef.current) {
       return;
     }
 
-    checkingNewEntries = true;
+    checkingNewEntriesRef.current = true;
     const lastRun = await getLatestRunByExtensionId(extensionId);
     // Keep the Redux log clean. Don't setExtensionTrace unless we have to
     if (
@@ -72,7 +73,7 @@ function useExtensionTrace() {
       dispatch(setExtensionTrace({ extensionId, records: lastRun }));
     }
 
-    checkingNewEntries = false;
+    checkingNewEntriesRef.current = false;
   };
 
   useInterval(refreshTrace, TRACE_RELOAD_MILLIS);

--- a/src/devTools/editor/tabs/LogsTab.tsx
+++ b/src/devTools/editor/tabs/LogsTab.tsx
@@ -31,7 +31,6 @@ const LogsTab: React.FunctionComponent<{
   return (
     <Tab.Pane eventKey={eventKey} mountOnEnter unmountOnExit className="h-100">
       <RunLogCard
-        extensionPointId={values.extensionPoint.metadata.id}
         extensionId={values.uuid}
         initialLevel="debug"
         refreshInterval={750}

--- a/src/devTools/editor/tabs/RunLogCard.tsx
+++ b/src/devTools/editor/tabs/RunLogCard.tsx
@@ -22,18 +22,16 @@ import { Card } from "react-bootstrap";
 import LogTable from "@/components/logViewer/LogTable";
 import useLogEntries from "@/components/logViewer/useLogEntries";
 import LogToolbar from "@/components/logViewer/LogToolbar";
-import { RegistryId, UUID } from "@/core";
+import { UUID } from "@/core";
 
 type OwnProps = {
   initialLevel?: MessageLevel;
-  extensionPointId: RegistryId;
   extensionId: UUID;
   perPage?: number;
   refreshInterval?: number;
 };
 
 const RunLogCard: React.FunctionComponent<OwnProps> = ({
-  extensionPointId,
   extensionId,
   initialLevel = "info",
   perPage = 10,

--- a/src/devTools/editor/tabs/RunLogCard.tsx
+++ b/src/devTools/editor/tabs/RunLogCard.tsx
@@ -42,10 +42,7 @@ const RunLogCard: React.FunctionComponent<OwnProps> = ({
   const [level, setLevel] = useState<MessageLevel>(initialLevel);
   const [page, setPage] = useState(0);
 
-  const messageContext = useMemo(() => ({ extensionPointId, extensionId }), [
-    extensionPointId,
-    extensionId,
-  ]);
+  const messageContext = useMemo(() => ({ extensionId }), [extensionId]);
 
   const logs = useLogEntries({
     context: messageContext,

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ import { AxiosRequestConfig } from "axios";
 import { BackgroundLogger } from "@/background/logging";
 import { Permissions } from "webextension-polyfill";
 import { validateRegistryId } from "@/types/helpers";
+import { recordLog } from "./background/messenger/api";
 
 type SanitizedBrand = { _sanitizedConfigBrand: null };
 type SecretBrand = { _serviceConfigBrand: null };
@@ -259,6 +260,13 @@ export abstract class Effect extends Block {
   abstract effect(inputs: BlockArg, env?: BlockOptions): Promise<void>;
 
   async run(value: BlockArg, options: BlockOptions): Promise<void> {
+    for (let i = 0; i !== 100; i++) {
+      recordLog(options.logger.context, "debug", "Running effect", {
+        name: this.name,
+        index: i,
+      });
+    }
+
     return this.effect(value, options);
   }
 }
@@ -306,6 +314,13 @@ export abstract class Renderer extends Block {
   }
 
   async run(value: BlockArg, options: BlockOptions): Promise<RendererOutput> {
+    for (let i = 0; i !== 100; i++) {
+      recordLog(options.logger.context, "debug", "Running renderer", {
+        name: this.name,
+        index: i,
+      });
+    }
+
     return this.render(value, options);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,10 +260,17 @@ export abstract class Effect extends Block {
   abstract effect(inputs: BlockArg, env?: BlockOptions): Promise<void>;
 
   async run(value: BlockArg, options: BlockOptions): Promise<void> {
-    recordLogBkg(options.logger.context, "debug", "Running effect bkg", {
-      id: this.id,
-      name: this.name,
-    });
+    for (let i = 0; i !== 100; i++) {
+      recordLogBkg(
+        options.logger.context,
+        "debug",
+        `Running effect bkg, ${i}`,
+        {
+          id: this.id,
+          name: this.name,
+        }
+      );
+    }
 
     return this.effect(value, options);
   }
@@ -312,6 +319,17 @@ export abstract class Renderer extends Block {
   }
 
   async run(value: BlockArg, options: BlockOptions): Promise<RendererOutput> {
+    for (let i = 0; i !== 100; i++) {
+      recordLogBkg(
+        options.logger.context,
+        "debug",
+        `Running renderer bkg, ${i}`,
+        {
+          id: this.id,
+          name: this.name,
+        }
+      );
+    }
     return this.render(value, options);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,6 @@ import { AxiosRequestConfig } from "axios";
 import { BackgroundLogger } from "@/background/logging";
 import { Permissions } from "webextension-polyfill";
 import { validateRegistryId } from "@/types/helpers";
-import { recordLog as recordLogBkg } from "@/background/messenger/api";
 
 type SanitizedBrand = { _sanitizedConfigBrand: null };
 type SecretBrand = { _serviceConfigBrand: null };
@@ -260,18 +259,6 @@ export abstract class Effect extends Block {
   abstract effect(inputs: BlockArg, env?: BlockOptions): Promise<void>;
 
   async run(value: BlockArg, options: BlockOptions): Promise<void> {
-    for (let i = 0; i !== 100; i++) {
-      recordLogBkg(
-        options.logger.context,
-        "debug",
-        `Running effect bkg, ${i}`,
-        {
-          id: this.id,
-          name: this.name,
-        }
-      );
-    }
-
     return this.effect(value, options);
   }
 }
@@ -319,17 +306,6 @@ export abstract class Renderer extends Block {
   }
 
   async run(value: BlockArg, options: BlockOptions): Promise<RendererOutput> {
-    for (let i = 0; i !== 100; i++) {
-      recordLogBkg(
-        options.logger.context,
-        "debug",
-        `Running renderer bkg, ${i}`,
-        {
-          id: this.id,
-          name: this.name,
-        }
-      );
-    }
     return this.render(value, options);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ import {
   RendererOutput,
 } from "@/core";
 import { AxiosRequestConfig } from "axios";
-import { BackgroundLogger, recordLog } from "@/background/logging";
+import { BackgroundLogger } from "@/background/logging";
 import { Permissions } from "webextension-polyfill";
 import { validateRegistryId } from "@/types/helpers";
 import { recordLog as recordLogBkg } from "@/background/messenger/api";

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,13 +260,6 @@ export abstract class Effect extends Block {
   abstract effect(inputs: BlockArg, env?: BlockOptions): Promise<void>;
 
   async run(value: BlockArg, options: BlockOptions): Promise<void> {
-    for (let i = 0; i !== 100; i++) {
-      recordLog(options.logger.context, "debug", "Running effect", {
-        name: this.name,
-        index: i,
-      });
-    }
-
     return this.effect(value, options);
   }
 }
@@ -314,13 +307,6 @@ export abstract class Renderer extends Block {
   }
 
   async run(value: BlockArg, options: BlockOptions): Promise<RendererOutput> {
-    for (let i = 0; i !== 100; i++) {
-      recordLog(options.logger.context, "debug", "Running renderer", {
-        name: this.name,
-        index: i,
-      });
-    }
-
     return this.render(value, options);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,6 @@ import { AxiosRequestConfig } from "axios";
 import { BackgroundLogger } from "@/background/logging";
 import { Permissions } from "webextension-polyfill";
 import { validateRegistryId } from "@/types/helpers";
-import { recordLog } from "./background/messenger/api";
 
 type SanitizedBrand = { _sanitizedConfigBrand: null };
 type SecretBrand = { _serviceConfigBrand: null };

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,9 +37,10 @@ import {
   RendererOutput,
 } from "@/core";
 import { AxiosRequestConfig } from "axios";
-import { BackgroundLogger } from "@/background/logging";
+import { BackgroundLogger, recordLog } from "@/background/logging";
 import { Permissions } from "webextension-polyfill";
 import { validateRegistryId } from "@/types/helpers";
+import { recordLog as recordLogBkg } from "@/background/messenger/api";
 
 type SanitizedBrand = { _sanitizedConfigBrand: null };
 type SecretBrand = { _serviceConfigBrand: null };
@@ -259,6 +260,11 @@ export abstract class Effect extends Block {
   abstract effect(inputs: BlockArg, env?: BlockOptions): Promise<void>;
 
   async run(value: BlockArg, options: BlockOptions): Promise<void> {
+    recordLogBkg(options.logger.context, "debug", "Running effect bkg", {
+      id: this.id,
+      name: this.name,
+    });
+
     return this.effect(value, options);
   }
 }


### PR DESCRIPTION
Related to #2216 

1. Fetching logs. Making requests to IDB by index, applying the rest of the context filters in code. `extensionId` and `blueprintId` are the most commonly used filters, hence building indexes for these properties.
2. Waiting for the previous request for Logs or Traces to finish before making a new one.
3. Clearing all traces when DevTools gets closed (trace is bound to a block by `blockId` which exists only within app lifetime, i.e. on the next start of the Edit Page old traces will not get fetched).