### PR TITLE
Fix the search input label width in the data panel

### DIFF
--- a/src/components/jsonTree/JsonTree.tsx
+++ b/src/components/jsonTree/JsonTree.tsx
@@ -100,6 +100,7 @@ const JsonTree: React.FunctionComponent<JsonTreeProps> = ({
           label="Search"
           placeholder="Search for a property or value"
           onChange={onChangeQuery}
+          fitLabelWidth
         />
       )}
       {labelText && <span>{labelText}</span>}


### PR DESCRIPTION
Label no longer wraps:

<img width="387" alt="image" src="https://user-images.githubusercontent.com/2801308/162266534-4b1b24bd-e377-4377-8bd6-6077756dffeb.png">
