### PR TITLE
Fixing assignment of MouseEvent handlers

### DIFF
--- a/src/devTools/editor/sidebar/DynamicEntry.tsx
+++ b/src/devTools/editor/sidebar/DynamicEntry.tsx
@@ -63,8 +63,8 @@ const DynamicEntry: React.FunctionComponent<{
       action
       active={active}
       key={`dynamic-${item.uuid}`}
-      onMouseEnter={isButton && (async () => showOverlay(item.uuid))}
-      onMouseLeave={isButton && (async () => hideOverlay())}
+      onMouseEnter={isButton ? async () => showOverlay(item.uuid) : undefined}
+      onMouseLeave={isButton ? async () => hideOverlay() : undefined}
       onClick={() => dispatch(actions.selectElement(item.uuid))}
     >
       <span className={styles.icon}>

--- a/src/devTools/editor/sidebar/InstalledEntry.tsx
+++ b/src/devTools/editor/sidebar/InstalledEntry.tsx
@@ -94,8 +94,10 @@ const InstalledEntry: React.FunctionComponent<{
       action
       active={active}
       key={`installed-${extension.id}`}
-      onMouseEnter={isButton && (async () => showOverlay(extension.id))}
-      onMouseLeave={isButton && (async () => hideOverlay())}
+      onMouseEnter={
+        isButton ? async () => showOverlay(extension.id) : undefined
+      }
+      onMouseLeave={isButton ? async () => hideOverlay() : undefined}
       onClick={async () => selectHandler(extension)}
     >
       <span className={styles.icon}>


### PR DESCRIPTION
Improper assignment of Mouse events causes React to throw (`undefined` is allowed for optional event handlers, `false` is not).

<img width="844" alt="Screen Shot 2022-02-08 at 11 51 00 AM" src="https://user-images.githubusercontent.com/3116723/152973295-648522c9-c504-4773-aad7-1df0bb6f857d.png">
