### PR TITLE
#3308: allow unrestricted users to reinstall/uninstall deployments

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -25,7 +25,10 @@
     "jest-webextension-mock",
     "fake-indexeddb/auto"
   ],
-  "setupFilesAfterEnv": ["<rootDir>/src/testUtils/testAfterEnv.js"],
+  "setupFilesAfterEnv": [
+    "<rootDir>/src/testUtils/testAfterEnv.js",
+    "jest-extended/all"
+  ],
   "collectCoverageFrom": [
     "src/**/*.{ts,tsx}",
     "!src/**/*.stories.tsx",

--- a/package-lock.json
+++ b/package-lock.json
@@ -217,6 +217,7 @@
         "jest": "^27.0.6",
         "jest-environment-jsdom": "^27.0.6",
         "jest-environment-jsdom-global": "^3.0.0",
+        "jest-extended": "^2.0.0",
         "jest-raw-loader": "^1.0.1",
         "jest-webextension-mock": "^3.7.17",
         "min-document": "^2.19.0",
@@ -25712,6 +25713,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-extended": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-2.0.0.tgz",
+      "integrity": "sha512-6AgjJQVaBEKGSK3FH90kOiRUWJsbzn9NWtW0pjGkAFIdH0oPilfkV/gHPJdVvJeBiqT3jMHw8TUg9pUGC1azDg==",
+      "dev": true,
+      "dependencies": {
+        "jest-diff": "^27.2.5",
+        "jest-get-type": "^27.0.6"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "jest": ">=27.2.5"
       }
     },
     "node_modules/jest-get-type": {
@@ -57770,6 +57787,16 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "jest-extended": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-2.0.0.tgz",
+      "integrity": "sha512-6AgjJQVaBEKGSK3FH90kOiRUWJsbzn9NWtW0pjGkAFIdH0oPilfkV/gHPJdVvJeBiqT3jMHw8TUg9pUGC1azDg==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^27.2.5",
+        "jest-get-type": "^27.0.6"
       }
     },
     "jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
     "jest": "^27.0.6",
     "jest-environment-jsdom": "^27.0.6",
     "jest-environment-jsdom-global": "^3.0.0",
+    "jest-extended": "^2.0.0",
     "jest-raw-loader": "^1.0.1",
     "jest-webextension-mock": "^3.7.17",
     "min-document": "^2.19.0",

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -182,3 +182,5 @@ interface ChromeifiedBrowser extends Browser {
 }
 
 declare const browser: ChromeifiedBrowser;
+
+import "jest-extended";

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 // This cannot be a regular import because it turns `globals.d.ts` in a "module definition", which it isn't
 type Browser = import("webextension-polyfill").Browser;
 
@@ -182,5 +181,3 @@ interface ChromeifiedBrowser extends Browser {
 }
 
 declare const browser: ChromeifiedBrowser;
-
-import "jest-extended";

--- a/src/options/pages/blueprints/BlueprintActions.tsx
+++ b/src/options/pages/blueprints/BlueprintActions.tsx
@@ -54,6 +54,7 @@ const BlueprintActions: React.FunctionComponent<{
           </>
         ),
         action: actions.exportBlueprint,
+        hide: !actions.exportBlueprint,
       },
       {
         title: (

--- a/src/options/pages/blueprints/useInstallableViewItemActions.test.tsx
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.test.tsx
@@ -16,6 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference -- test file
+/// <reference types="jest-extended" />
+
 import { renderHook } from "@testing-library/react-hooks";
 import { extensionFactory, recipeFactory } from "@/testUtils/factories";
 import useInstallableViewItemActions, {
@@ -39,6 +42,7 @@ const expectActions = (
   expectedActions: string[],
   actualActions: InstallableViewItemActions
 ) => {
+  // Union both set of keys to ensure all possible keys are covered
   const allActions = uniq([...Object.keys(actualActions), ...expectedActions]);
   const expected = Object.fromEntries(
     allActions.map((action) => [

--- a/src/options/pages/blueprints/useInstallableViewItemActions.test.tsx
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.test.tsx
@@ -259,6 +259,9 @@ describe("useInstallableViewItemActions", () => {
     const {
       result: { current: actions },
     } = renderHook(() => useInstallableViewItemActions(deploymentItem));
+
+    // Unrestricted users (e.g., developers) need to be able to uninstall/reactivate a deployment to use a later
+    // version of the blueprint for development/testing.
     expectActions(["viewLogs", "uninstall", "reinstall"], actions);
   });
 

--- a/src/options/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.ts
@@ -88,9 +88,10 @@ function useInstallableViewItemActions(
   const hasBlueprint =
     isExtensionFromRecipe(installable) || isBlueprint(installable);
 
+  const isDeployment = sharing.source.type === "Deployment";
+
   // TODO: double-check how team role factors into the uninstall flag. Do we need to check for team role?
-  const isManaged =
-    sharing.source.type === "Deployment" && restrict("uninstall");
+  const isManaged = isDeployment && restrict("uninstall");
 
   const extensionsFromInstallable = useSelector(
     (state: { options: OptionsState }) =>
@@ -245,7 +246,7 @@ function useInstallableViewItemActions(
   );
 
   return {
-    viewShare: isCloudExtension ? null : viewShare,
+    viewShare: isCloudExtension || isDeployment ? null : viewShare,
     deleteExtension: isCloudExtension ? deleteExtension : null,
     uninstall: isInstalled && !isManaged ? uninstall : null,
     // Only blueprints/deployments can be reinstalled. (Because there's no reason to reinstall an extension... there's
@@ -253,7 +254,7 @@ function useInstallableViewItemActions(
     reinstall: hasBlueprint && isInstalled && !isManaged ? reinstall : null,
     viewLogs: status === "Inactive" ? null : viewLogs,
     activate: status === "Inactive" ? activate : null,
-    exportBlueprint,
+    exportBlueprint: isDeployment ? null : exportBlueprint,
     requestPermissions: hasPermissions ? null : requestPermissions,
   };
 }


### PR DESCRIPTION
What does this PR do?
---
- Closes #3308
- Makes the uninstall/reinstall actions available to unrestricted users on deployments
- Hides the "Share" button for all deployments because they're managed via Admin Console
- Hides the "Export" button for all deployments 
- Adds the jest-extended library for additional test matchers for comparing actual/expected objects