### PR TITLE
#3131: remove unnecessary error handler on error banner

### DIFF
--- a/src/pageEditor/ErrorBanner.tsx
+++ b/src/pageEditor/ErrorBanner.tsx
@@ -17,17 +17,19 @@
 
 import React, { useContext } from "react";
 import { PageEditorTabContext } from "@/pageEditor/context";
-import { getErrorMessage } from "@/errors";
 import { Button } from "react-bootstrap";
-import { useGetMeQuery } from "@/services/api";
 
+/**
+ * Error banner for Page Editor browser connection errors.
+ *
+ * Errors contacting the PixieBrix server are handled via `RequireAuth` and `ErrorBoundary`s
+ *
+ * @see RequireAuth
+ */
 const ErrorBanner: React.VFC = () => {
   const context = useContext(PageEditorTabContext);
-  const { error: accountError } = useGetMeQuery();
 
-  const error = accountError
-    ? `Authentication error: ${getErrorMessage(accountError)}`
-    : context.tabState.error;
+  const { error } = context.tabState;
 
   if (!error) {
     return null;


### PR DESCRIPTION
Closes #3131 

https://github.com/pixiebrix/pixiebrix-extension/pull/3167 fixed the original root cause by having RTK throw normal errors. 

Removes the old auth check. Given that the Page Editor panel is wrapped in a RequireAuth, authentication is already checked and an ErrorBoundary is shown at the top-level if the connection to the server is broken