### PR TITLE
#3501: add URL pattern control to page editor

### DIFF
--- a/src/components/fields/schemaFields/widgets/registerDefaultWidgets.ts
+++ b/src/components/fields/schemaFields/widgets/registerDefaultWidgets.ts
@@ -16,6 +16,7 @@
  */
 
 import UrlMatchPatternWidget from "@/pageEditor/components/UrlMatchPatternWidget";
+import UrlPatternWidget from "@/pageEditor/components/UrlPatternWidget";
 import ArrayWidget from "./ArrayWidget";
 import BooleanWidget from "./BooleanWidget";
 import IntegerWidget from "./IntegerWidget";
@@ -41,6 +42,7 @@ function registerDefaultWidgets() {
   widgetsRegistry.TextWidget = TextWidget;
   widgetsRegistry.UnsupportedWidget = UnsupportedWidget;
   widgetsRegistry.UrlMatchPatternWidget = UrlMatchPatternWidget;
+  widgetsRegistry.UrlPatternWidget = UrlPatternWidget;
   widgetsRegistry.WorkshopMessageWidget = WorkshopMessageWidget;
 }
 

--- a/src/components/fields/schemaFields/widgets/widgetsRegistry.ts
+++ b/src/components/fields/schemaFields/widgets/widgetsRegistry.ts
@@ -37,6 +37,7 @@ type Widgets = {
   TextWidget: React.VFC<SchemaFieldProps & FormControlProps>;
   UnsupportedWidget: React.VFC<SchemaFieldProps>;
   UrlMatchPatternWidget: React.VFC<SchemaFieldProps & FormControlProps>;
+  UrlPatternWidget: React.VFC<SchemaFieldProps>;
   WorkshopMessageWidget: React.VFC<Partial<SchemaFieldProps>>;
 };
 
@@ -63,6 +64,7 @@ const widgetsRegistry: Widgets = {
   TextWidget: UnsetWidget,
   UnsupportedWidget: UnsetWidget,
   UrlMatchPatternWidget: UnsetWidget,
+  UrlPatternWidget: UnsetWidget,
   WorkshopMessageWidget: UnsetWidget,
 };
 

--- a/src/pageEditor/components/UrlPatternWidget.test.tsx
+++ b/src/pageEditor/components/UrlPatternWidget.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render } from "@/pageEditor/testHelpers";
+import UrlPatternWidget, {
+  urlSchemaProject,
+} from "@/pageEditor/components/UrlPatternWidget";
+import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
+
+beforeEach(() => {
+  registerDefaultWidgets();
+});
+
+describe("UrlPatternWidget", () => {
+  test("render empty widget", () => {
+    expect(
+      render(<UrlPatternWidget name="pattern" schema={urlSchemaProject} />, {
+        initialValues: {
+          pattern: [],
+        },
+      }).asFragment()
+    ).toMatchSnapshot();
+  });
+
+  test("render single pattern", () => {
+    expect(
+      render(<UrlPatternWidget name="pattern" schema={urlSchemaProject} />, {
+        initialValues: {
+          pattern: [
+            {
+              hash: "/requests/ref/16-2",
+            },
+          ],
+        },
+      }).asFragment()
+    ).toMatchSnapshot();
+  });
+});

--- a/src/pageEditor/components/UrlPatternWidget.tsx
+++ b/src/pageEditor/components/UrlPatternWidget.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { useFormikContext } from "formik";
+import ArrayWidget from "@/components/fields/schemaFields/widgets/ArrayWidget";
+import FieldRuntimeContext from "@/components/fields/schemaFields/FieldRuntimeContext";
+import { PAGE_EDITOR_DEFAULT_BRICK_API_VERSION } from "@/pageEditor/extensionPoints/base";
+import { FormState } from "@/pageEditor/pageEditorTypes";
+import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
+import { Schema } from "@/core";
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/API/URLPattern
+ *
+ * Leaving off the more obscure URL parts for now
+ */
+export const urlSchemaProject: Schema = {
+  type: "object",
+  properties: {
+    hostname: {
+      type: "string",
+      description:
+        "A string containing a pattern to match the hash part of a URL.",
+    },
+    pathname: {
+      type: "string",
+      description:
+        "A string containing a pattern to match the pathname part of a URL.",
+    },
+    hash: {
+      type: "string",
+      description:
+        "A string containing a pattern to match the hash part of a URL.",
+    },
+    search: {
+      type: "string",
+      description:
+        "A string containing a pattern to match the search part of a URL.",
+    },
+  },
+  additionalProperties: {
+    type: "string",
+  },
+};
+
+const UrlPatternWidget: React.VFC<SchemaFieldProps> = (props) => {
+  const { values: formState } = useFormikContext<FormState>();
+
+  return (
+    <FieldRuntimeContext.Provider
+      value={{
+        apiVersion:
+          formState.apiVersion ?? PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
+        allowExpressions: false,
+      }}
+    >
+      <ArrayWidget
+        schema={{ items: urlSchemaProject }}
+        addButtonCaption="Add URL Pattern"
+        {...props}
+      />
+    </FieldRuntimeContext.Provider>
+  );
+};
+
+export default UrlPatternWidget;

