### PR TITLE
Avoid wonky sizing of Settings page in Options

### DIFF
--- a/src/options/pages/settings/AdvancedSettings.module.scss
+++ b/src/options/pages/settings/AdvancedSettings.module.scss
@@ -15,8 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-.footer {
+$card-footer-padding: 0.75rem;
+
+.cardFooter {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px 7px;
+  gap: $card-footer-padding;
+  & > * {
+    margin: 0; // Drop Bootstrap’s automatic margin on buttons
+  }
 }

--- a/src/options/pages/settings/AdvancedSettings.module.scss
+++ b/src/options/pages/settings/AdvancedSettings.module.scss
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 7px;
+}

--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -104,7 +104,7 @@ const AdvancedSettings: React.FunctionComponent = () => {
           </Form.Group>
         </Form>
       </Card.Body>
-      <Card.Footer className={styles.footer}>
+      <Card.Footer className={styles.cardFooter}>
         <Button variant="info" onClick={reload}>
           Reload Extension
         </Button>

--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import styles from "./AdvancedSettings.module.scss";
+
 import { Button, Card, Form } from "react-bootstrap";
 import { DEFAULT_SERVICE_URL, useConfiguredHost } from "@/services/baseService";
 import React, { useCallback } from "react";
@@ -102,7 +104,7 @@ const AdvancedSettings: React.FunctionComponent = () => {
           </Form.Group>
         </Form>
       </Card.Body>
-      <Card.Footer>
+      <Card.Footer className={styles.footer}>
         <Button variant="info" onClick={reload}>
           Reload Extension
         </Button>

--- a/src/options/pages/settings/SettingsPage.module.scss
+++ b/src/options/pages/settings/SettingsPage.module.scss
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.root {
+  max-width: 550px;
+  margin-bottom: 20px;
+}

--- a/src/options/pages/settings/SettingsPage.tsx
+++ b/src/options/pages/settings/SettingsPage.tsx
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import styles from "./SettingsPage.module.scss";
+
 import React from "react";
 import Page from "@/layout/Page";
 import { faCogs } from "@fortawesome/free-solid-svg-icons";
@@ -24,7 +26,6 @@ import LoggingSettings from "@/options/pages/settings/LoggingSettings";
 import PermissionsSettings from "@/options/pages/settings/PermissionsSettings";
 import FactoryResetSettings from "@/options/pages/settings/FactoryResetSettings";
 import AdvancedSettings from "@/options/pages/settings/AdvancedSettings";
-import { Col, Row } from "react-bootstrap";
 import ExperimentalSettings from "@/options/pages/settings/ExperimentalSettings";
 import useFlags from "@/hooks/useFlags";
 
@@ -32,11 +33,7 @@ import useFlags from "@/hooks/useFlags";
 const DEBUG = process.env.DEBUG;
 
 const Section: React.FunctionComponent = ({ children }) => (
-  <Row className="mb-4">
-    <Col lg={6} md={8}>
-      {children}
-    </Col>
-  </Row>
+  <div className={styles.root}>{children}</div>
 );
 
 const SettingsPage: React.FunctionComponent = () => {


### PR DESCRIPTION
## Problem

Bootstrap’s column sizing isn't beneficial here and it causes the content to vary between too wide and too tight, even when there's plenty of space:

<img width="1045" alt="Screen Shot 22" src="https://user-images.githubusercontent.com/1402241/154796282-822c067d-2653-43c7-8faa-a58330097f52.png">


This applies to other option pages as well, like Workshop and its overflow, but I wanted the go-ahead before touching more pages.

<img width="500" alt="Screen Shot 24" src="https://user-images.githubusercontent.com/1402241/154796436-63844018-0868-49b4-86d0-7a8f3438ebcd.png">


## Solution

Let's find a width that works best for the content and stick to it. It does not have to be the same across every page.



## Before



https://user-images.githubusercontent.com/1402241/154802310-3caacdfa-0e4f-4c62-ac86-052de8e0136d.mov




## After

https://user-images.githubusercontent.com/1402241/154796174-12a1f31e-cdb6-44eb-b631-830e7b49ec01.mov


