### PR TITLE
Add unix timestamps to timestamp and parse date bricks

### DIFF
--- a/src/blocks/readers/TimestampReader.test.ts
+++ b/src/blocks/readers/TimestampReader.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import TimestampReader from "@/blocks/readers/TimestampReader";
+
+describe("TimestampReader", () => {
+  test("generates equivalent timestamps", async () => {
+    const { timestamp, unixTimestamp } = await new TimestampReader().read();
+    expect(new Date(unixTimestamp).toISOString()).toBe(timestamp);
+  });
+});

--- a/src/blocks/readers/TimestampReader.test.ts
+++ b/src/blocks/readers/TimestampReader.test.ts
@@ -19,7 +19,7 @@ import TimestampReader from "@/blocks/readers/TimestampReader";
 
 describe("TimestampReader", () => {
   test("generates equivalent timestamps", async () => {
-    const { timestamp, unixTimestamp } = await new TimestampReader().read();
-    expect(new Date(unixTimestamp).toISOString()).toBe(timestamp);
+    const { timestamp, epochMillis } = await new TimestampReader().read();
+    expect(new Date(epochMillis).toISOString()).toBe(timestamp);
   });
 });

--- a/src/blocks/readers/TimestampReader.ts
+++ b/src/blocks/readers/TimestampReader.ts
@@ -25,13 +25,16 @@ class TimestampReader extends Reader {
     super(
       "@pixiebrix/timestamp",
       "Generate a timestamp",
-      "Get the current date-time in ISO format"
+      "Get the current date-time in multiple formats"
     );
   }
 
   async read() {
+    const date = new Date();
+
     return {
-      timestamp: new Date().toISOString(),
+      timestamp: date.toISOString(),
+      unixTimestamp: date.valueOf(),
     };
   }
 
@@ -45,8 +48,14 @@ class TimestampReader extends Reader {
     properties: {
       timestamp: {
         type: "string",
-        description: "Current ISO date-time",
+        description:
+          "Current ISO date-time in simplified extended ISO format (ISO 8601)",
         format: "date-time",
+      },
+      unixTimestamp: {
+        type: "number",
+        description:
+          "The number of milliseconds between 1 January 1970 00:00:00 UTC and the given date",
       },
     },
   };

--- a/src/blocks/readers/TimestampReader.ts
+++ b/src/blocks/readers/TimestampReader.ts
@@ -34,7 +34,7 @@ class TimestampReader extends Reader {
 
     return {
       timestamp: date.toISOString(),
-      unixTimestamp: date.valueOf(),
+      epochMillis: date.getTime(),
     };
   }
 
@@ -52,7 +52,7 @@ class TimestampReader extends Reader {
           "Current ISO date-time in simplified extended ISO format (ISO 8601)",
         format: "date-time",
       },
