### PR TITLE
#3021: Wrap invalid selector errors into BusinessErrors

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -277,12 +277,13 @@ export function getRootCause(error: ErrorObject): ErrorObject {
 
 // Manually list subclasses because the prototype chain is lost in serialization/deserialization
 // See https://github.com/sindresorhus/serialize-error/issues/48
-const BUSINESS_ERROR_CLASSES = [
+const BUSINESS_ERROR_CLASSES = new Set([
   BusinessError,
   NoElementsFoundError,
   MultipleElementsFoundError,
+  InvalidSelectorError,
   PropError,
-];
+]);
 // Name classes from other modules separately, because otherwise we'll get a circular dependency with this module
 const BUSINESS_ERROR_NAMES = new Set([
   "PropError",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -29,6 +29,9 @@ import {
 
 const DEFAULT_ERROR_MESSAGE = "Unknown error";
 
+export const JQUERY_INVALID_SELECTOR_ERROR =
+  "Syntax error, unrecognized expression: ";
+
 /**
  * Base class for Errors arising from business logic in the brick, not the PixieBrix application/extension itself.
  *
@@ -133,6 +136,22 @@ export class MultipleElementsFoundError extends BusinessError {
   ) {
     super(message);
     this.name = "MultipleElementsFoundError";
+    this.selector = selector;
+  }
+}
+
+export class InvalidSelectorError extends BusinessError {
+  override name = "InvalidSelectorError";
+  readonly selector: string;
+
+  /**
+   * @param message The error message jQuery creates, example in https://cs.github.com/jquery/jquery/blob/2525cffc42934c0d5c7aa085bc45dd6a8282e840/src/selector.js#L787
+   */
+  constructor(message: string, selector: string) {
+    // Make the error message more specific than "Syntax error"
+    super(
+      "Invalid selector: " + message.replace(JQUERY_INVALID_SELECTOR_ERROR, "")
+    );
     this.selector = selector;
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -16,6 +16,11 @@
  */
 
 import { Schema, SchemaProperties } from "@/core";
+import {
+  getErrorMessage,
+  InvalidSelectorError,
+  JQUERY_INVALID_SELECTOR_ERROR,
+} from "@/errors";
 
 /**
  * Return the names of top-level required properties that are missing
@@ -62,5 +67,14 @@ export function $safeFind<Element extends HTMLElement>(
   selector: string,
   parent: Document | HTMLElement | JQuery<HTMLElement | Document> = document
 ): JQuery<Element> {
-  return $(parent).find<Element>(selector);
+  try {
+    return $(parent).find<Element>(selector);
+  } catch (error) {
+    const message = getErrorMessage(error);
+    if (message.startsWith(JQUERY_INVALID_SELECTOR_ERROR)) {
+      throw new InvalidSelectorError(message, selector);
+    }
+
+    throw error;
+  }
 }

--- a/src/vendors/initialize.js
+++ b/src/vendors/initialize.js
@@ -1,8 +1,11 @@
 // Copyright (c) 2015-2016 Adam Pietrasiak
 // https://github.com/pie6k/jquery.initialize/blob/master/jquery.initialize.js
-// Copied to expose as a module instead of JQuery plugin, and check if Element type is defined
+// Changes:
+// - expose as a module instead of JQuery plugin
+// - check if Element type is defined
+// - use $safeFind to catch invalid selectors #3061
 
-"use strict";
+import { $safeFind } from "@/helpers";
 
 var combinators = [" ", ">", "+", "~"]; // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors#Combinators
 var fraternisers = ["+", "~"]; // These combinators involve siblings.
@@ -72,7 +75,7 @@ msobservers.initialize = function (selector, callback, options) {
   };
 
   // See if the selector matches any elements already on the page.
-  $(options.target).find(selector).each(callbackOnce);
+  $safeFind(selector, options.target).each(callbackOnce);
 
   // Then, add it to the list of selector observers.
   var msobserver = new MutationSelectorObserver(
@@ -108,12 +111,12 @@ msobservers.initialize = function (selector, callback, options) {
         if (msobserver.isFraternal)
           matches.push.apply(
             matches,
-            $(mutations[m].target.parentElement).find(msobserver.selector)
+            $safeFind(msobserver.selector, mutations[m].target.parentElement)
           );
         else
           matches.push.apply(
             matches,
-            $(mutations[m].target).find(msobserver.selector)
+            $safeFind(msobserver.selector, mutations[m].target)
           );
       }
 
@@ -131,14 +134,15 @@ msobservers.initialize = function (selector, callback, options) {
           if (msobserver.isFraternal)
             matches.push.apply(
               matches,
-              $(mutations[m].addedNodes[n].parentElement).find(
-                msobserver.selector
+              $safeFind(
+                msobserver.selector,
+                mutations[m].addedNodes[n].parentElement
               )
             );
           else
             matches.push.apply(
               matches,
-              $(mutations[m].addedNodes[n]).find(msobserver.selector)
+              $safeFind(msobserver.selector, mutations[m].addedNodes[n])
             );
         }
       }


### PR DESCRIPTION
- Close #3021

I looked into wrapping the errors in jQuery itself, but:

- I couldn't find a public hook into its [error generator](https://cs.github.com/jquery/jquery/blob/2525cffc42934c0d5c7aa085bc45dd6a8282e840/src/selector.js#L148)
- if the selector is not user-provided, then we should not report BusinessErrors

For these reasons, I added this wrapper in `$safeFind`, which is presumably the only method we should use to handle user-provided selectors (+ `initialize.js`)


## Before

<img width="1392" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/161074133-e8dbef7e-7d0a-40e8-9eee-6355d137f2b1.png">


## After

<img width="1377" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/161074223-151b5860-332b-45fa-8f71-4ed4b94f0640.png">
