### PR TITLE
Fix NPE in storybook stories

### DIFF
--- a/src/components/fields/schemaFields/fieldInputMode.test.ts
+++ b/src/components/fields/schemaFields/fieldInputMode.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { inferInputMode } from "@/components/fields/schemaFields/fieldInputMode";
+
+describe("test input mode", () => {
+  test("variable expression", () => {
+    expect(
+      inferInputMode(
+        { field: { __type__: "var", __value__: "@foo" } },
+        "field",
+        {
+          type: "string",
+        }
+      )
+    ).toBe("var");
+  });
+
+  test("nunjucks expression", () => {
+    expect(
+      inferInputMode(
+        { field: { __type__: "nunjucks", __value__: "{{ foo }}" } },
+        "field",
+        {
+          type: "string",
+        }
+      )
+    ).toBe("string");
+  });
+
+  test("number literal", () => {
+    expect(
+      inferInputMode({ field: 42 }, "field", {
+        type: "number",
+      })
+    ).toBe("number");
+  });
+
+  test("string enum", () => {
+    expect(
+      inferInputMode({ field: "apple" }, "field", {
+        type: "string",
+        enum: ["apple", "banana"],
+      })
+    ).toBe("select");
+  });
+});

--- a/src/components/fields/schemaFields/fieldInputMode.ts
+++ b/src/components/fields/schemaFields/fieldInputMode.ts
@@ -30,6 +30,12 @@ export type FieldInputMode =
   | "select"
   | "omit"; // An input option to remove a property
 
+/**
+ * Try to infer the field toggle input mode from the current value of the field.
+ * @param fieldConfig the current state/configuration of the field
+ * @param fieldName the name of the field in the configuration
+ * @param fieldSchema the JSON Schema for the field
+ */
 export function inferInputMode(
   fieldConfig: UnknownObject,
   fieldName: string,

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -101,7 +101,8 @@ const defaultRenderStatus: RenderStatus = ({ status }) => (
 );
 
 const Form: React.FC<FormProps> = ({
-  initialValues,
+  // Default to {} to be defensive against callers that pass through null/undefined form state when uninitialized
+  initialValues = {},
   validationSchema,
   validateOnMount,
   enableReinitialize,

--- a/src/options/pages/services/ServiceEditorModal.stories.tsx
+++ b/src/options/pages/services/ServiceEditorModal.stories.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { ComponentProps, useEffect } from "react";
+import React, { ComponentProps } from "react";
 import { ComponentMeta, Story } from "@storybook/react";
 import ServiceEditorModal from "./ServiceEditorModal";
 import { action } from "@storybook/addon-actions";

--- a/src/options/pages/services/ServiceEditorModal.stories.tsx
+++ b/src/options/pages/services/ServiceEditorModal.stories.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { ComponentProps } from "react";
+import React, { ComponentProps, useEffect } from "react";
 import { ComponentMeta, Story } from "@storybook/react";
 import ServiceEditorModal from "./ServiceEditorModal";
 import { action } from "@storybook/addon-actions";
@@ -25,6 +25,7 @@ import { ServiceDefinition } from "@/types/definitions";
 
 import pipedriveYaml from "@contrib/services/pipedrive.yaml?loadAsText";
 import automationAnywhereYaml from "@contrib/services/automation-anywhere.yaml?loadAsText";
+import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 
 const FIXTURES = {
   pipedrive: pipedriveYaml,
@@ -44,10 +45,11 @@ const Template: Story<StoryType> = ({ fixture, ...args }) => {
   // eslint-disable-next-line security/detect-object-injection -- type checked from fixture object
   const service = fromJS(loadBrickYaml(FIXTURES[fixture]) as ServiceDefinition);
 
+  // Cheap call, just call in the render function
+  registerDefaultWidgets();
+
   return <ServiceEditorModal {...args} service={service} />;
 };
-
-// FIXME: the modals get rendered behind their own overlay so you can't interact with them on the page
 
 export const Pipedrive = Template.bind({});
 Pipedrive.args = {

--- a/src/options/pages/services/ServiceEditorModal.tsx
+++ b/src/options/pages/services/ServiceEditorModal.tsx
@@ -109,7 +109,7 @@ const ServiceEditorModal: React.FunctionComponent<OwnProps> = ({
     }
 
     try {
-      // The dereferenced schema is frozen, buildYup can mutate it, so we need to "unfreeze" the schema
+      // The de-referenced schema is frozen, buildYup can mutate it, so we need to "unfreeze" the schema
       return buildYup(cloneDeep(schema), {});
     } catch (error) {
       console.error("Error building Yup validator from JSON Schema");


### PR DESCRIPTION
## What does this PR do?

- Fixes the ServiceEditorModal stories
- Adds some basic test coverage for inferInputMode
- The fix: 
  - Call registerDefaultWidgets to match the test code
  - In Form.tsx, default the initialValues to `{}` if the called passes null/undefined

