### PR TITLE
#2575: redirect to admin console from configure button

### DIFF
--- a/src/hooks/useAuthorizationGrantFlow.ts
+++ b/src/hooks/useAuthorizationGrantFlow.ts
@@ -50,7 +50,7 @@ function useAuthorizationGrantFlow() {
 
       const confirm = await modals.showConfirmation({
         title: "Configure Integration",
-        message: `${name} uses a type of authentication that's only supported in the Admin Console. Click below to continue to the Admin Console`,
+        message: `${name} uses a type of authentication that's supported in the Admin Console. Click Configure to continue to the Admin Console`,
         cancelCaption: "Cancel",
         submitCaption: "Configure",
         submitVariant: "primary",

--- a/src/options/pages/marketplace/AuthWidget.tsx
+++ b/src/options/pages/marketplace/AuthWidget.tsx
@@ -162,13 +162,16 @@ const AuthWidget: React.FunctionComponent<{
               size="sm"
               style={{ height: "36px", marginTop: "1px" }}
               onClick={() => {
+                if (serviceDefinition.isAuthorizationGrant) {
+                  void launchAuthorizationGrantFlow(serviceDefinition, {
+                    target: "_self",
+                  });
+                  return;
+                }
+
                 setShowServiceModal(true);
               }}
-              disabled={
-                isPending ||
-                error != null ||
-                serviceDefinition?.isAuthorizationGrant
-              }
+              disabled={isPending || error != null}
             >
               <FontAwesomeIcon icon={faPlus} /> Configure
             </Button>

--- a/src/options/pages/marketplace/ServicesBody.tsx
+++ b/src/options/pages/marketplace/ServicesBody.tsx
@@ -18,17 +18,17 @@
 import React, { useMemo } from "react";
 import { Card, Table } from "react-bootstrap";
 import { Link } from "react-router-dom";
-import { RecipeDefinition, ServiceDefinition } from "@/types/definitions";
+import { RecipeDefinition } from "@/types/definitions";
 import { useSelectedExtensions } from "@/options/pages/marketplace/ConfigureBody";
 import { faCloud, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import useFetch from "@/hooks/useFetch";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import AuthWidget from "@/options/pages/marketplace/AuthWidget";
 import ServiceDescriptor from "@/options/pages/marketplace/ServiceDescriptor";
 import { useField } from "formik";
 import { ServiceAuthPair } from "@/core";
 import { useAuthOptions } from "@/hooks/auth";
+import { useGetServicesQuery } from "@/services/api";
 
 interface OwnProps {
   blueprint: RecipeDefinition;
@@ -41,9 +41,7 @@ const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
 
   const selected = useSelectedExtensions(blueprint.extensionPoints);
 
-  const { data: serviceConfigs } = useFetch<ServiceDefinition[]>(
-    "/api/services/"
-  );
+  const { data: serviceConfigs } = useGetServicesQuery();
 
   const visibleServiceIds = useMemo(
     // The PixieBrix service gets automatically configured, so don't need to show it. If the PixieBrix service is
@@ -63,7 +61,7 @@ const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
         <Card.Title>Select Integrations</Card.Title>
         <p>
           Integrations tell PixieBrix how to connect to the other applications
-          and integrations you use
+          you use
         </p>
         <p className="text-info">
           <FontAwesomeIcon icon={faInfoCircle} /> You can configure integrations


### PR DESCRIPTION
Part of #2575 

From the Activation Wizard, redirect to the Admin Console. This will force the set of services to load when the user goes back. Not a perfect UX, but good enough for initial OAuth2 release