### PR TITLE
#3352 Indicate when rendered sidebar is out of date with document builder

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { PropsWithChildren } from "react";
+import { IconDefinition } from "@fortawesome/fontawesome-common-types";
+import {
+  faExclamationCircle,
+  faExclamationTriangle,
+  faInfoCircle,
+} from "@fortawesome/free-solid-svg-icons";
+import { Alert as BootstrapAlert } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+type AlertProps = PropsWithChildren<{
+  variant: "info" | "warning" | "danger";
+}>;
+
+const Alert: React.FunctionComponent<AlertProps> = ({ variant, children }) => {
+  let icon: IconDefinition;
+  switch (variant) {
+    case "info":
+      icon = faInfoCircle;
+      break;
+    case "warning":
+      icon = faExclamationTriangle;
+      break;
+    case "danger":
+      icon = faExclamationCircle;
+      break;
+
+    default:
+      throw new Error(`Unknown variant: ${variant}`);
+  }
+
+  return (
+    <BootstrapAlert variant={variant}>
+      <FontAwesomeIcon icon={icon} /> {children}
+    </BootstrapAlert>
+  );
+};
+
+export default Alert;

--- a/src/pageEditor/fields/DocumentOptions.tsx
+++ b/src/pageEditor/fields/DocumentOptions.tsx
@@ -23,7 +23,7 @@ import DocumentEditor from "@/components/documentBuilder/edit/DocumentEditor";
 import useReduxState from "@/hooks/useReduxState";
 import { DocumentElement } from "@/components/documentBuilder/documentBuilderTypes";
 import ConfigErrorBoundary from "@/pageEditor/fields/ConfigErrorBoundary";
-import { selectNodePreviewActiveElement } from "@/pageEditor/uiState/uiState";
+import { selectNodePreviewActiveElement } from "@/pageEditor/slices/editorSelectors";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 
 export const DOCUMENT_ID = validateRegistryId("@pixiebrix/document");

--- a/src/pageEditor/fields/FormModalOptions.tsx
+++ b/src/pageEditor/fields/FormModalOptions.tsx
@@ -22,7 +22,7 @@ import { validateRegistryId } from "@/types/helpers";
 import FormEditor from "@/components/formBuilder/edit/FormEditor";
 import useReduxState from "@/hooks/useReduxState";
 import ConfigErrorBoundary from "@/pageEditor/fields/ConfigErrorBoundary";
-import { selectNodePreviewActiveElement } from "@/pageEditor/uiState/uiState";
+import { selectNodePreviewActiveElement } from "@/pageEditor/slices/editorSelectors";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 
 export const FORM_MODAL_ID = validateRegistryId("@pixiebrix/form-modal");

--- a/src/pageEditor/fields/FormRendererOptions.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.tsx
@@ -22,7 +22,7 @@ import { validateRegistryId } from "@/types/helpers";
 import FormEditor from "@/components/formBuilder/edit/FormEditor";
 import useReduxState from "@/hooks/useReduxState";
 import ConfigErrorBoundary from "@/pageEditor/fields/ConfigErrorBoundary";
-import { selectNodePreviewActiveElement } from "@/pageEditor/uiState/uiState";
+import { selectNodePreviewActiveElement } from "@/pageEditor/slices/editorSelectors";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 
 export const FORM_RENDERER_ID = validateRegistryId("@pixiebrix/form");

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -40,10 +40,8 @@ import {
   NodeId,
 } from "@/pageEditor/tabs/editTab/editorNode/EditorNode";
 import { useDispatch, useSelector } from "react-redux";
-import {
-  FOUNDATION_NODE_ID,
-  selectActiveNodeId,
-} from "@/pageEditor/uiState/uiState";
+import { FOUNDATION_NODE_ID } from "@/pageEditor/uiState/uiState";
+import { selectActiveNodeId } from "@/pageEditor/slices/editorSelectors";
 import ApiVersionField from "@/pageEditor/fields/ApiVersionField";
 import useBlockPipelineActions from "@/pageEditor/tabs/editTab/useBlockPipelineActions";
 import useApiVersionAtLeast from "@/pageEditor/hooks/useApiVersionAtLeast";

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -29,11 +29,7 @@ import BlockPreview, {
   usePreviewInfo,
 } from "@/pageEditor/tabs/effect/BlockPreview";
 import useReduxState from "@/hooks/useReduxState";
