### PR TITLE
Allow disabling redux-logger via ENV

### DIFF
--- a/src/options/store.ts
+++ b/src/options/store.ts
@@ -65,7 +65,7 @@ export const persistWorkshopConfig = {
 };
 
 const conditionalMiddleware: Middleware[] = [];
-if (process.env.NODE_ENV === "development") {
+if (typeof createLogger === "function") {
   // Allow tree shaking of logger in production
   // https://github.com/LogRocket/redux-logger/issues/6
   conditionalMiddleware.push(

--- a/src/pageEditor/store.ts
+++ b/src/pageEditor/store.ts
@@ -63,7 +63,7 @@ export type RootState = LogRootState & {
 };
 
 const conditionalMiddleware: Middleware[] = [];
-if (process.env.NODE_ENV === "development") {
+if (typeof createLogger === "function") {
   // Allow tree shaking of logger in production
   // https://github.com/LogRocket/redux-logger/issues/6
   conditionalMiddleware.push(


### PR DESCRIPTION
I believe this was asked on Slack a few months ago. With RKT being used more and more I think I've been seeing more messages in the console. This silences them by setting `DEV_REDUX_LOGGER=false` (prod builds are silent regardless)