### PR TITLE
#2715: log page name with errors

### DIFF
--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -79,7 +79,10 @@ interface LogDB extends DBSchema {
   };
 }
 
-type IndexKey = keyof Except<MessageContext, "deploymentId" | "label">;
+type IndexKey = keyof Except<
+  MessageContext,
+  "deploymentId" | "label" | "pageName"
+>;
 const indexKeys: IndexKey[] = [
   "extensionId",
   "blueprintId",
@@ -269,9 +272,10 @@ export async function recordError(
     const message = getErrorMessage(error);
 
     // For noisy errors, don't record/submit telemetry unless the error prevented an extension point
-    // from being installed or an extension to fail. (In that case, we'd have some context about the error)
+    // from being installed or an extension to fail. (In that case, we'd have some context about the error).
+    const { pageName, ...extensionContext } = context;
     if (
-      isEmpty(context) &&
+      isEmpty(extensionContext) &&
       matchesAnyPattern(message, IGNORED_ERROR_PATTERNS)
     ) {
       console.debug("Ignoring error matching IGNORED_ERROR_PATTERNS", {

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -273,7 +273,7 @@ export async function recordError(
 
     // For noisy errors, don't record/submit telemetry unless the error prevented an extension point
     // from being installed or an extension to fail. (In that case, we'd have some context about the error).
-    const { pageName, ...extensionContext } = context;
+    const { pageName, ...extensionContext } = context ?? {};
     if (
       isEmpty(extensionContext) &&
       matchesAnyPattern(message, IGNORED_ERROR_PATTERNS)

--- a/src/core.ts
+++ b/src/core.ts
@@ -187,6 +187,16 @@ export interface Message<
   meta?: TMeta;
 }
 
+// `ContextName`s from webext-detect-page
+export type ContextName =
+  | "contentScript"
+  | "background"
+  | "options"
+  | "devToolsPage"
+  | "extension"
+  | "web"
+  | "unknown";
+
 /**
  * Log event metadata for the extensions internal logging infrastructure.
  * @see Logger
@@ -204,6 +214,7 @@ export type MessageContext = {
   readonly extensionId?: UUID;
   readonly serviceId?: RegistryId;
   readonly authId?: UUID;
+  readonly pageName?: ContextName;
 };
 
 export type SerializedError = Primitive | ErrorObject;

--- a/src/telemetry/reportError.ts
+++ b/src/telemetry/reportError.ts
@@ -20,6 +20,7 @@ import { recordError } from "@/background/messenger/api";
 import { serializeError } from "serialize-error";
 import { selectError } from "@/errors";
 import { expectContext } from "@/utils/expectContext";
+import { getContextName } from "webext-detect-page";
 
 expectContext(
   "extension",
@@ -32,7 +33,13 @@ expectContext(
  * @param context optional context for error telemetry
  */
 function reportError(error: unknown, context?: MessageContext): void {
-  void _reportError(error, context).catch((reportingError) => {
+  // Add on the reporter side of the message. On the receiving side it would always be `background`
+  const extendedContext: MessageContext = {
+    ...context,
+    pageName: getContextName(),
+  };
+
+  void _reportError(error, extendedContext).catch((reportingError) => {
     console.error("An error occurred when reporting an error", {
       originalError: error,
       reportingError,


### PR DESCRIPTION
Part of #2715 

Log page name (e.g., contentScript vs. options) with errors to collect more information about potentially invalid network calls