### PR TITLE
Reduce watch script noise

### DIFF
--- a/webpack.sharedConfig.js
+++ b/webpack.sharedConfig.js
@@ -29,11 +29,15 @@ const merge = mergeWithCustomize({
 
 const tsconfig = JSON5.parse(fs.readFileSync("./tsconfig.json", "utf8"));
 
+/** @type import("webpack").Configuration */
 const shared = {
   stats: {
     preset: "errors-warnings",
-    entrypoints: true,
+    entrypoints: process.argv.includes("production"),
     timings: true,
+  },
+  watchOptions: {
+    aggregateTimeout: 200,
   },
   resolve: {
     alias: {
@@ -116,4 +120,7 @@ for (const [from, [to]] of Object.entries(tsconfig.compilerOptions.paths)) {
   );
 }
 
+/**
+ * @param {import("webpack").Configuration} baseConfig
+ */
 module.exports = (baseConfig) => merge(shared, baseConfig);


### PR DESCRIPTION
Let's be honest, nobody is reading this while in `watch` mode. It's just noise. 

<img width="836" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/154806594-659e8753-8931-4ede-bbd8-a1cfbae6459c.png">


If we care about file size we should prioritize https://github.com/pixiebrix/pixiebrix-extension/issues/1623

This PR:

<img width="506" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/154806600-1ce5be8a-7e71-41af-b4c8-095193675eff.png">

