### PR TITLE
#2492: automatic deployment update enhancements/fixes

### DIFF
--- a/src/__mocks__/logging.ts
+++ b/src/__mocks__/logging.ts
@@ -8,5 +8,7 @@ export function reportError(error: unknown, context?: MessageContext): void {
     context,
   });
 
-  throw new Error(`Error: ${getErrorMessage(error)}`);
+  throw new Error(
+    `Unexpected call to reportError during test: ${getErrorMessage(error)}`
+  );
 }

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -35,7 +35,7 @@ export interface AuthData extends UserData {
   token: string;
 }
 
-async function readAuthData(): Promise<AuthData | Partial<AuthData>> {
+export async function readAuthData(): Promise<AuthData | Partial<AuthData>> {
   return readStorage(STORAGE_EXTENSION_KEY, {});
 }
 

--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -40,6 +40,12 @@ jest.mock("@/background/util", () => ({
 
 jest.mock("webext-messenger");
 
+jest.mock("@/permissions", () => ({
+  deploymentPermissions: jest
+    .fn()
+    .mockResolvedValue({ permissions: [], origins: [] }),
+}));
+
 jest.mock("@/telemetry/events", () => ({
   reportEvent: jest.fn(),
 }));
@@ -51,6 +57,9 @@ jest.mock("@/background/messenger/api", () => ({
   traces: {
     // eslint-disable-next-line unicorn/no-useless-undefined -- argument is required
     clear: jest.fn().mockResolvedValue(undefined),
+  },
+  contextMenus: {
+    preload: jest.fn(),
   },
 }));
 
@@ -119,6 +128,10 @@ describe("updateDeployments", () => {
     axiosMock.onAny().reply(201, [deployment]);
 
     await updateDeployments();
+
+    const { extensions } = await loadOptions();
+
+    expect(extensions.length).toBe(1);
   });
 
   test("skip update and uninstall if not linked", async () => {

--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { updateDeployments } from "@/background/deployment";
+
+jest.mock("@/contentScript/messenger/api");
+
+jest.mock("@/background/telemetry", () => ({
+  getUID: async () => "UID",
+}));
+
+jest.mock("@/auth/token", () => ({
+  getExtensionToken: async () => "TESTTOKEN",
+  readAuthData: async () => ({
+    organizationId: "00000000-00000000-00000000-00000000",
+  }),
+  isLinked: async () => true,
+}));
+import { isLinked, readAuthData } from "@/auth/token";
+
+jest.mock("webext-detect-page", () => ({
+  isBackground: () => true,
+  isDevToolsPage: () => false,
+  isExtensionContext: () => false,
+}));
+
+jest.mock("webextension-polyfill", () => ({
+  __esModule: true,
+  default: {
+    runtime: {
+      getManifest: () => ({
+        version: "1.5.2",
+      }),
+    },
+  },
+}));
+
+afterEach(() => {
+  (isLinked as any).mockClear();
+  (readAuthData as any).mockClear();
+});
+
+describe("updateDeployments", () => {
+  test("can update deployments", async () => {
+    (isLinked as any).mockResolvedValue(async () => true);
+
+    await updateDeployments();
+  });
+
+  test("skip if not linked", async () => {
+    (isLinked as any).mockResolvedValue(async () => false);
+    (readAuthData as any).mockResolvedValue(
+      async () => ({ organizationId: null } as any)
+    );
+
+    await updateDeployments();
+  });
+
+  test("can uninstall all deployments", async () => {
+    (isLinked as any).mockResolvedValue(async () => true);
+
+    await updateDeployments();
+  });
+});

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -88,7 +88,7 @@ function uninstallExtension(
 /**
  * Uninstall all deployments by uninstalling all extensions associated with the deployment.
  */
-async function uninstallAllDeployments(): Promise<void> {
+export async function uninstallAllDeployments(): Promise<void> {
   let state = await loadOptions();
   const installed = selectExtensions({ options: state });
 
@@ -277,6 +277,9 @@ export async function updateDeployments(): Promise<void> {
   ]);
 
   if (!linked) {
+    // If the Browser extension is unlinked (it doesn't have the API key), just NOP. If it's an enterprise user, it's
+    // likely they just need to reconnect their extension. If it's a non-enterprise user, they shouldn't have any
+    // deployments installed anyway.
     return;
   }
 

--- a/src/devTools/editor/panes/save/SavingExtensionModal.test.tsx
+++ b/src/devTools/editor/panes/save/SavingExtensionModal.test.tsx
@@ -21,7 +21,7 @@ import SavingExtensionModal from "./SavingExtensionModal";
 import { FormState } from "@/devTools/editor/slices/editorSlice";
 import { define } from "cooky-cutter";
 import {
-  extensionPointFactory,
+  extensionPointConfigFactory,
   installedRecipeMetadataFactory,
   recipeFactory,
   recipeMetadataFactory,
@@ -141,7 +141,10 @@ test("doesn't render recipe buttons when extension API is not compatible with re
   const recipe = recipeFactory({
     apiVersion: "v2",
     definitions: null,
-    extensionPoints: [extensionPointFactory(), extensionPointFactory()],
+    extensionPoints: [
+      extensionPointConfigFactory(),
+      extensionPointConfigFactory(),
+    ],
   });
   const element = simpleElementFactory({
     apiVersion: "v3",

--- a/src/devTools/editor/panes/save/saveHelpers.test.ts
+++ b/src/devTools/editor/panes/save/saveHelpers.test.ts
@@ -21,7 +21,7 @@ import {
 } from "@/devTools/editor/panes/save/saveHelpers";
 import { validateRegistryId } from "@/types/helpers";
 import {
-  recipeDefinitionFactory,
+  extensionPointDefinitionFactory,
   innerExtensionPointRecipeFactory,
   versionedExtensionPointRecipeFactory,
   extensionPointFactory,
@@ -65,7 +65,7 @@ describe("generatePersonalBrickId", () => {
 
 describe("replaceRecipeExtension round trip", () => {
   test("single extension with versioned extensionPoint", async () => {
-    const extensionPoint = recipeDefinitionFactory();
+    const extensionPoint = extensionPointDefinitionFactory();
     const recipe = versionedExtensionPointRecipeFactory({
       extensionPointId: extensionPoint.metadata.id,
     })();
@@ -105,7 +105,7 @@ describe("replaceRecipeExtension round trip", () => {
   });
 
   test("does not modify other extension point", async () => {
-    const extensionPoint = recipeDefinitionFactory();
+    const extensionPoint = extensionPointDefinitionFactory();
 
     const recipe = versionedExtensionPointRecipeFactory({
       extensionPointId: extensionPoint.metadata.id,
@@ -311,7 +311,7 @@ describe("replaceRecipeExtension round trip", () => {
   });
 
   test("updates Recipe API version with single extension", async () => {
-    const extensionPoint = recipeDefinitionFactory({
+    const extensionPoint = extensionPointDefinitionFactory({
       apiVersion: "v2",
     });
 
@@ -363,7 +363,7 @@ describe("replaceRecipeExtension round trip", () => {
   });
 
   test("throws when API version mismatch and cannot update recipe", async () => {
-    const extensionPoint = recipeDefinitionFactory();
+    const extensionPoint = extensionPointDefinitionFactory();
     const recipe = versionedExtensionPointRecipeFactory({
       extensionPointId: extensionPoint.metadata.id,
     })({

--- a/src/devTools/editor/panes/save/saveHelpers.test.ts
+++ b/src/devTools/editor/panes/save/saveHelpers.test.ts
@@ -24,7 +24,7 @@ import {
   extensionPointDefinitionFactory,
   innerExtensionPointRecipeFactory,
   versionedExtensionPointRecipeFactory,
-  extensionPointFactory,
+  extensionPointConfigFactory,
 } from "@/tests/factories";
 import menuItemExtensionAdapter from "@/devTools/editor/extensionPoints/menuItem";
 import { UnknownObject } from "@/types";
@@ -369,10 +369,10 @@ describe("replaceRecipeExtension round trip", () => {
     })({
       apiVersion: "v2",
       extensionPoints: [
-        extensionPointFactory({
+        extensionPointConfigFactory({
           id: extensionPoint.metadata.id,
         }),
-        extensionPointFactory(),
+        extensionPointConfigFactory(),
       ],
     });
 

--- a/src/store/extensionsStorage.ts
+++ b/src/store/extensionsStorage.ts
@@ -43,7 +43,7 @@ export async function loadOptions(): Promise<ExtensionOptionsState> {
   console.debug("Loading raw options from storage");
 
   const base = await getOptionsState();
-  // The redux persist layer persists the extensions value as as JSON-string.
+  // The redux persist layer persists the extensions value as JSON-string.
   // Also apply the upgradeExtensionsState migration here because the migration in store might not have run yet.
   return migrateActiveExtensions(
     migrateExtensionsShape({


### PR DESCRIPTION
- Closes #2492
- Closes #2493 
- Closes #2494 

TODO
- [x] Write all the test mocks

Out of Scope
- Allow user to snooze deployment update for deployments requiring manual intervention

Follow-up Work
- Add more tests covering update logic (version numbers and update timestamps