### PR TITLE
Avoid red on blue in editor "Unsaved changes" icon

### DIFF
--- a/src/devTools/editor/sidebar/DynamicEntry.tsx
+++ b/src/devTools/editor/sidebar/DynamicEntry.tsx
@@ -82,7 +82,7 @@ const DynamicEntry: React.FunctionComponent<{
         </span>
       )}
       {isDirty && (
-        <span className={cx(styles.icon, "text-danger")}>
+        <span className={styles.icon}>
           <UnsavedChangesIcon />
         </span>
       )}


### PR DESCRIPTION
Tiny proposal, we don't need to spend much time on this.

## Context

- https://www.cdgi.com/2016/07/design-lesson-vibrating-color-theory/

![](https://user-images.githubusercontent.com/1402241/154785370-909e9787-2dea-469f-a9aa-c144121441a3.jpg)


## Current

The "unsaved changes" icon is bright red and it lies in a bright blue area

<img width="259" alt="Screen Shot 9" src="https://user-images.githubusercontent.com/1402241/154785223-3a5acb39-597a-4b5e-a797-01f664635550.png">

## Possible improvement

The simple solution is to add some padding. I tried a circle but it doesn't work well with the floppy icon square. This fits better but it isn't particularly beautiful.

<img width="259" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/154785235-5902d287-2968-4562-a188-65c5e8d95e96.png">

## This PR

I think perhaps we don't need red at all. This looks nice:

<img width="259" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/154785237-ffbfeae2-ca19-4587-9d4c-6b8e52167e4b.png">
