### PR TITLE
#3029 RegistryId widget

### DIFF
--- a/src/auth/authTypes.ts
+++ b/src/auth/authTypes.ts
@@ -114,10 +114,14 @@ export type AuthState = {
    */
   readonly organization?: OrganizationAuthState | null;
 
+  /**
+   * Organizations the user is a member of
+   */
   readonly organizations: Array<{
     id: UUID;
     name: string;
     role: Me["organization_memberships"][number]["role"];
+    scope?: string | null;
   }>;
 
   readonly groups: Array<{

--- a/src/auth/authUtils.ts
+++ b/src/auth/authUtils.ts
@@ -26,10 +26,11 @@ export function selectOrganizations(
   }
 
   return organizationMemberships.map(
-    ({ organization, organization_name, role }) => ({
+    ({ organization, organization_name, role, scope }) => ({
       id: organization,
       name: organization_name,
       role,
+      scope,
     })
   );
 }

--- a/src/components/form/widgets/RegistryIdWidget.module.scss
+++ b/src/components/form/widgets/RegistryIdWidget.module.scss
@@ -23,6 +23,7 @@
 
 .select {
   flex-grow: 1;
+  font-size: 0.8125rem;
 }
 
 .idInput {

--- a/src/components/form/widgets/RegistryIdWidget.module.scss
+++ b/src/components/form/widgets/RegistryIdWidget.module.scss
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.root {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.select {
+  flex-grow: 1;
+}
+
+.idInput {
+  width: auto;
+  flex-grow: 2;
+  text-overflow: ellipsis;
+}

--- a/src/components/form/widgets/RegistryIdWidget.test.tsx
+++ b/src/components/form/widgets/RegistryIdWidget.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getScopeAndId } from "@/components/form/widgets/RegistryIdWidget";
+import { RegistryId } from "@/core";
+
+describe("getScopeAndId", () => {
+  test("normal id", () => {
+    const id = "@foo/bar" as RegistryId;
+    expect(getScopeAndId(id)).toStrictEqual(["@foo", "bar"]);
+  });
+  test("id with slash", () => {
+    const id = "@foo/bar/baz" as RegistryId;
+    expect(getScopeAndId(id)).toStrictEqual(["@foo", "bar/baz"]);
+  });
+  test("id without scope", () => {
+    const id = "foobar" as RegistryId;
+    expect(getScopeAndId(id)).toStrictEqual([undefined, "foobar"]);
+  });
+  test("id without scope with slash", () => {
+    const id = "foo/bar/baz" as RegistryId;
+    expect(getScopeAndId(id)).toStrictEqual([undefined, "foo/bar/baz"]);
+  });
+  test("scope without id", () => {
+    const id = "@foo" as RegistryId;
+    expect(getScopeAndId(id)).toStrictEqual(["@foo", undefined]);
+  });
+});

--- a/src/components/form/widgets/RegistryIdWidget.tsx
+++ b/src/components/form/widgets/RegistryIdWidget.tsx
@@ -29,16 +29,24 @@ import { validateRegistryId } from "@/types/helpers";
 import { Form } from "react-bootstrap";
 import styles from "./RegistryIdWidget.module.scss";
 import { StylesConfig } from "react-select";
+import { UserRole } from "@/types/contract";
 
 const RegistryIdWidget: React.VFC<{
   name: string;
   selectStyles: StylesConfig;
 }> = ({ name, selectStyles }) => {
   const [{ value }, , { setValue }] = useField<RegistryId>(name);
-  const { scope: userScope, organization } = useSelector(selectAuth);
-  const orgScope = organization?.scope;
+  const { scope: userScope, organizations } = useSelector(selectAuth);
+  const orgScopes = organizations
+    .filter(
+      (organization) =>
+        organization.role === UserRole.admin ||
+        organization.role === UserRole.developer ||
+        organization.role === UserRole.manager
+    )
+    .map((organization) => organization.scope);
 
-  const options = makeStringOptions(userScope, orgScope);
+  const options = makeStringOptions(userScope, ...orgScopes);
 
   const [scope, id] = split(value, "/", 2);
 

--- a/src/components/form/widgets/RegistryIdWidget.tsx
+++ b/src/components/form/widgets/RegistryIdWidget.tsx
@@ -28,8 +28,12 @@ import { RegistryId } from "@/core";
 import { validateRegistryId } from "@/types/helpers";
 import { Form } from "react-bootstrap";
 import styles from "./RegistryIdWidget.module.scss";
+import { StylesConfig } from "react-select";
 
-const RegistryIdWidget: React.VFC<{ name: string }> = ({ name }) => {
+const RegistryIdWidget: React.VFC<{
+  name: string;
+  selectStyles: StylesConfig;
+}> = ({ name, selectStyles }) => {
   const [{ value }, , { setValue }] = useField<RegistryId>(name);
   const { scope: userScope, organization } = useSelector(selectAuth);
   const orgScope = organization?.scope;
@@ -65,6 +69,7 @@ const RegistryIdWidget: React.VFC<{ name: string }> = ({ name }) => {
         onChange={onChangeScope}
         options={options}
         className={styles.select}
+        styles={selectStyles}
       />
       <span> / </span>
       <Form.Control

--- a/src/components/form/widgets/RegistryIdWidget.tsx
+++ b/src/components/form/widgets/RegistryIdWidget.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useField } from "formik";
+import React from "react";
+import { useSelector } from "react-redux";
+import { selectAuth } from "@/auth/authSelectors";
+import SelectWidget, {
+  makeStringOptions,
+  SelectWidgetOnChange,
+} from "@/components/form/widgets/SelectWidget";
+import { split } from "lodash";
+import { RegistryId } from "@/core";
+import { validateRegistryId } from "@/types/helpers";
+import { Form } from "react-bootstrap";
+import styles from "./RegistryIdWidget.module.scss";
+
+const RegistryIdWidget: React.VFC<{ name: string }> = ({ name }) => {
+  const [{ value }, , { setValue }] = useField<RegistryId>(name);
+  const { scope: userScope, organization } = useSelector(selectAuth);
+  const orgScope = organization?.scope;
+
+  const options = makeStringOptions(userScope, orgScope);
+
+  const [scope, id] = split(value, "/", 2);
+
+  const scopeValue = scope ?? userScope;
+
+  const idValue = id ?? scope ?? "";
+
+  const onChangeScope: SelectWidgetOnChange = (event) => {
+    const newScope =
+      options.find((option) => option.value === event.target.value)?.value ??
+      scopeValue;
+    const newValue = validateRegistryId(`${newScope}/${idValue}`);
+    setValue(newValue);
+  };
+
+  const onChangeId: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    const newId = event.target.value;
+    const newValue = validateRegistryId(`${scopeValue}/${newId}`);
+    setValue(newValue);
+  };
+
+  return (
+    <div className={styles.root}>
+      <SelectWidget
+        name={name}
+        value={scopeValue}
+        isClearable={false}
+        onChange={onChangeScope}
+        options={options}
+        components={{
+          DropdownIndicator: () => null,
+          IndicatorSeparator: () => null,
+        }}
+        className={styles.select}
+      />
+      <span> / </span>
+      <Form.Control
+        value={idValue}
+        onChange={onChangeId}
+        className={styles.idInput}
+      />
+    </div>
+  );
+};
+
+export default RegistryIdWidget;

--- a/src/components/form/widgets/RegistryIdWidget.tsx
+++ b/src/components/form/widgets/RegistryIdWidget.tsx
@@ -64,10 +64,6 @@ const RegistryIdWidget: React.VFC<{ name: string }> = ({ name }) => {
         isClearable={false}
         onChange={onChangeScope}
         options={options}
-        components={{
-          DropdownIndicator: () => null,
-          IndicatorSeparator: () => null,
-        }}
         className={styles.select}
       />
       <span> / </span>

--- a/src/components/form/widgets/SelectWidget.tsx
+++ b/src/components/form/widgets/SelectWidget.tsx
@@ -51,7 +51,18 @@ type SelectWidgetProps<TOption extends Option<TOption["value"]>> =
     error?: unknown;
     disabled?: boolean;
     components?: SelectComponentsConfig<TOption, boolean, GroupBase<TOption>>;
+    className?: string;
   };
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+export const makeStringOptions = (...items: string[]) =>
+  items.map(
+    (item) =>
+      ({
+        label: item,
+        value: item,
+      } as Option)
+  );
 
 const SelectWidget = <TOption extends Option<TOption["value"]>>({
   id,
@@ -64,6 +75,7 @@ const SelectWidget = <TOption extends Option<TOption["value"]>>({
   onChange,
   name,
   components,
+  className,
 }: SelectWidgetProps<TOption>) => {
   if (loadError) {
     return (
@@ -86,6 +98,7 @@ const SelectWidget = <TOption extends Option<TOption["value"]>>({
 
   return (
     <Select
+      className={className}
       menuPlacement="auto"
       inputId={id}
       name={name}

--- a/src/components/form/widgets/SelectWidget.tsx
+++ b/src/components/form/widgets/SelectWidget.tsx
@@ -17,7 +17,11 @@
 
 import React, { ChangeEvent } from "react";
 import { CustomFieldWidgetProps } from "@/components/form/FieldTemplate";
-import Select, { GroupBase, SelectComponentsConfig } from "react-select";
+import Select, {
+  GroupBase,
+  SelectComponentsConfig,
+  StylesConfig,
+} from "react-select";
 import { getErrorMessage } from "@/errors";
 
 // Type of the Select options
@@ -52,12 +56,13 @@ type SelectWidgetProps<TOption extends Option<TOption["value"]>> =
     disabled?: boolean;
     components?: SelectComponentsConfig<TOption, boolean, GroupBase<TOption>>;
     className?: string;
+    styles?: StylesConfig;
   };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export const makeStringOptions = (...items: string[]) =>
   items.map(
     (item) =>
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       ({
         label: item,
         value: item,
@@ -76,6 +81,7 @@ const SelectWidget = <TOption extends Option<TOption["value"]>>({
   name,
   components,
   className,
+  styles,
 }: SelectWidgetProps<TOption>) => {
   if (loadError) {
     return (
@@ -109,6 +115,7 @@ const SelectWidget = <TOption extends Option<TOption["value"]>>({
       value={selectValue}
       onChange={patchedOnChange}
       components={components}
+      styles={styles}
     />
   );
 };

--- a/src/components/form/widgets/SelectWidget.tsx
+++ b/src/components/form/widgets/SelectWidget.tsx
@@ -59,15 +59,11 @@ type SelectWidgetProps<TOption extends Option<TOption["value"]>> =
     styles?: StylesConfig;
   };
 
-export const makeStringOptions = (...items: string[]) =>
-  items.map(
-    (item) =>
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      ({
-        label: item,
-        value: item,
-      } as Option)
-  );
+export const makeStringOptions = (...items: string[]): Option[] =>
+  items.map((item) => ({
+    label: item,
+    value: item,
+  }));
 
 const SelectWidget = <TOption extends Option<TOption["value"]>>({
   id,

--- a/src/options/pages/blueprints/modals/ShareExtensionModal.module.scss
+++ b/src/options/pages/blueprints/modals/ShareExtensionModal.module.scss
@@ -19,3 +19,23 @@
   width: 100%;
   max-width: 700px;
 }
+
+.idScopeSelect {
+  border-radius: 0;
+
+  // Hack react-select to match styling
+  div:global(.css-1s2u09g-control) {
+    border-radius: 0;
+    border: none;
+  }
+  div:global(.css-319lph-ValueContainer) {
+    padding: 0.875rem 1.375rem;
+  }
+  div:global(.css-qc6sy-singleValue),
+  div:global(.css-6j8wv5-Input) {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}

--- a/src/options/pages/blueprints/modals/ShareExtensionModal.module.scss
+++ b/src/options/pages/blueprints/modals/ShareExtensionModal.module.scss
@@ -19,23 +19,3 @@
   width: 100%;
   max-width: 700px;
 }
-
-.idScopeSelect {
-  border-radius: 0;
-
-  // Hack react-select to match styling
-  div:global(.css-1s2u09g-control) {
-    border-radius: 0;
-    border: none;
-  }
-  div:global(.css-319lph-ValueContainer) {
-    padding: 0.875rem 1.375rem;
-  }
-  div:global(.css-qc6sy-singleValue),
-  div:global(.css-6j8wv5-Input) {
-    margin-top: 0;
-    margin-bottom: 0;
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-}

--- a/src/options/pages/blueprints/modals/ShareExtensionModal.tsx
+++ b/src/options/pages/blueprints/modals/ShareExtensionModal.tsx
@@ -60,6 +60,7 @@ import { selectExtensions } from "@/store/extensionsSelectors";
 import { RequireScope } from "@/auth/RequireScope";
 import { selectScope } from "@/auth/authSelectors";
 import { FieldDescriptions } from "@/utils/strings";
+import RegistryIdWidget from "@/components/form/widgets/RegistryIdWidget";
 
 const { attachExtension } = extensionsSlice.actions;
 
@@ -198,6 +199,8 @@ const ShareExtensionModal: React.FC<{
             <i>Cannot be modified once shared.</i>
           </span>
         }
+        as={RegistryIdWidget}
+        className={styles.idScopeSelect}
       />
       <ConnectedFieldTemplate
         name="description"

--- a/src/options/pages/blueprints/modals/ShareExtensionModal.tsx
+++ b/src/options/pages/blueprints/modals/ShareExtensionModal.tsx
@@ -61,6 +61,7 @@ import { RequireScope } from "@/auth/RequireScope";
 import { selectScope } from "@/auth/authSelectors";
 import { FieldDescriptions } from "@/utils/strings";
 import RegistryIdWidget from "@/components/form/widgets/RegistryIdWidget";
+import { StylesConfig } from "react-select";
 
 const { attachExtension } = extensionsSlice.actions;
 
@@ -109,6 +110,32 @@ async function convertAndShare(
     ...pick(data, ["updated_at"]),
   };
 }
+
+const selectStylesOverride: StylesConfig = {
+  control: (base) => ({
+    ...base,
+    borderRadius: 0,
+    border: "none",
+  }),
+  valueContainer: (base) => ({
+    ...base,
+    padding: "0.875rem 1.375rem",
+  }),
+  singleValue: (base) => ({
+    ...base,
+    marginTop: 0,
+    marginBottom: 0,
+    paddingTop: 0,
+    paddingBottom: 0,
+  }),
+  input: (base) => ({
+    ...base,
+    marginTop: 0,
+    marginBottom: 0,
+    paddingTop: 0,
+    paddingBottom: 0,
+  }),
+};
 
 // XXX: this is a connected component. To simplify testing split out the presentational component
 const ShareExtensionModal: React.FC<{
@@ -200,7 +227,7 @@ const ShareExtensionModal: React.FC<{
           </span>
         }
         as={RegistryIdWidget}
-        className={styles.idScopeSelect}
+        selectStyles={selectStylesOverride}
       />
       <ConnectedFieldTemplate
         name="description"

--- a/src/options/pages/blueprints/modals/__snapshots__/ShareExtensionModal.test.tsx.snap
+++ b/src/options/pages/blueprints/modals/__snapshots__/ShareExtensionModal.test.tsx.snap
@@ -71,11 +71,6 @@ exports[`renders modal 1`] = `
                 <div
                   class="root"
                 >
-                  <input
-                    hidden=""
-                    id="backingInput"
-                    value="@test/testextension"
-                  />
                   <div
                     class="select css-b62m3t-container"
                   >

--- a/src/options/pages/blueprints/modals/__snapshots__/ShareExtensionModal.test.tsx.snap
+++ b/src/options/pages/blueprints/modals/__snapshots__/ShareExtensionModal.test.tsx.snap
@@ -68,12 +68,99 @@ exports[`renders modal 1`] = `
               <div
                 class="col-xl-10 col-lg-9"
               >
-                <input
-                  class="form-control"
-                  id="blueprintId"
-                  name="blueprintId"
-                  value="@test/testextension"
-                />
+                <div
+                  class="root"
+                >
+                  <input
+                    hidden=""
+                    id="backingInput"
+                    value="@test/testextension"
+                  />
+                  <div
+                    class="select css-b62m3t-container"
+                  >
+                    <span
+                      class="css-1f43avz-a11yText-A11yText"
+                      id="react-select-2-live-region"
+                    />
+                    <span
+                      aria-atomic="false"
+                      aria-live="polite"
+                      aria-relevant="additions text"
+                      class="css-1f43avz-a11yText-A11yText"
+                    />
+                    <div
+                      class=" css-10lovj7-control"
+                    >
+                      <div
+                        class=" css-12yna7l-ValueContainer"
+                      >
+                        <div
+                          class=" css-j966x-singleValue"
+                        >
+                          @test
+                        </div>
+                        <div
+                          class=" css-eefzcu-Input"
+                          data-value=""
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-expanded="false"
+                            aria-haspopup="true"
+                            autocapitalize="none"
+                            autocomplete="off"
+                            autocorrect="off"
+                            class=""
+                            id="react-select-2-input"
+                            role="combobox"
+                            spellcheck="false"
+                            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                            tabindex="0"
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class=" css-1hb7zxy-IndicatorsContainer"
+                      >
+                        <span
+                          class=" css-1okebmr-indicatorSeparator"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class=" css-tlfecz-indicatorContainer"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="css-tj5bde-Svg"
+                            focusable="false"
+                            height="20"
+                            viewBox="0 0 20 20"
+                            width="20"
+                          >
+                            <path
+                              d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+                    <input
+                      name="blueprintId"
+                      type="hidden"
+                      value="@test"
+                    />
+                  </div>
+                  <span>
+                     / 
+                  </span>
+                  <input
+                    class="idInput form-control"
+                    value="testextension"
+                  />
+                </div>
                 <small
                   class="text-muted form-text"
                 >

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -61,6 +61,7 @@ import { inferRecipeAuths, inferRecipeOptions } from "@/store/extensionsUtils";
 import { RegistryId } from "@/core";
 import useRemoveExtension from "@/pageEditor/hooks/useRemoveExtension";
 import useRemoveRecipe from "@/pageEditor/hooks/useRemoveRecipe";
+import RegistryIdWidget from "@/components/form/widgets/RegistryIdWidget";
 
 const { actions: optionsActions } = extensionsSlice;
 
@@ -351,6 +352,7 @@ const CreateRecipeModal: React.VFC = () => {
         label="Blueprint ID"
         description={FieldDescriptions.BLUEPRINT_ID}
         widerLabel
+        as={RegistryIdWidget}
       />
       <ConnectedFieldTemplate
         name="name"

--- a/src/pageEditor/sidebar/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/CreateRecipeModal.tsx
@@ -202,6 +202,7 @@ function useSaveCallbacks({ activeElement }: { activeElement: FormState }) {
       editorFormElements,
       installedExtensions,
       isDirtyByElementId,
+      removeRecipe,
     ]
   );
 

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -76,6 +76,7 @@ export enum UserRole {
   admin = 2,
   developer = 3,
   restricted = 4,
+  manager = 5,
 }
 
 export type Organization = components["schemas"]["Organization"] & {

--- a/src/types/swagger.ts
+++ b/src/types/swagger.ts
@@ -888,6 +888,7 @@ export interface components {
         organization_name: string;
         /** @enum {integer} */
         role: 1 | 2 | 3 | 4 | 5;
+        scope?: string | null;
       }[];
       group_memberships?: {
         /** Format: uuid */


### PR DESCRIPTION
## What does this PR do?

- Close #3029 
- Adds a new `RegistryIdWidget` component that loads user-accessible scopes and presents the id with a split input including a dropdown for scope and text input for the rest of the id

## Demo

Page Editor:
<img width="502" alt="image" src="https://user-images.githubusercontent.com/2801308/167318820-7bda1cc0-1589-4e77-8bf4-4cae560f3887.png">
<img width="508" alt="image" src="https://user-images.githubusercontent.com/2801308/167318853-dc7551f5-b04e-49ff-9006-07a635e2e6ab.png">

Share Extension Modal:
<img width="705" alt="image" src="https://user-images.githubusercontent.com/2801308/167319600-1e7a9034-4978-48ef-b568-46e0fc68e668.png">

## Future Work

* We should probably take a look at using the `react-select` styles api to make sure it matches the app styling in a more general way at some point
