### PR TITLE
Support DL tag in TableReader brick

### DIFF
--- a/src/blocks/transformers/component/TableReader.ts
+++ b/src/blocks/transformers/component/TableReader.ts
@@ -23,7 +23,7 @@ import {
   parseDefinitionList,
   getAllDefinitionLists,
 } from "@/utils/parseDefinitionList";
-import { $safeFind } from "@/helpers";
+import { requireSingleElement } from "@/utils/requireSingleElement";
 
 export const TABLE_READER_ID = validateRegistryId("@pixiebrix/table-reader");
 export const TABLE_READER_ALL_ID = validateRegistryId(
@@ -85,7 +85,7 @@ export class TableReader extends Transformer {
   }
 
   async transform(args: BlockArg, { root }: BlockOptions): Promise<unknown> {
-    const [table] = $safeFind<HTMLTableElement | HTMLDListElement>(
+    const table = requireSingleElement<HTMLTableElement | HTMLDListElement>(
       args.selector,
       root
     );

--- a/src/blocks/transformers/component/TableReader.ts
+++ b/src/blocks/transformers/component/TableReader.ts
@@ -19,6 +19,10 @@ import { Transformer } from "@/types";
 import { BlockArg, BlockOptions, Schema } from "@/core";
 import { validateRegistryId } from "@/types/helpers";
 import { parseDomTable, getAllTables } from "@/utils/parseDomTable";
+import {
+  parseDefinitionList,
+  getAllDefinitionLists,
+} from "@/utils/parseDefinitionList";
 import { $safeFind } from "@/helpers";
 
 export const TABLE_READER_ID = validateRegistryId("@pixiebrix/table-reader");
@@ -81,8 +85,15 @@ export class TableReader extends Transformer {
   }
 
   async transform(args: BlockArg, { root }: BlockOptions): Promise<unknown> {
-    const $table = $safeFind<HTMLTableElement>(args.selector, root);
-    return parseDomTable($table.get(0), { orientation: args.orientation });
+    const [table] = $safeFind<HTMLTableElement | HTMLDListElement>(
+      args.selector,
+      root
+    );
+    if (table instanceof HTMLDListElement) {
+      return parseDefinitionList(table);
+    }
+
+    return parseDomTable(table, { orientation: args.orientation });
   }
 }
 
@@ -129,6 +140,9 @@ export class TablesReader extends Transformer {
   }
 
   async transform(_: BlockArg, { root }: BlockOptions): Promise<unknown> {
-    return Object.fromEntries(getAllTables(root).entries());
+    return Object.fromEntries([
+      ...getAllTables(root).entries(),
+      ...getAllDefinitionLists(root).entries(),
+    ]);
   }
 }

--- a/src/blocks/transformers/component/TableReader.ts
+++ b/src/blocks/transformers/component/TableReader.ts
@@ -18,7 +18,7 @@
 import { Transformer } from "@/types";
 import { BlockArg, BlockOptions, Schema } from "@/core";
 import { validateRegistryId } from "@/types/helpers";
-import parseDomTable, { getAllTables } from "@/utils/parseDomTable";
+import { parseDomTable, getAllTables } from "@/utils/parseDomTable";
 import { $safeFind } from "@/helpers";
 
 export const TABLE_READER_ID = validateRegistryId("@pixiebrix/table-reader");

--- a/src/utils/parseDefinitionList.test.ts
+++ b/src/utils/parseDefinitionList.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { parseDefinitionList } from "./parseDefinitionList";
+import { JSDOM } from "jsdom";
+
+function getDL(
+  html: string,
+  attributes: Record<string, string> = {}
+): HTMLDListElement {
+  const list = JSDOM.fragment("<dl>" + html)
+    .firstElementChild as HTMLDListElement;
+
+  for (const [name, value] of Object.entries(attributes)) {
+    list.setAttribute(name, value);
+  }
+
+  return list;
+}
+
+describe("parseDefinitionList", () => {
+  test("parse simple list", () => {
+    const list = getDL(`
+      <dt>YOLO</dt>
+        <dd>You Only Live Once</dd>
+      <dt>SMH</dt>
+        <dd>Shaking My Head</dd>
+    `);
+
+    expect(parseDefinitionList(list)).toMatchInlineSnapshot(`
+      Object {
+        "fieldNames": Array [
+          "YOLO",
+          "SMH",
+        ],
+        "records": Array [
+          Object {
+            "SMH": "Shaking My Head",
+            "YOLO": "You Only Live Once",
+          },
+        ],
+      }
+    `);
+  });
+
+  test("parse list with multiple definitions and terms", () => {
+    const list = getDL(`
+      <dt>sup</dt>
+      <dt>wassup</dt>
+        <dd>What is up</dd>
+        <dd>Hello</dd>
+      <dt>lol</dt>
+        <dd>Laughing Out Loud</dd>
+    `);
+
+    expect(parseDefinitionList(list)).toMatchInlineSnapshot(`
+      Object {
+        "fieldNames": Array [
+          "sup",
+          "wassup",
+          "lol",
+        ],
+        "records": Array [
+          Object {
+            "lol": "Laughing Out Loud",
+            "sup": "What is up
+      Hello",
+            "wassup": "What is up
+      Hello",
+          },
+        ],
+      }
+    `);
+  });
+
+  test("parse list wrapped in divs", () => {
+    const list = getDL(`
+      <div>
+        <dt>sus</dt>
+          <dd>Suspicious</dd>
+      </div>
+      <div>
+        <dt>lit</dt>
+        <dt>bussin</dt>
+          <dd>Amazing</dd>
+      </div>
+    `);
+
+    expect(parseDefinitionList(list)).toMatchInlineSnapshot(`
+      Object {
+        "fieldNames": Array [
+          "sus",
+          "lit",
+          "bussin",
+        ],
+        "records": Array [
+          Object {
+            "bussin": "Amazing",
+            "lit": "Amazing",
+            "sus": "Suspicious",
+          },
+        ],
+      }
+    `);
+  });
+});

--- a/src/utils/parseDefinitionList.test.ts
+++ b/src/utils/parseDefinitionList.test.ts
@@ -15,8 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { parseDefinitionList } from "./parseDefinitionList";
+import {
+  parseDefinitionList,
+  getAllDefinitionLists,
+} from "./parseDefinitionList";
 import { JSDOM } from "jsdom";
+import { html } from "@/utils";
 
 function getDL(
   html: string,
@@ -32,13 +36,20 @@ function getDL(
   return list;
 }
 
+function getDocument(html: string): Document {
+  const { window } = new JSDOM();
+  window.document.body.innerHTML = html;
+  return window.document;
+}
+
 describe("parseDefinitionList", () => {
   test("parse simple list", () => {
-    const list = getDL(`
+    const list = getDL(html`
       <dt>YOLO</dt>
-        <dd>You Only Live Once</dd>
+      <dd>You Only Live Once</dd>
+
       <dt>SMH</dt>
-        <dd>Shaking My Head</dd>
+      <dd>Shaking My Head</dd>
     `);
 
     expect(parseDefinitionList(list)).toMatchInlineSnapshot(`
@@ -58,13 +69,14 @@ describe("parseDefinitionList", () => {
   });
 
   test("parse list with multiple definitions and terms", () => {
-    const list = getDL(`
+    const list = getDL(html`
       <dt>sup</dt>
       <dt>wassup</dt>
-        <dd>What is up</dd>
-        <dd>Hello</dd>
+      <dd>What is up</dd>
+      <dd>Hello</dd>
+
       <dt>lol</dt>
-        <dd>Laughing Out Loud</dd>
+      <dd>Laughing Out Loud</dd>
     `);
 
     expect(parseDefinitionList(list)).toMatchInlineSnapshot(`
@@ -88,15 +100,15 @@ describe("parseDefinitionList", () => {
   });
 
   test("parse list wrapped in divs", () => {
-    const list = getDL(`
+    const list = getDL(html`
       <div>
         <dt>sus</dt>
-          <dd>Suspicious</dd>
+        <dd>Suspicious</dd>
       </div>
       <div>
         <dt>lit</dt>
         <dt>bussin</dt>
-          <dd>Amazing</dd>
+        <dd>Amazing</dd>
       </div>
     `);
 
@@ -114,6 +126,159 @@ describe("parseDefinitionList", () => {
             "sus": "Suspicious",
           },
         ],
+      }
+    `);
+  });
+});
+
+describe("getAllDefinitionLists", () => {
+  test("find multiple unnamed lists", () => {
+    const document = getDocument(html`
+      <dl>
+        <dt>bloke</dt>
+        <dd>man</dd>
+
+        <dt>lad</dt>
+        <dd>young man</dd>
+
+        <dt>bird</dt>
+        <dd>girl or woman</dd>
+      </dl>
+      <dl>
+        <dt>mental</dt>
+        <dt>bonkers</dt>
+        <dd>mad</dd>
+        <dd>crazy</dd>
+
+        <dt>daft</dt>
+        <dd>silly</dd>
+      </dl>
+    `);
+
+    expect(getAllDefinitionLists(document)).toMatchInlineSnapshot(`
+      Map {
+        "table_2c6a1" => Object {
+          "fieldNames": Array [
+            "bloke",
+            "lad",
+            "bird",
+          ],
+          "records": Array [
+            Object {
+              "bird": "girl or woman",
+              "bloke": "man",
+              "lad": "young man",
+            },
+          ],
+        },
+        "table_4e8c8" => Object {
+          "fieldNames": Array [
+            "mental",
+            "bonkers",
+            "daft",
+          ],
+          "records": Array [
+            Object {
+              "bonkers": "mad
+      crazy",
+              "daft": "silly",
+              "mental": "mad
+      crazy",
+            },
+          ],
+        },
+      }
+    `);
+  });
+
+  test("use id as name", () => {
+    const document = getDocument(html`
+      <dl id="british-money-slang">
+        <dt>quid</dt>
+        <dd>British pound</dd>
+
+        <dt>fiver</dt>
+        <dd>5 British pounds</dd>
+
+        <dt>tenner</dt>
+        <dd>10 British pounds</dd>
+      </dl>
+    `);
+
+    expect(getAllDefinitionLists(document)).toMatchInlineSnapshot(`
+      Map {
+        "british-money-slang" => Object {
+          "fieldNames": Array [
+            "quid",
+            "fiver",
+            "tenner",
+          ],
+          "records": Array [
+            Object {
+              "fiver": "5 British pounds",
+              "quid": "British pound",
+              "tenner": "10 British pounds",
+            },
+          ],
+        },
+      }
+    `);
+  });
+
+  test("use aria-label as name", () => {
+    const document = getDocument(html`
+      <dl aria-label="british-slang">
+        <dt>gobsmacked</dt>
+        <dd>shocked</dd>
+
+        <dt>dodgy</dt>
+        <dd>sketchy</dd>
+      </dl>
+    `);
+
+    expect(getAllDefinitionLists(document)).toMatchInlineSnapshot(`
+      Map {
+        "british-slang" => Object {
+          "fieldNames": Array [
+            "gobsmacked",
+            "dodgy",
+          ],
+          "records": Array [
+            Object {
+              "dodgy": "sketchy",
+              "gobsmacked": "shocked",
+            },
+          ],
+        },
+      }
+    `);
+  });
+
+  test("use aria-describedby as name", () => {
+    const document = getDocument(html`
+      <dl aria-describedby="other-element">
+        <dt>kerfuffle</dt>
+        <dd>fuss</dd>
+        <dt>innit</dt>
+        <dd>isn't it</dd>
+      </dl>
+      <p id="other-element">Funny british terms</p>
+    `);
+
+    expect(getAllDefinitionLists(document)).toMatchInlineSnapshot(`
+      Map {
+        "funny_british_terms" => Object {
+          "fieldNames": Array [
+            "kerfuffle",
+            "innit",
+          ],
+          "records": Array [
+            Object {
+              "innit": "isn't it",
+              "kerfuffle": "fuss",
+            },
+          ],
+        },
       }
     `);
   });

--- a/src/utils/parseDefinitionList.ts
+++ b/src/utils/parseDefinitionList.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { describeTable, ParsedTable, TableRecord } from "./parseDomTable";
+
+/** Normalized data extracted from definition list */
+interface NormalizedItem {
+  terms: string[];
+  definitions: string[];
+}
+
+function flattenListContent(list: HTMLDListElement): NormalizedItem[] {
+  const flattened: NormalizedItem[] = [];
+  let current: NormalizedItem;
+  let seenDefinition = true;
+  for (const element of list.querySelectorAll("dt, dd")) {
+    if (element.tagName === "DT") {
+      if (seenDefinition) {
+        seenDefinition = false;
+        current = {
+          terms: [],
+          definitions: [],
+        };
+        flattened.push(current);
+      }
+
+      current.terms.push(element.textContent.trim());
+    } else if (element.tagName === "DD") {
+      seenDefinition = true;
+      current.definitions.push(element.textContent.trim());
+    }
+  }
+
+  return flattened;
+}
+
+export function parseDefinitionList(list: HTMLDListElement): ParsedTable {
+  // Lists are monodimensional, there can only be one record
+  const record: TableRecord = {};
+
+  for (const { terms, definitions } of flattenListContent(list)) {
+    for (const term of terms) {
+      // TODO: Possible injection with `<dt>__proto__</dt>`
+      record[term] = definitions.join("\n");
+    }
+  }
+
+  return {
+    fieldNames: Object.keys(record),
+    records: [record],
+  };
+}
+
+export function getAllDefinitionLists(
+  root: HTMLElement | Document = document
+): Map<string, ParsedTable> {
+  const tables = new Map();
+  for (const table of $<HTMLDListElement>("dl", root)) {
+    const parsedTable = parseDefinitionList(table);
+
+    tables.set(describeTable(table, parsedTable), parsedTable);
+  }
+
+  return tables;
+}

--- a/src/utils/parseDefinitionList.ts
+++ b/src/utils/parseDefinitionList.ts
@@ -26,11 +26,17 @@ interface NormalizedItem {
 function flattenListContent(list: HTMLDListElement): NormalizedItem[] {
   const flattened: NormalizedItem[] = [];
   let current: NormalizedItem;
-  let seenDefinition = true;
+
+  // This boolean marks the `dd -> dt` sequence, where the old definition ends
+  // and a new term is found. This allows `dt, dt, dd, dd` sequences which are
+  // for a single term group, like:
+  // Terms: hi, hello
+  // Definitions: excl. to begin a conversation, excl. to attract someone's attention
+  let dtStartsNewGroup = true;
   for (const element of list.querySelectorAll("dt, dd")) {
     if (element.tagName === "DT") {
-      if (seenDefinition) {
-        seenDefinition = false;
+      if (dtStartsNewGroup) {
+        dtStartsNewGroup = false;
         current = {
           terms: [],
           definitions: [],
@@ -40,7 +46,7 @@ function flattenListContent(list: HTMLDListElement): NormalizedItem[] {
 
       current.terms.push(element.textContent.trim());
     } else if (element.tagName === "DD") {
-      seenDefinition = true;
+      dtStartsNewGroup = true;
       current.definitions.push(element.textContent.trim());
     }
   }

--- a/src/utils/parseDomTable.test.ts
+++ b/src/utils/parseDomTable.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import parseDomTable, { getAllTables } from "./parseDomTable";
+import { parseDomTable, getAllTables } from "./parseDomTable";
 import { JSDOM } from "jsdom";
 
 function getTable(

--- a/src/utils/parseDomTable.test.ts
+++ b/src/utils/parseDomTable.test.ts
@@ -97,6 +97,76 @@ describe("parseDomTable", () => {
 
     expect(actual).toStrictEqual(expected);
   });
+
+  test("parse table with rowspan", () => {
+    const table = getTable(`
+      <tr><th>Name    <th>Min            <th>Max
+      <tr><td>Mario   <td rowspan="2">1  <td>2
+      <tr><td>Luigi                      <td rowspan="2">3
+      <tr><td>Bowser  <td>4
+    `);
+
+    const expected = {
+      fieldNames: ["Name", "Min", "Max"],
+      records: [
+        { Name: "Mario", Min: "1", Max: "2" },
+        { Name: "Luigi", Min: "1", Max: "3" },
+        { Name: "Bowser", Min: "4", Max: "3" },
+      ],
+    };
+
+    const actual = parseDomTable(table);
+
+    expect(actual).toStrictEqual(expected);
+  });
+
+  test("parse table with colspan", () => {
+    const table = getTable(`
+      <tr><th>Name   <th>Min            <th>Max           <th>Average
+      <tr><td>Mario  <td colspan="2">1                    <td>2
+      <tr><td>Luigi  <td>3              <td colspan="2">4
+      <tr><td>Bowser <td>5              <td>6             <td>7
+    `);
+
+    const expected = {
+      fieldNames: ["Name", "Min", "Max", "Average"],
+      records: [
+        { Name: "Mario", Min: "1", Max: "1", Average: "2" },
+        { Name: "Luigi", Min: "3", Max: "4", Average: "4" },
+        { Name: "Bowser", Min: "5", Max: "6", Average: "7" },
+      ],
+    };
+
+    const actual = parseDomTable(table);
+
+    expect(actual).toStrictEqual(expected);
+  });
+
+  test("parse table with rowspan and colspan", () => {
+    const table = getTable(`
+      <tr><th>Name   <th>Min            <th>Max           <th>Average        <th>Mean
+      <tr><td>Mario  <td rowspan="3" colspan="2">1        <td>2              <td rowspan="2">3
+      <tr><td>Luigi                                       <td rowspan="2">4
+      <tr><td>Bowser                                                         <td rowspan="3">5
+      <tr><td>Toad   <td>6              <td>7             <td>8
+      <tr><td>Yoshi  <td>9              <td>10            <td>11
+    `);
+
+    const expected = {
+      fieldNames: ["Name", "Min", "Max", "Average", "Mean"],
+      records: [
+        { Name: "Mario", Min: "1", Max: "1", Average: "2", Mean: "3" },
+        { Name: "Luigi", Min: "1", Max: "1", Average: "4", Mean: "3" },
+        { Name: "Bowser", Min: "1", Max: "1", Average: "4", Mean: "5" },
+        { Name: "Toad", Min: "6", Max: "7", Average: "8", Mean: "5" },
+        { Name: "Yoshi", Min: "9", Max: "10", Average: "11", Mean: "5" },
+      ],
+    };
+
+    const actual = parseDomTable(table, { orientation: "vertical" });
+
+    expect(actual).toStrictEqual(expected);
+  });
 });
 
 describe("getAllTables", () => {
@@ -169,76 +239,6 @@ describe("getAllTables", () => {
     );
 
     const expected = new Map([["characters", parseDomTable(table1)]]);
-
-    expect(actual).toStrictEqual(expected);
-  });
-
-  test("parse table with rowspan", () => {
-    const table = getTable(`
-      <tr><th>Name    <th>Min            <th>Max
-      <tr><td>Mario   <td rowspan="2">1  <td>2
-      <tr><td>Luigi                      <td rowspan="2">3
-      <tr><td>Bowser  <td>4
-    `);
-
-    const expected = {
-      fieldNames: ["Name", "Min", "Max"],
-      records: [
-        { Name: "Mario", Min: "1", Max: "2" },
-        { Name: "Luigi", Min: "1", Max: "3" },
-        { Name: "Bowser", Min: "4", Max: "3" },
-      ],
-    };
-
-    const actual = parseDomTable(table);
-
-    expect(actual).toStrictEqual(expected);
-  });
-
-  test("parse table with colspan", () => {
-    const table = getTable(`
-      <tr><th>Name   <th>Min            <th>Max           <th>Average
-      <tr><td>Mario  <td colspan="2">1                    <td>2
-      <tr><td>Luigi  <td>3              <td colspan="2">4
-      <tr><td>Bowser <td>5              <td>6             <td>7
-    `);
-
-    const expected = {
-      fieldNames: ["Name", "Min", "Max", "Average"],
-      records: [
-        { Name: "Mario", Min: "1", Max: "1", Average: "2" },
-        { Name: "Luigi", Min: "3", Max: "4", Average: "4" },
-        { Name: "Bowser", Min: "5", Max: "6", Average: "7" },
-      ],
-    };
-
-    const actual = parseDomTable(table);
-
-    expect(actual).toStrictEqual(expected);
-  });
-
-  test("parse table with rowspan and colspan", () => {
-    const table = getTable(`
-      <tr><th>Name   <th>Min            <th>Max           <th>Average        <th>Mean
-      <tr><td>Mario  <td rowspan="3" colspan="2">1        <td>2              <td rowspan="2">3
-      <tr><td>Luigi                                       <td rowspan="2">4
-      <tr><td>Bowser                                                         <td rowspan="3">5
-      <tr><td>Toad   <td>6              <td>7             <td>8
-      <tr><td>Yoshi  <td>9              <td>10            <td>11
-    `);
-
-    const expected = {
-      fieldNames: ["Name", "Min", "Max", "Average", "Mean"],
-      records: [
-        { Name: "Mario", Min: "1", Max: "1", Average: "2", Mean: "3" },
-        { Name: "Luigi", Min: "1", Max: "1", Average: "4", Mean: "3" },
-        { Name: "Bowser", Min: "1", Max: "1", Average: "4", Mean: "5" },
-        { Name: "Toad", Min: "6", Max: "7", Average: "8", Mean: "5" },
-        { Name: "Yoshi", Min: "9", Max: "10", Average: "11", Mean: "5" },
-      ],
-    };
-
-    const actual = parseDomTable(table, { orientation: "vertical" });
 
     expect(actual).toStrictEqual(expected);
   });

--- a/src/utils/parseDomTable.ts
+++ b/src/utils/parseDomTable.ts
@@ -26,7 +26,7 @@ interface ParsingOptions {
 type Cell = { type: "value" | "header"; value: string };
 
 type FieldNames = Array<number | string>;
-type Records = Array<Record<string, string>>;
+export type TableRecord = Record<string, string>;
 
 /** Flattened data extracted from table */
 type RawTableContent = Cell[][];
@@ -38,9 +38,9 @@ interface NormalizedData {
 }
 
 /** Final parsed records and field names */
-interface ParsedTable {
+export interface ParsedTable {
   fieldNames: FieldNames;
-  records: Records;
+  records: TableRecord[];
 }
 
 function guessDirection(
@@ -53,12 +53,13 @@ function guessDirection(
 }
 
 function flattenTableContent(table: HTMLTableElement): RawTableContent {
-  // This table will be pre-filled in the adjactent rows and colums when rowspan and colspan are found.
-  // Colspan means that the current cell exist on [X, Y] and [X + 1, Y]
-  // Rowspan means that the current cell exist on [X, Y] and [X, Y + 1]
+  // This table will be pre-filled in the adjacent rows and colums when rowspan and colspan are found.
+  // Colspan means that the current cell exists on [X, Y] and [X + 1, Y]
+  // Rowspan means that the current cell exists on [X, Y] and [X, Y + 1]
   // Having both means that a colspan × rowspan matrix will be pre-filled.
   // When a pre-filled cell is found, +1 until the first available column and fill the whole matrix there.
   const flattened: RawTableContent = [];
+
   /* eslint-disable security/detect-object-injection -- Native indexes */
   for (const [rowIndex, row] of [...table.rows].entries()) {
     for (let [cellIndex, cell] of [...row.cells].entries()) {
@@ -83,7 +84,7 @@ function flattenTableContent(table: HTMLTableElement): RawTableContent {
     }
   }
 
-  // Temporary patch to "support" tables with rowspan/colspan without throwing errors
+  // In case of malformed tables, ensure that the result is a perfect matrix so we don't have runtime errors
   const maxRowlength = Math.max(...flattened.map((row) => row.length));
   for (const row of flattened) {
     while (row.length < maxRowlength) {
@@ -118,7 +119,7 @@ function extractData(
   return { fieldNames: [...(firstRow ?? []).keys()], body: textTable };
 }
 
-export default function parseDomTable(
+export function parseDomTable(
   table: HTMLTableElement,
   { orientation = "infer" }: ParsingOptions = {}
 ): ParsedTable {
@@ -142,6 +143,22 @@ function getNameFromFields(fields: Array<number | string>): string {
   return "Table_" + objectHash(fields).slice(0, 5);
 }
 
+export function describeTable(
+  table: HTMLTableElement | HTMLDListElement,
+  parsedTable: ParsedTable
+): string {
+  // Uses || instead of ?? to exclude empty strings
+  const tableName =
+    table.querySelector("caption")?.textContent ||
+    getAriaDescription(table) ||
+    table.getAttribute("aria-label") ||
+    // TODO: Exclude random identifiers #2498
+    table.id ||
+    getNameFromFields(parsedTable.fieldNames);
+
+  return slugify(tableName, { replacement: "_", lower: true });
+}
+
 export function getAllTables(
   root: HTMLElement | Document = document
 ): Map<string, ParsedTable> {
@@ -149,18 +166,7 @@ export function getAllTables(
   for (const table of $<HTMLTableElement>("table", root)) {
     const parsedTable = parseDomTable(table);
 
-    // Uses || instead of ?? to exclude empty strings
-    const tableName =
-      table.querySelector("caption")?.textContent ||
-      getAriaDescription(table) ||
-      table.getAttribute("aria-label") ||
-      // TODO: Exclude random identifiers #2498
-      table.id ||
-      getNameFromFields(parsedTable.fieldNames);
-    tables.set(
-      slugify(tableName, { replacement: "_", lower: true }),
-      parsedTable
-    );
+    tables.set(describeTable(table, parsedTable), parsedTable);
   }
 
   return tables;

--- a/src/utils/requireSingleElement.ts
+++ b/src/utils/requireSingleElement.ts
@@ -23,15 +23,18 @@ import { MultipleElementsFoundError, NoElementsFoundError } from "@/errors";
  * @throws NoElementsFoundError if not elements are found
  * @throws MultipleElementsFoundError if multiple elements are found
  */
-export function requireSingleElement(selector: string): HTMLElement {
-  const $elt = $(document).find(selector);
-  if ($elt.length === 0) {
+export function requireSingleElement<Element extends HTMLElement>(
+  selector: string,
+  parent: Document | HTMLElement | JQuery<HTMLElement | Document> = document
+): Element {
+  const $elements = $(parent).find<Element>(selector);
+  if ($elements.length === 0) {
     throw new NoElementsFoundError(selector);
   }
 
-  if ($elt.length > 1) {
+  if ($elements.length > 1) {
     throw new MultipleElementsFoundError(selector);
   }
 
-  return $elt.get(0);
+  return $elements.get(0);
 }


### PR DESCRIPTION
- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/2831



## Live test area


<table id="support-table">
<tr>
	<th>
	<th>Chrome
	<th>Firefox
<tr>
	<th>Coolness
	<td>No
	<td>Yes
</table>


<dl id="definitions">
	<dt>Chrome</dt>
	<dd>Google’s browser</dd>
	<dt>Firefox</dt>
	<dd>Mozilla’s browser</dd>
</dl>

## Live test output

Side note: refer to https://github.com/pixiebrix/pixiebrix-extension/issues/2882 for table output expectations

<img width="329" alt="Screen Shot 14" src="https://user-images.githubusercontent.com/1402241/156985641-2557c77b-a0fa-4f90-8b78-a4ea4dd18b2c.png">

