### PR TITLE
Add documentation to Append to Google Sheets brick metadata

### DIFF
--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -98,7 +98,7 @@ const AppendSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
       <ConnectedFieldTemplate
         name={joinName(basePath, "spreadsheetId")}
         label="Google Sheet"
-        description="Select a Google Sheet"
+        description="Select a Google Sheet. The first row in your sheet MUST contain headings."
         as={FileWidget}
         doc={doc}
         onSelect={setDoc}

--- a/src/contrib/google/sheets/append.ts
+++ b/src/contrib/google/sheets/append.ts
@@ -116,7 +116,7 @@ export class GoogleSheetsAppend extends Effect {
     super(
       GOOGLE_SHEETS_APPEND_ID,
       "Add Google sheet row",
-      "Add a row of data to a Google sheet. The first row must be named headings.",
+      "Add a row of data to a Google sheet. The first row should contain headings.",
       "faTable"
     );
   }

--- a/src/contrib/google/sheets/append.ts
+++ b/src/contrib/google/sheets/append.ts
@@ -116,7 +116,7 @@ export class GoogleSheetsAppend extends Effect {
     super(
       GOOGLE_SHEETS_APPEND_ID,
       "Add Google sheet row",
-      "Add a row of data to a Google sheet",
+      "Add a row of data to a Google sheet. The first row must be named headings.",
       "faTable"
     );
   }

--- a/src/contrib/google/sheets/append.ts
+++ b/src/contrib/google/sheets/append.ts
@@ -116,7 +116,7 @@ export class GoogleSheetsAppend extends Effect {
     super(
       GOOGLE_SHEETS_APPEND_ID,
       "Add Google sheet row",
-      "Add a row of data to a Google sheet. The first row should contain headings.",
+      "Add a row of data to a Google sheet with headings",
       "faTable"
     );
   }


### PR DESCRIPTION
#2897 - This small changes might users who do not know that the Spreadsheet they're editing needs to have named headers 