### PR TITLE
Add tracking when creating a new extension point

### DIFF
--- a/src/pageEditor/panes/insert/GenericInsertPane.tsx
+++ b/src/pageEditor/panes/insert/GenericInsertPane.tsx
@@ -15,10 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import React, { useCallback } from "react";
 import paneStyles from "@/pageEditor/panes/Pane.module.scss";
 import styles from "./GenericInsertPane.module.scss";
-
-import React, { useCallback } from "react";
 import { useDispatch } from "react-redux";
 import useAvailableExtensionPoints from "@/pageEditor/hooks/useAvailableExtensionPoints";
 import Centered from "@/pageEditor/components/Centered";
@@ -105,7 +104,7 @@ const GenericInsertPane: React.FunctionComponent<{
       );
 
       await start(formState);
-      
+
       reportEvent("ExtensionAddNew", {
         type: config.elementType,
       });

--- a/src/pageEditor/panes/insert/GenericInsertPane.tsx
+++ b/src/pageEditor/panes/insert/GenericInsertPane.tsx
@@ -107,9 +107,9 @@ const GenericInsertPane: React.FunctionComponent<{
       await start(formState);
       
       reportEvent("ExtensionAddNew", {
-          type: config.elementType,
-        });
-      
+        type: config.elementType,
+      });
+
     } catch (error) {
       notify.error({ message: "Error using adding new element", error });
     }

--- a/src/pageEditor/panes/insert/GenericInsertPane.tsx
+++ b/src/pageEditor/panes/insert/GenericInsertPane.tsx
@@ -109,7 +109,6 @@ const GenericInsertPane: React.FunctionComponent<{
       reportEvent("ExtensionAddNew", {
         type: config.elementType,
       });
-
     } catch (error) {
       notify.error({ message: "Error using adding new element", error });
     }

--- a/src/pageEditor/panes/insert/GenericInsertPane.tsx
+++ b/src/pageEditor/panes/insert/GenericInsertPane.tsx
@@ -105,6 +105,11 @@ const GenericInsertPane: React.FunctionComponent<{
       );
 
       await start(formState);
+      
+      reportEvent("ExtensionAddNew", {
+          type: config.elementType,
+        });
+      
     } catch (error) {
       notify.error({ message: "Error using adding new element", error });
     }


### PR DESCRIPTION
## What does this PR do?

I am creating a new event called ExtensionAddNew that gets triggered when a user adds actively a new extension and to track its type

## Reviewer Tips

Hoping config.elementType is the right one to hold the name of the extension trigger-brick, otherwise I would be considering using config.label - thoughts?

## Discussion

As a Mixpanel user, I want to see an event when a user creates a brand new extension, I want to know which is the trigger-brick - so that I can quickly identify which bricks are being added freshly to the page editor when a user is active.

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
