### PR TITLE
fix global filter

### DIFF
--- a/src/options/pages/blueprints/ListFilters.tsx
+++ b/src/options/pages/blueprints/ListFilters.tsx
@@ -40,8 +40,9 @@ function ListFilters({ teamFilters, tableInstance }: ListFiltersProps) {
   // By default, search everything with the option to re-select
   // filtered category
   useEffect(() => {
+    setGlobalFilter(debouncedQuery);
+
     if (debouncedQuery) {
-      setGlobalFilter(debouncedQuery);
       setFilters([]);
     }
   }, [debouncedQuery, setFilters, setGlobalFilter]);


### PR DESCRIPTION
Fixes #3002 

Ensures that the global filter is set for empty queries.