### PR TITLE
#2812: Deprioritize :nth-child in selector dropdown

### DIFF
--- a/src/contentScript/nativeEditor/infer.test.tsx
+++ b/src/contentScript/nativeEditor/infer.test.tsx
@@ -408,6 +408,10 @@ test("getSelectorPreference: matches expected sorting", () => {
   expect(getSelectorPreference(".birdsArentReal")).toBe(2);
   const selector = '[aria-label="Click elsewhere"]';
   expect(getSelectorPreference(selector)).toBe(selector.length);
+
+  // Even if it contains an ID, the selector is low quality
+  const selector2 = "#name > :nth-child(2)";
+  expect(getSelectorPreference(selector2)).toBe(selector2.length);
 });
 
 describe("inferSelectors", () => {

--- a/src/contentScript/nativeEditor/infer.ts
+++ b/src/contentScript/nativeEditor/infer.ts
@@ -107,9 +107,14 @@ function isSelectorUsuallyUnique(selector: string): boolean {
  * 1   '[data-cy="b4da55"]'
  * 2   '.navItem'
  * 2   '.birdsArentReal'
+ * 21  '#name > :nth-child(2)'
  * 30  '[aria-label="Click elsewhere"]'
  */
 export function getSelectorPreference(selector: string): number {
+  if (selector.includes(":nth-child")) {
+    return selector.length;
+  }
+
   if (selector.startsWith("#")) {
     return 0;
   }


### PR DESCRIPTION
- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/2812

I changed the sorter to only prefer ID- and class-based selectors if they don't contain :nth-child

## Before

<img width="500" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/161047783-7453de57-72d8-4004-962a-272283d0774b.png">


## After

<img width="530" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/161047797-0a039bc4-6e70-4a95-84b9-35fce9428f18.png">

