### PR TITLE
Blueprints page information hierarchy improvements

### DIFF
--- a/src/options/pages/blueprints/BlueprintActions.tsx
+++ b/src/options/pages/blueprints/BlueprintActions.tsx
@@ -93,7 +93,7 @@ const BlueprintActions: React.FunctionComponent<{
       {
         title: (
           <>
-            <FontAwesomeIcon icon={faTimes} /> Uninstall
+            <FontAwesomeIcon icon={faTimes} /> Deactivate
           </>
         ),
         action: actions.uninstall,

--- a/src/options/pages/blueprints/BlueprintsCard.tsx
+++ b/src/options/pages/blueprints/BlueprintsCard.tsx
@@ -31,14 +31,12 @@ import ListView from "./listView/ListView";
 import ListFilters from "./ListFilters";
 import { Installable, InstallableViewItem } from "./blueprintsTypes";
 import GridView from "./gridView/GridView";
-import useReduxState from "@/hooks/useReduxState";
 import {
   selectFilters,
   selectGroupBy,
   selectSortBy,
   selectView,
 } from "./blueprintsSelectors";
-import blueprintsSlice from "./blueprintsSlice";
 import { useSelector } from "react-redux";
 import { uniq } from "lodash";
 import useInstallableViewItems from "@/options/pages/blueprints/useInstallableViewItems";
@@ -103,18 +101,9 @@ const BlueprintsCard: React.FunctionComponent<{
     [data]
   );
 
-  const [view] = useReduxState(selectView, blueprintsSlice.actions.setView);
-
-  const [groupBy] = useReduxState(
-    selectGroupBy,
-    blueprintsSlice.actions.setGroupBy
-  );
-
-  const [sortBy] = useReduxState(
-    selectSortBy,
-    blueprintsSlice.actions.setSortBy
-  );
-
+  const view = useSelector(selectView);
+  const groupBy = useSelector(selectGroupBy);
+  const sortBy = useSelector(selectSortBy);
   const filters = useSelector(selectFilters);
 
   const tableInstance = useTable<InstallableViewItem>(

--- a/src/options/pages/blueprints/BlueprintsCard.tsx
+++ b/src/options/pages/blueprints/BlueprintsCard.tsx
@@ -17,9 +17,8 @@
 
 import styles from "./BlueprintsCard.module.scss";
 
-import { Button, Col, Row as BootstrapRow } from "react-bootstrap";
+import { Col, Row as BootstrapRow } from "react-bootstrap";
 import React, { useMemo } from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   Column,
   useFilters,
@@ -28,13 +27,6 @@ import {
   useSortBy,
   useTable,
 } from "react-table";
-import Select from "react-select";
-import {
-  faList,
-  faSortAmountDownAlt,
-  faSortAmountUpAlt,
-  faThLarge,
-} from "@fortawesome/free-solid-svg-icons";
 import ListView from "./listView/ListView";
 import ListFilters from "./ListFilters";
 import { Installable, InstallableViewItem } from "./blueprintsTypes";

--- a/src/options/pages/blueprints/BlueprintsCard.tsx
+++ b/src/options/pages/blueprints/BlueprintsCard.tsx
@@ -85,6 +85,7 @@ const columns: Array<Column<InstallableViewItem>> = [
     Header: "Status",
     accessor: "status",
     disableGlobalFilter: true,
+    filter: "exactText",
   },
 ];
 

--- a/src/options/pages/blueprints/BlueprintsCard.tsx
+++ b/src/options/pages/blueprints/BlueprintsCard.tsx
@@ -51,6 +51,7 @@ import { useSelector } from "react-redux";
 import { uniq } from "lodash";
 import useInstallableViewItems from "@/options/pages/blueprints/useInstallableViewItems";
 import AutoSizer from "react-virtualized-auto-sizer";
+import BlueprintsToolbar from "@/options/pages/blueprints/BlueprintsToolbar";
 
 // These react-table columns aren't rendered as column headings,
 // but used to expose grouping, sorting, filtering, and global
@@ -110,17 +111,14 @@ const BlueprintsCard: React.FunctionComponent<{
     [data]
   );
 
-  const [view, setView] = useReduxState(
-    selectView,
-    blueprintsSlice.actions.setView
-  );
+  const [view] = useReduxState(selectView, blueprintsSlice.actions.setView);
 
-  const [groupBy, setGroupBy] = useReduxState(
+  const [groupBy] = useReduxState(
     selectGroupBy,
     blueprintsSlice.actions.setGroupBy
   );
 
-  const [sortBy, setSortBy] = useReduxState(
+  const [sortBy] = useReduxState(
     selectSortBy,
     blueprintsSlice.actions.setSortBy
   );
@@ -154,37 +152,7 @@ const BlueprintsCard: React.FunctionComponent<{
     useSortBy
   );
 
-  const {
-    rows,
-    flatRows,
-    flatHeaders,
-    setGlobalFilter,
-    state: { globalFilter },
-  } = tableInstance;
-
-  const isGrouped = groupBy.length > 0;
-  const isSorted = sortBy.length > 0;
-  const numberOfBlueprints = isGrouped
-    ? flatRows.length - rows.length
-    : rows.length;
-
-  const { groupByOptions, sortByOptions } = useMemo(() => {
-    const groupByOptions = flatHeaders
-      .filter((column) => column.canGroupBy)
-      .map((column) => ({
-        label: column.Header,
-        value: column.id,
-      }));
-
-    const sortByOptions = flatHeaders
-      .filter((column) => column.canSort)
-      .map((column) => ({
-        label: column.Header,
-        value: column.id,
-      }));
-
-    return { groupByOptions, sortByOptions };
-  }, [flatHeaders]);
+  const { rows, setGlobalFilter } = tableInstance;
 
   const BlueprintsView = view === "list" ? ListView : GridView;
 
@@ -195,82 +163,7 @@ const BlueprintsCard: React.FunctionComponent<{
         setGlobalFilter={setGlobalFilter}
       />
       <Col className={styles.mainContainer}>
-        <div className="d-flex justify-content-between align-items-center mb-3">
-          <h3 className={styles.filterTitle}>
-            {globalFilter
-              ? `${numberOfBlueprints} results for "${globalFilter}"`
-              : `${filters.length > 0 ? filters[0].value : "All"} Blueprints`}
-          </h3>
-          <span className="d-flex align-items-center small">
-            <span className="ml-3 mr-2">Group by:</span>
-            <Select
-              isClearable
-              placeholder="Group by"
-              options={groupByOptions}
-              onChange={(option, { action }) => {
-                const value = action === "clear" ? [] : [option.value];
-                setGroupBy(value);
-              }}
-              value={groupByOptions.find((opt) => opt.value === groupBy[0])}
-            />
-
-            <span className="ml-3 mr-2">Sort by:</span>
-            <Select
-              isClearable
-              placeholder="Sort by"
-              options={sortByOptions}
-              onChange={(option, { action }) => {
-                const value =
-                  action === "clear" ? [] : [{ id: option.value, desc: false }];
-                setSortBy(value);
-              }}
-              value={sortByOptions.find((opt) => opt.value === sortBy[0]?.id)}
-            />
-
-            {isSorted && (
-              <Button
-                variant="link"
-                size="sm"
-                onClick={() => {
-                  const value = [{ id: sortBy[0].id, desc: !sortBy[0].desc }];
-                  setSortBy(value);
-                }}
-              >
-                <FontAwesomeIcon
-                  icon={
-                    sortBy[0].id === "updatedAt"
-                      ? sortBy[0].desc
-                        ? faSortAmountDownAlt
-                        : faSortAmountUpAlt
-                      : sortBy[0].desc
-                      ? faSortAmountUpAlt
-                      : faSortAmountDownAlt
-                  }
-                  size="lg"
-                />
-              </Button>
-            )}
-            <Button
-              variant={view === "list" ? "link" : "outline-link"}
-              size="sm"
-              className="ml-3"
-              onClick={() => {
-                setView("list");
-              }}
-            >
-              <FontAwesomeIcon icon={faList} size="lg" />
-            </Button>
-            <Button
-              variant={view === "grid" ? "link" : "outline-link"}
-              size="sm"
-              onClick={() => {
-                setView("grid");
-              }}
-            >
-              <FontAwesomeIcon icon={faThLarge} size="lg" />
-            </Button>
-          </span>
-        </div>
+        <BlueprintsToolbar tableInstance={tableInstance} />
         {/* This wrapper prevents AutoSizer overflow in a flex box container */}
         <div style={{ flex: "1 1 auto" }}>
           <AutoSizer defaultHeight={500}>

--- a/src/options/pages/blueprints/BlueprintsCard.tsx
+++ b/src/options/pages/blueprints/BlueprintsCard.tsx
@@ -84,7 +84,7 @@ const columns: Array<Column<InstallableViewItem>> = [
     disableGlobalFilter: true,
   },
   {
-    Header: "Last modified",
+    Header: "Last updated",
     accessor: "updatedAt",
     disableGroupBy: true,
     disableFilters: true,

--- a/src/options/pages/blueprints/BlueprintsToolbar.tsx
+++ b/src/options/pages/blueprints/BlueprintsToolbar.tsx
@@ -17,7 +17,7 @@
 
 import styles from "@/options/pages/blueprints/BlueprintsCard.module.scss";
 import Select from "react-select";
-import { Button } from "react-bootstrap";
+import { Button, ButtonGroup } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faList,
@@ -145,25 +145,28 @@ const BlueprintsToolbar: React.FunctionComponent<{
             />
           </Button>
         )}
-        <Button
-          variant={view === "list" ? "link" : "outline-link"}
-          size="sm"
-          className="ml-3"
-          onClick={() => {
-            setView("list");
-          }}
-        >
-          <FontAwesomeIcon icon={faList} size="lg" />
-        </Button>
-        <Button
-          variant={view === "grid" ? "link" : "outline-link"}
-          size="sm"
-          onClick={() => {
-            setView("grid");
-          }}
-        >
-          <FontAwesomeIcon icon={faThLarge} size="lg" />
-        </Button>
+
+        <ButtonGroup>
+          <Button
+            variant={view === "list" ? "info" : "outline-info"}
+            size="sm"
+            className="ml-3"
+            onClick={() => {
+              setView("list");
+            }}
+          >
+            <FontAwesomeIcon icon={faList} size="1x" />
+          </Button>
+          <Button
+            variant={view === "grid" ? "info" : "outline-info"}
+            size="sm"
+            onClick={() => {
+              setView("grid");
+            }}
+          >
+            <FontAwesomeIcon icon={faThLarge} size="1x" />
+          </Button>
+        </ButtonGroup>
       </span>
     </div>
   );

--- a/src/options/pages/blueprints/BlueprintsToolbar.tsx
+++ b/src/options/pages/blueprints/BlueprintsToolbar.tsx
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styles from "@/options/pages/blueprints/BlueprintsCard.module.scss";
+import Select from "react-select";
+import { Button } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faList,
+  faSortAmountDownAlt,
+  faSortAmountUpAlt,
+  faThLarge,
+} from "@fortawesome/free-solid-svg-icons";
+import React, { useMemo } from "react";
+import { TableInstance } from "react-table";
+import useReduxState from "@/hooks/useReduxState";
+import {
+  selectFilters,
+  selectGroupBy,
+  selectSortBy,
+  selectView,
+} from "@/options/pages/blueprints/blueprintsSelectors";
+import blueprintsSlice from "@/options/pages/blueprints/blueprintsSlice";
+import { useSelector } from "react-redux";
+
+const BlueprintsToolbar: React.FunctionComponent<{
+  tableInstance: TableInstance;
+}> = ({ tableInstance }) => {
+  const {
+    flatHeaders,
+    flatRows,
+    rows,
+    state: { globalFilter },
+  } = tableInstance;
+
+  const [view, setView] = useReduxState(
+    selectView,
+    blueprintsSlice.actions.setView
+  );
+
+  const [groupBy, setGroupBy] = useReduxState(
+    selectGroupBy,
+    blueprintsSlice.actions.setGroupBy
+  );
+
+  const [sortBy, setSortBy] = useReduxState(
+    selectSortBy,
+    blueprintsSlice.actions.setSortBy
+  );
+
+  const filters = useSelector(selectFilters);
+
+  const isGrouped = groupBy.length > 0;
+
+  const isSorted = sortBy.length > 0;
+  const numberOfBlueprints = isGrouped
+    ? flatRows.length - rows.length
+    : rows.length;
+
+  const { groupByOptions, sortByOptions } = useMemo(() => {
+    const groupByOptions = flatHeaders
+      .filter((column) => column.canGroupBy)
+      .map((column) => ({
+        label: column.Header,
+        value: column.id,
+      }));
+
+    const sortByOptions = flatHeaders
+      .filter((column) => column.canSort)
+      .map((column) => ({
+        label: column.Header,
+        value: column.id,
+      }));
+
+    return { groupByOptions, sortByOptions };
+  }, [flatHeaders]);
+
+  return (
+    <div className="d-flex justify-content-between align-items-center mb-3">
+      <h3 className={styles.filterTitle}>
+        {globalFilter
+          ? `${numberOfBlueprints} results for "${globalFilter}"`
+          : `${filters.length > 0 ? filters[0].value : "All"} Blueprints`}
+      </h3>
+      <span className="d-flex align-items-center small">
+        <span className="ml-3 mr-2">Group by:</span>
+        <Select
+          isClearable
+          placeholder="Group by"
+          options={groupByOptions}
+          onChange={(option, { action }) => {
+            const value = action === "clear" ? [] : [option.value];
+            setGroupBy(value);
+          }}
+          value={groupByOptions.find((opt) => opt.value === groupBy[0])}
+        />
+
+        <span className="ml-3 mr-2">Sort by:</span>
+        <Select
+          isClearable
+          placeholder="Sort by"
+          options={sortByOptions}
+          onChange={(option, { action }) => {
+            const value =
+              action === "clear" ? [] : [{ id: option.value, desc: false }];
+            setSortBy(value);
+          }}
+          value={sortByOptions.find((opt) => opt.value === sortBy[0]?.id)}
+        />
+
+        {isSorted && (
+          <Button
+            variant="link"
+            size="sm"
+            onClick={() => {
+              const value = [{ id: sortBy[0].id, desc: !sortBy[0].desc }];
+              setSortBy(value);
+            }}
+          >
+            <FontAwesomeIcon
+              icon={
+                sortBy[0].id === "updatedAt"
+                  ? sortBy[0].desc
+                    ? faSortAmountDownAlt
+                    : faSortAmountUpAlt
+                  : sortBy[0].desc
+                  ? faSortAmountUpAlt
+                  : faSortAmountDownAlt
+              }
+              size="lg"
+            />
+          </Button>
+        )}
+        <Button
+          variant={view === "list" ? "link" : "outline-link"}
+          size="sm"
+          className="ml-3"
+          onClick={() => {
+            setView("list");
+          }}
+        >
+          <FontAwesomeIcon icon={faList} size="lg" />
+        </Button>
+        <Button
+          variant={view === "grid" ? "link" : "outline-link"}
+          size="sm"
+          onClick={() => {
+            setView("grid");
+          }}
+        >
+          <FontAwesomeIcon icon={faThLarge} size="lg" />
+        </Button>
+      </span>
+    </div>
+  );
+};
+
+export default BlueprintsToolbar;

--- a/src/options/pages/blueprints/InstallableIcon.tsx
+++ b/src/options/pages/blueprints/InstallableIcon.tsx
@@ -94,7 +94,9 @@ const InstallableIcon: React.FunctionComponent<{
   const cssSize = `${sizeMultiplier}em`;
 
   if (isLoading) {
-    return <FontAwesomeIcon icon={faCube} color="darkGrey" size={size} />;
+    return (
+      <FontAwesomeIcon icon={faCube} color="rgb(101, 98, 170)" size={size} />
+    );
   }
 
   return listing?.image ? (
@@ -107,7 +109,7 @@ const InstallableIcon: React.FunctionComponent<{
   ) : (
     <FontAwesomeIcon
       icon={iconToUse}
-      color={listing?.icon_color ?? "darkGrey"}
+      color={listing?.icon_color ?? "rgb(101, 98, 170)"}
       className={faIconClass}
       size={size}
       fixedWidth

--- a/src/options/pages/blueprints/InstallableIcon.tsx
+++ b/src/options/pages/blueprints/InstallableIcon.tsx
@@ -35,6 +35,7 @@ function getDefaultInstallableIcon(installable: Installable) {
 }
 
 const SIZE_REGEX = /^(?<size>\d)x$/i;
+const DARK_LAVENDER = "rgb(101, 98, 170)";
 
 const InstallableIcon: React.FunctionComponent<{
   listing: MarketplaceListing;
@@ -94,9 +95,7 @@ const InstallableIcon: React.FunctionComponent<{
   const cssSize = `${sizeMultiplier}em`;
 
   if (isLoading) {
-    return (
-      <FontAwesomeIcon icon={faCube} color="rgb(101, 98, 170)" size={size} />
-    );
+    return <FontAwesomeIcon icon={faCube} color={DARK_LAVENDER} size={size} />;
   }
 
   return listing?.image ? (
@@ -109,7 +108,7 @@ const InstallableIcon: React.FunctionComponent<{
   ) : (
     <FontAwesomeIcon
       icon={iconToUse}
-      color={listing?.icon_color ?? "rgb(101, 98, 170)"}
+      color={listing?.icon_color ?? DARK_LAVENDER}
       className={faIconClass}
       size={size}
       fixedWidth

--- a/src/options/pages/blueprints/Status.tsx
+++ b/src/options/pages/blueprints/Status.tsx
@@ -20,7 +20,7 @@ import { Button } from "react-bootstrap";
 import { InstallableViewItem } from "./blueprintsTypes";
 import useInstallableActions from "./useInstallableActions";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck, faRedo, faSync } from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faSync } from "@fortawesome/free-solid-svg-icons";
 
 type StatusProps = {
   installableViewItem: InstallableViewItem;

--- a/src/options/pages/blueprints/Status.tsx
+++ b/src/options/pages/blueprints/Status.tsx
@@ -19,6 +19,8 @@ import React from "react";
 import { Button } from "react-bootstrap";
 import { InstallableViewItem } from "./blueprintsTypes";
 import useInstallableActions from "./useInstallableActions";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCheck, faRedo, faSync } from "@fortawesome/free-solid-svg-icons";
 
 type StatusProps = {
   installableViewItem: InstallableViewItem;
@@ -33,11 +35,13 @@ const Status: React.VoidFunctionComponent<StatusProps> = ({
   return status === "Active" ? (
     <>
       {hasUpdate ? (
-        <Button size="sm" variant="warning" onClick={reinstall}>
-          Update
+        <Button size="sm" variant="info" onClick={reinstall}>
+          <FontAwesomeIcon icon={faSync} /> Update
         </Button>
       ) : (
-        <div className="text-info py-2">Active</div>
+        <div className="text-success py-2">
+          <FontAwesomeIcon icon={faCheck} /> Active
+        </div>
       )}
     </>
   ) : (

--- a/src/options/pages/blueprints/blueprintsTypes.ts
+++ b/src/options/pages/blueprints/blueprintsTypes.ts
@@ -33,7 +33,7 @@ export type InstallableViewItem = {
     source: SharingSource;
   };
   updatedAt: string;
-  status: "Active" | "Uninstalled";
+  status: "Active" | "Inactive";
   hasUpdate: boolean;
   icon: ReactNode;
   // Used to get Installable actions from useInstallableActions

--- a/src/options/pages/blueprints/gridView/GridCard.module.scss
+++ b/src/options/pages/blueprints/gridView/GridCard.module.scss
@@ -48,7 +48,6 @@
   align-items: center;
   color: darkgray;
   padding: 0 15px 15px 15px;
-  //white-space: nowrap;
 
   div {
     width: auto;

--- a/src/options/pages/blueprints/gridView/GridCard.module.scss
+++ b/src/options/pages/blueprints/gridView/GridCard.module.scss
@@ -20,11 +20,50 @@
 }
 
 .card {
-  padding: 15px;
   height: 100%;
+}
+
+.cardBody {
+  padding: 15px !important;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+}
+
+.primaryInfo {
+  max-height: 100px;
+  overflow: hidden;
+}
+
+.name {
+  margin-left: 1rem;
+}
+
+.cardFooter {
+  background-color: transparent;
+  border: none;
+  font-size: 0.7rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: darkgray;
+  padding: 0 15px 15px 15px;
+  //white-space: nowrap;
+
+  div {
+    width: auto;
+    white-space: nowrap;
+  }
+
+  span {
+    flex-grow: 1;
+    text-align: right;
+  }
+}
+
+.description {
+  font-size: 0.8rem;
+  align-self: center;
 }
 
 .actions {

--- a/src/options/pages/blueprints/gridView/GridCard.module.scss
+++ b/src/options/pages/blueprints/gridView/GridCard.module.scss
@@ -31,7 +31,7 @@
 }
 
 .primaryInfo {
-  max-height: 100px;
+  height: 110px;
   overflow: hidden;
 }
 

--- a/src/options/pages/blueprints/gridView/GridCard.module.scss
+++ b/src/options/pages/blueprints/gridView/GridCard.module.scss
@@ -31,7 +31,7 @@
 }
 
 .primaryInfo {
-  height: 110px;
+  max-height: 110px;
   overflow: hidden;
 }
 
@@ -48,16 +48,18 @@
   align-items: center;
   color: darkgray;
   padding: 0 15px 15px 15px;
+}
 
-  div {
-    width: auto;
-    white-space: nowrap;
-  }
+.sharingLabel {
+  width: auto;
+  white-space: nowrap;
+}
 
-  span {
-    flex-grow: 1;
-    text-align: right;
-  }
+.updatedAt {
+  flex-grow: 1;
+  text-align: right;
+  font-size: 80%;
+  padding-left: 0.5rem;
 }
 
 .description {

--- a/src/options/pages/blueprints/gridView/GridCard.tsx
+++ b/src/options/pages/blueprints/gridView/GridCard.tsx
@@ -56,7 +56,6 @@ const GridCard: React.VoidFunctionComponent<GridCardProps> = ({
         </Card.Body>
         <Card.Footer className={styles.cardFooter}>
           <SharingLabel sharing={sharing.source} />
-          {/*//TODO: add a middle date truncation where the year is, that expands on hover */}
           <span className="small">
             <FontAwesomeIcon icon={faClock} /> {updatedAtFormatted}
           </span>

--- a/src/options/pages/blueprints/gridView/GridCard.tsx
+++ b/src/options/pages/blueprints/gridView/GridCard.tsx
@@ -21,9 +21,10 @@ import React from "react";
 import { InstallableViewItem } from "@/options/pages/blueprints/blueprintsTypes";
 import { Card } from "react-bootstrap";
 import SharingLabel from "@/options/pages/blueprints/SharingLabel";
-import { timeSince } from "@/utils/timeUtils";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Status from "@/options/pages/blueprints/Status";
 import BlueprintActions from "@/options/pages/blueprints/BlueprintActions";
+import { faClock } from "@fortawesome/free-regular-svg-icons";
 
 type GridCardProps = {
   installableItem: InstallableViewItem;
@@ -32,25 +33,34 @@ type GridCardProps = {
 const GridCard: React.VoidFunctionComponent<GridCardProps> = ({
   installableItem,
 }) => {
-  const { name, updatedAt, sharing, icon } = installableItem;
+  const { name, updatedAt, sharing, icon, description } = installableItem;
+  const updatedAtFormatted = new Date(updatedAt).toLocaleString();
 
   return (
     <div className={styles.root}>
       <Card className={styles.card}>
-        <div className="d-flex">
-          {icon}
-          <h5 className="ml-2">{name}</h5>
-        </div>
-        <div>
-          <SharingLabel sharing={sharing.source} />
-          <Card.Text className="small">
-            Updated: {timeSince(updatedAt)}
-          </Card.Text>
-          <div className={styles.actions}>
-            <Status installableViewItem={installableItem} />
-            <BlueprintActions installableViewItem={installableItem} />
+        <Card.Body className={styles.cardBody}>
+          <div className={styles.primaryInfo}>
+            <div className="d-flex">
+              {icon}
+              <h5 className={styles.name}>{name}</h5>
+            </div>
+            <span className={styles.description}>{description}</span>
           </div>
-        </div>
+          <div>
+            <div className={styles.actions}>
+              <Status installableViewItem={installableItem} />
+              <BlueprintActions installableViewItem={installableItem} />
+            </div>
+          </div>
+        </Card.Body>
+        <Card.Footer className={styles.cardFooter}>
+          <SharingLabel sharing={sharing.source} />
+          {/*//TODO: add a middle date truncation where the year is, that expands on hover */}
+          <span className="small">
+            <FontAwesomeIcon icon={faClock} /> {updatedAtFormatted}
+          </span>
+        </Card.Footer>
       </Card>
     </div>
   );

--- a/src/options/pages/blueprints/gridView/GridCard.tsx
+++ b/src/options/pages/blueprints/gridView/GridCard.tsx
@@ -55,8 +55,10 @@ const GridCard: React.VoidFunctionComponent<GridCardProps> = ({
           </div>
         </Card.Body>
         <Card.Footer className={styles.cardFooter}>
-          <SharingLabel sharing={sharing.source} />
-          <span className="small">
+          <span className={styles.sharingLabel}>
+            <SharingLabel sharing={sharing.source} />
+          </span>
+          <span className={styles.updatedAt}>
             <FontAwesomeIcon icon={faClock} /> {updatedAtFormatted}
           </span>
         </Card.Footer>

--- a/src/options/pages/blueprints/gridView/GridCard.tsx
+++ b/src/options/pages/blueprints/gridView/GridCard.tsx
@@ -42,7 +42,7 @@ const GridCard: React.VoidFunctionComponent<GridCardProps> = ({
         <Card.Body className={styles.cardBody}>
           <div className={styles.primaryInfo}>
             <div className="d-flex">
-              {icon}
+              <span className="mb-2">{icon}</span>
               <h5 className={styles.name}>{name}</h5>
             </div>
             <span className={styles.description}>{description}</span>

--- a/src/options/pages/blueprints/gridView/GridView.module.scss
+++ b/src/options/pages/blueprints/gridView/GridView.module.scss
@@ -17,6 +17,6 @@
 
 .root {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 15px;
 }

--- a/src/options/pages/blueprints/gridView/GridView.tsx
+++ b/src/options/pages/blueprints/gridView/GridView.tsx
@@ -99,7 +99,7 @@ const GridView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
     (index: number): number => {
       // eslint-disable-next-line security/detect-object-injection
       const row = expandedGridRows[index];
-      return "isGrouped" in row ? HEADER_ROW_HEIGHT_PX : MIN_CARD_DIMENSIONS_PX;
+      return "isGrouped" in row ? HEADER_ROW_HEIGHT_PX : 215;
     },
     [expandedGridRows]
   );

--- a/src/options/pages/blueprints/gridView/GridView.tsx
+++ b/src/options/pages/blueprints/gridView/GridView.tsx
@@ -99,7 +99,7 @@ const GridView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
     (index: number): number => {
       // eslint-disable-next-line security/detect-object-injection
       const row = expandedGridRows[index];
-      return "isGrouped" in row ? HEADER_ROW_HEIGHT_PX : 215;
+      return "isGrouped" in row ? HEADER_ROW_HEIGHT_PX : MIN_CARD_DIMENSIONS_PX;
     },
     [expandedGridRows]
   );

--- a/src/options/pages/blueprints/gridView/GridView.tsx
+++ b/src/options/pages/blueprints/gridView/GridView.tsx
@@ -71,9 +71,10 @@ export function expandGridRows(
   return gridRows;
 }
 
-// 200px min card width & height, 15px padding
+// 220px min card width + 15px padding
 // see: GridView.module.scss
-const MIN_CARD_DIMENSIONS_PX = 215;
+const MIN_CARD_WIDTH_PX = 235;
+const CARD_HEIGHT_PX = 230;
 const HEADER_ROW_HEIGHT_PX = 43;
 
 const GridView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
@@ -86,7 +87,7 @@ const GridView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
   const [listKey, setListKey] = useState(uuidv4());
 
   const columnCount = useMemo(
-    () => Math.floor(width / MIN_CARD_DIMENSIONS_PX),
+    () => Math.floor(width / MIN_CARD_WIDTH_PX),
     [width]
   );
 
@@ -99,7 +100,7 @@ const GridView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
     (index: number): number => {
       // eslint-disable-next-line security/detect-object-injection
       const row = expandedGridRows[index];
-      return "isGrouped" in row ? HEADER_ROW_HEIGHT_PX : MIN_CARD_DIMENSIONS_PX;
+      return "isGrouped" in row ? HEADER_ROW_HEIGHT_PX : CARD_HEIGHT_PX;
     },
     [expandedGridRows]
   );

--- a/src/options/pages/blueprints/installableUtils.ts
+++ b/src/options/pages/blueprints/installableUtils.ts
@@ -89,8 +89,13 @@ export const getDescription = (installable: Installable): string => {
     : installable.metadata.description;
 
   if (!description && isExtension(installable)) {
-    const createDate = new Date(installable.createTimestamp);
-    description = `Created on ${createDate.toLocaleDateString()} at ${createDate.toLocaleTimeString()} in the page editor.`;
+    const createDate =
+      "createTimestamp" in installable
+        ? new Date(installable.createTimestamp)
+        : null;
+    description = createDate
+      ? `Created on ${createDate.toLocaleDateString()} at ${createDate.toLocaleTimeString()} in the page editor`
+      : "Created in the page editor";
   }
 
   return description;

--- a/src/options/pages/blueprints/installableUtils.ts
+++ b/src/options/pages/blueprints/installableUtils.ts
@@ -16,7 +16,13 @@
  */
 
 import { RecipeDefinition } from "@/types/definitions";
-import { IExtension, RegistryId, ResolvedExtension, UUID } from "@/core";
+import {
+  IExtension,
+  PersistedExtension,
+  RegistryId,
+  ResolvedExtension,
+  UUID,
+} from "@/core";
 import * as semver from "semver";
 import { Organization } from "@/types/contract";
 import { Installable } from "./blueprintsTypes";
@@ -91,11 +97,12 @@ export const getDescription = (installable: Installable): string => {
   if (!description && isExtension(installable)) {
     const createDate =
       "createTimestamp" in installable
-        ? new Date(installable.createTimestamp)
+        ? new Date((installable as PersistedExtension).createTimestamp)
         : null;
-    description = createDate
-      ? `Created on ${createDate.toLocaleDateString()} at ${createDate.toLocaleTimeString()} in the page editor`
-      : "Created in the page editor";
+    description =
+      "createTimestamp" in installable
+        ? `Created on ${createDate.toLocaleDateString()} at ${createDate.toLocaleTimeString()} in the page editor`
+        : "Created in the page editor";
   }
 
   return description;

--- a/src/options/pages/blueprints/installableUtils.ts
+++ b/src/options/pages/blueprints/installableUtils.ts
@@ -83,10 +83,18 @@ export const getUniqueId = (installable: Installable): UUID | RegistryId =>
 export const getLabel = (installable: Installable): string =>
   isExtension(installable) ? installable.label : installable.metadata.name;
 
-export const getDescription = (installable: Installable): string =>
-  isExtension(installable)
+export const getDescription = (installable: Installable): string => {
+  let description = isExtension(installable)
     ? installable._recipe?.description
     : installable.metadata.description;
+
+  if (!description && isExtension(installable)) {
+    const createDate = new Date(installable.createTimestamp);
+    description = `Created on ${createDate.toLocaleDateString()} at ${createDate.toLocaleTimeString()} in the page editor.`;
+  }
+
+  return description;
+};
 
 export const getPackageId = (installable: Installable): RegistryId =>
   isExtension(installable) ? installable._recipe?.id : installable.metadata.id;

--- a/src/options/pages/blueprints/listView/ListItem.module.scss
+++ b/src/options/pages/blueprints/listView/ListItem.module.scss
@@ -36,10 +36,12 @@
   padding-right: 1rem;
 }
 
-.name {
+.primaryInfo {
   text-wrap: normal;
   flex-grow: 1;
+}
 
+.name {
   h5 {
     text-overflow: ellipsis;
     margin: 0;

--- a/src/options/pages/blueprints/listView/ListItem.module.scss
+++ b/src/options/pages/blueprints/listView/ListItem.module.scss
@@ -49,13 +49,8 @@
 .sharing {
   flex-grow: 1;
   text-align: right;
-}
-
-.updatedAt {
-  color: grey;
-  text-wrap: normal;
-  font-size: 80%;
-  font-weight: 400;
+  color: darkgray;
+  font-size: 0.7rem;
 }
 
 .status {

--- a/src/options/pages/blueprints/listView/ListItem.tsx
+++ b/src/options/pages/blueprints/listView/ListItem.tsx
@@ -20,7 +20,7 @@ import styles from "./ListItem.module.scss";
 import React from "react";
 import SharingLabel from "@/options/pages/blueprints/SharingLabel";
 import BlueprintActions from "@/options/pages/blueprints/BlueprintActions";
-import { timeSince } from "@/utils/timeUtils";
+
 import { InstallableViewItem } from "@/options/pages/blueprints/blueprintsTypes";
 import Status from "@/options/pages/blueprints/Status";
 import { ListGroup } from "react-bootstrap";
@@ -29,20 +29,20 @@ const ListItem: React.VoidFunctionComponent<{
   installableItem: InstallableViewItem;
   style: React.CSSProperties;
 }> = ({ installableItem, style }) => {
-  const { name, sharing, updatedAt, icon } = installableItem;
+  const { name, sharing, updatedAt, icon, description } = installableItem;
+  const updatedAtFormatted = new Date(updatedAt).toLocaleString();
 
   return (
     <ListGroup.Item className={styles.root} style={style}>
       <div className={styles.icon}>{icon}</div>
       <div className={styles.name}>
         <h5>{name}</h5>
+        <span className="small">{description}</span>
       </div>
       <div>
         <div className={styles.sharing}>
-          <span className={styles.updatedAt}>
-            Updated: {timeSince(updatedAt)}
-          </span>
           <SharingLabel sharing={sharing.source} />
+          <span>Updated {updatedAtFormatted}</span>
         </div>
       </div>
       <div className={styles.status}>

--- a/src/options/pages/blueprints/listView/ListItem.tsx
+++ b/src/options/pages/blueprints/listView/ListItem.tsx
@@ -35,8 +35,10 @@ const ListItem: React.VoidFunctionComponent<{
   return (
     <ListGroup.Item className={styles.root} style={style}>
       <div className={styles.icon}>{icon}</div>
-      <div className={styles.name}>
-        <h5>{name}</h5>
+      <div className={styles.primaryInfo}>
+        <div className={styles.name}>
+          <h5>{name}</h5>
+        </div>
         <span className="small">{description}</span>
       </div>
       <div>

--- a/src/options/pages/blueprints/useInstallableViewItems.tsx
+++ b/src/options/pages/blueprints/useInstallableViewItems.tsx
@@ -104,7 +104,7 @@ function useInstallableViewItems(
           source: getSharingType(installable, organizations ?? [], scope),
         },
         updatedAt: getUpdatedAt(installable),
-        status: isActive(installable) ? "Active" : "Uninstalled",
+        status: isActive(installable) ? "Active" : "Inactive",
         hasUpdate: isExtension(installable)
           ? updateAvailable(recipes.data, installable)
           : false,

--- a/src/options/pages/blueprints/useInstallables.ts
+++ b/src/options/pages/blueprints/useInstallables.ts
@@ -88,13 +88,15 @@ function useInstallables(): InstallablesState {
       []
     );
 
-  const extensionsWithoutRecipe = useMemo(() => {
-    return resolvedExtensions.filter((extension) =>
-      extension._recipe?.id
-        ? !installedRecipeIds.has(extension._recipe?.id)
-        : true
-    );
-  }, [installedRecipeIds, resolvedExtensions]);
+  const extensionsWithoutRecipe = useMemo(
+    () =>
+      resolvedExtensions.filter((extension) =>
+        extension._recipe?.id
+          ? !installedRecipeIds.has(extension._recipe?.id)
+          : true
+      ),
+    [installedRecipeIds, resolvedExtensions]
+  );
 
   return {
     installables: [...extensionsWithoutRecipe, ...personalOrTeamBlueprints],

--- a/src/options/pages/blueprints/useInstallables.ts
+++ b/src/options/pages/blueprints/useInstallables.ts
@@ -59,13 +59,14 @@ function useInstallables(): InstallablesState {
     () =>
       (recipes.data ?? []).filter(
         (recipe) =>
-          (recipe.metadata.id.includes(scope) ||
-            recipe.sharing.organizations.length > 0) &&
-          // Remove duplicate Installable entries for Active extension
-          // and Recipe pairs
-          !installedRecipeIds.has(recipe.metadata.id)
+          // Is personal blueprint
+          recipe.metadata.id.includes(scope) ||
+          // Is blueprint shared with user
+          recipe.sharing.organizations.length > 0 ||
+          // Is blueprint active, e.g. installed via marketplace
+          installedRecipeIds.has(recipe.metadata.id)
       ),
-    [recipes.data, scope]
+    [installedRecipeIds, recipes.data, scope]
   );
 
   const allExtensions = useMemo(() => {
@@ -87,13 +88,16 @@ function useInstallables(): InstallablesState {
       []
     );
 
-  const installables = useMemo(
-    () => [...resolvedExtensions, ...personalOrTeamBlueprints],
-    [personalOrTeamBlueprints, resolvedExtensions]
-  );
+  const extensionsWithoutRecipe = useMemo(() => {
+    return resolvedExtensions.filter((extension) =>
+      extension._recipe?.id
+        ? !installedRecipeIds.has(extension._recipe?.id)
+        : true
+    );
+  }, [installedRecipeIds, resolvedExtensions]);
 
   return {
-    installables,
+    installables: [...extensionsWithoutRecipe, ...personalOrTeamBlueprints],
     isLoading:
       recipes.isLoading ||
       cloudExtensions.isLoading ||


### PR DESCRIPTION
Closes #2552 

These improvements aren't perfect, but they will have to do for now until we collect & distill additional feedback. Makes additional information hierarchy improvements to the Blueprints page:

- Boldens some of the font and icon colors to make blueprints appear more vivid
- Changes the "active" status from color info to color success -> and adds a checkmark icon
- Transforms the list view/grid view buttons into a button group to better communicate toggle-ability
- Shrinks and mutes the Sharing label and the Updated at labels, and moves them to the bottom of a Grid View card
- Addresses some inconsistent terminology: "Unisntalled" -> "Inactive", "Uninstall" -> "Deactivate", "Last modified" -> "Last Updated"
- Adds an in-progress default description for extensions that were created directly, i.e. weren't installed via blueprint

This also makes changes to the `useInstallables` hook so that only extensions without recipes are shown in the Blueprints page.

<img width="1178" alt="Screen Shot 2022-03-01 at 5 03 42 PM" src="https://user-images.githubusercontent.com/36575242/156274849-94619364-d9ac-4398-9a78-e8a983032e0f.png">