### PR TITLE
#2471: remove extension when loaded in page editor; document trigger watch

### DIFF
--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -106,6 +106,21 @@ export function getInstalledIds(): RegistryId[] {
   return _installedExtensionPoints.map((x) => x.id);
 }
 
+/**
+ * Remove an extension from an extension point on the page
+ */
+export function removeExtension(
+  extensionPointId: RegistryId,
+  extensionId: UUID
+) {
+  const extensionPoint = _installedExtensionPoints.find((x) => x.id);
+  if (extensionPoint) {
+    extensionPoint.removeExtension(extensionId);
+  } else {
+    console.warn("Extension point %s not found", extensionPointId);
+  }
+}
+
 function markUninstalled(id: RegistryId) {
   // Remove from _installedExtensionPoints so they'll be re-added on a call to loadExtensions
   const index = _installedExtensionPoints.findIndex((x) => x.id === id);

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -23,6 +23,7 @@ export const resolveForm = getMethod("FORM_RESOLVE");
 export const cancelForm = getMethod("FORM_CANCEL");
 export const queueReactivateTab = getNotifier("QUEUE_REACTIVATE_TAB");
 export const reactivateTab = getNotifier("REACTIVATE_TAB");
+export const removeExtension = getNotifier("REMOVE_EXTENSION");
 export const resetTab = getNotifier("RESET_TAB");
 
 export const toggleQuickBar = getMethod("TOGGLE_QUICK_BAR");

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -24,6 +24,7 @@ import {
   handleNavigate,
   queueReactivateTab,
   reactivateTab,
+  removeExtension,
 } from "@/contentScript/lifecycle";
 import {
   getFormDefinition,
@@ -34,7 +35,7 @@ import {
   hideActionPanel,
   showActionPanel,
   toggleActionPanel,
-  removeExtension,
+  removeExtension as removeActionPanel,
 } from "@/actionPanel/native";
 import { insertPanel } from "@/nativeEditor/insertPanel";
 import { insertButton } from "@/nativeEditor/insertButton";
@@ -75,6 +76,7 @@ declare global {
 
     QUEUE_REACTIVATE_TAB: typeof queueReactivateTab;
     REACTIVATE_TAB: typeof reactivateTab;
+    REMOVE_EXTENSION: typeof removeExtension;
     RESET_TAB: typeof resetTab;
 
     TOGGLE_QUICK_BAR: typeof toggleQuickBar;
@@ -82,7 +84,7 @@ declare global {
     TOGGLE_ACTION_PANEL: typeof toggleActionPanel;
     SHOW_ACTION_PANEL: typeof showActionPanel;
     HIDE_ACTION_PANEL: typeof hideActionPanel;
-    REMOVE_ACTION_PANEL: typeof removeExtension;
+    REMOVE_ACTION_PANEL: typeof removeActionPanel;
     INSERT_PANEL: typeof insertPanel;
     INSERT_BUTTON: typeof insertButton;
 
@@ -123,6 +125,7 @@ registerMethods({
 
   QUEUE_REACTIVATE_TAB: queueReactivateTab,
   REACTIVATE_TAB: reactivateTab,
+  REMOVE_EXTENSION: removeExtension,
   RESET_TAB: resetTab,
 
   TOGGLE_QUICK_BAR: toggleQuickBar,
@@ -130,7 +133,7 @@ registerMethods({
   TOGGLE_ACTION_PANEL: toggleActionPanel,
   SHOW_ACTION_PANEL: showActionPanel,
   HIDE_ACTION_PANEL: hideActionPanel,
-  REMOVE_ACTION_PANEL: removeExtension,
+  REMOVE_ACTION_PANEL: removeActionPanel,
   INSERT_PANEL: insertPanel,
   INSERT_BUTTON: insertButton,
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -586,6 +586,11 @@ export interface IExtensionPoint extends Metadata {
   uninstall(options?: { global?: boolean }): void;
 
   /**
+   * Remove the extension from the extension point.
+   */
+  removeExtension(extensionId: UUID): void;
+
+  /**
    * Register an extension with the extension point. Does not actually install/run the extension.
    */
   addExtension(extension: ResolvedExtension): void;

--- a/src/devTools/editor/sidebar/InstalledEntry.tsx
+++ b/src/devTools/editor/sidebar/InstalledEntry.tsx
@@ -31,6 +31,9 @@ import {
   NotAvailableIcon,
   ExtensionIcon,
 } from "@/devTools/editor/sidebar/ExtensionIcons";
+import { removeExtension } from "@/contentScript/messenger/api";
+import { thisTab } from "@/devTools/utils";
+import { resolveDefinitions } from "@/registry/internal";
 
 /**
  * A sidebar menu entry corresponding to an installed/saved extension point
@@ -49,6 +52,11 @@ const InstalledEntry: React.FunctionComponent<{
   const selectHandler = useCallback(
     async (extension: IExtension) => {
       try {
+        // Remove the extension so that we don't get double-actions when editing a trigger.
+        // At this point the extensionPointId can be a
+        const resolved = await resolveDefinitions(extension);
+        removeExtension(thisTab, resolved.extensionPointId, resolved.id);
+
         const state = await extensionToFormState(extension);
         // FIXME: is where we need to uninstall the extension because it will now be a dynamic element? Or should it
         //  be getting handled by lifecycle.ts? Need to add some logging to figure out how other ones work

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -206,6 +206,9 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
 
     // Find the latest set of DOM elements and uninstall handlers
     if (this.triggerSelector) {
+      // NOTE: you might think we could use a WeakSet of HTMLElement to track which elements we've actually attached
+      // DOM events too. However, we can't because WeakSet is not an enumerable collection
+      // https://esdiscuss.org/topic/removal-of-weakmap-weakset-clear
       const $currentElements = $safeFind(this.triggerSelector);
 
       console.debug(
@@ -445,12 +448,17 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     $element: JQuery,
     { watch = false }: { watch?: boolean }
   ): void {
+    // Avoid duplicate events caused by:
+    // 1) Navigation events on SPAs where the element remains on the page
+    // 2) `watch` mode, because the observer will fire the existing elements on the page. (That re-fire will have
+    //  watch: false, see observer handler below.)
     console.debug(
       "Removing existing %s handler for extension point",
       this.trigger
     );
     $element.off(this.trigger, this.boundEventHandler);
 
+    // Install the DOM trigger
     $element.on(this.trigger, this.boundEventHandler);
     this.installedEvents.add(this.trigger);
     console.debug(
@@ -466,9 +474,12 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     );
 
     if (watch) {
+      // Clear out the existing mutation observer on SPA navigation events.
+      // On mutation events, this watch branch is not executed because the mutation handler below passes `watch: false`
       this.cancelWatchNewElements?.();
       this.cancelWatchNewElements = null;
 
+      // Watch for new elements on the page
       const mutationObserver = initialize(
         this.triggerSelector,
         (index, element) => {

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -192,7 +192,9 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
   }
 
   uninstall(): void {
-    console.debug("triggerExtension:uninstall");
+    console.debug("triggerExtension:uninstall", {
+      id: this.id,
+    });
 
     // Clean up observers
     this.cancelInitialWaitElements?.();
@@ -212,7 +214,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
       const $currentElements = $safeFind(this.triggerSelector);
 
       console.debug(
-        "Removing %s handler from %d elements",
+        "Removing %s handler from %d element(s)",
         this.trigger,
         $currentElements.length
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,10 @@ export abstract class ExtensionPoint<TConfig extends EmptyConfig>
     });
   }
 
+  removeExtension(extensionId: UUID) {
+    this.syncExtensions(this.extensions.filter((x) => x.id !== extensionId));
+  }
+
   addExtension(extension: ResolvedExtension<TConfig>): void {
     const index = this.extensions.findIndex((x) => x.id === extension.id);
     if (index >= 0) {


### PR DESCRIPTION
Part of #2471 

- Remove extension from page prior to loading in page editor (to avoid repeat triggers)
- Document trigger watch mode code

Tested on menu items, side bar, and blur interval