### PR TITLE
Unfreezing the service schema

### DIFF
--- a/src/options/pages/services/ServiceEditorModal.tsx
+++ b/src/options/pages/services/ServiceEditorModal.tsx
@@ -108,7 +108,8 @@ const ServiceEditorModal: React.FunctionComponent<OwnProps> = ({
     }
 
     try {
-      return buildYup(schema, {});
+      // The dereferenced schema is frozen, buildYup can mutate it, so we need to "unfreeze" the schema
+      return buildYup(cloneDeep(schema), {});
     } catch (error) {
       console.error("Error building Yup validator from JSON Schema");
       reportError(error);

--- a/src/validators/generic.ts
+++ b/src/validators/generic.ts
@@ -233,8 +233,6 @@ export function useExtensionValidator(
   return useAsyncState(validationPromise);
 }
 
-// Const PIXIEBRIX_SCHEMA = /^https:\/\/app.pixiebrix\.com\/schemas\//i;
-
 const pixieResolver: ResolverOptions = {
   order: 1,
   canRead: /^https?:\/\//i,


### PR DESCRIPTION
`ServiceEditorModal`, `buildYup` fails with an error.

![image](https://user-images.githubusercontent.com/3116723/155785087-9b23dd9f-ba43-475a-830c-5b61867aff39.png)

1. The error started to appear after update of `schema-to-yup` #2732 
2. Before the update `buildYup` failed silently and validation schema was only partially built. For Automation Anywhere Control Room it had `required = true` for label but not for the config properties (like `username`).
3. Problem is that `buildYup` tries to "normalize" the required properties, i.e. sets the required attribute on a property itself rather than have it in the required array ([here](https://github.com/kristianmandrup/schema-to-yup/blob/master/src/yup-builder.js#L94)). I'm not sure why, but the schema produced by `$RefParser.dereference` is "frozen" and `buildYup` can't set the property required on `username`