### PR TITLE
Avoid duplicate `marked` import

### DIFF
--- a/src/components/formBuilder/DescriptionField.tsx
+++ b/src/components/formBuilder/DescriptionField.tsx
@@ -17,9 +17,9 @@
 
 import React from "react";
 import sanitize from "@/utils/sanitize";
-import { marked } from "marked";
 import { Field } from "@rjsf/core";
 import cx from "classnames";
+import { useAsyncState } from "@/hooks/common";
 
 type FormPreviewDescriptionFieldProps = {
   id: string;
@@ -31,21 +31,34 @@ type FormPreviewDescriptionFieldProps = {
 export const DescriptionField: React.VoidFunctionComponent<
   FormPreviewDescriptionFieldProps
 > = ({ id, description, className: classNameProp }) => {
+  const [content] = useAsyncState(
+    async () => {
+      if (typeof description === "string") {
+        const { marked } = await import(
+          /* webpackChunkName: "marked" */ "marked"
+        );
+        return (
+          <div
+            dangerouslySetInnerHTML={{
+              __html: sanitize(marked(description)),
+            }}
+          />
+        );
+      }
+
+      return description;
+    },
+    [],
+    ""
+  );
+
   if (!description) {
     return null;
   }
 
-  const className = cx("field-description", classNameProp);
-
-  return typeof description === "string" ? (
-    <div
-      id={id}
-      className={className}
-      dangerouslySetInnerHTML={{ __html: sanitize(marked(description)) }}
-    />
-  ) : (
-    <div id={id} className={className}>
-      {description}
+  return (
+    <div id={id} className={cx("field-description", classNameProp)}>
+      {content}
     </div>
   );
 };

--- a/src/components/formBuilder/DescriptionField.tsx
+++ b/src/components/formBuilder/DescriptionField.tsx
@@ -48,7 +48,7 @@ export const DescriptionField: React.VoidFunctionComponent<
 
       return description;
     },
-    [],
+    [description],
     ""
   );
 

--- a/src/components/formBuilder/DescriptionField.tsx
+++ b/src/components/formBuilder/DescriptionField.tsx
@@ -16,10 +16,10 @@
  */
 
 import React from "react";
-import sanitize from "@/utils/sanitize";
 import { Field } from "@rjsf/core";
 import cx from "classnames";
 import { useAsyncState } from "@/hooks/common";
+import safeMarkdown from "@/utils/safeMarkdown";
 
 type FormPreviewDescriptionFieldProps = {
   id: string;
@@ -34,13 +34,11 @@ export const DescriptionField: React.VoidFunctionComponent<
   const [content] = useAsyncState(
     async () => {
       if (typeof description === "string") {
-        const { marked } = await import(
-          /* webpackChunkName: "marked" */ "marked"
-        );
+        const markdown = await safeMarkdown(description);
         return (
           <div
             dangerouslySetInnerHTML={{
-              __html: sanitize(marked(description)),
+              __html: markdown,
             }}
           />
         );

--- a/src/components/formBuilder/FormPreview.test.tsx
+++ b/src/components/formBuilder/FormPreview.test.tsx
@@ -27,6 +27,7 @@ describe("FormPreview", () => {
   };
 
   testItRenders({
+    isAsync: true,
     testName: "it renders empty schema",
     Component: FormPreview,
     props: defaultProps,
@@ -62,6 +63,7 @@ describe("FormPreview", () => {
     };
 
     const options: ItRendersOptions<FormPreviewProps> = {
+      isAsync: true,
       testName: "it renders simple schema",
       Component: FormPreview,
       props,

--- a/src/components/formBuilder/FormPreview.test.tsx
+++ b/src/components/formBuilder/FormPreview.test.tsx
@@ -71,6 +71,7 @@ describe("FormPreview", () => {
   });
 
   testItRenders({
+    isAsync: true,
     testName: "it renders markdown in description",
     Component: FormPreview,
     props: {

--- a/src/components/formBuilder/__snapshots__/FormPreview.test.tsx.snap
+++ b/src/components/formBuilder/__snapshots__/FormPreview.test.tsx.snap
@@ -130,7 +130,15 @@ exports[`FormPreview it renders simple schema 1`] = `
       <div
         class="field-description"
         id="root-description"
-      />
+      >
+        <div>
+          <p>
+            A form example.
+          </p>
+          
+
+        </div>
+      </div>
       <div
         class="p-0 container-fluid"
       >

--- a/src/components/formBuilder/__snapshots__/FormPreview.test.tsx.snap
+++ b/src/components/formBuilder/__snapshots__/FormPreview.test.tsx.snap
@@ -33,13 +33,15 @@ exports[`FormPreview it renders markdown in description 1`] = `
         class="field-description"
         id="root-description"
       >
-        <p>
-          <em>
-            Form description
-          </em>
-        </p>
-        
+        <div>
+          <p>
+            <em>
+              Form description
+            </em>
+          </p>
+          
 
+        </div>
       </div>
       <div
         class="p-0 container-fluid"
@@ -80,19 +82,21 @@ exports[`FormPreview it renders markdown in description 1`] = `
                 class="field-description text-muted"
                 id="root_firstName"
               >
-                <p>
-                  <a
-                    href="https://example.com"
-                  >
-                    link
-                  </a>
-                   in 
-                  <strong>
-                    description
-                  </strong>
-                </p>
-                
+                <div>
+                  <p>
+                    <a
+                      href="https://example.com"
+                    >
+                      link
+                    </a>
+                     in 
+                    <strong>
+                      description
+                    </strong>
+                  </p>
+                  
 
+                </div>
               </div>
             </div>
           </div>
@@ -126,13 +130,7 @@ exports[`FormPreview it renders simple schema 1`] = `
       <div
         class="field-description"
         id="root-description"
-      >
-        <p>
-          A form example.
-        </p>
-        
-
-      </div>
+      />
       <div
         class="p-0 container-fluid"
       >

--- a/src/utils/safeMarkdown.ts
+++ b/src/utils/safeMarkdown.ts
@@ -15,32 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Renderer } from "@/types";
-import { propertiesToSchema } from "@/validators/generic";
-import { BlockArg, SafeHTML } from "@/core";
-import safeMarkdown from "@/utils/safeMarkdown";
+import { SafeHTML } from "@/core";
+import sanitize from "@/utils/sanitize";
 
-export class MarkdownRenderer extends Renderer {
-  constructor() {
-    super(
-      "@pixiebrix/markdown",
-      "Render Markdown",
-      "Render Markdown to sanitized HTML"
-    );
-  }
-
-  inputSchema = propertiesToSchema(
-    {
-      markdown: {
-        type: "string",
-        description: "The Markdown to render",
-        format: "markdown",
-      },
-    },
-    ["markdown"]
-  );
-
-  async render({ markdown }: BlockArg): Promise<SafeHTML> {
-    return safeMarkdown(markdown);
-  }
+async function safeMarkdown(markdown: string): Promise<SafeHTML> {
+  const { marked } = await import(/* webpackChunkName: "marked" */ "marked");
+  return sanitize(marked(markdown));
 }
+
+export default safeMarkdown;


### PR DESCRIPTION
This static import caused `marked` to appear in every bundle even though we already used `import()` elsewhere, essentially loading it twice in some cases.

Please ensure:

- I'm using useAsyncState correctly
- that the extra element is fine

PR test status: It appears to work in the Editor form preview’s description

![gif](https://user-images.githubusercontent.com/1402241/154829145-c49a06de-43b1-4f74-822f-b4a212170c7c.gif)

