### PR TITLE
#2992: fix blueprint update and reactivate

### DIFF
--- a/src/options/pages/blueprints/BlueprintActions.tsx
+++ b/src/options/pages/blueprints/BlueprintActions.tsx
@@ -88,7 +88,10 @@ const BlueprintActions: React.FunctionComponent<{
         ),
         action: actions.reinstall,
         // Managed extensions are updated via the deployment banner
-        hide: !actions.reinstall || sharing.source.type === "Deployment",
+        hide:
+          actions.reinstall === null ||
+          sharing.source.type === "Deployment" ||
+          status === "Inactive",
       },
       {
         title: (

--- a/src/options/pages/blueprints/BlueprintActions.tsx
+++ b/src/options/pages/blueprints/BlueprintActions.tsx
@@ -89,7 +89,7 @@ const BlueprintActions: React.FunctionComponent<{
         action: actions.reinstall,
         // Managed extensions are updated via the deployment banner
         hide:
-          actions.reinstall === null ||
+          actions.reinstall == null ||
           sharing.source.type === "Deployment" ||
           status === "Inactive",
       },

--- a/src/options/pages/blueprints/ListFilters.tsx
+++ b/src/options/pages/blueprints/ListFilters.tsx
@@ -40,8 +40,10 @@ function ListFilters({ teamFilters, tableInstance }: ListFiltersProps) {
   // By default, search everything with the option to re-select
   // filtered category
   useEffect(() => {
-    setGlobalFilter(debouncedQuery);
-    setFilters([]);
+    if (debouncedQuery) {
+      setGlobalFilter(debouncedQuery);
+      setFilters([]);
+    }
   }, [debouncedQuery, setFilters, setGlobalFilter]);
 
   const activeKey = filters[0]?.value ?? "All";

--- a/src/options/pages/blueprints/useInstallableViewItems.tsx
+++ b/src/options/pages/blueprints/useInstallableViewItems.tsx
@@ -105,9 +105,11 @@ function useInstallableViewItems(
         },
         updatedAt: getUpdatedAt(installable),
         status: isActive(installable) ? "Active" : "Inactive",
-        hasUpdate: isExtension(installable)
-          ? updateAvailable(recipes.data, installable)
-          : false,
+        hasUpdate: updateAvailable(
+          recipes.data,
+          installedExtensions,
+          installable
+        ),
         icon: installableIcon(installable),
         installable,
       })),


### PR DESCRIPTION
This fixes #2992, which is actually not a problem of missing reactivate, but missing update:
1. fixes the "update" action not showing on blueprints in the blueprints page
2. hides "reactivate" ellipsis menu action for inactive blueprints