### PR TITLE
#2817: Unify source upload + notify Rollbar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
   build-stage:
     runs-on: ubuntu-latest
     env:
-      # Uploads sourcemaps to S3, if it's a public release
-      SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}
+      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com/sourcemaps/${{ github.job }}/${{ github.sha }}/
 
     steps:
       - uses: actions/checkout@v2
@@ -71,7 +70,7 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
-      - run: npm run upload:sourcemaps
+      - run: bash scripts/upload-sourcemaps.sh
         if: ${{ fromJSON(env.PUBLIC_RELEASE)}}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SOURCEMAP_USER_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
   build-stage:
     runs-on: ubuntu-latest
     env:
-      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com/sourcemaps/${{ github.job }}/${{ github.sha }}/
+      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com
+      SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -30,7 +30,7 @@ jobs:
           ROLLBAR_POST_SERVER_ITEM_TOKEN: ${{ secrets.ROLLBAR_POST_SERVER_ITEM_TOKEN }}
           CHROME_MANIFEST_KEY: ${{ secrets.CHROME_MANIFEST_PROD_PUBLIC_KEY }}
 
-      - run: npm run upload:extension
+      - run: bash scripts/upload-extension.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SOURCEMAP_USER_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SOURCEMAP_USER_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
   build-for-store:
     runs-on: ubuntu-latest
     env:
-      SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}
+      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com/sourcemaps/${{ github.job }}/${{ github.sha }}/
 
     steps:
       - uses: actions/checkout@v2
@@ -30,11 +30,12 @@ jobs:
           ROLLBAR_BROWSER_ACCESS_TOKEN: ${{ secrets.ROLLBAR_BROWSER_ACCESS_TOKEN }}
           ROLLBAR_POST_SERVER_ITEM_TOKEN: ${{ secrets.ROLLBAR_POST_SERVER_ITEM_TOKEN }}
 
-      - run: npm run upload:sourcemaps
+      - run: bash scripts/upload-sourcemaps.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SOURCEMAP_USER_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SOURCEMAP_USER_KEY }}
           AWS_DEFAULT_REGION: "us-east-2"
+          ROLLBAR_BROWSER_ACCESS_TOKEN: ${{ secrets.ROLLBAR_BROWSER_ACCESS_TOKEN }}
       - name: Save extension
         uses: ./.github/actions/upload-zipped-artifact
         with:
@@ -46,7 +47,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}
+      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com/sourcemaps/${{ github.job }}/${{ github.sha }}/
 
     steps:
       - uses: actions/checkout@v2
@@ -63,11 +64,12 @@ jobs:
           ROLLBAR_BROWSER_ACCESS_TOKEN: ${{ secrets.ROLLBAR_BROWSER_ACCESS_TOKEN }}
           ROLLBAR_POST_SERVER_ITEM_TOKEN: ${{ secrets.ROLLBAR_POST_SERVER_ITEM_TOKEN }}
           CHROME_MANIFEST_KEY: ${{ secrets.CHROME_MANIFEST_PROD_PUBLIC_KEY }}
-      - run: npm run upload:sourcemaps
+      - run: bash scripts/upload-sourcemaps.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SOURCEMAP_USER_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SOURCEMAP_USER_KEY }}
           AWS_DEFAULT_REGION: "us-east-2"
+          ROLLBAR_BROWSER_ACCESS_TOKEN: ${{ secrets.ROLLBAR_BROWSER_ACCESS_TOKEN }}
       - name: Save extension
         uses: ./.github/actions/upload-zipped-artifact
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,8 @@ jobs:
   build-for-store:
     runs-on: ubuntu-latest
     env:
-      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com/sourcemaps/${{ github.job }}/${{ github.sha }}/
+      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com/
+      SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}
 
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +48,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com/sourcemaps/${{ github.job }}/${{ github.sha }}/
+      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com/
+      SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
   build-for-store:
     runs-on: ubuntu-latest
     env:
-      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com/
+      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com
       SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}
 
     steps:
@@ -48,7 +48,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com/
+      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com
       SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}
 
     steps:

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "build:webpack": "NODE_OPTIONS=--max_old_space_size=8192 webpack --mode production",
     "build:typescript": "tsc --noEmit",
     "build:scripts": "webpack --config scripts/webpack.scripts.js",
