### PR TITLE
#2502 Data panel tab for page state observability

### DIFF
--- a/src/blocks/effects/getPageState.ts
+++ b/src/blocks/effects/getPageState.ts
@@ -15,23 +15,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import JsonTree from "@/components/jsonTree/JsonTree";
-import { getPageState } from "@/contentScript/messenger/api";
-import { useAsyncState } from "@/hooks/common";
-import { thisTab } from "@/pageEditor/utils";
-import React from "react";
+import { BlockOptions, RegistryId, UUID } from "@/core";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import ConsoleLogger from "@/tests/ConsoleLogger";
+import { GetPageState, Namespace } from "./pageState";
 
-const PageStateTab: React.VFC = () => {
-  const [sharedState, isSharedStateLoading, sharedStateError] = useAsyncState(
-    async () => getPageState(thisTab, "shared"),
-    []
-  );
+export async function getStateValue<TResult>(
+  namespace: Namespace,
+  blueprintId?: RegistryId | null,
+  extensionId?: UUID | null
+): Promise<TResult> {
+  const getState = new GetPageState();
+  const logger = new ConsoleLogger({
+    extensionId,
+    blueprintId,
+  });
 
-  const state = {
-    shared: isSharedStateLoading ? "loading..." : sharedState,
-  };
+  const result: TResult = (await getState.transform(
+    unsafeAssumeValidArg({ namespace }),
+    { logger } as BlockOptions
+  )) as TResult;
 
-  return <JsonTree data={state} />;
-};
-
-export default PageStateTab;
+  return result;
+}

--- a/src/blocks/effects/pageState.ts
+++ b/src/blocks/effects/pageState.ts
@@ -29,7 +29,7 @@ const extensionState = new Map<UUID, UnknownObject>();
 const blueprintState = new Map<RegistryId | null, UnknownObject>();
 
 type MergeStrategy = "shallow" | "replace" | "deep";
