### PR TITLE
#3063 Fixes updating a public blueprint in the Page Editor removes public sharing

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -314,8 +314,13 @@ export const appApi = createApi({
           url: `api/bricks/${packageId}/`,
           method: "put",
           data: {
+            id: packageId,
+            name: recipe.metadata.id,
             config: recipeConfig,
             kind: "recipe" as RecipeDefinition["kind"],
+            public: Boolean((recipe as RecipeDefinition).sharing?.public),
+            organizations:
+              (recipe as RecipeDefinition).sharing?.organizations ?? [],
           },
         };
       },


### PR DESCRIPTION
Closes #3063 