### PR TITLE
#2434: Add multiple-table reader

### DIFF
--- a/src/blocks/transformers/component/TableReader.ts
+++ b/src/blocks/transformers/component/TableReader.ts
@@ -138,7 +138,6 @@ export class TablesReader extends Transformer {
   }
 
   async transform(_: BlockArg, { root }: BlockOptions): Promise<unknown> {
-    const tables = Object.fromEntries(getAllTables(root).entries());
-    return { tables: Object.keys(tables).length === 0 ? undefined : tables };
+    return Object.fromEntries(getAllTables(root).entries());
   }
 }

--- a/src/blocks/transformers/component/TableReader.ts
+++ b/src/blocks/transformers/component/TableReader.ts
@@ -18,7 +18,7 @@
 import { Transformer } from "@/types";
 import { BlockArg, BlockOptions, Schema } from "@/core";
 import { validateRegistryId } from "@/types/helpers";
-import parseDomTable from "@/utils/parseDomTable";
+import parseDomTable, { getAllTables } from "@/utils/parseDomTable";
 import { $safeFind } from "@/helpers";
 import slugify from "slugify";
 
@@ -137,17 +137,6 @@ export class TablesReader extends Transformer {
   }
 
   async transform(_: BlockArg, { root }: BlockOptions): Promise<unknown> {
-    const tables = new Map();
-    for (const table of $<HTMLTableElement>("table", root)) {
-      const parsedTable = parseDomTable(table);
-      const tableName =
-        table.querySelector("caption")?.textContent ??
-        parsedTable.fieldNames.join("-");
-      if (tableName) {
-        tables.set(slugify(tableName, { lower: true }), parsedTable);
-      }
-    }
-
-    return { tables: Object.fromEntries(tables.entries()) };
+    return { tables: Object.fromEntries(getAllTables(root).entries()) };
   }
 }

--- a/src/blocks/transformers/component/TableReader.ts
+++ b/src/blocks/transformers/component/TableReader.ts
@@ -106,25 +106,16 @@ export class TablesReader extends Transformer {
     $schema: "https://json-schema.org/draft/2019-09/schema#",
     type: "object",
     properties: {
-      tables: {
-        description: "The tables found on the page",
-        type: "object",
-        additionalProperties: {
-          type: "object",
-          properties: {
-            records: {
-              description:
-                "The records in the table (rows or columns, depending on orientation)",
-              type: "array",
-              items: { type: "object" },
-            },
-            fieldNames: {
-              description: "The field names in the table",
-              type: "array",
-              items: { type: "string" },
-            },
-          },
-        },
+      records: {
+        description:
+          "The records in the table (rows or columns, depending on orientation)",
+        type: "array",
+        items: { type: "object" },
+      },
+      fieldNames: {
+        description: "The field names in the table",
+        type: "array",
+        items: { type: "string" },
       },
     },
   };

--- a/src/blocks/transformers/component/TableReader.ts
+++ b/src/blocks/transformers/component/TableReader.ts
@@ -136,6 +136,7 @@ export class TablesReader extends Transformer {
   }
 
   async transform(_: BlockArg, { root }: BlockOptions): Promise<unknown> {
-    return { tables: Object.fromEntries(getAllTables(root).entries()) };
+    const tables = Object.fromEntries(getAllTables(root).entries());
+    return { tables: Object.keys(tables).length === 0 ? undefined : tables };
   }
 }

--- a/src/blocks/transformers/component/TableReader.ts
+++ b/src/blocks/transformers/component/TableReader.ts
@@ -22,7 +22,9 @@ import parseDomTable, { getAllTables } from "@/utils/parseDomTable";
 import { $safeFind } from "@/helpers";
 
 export const TABLE_READER_ID = validateRegistryId("@pixiebrix/table-reader");
