### PR TITLE
#2547: basic OAuth2 authorization grant flow

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -796,6 +796,8 @@ export interface IService<
 
   isOAuth2: boolean;
 
+  isAuthorizationGrant: boolean;
+
   isToken: boolean;
 
   getOrigins: (serviceConfig: TSanitized) => string[];

--- a/src/options/pages/services/ServicesEditor.tsx
+++ b/src/options/pages/services/ServicesEditor.tsx
@@ -36,6 +36,7 @@ import BrickModal from "@/components/brickModal/BrickModal";
 import styles from "@/options/pages/services/PrivateServicesCard.module.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { uuidv4 } from "@/types/helpers";
+import { getBaseURL } from "@/services/baseService";
 
 const { updateServiceConfig, deleteServiceConfig } = servicesSlice.actions;
 
@@ -114,7 +115,19 @@ const ServicesEditor: React.FunctionComponent<OwnProps> = ({
   );
 
   const handleCreate = useCallback(
-    (service: IService) => {
+    async (service: IService) => {
+      const definition = (serviceDefinitions ?? []).find(
+        (x) => x.id === service.id
+      );
+
+      if (definition.isAuthorizationGrant) {
+        const url = new URL("services/", await getBaseURL());
+        url.searchParams.set("id", service.id);
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- browser window
+        window.open(url.href);
+        return;
+      }
+
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- nominal tying
       const config = {
         id: uuidv4(),
@@ -124,9 +137,7 @@ const ServicesEditor: React.FunctionComponent<OwnProps> = ({
       } as RawServiceConfiguration;
 
       setNewConfiguration(config);
-      setNewConfigurationService(
-        (serviceDefinitions ?? []).find((x) => x.id === config.serviceId)
-      );
+      setNewConfigurationService(definition);
       navigate(`/services/${encodeURIComponent(config.id)}`);
     },
     [

--- a/src/services/factory.ts
+++ b/src/services/factory.ts
@@ -38,6 +38,7 @@ import {
   KeyAuthenticationDefinition,
   OAuth2AuthenticationDefinition,
   TokenAuthenticationDefinition,
+  OAuth2AuthorizationGrantDefinition,
 } from "@/types/definitions";
 import { AxiosRequestConfig } from "axios";
 import { isAbsoluteUrl } from "@/utils";
@@ -91,6 +92,17 @@ class LocalDefinedService<
     return (
       this._definition.authentication != null &&
       "oauth2" in this._definition.authentication
+    );
+  }
+
+  /**
+   * Return true if service uses OAuth2 authorization grant
+   */
+  get isAuthorizationGrant(): boolean {
+    return (
+      this.isOAuth2 &&
+      (this._definition.authentication as OAuth2AuthorizationGrantDefinition)
+        .oauth2.grantType === "authorization_code"
     );
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,8 @@ export abstract class Service<
 
   abstract get isOAuth2(): boolean;
 
+  abstract get isAuthorizationGrant(): boolean;
+
   abstract get isToken(): boolean;
 
   protected constructor(

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -82,6 +82,7 @@ export type SanitizedAuth = components["schemas"]["SanitizedAuth"] & {
   config: SanitizedConfig;
   // XXX: update serializer to include proper metadata child serializer
   service: { config: { metadata: Metadata } };
+  user?: UUID;
 };
 
 export type ConfigurableAuth = components["schemas"]["EditableAuth"] & {

--- a/src/types/definitions.ts
+++ b/src/types/definitions.ts
@@ -207,11 +207,19 @@ export interface OAuth2AuthenticationDefinition {
   headers: Record<string, string>;
 }
 
+export interface OAuth2AuthorizationGrantDefinition {
+  oauth2: {
+    grantType: "authorization_code";
+  };
+  headers: Record<string, string>;
+}
+
 export interface ServiceDefinition<
   TAuth =
     | KeyAuthenticationDefinition
     | OAuth2AuthenticationDefinition
     | TokenAuthenticationDefinition
+    | OAuth2AuthorizationGrantDefinition
 > {
   metadata: Metadata;
   inputSchema: Schema;


### PR DESCRIPTION
What does this PR do?
- When user selects a service that uses OAuth2 authorization grant (currently Slack), opens an app authorization flow
- Shows the remote user-managed credential in the service selection dropdown

Corresponding app PR:
- https://github.com/pixiebrix/pixiebrix-app/pull/1112

Out of Scope (future PRs)
- Put the authorization grant services behind feature flag so general can't find them in the dropdown
- Trigger from activation wizard