### PR TITLE
#3332: report user-defined extension errors to errors endpoint

### DIFF
--- a/src/auth/authTypes.ts
+++ b/src/auth/authTypes.ts
@@ -43,11 +43,11 @@ export type UserData = Partial<{
   /**
    * The user's primary organization.
    */
-  organizationId: string;
+  organizationId: UUID;
   /**
    * The user's organization for engagement and error attribution
    */
-  telemetryOrganizationId: string;
+  telemetryOrganizationId: UUID;
   /**
    * Feature flags
    */

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -79,7 +79,13 @@ interface LogDB extends DBSchema {
 
 type IndexKey = keyof Except<
   MessageContext,
-  "deploymentId" | "label" | "pageName"
+  | "deploymentId"
+  | "label"
+  | "pageName"
+  | "blueprintVersion"
+  | "blockVersion"
+  | "serviceVersion"
+  | "extensionLabel"
 >;
 const indexKeys: IndexKey[] = [
   "extensionId",

--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -26,23 +26,13 @@ import { allowsTrack } from "@/telemetry/dnt";
 import { ManualStorageKey, readStorage, setStorage } from "@/chrome";
 import {
   getErrorMessage,
-  getRootCause,
   hasBusinessRootCause,
   hasCancelRootCause,
   IGNORED_ERROR_PATTERNS,
-  isAxiosError,
   isContextError,
 } from "@/errors";
 import { expectContext, forbidContext } from "@/utils/expectContext";
-import { isAppRequest, selectAbsoluteUrl } from "@/services/requestErrorUtils";
-import { readAuthData } from "@/auth/token";
-import { UnknownObject } from "@/types";
-import { isObject, matchesAnyPattern } from "@/utils";
-import axios from "axios";
-import {
-  getLinkedApiClient,
-  maybeGetLinkedApiClient,
-} from "@/services/apiClient";
+import { matchesAnyPattern } from "@/utils";
 import {
   reportToErrorService,
   selectExtraContext,

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -16,7 +16,12 @@
  */
 
 import axios, { AxiosRequestConfig, AxiosResponse, Method } from "axios";
-import { IService, SanitizedServiceConfiguration, ServiceConfig } from "@/core";
+import {
+  IService,
+  MessageContext,
+  SanitizedServiceConfiguration,
+  ServiceConfig,
+} from "@/core";
 import { pixieServiceFactory } from "@/services/locator";
 import { ProxiedRemoteServiceError } from "@/services/errors";
 import serviceRegistry from "@/services/registry";
@@ -210,6 +215,24 @@ async function performConfiguredRequest(
   }
 }
 
+async function getServiceContext(
+  config: SanitizedServiceConfiguration
+): Promise<MessageContext> {
+  // Try resolving the service to get metadata to include with the error
+  let resolvedService: IService;
+  try {
+    resolvedService = await serviceRegistry.lookup(config.serviceId);
+  } catch {
+    // NOP
+  }
+
+  return {
+    serviceId: config.serviceId,
+    serviceVersion: resolvedService?.version,
+    authId: config.id,
+  };
+}
+
 /**
  * Perform a request either directly, or via the PixieBrix authentication proxy
  * @param serviceConfig the PixieBrix service configuration (used to locate the full configuration)
@@ -242,21 +265,9 @@ export async function proxyService<TData>(
       requestConfig
     )) as RemoteResponse<TData>;
   } catch (error) {
-    // Try resolving the service to get metadata to include with the error
-    let resolvedService: IService;
-    try {
-      resolvedService = await serviceRegistry.lookup(serviceConfig.serviceId);
-    } catch {
-      // NOP
-    }
-
     throw new ContextError("Error performing request", {
       cause: error,
-      context: {
-        serviceId: serviceConfig.serviceId,
-        serviceVersion: resolvedService?.version,
-        authId: serviceConfig.id,
-      },
+      context: await getServiceContext(serviceConfig),
     });
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -197,16 +197,27 @@ export type ContextName = keyof typeof contextNames | "unknown";
  */
 export type MessageContext = {
   /**
-   * A human-readable label, e.g., provided via a `label:` directive to help identify the context when there's multiple
-   * blocks with the same id being used.
+   * A human-readable label, e.g., provided via a `label:` directive to help identify the step context when there's
+   * multiple blocks with the same id being used.
+   *
+   * @see MessageContext.extensionLabel
    */
   readonly label?: string;
   readonly deploymentId?: UUID;
   readonly blueprintId?: RegistryId;
+  readonly blueprintVersion?: SemVerString;
   readonly extensionPointId?: RegistryId;
   readonly blockId?: RegistryId;
+  readonly blockVersion?: SemVerString;
   readonly extensionId?: UUID;
+  /**
+   * The human-readable label for the extension. Used to identify the extension when reporting telemetry from a
+   * blueprint. (Each extension install has a different UUID)
+   * @since 1.6.2
+   */
+  readonly extensionLabel?: string;
   readonly serviceId?: RegistryId;
+  readonly serviceVersion?: SemVerString;
   readonly authId?: UUID;
   readonly pageName?: ContextName;
 };
@@ -302,7 +313,7 @@ export type BlockIcon = string;
 export interface Metadata {
   readonly id: RegistryId;
   readonly name: string;
-  readonly version?: string;
+  readonly version?: SemVerString;
   readonly description?: string;
 
   /**
@@ -387,7 +398,7 @@ export type DeploymentContext = {
   timestamp: string;
 
   /**
-   * Whether or not the deployment is temporarily disabled.
+   * True iff the deployment is temporarily disabled.
    *
    * If undefined, is considered active for backward compatability
    *

--- a/src/core.ts
+++ b/src/core.ts
@@ -330,6 +330,7 @@ export interface Metadata {
    * PixieBrix extension version required to install the brick/run the extension
    * @since 1.4.0
    */
+  // FIXME: this type is wrong. In practice, the value should be a semantic version range, e.g., >=1.4.0
   readonly extensionVersion?: SemVerString;
 }
 

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -219,14 +219,20 @@ export function acquireElement(
   return onNodeRemoved(element, onRemove);
 }
 
+/**
+ * Returns the MessageContext associated with `extension`.
+ */
 export function selectExtensionContext(
   extension: ResolvedExtension
 ): MessageContext {
   return {
+    // The step label will be re-assigned later in reducePipeline
     label: extension.label,
+    extensionLabel: extension.label,
     extensionId: extension.id,
     extensionPointId: extension.extensionPointId,
     deploymentId: extension._deployment?.id,
     blueprintId: extension._recipe?.id,
+    blueprintVersion: extension._recipe?.version,
   };
 }

--- a/src/options/pages/blueprints/modals/ShareExtensionModal.tsx
+++ b/src/options/pages/blueprints/modals/ShareExtensionModal.tsx
@@ -29,7 +29,7 @@ import { FormikHelpers } from "formik";
 import { compact, isEmpty, pick, sortBy, uniq } from "lodash";
 import { RegistryId, UnresolvedExtension, UUID } from "@/core";
 import * as Yup from "yup";
-import { PACKAGE_REGEX } from "@/types/helpers";
+import { PACKAGE_REGEX, validateSemVerString } from "@/types/helpers";
 import { appApi, useGetOrganizationsQuery } from "@/services/api";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import slugify from "slugify";
@@ -91,7 +91,7 @@ async function convertAndShare(
     id: form.blueprintId,
     name: form.name,
     description: form.description,
-    version: "1.0.0",
+    version: validateSemVerString("1.0.0"),
   });
 
   const { data } = await client.post<PackageUpsertResponse>("api/bricks/", {

--- a/src/options/pages/blueprints/utils/exportBlueprint.ts
+++ b/src/options/pages/blueprints/utils/exportBlueprint.ts
@@ -33,6 +33,7 @@ import { isNullOrBlank } from "@/utils";
 import GenerateSchema from "generate-schema";
 import { isInnerExtensionPoint } from "@/registry/internal";
 import filenamify from "filenamify";
+import { validateSemVerString } from "@/types/helpers";
 
 /**
  * Infer optionsSchema from the options provided to the extension.
@@ -100,7 +101,7 @@ export function exportBlueprint(extension: UnresolvedExtension): void {
     id: "" as RegistryId,
     name: extension.label,
     description: "Blueprint exported from PixieBrix",
-    version: "1.0.0",
+    version: validateSemVerString("1.0.0"),
   });
 
   const blueprintYAML = objToYaml(blueprint);

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -41,7 +41,11 @@ import {
   SingleLayerReaderConfig,
 } from "@/pageEditor/extensionPoints/elementConfig";
 import { Except } from "type-fest";
-import { uuidv4, validateRegistryId } from "@/types/helpers";
+import {
+  uuidv4,
+  validateRegistryId,
+  validateSemVerString,
+} from "@/types/helpers";
 import {
   BlockPipeline,
   NormalizedAvailability,
@@ -330,7 +334,7 @@ export function baseSelectExtensionPoint(
       id: metadata.id,
       // The server requires the version to save the brick, even though it's not marked as required
       // in the front-end schemas
-      version: metadata.version ?? "1.0.0",
+      version: metadata.version ?? validateSemVerString("1.0.0"),
       name: metadata.name,
       // The server requires the description to save the brick, even though it's not marked as required
       // in the front-end schemas

--- a/src/pageEditor/panes/save/RecipeConfigurationModal.tsx
+++ b/src/pageEditor/panes/save/RecipeConfigurationModal.tsx
@@ -20,14 +20,14 @@ import { Button, Modal } from "react-bootstrap";
 import { PACKAGE_REGEX } from "@/types/helpers";
 import Form, { OnSubmit } from "@/components/form/Form";
 import * as yup from "yup";
-import { RegistryId } from "@/core";
+import { RegistryId, SemVerString } from "@/core";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import { RequireScope } from "@/auth/RequireScope";
 
 export type RecipeConfiguration = {
   id: RegistryId;
   name: string;
-  version?: string;
+  version?: SemVerString;
   description?: string;
 };
 

--- a/src/pageEditor/panes/save/SavingExtensionModal.test.tsx
+++ b/src/pageEditor/panes/save/SavingExtensionModal.test.tsx
@@ -26,6 +26,7 @@ import {
   recipeMetadataFactory,
 } from "@/testUtils/factories";
 import { FormState } from "@/pageEditor/pageEditorTypes";
+import { validateSemVerString } from "@/types/helpers";
 
 const simpleElementFactory = define<FormState>({
   apiVersion: "v2",
@@ -86,7 +87,7 @@ test("renders all buttons when Recipe is editable", () => {
 test("doesn't render recipe buttons when recipe is editable and not latest version", () => {
   const recipe = recipeFactory({
     metadata: installedRecipeMetadataFactory({
-      version: "2.0.0",
+      version: validateSemVerString("2.0.0"),
     }),
   });
   const element = simpleElementFactory();

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -22,7 +22,7 @@ import {
   isRecipeEditable,
   replaceRecipeExtension,
 } from "@/pageEditor/panes/save/saveHelpers";
-import { validateRegistryId } from "@/types/helpers";
+import { validateRegistryId, validateSemVerString } from "@/types/helpers";
 import {
   extensionPointDefinitionFactory,
   innerExtensionPointRecipeFactory,
@@ -190,7 +190,7 @@ describe("replaceRecipeExtension round trip", () => {
       metadata: {
         id: makeInternalId(recipe.definitions.extensionPoint),
         name: "Internal Extension Point",
-        version: "1.0.0",
+        version: validateSemVerString("1.0.0"),
       },
     });
 
@@ -240,7 +240,7 @@ describe("replaceRecipeExtension round trip", () => {
       metadata: {
         id: makeInternalId(recipe.definitions.extensionPoint),
         name: "Internal Extension Point",
-        version: "1.0.0",
+        version: validateSemVerString("1.0.0"),
       },
     });
 
@@ -300,7 +300,7 @@ describe("replaceRecipeExtension round trip", () => {
       metadata: {
         id: makeInternalId(recipe.definitions.extensionPoint),
         name: "Internal Extension Point",
-        version: "1.0.0",
+        version: validateSemVerString("1.0.0"),
       },
     });
 

--- a/src/pageEditor/panes/save/useSavingWizard.ts
+++ b/src/pageEditor/panes/save/useSavingWizard.ts
@@ -32,6 +32,7 @@ import {
   PersistedExtension,
   RecipeMetadata,
   RegistryId,
+  SemVerString,
 } from "@/core";
 import { UnsavedRecipeDefinition } from "@/types/definitions";
 import notify from "@/utils/notify";
@@ -54,7 +55,7 @@ const { actions: optionsActions } = extensionsSlice;
 export type RecipeConfiguration = {
   id: RegistryId;
   name: string;
-  version?: string;
+  version?: SemVerString;
   description?: string;
 };
 

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -262,7 +262,7 @@ function useFormSchema() {
       .test(
         "semver",
         "Version must follow the X.Y.Z semantic version format, without a leading 'v'",
-        (value: string) => testIsSemVerString(value, false)
+        (value: string) => testIsSemVerString(value, { allowLeadingV: false })
       )
       .required(),
     description: string(),

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -16,7 +16,12 @@
  */
 
 import React, { useCallback } from "react";
-import { PACKAGE_REGEX, uuidv4, validateSemVerString } from "@/types/helpers";
+import {
+  PACKAGE_REGEX,
+  uuidv4,
+  testIsSemVerString,
+  validateSemVerString,
+} from "@/types/helpers";
 import { useDispatch, useSelector } from "react-redux";
 import {
   selectActiveElement,
@@ -221,7 +226,7 @@ function useInitialFormState({
     return {
       id: generateScopeBrickId(scope, recipeMetadata.id),
       name: recipeMetadata.name,
-      version: "1.0.0",
+      version: validateSemVerString("1.0.0"),
       description: recipeMetadata.description,
     };
   }
@@ -231,7 +236,7 @@ function useInitialFormState({
     return {
       id: generateRecipeId(scope, activeElement.label) ?? ("" as RegistryId),
       name: activeElement.label,
-      version: "1.0.0",
+      version: validateSemVerString("1.0.0"),
       description: "Created with the PixieBrix Page Editor",
     };
   }
@@ -257,7 +262,7 @@ function useFormSchema() {
       .test(
         "semver",
         "Version must follow the X.Y.Z semantic version format, without a leading 'v'",
-        (value: string) => validateSemVerString(value, false)
+        (value: string) => testIsSemVerString(value, false)
       )
       .required(),
     description: string(),

--- a/src/pageEditor/tabs/editRecipeTab/EditRecipe.tsx
+++ b/src/pageEditor/tabs/editRecipeTab/EditRecipe.tsx
@@ -33,7 +33,7 @@ import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import styles from "./EditRecipe.module.scss";
 import { FieldDescriptions } from "@/utils/strings";
 import { object, string } from "yup";
-import { validateSemVerString } from "@/types/helpers";
+import { testIsSemVerString } from "@/types/helpers";
 import Form, { RenderBody } from "@/components/form/Form";
 
 const EditRecipe: React.VoidFunctionComponent = () => {
@@ -54,7 +54,7 @@ const EditRecipe: React.VoidFunctionComponent = () => {
       .test(
         "semver",
         "Version must follow the X.Y.Z semantic version format, without a leading 'v'",
-        (value: string) => validateSemVerString(value, false)
+        (value: string) => testIsSemVerString(value, false)
       )
       .required(),
     description: string(),

--- a/src/pageEditor/tabs/editRecipeTab/EditRecipe.tsx
+++ b/src/pageEditor/tabs/editRecipeTab/EditRecipe.tsx
@@ -54,7 +54,7 @@ const EditRecipe: React.VoidFunctionComponent = () => {
       .test(
         "semver",
         "Version must follow the X.Y.Z semantic version format, without a leading 'v'",
-        (value: string) => testIsSemVerString(value, false)
+        (value: string) => testIsSemVerString(value, { allowLeadingV: false })
       )
       .required(),
     description: string(),

--- a/src/runtime/pipelineTests/component.test.ts
+++ b/src/runtime/pipelineTests/component.test.ts
@@ -29,6 +29,7 @@ import {
 // them with `void` instead of awaiting them in the reducePipeline methods
 import * as logging from "@/background/messenger/api";
 import { fromJS } from "@/blocks/transformers/blockFactory";
+import { validateSemVerString } from "@/types/helpers";
 
 (logging.getLoggingConfig as any) = jest.fn().mockResolvedValue({
   logValues: true,
@@ -45,7 +46,7 @@ const componentBlock = fromJS({
   metadata: {
     id: "test/component",
     name: "Component Block",
-    version: "1.0.0",
+    version: validateSemVerString("1.0.0"),
     description: "Component block using v1 runtime",
   },
   inputSchema: {

--- a/src/services/errorService.ts
+++ b/src/services/errorService.ts
@@ -16,7 +16,7 @@
  */
 
 import { JsonObject } from "type-fest";
-import { debounce, omit } from "lodash";
+import { debounce } from "lodash";
 import { maybeGetLinkedApiClient } from "@/services/apiClient";
 import { MessageContext, SerializedError } from "@/core";
 import {
@@ -111,6 +111,8 @@ export async function reportToErrorService(
     return;
   }
 
+  const { extensionVersion, ...data } = await selectExtraContext(error);
+
   buffer.push({
     uuid: uuidv4(),
     error_name: error.name,
@@ -123,7 +125,7 @@ export async function reportToErrorService(
     extension_label: flatContext.label,
     step_label: flatContext.label,
     user_agent: window.navigator.userAgent,
-    user_agent_extension_version: browser.runtime.getManifest().version,
+    user_agent_extension_version: extensionVersion,
     is_application_error: !hasBusinessRootCause(error),
     blueprint_id: flatContext.blueprintId,
     // FIXME: track blueprint version in the MessageContext
@@ -131,7 +133,7 @@ export async function reportToErrorService(
     brick_id: flatContext.blockId ?? flatContext.serviceId,
     brick_version: null,
     // Already capturing extension version in user_agent_extension_version
-    error_data: omit(await selectExtraContext(error), ["extensionVersion"]),
+    error_data: data,
   });
 
   await debouncedFlush();

--- a/src/services/errorService.ts
+++ b/src/services/errorService.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { JsonObject } from "type-fest";
+import { debounce, omit } from "lodash";
+import { maybeGetLinkedApiClient } from "@/services/apiClient";
+import { MessageContext, SerializedError } from "@/core";
+import {
+  getRootCause,
+  hasBusinessRootCause,
+  hasCancelRootCause,
+  isAxiosError,
+} from "@/errors";
+import { allowsTrack } from "@/telemetry/dnt";
+import { uuidv4 } from "@/types/helpers";
+import { isObject } from "@/utils";
+import { readAuthData } from "@/auth/token";
+import { isAppRequest, selectAbsoluteUrl } from "@/services/requestErrorUtils";
+
+const EVENT_BUFFER_DEBOUNCE_MS = 2000;
+const EVENT_BUFFER_MAX_MS = 10_000;
+
+// FIXME: this type should be pulled from Swagger
+const buffer: JsonObject[] = [];
+
+const debouncedFlush = debounce(flush, EVENT_BUFFER_DEBOUNCE_MS, {
+  trailing: true,
+  leading: false,
+  maxWait: EVENT_BUFFER_MAX_MS,
+});
+
+async function flush(): Promise<void> {
+  if (buffer.length > 0) {
+    const client = await maybeGetLinkedApiClient();
+    if (client) {
+      const events = buffer.splice(0, buffer.length);
+      await client.post("/api/errors/", { events });
+    }
+  }
+}
+
+/**
+ * Select extra error context for:
+ * - Extension version, so we don't have to maintain a separate mapping of commit SHAs to versions for reporting
+ * - Requests to PixieBrix API to detect network problems client side
+ * - Any service request if enterprise has enabled `enterprise-telemetry`
+ */
+export async function selectExtraContext(
+  error: Error | SerializedError
+): Promise<JsonObject> {
+  const { version: extensionVersion } = browser.runtime.getManifest();
+
+  if (!isObject(error)) {
+    return { extensionVersion };
+  }
+
+  const cause = getRootCause(error);
+
+  // Handle base classes of ClientRequestError
+  if ("error" in cause && isAxiosError(cause.error)) {
+    const { flags = [] } = await readAuthData();
+    if (
+      (await isAppRequest(cause.error)) ||
+      flags.includes("enterprise-telemetry")
+    ) {
+      return {
+        extensionVersion,
+        url: selectAbsoluteUrl(cause.error.config),
+      };
+    }
+  }
+
+  return { extensionVersion };
+}
+
+/**
+ * Report to the PixieBrix error telemetry service/
+ * @see reportToRollbar
+ */
+export async function reportToErrorService(
+  error: Error,
+  flatContext: MessageContext,
+  message: string
+): Promise<void> {
+  if (flatContext.extensionId == null) {
+    // Only report errors that occurred within a user-defined extension/blueprint. Other errors only got to Rollbar
+    // because they're problems with our software.
+    return;
+  }
+
+  if (hasCancelRootCause(error)) {
+    return;
+  }
+
+  if (!(await allowsTrack())) {
+    // We warn that tracking is disabled in the analogous call to report to Rollbar
+    return;
+  }
+
+  buffer.push({
+    uuid: uuidv4(),
+    error_name: error.name,
+    message,
+    // FIXME: this is redundant. The backend should take a single id which it attempts to match to a UserExtension
+    //  instance? Or we can just index the field on the backend but not enforce the FK constraint
+    user_extension: flatContext.extensionId,
+    extension_uuid: flatContext.extensionId,
+    // FIXME: we need to track step/extension label separately in MessageContext
+    extension_label: flatContext.label,
+    step_label: flatContext.label,
+    user_agent: window.navigator.userAgent,
+    user_agent_extension_version: browser.runtime.getManifest().version,
+    is_application_error: !hasBusinessRootCause(error),
+    blueprint_id: flatContext.blueprintId,
+    // FIXME: track blueprint version in the MessageContext
+    blueprint_version: null,
+    brick_id: flatContext.blockId ?? flatContext.serviceId,
+    brick_version: null,
+    // Already capturing extension version in user_agent_extension_version
+    error_data: omit(await selectExtraContext(error), ["extensionVersion"]),
+  });
+
+  await debouncedFlush();
+}

--- a/src/services/errorService.ts
+++ b/src/services/errorService.ts
@@ -107,7 +107,7 @@ export async function reportToErrorService(
   }
 
   if (!(await allowsTrack())) {
-    // We warn that tracking is disabled in the analogous call to report to Rollbar
+    // We warn that tracking is disabled in the analogous call to report to Rollbar. See reportToRollbar
     return;
   }
 
@@ -121,17 +121,17 @@ export async function reportToErrorService(
     //  instance? Or we can just index the field on the backend but not enforce the FK constraint
     user_extension: flatContext.extensionId,
     extension_uuid: flatContext.extensionId,
-    // FIXME: we need to track step/extension label separately in MessageContext
-    extension_label: flatContext.label,
+    extension_label: flatContext.extensionLabel,
     step_label: flatContext.label,
     user_agent: window.navigator.userAgent,
     user_agent_extension_version: extensionVersion,
     is_application_error: !hasBusinessRootCause(error),
     blueprint_id: flatContext.blueprintId,
-    // FIXME: track blueprint version in the MessageContext
-    blueprint_version: null,
-    brick_id: flatContext.blockId ?? flatContext.serviceId,
-    brick_version: null,
+    blueprint_version: flatContext.blueprintVersion,
+    // FIXME: if/when do we want to use service here instead of brick? We probably want to expose entries for both
+    //  because a brick might be broken only for particular versions of the service.
+    brick_id: flatContext.blockId,
+    brick_version: flatContext.blockVersion,
     // Already capturing extension version in user_agent_extension_version
     error_data: data,
   });

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -36,6 +36,7 @@ import {
 import { TraceError, TraceRecord } from "@/telemetry/trace";
 import {
   validateRegistryId,
+  validateSemVerString,
   validateTimestamp,
   validateUUID,
 } from "@/types/helpers";
@@ -79,7 +80,7 @@ export const recipeMetadataFactory = define<Metadata>({
   id: (n: number) => validateRegistryId(`test/recipe-${n}`),
   name: (n: number) => `Recipe ${n}`,
   description: "Recipe generated from factory",
-  version: "1.0.0",
+  version: validateSemVerString("1.0.0"),
 });
 
 export const sharingDefinitionFactory = define<SharingDefinition>({
@@ -91,7 +92,7 @@ export const installedRecipeMetadataFactory = define<RecipeMetadata>({
   id: (n: number) => validateRegistryId(`test/recipe-${n}`),
   name: (n: number) => `Recipe ${n}`,
   description: "Recipe generated from factory",
-  version: "1.0.0",
+  version: validateSemVerString("1.0.0"),
   updated_at: validateTimestamp("2021-10-07T12:52:16.189Z"),
   sharing: sharingDefinitionFactory,
 });
@@ -282,7 +283,7 @@ export const versionedExtensionPointRecipeFactory = ({
       id: validateRegistryId(`test/recipe-${n}`),
       name: `Recipe ${n}`,
       description: "Recipe generated from factory",
-      version: "1.0.0",
+      version: validateSemVerString("1.0.0"),
     }),
     sharing: sharingDefinitionFactory,
     updated_at: validateTimestamp("2021-10-07T12:52:16.189Z"),
@@ -336,7 +337,7 @@ export const versionedRecipeWithResolvedExtensions = (extensionCount = 1) => {
       id: validateRegistryId(`test/recipe-${n}`),
       name: `Recipe ${n}`,
       description: "Recipe generated from factory",
-      version: "1.0.0",
+      version: validateSemVerString("1.0.0"),
     }),
     sharing: sharingDefinitionFactory,
     updated_at: validateTimestamp("2021-10-07T12:52:16.189Z"),

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -42,8 +42,6 @@ import { AxiosResponse } from "axios";
 
 export type Kind = "block" | "foundation" | "service" | "blueprint" | "reader";
 
-export type Invitation = components["schemas"]["Invitation"];
-
 type MeGroup = components["schemas"]["Me"]["group_memberships"][number] & {
   id: UUID;
 };
@@ -215,14 +213,13 @@ export type RemoteResponse<T = unknown> = Pick<
   $$proxied?: boolean;
 };
 
-// Exclude fields assigned by the server. (And in the future might not be included on the response)
-export type ErrorItem = Required<
-  Except<
-    components["schemas"]["ErrorItem"],
-    "id" | "user" | "user_extension"
-  > & {
-    deployment: UUID | null;
-    organization: UUID | null;
-    user_agent_extension_version: SemVerString;
-  }
->;
+// Exclude fields assigned by the server. (And in the future might not be included on the response).
+// Can't use Required. For blueprint_version, etc. the backend expects the property to be excluded or to have a value
+export type ErrorItem = Except<
+  components["schemas"]["ErrorItem"],
+  "id" | "user" | "user_extension"
+> & {
+  deployment: UUID | null;
+  organization: UUID | null;
+  user_agent_extension_version: SemVerString;
+};

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -32,6 +32,7 @@ import {
   PersistedExtension,
   Timestamp,
   RegistryId,
+  SemVerString,
 } from "@/core";
 
 import { components } from "@/types/swagger";
@@ -47,27 +48,32 @@ type MeGroup = components["schemas"]["Me"]["group_memberships"][number] & {
   id: UUID;
 };
 
-type MeOrganization =
+type MeMembershipOrganization =
   components["schemas"]["Me"]["organization_memberships"][number] & {
     organization: UUID;
   };
+
+type MeOrganization = Required<components["schemas"]["Me"]["organization"]> & {
+  id: UUID;
+};
 
 export type Me = Except<
   components["schemas"]["Me"],
   | "flags"
   | "is_onboarded"
   | "organization"
+  | "telemetry_organization"
   | "organization_memberships"
   | "group_memberships"
 > & {
   // Serializer method fields
   flags: string[];
   is_onboarded: boolean;
-  // Swagger type lists id as optional
-  organization: Required<components["schemas"]["Me"]["organization"]> | null;
 
   // Fix UUID types
-  organization_memberships: MeOrganization[];
+  organization: MeOrganization | null;
+  telemetry_organization: MeOrganization | null;
+  organization_memberships: MeMembershipOrganization[];
   group_memberships: MeGroup[];
 };
 
@@ -208,3 +214,15 @@ export type RemoteResponse<T = unknown> = Pick<
 > & {
   $$proxied?: boolean;
 };
+
+// Exclude fields assigned by the server. (And in the future might not be included on the response)
+export type ErrorItem = Required<
+  Except<
+    components["schemas"]["ErrorItem"],
+    "id" | "user" | "user_extension"
+  > & {
+    deployment: UUID | null;
+    organization: UUID | null;
+    user_agent_extension_version: SemVerString;
+  }
+>;

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -102,7 +102,7 @@ export function validateSemVerString(
     return value as SemVerString;
   }
 
-  if (testIsSemVerString(value, allowLeadingV)) {
+  if (testIsSemVerString(value, { allowLeadingV })) {
     return value;
   }
 
@@ -113,8 +113,9 @@ export function validateSemVerString(
 
 export function testIsSemVerString(
   value: string,
-  allowLeadingV = true
-  // FIXME: the SemVerString type doesn't support a leading v. See documentation
+  // FIXME: the SemVerString type wasn't intended to support a leading `v`. See documentation
+  // Default to `false` to be stricter.
+  { allowLeadingV = false }: { allowLeadingV?: boolean } = {}
 ): value is SemVerString {
   if (semVerValid(value) != null) {
     return allowLeadingV || !startsWith(value, "v");

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -93,7 +93,28 @@ export function validateTimestamp(value: string): Timestamp {
 
 export function validateSemVerString(
   value: string,
+  // Default to `false` to be stricter.
+  { allowLeadingV = false }: { allowLeadingV?: boolean } = {}
+): SemVerString {
+  if (value == null) {
+    // We don't have strictNullChecks on, so null values will find there way here. We should pass them along. Eventually
+    // we can remove this check as strictNullChecks will check the call site
+    return value as SemVerString;
+  }
+
+  if (testIsSemVerString(value, allowLeadingV)) {
+    return value;
+  }
+
+  console.debug("Invalid semver %s", value);
+
+  throw new TypeError("Invalid semantic version");
+}
+
+export function testIsSemVerString(
+  value: string,
   allowLeadingV = true
+  // FIXME: the SemVerString type doesn't support a leading v. See documentation
 ): value is SemVerString {
   if (semVerValid(value) != null) {
     return allowLeadingV || !startsWith(value, "v");

--- a/src/utils/deployment.test.ts
+++ b/src/utils/deployment.test.ts
@@ -21,7 +21,7 @@ import {
   makeUpdatedFilter,
 } from "./deployment";
 import { deploymentFactory, extensionFactory } from "@/testUtils/factories";
-import { validateTimestamp } from "@/types/helpers";
+import { validateSemVerString, validateTimestamp } from "@/types/helpers";
 
 describe("makeUpdatedFilter", () => {
   test.each([[{ restricted: true }, { restricted: false }]])(
@@ -102,7 +102,7 @@ describe("makeUpdatedFilter", () => {
         _recipe: {
           ...deployment.package.config.metadata,
           // The factory produces version "1.0.1"
-          version: "1.0.1",
+          version: validateSemVerString("1.0.1"),
           updated_at: validateTimestamp(deployment.updated_at),
           // `sharing` doesn't impact the predicate. Pass an arbitrary value
           sharing: undefined,

--- a/src/utils/objToYaml.test.ts
+++ b/src/utils/objToYaml.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { brickToYaml } from "./objToYaml";
+import { validateSemVerString } from "@/types/helpers";
 
 describe("brickToYaml", () => {
   test("serializes arbitrary object", () => {
@@ -39,7 +40,7 @@ lorem: ipsum
       metadata: {
         id: "google/api",
         name: "Google API",
-        version: "1.0.0",
+        version: validateSemVerString("1.0.0"),
         description: "Generic Google API authentication via API key",
       },
       apiVersion: "v1",
@@ -103,7 +104,7 @@ outputSchema:
       metadata: {
         id: "google/api",
         name: "Google API",
-        version: "1.0.0",
+        version: validateSemVerString("1.0.0"),
         description: "Generic Google API authentication via API key",
       },
       apiVersion: "v1",


### PR DESCRIPTION
## What does this PR do?
- Closes #3332 
- Reports user-defined extension errors to PixieBrix error telemetry endpoint introduced here: https://github.com/pixiebrix/pixiebrix-app/pull/1615/

## Remaining Work
- [x] Copy the Swagger schema from the endpoint and use to ensure the types match
- [x] Flow the blueprint/brick version through the message context so PixieBrix can report to the endpoint
- [x] Flow the extension vs. step label through the message context so PixieBrix can report to the endpoint
- [x] Rationalize use of user_extension, extension_uuid parameters
- [x] Clean up nominal type errors for hard-coded semver constants
- [x] Ensure step label flowing through properly (for some reason extension label is flowing through for step label)
- [ ] Add test cases