-export const TABLES_READER_ID = validateRegistryId("@pixiebrix/tables-reader");
+export const TABLE_READER_ALL_ID = validateRegistryId(
+  "@pixiebrix/table-reader-all"
+);
 
 export class TableReader extends Transformer {
   constructor() {
@@ -87,9 +89,9 @@ export class TableReader extends Transformer {
 export class TablesReader extends Transformer {
   constructor() {
     super(
-      TABLES_READER_ID,
-      "Tables Reader",
-      "Extract data from all the tables"
+      TABLE_READER_ALL_ID,
+      "Read All Tables",
+      "Extract data from all the tables on the page"
     );
   }
 

--- a/src/blocks/transformers/component/TableReader.ts
+++ b/src/blocks/transformers/component/TableReader.ts
@@ -20,7 +20,6 @@ import { BlockArg, BlockOptions, Schema } from "@/core";
 import { validateRegistryId } from "@/types/helpers";
 import parseDomTable, { getAllTables } from "@/utils/parseDomTable";
 import { $safeFind } from "@/helpers";
-import slugify from "slugify";
 
 export const TABLE_READER_ID = validateRegistryId("@pixiebrix/table-reader");
 export const TABLES_READER_ID = validateRegistryId("@pixiebrix/tables-reader");

--- a/src/blocks/transformers/registerTransformers.ts
+++ b/src/blocks/transformers/registerTransformers.ts
@@ -38,7 +38,7 @@ import { ParseCsv } from "./parseCsv";
 import { ParseDataUrl } from "./parseDataUrl";
 import { ParseDate } from "@/blocks/transformers/parseDate";
 import { ScreenshotTab } from "@/blocks/transformers/screenshotTab";
-import { TableReader } from "./component/TableReader";
+import { TableReader, TablesReader } from "./component/TableReader";
 
 function registerTransformers() {
   registerBlock(new JQTransformer());
@@ -60,6 +60,7 @@ function registerTransformers() {
   registerBlock(new JQueryReader());
   registerBlock(new ComponentReader());
   registerBlock(new TableReader());
+  registerBlock(new TablesReader());
   registerBlock(new ParseCsv());
   registerBlock(new ParseDataUrl());
   registerBlock(new ParseDate());

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import blockRegistry from "@/blocks/registry";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 92;
+const EXPECTED_HEADER_COUNT = 93;
 
 // Import for side-effects (these modules register the blocks)
 // NOTE: we don't need to also include extensionPoints because we got rid of all the legacy hard-coded extension points

--- a/src/utils/parseDomTable.test.ts
+++ b/src/utils/parseDomTable.test.ts
@@ -38,6 +38,67 @@ function getDocument(...elements: Node[]): Document {
   return window.document;
 }
 
+describe("parseDomTable", () => {
+  test("parse simple table", () => {
+    const table = getTable(`
+      <tr><th>Name<th>Age
+      <tr><td>Mario<td>42
+      <tr><td>Luigi<td>39
+    `);
+
+    const expected = {
+      fieldNames: ["Name", "Age"],
+      records: [
+        { Name: "Mario", Age: "42" },
+        { Name: "Luigi", Age: "39" },
+      ],
+    };
+
+    const actual = parseDomTable(table);
+
+    expect(actual).toStrictEqual(expected);
+  });
+
+  test("parse header-less table", () => {
+    const table = getTable(`
+      <tr><td>Mario<td>42
+      <tr><td>Luigi<td>39
+    `);
+
+    const expected = {
+      fieldNames: [0, 1],
+      records: [
+        { 0: "Mario", 1: "42" },
+        { 0: "Luigi", 1: "39" },
+      ],
+    };
+
+    const actual = parseDomTable(table);
+
+    expect(actual).toStrictEqual(expected);
+  });
+
+  test("parse horizontal table", () => {
+    const table = getTable(`
+      <tr><th>Name<td>Mario<td>Luigi
+      <tr><th>Age<td>42<td>39
+      <tr><th>Height<td>5' 6"<td>5' 8"
+    `);
+
+    const expected = {
+      fieldNames: ["Name", "Age", "Height"],
+      records: [
+        { Name: "Mario", Age: "42", Height: "5' 6\"" },
+        { Name: "Luigi", Age: "39", Height: "5' 8\"" },
+      ],
+    };
+
+    const actual = parseDomTable(table);
+
+    expect(actual).toStrictEqual(expected);
+  });
+});
+
 describe("getAllTables", () => {
   test("use caption as name", () => {
     const table1 = getTable(`
@@ -130,67 +191,6 @@ describe("getAllTables", () => {
       ["name-age", parseDomTable(table1)],
       ["0-1", parseDomTable(table2)],
     ]);
-
-    expect(actual).toStrictEqual(expected);
-  });
-});
-
-describe("parseDomTable", () => {
-  test("parse simple table", () => {
-    const table = getTable(`
-      <tr><th>Name<th>Age
-      <tr><td>Mario<td>42
-      <tr><td>Luigi<td>39
-    `);
-
-    const expected = {
-      fieldNames: ["Name", "Age"],
-      records: [
-        { Name: "Mario", Age: "42" },
-        { Name: "Luigi", Age: "39" },
-      ],
-    };
-
-    const actual = parseDomTable(table);
-
-    expect(actual).toStrictEqual(expected);
-  });
-
-  test("parse header-less table", () => {
-    const table = getTable(`
-      <tr><td>Mario<td>42
-      <tr><td>Luigi<td>39
-    `);
-
-    const expected = {
-      fieldNames: [0, 1],
-      records: [
-        { 0: "Mario", 1: "42" },
-        { 0: "Luigi", 1: "39" },
-      ],
-    };
-
-    const actual = parseDomTable(table);
-
-    expect(actual).toStrictEqual(expected);
-  });
-
-  test("parse horizontal table", () => {
-    const table = getTable(`
-      <tr><th>Name<td>Mario<td>Luigi
-      <tr><th>Age<td>42<td>39
-      <tr><th>Height<td>5' 6"<td>5' 8"
-    `);
-
-    const expected = {
-      fieldNames: ["Name", "Age", "Height"],
-      records: [
-        { Name: "Mario", Age: "42", Height: "5' 6\"" },
-        { Name: "Luigi", Age: "39", Height: "5' 8\"" },
-      ],
-    };
-
-    const actual = parseDomTable(table);
 
     expect(actual).toStrictEqual(expected);
   });

--- a/src/utils/parseDomTable.test.ts
+++ b/src/utils/parseDomTable.test.ts
@@ -111,7 +111,7 @@ describe("getAllTables", () => {
     const actual = getAllTables(getDocument(table1));
 
     const expected = new Map([
-      ["characters-in-mario-3", parseDomTable(table1)],
+      ["characters_in_mario_3", parseDomTable(table1)],
     ]);
 
     expect(actual).toStrictEqual(expected);
@@ -188,8 +188,8 @@ describe("getAllTables", () => {
     const actual = getAllTables(getDocument(table1, table2));
 
     const expected = new Map([
-      ["name-age", parseDomTable(table1)],
-      ["0-1", parseDomTable(table2)],
+      ["table_c07b8", parseDomTable(table1)],
+      ["table_8af45", parseDomTable(table2)],
     ]);
 
     expect(actual).toStrictEqual(expected);

--- a/src/utils/parseDomTable.ts
+++ b/src/utils/parseDomTable.ts
@@ -107,7 +107,7 @@ function getAriaDescription(element: HTMLElement): string | undefined {
 }
 
 function getNameFromFiels(fields: Array<number | string>): string {
-  return "Table_" + objectHash(fields);
+  return "Table_" + objectHash(fields).slice(0, 5);
 }
 
 export function getAllTables(

--- a/src/utils/parseDomTable.ts
+++ b/src/utils/parseDomTable.ts
@@ -106,7 +106,7 @@ function getAriaDescription(element: HTMLElement): string | undefined {
   }
 }
 
-function getNameFromFiels(fields: Array<number | string>): string {
+function getNameFromFields(fields: Array<number | string>): string {
   return "Table_" + objectHash(fields).slice(0, 5);
 }
 
@@ -124,7 +124,7 @@ export function getAllTables(
       table.getAttribute("aria-label") ||
       // TODO: Exclude random identifiers #2498
       table.id ||
-      getNameFromFiels(parsedTable.fieldNames);
+      getNameFromFields(parsedTable.fieldNames);
     tables.set(
       slugify(tableName, { replacement: "_", lower: true }),
       parsedTable

--- a/src/utils/parseDomTable.ts
+++ b/src/utils/parseDomTable.ts
@@ -16,6 +16,7 @@
  */
 
 import { zip, zipObject } from "lodash";
+import slugify from "slugify";
 
 interface ParsingOptions {
   orientation?: "vertical" | "horizontal" | "infer";
@@ -95,4 +96,21 @@ export default function parseDomTable(
 
   const records = body.map((row) => zipObject(fieldNames, row));
   return { records, fieldNames };
+}
+
+export function getAllTables(
+  root: HTMLElement | Document = document
+): Map<string, ParsedTable> {
+  const tables = new Map();
+  for (const table of $<HTMLTableElement>("table", root)) {
+    const parsedTable = parseDomTable(table);
+    const tableName =
+      table.querySelector("caption")?.textContent ??
+      parsedTable.fieldNames.join("-");
+    if (tableName) {
+      tables.set(slugify(tableName, { lower: true }), parsedTable);
+    }
+  }
+
+  return tables;
 }

--- a/src/utils/parseDomTable.ts
+++ b/src/utils/parseDomTable.ts
@@ -98,18 +98,29 @@ export default function parseDomTable(
   return { records, fieldNames };
 }
 
+function getAriaDescription(element: HTMLElement): string | undefined {
+  const describedBy = element.getAttribute("aria-describedby");
+  if (describedBy) {
+    return element.ownerDocument.querySelector("#" + describedBy)?.textContent;
+  }
+}
+
 export function getAllTables(
   root: HTMLElement | Document = document
 ): Map<string, ParsedTable> {
   const tables = new Map();
   for (const table of $<HTMLTableElement>("table", root)) {
     const parsedTable = parseDomTable(table);
+
+    // Uses || instead of ?? to exclude empty strings
     const tableName =
-      table.querySelector("caption")?.textContent ??
+      table.querySelector("caption")?.textContent ||
+      getAriaDescription(table) ||
+      table.getAttribute("aria-label") ||
+      // TODO: Exclude random identifiers #2498
+      table.id ||
       parsedTable.fieldNames.join("-");
-    if (tableName) {
-      tables.set(slugify(tableName, { lower: true }), parsedTable);
-    }
+    tables.set(slugify(tableName, { lower: true }), parsedTable);
   }
 
   return tables;

--- a/src/utils/parseDomTable.ts
+++ b/src/utils/parseDomTable.ts
@@ -16,6 +16,7 @@
  */
 
 import { zip, zipObject } from "lodash";
+import objectHash from "object-hash";
 import slugify from "slugify";
 
 interface ParsingOptions {
@@ -106,7 +107,7 @@ function getAriaDescription(element: HTMLElement): string | undefined {
 }
 
 function getNameFromFiels(fields: Array<number | string>): string {
-  return "Table_" + fields.slice(0, 2).join("_");
+  return "Table_" + objectHash(fields);
 }
 
 export function getAllTables(

--- a/src/utils/parseDomTable.ts
+++ b/src/utils/parseDomTable.ts
@@ -105,6 +105,10 @@ function getAriaDescription(element: HTMLElement): string | undefined {
   }
 }
 
+function getNameFromFiels(fields: Array<number | string>): string {
+  return "Table_" + fields.slice(0, 2).join("_");
+}
+
 export function getAllTables(
   root: HTMLElement | Document = document
 ): Map<string, ParsedTable> {
@@ -119,8 +123,11 @@ export function getAllTables(
       table.getAttribute("aria-label") ||
       // TODO: Exclude random identifiers #2498
       table.id ||
-      parsedTable.fieldNames.join("-");
-    tables.set(slugify(tableName, { lower: true }), parsedTable);
+      getNameFromFiels(parsedTable.fieldNames);
+    tables.set(
+      slugify(tableName, { replacement: "_", lower: true }),
+      parsedTable
+    );
   }
 
   return tables;


### PR DESCRIPTION
- closes https://github.com/pixiebrix/pixiebrix-extension/issues/2434

Tested on https://pbx.vercel.app/create-react-app/table/

Notes:

- I guess that the vast majority of tables on the internet are not labelled/captioned, so we should probably default to using the headers as key

To do:

- [x] Add more ways to figure out the table name as [previously suggested](https://github.com/pixiebrix/pixiebrix-extension/issues/2434)
- [x] Add some automated tests

<img width="1009" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/151125559-7b4b95ff-4e6c-445e-b0dd-dd59f2d53fe2.png">

