### PR TITLE
Fix storybook stories by mocking browser

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -102,6 +102,10 @@ module.exports = {
         new webpack.ProvidePlugin({
           $: "jquery",
           jQuery: "jquery",
+          browser: [
+            path.resolve(rootDir, "src/__mocks__/browserMock.mjs"),
+            "default",
+          ],
         }),
       ]
     );

--- a/src/__mocks__/browserMock.mjs
+++ b/src/__mocks__/browserMock.mjs
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export default {};


### PR DESCRIPTION
## What does this PR do?

- Part of #2152
- We are temporarily fixing broken storybook stories that use the extension api by writing a quick global import mock for browser in the storybook config.

## Reviewer Tips

- Perhaps run storybook and verify that all stories are working as expected.

## Discussion

- Eventually, we might want to move towards using a browser mock [like `jest-webextension-mock`](https://github.com/clarkbw/jest-webextension-mock) for storybook stories.

## Demo

- n/a

## Future Work

- Finish adding onboarding stories to finish #2152 
- Implement a better browser mock (mentioned above)

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @twschiller 
