### PR TITLE
#2718 Can't enter keys with periods into Object Entry in Page Editor

### DIFF
--- a/src/components/fields/schemaFields/widgets/ObjectWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/ObjectWidget.tsx
@@ -81,6 +81,7 @@ const ValuePropertyRow: React.FunctionComponent<PropertyRowProps> = ({
     [onRename]
   );
 
+  console.log("field name", field.name);
   const currentProperty = getFieldNamesFromPathString(field.name)[1];
 
   return (

--- a/src/components/fields/schemaFields/widgets/ObjectWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/ObjectWidget.tsx
@@ -23,7 +23,7 @@ import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import { isEmpty } from "lodash";
 import { useField, useFormikContext } from "formik";
 import { produce } from "immer";
-import { freshIdentifier } from "@/utils";
+import { freshIdentifier, joinName } from "@/utils";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { getFieldNamesFromPathString } from "@/runtime/pathHelpers";
 import { UnknownObject } from "@/types";
@@ -263,7 +263,7 @@ const ObjectWidget: React.FC<SchemaFieldProps> = (props) => {
             <ObjectFieldRow
               key={property}
               parentSchema={schema}
-              name={[field.name, property].join(".")}
+              name={joinName(field.name, property)}
               property={property}
               defined={Object.prototype.hasOwnProperty.call(
                 declaredProperties,

--- a/src/components/fields/schemaFields/widgets/ObjectWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/ObjectWidget.tsx
@@ -265,7 +265,7 @@ const ObjectWidget: React.FC<SchemaFieldProps> = (props) => {
               parentSchema={schema}
               name={
                 // Always use nesting even if property name is empty
-                property == null
+                property == null || property === ""
                   ? `${field.name}.`
                   : joinName(field.name, property)
               }

--- a/src/components/fields/schemaFields/widgets/ObjectWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/ObjectWidget.tsx
@@ -263,7 +263,12 @@ const ObjectWidget: React.FC<SchemaFieldProps> = (props) => {
             <ObjectFieldRow
               key={property}
               parentSchema={schema}
-              name={joinName(field.name, property)}
+              name={
+                // Always use nesting even if property name is empty
+                property == null
+                  ? `${field.name}.`
+                  : joinName(field.name, property)
+              }
               property={property}
               defined={Object.prototype.hasOwnProperty.call(
                 declaredProperties,

--- a/src/components/fields/schemaFields/widgets/ObjectWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/ObjectWidget.tsx
@@ -81,7 +81,6 @@ const ValuePropertyRow: React.FunctionComponent<PropertyRowProps> = ({
     [onRename]
   );
 
-  console.log("field name", field.name);
   const currentProperty = getFieldNamesFromPathString(field.name)[1];
 
   return (

--- a/src/contrib/zapier/PushOptions.tsx
+++ b/src/contrib/zapier/PushOptions.tsx
@@ -17,7 +17,6 @@
 
 import React, { useCallback, useMemo, useState } from "react";
 import { BlockOptionProps } from "@/components/fields/schemaFields/genericOptionsFactory";
-import { compact } from "lodash";
 import { Expression, Schema } from "@/core";
 import { useField } from "formik";
 import { useAsyncState } from "@/hooks/common";
@@ -37,6 +36,7 @@ import { makeLabelForSchemaField } from "@/components/fields/schemaFields/schema
 import { isExpression } from "@/runtime/mapArgs";
 import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 import FieldTemplate from "@/components/form/FieldTemplate";
+import { joinName } from "@/utils";
 
 function useHooks(): {
   hooks: Webhook[];
@@ -92,7 +92,7 @@ const PushOptions: React.FunctionComponent<BlockOptionProps> = ({
   name,
   configKey,
 }) => {
-  const basePath = compact([name, configKey]).join(".");
+  const basePath = joinName(name, configKey);
 
   const [grantedPermissions, setGrantedPermissions] = useState<boolean>(false);
   const [hasPermissions] = useAsyncState(

--- a/src/options/pages/activateExtension/ServicesCard.tsx
+++ b/src/options/pages/activateExtension/ServicesCard.tsx
@@ -25,6 +25,7 @@ import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import { Card, Table } from "react-bootstrap";
 import ServiceDescriptor from "@/options/pages/marketplace/ServiceDescriptor";
 import AuthWidget from "@/options/pages/marketplace/AuthWidget";
+import { joinName } from "@/utils";
 
 const ServicesCard: React.FunctionComponent<{ authOptions: AuthOption[] }> = ({
   authOptions,
@@ -70,7 +71,7 @@ const ServicesCard: React.FunctionComponent<{ authOptions: AuthOption[] }> = ({
                 <AuthWidget
                   authOptions={authOptions}
                   serviceId={dependency.id}
-                  name={[field.name, valueIndex, "config"].join(".")}
+                  name={joinName(field.name, String(valueIndex), "config")}
                 />
               </td>
             </tr>

--- a/src/options/pages/marketplace/ServicesBody.tsx
+++ b/src/options/pages/marketplace/ServicesBody.tsx
@@ -29,6 +29,7 @@ import { useField } from "formik";
 import { ServiceAuthPair } from "@/core";
 import { useAuthOptions } from "@/hooks/auth";
 import { useGetServicesQuery } from "@/services/api";
+import { joinName } from "@/utils";
 
 interface OwnProps {
   blueprint: RecipeDefinition;
@@ -97,7 +98,7 @@ const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
                   <AuthWidget
                     authOptions={authOptions}
                     serviceId={serviceId}
-                    name={[field.name, index, "config"].join(".")}
+                    name={joinName(field.name, String(index), "config")}
                     onRefresh={refreshAuthOptions}
                   />
                 </td>

--- a/src/runtime/pathHelpers.test.ts
+++ b/src/runtime/pathHelpers.test.ts
@@ -61,8 +61,8 @@ describe("getPropByPath", () => {
       '["foo.bar"].baz',
       "qux",
     ],
-  ])("can get property accessed by []", (ctx, path, expected) => {
-    expect(getPropByPath(ctx, path)).toBe(expected);
+  ])("can get property accessed by []", (context, path, expected) => {
+    expect(getPropByPath(context, path)).toBe(expected);
   });
 });
 

--- a/src/runtime/pathHelpers.test.ts
+++ b/src/runtime/pathHelpers.test.ts
@@ -86,4 +86,11 @@ describe("getFieldNamesFromPathString", () => {
       "baz",
     ]);
   });
+
+  test("path with periods", () => {
+    expect(getFieldNamesFromPathString("foo['bar.baz']")).toStrictEqual([
+      "foo",
+      "bar.baz",
+    ]);
+  });
 });

--- a/src/runtime/pathHelpers.test.ts
+++ b/src/runtime/pathHelpers.test.ts
@@ -41,6 +41,29 @@ describe("getPropByPath", () => {
       getPropByPath({ array: [{ key: "foo" }] }, "array.1?.key")
     ).toBeNull();
   });
+
+  test.each([
+    [
+      {
+        foo: {
+          "bar.baz": "qux",
+        },
+      },
+      'foo["bar.baz"]',
+      "qux",
+    ],
+    [
+      {
+        "foo.bar": {
+          baz: "qux",
+        },
+      },
+      '["foo.bar"].baz',
+      "qux",
+    ],
+  ])("can get property accessed by []", (ctx, path, expected) => {
+    expect(getPropByPath(ctx, path)).toBe(expected);
+  });
 });
 
 describe("isSimplePath", () => {

--- a/src/runtime/pathHelpers.test.ts
+++ b/src/runtime/pathHelpers.test.ts
@@ -87,10 +87,12 @@ describe("getFieldNamesFromPathString", () => {
     ]);
   });
 
-  test("path with periods", () => {
-    expect(getFieldNamesFromPathString("foo['bar.baz']")).toStrictEqual([
-      "foo",
-      "bar.baz",
-    ]);
+  test.each([
+    ['foo["bar.baz"]', ["foo", "bar.baz"]],
+    ['foo.bar["baz.qux"]', ["foo.bar", "baz.qux"]],
+    ['foo["bar.baz"].qux', ['foo["bar.baz"]', "qux"]],
+    ['foo["bar.baz"].qux.quux', ['foo["bar.baz"].qux', "quux"]],
+  ])("path with periods", (name, expected) => {
+    expect(getFieldNamesFromPathString(name)).toStrictEqual(expected);
   });
 });

--- a/src/runtime/pathHelpers.ts
+++ b/src/runtime/pathHelpers.ts
@@ -85,7 +85,7 @@ export function getPropByPath(
   const { toJS = noopProxy.toJS, get = noopProxy.get } = proxy;
 
   let value: unknown = obj;
-  const rawParts = path.trim().split(".");
+  const rawParts = toPath(path.trim());
 
   for (const [index, rawPart] of rawParts.entries()) {
     const previous = value;

--- a/src/runtime/pathHelpers.ts
+++ b/src/runtime/pathHelpers.ts
@@ -137,10 +137,6 @@ export function getFieldNamesFromPathString(
   name: string
 ): [parentFieldName: string | undefined, fieldName: string] {
   const path = toPath(name);
-  console.log("getFieldNamesFromPathString", {
-    path,
-    name,
-  });
   const fieldName = path.pop();
   const parentFieldName = path.length > 0 ? path.join(".") : undefined;
   return [parentFieldName, fieldName];

--- a/src/runtime/pathHelpers.ts
+++ b/src/runtime/pathHelpers.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { identity } from "lodash";
+import { identity, toPath } from "lodash";
 import { getErrorMessage } from "@/errors";
 import { cleanValue, InvalidPathError, isObject } from "@/utils";
 import { UnknownObject } from "@/types";
@@ -136,11 +136,12 @@ export function getPropByPath(
 export function getFieldNamesFromPathString(
   name: string
 ): [parentFieldName: string | undefined, fieldName: string] {
-  const fieldName = name.includes(".")
-    ? name.slice(name.lastIndexOf(".") + 1)
-    : name;
-  const parentFieldName = name.includes(".")
-    ? name.slice(0, name.lastIndexOf("."))
-    : undefined;
+  const path = toPath(name);
+  console.log("getFieldNamesFromPathString", {
+    path,
+    name,
+  });
+  const fieldName = path.pop();
+  const parentFieldName = path.length > 0 ? path.join(".") : undefined;
   return [parentFieldName, fieldName];
 }

--- a/src/runtime/pathHelpers.ts
+++ b/src/runtime/pathHelpers.ts
@@ -17,7 +17,7 @@
 
 import { identity, toPath } from "lodash";
 import { getErrorMessage } from "@/errors";
-import { cleanValue, InvalidPathError, isObject } from "@/utils";
+import { cleanValue, InvalidPathError, isObject, joinName } from "@/utils";
 import { UnknownObject } from "@/types";
 
 // First part of the path can be global context with a @
@@ -138,6 +138,6 @@ export function getFieldNamesFromPathString(
 ): [parentFieldName: string | undefined, fieldName: string] {
   const path = toPath(name);
   const fieldName = path.pop();
-  const parentFieldName = path.length > 0 ? path.join(".") : undefined;
+  const parentFieldName = path.length > 0 ? joinName(null, ...path) : undefined;
   return [parentFieldName, fieldName];
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -82,6 +82,14 @@ describe("joinName", () => {
     expect(joinName(null, "foo")).toBe("foo");
     expect(joinName(undefined, "foo")).toBe("foo");
   });
+
+  test.each([
+    [["bar.baz"], 'foo["bar.baz"]'],
+    [["bar", "baz.qux"], 'foo.bar["baz.qux"]'],
+    [["bar.baz", "qux"], 'foo["bar.baz"].qux'],
+  ])("accepts periods in path parts (%s)", (pathParts, expected) => {
+    expect(joinName("foo", ...pathParts)).toBe(expected);
+  });
 });
 
 describe("matchesAnyPattern", () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -90,6 +90,13 @@ describe("joinName", () => {
   ])("accepts periods in path parts (%s)", (pathParts, expected) => {
     expect(joinName("foo", ...pathParts)).toBe(expected);
   });
+  test.each([
+    [["bar[baz"], 'foo["bar[baz"]'],
+    [["bar", "[baz]qux"], 'foo.bar["[baz]qux"]'],
+    [["bar[]baz", "qux"], 'foo["bar[]baz"].qux'],
+  ])("accepts square brackets in path parts (%s)", (pathParts, expected) => {
+    expect(joinName("foo", ...pathParts)).toBe(expected);
+  });
 });
 
 describe("matchesAnyPattern", () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -74,10 +74,6 @@ describe("joinName", () => {
     expect(joinName("foo", null, "bar")).toBe("foo.bar");
   });
 
-  test("rejects path part with period", () => {
-    expect(() => joinName("foo", "bar.baz")).toThrow("cannot contain periods");
-  });
-
   test("accepts base path part with period", () => {
     expect(joinName("foo.bar", "baz")).toBe("foo.bar.baz");
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,6 +42,8 @@ import { Primitive } from "type-fest";
 import { ApiVersion, SafeString } from "@/core";
 import { UnknownObject } from "@/types";
 
+const specialCharsRegex = /[.[\]]/;
+
 /**
  * Create a Formik field name, validating the individual path parts.
  * @param baseFieldName The base field name
@@ -62,7 +64,7 @@ export function joinName(
 
   let path = baseFieldName || "";
   for (const fieldName of fieldNames) {
-    if (fieldName.includes(".")) {
+    if (specialCharsRegex.test(fieldName)) {
       path += `["${fieldName}"]`;
     } else if (path === "") {
       path = fieldName;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,7 +63,7 @@ export function joinName(
   let path = baseFieldName || "";
   for (const fieldName of fieldNames) {
     if (fieldName.includes(".")) {
-      path += `[${fieldName}]`;
+      path += `["${fieldName}"]`;
     } else if (path === "") {
       path = fieldName;
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,11 +60,18 @@ export function joinName(
     );
   }
 
-  if (fieldNames.some((x) => x.includes("."))) {
-    throw new Error("Formik path parts cannot contain periods");
+  let path = baseFieldName || "";
+  for (const fieldName of fieldNames) {
+    if (fieldName.includes(".")) {
+      path += `[${fieldName}]`;
+    } else if (path === "") {
+      path = fieldName;
+    } else {
+      path += `.${fieldName}`;
+    }
   }
 
-  return compact([baseFieldName, ...fieldNames]).join(".");
+  return path;
 }
 
 export function mostCommonElement<T>(items: T[]): T {


### PR DESCRIPTION
Closes #2718 

Property keys support periods.
It is possible to set a variable with a property with a period (`@elements["a.b"]`), but this means we will not be able to use square brackets.

<img width="898" alt="Screen Shot 2022-02-24 at 10 10 14 PM" src="https://user-images.githubusercontent.com/3116723/155609586-c48b94bc-ab0b-42ac-9cf8-7c058ca9f2ce.png">


- [x] Support for periods in var fields
- [x] Test with API and Mapper
