### PR TITLE
Feature/3236 theme poc hsl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ staticfiles
 .idea/uiDesigner.xml
 .idea/misc.xml
 .idea/runConfigurations.xml
+.idea/GitLink.xml
 *.log
 
 # MacOS files

--- a/src/vendors/theme/assets/styles/_variables.scss
+++ b/src/vendors/theme/assets/styles/_variables.scss
@@ -37,25 +37,29 @@ $colors: (
   black: #000000,
 );
 
-:root {
-  --theme-primary-color: 0, 100%; /*the base color*/
-  --l: 50%; /*the initial lightness*/
+$variable-theme-colors: (
+  primary: --theme-primary,
+  info: --theme-info,
+);
 
-  --theme-primary: hsl(var(--theme-primary-color), var(--l));
+:root {
+  --theme-primary-hs: 0, 100%; /*the base color*/
+  --theme-primary-l: 50%; /*the initial lightness*/
+  --theme-primary: hsl(var(--theme-primary-hs), var(--theme-primary-l));
+
+  --theme-info-hs: 180, 100%; /*the base color*/
+  --theme-info-l: 50%; /*the initial lightness*/
+  --theme-info: hsl(var(--theme-info-hs), var(--theme-info-l));
 }
 
 :root.default {
-  --theme-primary-color: 270, 100%; /*the base color*/
-  --l: 71%; /*the initial lightness*/
+  --theme-primary-hs: 270, 100%; /*the base color*/
+  --theme-primary-l: 71%; /*the initial lightness*/
+  --theme-primary: hsl(var(--theme-primary-hs), var(--theme-primary-l));
 
-  --theme-primary: hsl(var(--theme-primary-color), var(--l));
-}
-
-:root.cyan {
-  --theme-primary-color: 180, 100%; /*the base color*/
-  --l: 50%; /*the initial lightness*/
-
-  --theme-primary: hsl(var(--theme-primary-color), var(--l));
+  --theme-info-hs: 206, 80%;
+  --theme-info-l: 49%;
+  --theme-info: hsl(var(--theme-info-hs), var(--theme-info-l));
 }
 
 $theme-colors: (

--- a/src/vendors/theme/assets/styles/_variables.scss
+++ b/src/vendors/theme/assets/styles/_variables.scss
@@ -37,6 +37,13 @@ $colors: (
   black: #000000,
 );
 
+:root {
+  --theme-primary-color: 0, 100%; /*the base color*/
+  --l: 50%; /*the initial lightness*/
+
+  --theme-primary: hsl(var(--color),var(--l));
+}
+
 $theme-colors: (
   primary: #b66dff,
   secondary: #d8d8d8,

--- a/src/vendors/theme/assets/styles/_variables.scss
+++ b/src/vendors/theme/assets/styles/_variables.scss
@@ -41,7 +41,21 @@ $colors: (
   --theme-primary-color: 0, 100%; /*the base color*/
   --l: 50%; /*the initial lightness*/
 
-  --theme-primary: hsl(var(--color),var(--l));
+  --theme-primary: hsl(var(--theme-primary-color), var(--l));
+}
+
+:root.default {
+  --theme-primary-color: 270, 100%; /*the base color*/
+  --l: 71%; /*the initial lightness*/
+
+  --theme-primary: hsl(var(--theme-primary-color), var(--l));
+}
+
+:root.cyan {
+  --theme-primary-color: 180, 100%; /*the base color*/
+  --l: 50%; /*the initial lightness*/
+
+  --theme-primary: hsl(var(--theme-primary-color), var(--l));
 }
 
 $theme-colors: (

--- a/src/vendors/theme/assets/styles/components/_buttons.scss
+++ b/src/vendors/theme/assets/styles/components/_buttons.scss
@@ -1,8 +1,8 @@
 /* Buttons */
 
-@each $color, $value in $theme-colors {
+@each $color, $value in $variable-theme-colors {
   .btn-#{$color} {
-    @include button-variant($value, $value);
+    @include button-variant($color, $value);
   }
 }
 

--- a/src/vendors/theme/assets/styles/components/_buttons.scss
+++ b/src/vendors/theme/assets/styles/components/_buttons.scss
@@ -1,5 +1,11 @@
 /* Buttons */
 
+@each $color, $value in $theme-colors {
+  .btn-#{$color} {
+    @include button-variant($value, $value);
+  }
+}
+
 .btn {
   font-size: $btn-font-size;
   line-height: 1;

--- a/src/vendors/theme/assets/styles/mixins/_buttons.scss
+++ b/src/vendors/theme/assets/styles/mixins/_buttons.scss
@@ -1,19 +1,28 @@
 @import "bootstrap";
 
-@mixin button-variant($background, $border, $hover-background: darken($background, 7.5%), $hover-border: darken($border, 10%), $active-background: darken($background, 10%), $active-border: darken($border, 12.5%)) {
+@mixin button-variant(
+  $background,
+  $border,
+  $hover-background: darken($background, 7.5%),
+  $hover-border: darken($border, 10%),
+  $active-background: darken($background, 10%),
+  $active-border: darken($border, 12.5%)
+) {
   color: color-yiq($background);
-  @include gradient-bg($background);
-  border-color: $border;
+  border-color: var(--theme-primary);
   @include box-shadow($btn-box-shadow);
 
-  @include hover() {
-    color: color-yiq($hover-background);
-    @include gradient-bg($hover-background);
-    border-color: $hover-border;
-  }
+  //@include hover() {
+  //  color: color-yiq($hover-background);
+  //  @include gradient-bg($hover-background);
+  //  border-color: $hover-border;
+  //}
+
+  background-color: var(--theme-primary);
 
   &:hover {
-    background-color: #{"hsl(var(--theme-primary-color), calc(var(--l) - 5%))"};
+    background-color: #{"hsl(var(--theme-primary-color), calc(var(--l) - 7.5%))"};
+    border-color: #{"hsl(var(--theme-primary-color), calc(var(--l) - 10%))"};
   }
 
   &:focus,
@@ -22,10 +31,18 @@
     @include gradient-bg($hover-background);
     border-color: $hover-border;
     @if $enable-shadows {
-      @include box-shadow($btn-box-shadow, 0 0 0 $btn-focus-width rgba(mix(color-yiq($background), $border, 15%), .5));
+      @include box-shadow(
+        $btn-box-shadow,
+        0 0 0 $btn-focus-width
+          rgba(mix(color-yiq($background), $border, 15%), 0.5)
+      );
     } @else {
       // Avoid using mixin so we can pass custom focus shadow properly
-      box-shadow: 0 0 0 $btn-focus-width rgba(mix(color-yiq($background), $border, 15%), .5);
+      box-shadow: 0
+        0
+        0
+        $btn-focus-width
+        rgba(mix(color-yiq($background), $border, 15%), 0.5);
     }
   }
 
@@ -53,15 +70,22 @@
 
     &:focus {
       @if $enable-shadows and $btn-active-box-shadow != none {
-        @include box-shadow($btn-active-box-shadow, 0 0 0 $btn-focus-width rgba(mix(color-yiq($background), $border, 15%), .5));
+        @include box-shadow(
+          $btn-active-box-shadow,
+          0 0 0 $btn-focus-width
+            rgba(mix(color-yiq($background), $border, 15%), 0.5)
+        );
       } @else {
         // Avoid using mixin so we can pass custom focus shadow properly
-        box-shadow: 0 0 0 $btn-focus-width rgba(mix(color-yiq($background), $border, 15%), .5);
+        box-shadow: 0
+          0
+          0
+          $btn-focus-width
+          rgba(mix(color-yiq($background), $border, 15%), 0.5);
       }
     }
   }
 }
-
 
 @mixin social-button($color) {
   background: $color;

--- a/src/vendors/theme/assets/styles/mixins/_buttons.scss
+++ b/src/vendors/theme/assets/styles/mixins/_buttons.scss
@@ -1,89 +1,12 @@
 @import "bootstrap";
 
-@mixin button-variant(
-  $background,
-  $border,
-  $hover-background: darken($background, 7.5%),
-  $hover-border: darken($border, 10%),
-  $active-background: darken($background, 10%),
-  $active-border: darken($border, 12.5%)
-) {
-  color: color-yiq($background);
-  border-color: var(--theme-primary);
-  @include box-shadow($btn-box-shadow);
-
-  //@include hover() {
-  //  color: color-yiq($hover-background);
-  //  @include gradient-bg($hover-background);
-  //  border-color: $hover-border;
-  //}
-
-  background-color: var(--theme-primary);
+@mixin button-variant($color-name, $color-variable) {
+  background-color: var($color-variable);
+  border-color: var($color-variable);
 
   &:hover {
-    background-color: #{"hsl(var(--theme-primary-color), calc(var(--l) - 7.5%))"};
-    border-color: #{"hsl(var(--theme-primary-color), calc(var(--l) - 10%))"};
-  }
-
-  &:focus,
-  &.focus {
-    color: color-yiq($hover-background);
-    @include gradient-bg($hover-background);
-    border-color: $hover-border;
-    @if $enable-shadows {
-      @include box-shadow(
-        $btn-box-shadow,
-        0 0 0 $btn-focus-width
-          rgba(mix(color-yiq($background), $border, 15%), 0.5)
-      );
-    } @else {
-      // Avoid using mixin so we can pass custom focus shadow properly
-      box-shadow: 0
-        0
-        0
-        $btn-focus-width
-        rgba(mix(color-yiq($background), $border, 15%), 0.5);
-    }
-  }
-
-  // Disabled comes first so active can properly restyle
-  &.disabled,
-  &:disabled {
-    color: color-yiq($background);
-    background-color: $background;
-    border-color: $border;
-    // Remove CSS gradients if they're enabled
-    @if $enable-gradients {
-      background-image: none;
-    }
-  }
-
-  &:not(:disabled):not(.disabled):active,
-  &:not(:disabled):not(.disabled).active,
-  .show > &.dropdown-toggle {
-    color: color-yiq($active-background);
-    background-color: $active-background;
-    @if $enable-gradients {
-      background-image: none; // Remove the gradient for the pressed/active state
-    }
-    border-color: $active-border;
-
-    &:focus {
-      @if $enable-shadows and $btn-active-box-shadow != none {
-        @include box-shadow(
-          $btn-active-box-shadow,
-          0 0 0 $btn-focus-width
-            rgba(mix(color-yiq($background), $border, 15%), 0.5)
-        );
-      } @else {
-        // Avoid using mixin so we can pass custom focus shadow properly
-        box-shadow: 0
-          0
-          0
-          $btn-focus-width
-          rgba(mix(color-yiq($background), $border, 15%), 0.5);
-      }
-    }
+    background-color: #{"hsl(var(--theme-#{$color-name}-hs), calc(var(--theme-#{$color-name}-l) - 7.5%))"};
+    border-color: #{"hsl(var(--theme-#{$color-name}-hs), calc(var(--theme-#{$color-name}-l) - 10%))"};
   }
 }
 

--- a/src/vendors/theme/assets/styles/mixins/_buttons.scss
+++ b/src/vendors/theme/assets/styles/mixins/_buttons.scss
@@ -1,3 +1,68 @@
+@import "bootstrap";
+
+@mixin button-variant($background, $border, $hover-background: darken($background, 7.5%), $hover-border: darken($border, 10%), $active-background: darken($background, 10%), $active-border: darken($border, 12.5%)) {
+  color: color-yiq($background);
+  @include gradient-bg($background);
+  border-color: $border;
+  @include box-shadow($btn-box-shadow);
+
+  @include hover() {
+    color: color-yiq($hover-background);
+    @include gradient-bg($hover-background);
+    border-color: $hover-border;
+  }
+
+  &:hover {
+    background-color: #{"hsl(var(--theme-primary-color), calc(var(--l) - 5%))"};
+  }
+
+  &:focus,
+  &.focus {
+    color: color-yiq($hover-background);
+    @include gradient-bg($hover-background);
+    border-color: $hover-border;
+    @if $enable-shadows {
+      @include box-shadow($btn-box-shadow, 0 0 0 $btn-focus-width rgba(mix(color-yiq($background), $border, 15%), .5));
+    } @else {
+      // Avoid using mixin so we can pass custom focus shadow properly
+      box-shadow: 0 0 0 $btn-focus-width rgba(mix(color-yiq($background), $border, 15%), .5);
+    }
+  }
+
+  // Disabled comes first so active can properly restyle
+  &.disabled,
+  &:disabled {
+    color: color-yiq($background);
+    background-color: $background;
+    border-color: $border;
+    // Remove CSS gradients if they're enabled
+    @if $enable-gradients {
+      background-image: none;
+    }
+  }
+
+  &:not(:disabled):not(.disabled):active,
+  &:not(:disabled):not(.disabled).active,
+  .show > &.dropdown-toggle {
+    color: color-yiq($active-background);
+    background-color: $active-background;
+    @if $enable-gradients {
+      background-image: none; // Remove the gradient for the pressed/active state
+    }
+    border-color: $active-border;
+
+    &:focus {
+      @if $enable-shadows and $btn-active-box-shadow != none {
+        @include box-shadow($btn-active-box-shadow, 0 0 0 $btn-focus-width rgba(mix(color-yiq($background), $border, 15%), .5));
+      } @else {
+        // Avoid using mixin so we can pass custom focus shadow properly
+        box-shadow: 0 0 0 $btn-focus-width rgba(mix(color-yiq($background), $border, 15%), .5);
+      }
+    }
+  }
+}
+
+
 @mixin social-button($color) {
   background: $color;
   color: $white;


### PR DESCRIPTION
poc for #3136, alternative implementation of https://github.com/pixiebrix/pixiebrix-extension/pull/3236

This overrides the bootstrap `button-variant` mixin and button generation in `_buttons.scss` to use css variables. In order to replace the use of the scss `darken` utility, we use the built-in [hsl utility](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl).

https://user-images.githubusercontent.com/36575242/165649381-15c7403b-be80-4d26-b9d1-6e8655929018.mov


