### PR TITLE
Fix Loader usage and subtle margin-collapsing bug

### DIFF
--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -19,7 +19,8 @@ import React from "react";
 import GridLoader from "react-spinners/GridLoader";
 
 const DEFAULT_STYLE = {
-  margin: "20px auto", // Centet
+  margin: "auto", // Center
+  padding: "20px",
   display: "flex",
   justifyContent: "center",
 };

--- a/src/options/pages/blueprints/BlueprintsPage.tsx
+++ b/src/options/pages/blueprints/BlueprintsPage.tsx
@@ -32,7 +32,7 @@ import {
 import ShareExtensionModal from "@/options/pages/installed/ShareExtensionModal";
 import ShareLinkModal from "@/options/pages/installed/ShareLinkModal";
 import { useTitle } from "@/hooks/title";
-import GridLoader from "react-spinners/GridLoader";
+import Loader from "@/components/Loader";
 import { ErrorDisplay } from "@/layout/Page";
 
 const BlueprintsPage: React.FunctionComponent = () => {
@@ -47,7 +47,7 @@ const BlueprintsPage: React.FunctionComponent = () => {
 
   const body = useMemo(() => {
     if (isLoading) {
-      return <GridLoader />;
+      return <Loader />;
     }
 
     if (error) {


### PR DESCRIPTION
I noticed a very subtle bug due to [margin collapsing](https://stackoverflow.com/q/7742720/288906).

## Before

1. Notice the unnecessary scrollbar that briefly appears during the first loader. This appears regardless of the window height and probably causes similar issues elsewhere.
2. Notice the second loader on the left instead of being centered

https://user-images.githubusercontent.com/1402241/156134853-fa8e958f-c48d-46e8-8a40-f4c936848d55.mov



## After

https://user-images.githubusercontent.com/1402241/156134843-aa29c283-7340-4e6f-81e4-385470d8c1e9.mov


