### PR TITLE
Fix notification display

### DIFF
--- a/src/pageEditor/ElementWizard.module.scss
+++ b/src/pageEditor/ElementWizard.module.scss
@@ -29,6 +29,7 @@
     border-radius: 0 !important;
     padding-top: 0.3em;
     padding-bottom: 0.3em;
+    font-size: 0.875rem;
   }
 }
 

--- a/src/utils/notify.tsx
+++ b/src/utils/notify.tsx
@@ -116,10 +116,12 @@ export function showNotification({
 }: RequireAtLeastOne<Notification, "message" | "error">): string {
   const options = { id, duration };
 
-  if (!message) {
-    message = getErrorMessage(error);
-  } else if (includeErrorDetails) {
-    message = message.replace(/[\s.:]$/, ": ") + getErrorMessage(error);
+  if (error) {
+    if (!message) {
+      message = getErrorMessage(error);
+    } else if (includeErrorDetails) {
+      message = message.replace(/[\s.:]$/, "") + ": " + getErrorMessage(error);
+    }
   }
 
   duration ??= getMessageDisplayTime(message);


### PR DESCRIPTION
I made a mistake in a commit before merging https://github.com/pixiebrix/pixiebrix-extension/pull/2836, the colon and space was not added + the error was appended even if it was not an error at all. 

<img width="409" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/157023187-f7c6b947-6b80-4c0f-b38e-0139027179d2.png">
