### PR TITLE
#2822: Show `SelectorSelector` suggestions even if the field is empty

### DIFF
--- a/src/devTools/editor/fields/creatableAutosuggest/CreatableAutosuggest.tsx
+++ b/src/devTools/editor/fields/creatableAutosuggest/CreatableAutosuggest.tsx
@@ -225,6 +225,8 @@ const CreatableAutosuggest = <SuggestionType extends SuggestionTypeBase>({
 
   return (
     <Autosuggest
+      // Always show when the field is focused #2822
+      shouldRenderSuggestions={() => true}
       suggestions={currentSuggestions}
       focusInputOnSuggestionClick
       getSuggestionValue={getSuggestionValue}


### PR DESCRIPTION
- Closes #2822

Updated behavior:

- Shows suggestions on `focus`, regardless of field content _(new)_
- Hides suggestions when one selection is picked (unchanged)
- Shows suggestions again when the content is modified (unchanged)

![gif](https://user-images.githubusercontent.com/1402241/156194707-ea73024f-fecf-464e-a32e-d9c97d9e1b27.gif)