-type Namespace = "blueprint" | "extension" | "shared";
+export type Namespace = "blueprint" | "extension" | "shared";
 
 function mergeState(
   previous: UnknownObject,
@@ -170,6 +170,14 @@ export class GetPageState extends Transformer {
     { logger }: BlockOptions
   ): Promise<UnknownObject> {
     const { blueprintId = null, extensionId } = logger.context;
+
+    console.log("GetPageState", {
+      namespace,
+      blueprintId,
+      extensionId,
+      blueprintState,
+      extensionState,
+    });
 
     switch (namespace) {
       case "shared": {

--- a/src/blocks/effects/pageState.ts
+++ b/src/blocks/effects/pageState.ts
@@ -171,14 +171,6 @@ export class GetPageState extends Transformer {
   ): Promise<UnknownObject> {
     const { blueprintId = null, extensionId } = logger.context;
 
-    console.log("GetPageState", {
-      namespace,
-      blueprintId,
-      extensionId,
-      blueprintState,
-      extensionState,
-    });
-
     switch (namespace) {
       case "shared": {
         return blueprintState.get(null) ?? {};

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -62,6 +62,8 @@ export const runRendererPipeline = getMethod("RUN_RENDERER_PIPELINE");
 export const runEffectPipeline = getMethod("RUN_EFFECT_PIPELINE");
 export const runMapArgs = getMethod("RUN_MAP_ARGS");
 
+export const getPageState = getMethod("GET_PAGE_STATE");
+
 export const notify = {
   info: getNotifier("NOTIFY_INFO"),
   error: getNotifier("NOTIFY_ERROR"),

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -69,6 +69,7 @@ import {
   runRendererPipeline,
 } from "@/contentScript/pipelineProtocol";
 import { toggleQuickBar } from "@/components/quickBar/QuickBarApp";
+import { getStateValue } from "@/blocks/effects/getPageState";
 
 expectContext("contentScript");
 
@@ -123,6 +124,8 @@ declare global {
     NOTIFY_INFO: typeof notify.info;
     NOTIFY_ERROR: typeof notify.error;
     NOTIFY_SUCCESS: typeof notify.success;
+
+    GET_PAGE_STATE: typeof getStateValue;
   }
 }
 
@@ -178,5 +181,7 @@ export default function registerMessenger(): void {
     NOTIFY_INFO: notify.info,
     NOTIFY_ERROR: notify.error,
     NOTIFY_SUCCESS: notify.success,
+
+    GET_PAGE_STATE: getStateValue,
   });
 }

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -333,7 +333,7 @@ const DataPanel: React.FC<{
               </div>
             )}
           </DataTab>
-          <DataTab eventKey="pageState">
+          <DataTab eventKey="pageState" mountOnEnter unmountOnExit>
             <PageStateTab />
           </DataTab>
         </Tab.Content>

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -333,7 +333,7 @@ const DataPanel: React.FC<{
               </div>
             )}
           </DataTab>
-          <DataTab eventKey="pageState" mountOnEnter unmountOnExit>
+          <DataTab eventKey="pageState">
             <PageStateTab />
           </DataTab>
         </Tab.Content>

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -50,6 +50,7 @@ import copy from "copy-to-clipboard";
 import useFlags from "@/hooks/useFlags";
 import ErrorDisplay from "./ErrorDisplay";
 import { FormState } from "@/pageEditor/pageEditorTypes";
+import PageStateTab from "./PageStateTab";
 
 /**
  * Exclude irrelevant top-level keys.
@@ -185,6 +186,9 @@ const DataPanel: React.FC<{
           </Nav.Item>
           <Nav.Item className={dataPanelStyles.tabNav}>
             <Nav.Link eventKey="preview">Preview</Nav.Link>
+          </Nav.Item>
+          <Nav.Item className={dataPanelStyles.tabNav}>
+            <Nav.Link eventKey="pageState">Page State</Nav.Link>
           </Nav.Item>
         </Nav>
         <Tab.Content className={dataPanelStyles.tabContent}>
@@ -328,6 +332,9 @@ const DataPanel: React.FC<{
                 Run the extension once to enable live preview
               </div>
             )}
+          </DataTab>
+          <DataTab eventKey="pageState">
+            <PageStateTab />
           </DataTab>
         </Tab.Content>
       </div>

--- a/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
@@ -144,7 +144,12 @@ const FoundationDataPanel: React.FC<{
         <Tab.Pane eventKey="preview" className={dataPanelStyles.tabPane}>
           <ExtensionPointPreview element={formState} />
         </Tab.Pane>
-        <Tab.Pane eventKey="pageState" className={dataPanelStyles.tabPane}>
+        <Tab.Pane
+          eventKey="pageState"
+          className={dataPanelStyles.tabPane}
+          mountOnEnter
+          unmountOnExit
+        >
           <PageStateTab />
         </Tab.Pane>
       </Tab.Content>

--- a/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
@@ -144,12 +144,7 @@ const FoundationDataPanel: React.FC<{
         <Tab.Pane eventKey="preview" className={dataPanelStyles.tabPane}>
           <ExtensionPointPreview element={formState} />
         </Tab.Pane>
-        <Tab.Pane
-          eventKey="pageState"
-          className={dataPanelStyles.tabPane}
-          mountOnEnter
-          unmountOnExit
-        >
+        <Tab.Pane eventKey="pageState" className={dataPanelStyles.tabPane}>
           <PageStateTab />
         </Tab.Pane>
       </Tab.Content>

--- a/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
@@ -30,6 +30,7 @@ import useDataPanelActiveTabKey from "@/pageEditor/tabs/editTab/dataPanel/useDat
 import useDataPanelTabSearchQuery from "@/pageEditor/tabs/editTab/dataPanel/useDataPanelTabSearchQuery";
 import useFlags from "@/hooks/useFlags";
 import { FormState } from "@/pageEditor/pageEditorTypes";
+import PageStateTab from "./PageStateTab";
 
 const FoundationDataPanel: React.FC<{
   firstBlockInstanceId?: UUID;
@@ -76,6 +77,9 @@ const FoundationDataPanel: React.FC<{
         </Nav.Item>
         <Nav.Item className={dataPanelStyles.tabNav}>
           <Nav.Link eventKey="preview">Preview</Nav.Link>
+        </Nav.Item>
+        <Nav.Item className={dataPanelStyles.tabNav}>
+          <Nav.Link eventKey="pageState">Page State</Nav.Link>
         </Nav.Item>
       </Nav>
       <Tab.Content>
@@ -139,6 +143,9 @@ const FoundationDataPanel: React.FC<{
         </Tab.Pane>
         <Tab.Pane eventKey="preview" className={dataPanelStyles.tabPane}>
           <ExtensionPointPreview element={formState} />
+        </Tab.Pane>
+        <Tab.Pane eventKey="pageState" className={dataPanelStyles.tabPane}>
+          <PageStateTab />
         </Tab.Pane>
       </Tab.Content>
     </Tab.Container>

--- a/src/pageEditor/tabs/editTab/dataPanel/PageStateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/PageStateTab.tsx
@@ -22,7 +22,7 @@ import { getErrorMessage } from "@/errors";
 import { useAsyncState } from "@/hooks/common";
 import { selectActiveElement } from "@/pageEditor/slices/editorSelectors";
 import { thisTab } from "@/pageEditor/utils";
-import { faSync } from "@fortawesome/free-solid-svg-icons";
+import { faExternalLinkAlt, faSync } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button } from "react-bootstrap";
 import { useSelector } from "react-redux";
@@ -48,34 +48,46 @@ const PageStateTab: React.VFC = () => {
     },
     [],
     {
-      extension: "loading...",
-      blueprint: "loading...",
-      shared: "loading...",
+      extension: "Loading...",
+      blueprint: "Loading...",
+      shared: "Loading...",
     }
   );
 
   return (
     <div>
-      <Button variant="info" size="sm" disabled={isLoading} onClick={refresh}>
-        <FontAwesomeIcon icon={faSync} /> Refresh
-      </Button>
+      <div className="mb-1 d-flex">
+        <div>
+          <Button
+            variant="info"
+            size="sm"
+            disabled={isLoading}
+            onClick={refresh}
+          >
+            <FontAwesomeIcon icon={faSync} /> Refresh
+          </Button>
+        </div>
+        <div className="ml-2">
+          <a
+            href="https://docs.pixiebrix.com/page-state"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <small>
+              <FontAwesomeIcon icon={faExternalLinkAlt} />
+              &nbsp;Learn more about Page State
+            </small>
+          </a>
+        </div>
+      </div>
       {error ? (
         <div>
-          <p>Error</p>
+          <div className="text-danger">Error</div>
           <p>{getErrorMessage(error)}</p>
         </div>
       ) : (
-        <JsonTree data={state} copyable shouldExpandNode={() => true} />
+        <JsonTree data={state} copyable={false} shouldExpandNode={() => true} />
       )}
-      <p className="mt-4">
-        <a
-          href="https://docs.pixiebrix.com/page-state"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <small>Learn more about Page State</small>
-        </a>
-      </p>
     </div>
   );
 };

--- a/src/pageEditor/tabs/editTab/dataPanel/PageStateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/PageStateTab.tsx
@@ -68,10 +68,6 @@ const PageStateTab: React.VFC = () => {
     void refreshExtensionState();
   };
 
-  if (error != null) {
-    return <ErrorDisplay error={error} />;
-  }
-
   const state = {
     extension: isExtensionStateLoading ? "loading..." : extensionState,
     blueprint: isBlueprintStateLoading ? "loading..." : blueprintState,
@@ -88,7 +84,11 @@ const PageStateTab: React.VFC = () => {
       >
         <FontAwesomeIcon icon={faSync} /> Refresh
       </Button>
-      <JsonTree data={state} copyable shouldExpandNode={() => true} />
+      {error ? (
+        <ErrorDisplay error={error} />
+      ) : (
+        <JsonTree data={state} copyable shouldExpandNode={() => true} />
+      )}
     </div>
   );
 };

--- a/src/pageEditor/tabs/editTab/dataPanel/PageStateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/PageStateTab.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+type PageStateTabProps = {};
+
+const PageStateTab: React.VoidFunctionComponent<PageStateTabProps> = (
+  props
+) => {
+  return <div>Page State</div>;
+};
+
+export default PageStateTab;

--- a/src/pageEditor/tabs/editTab/dataPanel/PageStateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/PageStateTab.tsx
@@ -67,6 +67,15 @@ const PageStateTab: React.VFC = () => {
       ) : (
         <JsonTree data={state} copyable shouldExpandNode={() => true} />
       )}
+      <p className="mt-4">
+        <a
+          href="https://docs.pixiebrix.com/page-state"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <small>Learn more about Page State</small>
+        </a>
+      </p>
     </div>
   );
 };

--- a/src/pageEditor/tabs/editTab/dataPanel/PageStateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/PageStateTab.tsx
@@ -15,17 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import React from "react";
 import JsonTree from "@/components/jsonTree/JsonTree";
 import { getPageState } from "@/contentScript/messenger/api";
+import { getErrorMessage } from "@/errors";
 import { useAsyncState } from "@/hooks/common";
 import { selectActiveElement } from "@/pageEditor/slices/editorSelectors";
 import { thisTab } from "@/pageEditor/utils";
 import { faSync } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import React from "react";
 import { Button } from "react-bootstrap";
 import { useSelector } from "react-redux";
-import ErrorDisplay from "./ErrorDisplay";
 
 const PageStateTab: React.VFC = () => {
   const activeElement = useSelector(selectActiveElement);
@@ -60,7 +60,10 @@ const PageStateTab: React.VFC = () => {
         <FontAwesomeIcon icon={faSync} /> Refresh
       </Button>
       {error ? (
-        <ErrorDisplay error={error} />
+        <div>
+          <p>Error</p>
+          <p>{getErrorMessage(error)}</p>
+        </div>
       ) : (
         <JsonTree data={state} copyable shouldExpandNode={() => true} />
       )}


### PR DESCRIPTION
Closes #2502 

A blueprint extension:
<img width="1125" alt="Screen Shot 2022-03-30 at 6 31 31 PM" src="https://user-images.githubusercontent.com/3116723/160885938-47700b9b-c781-4e31-aa3c-9c92b1a08d84.png">


A non-blueprint extension:
<img width="1123" alt="image" src="https://user-images.githubusercontent.com/3116723/160932973-ef426391-660f-450f-a66f-b803ac7c1d71.png">


An error:
<img width="1121" alt="Screen Shot 2022-03-30 at 6 18 57 PM" src="https://user-images.githubusercontent.com/3116723/160886036-999e733a-3652-47b3-af8d-0b04f6ee3e98.png">
