### PR TITLE
#3485: insert custom HTML element brick

### DIFF
--- a/src/blocks/effects/insertHtml.ts
+++ b/src/blocks/effects/insertHtml.ts
@@ -21,13 +21,14 @@ import { propertiesToSchema } from "@/validators/generic";
 import { $safeFind } from "@/helpers";
 import { BusinessError } from "@/errors";
 import sanitize from "@/utils/sanitize";
+import { escapeSelector } from "jquery";
 
-export class InsertHtml extends Effect {
+class InsertHtml extends Effect {
   constructor() {
     super(
       "@pixiebrix/html/insert",
-      "Insert HTML",
-      "Insert HTML relative to another element on the page"
+      "Insert HTML Element",
+      "Insert HTML Element relative to another element on the page"
     );
   }
 
@@ -78,19 +79,18 @@ export class InsertHtml extends Effect {
     { root = document }: BlockOptions
   ): Promise<void> {
     const sanitizedHTML = sanitize(html);
-
     const sanitizedElement = $(sanitizedHTML).get(0);
 
     if (id) {
-      $safeFind(`#${id}`, root).remove();
+      $safeFind(`#${escapeSelector(id)}`, root).remove();
       sanitizedElement.setAttribute("id", id);
     }
 
-    const elements = $safeFind(anchor, root);
+    const anchorElements = $safeFind(anchor, root);
 
-    for (const element of elements.get()) {
+    for (const anchorElement of anchorElements.get()) {
       try {
-        element.insertAdjacentHTML(position, sanitizedElement.outerHTML);
+        anchorElement.insertAdjacentHTML(position, sanitizedElement.outerHTML);
       } catch (error) {
         if (error instanceof DOMException) {
           throw new BusinessError("Error inserting element", { cause: error });

--- a/src/blocks/effects/insertHtml.ts
+++ b/src/blocks/effects/insertHtml.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Effect } from "@/types";
+import { BlockArg, BlockOptions, Schema } from "@/core";
+import { propertiesToSchema } from "@/validators/generic";
+import { $safeFind } from "@/helpers";
+import { BusinessError } from "@/errors";
+import sanitize from "@/utils/sanitize";
+
+export class InsertHtml extends Effect {
+  constructor() {
+    super(
+      "@pixiebrix/html/insert",
+      "Insert HTML",
+      "Insert HTML relative to another element on the page"
+    );
+  }
+
+  inputSchema: Schema = propertiesToSchema(
+    {
+      anchor: {
+        type: "string",
+        description: "An element to insert the HTML relative to",
+        format: "selector",
+      },
+      html: {
+        type: "string",
+        description: "The HTML element to insert into the page",
+        format: "html",
+      },
+      position: {
+        type: "string",
+        description:
+          "https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML",
+        enum: ["beforebegin", "afterbegin", "beforeend", "afterend"],
+        default: "beforeend",
+      },
+      id: {
+        type: "string",
+        description:
+          "Pass a unique identifier (id) to replace element from previous run",
+      },
+    },
+    ["anchor", "html"]
+  );
+
+  override async isRootAware(): Promise<boolean> {
+    return true;
+  }
+
+  async effect(
+    {
+      anchor,
+      html,
+      position = "beforeend",
+      id,
+    }: BlockArg<{
+      anchor: string;
+      html: string;
+      id: string;
+      position: "beforebegin" | "afterbegin" | "beforeend" | "afterend";
+    }>,
+    { root = document }: BlockOptions
+  ): Promise<void> {
+    const sanitizedHTML = sanitize(html);
+
+    const sanitizedElement = $(sanitizedHTML).get(0);
+
+    if (id) {
+      $safeFind(`#${id}`, root).remove();
+      sanitizedElement.setAttribute("id", id);
+    }
+
+    const elements = $safeFind(anchor, root);
+
+    for (const element of elements.get()) {
+      try {
+        element.insertAdjacentHTML(position, sanitizedElement.outerHTML);
+      } catch (error) {
+        if (error instanceof DOMException) {
+          throw new BusinessError("Error inserting element", { cause: error });
+        }
+      }
+    }
+  }
+}
+
+export default InsertHtml;

--- a/src/blocks/effects/registerEffects.ts
+++ b/src/blocks/effects/registerEffects.ts
@@ -41,6 +41,7 @@ import { ReactivateEffect } from "./reactivate";
 import { SoundEffect } from "./sound";
 import { DisableEffect } from "./disable";
 import { EnableEffect } from "./enable";
+import InsertHtml from "@/blocks/effects/insertHtml";
 
 function registerEffects(): void {
   registerBlock(new LogEffect());
@@ -74,6 +75,7 @@ function registerEffects(): void {
   registerBlock(new SoundEffect());
   registerBlock(new EnableEffect());
   registerBlock(new DisableEffect());
+  registerBlock(new InsertHtml());
 }
 
 export default registerEffects;

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import blockRegistry from "@/blocks/registry";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 96;
+const EXPECTED_HEADER_COUNT = 97;
 
 // Import for side-effects (these modules register the blocks)
 // NOTE: we don't need to also include extensionPoints because we got rid of all the legacy hard-coded extension points


### PR DESCRIPTION
## What does this PR do?

- Prototype of #3485
- Adds a Insert HTML brick for inserting an arbitrary non-interactive element into the page

## Discussion

- For timer use case if it will be triggered every 1 second, we need a way to not send events for every trigger run. This is out of scope of this PR. (It also applies to other triggers, e.g., key up)
- I matched the DOM native API of insertAdjacentHTML. However, the position names aren't very intuitive :(
- I had waiting adding this kind of brick because it’s pretty ad-hoc and can be unreliable. E.g., the host page might remove the element during a render loop so your element would disappear. Our button and inline panel extension points take steps to prevent that. They watch to see if they’ve been removed and will re-add themselves. We could implement that kind of behavior for this brick too, though in the future

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @fregante 
