### PR TITLE
 #2598: Avoid breaking `@pixiebrix/table-reader-all` on colspan

### DIFF
--- a/src/utils/parseDomTable.ts
+++ b/src/utils/parseDomTable.ts
@@ -54,12 +54,22 @@ function guessDirection(
 
 // TODO: Normalize rowspan and colspan in here as well
 function flattenTableContent(table: HTMLTableElement): RawTableContent {
-  return [...table.rows].map((row) =>
+  const flattened: RawTableContent = [...table.rows].map((row) =>
     [...row.cells].map((cell) => ({
       type: cell.tagName === "TH" ? "header" : "value",
       value: cell.textContent.trim(),
     }))
   );
+
+  // Temporary patch to "support" tables with rowspan/colspan without throwing errors
+  const maxRowlength = Math.max(...flattened.map((row) => row.length));
+  for (const row of flattened) {
+    while (row.length < maxRowlength) {
+      row.push({ type: "value", value: "" });
+    }
+  }
+
+  return flattened;
 }
 
 function extractData(


### PR DESCRIPTION
- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/2598

This avoids breaking the whole brick when encountering colspan/rowspan. The result won't be right but the fix is quick and easy.

I think this can be merged as is as a hotfix and then I can work on proper colspan support (which might take a bit)

Tested on https://en.wikipedia.org/wiki/Stanley_Cup

<img width="338" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/152629394-047ba315-fd46-464c-af0b-504749b3fb35.png">

