### PR TITLE
#2966: diagnose service lookup errors

### DIFF
--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -59,7 +59,7 @@ export async function getCachedAuthData(
 ): Promise<AuthData | undefined> {
   expectContext(
     "background",
-    "Only the background page can access oauth2 information"
+    "Only the background page can access token and oauth2 data"
   );
 
   const current = await readStorage<Record<UUID, AuthData>>(
@@ -67,7 +67,7 @@ export async function getCachedAuthData(
     {}
   );
   if (Object.prototype.hasOwnProperty.call(current, serviceAuthId)) {
-    // eslint-disable-next-line security/detect-object-injection -- Just checked with `hasOwnProperty`
+    // eslint-disable-next-line security/detect-object-injection -- just checked with `hasOwnProperty`
     return current[serviceAuthId];
   }
 }

--- a/src/background/proxyService.test.ts
+++ b/src/background/proxyService.test.ts
@@ -15,11 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  RawServiceConfiguration,
-  SanitizedServiceConfiguration,
-  ServiceConfig,
-} from "@/core";
+import { RawServiceConfiguration, ServiceConfig } from "@/core";
 import serviceRegistry from "@/services/registry";
 import axios, { AxiosError, AxiosRequestConfig } from "axios";
 import MockAdapter from "axios-mock-adapter";
@@ -32,6 +28,7 @@ import * as locator from "@/services/locator";
 import { RemoteServiceError } from "@/services/errors";
 import { validateRegistryId } from "@/types/helpers";
 import enrichAxiosErrors from "@/utils/enrichAxiosErrors";
+import { sanitizedServiceConfigurationFactory } from "@/testUtils/factories";
 
 const axiosMock = new MockAdapter(axios);
 const mockIsBackground = isBackground as jest.MockedFunction<
@@ -89,19 +86,15 @@ const requestConfig: AxiosRequestConfig = {
   method: "get",
 };
 
-const directServiceConfig = {
-  id: "124",
+const directServiceConfig = sanitizedServiceConfigurationFactory({
   proxy: false,
   serviceId: EXAMPLE_SERVICE_API,
-  config: {},
-} as SanitizedServiceConfiguration;
+});
 
-const proxiedServiceConfig = {
-  id: "123",
+const proxiedServiceConfig = sanitizedServiceConfigurationFactory({
   proxy: true,
   serviceId: EXAMPLE_SERVICE_API,
-  config: {},
-} as SanitizedServiceConfiguration;
+});
 
 describe("unauthenticated direct requests", () => {
   it("makes an unauthenticated request", async () => {
@@ -143,6 +136,14 @@ describe("authenticated direct requests", () => {
     axiosMock.onAny().reply(200, {});
     const response = await proxyService(directServiceConfig, requestConfig);
     expect(response.status).toEqual(200);
+  });
+
+  it("throws on missing local config", async () => {
+    jest.spyOn(Locator.prototype, "getLocalConfig").mockResolvedValue(null);
+
+    await expect(async () =>
+      proxyService(directServiceConfig, requestConfig)
+    ).rejects.toThrow("Local integration configuration not found:");
   });
 
   it("throws error on bad request", async () => {

--- a/src/background/proxyService.test.ts
+++ b/src/background/proxyService.test.ts
@@ -175,7 +175,7 @@ describe("proxy service requests", () => {
     expect(JSON.parse(axiosMock.history.post[0].data)).toEqual({
       ...requestConfig,
       service_id: EXAMPLE_SERVICE_API,
-      auth_id: "123",
+      auth_id: proxiedServiceConfig.id,
     });
     expect(status).toEqual(200);
     expect(data).toEqual({ foo: 42 });

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -80,7 +80,7 @@ async function authenticate(
 
   if (config.proxy) {
     throw new Error(
-      `Integration configuration is not a local configuration: ${config.id}`
+      `Integration configuration for service ${config.serviceId} is not a local configuration: ${config.id}`
     );
   }
 

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -199,7 +199,11 @@ class LazyLocatorFactory {
     return LazyLocatorFactory.prototype.locate.bind(this);
   }
 
-  async getLocalConfig(authId: UUID): Promise<RawServiceConfiguration> {
+  /**
+   * Return the raw integration configuration with UUID authId, or return `null` if not available locally.
+   * @param authId UUID of the integration configuration
+   */
+  async getLocalConfig(authId: UUID): Promise<RawServiceConfiguration | null> {
     if (!this.initialized) {
       await this.refresh();
     }

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -32,6 +32,8 @@ import {
   UUID,
   InnerDefinitions,
   SafeString,
+  SanitizedServiceConfiguration,
+  SanitizedConfig,
 } from "@/core";
 import { TraceError, TraceRecord } from "@/telemetry/trace";
 import {
@@ -497,3 +499,12 @@ export const menuItemFormStateFactory = (
     blockConfigOverride
   ) as ActionFormState;
 };
+
+export const sanitizedServiceConfigurationFactory =
+  define<SanitizedServiceConfiguration>({
+    id: uuidSequence,
+    proxy: false,
+    serviceId: (n: number) => validateRegistryId(`test/service-${n}`),
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- object literal
+    config: () => ({} as SanitizedConfig),
+  } as unknown as SanitizedServiceConfiguration);


### PR DESCRIPTION
## What does this PR do?

- Part of #2966
- Adds checks to help isolate cause of service lookup errors
- Adds a sanitized service auth factory
