### PR TITLE
create auth slice

### DIFF
--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -17,7 +17,7 @@
 
 import React, { useEffect } from "react";
 import store, { hashHistory, persistor } from "./store";
-import { Provider, useSelector } from "react-redux";
+import { Provider, useDispatch, useSelector } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 import Loader from "@/components/Loader";
 import { Container } from "react-bootstrap";
@@ -57,6 +57,7 @@ import { SettingsState } from "@/store/settingsTypes";
 import BrowserBanner from "./pages/BrowserBanner";
 import useFlags from "@/hooks/useFlags";
 import { selectSettings } from "@/store/settingsSelectors";
+import { setAuth } from "@/store/authSlice";
 
 // Register the built-in bricks
 registerEditors();
@@ -84,15 +85,18 @@ const Layout = () => {
   // Get the latest brick definitions. Put it here in Layout instead of App to ensure the Redux store has been hydrated
   // by the time refresh is called.
   useRefresh();
+  const dispatch = useDispatch();
 
   const { permit } = useFlags();
   const { isBlueprintsPageEnabled } = useSelector(selectSettings);
 
-  const { isLoading } = useGetAuthQuery();
+  const { data, isLoading } = useGetAuthQuery();
 
   if (isLoading) {
     return <Loader />;
   }
+
+  dispatch(setAuth(data));
 
   return (
     <div>

--- a/src/options/pages/blueprints/BlueprintActions.tsx
+++ b/src/options/pages/blueprints/BlueprintActions.tsx
@@ -28,14 +28,14 @@ import {
 import React from "react";
 import useInstallableActions from "@/options/pages/blueprints/useInstallableActions";
 import { InstallableViewItem } from "./blueprintsTypes";
-import { useGetAuthQuery } from "@/services/api";
+import { selectAuth } from "@/store/authSelectors";
+import { useSelector } from "react-redux";
 
 const BlueprintActions: React.FunctionComponent<{
   installableViewItem: InstallableViewItem;
 }> = ({ installableViewItem }) => {
-  const {
-    data: { flags },
-  } = useGetAuthQuery();
+  const { flags } = useSelector(selectAuth);
+
   const { installable, hasUpdate, status, sharing } = installableViewItem;
   const {
     uninstall,

--- a/src/options/pages/blueprints/useInstallableActions.ts
+++ b/src/options/pages/blueprints/useInstallableActions.ts
@@ -25,7 +25,7 @@ import {
   isShared,
 } from "@/options/pages/blueprints/installableUtils";
 import { Installable } from "./blueprintsTypes";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { reportEvent } from "@/telemetry/events";
 import {
   reactivateEveryTab,
@@ -37,14 +37,12 @@ import { useCallback } from "react";
 import useNotifications from "@/hooks/useNotifications";
 import { push } from "connected-react-router";
 import { exportBlueprint as exportBlueprintYaml } from "@/options/pages/installed/exportBlueprint";
-import {
-  useDeleteCloudExtensionMutation,
-  useGetAuthQuery,
-} from "@/services/api";
+import { useDeleteCloudExtensionMutation } from "@/services/api";
 import extensionsSlice from "@/store/extensionsSlice";
 import useUserAction from "@/hooks/useUserAction";
 import { CancelError } from "@/errors";
 import { useModals } from "@/components/ConfirmationModal";
+import { selectAuth } from "@/store/authSelectors";
 
 const { removeExtension } = extensionsSlice.actions;
 
@@ -54,9 +52,7 @@ function useInstallableActions(installable: Installable) {
   const modals = useModals();
   const [deleteCloudExtension] = useDeleteCloudExtensionMutation();
 
-  const {
-    data: { scope },
-  } = useGetAuthQuery();
+  const { scope } = useSelector(selectAuth);
 
   const reinstall = () => {
     if (!isExtension(installable) || !installable._recipe) {

--- a/src/options/store.ts
+++ b/src/options/store.ts
@@ -45,6 +45,8 @@ import blueprintsSlice, {
 } from "./pages/blueprints/blueprintsSlice";
 import { logActions, logSlice } from "@/components/logViewer/logSlice";
 import { LogRootState } from "@/components/logViewer/logViewerTypes";
+import { AuthState } from "@/core";
+import authSlice from "@/store/authSlice";
 
 const REDUX_DEV_TOOLS: boolean = boolean(process.env.REDUX_DEV_TOOLS);
 
@@ -53,6 +55,7 @@ export const hashHistory = createHashHistory({ hashType: "slash" });
 export type RootState = LogRootState & {
   options: OptionsState;
   blueprints: BlueprintsState;
+  auth: AuthState;
   services: ServicesState;
   settings: SettingsState;
   workshop: WorkshopState;
@@ -87,6 +90,7 @@ const store = configureStore({
       persistBlueprintsConfig,
       blueprintsSlice.reducer
     ),
+    auth: authSlice.reducer,
     services: persistReducer(persistServicesConfig, servicesSlice.reducer),
     // XXX: settings and workshop use the same persistor config?
     settings: persistReducer(persistSettingsConfig, settingsSlice.reducer),

--- a/src/store/authSelectors.ts
+++ b/src/store/authSelectors.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { AuthState } from "@/core";
+
+type StateWithAuth = {
+  auth: AuthState;
+};
+
+export const selectAuth = ({ auth }: StateWithAuth) => auth;

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { createSlice } from "@reduxjs/toolkit";
+import { AuthState } from "@/core";
+
+const initialState: AuthState = {
+  isLoggedIn: false,
+  isOnboarded: false,
+  extension: false,
+  flags: [],
+};
+
+const authSlice = createSlice({
+  name: "auth",
+  initialState,
+  reducers: {
+    setAuth(state, { payload: auth }) {
+      console.log("inside setAuth:", auth);
+      state = auth;
+      return state;
+    },
+  },
+});
+
+export const { setAuth } = authSlice.actions;
+export default authSlice;


### PR DESCRIPTION
Closes #2823, part of #2759

This adds a Redux authSlice that stores data returned from useGetAuthQuery. Additionally, this refactors useGetAuthQuery in the blueprints page and blueprints hooks with useSelector.

This is a draft PR because I am sure I'm missing some considerations here. Feedback is appreciated.