### PR TITLE
Hide Messenger logging by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,7 @@
         "webext-content-scripts": "^1.0.1",
         "webext-detect-page": "^4.0.0",
         "webext-dynamic-content-scripts": "^8.0.1",
-        "webext-messenger": "^0.17.0-0",
+        "webext-messenger": "^0.17.1",
         "webext-patterns": "^1.1.1",
         "webext-polyfill-kinda": "^0.1.0",
         "webext-tools": "^0.3.0",
@@ -35994,9 +35994,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.11.0.tgz",
-      "integrity": "sha512-GwRKR1jZMAQP/hVR929DWB5Z2lwSIM/nNcHEfDj2E0vOMhcYbqFxGKE5JaSzMdzmEtWJiamEn6VwHs/YVXVhEQ==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.11.1.tgz",
+      "integrity": "sha512-fPcV5KLAqFfmhHobtAUwEpbpfYhVF7wSLVgbG/7mIGe/Pete7ky/bPAPRkzbWdrj0/EkswFAAR2feJCgigkUKg==",
       "engines": {
         "node": ">=12.20"
       },
@@ -37353,13 +37353,13 @@
       "integrity": "sha512-TTtitT7rgdaR2nx0+TZDIYHpZ5TXH9Ak8C2TaBaJT9qNeHXexKzde6uQ6cjdOK2G80C04r8fcx98Iy+PTCNN7Q=="
     },
     "node_modules/webext-messenger": {
-      "version": "0.17.0-0",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.17.0-0.tgz",
-      "integrity": "sha512-S0L62MJSimxt/WKZIk7yk1WBEBI6GuhWEGt2KSekO7x8UrCCDj6Se9VEyFixCVLC1sougkD/iZONn419blPo5w==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.17.1.tgz",
+      "integrity": "sha512-kZzesaD9JduO2Qe7umIooX8V8t5PcMkn/vQL6S2mqAuxhi9W7fqu/k7LhgLt1hVxy32ivsq7nMVtAvETG7Z63g==",
       "dependencies": {
         "p-retry": "^5.0.0",
         "serialize-error": "^9.0.0",
-        "type-fest": "^2.8.0",
+        "type-fest": "^2.11.1",
         "webext-detect-page": "^4.0.0",
         "webextension-polyfill": "^0.8.0"
       }
@@ -66030,9 +66030,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.11.0.tgz",
-      "integrity": "sha512-GwRKR1jZMAQP/hVR929DWB5Z2lwSIM/nNcHEfDj2E0vOMhcYbqFxGKE5JaSzMdzmEtWJiamEn6VwHs/YVXVhEQ=="
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.11.1.tgz",
+      "integrity": "sha512-fPcV5KLAqFfmhHobtAUwEpbpfYhVF7wSLVgbG/7mIGe/Pete7ky/bPAPRkzbWdrj0/EkswFAAR2feJCgigkUKg=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -67121,13 +67121,13 @@
       }
     },
     "webext-messenger": {
-      "version": "0.17.0-0",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.17.0-0.tgz",
-      "integrity": "sha512-S0L62MJSimxt/WKZIk7yk1WBEBI6GuhWEGt2KSekO7x8UrCCDj6Se9VEyFixCVLC1sougkD/iZONn419blPo5w==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.17.1.tgz",
+      "integrity": "sha512-kZzesaD9JduO2Qe7umIooX8V8t5PcMkn/vQL6S2mqAuxhi9W7fqu/k7LhgLt1hVxy32ivsq7nMVtAvETG7Z63g==",
       "requires": {
         "p-retry": "^5.0.0",
         "serialize-error": "^9.0.0",
-        "type-fest": "^2.8.0",
+        "type-fest": "^2.11.1",
         "webext-detect-page": "^4.0.0",
         "webextension-polyfill": "^0.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "webext-content-scripts": "^1.0.1",
     "webext-detect-page": "^4.0.0",
     "webext-dynamic-content-scripts": "^8.0.1",
-    "webext-messenger": "^0.17.0-0",
+    "webext-messenger": "^0.17.1",
     "webext-patterns": "^1.1.1",
     "webext-polyfill-kinda": "^0.1.0",
     "webext-tools": "^0.3.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,6 @@ function parseEnv(value) {
 // Default ENVs used by webpack
 // Note: Default ENVs used by the extension itself should be set in EnvironmentPlugin
 const defaults = {
-  WEBEXT_MESSENGER_LOGGING: "false",
   DEV_NOTIFY: "true",
   DEV_SLIM: "false",
   CHROME_EXTENSION_ID: "mpjjildhmpddojocokjkgmlkkkfjnepo",
@@ -337,6 +336,7 @@ module.exports = (env, options) =>
         REDUX_DEV_TOOLS: !isProd(options),
         NPM_PACKAGE_VERSION: process.env.npm_package_version,
         ENVIRONMENT: process.env.ENVIRONMENT ?? options.mode,
+        WEBEXT_MESSENGER_LOGGING: "false",
 
         // If not found, "undefined" will cause the build to fail
         SERVICE_URL: undefined,
@@ -349,7 +349,6 @@ module.exports = (env, options) =>
         SUPPORT_WIDGET_ID: null,
         GOOGLE_API_KEY: null,
         GOOGLE_APP_ID: null,
-        WEBEXT_MESSENGER_LOGGING: null,
       }),
 
       new MiniCssExtractPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,7 @@ function parseEnv(value) {
 // Default ENVs used by webpack
 // Note: Default ENVs used by the extension itself should be set in EnvironmentPlugin
 const defaults = {
+  WEBEXT_MESSENGER_LOGGING: "false",
   DEV_NOTIFY: "true",
   DEV_SLIM: "false",
   CHROME_EXTENSION_ID: "mpjjildhmpddojocokjkgmlkkkfjnepo",
@@ -348,6 +349,7 @@ module.exports = (env, options) =>
         SUPPORT_WIDGET_ID: null,
         GOOGLE_API_KEY: null,
         GOOGLE_APP_ID: null,
+        WEBEXT_MESSENGER_LOGGING: null,
       }),
 
       new MiniCssExtractPlugin({


### PR DESCRIPTION
_Enjoy the silence._

The Messenger will no longer automatically log all of its operations to the console. If you want to see them, append `WEBEXT_MESSENGER_LOGGING=true` to your .env files **or** run build/watch as:

```js
WEBEXT_MESSENGER_LOGGING=true npm run build
WEBEXT_MESSENGER_LOGGING=true npm run watch
```