### PR TITLE
#3007: throw on error deleting extension

### DIFF
--- a/src/options/pages/blueprints/useInstallableActions.ts
+++ b/src/options/pages/blueprints/useInstallableActions.ts
@@ -133,13 +133,13 @@ function useInstallableActions(installable: Installable) {
         throw new CancelError();
       }
 
-      await deleteCloudExtension({ extensionId: installable.id });
+      await deleteCloudExtension({ extensionId: installable.id }).unwrap();
     },
     {
-      successMessage: `Deleted brick ${getLabel(
+      successMessage: `Deleted extension ${getLabel(
         installable
       )} from your account`,
-      errorMessage: `Error deleting brick ${getLabel(
+      errorMessage: `Error deleting extension ${getLabel(
         installable
       )} from your account`,
       event: "ExtensionCloudDelete",


### PR DESCRIPTION
Closes #3007 

- Calls unwrap on the mutation result to throw the error
- The CSRF error from the issue is not a real error, was caused in part by my testing of https://github.com/pixiebrix/pixiebrix-extension/issues/3004