-    "upload:sourcemaps": "aws s3 cp ./dist s3://pixiebrix-extension-source-maps/$SOURCE_MAP_PATH --exclude '*' --include '*.map' --include '*.js' --recursive --no-progress",
-    "upload:extension": "zip -r $BUILD_FILENAME dist -x '*.map' && aws s3 cp $BUILD_FILENAME s3://pixiebrix-extension-builds/$BUILD_PATH --no-progress",
     "generate:headers": "NODE_OPTIONS=--stack-trace-limit=100 node scripts/bin/headers.js",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/scripts/upload-extension.sh
+++ b/scripts/upload-extension.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Automatically exit on error
+set -e
+
 # Ensure ENVs are set https://stackoverflow.com/a/307735/288906
 : "${BUILD_PATH?Need to set BUILD_PATH}"
 : "${BUILD_FILENAME?Need to set BUILD_FILENAME}"

--- a/scripts/upload-extension.sh
+++ b/scripts/upload-extension.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Ensure ENVs are set https://stackoverflow.com/a/307735/288906
+: "${BUILD_PATH?Need to set BUILD_PATH}"
+: "${BUILD_FILENAME?Need to set BUILD_FILENAME}"
+
+: "${AWS_ACCESS_KEY_ID?Need to set AWS_ACCESS_KEY_ID}"
+: "${AWS_SECRET_ACCESS_KEY?Need to set AWS_SECRET_ACCESS_KEY}"
+: "${AWS_DEFAULT_REGION?Need to set AWS_DEFAULT_REGION}"
+
+zip -r "$BUILD_FILENAME" dist -x '*.map'
+aws s3 cp "$BUILD_FILENAME" "s3://pixiebrix-extension-builds/$BUILD_PATH" --no-progress

--- a/scripts/upload-sourcemaps.sh
+++ b/scripts/upload-sourcemaps.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 
 # Ensure ENVs are set https://stackoverflow.com/a/307735/288906
-: "${GITHUB_JOB?Need to set GITHUB_JOB}"
-: "${GITHUB_SHA?Need to set GITHUB_SHA}"
-
+: "${SOURCE_MAP_PATH?Need to set SOURCE_MAP_PATH}"
 : "${SOURCE_MAP_URL_BASE?Need to set SOURCE_MAP_URL_BASE}"
 : "${ROLLBAR_BROWSER_ACCESS_TOKEN?Need to set ROLLBAR_BROWSER_ACCESS_TOKEN}"
 
@@ -12,7 +10,7 @@
 : "${AWS_DEFAULT_REGION?Need to set AWS_DEFAULT_REGION}"
 
 SOURCE_VERSION=$(git rev-parse --short HEAD)
-S3_UPLOAD_BASE_URL="s3://pixiebrix-extension-source-maps/sourcemaps/$GITHUB_JOB/$GITHUB_SHA"
+S3_UPLOAD_BASE_URL="s3://pixiebrix-extension-source-maps/$SOURCE_MAP_PATH"
 
 aws s3 cp ./dist "$S3_UPLOAD_BASE_URL" --exclude '*' --include '*.map' --include '*.js' --recursive --no-progress
 
@@ -22,4 +20,4 @@ aws s3 cp ./dist "$S3_UPLOAD_BASE_URL" --exclude '*' --include '*.map' --include
 find dist -name '*.js' | parallel curl https://api.rollbar.com/api/1/sourcemap/download \
 	-F version="$SOURCE_VERSION" \
 	-F access_token="$ROLLBAR_BROWSER_ACCESS_TOKEN" \
-	-F minified_url="$SOURCE_MAP_URL_BASE"/{}
+	-F minified_url="$SOURCE_MAP_URL_BASE/$SOURCE_MAP_PATH/"{}

