### PR TITLE
Avoid `trigger="hover"` on `OverlayTrigger`

### DIFF
--- a/src/options/pages/blueprints/labels/LastUpdatedLabel.tsx
+++ b/src/options/pages/blueprints/labels/LastUpdatedLabel.tsx
@@ -33,7 +33,6 @@ const LastUpdatedLabel: React.VoidFunctionComponent<{
   // noinspection RequiredAttributes
   return (
     <OverlayTrigger
-      trigger="hover"
       key="updateAt"
       placement="top"
       delay={600}

--- a/src/options/pages/blueprints/labels/SharingLabel.tsx
+++ b/src/options/pages/blueprints/labels/SharingLabel.tsx
@@ -41,7 +41,6 @@ const SharingLabel: React.VoidFunctionComponent<{
   className?: string;
 }> = ({ sharing, className }) => (
   <OverlayTrigger
-    trigger="hover"
     key="updateAt"
     placement="top"
     delay={600}


### PR DESCRIPTION
Fixes:
```
Warning: [react-bootstrap] Specifying only the `"hover"` trigger limits the visibility of the overlay to just mouse users. Consider also including the `"focus"` trigger so that touch and keyboard only users can see the overlay as well.
```
<img width="1049" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/159856023-82aad465-7d37-4842-87ab-83933cb834be.png">

"hover focus" is the default, it doesn't need to be set

![gif](https://user-images.githubusercontent.com/1402241/159856092-d2532d0e-cad9-4d2f-979d-c8f223e52e00.gif)

