### PR TITLE
Add additional selector inference tests

### DIFF
--- a/src/nativeEditor/infer.test.tsx
+++ b/src/nativeEditor/infer.test.tsx
@@ -16,7 +16,13 @@
  */
 
 import { $safeFind } from "@/helpers";
-import { inferButtonHTML, inferPanelHTML } from "@/nativeEditor/infer";
+import {
+  inferButtonHTML,
+  inferPanelHTML,
+  inferSelectors,
+  safeCssSelector,
+} from "@/nativeEditor/infer";
+import * as assert from "assert";
 
 test("infer basic button", () => {
   document.body.innerHTML = "<div><button>More</button></div>";
@@ -315,5 +321,52 @@ test("infer header structure mismatch", () => {
 
   expect(inferred).toBe(
     "<section><h2>{{{ heading }}}</h2><div>{{{ body }}}</div></section>"
+  );
+});
+
+describe("safeCssSelector", () => {
+  test("infer aria-label", () => {
+    document.body.innerHTML =
+      "<div>" +
+      "<input aria-label='foo'/>" +
+      "<input aria-label='bar'/>" +
+      "</div>";
+
+    const selector = safeCssSelector(
+      document.body.querySelector("input[aria-label='foo']"),
+      null
+    );
+
+    expect(selector).toBe("[aria-label='foo']");
+  });
+});
+
+describe("inferSelectors", () => {
+  test("infer aria-label", () => {
+    document.body.innerHTML =
+      "<div>" +
+      "<input aria-label='foo'/>" +
+      "<input aria-label='bar'/>" +
+      "</div>";
+
+    const selector = inferSelectors(
+      document.body.querySelector("input[aria-label='foo']")
+    );
+
+    expect(selector).toStrictEqual(["[aria-label='foo']"]);
+  });
+
+  test.each([["data-testid"], ["data-cy"], ["data-test"]])(
+    "infer test attribute: %s",
+    (attr: string) => {
+      document.body.innerHTML =
+        "<div>" + `<input ${attr}='a' />` + `<input ${attr}='b' />` + "</div>";
+
+      const selector = inferSelectors(
+        document.body.querySelector(`input[${attr}='a']`)
+      );
+
+      expect(selector).toStrictEqual([`[${attr}='a']`]);
+    }
   );
 });

--- a/src/nativeEditor/infer.test.tsx
+++ b/src/nativeEditor/infer.test.tsx
@@ -22,7 +22,6 @@ import {
   inferSelectors,
   safeCssSelector,
 } from "@/nativeEditor/infer";
-import * as assert from "assert";
 
 test("infer basic button", () => {
   document.body.innerHTML = "<div><button>More</button></div>";
@@ -358,15 +357,14 @@ describe("inferSelectors", () => {
 
   test.each([["data-testid"], ["data-cy"], ["data-test"]])(
     "infer test attribute: %s",
-    (attr: string) => {
-      document.body.innerHTML =
-        "<div>" + `<input ${attr}='a' />` + `<input ${attr}='b' />` + "</div>";
+    (attribute: string) => {
+      document.body.innerHTML = `<div><input ${attribute}='a' /><input ${attribute}='b' /></div>`;
 
       const selector = inferSelectors(
-        document.body.querySelector(`input[${attr}='a']`)
+        document.body.querySelector(`input[${attribute}='a']`)
       );
 
-      expect(selector).toStrictEqual([`[${attr}='a']`]);
+      expect(selector).toStrictEqual([`[${attribute}='a']`]);
     }
   );
 });


### PR DESCRIPTION
Attempting to reproduce behavior where inference doesn't find good selectors. 

Seems to be working on the small scale, I'll have to reproduce on a live site and try to figure out what's difference