--- a/scripts/upload-sourcemaps.sh
+++ b/scripts/upload-sourcemaps.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Ensure ENVs are set https://stackoverflow.com/a/307735/288906
+: "${GITHUB_JOB?Need to set GITHUB_JOB}"
+: "${GITHUB_SHA?Need to set GITHUB_SHA}"
+
+: "${SOURCE_MAP_URL_BASE?Need to set SOURCE_MAP_URL_BASE}"
+: "${ROLLBAR_BROWSER_ACCESS_TOKEN?Need to set ROLLBAR_BROWSER_ACCESS_TOKEN}"
+
+: "${AWS_ACCESS_KEY_ID?Need to set AWS_ACCESS_KEY_ID}"
+: "${AWS_SECRET_ACCESS_KEY?Need to set AWS_SECRET_ACCESS_KEY}"
+: "${AWS_DEFAULT_REGION?Need to set AWS_DEFAULT_REGION}"
+
+SOURCE_VERSION=$(git rev-parse --short HEAD)
+S3_UPLOAD_BASE_URL="s3://pixiebrix-extension-source-maps/sourcemaps/$GITHUB_JOB/$GITHUB_SHA"
+
+aws s3 cp ./dist "$S3_UPLOAD_BASE_URL" --exclude '*' --include '*.map' --include '*.js' --recursive --no-progress
+
+# Notify Rollbar to trigger a download for each of the minified files.
+# https://docs.rollbar.com/docs/source-maps#3-upload-your-source-map-files
+# Parallel automatically limits concurrency and curl automatically retries.
+find dist -name '*.js' | parallel curl https://api.rollbar.com/api/1/sourcemap/download \
+	-F version="$SOURCE_VERSION" \
+	-F access_token="$ROLLBAR_BROWSER_ACCESS_TOKEN" \
+	-F minified_url="$SOURCE_MAP_URL_BASE"/{}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,7 +89,8 @@ const produceSourcemap =
   !parseEnv(process.env.CI) || parseEnv(process.env.PUBLIC_RELEASE);
 
 const sourceMapPublicUrl =
-  parseEnv(process.env.PUBLIC_RELEASE) && process.env.SOURCE_MAP_URL_BASE;
+  parseEnv(process.env.PUBLIC_RELEASE) &&
+  `${process.env.SOURCE_MAP_URL_BASE}/${process.env.SOURCE_MAP_PATH}/`;
 console.log(
   "Sourcemaps:",
   sourceMapPublicUrl ? sourceMapPublicUrl : produceSourcemap ? "Local" : "No"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,8 +89,7 @@ const produceSourcemap =
   !parseEnv(process.env.CI) || parseEnv(process.env.PUBLIC_RELEASE);
 
 const sourceMapPublicUrl =
-  parseEnv(process.env.PUBLIC_RELEASE) &&
-  `https://pixiebrix-extension-source-maps.s3.amazonaws.com/${process.env.SOURCE_MAP_PATH}/`;
+  parseEnv(process.env.PUBLIC_RELEASE) && process.env.SOURCE_MAP_URL_BASE;
 console.log(
   "Sourcemaps:",
   sourceMapPublicUrl ? sourceMapPublicUrl : produceSourcemap ? "Local" : "No"
@@ -336,7 +335,7 @@ module.exports = (env, options) =>
         NPM_PACKAGE_VERSION: process.env.npm_package_version,
         ENVIRONMENT: process.env.ENVIRONMENT ?? options.mode,
         WEBEXT_MESSENGER_LOGGING: "false",
-        ROLLBAR_PUBLIC_PATH: sourceMapPublicUrl ?? "extension://dynamichost",
+        ROLLBAR_PUBLIC_PATH: sourceMapPublicUrl ?? "extension://dynamichost/",
 
         // If not found, "undefined" will cause the build to fail
         SERVICE_URL: undefined,


### PR DESCRIPTION
- Closes #2817 

Notable changes:

- I extracted the 2 the upload scripts to separate files to ensure readability (and IDE ShellCheck analysis)
- I extracted the SOURCE_MAP_URL_BASE creation to the CI workflow because it's used by both Webpack and the uploader
- I appended the Rollbar notification right after the sourcemap upload, which [should work](https://aws.amazon.com/about-aws/whats-new/2020/12/amazon-s3-now-delivers-strong-read-after-write-consistency-automatically-for-all-applications/)
