### PR TITLE
#3307: ignore special chars in recipe id generation

### DIFF
--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -17,6 +17,7 @@
 
 import {
   buildRecipe,
+  generateRecipeId,
   generateScopeBrickId,
   isRecipeEditable,
   replaceRecipeExtension,
@@ -819,4 +820,28 @@ describe("buildRecipe", () => {
       expect(newRecipe).toStrictEqual(updated);
     }
   );
+});
+
+describe("generateRecipeId", () => {
+  test("no special chars", () => {
+    expect(generateRecipeId("@test", "This Is a Test")).toEqual(
+      "@test/this-is-a-test"
+    );
+  });
+
+  test("handle colon", () => {
+    expect(generateRecipeId("@test", "This: Is a Test")).toEqual(
+      "@test/this-is-a-test"
+    );
+  });
+
+  test("collapse spaces", () => {
+    expect(generateRecipeId("@test", "This   Is a Test")).toEqual(
+      "@test/this-is-a-test"
+    );
+  });
+
+  test("return empty on invalid", () => {
+    expect(generateRecipeId("", "This   Is a Test")).toBe(null);
+  });
 });

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -61,13 +61,22 @@ export function generateScopeBrickId(
   );
 }
 
+/**
+ * Return a valid recipe id, or return null
+ * @param userScope a user scope, with the leading @
+ * @param extensionLabel the extension label
+ */
 export function generateRecipeId(
   userScope: string,
   extensionLabel: string
-): RegistryId {
-  return validateRegistryId(
-    `${userScope}/${slugify(extensionLabel).toLowerCase()}`
-  );
+): RegistryId | null {
+  try {
+    return validateRegistryId(
+      `${userScope}/${slugify(extensionLabel, { lower: true, strict: true })}`
+    );
+  } catch {
+    return null;
+  }
 }
 
 export function isRecipeEditable(

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -58,6 +58,7 @@ import LoadingDataModal from "@/pageEditor/panes/save/LoadingDataModal";
 import { FormState } from "@/pageEditor/pageEditorTypes";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import { inferRecipeAuths, inferRecipeOptions } from "@/store/extensionsUtils";
+import { RegistryId } from "@/core";
 
 const { actions: optionsActions } = extensionsSlice;
 
@@ -228,7 +229,7 @@ function useInitialFormState({
   if (activeElement) {
     // Handle creating a new blueprint from a selected extension
     return {
-      id: generateRecipeId(scope, activeElement.label),
+      id: generateRecipeId(scope, activeElement.label) ?? ("" as RegistryId),
       name: activeElement.label,
       version: "1.0.0",
       description: "Created with the PixieBrix Page Editor",


### PR DESCRIPTION
What does this PR do?
---
- Closes #3307 
- Removes special characters during registry id generation
- Falls back to null if a valid id is not generated