### PR TITLE
Improve loading error experience

### DIFF
--- a/static/loadingScreen.js
+++ b/static/loadingScreen.js
@@ -19,15 +19,27 @@
 
 function showErrors(errorEvent) {
   const logger = document.querySelector(".global-loading-message");
-  if (logger.childElementCount > 0) {
+  if (!logger) {
     // The view was initialized, stop showing errors
     window.removeEventListener("error", showErrors);
     return;
   }
 
-  logger.textContent = String(errorEvent.error);
-  logger.style.fontFamily = "monospace";
-  logger.style.whiteSpace = "pre";
+  logger.textContent = ""; // Drop loading or previous errors
+  const wrapper = document.createElement("div");
+
+  const error = document.createElement("p");
+  error.textContent = String(errorEvent.error);
+  error.style.fontFamily = "monospace";
+  error.style.whiteSpace = "pre-wrap";
+
+  const reloadButton = document.createElement("button");
+  reloadButton.textContent = "Retry";
+  reloadButton.classList.add("btn", "btn-sm", "btn-primary");
+  reloadButton.addEventListener("click", location.reload.bind(location));
+
+  wrapper.append(error, document.createElement("br"), reloadButton);
+  logger.append(wrapper);
 }
 
 window.addEventListener("error", showErrors);


### PR DESCRIPTION
Related:

- https://github.com/pixiebrix/pixiebrix-extension/pull/2656

This PR:

- wraps the error message instead of overflowing the window (e.g.  in the sidebar)
- adds a reload button (useful in the editor, since the React button isn't available https://github.com/pixiebrix/pixiebrix-extension/issues/2377)

## Before

<img width="417" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/154798014-ab4c5683-a225-40b2-9f0b-32cdfbc9bf30.png">

## After

<img width="413" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/154798019-1d036d61-0ad6-475a-90fa-3e37f0d2a89a.png">


