### PR TITLE
Fix type of field on api response object

### DIFF
--- a/src/auth/authTypes.ts
+++ b/src/auth/authTypes.ts
@@ -121,7 +121,7 @@ export type AuthState = {
     id: UUID;
     name: string;
     role: Me["organization_memberships"][number]["role"];
-    scope?: string | null;
+    scope: string | null;
   }>;
 
   readonly groups: Array<{


### PR DESCRIPTION
## What does this PR do?

- Following up from #3029, this field should always be present
