### PR TITLE
#2459 Temporary workshop messages for custom block options fields

### DIFF
--- a/src/components/fields/schemaFields/BasicSchemaField.tsx
+++ b/src/components/fields/schemaFields/BasicSchemaField.tsx
@@ -39,7 +39,7 @@ import TemplateToggleWidget, {
 } from "@/components/fields/schemaFields/widgets/TemplateToggleWidget";
 import TextWidget from "@/components/fields/schemaFields/widgets/TextWidget";
 import { ExpressionType, Schema } from "@/core";
-import ComplexObjectWidget from "@/components/fields/schemaFields/widgets/ComplexObjectWidget";
+import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 import ArrayWidget from "@/components/fields/schemaFields/widgets/ArrayWidget";
 import ObjectWidget from "@/components/fields/schemaFields/widgets/ObjectWidget";
 import IntegerWidget from "@/components/fields/schemaFields/widgets/IntegerWidget";
@@ -199,7 +199,7 @@ function getToggleOptions({
   if (fieldSchema.type === "array" || anyType) {
     // Don't allow editing array fields nested inside objects/arrays
     const Widget =
-      isObjectProperty || isArrayItem ? ComplexObjectWidget : ArrayWidget;
+      isObjectProperty || isArrayItem ? WorkshopMessageWidget : ArrayWidget;
     pushOptions({
       label: "Array items",
       value: "array",
@@ -222,7 +222,7 @@ function getToggleOptions({
     isEmpty(fieldSchema)
   ) {
     // Don't allow editing objects inside other objects
-    const Widget = isObjectProperty ? ComplexObjectWidget : ObjectWidget;
+    const Widget = isObjectProperty ? WorkshopMessageWidget : ObjectWidget;
     pushOptions({
       label: "Object properties",
       value: "object",

--- a/src/components/fields/schemaFields/WorkshopMessage.tsx
+++ b/src/components/fields/schemaFields/WorkshopMessage.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import styles from "@/devTools/editor/tabs/editTab/UpgradedToApiV3.module.scss";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
+import { Alert } from "react-bootstrap";
+
+const WorkshopMessage: React.FC = () => (
+  <Alert variant="info" className={styles.alert}>
+    <FontAwesomeIcon icon={faExclamationCircle} size="lg" className="mt-1" />
+    <p>
+      This brick contains advanced configurations not yet supported in the page
+      editor, please open this extension in the Workshop if you would like to
+      make changes.{" "}
+      <a
+        href="https://docs.pixiebrix.com/runtime"
+        target="_blank"
+        rel="noreferrer"
+      >
+        Read more about runtime configurations here.
+      </a>
+    </p>
+  </Alert>
+);
+
+export default WorkshopMessage;

--- a/src/components/fields/schemaFields/WorkshopMessage.tsx
+++ b/src/components/fields/schemaFields/WorkshopMessage.tsx
@@ -25,15 +25,15 @@ const WorkshopMessage: React.FC = () => (
   <Alert variant="info" className={styles.alert}>
     <FontAwesomeIcon icon={faExclamationCircle} size="lg" className="mt-1" />
     <p>
-      This brick contains advanced configurations not yet supported in the page
-      editor, please open this extension in the Workshop if you would like to
-      make changes.{" "}
+      This brick configuration uses advanced features not yet supported in the
+      Page Editor. To make changes, please open the source blueprint in the
+      Workshop.{" "}
       <a
-        href="https://docs.pixiebrix.com/runtime"
+        href="https://docs.pixiebrix.com/developer-guide"
         target="_blank"
         rel="noreferrer"
       >
-        Read more about runtime configurations here.
+        Read more in the Developer Guide
       </a>
     </p>
   </Alert>

--- a/src/components/fields/schemaFields/widgets/TextWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TextWidget.tsx
@@ -34,7 +34,7 @@ import {
   schemaSupportsTemplates,
 } from "@/components/fields/schemaFields/BasicSchemaField";
 import FieldRuntimeContext from "@/components/fields/schemaFields/FieldRuntimeContext";
-import ComplexObjectWidget from "@/components/fields/schemaFields/widgets/ComplexObjectWidget";
+import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 import { isMustacheOnly } from "@/components/fields/fieldUtils";
 
 function isVarValue(value: string): boolean {
@@ -162,7 +162,7 @@ const TextWidget: React.FC<SchemaFieldProps & FormControlProps> = ({
   }, [allowExpressions, onChangeForTemplate, setValue, value]);
 
   if (isTemplateExpression(value) && isMustacheOnly(value.__value__)) {
-    return <ComplexObjectWidget />;
+    return <WorkshopMessageWidget />;
   }
 
   if (

--- a/src/components/fields/schemaFields/widgets/WorkshopMessageWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/WorkshopMessageWidget.tsx
@@ -19,7 +19,7 @@ import React from "react";
 import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import { Form } from "react-bootstrap";
 
-const ComplexObjectWidget: React.FC<Partial<SchemaFieldProps>> = () => (
+const WorkshopMessageWidget: React.FC<Partial<SchemaFieldProps>> = () => (
   <Form.Control
     className="px-1"
     plaintext
@@ -28,4 +28,4 @@ const ComplexObjectWidget: React.FC<Partial<SchemaFieldProps>> = () => (
   />
 );
 
-export default ComplexObjectWidget;
+export default WorkshopMessageWidget;

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -19,7 +19,7 @@ import React, { useState } from "react";
 import { BlockOptionProps } from "@/components/fields/schemaFields/genericOptionsFactory";
 import { sheets } from "@/background/messenger/api";
 import { useField } from "formik";
-import { Schema } from "@/core";
+import { Expression, Schema } from "@/core";
 import { useAsyncState } from "@/hooks/common";
 import { APPEND_SCHEMA } from "@/contrib/google/sheets/append";
 import { isNullOrBlank, joinName } from "@/utils";
@@ -29,6 +29,7 @@ import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import { getErrorMessage } from "@/errors";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import TabField from "@/contrib/google/sheets/TabField";
+import { isExpression } from "@/runtime/mapArgs";
 
 const DEFAULT_FIELDS_SCHEMA: Schema = {
   type: "object",
@@ -38,10 +39,10 @@ const DEFAULT_FIELDS_SCHEMA: Schema = {
 const PropertiesField: React.FunctionComponent<{
   name: string;
   doc: SheetMeta | null;
-  tabName: string;
+  tabName: string | Expression;
 }> = ({ name, tabName, doc }) => {
   const [sheetSchema, , schemaError] = useAsyncState(async () => {
-    if (doc?.id && tabName) {
+    if (doc?.id && tabName && !isExpression(tabName)) {
       const headers = await sheets.getHeaders({
         spreadsheetId: doc.id,
         tabName,
@@ -84,7 +85,9 @@ const AppendSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
 
   const [doc, setDoc] = useState<SheetMeta>(null);
 
-  const [{ value: tabName }] = useField<string>(joinName(basePath, "tabName"));
+  const [{ value: tabName }] = useField<string | Expression>(
+    joinName(basePath, "tabName")
+  );
 
   return (
     <div className="my-2">

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -41,7 +41,7 @@ const PropertiesField: React.FunctionComponent<{
   doc: SheetMeta | null;
   tabName: string | Expression;
 }> = ({ name, tabName, doc }) => {
-  const [sheetSchema, , schemaError] = useAsyncState(async () => {
+  const [sheetSchema, , schemaError] = useAsyncState<Schema>(async () => {
     if (doc?.id && tabName && !isExpression(tabName)) {
       const headers = await sheets.getHeaders({
         spreadsheetId: doc.id,
@@ -54,7 +54,7 @@ const PropertiesField: React.FunctionComponent<{
             .filter((x) => !isNullOrBlank(x))
             .map((header) => [header, { type: "string" }])
         ),
-      } as Schema;
+      };
     }
 
     return DEFAULT_FIELDS_SCHEMA;

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -41,24 +41,28 @@ const PropertiesField: React.FunctionComponent<{
   doc: SheetMeta | null;
   tabName: string | Expression;
 }> = ({ name, tabName, doc }) => {
-  const [sheetSchema, , schemaError] = useAsyncState<Schema>(async () => {
-    if (doc?.id && tabName && !isExpression(tabName)) {
-      const headers = await sheets.getHeaders({
-        spreadsheetId: doc.id,
-        tabName,
-      });
-      return {
-        type: "object",
-        properties: Object.fromEntries(
-          headers
-            .filter((x) => !isNullOrBlank(x))
-            .map((header) => [header, { type: "string" }])
-        ),
-      };
-    }
+  const [sheetSchema, , schemaError] = useAsyncState<Schema>(
+    async () => {
+      if (doc?.id && tabName && !isExpression(tabName)) {
+        const headers = await sheets.getHeaders({
+          spreadsheetId: doc.id,
+          tabName,
+        });
+        return {
+          type: "object",
+          properties: Object.fromEntries(
+            headers
+              .filter((x) => !isNullOrBlank(x))
+              .map((header) => [header, { type: "string" }])
+          ),
+        };
+      }
 
-    return DEFAULT_FIELDS_SCHEMA;
-  }, [doc?.id, tabName]);
+      return DEFAULT_FIELDS_SCHEMA;
+    },
+    [doc?.id, tabName],
+    DEFAULT_FIELDS_SCHEMA
+  );
 
   return (
     <SchemaField
@@ -72,7 +76,7 @@ const PropertiesField: React.FunctionComponent<{
           </span>
         ) : null
       }
-      schema={sheetSchema ?? DEFAULT_FIELDS_SCHEMA}
+      schema={sheetSchema}
     />
   );
 };

--- a/src/contrib/google/sheets/FileWidget.tsx
+++ b/src/contrib/google/sheets/FileWidget.tsx
@@ -29,6 +29,9 @@ import { Form, InputGroup } from "react-bootstrap";
 import useNotifications from "@/hooks/useNotifications";
 import { getErrorMessage } from "@/errors";
 import AsyncButton from "@/components/AsyncButton";
+import { Expression } from "@/core";
+import { isExpression } from "@/runtime/mapArgs";
+import ComplexObjectWidget from "@/components/fields/schemaFields/widgets/ComplexObjectWidget";
 
 const API_KEY = process.env.GOOGLE_API_KEY;
 const APP_ID = process.env.GOOGLE_APP_ID;
@@ -43,7 +46,7 @@ type FileWidgetProps = {
 const FileWidget: React.FC<FileWidgetProps> = ({ doc, onSelect, ...props }) => {
   const notify = useNotifications();
 
-  const [field, , helpers] = useField<string>(props);
+  const [field, , helpers] = useField<string | Expression>(props);
   const [sheetError, setSheetError] = useState(null);
 
   useEffect(
@@ -60,6 +63,11 @@ const FileWidget: React.FC<FileWidgetProps> = ({ doc, onSelect, ...props }) => {
 
   useAsyncEffect(
     async (isMounted) => {
+      if (isExpression(field.value)) {
+        // Showing a workshop message for now here
+        return;
+      }
+
       const spreadsheetId = field.value;
 
       if (doc?.id === spreadsheetId) {
@@ -146,7 +154,9 @@ const FileWidget: React.FC<FileWidgetProps> = ({ doc, onSelect, ...props }) => {
     }
   }, [notify, helpers, onSelect]);
 
-  return (
+  return isExpression(field.value) ? (
+    <ComplexObjectWidget />
+  ) : (
     <InputGroup>
       {doc ? (
         // There's a time when doc.name is blank, so we're getting warnings about controlled/uncontrolled components

--- a/src/contrib/google/sheets/FileWidget.tsx
+++ b/src/contrib/google/sheets/FileWidget.tsx
@@ -31,7 +31,7 @@ import { getErrorMessage } from "@/errors";
 import AsyncButton from "@/components/AsyncButton";
 import { Expression } from "@/core";
 import { isExpression } from "@/runtime/mapArgs";
-import ComplexObjectWidget from "@/components/fields/schemaFields/widgets/ComplexObjectWidget";
+import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 
 const API_KEY = process.env.GOOGLE_API_KEY;
 const APP_ID = process.env.GOOGLE_APP_ID;
@@ -155,7 +155,7 @@ const FileWidget: React.FC<FileWidgetProps> = ({ doc, onSelect, ...props }) => {
   }, [notify, helpers, onSelect]);
 
   return isExpression(field.value) ? (
-    <ComplexObjectWidget />
+    <WorkshopMessageWidget />
   ) : (
     <InputGroup>
       {doc ? (

--- a/src/contrib/google/sheets/SheetServiceOptions.tsx
+++ b/src/contrib/google/sheets/SheetServiceOptions.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import { BlockOptionProps } from "@/components/fields/schemaFields/genericOptionsFactory";
 import FileWidget from "@/contrib/google/sheets/FileWidget";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
@@ -29,13 +29,6 @@ const SheetServiceOptions: React.FunctionComponent<BlockOptionProps> = ({
 }) => {
   const [doc, setDoc] = useState<SheetMeta>(null);
 
-  const handleSelect = useCallback(
-    (doc: SheetMeta) => {
-      setDoc(doc);
-    },
-    [doc]
-  );
-
   return (
     <div className="my-2">
       <ConnectedFieldTemplate
@@ -43,7 +36,7 @@ const SheetServiceOptions: React.FunctionComponent<BlockOptionProps> = ({
         description="The ID of the spreadsheet to update."
         label="Google Sheet"
         as={FileWidget}
-        onSelect={handleSelect}
+        onSelect={setDoc}
         doc={doc}
       />
     </div>

--- a/src/contrib/google/sheets/TabField.tsx
+++ b/src/contrib/google/sheets/TabField.tsx
@@ -24,11 +24,14 @@ import { sheets } from "@/background/messenger/api";
 import { compact, uniq } from "lodash";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import SelectWidget from "@/components/form/widgets/SelectWidget";
+import { Expression } from "@/core";
+import { isExpression } from "@/runtime/mapArgs";
+import ComplexObjectWidget from "@/components/fields/schemaFields/widgets/ComplexObjectWidget";
 
 const TabField: React.FunctionComponent<
   SchemaFieldProps & { doc: SheetMeta | null }
 > = ({ name, doc }) => {
-  const [field] = useField<string>(name);
+  const [field] = useField<string | Expression>(name);
 
   const [tabNames, tabsPending, tabsError] = useAsyncState(async () => {
     if (doc?.id) {
@@ -57,7 +60,9 @@ const TabField: React.FunctionComponent<
   //         </span>
   // )}
 
-  return (
+  return isExpression(field.value) ? (
+    <ComplexObjectWidget />
+  ) : (
     <ConnectedFieldTemplate
       name={name}
       label="Tab Name"

--- a/src/contrib/google/sheets/TabField.tsx
+++ b/src/contrib/google/sheets/TabField.tsx
@@ -26,7 +26,7 @@ import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import SelectWidget from "@/components/form/widgets/SelectWidget";
 import { Expression } from "@/core";
 import { isExpression } from "@/runtime/mapArgs";
-import ComplexObjectWidget from "@/components/fields/schemaFields/widgets/ComplexObjectWidget";
+import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 
 const TabField: React.FunctionComponent<
   SchemaFieldProps & { doc: SheetMeta | null }
@@ -61,7 +61,7 @@ const TabField: React.FunctionComponent<
   // )}
 
   return isExpression(field.value) ? (
-    <ComplexObjectWidget />
+    <WorkshopMessageWidget />
   ) : (
     <ConnectedFieldTemplate
       name={name}

--- a/src/contrib/uipath/LocalProcessOptions.tsx
+++ b/src/contrib/uipath/LocalProcessOptions.tsx
@@ -18,7 +18,7 @@
 import React, { useMemo, useState } from "react";
 import { partial } from "lodash";
 import { UIPATH_PROPERTIES as REMOTE_UIPATH_PROPERTIES } from "@/contrib/uipath/process";
-import { Schema } from "@/core";
+import { Expression, Schema } from "@/core";
 import { useAsyncEffect } from "use-async-effect";
 import ChildObjectField from "@/components/fields/schemaFields/ChildObjectField";
 import { BlockOptionProps } from "@/components/fields/schemaFields/genericOptionsFactory";
@@ -30,6 +30,9 @@ import RemoteSelectWidget from "@/components/form/widgets/RemoteSelectWidget";
 import { thisTab } from "@/devTools/utils";
 import { getProcesses, initRobot } from "@/contentScript/messenger/api";
 import { isDevToolsPage } from "webext-detect-page";
+import { useField } from "formik";
+import { isExpression } from "@/runtime/mapArgs";
+import WorkshopMessage from "@/components/fields/schemaFields/WorkshopMessage";
 
 function useLocalRobot() {
   const [robotAvailable, setRobotAvailable] = useState(false);
@@ -66,6 +69,10 @@ const LocalProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
 }) => {
   const configName = partial(joinName, name, configKey);
 
+  const [{ value: releaseKey }] = useField<string | Expression>(
+    configName("releaseKey")
+  );
+
   const { robotAvailable, consentCode } = useLocalRobot();
   const { selectedRelease } = useSelectedRelease(configName("releaseKey"));
 
@@ -94,7 +101,9 @@ const LocalProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
     );
   }
 
-  return (
+  return isExpression(releaseKey) ? (
+    <WorkshopMessage />
+  ) : (
     <div>
       {consentCode && (
         <span className="text-info">

--- a/src/contrib/uipath/ProcessOptions.tsx
+++ b/src/contrib/uipath/ProcessOptions.tsx
@@ -19,7 +19,7 @@ import React, { useCallback, useEffect } from "react";
 import { BlockOptionProps } from "@/components/fields/schemaFields/genericOptionsFactory";
 import { partial } from "lodash";
 import { UIPATH_PROPERTIES } from "@/contrib/uipath/process";
-import { SanitizedServiceConfiguration, Schema } from "@/core";
+import { Expression, SanitizedServiceConfiguration, Schema } from "@/core";
 import { useField } from "formik";
 import { proxyService } from "@/background/messenger/api";
 import ChildObjectField from "@/components/fields/schemaFields/ChildObjectField";
@@ -33,6 +33,8 @@ import RequireServiceConfig from "@/contrib/RequireServiceConfig";
 import RemoteMultiSelectWidget from "@/components/form/widgets/RemoteMultiSelectWidget";
 import { useSelectedRelease } from "@/contrib/uipath/uipathHooks";
 import cachePromise from "@/utils/cachePromise";
+import { isExpression } from "@/runtime/mapArgs";
+import WorkshopMessage from "@/components/fields/schemaFields/WorkshopMessage";
 
 async function fetchRobots(
   config: SanitizedServiceConfiguration
@@ -60,6 +62,10 @@ const ProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
     configName("jobsCount")
   );
 
+  const [{ value: releaseKey }] = useField<string | Expression>(
+    configName("releaseKey")
+  );
+
   const { selectedRelease, releasesPromise } = useSelectedRelease(
     configName("releaseKey")
   );
@@ -83,7 +89,9 @@ const ProcessOptions: React.FunctionComponent<BlockOptionProps> = ({
     []
   );
 
-  return (
+  return isExpression(releaseKey) ? (
+    <WorkshopMessage />
+  ) : (
     <RequireServiceConfig
       serviceSchema={UIPATH_PROPERTIES.uipath as Schema}
       serviceFieldName={configName("uipath")}

--- a/src/contrib/zapier/pushOptions.tsx
+++ b/src/contrib/zapier/pushOptions.tsx
@@ -36,7 +36,7 @@ import ObjectWidget from "@/components/fields/schemaFields/widgets/ObjectWidget"
 import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFieldContext";
 import { makeLabelForSchemaField } from "@/components/fields/schemaFields/schemaFieldUtils";
 import { isExpression } from "@/runtime/mapArgs";
-import ComplexObjectWidget from "@/components/fields/schemaFields/widgets/ComplexObjectWidget";
+import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 
 function useHooks(): {
   hooks: Webhook[];
@@ -131,7 +131,7 @@ const PushOptions: React.FunctionComponent<BlockOptionProps> = ({
   }
 
   return isExpression(pushKey) ? (
-    <ComplexObjectWidget />
+    <WorkshopMessageWidget />
   ) : (
     <div>
       <ZapField

--- a/src/contrib/zapier/pushOptions.tsx
+++ b/src/contrib/zapier/pushOptions.tsx
@@ -19,10 +19,9 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { BlockOptionProps } from "@/components/fields/schemaFields/genericOptionsFactory";
 import { compact } from "lodash";
-import { Schema } from "@/core";
+import { Expression, Schema } from "@/core";
 import { useField } from "formik";
 import { useAsyncState } from "@/hooks/common";
-import { fieldLabel } from "@/components/fields/fieldUtils";
 import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import { Webhook } from "@/contrib/zapier/contract";
 import { pixieServiceFactory } from "@/services/locator";
@@ -35,6 +34,9 @@ import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import SelectWidget from "@/components/form/widgets/SelectWidget";
 import ObjectWidget from "@/components/fields/schemaFields/widgets/ObjectWidget";
 import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFieldContext";
+import { makeLabelForSchemaField } from "@/components/fields/schemaFields/schemaFieldUtils";
+import { isExpression } from "@/runtime/mapArgs";
+import ComplexObjectWidget from "@/components/fields/schemaFields/widgets/ComplexObjectWidget";
 
 function useHooks(): {
   hooks: Webhook[];
@@ -59,9 +61,7 @@ function useHooks(): {
 
 export const ZapField: React.FunctionComponent<
   SchemaFieldProps & { hooks: Webhook[]; error: unknown }
-> = ({ label, schema, hooks, error, ...props }) => {
-  const [{ value, ...field }] = useField(props);
-
+> = ({ hooks, error, ...props }) => {
   const options = useMemo(
     () =>
       (hooks ?? []).map((x) => ({
@@ -75,7 +75,7 @@ export const ZapField: React.FunctionComponent<
   return (
     <ConnectedFieldTemplate
       name={props.name}
-      label={label ?? fieldLabel(field.name)}
+      label={makeLabelForSchemaField(props)}
       description="The Zap to run"
       as={SelectWidget}
       blankValue={null}
@@ -100,7 +100,9 @@ const PushOptions: React.FunctionComponent<BlockOptionProps> = ({
     []
   );
 
-  const [{ value: pushKey }] = useField<string>(`${basePath}.pushKey`);
+  const [{ value: pushKey }] = useField<string | Expression>(
+    `${basePath}.pushKey`
+  );
 
   const { hooks, error } = useHooks();
 
@@ -128,7 +130,9 @@ const PushOptions: React.FunctionComponent<BlockOptionProps> = ({
     );
   }
 
-  return (
+  return isExpression(pushKey) ? (
+    <ComplexObjectWidget />
+  ) : (
     <div>
       <ZapField
         label="Zap"

--- a/src/devTools/editor/fields/DatabaseOptions.tsx
+++ b/src/devTools/editor/fields/DatabaseOptions.tsx
@@ -18,7 +18,7 @@
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import SelectWidget from "@/components/form/widgets/SelectWidget";
-import { Schema, UUID } from "@/core";
+import { Expression, Schema, UUID } from "@/core";
 import { joinName } from "@/utils";
 import { partial } from "lodash";
 import React, { useEffect, useRef, useState } from "react";
@@ -29,6 +29,9 @@ import AppServiceField from "@/components/fields/schemaFields/AppServiceField";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import { useField } from "formik";
 import { SERVICE_BASE_SCHEMA } from "@/services/serviceUtils";
+import { isExpression } from "@/runtime/mapArgs";
+import FieldTemplate from "@/components/form/FieldTemplate";
+import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 
 const keySchema: Schema = {
   type: "string",
@@ -65,7 +68,9 @@ const DatabaseOptions: React.FC<DatabaseOptionsProps> = ({
   const databaseFieldName = configName("databaseId");
 
   const [showModal, setShowModal] = useState(false);
-  const { setValue: setDatabaseId } = useField<UUID>(databaseFieldName)[2];
+  const [{ value: databaseId }, , { setValue: setDatabaseId }] = useField<
+    UUID | Expression
+  >(databaseFieldName);
 
   const {
     databaseOptions,
@@ -106,18 +111,26 @@ const DatabaseOptions: React.FC<DatabaseOptionsProps> = ({
         />
       )}
 
-      <ConnectedFieldTemplate
-        name={databaseFieldName}
-        label="Database"
-        as={SelectWidget}
-        options={databaseOptions}
-        isLoading={isLoadingDatabaseOptions}
-        components={{
-          MenuList: createMenuListWithAddButton(() => {
-            setShowModal(true);
-          }),
-        }}
-      />
+      {isExpression(databaseId) ? (
+        <FieldTemplate
+          name={databaseFieldName}
+          label="Database"
+          as={WorkshopMessageWidget}
+        />
+      ) : (
+        <ConnectedFieldTemplate
+          name={databaseFieldName}
+          label="Database"
+          as={SelectWidget}
+          options={databaseOptions}
+          isLoading={isLoadingDatabaseOptions}
+          components={{
+            MenuList: createMenuListWithAddButton(() => {
+              setShowModal(true);
+            }),
+          }}
+        />
+      )}
 
       <SchemaField name={configName("key")} schema={keySchema} isRequired />
 

--- a/src/devTools/editor/fields/SelectorSelectorField.tsx
+++ b/src/devTools/editor/fields/SelectorSelectorField.tsx
@@ -17,7 +17,7 @@
 
 import React, { useMemo } from "react";
 import { useField } from "formik";
-import ComplexObjectValue from "@/components/fields/schemaFields/widgets/ComplexObjectWidget";
+import ComplexObjectValue from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 import SelectorSelectorWidget, {
   SelectorSelectorProps,
 } from "@/devTools/editor/fields/SelectorSelectorWidget";


### PR DESCRIPTION
Related to #2459 

This is a temporary fix so that the page editor no longer crashes when expression values are used in custom block options configs. Instead, we detect expression values and show an "edit in the workshop" message.