### PR TITLE
#3344: skip personalize on empty options schema

### DIFF
--- a/src/options/pages/marketplace/useWizard.test.tsx
+++ b/src/options/pages/marketplace/useWizard.test.tsx
@@ -65,6 +65,25 @@ jest.mock("connected-react-router");
 // });
 
 describe("useWizard", () => {
+  test("show personalized tab", () => {
+    const spy = jest.spyOn(redux, "useSelector");
+    spy.mockReturnValue([]);
+
+    const { result } = renderHook(() =>
+      useWizard(
+        recipeDefinitionFactory({
+          // Page Editor produces normalized form
+          options: {
+            schema: { properties: { foo: { type: "string" } } },
+          } as OptionsDefinition,
+        })
+      )
+    );
+
+    const [steps] = result.current;
+    expect(steps).toHaveLength(3);
+  });
+
   test("hide personalized tab for empty schema", () => {
     const spy = jest.spyOn(redux, "useSelector");
     spy.mockReturnValue([]);

--- a/src/options/pages/marketplace/useWizard.test.tsx
+++ b/src/options/pages/marketplace/useWizard.test.tsx
@@ -18,11 +18,17 @@
 // import useWizard from "@/options/pages/marketplace/useWizard";
 // import * as redux from "react-redux";
 
-jest.mock("@/options/store");
-jest.mock("@/options/pages/marketplace/AuthWidget");
+import React from "react";
+import * as redux from "react-redux";
+import { recipeDefinitionFactory } from "@/testUtils/factories";
+import useWizard from "@/options/pages/marketplace/useWizard";
+import { OptionsDefinition } from "@/types/definitions";
+import { renderHook } from "@testing-library/react-hooks";
+
+jest.mock("@/options/pages/marketplace/AuthWidget", () => {});
 jest.mock("react-redux");
 jest.mock("connected-react-router");
-//
+
 // describe("useWizard reinstall", () => {
 //   test("prefills existing options", () => {
 //     const blueprint = versionedExtensionPointRecipeFactory()({
@@ -58,6 +64,38 @@ jest.mock("connected-react-router");
 //   });
 // });
 
-test("dummy test", () => {
-  // NOP: dummy test so that Jest doesn't complain about a test module without any tests
+describe("useWizard", () => {
+  test("hide personalized tab for empty schema", () => {
+    const spy = jest.spyOn(redux, "useSelector");
+    spy.mockReturnValue([]);
+
+    const { result } = renderHook(() =>
+      useWizard(
+        recipeDefinitionFactory({
+          // Page Editor produces normalized form
+          options: { schema: { properties: {} } } as OptionsDefinition,
+        })
+      )
+    );
+
+    const [steps] = result.current;
+    expect(steps).toHaveLength(2);
+  });
+
+  test("hide personalized tab for empty shorthand schema", () => {
+    const spy = jest.spyOn(redux, "useSelector");
+    spy.mockReturnValue([]);
+
+    const { result } = renderHook(() =>
+      useWizard(
+        recipeDefinitionFactory({
+          // Shorthand manually written
+          options: { schema: {} } as OptionsDefinition,
+        })
+      )
+    );
+
+    const [steps] = result.current;
+    expect(steps).toHaveLength(2);
+  });
 });

--- a/src/options/pages/marketplace/useWizard.test.tsx
+++ b/src/options/pages/marketplace/useWizard.test.tsx
@@ -14,11 +14,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-// import {extensionFactory, versionedExtensionPointRecipeFactory} from "@/tests/factories";
-// import useWizard from "@/options/pages/marketplace/useWizard";
-// import * as redux from "react-redux";
-
-import React from "react";
 import * as redux from "react-redux";
 import { recipeDefinitionFactory } from "@/testUtils/factories";
 import useWizard from "@/options/pages/marketplace/useWizard";
@@ -28,41 +23,6 @@ import { renderHook } from "@testing-library/react-hooks";
 jest.mock("@/options/pages/marketplace/AuthWidget", () => {});
 jest.mock("react-redux");
 jest.mock("connected-react-router");
-
-// describe("useWizard reinstall", () => {
-//   test("prefills existing options", () => {
-//     const blueprint = versionedExtensionPointRecipeFactory()({
-//       options: {
-//         schema: {
-//           properties: {
-//             textField: {
-//               type: "string",
-//             },
-//             newField: {
-//               type: "string",
-//               default: "new field default",
-//             }
-//           }
-//         },
-//       }
-//     });
-//
-//     (redux.useSelector as any).mockReturnValue([
-//       extensionFactory({
-//         optionsArgs: {
-//           textField: "hello, world!",
-//         }
-//       }),
-//     ])
-//
-//     const [, initialValues] = useWizard(blueprint);
-//
-//     expect(initialValues.optionsArgs).toStrictEqual({
-//       textField: "hello, world!",
-//       newField: "new field default",
-//     });
-//   });
-// });
 
 describe("useWizard", () => {
   test("show personalized tab", () => {

--- a/src/options/pages/marketplace/useWizard.ts
+++ b/src/options/pages/marketplace/useWizard.ts
@@ -18,6 +18,7 @@ import ConfigureBody from "@/options/pages/marketplace/ConfigureBody";
 import OptionsBody from "@/options/pages/marketplace/OptionsBody";
 import ServicesBody from "@/options/pages/marketplace/ServicesBody";
 import ActivateBody from "@/options/pages/marketplace/ActivateBody";
+import { inputProperties } from "@/helpers";
 
 const STEPS: WizardStep[] = [
   { key: "review", label: "Select Bricks", Component: ConfigureBody },
@@ -62,7 +63,7 @@ function useWizard(blueprint: RecipeDefinition): [WizardStep[], WizardValues] {
         }
 
         case "options": {
-          return !isEmpty(blueprint.options?.schema);
+          return !isEmpty(inputProperties(blueprint.options?.schema ?? {}));
         }
 
         default: {


### PR DESCRIPTION
## What does this PR do?

- Closes #3344 
- Adds `@testing-library/react-hooks` for helping to test hooks
