### PR TITLE
#3368 Can't rename date field in form builder

### DIFF
--- a/src/components/documentBuilder/edit/DocumentEditor.test.tsx
+++ b/src/components/documentBuilder/edit/DocumentEditor.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { render } from "@testing-library/react";
-import { Formik, useFormikContext } from "formik";
+import { useFormikContext } from "formik";
 import React, { useState } from "react";
 import { createNewElement } from "@/components/documentBuilder/createNewElement";
 import { DocumentElement } from "@/components/documentBuilder/documentBuilderTypes";

--- a/src/components/documentBuilder/edit/DocumentEditor.test.tsx
+++ b/src/components/documentBuilder/edit/DocumentEditor.test.tsx
@@ -16,43 +16,42 @@
  */
 
 import { render } from "@testing-library/react";
-import { Formik } from "formik";
 import React, { useState } from "react";
 import { createNewElement } from "@/components/documentBuilder/createNewElement";
 import { DocumentElement } from "@/components/documentBuilder/documentBuilderTypes";
 import DocumentEditor from "./DocumentEditor";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import userEvent from "@testing-library/user-event";
+import { createFormikTemplate } from "@/testUtils/formHelpers";
 
 function renderDocumentEditor(
   documentElements: DocumentElement[],
   initialActiveElement: string = null
 ) {
-  const document = {
-    body: documentElements,
-  };
+  const FormikTemplate = createFormikTemplate({
+    document: {
+      body: documentElements,
+    },
+  });
 
-  const PreviewContainer = () => {
+  const DocumentEditorContainer = () => {
     const [activeElement, setActiveElement] = useState<string | null>(
       initialActiveElement
     );
     return (
-      <Formik
-        initialValues={{
-          document,
-        }}
-        onSubmit={jest.fn()}
-      >
-        <DocumentEditor
-          name="document.body"
-          activeElement={activeElement}
-          setActiveElement={setActiveElement}
-        />
-      </Formik>
+      <DocumentEditor
+        name="document.body"
+        activeElement={activeElement}
+        setActiveElement={setActiveElement}
+      />
     );
   };
 
-  return render(<PreviewContainer />);
+  return render(
+    <FormikTemplate>
+      <DocumentEditorContainer />
+    </FormikTemplate>
+  );
 }
 
 beforeAll(() => {

--- a/src/components/documentBuilder/edit/DocumentEditor.test.tsx
+++ b/src/components/documentBuilder/edit/DocumentEditor.test.tsx
@@ -29,9 +29,7 @@ function renderDocumentEditor(
   initialActiveElement: string = null
 ) {
   const FormikTemplate = createFormikTemplate({
-    document: {
-      body: documentElements,
-    },
+    documentElements,
   });
 
   const DocumentEditorContainer = () => {
@@ -40,7 +38,7 @@ function renderDocumentEditor(
     );
     return (
       <DocumentEditor
-        name="document.body"
+        name="documentElements"
         activeElement={activeElement}
         setActiveElement={setActiveElement}
       />

--- a/src/components/formBuilder/FormBuilder.test.tsx
+++ b/src/components/formBuilder/FormBuilder.test.tsx
@@ -318,12 +318,9 @@ describe("rename a field", () => {
   });
 
   test("can add and rename date field", async () => {
-    const FormikTemplate = createFormikTemplate(
-      {
-        [RJSF_SCHEMA_PROPERTY_NAME]: {},
-      },
-      jest.fn()
-    );
+    const FormikTemplate = createFormikTemplate({
+      [RJSF_SCHEMA_PROPERTY_NAME]: {},
+    });
 
     const rendered = render(
       <FormikTemplate>

--- a/src/components/formBuilder/FormBuilder.tsx
+++ b/src/components/formBuilder/FormBuilder.tsx
@@ -32,14 +32,14 @@ const FormBuilder: React.FC<{
 
   return (
     <div className={styles.root}>
-      <div className={styles.column}>
+      <div className={styles.column} data-testid="editor">
         <FormEditor
           name={name}
           activeField={activeField}
           setActiveField={setActiveField}
         />
       </div>
-      <div className={styles.column}>
+      <div className={styles.column} data-testid="preview">
         <FormPreview
           rjsfSchema={rjsfSchema}
           activeField={activeField}

--- a/src/components/formBuilder/edit/FormEditor.tsx
+++ b/src/components/formBuilder/edit/FormEditor.tsx
@@ -31,7 +31,7 @@ import {
   generateNewPropertyName,
   moveStringInArray,
   normalizeSchema,
-  normalizeUiOrder,
+  getNormalizedUiOrder,
   replaceStringInArray,
 } from "@/components/formBuilder/formBuilderHelpers";
 import { UI_ORDER } from "@/components/formBuilder/schemaFieldNames";
@@ -120,20 +120,21 @@ const FormEditor: React.FC<FormEditorProps> = ({
     };
     const nextUiOrder = activeField
       ? replaceStringInArray(
-          normalizeUiOrder(propertyKeys, uiOrder),
+          getNormalizedUiOrder(propertyKeys, uiOrder),
           activeField,
           activeField,
           propertyName
         )
       : replaceStringInArray(
-          normalizeUiOrder(propertyKeys, uiOrder),
+          getNormalizedUiOrder(propertyKeys, uiOrder),
           "*",
           propertyName,
           "*"
         );
 
     const nextRjsfSchema = produce(rjsfSchema, (draft) => {
-      draft.schema = normalizeSchema(schema);
+      normalizeSchema(draft);
+
       // eslint-disable-next-line security/detect-object-injection -- prop name is generated
       draft.schema.properties[propertyName] = newProperty;
 
@@ -150,7 +151,7 @@ const FormEditor: React.FC<FormEditorProps> = ({
 
   const moveProperty = (direction: "up" | "down") => {
     const nextUiOrder = moveStringInArray(
-      normalizeUiOrder(propertyKeys, uiOrder),
+      getNormalizedUiOrder(propertyKeys, uiOrder),
       activeField,
       direction
     );
@@ -160,7 +161,7 @@ const FormEditor: React.FC<FormEditorProps> = ({
   const removeProperty = () => {
     const propertyToRemove = activeField;
     const nextUiOrder = replaceStringInArray(
-      normalizeUiOrder(propertyKeys, uiOrder),
+      getNormalizedUiOrder(propertyKeys, uiOrder),
       propertyToRemove
     );
     const nextActiveField = nextUiOrder.length > 1 ? nextUiOrder[0] : undefined;
@@ -168,7 +169,7 @@ const FormEditor: React.FC<FormEditorProps> = ({
     setActiveField(nextActiveField);
 
     const nextRjsfSchema = produce(rjsfSchema, (draft) => {
-      draft.schema = normalizeSchema(schema);
+      normalizeSchema(draft);
 
       if (schema.required?.length > 0) {
         draft.schema.required = replaceStringInArray(

--- a/src/components/formBuilder/formBuilderHelpers.test.ts
+++ b/src/components/formBuilder/formBuilderHelpers.test.ts
@@ -19,8 +19,8 @@ import { KEYS_OF_UI_SCHEMA, Schema } from "@/core";
 import { produce } from "immer";
 import {
   DEFAULT_FIELD_TYPE,
-  MINIMAL_SCHEMA,
-  MINIMAL_UI_SCHEMA,
+  getMinimalSchema,
+  getMinimalUiSchema,
   normalizeSchema,
   getNormalizedUiOrder,
   produceSchemaOnPropertyNameChange,
@@ -87,7 +87,7 @@ describe("produceSchemaOnPropertyNameChange", () => {
 
 describe("validateNextPropertyName", () => {
   const schema: Schema = {
-    ...MINIMAL_SCHEMA,
+    ...getMinimalSchema(),
     properties: {
       field1: {
         title: "Field 1",
@@ -141,14 +141,14 @@ describe("normalizeSchema", () => {
     const actual = produce(
       {
         schema,
-        uiSchema: MINIMAL_UI_SCHEMA,
+        uiSchema: getMinimalUiSchema(),
       } as RJSFSchema,
       (draft) => {
         normalizeSchema(draft);
       }
     );
 
-    expect(actual.schema).toStrictEqual(MINIMAL_SCHEMA);
+    expect(actual.schema).toStrictEqual(getMinimalSchema());
   });
 
   test("add properties", () => {
@@ -159,7 +159,7 @@ describe("normalizeSchema", () => {
     const actual = produce(
       {
         schema,
-        uiSchema: MINIMAL_UI_SCHEMA,
+        uiSchema: getMinimalUiSchema(),
       } as RJSFSchema,
       (draft) => {
         normalizeSchema(draft);
@@ -186,7 +186,7 @@ describe("normalizeSchema", () => {
     const actual = produce(
       {
         schema,
-        uiSchema: MINIMAL_UI_SCHEMA,
+        uiSchema: getMinimalUiSchema(),
       } as RJSFSchema,
       (draft) => {
         normalizeSchema(draft);
@@ -242,7 +242,7 @@ describe("produceSchemaOnUiTypeChange", () => {
   test("converts Dropdown to Dropdown with labels", () => {
     const schema: RJSFSchema = {
       schema: {
-        ...MINIMAL_SCHEMA,
+        ...getMinimalSchema(),
         properties: {
           field1: {
             title: "Field 1",
@@ -252,7 +252,7 @@ describe("produceSchemaOnUiTypeChange", () => {
         },
       },
       uiSchema: {
-        ...MINIMAL_UI_SCHEMA,
+        ...getMinimalUiSchema(),
         field1: {
           [UI_WIDGET]: "select",
         },
@@ -288,7 +288,7 @@ describe("produceSchemaOnUiTypeChange", () => {
   test("converts Dropdown with labels to Dropdown", () => {
     const schema: RJSFSchema = {
       schema: {
-        ...MINIMAL_SCHEMA,
+        ...getMinimalSchema(),
         properties: {
           field1: {
             title: "Field 1",
@@ -311,7 +311,7 @@ describe("produceSchemaOnUiTypeChange", () => {
         },
       },
       uiSchema: {
-        ...MINIMAL_UI_SCHEMA,
+        ...getMinimalUiSchema(),
         field1: {
           [UI_WIDGET]: "select",
         },

--- a/src/components/formBuilder/formBuilderHelpers.test.ts
+++ b/src/components/formBuilder/formBuilderHelpers.test.ts
@@ -137,7 +137,10 @@ describe("normalizeSchema", () => {
   test("init schema", () => {
     // eslint-disable-next-line unicorn/no-useless-undefined
     const actual = normalizeSchema(undefined);
-    expect(actual).toStrictEqual(MINIMAL_SCHEMA);
+    expect(actual).toStrictEqual({
+      type: "object",
+      properties: {},
+    });
   });
 
   test("add properties", () => {

--- a/src/components/formBuilder/formBuilderHelpers.test.ts
+++ b/src/components/formBuilder/formBuilderHelpers.test.ts
@@ -148,7 +148,10 @@ describe("normalizeSchema", () => {
       }
     );
 
-    expect(actual.schema).toStrictEqual(getMinimalSchema());
+    expect(actual.schema).toStrictEqual({
+      type: "object",
+      properties: {},
+    });
   });
 
   test("add properties", () => {

--- a/src/components/formBuilder/formBuilderHelpers.ts
+++ b/src/components/formBuilder/formBuilderHelpers.ts
@@ -244,12 +244,14 @@ export const produceSchemaOnPropertyNameChange = (
       );
     }
 
-    const nextUiOrder = replaceStringInArray(
-      draft.uiSchema[UI_ORDER],
-      propertyName,
-      nextPropertyName
-    );
-    draft.uiSchema[UI_ORDER] = nextUiOrder;
+    if (draft.uiSchema[UI_ORDER] != null) {
+      const nextUiOrder = replaceStringInArray(
+        draft.uiSchema[UI_ORDER],
+        propertyName,
+        nextPropertyName
+      );
+      draft.uiSchema[UI_ORDER] = nextUiOrder;
+    }
 
     if (draft.uiSchema[propertyName]) {
       draft.uiSchema[nextPropertyName] = draft.uiSchema[propertyName];
@@ -321,12 +323,8 @@ export const produceSchemaOnUiTypeChange = (
   });
 };
 
-export const normalizeSchema = (schema: Schema | undefined) => {
-  if (!schema) {
-    return MINIMAL_SCHEMA;
-  }
-
-  return produce(schema, (draft) => {
+export const normalizeSchema = (schema: Schema | undefined) =>
+  produce(schema ?? MINIMAL_SCHEMA, (draft) => {
     // Should we initialize the 'required' field?
     if (
       Boolean(schema) &&
@@ -340,7 +338,6 @@ export const normalizeSchema = (schema: Schema | undefined) => {
       draft.properties = {};
     }
   });
-};
 
 export const normalizeUiOrder = (
   propertyKeys: string[],

--- a/src/components/formBuilder/formBuilderHelpers.ts
+++ b/src/components/formBuilder/formBuilderHelpers.ts
@@ -28,16 +28,14 @@ import { UI_ORDER, UI_WIDGET } from "./schemaFieldNames";
 import { freshIdentifier } from "@/utils";
 import { produce } from "immer";
 import { WritableDraft } from "immer/dist/types/types-external";
-import { cloneDeep } from "lodash";
 
-export const MINIMAL_SCHEMA: Schema = {
+export const getMinimalSchema: () => Schema = () => ({
   type: "object",
-  properties: {},
-};
+});
 
-export const MINIMAL_UI_SCHEMA: UiSchema = {
+export const getMinimalUiSchema: () => UiSchema = () => ({
   [UI_ORDER]: ["*"],
-};
+});
 
 export const DEFAULT_FIELD_TYPE = "string";
 
@@ -332,13 +330,9 @@ export const produceSchemaOnUiTypeChange = (
  */
 export const normalizeSchema = (rjsfSchemaDraft: WritableDraft<RJSFSchema>) => {
   if (rjsfSchemaDraft.schema == null) {
-    // Always create a deep copy of the MINIMAL_SCHEMA
-    // because this object will be mutated in the produce function that called for normalization
-    rjsfSchemaDraft.schema = cloneDeep(MINIMAL_SCHEMA);
-    return;
+    rjsfSchemaDraft.schema = getMinimalSchema();
   }
 
-  // Should we initialize the 'required' field?
   if (
     typeof rjsfSchemaDraft.schema.required !== "undefined" &&
     !Array.isArray(rjsfSchemaDraft.schema.required)

--- a/src/components/formBuilder/formEditor.testCases.ts
+++ b/src/components/formBuilder/formEditor.testCases.ts
@@ -1,4 +1,4 @@
-import { MINIMAL_SCHEMA, MINIMAL_UI_SCHEMA } from "./formBuilderHelpers";
+import { getMinimalSchema, getMinimalUiSchema } from "./formBuilderHelpers";
 import { RJSFSchema } from "./formBuilderTypes";
 
 export const initOneFieldSchemaCase: (fieldName: string) => RJSFSchema = (
@@ -15,7 +15,7 @@ export const initOneFieldSchemaCase: (fieldName: string) => RJSFSchema = (
         },
       },
     },
-    uiSchema: MINIMAL_UI_SCHEMA,
+    uiSchema: getMinimalUiSchema(),
   } as RJSFSchema);
 
 export const initAddingFieldCases: () => Array<
@@ -24,8 +24,8 @@ export const initAddingFieldCases: () => Array<
   [
     null,
     {
-      schema: MINIMAL_SCHEMA,
-      uiSchema: MINIMAL_UI_SCHEMA,
+      schema: getMinimalSchema(),
+      uiSchema: getMinimalUiSchema(),
     },
     {
       schema: {

--- a/src/components/formBuilder/formEditor.testCases.ts
+++ b/src/components/formBuilder/formEditor.testCases.ts
@@ -86,6 +86,7 @@ export const initRenamingCases = () => {
   const newFieldName = "newFieldName";
 
   const renamingCases: RJSFSchema[][] = [
+    // Renaming a required field
     [
       {
         schema: {
@@ -128,6 +129,8 @@ export const initRenamingCases = () => {
         },
       },
     ],
+
+    // Simple text field
     [
       {
         schema: {
@@ -168,6 +171,52 @@ export const initRenamingCases = () => {
         },
       },
     ],
+
+    // Date field
+    [
+      {
+        schema: {
+          title: "A form",
+          type: "object",
+          properties: {
+            [fieldName]: {
+              type: "string",
+              title: "First name",
+              format: "date",
+            },
+            anotherFieldName: {
+              type: "string",
+              title: "Another field name",
+            },
+          },
+        },
+        uiSchema: {
+          "ui:order": [fieldName, "*"],
+        },
+      },
+      {
+        schema: {
+          title: "A form",
+          type: "object",
+          properties: {
+            [newFieldName]: {
+              type: "string",
+              title: "First name",
+              format: "date",
+            },
+            anotherFieldName: {
+              type: "string",
+              title: "Another field name",
+            },
+          },
+        },
+        uiSchema: {
+          "ui:order": [newFieldName, "*"],
+        },
+      },
+    ],
+
+    // Renaming text area
     [
       {
         schema: {

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -56,8 +56,8 @@ import { UnknownObject } from "@/types";
 import { isExpression } from "@/runtime/mapArgs";
 import { RecipeDefinition } from "@/types/definitions";
 import {
-  MINIMAL_SCHEMA,
-  MINIMAL_UI_SCHEMA,
+  getMinimalSchema,
+  getMinimalUiSchema,
 } from "@/components/formBuilder/formBuilderHelpers";
 import {
   hasInnerExtensionPoint,
@@ -149,8 +149,8 @@ export function initRecipeOptionsIfNeeded<TElement extends BaseFormState>(
 
     if (recipe?.options == null) {
       element.optionsDefinition = {
-        schema: MINIMAL_SCHEMA,
-        uiSchema: MINIMAL_UI_SCHEMA,
+        schema: getMinimalSchema(),
+        uiSchema: getMinimalUiSchema(),
       };
     } else {
       element.optionsDefinition = {

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -46,8 +46,8 @@ import { InnerDefinitionRef, UnresolvedExtension } from "@/core";
 import { MenuDefinition } from "@/extensionPoints/menuItemExtension";
 import extensionsSlice from "@/store/extensionsSlice";
 import {
-  MINIMAL_SCHEMA,
-  MINIMAL_UI_SCHEMA,
+  getMinimalSchema,
+  getMinimalUiSchema,
 } from "@/components/formBuilder/formBuilderHelpers";
 import {
   EditablePackage,
@@ -454,8 +454,8 @@ describe("blueprint options", () => {
 
   test("doesn't add empty schema when blueprint options is empty", async () => {
     const emptyOptions = {
-      schema: MINIMAL_SCHEMA,
-      uiSchema: MINIMAL_UI_SCHEMA,
+      schema: getMinimalSchema(),
+      uiSchema: getMinimalUiSchema(),
     };
 
     const updatedRecipe = await runReplaceRecipeExtensions(
@@ -477,7 +477,7 @@ describe("blueprint options", () => {
           },
         },
       },
-      uiSchema: MINIMAL_UI_SCHEMA,
+      uiSchema: getMinimalUiSchema(),
     };
 
     const updatedRecipe = await runReplaceRecipeExtensions(
@@ -499,7 +499,7 @@ describe("blueprint options", () => {
           },
         },
       },
-      uiSchema: MINIMAL_UI_SCHEMA,
+      uiSchema: getMinimalUiSchema(),
     };
 
     const elementOptions: OptionsDefinition = {
@@ -511,7 +511,7 @@ describe("blueprint options", () => {
           },
         },
       },
-      uiSchema: MINIMAL_UI_SCHEMA,
+      uiSchema: getMinimalUiSchema(),
     };
 
     const updatedRecipe = await runReplaceRecipeExtensions(
@@ -533,12 +533,12 @@ describe("blueprint options", () => {
           },
         },
       },
-      uiSchema: MINIMAL_UI_SCHEMA,
+      uiSchema: getMinimalUiSchema(),
     };
 
     const elementOptions: OptionsDefinition = {
-      schema: MINIMAL_SCHEMA,
-      uiSchema: MINIMAL_UI_SCHEMA,
+      schema: getMinimalSchema(),
+      uiSchema: getMinimalUiSchema(),
     };
 
     const updatedRecipe = await runReplaceRecipeExtensions(

--- a/src/pageEditor/panes/save/useSavingWizard.test.tsx
+++ b/src/pageEditor/panes/save/useSavingWizard.test.tsx
@@ -44,7 +44,7 @@ import menuItem from "@/pageEditor/extensionPoints/menuItem";
 import pDefer from "p-defer";
 import { pick } from "lodash";
 import extensionsSlice from "@/store/extensionsSlice";
-import { MINIMAL_UI_SCHEMA } from "@/components/formBuilder/formBuilderHelpers";
+import { getMinimalUiSchema } from "@/components/formBuilder/formBuilderHelpers";
 import { OptionsDefinition } from "@/types/definitions";
 
 jest.unmock("react-redux");
@@ -163,7 +163,7 @@ describe("saving a Recipe Extension", () => {
         },
       },
     },
-    uiSchema: MINIMAL_UI_SCHEMA,
+    uiSchema: getMinimalUiSchema(),
   };
   const setupMocks = () => {
     const recipe = recipeFactory({

--- a/src/pageEditor/tabs/RecipeOptions.tsx
+++ b/src/pageEditor/tabs/RecipeOptions.tsx
@@ -31,8 +31,8 @@ import FormPreview from "@/components/formBuilder/preview/FormPreview";
 import { RJSFSchema } from "@/components/formBuilder/formBuilderTypes";
 import {
   FIELD_TYPE_OPTIONS,
-  MINIMAL_SCHEMA,
-  MINIMAL_UI_SCHEMA,
+  getMinimalSchema,
+  getMinimalUiSchema,
 } from "@/components/formBuilder/formBuilderHelpers";
 import { useDispatch, useSelector } from "react-redux";
 import {
@@ -57,8 +57,8 @@ const formRuntimeContext: RuntimeContext = {
 };
 
 const emptyOptions: OptionsDefinition = {
-  schema: MINIMAL_SCHEMA,
-  uiSchema: MINIMAL_UI_SCHEMA,
+  schema: getMinimalSchema(),
+  uiSchema: getMinimalUiSchema(),
 };
 
 const RecipeOptions: React.VFC = () => {


### PR DESCRIPTION
## What does this PR do?

- Fixes #3368
- Initialized with the default (example) config, FormBuilder was not able to rename the field because `ui:order` property was `undefined`


## Future Work

- Move the from builder helpers defined in the scope of test file to `testUtils/formBuilderHelpers.ts`?

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer, @BLoe this is connected with the latest changes related to Blueprint options
