### PR TITLE
Avoid broken overlay on non-buttons

### DIFF
--- a/src/devTools/editor/sidebar/DynamicEntry.tsx
+++ b/src/devTools/editor/sidebar/DynamicEntry.tsx
@@ -47,6 +47,8 @@ const DynamicEntry: React.FunctionComponent<{
     (x) => x.editor.dirty[item.uuid] ?? false
   );
 
+  const isButton = item.type === "menuItem";
+
   const showOverlay = useCallback(async (uuid: UUID) => {
     await enableOverlay(thisTab, `[data-pb-uuid="${uuid}"]`);
   }, []);
@@ -61,8 +63,8 @@ const DynamicEntry: React.FunctionComponent<{
       action
       active={active}
       key={`dynamic-${item.uuid}`}
-      onMouseEnter={async () => showOverlay(item.uuid)}
-      onMouseLeave={async () => hideOverlay()}
+      onMouseEnter={isButton && (async () => showOverlay(item.uuid))}
+      onMouseLeave={isButton && (async () => hideOverlay())}
       onClick={() => dispatch(actions.selectElement(item.uuid))}
     >
       <span className={styles.icon}>

--- a/src/devTools/editor/sidebar/InstalledEntry.tsx
+++ b/src/devTools/editor/sidebar/InstalledEntry.tsx
@@ -17,7 +17,7 @@
 
 import styles from "./Entry.module.scss";
 import React, { useCallback } from "react";
-import { IExtension } from "@/core";
+import { IExtension, UUID } from "@/core";
 import { useDispatch } from "react-redux";
 import { useAsyncState } from "@/hooks/common";
 import {
@@ -33,7 +33,11 @@ import {
 } from "@/devTools/editor/sidebar/ExtensionIcons";
 import { RecipeDefinition } from "@/types/definitions";
 import { initRecipeOptionsIfNeeded } from "@/devTools/editor/extensionPoints/base";
-import { removeExtension } from "@/contentScript/messenger/api";
+import {
+  disableOverlay,
+  enableOverlay,
+  removeExtension,
+} from "@/contentScript/messenger/api";
 import { thisTab } from "@/devTools/utils";
 import { resolveDefinitions } from "@/registry/internal";
 
@@ -74,12 +78,24 @@ const InstalledEntry: React.FunctionComponent<{
     [dispatch, recipes]
   );
 
+  const isButton = type === "menuItem";
+
+  const showOverlay = useCallback(async (uuid: UUID) => {
+    await enableOverlay(thisTab, `[data-pb-uuid="${uuid}"]`);
+  }, []);
+
+  const hideOverlay = useCallback(async () => {
+    await disableOverlay(thisTab);
+  }, []);
+
   return (
     <ListGroup.Item
       className={styles.root}
       action
       active={active}
       key={`installed-${extension.id}`}
+      onMouseEnter={isButton && (async () => showOverlay(extension.id))}
+      onMouseLeave={isButton && (async () => hideOverlay())}
       onClick={async () => selectHandler(extension)}
     >
       <span className={styles.icon}>

--- a/src/nativeEditor/dynamic.ts
+++ b/src/nativeEditor/dynamic.ts
@@ -195,8 +195,10 @@ export async function enableOverlay(selector: string): Promise<void> {
     _overlay = new Overlay();
   }
 
-  const $elt = $safeFind(selector);
-  _overlay.inspect($elt.toArray(), null);
+  const elements = $safeFind(selector).toArray();
+  if (elements.length > 0) {
+    _overlay.inspect(elements, null);
+  }
 }
 
 export async function disableOverlay(): Promise<void> {

--- a/src/nativeEditor/selector.ts
+++ b/src/nativeEditor/selector.ts
@@ -69,7 +69,9 @@ export async function userSelectElement({
           setTimeout(() => requestAnimationFrame(updateOverlay), 30); // Only when the tab is visible
         };
 
-        updateOverlay();
+        if (filteredElements.length > 0) {
+          updateOverlay();
+        }
       }
     }
 


### PR DESCRIPTION
- Follows #2507

This brings 2 changes:

- avoid showing a broken overlay (the black bar) on non-button extensions
- copy overlay feature to InstalledEntry as well

### Bug before

Notice the black bar appearing under "Action" on hover

![bad](https://user-images.githubusercontent.com/1402241/152648689-c4f6ad7f-909c-4513-b44c-2a4bc83acaeb.gif)

### Fixed

![good](https://user-images.githubusercontent.com/1402241/152648693-4f994ae7-ea4e-4114-98ba-3dc4ac78120e.gif)