-import {
-  faExclamationCircle,
-  faExclamationTriangle,
-  faInfoCircle,
-} from "@fortawesome/free-solid-svg-icons";
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useSelector } from "react-redux";
 import { selectExtensionTrace } from "@/pageEditor/slices/runtimeSelectors";
@@ -50,7 +46,7 @@ import { DataPanelTabKey } from "./dataPanelTypes";
 import DataTabJsonTree from "./DataTabJsonTree";
 import { selectNodePreviewActiveElement } from "@/pageEditor/slices/editorSelectors";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
-import StalePreview from "./StalePreview";
+import StalePanelAlert from "./StalePanelAlert";
 import Alert from "@/components/Alert";
 
 /**
@@ -317,7 +313,7 @@ const DataPanel: React.FC<{
             )}
             {showFormPreview || showDocumentPreview ? (
               <ErrorBoundary>
-                <StalePreview />
+                <StalePanelAlert />
                 {showFormPreview ? (
                   <div className={dataPanelStyles.selectablePreviewContainer}>
                     <FormPreview

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -21,7 +21,7 @@ import { UUID } from "@/core";
 import { FormState } from "@/pageEditor/pageEditorTypes";
 import { isEmpty, isEqual, pickBy } from "lodash";
 import { useFormikContext } from "formik";
-import { Alert, Button, Nav, Tab } from "react-bootstrap";
+import { Button, Nav, Tab } from "react-bootstrap";
 import dataPanelStyles from "@/pageEditor/tabs/dataPanelTabs.module.scss";
 import FormPreview from "@/components/formBuilder/preview/FormPreview";
 import ErrorBoundary from "@/components/ErrorBoundary";
@@ -48,8 +48,10 @@ import ErrorDisplay from "./ErrorDisplay";
 import PageStateTab from "./PageStateTab";
 import { DataPanelTabKey } from "./dataPanelTypes";
 import DataTabJsonTree from "./DataTabJsonTree";
-import { selectNodePreviewActiveElement } from "@/pageEditor/uiState/uiState";
+import { selectNodePreviewActiveElement } from "@/pageEditor/slices/editorSelectors";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
+import StalePreview from "./StalePreview";
+import Alert from "@/components/Alert";
 
 /**
  * Exclude irrelevant top-level keys.
@@ -193,8 +195,7 @@ const DataPanel: React.FC<{
           <DataTab eventKey={DataPanelTabKey.Context} isTraceEmpty={!record}>
             {isInputStale && (
               <Alert variant="warning">
-                <FontAwesomeIcon icon={faExclamationTriangle} /> A previous
-                block has changed, input context may be out of date
+                A previous block has changed, input context may be out of date
               </Alert>
             )}
             <DataTabJsonTree
@@ -247,14 +248,12 @@ const DataPanel: React.FC<{
               <>
                 {record.skippedRun ? (
                   <Alert variant="info">
-                    <FontAwesomeIcon icon={faInfoCircle} /> Error rendering
-                    input arguments, but brick was skipped because condition was
-                    not met
+                    Error rendering input arguments, but brick was skipped
+                    because condition was not met
                   </Alert>
                 ) : (
                   <Alert variant="danger">
-                    <FontAwesomeIcon icon={faExclamationCircle} /> Error
-                    rendering input arguments
+                    Error rendering input arguments
                   </Alert>
                 )}
                 <ErrorDisplay error={record.renderError} />
@@ -263,8 +262,8 @@ const DataPanel: React.FC<{
               <>
                 {isInputStale && (
                   <Alert variant="warning">
-                    <FontAwesomeIcon icon={faExclamationTriangle} /> A previous
-                    block has changed, input context may be out of date
+                    A previous block has changed, input context may be out of
+                    date
                   </Alert>
                 )}
                 <DataTabJsonTree
@@ -284,16 +283,15 @@ const DataPanel: React.FC<{
           >
             {record?.skippedRun && (
               <Alert variant="info">
-                <FontAwesomeIcon icon={faInfoCircle} /> The brick did not run
-                because the condition was not met
+                The brick did not run because the condition was not met
               </Alert>
             )}
             {!record?.skippedRun && outputObj && (
               <>
                 {isCurrentStale && (
                   <Alert variant="warning">
-                    <FontAwesomeIcon icon={faExclamationTriangle} /> This or a
-                    previous brick has changed, output may be out of date
+                    This or a previous brick has changed, output may be out of
+                    date
                   </Alert>
                 )}
                 <DataTabJsonTree
@@ -313,13 +311,13 @@ const DataPanel: React.FC<{
             {/* The value of block.if can be `false`, in this case we also need to show the warning */}
             {block.if != null && (
               <Alert variant="info">
-                <FontAwesomeIcon icon={faInfoCircle} /> This brick has a
-                condition. The brick will not execute if the condition is not
-                met
+                This brick has a condition. The brick will not execute if the
+                condition is not met
               </Alert>
             )}
             {showFormPreview || showDocumentPreview ? (
               <ErrorBoundary>
+                <StalePreview />
                 {showFormPreview ? (
                   <div className={dataPanelStyles.selectablePreviewContainer}>
                     <FormPreview

--- a/src/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree.tsx
@@ -19,7 +19,7 @@ import JsonTree, {
   JsonTreeProps,
   TreeExpandedState,
 } from "@/components/jsonTree/JsonTree";
-import { selectNodeDataPanelTabState } from "@/pageEditor/uiState/uiState";
+import { selectNodeDataPanelTabState } from "@/pageEditor/slices/editorSelectors";
 import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Except } from "type-fest";

--- a/src/pageEditor/tabs/editTab/dataPanel/StalePanelAlert.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/StalePanelAlert.tsx
@@ -18,17 +18,31 @@
 import React from "react";
 import { selectExtensionTrace } from "@/pageEditor/slices/runtimeSelectors";
 import { useSelector } from "react-redux";
-import { selectActiveNode } from "@/pageEditor/slices/editorSelectors";
+import {
+  selectActiveElement,
+  selectActiveNode,
+} from "@/pageEditor/slices/editorSelectors";
 import { isEqual } from "lodash";
 import Alert from "@/components/Alert";
 
-const StalePreview: React.FunctionComponent = () => {
+const StalePanelAlert: React.FunctionComponent = () => {
+  const activeElement = useSelector(selectActiveElement);
   const traces = useSelector(selectExtensionTrace);
   const activeNode = useSelector(selectActiveNode);
+
+  // Only show alert for Panel and Side Panel extensions
+  if (
+    activeElement?.type !== "panel" &&
+    activeElement?.type !== "actionPanel"
+  ) {
+    return null;
+  }
+
   const trace = traces.find(
     (trace) => trace.blockInstanceId === activeNode?.instanceId
   );
 
+  // No traces or no changes since the last render, we are good, no alert
   if (
     traces.length === 0 ||
     trace == null ||
@@ -39,9 +53,10 @@ const StalePreview: React.FunctionComponent = () => {
 
   return (
     <Alert variant="info">
-      The rendered sidebar is out of date with the preview
+      The rendered {activeElement.type === "panel" ? "Panel" : "Sidebar Panel"}{" "}
+      is out of date with the preview
     </Alert>
   );
 };
 
-export default StalePreview;
+export default StalePanelAlert;

--- a/src/pageEditor/tabs/editTab/dataPanel/StalePreview.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/StalePreview.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { selectExtensionTrace } from "@/pageEditor/slices/runtimeSelectors";
+import { useSelector } from "react-redux";
+import { selectActiveNode } from "@/pageEditor/slices/editorSelectors";
+import { isEqual } from "lodash";
+import Alert from "@/components/Alert";
+
+const StalePreview: React.FunctionComponent = () => {
+  const traces = useSelector(selectExtensionTrace);
+  const activeNode = useSelector(selectActiveNode);
+  const trace = traces.find(
+    (trace) => trace.blockInstanceId === activeNode?.instanceId
+  );
+
+  if (
+    traces.length === 0 ||
+    trace == null ||
+    isEqual(trace.blockConfig, activeNode)
+  ) {
+    return null;
+  }
+
+  return (
+    <Alert variant="info">
+      The rendered sidebar is out of date with the preview
+    </Alert>
+  );
+};
+
+export default StalePreview;

--- a/src/pageEditor/tabs/editTab/dataPanel/useDataPanelActiveTabKey.ts
+++ b/src/pageEditor/tabs/editTab/dataPanel/useDataPanelActiveTabKey.ts
@@ -16,7 +16,7 @@
  */
 
 import { useDispatch, useSelector } from "react-redux";
-import { selectNodeDataPanelTabSelected } from "@/pageEditor/uiState/uiState";
+import { selectNodeDataPanelTabSelected } from "@/pageEditor/slices/editorSelectors";
 import { useCallback, useEffect, useMemo } from "react";
 import { actions } from "@/pageEditor/slices/editorSlice";
 import { DataPanelTabKey } from "./dataPanelTypes";

--- a/src/pageEditor/uiState/uiState.ts
+++ b/src/pageEditor/uiState/uiState.ts
@@ -17,7 +17,6 @@
 
 import { NodeId } from "@/pageEditor/tabs/editTab/editorNode/EditorNode";
 import { UUID } from "@/core";
-import { RootState } from "@/pageEditor/pageEditorTypes";
 import {
   ElementUIState,
   NodeUIState,
@@ -59,44 +58,4 @@ export function makeInitialElementUIState(): ElementUIState {
       [FOUNDATION_NODE_ID]: makeInitialNodeUIState(FOUNDATION_NODE_ID),
     },
   };
-}
-
-export function selectActiveElementUIState(
-  rootState: RootState
-): ElementUIState {
-  return rootState.editor.elementUIStates[rootState.editor.activeElementId];
-}
-
-export function selectActiveNodeUIState(rootState: RootState): NodeUIState {
-  const elementUIState = selectActiveElementUIState(rootState);
-  return elementUIState.nodeUIStates[elementUIState.activeNodeId];
-}
-
-export function selectActiveNodeId(rootState: RootState): NodeId {
-  const elementUIState = selectActiveElementUIState(rootState);
-  return elementUIState.activeNodeId;
-}
-
-export function selectNodeDataPanelTabSelected(
-  rootState: RootState
-): DataPanelTabKey {
-  const nodeUIState = selectActiveNodeUIState(rootState);
-  return nodeUIState.dataPanel.activeTabKey;
-}
-
-export function selectNodeDataPanelTabState(
-  rootState: RootState,
-  tabKey: DataPanelTabKey
-): TabUIState {
-  const nodeUIState = selectActiveNodeUIState(rootState);
-  // eslint-disable-next-line security/detect-object-injection -- tabKeys will be hard-coded strings
-  return nodeUIState.dataPanel[tabKey];
-}
-
-/**
- * Selects the activeElement of the Document or Form builder on the Preview tab
- */
-export function selectNodePreviewActiveElement(rootState: RootState): string {
-  return selectNodeDataPanelTabState(rootState, DataPanelTabKey.Preview)
-    .activeElement;
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #3352
- Shows and alert for Panel and Sidebar panel when the rendered view is outdated
- Moves Data Panel selectors to `editorSelectors.ts`
- Adds an Alert component

## Demo

- Panel
https://www.loom.com/share/69adfe42d70142f1a6375cdb32e02c67

- Sidebar panel
https://www.loom.com/share/e92552ae35a54c3ea8ab8db00014cea5

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
