### PR TITLE
#2924: page editor session tracking MVP

### DIFF
--- a/src/components/documentBuilder/edit/ElementBlockEdit.tsx
+++ b/src/components/documentBuilder/edit/ElementBlockEdit.tsx
@@ -26,6 +26,9 @@ import { BlockType, defaultBlockConfig } from "@/blocks/util";
 import { IBlock } from "@/core";
 import { uuidv4 } from "@/types/helpers";
 import { reportEvent } from "@/telemetry/events";
+import { useSelector } from "react-redux";
+import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
+import { selectActiveExtensionId } from "@/pageEditor/slices/editorSelectors";
 
 type ElementBlockEditProps = {
   blockTypes: BlockType[];
@@ -40,6 +43,9 @@ const ElementBlockEdit: React.FC<ElementBlockEditProps> = ({
   blockConfig,
   onBlockSelected,
 }) => {
+  const sessionId = useSelector(selectSessionId);
+  const extensionId = useSelector(selectActiveExtensionId);
+
   const [renderBlocks] = useAsyncState<IBlock[]>(
     async () => {
       const allBlocks = await blockRegistry.allTyped();
@@ -63,6 +69,8 @@ const ElementBlockEdit: React.FC<ElementBlockEditProps> = ({
 
     reportEvent("BrickAdd", {
       brickId: block.id,
+      sessionId,
+      extensionId,
       source: "PageEditor-DocumentBuilder",
     });
     onBlockSelected(blockConfig);

--- a/src/pageEditor/Panel.tsx
+++ b/src/pageEditor/Panel.tsx
@@ -15,14 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { useEffect } from "react";
 import { HashRouter as Router } from "react-router-dom";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { PageEditorTabContext, useDevConnection } from "@/pageEditor/context";
 import Editor from "@/pageEditor/Editor";
 import store, { persistor } from "./store";
 import { PersistGate } from "redux-persist/integration/react";
-import { Provider } from "react-redux";
+import { Provider, useSelector } from "react-redux";
 import { useAsyncEffect } from "use-async-effect";
 import blockRegistry from "@/blocks/registry";
 import { ModalProvider } from "@/components/ConfirmationModal";
@@ -34,6 +34,8 @@ import registerEditors from "@/contrib/editors";
 import Loader from "@/components/Loader";
 import ErrorBanner from "@/pageEditor/ErrorBanner";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
+import { reportEvent } from "@/telemetry/events";
+import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 
 // Register the built-in bricks
 registerEditors();
@@ -45,10 +47,23 @@ registerDefaultWidgets();
 
 const Panel: React.VoidFunctionComponent = () => {
   const context = useDevConnection();
+  const sessionId = useSelector(selectSessionId);
 
   useAsyncEffect(async () => {
     await blockRegistry.fetch();
   }, []);
+
+  useEffect(() => {
+    reportEvent("PageEditorSessionStart", {
+      sessionId,
+    });
+
+    return () => {
+      reportEvent("PageEditorSessionEnd", {
+        sessionId,
+      });
+    };
+  }, [sessionId]);
 
   return (
     <Provider store={store}>

--- a/src/pageEditor/hooks/useCreate.ts
+++ b/src/pageEditor/hooks/useCreate.ts
@@ -16,7 +16,7 @@
  */
 
 import { editorSlice, FormState } from "@/pageEditor/slices/editorSlice";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useCallback } from "react";
 import notify from "@/utils/notify";
 import { getErrorMessage, isAxiosError } from "@/errors";
@@ -35,6 +35,7 @@ import { useGetEditablePackagesQuery } from "@/services/api";
 import { UnknownObject } from "@/types";
 import extensionsSlice from "@/store/extensionsSlice";
 import { isInnerExtensionPoint } from "@/runtime/runtimeUtils";
+import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 
 const { saveExtension } = extensionsSlice.actions;
 const { markSaved } = editorSlice.actions;
@@ -114,6 +115,7 @@ function useCreate(): CreateCallback {
   //  fire-and-forget notification).
 
   const dispatch = useDispatch();
+  const sessionId = useSelector(selectSessionId);
   const { data: editablePackages } = useGetEditablePackagesQuery();
 
   return useCallback(
@@ -178,6 +180,7 @@ function useCreate(): CreateCallback {
         }
 
         reportEvent("PageEditorCreate", {
+          sessionId,
           type: element.type,
         });
 
@@ -233,7 +236,7 @@ function useCreate(): CreateCallback {
         return "Error saving extension";
       }
     },
-    [dispatch, editablePackages]
+    [dispatch, sessionId, editablePackages]
   );
 }
 

--- a/src/pageEditor/hooks/useRemove.ts
+++ b/src/pageEditor/hooks/useRemove.ts
@@ -61,7 +61,7 @@ function useRemove(element: FormState): () => void {
     };
 
     reportEvent("PageEditorRemove", {
-      sessionId: sessionId,
+      sessionId,
       extensionId: values.uuid,
     });
 

--- a/src/pageEditor/hooks/useRemove.ts
+++ b/src/pageEditor/hooks/useRemove.ts
@@ -19,7 +19,7 @@ import { actions, FormState } from "@/pageEditor/slices/editorSlice";
 import { useCallback } from "react";
 import notify from "@/utils/notify";
 import { useFormikContext } from "formik";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useModals } from "@/components/ConfirmationModal";
 import { uninstallContextMenu } from "@/background/messenger/api";
 import { thisTab } from "@/pageEditor/utils";
@@ -28,6 +28,8 @@ import {
   removeSidebar,
 } from "@/contentScript/messenger/api";
 import extensionsSlice from "@/store/extensionsSlice";
+import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
+import { reportEvent } from "@/telemetry/events";
 
 /**
  * Remove the current element from the page and installed extensions
@@ -36,6 +38,7 @@ import extensionsSlice from "@/store/extensionsSlice";
 function useRemove(element: FormState): () => void {
   const { values } = useFormikContext<FormState>();
   const dispatch = useDispatch();
+  const sessionId = useSelector(selectSessionId);
   const { showConfirmation } = useModals();
 
   return useCallback(async () => {
@@ -56,6 +59,11 @@ function useRemove(element: FormState): () => void {
       extensionPointId: values.extensionPoint.metadata.id,
       extensionId: values.uuid,
     };
+
+    reportEvent("PageEditorRemove", {
+      sessionId: sessionId,
+      extensionId: values.uuid,
+    });
 
     try {
       // Remove from storage first so it doesn't get re-added by any subsequent steps
@@ -86,7 +94,7 @@ function useRemove(element: FormState): () => void {
         error,
       });
     }
-  }, [showConfirmation, values, element, dispatch]);
+  }, [showConfirmation, sessionId, values, element, dispatch]);
 }
 
 export default useRemove;

--- a/src/pageEditor/panes/insert/useAddExisting.ts
+++ b/src/pageEditor/panes/insert/useAddExisting.ts
@@ -17,12 +17,13 @@
 
 import { useCallback } from "react";
 import { reportEvent } from "@/telemetry/events";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import notify from "@/utils/notify";
 import { editorSlice, FormState } from "@/pageEditor/slices/editorSlice";
 import { ElementConfig } from "@/pageEditor/extensionPoints/elementConfig";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import { getCurrentURL } from "@/pageEditor/utils";
+import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 
 const { addElement } = editorSlice.actions;
 
@@ -31,6 +32,8 @@ function useAddExisting<T extends { rawConfig: ExtensionPointConfig }>(
   cancel: () => void
 ): (extensionPoint: { rawConfig: ExtensionPointConfig }) => Promise<void> {
   const dispatch = useDispatch();
+  const sessionId = useSelector(selectSessionId);
+
   return useCallback(
     async (extensionPoint: T) => {
       try {
@@ -45,6 +48,7 @@ function useAddExisting<T extends { rawConfig: ExtensionPointConfig }>(
 
         // TODO: report if created new, or using existing foundation
         reportEvent("PageEditorStart", {
+          sessionId,
           type: config.elementType,
         });
 
@@ -53,7 +57,7 @@ function useAddExisting<T extends { rawConfig: ExtensionPointConfig }>(
         notify.error({ message: `Error adding ${config.label}`, error });
       }
     },
-    [config, dispatch, cancel]
+    [dispatch, sessionId, config, cancel]
   );
 }
 

--- a/src/pageEditor/sidebar/DynamicEntry.tsx
+++ b/src/pageEditor/sidebar/DynamicEntry.tsx
@@ -31,6 +31,8 @@ import { UUID } from "@/core";
 import { disableOverlay, enableOverlay } from "@/contentScript/messenger/api";
 import { thisTab } from "@/pageEditor/utils";
 import cx from "classnames";
+import { reportEvent } from "@/telemetry/events";
+import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 
 /**
  * A sidebar menu entry corresponding to an extension that is new or is currently being edited.
@@ -43,6 +45,7 @@ const DynamicEntry: React.FunctionComponent<{
   isNested?: boolean;
 }> = ({ item, available, active, isNested = false }) => {
   const dispatch = useDispatch();
+  const sessionId = useSelector(selectSessionId);
 
   const isDirty = useSelector<RootState>(
     (x) => x.editor.dirty[item.uuid] ?? false
@@ -66,7 +69,14 @@ const DynamicEntry: React.FunctionComponent<{
       key={`dynamic-${item.uuid}`}
       onMouseEnter={isButton ? async () => showOverlay(item.uuid) : undefined}
       onMouseLeave={isButton ? async () => hideOverlay() : undefined}
-      onClick={() => dispatch(actions.selectElement(item.uuid))}
+      onClick={() => {
+        reportEvent("PageEditorOpen", {
+          sessionId,
+          extensionId: item.uuid,
+        });
+
+        dispatch(actions.selectElement(item.uuid));
+      }}
     >
       <span
         className={cx(styles.icon, {

--- a/src/pageEditor/slices/sessionSelectors.ts
+++ b/src/pageEditor/slices/sessionSelectors.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { SessionState } from "@/pageEditor/slices/sessionSlice";
+
+export const selectSessionId = ({ session }: { session: SessionState }) =>
+  session.sessionId;

--- a/src/pageEditor/slices/sessionSlice.ts
+++ b/src/pageEditor/slices/sessionSlice.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { createSlice } from "@reduxjs/toolkit";
+import { UUID } from "@/core";
+import { uuidv4 } from "@/types/helpers";
+
+export type SessionState = {
+  sessionId: UUID;
+};
+
+const initialState: SessionState = {
+  sessionId: uuidv4(),
+};
+
+const runtimeSlice = createSlice({
+  name: "session",
+  initialState,
+  reducers: {},
+});
+
+export default runtimeSlice;

--- a/src/pageEditor/store.ts
+++ b/src/pageEditor/store.ts
@@ -41,6 +41,7 @@ import settingsSlice from "@/store/settingsSlice";
 import { persistExtensionOptionsConfig } from "@/store/extensionsStorage";
 import servicesSlice, { persistServicesConfig } from "@/store/servicesSlice";
 import extensionsSlice from "@/store/extensionsSlice";
+import sessionSlice from "@/pageEditor/slices/sessionSlice";
 import { SettingsState } from "@/store/settingsTypes";
 import { LogRootState } from "@/components/logViewer/logViewerTypes";
 import { logSlice, logActions } from "@/components/logViewer/logSlice";
@@ -83,6 +84,7 @@ const store = configureStore({
     services: persistReducer(persistServicesConfig, servicesSlice.reducer),
     settings: persistReducer(persistSettingsConfig, settingsSlice.reducer),
     editor: editorSlice.reducer,
+    session: sessionSlice.reducer,
     savingExtension: savingExtensionSlice.reducer,
     runtime: runtimeSlice.reducer,
     formBuilder: formBuilderSlice.reducer,

--- a/src/pageEditor/tabs/editTab/useBlockPipelineActions.ts
+++ b/src/pageEditor/tabs/editTab/useBlockPipelineActions.ts
@@ -33,6 +33,7 @@ import { produceExcludeUnusedDependencies } from "@/components/fields/schemaFiel
 import { useDispatch, useSelector } from "react-redux";
 import { reportEvent } from "@/telemetry/events";
 import { RootState } from "@/pageEditor/store";
+import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 
 type BlockPipelineActions = {
   addBlock: (block: IBlock, pipelineIndex: number) => void;
@@ -53,6 +54,7 @@ function useBlockPipelineActions(
   setActiveNodeId: (nodeId: NodeId) => void
 ): BlockPipelineActions {
   const dispatch = useDispatch();
+  const sessionId = useSelector(selectSessionId);
 
   const addBlock = useCallback(
     async (block: IBlock, pipelineIndex: number) => {
@@ -78,12 +80,15 @@ function useBlockPipelineActions(
       });
       setFormValues(nextState, true);
       setActiveNodeId(newBlock.instanceId);
+
       reportEvent("BrickAdd", {
         brickId: block.id,
+        sessionId,
+        extensionId: values.uuid,
         source: "PageEditor-BrickSearchModal",
       });
     },
-    [blockPipeline, values, setFormValues, setActiveNodeId]
+    [blockPipeline, values, setFormValues, setActiveNodeId, sessionId]
   );
 
   const removeBlock = (nodeIdToRemove: NodeId) => {


### PR DESCRIPTION
MVP of #2924 

I want to get this PR out for 1.5.7 and then layer in more events in the 1.5.8 release

- Adds SessionStart/SessionEnd events
- Adds Open/Reset/Remove events
- Adds sessionId and extensionId to existing page editor telemetry 

Questions
- How do we feel about using useSelector? Should we introduce a helper hook (where the hook is connected to the Redux store)? That helper hook can have an option for whether or not extension should be reported with the event. (However, in some cases we have to manually provide the extension id if it hasn't been selected yet)

Out of Scope
- Need to report manually triggered runs
- Need to report run success/failure