### PR TITLE
#2567: Show custom QuickBar extensions on top

### DIFF
--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -243,6 +243,7 @@ function useActions(): void {
     };
 
     quickBarRegistry.addListener(handler);
+    quickBarRegistry.addDefaults();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount; query will be defined on initial mount
   }, []);
 }
@@ -286,7 +287,7 @@ const KBarComponent: React.FC = () => {
 const QuickBarApp: React.FC = () => (
   <ReactShadowRoot mode="closed">
     <Stylesheet href={faStyleSheet}>
-      <KBarProvider actions={quickBarRegistry.actions}>
+      <KBarProvider actions={[]}>
         <AutoShow />
         <KBarToggle>
           <KBarComponent />

--- a/src/components/quickBar/quickBarRegistry.tsx
+++ b/src/components/quickBar/quickBarRegistry.tsx
@@ -101,7 +101,7 @@ class QuickBarRegistry {
 
   add(action: Action): void {
     this._actions = this._actions.filter((x) => x.id !== action.id);
-    this._actions.push(action);
+    this._actions.unshift(action);
     this.notifyListeners();
   }
 
@@ -112,6 +112,12 @@ class QuickBarRegistry {
   addListener(handler: ChangeHandler) {
     this.listeners.push(handler);
     this.notifyListeners();
+  }
+
+  // These must be added dynamically or else they're static and unremovable/unsortable
+  // https://github.com/timc1/kbar/issues/66
+  addDefaults(): void {
+    this._actions.push(...defaultActions);
   }
 
   public get actions(): Action[] {


### PR DESCRIPTION
- Closes #2567

The documentation seems to suggest that the initial actions cannot be changed and indeed even if I set `this._actions` to an empty array they are not removed.

What do you think about this solution?

<img width="772" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/152365001-93cbe9c0-edaa-4881-800d-e0d0db9443a6.png">

