### PR TITLE
#3013: Detect CSP errors when fetching

### DIFF
--- a/src/services/errors.ts
+++ b/src/services/errors.ts
@@ -103,6 +103,30 @@ export class RemoteServiceError extends ClientRequestError {
 }
 
 /**
+ * An error caused by a strict CSP policy.
+ */
+export class CSPPolicyError extends ClientRequestError {
+  override name = "CSPPolicyError";
+  readonly blockedURI: string;
+  readonly policy: string;
+
+  constructor(
+    message: string,
+    { blockedURI, policy, cause }: CSPPolicyErrorOptions
+  ) {
+    super(message, cause);
+    this.blockedURI = blockedURI;
+    this.policy = policy;
+  }
+}
+
+interface CSPPolicyErrorOptions {
+  blockedURI: string;
+  policy: string;
+  cause: AxiosError;
+}
+
+/**
  * An error triggered by a failed network request due to missing permissions
  *
  * - Blocked by browser due to CORS

--- a/src/utils/cspCatcher.test.ts
+++ b/src/utils/cspCatcher.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getLastCspViolation } from "./cspCatcher";
+
+function dispatchCspViolationEvent(blockedURI: string): Event {
+  const event = new Event("securitypolicyviolation");
+  (event as any).blockedURI = blockedURI;
+  document.dispatchEvent(event);
+  return event;
+}
+
+describe("getLastCspViolation", () => {
+  test("should resolve with undefined", async () => {
+    await expect(
+      getLastCspViolation("https://example.com")
+    ).resolves.toBeUndefined();
+  });
+
+  test("should ignore violations for unrelated URLs", async () => {
+    const failedFetchUrl = "https://example.com/api";
+    const browserCspEventUrl = "https://example.com/api2"; // Different url
+    const violationPromise = getLastCspViolation(failedFetchUrl);
+    dispatchCspViolationEvent(browserCspEventUrl);
+    await expect(violationPromise).resolves.toBeUndefined();
+  });
+
+  test("should catch violations for exact URL matches", async () => {
+    const failedFetchUrl = "https://example.com/api";
+    const browserCspEventUrl = failedFetchUrl; // Same URL
+    const violationPromise = getLastCspViolation(failedFetchUrl);
+    const event = dispatchCspViolationEvent(browserCspEventUrl);
+    await expect(violationPromise).resolves.toBe(event);
+  });
+});

--- a/src/utils/cspCatcher.ts
+++ b/src/utils/cspCatcher.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import pDefer from "p-defer";
+
+// CSP events are dispatched "immediately" after the `fetch` request.
+// This usually happens within one millisecond but I've seen 20ms too.
+const CSP_REPORT_TIMEOUT_MS = 100;
+
+/**
+ * Wait for any CSP violation events that might be dispatched after a `fetch` failure.
+ * This must be called immediately after a `fetch` failure.
+ * It resolve at most CSP_REPORT_TIMEOUT_MS later.
+ */
+export async function getLastCspViolation(
+  requestedUrl: string
+): Promise<SecurityPolicyViolationEvent | undefined> {
+  const { promise, resolve } = pDefer<SecurityPolicyViolationEvent>();
+  const listener = (event: SecurityPolicyViolationEvent) => {
+    if (event.blockedURI === requestedUrl) {
+      resolve(event);
+    }
+  };
+
+  setTimeout(resolve, CSP_REPORT_TIMEOUT_MS);
+  document.addEventListener("securitypolicyviolation", listener);
+
+  try {
+    return await promise;
+  } finally {
+    document.removeEventListener("securitypolicyviolation", listener);
+  }
+}


### PR DESCRIPTION
## What does this PR do?

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/3013
- Matches undetermined network request failures to CSP events, thus making the errors more specific than "Fetch failed"

## Discussion

- How can we trigger CSP events? Aren't all fetches already routed via the background page? There all `https` URLs should be allowed.

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer
