### PR TITLE
#3279: fix error event handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ staticfiles
 .idea/dictionaries
 .idea/vcs.xml
 .idea/jsLibraryMappings.xml
+.idea/GitLink.xml
 
 # Sensitive or high-churn files:
 .idea/dataSources.ids

--- a/src/blocks/transformers/parseUrl.test.ts
+++ b/src/blocks/transformers/parseUrl.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { UrlParser } from "@/blocks/transformers/parseUrl";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { BusinessError } from "@/errors";
+
+describe("parseUrl", () => {
+  it("parses absolute URL", async () => {
+    const url = new URL("https://www.example.com");
+
+    // Use `toMatchInlineSnapshot` since we can't spread the URL instance to get its properties
+    expect(new UrlParser().transform(unsafeAssumeValidArg({ url: url.href })))
+      .resolves.toMatchInlineSnapshot(`
+      Object {
+        "hash": "",
+        "host": "www.example.com",
+        "hostname": "www.example.com",
+        "origin": "https://www.example.com",
+        "password": "",
+        "pathname": "/",
+        "port": "",
+        "protocol": "https:",
+        "publicSuffix": "example.com",
+        "search": "",
+        "searchParams": Object {},
+        "username": "",
+      }
+    `);
+  });
+
+  it("parses relative URL with search params", async () => {
+    // Use `toMatchInlineSnapshot` since we can't spread the URL instance to get its properties
+    expect(
+      new UrlParser().transform(
+        unsafeAssumeValidArg({
+          url: "/api/foo/?bar=42",
+          base: "https://www.example.com",
+        })
+      )
+    ).resolves.toMatchInlineSnapshot(`
+      Object {
+        "hash": "",
+        "host": "www.example.com",
+        "hostname": "www.example.com",
+        "origin": "https://www.example.com",
+        "password": "",
+        "pathname": "/api/foo/",
+        "port": "",
+        "protocol": "https:",
+        "publicSuffix": "example.com",
+        "search": "?bar=42",
+        "searchParams": Object {
+          "bar": "42",
+        },
+        "username": "",
+      }
+    `);
+  });
+
+  it("throws BusinessError for malformed URL", async () => {
+    expect(async () => {
+      await new UrlParser().transform(unsafeAssumeValidArg({ url: "42" }));
+    }).rejects.toThrowError(new BusinessError("Invalid URL: 42"));
+  });
+});

--- a/src/blocks/transformers/parseUrl.test.ts
+++ b/src/blocks/transformers/parseUrl.test.ts
@@ -76,7 +76,7 @@ describe("parseUrl", () => {
     const promise = new UrlParser().transform(
       unsafeAssumeValidArg({ url: "42" })
     );
-    expect(promise).rejects.toThrowError(BusinessError);
-    expect(promise).rejects.toThrowError("Invalid URL: 42");
+    await expect(promise).rejects.toThrowError(BusinessError);
+    await expect(promise).rejects.toThrowError("Invalid URL: 42");
   });
 });

