### PR TITLE
#3200: run brick in top frame of window

### DIFF
--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -76,6 +76,7 @@ export const requestRun = {
   onServer: getMethod("REQUEST_RUN_ON_SERVER", bg),
   inOpener: getMethod("REQUEST_RUN_IN_OPENER", bg),
   inTarget: getMethod("REQUEST_RUN_IN_TARGET", bg),
+  inTop: getMethod("REQUEST_RUN_IN_TOP", bg),
   inAll: getMethod("REQUEST_RUN_IN_ALL", bg),
 };
 

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -35,6 +35,7 @@ import {
   requestRunInTarget,
   requestRunInBroadcast,
   waitForTargetByUrl,
+  requestRunInTop,
 } from "@/background/executor";
 import * as registry from "@/registry/localRegistry";
 import { ensureContentScript } from "@/background/util";
@@ -105,6 +106,7 @@ declare global {
     REQUEST_RUN_ON_SERVER: typeof requestRunOnServer;
     REQUEST_RUN_IN_OPENER: typeof requestRunInOpener;
     REQUEST_RUN_IN_TARGET: typeof requestRunInTarget;
+    REQUEST_RUN_IN_TOP: typeof requestRunInTop;
     REQUEST_RUN_IN_ALL: typeof requestRunInBroadcast;
 
     HTTP_REQUEST: typeof serializableAxiosRequest;
@@ -174,6 +176,7 @@ export default function registerMessenger(): void {
     REQUEST_RUN_ON_SERVER: requestRunOnServer,
     REQUEST_RUN_IN_OPENER: requestRunInOpener,
     REQUEST_RUN_IN_TARGET: requestRunInTarget,
+    REQUEST_RUN_IN_TOP: requestRunInTop,
     REQUEST_RUN_IN_ALL: requestRunInBroadcast,
 
     HTTP_REQUEST: serializableAxiosRequest,

--- a/src/blocks/types.ts
+++ b/src/blocks/types.ts
@@ -79,11 +79,18 @@ export type ReaderConfig =
  * - self: the current tab
  * - opener: the tab that opened the current tab
  * - target: the last tab that the current tab opened
+ * - top: the top-most frame in the window
  * - broadcast: all tabs that PixieBrix has access to (the result is returned as an array)
  * - remote: the server (currently only support identity, get, and http bricks)
  * @see {@link BlockConfig.window}
  */
-export type BlockWindow = "self" | "opener" | "target" | "broadcast" | "remote";
+export type BlockWindow =
+  | "self"
+  | "opener"
+  | "target"
+  | "top"
+  | "broadcast"
+  | "remote";
 
 /**
  * Condition expression written in templateEngine for deciding if the step should be run.

--- a/src/pageEditor/tabs/effect/BlockConfiguration.tsx
+++ b/src/pageEditor/tabs/effect/BlockConfiguration.tsx
@@ -47,6 +47,7 @@ const targetOptions: Array<Option<BlockWindow>> = [
   { label: "Current Tab (self)", value: "self" },
   { label: "Opener Tab (opener)", value: "opener" },
   { label: "Target Tab (target)", value: "target" },
+  { label: "Top-level Frame (top)", value: "top" },
   { label: "All Tabs (broadcast)", value: "broadcast" },
   { label: "Server (remote)", value: "remote" },
 ];

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -231,6 +231,10 @@ async function execute(
       return requestRun.inTarget(request);
     }
 
+    case "top": {
+      return requestRun.inTop(request);
+    }
+
     case "broadcast": {
       return requestRun.inAll(request);
     }


### PR DESCRIPTION
What does this PR do?
---
- Quick implementation of #3200 
- Provides a "top" target to run a brick in the top-most frame of a window/tab

### Use Case Patterns Enabled
- Sub-frame can get context of the root page directly by running bricks in the top-level frame
- Top-level frame can get context from a sub-frame by having the sub-frame call "Set page state" on the top level from on page load, triggers, etc.

### Demo Site
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
