### PR TITLE
Drop last `liftBackground` usage

### DIFF
--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -73,9 +73,6 @@ jest.mock("@/background/messenger/api", () => ({
   contextMenus: {
     preload: jest.fn(),
   },
-}));
-
-jest.mock("@/background/telemetry", () => ({
   getUID: async () => "UID",
 }));
 

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -18,7 +18,7 @@
 import { Deployment, Me } from "@/types/contract";
 import { isEmpty, partition, uniqBy } from "lodash";
 import reportError from "@/telemetry/reportError";
-import { getUID } from "@/background/telemetry";
+import { getUID } from "@/background/messenger/api";
 import { getExtensionVersion, ManualStorageKey, readStorage } from "@/chrome";
 import { isLinked, readAuthData, updateUserData } from "@/auth/token";
 import { reportEvent } from "@/telemetry/events";

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -17,7 +17,8 @@
 
 import { Runtime } from "webextension-polyfill";
 import { reportEvent } from "@/telemetry/events";
-import { getUID, initTelemetry } from "@/background/telemetry";
+import { initTelemetry } from "@/background/telemetry";
+import { getUID } from "@/background/messenger/api";
 import { DNT_STORAGE_KEY, allowsTrack } from "@/telemetry/dnt";
 import { gt } from "semver";
 

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -33,6 +33,7 @@ export const containsPermissions = browser.permissions
 export const getAvailableVersion = getMethod("GET_AVAILABLE_VERSION", bg);
 export const ensureContentScript = getMethod("INJECT_SCRIPT", bg);
 export const openPopupPrompt = getMethod("OPEN_POPUP_PROMPT", bg);
+export const getUID = getMethod("GET_UID", bg);
 export const whoAmI = getMethod("ECHO_SENDER", bg);
 export const waitForTargetByUrl = getMethod("WAIT_FOR_TARGET_BY_URL", bg);
 

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -67,6 +67,7 @@ import {
   initTelemetry,
   recordEvent,
   sendDeploymentAlert,
+  uid,
 } from "@/background/telemetry";
 import { captureTab } from "@/background/capture";
 import { getUserData } from "@/auth/token";
@@ -93,6 +94,7 @@ declare global {
 
     ACTIVATE_PARTNER_THEME: typeof initPartnerTheme;
 
+    GET_UID: typeof uid;
     ECHO_SENDER: typeof whoAmI;
     WAIT_FOR_TARGET_BY_URL: typeof waitForTargetByUrl;
 
@@ -165,6 +167,7 @@ export default function registerMessenger(): void {
     ENSURE_CONTEXT_MENU: ensureContextMenu,
     OPEN_POPUP_PROMPT: openPopupPrompt,
 
+    GET_UID: uid,
     ECHO_SENDER: whoAmI,
     WAIT_FOR_TARGET_BY_URL: waitForTargetByUrl,
 

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { liftBackground } from "@/background/protocol";
 import { JsonObject } from "type-fest";
 import { uuidv4 } from "@/types/helpers";
 import { compact, debounce, throttle, uniq } from "lodash";
@@ -47,7 +46,7 @@ const buffer: UserEvent[] = [];
 /**
  * Return a random ID for this browser profile.
  */
-async function uid(): Promise<UUID> {
+export async function uid(): Promise<UUID> {
   if (_uid != null) {
     return _uid;
   }
@@ -79,8 +78,6 @@ const debouncedFlush = debounce(flush, EVENT_BUFFER_DEBOUNCE_MS, {
   leading: false,
   maxWait: EVENT_BUFFER_MAX_MS,
 });
-
-export const getUID = liftBackground("GET_UID", async () => uid());
 
 async function userSummary() {
   const { os } = await browser.runtime.getPlatformInfo();

--- a/src/hooks/useDeployments.ts
+++ b/src/hooks/useDeployments.ts
@@ -23,7 +23,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { reportEvent } from "@/telemetry/events";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import notify from "@/utils/notify";
-import { getUID } from "@/background/telemetry";
+import { getUID } from "@/background/messenger/api";
 import { getExtensionVersion } from "@/chrome";
 import { selectInstalledDeployments } from "@/background/deployment";
 import { refreshRegistries } from "@/hooks/useRefresh";

--- a/src/telemetry/initRollbar.ts
+++ b/src/telemetry/initRollbar.ts
@@ -19,7 +19,7 @@ import Rollbar from "rollbar";
 import { isContentScript } from "webext-detect-page";
 import { addListener as addAuthListener, readAuthData } from "@/auth/token";
 import { UserData } from "@/auth/authTypes";
-import { getUID } from "@/background/telemetry";
+import { getUID } from "@/background/messenger/api";
 import pMemoize from "p-memoize";
 
 const accessToken = process.env.ROLLBAR_BROWSER_ACCESS_TOKEN;


### PR DESCRIPTION
Last piece from the non-external Messenger migration. Not sure how we missed it!