### PR TITLE
Send extension version in identify request

### DIFF
--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -84,6 +84,7 @@ export const getUID = liftBackground("GET_UID", async () => uid());
 
 async function userSummary() {
   const { os } = await browser.runtime.getPlatformInfo();
+  const { version, version_name: versionName } = browser.runtime.getManifest();
   // Getting browser information would require additional permissions
   // const {name: browserName} = await browser.runtime.getBrowserInfo();
   let numActiveExtensions: number = null;
@@ -107,6 +108,8 @@ async function userSummary() {
     numActiveExtensions,
     numActiveBlueprints,
     numActiveExtensionPoints,
+    versionName,
+    version,
     $os: os,
   };
 }


### PR DESCRIPTION
What does this PR do?
---
- Include extension version in `/api/identify/` request so we can reference it during user support
- Will also require changes on the backend