### PR TITLE
#3311: don't prompt developers to install deployments of blueprints they have installed

### DIFF
--- a/src/hooks/useDeployments.test.ts
+++ b/src/hooks/useDeployments.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { makeUpdatedFilter } from "@/hooks/useDeployments";
+import { deploymentFactory, extensionFactory } from "@/testUtils/factories";
+import { validateTimestamp } from "@/types/helpers";
+
+describe("makeUpdatedFilter", () => {
+  test.each([[{ restricted: true }, { restricted: false }]])(
+    "unmatched deployment",
+    ({ restricted }) => {
+      const extensions = [extensionFactory()];
+
+      const filter = makeUpdatedFilter(extensions, { restricted });
+      expect(filter(deploymentFactory())).toBeTrue();
+    }
+  );
+
+  test.each([[{ restricted: true }, { restricted: false }]])(
+    "matched up-to-date deployment",
+    ({ restricted }) => {
+      const deployment = deploymentFactory();
+
+      const extensions = [
+        extensionFactory({
+          _deployment: {
+            id: deployment.id,
+            timestamp: deployment.updated_at,
+            active: true,
+          },
+        }),
+      ];
+
+      const filter = makeUpdatedFilter(extensions, { restricted });
+      expect(filter(deployment)).toBeFalse();
+    }
+  );
+
+  test("matched stale deployment", () => {
+    const deployment = deploymentFactory();
+
+    const extensions = [
+      extensionFactory({
+        _deployment: {
+          id: deployment.id,
+          timestamp: "2020-10-07T12:52:16.189Z",
+          active: true,
+        },
+      }),
+    ];
+
+    const filter = makeUpdatedFilter(extensions, { restricted: true });
+    expect(filter(deployment)).toBeTrue();
+  });
+
+  test("matched blueprint for restricted user", () => {
+    const deployment = deploymentFactory();
+
+    const extensions = [
+      extensionFactory({
+        _deployment: undefined,
+        _recipe: {
+          ...deployment.package.config.metadata,
+          updated_at: validateTimestamp(deployment.updated_at),
+          // `sharing` doesn't impact the predicate. Pass an arbitrary value
+          sharing: undefined,
+        },
+      }),
+    ];
+
+    const filter = makeUpdatedFilter(extensions, { restricted: true });
+    expect(filter(deployment)).toBeTrue();
+  });
+
+  test("matched blueprint for unrestricted user / developer", () => {
+    const deployment = deploymentFactory();
+
+    const extensions = [
+      extensionFactory({
+        _deployment: undefined,
+        _recipe: {
+          ...deployment.package.config.metadata,
+          // The factory produces version "1.0.1"
+          version: "1.0.1",
+          updated_at: validateTimestamp(deployment.updated_at),
+          // `sharing` doesn't impact the predicate. Pass an arbitrary value
+          sharing: undefined,
+        },
+      }),
+    ];
+
+    const filter = makeUpdatedFilter(extensions, { restricted: false });
+    expect(filter(deployment)).toBeFalse();
+  });
+});

--- a/src/hooks/useDeployments.ts
+++ b/src/hooks/useDeployments.ts
@@ -30,13 +30,15 @@ import { refreshRegistries } from "@/hooks/useRefresh";
 import { Dispatch } from "redux";
 import { mergePermissions } from "@/utils/permissions";
 import { Permissions } from "webextension-polyfill";
-import { IExtension, UUID, RegistryId } from "@/core";
+import { IExtension, RegistryId, UUID } from "@/core";
 import { maybeGetLinkedApiClient } from "@/services/apiClient";
-import { satisfies } from "semver";
-import { compact, gte } from "lodash";
 import chromeP from "webext-polyfill-kinda";
 import extensionsSlice from "@/store/extensionsSlice";
 import useFlags from "@/hooks/useFlags";
+import {
+  checkExtensionUpdateRequired,
+  makeUpdatedFilter,
+} from "@/utils/deployment";
 
 const { actions } = extensionsSlice;
 
@@ -75,61 +77,6 @@ async function fetchDeployments(
 
   return deployments;
 }
