### PR TITLE
#3135: relax image CSP on frame page

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
     "48": "icons/logo48.png",
     "128": "icons/logo128.png"
   },
-  "content_security_policy": "script-src 'self' https://apis.google.com 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https:; object-src 'self'; img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-src 'self' https: https://*.googleapis.com https://docs.google.com",
+  "content_security_policy": "script-src 'self' https://apis.google.com 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https:; object-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-src 'self' https: https://*.googleapis.com https://docs.google.com",
   "content_scripts": [
     {
       "matches": ["https://*.pixiebrix.com/*"],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
     "48": "icons/logo48.png",
     "128": "icons/logo128.png"
   },
-  "content_security_policy": "script-src 'self' https://apis.google.com 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https:; object-src 'self'; img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-src 'self' https: https://*.googleapis.com https://docs.google.com",
+  "content_security_policy": "script-src 'self' https://apis.google.com 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https:; object-src 'self'; img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-src 'self' https: https://*.googleapis.com https://docs.google.com",
   "content_scripts": [
     {
       "matches": ["https://*.pixiebrix.com/*"],

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -25,7 +25,7 @@
     <title>Browser Extension | PixieBrix</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com https:;"
+      content="img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com;"
     />
     <link rel="stylesheet" href="loadingScreen.css" />
     <link rel="stylesheet" href="options.css" />

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -23,6 +23,10 @@
     <!--<script src="http://localhost:8097"></script>-->
     <meta charset="utf-8" />
     <title>Browser Extension | PixieBrix</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com https:;"
+    />
     <link rel="stylesheet" href="loadingScreen.css" />
     <link rel="stylesheet" href="options.css" />
   </head>

--- a/src/pageEditor/pageEditor.html
+++ b/src/pageEditor/pageEditor.html
@@ -21,6 +21,10 @@
     <!--See https://github.com/pixiebrix/pixiebrix-extension/wiki/Development-commands#react-dev-tools -->
     <!--<script src="http://localhost:8097"></script>-->
     <meta charset="utf8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com https:;"
+    />
     <link rel="stylesheet" href="loadingScreen.css" />
     <link rel="stylesheet" href="pageEditor.css" />
   </head>

--- a/src/pageEditor/pageEditor.html
+++ b/src/pageEditor/pageEditor.html
@@ -23,7 +23,7 @@
     <meta charset="utf8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com https:;"
+      content="img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com;"
     />
     <link rel="stylesheet" href="loadingScreen.css" />
     <link rel="stylesheet" href="pageEditor.css" />

--- a/src/sidebar/sidebar.html
+++ b/src/sidebar/sidebar.html
@@ -22,6 +22,10 @@
     <!-- Open all links in new tab, never in the sidebar #851 -->
     <base target="_blank" />
     <title>PixieBrix: Page Panel</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com https:;"
+    />
     <link rel="stylesheet" href="loadingScreen.css" />
     <link rel="stylesheet" href="sidebar.css" />
   </head>

--- a/src/sidebar/sidebar.html
+++ b/src/sidebar/sidebar.html
@@ -22,10 +22,6 @@
     <!-- Open all links in new tab, never in the sidebar #851 -->
     <base target="_blank" />
     <title>PixieBrix: Page Panel</title>
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com https:;"
-    />
     <link rel="stylesheet" href="loadingScreen.css" />
     <link rel="stylesheet" href="sidebar.css" />
   </head>

--- a/src/tinyPages/permissionsPopup.html
+++ b/src/tinyPages/permissionsPopup.html
@@ -20,6 +20,10 @@
   <head>
     <meta charset="utf-8" />
     <title>PixieBrix</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="img-src 'self' data: https://pixiebrix-marketplace.s3.amazonaws.com;"
+    />
     <link rel="stylesheet" href="loadingScreen.css" />
     <link rel="stylesheet" href="permissionsPopup.css" />
   </head>


### PR DESCRIPTION
What does this PR do?
---
- Closes #3135 
- Relaxes the CSP on the extension, and re-enforces it on the extension pages: options page, devtools
- Don't enforce on the sidebar.html and ephemeralForm.html since the former supports rendered, and the later support markdown in the form description

Bananas for scale
![image](https://user-images.githubusercontent.com/1879821/165202757-96d0fbcb-7694-4bfa-9fdd-1bc79386855d.png)
