### PR TITLE
#3326 Fix dupe sidebar panels with blueprint actions

### DIFF
--- a/src/pageEditor/hooks/useRemoveExtension.ts
+++ b/src/pageEditor/hooks/useRemoveExtension.ts
@@ -24,7 +24,7 @@ import { reportEvent } from "@/telemetry/events";
 import notify from "@/utils/notify";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 import extensionsSlice from "@/store/extensionsSlice";
-import { uninstallContextMenu } from "@/background/messenger/api";
+import { traces, uninstallContextMenu } from "@/background/messenger/api";
 import {
   clearDynamicElements,
   removeSidebar,
@@ -72,6 +72,7 @@ function useRemoveExtension(): (useRemoveConfig: Config) => Promise<void> {
         await Promise.allSettled([
           uninstallContextMenu({ extensionId }),
           removeSidebar(thisTab, extensionId),
+          traces.clear(extensionId),
         ]);
 
         // Remove from page editor

--- a/src/pageEditor/hooks/useRemoveRecipe.ts
+++ b/src/pageEditor/hooks/useRemoveRecipe.ts
@@ -26,7 +26,12 @@ import { useModals } from "@/components/ConfirmationModal";
 import { actions } from "@/pageEditor/slices/editorSlice";
 import { getIdForElement, getRecipeIdForElement } from "@/pageEditor/utils";
 
-function useRemoveRecipe(): (recipeId: RegistryId) => Promise<void> {
+type Config = {
+  recipeId: RegistryId;
+  shouldShowConfirmation?: boolean;
+};
+
+function useRemoveRecipe(): (useRemoveConfig: Config) => Promise<void> {
   const dispatch = useDispatch();
   const removeExtension = useRemoveExtension();
   const extensions = useSelector(selectExtensions);
@@ -34,16 +39,18 @@ function useRemoveRecipe(): (recipeId: RegistryId) => Promise<void> {
   const { showConfirmation } = useModals();
 
   return useCallback(
-    async (recipeId: RegistryId) => {
-      const confirmed = await showConfirmation({
-        title: "Remove Blueprint?",
-        message:
-          "You can reactivate extensions and blueprints from the PixieBrix Options page",
-        submitCaption: "Remove",
-      });
+    async ({ recipeId, shouldShowConfirmation }) => {
+      if (shouldShowConfirmation) {
+        const confirmed = await showConfirmation({
+          title: "Remove Blueprint?",
+          message:
+            "You can reactivate extensions and blueprints from the PixieBrix Options page",
+          submitCaption: "Remove",
+        });
 
-      if (!confirmed) {
-        return;
+        if (!confirmed) {
+          return;
+        }
       }
 
       const extensionIds = uniq(

--- a/src/pageEditor/hooks/useRemoveRecipe.ts
+++ b/src/pageEditor/hooks/useRemoveRecipe.ts
@@ -39,7 +39,7 @@ function useRemoveRecipe(): (useRemoveConfig: Config) => Promise<void> {
   const { showConfirmation } = useModals();
 
   return useCallback(
-    async ({ recipeId, shouldShowConfirmation }) => {
+    async ({ recipeId, shouldShowConfirmation = true }) => {
       if (shouldShowConfirmation) {
         const confirmed = await showConfirmation({
           title: "Remove Blueprint?",

--- a/src/pageEditor/panes/RecipePane.tsx
+++ b/src/pageEditor/panes/RecipePane.tsx
@@ -124,7 +124,7 @@ const RecipePane: React.VFC = () => {
       // Remove
       variant: "danger",
       onClick() {
-        void removeRecipe(activeRecipeId);
+        void removeRecipe({ recipeId: activeRecipeId });
         forceRefreshLayout();
       },
       caption: "Remove",

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -59,6 +59,7 @@ import { FormState } from "@/pageEditor/pageEditorTypes";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import { inferRecipeAuths, inferRecipeOptions } from "@/store/extensionsUtils";
 import { RegistryId } from "@/core";
+import useRemoveExtension from "@/pageEditor/hooks/useRemoveExtension";
 
 const { actions: optionsActions } = extensionsSlice;
 
@@ -66,6 +67,7 @@ function useSaveCallbacks({ activeElement }: { activeElement: FormState }) {
   const dispatch = useDispatch();
   const [createRecipe] = useCreateRecipeMutation();
   const createExtension = useCreate();
+  const removeExtension = useRemoveExtension();
 
   const editorFormElements = useSelector(selectElements);
   const isDirtyByElementId = useSelector(selectDirty);
@@ -96,13 +98,20 @@ function useSaveCallbacks({ activeElement }: { activeElement: FormState }) {
       // Don't push to cloud since we're saving it with the recipe
       await createExtension({ element: recipeElement, pushToCloud: false });
       if (!keepLocalCopy) {
-        dispatch(editorActions.removeElement(activeElement.uuid));
-        dispatch(
-          optionsActions.removeExtension({ extensionId: activeElement.uuid })
-        );
+        await removeExtension({
+          extensionId: activeElement.uuid,
+          shouldShowConfirmation: false,
+        });
       }
     },
-    [activeElement, createExtension, createRecipe, dispatch, keepLocalCopy]
+    [
+      activeElement,
+      createExtension,
+      createRecipe,
+      dispatch,
+      keepLocalCopy,
+      removeExtension,
+    ]
   );
 
   const createRecipeFromRecipe = useCallback(

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -60,6 +60,7 @@ import { selectExtensions } from "@/store/extensionsSelectors";
 import { inferRecipeAuths, inferRecipeOptions } from "@/store/extensionsUtils";
 import { RegistryId } from "@/core";
 import useRemoveExtension from "@/pageEditor/hooks/useRemoveExtension";
+import useRemoveRecipe from "@/pageEditor/hooks/useRemoveRecipe";
 
 const { actions: optionsActions } = extensionsSlice;
 
@@ -68,6 +69,7 @@ function useSaveCallbacks({ activeElement }: { activeElement: FormState }) {
   const [createRecipe] = useCreateRecipeMutation();
   const createExtension = useCreate();
   const removeExtension = useRemoveExtension();
+  const removeRecipe = useRemoveRecipe();
 
   const editorFormElements = useSelector(selectElements);
   const isDirtyByElementId = useSelector(selectDirty);
@@ -165,7 +167,7 @@ function useSaveCallbacks({ activeElement }: { activeElement: FormState }) {
 
       // Replace the old recipe with the new recipe locally. The logic here is similar to what's in useReinstall.ts
 
-      dispatch(optionsActions.removeRecipeById(recipeId));
+      await removeRecipe({ recipeId, shouldShowConfirmation: false });
 
       dispatch(
         optionsActions.installRecipe({
@@ -281,11 +283,11 @@ const CreateRecipeModal: React.VFC = () => {
   // `selectActiveRecipeId` returns the recipe id _if the recipe element is selected_. Assumption: if the CreateModal
   // is open an extension element is active, then we're performing a "Save a New" on that recipe.
   const directlyActiveRecipeId = useSelector(selectActiveRecipeId);
-  const activeRecipeId = directlyActiveRecipeId ?? activeElement.recipe?.id;
+  const activeRecipeId = directlyActiveRecipeId ?? activeElement?.recipe?.id;
 
   const { data: recipes, isLoading: isRecipesLoading } = useGetRecipesQuery();
   const activeRecipe = recipes?.find(
-    (recipe) => recipe.metadata.id === activeRecipeId
+    (recipe) => activeRecipeId && recipe.metadata.id === activeRecipeId
   );
 
   const formSchema = useFormSchema();

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -291,9 +291,9 @@ const CreateRecipeModal: React.VFC = () => {
   const activeRecipeId = directlyActiveRecipeId ?? activeElement?.recipe?.id;
 
   const { data: recipes, isLoading: isRecipesLoading } = useGetRecipesQuery();
-  const activeRecipe = recipes?.find(
-    (recipe) => activeRecipeId && recipe.metadata.id === activeRecipeId
-  );
+  const activeRecipe = activeRecipeId
+    ? recipes?.find((recipe) => recipe.metadata.id === activeRecipeId)
+    : undefined;
 
   const formSchema = useFormSchema();
 

--- a/src/pageEditor/toolbar/ActionToolbar.tsx
+++ b/src/pageEditor/toolbar/ActionToolbar.tsx
@@ -37,7 +37,7 @@ const ActionToolbar: React.FunctionComponent<{
 
   const removeElement = async () => {
     if (element.recipe) {
-      await removeRecipe(element.recipe.id);
+      await removeRecipe({ recipeId: element.recipe.id });
     } else {
       await removeExtension({ extensionId: element.uuid });
     }

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -41,7 +41,6 @@ import {
 } from "@/store/extensionsTypes";
 import { Except } from "type-fest";
 import { assertExtensionNotResolved } from "@/runtime/runtimeUtils";
-import { uninstallNativeExtension } from "@/store/extensionsUtils";
 
 const initialExtensionsState: ExtensionOptionsState = {
   extensions: [],
@@ -314,17 +313,12 @@ const extensionsSlice = createSlice({
     removeRecipeById(state, { payload: recipeId }: PayloadAction<RegistryId>) {
       requireLatestState(state);
 
-      const [recipeExtension, extensions] = partition(
+      const [, extensions] = partition(
         state.extensions,
         (x) => x._recipe?.id === recipeId
       );
 
       state.extensions = extensions;
-
-      // XXX: this should be in an action creator, not the reducer
-      void Promise.all(
-        recipeExtension.map(async ({ id }) => uninstallNativeExtension(id))
-      );
     },
 
     removeExtension(
@@ -335,9 +329,6 @@ const extensionsSlice = createSlice({
 
       // NOTE: We aren't deleting the extension on the server. The user must do that separately from the dashboard
       state.extensions = state.extensions.filter((x) => x.id !== extensionId);
-
-      // XXX: this should be in an action creator, not the reducer
-      void uninstallNativeExtension(extensionId);
     },
   },
 });

--- a/src/store/extensionsUtils.ts
+++ b/src/store/extensionsUtils.ts
@@ -17,7 +17,6 @@
 
 import { IExtension, RegistryId, UserOptions, UUID } from "@/core";
 import { compact, groupBy, uniq } from "lodash";
-import { traces, uninstallContextMenu } from "@/background/messenger/api";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 
 /**
@@ -66,15 +65,4 @@ export function inferRecipeAuths(
   }
 
   return result;
-}
-
-/**
- * Cleanup native extension data/registrations
- */
-// XXX: where does this method belong?
-export async function uninstallNativeExtension(
-  extensionId: UUID
-): Promise<void> {
-  await uninstallContextMenu({ extensionId });
-  await traces.clear(extensionId);
 }


### PR DESCRIPTION
## What does this PR do?

- Fixes #3326 
- `removeRecipe()` now takes a config input similar to `removeExtension()` with a flag to bypass the confirmation modal

## Demo

[Panel is no longer duplicated after adding the extension to a blueprint](https://www.loom.com/share/79cb06cfff084d85ad7130fcd8c04ed6)

## Future Work

- other bug discovered: https://github.com/pixiebrix/pixiebrix-extension/issues/3337

