### PR TITLE
#725: Use jQuery Slim

### DIFF
--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -40,8 +40,6 @@ import {
   selectExtensionContext,
 } from "@/extensionPoints/helpers";
 import { notifyError } from "@/contentScript/notify";
-// @ts-expect-error using jquery for the JQuery.EventHandler type below
-import JQuery from "jquery";
 import { BlockConfig, BlockPipeline } from "@/blocks/types";
 import { selectEventData } from "@/telemetry/deployments";
 import apiVersionOptions from "@/runtime/apiVersionOptions";

--- a/src/nativeEditor/utils.ts
+++ b/src/nativeEditor/utils.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import jQuery from "jquery";
 import { MultipleElementsFoundError, NoElementsFoundError } from "@/errors";
 
 /**
@@ -25,7 +24,7 @@ import { MultipleElementsFoundError, NoElementsFoundError } from "@/errors";
  * @throws MultipleElementsFoundError if multiple elements are found
  */
 export function requireSingleElement(selector: string): HTMLElement {
-  const $elt = jQuery(document).find(selector);
+  const $elt = $(document).find(selector);
   if ($elt.length === 0) {
     throw new NoElementsFoundError(selector);
   }

--- a/src/script.ts
+++ b/src/script.ts
@@ -42,7 +42,6 @@ if (window[PAGESCRIPT_SYMBOL]) {
 // eslint-disable-next-line security/detect-object-injection -- using constant symbol defined above
 window[PAGESCRIPT_SYMBOL] = uuidv4();
 
-import jQuery from "jquery";
 import { isEmpty, identity, castArray, cloneDeep } from "lodash";
 import {
   CONNECT_EXTENSION,
@@ -284,4 +283,4 @@ setTimeout(() => {
 // Ensure jquery is available for testing selectors when debugging PixieBrix errors
 // Cast as any because we don't want to pollute namespace with TypeScript declaration
 // eslint-disable-next-line security/detect-object-injection
-window[JQUERY_WINDOW_PROP] = jQuery;
+window[JQUERY_WINDOW_PROP] = $;

--- a/src/vendors/initialize.js
+++ b/src/vendors/initialize.js
@@ -4,8 +4,6 @@
 
 "use strict";
 
-import $ from "jquery";
-
 var combinators = [" ", ">", "+", "~"]; // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors#Combinators
 var fraternisers = ["+", "~"]; // These combinators involve siblings.
 var complexTypes = ["ATTR", "PSEUDO", "ID", "CLASS"]; // These selectors are based upon attributes.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -272,6 +272,9 @@ module.exports = (env, options) =>
         "webext-detect-page": path.resolve(
           "src/vendors/webextDetectPage.static.js"
         ),
+
+        // Lighter jQuery version
+        jquery: "jquery/dist/jquery.slim.min.js",
       },
     },
 


### PR DESCRIPTION
- Closes #725

I looked into using Sizzle but I figured it's probably not worth for you since stuff like `.css()` is more convenient than its native counterpart. So I went for the low-hanging fruit: jQuery Slim, which excludes animations/effects and Ajax.

## Before
<img width="355" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/152154070-a545327c-88e8-426b-a719-74c2e601d46a.png">
## After


<img width="388" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/152154081-caa86b88-6ebf-4f26-b26f-38536487d4d4.png">
