### PR TITLE
#2441: make highlight brick root aware

### DIFF
--- a/src/blocks/effects/highlight.ts
+++ b/src/blocks/effects/highlight.ts
@@ -16,9 +16,10 @@
  */
 
 import { Effect } from "@/types";
-import { BlockArg, Schema } from "@/core";
+import { BlockArg, BlockOptions, Schema } from "@/core";
 import { propertiesToSchema } from "@/validators/generic";
 import { boolean } from "@/utils";
+import { $safeFind } from "@/helpers";
 
 type ColorRule =
   | string
@@ -49,15 +50,16 @@ export class HighlightEffect extends Effect {
       },
       rootSelector: {
         type: "string",
-        description: "Optional root selector to find the elements within",
+        description: "Optional root selector to find the elements within.",
         format: "selector",
       },
       condition: {
         anyOf: [{ type: "string" }, { type: "boolean" }, { type: "number" }],
-        description: "Whether or not to apply the highlighting rule",
+        description: "Whether or not to apply the highlighting rule.",
       },
       elements: {
         type: "array",
+        description: "An array of highlighting sub-rules",
         items: {
           oneOf: [
             {
@@ -96,18 +98,25 @@ export class HighlightEffect extends Effect {
     []
   );
 
-  async effect({
-    condition,
-    backgroundColor = "#FFFF00",
-    rootSelector,
-    elements,
-  }: BlockArg<{
-    condition: string | number | boolean;
-    backgroundColor: string;
-    rootSelector: string | undefined;
-    elements: ColorRule[];
-  }>): Promise<void> {
-    const $roots = rootSelector ? $(rootSelector) : $(document);
+  async isRootAware(): Promise<boolean> {
+    return true;
+  }
+
+  async effect(
+    {
+      condition,
+      backgroundColor = "#FFFF00",
+      rootSelector,
+      elements,
+    }: BlockArg<{
+      condition: string | number | boolean;
+      backgroundColor: string;
+      rootSelector: string | undefined;
+      elements: ColorRule[];
+    }>,
+    { root }: BlockOptions
+  ): Promise<void> {
+    const $roots = rootSelector ? $safeFind(rootSelector, root) : $(root);
 
     if (condition !== undefined && !boolean(condition)) {
       return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,7 +252,7 @@ export abstract class Effect extends Block {
   }
 
   async isRootAware(): Promise<boolean> {
-    // Most transformers don't use the root, so have them opt-in
+    // Most effects don't use the root, so have them opt-in
     return false;
   }
 


### PR DESCRIPTION
Closes #2441 

NOTE: this is a backward incompatible change, but it's very unlikely it will impact anyone. If it does, the migration is to just set the brick context as "document" and not "inherit"