### PR TITLE
#2659: Avoid duplicate registration in context menus

### DIFF
--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -198,6 +198,12 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
   }
 
   private async registerExtensions(): Promise<void> {
+    console.debug(
+      "Registering",
+      this.extensions.length,
+      "contextMenu extension points"
+    );
+
     const results = await Promise.allSettled(
       this.extensions.map(async (extension) => {
         try {
@@ -308,14 +314,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
   }
 
   async run(): Promise<void> {
-    if (this.extensions.length === 0) {
-      console.debug(
-        `contextMenu extension point ${this.id} has no installed extensions`
-      );
-      return;
-    }
-
-    await this.registerExtensions();
+    // Already taken care by the `install` method
   }
 }
 


### PR DESCRIPTION
- Fixes half of #2659

It appears that `run` is always preceded by `install` and both of them are calling the same `registerExtension`. Is it ok to drop `run` in this extension point?

https://github.com/pixiebrix/pixiebrix-extension/blob/5deb9710968fc19266c6016c5dbec3fd3c37f8ec/src/contentScript/lifecycle.ts#L73-L102
