### PR TITLE
Refactor theme utilities

### DIFF
--- a/src/background/partnerTheme.ts
+++ b/src/background/partnerTheme.ts
@@ -16,7 +16,7 @@
  */
 
 import { getSettingsState } from "@/store/settingsStorage";
-import { getThemeLogo } from "@/hooks/useTheme";
+import { getThemeLogo } from "@/utils/themeUtils";
 
 async function setToolbarIcon(): Promise<void> {
   const { theme } = await getSettingsState();

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -19,48 +19,14 @@ import { useEffect } from "react";
 import { selectSettings } from "@/store/settingsSelectors";
 import settingsSlice from "@/store/settingsSlice";
 import { useDispatch, useSelector } from "react-redux";
-import { DEFAULT_THEME, Theme, THEMES } from "@/options/constants";
-import logo from "@img/logo.svg";
-import logoSmall from "@img/logo-small-rounded.svg";
-import aaLogo from "@img/aa-logo.svg";
-import aaLogoSmall from "@img/aa-logo-small.svg";
+import { DEFAULT_THEME, THEMES } from "@/options/constants";
 import { activatePartnerTheme } from "@/background/messenger/api";
 import { persistor } from "@/options/store";
 import { useAsyncState } from "@/hooks/common";
 import { ManualStorageKey, readStorage } from "@/chrome";
-import { isValidTheme } from "@/utils/themeUtils";
+import { getThemeLogo, ThemeLogo } from "@/utils/themeUtils";
 
 const MANAGED_PARTNER_ID_KEY = "partnerId" as ManualStorageKey;
-
-type ThemeLogo = {
-  regular: string;
-  small: string;
-};
-
-type ThemeLogoMap = {
-  [key in Theme]: ThemeLogo;
-};
-
-const THEME_LOGOS: ThemeLogoMap = {
-  default: {
-    regular: logo,
-    small: logoSmall,
-  },
-  "automation-anywhere": {
-    regular: aaLogo,
-    small: aaLogoSmall,
-  },
-};
-
-export const getThemeLogo = (theme: string): ThemeLogo => {
-  if (isValidTheme(theme)) {
-    // eslint-disable-next-line security/detect-object-injection -- theme is type Theme, a union type of string literal
-    return THEME_LOGOS[theme];
-  }
-
-  // eslint-disable-next-line security/detect-object-injection -- theme not user defined
-  return THEME_LOGOS[DEFAULT_THEME];
-};
 
 const activateBackgroundTheme = async (): Promise<void> => {
   // Flush the Redux state to localStorage to ensure the background page sees the latest state

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -19,12 +19,16 @@ import { useEffect } from "react";
 import { selectSettings } from "@/store/settingsSelectors";
 import settingsSlice from "@/store/settingsSlice";
 import { useDispatch, useSelector } from "react-redux";
-import { DEFAULT_THEME, Theme, THEMES } from "@/options/constants";
+import { DEFAULT_THEME } from "@/options/constants";
 import { activatePartnerTheme } from "@/background/messenger/api";
 import { persistor } from "@/options/store";
 import { useAsyncState } from "@/hooks/common";
 import { ManualStorageKey, readStorage } from "@/chrome";
-import { getThemeLogo, ThemeLogo } from "@/utils/themeUtils";
+import {
+  addThemeClassToDocumentRoot,
+  getThemeLogo,
+  ThemeLogo,
+} from "@/utils/themeUtils";
 
 const MANAGED_PARTNER_ID_KEY = "partnerId" as ManualStorageKey;
 
@@ -32,16 +36,6 @@ const activateBackgroundTheme = async (): Promise<void> => {
   // Flush the Redux state to localStorage to ensure the background page sees the latest state
   await persistor.flush();
   await activatePartnerTheme();
-};
-
-const addThemeClassToDocumentRoot = (theme: Theme): void => {
-  for (const theme of THEMES) {
-    document.documentElement.classList.remove(theme);
-  }
-
-  if (theme && theme !== DEFAULT_THEME) {
-    document.documentElement.classList.add(theme);
-  }
 };
 
 const useTheme = (): { logo: ThemeLogo } => {

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -19,7 +19,7 @@ import { useEffect } from "react";
 import { selectSettings } from "@/store/settingsSelectors";
 import settingsSlice from "@/store/settingsSlice";
 import { useDispatch, useSelector } from "react-redux";
-import { DEFAULT_THEME, THEMES } from "@/options/constants";
+import { DEFAULT_THEME, Theme, THEMES } from "@/options/constants";
 import { activatePartnerTheme } from "@/background/messenger/api";
 import { persistor } from "@/options/store";
 import { useAsyncState } from "@/hooks/common";
@@ -32,6 +32,16 @@ const activateBackgroundTheme = async (): Promise<void> => {
   // Flush the Redux state to localStorage to ensure the background page sees the latest state
   await persistor.flush();
   await activatePartnerTheme();
+};
+
+const addThemeClassToDocumentRoot = (theme: Theme): void => {
+  for (const theme of THEMES) {
+    document.documentElement.classList.remove(theme);
+  }
+
+  if (theme && theme !== DEFAULT_THEME) {
+    document.documentElement.classList.add(theme);
+  }
 };
 
 const useTheme = (): { logo: ThemeLogo } => {
@@ -64,14 +74,7 @@ const useTheme = (): { logo: ThemeLogo } => {
     );
 
     void activateBackgroundTheme();
-
-    for (const theme of THEMES) {
-      document.documentElement.classList.remove(theme);
-    }
-
-    if (theme && theme !== DEFAULT_THEME) {
-      document.documentElement.classList.add(theme);
-    }
+    addThemeClassToDocumentRoot(theme);
   }, [dispatch, partnerId, theme]);
 
   return {

--- a/src/utils/themeUtils.ts
+++ b/src/utils/themeUtils.ts
@@ -15,7 +15,41 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Theme, THEMES } from "@/options/constants";
+import { DEFAULT_THEME, Theme, THEMES } from "@/options/constants";
+import logo from "@img/logo.svg";
+import logoSmall from "@img/logo-small-rounded.svg";
+import aaLogo from "@img/aa-logo.svg";
+import aaLogoSmall from "@img/aa-logo-small.svg";
 
 export const isValidTheme = (theme: string): theme is Theme =>
   THEMES.includes(theme as Theme);
+
+export type ThemeLogo = {
+  regular: string;
+  small: string;
+};
+
+type ThemeLogoMap = {
+  [key in Theme]: ThemeLogo;
+};
+
+const THEME_LOGOS: ThemeLogoMap = {
+  default: {
+    regular: logo,
+    small: logoSmall,
+  },
+  "automation-anywhere": {
+    regular: aaLogo,
+    small: aaLogoSmall,
+  },
+};
+
+export const getThemeLogo = (theme: string): ThemeLogo => {
+  if (isValidTheme(theme)) {
+    // eslint-disable-next-line security/detect-object-injection -- theme is type Theme, a union type of string literal
+    return THEME_LOGOS[theme];
+  }
+
+  // eslint-disable-next-line security/detect-object-injection -- theme not user defined
+  return THEME_LOGOS[DEFAULT_THEME];
+};

--- a/src/utils/themeUtils.ts
+++ b/src/utils/themeUtils.ts
@@ -44,6 +44,8 @@ const THEME_LOGOS: ThemeLogoMap = {
   },
 };
 
+// Note: this function is re-used in the app. Should not reference
+// anything unavailable in the app environment, e.g. the background page
 export const getThemeLogo = (theme: string): ThemeLogo => {
   if (isValidTheme(theme)) {
     // eslint-disable-next-line security/detect-object-injection -- theme is type Theme, a union type of string literal
@@ -52,4 +54,16 @@ export const getThemeLogo = (theme: string): ThemeLogo => {
 
   // eslint-disable-next-line security/detect-object-injection -- theme not user defined
   return THEME_LOGOS[DEFAULT_THEME];
+};
+
+// Note: this function is re-used in the app. Should not reference
+// anything unavailable in the app environment, e.g. the background page
+export const addThemeClassToDocumentRoot = (theme: Theme): void => {
+  for (const theme of THEMES) {
+    document.documentElement.classList.remove(theme);
+  }
+
+  if (theme && theme !== DEFAULT_THEME) {
+    document.documentElement.classList.add(theme);
+  }
 };


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-app/issues/1470
- In order to prevent running into redux import conflicts while re-using the `getThemeLogo`, which formerly lived in the `useTheme` hook.

## Reviewer Tips
- Are there any other refactoring opportunities here? Ideally, I'd love to reuse the `useTheme` hook in the app, but this implementation currently touches both the options slice and the background script, which conflicts with the app.

## Discussion

- I was considering splitting off a `useGetTheme` from the `useTheme` hook, and `useTheme` could take a Theme as a parameter.

## Demo

n/a

## Future Work

n/a

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
