### PR TITLE
Show reset button for new extensions in blueprints

### DIFF
--- a/src/pageEditor/toolbar/ActionToolbar.tsx
+++ b/src/pageEditor/toolbar/ActionToolbar.tsx
@@ -56,7 +56,7 @@ const ActionToolbar: React.FunctionComponent<{
       <Button disabled={disabled} size="sm" variant="primary" onClick={onSave}>
         <FontAwesomeIcon icon={faSave} /> Save
       </Button>
-      {element.installed && (
+      {(element.installed || element.recipe != null) && (
         <Button
           disabled={disabled}
           size="sm"


### PR DESCRIPTION
Closes #3211 

When a new extension is moved into a blueprint, we should show the reset button even if it's unsaved, because it's going to reset the blueprint, not the extension.