### PR TITLE
Fix blueprint actions from consolidated blueprints change

### DIFF
--- a/src/options/pages/blueprints/useInstallableActions.ts
+++ b/src/options/pages/blueprints/useInstallableActions.ts
@@ -51,10 +51,6 @@ function useInstallableActions(installable: Installable) {
   const [deleteCloudExtension] = useDeleteCloudExtensionMutation();
   const unresolvedExtensions = useSelector(selectExtensions);
 
-  const installedExtensionIds = new Set<UUID>(
-    unresolvedExtensions.map((extension) => extension.id)
-  );
-
   // Select cached auth data for performance reasons
   const {
     data: { scope },
@@ -148,8 +144,6 @@ function useInstallableActions(installable: Installable) {
       extensionsToUninstall.push(installable);
     }
 
-    console.log("extensions to uninstall:", extensionsToUninstall);
-
     for (const extension of extensionsToUninstall) {
       // Remove from storage first so it doesn't get re-added in reactivate step below
       dispatch(removeExtension({ extensionId: extension.id }));
@@ -166,14 +160,16 @@ function useInstallableActions(installable: Installable) {
   };
 
   const viewLogs = () => {
-    if (!isExtension(installable)) {
-      return;
-    }
-
+    console.log("installable");
     dispatch(
       installedPageSlice.actions.setLogsContext({
-        title: installable.label,
-        messageContext: selectExtensionContext(installable),
+        title: getLabel(installable),
+        messageContext: isBlueprint(installable)
+          ? {
+              label: getLabel(installable),
+              blueprintId: installable.metadata.id,
+            }
+          : selectExtensionContext(installable),
       })
     );
   };

--- a/src/options/pages/blueprints/useInstallableActions.ts
+++ b/src/options/pages/blueprints/useInstallableActions.ts
@@ -42,7 +42,8 @@ import useUserAction from "@/hooks/useUserAction";
 import { CancelError } from "@/errors";
 import { useModals } from "@/components/ConfirmationModal";
 import { selectExtensions } from "@/store/extensionsSelectors";
-import { IExtension, UUID } from "@/core";
+import { IExtension } from "@/core";
+
 const { removeExtension } = extensionsSlice.actions;
 
 function useInstallableActions(installable: Installable) {
@@ -160,7 +161,6 @@ function useInstallableActions(installable: Installable) {
   };
 
   const viewLogs = () => {
-    console.log("installable");
     dispatch(
       installedPageSlice.actions.setLogsContext({
         title: getLabel(installable),

--- a/src/options/pages/blueprints/useInstallableActions.ts
+++ b/src/options/pages/blueprints/useInstallableActions.ts
@@ -41,13 +41,19 @@ import extensionsSlice from "@/store/extensionsSlice";
 import useUserAction from "@/hooks/useUserAction";
 import { CancelError } from "@/errors";
 import { useModals } from "@/components/ConfirmationModal";
-
+import { selectExtensions } from "@/store/extensionsSelectors";
+import { IExtension, UUID } from "@/core";
 const { removeExtension } = extensionsSlice.actions;
 
 function useInstallableActions(installable: Installable) {
   const dispatch = useDispatch();
   const modals = useModals();
   const [deleteCloudExtension] = useDeleteCloudExtensionMutation();
+  const unresolvedExtensions = useSelector(selectExtensions);
+
+  const installedExtensionIds = new Set<UUID>(
+    unresolvedExtensions.map((extension) => extension.id)
+  );
 
   // Select cached auth data for performance reasons
   const {
@@ -55,14 +61,16 @@ function useInstallableActions(installable: Installable) {
   } = useSelector(appApi.endpoints.getAuth.select());
 
   const reinstall = () => {
-    if (!isExtension(installable) || !installable._recipe) {
+    if (!isExtensionFromRecipe(installable) && !isBlueprint(installable)) {
       return;
     }
 
     dispatch(
       push(
         `marketplace/activate/${encodeURIComponent(
-          installable._recipe.id
+          isExtension(installable)
+            ? installable._recipe.id
+            : installable.metadata.id
         )}?reinstall=1`
       )
     );
@@ -129,19 +137,32 @@ function useInstallableActions(installable: Installable) {
   );
 
   const uninstall = () => {
-    if (!isExtension(installable)) {
-      return;
+    const extensionsToUninstall: IExtension[] = [];
+    if (isBlueprint(installable)) {
+      extensionsToUninstall.push(
+        ...unresolvedExtensions.filter(
+          (extension) => extension._recipe?.id === installable.metadata.id
+        )
+      );
+    } else {
+      extensionsToUninstall.push(installable);
     }
 
-    notify.success(`Removed brick ${getLabel(installable)}`);
-    reportEvent("ExtensionRemove", {
-      extensionId: installable.id,
-    });
-    // Remove from storage first so it doesn't get re-added in reactivate step below
-    dispatch(removeExtension({ extensionId: installable.id }));
-    // XXX: also remove remove side panel panels that are already open?
-    void uninstallContextMenu({ extensionId: installable.id });
-    reactivateEveryTab();
+    console.log("extensions to uninstall:", extensionsToUninstall);
+
+    for (const extension of extensionsToUninstall) {
+      // Remove from storage first so it doesn't get re-added in reactivate step below
+      dispatch(removeExtension({ extensionId: extension.id }));
+      // XXX: also remove remove side panel panels that are already open?
+      void uninstallContextMenu({ extensionId: extension.id });
+      reactivateEveryTab();
+
+      reportEvent("ExtensionRemove", {
+        extensionId: extension.id,
+      });
+    }
+
+    notify.success(`Deactivated blueprint ${getLabel(installable)}`);
   };
 
   const viewLogs = () => {
@@ -175,7 +196,10 @@ function useInstallableActions(installable: Installable) {
     exportBlueprint,
     activate,
     deleteExtension: isExtension(installable) ? deleteExtension : null,
-    reinstall: isExtensionFromRecipe(installable) ? reinstall : null,
+    reinstall:
+      isExtensionFromRecipe(installable) || isBlueprint(installable)
+        ? reinstall
+        : null,
   };
 }
 


### PR DESCRIPTION
Some blueprint actions weren't working after consolidating extensions into a single blueprint. This fixes blueprint reactivate, deactivate, and view logs actions.