### PR TITLE
POC: Automate vendor chunks creation and save 15% or more on geckos 

### DIFF
--- a/src/action.html
+++ b/src/action.html
@@ -30,7 +30,6 @@
       <div class="global-loading-message">Loading PixieBrix 🚀</div>
     </div>
     <script src="loadingScreen.js"></script>
-    <script src="vendors.js"></script>
     <script src="action.js"></script>
   </body>
 </html>

--- a/src/devtoolsPanel.html
+++ b/src/devtoolsPanel.html
@@ -54,7 +54,6 @@
       <div class="global-loading-message">Loading PixieBrix Editor 🚀</div>
     </div>
     <script src="loadingScreen.js"></script>
-    <script src="vendors.js"></script>
     <script src="devtoolsPanel.js"></script>
   </body>
 </html>

--- a/src/ephemeralForm.html
+++ b/src/ephemeralForm.html
@@ -26,7 +26,6 @@
   </head>
   <body>
     <div id="container"></div>
-    <script src="vendors.js"></script>
     <script src="ephemeralForm.js"></script>
   </body>
 </html>

--- a/src/options.html
+++ b/src/options.html
@@ -28,7 +28,6 @@
       <div class="global-loading-message">Loading PixieBrix Options 🚀</div>
     </div>
     <script src="loadingScreen.js"></script>
-    <script src="vendors.js"></script>
     <script src="options.js"></script>
   </body>
 </html>

--- a/src/permissionsPopup.html
+++ b/src/permissionsPopup.html
@@ -28,7 +28,6 @@
       <div class="global-loading-message">Loading PixieBrix 🚀</div>
     </div>
     <script src="loadingScreen.js"></script>
-    <script src="vendors.js"></script>
     <script src="permissionsPopup.js"></script>
   </body>
 </html>

--- a/static/background.worker.js
+++ b/static/background.worker.js
@@ -1,6 +1,2 @@
 // Don't include `background.worker.js` in webpack, there's no advantage in doing so
-self.importScripts(
-  "./grayIconWhileLoading.js",
-  "./vendors.js",
-  "./background.js"
-);
+self.importScripts("./grayIconWhileLoading.js", "./background.js");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -225,43 +225,20 @@ module.exports = (env, options) =>
         dynamicImport: true,
       },
     },
-    entry: {
-      // All of these entries require the `vendors.js` file to be included first
-      ...Object.fromEntries(
-        [
-          "background",
-          "contentScript",
-          "devtoolsPanel",
-          "ephemeralForm",
-          "options",
-          "action",
-          "permissionsPopup",
-        ].map((name) => [
-          name,
-          { import: `./src/${name}`, dependOn: "vendors" },
-        ])
-      ),
-
-      // This creates a `vendors.js` file that must be included together with the bundles generated above
-      vendors: [
-        "react",
-        "react-dom",
-        "webextension-polyfill",
-        "jquery",
-        "lodash-es",
-        "js-beautify",
-        "css-selector-generator",
-        "@rjsf/bootstrap-4",
-        "@fortawesome/free-solid-svg-icons",
-      ],
-
-      // Tiny files without imports, no vendors needed
-      frame: "./src/frame",
-      devtools: "./src/devtools",
-
-      // The script that gets injected into the host page should not have a vendor chunk
-      script: "./src/script",
-    },
+    entry: Object.fromEntries(
+      [
+        "background",
+        "contentScript",
+        "devtoolsPanel",
+        "ephemeralForm",
+        "options",
+        "action",
+        "permissionsPopup",
+        "devtools",
+        "script",
+        "frame",
+      ].map((name) => [name, `./src/${name}`])
+    ),
 
     resolve: {
       alias: {
@@ -282,9 +259,7 @@ module.exports = (env, options) =>
       // Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=1108199
       splitChunks: {
         automaticNameDelimiter: "-",
-        cacheGroups: {
-          vendors: false,
-        },
+        chunks: "all",
       },
 
       minimizer: [
@@ -352,6 +327,7 @@ module.exports = (env, options) =>
 
       new MiniCssExtractPlugin({
         chunkFilename: "css/[id].css",
+        ignoreOrder: true,
       }),
       new CopyPlugin({
         patterns: [


### PR DESCRIPTION
https://github.com/pixiebrix/pixiebrix-extension/pull/1062 introduced a manual vendor chunk to save some space. It turns out webpack has an option to create as many vendor bundles as necessary and **load them autonomously**.

### Advantages

- automatic: we don't need to pick what belongs to the vendor bundle and what doesn't
- never load more code than necessary: our single vendor.js may contain unnecessary code
- 15% smaller zip (9.3MB->7.9MB): this is because there's even less duplicated code

### To fix

Since this creates like 20 additional custom bundles, `BundleAnalyzerPlugin` becomes useless because it no longer tells us what code is loaded where.

- [ ] Don't run BundleAnalyzerPlugin by default
- [ ] Add extra command with the analyzer but without chunks, only for dependencies analysis

Also:

- [ ] Ensure that the page script still works even with extra chunks — or exclude it
- [ ] Limit amount of chunks, if possible, just to keep it saner

### Docs

https://webpack.js.org/guides/code-splitting/#splitchunksplugin