### PR TITLE
Disable some lint rules on mocks and stories

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,12 +42,6 @@ module.exports = {
   ],
   overrides: [
     {
-      files: ["*.stories.tsx"],
-      rules: {
-        "filenames/match-exported": "off",
-      },
-    },
-    {
       files: [
         "webpack.*.js",
         "*.config.js",
@@ -63,6 +57,14 @@ module.exports = {
       rules: {
         // TODO: Import extended config from app, after improving it
         "@typescript-eslint/naming-convention": "off",
+      },
+    },
+    {
+      files: ["*.stories.tsx", "**/__mocks__/**"],
+      rules: {
+        "filenames/match-exported": "off",
+        "unicorn/filename-case": "off",
+        "import/no-anonymous-default-export": "off",
       },
     },
   ],

--- a/__mocks__/connected-react-router.js
+++ b/__mocks__/connected-react-router.js
@@ -1,6 +1,3 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-disable filenames/match-exported */
-
 /*
  * Copyright (C) 2022 PixieBrix, Inc.
  *

--- a/__mocks__/fit-textarea.js
+++ b/__mocks__/fit-textarea.js
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/filename-case */
-
 /*
  * Copyright (C) 2022 PixieBrix, Inc.
  *

--- a/__mocks__/react-redux.js
+++ b/__mocks__/react-redux.js
@@ -1,6 +1,3 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-disable filenames/match-exported */
-
 /*
  * Copyright (C) 2022 PixieBrix, Inc.
  *

--- a/__mocks__/react-toast-notifications.js
+++ b/__mocks__/react-toast-notifications.js
@@ -1,6 +1,3 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-disable filenames/match-exported */
-
 /*
  * Copyright (C) 2022 PixieBrix, Inc.
  *

--- a/src/__mocks__/browserMocks.ts
+++ b/src/__mocks__/browserMocks.ts
@@ -1,4 +1,3 @@
-/* eslint-disable filenames/match-exported */
 /*
  * Copyright (C) 2022 PixieBrix, Inc.
  *

--- a/src/__mocks__/svgAsComponentMock.js
+++ b/src/__mocks__/svgAsComponentMock.js
@@ -15,5 +15,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// eslint-disable-next-line import/no-anonymous-default-export -- Just a mock
 export default "svg";


### PR DESCRIPTION
Mocks and stories follow their own formats, so we can't enforce the regular rules on them (in fact they've always been disabled locally)

Side note: I think `filenames/match-exported` isn't worth it: https://github.com/pixiebrix/pixiebrix-extension/search?q=%22filenames%2Fmatch-exported%22

Maybe we should just enable it in the components folder