### PR TITLE
#3101 Page Editor crashes when traces/logs fill up

### DIFF
--- a/__mocks__/webext-messenger.js
+++ b/__mocks__/webext-messenger.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const getMethod = jest.fn(() => jest.fn());
+export const getNotifier = jest.fn(() => jest.fn());

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -17,7 +17,7 @@
 
 import { uuidv4 } from "@/types/helpers";
 import { getRollbar } from "@/telemetry/initRollbar";
-import { MessageContext, SerializedError } from "@/core";
+import { MessageContext, SerializedError, UUID } from "@/core";
 import { Except, JsonObject } from "type-fest";
 import { deserializeError } from "serialize-error";
 import { DBSchema, openDB } from "idb/with-async-ittr";

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -403,7 +403,9 @@ export async function setLoggingConfig(config: LoggingConfig): Promise<void> {
   _config = config;
 }
 
-export async function clearExtensionDebugLogs(extensionId: UUID) {
+export async function clearExtensionDebugLogs(
+  extensionId: UUID
+): Promise<void> {
   const db = await getDB();
   const tx = db.transaction(ENTRY_OBJECT_STORE, "readwrite");
   const index = tx.store.index("extensionId");

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -403,7 +403,7 @@ export async function setLoggingConfig(config: LoggingConfig): Promise<void> {
   _config = config;
 }
 
-export async function clearExtensionDebugLogs(extensionId: string) {
+export async function clearExtensionDebugLogs(extensionId: UUID) {
   const db = await getDB();
   const tx = db.transaction(ENTRY_OBJECT_STORE, "readwrite");
   const index = tx.store.index("extensionId");

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -402,3 +402,14 @@ export async function setLoggingConfig(config: LoggingConfig): Promise<void> {
   await setStorage(LOG_CONFIG_STORAGE_KEY, config);
   _config = config;
 }
+
+export async function clearExtensionDebugLogs(extensionId: string) {
+  const db = await getDB();
+  const tx = db.transaction(ENTRY_OBJECT_STORE, "readwrite");
+  const index = tx.store.index("extensionId");
+  for await (const cursor of index.iterate(extensionId)) {
+    if (cursor.value.level === "debug") {
+      await cursor.delete();
+    }
+  }
+}

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -111,11 +111,15 @@ export const recordEvent = getNotifier("RECORD_EVENT", bg);
 export const getLoggingConfig = getMethod("GET_LOGGING_CONFIG", bg);
 export const setLoggingConfig = getMethod("SET_LOGGING_CONFIG", bg);
 export const clearLogs = getMethod("CLEAR_LOGS", bg);
+export const clearExtensionDebugLogs = getMethod(
+  "CLEAR_EXTENSION_DEBUG_LOGS",
+  bg
+);
 
 export const traces = {
   addEntry: getNotifier("ADD_TRACE_ENTRY", bg),
   addExit: getNotifier("ADD_TRACE_EXIT", bg),
-  clear: getNotifier("CLEAR_TRACES", bg),
+  clear: getMethod("CLEAR_TRACES", bg),
   clearAll: getNotifier("CLEAR_ALL_TRACES", bg),
 };
 

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -47,6 +47,7 @@ import { getAvailableVersion } from "@/background/installer";
 import { locator, refreshServices } from "@/background/locator";
 import { reactivateEveryTab } from "@/background/navigation";
 import {
+  clearExtensionDebugLogs,
   clearLogs,
   getLoggingConfig,
   recordError,
@@ -121,6 +122,7 @@ declare global {
     GET_LOGGING_CONFIG: typeof getLoggingConfig;
     SET_LOGGING_CONFIG: typeof setLoggingConfig;
     CLEAR_LOGS: typeof clearLogs;
+    CLEAR_EXTENSION_DEBUG_LOGS: typeof clearExtensionDebugLogs;
 
     ADD_TRACE_ENTRY: typeof addTraceEntry;
     ADD_TRACE_EXIT: typeof addTraceExit;
@@ -189,6 +191,7 @@ export default function registerMessenger(): void {
     GET_LOGGING_CONFIG: getLoggingConfig,
     SET_LOGGING_CONFIG: setLoggingConfig,
     CLEAR_LOGS: clearLogs,
+    CLEAR_EXTENSION_DEBUG_LOGS: clearExtensionDebugLogs,
 
     ADD_TRACE_ENTRY: addTraceEntry,
     ADD_TRACE_EXIT: addTraceExit,

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -164,7 +164,7 @@ export function clearDynamic(
     }
 
     if (clearTrace) {
-      traces.clear(extensionId);
+      void traces.clear(extensionId);
     }
   } else {
     for (const extensionPoint of _dynamic.values()) {

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -608,8 +608,11 @@ export async function reducePipeline(
     "@options": optionsArgs ?? {},
   } as unknown as BlockArgContext;
 
-  await traces.clear(pipelineLogger.context.extensionId);
-  await clearExtensionDebugLogs(pipelineLogger.context.extensionId);
+  // `await` promises to avoid race condition where the calls here delete debug entries from this call to reducePipeline
+  await Promise.allSettled([
+    traces.clear(pipelineLogger.context.extensionId),
+    clearExtensionDebugLogs(pipelineLogger.context.extensionId),
+  ]);
 
   // When using explicit data flow, the first block (and other blocks) use `@input` in the context to get the inputs
   let output: unknown = explicitDataFlow ? {} : input;

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -28,6 +28,7 @@ import {
 import { castArray, isPlainObject } from "lodash";
 import { BusinessError, ContextError } from "@/errors";
 import {
+  clearExtensionDebugLogs,
   getLoggingConfig,
   requestRun,
   sendDeploymentAlert,
@@ -606,6 +607,9 @@ export async function reducePipeline(
     "@input": input,
     "@options": optionsArgs ?? {},
   } as unknown as BlockArgContext;
+
+  await traces.clear(pipelineLogger.context.extensionId);
+  await clearExtensionDebugLogs(pipelineLogger.context.extensionId);
 
   // When using explicit data flow, the first block (and other blocks) use `@input` in the context to get the inputs
   let output: unknown = explicitDataFlow ? {} : input;

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -298,7 +298,7 @@ const extensionsSlice = createSlice({
       requireLatestState(state);
 
       // Make sure we're not keeping any private data around from Page Editor sessions
-      traces.clear(extensionId);
+      void traces.clear(extensionId);
 
       // NOTE: We aren't deleting the extension on the server. The user must do that separately from the dashboard
       state.extensions = state.extensions.filter((x) => x.id !== extensionId);

--- a/src/telemetry/trace.ts
+++ b/src/telemetry/trace.ts
@@ -193,15 +193,11 @@ export async function clearExtensionTraces(extensionId: UUID): Promise<void> {
   let cnt = 0;
 
   const db = await getDB();
-
   const tx = db.transaction(ENTRY_OBJECT_STORE, "readwrite");
-
-  // There's probably a better way to write this using the index
-  for await (const cursor of tx.store) {
-    if (cursor.value.extensionId === extensionId) {
-      cnt++;
-      await cursor.delete();
-    }
+  const index = tx.store.index("extensionId");
+  for await (const cursor of index.iterate(extensionId)) {
+    cnt++;
+    await cursor.delete();
   }
 
   console.debug("Cleared %d trace entries for extension %s", cnt, extensionId);


### PR DESCRIPTION
Closes #3101 

The implementation is not ideal. The traces and logs clean-up blocks the `reducePipeline`.

Alternatives:
1. Run the cleanup at the end of `reducePipeline`, select IDB entries by `runId` (although log entries do not have `runId`).
2. Clean the traces and debug logs when the DevTools start.
3. Do not write traces and debug logs if DevTools is not open.