### PR TITLE
#2574: refresh button and auto-refresh integrations

### DIFF
--- a/src/background/locator.ts
+++ b/src/background/locator.ts
@@ -16,16 +16,18 @@
  */
 
 import LazyLocatorFactory from "@/services/locator";
-import { forbidContext } from "@/utils/expectContext";
+import { expectContext } from "@/utils/expectContext";
 
 export const locator = new LazyLocatorFactory();
 
 export default async function initLocator() {
-  // Service locator cannot run in contentScript due to CSP and wanting to isolate local secrets
-  forbidContext(
-    "contentScript",
-    "The service locator cannot run in the contentScript"
+  // Service locator cannot run in contentScript due to CSP and wanting to isolate local secrets.
+  // Force use of background page to ensure there's a singleton locator instance across all frames/pages.
+  expectContext(
+    "background",
+    "The service locator must run in the background worker"
   );
+
   console.debug("Eagerly initializing service locator");
   await locator.refresh();
 }
@@ -34,10 +36,11 @@ export async function refreshServices({
   local = true,
   remote = true,
 } = {}): Promise<void> {
-  // Service locator cannot run in contentScript due to CSP and wanting to isolate local secrets
-  forbidContext(
-    "contentScript",
-    "The service locator cannot run in the contentScript"
+  // Service locator cannot run in contentScript due to CSP and wanting to isolate local secrets.
+  // Force use of background page to ensure there's a singleton locator instance across all frames/pages.
+  expectContext(
+    "background",
+    "The service locator must run in the background worker"
   );
 
   if (remote && local) {

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -226,7 +226,7 @@ async function performConfiguredRequest(
   }
 }
 
-async function getServiceContext(
+async function getServiceMessageContext(
   config: SanitizedServiceConfiguration
 ): Promise<MessageContext> {
   // Try resolving the service to get metadata to include with the error
@@ -278,7 +278,7 @@ export async function proxyService<TData>(
   } catch (error) {
     throw new ContextError("Error performing request", {
       cause: error,
-      context: await getServiceContext(serviceConfig),
+      context: await getServiceMessageContext(serviceConfig),
     });
   }
 }

--- a/src/components/fields/schemaFields/ServiceField.tsx
+++ b/src/components/fields/schemaFields/ServiceField.tsx
@@ -35,7 +35,7 @@ import { PACKAGE_REGEX } from "@/types/helpers";
 import { freshIdentifier } from "@/utils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCloud } from "@fortawesome/free-solid-svg-icons";
-import SelectWidget, {
+import {
   SelectLike,
   SelectWidgetOnChange,
 } from "@/components/form/widgets/SelectWidget";
@@ -49,6 +49,7 @@ import {
 import { makeLabelForSchemaField } from "@/components/fields/schemaFields/schemaFieldUtils";
 import { FormState } from "@/pageEditor/pageEditorTypes";
 import { selectVariables } from "./serviceFieldUtils";
+import ServiceSelectWidget from "@/components/fields/schemaFields/widgets/ServiceSelectWidget";
 
 const DEFAULT_SERVICE_OUTPUT_KEY = "service" as OutputKey;
 
@@ -202,7 +203,7 @@ const ServiceField: React.FunctionComponent<
   }
 > = ({ detectDefault = true, ...props }) => {
   const { schema } = props;
-  const [authOptions] = useAuthOptions();
+  const [authOptions, refreshOptions] = useAuthOptions();
   const { values: root, setValues: setRootValues } =
     useFormikContext<ServiceSlice>();
   const [{ value, ...field }, meta, helpers] =
@@ -313,9 +314,10 @@ const ServiceField: React.FunctionComponent<
           </span>
         </>
       }
-      as={SelectWidget}
+      as={ServiceSelectWidget}
       isClearable
       options={options}
+      refreshOptions={refreshOptions}
       value={selectedValue}
       onChange={onChange}
       error={meta.error}

--- a/src/components/fields/schemaFields/widgets/ServiceSelectWidget.stories.tsx
+++ b/src/components/fields/schemaFields/widgets/ServiceSelectWidget.stories.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import ServiceSelectWidget from "@/components/fields/schemaFields/widgets/ServiceSelectWidget";
+import { uuidv4, validateRegistryId } from "@/types/helpers";
+
+export default {
+  title: "Widgets/ServiceSelectWidget",
+  component: ServiceSelectWidget,
+} as ComponentMeta<typeof ServiceSelectWidget>;
+
+const Template: ComponentStory<typeof ServiceSelectWidget> = ({ options }) => (
+  // FIXME: the refresh button in the story doesn't match the height of the input field b/c of the theme.
+  //  In the Page Editor the height renders OK
+  <ServiceSelectWidget
+    name="service"
+    value={null}
+    onChange={action("onChange")}
+    options={options}
+    refreshOptions={action("refreshOptions")}
+  />
+);
+
+export const Empty = Template.bind({});
+Empty.args = {
+  options: [],
+};
+
+export const SelectedOption = Template.bind({});
+SelectedOption.args = {
+  options: [
+    {
+      label: "Local Config",
+      local: true,
+      value: uuidv4(),
+      serviceId: validateRegistryId("@story/service"),
+    },
+    {
+      label: "Team Config",
+      local: false,
+      value: uuidv4(),
+      serviceId: validateRegistryId("@story/service"),
+    },
+  ],
+};

--- a/src/components/fields/schemaFields/widgets/ServiceSelectWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/ServiceSelectWidget.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import SelectWidget, {
+  SelectWidgetProps,
+} from "@/components/form/widgets/SelectWidget";
+import { AuthOption } from "@/auth/authTypes";
+import { Button } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSync } from "@fortawesome/free-solid-svg-icons";
+
+const ServiceSelectWidget: React.FunctionComponent<
+  SelectWidgetProps<AuthOption> & { refreshOptions: () => void }
+> = ({ refreshOptions, ...selectProps }) => (
+  <div className="d-flex">
+    <div className="flex-grow-1">
+      <SelectWidget {...selectProps} />
+    </div>
+    <div>
+      <Button
+        onClick={refreshOptions}
+        variant="info"
+        title="Refresh configured integrations"
+      >
+        <FontAwesomeIcon icon={faSync} />
+      </Button>
+    </div>
+  </div>
+);
+
+export default ServiceSelectWidget;

--- a/src/components/form/widgets/SelectWidget.tsx
+++ b/src/components/form/widgets/SelectWidget.tsx
@@ -41,7 +41,7 @@ export type SelectWidgetOnChange<
 > = React.ChangeEventHandler<SelectLike<TOption>>;
 
 // Type of the SelectWidget props
-type SelectWidgetProps<TOption extends Option<TOption["value"]>> =
+export type SelectWidgetProps<TOption extends Option<TOption["value"]>> =
   CustomFieldWidgetProps<TOption["value"], SelectLike<TOption>> & {
     isClearable?: boolean;
     options: TOption[];

--- a/src/options/pages/activateExtension/ActivateForm.tsx
+++ b/src/options/pages/activateExtension/ActivateForm.tsx
@@ -26,17 +26,19 @@ import ServicesCard from "@/options/pages/activateExtension/ServicesCard";
 import { FormState } from "@/options/pages/activateExtension/activateTypes";
 import ActivateCard from "@/options/pages/activateExtension/ActivateCard";
 import extensionsSlice from "@/store/extensionsSlice";
+import { UUID } from "@/core";
 
 const { actions } = extensionsSlice;
 
 const ActivateForm: React.FunctionComponent<{
   extension: CloudExtension;
   authOptions: AuthOption[];
-}> = ({ extension, authOptions }) => {
+  refreshAuthOptions: () => void;
+}> = ({ extension, authOptions, refreshAuthOptions }) => {
   const dispatch = useDispatch();
 
   const initialValues: FormState = useMemo(() => {
-    const uuids = new Set<string>(authOptions.map((x) => x.value));
+    const uuids = new Set<UUID>(authOptions.map((x) => x.value));
     return {
       services: extension.services.map((service) => ({
         ...service,
@@ -53,10 +55,10 @@ const ActivateForm: React.FunctionComponent<{
             extension: { ...extension, ...values },
           })
         );
-        notify.success("Activated brick");
+        notify.success("Activated extension");
         dispatch(push("/blueprints"));
       } catch (error) {
-        notify.error({ message: "Error activating brick", error });
+        notify.error({ message: "Error activating extension", error });
       } finally {
         helpers.setSubmitting(false);
       }
@@ -68,7 +70,10 @@ const ActivateForm: React.FunctionComponent<{
     <Formik initialValues={initialValues} onSubmit={onSubmit}>
       {() => (
         <Form id="activate-wizard" noValidate>
-          <ServicesCard authOptions={authOptions} />
+          <ServicesCard
+            authOptions={authOptions}
+            refreshAuthOptions={refreshAuthOptions}
+          />
           <ActivateCard extension={extension} />
         </Form>
       )}

--- a/src/options/pages/activateExtension/ActivatePage.tsx
+++ b/src/options/pages/activateExtension/ActivatePage.tsx
@@ -38,17 +38,17 @@ const ActivatePage: React.FunctionComponent = () => {
     error,
   } = useFetch<CloudExtension>(`/api/extensions/${extensionId}`);
 
-  const [authOptions] = useAuthOptions();
+  const [authOptions, refreshAuthOptions] = useAuthOptions();
 
   return (
     <Page
       title={
         extension
           ? `Activate: ${extension.label ?? extension.id}`
-          : "Activate Brick"
+          : "Activate Extension"
       }
       icon={faCloudDownloadAlt}
-      description="Activate a personal brick from the cloud"
+      description="Activate a personal extension from the cloud"
       error={error}
       isPending={isLoading || authOptions == null}
     >
@@ -56,7 +56,11 @@ const ActivatePage: React.FunctionComponent = () => {
         <Col xl={8} lg={10} md={12}>
           <ErrorBoundary>
             {extension && authOptions && (
-              <ActivateForm extension={extension} authOptions={authOptions} />
+              <ActivateForm
+                extension={extension}
+                authOptions={authOptions}
+                refreshAuthOptions={refreshAuthOptions}
+              />
             )}
           </ErrorBoundary>
         </Col>

--- a/src/options/pages/activateExtension/ServicesCard.tsx
+++ b/src/options/pages/activateExtension/ServicesCard.tsx
@@ -27,9 +27,10 @@ import ServiceDescriptor from "@/options/pages/marketplace/ServiceDescriptor";
 import AuthWidget from "@/options/pages/marketplace/AuthWidget";
 import { joinName } from "@/utils";
 
-const ServicesCard: React.FunctionComponent<{ authOptions: AuthOption[] }> = ({
-  authOptions,
-}) => {
+const ServicesCard: React.FunctionComponent<{
+  authOptions: AuthOption[];
+  refreshAuthOptions: () => void;
+}> = ({ authOptions, refreshAuthOptions }) => {
   const [field] = useField<ServiceDependency[]>("services");
 
   const { data: serviceConfigs } =
@@ -50,7 +51,7 @@ const ServicesCard: React.FunctionComponent<{ authOptions: AuthOption[] }> = ({
 
   return (
     <Card className="mb-3">
-      <Card.Header>Configure Services</Card.Header>
+      <Card.Header>Configure Integrations</Card.Header>
       <Table>
         <thead>
           <tr>
@@ -60,7 +61,7 @@ const ServicesCard: React.FunctionComponent<{ authOptions: AuthOption[] }> = ({
         </thead>
         <tbody>
           {configurable.map(({ dependency, valueIndex }) => (
-            <tr key={`dependency.outputKey-${valueIndex}`}>
+            <tr key={`${dependency.outputKey}-${valueIndex}`}>
               <td>
                 <ServiceDescriptor
                   serviceId={dependency.id}
@@ -72,6 +73,7 @@ const ServicesCard: React.FunctionComponent<{ authOptions: AuthOption[] }> = ({
                   authOptions={authOptions}
                   serviceId={dependency.id}
                   name={joinName(field.name, String(valueIndex), "config")}
+                  onRefresh={refreshAuthOptions}
                 />
               </td>
             </tr>

--- a/src/options/pages/marketplace/AuthWidget.module.scss
+++ b/src/options/pages/marketplace/AuthWidget.module.scss
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.actionButton {
+  height: 36px;
+  margin-top: 1px;
+}
+
+.selector {
+  min-width: 300px;
+  margin-right: 1em;
+}

--- a/src/options/pages/marketplace/AuthWidget.tsx
+++ b/src/options/pages/marketplace/AuthWidget.tsx
@@ -29,11 +29,12 @@ import { services } from "@/background/messenger/api";
 import { Button } from "react-bootstrap";
 import ServiceEditorModal from "@/options/pages/services/ServiceEditorModal";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faSync } from "@fortawesome/free-solid-svg-icons";
 import servicesSlice from "@/store/servicesSlice";
 import notify from "@/utils/notify";
 import createMenuListWithAddButton from "@/components/form/widgets/createMenuListWithAddButton";
 import useAuthorizationGrantFlow from "@/hooks/useAuthorizationGrantFlow";
+import styles from "./AuthWidget.module.scss";
 
 const { updateServiceConfig } = servicesSlice.actions;
 
@@ -67,6 +68,12 @@ const AuthWidget: React.FunctionComponent<{
     () => authOptions.filter((x) => x.serviceId === serviceId),
     [authOptions, serviceId]
   );
+
+  const refreshAuthOptions = () => {
+    // `onRefresh` is not awaitable. Indicate that clicking the button did something
+    notify.info("Refreshing integration configurations");
+    onRefresh();
+  };
 
   const save = useCallback(
     async (values: RawServiceConfiguration) => {
@@ -144,22 +151,36 @@ const AuthWidget: React.FunctionComponent<{
       )}
 
       <div className="d-inline-flex">
-        {options.length > 0 && (
-          <div style={{ minWidth: "300px" }} className="mr-2">
-            <ServiceAuthSelector
-              name={name}
-              serviceId={serviceId}
-              authOptions={options}
-              CustomMenuList={CustomMenuList}
-            />
-          </div>
-        )}
-        <div>
-          {options.length === 0 && (
+        {options.length > 0 ? (
+          <>
+            <div className={styles.selector}>
+              <ServiceAuthSelector
+                name={name}
+                serviceId={serviceId}
+                authOptions={options}
+                CustomMenuList={CustomMenuList}
+              />
+            </div>
+            {onRefresh && (
+              <div>
+                <Button
+                  size="sm"
+                  variant="info"
+                  className={styles.actionButton}
+                  onClick={refreshAuthOptions}
+                  title="Refresh integration configurations"
+                >
+                  <FontAwesomeIcon icon={faSync} />
+                </Button>
+              </div>
+            )}
+          </>
+        ) : (
+          <>
             <Button
-              variant={options.length > 0 ? "info" : "primary"}
+              variant="info"
               size="sm"
-              style={{ height: "36px", marginTop: "1px" }}
+              className={styles.actionButton}
               onClick={() => {
                 if (serviceDefinition.isAuthorizationGrant) {
                   void launchAuthorizationGrantFlow(serviceDefinition, {
@@ -174,8 +195,20 @@ const AuthWidget: React.FunctionComponent<{
             >
               <FontAwesomeIcon icon={faPlus} /> Configure
             </Button>
-          )}
-        </div>
+
+            {onRefresh && (
+              <Button
+                size="sm"
+                variant="info"
+                className={styles.actionButton}
+                onClick={refreshAuthOptions}
+                title="Refresh integration configurations"
+              >
+                <FontAwesomeIcon icon={faSync} /> Refresh
+              </Button>
+            )}
+          </>
+        )}
       </div>
     </>
   );

--- a/src/services/serviceUtils.ts
+++ b/src/services/serviceUtils.ts
@@ -15,10 +15,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { RegistryId, Schema, ServiceContext, ServiceDependency } from "@/core";
+import {
+  RegistryId,
+  SanitizedServiceConfiguration,
+  Schema,
+  ServiceContext,
+  ServiceDependency,
+  UUID,
+} from "@/core";
 import { services } from "@/background/messenger/api";
 import { pickBy } from "lodash";
 import { resolveObj } from "@/utils";
+import { isErrorLike } from "serialize-error";
 
 export const SERVICE_FIELD_REFS = [
   "https://app.pixiebrix.com/schemas/service#/definitions/configuredServiceOrVar",
@@ -50,6 +58,31 @@ export function extractServiceIds(schema: Schema): RegistryId[] {
   throw new Error("Expected $ref or anyOf in schema for service");
 }
 
+async function locateWithRetry(
+  serviceId: RegistryId,
+  authId: UUID,
+  { retry = true }: { retry: boolean }
+): Promise<SanitizedServiceConfiguration> {
+  try {
+    return await services.locate(serviceId, authId);
+  } catch (error) {
+    if (
+      retry &&
+      isErrorLike(error) &&
+      error.name === "MissingConfigurationError"
+    ) {
+      // Retry
+    } else {
+      throw error;
+    }
+  }
+
+  // Ensure the locator has the latest configurations (remote and local)
+  await services.refresh();
+
+  return services.locate(serviceId, authId);
+}
+
 /** Build the service context by locating the dependencies */
 export async function makeServiceContext(
   // `IExtension.services` is an optional field. Since we don't have strict-nullness checking on, calls to this method
@@ -58,7 +91,11 @@ export async function makeServiceContext(
   dependencies: ServiceDependency[] | null = []
 ): Promise<ServiceContext> {
   const dependencyContext = async ({ id, config }: ServiceDependency) => {
-    const configuredService = await services.locate(id, config);
+    // Should be safe to call locateWithRetry in parallel b/c the locator.refresh() method debounces/coalesces
+    // the promise
+    const configuredService = await locateWithRetry(id, config, {
+      retry: true,
+    });
     return {
       // Our JSON validator gets mad at undefined values
       ...pickBy(configuredService.config, (x) => x !== undefined),


### PR DESCRIPTION
## What does this PR do?

- Closes #2574 
- Adds a "refresh" button next to service selection widgets
- If service lookup fails in the background page, refreshes the service locator and tries the lookup again

## Out of Scope

- There are two parallel auth selection widgets. One set used by the options page and one used by schema fields. We should consolidate the service selection code