### PR TITLE
#2459 Wrap WorkshopMessageWidget in FieldTemplate for Zapier and Sheets

### DIFF
--- a/src/contrib/google/sheets/TabField.tsx
+++ b/src/contrib/google/sheets/TabField.tsx
@@ -27,11 +27,12 @@ import SelectWidget from "@/components/form/widgets/SelectWidget";
 import { Expression } from "@/core";
 import { isExpression } from "@/runtime/mapArgs";
 import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
+import FieldTemplate from "@/components/form/FieldTemplate";
 
 const TabField: React.FunctionComponent<
   SchemaFieldProps & { doc: SheetMeta | null }
 > = ({ name, doc }) => {
-  const [field] = useField<string | Expression>(name);
+  const [{ value: tabName }] = useField<string | Expression>(name);
 
   const [tabNames, tabsPending, tabsError] = useAsyncState(async () => {
     if (doc?.id) {
@@ -43,11 +44,11 @@ const TabField: React.FunctionComponent<
 
   const sheetOptions = useMemo(
     () =>
-      uniq(compact([...(tabNames ?? []), field.value])).map((value) => ({
+      uniq(compact([...(tabNames ?? []), tabName])).map((value) => ({
         label: value,
         value,
       })),
-    [tabNames, field.value]
+    [tabNames, tabName]
   );
 
   // TODO: re-add info message that tab will be created
@@ -60,8 +61,13 @@ const TabField: React.FunctionComponent<
   //         </span>
   // )}
 
-  return isExpression(field.value) ? (
-    <WorkshopMessageWidget />
+  return isExpression(tabName) ? (
+    <FieldTemplate
+      name={name}
+      label="Tab Name"
+      description="The spreadsheet tab"
+      as={WorkshopMessageWidget}
+    />
   ) : (
     <ConnectedFieldTemplate
       name={name}

--- a/src/contrib/zapier/pushOptions.tsx
+++ b/src/contrib/zapier/pushOptions.tsx
@@ -37,6 +37,7 @@ import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFiel
 import { makeLabelForSchemaField } from "@/components/fields/schemaFields/schemaFieldUtils";
 import { isExpression } from "@/runtime/mapArgs";
 import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
+import FieldTemplate from "@/components/form/FieldTemplate";
 
 function useHooks(): {
   hooks: Webhook[];
@@ -130,14 +131,21 @@ const PushOptions: React.FunctionComponent<BlockOptionProps> = ({
     );
   }
 
+  const schema: Schema = ZAPIER_PROPERTIES.pushKey as Schema;
+
   return isExpression(pushKey) ? (
-    <WorkshopMessageWidget />
+    <FieldTemplate
+      name={`${basePath}.pushKey`}
+      label="Zap"
+      description={schema.description}
+      as={WorkshopMessageWidget}
+    />
   ) : (
     <div>
       <ZapField
         label="Zap"
         name={`${basePath}.pushKey`}
-        schema={ZAPIER_PROPERTIES.pushKey as Schema}
+        schema={schema}
         hooks={hooks}
         error={error}
       />


### PR DESCRIPTION
This fixes a bug with the implementation in #2517 where the widget only, without a fieldtemplate, was being shown in the zapier and sheets bricks