### PR TITLE
#3417: include brick version for YAML bricks

### DIFF
--- a/src/blocks/readers/factory.ts
+++ b/src/blocks/readers/factory.ts
@@ -25,6 +25,7 @@ import {
   ReaderOutput,
   ReaderRoot,
   ApiVersion,
+  SemVerString,
 } from "@/core";
 import { Availability } from "@/blocks/types";
 import { Validator } from "@cfworker/json-schema";
@@ -98,7 +99,7 @@ export function readerFactory(component: unknown): IReader {
   const cloned = cloneDeep(component);
 
   const {
-    metadata: { id, name, description },
+    metadata: { id, name, description, version },
     outputSchema = {},
     definition,
   } = cloned;
@@ -113,6 +114,8 @@ export function readerFactory(component: unknown): IReader {
     constructor() {
       super(id, name, description);
     }
+
+    public readonly version: SemVerString = version;
 
     override outputSchema: Schema = outputSchema;
 

--- a/src/blocks/transformers/blockFactory.test.js
+++ b/src/blocks/transformers/blockFactory.test.js
@@ -38,6 +38,16 @@ test("can read trello reader", async () => {
   expect(block.id).toBe("trello/card");
 });
 
+test("reader includes version", async () => {
+  const block = fromJS(trelloReader);
+  expect(block.version).toBe("0.0.1");
+});
+
+test("block includes version", async () => {
+  const block = fromJS(nytimes);
+  expect(block.version).toBe("0.0.1");
+});
+
 test("reject invalid fixture fixture", async () => {
   try {
     fromJS({ foo: "bar" });

--- a/src/blocks/transformers/blockFactory.ts
+++ b/src/blocks/transformers/blockFactory.ts
@@ -30,6 +30,7 @@ import {
   Metadata,
   RegistryId,
   Schema,
+  SemVerString,
 } from "@/core";
 import { dereference } from "@/validators/generic";
 import blockSchema from "@schemas/component.json";
@@ -70,6 +71,9 @@ function validateBlockDefinition(
   }
 }
 
+/**
+ * A non-native (i.e., non-JS) Block. Typically defined in YAML/JSON.
+ */
 class ExternalBlock extends Block {
   public readonly component: ComponentConfig;
 
@@ -77,13 +81,16 @@ class ExternalBlock extends Block {
 
   readonly inputSchema: Schema;
 
+  readonly version: SemVerString;
+
   constructor(component: ComponentConfig) {
-    const { id, name, description, icon } = component.metadata;
+    const { id, name, description, icon, version } = component.metadata;
     super(id, name, description, icon);
     this.apiVersion = component.apiVersion ?? "v1";
     this.component = component;
     this.inputSchema = this.component.inputSchema;
     this.outputSchema = this.component.outputSchema;
+    this.version = version;
   }
 
   override async isPure(): Promise<boolean> {
@@ -143,7 +150,7 @@ class ExternalBlock extends Block {
       logger: options.logger,
       headless: options.headless,
       // The component uses its declared version of the runtime API, regardless of what version of the runtime
-      // is used to call the the component
+      // is used to call the component
       ...apiVersionOptions(this.component.apiVersion),
     });
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -313,6 +313,7 @@ export type BlockIcon = string;
 export interface Metadata {
   readonly id: RegistryId;
   readonly name: string;
+  // XXX: why is this optional? Should default to the version of the extension?
   readonly version?: SemVerString;
   readonly description?: string;
 

--- a/src/services/factory.test.ts
+++ b/src/services/factory.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import automationAnywhere from "@contrib/services/automation-anywhere.yaml";
+import { fromJS } from "@/services/factory";
+
+describe("LocalDefinedService", () => {
+  test("includes version", () => {
+    const service = fromJS(automationAnywhere as any);
+    expect(service.version).toBe("1.0.0");
+  });
+});

--- a/src/services/factory.ts
+++ b/src/services/factory.ts
@@ -29,6 +29,7 @@ import {
   ServiceConfig,
   TokenContext,
   SanitizedConfig,
+  SemVerString,
 } from "@/core";
 import { testMatchPatterns } from "@/blocks/available";
 import { isEmpty, castArray, uniq, compact } from "lodash";
@@ -57,12 +58,15 @@ class LocalDefinedService<
 
   public readonly hasAuth: boolean;
 
+  public readonly version: SemVerString;
+
   constructor(definition: TDefinition) {
-    const { id, name, description, icon } = definition.metadata;
+    const { id, name, description, icon, version } = definition.metadata;
     super(id, name, description, icon);
     this._definition = definition;
     this.schema = this._definition.inputSchema;
     this.hasAuth = !isEmpty(this._definition.authentication);
+    this.version = version;
   }
 
   /**


### PR DESCRIPTION
## What does this PR do?

- Closes #3417
- Brick/Service ID weren't being reported for YAML based bricks because the version was never passed along through the corresponding brick factories

## Considerations
- Currently for JS bricks, we're default the version when adding the logging context: https://github.com/pixiebrix/pixiebrix-extension/blob/472e43f01561a1b8047a6b33c3dae45aefa67daa/src/runtime/reducePipeline.ts#L637-L637. In the future, we might consider having the JS bricks default in their constructor base classes instead

## Reviewer Notes
- If you're testing this locally, you have to run generate headers and then upload the updated headers for the JS bricks to the app project

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @johnnymetz 
