### PR TITLE
#3269: remove outdated TODO comment about inconsistent status on blueprints screen

### DIFF
--- a/src/options/pages/blueprints/Status.tsx
+++ b/src/options/pages/blueprints/Status.tsx
@@ -46,7 +46,6 @@ const Status: React.VoidFunctionComponent<{
     );
   }
 
-  // XXX: https://github.com/pixiebrix/pixiebrix-extension/issues/3269
   if (hasUpdate && reinstall) {
     return (
       <Button size="sm" variant="info" onClick={reinstall}>


### PR DESCRIPTION
What does this PR do?
---
- Closes #3269 by removing TODO comment
- The underlying issue (where some actions weren't being set to null when unavailable) was fixed in https://github.com/pixiebrix/pixiebrix-extension/pull/3309