### PR TITLE
#3262: fix NPEs on `services`

### DIFF
--- a/src/options/pages/blueprints/utils/useReinstall.ts
+++ b/src/options/pages/blueprints/utils/useReinstall.ts
@@ -29,7 +29,7 @@ const { installRecipe, removeExtension } = extensionsSlice.actions;
 type Reinstall = (recipe: RecipeDefinition) => Promise<void>;
 
 function selectOptions(extensions: IExtension[]): UserOptions {
-  // For a given recipe, all of the extensions receive the same options during the install process (even if they don't
+  // For a given recipe, all the extensions receive the same options during the install process (even if they don't
   // use the options), so we can just take the optionsArgs for any of the extensions
   return extensions[0]?.optionsArgs ?? {};
 }
@@ -43,7 +43,7 @@ function selectAuths(
   // inconsistent for a given service key, but guard against that case anyway.
 
   const serviceAuths = groupBy(
-    extensions.flatMap((x) => x.services),
+    extensions.flatMap((x) => x.services ?? []),
     (x) => x.id
   );
   const result: Record<RegistryId, UUID> = {};

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -200,7 +200,7 @@ export function replaceRecipeExtension(
       ]),
     };
 
-    // The services field is optional, so only add it to the config if the raw
+    // The `services` field is optional, so only add it to the config if the raw
     // extension has a value. Normalizing here makes testing harder because we
     // then have to account for the normalized value in assertions.
     if (rawExtension.services) {

--- a/src/services/serviceUtils.ts
+++ b/src/services/serviceUtils.ts
@@ -52,7 +52,10 @@ export function extractServiceIds(schema: Schema): RegistryId[] {
 
 /** Build the service context by locating the dependencies */
 export async function makeServiceContext(
-  dependencies: ServiceDependency[]
+  // `IExtension.services` is an optional field. Since we don't have strict-nullness checking on, calls to this method
+  // are error-prone. So just be defensive in the signature
+  // https://github.com/pixiebrix/pixiebrix-extension/issues/3262
+  dependencies: ServiceDependency[] | null = []
 ): Promise<ServiceContext> {
   const dependencyContext = async ({ id, config }: ServiceDependency) => {
     const configuredService = await services.locate(id, config);

--- a/src/validators/generic.ts
+++ b/src/validators/generic.ts
@@ -410,19 +410,17 @@ async function validateExtension(
   const notConfigured = [];
   const missingConfiguration = [];
 
-  if (extension.services?.length) {
-    for (const service of extension.services) {
-      console.debug(`Validating ${extension.id} service ${service.id}`);
-      try {
-        await services.locate(service.id, service.config);
-      } catch (error) {
-        if (error instanceof MissingConfigurationError) {
-          missingConfiguration.push(error);
-        } else if (error instanceof NotConfiguredError) {
-          notConfigured.push(error);
-        } else {
-          console.debug(error);
-        }
+  for (const service of extension.services ?? []) {
+    console.debug(`Validating ${extension.id} service ${service.id}`);
+    try {
+      await services.locate(service.id, service.config);
+    } catch (error) {
+      if (error instanceof MissingConfigurationError) {
+        missingConfiguration.push(error);
+      } else if (error instanceof NotConfiguredError) {
+        notConfigured.push(error);
+      } else {
+        console.debug(error);
       }
     }
   }


### PR DESCRIPTION
What does this PR do?
---
- Fixes #3262 
- Handles cases where `IExtension.services` is not defined. (It's optional in the type, but in practice was always defined since we were normalizing values)
- PR implemented by searching for ".services" across the project and handling the cases of `IExtension.services`. For PageEditor FormState's services that will alsways be defined