### PR TITLE
change Installable extension type narrowing to `extensionPointId`

### DIFF
--- a/src/options/pages/blueprints/installableUtils.ts
+++ b/src/options/pages/blueprints/installableUtils.ts
@@ -68,7 +68,7 @@ export const getSharingType = (
 
 export const isExtension = (
   installable: Installable
-): installable is ResolvedExtension => "_recipe" in installable;
+): installable is ResolvedExtension => "extensionPointId" in installable;
 
 export const isExtensionFromRecipe = (installable: Installable) =>
   isExtension(installable) && Boolean(installable._recipe);
@@ -173,10 +173,9 @@ export const getOrganization = (
   installable: Installable,
   organizations: Organization[]
 ) => {
-  const sharing =
-    "_recipe" in installable
-      ? installable._recipe?.sharing
-      : installable.sharing;
+  const sharing = isExtension(installable)
+    ? installable._recipe?.sharing
+    : installable.sharing;
 
   if (!sharing || sharing.organizations.length === 0) {
     return null;

--- a/src/options/pages/blueprints/useInstallableViewItems.tsx
+++ b/src/options/pages/blueprints/useInstallableViewItems.tsx
@@ -22,8 +22,8 @@ import {
 import React, { useCallback, useMemo } from "react";
 import { useSelector } from "react-redux";
 import { selectExtensions } from "@/store/extensionsSelectors";
-import { ResolvedExtension, UUID } from "@/core";
-import { RecipeDefinition } from "@/types/definitions";
+import { UUID } from "@/core";
+
 import {
   getDescription,
   getLabel,
@@ -66,12 +66,12 @@ function useInstallableViewItems(
   );
 
   const isActive = useCallback(
-    (extensionOrRecipe: RecipeDefinition | ResolvedExtension) => {
-      if ("_recipe" in extensionOrRecipe) {
-        return installedExtensionIds.has(extensionOrRecipe.id);
+    (installable: Installable) => {
+      if (isExtension(installable)) {
+        return installedExtensionIds.has(installable.id);
       }
 
-      return installedRecipeIds.has(extensionOrRecipe.metadata.id);
+      return installedRecipeIds.has(installable.metadata.id);
     },
     [installedExtensionIds, installedRecipeIds]
   );


### PR DESCRIPTION
Originally, type narrowing for an `Installable` involved checking for `_recipe` on a ResolvedExtension. While being a required field on `IExtension`, recipe can be `undefined`. This was causing undefined field errors on the Blueprints page.

This PR resolves this issue by changing the field used for type narrowing on an `Installable` from `_recipe` to `extensionPointId`.