### PR TITLE
Match `css-selector-generator` escaping

### DIFF
--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -25,7 +25,7 @@ import {
   PIXIEBRIX_READY_ATTRIBUTE,
 } from "@/common";
 import { guessUsefulness, isRandomString } from "@/utils/detectRandomString";
-import { escapeDoubleQuotes } from "@/utils/escape";
+import { escapeSingleQuotes } from "@/utils/escape";
 
 export const BUTTON_TAGS: string[] = [
   "li",
@@ -103,7 +103,7 @@ export function sortBySelector<Item = string>(
  *
  * @example
  * -2  '#best-link-on-the-page'
- * -1  '[data-cy="b4da55"]'
+ * -1  "[data-cy='b4da55']"
  *  0  '.navItem'
  *  0  '.birdsArentReal'
  *  1  'a'
@@ -337,15 +337,15 @@ export function findContainerForElement(element: HTMLElement): {
 
     if (element.tagName === "INPUT") {
       extra.push(
-        `${container.tagName.toLowerCase()}:has(${descendent} input[value="${escapeDoubleQuotes(
+        `${container.tagName.toLowerCase()}:has(${descendent} input[value='${escapeSingleQuotes(
           element.getAttribute("value")
-        )}"])`
+        )}'])`
       );
     } else {
       extra.push(
-        `${container.tagName.toLowerCase()}:has(${descendent} ${element.tagName.toLowerCase()}:contains("${escapeDoubleQuotes(
+        `${container.tagName.toLowerCase()}:has(${descendent} ${element.tagName.toLowerCase()}:contains('${escapeSingleQuotes(
           $(element).text().trim()
-        )}"))`
+        )}'))`
       );
     }
   }
@@ -403,9 +403,8 @@ export function getAttributeSelector(
     name.startsWith("aria-") ||
     UNIQUE_ATTRIBUTES.includes(name)
   ) {
-    // Don't use CSS.escape because it also escapes spaces, which isn't necessary here.
-    // It would break our deduplication logic.
-    return `[${name}="${escapeDoubleQuotes(value)}"]`;
+    //  Must use single quotes to match `css-selector-generator`
+    return `[${name}='${CSS.escape(value)}']`;
   }
 }
 

--- a/src/contentScript/selectorInference.test.ts
+++ b/src/contentScript/selectorInference.test.ts
@@ -75,17 +75,17 @@ describe("getAttributeSelector", () => {
     expect(getAttributeSelector("id", "example.com")).toBe("#example\\.com");
   });
   test("find title selectors", () => {
-    expect(getAttributeSelector("title", "Book")).toBe('[title="Book"]');
+    expect(getAttributeSelector("title", "Book")).toBe("[title='Book']");
     expect(getAttributeSelector("title", "Book name")).toBe(
-      '[title="Book name"]'
+      "[title='Book\\ name']"
     );
     expect(getAttributeSelector("title", 'The "Great" Gatsby')).toBe(
-      '[title="The \\"Great\\" Gatsby"]'
+      "[title='The\\ \\\"Great\\\"\\ Gatsby']"
     );
   });
   test("find aria attribute selectors", () => {
     expect(getAttributeSelector("aria-title", "Your email")).toBe(
-      '[aria-title="Your email"]'
+      "[aria-title='Your\\ email']"
     );
   });
   test("exclude non-unique selectors", () => {
@@ -196,6 +196,7 @@ test("getSelectorPreference: matches expected sorting", () => {
 });
 
 describe("inferSelectors", () => {
+  /* eslint-disable jest/expect-expect -- Custom expectSelectors */
   const expectSelectors = (selectors: string[], body: string) => {
     document.body.innerHTML = body;
 
@@ -258,4 +259,6 @@ describe("inferSelectors", () => {
       );
     }
   );
+
+  /* eslint-enable jest/expect-expect */
 });

--- a/src/utils/escape.ts
+++ b/src/utils/escape.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export function escapeDoubleQuotes(str: string): string {
+export function escapeSingleQuotes(str: string): string {
   // https://gist.github.com/getify/3667624
-  return str.replace(/\\([\S\s])|(")/g, "\\$1$2");
+  return str.replace(/\\([\S\s])|(')/g, "\\$1$2");
 }


### PR DESCRIPTION
## What does this PR do?

By adding more tests for both `css-selector-generator` and our other partial generators, I realized that the former escapes spaces, not just quotes, so we should probably match that to avoid duplicated selectors.

I didn't use `CSS.escape` to `findContainerForElement` because there's most likely zero overlap with `css-selector-generator`, so we don't need to match its (excessive) escaping.

## Related

- https://github.com/pixiebrix/pixiebrix-extension/pull/3497## Checklist

- [x] Add tests
- [x] Designate a primary reviewer
