### PR TITLE
#3122: fix use of baseUrl in assertHttpsUrl to fix request error enrichment

### DIFF
--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -58,6 +58,7 @@ export async function serializableAxiosRequest<T>(
     "Network requests must be made from the background page"
   );
 
+  // Axios does not perform validation, so call before the axios call.
   assertHttpsUrl(config.url, config.baseURL);
 
   const { data, status, statusText } = await axios(config);

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -23,6 +23,7 @@ import { faRedo } from "@fortawesome/free-solid-svg-icons";
 import { getErrorMessage } from "@/errors";
 import reportError from "@/telemetry/reportError";
 import { UnknownObject } from "@/types";
+import { isEmpty } from "lodash";
 
 interface Props {
   /**
@@ -64,9 +65,11 @@ class ErrorBoundary extends Component<Props, State> {
         <div className="p-3">
           <h1>Something went wrong.</h1>
           {this.props.errorContext && <h2>{this.props.errorContext}</h2>}
-          <div>
-            <p>{this.state.errorMessage}</p>
-          </div>
+          {!isEmpty(this.state.errorMessage) && (
+            <div>
+              <p>{this.state.errorMessage}</p>
+            </div>
+          )}
           <div>
             <Button
               onClick={() => {
@@ -76,16 +79,18 @@ class ErrorBoundary extends Component<Props, State> {
               <FontAwesomeIcon icon={faRedo} /> Reload the Page
             </Button>
           </div>
-          <pre className="mt-2 small text-secondary">
-            {this.state.stack
-              // In the app
-              .replaceAll(location.origin + "/", "")
-              // In the content script
-              .replaceAll(
-                `chrome-extension://${process.env.CHROME_EXTENSION_ID}/`,
-                ""
-              )}
-          </pre>
+          {this.state.stack && (
+            <pre className="mt-2 small text-secondary">
+              {this.state.stack
+                // In the app
+                .replaceAll(location.origin + "/", "")
+                // In the content script
+                .replaceAll(
+                  `chrome-extension://${process.env.CHROME_EXTENSION_ID}/`,
+                  ""
+                )}
+            </pre>
+          )}
         </div>
       );
     }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -66,12 +66,9 @@ describe("assertHttpsUrl", () => {
   });
   test("rejects invalid URLs", () => {
     expect(() => assertHttpsUrl("https::/example.com")).toThrow(
-      new BusinessError(
-        "Invalid URL: https::/example.com (base URL: http://localhost/)"
-      )
+      new BusinessError("Invalid URL: https::/example.com")
     );
   });
-
   test("parses relative URLs with a base", () => {
     expect(
       assertHttpsUrl("/cool/path", "https://example.com/page")

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -461,29 +461,42 @@ export function safeParseUrl(url: string, baseUrl?: string): URL {
   }
 }
 
+/**
+ * Returns an https: schema URL, or throws a BusinessError
+ * @param url an absolute or relative URL
+ * @param baseUrl the baseUrl to use if url is relative
+ * @return the URL instance
+ * @throws BusinessError if the URL is invalid
+ */
 export function assertHttpsUrl(
   url: string,
-  baseUrl: string = location.href
+  // Don't default baseUrl to location.href here. API calls are always routed through a chrome-extension:// page (e.g.,
+  // the background page. So they would always be flagged as having an invalid schema)
+  baseUrl?: string
 ): URL {
   const parsedUrl = safeParseUrl(url, baseUrl);
 
   // Allow local non-HTTPS URLs when testing locally
-  if (process.env.DEBUG && parsedUrl.protocol === "http") {
+  if (process.env.DEBUG && parsedUrl.protocol === "http:") {
     return parsedUrl;
   }
 
   switch (parsedUrl.protocol) {
-    case "https:":
+    case "https:": {
       return parsedUrl;
+    }
 
-    case "invalid-url:":
-      baseUrl = isAbsoluteUrl(url) ? "" : ` (base URL: ${baseUrl})`;
+    case "invalid-url:": {
+      baseUrl =
+        isAbsoluteUrl(url) || isEmpty(baseUrl) ? "" : ` (base URL: ${baseUrl})`;
       throw new BusinessError(`Invalid URL: ${url}${baseUrl}`);
+    }
 
-    default:
+    default: {
       throw new BusinessError(
         `Unsupported protocol: ${parsedUrl.protocol}. Use https:`
       );
+    }
   }
 }
 

--- a/src/utils/enrichAxiosErrors.ts
+++ b/src/utils/enrichAxiosErrors.ts
@@ -47,7 +47,7 @@ async function enrichBusinessRequestError(error: unknown): Promise<never> {
   console.trace("enrichBusinessRequestError", { error });
 
   // This should have already been called before attempting the request because Axios does not actually catch invalid URLs
-  const url = assertHttpsUrl(error.config.url);
+  const url = assertHttpsUrl(error.config.url, error.config.baseURL);
 
   if (error.response) {
     // Exclude app errors, unless they're proxied requests


### PR DESCRIPTION
Closes #3122 

- The bug was causing all request errors involving relative URLs to be reported as invalid scheme chrome-extension: