### PR TITLE
Minor `reportError` cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,7 @@
         "uuid": "^8.3.2",
         "webext-additional-permissions": "^2.3.0",
         "webext-content-scripts": "^1.0.1",
-        "webext-detect-page": "^4.0.0",
+        "webext-detect-page": "^4.0.1",
         "webext-dynamic-content-scripts": "^8.0.1",
         "webext-messenger": "^0.17.1",
         "webext-patterns": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "uuid": "^8.3.2",
     "webext-additional-permissions": "^2.3.0",
     "webext-content-scripts": "^1.0.1",
-    "webext-detect-page": "^4.0.0",
+    "webext-detect-page": "^4.0.1",
     "webext-dynamic-content-scripts": "^8.0.1",
     "webext-messenger": "^0.17.1",
     "webext-patterns": "^1.1.1",

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -261,7 +261,7 @@ let loggedDNT = false;
 export async function recordError(
   error: SerializedError,
   context: MessageContext,
-  data: JsonObject | undefined
+  data?: JsonObject
 ): Promise<void> {
   forbidContext(
     "contentScript",

--- a/src/core.ts
+++ b/src/core.ts
@@ -28,6 +28,7 @@ import type { Permissions } from "webextension-polyfill";
 import type React from "react";
 
 import { pick } from "lodash";
+import { contextNames } from "webext-detect-page";
 
 // Use our own name in the project so we can re-map/adjust the typing as necessary
 export type Schema = JSONSchema7;
@@ -188,14 +189,7 @@ export interface Message<
 }
 
 // `ContextName`s from webext-detect-page
-export type ContextName =
-  | "contentScript"
-  | "background"
-  | "options"
-  | "devToolsPage"
-  | "extension"
-  | "web"
-  | "unknown";
+export type ContextName = keyof typeof contextNames | "unknown";
 
 /**
  * Log event metadata for the extensions internal logging infrastructure.

--- a/src/telemetry/reportError.ts
+++ b/src/telemetry/reportError.ts
@@ -32,37 +32,30 @@ expectContext(
  * @param error the error object
  * @param context optional context for error telemetry
  */
-function reportError(error: unknown, context?: MessageContext): void {
-  // Add on the reporter side of the message. On the receiving side it would always be `background`
-  const extendedContext: MessageContext = {
-    ...context,
-    pageName: getContextName(),
-  };
+function reportError(
+  error: unknown, // It might also be an ErrorEvent
+  context?: MessageContext,
+  { logToConsole = true } = {}
+): void {
+  if (logToConsole) {
+    console.error(error);
+  }
 
-  void _reportError(error, extendedContext).catch((reportingError) => {
+  try {
+    recordError(serializeError(selectError(error)), {
+      ...context,
+      // Add on the reporter side of the message. On the receiving side it would always be `background`
+      pageName: getContextName(),
+    });
+  } catch (reportingError) {
+    // The messenger does not throw async errors on "notifiers" but if this is
+    // called in the background the call will be executed directly and it could
+    // theoretically throw a synchronous error
     console.error("An error occurred when reporting an error", {
       originalError: error,
       reportingError,
     });
-  });
-}
-
-// Extracted async function to avoid turning `reportError` into an async function
-// which would trigger `eslint/no-floating-promises` at every `reportError` call
-async function _reportError(
-  error: unknown, // It might also be an ErrorEvent
-  context?: MessageContext
-): Promise<void> {
-  const errorObject = selectError(error);
-
-  // Events are already natively logged to the console by the browser
-  if (
-    !(error instanceof ErrorEvent || error instanceof PromiseRejectionEvent)
-  ) {
-    console.error(error);
   }
-
-  recordError(serializeError(errorObject), context, null);
 }
 
 export default reportError;

--- a/src/telemetry/reportUncaughtErrors.ts
+++ b/src/telemetry/reportUncaughtErrors.ts
@@ -39,7 +39,8 @@ function defaultErrorHandler(
     }
   }
 
-  reportError(errorEvent);
+  // The browser already shows uncaught errors in the console
+  reportError(errorEvent, undefined, { logToConsole: false });
 }
 
 /**


### PR DESCRIPTION
Changes:

- drop unnecessary `_reportError` wrapper (we no longer have any async calls in there) — this also re-unifies the logic that was currently half in the wrapper and half in the regular `reportError`
- replace inline `ErrorEvent` exclusion logic with explicit setting (this makes `reportUncaughtErrors`’s self-contained)