### PR TITLE
#2902: Throw BusinessError on `runBrick` if tab is closed or has no access

### DIFF
--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -44,7 +44,12 @@ async function safelyRunBrick(...args: Parameters<typeof runBrick>) {
     return await runBrick(...args);
   } catch (error) {
     if (getErrorMessage(error) === NO_TARGET_FOUND_CONNECTION_ERROR) {
-      throw new BusinessError("The tab doesn't exist or it was closed");
+      // We can only be sure that the tab was closed because `safelyRunBrick` is called on
+      // specific, existing `tabId`s, and not on named targets that may or may not exist.
+
+      // The caught error isn't "The tab was closed" because of:
+      // https://github.com/pixiebrix/pixiebrix-extension/issues/2902#issuecomment-1062658248
+      throw new BusinessError("The tab was closed");
     }
 
     throw error;

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -43,13 +43,15 @@ async function safelyRunBrick(...args: Parameters<typeof runBrick>) {
   try {
     return await runBrick(...args);
   } catch (error) {
+    // The caught error isn't "The tab was closed" because of:
+    // https://github.com/pixiebrix/pixiebrix-extension/issues/2902#issuecomment-1062658248
     if (getErrorMessage(error) === NO_TARGET_FOUND_CONNECTION_ERROR) {
-      // We can only be sure that the tab was closed because `safelyRunBrick` is called on
-      // specific, existing `tabId`s, and not on named targets that may or may not exist.
-
-      // The caught error isn't "The tab was closed" because of:
-      // https://github.com/pixiebrix/pixiebrix-extension/issues/2902#issuecomment-1062658248
-      throw new BusinessError("The tab was closed");
+      // NO_TARGET_FOUND_CONNECTION_ERROR is thrown when:
+      // - the target has no permissions
+      // - the target was closed after creation
+      throw new BusinessError(
+        "PixieBrix doesn't have access to the tab or it was closed"
+      );
     }
 
     throw error;

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -138,3 +138,13 @@ export async function setReduxStorage<T extends JsonValue = JsonValue>(
 ): Promise<void> {
   await browser.storage.local.set({ [storageKey]: JSON.stringify(value) });
 }
+
+export async function onTabClose(watchedTabId: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    browser.tabs.onRemoved.addListener((closedTabId) => {
+      if (closedTabId === watchedTabId) {
+        resolve();
+      }
+    });
+  });
+}

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -141,10 +141,13 @@ export async function setReduxStorage<T extends JsonValue = JsonValue>(
 
 export async function onTabClose(watchedTabId: number): Promise<void> {
   await new Promise<void>((resolve) => {
-    browser.tabs.onRemoved.addListener((closedTabId) => {
+    const listener = (closedTabId: number) => {
       if (closedTabId === watchedTabId) {
         resolve();
+        browser.tabs.onRemoved.removeListener(listener);
       }
-    });
+    };
+
+    browser.tabs.onRemoved.addListener(listener);
   });
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -174,9 +174,11 @@ export class ContextError extends Error {
   }
 }
 
+export const NO_TARGET_FOUND_CONNECTION_ERROR =
+  "Could not establish connection. Receiving end does not exist.";
 /** Browser Messenger API error message patterns */
 export const CONNECTION_ERROR_MESSAGES = [
-  "Could not establish connection. Receiving end does not exist.",
+  NO_TARGET_FOUND_CONNECTION_ERROR,
   "Extension context invalidated.",
 ];
 


### PR DESCRIPTION
- Closes #2902

After the tab is closed, the timeout continues and then it throws a BusinessError.

https://user-images.githubusercontent.com/1402241/157635945-245d43c4-d567-450a-9d26-11507d7a9d78.mov


![business-appropriate-business](https://user-images.githubusercontent.com/1402241/157636615-aa1de9de-3d30-45c3-8b5f-6a8c0b736967.gif)

