### PR TITLE
#2757: Ensure `react-toast-notifications` is shown above everything in the o…

### DIFF
--- a/src/options.scss
+++ b/src/options.scss
@@ -24,3 +24,8 @@ html {
   // keep behind services modal of 999
   z-index: 998;
 }
+
+// Notifications must be above everything
+.react-toast-notifications__container {
+  z-index: 2147483647 !important;
+}


### PR DESCRIPTION
- Fixes #2757

I think the issue came to light after _unboxing_ the options page in https://github.com/pixiebrix/pixiebrix-extension/pull/2704, but I'm not too sure.

Anyway the z-index has appears to be a measly [1000](https://github.com/jossmac/react-toast-notifications/blob/9d4b5d6cf40c9062fa23d1346a2093b44c182fc8/src/ToastContainer.js#L41) so here I'm bumping it via CSS until this other issue is resolved:

- https://github.com/pixiebrix/pixiebrix-extension/issues/2174