-      unixTimestamp: {
+      epochMillis: {
         type: "number",
         description:
           "The number of milliseconds between 1 January 1970 00:00:00 UTC and the given date",

--- a/src/blocks/transformers/parseDate.test.ts
+++ b/src/blocks/transformers/parseDate.test.ts
@@ -70,7 +70,7 @@ describe("ParseDate block", () => {
         date: "12/10/2021",
         time: "3:00:00 AM",
         humanReadable: "Fri, 10 Dec 2021 03:00:00 GMT",
-        unixTimestamp: 1_639_123_200_000,
+        epochMillis: 1_639_105_200_000,
       },
       local: {
         iso8601: "2021-12-09T22:00:00.000-05:00",
@@ -130,8 +130,7 @@ describe("ParseDate block", () => {
         date: "12/9/2021",
         time: "3:00:00 AM",
         humanReadable: "Thu, 09 Dec 2021 03:00:00 GMT",
-        // FIXME: https://www.unixtimestamp.com/ is saying the timestamp is for Thu Dec 09 2021 08:00:00 GMT+0000
-        unixTimestamp: 1_639_036_800_000,
+        epochMillis: 1_639_018_800_000,
       },
       local: {
         iso8601: "2021-12-08T22:00:00.000-05:00",

--- a/src/blocks/transformers/parseDate.test.ts
+++ b/src/blocks/transformers/parseDate.test.ts
@@ -70,6 +70,7 @@ describe("ParseDate block", () => {
         date: "12/10/2021",
         time: "3:00:00 AM",
         humanReadable: "Fri, 10 Dec 2021 03:00:00 GMT",
+        unixTimestamp: 1_639_105_200_000,
       },
       local: {
         iso8601: "2021-12-09T22:00:00.000-05:00",
@@ -129,6 +130,7 @@ describe("ParseDate block", () => {
         date: "12/9/2021",
         time: "3:00:00 AM",
         humanReadable: "Thu, 09 Dec 2021 03:00:00 GMT",
+        unixTimestamp: 1_639_105_200_000,
       },
       local: {
         iso8601: "2021-12-08T22:00:00.000-05:00",

--- a/src/blocks/transformers/parseDate.test.ts
+++ b/src/blocks/transformers/parseDate.test.ts
@@ -70,7 +70,7 @@ describe("ParseDate block", () => {
         date: "12/10/2021",
         time: "3:00:00 AM",
         humanReadable: "Fri, 10 Dec 2021 03:00:00 GMT",
-        unixTimestamp: 1_639_105_200_000,
+        unixTimestamp: 1_639_123_200_000,
       },
       local: {
         iso8601: "2021-12-09T22:00:00.000-05:00",
@@ -130,7 +130,8 @@ describe("ParseDate block", () => {
         date: "12/9/2021",
         time: "3:00:00 AM",
         humanReadable: "Thu, 09 Dec 2021 03:00:00 GMT",
-        unixTimestamp: 1_639_105_200_000,
+        // FIXME: https://www.unixtimestamp.com/ is saying the timestamp is for Thu Dec 09 2021 08:00:00 GMT+0000
+        unixTimestamp: 1_639_036_800_000,
       },
       local: {
         iso8601: "2021-12-08T22:00:00.000-05:00",

--- a/src/blocks/transformers/parseDate.ts
+++ b/src/blocks/transformers/parseDate.ts
@@ -141,7 +141,7 @@ export class ParseDate extends Transformer {
         date: utc.toLocaleDateString(),
         time: utc.toLocaleTimeString(),
         humanReadable: parsed.toUTCString(),
-        unixTimestamp: parsed.valueOf(),
+        unixTimestamp: utc.valueOf(),
       },
       local: {
         iso8601: getLocalISOString(parsed),

--- a/src/blocks/transformers/parseDate.ts
+++ b/src/blocks/transformers/parseDate.ts
@@ -88,7 +88,7 @@ export class ParseDate extends Transformer {
           humanReadable: {
             type: "string",
           },
-          unixTimestamp: {
+          epochMillis: {
             type: "number",
             description:
               "The number of milliseconds between 1 January 1970 00:00:00 UTC and the given date.",
@@ -133,6 +133,8 @@ export class ParseDate extends Transformer {
 
     const millisPerMinute = 60 * 1000;
     const offsetInMinutes = parsed.getTimezoneOffset();
+    // `getTime()` always uses UTC for time representation. For example, a client browser in one timezone, getTime()
+    // will be the same as a client browser in any other timezone.
     const utc = new Date(parsed.getTime() + offsetInMinutes * millisPerMinute);
 
     return {
@@ -141,7 +143,7 @@ export class ParseDate extends Transformer {
         date: utc.toLocaleDateString(),
         time: utc.toLocaleTimeString(),
         humanReadable: parsed.toUTCString(),
-        unixTimestamp: utc.valueOf(),
+        epochMillis: parsed.getTime(),
       },
       local: {
         iso8601: getLocalISOString(parsed),

--- a/src/blocks/transformers/parseDate.ts
+++ b/src/blocks/transformers/parseDate.ts
@@ -88,6 +88,11 @@ export class ParseDate extends Transformer {
           humanReadable: {
             type: "string",
           },
+          unixTimestamp: {
+            type: "number",
+            description:
+              "The number of milliseconds between 1 January 1970 00:00:00 UTC and the given date.",
+          },
         },
       },
       local: {
@@ -136,6 +141,7 @@ export class ParseDate extends Transformer {
         date: utc.toLocaleDateString(),
         time: utc.toLocaleTimeString(),
         humanReadable: parsed.toUTCString(),
+        unixTimestamp: parsed.valueOf(),
       },
       local: {
         iso8601: getLocalISOString(parsed),


### PR DESCRIPTION
## What does this PR do?

- Adds epochMillis output fields to the generate timestamp and parse date bricks to make it easier to work with date math (e.g., for timers)

## TODO

- [x] Look into unix timestamp discrepancy in parsed date

## Checklist

- [X] Add tests
- [X] Designate a primary reviewer: @BLoe 
