### PR TITLE
Use Messenger for locator in useDependency

### DIFF
--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -64,9 +64,6 @@ jest.mock("@/contentScript/messenger/api", () => ({
 }));
 
 jest.mock("@/background/messenger/api", () => ({
-  // eslint-disable-next-line unicorn/no-useless-undefined -- argument is required
-  uninstallContextMenu: jest.fn().mockResolvedValue(undefined),
-  containsPermissions: jest.fn().mockResolvedValue(true),
   traces: {
     // eslint-disable-next-line unicorn/no-useless-undefined -- argument is required
     clear: jest.fn().mockResolvedValue(undefined),
@@ -104,6 +101,9 @@ jest.mock("webextension-polyfill", () => {
     default: {
       // Keep the existing local storage mock
       ...mock,
+      permissions: {
+        contains: jest.fn().mockResolvedValue(true),
+      },
       runtime: {
         openOptionsPage: jest.fn(),
         getManifest: jest.fn().mockReturnValue({
@@ -119,7 +119,6 @@ jest.mock("@/background/installer", () => ({
 }));
 
 import { isLinked, readAuthData } from "@/auth/token";
-import { containsPermissions } from "@/background/messenger/api";
 import { refreshRegistries } from "@/hooks/useRefresh";
 import { isUpdateAvailable } from "@/background/installer";
 import { getSettingsState } from "@/store/settingsStorage";
@@ -128,7 +127,7 @@ const isLinkedMock = isLinked as jest.Mock;
 const readAuthDataMock = readAuthData as jest.Mock;
 const getManifestMock = browser.runtime.getManifest as jest.Mock;
 const openOptionsPageMock = browser.runtime.openOptionsPage as jest.Mock;
-const containsPermissionsMock = containsPermissions as jest.Mock;
+const containsPermissionsMock = browser.permissions.contains as jest.Mock;
 const refreshRegistriesMock = refreshRegistries as jest.Mock;
 const isUpdateAvailableMock = isUpdateAvailable as jest.Mock;
 const getSettingsStateMock = getSettingsState as jest.Mock;

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -24,10 +24,6 @@ import { isLinked, readAuthData, updateUserData } from "@/auth/token";
 import { reportEvent } from "@/telemetry/events";
 import { refreshRegistries } from "@/hooks/useRefresh";
 import { selectExtensions } from "@/store/extensionsSelectors";
-import {
-  uninstallContextMenu,
-  containsPermissions,
-} from "@/background/messenger/api";
 import { deploymentPermissions } from "@/permissions";
 import { IExtension, UUID, RegistryId } from "@/core";
 import { maybeGetLinkedApiClient } from "@/services/apiClient";
@@ -41,6 +37,7 @@ import { expectContext } from "@/utils/expectContext";
 import { getSettingsState } from "@/store/settingsStorage";
 import { isUpdateAvailable } from "@/background/installer";
 import { selectUserDataUpdate } from "@/auth/authUtils";
+import { uninstallContextMenu } from "@/background/contextMenus";
 
 const { reducer, actions } = extensionsSlice;
 
@@ -386,7 +383,7 @@ export async function updateDeployments(): Promise<void> {
   const deploymentRequirements = await Promise.all(
     updatedDeployments.map(async (deployment) => ({
       deployment,
-      hasPermissions: await containsPermissions(
+      hasPermissions: await browser.permissions.contains(
         await deploymentPermissions(deployment)
       ),
     }))

--- a/src/services/useDependency.ts
+++ b/src/services/useDependency.ts
@@ -24,11 +24,10 @@ import {
   ServiceDependency,
 } from "@/core";
 import { castArray, head } from "lodash";
-import { locator } from "@/background/locator";
 import registry from "@/services/registry";
 import { Service } from "@/types";
 import { requestPermissions } from "@/utils/permissions";
-import { containsPermissions } from "@/background/messenger/api";
+import { containsPermissions, services } from "@/background/messenger/api";
 import notify from "@/utils/notify";
 
 type Listener = () => void;
@@ -65,7 +64,7 @@ function useDependency(serviceId: RegistryId | RegistryId[]): Dependency {
 
   const [serviceResult] = useAsyncState(async () => {
     if (dependency?.config) {
-      const localConfig = await locator.locate(
+      const localConfig = await services.locate(
         dependency.id,
         dependency.config
       );


### PR DESCRIPTION
- Should close https://github.com/pixiebrix/pixiebrix-extension/issues/2925

I don't see any other references to `locator` and its services outside this function, that already don't go through the messenger.

This was probably code I left behind during my last Messenger migration PR