### PR TITLE
#3275: don't submit activation wizard form on enter key

### DIFF
--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -114,11 +114,17 @@ const ActivateWizard: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
         <Form
           id="activate-wizard"
           noValidate
-          onKeyDown={(event) => {
-            // Don't submit form on "enter" key. Only submit on using "activate"
-            event.preventDefault();
-          }}
           onSubmit={handleSubmit}
+          onKeyDown={(event) => {
+            if (
+              event.key === "Enter" &&
+              (event.nativeEvent.target as HTMLElement).tagName !== "TEXTAREA"
+            ) {
+              // Don't submit form on "enter" key. Only submit on using "Activate" button
+              event.preventDefault();
+              return false;
+            }
+          }}
         >
           <Tab.Container activeKey={stepKey}>
             <Nav

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -111,7 +111,15 @@ const ActivateWizard: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
   return (
     <Formik initialValues={initialValues} onSubmit={install}>
       {({ handleSubmit }) => (
-        <Form id="activate-wizard" noValidate onSubmit={handleSubmit}>
+        <Form
+          id="activate-wizard"
+          noValidate
+          onKeyDown={(event) => {
+            // Don't submit form on "enter" key. Only submit on using "activate"
+            event.preventDefault();
+          }}
+          onSubmit={handleSubmit}
+        >
           <Tab.Container activeKey={stepKey}>
             <Nav
               variant="pills"


### PR DESCRIPTION
## What does this PR do?

- Closes: #3275
- Ignores "enter" key press in activation wizard

Future Work
- This PR prevents you from using the "Enter" key to select an item from a dropdown