### PR TITLE
Cutover direct Formik usage to our Form component, and add semver validation

### DIFF
--- a/src/auth/ScopeSettings.module.scss
+++ b/src/auth/ScopeSettings.module.scss
@@ -34,3 +34,11 @@
   font-size: 1.3rem;
   margin-bottom: 10px;
 }
+
+.submitDiv {
+  display: flex;
+}
+
+.submit {
+  margin-left: auto;
+}

--- a/src/auth/ScopeSettings.tsx
+++ b/src/auth/ScopeSettings.tsx
@@ -109,7 +109,7 @@ const ScopeSettings: React.VoidFunctionComponent<ScopeSettingsProps> = ({
       label="Account Alias"
       fitLabelWidth
       placeholder="@peter-parker"
-      description="Your @alias for publishing bricks"
+      description="Your @alias for publishing bricks, e.g. @peter-parker"
     />
   );
 

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -46,6 +46,7 @@ type FormProps = {
   initialValues: FormikValues;
   validationSchema: yup.AnyObjectSchema;
   validateOnMount?: boolean;
+  enableReinitialize?: boolean;
   renderBody?: RenderBody;
   renderSubmit?: RenderSubmit;
   renderStatus?: RenderStatus;
@@ -66,6 +67,7 @@ const Form: React.FC<FormProps> = ({
   initialValues,
   validationSchema,
   validateOnMount,
+  enableReinitialize,
   children,
   renderBody,
   renderSubmit = defaultRenderSubmit,
@@ -76,6 +78,7 @@ const Form: React.FC<FormProps> = ({
     initialValues={initialValues}
     validationSchema={validationSchema}
     validateOnMount={validateOnMount}
+    enableReinitialize={enableReinitialize}
     onSubmit={onSubmit}
   >
     {({

--- a/src/options/pages/blueprints/modals/__snapshots__/ShareExtensionModal.test.tsx.snap
+++ b/src/options/pages/blueprints/modals/__snapshots__/ShareExtensionModal.test.tsx.snap
@@ -306,20 +306,20 @@ exports[`requires user scope 1`] = `
             class="container"
           >
             <form
-              class="mt-2"
+              class=""
               novalidate=""
             >
               <div
                 class="formGroup form-group row"
               >
                 <label
-                  class="label form-label col-form-label col-xl-2 col-lg-3"
+                  class="label form-label col-form-label col-lg-auto"
                   for="scope"
                 >
                   Account Alias
                 </label>
                 <div
-                  class="col-xl-10 col-lg-9"
+                  class="col-lg"
                 >
                   <input
                     class="form-control"
@@ -331,16 +331,20 @@ exports[`requires user scope 1`] = `
                   <small
                     class="text-muted form-text"
                   >
-                    Your @alias for publishing bricks, e.g., @peter-parker
+                    Your @alias for publishing bricks
                   </small>
                 </div>
               </div>
-              <button
-                class="btn btn-primary"
-                type="submit"
+              <div
+                class="submitDiv"
               >
-                Set My Account Alias
-              </button>
+                <button
+                  class="submit btn btn-primary"
+                  type="submit"
+                >
+                  Set My Account Alias
+                </button>
+              </div>
             </form>
           </div>
         </div>

--- a/src/options/pages/blueprints/modals/__snapshots__/ShareExtensionModal.test.tsx.snap
+++ b/src/options/pages/blueprints/modals/__snapshots__/ShareExtensionModal.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`requires user scope 1`] = `
                   <small
                     class="text-muted form-text"
                   >
-                    Your @alias for publishing bricks
+                    Your @alias for publishing bricks, e.g. @peter-parker
                   </small>
                 </div>
               </div>

--- a/src/pageEditor/sidebar/AddToRecipeModal.tsx
+++ b/src/pageEditor/sidebar/AddToRecipeModal.tsx
@@ -125,7 +125,7 @@ const AddToRecipeModal: React.VFC = () => {
   ];
 
   const renderBody: RenderBody = () => (
-    <>
+    <Modal.Body>
       <ConnectedFieldTemplate
         name="recipeId"
         hideLabel
@@ -141,7 +141,7 @@ const AddToRecipeModal: React.VFC = () => {
         as={SwitchButtonWidget}
         widerLabel
       />
-    </>
+    </Modal.Body>
   );
 
   const renderSubmit: RenderSubmit = ({ isSubmitting, isValid }) => (
@@ -166,15 +166,13 @@ const AddToRecipeModal: React.VFC = () => {
           Add <em>{activeElement?.label}</em> to a blueprint
         </Modal.Title>
       </Modal.Header>
-      <Modal.Body>
-        <Form
-          validationSchema={formStateSchema}
-          initialValues={initialFormState}
-          onSubmit={onSubmit}
-          renderBody={renderBody}
-          renderSubmit={renderSubmit}
-        />
-      </Modal.Body>
+      <Form
+        validationSchema={formStateSchema}
+        initialValues={initialFormState}
+        onSubmit={onSubmit}
+        renderBody={renderBody}
+        renderSubmit={renderSubmit}
+      />
     </Modal>
   );
 };

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useCallback } from "react";
-import { PACKAGE_REGEX, uuidv4 } from "@/types/helpers";
+import { PACKAGE_REGEX, uuidv4, validateSemVerString } from "@/types/helpers";
 import { useDispatch, useSelector } from "react-redux";
 import {
   selectActiveElement,
@@ -58,7 +58,7 @@ const CreateRecipeModal: React.VFC = () => {
   const create = useCreate();
   const keepLocalCopy = useSelector(selectKeepLocalCopyOnCreateRecipe);
 
-  // TODO: This should be yup.SchemaOf<RecipeConfiguration> but we can't set the `id` property to `RegistryId`
+  // TODO: This should be yup.SchemaOf<RecipeMetadataFormState> but we can't set the `id` property to `RegistryId`
   // see: https://github.com/jquense/yup/issues/1183#issuecomment-749186432
   const createRecipeSchema = object({
     id: string()
@@ -66,7 +66,13 @@ const CreateRecipeModal: React.VFC = () => {
       .notOneOf(newRecipeIds, "This id is already in use")
       .required(),
     name: string().required(),
-    version: string().required(),
+    version: string()
+      .test(
+        "semver",
+        "Version must follow the X.Y.Z semantic version format, without a leading 'v'",
+        (value: string) => validateSemVerString(value, false)
+      )
+      .required(),
     description: string(),
   });
 

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -16,7 +16,6 @@
  */
 
 import React, { useCallback } from "react";
-import * as yup from "yup";
 import { PACKAGE_REGEX, uuidv4 } from "@/types/helpers";
 import { useDispatch, useSelector } from "react-redux";
 import {
@@ -47,6 +46,7 @@ import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import { produce } from "immer";
 import { selectRecipeMetadata } from "@/pageEditor/panes/save/useSavingWizard";
 import { FieldDescriptions } from "@/utils/strings";
+import { object, string } from "yup";
 
 const { actions: optionsActions } = extensionsSlice;
 
@@ -60,15 +60,14 @@ const CreateRecipeModal: React.VFC = () => {
 
   // TODO: This should be yup.SchemaOf<RecipeConfiguration> but we can't set the `id` property to `RegistryId`
   // see: https://github.com/jquense/yup/issues/1183#issuecomment-749186432
-  const createRecipeSchema = yup.object().shape({
-    id: yup
-      .string()
+  const createRecipeSchema = object({
+    id: string()
       .matches(PACKAGE_REGEX, "Invalid registry id")
       .notOneOf(newRecipeIds, "This id is already in use")
       .required(),
-    name: yup.string().required(),
-    version: yup.string().required(),
-    description: yup.string(),
+    name: string().required(),
+    version: string().required(),
+    description: string(),
   });
 
   const dispatch = useDispatch();

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -136,7 +136,7 @@ const CreateRecipeModal: React.VFC = () => {
   );
 
   const renderBody: RenderBody = () => (
-    <>
+    <Modal.Body>
       <ConnectedFieldTemplate
         name="id"
         label="Blueprint ID"
@@ -161,7 +161,7 @@ const CreateRecipeModal: React.VFC = () => {
         widerLabel
         description={FieldDescriptions.BLUEPRINT_DESCRIPTION}
       />
-    </>
+    </Modal.Body>
   );
 
   const renderSubmit: RenderSubmit = ({ isSubmitting, isValid }) => (
@@ -184,17 +184,15 @@ const CreateRecipeModal: React.VFC = () => {
       <Modal.Header closeButton>
         <Modal.Title>Create new blueprint</Modal.Title>
       </Modal.Header>
-      <Modal.Body>
-        <RequireScope scopeSettingsDescription="To create a blueprint, you must first set an account alias for your PixieBrix account">
-          <Form
-            validationSchema={createRecipeSchema}
-            initialValues={initialFormState}
-            onSubmit={onSubmit}
-            renderBody={renderBody}
-            renderSubmit={renderSubmit}
-          />
-        </RequireScope>
-      </Modal.Body>
+      <RequireScope scopeSettingsDescription="To create a blueprint, you must first set an account alias for your PixieBrix account">
+        <Form
+          validationSchema={createRecipeSchema}
+          initialValues={initialFormState}
+          onSubmit={onSubmit}
+          renderBody={renderBody}
+          renderSubmit={renderSubmit}
+        />
+      </RequireScope>
     </Modal>
   );
 };

--- a/src/pageEditor/sidebar/RemoveFromRecipeModal.tsx
+++ b/src/pageEditor/sidebar/RemoveFromRecipeModal.tsx
@@ -77,7 +77,7 @@ const RemoveFromRecipeModal: React.VFC = () => {
   );
 
   const renderBody: RenderBody = ({ values }) => (
-    <>
+    <Modal.Body>
       <ConnectedFieldTemplate
         name="keepLocalCopy"
         label="Keep a local copy of the extension?"
@@ -91,7 +91,7 @@ const RemoveFromRecipeModal: React.VFC = () => {
           button.
         </Alert>
       )}
-    </>
+    </Modal.Body>
   );
 
   const renderSubmit: RenderSubmit = ({ isSubmitting, isValid, values }) => (
@@ -117,15 +117,13 @@ const RemoveFromRecipeModal: React.VFC = () => {
           <em>{activeElement?.recipe?.name}</em>?
         </Modal.Title>
       </Modal.Header>
-      <Modal.Body>
-        <Form
-          initialValues={initialFormState}
-          validationSchema={formStateSchema}
-          onSubmit={onSubmit}
-          renderBody={renderBody}
-          renderSubmit={renderSubmit}
-        />
-      </Modal.Body>
+      <Form
+        initialValues={initialFormState}
+        validationSchema={formStateSchema}
+        onSubmit={onSubmit}
+        renderBody={renderBody}
+        renderSubmit={renderSubmit}
+      />
     </Modal>
   );
 };

--- a/src/pageEditor/tabs/editRecipeTab/EditRecipe.tsx
+++ b/src/pageEditor/tabs/editRecipeTab/EditRecipe.tsx
@@ -28,11 +28,13 @@ import Loader from "@/components/Loader";
 import { getErrorMessage } from "@/errors";
 import { actions } from "@/pageEditor/slices/editorSlice";
 import ErrorBoundary from "@/components/ErrorBoundary";
-import { Formik } from "formik";
 import Effect from "@/pageEditor/components/Effect";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import styles from "./EditRecipe.module.scss";
 import { FieldDescriptions } from "@/utils/strings";
+import { object, string } from "yup";
+import { validateSemVerString } from "@/types/helpers";
+import Form, { RenderBody } from "@/components/form/Form";
 
 const EditRecipe: React.VoidFunctionComponent = () => {
   const recipeId = useSelector(selectActiveRecipeId);
@@ -43,14 +45,27 @@ const EditRecipe: React.VoidFunctionComponent = () => {
   )?.metadata;
   const metadata = dirtyMetadata ?? savedMetadata;
 
+  // TODO: This should be yup.SchemaOf<RecipeMetadataFormState> but we can't set the `id` property to `RegistryId`
+  // see: https://github.com/jquense/yup/issues/1183#issuecomment-749186432
+  const editRecipeSchema = object({
+    id: string().required(), // Recipe id is readonly here
+    name: string().required(),
+    version: string()
+      .test(
+        "semver",
+        "Version must follow the X.Y.Z semantic version format, without a leading 'v'",
+        (value: string) => validateSemVerString(value, false)
+      )
+      .required(),
+    description: string(),
+  });
+
   const initialFormState: RecipeMetadataFormState = {
     id: metadata?.id,
     name: metadata?.name,
     version: metadata?.version,
     description: metadata?.description,
   };
-
-  const initialValues = { metadata: initialFormState };
 
   const dispatch = useDispatch();
   const updateRedux = useCallback(
@@ -76,57 +91,56 @@ const EditRecipe: React.VoidFunctionComponent = () => {
     );
   }
 
+  const renderBody: RenderBody = ({ values }) => (
+    <>
+      <Effect values={values} onChange={updateRedux} delayMillis={100} />
+
+      <Card>
+        <Card.Header>Blueprint Metadata</Card.Header>
+        <Card.Body>
+          <ConnectedFieldTemplate
+            name="id"
+            label="Blueprint ID"
+            description={FieldDescriptions.BLUEPRINT_ID}
+            // Blueprint IDs may not be changed after creation
+            readOnly
+          />
+          <ConnectedFieldTemplate
+            name="name"
+            label="Name"
+            description={FieldDescriptions.BLUEPRINT_NAME}
+          />
+          <ConnectedFieldTemplate
+            name="version"
+            label="Version"
+            description={FieldDescriptions.BLUEPRINT_VERSION}
+          />
+          <ConnectedFieldTemplate
+            name="description"
+            label="Description"
+            description={FieldDescriptions.BLUEPRINT_DESCRIPTION}
+          />
+        </Card.Body>
+      </Card>
+    </>
+  );
+
   return (
     <Container fluid className={styles.root}>
       <Row className={styles.row}>
         <Col sm={11} md={10} lg={9} xl={8}>
           <ErrorBoundary>
-            <Formik
-              initialValues={initialValues}
+            <Form
+              validationSchema={editRecipeSchema}
+              initialValues={initialFormState}
               onSubmit={() => {
                 console.error(
-                  "Formik's submit should not be called to save recipe metadata. Use 'saveRecipe' from 'useRecipeSaver' instead."
+                  "The form's submit should not be called to save recipe metadata. Use 'saveRecipe' from 'useRecipeSaver' instead."
                 );
               }}
-            >
-              {({ values }) => (
-                <>
-                  <Effect
-                    values={values.metadata}
-                    onChange={updateRedux}
-                    delayMillis={100}
-                  />
-
-                  <Card>
-                    <Card.Header>Blueprint Metadata</Card.Header>
-                    <Card.Body>
-                      <ConnectedFieldTemplate
-                        name="metadata.id"
-                        label="Blueprint ID"
-                        description={FieldDescriptions.BLUEPRINT_ID}
-                        // Blueprint IDs may not be changed after creation
-                        readOnly
-                      />
-                      <ConnectedFieldTemplate
-                        name="metadata.name"
-                        label="Name"
-                        description={FieldDescriptions.BLUEPRINT_NAME}
-                      />
-                      <ConnectedFieldTemplate
-                        name="metadata.version"
-                        label="Version"
-                        description={FieldDescriptions.BLUEPRINT_VERSION}
-                      />
-                      <ConnectedFieldTemplate
-                        name="metadata.description"
-                        label="Description"
-                        description={FieldDescriptions.BLUEPRINT_DESCRIPTION}
-                      />
-                    </Card.Body>
-                  </Card>
-                </>
-              )}
-            </Formik>
+              renderBody={renderBody}
+              renderSubmit={() => null}
+            />
           </ErrorBoundary>
         </Col>
       </Row>

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -18,6 +18,7 @@
 import { validate, v4 as uuidFactory } from "uuid";
 import { RegistryId, SemVerString, Timestamp, UUID } from "@/core";
 import { valid as semVerValid } from "semver";
+import { startsWith } from "lodash";
 
 export const PACKAGE_REGEX =
   /^((?<scope>@[\da-z~-][\d._a-z~-]*)\/)?((?<collection>[\da-z~-][\d._a-z~-]*)\/)?(?<name>[\da-z~-][\d._a-z~-]*)$/;
@@ -90,6 +91,13 @@ export function validateTimestamp(value: string): Timestamp {
   throw new TypeError("Invalid timestamp");
 }
 
-export function validateSemVerString(value: string): value is SemVerString {
-  return semVerValid(value) != null;
+export function validateSemVerString(
+  value: string,
+  allowLeadingV = true
+): value is SemVerString {
+  if (semVerValid(value) != null) {
+    return allowLeadingV || !startsWith(value, "v");
+  }
+
+  return false;
 }

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -19,6 +19,5 @@ export const FieldDescriptions = {
   BLUEPRINT_ID: "A unique id for the blueprint",
   BLUEPRINT_NAME: "A display name for the blueprint",
   BLUEPRINT_DESCRIPTION: "A short description of the blueprint",
-  BLUEPRINT_VERSION:
-    "The current blueprint version; must follow the X.Y.Z semantic version format",
+  BLUEPRINT_VERSION: "The current blueprint version",
 };


### PR DESCRIPTION
This cleans up some messy, direct usages of `<Formik/>` that can be cleaned up using our `<Form/>` component. This improves the field validation and standardizes/simplifies the code.

Also added validation for semver `Version` strings in the recipe metadata.