### PR TITLE
#2560: support appending multiple rows to a Google Spreadsheet

### DIFF
--- a/src/contrib/google/sheets/append.test.ts
+++ b/src/contrib/google/sheets/append.test.ts
@@ -59,7 +59,7 @@ describe("Normalize shape", () => {
     ).toStrictEqual([[{ header: "Foo", value: "bar" }]]);
   });
 
-  it("Normalize entries shape", () => {
+  it("Normalize multi shape", () => {
     expect(
       normalizeShape("infer", [{ "column A": "Foo", "column B": "Bar" }])
     ).toStrictEqual([

--- a/src/contrib/google/sheets/append.test.ts
+++ b/src/contrib/google/sheets/append.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { detectShape, normalizeShape } from "@/contrib/google/sheets/append";
+
+describe("Infer shape", () => {
+  it("Infer entries shape", () => {
+    expect(detectShape([{ header: "Foo", value: "bar" }])).toEqual("entries");
+  });
+
+  it("Infer multi shape for additional properties", () => {
+    expect(detectShape([{ header: "Foo", value: "bar", other: "42" }])).toEqual(
+      "multi"
+    );
+  });
+
+  it("Infer multi shape", () => {
+    expect(detectShape([{ "column A": "Foo" }, { "column A": "Foo" }])).toEqual(
+      "multi"
+    );
+  });
+
+  it("Infer single shape", () => {
+    expect(detectShape({ "column A": "Foo", "column B": "Bar" })).toEqual(
+      "single"
+    );
+  });
+});
+
+describe("Normalize shape", () => {
+  it("Normalize single shape", () => {
+    expect(
+      normalizeShape("infer", { "column A": "Foo", "column B": "Bar" })
+    ).toStrictEqual([
+      [
+        { header: "column A", value: "Foo" },
+        { header: "column B", value: "Bar" },
+      ],
+    ]);
+  });
+
+  it("Normalize entries shape", () => {
+    expect(
+      normalizeShape("infer", [{ header: "Foo", value: "bar" }])
+    ).toStrictEqual([[{ header: "Foo", value: "bar" }]]);
+  });
+
+  it("Normalize entries shape", () => {
+    expect(
+      normalizeShape("infer", [{ "column A": "Foo", "column B": "Bar" }])
+    ).toStrictEqual([
+      [
+        { header: "column A", value: "Foo" },
+        { header: "column B", value: "Bar" },
+      ],
+    ]);
+  });
+});


### PR DESCRIPTION
What does this PR do?
---
- Closes #2560 
- Adds a rowValues alternative for passing multiple rows in one call
- Adds a `shape` property that defaults to "infer" to handle the corner case where the sheet has "header"/"value" as the only two column names. This property is not exposed in the page editor
- Does not change the Page Editor interface. If you are trying to pass multiple rows, you'd need to pass them as a variable

**Discussion**
- The JSON Schema could be re-written to be a combination of 4 oneOfs (one for each shape). That would let use avoid validateShape, but would complicate the schema

