### PR TITLE
#1931: Don't display overlapping permissions in the options page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,7 @@
         "use-debounce": "^7.0.0",
         "use-immer": "^0.6.0",
         "uuid": "^8.3.2",
-        "webext-additional-permissions": "^2.2.0",
+        "webext-additional-permissions": "^2.3.0",
         "webext-content-scripts": "^1.0.1",
         "webext-detect-page": "^4.0.0",
         "webext-dynamic-content-scripts": "^8.0.1",
@@ -36871,9 +36871,9 @@
       }
     },
     "node_modules/webext-additional-permissions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/webext-additional-permissions/-/webext-additional-permissions-2.2.0.tgz",
-      "integrity": "sha512-raI6w8KVbtYM4J4CmL/tofv8uetmxSnTcIfbc1S9OxBbka4XKwUz4xCpXMh7iBS/RXEFfKX5RJ3HaVwFjMp/Dg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/webext-additional-permissions/-/webext-additional-permissions-2.3.0.tgz",
+      "integrity": "sha512-WhrE049ubufZbZ9AZbC9ULQX57+R22L5IUXUNOzMuh73QKXVomcXP5H6xa8Nm5wBLFjkgB0q5HB4SPO9+Rra2Q==",
       "dependencies": {
         "@types/chrome": "0.0.178",
         "webext-patterns": "^1.1.1"
@@ -66327,9 +66327,9 @@
       "dev": true
     },
     "webext-additional-permissions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/webext-additional-permissions/-/webext-additional-permissions-2.2.0.tgz",
-      "integrity": "sha512-raI6w8KVbtYM4J4CmL/tofv8uetmxSnTcIfbc1S9OxBbka4XKwUz4xCpXMh7iBS/RXEFfKX5RJ3HaVwFjMp/Dg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/webext-additional-permissions/-/webext-additional-permissions-2.3.0.tgz",
+      "integrity": "sha512-WhrE049ubufZbZ9AZbC9ULQX57+R22L5IUXUNOzMuh73QKXVomcXP5H6xa8Nm5wBLFjkgB0q5HB4SPO9+Rra2Q==",
       "requires": {
         "@types/chrome": "0.0.178",
         "webext-patterns": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "use-debounce": "^7.0.0",
     "use-immer": "^0.6.0",
     "uuid": "^8.3.2",
-    "webext-additional-permissions": "^2.2.0",
+    "webext-additional-permissions": "^2.3.0",
     "webext-content-scripts": "^1.0.1",
     "webext-detect-page": "^4.0.0",
     "webext-dynamic-content-scripts": "^8.0.1",

--- a/src/options/pages/settings/PermissionsSettings.tsx
+++ b/src/options/pages/settings/PermissionsSettings.tsx
@@ -17,12 +17,14 @@
 
 import React, { useCallback, useMemo, useState } from "react";
 import { useToasts } from "react-toast-notifications";
-import { getAdditionalPermissions } from "webext-additional-permissions";
+import {
+  getAdditionalPermissions,
+  dropOverlappingPermissions,
+} from "webext-additional-permissions";
 import browser, { Manifest } from "webextension-polyfill";
 import { sortBy } from "lodash";
 import { useAsyncEffect } from "use-async-effect";
 import { Button, Card, ListGroup } from "react-bootstrap";
-import { patternToRegex } from "webext-patterns";
 
 type OptionalPermission = Manifest.OptionalPermission;
 type Permissions = chrome.permissions.Permissions;
@@ -32,9 +34,7 @@ const PermissionRow: React.FunctionComponent<{
   remove: (value: string) => void;
 }> = ({ value, remove }) => (
   <ListGroup.Item className="d-flex">
-    <div className="flex-grow-1 align-self-center">
-      {value === "*://*/*" ? "Every website" : value}
-    </div>
+    <div className="flex-grow-1 align-self-center">{value}</div>
     <div className="align-self-center">
       <Button
         variant="danger"
@@ -58,35 +58,6 @@ const PermissionsSettings: React.FunctionComponent = () => {
   const [permissions, setPermissions] = useState<Permissions>();
 
   const refresh = useCallback(async () => {
-    function dropOverlappingPermissions({
-      origins,
-      permissions,
-    }: chrome.permissions.Permissions): chrome.permissions.Permissions {
-      const result: chrome.permissions.Permissions = {};
-      if (origins) {
-        if (origins.includes("<all_urls>")) {
-          result.origins = ["<all_urls>"];
-        } else if (origins.includes("*://*/*")) {
-          result.origins = ["*://*/*"];
-        } else {
-          result.origins = origins.filter(
-            (possibleSubset) =>
-              !origins.some(
-                (possibleSuperset) =>
-                  possibleSubset !== possibleSuperset &&
-                  patternToRegex(possibleSuperset).test(possibleSubset)
-              )
-          );
-        }
-      }
-
-      if (permissions) {
-        result.permissions = [...permissions];
-      }
-
-      return result;
-    }
-
     setPermissions(
       dropOverlappingPermissions(await getAdditionalPermissions())
     );


### PR DESCRIPTION
- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/1931
- Based on: 
	- https://github.com/fregante/webext-additional-permissions/pull/12
	- https://github.com/fregante/webext-additional-permissions/releases/tag/v2.3.0
- Possible future improvement, if the bug is verified:
	- [ ] https://github.com/fregante/webext-dynamic-content-scripts/issues/35

## Before


<img width="567" alt="Screen Shot 20" src="https://user-images.githubusercontent.com/1402241/154794990-f4c2a681-1c86-4cdc-ad50-ec40fc0efcbf.png">

## After

<img width="566" alt="Screen Shot 19" src="https://user-images.githubusercontent.com/1402241/154794994-f00e444a-69c3-421e-87d9-e6dbd8dc59c9.png">

# Nota bene

While at first sight this may seem that _the user can no longer remove the permission from specific hosts_, this was never possible. Dropping an overlapping permission has always been a meaningless operation: `*://*/*` will still cover every website, whether explicitly in the list or not.