### PR TITLE
Always show an icon on QuickBar actions

### DIFF
--- a/src/extensionPoints/quickBarExtension.tsx
+++ b/src/extensionPoints/quickBarExtension.tsx
@@ -192,7 +192,9 @@ export abstract class QuickBarExtensionPoint extends ExtensionPoint<QuickBarConf
 
     const icon = iconConfig ? (
       <Icon icon={iconConfig.id} library={iconConfig.library} />
-    ) : undefined;
+    ) : (
+      <Icon />
+    ); // Defaults to a box
 
     quickBarRegistry.add({
       id: extension.id,

--- a/src/icons/Icon.tsx
+++ b/src/icons/Icon.tsx
@@ -23,8 +23,8 @@ import getSvgIcon from "@/icons/getSvgIcon";
 import cx from "classnames";
 
 const Icon: React.FunctionComponent<{
-  icon: string;
-  library: IconLibrary;
+  icon?: string;
+  library?: IconLibrary;
   size?: number;
   className?: string;
 }> = ({ icon, library, size = 16, className }) => {


### PR DESCRIPTION
I think we should always show icons next to each action, at least to align them. The lack of icon becomes messy especially when some actions do have one:


![image](https://user-images.githubusercontent.com/1879821/152228235-a20fb6e6-dec3-4598-88ca-cac368bb5faa.png)

## Before


<img width="772" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/152365001-93cbe9c0-edaa-4881-800d-e0d0db9443a6.png">


## After
<img width="731" alt="Screen Shot 8" src="https://user-images.githubusercontent.com/1402241/152367416-f7c92033-d9fe-4acb-a88c-360b40526708.png">

