### PR TITLE
Add default for mode prop of hide brick

### DIFF
--- a/src/blocks/effects/hide.ts
+++ b/src/blocks/effects/hide.ts
@@ -38,6 +38,7 @@ export class HideEffect extends Effect {
       mode: {
         type: "string",
         enum: ["hide", "remove"],
+        default: "hide",
       },
     },
     ["selector"]


### PR DESCRIPTION
Adds a default for the mode prop of the Hide brick so the Page Editor shows as a select widget instead of omit by default