### PR TITLE
Re-enable Storybook upload

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -14,10 +14,11 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build-storybook
-# Upload is very slow since there is a lot of small files (for the icons). Leave off for now so it doesn't slow down CI
-#      - uses: actions/upload-artifact@v2
-#        with:
-#          name: storybook
-#          path: storybook-static
-#          retention-days: 3
-#          if-no-files-found: error
+      - name: Upload Storybook
+        # Upload zipped artifact because otherwise upload is slow due to a lot of small files (for the icons)
+        uses: ./.github/actions/upload-zipped-artifact
+        with:
+          name: storybook
+          directory: storybook-static
+          if-no-files-found: error
+          retention-days: 3


### PR DESCRIPTION
What does this PR do?
---
- Turns back on Storybook artifact upload
- Uses our custom `.github/actions/upload-zipped-artifact` action for performance since there's a lot of small files