### PR TITLE
Continue saving while asking for permissions

### DIFF
--- a/src/devTools/editor/hooks/useCreate.ts
+++ b/src/devTools/editor/hooks/useCreate.ts
@@ -140,10 +140,7 @@ function useCreate(): CreateCallback {
       try {
         const adapter = ADAPTERS.get(element.type);
 
-        try {
-          await ensurePermissions(element, addToast);
-        } catch (error) {
-          // Continue to allow saving (because there's a workaround)
+        void ensurePermissions(element, addToast).catch((error) => {
           reportError(error);
           console.error("Error checking/enabling permissions", { error });
           addToast(
@@ -153,7 +150,7 @@ function useCreate(): CreateCallback {
               autoDismiss: true,
             }
           );
-        }
+        });
 
         const extensionPointId = element.extensionPoint.metadata.id;
         const hasInnerExtensionPoint = isInnerExtensionPoint(extensionPointId);


### PR DESCRIPTION
## Before

Notice how the saving progress is (unnecessarily) waiting for the permissions to be granted

https://user-images.githubusercontent.com/1402241/154786164-0b2dc3d3-a319-4aac-8bee-d19a1943a051.mov

## After

The saving continues while the user confirms the permissions. This parallelizes the two actions (app saving, user confirmation).

This is fine because the result of the permission request isn't immediately used nor it is necessary.

https://user-images.githubusercontent.com/1402241/154786185-5d4feb9c-0993-4830-b0fe-d6f119113cf2.mov


