### PR TITLE
#622: Show first loading screen errors + center message

### DIFF
--- a/src/action.html
+++ b/src/action.html
@@ -22,14 +22,14 @@
     <!-- Open all links in new tab, never in the sidebar #851 -->
     <base target="_blank" />
     <title>PixieBrix: Page Panel</title>
+    <link rel="stylesheet" href="loadingScreen.css" />
     <link rel="stylesheet" href="action.css" />
   </head>
   <body>
     <div id="container" class="full-height">
-      <div class="action-sidebar-loader">
-        <div>Loading PixieBrix&nbsp;&nbsp;🚀</div>
-      </div>
+      <div class="global-loading-message">Loading PixieBrix 🚀</div>
     </div>
+    <script src="loadingScreen.js"></script>
     <script src="vendors.js"></script>
     <script src="action.js"></script>
   </body>

--- a/src/devtoolsPanel.html
+++ b/src/devtoolsPanel.html
@@ -46,11 +46,14 @@
       }
     </style>
 
+    <link rel="stylesheet" href="loadingScreen.css" />
     <link rel="stylesheet" href="devtoolsPanel.css" />
   </head>
   <body>
-    <!-- main react mount point -->
-    <div id="container">🚀 Loading PixieBrix devtools.</div>
+    <div id="container">
+      <div class="global-loading-message">Loading PixieBrix Editor 🚀</div>
+    </div>
+    <script src="loadingScreen.js"></script>
     <script src="vendors.js"></script>
     <script src="devtoolsPanel.js"></script>
   </body>

--- a/src/options.html
+++ b/src/options.html
@@ -20,14 +20,14 @@
   <head>
     <meta charset="utf-8" />
     <title>Browser Extension | PixieBrix</title>
+    <link rel="stylesheet" href="loadingScreen.css" />
     <link rel="stylesheet" href="options.css" />
   </head>
   <body>
     <div id="container">
-      <div class="options-loader">
-        <div>Loading PixieBrix Options 🚀</div>
-      </div>
+      <div class="global-loading-message">Loading PixieBrix Options 🚀</div>
     </div>
+    <script src="loadingScreen.js"></script>
     <script src="vendors.js"></script>
     <script src="options.js"></script>
   </body>

--- a/src/options.scss
+++ b/src/options.scss
@@ -37,13 +37,6 @@ body {
   right: 0;
   bottom: 0;
   overflow-y: auto;
-
-  .options-loader {
-    width: 100%;
-    margin-top: 60px;
-    display: flex;
-    justify-content: center;
-  }
 }
 
 .modal-backdrop {

--- a/src/permissionsPopup.html
+++ b/src/permissionsPopup.html
@@ -20,15 +20,15 @@
   <head>
     <meta charset="utf-8" />
     <title>PixieBrix</title>
-    <script defer src="vendors.js"></script>
-    <script defer src="permissionsPopup.js"></script>
+    <link rel="stylesheet" href="loadingScreen.css" />
     <link rel="stylesheet" href="permissionsPopup.css" />
   </head>
   <body>
     <div id="container">
-      <div class="options-loader">
-        <div>Loading PixieBrix Permissions Dialog 🚀</div>
-      </div>
+      <div class="global-loading-message">Loading PixieBrix 🚀</div>
     </div>
+    <script src="loadingScreen.js"></script>
+    <script src="vendors.js"></script>
+    <script src="permissionsPopup.js"></script>
   </body>
 </html>

--- a/static/loadingScreen.css
+++ b/static/loadingScreen.css
@@ -1,0 +1,18 @@
+.global-loading-message {
+  position: fixed;
+  display: flex;
+  inset: 20px;
+  place-content: center;
+  align-items: center;
+  text-align: center;
+
+  /* If the loading is quick enough, we don't need to show the message. */
+  /* This leads to a cleaner loading experience since there will be one fewer flash of intermediary content. */
+  animation: loading-fade-in 0.5s 0.5s both;
+}
+
+@keyframes loading-fade-in {
+  from {
+    opacity: 0;
+  }
+}

--- a/static/loadingScreen.js
+++ b/static/loadingScreen.js
@@ -15,42 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#container {
-  height: 100vh;
-}
+/** @file Plain file to show loading errors on the page. It must be simple and outside the build specifically to show even build errors. */
 
-.tab-content {
-  border: none;
-}
-
-.action-panel-button {
-  color: #6562aa;
-
-  &:hover {
-    color: #4d4b8b;
-    background-color: #d1c2d7;
-  }
-}
-
-.center-content {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.full-height {
-  display: flex;
-  flex-direction: column;
-  & > :last-child {
-    flex-grow: 1;
+function showErrors(errorEvent) {
+  const logger = document.querySelector(".global-loading-message");
+  if (logger.childElementCount > 0) {
+    // The view was initialized, stop showing errors
+    window.removeEventListener("error", showErrors);
+    return;
   }
 
-  .scrollable-area {
-    height: 0;
-    overflow-y: auto;
-  }
+  logger.textContent = String(errorEvent.error);
 }
 
-.tab-content > .active.full-height {
-  display: flex; /* Overrides Bootstrap’s "block"*/
-}
+window.addEventListener("error", showErrors);


### PR DESCRIPTION
- Closes #622
- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/1004

## Show loading errors

https://user-images.githubusercontent.com/1402241/152931649-46ac310c-d698-447f-9bf5-82160cccf1da.mov


## Delay loading screen

If the loading is quick enough, we don't need to show the message. This leads to a cleaner loading experience since there will be one fewer flash of intermediary content (which we already have too many)

https://user-images.githubusercontent.com/1402241/152931839-7455cd16-715c-4dd3-bb6d-1ba1256c15c3.mov




## Center message in every view

If loading takes long enough (FYI: dev builds always take longer) the message will still be shown, but faded in and centered


https://user-images.githubusercontent.com/1402241/152931709-aa701ec6-80b2-4574-9232-7683ed2cae2b.mov


