### PR TITLE
3354 Don't always show Block name in Title

### DIFF
--- a/src/pageEditor/tabs/effect/BlockConfiguration.tsx
+++ b/src/pageEditor/tabs/effect/BlockConfiguration.tsx
@@ -27,7 +27,7 @@ import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import { joinName } from "@/utils";
 import { useAsyncState } from "@/hooks/common";
 import SelectWidget, { Option } from "@/components/form/widgets/SelectWidget";
-import { partial } from "lodash";
+import { isEmpty, partial } from "lodash";
 import { BlockWindow } from "@/blocks/types";
 import AdvancedLinks, {
   DEFAULT_WINDOW_VALUE,
@@ -61,7 +61,7 @@ const BlockConfiguration: React.FunctionComponent<{
   const configName = partial(joinName, name);
 
   const context = useFormikContext<FormState>();
-
+  const blockLabel = getIn(context.values, configName("label"));
   const blockErrors = getIn(context.errors, name);
 
   const [{ block, error }, BlockOptions] = useBlockOptions(blockId);
@@ -109,7 +109,13 @@ const BlockConfiguration: React.FunctionComponent<{
 
       <Card>
         <FieldSection
-          title={<ConfigurationTitle block={block} listing={listing} />}
+          title={
+            <ConfigurationTitle
+              block={block}
+              listing={listing}
+              showBlockLabel={!isEmpty(blockLabel)}
+            />
+          }
         >
           <SchemaFieldContext.Provider value={devtoolFieldOverrides}>
             {blockErrors?.id && (

--- a/src/pageEditor/tabs/effect/ConfigurationTitle.module.scss
+++ b/src/pageEditor/tabs/effect/ConfigurationTitle.module.scss
@@ -27,5 +27,6 @@
 }
 
 .documentationLink {
+  // TODO move this color to a variable; need to settle on how to use variables with Page Editor
   color: #7abbef;
 }

--- a/src/pageEditor/tabs/effect/ConfigurationTitle.module.scss
+++ b/src/pageEditor/tabs/effect/ConfigurationTitle.module.scss
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 1 50%;
+}
+
+.blockName {
+  color: var(--gray);
+}
+
+.documentationLink {
+  color: #7abbef;
+}

--- a/src/pageEditor/tabs/effect/ConfigurationTitle.test.tsx
+++ b/src/pageEditor/tabs/effect/ConfigurationTitle.test.tsx
@@ -23,6 +23,13 @@ import ConfigurationTitle from "./ConfigurationTitle";
 
 test("renders block name", () => {
   const rendered = render(
+    <ConfigurationTitle block={echoBlock} listing={null} showBlockLabel />
+  );
+  expect(rendered.asFragment()).toMatchSnapshot();
+});
+
+test("renders plain 'Input' title", () => {
+  const rendered = render(
     <ConfigurationTitle block={echoBlock} listing={null} />
   );
   expect(rendered.asFragment()).toMatchSnapshot();
@@ -34,7 +41,7 @@ test("renders document link when How To is not empty", () => {
     instructions: "Test how to",
   } as MarketplaceListing;
   const rendered = render(
-    <ConfigurationTitle block={echoBlock} listing={listing} />
+    <ConfigurationTitle block={echoBlock} listing={listing} showBlockLabel />
   );
   expect(rendered.asFragment()).toMatchSnapshot();
 });
@@ -49,7 +56,7 @@ test("renders document link when Additional resources is not empty", () => {
     ],
   } as MarketplaceListing;
   const rendered = render(
-    <ConfigurationTitle block={echoBlock} listing={listing} />
+    <ConfigurationTitle block={echoBlock} listing={listing} showBlockLabel />
   );
   expect(rendered.asFragment()).toMatchSnapshot();
 });

--- a/src/pageEditor/tabs/effect/ConfigurationTitle.tsx
+++ b/src/pageEditor/tabs/effect/ConfigurationTitle.tsx
@@ -15,26 +15,31 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import React from "react";
 import { IBlock } from "@/core";
 import { MarketplaceListing } from "@/types/contract";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { isEmpty } from "lodash";
-import React from "react";
+import styles from "./ConfigurationTitle.module.scss";
 
 type ConfigurationTitleProps = {
   block: IBlock | null;
   listing: MarketplaceListing | null;
+  showBlockLabel?: boolean;
 };
 
 const ConfigurationTitle: React.FunctionComponent<ConfigurationTitleProps> = ({
   block,
   listing,
+  showBlockLabel = false,
 }) => {
-  const configurationTitle = (
-    <span>
-      Input: <span className="text-muted">{block?.name}</span>
+  const configurationTitle = showBlockLabel ? (
+    <span className={styles.title}>
+      Input: <span className={styles.blockName}>{block?.name}</span>
     </span>
+  ) : (
+    <span>Input</span>
   );
 
   return isEmpty(listing?.instructions) && isEmpty(listing?.assets) ? (
@@ -46,6 +51,7 @@ const ConfigurationTitle: React.FunctionComponent<ConfigurationTitleProps> = ({
         href={`https://www.pixiebrix.com/marketplace/${listing.id}/`}
         target="_blank"
         rel="noreferrer"
+        className={styles.documentationLink}
       >
         <FontAwesomeIcon icon={faExternalLinkAlt} /> View Documentation
       </a>

--- a/src/pageEditor/tabs/effect/ConfigurationTitle.tsx
+++ b/src/pageEditor/tabs/effect/ConfigurationTitle.tsx
@@ -48,7 +48,7 @@ const ConfigurationTitle: React.FunctionComponent<ConfigurationTitleProps> = ({
     <div className="d-flex justify-content-between">
       {configurationTitle}
       <a
-        href={`https://www.pixiebrix.com/marketplace/${listing.id}/`}
+        href={`https://www.pixiebrix.com/marketplace/${listing.id}/?utm_source=pixiebrix&utm_medium=page_editor&utm_campaign=docs&utm_content=view_docs_link`}
         target="_blank"
         rel="noreferrer"
         className={styles.documentationLink}

--- a/src/pageEditor/tabs/effect/__snapshots__/BlockConfiguration.test.tsx.snap
+++ b/src/pageEditor/tabs/effect/__snapshots__/BlockConfiguration.test.tsx.snap
@@ -12,12 +12,7 @@ exports[`renders 1`] = `
         class="cardHeader card-header"
       >
         <span>
-          Input: 
-          <span
-            class="text-muted"
-          >
-            Echo Block
-          </span>
+          Input
         </span>
       </div>
       <div

--- a/src/pageEditor/tabs/effect/__snapshots__/ConfigurationTitle.test.tsx.snap
+++ b/src/pageEditor/tabs/effect/__snapshots__/ConfigurationTitle.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`renders document link when Additional resources is not empty 1`] = `
     </span>
     <a
       class="documentationLink"
-      href="https://www.pixiebrix.com/marketplace/test_listing_id/"
+      href="https://www.pixiebrix.com/marketplace/test_listing_id/?utm_source=pixiebrix&utm_medium=page_editor&utm_campaign=docs&utm_content=view_docs_link"
       rel="noreferrer"
       target="_blank"
     >
@@ -74,7 +74,7 @@ exports[`renders document link when How To is not empty 1`] = `
     </span>
     <a
       class="documentationLink"
-      href="https://www.pixiebrix.com/marketplace/test_listing_id/"
+      href="https://www.pixiebrix.com/marketplace/test_listing_id/?utm_source=pixiebrix&utm_medium=page_editor&utm_campaign=docs&utm_content=view_docs_link"
       rel="noreferrer"
       target="_blank"
     >

--- a/src/pageEditor/tabs/effect/__snapshots__/ConfigurationTitle.test.tsx.snap
+++ b/src/pageEditor/tabs/effect/__snapshots__/ConfigurationTitle.test.tsx.snap
@@ -2,10 +2,12 @@
 
 exports[`renders block name 1`] = `
 <DocumentFragment>
-  <span>
+  <span
+    class="title"
+  >
     Input: 
     <span
-      class="text-muted"
+      class="blockName"
     >
       Echo Block
     </span>
@@ -18,15 +20,18 @@ exports[`renders document link when Additional resources is not empty 1`] = `
   <div
     class="d-flex justify-content-between"
   >
-    <span>
+    <span
+      class="title"
+    >
       Input: 
       <span
-        class="text-muted"
+        class="blockName"
       >
         Echo Block
       </span>
     </span>
     <a
+      class="documentationLink"
       href="https://www.pixiebrix.com/marketplace/test_listing_id/"
       rel="noreferrer"
       target="_blank"
@@ -57,15 +62,18 @@ exports[`renders document link when How To is not empty 1`] = `
   <div
     class="d-flex justify-content-between"
   >
-    <span>
+    <span
+      class="title"
+    >
       Input: 
       <span
-        class="text-muted"
+        class="blockName"
       >
         Echo Block
       </span>
     </span>
     <a
+      class="documentationLink"
       href="https://www.pixiebrix.com/marketplace/test_listing_id/"
       rel="noreferrer"
       target="_blank"
@@ -88,5 +96,13 @@ exports[`renders document link when How To is not empty 1`] = `
        View Documentation
     </a>
   </div>
+</DocumentFragment>
+`;
+
+exports[`renders plain 'Input' title 1`] = `
+<DocumentFragment>
+  <span>
+    Input
+  </span>
 </DocumentFragment>
 `;


### PR DESCRIPTION
## What does this PR do?

- Closes #3354
- Addresses the issues from https://github.com/pixiebrix/pixiebrix-extension/pull/3375#pullrequestreview-973196483
- Shows the brick name only when a custom label is set for the brick
- Adds UTM tags to the documentation link

## Discussion

- What would be the best way to define link color?

## Demo

https://www.loom.com/share/a2344b1f5ab24455bb0698f1daed02ca

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer
