### PR TITLE
Initial commit of PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## What does this PR do?
+
+- Closes/Fixes/Part of #123
+- _Are there other changes (e.g., refactoring) included that aren’t from the ticket?_
+
+## Reviewer Tips
+
+- _What order should the reviewer review the files in?_
+- _Are there any implementation approaches you want feedback on?_
+
+## Discussion
+
+- _Were there multiple approaches you were deciding between?_
+
+## Demo
+
+- _Paste a screenshot or demo video here_
+
+## Future Work
+
+- _Work for the issue/ticket that will be in a follow-up PR_
+
+## Team Coordination
+
+_Leave all that are relevant and check off as completed_
+
+- [ ] This PR requires security review
+- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
+- [ ] This PR requires a node/npm version update: let the team know on #engineering
+- [ ] This PR requires a documentation change (link to old docs)
+- [ ] This PR requires a tutorial update (link to old tutorials)
+- [ ] This PR requires a feature flag
+- [ ] This PR requires a environment variable change
+
+## Checklist
+
+- [ ] Add tests
+- [ ] Designate a primary reviewer


### PR DESCRIPTION
## What does this PR do?

- Adds a GitHub PR template
- It should show up automatically for new PRs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template

## Demo

![image](https://user-images.githubusercontent.com/1879821/166819250-ae598987-70ed-4724-a8fd-15d0b69fe229.png)


![image](https://user-images.githubusercontent.com/1879821/166819213-cc16a8a1-a477-4700-b29e-91877aecf7c5.png)

## Reviewer Tips

- I don't think the PR template shows up until we merge into main?

## Future Work

- Tweak the template based on our initial usage

