### PR TITLE
#3265: fix dropped services when using "Save as New"

### DIFF
--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -67,6 +67,7 @@ jest.mock("@/background/messenger/api", () => ({
     // eslint-disable-next-line unicorn/no-useless-undefined -- argument is required
     clear: jest.fn().mockResolvedValue(undefined),
   },
+  uninstallContextMenu: jest.fn().mockResolvedValue(undefined),
   contextMenus: {
     preload: jest.fn(),
   },

--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -67,6 +67,7 @@ jest.mock("@/background/messenger/api", () => ({
     // eslint-disable-next-line unicorn/no-useless-undefined -- argument is required
     clear: jest.fn().mockResolvedValue(undefined),
   },
+  // eslint-disable-next-line unicorn/no-useless-undefined -- argument is required
   uninstallContextMenu: jest.fn().mockResolvedValue(undefined),
   contextMenus: {
     preload: jest.fn(),

--- a/src/options/pages/blueprints/utils/useReinstall.ts
+++ b/src/options/pages/blueprints/utils/useReinstall.ts
@@ -20,50 +20,12 @@ import { useDispatch, useSelector } from "react-redux";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import { useCallback } from "react";
 import { uninstallContextMenu } from "@/background/messenger/api";
-import { groupBy, uniq } from "lodash";
-import { IExtension, UUID, RegistryId, UserOptions } from "@/core";
 import extensionsSlice from "@/store/extensionsSlice";
+import { inferRecipeAuths, inferRecipeOptions } from "@/store/extensionsUtils";
 
 const { installRecipe, removeExtension } = extensionsSlice.actions;
 
 type Reinstall = (recipe: RecipeDefinition) => Promise<void>;
-
-function selectOptions(extensions: IExtension[]): UserOptions {
-  // For a given recipe, all the extensions receive the same options during the install process (even if they don't
-  // use the options), so we can just take the optionsArgs for any of the extensions
-  return extensions[0]?.optionsArgs ?? {};
-}
-
-function selectAuths(
-  extensions: IExtension[],
-  { optional = false }: { optional?: boolean } = {}
-): Record<RegistryId, UUID> {
-  // The extensions for the recipe will only have the services that are declared on each extension. So we have to take
-  // the union of the service credentials. There's currently no way in the UX that the service auths could become
-  // inconsistent for a given service key, but guard against that case anyway.
-
-  const serviceAuths = groupBy(
-    extensions.flatMap((x) => x.services ?? []),
-    (x) => x.id
-  );
-  const result: Record<RegistryId, UUID> = {};
-  for (const [id, auths] of Object.entries(serviceAuths)) {
-    const configs = uniq(auths.map(({ config }) => config));
-    if (configs.length === 0 && !optional) {
-      throw new Error(`Service ${id} is not configured`);
-    }
-
-    // If optional is passed in, we know that the user is being given an opportunity to switch which config is applied,
-    // so the user can always switch to a different configuration if they want.
-    if (configs.length > 1 && !optional) {
-      throw new Error(`Service ${id} has multiple configurations`);
-    }
-
-    result[id as RegistryId] = configs[0];
-  }
-
-  return result;
-}
 
 function useReinstall(): Reinstall {
   const dispatch = useDispatch();
@@ -79,8 +41,10 @@ function useReinstall(): Reinstall {
         throw new Error(`No bricks to re-activate for ${recipe.metadata.id}`);
       }
 
-      const currentAuths = selectAuths(recipeExtensions, { optional: false });
-      const currentOptions = selectOptions(recipeExtensions);
+      const currentAuths = inferRecipeAuths(recipeExtensions, {
+        optional: false,
+      });
+      const currentOptions = inferRecipeOptions(recipeExtensions);
 
       // Uninstall first to avoid duplicates. Use a loop instead of Promise.all to ensure the sequence that each pair
       // of calls that uninstallContextMenu + dispatch occur in. We were having problems with the context menu not
@@ -105,5 +69,5 @@ function useReinstall(): Reinstall {
   );
 }
 
-export { selectAuths, selectOptions };
+export { inferRecipeAuths, inferRecipeOptions };
 export default useReinstall;

--- a/src/options/pages/marketplace/useWizard.ts
+++ b/src/options/pages/marketplace/useWizard.ts
@@ -7,8 +7,8 @@ import { useSelector } from "react-redux";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import React, { useMemo } from "react";
 import {
-  selectAuths,
-  selectOptions,
+  inferRecipeAuths,
+  inferRecipeOptions,
 } from "@/options/pages/blueprints/utils/useReinstall";
 import { isEmpty, mapValues, uniq } from "lodash";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
@@ -44,8 +44,8 @@ function useWizard(blueprint: RecipeDefinition): [WizardStep[], WizardValues] {
       (extension) => extension._recipe?.id === blueprint?.metadata.id
     );
 
-    const installedOptions = selectOptions(installedBlueprintExtensions);
-    const installedServices = selectAuths(installedBlueprintExtensions, {
+    const installedOptions = inferRecipeOptions(installedBlueprintExtensions);
+    const installedServices = inferRecipeAuths(installedBlueprintExtensions, {
       optional: true,
     });
 

--- a/src/pageEditor/pageEditorTypes.ts
+++ b/src/pageEditor/pageEditorTypes.ts
@@ -126,6 +126,8 @@ export interface EditorState {
    */
   dirtyRecipeMetadataById: Record<RegistryId, RecipeMetadataFormState>;
 
+  // XXX: refactor the is<Modal>Visible state: https://github.com/pixiebrix/pixiebrix-extension/issues/3264
+
   /**
    * Are we showing the "add extension to blueprint" modal?
    */
@@ -149,6 +151,8 @@ export interface EditorState {
   /**
    * When creating a new blueprint from an existing extension, should we keep a separate copy of the extension?
    */
+  // XXX: refactor & remove from top-level Redux state. This is a property of the create recipe workflow:
+  // https://github.com/pixiebrix/pixiebrix-extension/issues/3264
   keepLocalCopyOnCreateRecipe: boolean;
 
   /**

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -152,8 +152,10 @@ function useSaveCallbacks({ activeElement }: { activeElement: FormState }) {
         updated_at: response.updated_at,
       };
 
-      // Replace the old recipe with the new recipe locally
+      // Replace the old recipe with the new recipe locally. The logic here is similar to what's in useReinstall.ts
+
       dispatch(optionsActions.removeRecipeById(recipeId));
+
       dispatch(
         optionsActions.installRecipe({
           recipe: savedRecipe,

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -528,6 +528,7 @@ export const editorSlice = createSlice({
     clearActiveRecipe(state) {
       state.activeRecipeId = null;
     },
+    // XXX:
     transitionSaveAsNewToCreateRecipeModal(state) {
       state.isSaveAsNewRecipeModalVisible = false;
       state.keepLocalCopyOnCreateRecipe = false;

--- a/src/store/extensionsUtils.test.ts
+++ b/src/store/extensionsUtils.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { inferRecipeAuths, inferRecipeOptions } from "@/store/extensionsUtils";
+import { ServiceDependency } from "@/core";
+import { uuidv4, validateRegistryId } from "@/types/helpers";
+import { validateOutputKey } from "@/runtime/runtimeTypes";
+
+describe("inferRecipeOptions", () => {
+  it("returns first option", () => {
+    expect(inferRecipeOptions([{ optionsArgs: { foo: 42 } }])).toStrictEqual({
+      foo: 42,
+    });
+  });
+
+  it("return blank object if not set", () => {
+    expect(inferRecipeOptions([{ optionsArgs: undefined }])).toStrictEqual({});
+  });
+});
+
+describe("inferRecipeAuths", () => {
+  it("handles undefined services", () => {
+    expect(inferRecipeAuths([{ services: undefined }])).toStrictEqual({});
+  });
+
+  it("handles same service", () => {
+    const service = validateRegistryId("foo/bar");
+    const config = uuidv4();
+    const dependency: ServiceDependency = {
+      id: service,
+      outputKey: validateOutputKey("foo"),
+      config,
+    };
+
+    expect(
+      inferRecipeAuths([{ services: [dependency] }, { services: [dependency] }])
+    ).toStrictEqual({
+      [service]: config,
+    });
+  });
+
+  it("throw on mismatch", () => {
+    const service = validateRegistryId("foo/bar");
+    const config = uuidv4();
+    const dependency: ServiceDependency = {
+      id: service,
+      outputKey: validateOutputKey("foo"),
+      config,
+    };
+
+    expect(() =>
+      inferRecipeAuths([
+        { services: [dependency] },
+        { services: [{ ...dependency, config: uuidv4() }] },
+      ])
+    ).toThrowError(/has multiple configurations/);
+  });
+
+  it("throw on missing config", () => {
+    const service = validateRegistryId("foo/bar");
+    const dependency: ServiceDependency = {
+      id: service,
+      outputKey: validateOutputKey("foo"),
+    };
+
+    expect(() => inferRecipeAuths([{ services: [dependency] }])).toThrowError(
+      /is not configured/
+    );
+  });
+});

--- a/src/store/extensionsUtils.ts
+++ b/src/store/extensionsUtils.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { IExtension, RegistryId, UserOptions, UUID } from "@/core";
+import { groupBy, uniq } from "lodash";
+
+/**
+ * Infer options from existing extension-like instances for reinstalling a recipe
+ * @see installRecipe
+ */
+export function inferRecipeOptions(
+  extensions: Array<Pick<IExtension, "optionsArgs">>
+): UserOptions {
+  // For a given recipe, all the extensions receive the same options during the install process (even if they don't
+  // use the options), so we can just take the optionsArgs for any of the extensions
+  return extensions[0]?.optionsArgs ?? {};
+}
+
+/**
+ * Infer service configurations from existing extension-like instances for reinstalling a recipe
+ * @see installRecipe
+ */
+export function inferRecipeAuths(
+  extensions: Array<Pick<IExtension, "services">>,
+  { optional = false }: { optional?: boolean } = {}
+): Record<RegistryId, UUID> {
+  // The extensions for the recipe will only have the services that are declared on each extension. So we have to take
+  // the union of the service credentials. There's currently no way in the UX that the service auths could become
+  // inconsistent for a given service key, but guard against that case anyway.
+
+  const serviceAuths = groupBy(
+    extensions.flatMap((x) => x.services ?? []),
+    (x) => x.id
+  );
+  const result: Record<RegistryId, UUID> = {};
+  for (const [id, auths] of Object.entries(serviceAuths)) {
+    const configs = uniq(auths.map(({ config }) => config));
+    if (configs.length === 0 && !optional) {
+      throw new Error(`Service ${id} is not configured`);
+    }
+
+    // If optional is passed in, we know that the user is being given an opportunity to switch which config is applied,
+    // so the user can always switch to a different configuration if they want.
+    if (configs.length > 1 && !optional) {
+      throw new Error(`Service ${id} has multiple configurations`);
+    }
+
+    result[id as RegistryId] = configs[0];
+  }
+
+  return result;
+}

--- a/src/store/extensionsUtils.ts
+++ b/src/store/extensionsUtils.ts
@@ -16,8 +16,9 @@
  */
 
 import { IExtension, RegistryId, UserOptions, UUID } from "@/core";
-import { groupBy, uniq } from "lodash";
+import { compact, groupBy, uniq } from "lodash";
 import { traces, uninstallContextMenu } from "@/background/messenger/api";
+import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 
 /**
  * Infer options from existing extension-like instances for reinstalling a recipe
@@ -49,8 +50,9 @@ export function inferRecipeAuths(
   );
   const result: Record<RegistryId, UUID> = {};
   for (const [id, auths] of Object.entries(serviceAuths)) {
-    const configs = uniq(auths.map(({ config }) => config));
-    if (configs.length === 0 && !optional) {
+    const configs = uniq(compact(auths.map(({ config }) => config)));
+    if (id !== PIXIEBRIX_SERVICE_ID && configs.length === 0 && !optional) {
+      // PIXIEBRIX_SERVICE_ID gets the implicit configuration
       throw new Error(`Service ${id} is not configured`);
     }
 

--- a/src/store/extensionsUtils.ts
+++ b/src/store/extensionsUtils.ts
@@ -17,6 +17,7 @@
 
 import { IExtension, RegistryId, UserOptions, UUID } from "@/core";
 import { groupBy, uniq } from "lodash";
+import { traces, uninstallContextMenu } from "@/background/messenger/api";
 
 /**
  * Infer options from existing extension-like instances for reinstalling a recipe
@@ -63,4 +64,15 @@ export function inferRecipeAuths(
   }
 
   return result;
+}
+
+/**
+ * Cleanup native extension data/registrations
+ */
+// XXX: where does this method belong?
+export async function uninstallNativeExtension(
+  extensionId: UUID
+): Promise<void> {
+  await uninstallContextMenu({ extensionId });
+  await traces.clear(extensionId);
 }


### PR DESCRIPTION
What does this PR do?
---
- Closes #3265
- Refactors CreateRecipeModal into save hooks, schema, initialFormState, etc.
- Refactors logic for inferring options/auths from useReinstall into store/extensionUtils to re-use in CreateRecipeModal
- [x] Fixes bug where services weren't included when using "Save As New"