### PR TITLE
#3268 Improve error msg layout in Form component

### DIFF
--- a/src/components/form/Form.module.scss
+++ b/src/components/form/Form.module.scss
@@ -1,7 +1,21 @@
-$color-danger: #fc3939;
-$color-danger-active: #e50303;
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 .status {
-  color: $color-danger;
-  margin-bottom: 1rem;
+  border: none;
+  border-radius: 0;
 }

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -45,13 +45,46 @@ export type RenderSubmit = (state: {
 export type RenderStatus = (state: { status: string }) => ReactElement;
 
 type FormProps = {
+  /**
+   * The starting formik field values for the form
+   */
   initialValues: FormikValues;
+
+  /**
+   * The yup validation schema for the form
+   */
   validationSchema: yup.AnyObjectSchema;
+
+  /**
+   * Should the form be validated on component mount?
+   */
   validateOnMount?: boolean;
+
+  /**
+   * (from Formik): Should Formik reset the form when new initialValues change?
+   */
   enableReinitialize?: boolean;
+
+  /**
+   * The render function for the body of the form
+   */
   renderBody?: RenderBody;
+
+  /**
+   * The render function for the submit button (and any other co-located buttons)
+   */
   renderSubmit?: RenderSubmit;
+
+  /**
+   * The render function for the top-level form status message
+   *
+   * Note: This currently defaults to an "error" style layout
+   */
   renderStatus?: RenderStatus;
+
+  /**
+   * The submission handler for the form
+   */
   onSubmit: OnSubmit;
 };
 

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -18,9 +18,11 @@
 import styles from "./Form.module.scss";
 
 import React, { ReactElement } from "react";
-import { Button, Form as BootstrapForm } from "react-bootstrap";
+import { Alert, Button, Form as BootstrapForm } from "react-bootstrap";
 import { Formik, FormikHelpers, FormikValues } from "formik";
 import * as yup from "yup";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 
 export type OnSubmit<TValues = FormikValues> = (
   values: TValues,
@@ -60,7 +62,9 @@ const defaultRenderSubmit: RenderSubmit = ({ isSubmitting, isValid }) => (
 );
 
 const defaultRenderStatus: RenderStatus = ({ status }) => (
-  <div className={styles.status}>{status}</div>
+  <Alert variant="danger" className={styles.status}>
+    <FontAwesomeIcon icon={faExclamationTriangle} /> {status}
+  </Alert>
 );
 
 const Form: React.FC<FormProps> = ({

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -244,13 +244,18 @@ function useInitialFormState({
 
 function useFormSchema() {
   const newRecipeIds = useSelector(selectNewRecipeIds);
+  const { data: recipes } = useGetRecipesQuery();
+  const savedRecipeIds: RegistryId[] = (recipes ?? []).map(
+    (x) => x.metadata.id
+  );
+  const allRecipeIds = [...newRecipeIds, ...savedRecipeIds];
 
   // TODO: This should be yup.SchemaOf<RecipeMetadataFormState> but we can't set the `id` property to `RegistryId`
   // see: https://github.com/jquense/yup/issues/1183#issuecomment-749186432
   return object({
     id: string()
       .matches(PACKAGE_REGEX, "Invalid registry id")
-      .notOneOf(newRecipeIds, "This id is already in use")
+      .notOneOf(allRecipeIds, "This id is already in use")
       .required(),
     name: string().required(),
     version: string()


### PR DESCRIPTION
### Fixes #3268 


This updates the default layout for "status" in our `Form` component to a banner-style, error-alert layout across the top of the form.

### Further work
Right now we only use the "status" of the form for errors. It's possible to use it for any other sorts of "status" as well, and we might want to expand that at some point. The status handler accepts `any` as the type, so we could have our own status types that we pass in that are handled differently by default in the `Form` component, like a separate status for error or success, that show as red or green banners, for example.