-
-/**
- * Returns a predicate that returns `true` if a deployment requires an update.
- *
- * Restricted users:
- * - The remote deployment's extension updated_at timestamp is after the installed version. The updated_at timestamp
- *   can change even if the blueprint version doesn't change because of 1) the deployment was paused, or 2) the
- *   admin changed a binding on the deployment
- *
- * Unrestricted users:
- * - Same as above, but ignore deployments where the user has a newer version of the blueprint installed because that
- *   means they are doing local deployment on the blueprint.
- *
- * @param installed the user's currently installed extensions (including for paused deployments)
- * @param restricted `true` if the user is a restricted organization user (i.e., as opposed to a developer)
- */
-export const makeUpdatedFilter =
-  (installed: IExtension[], { restricted }: { restricted: boolean }) =>
-  (deployment: Deployment) => {
-    const deploymentMatch = installed.find(
-      (extension) => extension._deployment?.id === deployment.id
-    );
-
-    if (restricted) {
-      return (
-        !deploymentMatch ||
-        new Date(deploymentMatch._deployment.timestamp) <
-          new Date(deployment.updated_at)
-      );
-    }
-
-    // Local copies an unrestricted user (i.e., a developer role) is working on
-    const blueprintMatch = installed.find(
-      (extension) =>
-        extension._deployment == null &&
-        extension._recipe.id === deployment.package.package_id
-    );
-
-    if (!deploymentMatch && !blueprintMatch) {
-      return true;
-    }
-
-    if (
-      blueprintMatch &&
-      gte(blueprintMatch._recipe.version, deployment.package.version)
-    ) {
-      // The unrestricted user already has the blueprint (or a newer version of the blueprint), so don't prompt
-      return false;
-    }
-
-    return (
-      new Date(deploymentMatch._deployment.timestamp) <
-      new Date(deployment.updated_at)
-    );
-  };
 
 function activateDeployments(
   dispatch: Dispatch,
@@ -201,30 +148,6 @@ export type DeploymentState = {
   error: unknown | undefined;
 };
 
-/**
- * Returns `true` if the user needs to update their browser extension to install the deployments.
- *
- * For now assumes only minimum version requirements. (I.e., this method also returns true if there's a maximum version
- * violation).
- */
-function checkExtensionUpdateRequired(deployments: Deployment[]): boolean {
-  // Check that the user's extension van run the deployment
-  const { version: extensionVersion } = browser.runtime.getManifest();
-  const versionRanges = compact(
-    deployments.map((x) => x.package.config.metadata.extensionVersion)
-  );
-
-  console.debug("Checking deployment version requirements", {
-    versionRanges,
-    extensionVersion,
-  });
-
-  // For now assume the only version restrictions will be that the version must be greater than a certain number
-  return versionRanges.some(
-    (versionRange) => !satisfies(extensionVersion, versionRange)
-  );
-}
-
 function useDeployments(): DeploymentState {
   const dispatch = useDispatch();
   const installedExtensions = useSelector(selectExtensions);
@@ -244,7 +167,7 @@ function useDeployments(): DeploymentState {
       updatedDeployments,
       checkExtensionUpdateRequired(updatedDeployments),
     ];
-  }, [installedExtensions, deployments]);
+  }, [restrict, installedExtensions, deployments]);
 
   const handleUpdate = useCallback(async () => {
     if (deployments == null) {

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -31,6 +31,7 @@ import {
   EmptyConfig,
   PersistedExtension,
   Timestamp,
+  RegistryId,
 } from "@/core";
 
 import { components } from "@/types/swagger";
@@ -124,7 +125,14 @@ export type SanitizedAuth = components["schemas"]["SanitizedAuth"] & {
 
 export type Deployment = components["schemas"]["DeploymentDetail"] & {
   id: UUID;
-  package: { config: RecipeDefinition };
+  package: Except<
+    components["schemas"]["DeploymentDetail"]["package"],
+    "config" | "id" | "package_id"
+  > & {
+    id: UUID;
+    package_id: RegistryId;
+    config: RecipeDefinition;
+  };
 };
 
 export type Brick = components["schemas"]["PackageMeta"] & {

--- a/src/utils/deployment.test.ts
+++ b/src/utils/deployment.test.ts
@@ -15,7 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { checkExtensionUpdateRequired, makeUpdatedFilter } from "./deployment";
+import {
+  checkExtensionUpdateRequired,
+  isDeploymentActive,
+  makeUpdatedFilter,
+} from "./deployment";
 import { deploymentFactory, extensionFactory } from "@/testUtils/factories";
 import { validateTimestamp } from "@/types/helpers";
 
@@ -127,4 +131,41 @@ describe("checkExtensionUpdateRequired", () => {
     }`;
     expect(checkExtensionUpdateRequired([deployment])).toBeFalse();
   });
+});
+
+describe("isDeploymentActive", () => {
+  test("not a deployment", () => {
+    expect(isDeploymentActive(extensionFactory())).toBeTrue();
+  });
+
+  test("legacy deployment", () => {
+    const deployment = deploymentFactory();
+
+    const extension = extensionFactory({
+      _deployment: {
+        id: deployment.id,
+        timestamp: deployment.updated_at,
+        // Legacy deployments don't have an `active` field
+      },
+    });
+
+    expect(isDeploymentActive(extension)).toBeTrue();
+  });
+
+  test.each([[{ active: true }, { active: false }]])(
+    "deployment",
+    ({ active }) => {
+      const deployment = deploymentFactory();
+
+      const extension = extensionFactory({
+        _deployment: {
+          id: deployment.id,
+          timestamp: deployment.updated_at,
+          active,
+        },
+      });
+
+      expect(isDeploymentActive(extension)).toBe(active);
+    }
+  );
 });

--- a/src/utils/deployment.test.ts
+++ b/src/utils/deployment.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { makeUpdatedFilter } from "@/hooks/useDeployments";
+import { checkExtensionUpdateRequired, makeUpdatedFilter } from "./deployment";
 import { deploymentFactory, extensionFactory } from "@/testUtils/factories";
 import { validateTimestamp } from "@/types/helpers";
 
@@ -105,5 +105,26 @@ describe("makeUpdatedFilter", () => {
 
     const filter = makeUpdatedFilter(extensions, { restricted: false });
     expect(filter(deployment)).toBeFalse();
+  });
+});
+
+describe("checkExtensionUpdateRequired", () => {
+  test("no deployments", () => {
+    expect(checkExtensionUpdateRequired([])).toBeFalse();
+  });
+
+  test("update required", () => {
+    const deployment = deploymentFactory();
+    (deployment.package.config.metadata.extensionVersion as any) = ">=99.99.99";
+
+    expect(checkExtensionUpdateRequired([deployment])).toBeTrue();
+  });
+
+  test("update not required", () => {
+    const deployment = deploymentFactory();
+    (deployment.package.config.metadata.extensionVersion as any) = `>=${
+      browser.runtime.getManifest().version
+    }`;
+    expect(checkExtensionUpdateRequired([deployment])).toBeFalse();
   });
 });

--- a/src/utils/deployment.test.ts
+++ b/src/utils/deployment.test.ts
@@ -54,22 +54,25 @@ describe("makeUpdatedFilter", () => {
     }
   );
 
-  test("matched stale deployment", () => {
-    const deployment = deploymentFactory();
+  test.each([[{ restricted: true }, { restricted: false }]])(
+    "matched stale deployment",
+    ({ restricted }) => {
+      const deployment = deploymentFactory();
 
-    const extensions = [
-      extensionFactory({
-        _deployment: {
-          id: deployment.id,
-          timestamp: "2020-10-07T12:52:16.189Z",
-          active: true,
-        },
-      }),
-    ];
+      const extensions = [
+        extensionFactory({
+          _deployment: {
+            id: deployment.id,
+            timestamp: "2020-10-07T12:52:16.189Z",
+            active: true,
+          },
+        }),
+      ];
 
-    const filter = makeUpdatedFilter(extensions, { restricted: true });
-    expect(filter(deployment)).toBeTrue();
-  });
+      const filter = makeUpdatedFilter(extensions, { restricted });
+      expect(filter(deployment)).toBeTrue();
+    }
+  );
 
   test("matched blueprint for restricted user", () => {
     const deployment = deploymentFactory();

--- a/src/utils/deployment.ts
+++ b/src/utils/deployment.ts
@@ -29,6 +29,7 @@ export function isDeploymentActive(extensionLike: {
   _deployment?: DeploymentContext;
 }): boolean {
   return (
+    // Prior to extension version 1.4.0, there was no `active` field, because there was no ability to pause deployments
     extensionLike._deployment?.active == null ||
     extensionLike._deployment.active
   );

--- a/src/utils/deployment.ts
+++ b/src/utils/deployment.ts
@@ -15,7 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DeploymentContext } from "@/core";
+import { DeploymentContext, IExtension } from "@/core";
+import { Deployment } from "@/types/contract";
+import { gte, satisfies } from "semver";
+import { compact } from "lodash";
 
 /**
  * Returns `true` if a managed deployment is active (i.e., has not been remotely paused by an admin)
@@ -28,5 +31,86 @@ export function isDeploymentActive(extensionLike: {
   return (
     extensionLike._deployment?.active == null ||
     extensionLike._deployment.active
+  );
+}
+
+/**
+ * Returns a predicate that returns `true` if a deployment requires an update.
+ *
+ * Restricted users:
+ * - The remote deployment's extension updated_at timestamp is after the installed version. The updated_at timestamp
+ *   can change even if the blueprint version doesn't change because of 1) the deployment was paused, or 2) the
+ *   admin changed a binding on the deployment
+ *
+ * Unrestricted users:
+ * - Same as above, but ignore deployments where the user has a newer version of the blueprint installed because that
+ *   means they are doing local deployment on the blueprint.
+ *
+ * @param installed the user's currently installed extensions (including for paused deployments)
+ * @param restricted `true` if the user is a restricted organization user (i.e., as opposed to a developer)
+ */
+export const makeUpdatedFilter =
+  (installed: IExtension[], { restricted }: { restricted: boolean }) =>
+  (deployment: Deployment) => {
+    const deploymentMatch = installed.find(
+      (extension) => extension._deployment?.id === deployment.id
+    );
+
+    if (restricted) {
+      return (
+        !deploymentMatch ||
+        new Date(deploymentMatch._deployment.timestamp) <
+          new Date(deployment.updated_at)
+      );
+    }
+
+    // Local copies an unrestricted user (i.e., a developer role) is working on
+    const blueprintMatch = installed.find(
+      (extension) =>
+        extension._deployment == null &&
+        extension._recipe.id === deployment.package.package_id
+    );
+
+    if (!deploymentMatch && !blueprintMatch) {
+      return true;
+    }
+
+    if (
+      blueprintMatch &&
+      gte(blueprintMatch._recipe.version, deployment.package.version)
+    ) {
+      // The unrestricted user already has the blueprint (or a newer version of the blueprint), so don't prompt
+      return false;
+    }
+
+    return (
+      new Date(deploymentMatch._deployment.timestamp) <
+      new Date(deployment.updated_at)
+    );
+  };
+
+/**
+ * Returns `true` if the user needs to update their browser extension to install the deployments.
+ *
+ * For now assumes only minimum version requirements. (I.e., this method also returns true if there's a maximum version
+ * violation).
+ */
+export function checkExtensionUpdateRequired(
+  deployments: Deployment[]
+): boolean {
+  // Check that the user's extension van run the deployment
+  const { version: extensionVersion } = browser.runtime.getManifest();
+  const versionRanges = compact(
+    deployments.map((x) => x.package.config.metadata.extensionVersion)
+  );
+
+  console.debug("Checking deployment version requirements", {
+    versionRanges,
+    extensionVersion,
+  });
+
+  // For now assume the only version restrictions will be that the version must be greater than a certain number
+  return versionRanges.some(
+    (versionRange) => !satisfies(extensionVersion, versionRange)
   );
 }

--- a/src/utils/deployment.ts
+++ b/src/utils/deployment.ts
@@ -69,7 +69,7 @@ export const makeUpdatedFilter =
     const blueprintMatch = installed.find(
       (extension) =>
         extension._deployment == null &&
-        extension._recipe.id === deployment.package.package_id
+        extension._recipe?.id === deployment.package.package_id
     );
 
     if (!deploymentMatch && !blueprintMatch) {


### PR DESCRIPTION
What does this PR do?
---
- Closes #3311 
- A source of confusion is that PixieBrix will prompt a developer to install a version of a blueprint even if they have a newer version of it installed (e.g., during development). As a result, they install the deployment and then have the old version of the blueprint installed and accidentally modify that blueprint