### PR TITLE
Fix type check for append google sheet row

### DIFF
--- a/src/contrib/google/sheets/append.ts
+++ b/src/contrib/google/sheets/append.ts
@@ -135,13 +135,12 @@ export class GoogleSheetsAppend extends Effect {
     }>,
     { logger }: BlockOptions
   ): Promise<void> {
-    const rowValues =
-      typeof rawValues === "object"
-        ? Object.entries(rawValues).map(([header, value]) => ({
-            header,
-            value,
-          }))
-        : rawValues;
+    const rowValues = Array.isArray(rawValues)
+      ? rawValues
+      : Object.entries(rawValues).map(([header, value]) => ({
+          header,
+          value,
+        }));
 
     const valueHeaders = rowValues.map((x: RowValue) => x.header);
     let currentHeaders: string[];


### PR DESCRIPTION
Arrays return true for `typeof foo === "object"` , so we need to use the more specific `Array.isArray()` check instead.