### PR TITLE
Temporarily disable axios fetch adapter

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -22,7 +22,8 @@ import "@/development/autoreload";
 import "@/development/errorsBadge";
 
 // Required for MV3; Service Workers don't have XMLHttpRequest
-import "@/background/axiosFetch";
+// TODO: Disabled due to https://github.com/pixiebrix/pixiebrix-extension/issues/3020
+// import "@/background/axiosFetch";
 
 import "webext-dynamic-content-scripts";
 


### PR DESCRIPTION
- Close #3020 

As you found out, [the error is not used by the adapter](https://github.com/vespaiach/axios-fetch-adapter/blob/5fbe21087fbf10f266cff205e2647cd99e0d5260/index.js?rgh-link-date=2022-03-24T19%3A40%3A39Z#L50-L52). In theory [`fetch` only throws on Network errors](https://stackoverflow.com/a/61113372/288906), which I don’t think we can enrich, but in practice I see it throws on invalid URLs too, like `fetch("///")` (which throws a `TypeError`, but the adapter will only throw a network error.

I think we can drop the adapter for now, especially because there's no urgency to use it and hopefully Axios will eventually support it natively: This limitation is not exclusive to web extensions so I'm certain a better solution will surface sooner or later.

For reference, here's what that `createError` function looks like:

- https://www.unpkg.com/browse/axios@0.26.0/lib/core/enhanceError.js

Question:

- Do you think it'd be beneficial to use `fetch` directly? Axios seemed like a good idea when XMLHttpRquest was around, but with `fetch` and other [modern wrappers](https://github.com/sindresorhus/ky) maybe we can go closer to the metal. 