### PR TITLE
makeURL: Cleanup, test, and always default to `percent` space encoding

### DIFF
--- a/src/blocks/effects/redirectPage.ts
+++ b/src/blocks/effects/redirectPage.ts
@@ -19,7 +19,7 @@ import { Effect } from "@/types";
 import { BlockArg } from "@/core";
 import { openTab } from "@/background/messenger/api";
 import { URL_INPUT_SPEC } from "@/blocks/transformers/url";
-import { makeURL } from "@/utils";
+import { LEGACY_URL_INPUT_SPACE_ENCODING_DEFAULT, makeURL } from "@/utils";
 
 export class NavigateURLEffect extends Effect {
   constructor() {
@@ -33,7 +33,11 @@ export class NavigateURLEffect extends Effect {
 
   inputSchema = URL_INPUT_SPEC;
 
-  async effect({ url, params, spaceEncoding }: BlockArg): Promise<void> {
+  async effect({
+    url,
+    params,
+    spaceEncoding = LEGACY_URL_INPUT_SPACE_ENCODING_DEFAULT,
+  }: BlockArg): Promise<void> {
     document.location.href = makeURL(url, params, spaceEncoding);
   }
 }
@@ -50,7 +54,11 @@ export class OpenURLEffect extends Effect {
 
   inputSchema = URL_INPUT_SPEC;
 
-  async effect({ url, params, spaceEncoding }: BlockArg): Promise<void> {
+  async effect({
+    url,
+    params,
+    spaceEncoding = LEGACY_URL_INPUT_SPACE_ENCODING_DEFAULT,
+  }: BlockArg): Promise<void> {
     await openTab({
       url: makeURL(url, params, spaceEncoding),
     });

--- a/src/blocks/effects/redirectPage.ts
+++ b/src/blocks/effects/redirectPage.ts
@@ -18,10 +18,7 @@
 import { Effect } from "@/types";
 import { BlockArg } from "@/core";
 import { openTab } from "@/background/messenger/api";
-import {
-  URL_INPUT_SPACE_ENCODING_DEFAULT,
-  URL_INPUT_SPEC,
-} from "@/blocks/transformers/url";
+import { URL_INPUT_SPEC } from "@/blocks/transformers/url";
 import { makeURL } from "@/utils";
 
 export class NavigateURLEffect extends Effect {
@@ -36,11 +33,7 @@ export class NavigateURLEffect extends Effect {
 
   inputSchema = URL_INPUT_SPEC;
 
-  async effect({
-    url,
-    params,
-    spaceEncoding = URL_INPUT_SPACE_ENCODING_DEFAULT,
-  }: BlockArg): Promise<void> {
+  async effect({ url, params, spaceEncoding }: BlockArg): Promise<void> {
     document.location.href = makeURL(url, params, spaceEncoding);
   }
 }
@@ -57,11 +50,7 @@ export class OpenURLEffect extends Effect {
 
   inputSchema = URL_INPUT_SPEC;
 
-  async effect({
-    url,
-    params,
-    spaceEncoding = URL_INPUT_SPACE_ENCODING_DEFAULT,
-  }: BlockArg): Promise<void> {
+  async effect({ url, params, spaceEncoding }: BlockArg): Promise<void> {
     await openTab({
       url: makeURL(url, params, spaceEncoding),
     });

--- a/src/blocks/transformers/url.ts
+++ b/src/blocks/transformers/url.ts
@@ -17,7 +17,11 @@
 
 import { Transformer } from "@/types";
 import { BlockArg, Schema } from "@/core";
-import { makeURL, URL_INPUT_SPACE_ENCODING_DEFAULT } from "@/utils";
+import {
+  makeURL,
+  URL_INPUT_SPACE_ENCODING_DEFAULT,
+  LEGACY_URL_INPUT_SPACE_ENCODING_DEFAULT,
+} from "@/utils";
 
 export const URL_INPUT_SPEC: Schema = {
   $schema: "https://json-schema.org/draft/2019-09/schema#",
@@ -76,7 +80,7 @@ export class UrlParams extends Transformer {
   async transform({
     url,
     params,
-    spaceEncoding,
+    spaceEncoding = LEGACY_URL_INPUT_SPACE_ENCODING_DEFAULT,
   }: BlockArg): Promise<{ url: string }> {
     return {
       url: makeURL(url, params, spaceEncoding),

--- a/src/blocks/transformers/url.ts
+++ b/src/blocks/transformers/url.ts
@@ -17,9 +17,7 @@
 
 import { Transformer } from "@/types";
 import { BlockArg, Schema } from "@/core";
-import { makeURL } from "@/utils";
-
-export const URL_INPUT_SPACE_ENCODING_DEFAULT = "plus";
+import { makeURL, URL_INPUT_SPACE_ENCODING_DEFAULT } from "@/utils";
 
 export const URL_INPUT_SPEC: Schema = {
   $schema: "https://json-schema.org/draft/2019-09/schema#",
@@ -78,7 +76,7 @@ export class UrlParams extends Transformer {
   async transform({
     url,
     params,
-    spaceEncoding = URL_INPUT_SPACE_ENCODING_DEFAULT,
+    spaceEncoding,
   }: BlockArg): Promise<{ url: string }> {
     return {
       url: makeURL(url, params, spaceEncoding),

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -166,13 +166,21 @@ describe("makeURL", () => {
       "https://pixiebrix.com/?a=1&b=hi&c=false"
     );
   });
+
   test("spaces support", () => {
-    const origin = "https://pixiebrix.com";
+    const origin = "https://pixiebrix.com/path";
     expect(makeURL(origin, { a: "b c", d: "e+f" })).toBe(
-      "https://pixiebrix.com/?a=b+c&d=e%2Bf"
+      "https://pixiebrix.com/path?a=b%20c&d=e%2Bf"
     );
-    expect(makeURL(origin, { a: "b c", d: "e+f" }, "percent")).toBe(
-      "https://pixiebrix.com/?a=b%20c&d=e%2Bf"
+    expect(makeURL(origin, { a: "b c", d: "e+f" }, "plus")).toBe(
+      "https://pixiebrix.com/path?a=b+c&d=e%2Bf"
+    );
+  });
+
+  test("relative URLs support", () => {
+    expect(makeURL("bricks")).toBe("http://localhost/bricks");
+    expect(makeURL("/blueprints", { id: 1 })).toBe(
+      "http://localhost/blueprints?id=1"
     );
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -22,6 +22,7 @@ import {
   removeUndefined,
   matchesAnyPattern,
   assertHttpsUrl,
+  makeURL,
 } from "@/utils";
 import type { SafeString } from "@/core";
 import { BusinessError } from "@/errors";
@@ -150,5 +151,28 @@ describe("matchesAnyPattern", () => {
   test("matches a regex array", () => {
     expect(matchesAnyPattern("hello", [/^hel+o/, /(ho ){3}/])).toBeTruthy();
     expect(matchesAnyPattern("hello", [/^Hello$/])).toBeFalsy();
+  });
+});
+
+describe("makeURL", () => {
+  test("basic parameter support", () => {
+    const origin = "https://pixiebrix.com";
+    expect(makeURL(origin)).toBe("https://pixiebrix.com/");
+    expect(makeURL(origin, {})).toBe("https://pixiebrix.com/");
+    expect(makeURL(origin, { a: undefined, b: null })).toBe(
+      "https://pixiebrix.com/"
+    );
+    expect(makeURL(origin, { a: 1, b: "hi", c: false })).toBe(
+      "https://pixiebrix.com/?a=1&b=hi&c=false"
+    );
+  });
+  test("spaces support", () => {
+    const origin = "https://pixiebrix.com";
+    expect(makeURL(origin, { a: "b c", d: "e+f" })).toBe(
+      "https://pixiebrix.com/?a=b+c&d=e%2Bf"
+    );
+    expect(makeURL(origin, { a: "b c", d: "e+f" }, "percent")).toBe(
+      "https://pixiebrix.com/?a=b%20c&d=e%2Bf"
+    );
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,7 @@ import {
   maxBy,
   negate,
   ObjectIterator,
+  omitBy,
   partial,
   partialRight,
   pickBy,
@@ -396,30 +397,23 @@ export function isAbsoluteUrl(url: string): boolean {
 }
 
 export const SPACE_ENCODED_VALUE = "%20";
+export const URL_INPUT_SPACE_ENCODING_DEFAULT = "percent";
 
 export function makeURL(
   url: string,
-  params: Record<string, string | number | boolean> | undefined = {},
-  spaceEncoding: "plus" | "percent" = "plus"
+  params: Record<string, string | number | boolean> = {},
+  spaceEncoding: "plus" | "percent" = URL_INPUT_SPACE_ENCODING_DEFAULT
 ): string {
-  // https://javascript.info/url#searchparams
   const result = new URL(url);
-  for (const [name, value] of Object.entries(params ?? {})) {
-    if ((value ?? "") !== "") {
-      result.searchParams.append(name, String(value));
-    }
+  const cleanParams = omitBy(params, isNullOrBlank) as Record<string, string>;
+  // https://javascript.info/url#searchparams
+  result.search = new URLSearchParams(cleanParams).toString();
+
+  if (spaceEncoding === "percent" && result.search.length > 0) {
+    result.search = result.search.replaceAll("+", SPACE_ENCODED_VALUE);
   }
 
-  const fullURL = result.toString();
-
-  if (spaceEncoding === "plus" || result.search.length === 0) {
-    return fullURL;
-  }
-
-  return fullURL.replace(
-    result.search,
-    result.search.replaceAll("+", SPACE_ENCODED_VALUE)
-  );
+  return result.href;
 }
 
 export async function allSettledValues<T = unknown>(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -404,7 +404,7 @@ export function makeURL(
   params: Record<string, string | number | boolean> = {},
   spaceEncoding: "plus" | "percent" = URL_INPUT_SPACE_ENCODING_DEFAULT
 ): string {
-  const result = new URL(url);
+  const result = new URL(url, location.origin);
   const cleanParams = omitBy(params, isNullOrBlank) as Record<string, string>;
   // https://javascript.info/url#searchparams
   result.search = new URLSearchParams(cleanParams).toString();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -397,6 +397,10 @@ export function isAbsoluteUrl(url: string): boolean {
 }
 
 export const SPACE_ENCODED_VALUE = "%20";
+
+// Preserve the previous default for backwards compatibility
+// https://github.com/pixiebrix/pixiebrix-extension/pull/3076#discussion_r844564894
+export const LEGACY_URL_INPUT_SPACE_ENCODING_DEFAULT = "plus";
 export const URL_INPUT_SPACE_ENCODING_DEFAULT = "percent";
 
 export function makeURL(


### PR DESCRIPTION
- Closes #3031 

But I wonder why/when supporting both encodings would be beneficial. Even the native and modern `URL` constructor uses plus by default 