### PR TITLE
#3260: Limit the length of notifications and error messages

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -603,5 +603,6 @@ export function selectError(originalError: unknown): Error {
       safeJsonStringify(error)
     : String(error);
 
-  return new Error(errorMessage);
+  // Truncate error message in case it's an excessively-long JSON string
+  return new Error(truncate(errorMessage, { length: 2000 }));
 }

--- a/src/utils/notify.tsx
+++ b/src/utils/notify.tsx
@@ -26,6 +26,7 @@ import { NOTIFICATIONS_Z_INDEX } from "@/common";
 import reportError from "@/telemetry/reportError";
 import { Except, RequireAtLeastOne } from "type-fest";
 import { getErrorMessage } from "@/errors";
+import { truncate } from "lodash";
 
 const MINIMUM_NOTIFICATION_DURATION = 2000;
 
@@ -123,6 +124,9 @@ export function showNotification({
       message = message.replace(/[\s.:]$/, "") + ": " + getErrorMessage(error);
     }
   }
+
+  // Avoid excessively-long notification messages
+  message = truncate(message, { length: 400 });
 
   duration ??= getMessageDisplayTime(message);
 


### PR DESCRIPTION
- Closes #3260

This is what 400 characters look like. The limit is long enough to rarely be reached (truncating messages is never ideal) but short enough to avoid excessively-long notification messages.

> Municipiile erau orașe cu mai puține 
> drepturi decât coloniile, locuite de acei 
> cetățeni cu drepturi limitate. Satele 
> erau locuite de obicei de populația 
> autohtonă. Se așezau însă în ele și 
> coloniști romani. Romanizarea a mers 
> greu la sate, unde imensa majoritate 
> o formau geții, mai ales în primele 
> impuri după cucerire. Un rol important 
> în romanizare, la sate, l-au avut 
> veteranii, atât de origine 

I also placed a length limit on the error message to ensure we don't send out megabytes of errors to Rollbar.

Note: `JSON.stringify` is a last resort and we should figure out a pattern for RTK to never thrown these "errors"