### PR TITLE
Drop length-only sorting in `SelectorSelectorWidget`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pixiebrix/extension",
-  "version": "1.6.3-alpha.2",
+  "version": "1.6.3-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pixiebrix/extension",
-      "version": "1.6.3-alpha.2",
+      "version": "1.6.3-alpha.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",

--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -99,7 +99,7 @@ export function getSelectorPreference(selector: string): number {
     return LOWEST_ENUM_PREFERENCE;
   }
 
-  // Ensure that even an `a` selector (length=1) has higher number than `.a` (number=LOWEST_ENUM_PREFERENCE)
+  // Ensure that even an `a` selector (length=1) has higher number than `.a` (number=2)
   return LOWEST_ENUM_PREFERENCE + selector.length;
 }
 

--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -70,37 +70,36 @@ function isSelectorUsuallyUnique(selector: string): boolean {
   return selector.startsWith("#") || UNIQUE_ATTRIBUTES_REGEX.test(selector);
 }
 
-const LOWEST_ENUM_PREFERENCE = 2;
 /**
  * Prefers unique selectors and classes. A lower number means higher preference. To be used with lodash.sortBy
  * @example
- * 0   '#best-link-on-the-page'
- * 1   '[data-cy="b4da55"]'
- * 2   '.navItem'
- * 2   '.birdsArentReal'
- * 3   'a'
+ * -2  '#best-link-on-the-page'
+ * -1  '[data-cy="b4da55"]'
+ *  0  '.navItem'
+ *  0  '.birdsArentReal'
+ *  1  'a'
  * 21  '#name > :nth-child(2)'
  * 30  '[aria-label="Click elsewhere"]'
  */
 export function getSelectorPreference(selector: string): number {
   if (selector.includes(":nth-child")) {
-    return LOWEST_ENUM_PREFERENCE + selector.length;
+    return selector.length;
   }
 
   if (selector.startsWith("#")) {
-    return 0;
+    return -2;
   }
 
   if (isSelectorUsuallyUnique(selector)) {
-    return 1;
+    return -1;
   }
 
   if (selector.startsWith(".")) {
-    return LOWEST_ENUM_PREFERENCE;
+    return 0;
   }
 
   // Ensure that even an `a` selector (length=1) has higher number than `.a` (number=2)
-  return LOWEST_ENUM_PREFERENCE + selector.length;
+  return selector.length;
 }
 
 const DEFAULT_SELECTOR_PRIORITIES: Array<keyof typeof CssSelectorType> = [

--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -70,6 +70,7 @@ function isSelectorUsuallyUnique(selector: string): boolean {
   return selector.startsWith("#") || UNIQUE_ATTRIBUTES_REGEX.test(selector);
 }
 
+const LOWEST_ENUM_PREFERENCE = 2;
 /**
  * Prefers unique selectors and classes. A lower number means higher preference. To be used with lodash.sortBy
  * @example
@@ -77,12 +78,13 @@ function isSelectorUsuallyUnique(selector: string): boolean {
  * 1   '[data-cy="b4da55"]'
  * 2   '.navItem'
  * 2   '.birdsArentReal'
+ * 3   'a'
  * 21  '#name > :nth-child(2)'
  * 30  '[aria-label="Click elsewhere"]'
  */
 export function getSelectorPreference(selector: string): number {
   if (selector.includes(":nth-child")) {
-    return selector.length;
+    return LOWEST_ENUM_PREFERENCE + selector.length;
   }
 
   if (selector.startsWith("#")) {
@@ -94,10 +96,11 @@ export function getSelectorPreference(selector: string): number {
   }
 
   if (selector.startsWith(".")) {
-    return 2;
+    return LOWEST_ENUM_PREFERENCE;
   }
 
-  return selector.length;
+  // Ensure that even an `a` selector (length=1) has higher number than `.a` (number=LOWEST_ENUM_PREFERENCE)
+  return LOWEST_ENUM_PREFERENCE + selector.length;
 }
 
 const DEFAULT_SELECTOR_PRIORITIES: Array<keyof typeof CssSelectorType> = [

--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -98,7 +98,7 @@ export function getSelectorPreference(selector: string): number {
     return 0;
   }
 
-  // Ensure that even an `a` selector (length=1) has higher number than `.a` (number=2)
+  // Pre-defined preferences should not go higher than 0 to avoid conflicting with this length check
   return selector.length;
 }
 

--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -112,7 +112,8 @@ export function sortBySelector<Item = string>(
  */
 export function getSelectorPreference(selector: string): number {
   if (selector.includes(":nth-child")) {
-    return selector.length;
+    // Structural selectors are fragile to page changes, so give low score
+    return 2;
   }
 
   if (selector.startsWith("#")) {

--- a/src/contentScript/selectorInference.test.ts
+++ b/src/contentScript/selectorInference.test.ts
@@ -172,11 +172,11 @@ test("getSelectorPreference: matches expected sorting", () => {
   expect(getSelectorPreference(".navItem")).toBe(2);
   expect(getSelectorPreference(".birdsArentReal")).toBe(2);
   const selector = '[aria-label="Click elsewhere"]';
-  expect(getSelectorPreference(selector)).toBe(selector.length);
+  expect(getSelectorPreference(selector)).toBe(2 + selector.length);
 
   // Even if it contains an ID, the selector is low quality
   const selector2 = "#name > :nth-child(2)";
-  expect(getSelectorPreference(selector2)).toBe(selector2.length);
+  expect(getSelectorPreference(selector2)).toBe(2 + selector2.length);
 });
 
 describe("inferSelectors", () => {

--- a/src/contentScript/selectorInference.test.ts
+++ b/src/contentScript/selectorInference.test.ts
@@ -192,7 +192,7 @@ test("getSelectorPreference: matches expected sorting", () => {
 
   // Even if it contains an ID, the selector is low quality
   const selector2 = "#name > :nth-child(2)";
-  expect(getSelectorPreference(selector2)).toBe(1);
+  expect(getSelectorPreference(selector2)).toBe(2);
 });
 
 describe("inferSelectors", () => {

--- a/src/contentScript/selectorInference.test.ts
+++ b/src/contentScript/selectorInference.test.ts
@@ -21,6 +21,7 @@ import {
   getSelectorPreference,
   inferSelectors,
   safeCssSelector,
+  sortBySelector,
 } from "./nativeEditor/selectorInference";
 import { JSDOM } from "jsdom";
 import { html } from "@/utils";
@@ -166,17 +167,32 @@ describe("safeCssSelector", () => {
   });
 });
 
+describe("sortBySelector", () => {
+  test("selector length", () => {
+    expect(sortBySelector(["#abc", "#a"])).toStrictEqual(["#a", "#abc"]);
+  });
+
+  test("select field", () => {
+    expect(
+      sortBySelector(
+        [{ foo: ".a" }, { foo: "#a" }],
+        (x: { foo: string }) => x.foo
+      )
+    ).toStrictEqual([{ foo: "#a" }, { foo: ".a" }]);
+  });
+});
+
 test("getSelectorPreference: matches expected sorting", () => {
   expect(getSelectorPreference("#best-link-on-the-page")).toBe(-2);
   expect(getSelectorPreference('[data-cy="b4da55"]')).toBe(-1);
   expect(getSelectorPreference(".navItem")).toBe(0);
   expect(getSelectorPreference(".birdsArentReal")).toBe(0);
   const selector = '[aria-label="Click elsewhere"]';
-  expect(getSelectorPreference(selector)).toBe(selector.length);
+  expect(getSelectorPreference(selector)).toBe(1);
 
   // Even if it contains an ID, the selector is low quality
   const selector2 = "#name > :nth-child(2)";
-  expect(getSelectorPreference(selector2)).toBe(selector2.length);
+  expect(getSelectorPreference(selector2)).toBe(1);
 });
 
 describe("inferSelectors", () => {

--- a/src/contentScript/selectorInference.test.ts
+++ b/src/contentScript/selectorInference.test.ts
@@ -167,16 +167,16 @@ describe("safeCssSelector", () => {
 });
 
 test("getSelectorPreference: matches expected sorting", () => {
-  expect(getSelectorPreference("#best-link-on-the-page")).toBe(0);
-  expect(getSelectorPreference('[data-cy="b4da55"]')).toBe(1);
-  expect(getSelectorPreference(".navItem")).toBe(2);
-  expect(getSelectorPreference(".birdsArentReal")).toBe(2);
+  expect(getSelectorPreference("#best-link-on-the-page")).toBe(-2);
+  expect(getSelectorPreference('[data-cy="b4da55"]')).toBe(-1);
+  expect(getSelectorPreference(".navItem")).toBe(0);
+  expect(getSelectorPreference(".birdsArentReal")).toBe(0);
   const selector = '[aria-label="Click elsewhere"]';
-  expect(getSelectorPreference(selector)).toBe(2 + selector.length);
+  expect(getSelectorPreference(selector)).toBe(selector.length);
 
   // Even if it contains an ID, the selector is low quality
   const selector2 = "#name > :nth-child(2)";
-  expect(getSelectorPreference(selector2)).toBe(2 + selector2.length);
+  expect(getSelectorPreference(selector2)).toBe(selector2.length);
 });
 
 describe("inferSelectors", () => {

--- a/src/pageEditor/fields/SelectorSelectorWidget.test.ts
+++ b/src/pageEditor/fields/SelectorSelectorWidget.test.ts
@@ -25,12 +25,12 @@ test("getSuggestionsForElement", () => {
       selectors: [".a"],
     },
   } as ElementInfo;
-  expect(getSuggestionsForElement(elementInfo, false)).toMatchObject([
+  expect(getSuggestionsForElement(elementInfo, { sort: false })).toMatchObject([
     { value: "a" },
     { value: "#a" },
     { value: ".a" },
   ]);
-  expect(getSuggestionsForElement(elementInfo, true)).toMatchObject([
+  expect(getSuggestionsForElement(elementInfo, { sort: true })).toMatchObject([
     { value: "#a" },
     { value: ".a" },
     { value: "a" },

--- a/src/pageEditor/fields/SelectorSelectorWidget.test.ts
+++ b/src/pageEditor/fields/SelectorSelectorWidget.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ElementInfo } from "@/contentScript/nativeEditor/types";
+import { getSuggestionsForElement } from "./SelectorSelectorWidget";
+
+test("getSuggestionsForElement", () => {
+  const elementInfo = {
+    selectors: ["a", "#a"],
+    parent: {
+      selectors: [".a"],
+    },
+  } as ElementInfo;
+  expect(getSuggestionsForElement(elementInfo, false)).toMatchObject([
+    { value: "a" },
+    { value: "#a" },
+    { value: ".a" },
+  ]);
+  expect(getSuggestionsForElement(elementInfo, true)).toMatchObject([
+    { value: "#a" },
+    { value: ".a" },
+    { value: "a" },
+  ]);
+});


### PR DESCRIPTION
## What does this PR do

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/3321
- Fixes rare situation where a tag selector gets a higher preference than classes 


I was able to replicate the errors on https://developer.automationanywhere.com/challenges/automationanywherelabs-employeedatamigration.html

The selectors were sorted (by length) in multiple places. This PR ensures we use the new `getSelectorPreference` function for that.

## Reviewer Tips

- Do you remember any other places where we sort the selectors by length?

## Discussion

- The sorting currently happens repeatedly because more selectors are added in multiple parts or from multiple sources. This isn't ideal but doing otherwise would likely mean rewriting much of selectorInference.ts

## Demo

<img width="422" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/169205230-f91d6569-b0b5-4749-a302-ddede149fb14.png">

## Checklist

- [X] Add tests
- [x] Designate a primary reviewer
