### PR TITLE
Fix Blueprints page shrinking with long items

### DIFF
--- a/src/options/pages/blueprints/listView/ListItem.module.scss
+++ b/src/options/pages/blueprints/listView/ListItem.module.scss
@@ -61,4 +61,5 @@
 .status {
   text-align: center;
   flex-basis: 150px;
+  flex-shrink: 0;
 }

--- a/src/options/pages/blueprints/listView/ListItem.tsx
+++ b/src/options/pages/blueprints/listView/ListItem.tsx
@@ -37,7 +37,7 @@ const ListItem: React.VoidFunctionComponent<{
       <div className={styles.name}>
         <h5>{name}</h5>
       </div>
-      <div>
+      <div className="flex-shrink-0">
         <div className={styles.sharing}>
           <span className={styles.updatedAt}>
             Updated: {timeSince(updatedAt)}
@@ -48,7 +48,7 @@ const ListItem: React.VoidFunctionComponent<{
       <div className={styles.status}>
         <Status installableViewItem={installableItem} />
       </div>
-      <div>
+      <div className="flex-shrink-0">
         <BlueprintActions installableViewItem={installableItem} />
       </div>
     </ListGroup.Item>


### PR DESCRIPTION

## Before
<img width="630" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/156114874-8e9238ac-c725-452d-b2a2-5863b028e320.png">
## After 

<img width="630" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/156114857-8a341eb2-8b52-4c8e-be94-e71f02eb69f5.png">
