### PR TITLE
#3064: Add managed storage to bootstrap PixieBrix link

### DIFF
--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -19,7 +19,7 @@ import { Deployment, Me } from "@/types/contract";
 import { isEmpty, partition, uniqBy } from "lodash";
 import reportError from "@/telemetry/reportError";
 import { getUID } from "@/background/telemetry";
-import { getExtensionVersion } from "@/chrome";
+import { getExtensionVersion, ManualStorageKey, readStorage } from "@/chrome";
 import { isLinked, readAuthData, updateUserData } from "@/auth/token";
 import { reportEvent } from "@/telemetry/events";
 import { refreshRegistries } from "@/hooks/useRefresh";
@@ -42,6 +42,8 @@ import { uninstallContextMenu } from "@/background/contextMenus";
 const { reducer, actions } = extensionsSlice;
 
 const UPDATE_INTERVAL_MS = 5 * 60 * 1000;
+
+const MANAGED_CAMPAIGN_IDS_KEY = "campaignIds" as ManualStorageKey;
 
 /**
  * Deployment installed on the client. A deployment may be installed but not active (see DeploymentContext.active)
@@ -331,6 +333,11 @@ export async function updateDeployments(): Promise<void> {
       uid: await getUID(),
       version: await getExtensionVersion(),
       active: selectInstalledDeployments(extensions),
+      campaignId: await readStorage(
+        MANAGED_CAMPAIGN_IDS_KEY,
+        undefined,
+        "managed"
+      ),
     });
 
   if (deploymentResponseStatus >= 400) {

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -333,7 +333,7 @@ export async function updateDeployments(): Promise<void> {
       uid: await getUID(),
       version: await getExtensionVersion(),
       active: selectInstalledDeployments(extensions),
-      campaignId: await readStorage(
+      campaignIds: await readStorage(
         MANAGED_CAMPAIGN_IDS_KEY,
         undefined,
         "managed"

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -85,11 +85,12 @@ export class RuntimeNotFoundError extends Error {
 
 export async function readStorage<T = unknown>(
   storageKey: ManualStorageKey,
-  defaultValue?: T
+  defaultValue?: T,
+  area: "local" | "managed" = "local"
 ): Promise<T | undefined> {
   // `browser.storage.local` is supposed to have a signature that takes an object that includes default values.
   // On Chrome 93.0.4577.63 that signature appears to return the defaultValue even when the value is set?
-  const result = await browser.storage.local.get(storageKey);
+  const result = await browser.storage[area].get(storageKey);
 
   if (Object.prototype.hasOwnProperty.call(result, storageKey)) {
     // eslint-disable-next-line security/detect-object-injection -- Just checked with hasOwnProperty

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,6 +41,9 @@
   "externally_connectable": {
     "matches": ["https://app.pixiebrix.com/*"]
   },
+  "storage": {
+    "managed_schema": "managedStorageSchema.json"
+  },
   "web_accessible_resources": [
     "css/*",
     "bundles/*",

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -42,7 +42,7 @@ export async function absoluteApiUrl(
     return relativeOrAbsoluteURL;
   }
 
-  return new URL(relativeOrAbsoluteURL, await getBaseURL()).href;
+  return new URL(relativeOrAbsoluteURL, base).href;
 }
 
 /**

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -26,7 +26,7 @@ export const SERVICE_STORAGE_KEY = "service-url" as ManualStorageKey;
 
 type ConfiguredHost = string | null | undefined;
 
-const MANAGED_HOSTNAME_KEY = "hostname" as ManualStorageKey;
+const MANAGED_HOSTNAME_KEY = "serviceUrl" as ManualStorageKey;
 
 export function withoutTrailingSlash(url: string): string {
   return url.replace(/\/$/, "");
@@ -45,7 +45,7 @@ export async function getBaseURL(): Promise<string> {
       "managed"
     );
     if (!isEmpty(managed)) {
-      return withoutTrailingSlash("https://" + managed);
+      return withoutTrailingSlash(managed);
     }
   }
 

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -26,16 +26,27 @@ export const SERVICE_STORAGE_KEY = "service-url" as ManualStorageKey;
 
 type ConfiguredHost = string | null | undefined;
 
+const MANAGED_HOSTNAME_KEY = "hostname" as ManualStorageKey;
+
 export function withoutTrailingSlash(url: string): string {
-  return url.endsWith("/") ? url.slice(0, -1) : url;
+  return url.replace(/\/$/, "");
 }
 
 export async function getBaseURL(): Promise<string> {
   if (isExtensionContext()) {
     const configured = await readStorage<ConfiguredHost>(SERVICE_STORAGE_KEY);
-    return withoutTrailingSlash(
-      isEmpty(configured) ? DEFAULT_SERVICE_URL : configured
+    if (!isEmpty(configured)) {
+      return withoutTrailingSlash(configured);
+    }
+
+    const managed = await readStorage<string>(
+      MANAGED_HOSTNAME_KEY,
+      undefined,
+      "managed"
     );
+    if (!isEmpty(managed)) {
+      return withoutTrailingSlash("https://" + managed);
+    }
   }
 
   return withoutTrailingSlash(DEFAULT_SERVICE_URL);

--- a/static/managedStorageSchema.json
+++ b/static/managedStorageSchema.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "properties": {
+    "primaryOrganizationId": {
+      "type": "string",
+      "description": "PixieBrix organization ID the extension should link to"
+    },
+    "partnerId": {
+      "type": "string",
+      "description": "PixieBrix partner ID"
+    },
+    "campaignIds": {
+      "type": "array",
+      "description": "Campaign IDs the extension is associated with",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hostname": {
+      "type": "string",
+      "description": "PixieBrix API hostname",
+      "default": "app.pixiebrix.com"
+    }
+  }
+}

--- a/static/managedStorageSchema.json
+++ b/static/managedStorageSchema.json
@@ -16,10 +16,10 @@
         "type": "string"
       }
     },
-    "hostname": {
+    "serviceUrl": {
       "type": "string",
-      "description": "PixieBrix API hostname",
-      "default": "app.pixiebrix.com"
+      "description": "PixieBrix service URL",
+      "default": "https://app.pixiebrix.com"
     }
   }
 }


### PR DESCRIPTION
- Closes #3064

I wasn't able to test this directly but I can confirm:

- Chrome loads the schema
- Chrome validates the schema
