### PR TITLE
#3222 Add tests for buildRecipe() and fix some uncovered edge cases

### DIFF
--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -227,8 +227,8 @@ export function selectIsAvailable(
   const availability: NormalizedAvailability = {};
 
   // All 3 fields in NormalizedAvailability are optional, so we should only set each one if
-  // the ExtensionPointConfig has a value set for that field. Normalizing here causes more
-  // confusion than it helps.
+  // the ExtensionPointConfig has a value set for that field. Normalizing here makes testing
+  // harder because we then have to account for the normalized value in assertions.
   const { isAvailable } = extensionPoint.definition;
 
   if (isAvailable.matchPatterns) {

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -226,6 +226,9 @@ export function selectIsAvailable(
 
   const availability: NormalizedAvailability = {};
 
+  // All 3 fields in NormalizedAvailability are optional, so we should only set each one if
+  // the ExtensionPointConfig has a value set for that field. Normalizing here causes more
+  // confusion than it helps.
   const { isAvailable } = extensionPoint.definition;
 
   if (isAvailable.matchPatterns) {

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -224,16 +224,23 @@ export function selectIsAvailable(
 ): NormalizedAvailability {
   assertExtensionPointConfig(extensionPoint);
 
-  const { isAvailable } = extensionPoint.definition;
-  const matchPatterns = castArray(isAvailable.matchPatterns ?? []);
-  const urlPatterns = castArray(isAvailable.urlPatterns ?? []);
-  const selectors = castArray(isAvailable.selectors ?? []);
+  const availability: NormalizedAvailability = {};
 
-  return {
-    matchPatterns,
-    urlPatterns,
-    selectors,
-  };
+  const { isAvailable } = extensionPoint.definition;
+
+  if (isAvailable.matchPatterns) {
+    availability.matchPatterns = castArray(isAvailable.matchPatterns);
+  }
+
+  if (isAvailable.urlPatterns) {
+    availability.urlPatterns = castArray(isAvailable.urlPatterns);
+  }
+
+  if (isAvailable.selectors) {
+    availability.selectors = castArray(isAvailable.selectors);
+  }
+
+  return availability;
 }
 
 /**

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -628,11 +628,28 @@ describe("buildRecipe", () => {
     expect(newRecipe).toStrictEqual(recipe);
   });
 
-  // TODO: write more cases
-  // test("three clean extensions", () => {
-  //
-  // });
-  //
+  test("three clean extensions", () => {
+    const recipe = versionedRecipeWithResolvedExtensions(3)();
+
+    const state = extensionsSlice.reducer(
+      { extensions: [] },
+      extensionsSlice.actions.installRecipe({
+        recipe,
+        services: {},
+        extensionPoints: recipe.extensionPoints,
+      })
+    );
+
+    const newRecipe = buildRecipe({
+      sourceRecipe: recipe,
+      cleanRecipeExtensions: state.extensions,
+      dirtyRecipeElements: [],
+    });
+
+    expect(newRecipe).toStrictEqual(recipe);
+  });
+
+  // TODO: write more test cases
   // test("one dirty element", () => {
   //
   // });

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  buildRecipe,
   generateScopeBrickId,
   isRecipeEditable,
   replaceRecipeExtension,
@@ -27,6 +28,7 @@ import {
   versionedExtensionPointRecipeFactory,
   extensionPointConfigFactory,
   recipeFactory,
+  versionedRecipeWithResolvedExtensions,
 } from "@/testUtils/factories";
 import menuItemExtensionAdapter from "@/pageEditor/extensionPoints/menuItem";
 import { UnknownObject } from "@/types";
@@ -581,4 +583,81 @@ describe("isRecipeEditable", () => {
 
     expect(isRecipeEditable(editablePackages, null)).toBe(false);
   });
+});
+
+describe("buildRecipe", () => {
+  test("one clean extension", () => {
+    const recipe = versionedRecipeWithResolvedExtensions(1)();
+
+    const state = extensionsSlice.reducer(
+      { extensions: [] },
+      extensionsSlice.actions.installRecipe({
+        recipe,
+        services: {},
+        extensionPoints: recipe.extensionPoints,
+      })
+    );
+
+    const newRecipe = buildRecipe({
+      sourceRecipe: recipe,
+      cleanRecipeExtensions: state.extensions,
+      dirtyRecipeElements: [],
+    });
+
+    expect(newRecipe).toStrictEqual(recipe);
+  });
+
+  test("two clean extensions", () => {
+    const recipe = versionedRecipeWithResolvedExtensions(2)();
+
+    const state = extensionsSlice.reducer(
+      { extensions: [] },
+      extensionsSlice.actions.installRecipe({
+        recipe,
+        services: {},
+        extensionPoints: recipe.extensionPoints,
+      })
+    );
+
+    const newRecipe = buildRecipe({
+      sourceRecipe: recipe,
+      cleanRecipeExtensions: state.extensions,
+      dirtyRecipeElements: [],
+    });
+
+    expect(newRecipe).toStrictEqual(recipe);
+  });
+
+  // TODO: write more cases
+  // test("three clean extensions", () => {
+  //
+  // });
+  //
+  // test("one dirty element", () => {
+  //
+  // });
+  //
+  // test("two dirty elements", () => {
+  //
+  // });
+  //
+  // test("three dirty elements", () => {
+  //
+  // });
+  //
+  // test("one dirty element and one clean extension", () => {
+  //
+  // });
+  //
+  // test("one dirty element and two clean extensions", () => {
+  //
+  // });
+  //
+  // test("two dirty elements and one clean extension", () => {
+  //
+  // });
+  //
+  // test("one extension with changed options and metadata", () => {
+  //
+  // });
 });

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -49,6 +49,7 @@ import {
 import {
   EditablePackage,
   OptionsDefinition,
+  RecipeDefinition,
   UnsavedRecipeDefinition,
 } from "@/types/definitions";
 import {
@@ -57,6 +58,7 @@ import {
 } from "@/extensionPoints/types";
 import { ADAPTERS } from "@/pageEditor/extensionPoints/adapter";
 import { FormState } from "@/pageEditor/pageEditorTypes";
+import { ExtensionOptionsState } from "@/store/extensionsTypes";
 
 jest.mock("@/background/contextMenus");
 jest.mock("@/background/messenger/api");
@@ -602,18 +604,29 @@ function selectExtensionPoints(
   });
 }
 
+type InstalledRecipe = {
+  recipe: RecipeDefinition;
+  state: ExtensionOptionsState;
+};
+
+function installRecipe(extensionCount = 1): InstalledRecipe {
+  const recipe = versionedRecipeWithResolvedExtensions(extensionCount)();
+
+  const state = extensionsSlice.reducer(
+    { extensions: [] },
+    extensionsSlice.actions.installRecipe({
+      recipe,
+      services: {},
+      extensionPoints: recipe.extensionPoints,
+    })
+  );
+
+  return { recipe, state };
+}
+
 describe("buildRecipe", () => {
   test("one clean extension", () => {
-    const recipe = versionedRecipeWithResolvedExtensions(1)();
-
-    const state = extensionsSlice.reducer(
-      { extensions: [] },
-      extensionsSlice.actions.installRecipe({
-        recipe,
-        services: {},
-        extensionPoints: recipe.extensionPoints,
-      })
-    );
+    const { recipe, state } = installRecipe(1);
 
     const newRecipe = buildRecipe({
       sourceRecipe: recipe,
@@ -625,16 +638,7 @@ describe("buildRecipe", () => {
   });
 
   test("two clean extensions", () => {
-    const recipe = versionedRecipeWithResolvedExtensions(2)();
-
-    const state = extensionsSlice.reducer(
-      { extensions: [] },
-      extensionsSlice.actions.installRecipe({
-        recipe,
-        services: {},
-        extensionPoints: recipe.extensionPoints,
-      })
-    );
+    const { recipe, state } = installRecipe(2);
 
     const newRecipe = buildRecipe({
       sourceRecipe: recipe,
@@ -646,16 +650,7 @@ describe("buildRecipe", () => {
   });
 
   test("three clean extensions", () => {
-    const recipe = versionedRecipeWithResolvedExtensions(3)();
-
-    const state = extensionsSlice.reducer(
-      { extensions: [] },
-      extensionsSlice.actions.installRecipe({
-        recipe,
-        services: {},
-        extensionPoints: recipe.extensionPoints,
-      })
-    );
+    const { recipe, state } = installRecipe(3);
 
     const newRecipe = buildRecipe({
       sourceRecipe: recipe,
@@ -667,16 +662,7 @@ describe("buildRecipe", () => {
   });
 
   test("one dirty element", async () => {
-    const recipe = versionedRecipeWithResolvedExtensions(1)();
-
-    const state = extensionsSlice.reducer(
-      { extensions: [] },
-      extensionsSlice.actions.installRecipe({
-        recipe,
-        services: {},
-        extensionPoints: recipe.extensionPoints,
-      })
-    );
+    const { recipe, state } = installRecipe(1);
 
     const [extensionPoint] = selectExtensionPoints(recipe);
     (lookupExtensionPoint as jest.Mock).mockResolvedValue(extensionPoint);
@@ -702,16 +688,7 @@ describe("buildRecipe", () => {
   });
 
   test("two dirty elements", async () => {
-    const recipe = versionedRecipeWithResolvedExtensions(2)();
-
-    const state = extensionsSlice.reducer(
-      { extensions: [] },
-      extensionsSlice.actions.installRecipe({
-        recipe,
-        services: {},
-        extensionPoints: recipe.extensionPoints,
-      })
-    );
+    const { recipe, state } = installRecipe(2);
 
     const extensionPoints = selectExtensionPoints(recipe);
 
@@ -743,16 +720,7 @@ describe("buildRecipe", () => {
   });
 
   test("three dirty elements", async () => {
-    const recipe = versionedRecipeWithResolvedExtensions(3)();
-
-    const state = extensionsSlice.reducer(
-      { extensions: [] },
-      extensionsSlice.actions.installRecipe({
-        recipe,
-        services: {},
-        extensionPoints: recipe.extensionPoints,
-      })
-    );
+    const { recipe, state } = installRecipe(3);
 
     const extensionPoints = selectExtensionPoints(recipe);
 
@@ -774,26 +742,17 @@ describe("buildRecipe", () => {
       dirtyRecipeElements: elements,
     });
 
-    expect(newRecipe).toStrictEqual(
-      produce(recipe, (draft) => {
-        for (const [index, extensionPoint] of draft.extensionPoints.entries()) {
-          extensionPoint.label = `New Label ${index}`;
-        }
-      })
-    );
+    const updated = produce(recipe, (draft) => {
+      for (const [index, extensionPoint] of draft.extensionPoints.entries()) {
+        extensionPoint.label = `New Label ${index}`;
+      }
+    });
+
+    expect(newRecipe).toStrictEqual(updated);
   });
 
   test("one dirty element and one clean extension", async () => {
-    const recipe = versionedRecipeWithResolvedExtensions(2)();
-
-    const state = extensionsSlice.reducer(
-      { extensions: [] },
-      extensionsSlice.actions.installRecipe({
-        recipe,
-        services: {},
-        extensionPoints: recipe.extensionPoints,
-      })
-    );
+    const { recipe, state } = installRecipe(2);
 
     const [extensionPoint] = selectExtensionPoints(recipe);
     (lookupExtensionPoint as jest.Mock).mockResolvedValue(extensionPoint);
@@ -821,16 +780,7 @@ describe("buildRecipe", () => {
   });
 
   test("one dirty element and two clean extensions", async () => {
-    const recipe = versionedRecipeWithResolvedExtensions(3)();
-
-    const state = extensionsSlice.reducer(
-      { extensions: [] },
-      extensionsSlice.actions.installRecipe({
-        recipe,
-        services: {},
-        extensionPoints: recipe.extensionPoints,
-      })
-    );
+    const { recipe, state } = installRecipe(3);
 
     const [extensionPoint] = selectExtensionPoints(recipe);
     (lookupExtensionPoint as jest.Mock).mockResolvedValue(extensionPoint);
@@ -858,16 +808,7 @@ describe("buildRecipe", () => {
   });
 
   test("two dirty elements and one clean extension", async () => {
-    const recipe = versionedRecipeWithResolvedExtensions(3)();
-
-    const state = extensionsSlice.reducer(
-      { extensions: [] },
-      extensionsSlice.actions.installRecipe({
-        recipe,
-        services: {},
-        extensionPoints: recipe.extensionPoints,
-      })
-    );
+    const { recipe, state } = installRecipe(3);
 
     const extensionPoints = selectExtensionPoints(recipe);
 
@@ -903,16 +844,7 @@ describe("buildRecipe", () => {
   });
 
   test("two dirty elements and two clean extensions", async () => {
-    const recipe = versionedRecipeWithResolvedExtensions(4)();
-
-    const state = extensionsSlice.reducer(
-      { extensions: [] },
-      extensionsSlice.actions.installRecipe({
-        recipe,
-        services: {},
-        extensionPoints: recipe.extensionPoints,
-      })
-    );
+    const { recipe, state } = installRecipe(4);
 
     const extensionPoints = selectExtensionPoints(recipe);
 

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -200,6 +200,8 @@ export function replaceRecipeExtension(
       ]),
     };
 
+    // The services field is optional, so only add it to the config if the raw
+    // extension has a value. Normalizing here causes more confusion than it helps.
     if (rawExtension.services) {
       commonExtensionConfig.services = Object.fromEntries(
         rawExtension.services.map((x) => [x.outputKey, x.id])

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -385,6 +385,16 @@ export function buildRecipe({
         extension.definitions ?? {}
       )) {
         const innerKeys = Object.keys(recipeInnerDefinitions);
+
+        // eslint-disable-next-line security/detect-object-injection
+        if (
+          innerKeys.includes(innerId) &&
+          isEqual(definition, recipeInnerDefinitions[innerId])
+        ) {
+          // This definition has already been added to the recipe
+          continue;
+        }
+
         const newInnerId =
           innerKeys.includes(innerId) || isInnerExtensionPoint(innerId)
             ? freshIdentifier(

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -345,6 +345,7 @@ export function buildRecipe({
     }
 
     const versionedItems = [...cleanRecipeExtensions, ...dirtyRecipeElements];
+    // We need to handle the unlikely edge-case of zero extensions here, hence the null-coalesce
     const itemsApiVersion = versionedItems[0]?.apiVersion ?? recipe.apiVersion;
     const badApiVersion = versionedItems.find(
       (item) => item.apiVersion !== itemsApiVersion

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -201,7 +201,8 @@ export function replaceRecipeExtension(
     };
 
     // The services field is optional, so only add it to the config if the raw
-    // extension has a value. Normalizing here causes more confusion than it helps.
+    // extension has a value. Normalizing here makes testing harder because we
+    // then have to account for the normalized value in assertions.
     if (rawExtension.services) {
       commonExtensionConfig.services = Object.fromEntries(
         rawExtension.services.map((x) => [x.outputKey, x.id])

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -363,7 +363,7 @@ export function buildRecipe({
           const extensionPointConfig = adapter.selectExtensionPoint(element);
           partialExtension.definitions = {
             [extensionPointId]: {
-              kind: "extensionPoint",
+              kind: "extensionPoint1",
               definition: extensionPointConfig.definition,
             },
           };
@@ -410,11 +410,18 @@ export function buildRecipe({
         ...rest
       } = extension;
 
-      extensionPoints.push({
+      const extensionPoint: ExtensionPointConfig = {
         ...pick(rest, ["label", "config", "permissions", "templateEngine"]),
         id: extensionPointId ?? oldExtensionPointId,
-        services: Object.fromEntries(services.map((x) => [x.outputKey, x.id])),
-      });
+      };
+
+      if (!isEmpty(services)) {
+        extensionPoint.services = Object.fromEntries(
+          services.map((x) => [x.outputKey, x.id])
+        );
+      }
+
+      extensionPoints.push(extensionPoint);
     }
 
     draft.extensionPoints = extensionPoints;

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -448,6 +448,9 @@ export function buildRecipe({
       });
     }
 
+    // This sorting is mostly for test ergonomics for easier equality assertions when
+    // things stay in the same order in this array. The clean/dirty elements
+    // split/recombination logic causes things to get out of order in the result.
     draft.extensionPoints = sortBy(extensionPoints, (x) => x.id);
     draft.definitions = recipeInnerDefinitions;
   });

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -116,10 +116,14 @@ const extensionsSlice = createSlice({
       } = payload;
 
       for (const {
+        // Required
         id: extensionPointId,
         label,
-        services = {},
         config,
+        // Optional
+        services,
+        permissions,
+        templateEngine,
       } of extensionPoints) {
         const extensionId = uuidv4();
 
@@ -156,13 +160,6 @@ const extensionsSlice = createSlice({
           // uniqueness based on the content of the definition. Therefore, bricks will be re-used as necessary
           definitions: recipe.definitions ?? {},
           optionsArgs,
-          services: Object.entries(services).map(
-            ([outputKey, id]: [OutputKey, RegistryId]) => ({
-              outputKey,
-              config: auths[id], // eslint-disable-line security/detect-object-injection -- type-checked as RegistryId
-              id,
-            })
-          ),
           label,
           extensionPointId,
           config,
@@ -170,6 +167,24 @@ const extensionsSlice = createSlice({
           createTimestamp: timestamp,
           updateTimestamp: timestamp,
         };
+
+        if (services) {
+          extension.services = Object.entries(services).map(
+            ([outputKey, id]: [OutputKey, RegistryId]) => ({
+              outputKey,
+              config: auths[id], // eslint-disable-line security/detect-object-injection -- type-checked as RegistryId
+              id,
+            })
+          );
+        }
+
+        if (permissions) {
+          extension.permissions = permissions;
+        }
+
+        if (templateEngine) {
+          extension.templateEngine = templateEngine;
+        }
 
         assertExtensionNotResolved(extension);
 

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -169,7 +169,7 @@ const extensionsSlice = createSlice({
         };
 
         // Set optional fields only if the source extension has a value. Normalizing the values
-        // here causes more confusion than it helps.
+        // here makes testing harder because we then have to account for the normalized value in assertions.
         if (services) {
           extension.services = Object.entries(services).map(
             ([outputKey, id]: [OutputKey, RegistryId]) => ({

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -168,6 +168,8 @@ const extensionsSlice = createSlice({
           updateTimestamp: timestamp,
         };
 
+        // Set optional fields only if the source extension has a value. Normalizing the values
+        // here causes more confusion than it helps.
         if (services) {
           extension.services = Object.entries(services).map(
             ([outputKey, id]: [OutputKey, RegistryId]) => ({

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -304,7 +304,7 @@ export const versionedExtensionPointRecipeFactory = ({
  */
 export const versionedRecipeWithResolvedExtensions = (extensionCount = 1) => {
   const extensionPoints: ExtensionPointConfig[] = [];
-  for (let i = 1; i <= extensionCount; i++) {
+  for (let i = 0; i < extensionCount; i++) {
     // Don't use array(factory, count) here, because it will keep incrementing
     // the modifier number across multiple test runs and cause non-deterministic
     // test execution behavior.

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -34,7 +34,11 @@ import {
   SafeString,
 } from "@/core";
 import { TraceError, TraceRecord } from "@/telemetry/trace";
-import { uuidv4, validateRegistryId, validateTimestamp } from "@/types/helpers";
+import {
+  validateRegistryId,
+  validateTimestamp,
+  validateUUID,
+} from "@/types/helpers";
 import { Permissions } from "webextension-polyfill";
 import { BaseExtensionState } from "@/pageEditor/extensionPoints/elementConfig";
 import trigger from "@/pageEditor/extensionPoints/trigger";
@@ -66,6 +70,11 @@ import { freshIdentifier } from "@/utils";
 import { DEFAULT_EXTENSION_POINT_VAR } from "@/pageEditor/extensionPoints/base";
 import { padStart } from "lodash";
 
+// UUID sequence generator that's predictable across runs. A couple characters can't be 0
+// https://stackoverflow.com/a/19989922/402560
+const uuidSequence = (n: number) =>
+  validateUUID(`${padStart(String(n), 8, "0")}-0000-4000-A000-000000000000`);
+
 export const recipeMetadataFactory = define<Metadata>({
   id: (n: number) => validateRegistryId(`test/recipe-${n}`),
   name: (n: number) => `Recipe ${n}`,
@@ -90,7 +99,7 @@ export const installedRecipeMetadataFactory = define<RecipeMetadata>({
 const tabStateFactory = define<FrameConnectionState>({
   frameId: 0,
   hasPermissions: true,
-  navSequence: () => uuidv4(),
+  navSequence: uuidSequence,
   meta: null,
 });
 
@@ -100,7 +109,7 @@ export const activeDevToolContextFactory = define<PageEditorTabContextType>({
 });
 
 export const extensionFactory = define<IExtension>({
-  id: () => uuidv4(),
+  id: uuidSequence,
   apiVersion: "v2" as ApiVersion,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/extension-point-${n}`),
@@ -139,9 +148,9 @@ export const TEST_BLOCK_ID = validateRegistryId("testing/block-id");
 
 export const traceRecordFactory = define<TraceRecord>({
   timestamp: "2021-10-07T12:52:16.189Z",
-  extensionId: () => uuidv4(),
-  runId: () => uuidv4(),
-  blockInstanceId: () => uuidv4(),
+  extensionId: uuidSequence,
+  runId: uuidSequence,
+  blockInstanceId: uuidSequence,
   blockId: TEST_BLOCK_ID,
   templateContext: {},
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- nominal typing
@@ -191,7 +200,7 @@ export const blocksMapFactory: (
 };
 
 export const blockConfigFactory = define<BlockConfig>({
-  instanceId: () => uuidv4(),
+  instanceId: uuidSequence,
   id: (i: number) => validateRegistryId(`${TEST_BLOCK_ID}_${i}`),
   config: () => ({}),
 });
@@ -379,13 +388,13 @@ export const recipeFactory = innerExtensionPointRecipeFactory();
 const deploymentPackageFactory = define<Deployment["package"]>({
   id: validateRegistryId("@test/recipe"),
   name: "Deployment Package",
-  package_id: () => uuidv4(),
+  package_id: uuidSequence,
   version: "1.0.0",
   config: recipeDefinitionFactory as any,
 });
 
 export const deploymentFactory = define<Deployment>({
-  id: () => uuidv4(),
+  id: uuidSequence,
   name: (n: number) => `Deployment ${n}`,
   created_at: validateTimestamp("2021-10-07T12:52:16.189Z"),
   updated_at: validateTimestamp("2021-10-07T12:52:16.189Z"),
@@ -398,7 +407,7 @@ export const deploymentFactory = define<Deployment>({
 
 const internalFormStateFactory = define<FormState>({
   apiVersion: "v3" as ApiVersion,
-  uuid: () => uuidv4(),
+  uuid: uuidSequence,
   installed: true,
   optionsArgs: null as UserOptions,
   services: [] as ServiceDependency[],

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -295,6 +295,9 @@ export const versionedExtensionPointRecipeFactory = ({
 export const versionedRecipeWithResolvedExtensions = (extensionCount = 1) => {
   const extensionPoints: ExtensionPointConfig[] = [];
   for (let n = 1; n <= extensionCount; n++) {
+    // Don't use array(factory, count) here, because it will keep incrementing
+    // the modifier number across multiple test runs and cause non-deterministic
+    // test execution behavior.
     const extensionPoint = extensionPointConfigFactory();
     const ids = extensionPoints.map((x) => x.id);
     const id = freshIdentifier(DEFAULT_EXTENSION_POINT_VAR as SafeString, ids);

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -294,7 +294,7 @@ export const versionedExtensionPointRecipeFactory = ({
  */
 export const versionedRecipeWithResolvedExtensions = (extensionCount = 1) => {
   const extensionPoints: ExtensionPointConfig[] = [];
-  for (let n = 1; n <= extensionCount; n++) {
+  for (let i = 1; i <= extensionCount; i++) {
     // Don't use array(factory, count) here, because it will keep incrementing
     // the modifier number across multiple test runs and cause non-deterministic
     // test execution behavior.

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -64,6 +64,7 @@ import getType from "@/runtime/getType";
 import { FormState } from "@/pageEditor/pageEditorTypes";
 import { freshIdentifier } from "@/utils";
 import { DEFAULT_EXTENSION_POINT_VAR } from "@/pageEditor/extensionPoints/base";
+import { padStart } from "lodash";
 
 export const recipeMetadataFactory = define<Metadata>({
   id: (n: number) => validateRegistryId(`test/recipe-${n}`),
@@ -89,7 +90,7 @@ export const installedRecipeMetadataFactory = define<RecipeMetadata>({
 const tabStateFactory = define<FrameConnectionState>({
   frameId: 0,
   hasPermissions: true,
-  navSequence: uuidv4(),
+  navSequence: () => uuidv4(),
   meta: null,
 });
 
@@ -99,7 +100,7 @@ export const activeDevToolContextFactory = define<PageEditorTabContextType>({
 });
 
 export const extensionFactory = define<IExtension>({
-  id: uuidv4(),
+  id: () => uuidv4(),
   apiVersion: "v2" as ApiVersion,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/extension-point-${n}`),
@@ -138,9 +139,9 @@ export const TEST_BLOCK_ID = validateRegistryId("testing/block-id");
 
 export const traceRecordFactory = define<TraceRecord>({
   timestamp: "2021-10-07T12:52:16.189Z",
-  extensionId: uuidv4(),
-  runId: uuidv4(),
-  blockInstanceId: uuidv4(),
+  extensionId: () => uuidv4(),
+  runId: () => uuidv4(),
+  blockInstanceId: () => uuidv4(),
   blockId: TEST_BLOCK_ID,
   templateContext: {},
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- nominal typing
@@ -378,7 +379,7 @@ export const recipeFactory = innerExtensionPointRecipeFactory();
 const deploymentPackageFactory = define<Deployment["package"]>({
   id: validateRegistryId("@test/recipe"),
   name: "Deployment Package",
-  package_id: uuidv4(),
+  package_id: () => uuidv4(),
   version: "1.0.0",
   config: recipeDefinitionFactory as any,
 });


### PR DESCRIPTION
Fixes #3222 

This adds test coverage for the `buildRecipe()` function in the recipe save logic. Also includes lots of small tweaks to get tests working, and removes some unnecessary normalization of optional fields that makes testing harder.

We also needed to add logic to de-dupe the extension point `definitions` being added to the blueprints, to account for extension points that have their id changed to an `@internal/` reference in the page editor. This is because, when a blueprint is "installed" in the extensions slice, the entire `definitions` object is pushed down to each extension in the recipe, so each extension has dupes of the extension point definitions of every other extension in the blueprint.