### PR TITLE
#2568: Make selectionController reliable when nothing is selected

### DIFF
--- a/src/utils/selectionController.ts
+++ b/src/utils/selectionController.ts
@@ -49,7 +49,11 @@ export function guessSelectedElement(): HTMLElement | null {
 let selectionOverride: Range | undefined;
 const selectionController = {
   save(): void {
-    selectionOverride = getSelection().getRangeAt(0);
+    const selection = getSelection();
+    // It must be set to "undefined" even if there are selections
+    selectionOverride = selection.rangeCount
+      ? selection.getRangeAt(0)
+      : undefined;
   },
   restore(): void {
     if (!selectionOverride) {


### PR DESCRIPTION
- Fixes #2568

I could replicate the issue:

1. Open https://pbx.vercel.app/
2. Press cmd+k without selecting anything

Demo of this PR:

https://user-images.githubusercontent.com/1402241/152360030-c2b7d60a-1ae7-4746-95c4-bb358e6aaa7e.mov


