### PR TITLE
Improve quick bar configuration information

### DIFF
--- a/src/devTools/editor/extensionPoints/elementConfig.ts
+++ b/src/devTools/editor/extensionPoints/elementConfig.ts
@@ -160,13 +160,7 @@ export interface ElementConfig<
   readonly icon: IconProp;
 
   /**
-   * True if the element type should be considered "beta" functionality in the page editor. E.g., for showing a
-   * "beta" badge/indicator and/or warning the user that using this element is currently in beta
-   */
-  readonly beta?: boolean;
-
-  /**
-   * Feature flag that indicates whether or not the element type is enabled for the user. `undefined` to indicate
+   * Feature flag that indicates whether the element type is enabled for the user. `undefined` to indicate
    * all users should be able to create/edit the elements of this type.
    */
   readonly flag?: string;

--- a/src/devTools/editor/extensionPoints/quickBar.tsx
+++ b/src/devTools/editor/extensionPoints/quickBar.tsx
@@ -35,7 +35,10 @@ import {
 import { uuidv4 } from "@/types/helpers";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import { getDomain } from "@/permissions/patterns";
-import { faThLarge } from "@fortawesome/free-solid-svg-icons";
+import {
+  faExclamationTriangle,
+  faThLarge,
+} from "@fortawesome/free-solid-svg-icons";
 import {
   BaseExtensionState,
   BaseFormState,
@@ -45,6 +48,7 @@ import {
 import browser, { Menus } from "webextension-polyfill";
 import { NormalizedAvailability } from "@/blocks/types";
 import React, { useEffect, useState } from "react";
+import { Alert } from "react-bootstrap";
 import { Except } from "type-fest";
 import {
   QuickBarConfig,
@@ -54,9 +58,9 @@ import {
   QuickBarTargetMode,
 } from "@/extensionPoints/quickBarExtension";
 import QuickBarConfiguration from "@/devTools/editor/tabs/quickBar/QuickBarConfiguration";
-import { isMac } from "@/utils";
 import { isEmpty } from "lodash";
 import type { DynamicDefinition } from "@/contentScript/nativeEditor/types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 type Extension = BaseExtensionState & Except<QuickBarConfig, "action">;
 
@@ -240,13 +244,10 @@ function asDynamicElement(element: QuickBarFormState): DynamicDefinition {
   };
 }
 
-const DEFAULT_SHORTCUT = isMac() ? "⌘K" : "Ctrl+K";
-
 const config: ElementConfig<undefined, QuickBarFormState> = {
   displayOrder: 1,
   elementType: "quickBar",
   label: "Quick Bar",
-  beta: true,
   baseClass: QuickBarExtensionPoint,
   EditorNode: QuickBarConfiguration,
   selectNativeElement: undefined,
@@ -272,27 +273,37 @@ const config: ElementConfig<undefined, QuickBarFormState> = {
     }, []);
 
     return (
-      <div className="pb-2">
-        <p>
-          The quick bar can be triggered on any page by pressing{" "}
-          <kbd style={{ fontFamily: "system" }}>
-            {isEmpty(shortcut) ? DEFAULT_SHORTCUT : shortcut}
-          </kbd>
-          .{" "}
-          {isEmpty(shortcut) &&
-            "You have not configured a Quick Bar shortcut in Chrome, you're currently using the default. "}
-        </p>
-        <p>
-          <a
-            href="chrome://extensions/shortcuts"
-            onClick={(event) => {
-              event.preventDefault();
-              void browser.tabs.create({ url: event.currentTarget.href });
-            }}
-          >
-            Configure a Quick Bar shortcut in Chrome
-          </a>
-        </p>
+      <div className="text-center pb-2">
+        {isEmpty(shortcut) ? (
+          <Alert variant="warning">
+            <FontAwesomeIcon icon={faExclamationTriangle} />
+            &nbsp;You have not{" "}
+            <a
+              href="chrome://extensions/shortcuts"
+              onClick={(event) => {
+                event.preventDefault();
+                void browser.tabs.create({ url: event.currentTarget.href });
+              }}
+            >
+              configured a Quick Bar shortcut
+            </a>
+          </Alert>
+        ) : (
+          <p>
+            You&apos;ve configured&nbsp;
+            <kbd style={{ fontFamily: "system" }}>{shortcut}</kbd>&nbsp; to open
+            the Quick Bar.{" "}
+            <a
+              href="chrome://extensions/shortcuts"
+              onClick={(event) => {
+                event.preventDefault();
+                void browser.tabs.create({ url: event.currentTarget.href });
+              }}
+            >
+              Change your Quick Bar shortcut
+            </a>
+          </p>
+        )}
       </div>
     );
   },

--- a/src/devTools/editor/sidebar/Sidebar.tsx
+++ b/src/devTools/editor/sidebar/Sidebar.tsx
@@ -139,7 +139,6 @@ const SidebarExpanded: React.VoidFunctionComponent<
   const showDeveloperUI =
     process.env.ENVIRONMENT === "development" ||
     flagOn("page-editor-developer");
-  const showBetaExtensionPoints = flagOn("page-editor-beta");
   const groupByRecipe = flagOn("page-editor-blueprints");
 
   const {
@@ -232,13 +231,13 @@ const SidebarExpanded: React.VoidFunctionComponent<
               id="add-extension-point"
             >
               {sortBy([...ADAPTERS.values()], (x) => x.displayOrder)
-                .filter((element) => showBetaExtensionPoints || !element.beta)
+                .filter((element) => !element.flag || flagOn(element.flag))
                 .map((element) => (
                   <DropdownEntry
                     key={element.elementType}
                     caption={element.label}
                     icon={element.icon}
-                    beta={element.beta}
+                    beta={Boolean(element.flag)}
                     onClick={() => {
                       addElement(element);
                     }}

--- a/src/options/pages/marketplace/ActivateBody.tsx
+++ b/src/options/pages/marketplace/ActivateBody.tsx
@@ -29,18 +29,36 @@ import {
   faInfoCircle,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Card } from "react-bootstrap";
+import { Card, Alert } from "react-bootstrap";
 import useEnsurePermissions from "@/options/pages/marketplace/useEnsurePermissions";
 import PermissionsBody from "@/options/pages/marketplace/PermissionsBody";
 import { resolveRecipe } from "@/registry/internal";
 import extensionPointRegistry from "@/extensionPoints/registry";
-import { isMac } from "@/utils";
 import { useAsyncState } from "@/hooks/common";
 import { isEmpty } from "lodash";
-import { faChrome } from "@fortawesome/free-brands-svg-icons";
 import reportError from "@/telemetry/reportError";
 import { useSelector } from "react-redux";
 import { selectSettings } from "@/store/settingsSelectors";
+
+const QuickBarAlert = () => (
+  <Alert variant="warning">
+    <FontAwesomeIcon icon={faExclamationTriangle} /> This blueprint contains a
+    Quick Bar action, but you have not{" "}
+    <a
+      href="chrome://extensions/shortcuts"
+      onClick={(event) => {
+        event.preventDefault();
+        void browser.tabs.create({ url: event.currentTarget.href });
+      }}
+    >
+      <u>configured your Quick Bar shortcut</u>.
+    </a>{" "}
+    Learn more about{" "}
+    <a href="https://docs.pixiebrix.com/quick-bar-setup">
+      <u>configuring keyboard shortcuts</u>
+    </a>
+  </Alert>
+);
 
 const ActivateBody: React.FunctionComponent<{
   blueprint: RecipeDefinition;
@@ -86,41 +104,21 @@ const ActivateBody: React.FunctionComponent<{
     <>
       <Card.Body className="mb-0 p-3">
         <Card.Title>Review Permissions & Activate</Card.Title>
-        <p className="text-info">
-          <FontAwesomeIcon icon={faInfoCircle} /> You can de-activate bricks at
-          any time on the{" "}
-          <Link to={isBlueprintsPageEnabled ? "/blueprints" : "/installed"}>
-            <u className="text-nowrap">
-              <FontAwesomeIcon icon={faCubes} />{" "}
-              {isBlueprintsPageEnabled
-                ? "Blueprints page"
-                : "Active Bricks page"}
-            </u>
-          </Link>
-        </p>
-        {hasQuickBar && !hasShortcut && (
+
+        {hasQuickBar && !hasShortcut ? (
+          <QuickBarAlert />
+        ) : (
           <p className="text-info">
-            <FontAwesomeIcon icon={faExclamationTriangle} /> This blueprint
-            contains one or more Quick Bar extensions, but you have not
-            configured a Quick Bar shortcut in Chrome. Go to{" "}
-            <a
-              href="chrome://extensions/shortcuts"
-              onClick={(event) => {
-                event.preventDefault();
-                void browser.tabs.create({ url: event.currentTarget.href });
-              }}
-            >
-              <FontAwesomeIcon icon={faChrome} />
-              <u>chrome://extensions/shortcuts</u>
-            </a>{" "}
-            to configure a shortcut. For now, the default is{" "}
-            <kbd style={{ fontFamily: "system" }}>
-              {isMac() ? "⌘K" : "Ctrl+K"}
-            </kbd>
-            .{" "}
-            <a href="https://docs.pixiebrix.com/quick-bar-setup">
-              <u>Learn more about extension shortcuts.</u>
-            </a>
+            <FontAwesomeIcon icon={faInfoCircle} /> You can de-activate bricks
+            at any time on the{" "}
+            <Link to={isBlueprintsPageEnabled ? "/blueprints" : "/installed"}>
+              <u className="text-nowrap">
+                <FontAwesomeIcon icon={faCubes} />{" "}
+                {isBlueprintsPageEnabled
+                  ? "Blueprints page"
+                  : "Active Bricks page"}
+              </u>
+            </Link>
           </p>
         )}
       </Card.Body>


### PR DESCRIPTION
What does this PR do?
- Clarifies user messaging around quick bar activation
- There's no "default" shortcut. While KBar's hotkey works on pages PixieBrix has access to, it doesn't work on pages on which PixieBrix is not already active
- Removes the beta flag from the Quick Bar