--- a/src/pageEditor/components/UrlPatternWidget.tsx
+++ b/src/pageEditor/components/UrlPatternWidget.tsx
@@ -34,23 +34,19 @@ export const urlSchemaProject: Schema = {
   properties: {
     hostname: {
       type: "string",
-      description:
-        "A string containing a pattern to match the hash part of a URL.",
+      description: "Pattern to match the hostname part of a URL.",
     },
     pathname: {
       type: "string",
-      description:
-        "A string containing a pattern to match the pathname part of a URL.",
+      description: "Pattern to match the pathname part of a URL.",
     },
     hash: {
       type: "string",
-      description:
-        "A string containing a pattern to match the hash part of a URL.",
+      description: "Pattern to match the hash part of a URL.",
     },
     search: {
       type: "string",
-      description:
-        "A string containing a pattern to match the search part of a URL.",
+      description: "Pattern to match the search part of a URL.",
     },
   },
   additionalProperties: {

--- a/src/pageEditor/components/__snapshots__/UrlPatternWidget.test.tsx.snap
+++ b/src/pageEditor/components/__snapshots__/UrlPatternWidget.test.tsx.snap
@@ -1,0 +1,172 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UrlPatternWidget render empty widget 1`] = `
+<DocumentFragment>
+  <form
+    action="#"
+  >
+    <ul
+      class="list-group mb-2"
+    />
+    <button
+      class="btn btn-primary"
+      type="button"
+    >
+      Add URL Pattern
+    </button>
+    <button
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`UrlPatternWidget render single pattern 1`] = `
+<DocumentFragment>
+  <form
+    action="#"
+  >
+    <ul
+      class="list-group mb-2"
+    >
+      <li
+        class="list-group-item py-1"
+      >
+        <div
+          class="formGroup mb-0 form-group row"
+        >
+          <div
+            class="col-xl-12 col-lg-12"
+          >
+            <div
+              class="root"
+            >
+              <div
+                class="field"
+              >
+                <div>
+                  <table
+                    class="mb-0 table table-sm"
+                  >
+                    <thead>
+                      <tr>
+                        <th
+                          scope="col"
+                        >
+                          Property
+                        </th>
+                        <th
+                          scope="col"
+                        >
+                          Value
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>
+                          <input
+                            class="form-control"
+                            data-testid="pattern.0.hash-name"
+                            type="text"
+                            value="hash"
+                          />
+                        </td>
+                        <td>
+                          <div
+                            class="formGroup mb-0 form-group row"
+                          >
+                            <div
+                              class="col-xl-12 col-lg-12"
+                            >
+                              <div
+                                class="root"
+                              >
+                                <div
+                                  class="field"
+                                >
+                                  <textarea
+                                    class="form-control"
+                                    id="pattern.0.hash"
+                                    name="pattern.0.hash"
+                                    rows="1"
+                                  >
+                                    /requests/ref/16-2
+                                  </textarea>
+                                </div>
+                                <div
+                                  class="dropdown dropdown"
+                                  data-test-selected="Text"
+                                  data-testid="toggle-pattern.0.hash"
+                                >
+                                  <button
+                                    aria-expanded="false"
+                                    aria-haspopup="true"
+                                    class="dropdown-toggle btn btn-link"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="symbol"
+                                    >
+                                      <test-file-stub
+                                        classname="root"
+                                      />
+                                    </span>
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <button
+                    class="btn btn-primary"
+                    type="button"
+                  >
+                    Add Property
+                  </button>
+                </div>
+              </div>
+              <div
+                class="dropdown dropdown"
+                data-test-selected="Object properties"
+                data-testid="toggle-pattern.0"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="dropdown-toggle btn btn-link"
+                  type="button"
+                >
+                  <span
+                    class="symbol"
+                  >
+                    <test-file-stub
+                      classname="root"
+                    />
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+    </ul>
+    <button
+      class="btn btn-primary"
+      type="button"
+    >
+      Add URL Pattern
+    </button>
+    <button
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;

--- a/src/pageEditor/fields/UrlMatchPatternField.tsx
+++ b/src/pageEditor/fields/UrlMatchPatternField.tsx
@@ -30,13 +30,15 @@ export type UrlMatchPatternFieldProps = {
 
 const defaultDescription = (
   <span>
-    URL match patterns for which pages to run the extension on. See{" "}
+    URL match patterns permitting the extension to run on a site. If PixieBrix
+    does not already have access to a site, your browser will prompt you to
+    grant access. See{" "}
     <a
       href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/"
       target="_blank"
       rel="noreferrer"
     >
-      Patterns Documentation
+      <code>match_patterns</code> Documentation
     </a>{" "}
     for examples.
   </span>

--- a/src/pageEditor/fields/UrlPatternField.stories.tsx
+++ b/src/pageEditor/fields/UrlPatternField.stories.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import Form from "@/components/form/Form";
+import { action } from "@storybook/addon-actions";
+import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
+import UrlPatternField, {
+  UrlPatternFieldProps,
+} from "@/pageEditor/fields/UrlPatternField";
+
+registerDefaultWidgets();
+
+export default {
+  title: "Fields/UrlPatternField",
+  component: UrlPatternField,
+} as ComponentMeta<typeof UrlPatternField>;
+
+const defaultProps: UrlPatternFieldProps = {
+  name: "urlsPatterns",
+  label: "URL Patterns",
+};
+
+const Template: ComponentStory<
+  React.VoidFunctionComponent<UrlPatternFieldProps>
+> = (props) => (
+  <Form
+    initialValues={{
+      apiVersion: "v3",
+      matchPatterns: [],
+    }}
+    validationSchema={null}
+    onSubmit={(values, { setSubmitting }) => {
+      action("onSubmit")(values);
+      setSubmitting(false);
+    }}
+  >
+    <UrlPatternField {...props} />
+  </Form>
+);
+
+export const Default = Template.bind({});
+Default.args = defaultProps;

--- a/src/pageEditor/fields/UrlPatternField.tsx
+++ b/src/pageEditor/fields/UrlPatternField.tsx
@@ -20,7 +20,7 @@ import { Shortcut } from "@/pageEditor/components/urlMatchPatternWidgetTypes";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import widgetsRegistry from "@/components/fields/schemaFields/widgets/widgetsRegistry";
 
-export type UrlMatchPatternFieldProps = {
+export type UrlPatternFieldProps = {
   name: string;
   disabled?: boolean;
   label?: React.ReactNode;
@@ -30,33 +30,32 @@ export type UrlMatchPatternFieldProps = {
 
 const defaultDescription = (
   <span>
-    URL match patterns for which pages to run the extension on. See{" "}
+    Advanced: URL pattern rules restricting on which pages the extension runs.
+    See{" "}
     <a
-      href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/"
+      href="https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API"
       target="_blank"
       rel="noreferrer"
     >
-      Patterns Documentation
+      URL Pattern Documentation
     </a>{" "}
-    for examples.
+    for examples
   </span>
 );
 
-const UrlMatchPatternField: React.VFC<UrlMatchPatternFieldProps> = ({
+const UrlPatternField: React.VFC<UrlPatternFieldProps> = ({
   name,
   disabled,
-  label = "Sites",
+  label = "URL Patterns",
   description = defaultDescription,
-  shortcuts,
 }) => (
   <ConnectedFieldTemplate
     name={name}
-    as={widgetsRegistry.UrlMatchPatternWidget}
+    as={widgetsRegistry.UrlPatternWidget}
     disabled={disabled}
     label={label}
     description={description}
-    shortcuts={shortcuts}
   />
 );
 
-export default UrlMatchPatternField;
+export default UrlPatternField;

--- a/src/pageEditor/fields/UrlPatternField.tsx
+++ b/src/pageEditor/fields/UrlPatternField.tsx
@@ -30,16 +30,15 @@ export type UrlPatternFieldProps = {
 
 const defaultDescription = (
   <span>
-    Advanced: URL pattern rules restricting on which pages the extension runs.
-    See{" "}
+    Advanced: URL pattern rules restricting when the extension runs. See{" "}
     <a
       href="https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API"
       target="_blank"
       rel="noreferrer"
     >
-      URL Pattern Documentation
+      URL Pattern API Documentation
     </a>{" "}
-    for examples
+    for examples.
   </span>
 );
 

--- a/src/pageEditor/tabs/contextMenu/ContextMenuConfiguration.tsx
+++ b/src/pageEditor/tabs/contextMenu/ContextMenuConfiguration.tsx
@@ -78,6 +78,19 @@ const ContextMenuConfiguration: React.FC<{
       <UrlMatchPatternField
         name="extensionPoint.definition.documentUrlPatterns"
         {...makeLockableFieldProps("Sites", isLocked)}
+        description={
+          <span>
+            URL match patterns to show the menu item on. See{" "}
+            <a
+              href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <code>match_patterns</code> Documentation
+            </a>{" "}
+            for examples.
+          </span>
+        }
       />
     </FieldSection>
 

--- a/src/pageEditor/tabs/menuItem/MenuItemConfiguration.tsx
+++ b/src/pageEditor/tabs/menuItem/MenuItemConfiguration.tsx
@@ -25,6 +25,7 @@ import IconWidget from "@/components/fields/IconWidget";
 import LocationWidget from "@/pageEditor/fields/LocationWidget";
 import SelectWidget, { Option } from "@/components/form/widgets/SelectWidget";
 import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
+import UrlPatternField from "@/pageEditor/fields/UrlPatternField";
 
 const menuSnippets: Snippet[] = [
   { label: "caption", value: "{{{caption}}}" },
@@ -58,6 +59,11 @@ const MenuItemConfiguration: React.FC<{
       <UrlMatchPatternField
         name="extensionPoint.definition.isAvailable.matchPatterns"
         {...makeLockableFieldProps("Sites", isLocked)}
+      />
+
+      <UrlPatternField
+        name="extensionPoint.definition.isAvailable.urlPatterns"
+        {...makeLockableFieldProps("URL Patterns", isLocked)}
       />
     </FieldSection>
 

--- a/src/pageEditor/tabs/panel/PanelConfiguration.tsx
+++ b/src/pageEditor/tabs/panel/PanelConfiguration.tsx
@@ -24,6 +24,7 @@ import TemplateWidget, { Snippet } from "@/pageEditor/fields/TemplateWidget";
 import LocationWidget from "@/pageEditor/fields/LocationWidget";
 import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
 import SwitchButtonWidget from "@/components/form/widgets/switchButton/SwitchButtonWidget";
+import UrlPatternField from "@/pageEditor/fields/UrlPatternField";
 
 const panelSnippets: Snippet[] = [
   { label: "heading", value: "{{{heading}}}" },
@@ -51,6 +52,11 @@ const PanelConfiguration: React.FC<{
       <UrlMatchPatternField
         name="extensionPoint.definition.isAvailable.matchPatterns"
         {...makeLockableFieldProps("Sites", isLocked)}
+      />
+
+      <UrlPatternField
+        name="extensionPoint.definition.isAvailable.urlPatterns"
+        {...makeLockableFieldProps("URL Patterns", isLocked)}
       />
     </FieldSection>
 

--- a/src/pageEditor/tabs/quickBar/QuickBarConfiguration.tsx
+++ b/src/pageEditor/tabs/quickBar/QuickBarConfiguration.tsx
@@ -53,6 +53,19 @@ const QuickBarConfiguration: React.FC<{
       <UrlMatchPatternField
         name="extensionPoint.definition.documentUrlPatterns"
         {...makeLockableFieldProps("Sites", isLocked)}
+        description={
+          <span>
+            URL match patterns to show the menu item on. See{" "}
+            <a
+              href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <code>match_patterns</code> Documentation
+            </a>{" "}
+            for examples.
+          </span>
+        }
       />
     </FieldSection>
 

--- a/src/pageEditor/tabs/sidebar/Configuration.tsx
+++ b/src/pageEditor/tabs/sidebar/Configuration.tsx
@@ -21,6 +21,7 @@ import { Card } from "react-bootstrap";
 import UrlMatchPatternField from "@/pageEditor/fields/UrlMatchPatternField";
 import FieldSection from "@/pageEditor/fields/FieldSection";
 import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
+import UrlPatternField from "@/pageEditor/fields/UrlPatternField";
 
 const Configuration: React.FC<{
   isLocked: boolean;
@@ -36,6 +37,11 @@ const Configuration: React.FC<{
       <UrlMatchPatternField
         name="extensionPoint.definition.isAvailable.matchPatterns"
         {...makeLockableFieldProps("Sites", isLocked)}
+      />
+
+      <UrlPatternField
+        name="extensionPoint.definition.isAvailable.urlPatterns"
+        {...makeLockableFieldProps("URL Patterns", isLocked)}
       />
     </FieldSection>
   </Card>

--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
@@ -223,24 +223,6 @@ const TriggerConfiguration: React.FC<{
           name={fieldName("isAvailable", "urlPatterns")}
           {...makeLockableFieldProps("URL Patterns", isLocked)}
         />
-
-        <ConnectedFieldTemplate
-          name={fieldName("reportMode")}
-          as="select"
-          title="Report Mode"
-          description={
-            <p>
-              Events/errors to report telemetry. Select &ldquo;User
-              Actions&rdquo; to only report the first event, unless the trigger
-              corresponds to a user action (e.g., click).
-            </p>
-          }
-          {...makeLockableFieldProps("Report Mode", isLocked)}
-        >
-          <option value="action">User Actions</option>
-          <option value="all">All Events</option>
-          <option value="once">Report First Event</option>
-        </ConnectedFieldTemplate>
       </FieldSection>
     </Card>
   );

--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
@@ -33,6 +33,7 @@ import { joinName } from "@/utils";
 import SwitchButtonWidget, {
   CheckBoxLike,
 } from "@/components/form/widgets/switchButton/SwitchButtonWidget";
+import UrlPatternField from "@/pageEditor/fields/UrlPatternField";
 
 function supportsSelector(trigger: Trigger) {
   return !["load", "interval"].includes(trigger);
@@ -217,6 +218,29 @@ const TriggerConfiguration: React.FC<{
           name={fieldName("isAvailable", "matchPatterns")}
           {...makeLockableFieldProps("Sites", isLocked)}
         />
+
+        <UrlPatternField
+          name={fieldName("isAvailable", "urlPatterns")}
+          {...makeLockableFieldProps("URL Patterns", isLocked)}
+        />
+
+        <ConnectedFieldTemplate
+          name={fieldName("reportMode")}
+          as="select"
+          title="Report Mode"
+          description={
+            <p>
+              Events/errors to report telemetry. Select &ldquo;User
+              Actions&rdquo; to only report the first event, unless the trigger
+              corresponds to a user action (e.g., click).
+            </p>
+          }
+          {...makeLockableFieldProps("Report Mode", isLocked)}
+        >
+          <option value="action">User Actions</option>
+          <option value="all">All Events</option>
+          <option value="once">Report First Event</option>
+        </ConnectedFieldTemplate>
       </FieldSection>
     </Card>
   );


### PR DESCRIPTION
## What does this PR do?

- Closes #3501 
- Adds control for URL patterns rules in the Page Editor

## Discussion

- We will also be adding a control to require certain selectors to be on the on the page to run the extension. With these 2 additional "Advanced Fields" we may want to put them in an advanced section
- Because I wanted to use SchemaField/ObjectField, I left off some properties that are more obscure from the pre-coded rules. Otherwise there would be more hard-coded properties
- I did not add the control to Context Menu because Chrome's browser API can only use documentUrlPatterns to determine where to show menu item
- I left it off of QuickBar b/c our QuickBar config matches the Context Menu API. (Although in reality, we could have more control because we control what gets rendering in the bar after the user triggers the Chrome shortcut)

## Demo

![image](https://user-images.githubusercontent.com/1879821/170791718-577aca07-336e-43f9-bf7d-2574988b0429.png)

## Checklist

- [x] Add tests
- [X] Designate a primary reviewer: @BLoe 
