### PR TITLE
#2789: Fix rollbar path transform

### DIFF
--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -96,6 +96,7 @@ async function initRollbar(): Promise<Rollbar> {
         for (const frame of payload.body.trace?.frames ?? []) {
           if (frame.filename && !frame.filename.startsWith("http")) {
             frame.filename = frame.filename.replace(
+              // Include the slash because location.origin does not have a trailing slash but the ENV does
               location.origin + "/",
               process.env.ROLLBAR_PUBLIC_PATH
             );

--- a/src/telemetry/rollbar.ts
+++ b/src/telemetry/rollbar.ts
@@ -96,7 +96,7 @@ async function initRollbar(): Promise<Rollbar> {
         for (const frame of payload.body.trace?.frames ?? []) {
           if (frame.filename && !frame.filename.startsWith("http")) {
             frame.filename = frame.filename.replace(
-              location.origin,
+              location.origin + "/",
               process.env.ROLLBAR_PUBLIC_PATH
             );
           }


### PR DESCRIPTION
- Fixes #2789

Warning: untested

The idea is that `location.origin` does not have a trailing slash while the ENV does. Since the ENV is also used elsewhere, I'd rather not change it.
