### PR TITLE
#2684: introduce useFlags hook to consolidate flag/restriction logic

### DIFF
--- a/src/devTools/editor/ElementWizard.tsx
+++ b/src/devTools/editor/ElementWizard.tsx
@@ -36,9 +36,9 @@ import { produce } from "immer";
 import { useAsyncEffect } from "use-async-effect";
 import { upgradePipelineToV3 } from "@/devTools/editor/extensionPoints/upgrade";
 import BlueprintOptionsTab from "./tabs/blueprintOptionsTab/BlueprintOptionsTab";
-import { useGetAuthQuery } from "@/services/api";
 import styles from "./ElementWizard.module.scss";
 import AskQuestionModalButton from "./askQuestion/AskQuestionModalButton";
+import useFlags from "@/hooks/useFlags";
 
 const EDIT_STEP_NAME = "Edit";
 const LOG_STEP_NAME = "Logs";
@@ -100,9 +100,7 @@ const ElementWizard: React.FunctionComponent<{
   const [step, setStep] = useState(wizard[0].step);
 
   const { refresh: refreshLogs } = useContext(LogContext);
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
+  const { flagOn } = useFlags();
 
   const availableDefinition = element.extensionPoint.definition.isAvailable;
   const [available] = useAsyncState(
@@ -144,7 +142,7 @@ const ElementWizard: React.FunctionComponent<{
   } = useFormikContext<FormState>();
 
   const wizardSteps = [...wizard];
-  if (formState.recipe?.id && flags.includes("page-editor-beta")) {
+  if (formState.recipe?.id && flagOn("page-editor-beta")) {
     wizardSteps.push(blueprintOptionsStep);
   }
 

--- a/src/devTools/editor/hooks/useAddElement.ts
+++ b/src/devTools/editor/hooks/useAddElement.ts
@@ -18,7 +18,6 @@
 import { useDispatch, useSelector } from "react-redux";
 import { useCallback, useContext } from "react";
 import { DevToolsContext } from "@/devTools/context";
-import { useGetAuthQuery } from "@/services/api";
 import { useToasts } from "react-toast-notifications";
 import { actions, FormState } from "@/devTools/editor/slices/editorSlice";
 import { internalExtensionPointMetaFactory } from "@/devTools/editor/extensionPoints/base";
@@ -28,15 +27,14 @@ import { ElementConfig } from "@/devTools/editor/extensionPoints/elementConfig";
 import { getCurrentURL, thisTab } from "@/devTools/utils";
 import { updateDynamicElement } from "@/contentScript/messenger/api";
 import { SettingsState } from "@/store/settingsTypes";
+import useFlags from "@/hooks/useFlags";
 
 type AddElement = (config: ElementConfig) => void;
 
 function useAddElement(): AddElement {
   const dispatch = useDispatch();
   const { tabState } = useContext(DevToolsContext);
-  const {
-    data: { flags = [] },
-  } = useGetAuthQuery();
+  const { flagOff } = useFlags();
   const { addToast } = useToasts();
   const suggestElements = useSelector<{ settings: SettingsState }, boolean>(
     (x) => x.settings.suggestElements
@@ -44,7 +42,7 @@ function useAddElement(): AddElement {
 
   return useCallback(
     async (config: ElementConfig) => {
-      if (config.flag && !flags.includes(config.flag)) {
+      if (config.flag && flagOff(config.flag)) {
         dispatch(
           actions.betaError({ error: "This feature is in private beta" })
         );
@@ -99,7 +97,7 @@ function useAddElement(): AddElement {
         dispatch(actions.toggleInsert(null));
       }
     },
-    [dispatch, tabState.meta?.frameworks, addToast, flags, suggestElements]
+    [dispatch, tabState.meta?.frameworks, addToast, flagOff, suggestElements]
   );
 }
 

--- a/src/devTools/editor/sidebar/Sidebar.tsx
+++ b/src/devTools/editor/sidebar/Sidebar.tsx
@@ -50,9 +50,9 @@ import {
 import { CSSTransition } from "react-transition-group";
 import cx from "classnames";
 import { CSSTransitionProps } from "react-transition-group/CSSTransition";
-import { useGetAuthQuery } from "@/services/api";
 import { RecipeDefinition } from "@/types/definitions";
 import { GridLoader } from "react-spinners";
+import useFlags from "@/hooks/useFlags";
 
 const DropdownEntry: React.VoidFunctionComponent<{
   caption: string;
@@ -102,13 +102,11 @@ const SidebarExpanded: React.VoidFunctionComponent<
 }) => {
   const context = useContext(DevToolsContext);
 
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
+  const { flagOn } = useFlags();
   const showDeveloperUI =
     process.env.ENVIRONMENT === "development" ||
-    flags.includes("page-editor-developer");
-  const showBetaExtensionPoints = flags.includes("page-editor-beta");
+    flagOn("page-editor-developer");
+  const showBetaExtensionPoints = flagOn("page-editor-beta");
 
   const {
     tabState: { hasPermissions },

--- a/src/devTools/editor/tabs/editTab/EditTab.tsx
+++ b/src/devTools/editor/tabs/editTab/EditTab.tsx
@@ -42,7 +42,6 @@ import usePipelineField, {
 import { EditorNodeProps } from "@/devTools/editor/tabs/editTab/editorNode/EditorNode";
 import { useDispatch, useSelector } from "react-redux";
 import { selectActiveNodeId } from "@/devTools/editor/uiState/uiState";
-import { useGetAuthQuery } from "@/services/api";
 import ApiVersionField from "@/devTools/editor/fields/ApiVersionField";
 import useBlockPipelineActions from "@/devTools/editor/tabs/editTab/useBlockPipelineActions";
 import useApiVersionAtLeast from "@/devTools/editor/hooks/useApiVersionAtLeast";
@@ -52,6 +51,7 @@ import { isInnerExtensionPoint } from "@/runtime/runtimeUtils";
 import TooltipIconButton from "@/components/TooltipIconButton";
 import { faCopy, faTrash } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
+import useFlags from "@/hooks/useFlags";
 
 const EditTab: React.FC<{
   eventKey: string;
@@ -238,10 +238,8 @@ const EditTab: React.FC<{
         (blockPipelineErrors[activeBlockIndex] as string)
       : null;
 
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
-  const showVersionField = flags.includes("page-editor-developer");
+  const { flagOn } = useFlags();
+  const showVersionField = flagOn("page-editor-developer");
 
   return (
     <Tab.Pane eventKey={eventKey} className={styles.tabPane}>

--- a/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -37,7 +37,6 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FormState } from "@/devTools/editor/slices/editorSlice";
-import { useGetAuthQuery } from "@/services/api";
 import { useSelector } from "react-redux";
 import { selectExtensionTrace } from "@/devTools/editor/slices/runtimeSelectors";
 import { JsonObject } from "type-fest";
@@ -49,6 +48,7 @@ import DocumentPreview from "@/components/documentBuilder/preview/DocumentPrevie
 import documentBuilderSelectors from "@/devTools/editor/slices/documentBuilderSelectors";
 import { actions as documentBuilderActions } from "@/devTools/editor/slices/documentBuilderSlice";
 import copy from "copy-to-clipboard";
+import useFlags from "@/hooks/useFlags";
 
 /**
  * Exclude irrelevant top-level keys.
@@ -69,11 +69,8 @@ const contextFilter = (value: unknown, key: string) => {
 const DataPanel: React.FC<{
   instanceId: UUID;
 }> = ({ instanceId }) => {
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
-
-  const showDeveloperTabs = flags.includes("page-editor-developer");
+  const { flagOn } = useFlags();
+  const showDeveloperTabs = flagOn("page-editor-developer");
 
   const { values: formState, errors } = useFormikContext<FormState>();
   const formikData = { errors, ...formState };

--- a/src/devTools/editor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
+++ b/src/devTools/editor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
@@ -16,7 +16,6 @@
  */
 
 import React from "react";
-import { useGetAuthQuery } from "@/services/api";
 import { useFormikContext } from "formik";
 import { FormState } from "@/devTools/editor/slices/editorSlice";
 import { UUID } from "@/core";
@@ -30,14 +29,13 @@ import dataPanelStyles from "@/devTools/editor/tabs/dataPanelTabs.module.scss";
 import ExtensionPointPreview from "@/devTools/editor/tabs/effect/ExtensionPointPreview";
 import useDataPanelActiveTabKey from "@/devTools/editor/tabs/editTab/dataPanel/useDataPanelActiveTabKey";
 import useDataPanelTabSearchQuery from "@/devTools/editor/tabs/editTab/dataPanel/useDataPanelTabSearchQuery";
+import useFlags from "@/hooks/useFlags";
 
 const FoundationDataPanel: React.FC<{
   firstBlockInstanceId?: UUID;
 }> = ({ firstBlockInstanceId }) => {
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
-  const showDeveloperTabs = flags.includes("page-editor-developer");
+  const { flagOn } = useFlags();
+  const showDeveloperTabs = flagOn("page-editor-developer");
 
   const { values: formState } = useFormikContext<FormState>();
 

--- a/src/hooks/useFlags.ts
+++ b/src/hooks/useFlags.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useGetAuthQuery } from "@/services/api";
+import { useMemo } from "react";
+
+const RESTRICTED_PREFIX = "restricted";
+
+// Flags controlled on backend at http://github.com/pixiebrix/pixiebrix-app/blob/f082ff5161ff79f696d9a8c35c755430e88fa4ab/api/serializers/account.py#L173-L173
+export type RestrictedFeature =
+  | "workshop"
+  | "services"
+  | "permissions"
+  | "reset"
+  | "marketplace"
+  | "uninstall"
+  | "clear-token"
+  | "service-url";
+
+type Restrict = {
+  permit: (area: RestrictedFeature) => boolean;
+  restrict: (area: RestrictedFeature) => boolean;
+  flagOn: (flag: string) => boolean;
+  flagOff: (flag: string) => boolean;
+};
+
+/**
+ * Hook for feature flags and organization restrictions.
+ *
+ * For permit/restrict, features will be restricted in the fetching/loading state
+ */
+function useFlags(): Restrict {
+  // Future improvements:
+  // - Let caller of each method decide what to do during pending state, (i.e., add default argument)
+  // - Store flags in local storage to fetch faster than the query (and use last known values as fallback)
+  // - Standardize use of environment="development" and DEBUG in react app
+
+  const { data, isFetching, error } = useGetAuthQuery();
+
+  return useMemo(() => {
+    const { flags = [] } = data ?? {};
+    const pending = Boolean(error) || isFetching;
+
+    const flagSet = new Set(flags);
+
+    return {
+      permit: (area: RestrictedFeature) =>
+        !pending && !flagSet.has(`${RESTRICTED_PREFIX}-${area}`),
+      restrict: (area: RestrictedFeature) =>
+        pending || flagSet.has(`${RESTRICTED_PREFIX}-${area}`),
+      flagOn: (flag: string) => !pending && flagSet.has(flag),
+      flagOff: (flag: string) => pending || !flagSet.has(flag),
+    };
+  }, [data, isFetching, error]);
+}
+
+export default useFlags;

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -31,18 +31,16 @@ import {
 import cx from "classnames";
 import { SidebarLink } from "./SidebarLink";
 import { closeSidebarOnSmallScreen, SIDEBAR_ID } from "./toggleSidebar";
-import { useGetAuthQuery } from "@/services/api";
+import useFlags from "@/hooks/useFlags";
 
 const Sidebar: React.FunctionComponent = () => {
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
+  const { flagOn, permit } = useFlags();
 
   return (
     <OutsideClickHandler onOutsideClick={closeSidebarOnSmallScreen}>
       <nav className="sidebar sidebar-offcanvas" id={SIDEBAR_ID}>
         <ul className="nav">
-          {flags.includes("blueprints-page") && (
+          {flagOn("blueprints-page") && (
             <SidebarLink
               route="/blueprints-page"
               title="Blueprints"
@@ -66,11 +64,11 @@ const Sidebar: React.FunctionComponent = () => {
             icon={faScroll}
           />
 
-          {!flags.includes("restricted-workshop") && (
+          {permit("workshop") && (
             <SidebarLink route="/workshop" title="Workshop" icon={faHammer} />
           )}
 
-          {!flags.includes("restricted-services") && (
+          {permit("services") && (
             <SidebarLink
               route="/services"
               title="Integrations"
@@ -85,7 +83,7 @@ const Sidebar: React.FunctionComponent = () => {
             <span className="nav-text">Quick Links</span>
           </li>
 
-          {!flags.includes("restricted-marketplace") && (
+          {permit("marketplace") && (
             <li className={cx("nav-item")}>
               <a
                 href="https://www.pixiebrix.com/marketplace"

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -55,6 +55,7 @@ import WorkshopPage from "./pages/workshop/WorkshopPage";
 import InvitationBanner from "@/options/pages/InvitationBanner";
 import { SettingsState } from "@/store/settingsTypes";
 import BrowserBanner from "./pages/BrowserBanner";
+import useFlags from "@/hooks/useFlags";
 
 // Register the built-in bricks
 registerBuiltinBlocks();
@@ -78,17 +79,17 @@ const RequireInstall: React.FunctionComponent = ({ children }) => {
 };
 
 const Layout = () => {
-  // Get the latest brick definitions. Currently in Layout to ensure the Redux store has been hydrated by the time
-  // refresh is called.
+  // Get the latest brick definitions. Put it here in Layout instead of App to ensure the Redux store has been hydrated
+  // by the time refresh is called.
   useRefresh();
 
-  const { data: authData, isLoading } = useGetAuthQuery();
+  const { permit, flagOn } = useFlags();
+
+  const { isLoading } = useGetAuthQuery();
 
   if (isLoading) {
     return <GridLoader />;
   }
-
-  const { flags } = authData;
 
   return (
     <div className="w-100">
@@ -106,7 +107,7 @@ const Layout = () => {
             <div className="content-wrapper">
               <ErrorBoundary>
                 <Switch>
-                  {flags.includes("blueprints-page") && (
+                  {flagOn("blueprints-page") && (
                     <Route
                       exact
                       path="/blueprints-page"
@@ -127,15 +128,17 @@ const Layout = () => {
 
                   <Route exact path="/settings" component={SettingsPage} />
 
-                  {!flags.includes("restricted-services") && (
+                  {permit("services") && (
                     <Route path="/services/:id?" component={ServicesEditor} />
                   )}
 
-                  {!flags.includes("restricted-workshop") && (
+                  {/* Switch does not support consolidating Routes using a React fragment */}
+
+                  {permit("workshop") && (
                     <Route exact path="/workshop" component={WorkshopPage} />
                   )}
 
-                  {!flags.includes("restricted-workshop") && (
+                  {permit("workshop") && (
                     <Route
                       exact
                       path="/workshop/create/"
@@ -143,7 +146,7 @@ const Layout = () => {
                     />
                   )}
 
-                  {!flags.includes("restricted-workshop") && (
+                  {permit("workshop") && (
                     <Route
                       exact
                       path="/workshop/bricks/:id/"

--- a/src/options/pages/installed/ExtensionGroup.tsx
+++ b/src/options/pages/installed/ExtensionGroup.tsx
@@ -42,9 +42,9 @@ import styles from "./ExtensionGroup.module.scss";
 import ExtensionRows from "./ExtensionRows";
 import { useDispatch } from "react-redux";
 import { installedPageSlice } from "./installedPageSlice";
-import { useGetAuthQuery } from "@/services/api";
 import { Button } from "react-bootstrap";
 import { useHistory } from "react-router";
+import useFlags from "@/hooks/useFlags";
 
 const ExtensionGroup: React.FunctionComponent<{
   label: string;
@@ -81,12 +81,11 @@ const ExtensionGroup: React.FunctionComponent<{
   onExportBlueprint,
   hasUpdate,
 }) => {
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
   const notify = useNotifications();
   const dispatch = useDispatch();
   const history = useHistory();
+
+  const { restrict } = useFlags();
 
   const expandable = !managed;
   const [expanded, setExpanded] = useState(expandable && startExpanded);
@@ -226,14 +225,23 @@ const ExtensionGroup: React.FunctionComponent<{
         ),
         // #1532: temporary approach to controlling whether or not deployments can be uninstalled. In
         // the future we'll want this to depend on the member's role within the deployment's organization
-        hide: managed && flags.includes("restricted-uninstall"),
+        hide: managed && restrict("uninstall"),
         action: async () => {
           await removeMany(extensions);
         },
         className: "text-danger",
       },
     ],
-    [extensions, flags, hasUpdate, managed, onViewLogs, reinstall, removeMany]
+    [
+      onShare,
+      restrict,
+      extensions,
+      hasUpdate,
+      managed,
+      onViewLogs,
+      reinstall,
+      removeMany,
+    ]
   );
 
   return (

--- a/src/options/pages/installed/InstalledPage.test.tsx
+++ b/src/options/pages/installed/InstalledPage.test.tsx
@@ -161,8 +161,6 @@ const getRenderedOnboardingInformation = () => {
 
   const contactTeamAdminColumn = screen.queryByText("Contact your team admin");
 
-  const videoTour = screen.queryByText("Video Tour");
-
   const createBrickColumn = screen.queryByText("Create your Own");
 
   const activateFromDeploymentBannerColumn = screen.queryByText(
@@ -177,7 +175,6 @@ const getRenderedOnboardingInformation = () => {
     activateFromMarketplaceColumn,
     createBrickColumn,
     contactTeamAdminColumn,
-    videoTour,
     activateFromDeploymentBannerColumn,
     activateTeamBlueprintsColumn,
   };
@@ -214,7 +211,6 @@ describe("OnboardingPage", () => {
 
     expect(rendered.activateFromMarketplaceColumn).not.toBeNull();
     expect(rendered.createBrickColumn).not.toBeNull();
-    expect(rendered.videoTour).not.toBeNull();
   });
 
   test("enterprise user with `restricted-marketplace` flag", () => {
@@ -234,7 +230,6 @@ describe("OnboardingPage", () => {
 
     expect(rendered.activateFromMarketplaceColumn).toBeNull();
     expect(rendered.contactTeamAdminColumn).not.toBeNull();
-    expect(rendered.videoTour).toBeNull();
   });
 
   test("enterprise user with automatic team deployments", () => {
@@ -257,7 +252,6 @@ describe("OnboardingPage", () => {
 
     expect(rendered.activateFromMarketplaceColumn).toBeNull();
     expect(rendered.activateFromDeploymentBannerColumn).not.toBeNull();
-    expect(rendered.videoTour).toBeNull();
   });
 
   test("enterprise user with team blueprints", () => {
@@ -276,7 +270,6 @@ describe("OnboardingPage", () => {
 
     expect(rendered.activateTeamBlueprintsColumn).toBeNull();
     expect(rendered.createBrickColumn).not.toBeNull();
-    expect(rendered.videoTour).not.toBeNull();
   });
 
   test("enterprise user with no team blueprints or restrictions", () => {
@@ -294,7 +287,6 @@ describe("OnboardingPage", () => {
 
     expect(rendered.activateFromMarketplaceColumn).not.toBeNull();
     expect(rendered.createBrickColumn).not.toBeNull();
-    expect(rendered.videoTour).not.toBeNull();
   });
 
   function expectLoading() {

--- a/src/options/pages/installed/InstalledPage.tsx
+++ b/src/options/pages/installed/InstalledPage.tsx
@@ -27,7 +27,6 @@ import {
   reactivateEveryTab,
   uninstallContextMenu,
 } from "@/background/messenger/api";
-import { useGetAuthQuery } from "@/services/api";
 import { reportEvent } from "@/telemetry/events";
 import { Dispatch } from "redux";
 import { selectExtensions } from "@/store/extensionsSelectors";
@@ -51,6 +50,7 @@ import OnboardingPage from "@/options/pages/installed/OnboardingPage";
 import extensionsSlice from "@/store/extensionsSlice";
 import { OptionsState } from "@/store/extensionsTypes";
 import ShareLinkModal from "./ShareLinkModal";
+import useFlags from "@/hooks/useFlags";
 
 const { removeExtension } = extensionsSlice.actions;
 
@@ -58,9 +58,7 @@ export const _InstalledPage: React.FunctionComponent<{
   extensions: IExtension[];
   onRemove: RemoveAction;
 }> = ({ extensions, onRemove }) => {
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
+  const { flagOn } = useFlags();
 
   const [allExtensions, , cloudError] = useAsyncState(
     async () => {
@@ -155,7 +153,7 @@ export const _InstalledPage: React.FunctionComponent<{
             ) : (
               <p>
                 Here&apos;s a list of bricks you currently have activated.{" "}
-                {flags.includes("marketplace") ? (
+                {flagOn("marketplace") ? (
                   <>
                     You can find more to activate in{" "}
                     <Link to={"/blueprints"}>My Blueprints</Link>.

--- a/src/options/pages/installed/OnboardingPage.tsx
+++ b/src/options/pages/installed/OnboardingPage.tsx
@@ -20,13 +20,10 @@ import { Button, Card, Col, Row } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
-import {
-  useGetOrganizationsQuery,
-  useGetRecipesQuery,
-  useGetAuthQuery,
-} from "@/services/api";
+import { useGetOrganizationsQuery, useGetRecipesQuery } from "@/services/api";
 import useDeployments from "@/hooks/useDeployments";
 import GridLoader from "react-spinners/GridLoader";
+import useFlags from "@/hooks/useFlags";
 
 const ActivateFromMarketplaceColumn: React.FunctionComponent = () => (
   <Col xs={6}>
@@ -98,29 +95,9 @@ const CreateBrickColumn: React.FunctionComponent = () => (
   </Col>
 );
 
-const OnboardingVideoCard: React.FunctionComponent = () => (
-  <Card>
-    <Card.Header>Video Tour</Card.Header>
-    <Card.Body className="mx-auto">
-      <div>
-        <iframe
-          title="onboarding-video"
-          src="https://player.vimeo.com/video/514828533"
-          width="640"
-          height="400"
-          frameBorder="0"
-          allow="fullscreen; picture-in-picture"
-          allowFullScreen
-        />
-      </div>
-    </Card.Body>
-  </Card>
-);
-
 const OnboardingPage: React.FunctionComponent = () => {
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
+  const { restrict } = useFlags();
+
   const {
     data: rawRecipes,
     isLoading: isRecipesLoading,
@@ -143,22 +120,13 @@ const OnboardingPage: React.FunctionComponent = () => {
   const isLoading =
     isRecipesLoading || isOrganizationsLoading || isDeploymentsLoading;
 
-  // Video tour should be shown to typical users and enterprise users
-  //  that don't have deployments or marketplace restrictions
-  const showVideoTour = useMemo(
-    () =>
-      !hasOrganization ||
-      (!hasDeployments && !flags.includes("restricted-marketplace")),
-    [hasOrganization, hasDeployments, flags]
-  );
-
   const onBoardingInformation = useMemo(() => {
     if (hasOrganization) {
       if (hasDeployments) {
         return <ActivateFromDeploymentBannerColumn />;
       }
 
-      if (flags.includes("restricted-marketplace")) {
+      if (restrict("marketplace")) {
         return <ContactTeamAdminColumn />;
       }
 
@@ -178,7 +146,7 @@ const OnboardingPage: React.FunctionComponent = () => {
         <CreateBrickColumn />
       </>
     );
-  }, [hasOrganization, hasDeployments, hasTeamBlueprints, flags]);
+  }, [restrict, hasOrganization, hasDeployments, hasTeamBlueprints]);
 
   return (
     <>
@@ -198,13 +166,6 @@ const OnboardingPage: React.FunctionComponent = () => {
               </Card>
             </Col>
           </Row>
-          {showVideoTour && (
-            <Row>
-              <Col className="VideoCard mt-3">
-                <OnboardingVideoCard />
-              </Col>
-            </Row>
-          )}
         </>
       )}
     </>

--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -23,13 +23,12 @@ import browser from "webextension-polyfill";
 import chromeP from "webext-polyfill-kinda";
 import { isEmpty } from "lodash";
 import { useToasts } from "react-toast-notifications";
-import { useGetAuthQuery } from "@/services/api";
+import useFlags from "@/hooks/useFlags";
 
 const AdvancedSettings: React.FunctionComponent = () => {
   const { addToast } = useToasts();
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
+  const { restrict, permit } = useFlags();
+
   const [serviceURL, setServiceURL] = useConfiguredHost();
 
   const clear = useCallback(async () => {
@@ -95,7 +94,7 @@ const AdvancedSettings: React.FunctionComponent = () => {
               placeholder={DEFAULT_SERVICE_URL}
               defaultValue={serviceURL}
               onBlur={handleUpdate}
-              disabled={flags.includes("restricted-service-url")}
+              disabled={restrict("service-url")}
             />
             <Form.Text className="text-muted">
               The PixieBrix service URL
@@ -112,7 +111,7 @@ const AdvancedSettings: React.FunctionComponent = () => {
           Check Updates
         </Button>
 
-        {!flags.includes("restricted-clear-token") && (
+        {permit("clear-token") && (
           <Button variant="warning" onClick={clear}>
             Clear Token
           </Button>

--- a/src/options/pages/settings/SettingsPage.tsx
+++ b/src/options/pages/settings/SettingsPage.tsx
@@ -26,6 +26,7 @@ import FactoryResetSettings from "@/options/pages/settings/FactoryResetSettings"
 import AdvancedSettings from "@/options/pages/settings/AdvancedSettings";
 import { Col, Row } from "react-bootstrap";
 import ExperimentalSettings from "@/options/pages/settings/ExperimentalSettings";
+import useFlags from "@/hooks/useFlags";
 
 // eslint-disable-next-line prefer-destructuring -- process.env substitution
 const DEBUG = process.env.DEBUG;
@@ -40,8 +41,10 @@ const Section: React.FunctionComponent = ({ children }) => (
 
 const SettingsPage: React.FunctionComponent = () => {
   const {
-    data: { organization, flags },
+    data: { organization },
   } = useGetAuthQuery();
+
+  const { flagOn, permit } = useFlags();
 
   return (
     <Page
@@ -67,19 +70,19 @@ const SettingsPage: React.FunctionComponent = () => {
         <LoggingSettings />
       </Section>
 
-      {flags.includes("settings-experimental") && (
+      {flagOn("settings-experimental") && (
         <Section>
           <ExperimentalSettings />
         </Section>
       )}
 
-      {!flags.includes("restricted-permissions") && (
+      {permit("permissions") && (
         <Section>
           <PermissionsSettings />
         </Section>
       )}
 
-      {!flags.includes("restricted-reset") && (
+      {permit("reset") && (
         <Section>
           <FactoryResetSettings />
         </Section>

--- a/src/options/pages/workshop/WorkshopPage.tsx
+++ b/src/options/pages/workshop/WorkshopPage.tsx
@@ -34,6 +34,7 @@ import { push } from "connected-react-router";
 import CustomBricksCard from "./CustomBricksCard";
 import { EnrichedBrick, NavigateProps } from "./workshopTypes";
 import { RequireScope } from "@/auth/RequireScope";
+import useFlags from "@/hooks/useFlags";
 
 const { actions } = workshopSlice;
 
@@ -231,9 +232,11 @@ const CustomBricksSection: React.FunctionComponent<NavigateProps> = ({
 
 const WorkshopPage: React.FunctionComponent<NavigateProps> = ({ navigate }) => {
   const {
-    data: { isLoggedIn, flags },
+    data: { isLoggedIn },
     error: authError,
   } = useGetAuthQuery();
+
+  const { flagOn } = useFlags();
 
   return (
     <RequireScope
@@ -247,7 +250,7 @@ const WorkshopPage: React.FunctionComponent<NavigateProps> = ({ navigate }) => {
         description={
           <p>
             Build and attach bricks.{" "}
-            {flags.includes("marketplace") && (
+            {flagOn("marketplace") && (
               <>
                 To activate pre-made blueprints, visit the{" "}
                 <Link to={"/marketplace"}>Marketplace</Link>

--- a/src/pages/marketplace/MarketplacePage.tsx
+++ b/src/pages/marketplace/MarketplacePage.tsx
@@ -35,6 +35,7 @@ import { useGetAuthQuery, useGetOrganizationsQuery } from "@/services/api";
 import { sortBy } from "lodash";
 import Pagination from "@/components/pagination/Pagination";
 import { Organization } from "@/types/contract";
+import useFlags from "@/hooks/useFlags";
 
 export type InstallRecipe = (recipe: RecipeDefinition) => Promise<void>;
 
@@ -179,8 +180,11 @@ const MarketplacePage: React.FunctionComponent<MarketplaceProps> = ({
   const { data: rawRecipes } = useFetch<RecipeDefinition[]>("/api/recipes/");
   const [query, setQuery] = useState("");
   const {
-    data: { scope, flags },
+    data: { scope },
   } = useGetAuthQuery();
+
+  const { permit } = useFlags();
+
   const [page, setPage] = useState(0);
 
   const recipes = useMemo(() => {
@@ -221,7 +225,7 @@ const MarketplacePage: React.FunctionComponent<MarketplaceProps> = ({
           </div>
         </Col>
 
-        {!flags.includes("restricted-marketplace") && (
+        {permit("marketplace") && (
           <Col className="text-right">
             <a
               href="https://www.pixiebrix.com/marketplace"

--- a/src/pages/marketplace/useInstall.ts
+++ b/src/pages/marketplace/useInstall.ts
@@ -31,8 +31,8 @@ import { collectPermissions } from "@/permissions";
 import { push } from "connected-react-router";
 import { resolveRecipe } from "@/registry/internal";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
-import { useGetAuthQuery } from "@/services/api";
 import extensionsSlice from "@/store/extensionsSlice";
+import useFlags from "@/hooks/useFlags";
 
 const { installRecipe } = extensionsSlice.actions;
 
@@ -44,9 +44,7 @@ type InstallRecipe = (
 function useInstall(recipe: RecipeDefinition): InstallRecipe {
   const notify = useNotifications();
   const dispatch = useDispatch();
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
+  const { flagOn } = useFlags();
 
   return useCallback(
     async (values, { setSubmitting }: FormikHelpers<WizardValues>) => {
@@ -116,7 +114,7 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
 
         reactivateEveryTab();
 
-        if (flags.includes("blueprints-page")) {
+        if (flagOn("blueprints-page")) {
           dispatch(push("/blueprints-page"));
         } else {
           dispatch(push("/installed"));
@@ -128,7 +126,7 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
         setSubmitting(false);
       }
     },
-    [notify, dispatch, recipe]
+    [flagOn, notify, dispatch, recipe]
   );
 }
 

--- a/src/services/requestErrorUtils.ts
+++ b/src/services/requestErrorUtils.ts
@@ -35,6 +35,9 @@ import { getReasonPhrase } from "http-status-codes";
 import { isAbsoluteUrl } from "@/utils";
 import urljoin from "url-join";
 
+// eslint-disable-next-line prefer-destructuring -- process.env variable
+const DEBUG = process.env.DEBUG;
+
 /**
  * Get the absolute URL from a request configuration. Does NOT include the query params from the request unless
  * they were passed in with the URL instead of as params.
@@ -100,11 +103,11 @@ export async function enrichRequestError(
     url = new URL(selectAbsoluteUrl(maybeAxiosError.config));
   } catch (typeError) {
     return new BusinessError(
-      `Invalid Request URL: ${getErrorMessage(typeError)}`
+      `Invalid request URL: ${getErrorMessage(typeError)}`
     );
   }
 
-  if (url.protocol !== "https:") {
+  if (url.protocol !== "https:" && !DEBUG) {
     return new BusinessError(
       `Unsupported protocol ${url.protocol}. Use https:`
     );


### PR DESCRIPTION
Part of #2684 

We have some "anti"-flags for users on restricted enterprise accounts. This PR introduces a useFlags hook that consolidates the logic and properly handles loading/error state. 