### PR TITLE
#1080: Fix `ExtensionPoint` circular dependency

### DIFF
--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -19,7 +19,6 @@ import {
   InitialValues,
   reduceExtensionPipeline,
 } from "@/runtime/reducePipeline";
-import { ExtensionPoint } from "@/types";
 import {
   IBlock,
   IExtensionPoint,
@@ -31,6 +30,7 @@ import { propertiesToSchema } from "@/validators/generic";
 import { Manifest, Menus, Permissions } from "webextension-polyfill";
 import ArrayCompositeReader from "@/blocks/readers/ArrayCompositeReader";
 import {
+  ExtensionPoint,
   ExtensionPointConfig,
   ExtensionPointDefinition,
 } from "@/extensionPoints/types";

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -16,7 +16,6 @@
  */
 
 import { uuidv4 } from "@/types/helpers";
-import { ExtensionPoint } from "@/types";
 import { checkAvailable } from "@/blocks/available";
 import { castArray, cloneDeep, debounce, merge, once } from "lodash";
 import {
@@ -37,6 +36,7 @@ import {
   selectExtensionContext,
 } from "@/extensionPoints/helpers";
 import {
+  ExtensionPoint,
   ExtensionPointConfig,
   ExtensionPointDefinition,
 } from "@/extensionPoints/types";

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -16,7 +16,6 @@
  */
 
 import { uuidv4 } from "@/types/helpers";
-import { ExtensionPoint } from "@/types";
 import Mustache from "mustache";
 import { errorBoundary } from "@/blocks/renderers/common";
 import { checkAvailable } from "@/blocks/available";
@@ -47,6 +46,7 @@ import {
 import {
   ExtensionPointDefinition,
   ExtensionPointConfig,
+  ExtensionPoint,
 } from "@/extensionPoints/types";
 import { propertiesToSchema } from "@/validators/generic";
 import { render } from "@/extensionPoints/dom";

--- a/src/extensionPoints/quickBarExtension.tsx
+++ b/src/extensionPoints/quickBarExtension.tsx
@@ -20,7 +20,6 @@ import {
   InitialValues,
   reduceExtensionPipeline,
 } from "@/runtime/reducePipeline";
-import { ExtensionPoint } from "@/types";
 import {
   IBlock,
   IconConfig,
@@ -33,6 +32,7 @@ import {
 import { propertiesToSchema } from "@/validators/generic";
 import { Manifest, Menus, Permissions } from "webextension-polyfill";
 import {
+  ExtensionPoint,
   ExtensionPointConfig,
   ExtensionPointDefinition,
 } from "@/extensionPoints/types";

--- a/src/extensionPoints/sidebarExtension.ts
+++ b/src/extensionPoints/sidebarExtension.ts
@@ -19,7 +19,6 @@ import {
   InitialValues,
   reduceExtensionPipeline,
 } from "@/runtime/reducePipeline";
-import { ExtensionPoint } from "@/types";
 import {
   IBlock,
   IExtensionPoint,
@@ -32,6 +31,7 @@ import {
 } from "@/core";
 import { propertiesToSchema } from "@/validators/generic";
 import {
+  ExtensionPoint,
   ExtensionPointConfig,
   ExtensionPointDefinition,
 } from "@/extensionPoints/types";

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ExtensionPoint } from "@/types";
 import {
   InitialValues,
   reduceExtensionPipeline,
@@ -32,6 +31,7 @@ import {
 } from "@/core";
 import { propertiesToSchema } from "@/validators/generic";
 import {
+  ExtensionPoint,
   ExtensionPointConfig,
   ExtensionPointDefinition,
 } from "@/extensionPoints/types";

--- a/src/extensionPoints/types.ts
+++ b/src/extensionPoints/types.ts
@@ -15,8 +15,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ApiVersion, Metadata } from "@/core";
+import {
+  ApiVersion,
+  BlockIcon,
+  EmptyConfig,
+  IBlock,
+  IExtensionPoint,
+  IReader,
+  Logger,
+  Metadata,
+  RegistryId,
+  ResolvedExtension,
+  Schema,
+  UUID,
+} from "@/core";
 import { Availability, ReaderConfig } from "@/blocks/types";
+import { Permissions } from "webextension-polyfill";
+import { validateRegistryId } from "@/types/helpers";
 
 export type ExtensionPointType =
   | "panel"
@@ -73,4 +88,108 @@ export function assertExtensionPointConfig(
     console.warn("Expected object for definition.isAvailable", errorContext);
     throw new TypeError("Invalid definition in ExtensionPointConfig");
   }
+}
+
+export abstract class ExtensionPoint<TConfig extends EmptyConfig>
+  implements IExtensionPoint
+{
+  public readonly id: RegistryId;
+
+  public readonly name: string;
+
+  public readonly icon: BlockIcon;
+
+  public readonly description: string;
+
+  protected readonly extensions: Array<ResolvedExtension<TConfig>> = [];
+
+  protected readonly template?: string;
+
+  public abstract readonly inputSchema: Schema;
+
+  protected readonly logger: Logger;
+
+  public abstract get kind(): ExtensionPointType;
+
+  public get syncInstall() {
+    return false;
+  }
+
+  /**
+   * Permissions required to use this extensions
+   * https://developer.chrome.com/extensions/permission_warnings
+   */
+  public abstract readonly permissions: Permissions.Permissions;
+
+  public get defaultOptions(): Record<string, unknown> {
+    return {};
+  }
+
+  protected constructor(metadata: Metadata, logger: Logger) {
+    this.id = validateRegistryId(metadata.id);
+    this.name = metadata.name;
+    this.icon = metadata.icon;
+    this.description = metadata.description;
+    this.logger = logger.childLogger({ extensionPointId: this.id });
+  }
+
+  /**
+   * Internal method to unregister extension's triggers/observers/etc. from the page.
+   *
+   * When this method is called, the extensions will still be in this.extensions. The caller is responsible for
+   * updating this.extensions after the call to removeExtensions
+   */
+  protected abstract removeExtensions(extensionIds: UUID[]): void;
+
+  syncExtensions(extensions: Array<ResolvedExtension<TConfig>>): void {
+    const before = this.extensions.map((x) => x.id);
+
+    const updatedIds = new Set(extensions.map((x) => x.id));
+    const removed = this.extensions.filter(
+      (currentExtension) => !updatedIds.has(currentExtension.id)
+    );
+    this.removeExtensions(removed.map((x) => x.id));
+
+    // Clear extensions and re-populate with updated extensions
+    this.extensions.splice(0, this.extensions.length);
+    this.extensions.push(...extensions);
+
+    console.debug("syncExtensions for extension point %s", this.id, {
+      before,
+      after: extensions.map((x) => x.id),
+      removed: removed.map((x) => x.id),
+    });
+  }
+
+  removeExtension(extensionId: UUID) {
+    this.syncExtensions(this.extensions.filter((x) => x.id !== extensionId));
+  }
+
+  addExtension(extension: ResolvedExtension<TConfig>): void {
+    const index = this.extensions.findIndex((x) => x.id === extension.id);
+    if (index >= 0) {
+      console.warn(
+        `Extension ${extension.id} already registered for the extension point ${this.id}`
+      );
+      // Index is guaranteed to be a number, and this.extensions is an array
+      // eslint-disable-next-line security/detect-object-injection
+      this.extensions[index] = extension;
+    } else {
+      this.extensions.push(extension);
+    }
+  }
+
+  abstract defaultReader(): Promise<IReader>;
+
+  abstract getBlocks(extension: ResolvedExtension<TConfig>): Promise<IBlock[]>;
+
+  abstract isAvailable(): Promise<boolean>;
+
+  abstract install(): Promise<boolean>;
+
+  uninstall(_options?: { global?: boolean }): void {
+    console.warn(`Uninstall not implemented for extension point: ${this.id}`);
+  }
+
+  abstract run(): Promise<void>;
 }


### PR DESCRIPTION
- Follows #1080


Cycle:

- `@/types` <-> `@/extensionPoint/types`

Fix:

- move `ExtensionPoint` from `@/types` to `@/extensionPoint/types`

Warnings:

- 3 warnings fixed
- 54 warnings to go