### PR TITLE
Fix height of editor sidebar collapsing animation

### DIFF
--- a/src/devTools/editor/sidebar/Sidebar.module.scss
+++ b/src/devTools/editor/sidebar/Sidebar.module.scss
@@ -33,6 +33,7 @@ $logoSize: 31px;
 
   &.exitActive {
     position: absolute; // Take out of the flow during the transition
+    height: 100vh !important;
   }
 
   label {


### PR DESCRIPTION
Caused by https://github.com/pixiebrix/pixiebrix-extension/pull/2704 probably

## Before (slow animation just for the demo)

https://user-images.githubusercontent.com/1402241/154784765-6fd2cb33-4421-4c02-aab3-b704452e7cd6.mov

## After (slow animation just for the demo)

https://user-images.githubusercontent.com/1402241/154784770-a1c4a8a3-52ee-4fff-b8df-9f0b6e6a99bc.mov



