### PR TITLE
Avoid duplicate HANDLE_NAVIGATE call

### DIFF
--- a/src/background/navigation.ts
+++ b/src/background/navigation.ts
@@ -19,15 +19,23 @@
 import { reactivateTab, handleNavigate } from "@/contentScript/messenger/api";
 import { forEachTab } from "@/background/util";
 import browser from "webextension-polyfill";
+import { canAccessTab } from "webext-tools";
+import { Target } from "@/types";
 
 export function reactivateEveryTab(): void {
   console.debug("Reactivate all tabs");
   void forEachTab(reactivateTab);
 }
 
+async function onNavigation({ tabId, frameId }: Target): Promise<void> {
+  if (await canAccessTab({ tabId, frameId })) {
+    handleNavigate({ tabId, frameId });
+  }
+}
+
 function initNavigation(): void {
   // Let the content script know about navigation from the history API. Required for handling SPA navigation
-  browser.webNavigation.onHistoryStateUpdated.addListener(handleNavigate);
+  browser.webNavigation.onHistoryStateUpdated.addListener(onNavigation);
 }
 
 export default initNavigation;

--- a/src/devTools/context.ts
+++ b/src/devTools/context.ts
@@ -18,7 +18,7 @@
 import React, { useCallback, useState } from "react";
 import pTimeout from "p-timeout";
 import browser from "webextension-polyfill";
-import { navigationEvent } from "@/background/devtools/external";
+import { navigationEvent } from "@/devTools/events";
 import { useAsyncEffect } from "use-async-effect";
 import { FrameworkMeta } from "@/messaging/constants";
 import { reportError } from "@/telemetry/logging";

--- a/src/devTools/events.ts
+++ b/src/devTools/events.ts
@@ -21,3 +21,7 @@ import { SimpleEvent } from "@/hooks/events";
 type NavigationDetails = WebNavigation.OnHistoryStateUpdatedDetailsType;
 
 export const navigationEvent = new SimpleEvent<NavigationDetails>();
+
+export function updateDevTools() {
+  navigationEvent.emit(browser.devtools.inspectedWindow.tabId);
+}

--- a/src/devTools/events.ts
+++ b/src/devTools/events.ts
@@ -23,5 +23,5 @@ type NavigationDetails = WebNavigation.OnHistoryStateUpdatedDetailsType;
 export const navigationEvent = new SimpleEvent<NavigationDetails>();
 
 export function updateDevTools() {
-  navigationEvent.emit(browser.devtools.inspectedWindow.tabId);
+  navigationEvent.emit(chrome.devtools.inspectedWindow.tabId);
 }

--- a/src/devTools/messenger/registration.ts
+++ b/src/devTools/messenger/registration.ts
@@ -18,7 +18,7 @@
 /* Do not use `getMethod` in this file; Keep only registrations here, not implementations */
 import { expectContext } from "@/utils/expectContext";
 import { registerMethods } from "webext-messenger";
-import { updateDevTools } from "@/devTools/protocol";
+import { updateDevTools } from "@/devTools/events";
 
 expectContext("devTools");
 

--- a/src/devTools/protocol.ts
+++ b/src/devTools/protocol.ts
@@ -15,32 +15,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import browser, { WebNavigation } from "webextension-polyfill";
-import { navigationEvent } from "@/background/devtools/external";
-import { handleNavigate, resetTab } from "@/contentScript/messenger/api";
+import browser from "webextension-polyfill";
+import { resetTab } from "@/contentScript/messenger/api";
 import { thisTab } from "./utils";
-import { canAccessTab } from "webext-tools";
+import { Target } from "@/types";
+import { updateDevTools } from "./events";
 
 const TOP_LEVEL_FRAME_ID = 0;
 
-export function updateDevTools() {
-  navigationEvent.emit(browser.devtools.inspectedWindow.tabId);
-}
-
-async function onNavigation({
-  tabId,
-  frameId,
-}:
-  | WebNavigation.OnHistoryStateUpdatedDetailsType
-  | WebNavigation.OnDOMContentLoadedDetailsType): Promise<void> {
-  if (
+// The editor only cares for the top frame
+function isCurrentTopFrame({ tabId, frameId }: Target) {
+  return (
     frameId === TOP_LEVEL_FRAME_ID &&
     tabId === browser.devtools.inspectedWindow.tabId
-  ) {
+  );
+}
+
+async function onNavigation(target: Target): Promise<void> {
+  if (isCurrentTopFrame(target)) {
     updateDevTools();
-    if (await canAccessTab({ tabId, frameId })) {
-      handleNavigate({ tabId, frameId });
-    }
   }
 }
 

--- a/src/devTools/protocol.ts
+++ b/src/devTools/protocol.ts
@@ -42,7 +42,6 @@ function onEditorClose(): void {
 }
 
 export function watchNavigation(): void {
-  browser.webNavigation.onHistoryStateUpdated.addListener(onNavigation);
   browser.webNavigation.onDOMContentLoaded.addListener(onNavigation);
   window.addEventListener("beforeunload", onEditorClose);
 


### PR DESCRIPTION
This should more or less restore the code to what it was before both PRs

### Follows

- https://github.com/pixiebrix/pixiebrix-extension/pull/2596
- https://github.com/pixiebrix/pixiebrix-extension/pull/2426

### Logic

- On every page **with access**:
	- on load: webext-dynamic-content-scripts injects the CS
	- on hash change: `background/navigation.ts` will notify the CS
- On every page, in the editor:
	- on load: `devTools/protocol.ts` will emit a navigationEvent
	- on hash change: `devTools/protocol.ts` will emit a navigationEvent