### PR TITLE
#3056: force use of token auth for RTK queries,  fix RequireAuth checks, handle offline state

### DIFF
--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -19,7 +19,11 @@ import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import Loader from "@/components/Loader";
 import { ApiError, useGetMeQuery } from "@/services/api";
-import { isLinked, updateUserData } from "@/auth/token";
+import {
+  addListener as addAuthListener,
+  isLinked,
+  updateUserData,
+} from "@/auth/token";
 import {
   selectExtensionAuthState,
   selectUserDataUpdate,
@@ -45,7 +49,7 @@ type RequireAuthProps = {
  *   just the session cookies. However, the server needs an X-CSRFToken token for unsafe methods (e.g., POST, DELETE).
  *   NOTE: the CSRF token for session authentication is _not_ the same as the Authentication header token for
  *   token-based authentication.
- * - Therefore, also check the extension has received the Authentication header token from the server.
+ * - Therefore, also check the extension has the Authentication header token from the server.
  */
 const RequireAuth: React.FC<RequireAuthProps> = ({
   children,
@@ -54,29 +58,52 @@ const RequireAuth: React.FC<RequireAuthProps> = ({
 }) => {
   const dispatch = useDispatch();
 
-  const isLoggedIn = useSelector(selectIsLoggedIn);
+  const hasCachedLoggedIn = useSelector(selectIsLoggedIn);
+
   // See component documentation for why both isLinked and useGetMeQuery are required
-  const [hasToken, tokenLoading, tokenError] = useAsyncState(
+  const [hasToken, tokenLoading, tokenError, refreshToken] = useAsyncState(
     async () => isLinked(),
     []
   );
-  const { isLoading: meLoading, error, data: me } = useGetMeQuery();
+
+  useEffect(() => {
+    // Listen for token invalidation
+    addAuthListener(async () => {
+      console.debug("Auth state changed, checking for token");
+      void refreshToken();
+    });
+  }, [refreshToken]);
+
+  const {
+    isLoading: meLoading,
+    error: meError,
+    data: me,
+    isSuccess: isMeSuccess,
+  } = useGetMeQuery(null, {
+    // Only call /api/me/ if the extension is "linked" is with an Authorization token. If not, the session id will
+    // be passed in the header which leads to inconsistent results depending on whether the session is still valid
+    skip: !hasToken,
+  });
 
   const isLoading = tokenLoading || meLoading;
 
   useEffect(() => {
     // Before we get the first response from API, use the AuthRootState persisted with redux-persist.
-    if (meLoading) {
+
+    // The `Me` call should never error unless there's network connectivity issues. In this case, we should
+    // keep whatever was in redux-persist
+    if (!isMeSuccess) {
       return;
     }
 
-    // If me succeeds or errors, update the AuthRootState stored with redux-persist and updateUserData stored directly
+    // If me succeeds, update the AuthRootState stored with redux-persist and updateUserData stored directly
     // in browser.storage (that's used by the background page)
     const setAuth = async (me: Me) => {
       const update = selectUserDataUpdate(me);
       await updateUserData(update);
 
-      // `me` is nullish if the request errored
+      // Because we're waiting to the Authorization token, there should always be a value here. But, defensively, if
+      // not, then reset to the anonymous state
       if (me?.id) {
         const auth = selectExtensionAuthState(me);
         dispatch(authActions.setAuth(auth));
@@ -86,7 +113,7 @@ const RequireAuth: React.FC<RequireAuthProps> = ({
     };
 
     void setAuth(me);
-  }, [meLoading, me, dispatch]);
+  }, [isMeSuccess, me, dispatch]);
 
   // Show SetupPage if there is auth error or user not logged in
   if (
@@ -95,23 +122,25 @@ const RequireAuth: React.FC<RequireAuthProps> = ({
     // the user is not authenticated.
     // http://github.com/pixiebrix/pixiebrix-app/blob/0686663bf007cf4b33d547d9f124d1fa2a83ec9a/api/views/site.py#L210-L210
     // See: https://github.com/pixiebrix/pixiebrix-extension/issues/3056
-    (error as ApiError)?.status === 401 ||
-    (!isLoggedIn && !meLoading) ||
+    (meError as ApiError)?.status === 401 ||
+    (!hasCachedLoggedIn && !meLoading) ||
     (!hasToken && !tokenLoading)
   ) {
     return <LoginPage />;
   }
 
-  if (error ?? tokenError) {
+  const error = meError ?? tokenError;
+  if (error) {
     if (ErrorPage) {
-      return <ErrorPage error={error ?? tokenError} />;
+      return <ErrorPage error={error} />;
     }
 
+    // Will be handled by an ErrorBoundary
     throw error;
   }
 
   // Optimistically skip waiting if we have cached auth data
-  if (!isLoggedIn && isLoading) {
+  if (!hasCachedLoggedIn && isLoading) {
     return <Loader />;
   }
 

--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -97,7 +97,7 @@ const RequireAuth: React.FC<RequireAuthProps> = ({
         return deserializeError(meError.error);
       }
 
-      // Not sure why, but Typescript things that meError can be a SerializedError
+      // Not sure why, but Typescript thinks that meError can be a SerializedError
       return meError;
     }
 

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -25,7 +25,7 @@ import {
 } from "./authTypes";
 import { isExtensionContext } from "webext-detect-page";
 import { expectContext } from "@/utils/expectContext";
-import { omit } from "lodash";
+import { omit, remove } from "lodash";
 
 const STORAGE_EXTENSION_KEY = "extensionKey" as ManualStorageKey;
 
@@ -36,6 +36,10 @@ const listeners: AuthListener[] = [];
 // Use listeners to allow inversion of control and avoid circular dependency with rollbar.
 export function addListener(handler: AuthListener): void {
   listeners.push(handler);
+}
+
+export function removeListener(handler: AuthListener): void {
+  remove(listeners, (x) => x === handler);
 }
 
 export async function readAuthData(): Promise<

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -280,9 +280,12 @@ export async function updateDeployments(): Promise<void> {
   ]);
 
   if (!linked) {
-    // If the Browser extension is unlinked (it doesn't have the API key), just NOP. If it's an enterprise user, it's
-    // likely they just need to reconnect their extension. If it's a non-enterprise user, they shouldn't have any
-    // deployments installed anyway.
+    // If the Browser extension is unlinked (it doesn't have the API key):
+    // - If the was part of an organization, they must have somehow lost their token: 1) the token is no longer valid
+    //   so PixieBrix cleared it out, 2) something removed the local storage entry
+    // - If the user is not an enterprise user (or has not linked their extension yet), just NOP. They lik
+    //   likely they just need to reconnect their extension. If it's a non-enterprise user, they shouldn't have any
+    //   deployments installed anyway.
     if (organizationId != null) {
       reportEvent("OrganizationExtensionLink", {
         organizationId,
@@ -320,7 +323,7 @@ export async function updateDeployments(): Promise<void> {
   const client = await maybeGetLinkedApiClient();
   if (client == null) {
     console.debug(
-      "Skipping  deployments update because the extension is not linked to the PixieBrix service"
+      "Skipping deployments update because the extension is not linked to the PixieBrix service"
     );
     return;
   }
@@ -334,6 +337,7 @@ export async function updateDeployments(): Promise<void> {
     console.debug(
       "Skipping deployments update because /api/me/ request failed"
     );
+
     return;
   }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -365,6 +365,12 @@ export function isPrivatePageError(error: unknown): boolean {
   );
 }
 
+export const NO_INTERNET_MESSAGE =
+  "No response received. You are not connected to the internet.";
+
+export const NO_RESPONSE_MESSAGE =
+  "No response received. Your browser may have blocked the request. See https://docs.pixiebrix.com/network-errors for troubleshooting information";
+
 /**
  * Heuristically select the most user-friendly error message for an Axios response.
  *
@@ -383,6 +389,10 @@ export function isPrivatePageError(error: unknown): boolean {
 function selectServerErrorMessage({ response }: AxiosError): string | null {
   // For examples of DRF errors, see the pixiebrix-app repository:
   // http://github.com/pixiebrix/pixiebrix-app/blob/5ef1e4e414be6485fae999440b69f2b6da993668/api/tests/test_errors.py#L15-L15
+
+  if (response == null) {
+    return NO_RESPONSE_MESSAGE;
+  }
 
   // Handle 400 responses created by DRF serializers
   if (isBadRequestResponse(response)) {

--- a/src/layout/Centered.tsx
+++ b/src/layout/Centered.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { Col, Container, Row } from "react-bootstrap";
+import cx from "classnames";
+
+const Centered: React.FunctionComponent<{
+  isScrollable?: boolean;
+  vertically?: boolean;
+}> = ({ isScrollable = false, vertically = false, children }) => (
+  <Container
+    fluid
+    className={cx({
+      "h-100 pb-2 overflow-auto": isScrollable,
+      "h-100": vertically,
+    })}
+  >
+    <Row
+      className={cx({
+        "h-100 align-items-center": vertically,
+      })}
+    >
+      <Col className="mx-auto mt-4 text-center" sm={11} md={9} lg={6} xl={5}>
+        {children}
+      </Col>
+    </Row>
+  </Container>
+);
+
+export default Centered;

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -52,6 +52,7 @@ import useFlags from "@/hooks/useFlags";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import RequireAuth from "@/auth/RequireAuth";
 import { ErrorDisplay } from "@/layout/ErrorDisplay";
+import Centered from "@/layout/Centered";
 
 // Register the built-in bricks
 registerEditors();
@@ -67,6 +68,12 @@ const RefreshBricks: React.VFC = () => {
   return null;
 };
 
+const ErrorScreen: React.VFC<{ error: unknown }> = ({ error }) => (
+  <Centered>
+    <ErrorDisplay error={error} />
+  </Centered>
+);
+
 const Layout = () => {
   const { permit } = useFlags();
 
@@ -75,7 +82,7 @@ const Layout = () => {
       <Navbar />
       <Container fluid className="page-body-wrapper">
         {/* It is guaranteed that under RequireAuth the user has a valid API token. */}
-        <RequireAuth LoginPage={SetupPage} ErrorPage={ErrorDisplay}>
+        <RequireAuth LoginPage={SetupPage} ErrorPage={ErrorScreen}>
           <RefreshBricks />
           <Sidebar />
           <div className="main-panel">

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -61,19 +61,22 @@ registerContribBlocks();
 // Register Widgets
 registerDefaultWidgets();
 
-const Layout = () => {
-  // Get the latest brick definitions. Put it here in Layout instead of App to ensure the Redux store has been hydrated
-  // by the time refresh is called.
+const RefreshBricks: React.VFC = () => {
+  // Get the latest brick definitions. Defined as a component to put inside the RequireAuth gate in the layout.
   useRefresh();
+  return null;
+};
 
+const Layout = () => {
   const { permit } = useFlags();
 
   return (
     <div>
       <Navbar />
       <Container fluid className="page-body-wrapper">
-        {/* It is guaranteed that under RequireAuth the user is logged in. */}
+        {/* It is guaranteed that under RequireAuth the user has a valid API token. */}
         <RequireAuth LoginPage={SetupPage} ErrorPage={ErrorDisplay}>
+          <RefreshBricks />
           <Sidebar />
           <div className="main-panel">
             <ErrorModal />

--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -33,6 +33,8 @@ const AdvancedSettings: React.FunctionComponent = () => {
 
   const clear = useCallback(async () => {
     await clearExtensionAuth();
+    // Reload to force contentScripts and background page to reload. The RequireAuth component listens for auth changes,
+    // but we should for non-extension context to reload too.
     location.reload();
     notify.success(
       "Cleared the extension token. Visit the web app to set it again"

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -51,8 +51,8 @@ import { ErrorObject, serializeError } from "serialize-error";
 
 // Temporary type for RTK query errors. Matches the example from
 // https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#axios-basequery.
-// A future PR will have appBaseQuery return the AxiosError or enriched request error
 // See errorContract
+// TODO: remove in https://github.com/pixiebrix/pixiebrix-extension/issues/3126
 export type ApiError = {
   status: number;
   data: unknown | undefined;
@@ -126,7 +126,9 @@ const appBaseQuery: BaseQueryFn<QueryArgs, unknown, ApiError> = async ({
       };
     }
 
-    // Could be an ExtensionNotLinkedError
+    // Potential errors at this point: ExtensionNotLinked. Currently re-throwing the error since it can't match
+    // the {status, data} properties we had originally in RTK query
+    // TODO: remove in https://github.com/pixiebrix/pixiebrix-extension/issues/3126
     throw error;
   }
 };

--- a/src/utils/enrichAxiosErrors.ts
+++ b/src/utils/enrichAxiosErrors.ts
@@ -17,7 +17,12 @@
 
 import axios from "axios";
 import { expectContext } from "@/utils/expectContext";
-import { getErrorMessage, isAxiosError } from "@/errors";
+import {
+  getErrorMessage,
+  isAxiosError,
+  NO_INTERNET_MESSAGE,
+  NO_RESPONSE_MESSAGE,
+} from "@/errors";
 import { assertHttpsUrl } from "@/utils";
 import {
   ClientNetworkError,
@@ -62,6 +67,10 @@ async function enrichBusinessRequestError(error: unknown): Promise<never> {
     throw new RemoteServiceError(getErrorMessage(error), error);
   }
 
+  if (!navigator.onLine) {
+    throw new ClientNetworkError(NO_INTERNET_MESSAGE, error);
+  }
+
   const hasPermissions = await browser.permissions.contains({
     origins: [url.href],
   });
@@ -73,8 +82,5 @@ async function enrichBusinessRequestError(error: unknown): Promise<never> {
     );
   }
 
-  throw new ClientNetworkError(
-    "No response received. Your browser may have blocked the request. See https://docs.pixiebrix.com/network-errors for troubleshooting information",
-    error
-  );
+  throw new ClientNetworkError(NO_RESPONSE_MESSAGE, error);
 }


### PR DESCRIPTION
Closes #3056 
Closes #3036 

What does this PR do?
- Defaults requireLinked for RTK to `true`
- In RTK, clears auth state if the server responds with a 401.
- In RequireAuth, watches for the Token being lost (e.g., because the RTK error handler cleared the token) 
- In RequireAuth, doesn't clear existing auth on /api/me/
- In RequireAuth, waits to run /api/me/ query until the server because session-based state is inconsistent
- In RequireAuth and enrichBusinessRequestError check for the client being offline

Not in the PR:
- Does not handle ExtensionNotLinked in RequireAuth. That should only happen during a race condition with isLinked, because /api/me/ is only being called if the token is linked

Potential Improvements:
- If the user is offline, let the RequireAuth pass with the cached auth? (Any operations involving network requests would fail, but maybe that's OK)

Screenshots:

Page Editor
![image](https://user-images.githubusercontent.com/1879821/162348461-f3839820-28d4-415b-b8cf-bc6d51a3dba6.png)

![image](https://user-images.githubusercontent.com/1879821/162348624-b51c526b-5c35-4872-83f3-afc1660f3822.png)

Options Page
![image](https://user-images.githubusercontent.com/1879821/162348553-d7c8ea45-002a-45b1-b891-7830f9d30bf5.png)



