### PR TITLE
#2899: Avoid length-based filter in `inferSelectors`

### DIFF
--- a/src/contentScript/nativeEditor/infer.test.tsx
+++ b/src/contentScript/nativeEditor/infer.test.tsx
@@ -21,7 +21,6 @@ import {
   inferButtonHTML,
   inferPanelHTML,
   inferSelectors,
-  isSelectorPotentiallyUseful,
   safeCssSelector,
 } from "@/contentScript/nativeEditor/infer";
 import { PIXIEBRIX_DATA_ATTR, EXTENSION_POINT_DATA_ATTR } from "@/common";
@@ -352,22 +351,6 @@ test("getSelectorPreference: matches expected sorting", () => {
   expect(getSelectorPreference(".birdsArentReal")).toBe(2);
   const selector = '[aria-label="Click elsewhere"]';
   expect(getSelectorPreference(selector)).toBe(selector.length);
-});
-
-test("isSelectorPotentiallyUseful", () => {
-  const fn = isSelectorPotentiallyUseful;
-  expect(fn(".navItem")).toBeTruthy();
-  expect(fn(".birdsArentReal")).toBeTruthy();
-  expect(fn('[aria-label="Click elsewhere"]')).toBeTruthy();
-
-  // Always allow IDs
-  expect(fn("#yes")).toBeTruthy();
-
-  // Exclude utility classes
-  expect(fn(".p-1")).toBeFalsy();
-
-  // Exclude some short random classes
-  expect(fn("._d3f32f")).toBeFalsy();
 });
 
 describe("inferSelectors", () => {

--- a/src/contentScript/nativeEditor/infer.ts
+++ b/src/contentScript/nativeEditor/infer.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { uniq, sortBy, unary, intersection } from "lodash";
+import { uniq, sortBy, unary, intersection, isEmpty } from "lodash";
 import { getCssSelector } from "css-selector-generator";
 import { isNullOrBlank, mostCommonElement, matchesAnyPattern } from "@/utils";
 import { BusinessError } from "@/errors";
@@ -122,14 +122,6 @@ export function getSelectorPreference(selector: string): number {
   }
 
   return selector.length;
-}
-
-/** Excludes empty or short selectors (must have more than 3 letters, no numbers) */
-export function isSelectorPotentiallyUseful(selector: string): boolean {
-  // Remove the non-letter characters, and then compare the number of remaining letter characters
-  return (
-    selector.startsWith("#") || selector.replace(/[^a-z]/gi, "").length > 3
-  );
 }
 
 function outerHTML(element: Element | string): string {
@@ -603,7 +595,7 @@ export function inferSelectors(
     makeSelector(["id", "tag", "attribute", "nthchild"]),
     makeSelector(["id", "tag", "attribute"]),
     makeSelector(),
-  ]).filter((x) => isSelectorPotentiallyUseful(x));
+  ]).filter((x) => !isEmpty(x));
 
   return sortBy(generatedSelectors, getSelectorPreference);
 }


### PR DESCRIPTION
- Closes  #2899

This restores the previous null-check. The other PR as better logic to deal with length:

- https://github.com/pixiebrix/pixiebrix-extension/pull/2776#issuecomment-1056399114