--- a/src/blocks/transformers/parseUrl.test.ts
+++ b/src/blocks/transformers/parseUrl.test.ts
@@ -24,8 +24,9 @@ describe("parseUrl", () => {
     const url = new URL("https://www.example.com");
 
     // Use `toMatchInlineSnapshot` since we can't spread the URL instance to get its properties
-    expect(new UrlParser().transform(unsafeAssumeValidArg({ url: url.href })))
-      .resolves.toMatchInlineSnapshot(`
+    await expect(
+      new UrlParser().transform(unsafeAssumeValidArg({ url: url.href }))
+    ).resolves.toMatchInlineSnapshot(`
       Object {
         "hash": "",
         "host": "www.example.com",
@@ -45,7 +46,7 @@ describe("parseUrl", () => {
 
   it("parses relative URL with search params", async () => {
     // Use `toMatchInlineSnapshot` since we can't spread the URL instance to get its properties
-    expect(
+    await expect(
       new UrlParser().transform(
         unsafeAssumeValidArg({
           url: "/api/foo/?bar=42",

--- a/src/blocks/transformers/parseUrl.test.ts
+++ b/src/blocks/transformers/parseUrl.test.ts
@@ -73,8 +73,10 @@ describe("parseUrl", () => {
   });
 
   it("throws BusinessError for malformed URL", async () => {
-    expect(async () => {
-      await new UrlParser().transform(unsafeAssumeValidArg({ url: "42" }));
-    }).rejects.toThrowError(new BusinessError("Invalid URL: 42"));
+    const promise = new UrlParser().transform(
+      unsafeAssumeValidArg({ url: "42" })
+    );
+    expect(promise).rejects.toThrowError(BusinessError);
+    expect(promise).rejects.toThrowError("Invalid URL: 42");
   });
 });

--- a/src/blocks/transformers/parseUrl.ts
+++ b/src/blocks/transformers/parseUrl.ts
@@ -99,6 +99,8 @@ export class UrlParser extends Transformer {
     let parsed: URL;
 
     try {
+      // NOTE: this is a transform brick and can support any URL, not just https: URLs. Therefore, we don't need to
+      // call our assertHttpsUrl helper method or another method
       parsed = new URL(url, base);
     } catch (error) {
       // URL throws a TypeError on an invalid URL. However, for some reason instance TypeError and instanceof Error

--- a/src/blocks/transformers/parseUrl.ts
+++ b/src/blocks/transformers/parseUrl.ts
@@ -23,6 +23,7 @@ import { isNullOrBlank } from "@/utils";
 
 // Methods imported async in the brick
 import type { ParsedDomain } from "psl";
+import { BusinessError } from "@/errors";
 
 const URL_PROPERTIES = [
   "port",
@@ -95,7 +96,17 @@ export class UrlParser extends Transformer {
       /* webpackChunkName: "psl" */ "psl"
     );
 
-    const parsed = new URL(url, base);
+    let parsed: URL;
+
+    try {
+      parsed = new URL(url, base);
+    } catch (error) {
+      if (error instanceof TypeError) {
+        throw new BusinessError(error.message);
+      }
+
+      throw error;
+    }
 
     let publicSuffix: string;
 

--- a/src/blocks/transformers/parseUrl.ts
+++ b/src/blocks/transformers/parseUrl.ts
@@ -23,7 +23,7 @@ import { isNullOrBlank } from "@/utils";
 
 // Methods imported async in the brick
 import type { ParsedDomain } from "psl";
-import { BusinessError } from "@/errors";
+import { BusinessError, getErrorMessage } from "@/errors";
 
 const URL_PROPERTIES = [
   "port",
@@ -101,11 +101,9 @@ export class UrlParser extends Transformer {
     try {
       parsed = new URL(url, base);
     } catch (error) {
-      if (error instanceof TypeError) {
-        throw new BusinessError(error.message);
-      }
-
-      throw error;
+      // URL throws a TypeError on an invalid URL. However, for some reason instance TypeError and instanceof Error
+      // both fail for the thrown error. Therefore, just check for an error-like object
+      throw new BusinessError(getErrorMessage(error));
     }
 
     let publicSuffix: string;

--- a/src/blocks/transformers/regex.test.ts
+++ b/src/blocks/transformers/regex.test.ts
@@ -60,8 +60,8 @@ test("invalid regex is business error", async () => {
     })
   );
 
-  expect(promise).rejects.toThrowError(BusinessError);
-  expect(promise).rejects.toThrowError(
+  await expect(promise).rejects.toThrowError(BusinessError);
+  await expect(promise).rejects.toThrowError(
     new BusinessError(
       "Invalid regular expression: /BOOM\\/: \\ at end of pattern"
     )

--- a/src/blocks/transformers/regex.test.ts
+++ b/src/blocks/transformers/regex.test.ts
@@ -17,6 +17,7 @@
 
 import { RegexTransformer } from "./regex";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { BusinessError } from "@/errors";
 
 const transformer = new RegexTransformer();
 
@@ -48,4 +49,21 @@ test("handle multiple", async () => {
     })
   );
   expect(result).toEqual([{ name: "ABC" }, {}]);
+});
+
+test("invalid regex is business error", async () => {
+  // https://stackoverflow.com/a/61232874/402560
+
+  const promise = transformer.transform(
+    unsafeAssumeValidArg({
+      regex: "BOOM\\",
+    })
+  );
+
+  expect(promise).rejects.toThrowError(BusinessError);
+  expect(promise).rejects.toThrowError(
+    new BusinessError(
+      "Invalid regular expression: /BOOM\\/: \\ at end of pattern"
+    )
+  );
 });

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -22,6 +22,7 @@ import {
   getErrorMessage,
   hasBusinessRootCause,
   hasCancelRootCause,
+  IGNORED_ERROR_PATTERNS,
   isErrorObject,
   MultipleElementsFoundError,
   NoElementsFoundError,
@@ -30,6 +31,7 @@ import {
 import { range } from "lodash";
 import { deserializeError, serializeError } from "serialize-error";
 import { InputValidationError, OutputValidationError } from "@/blocks/errors";
+import { matchesAnyPattern } from "@/utils";
 
 const TEST_MESSAGE = "Test message";
 
@@ -207,19 +209,36 @@ describe("selectError", () => {
     expect(selectError(errorEvent)).toBe(error);
   });
 
+  it("handles ErrorEvent with null message and error", () => {
+    const errorEvent = new ErrorEvent("error", {
+      error: null,
+      message: null,
+    });
+
+    const selectedError = selectError(errorEvent);
+    expect(selectedError).toMatchInlineSnapshot("[Error: Unknown error event]");
+  });
+
   it("handles error event with message but no error object", () => {
+    const eventMessage = "ResizeObserver loop limit exceeded";
+
     // Seen on Chrome 100.0.4896.127. The message is provided, but there's no error object
     const errorEvent = new ErrorEvent("error", {
       filename: "https://dashboard.brex.com/card/transactions/yours",
       lineno: 0,
       colno: 10,
       error: null,
-      message: "ResizeObserver loop exceeded",
+      message: eventMessage,
     });
 
     const selectedError = selectError(errorEvent);
 
-    expect(selectedError.message).toBe("ResizeObserver loop exceeded");
+    expect(selectedError.message).toBe(eventMessage);
+
+    // This particular error should be ignored by recordError because it's in the IGNORED_ERROR_PATTERNS. Check here
+    // that the error message matches one of the ignored patterns.
+    const message = getErrorMessage(selectedError);
+    expect(matchesAnyPattern(message, IGNORED_ERROR_PATTERNS)).toBeTruthy();
   });
 
   it("wraps primitive from ErrorEvent and creates stack", () => {
@@ -247,6 +266,18 @@ describe("selectError", () => {
     );
 
     expect(selectError(errorEvent)).toBe(error);
+  });
+
+  it("handles PromiseRejectionEvent with null reason", () => {
+    const errorEvent = new PromiseRejectionEvent(
+      "error",
+      createUncaughtRejection(null)
+    );
+
+    const selectedError = selectError(errorEvent);
+    expect(selectedError).toMatchInlineSnapshot(
+      "[Error: Unknown promise rejection]"
+    );
   });
 
   it("wraps primitive from PromiseRejectionEvent", () => {

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -207,6 +207,21 @@ describe("selectError", () => {
     expect(selectError(errorEvent)).toBe(error);
   });
 
+  it("handles error event with message but no error object", () => {
+    // Seen on Chrome 100.0.4896.127. The message is provided, but there's no error object
+    const errorEvent = new ErrorEvent("error", {
+      filename: "https://dashboard.brex.com/card/transactions/yours",
+      lineno: 0,
+      colno: 10,
+      error: null,
+      message: "ResizeObserver loop exceeded",
+    });
+
+    const selectedError = selectError(errorEvent);
+
+    expect(selectedError.message).toBe("ResizeObserver loop exceeded");
+  });
+
   it("wraps primitive from ErrorEvent and creates stack", () => {
     const error = "It’s a non-error";
     const errorEvent = new ErrorEvent("error", {
@@ -217,11 +232,9 @@ describe("selectError", () => {
     });
 
     const selectedError = selectError(errorEvent);
-    expect(selectedError).toMatchInlineSnapshot(
-      "[Error: Synchronous error: It’s a non-error]"
-    );
+    expect(selectedError).toMatchInlineSnapshot("[Error: It’s a non-error]");
     expect(selectedError.stack).toMatchInlineSnapshot(`
-      "Error: Synchronous error: It’s a non-error
+      "Error: It’s a non-error
           at unknown (yoshi://mushroom-kingdom/bowser.js:2:10)"
     `);
   });
@@ -243,7 +256,7 @@ describe("selectError", () => {
     );
 
     expect(selectError(errorEvent)).toMatchInlineSnapshot(
-      "[Error: Asynchronous error: It’s a non-error]"
+      "[Error: It’s a non-error]"
     );
   });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -398,7 +398,7 @@ function selectNetworkErrorMessage(error: unknown): string | null {
  * enrichBusinessRequestError is a related method which wraps an AxiosError in an Error subclass that encodes information
  * about why the request failed.
  *
- * @param Response from the server. May not be null
+ * @param response Response from the server. May not be null
  *
  * @deprecated DO NOT CALL DIRECTLY. Call getErrorMessage
  * @see getErrorMessage
@@ -497,18 +497,67 @@ export function getErrorMessage(
 }
 
 /**
+ * Handle ErrorEvents, i.e., generated from window.onerror
+ * @param event the error event
+ */
+function selectErrorFromEvent(event: ErrorEvent): Error {
+  // https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
+  // https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent
+
+  // ErrorEvents have some information about the location of the error, so we use it as a single-level stack.
+  // The format follows Chrome’s. `unknown` is the function name
+  const stackFactory = (message: string) =>
+    `Error: ${message}\n    at unknown (${event.filename}:${event.lineno}:${event.colno})`;
+
+  if (event.error) {
+    const error = selectError(event.error);
+    // If the originalError didn't have a stack, generate a selected error for the stack. Otherwise the stack will be
+    // the stack of the call to selectError
+    if (event.error.stack == null) {
+      error.stack = stackFactory(error.message);
+    }
+
+    return error;
+  }
+
+  // WARNING: don't prefix the error message, e.g., with "Synchronous error:" because that breaks
+  // message-based error filtering via IGNORED_ERROR_PATTERNS
+  const message = event.message ?? "Unknown error event";
+  const error = new Error(message);
+  error.stack = stackFactory(message);
+
+  return error;
+}
+
+/**
+ * Handle unhandled promise rejections
+ * @param event the promise rejection event
+ */
+function selectErrorFromRejectionEvent(event: PromiseRejectionEvent): Error {
+  // WARNING: don't prefix the error message, e.g., with "Asynchronous error:" because that breaks
+  // message-based error filtering via IGNORED_ERROR_PATTERNS
+  if (typeof event.reason === "string" || event.reason == null) {
+    return new Error(event.reason ?? "Unknown promise rejection");
+  }
+
+  return selectError(event.reason);
+}
+
+/**
  * Finds or creates an Error starting from strings, error event, or real Errors.
  *
  * The result is suitable for passing to Rollbar (which treats Errors and objects differently.)
  */
 export function selectError(originalError: unknown): Error {
-  // Extract thrown error from event
-  const error: unknown =
-    originalError instanceof ErrorEvent
-      ? originalError.error
-      : originalError instanceof PromiseRejectionEvent
-      ? originalError.reason
-      : originalError; // Or use the received object/error as is
+  if (originalError instanceof ErrorEvent) {
+    return selectErrorFromEvent(originalError);
+  }
+
+  if (originalError instanceof PromiseRejectionEvent) {
+    return selectErrorFromRejectionEvent(originalError);
+  }
+
+  const error = originalError;
 
   if (error instanceof Error) {
     return error;
@@ -520,7 +569,7 @@ export function selectError(originalError: unknown): Error {
   }
 
   console.warn("A non-Error was thrown", {
-    originalError,
+    error,
   });
 
   // Wrap error if an unknown primitive or object
@@ -529,22 +578,6 @@ export function selectError(originalError: unknown): Error {
     ? // Use safeJsonStringify vs. JSON.stringify because it handles circular references
       safeJsonStringify(error)
     : String(error);
-
-  // Refactor beware: Keep the "primitive error event wrapper" logic separate from the
-  // "extract error from event" logic to avoid duplicating or missing the rest of the selectError’s logic
-  if (originalError instanceof ErrorEvent) {
-    const syncErrorMessage = `Synchronous error: ${errorMessage}`;
-    const errorError = new Error(syncErrorMessage);
-
-    // ErrorEvents have some information about the location of the error, so we use it as a single-level stack.
-    // The format follows Chrome’s. `unknown` is the function name
-    errorError.stack = `Error: ${syncErrorMessage}\n    at unknown (${originalError.filename}:${originalError.lineno}:${originalError.colno})`;
-    return errorError;
-  }
-
-  if (originalError instanceof PromiseRejectionEvent) {
-    return new Error(`Asynchronous error: ${errorMessage}`);
-  }
 
   return new Error(errorMessage);
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -522,7 +522,11 @@ function selectErrorFromEvent(event: ErrorEvent): Error {
 
   // WARNING: don't prefix the error message, e.g., with "Synchronous error:" because that breaks
   // message-based error filtering via IGNORED_ERROR_PATTERNS
-  const message = event.message ?? "Unknown error event";
+  // Oddly, if you pass null to ErrorEvent's constructor, it stringifies it (at least on Node)
+  const message =
+    event.message && event.message !== "null"
+      ? String(event.message)
+      : "Unknown error event";
   const error = new Error(message);
   error.stack = stackFactory(message);
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -510,9 +510,11 @@ function selectErrorFromEvent(event: ErrorEvent): Error {
     `Error: ${message}\n    at unknown (${event.filename}:${event.lineno}:${event.colno})`;
 
   if (event.error) {
+    // `selectError` will always return an Error. If event.error isn't an Error instance, it will wrap it in an error
+    // instance, but that Error instance will have an uninformative stack. (The stack will be the stack of the call
+    // to selectError, which will be our error handling code). Therefore, if the original event error didn't have
+    // a stack, create a stack for it from the event.
     const error = selectError(event.error);
-    // If the originalError didn't have a stack, generate a selected error for the stack. Otherwise the stack will be
-    // the stack of the call to selectError
     if (event.error.stack == null) {
       error.stack = stackFactory(error.message);
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -398,7 +398,7 @@ function selectNetworkErrorMessage(error: unknown): string | null {
  * enrichBusinessRequestError is a related method which wraps an AxiosError in an Error subclass that encodes information
  * about why the request failed.
  *
- * @param response Response from the server. May not be null
+ * @param response Response from the server. Must not be null
  *
  * @deprecated DO NOT CALL DIRECTLY. Call getErrorMessage
  * @see getErrorMessage

--- a/src/telemetry/reportError.ts
+++ b/src/telemetry/reportError.ts
@@ -29,9 +29,9 @@ expectContext(
 
 /**
  * Report an error for local logs, remote telemetry, etc.
- * @param errorLike the error object, error event, or promise rejection
+ * @param errorLike the error object
  * @param context optional context for error telemetry
- * @param logToConsole log the error to the browser console (default=true)
+ * @param logToConsole additionally log error to the browser console (default=true)
  */
 export default function reportError(
   errorLike: unknown, // It might also be an ErrorEvent
@@ -42,19 +42,13 @@ export default function reportError(
     console.error(errorLike, { context });
   }
 
-  let errorIsNull = false;
-
   try {
-    const error = selectError(errorLike);
-
-    errorIsNull = error == null || errorLike == null;
-
     messenger(
       // Low-level direct API call to avoid calls outside reportError
       "RECORD_ERROR",
       { isNotification: true },
       bg,
-      serializeError(error),
+      serializeError(selectError(errorLike)),
       {
         ...context,
         // Add on the reporter side of the message. On the receiving side it would always be `background`
@@ -69,10 +63,5 @@ export default function reportError(
       originalError: errorLike,
       reportingError,
     });
-  }
-
-  if (process.env.DEBUG && errorIsNull) {
-    // In DEBUG, make enough noise that the developer will know something is broken
-    throw new Error("reportError received nullish error");
   }
 }


### PR DESCRIPTION
What does this PR do?
---
- Part of #3279 (I'm not sure it solves the whole problem)
- Handles EventErrors where the message is defined, but error is null
- Removes "Synchronous Error:"/"Asynchronous Error:" message prefixes that were breaking message-based error filtering. E.g., for ResizeObserver loop limit exceeded

