### PR TITLE
#3347: include trigger event data

### DIFF
--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -377,12 +377,12 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
   ): Promise<unknown[]> {
     const reader = await this.defaultReader();
 
-    console.log("event", nativeEvent);
-
     const readerContext = {
+      // The default reader overrides the event property
       event: nativeEvent ? pickEventProperties(nativeEvent) : null,
       ...(await reader.read(root)),
     };
+
     const errors = await Promise.all(
       this.extensions.map(async (extension) => {
         const extensionLogger = this.logger.childLogger(

--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
@@ -98,6 +98,7 @@ const TriggerConfiguration: React.FC<{
           <option value="mouseover">Mouseover</option>
           <option value="keydown">Keydown</option>
           <option value="keyup">Keyup</option>
+          <option value="keypress">Keypress</option>
           <option value="change">Change</option>
         </ConnectedFieldTemplate>
 


### PR DESCRIPTION
## What does this PR do?

- Closes #3347 
- Passes keyboard event data in an "event" property in the input
- Adds support for "keypress" event

## Out of Scope
- Include an official reader with an output schema for event like we do for context menus. There's not much advantage since the shape changes per event
- Show in the the preview of the data panel. (Also would require creating a fake reader)