### PR TITLE
#627: Immediately detect when the context is invalidated

### DIFF
--- a/src/devTools/ErrorBanner.tsx
+++ b/src/devTools/ErrorBanner.tsx
@@ -34,11 +34,11 @@ const ErrorBanner: React.VFC = () => {
   }
 
   return (
-    <div className="d-flex p-1 align-items-center alert-danger flex-align-center">
+    <div className="d-flex p-2 align-items-center alert-danger flex-align-center">
       <div className="flex-grow-1">{error}</div>
       <div>
         <Button
-          className="mr-2"
+          className="ml-2"
           onClick={() => {
             location.reload();
           }}

--- a/src/devTools/context.ts
+++ b/src/devTools/context.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import pTimeout from "p-timeout";
 import browser from "webextension-polyfill";
 import { navigationEvent } from "@/devTools/events";
@@ -75,7 +75,7 @@ export interface Context {
 
 const initialValue: Context = {
   connecting: false,
-  tabState: { ...initialFrameState, frameId: 0 },
+  tabState: initialFrameState,
 };
 
 export const DevToolsContext = React.createContext(initialValue);
@@ -153,6 +153,22 @@ export function useDevConnection(): Context {
 
   const connect = useCallback(async () => {
     setLastUpdate(Date.now());
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (!chrome.runtime?.id) {
+        setTabState({
+          ...initialFrameState,
+          navSequence: uuidv4(),
+          error:
+            "The connection with the rest of the extension was lost. The editor should be reloaded.",
+        });
+      }
+    }, 500);
+    return () => {
+      clearInterval(interval);
+    };
   }, []);
 
   // Automatically connect on load


### PR DESCRIPTION
- Closes #627
- As mentioned in https://github.com/pixiebrix/pixiebrix-extension/pull/2617#issue-1125248180

This is mostly a DX issue but users could see this when the extension updates.

https://user-images.githubusercontent.com/1402241/152945787-f9abc259-6ae0-4e6d-bcac-cd588232f5dc.mov

# Future

- [ ] Split `tabState` into multiple properties so we can set the `error` separately from the rest of the state
