### PR TITLE
#3491 Update omitMetadata to remove instanceIds from bricks

### DIFF
--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -25,7 +25,7 @@ import {
   Schema,
   UUID,
 } from "@/core";
-import { castArray, cloneDeep, isEmpty, omit } from "lodash";
+import { castArray, cloneDeep, isEmpty } from "lodash";
 import {
   assertExtensionPointConfig,
   ExtensionPointConfig,
@@ -92,13 +92,6 @@ export function makeIsAvailable(url: string): NormalizedAvailability {
     urlPatterns: [],
     selectors: [],
   };
-}
-
-/**
- * Remove the automatically generated tracing ids.
- */
-export function omitEditorMetadata(pipeline: BlockPipeline): BlockPipeline {
-  return pipeline.map((blockConfig) => omit(blockConfig, "instanceId"));
 }
 
 /**

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -64,7 +64,7 @@ import {
   INNER_SCOPE,
   isInnerExtensionPoint,
 } from "@/registry/internal";
-import { normalizePipeline } from "./normalizePipeline";
+import { normalizePipelineForEditor } from "./pipelineMapping";
 
 export interface WizardStep {
   step: string;
@@ -421,7 +421,9 @@ export function extensionWithNormalizedPipeline<
 ): BaseExtensionState & Omit<T, Prop> {
   const { [pipelineProp]: pipeline, ...rest } = { ...config };
   return {
-    blockPipeline: normalizePipeline(castArray(pipeline) as BlockPipeline),
+    blockPipeline: normalizePipelineForEditor(
+      castArray(pipeline) as BlockPipeline
+    ),
     ...defaults,
     ...rest,
   };

--- a/src/pageEditor/extensionPoints/contextMenu.tsx
+++ b/src/pageEditor/extensionPoints/contextMenu.tsx
@@ -48,7 +48,7 @@ import React from "react";
 import ContextMenuConfiguration from "@/pageEditor/tabs/contextMenu/ContextMenuConfiguration";
 import type { DynamicDefinition } from "@/contentScript/nativeEditor/types";
 import { ContextMenuFormState } from "./formStateTypes";
-import { omitEditorMetadata } from "./normalizePipeline";
+import { omitEditorMetadata } from "./pipelineMapping";
 
 function fromNativeElement(
   url: string,

--- a/src/pageEditor/extensionPoints/contextMenu.tsx
+++ b/src/pageEditor/extensionPoints/contextMenu.tsx
@@ -27,7 +27,6 @@ import {
   makeInitialBaseState,
   makeIsAvailable,
   extensionWithNormalizedPipeline,
-  omitEditorMetadata,
   PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
   removeEmptyValues,
   selectIsAvailable,
@@ -49,6 +48,7 @@ import React from "react";
 import ContextMenuConfiguration from "@/pageEditor/tabs/contextMenu/ContextMenuConfiguration";
 import type { DynamicDefinition } from "@/contentScript/nativeEditor/types";
 import { ContextMenuFormState } from "./formStateTypes";
+import { omitEditorMetadata } from "./normalizePipeline";
 
 function fromNativeElement(
   url: string,

--- a/src/pageEditor/extensionPoints/menuItem.ts
+++ b/src/pageEditor/extensionPoints/menuItem.ts
@@ -25,12 +25,12 @@ import {
   makeInitialBaseState,
   makeIsAvailable,
   extensionWithNormalizedPipeline,
-  omitEditorMetadata,
   PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
   readerTypeHack,
   removeEmptyValues,
   selectIsAvailable,
 } from "@/pageEditor/extensionPoints/base";
+import { omitEditorMetadata } from "./normalizePipeline";
 import {
   MenuDefinition,
   MenuItemExtensionConfig,

--- a/src/pageEditor/extensionPoints/menuItem.ts
+++ b/src/pageEditor/extensionPoints/menuItem.ts
@@ -30,7 +30,7 @@ import {
   removeEmptyValues,
   selectIsAvailable,
 } from "@/pageEditor/extensionPoints/base";
-import { omitEditorMetadata } from "./normalizePipeline";
+import { omitEditorMetadata } from "./pipelineMapping";
 import {
   MenuDefinition,
   MenuItemExtensionConfig,

--- a/src/pageEditor/extensionPoints/normalizePipeline.ts
+++ b/src/pageEditor/extensionPoints/normalizePipeline.ts
@@ -82,7 +82,7 @@ export function normalizePipeline(pipeline: BlockPipeline): BlockPipeline {
 /**
  * Omit the Block's meta and invoke normalization for the sub pipelines
  */
-function omitDraftblockMetadata(
+function omitMetaInBlockDraft(
   block: WritableDraft<BlockConfig>,
   pipelineProps: string[] = []
 ) {
@@ -91,7 +91,7 @@ function omitDraftblockMetadata(
   for (const prop of pipelineProps) {
     const pipeline = block.config[prop];
     if (isPipelineExpression(pipeline)) {
-      omitDraft(pipeline.__value__);
+      omitMetaInPipelineDraft(pipeline.__value__);
     }
   }
 }
@@ -99,23 +99,23 @@ function omitDraftblockMetadata(
 /**
  * Find the sub pipelines in every block of the given pipeline
  */
-function omitDraft(pipeline: WritableDraft<BlockPipeline>) {
+function omitMetaInPipelineDraft(pipeline: WritableDraft<BlockPipeline>) {
   for (const block of pipeline) {
     switch (block.id) {
       case ForEach.BLOCK_ID:
-        omitDraftblockMetadata(block, ["body"]);
+        omitMetaInBlockDraft(block, ["body"]);
         break;
 
       case IfElse.BLOCK_ID:
-        omitDraftblockMetadata(block, ["if", "else"]);
+        omitMetaInBlockDraft(block, ["if", "else"]);
         break;
 
       case TryExcept.BLOCK_ID:
-        omitDraftblockMetadata(block, ["try", "except"]);
+        omitMetaInBlockDraft(block, ["try", "except"]);
         break;
 
       default:
-        omitDraftblockMetadata(block);
+        omitMetaInBlockDraft(block);
     }
   }
 }
@@ -124,5 +124,5 @@ function omitDraft(pipeline: WritableDraft<BlockPipeline>) {
  * Remove the automatically generated tracing ids.
  */
 export function omitEditorMetadata(pipeline: BlockPipeline): BlockPipeline {
-  return produce(pipeline, omitDraft);
+  return produce(pipeline, omitMetaInPipelineDraft);
 }

--- a/src/pageEditor/extensionPoints/panel.ts
+++ b/src/pageEditor/extensionPoints/panel.ts
@@ -25,12 +25,12 @@ import {
   makeInitialBaseState,
   makeIsAvailable,
   extensionWithNormalizedPipeline,
-  omitEditorMetadata,
   PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
   readerTypeHack,
   removeEmptyValues,
   selectIsAvailable,
 } from "@/pageEditor/extensionPoints/base";
+import { omitEditorMetadata } from "./normalizePipeline";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import {
   PanelConfig,

--- a/src/pageEditor/extensionPoints/panel.ts
+++ b/src/pageEditor/extensionPoints/panel.ts
@@ -30,7 +30,7 @@ import {
   removeEmptyValues,
   selectIsAvailable,
 } from "@/pageEditor/extensionPoints/base";
-import { omitEditorMetadata } from "./normalizePipeline";
+import { omitEditorMetadata } from "./pipelineMapping";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import {
   PanelConfig,

--- a/src/pageEditor/extensionPoints/pipelineMapping.test.ts
+++ b/src/pageEditor/extensionPoints/pipelineMapping.test.ts
@@ -26,7 +26,10 @@ import {
 } from "@/runtime/pipelineTests/pipelineTestHelpers";
 import { uuidSequence } from "@/testUtils/factories";
 import { toExpression } from "@/testUtils/testHelpers";
-import { normalizePipeline, omitEditorMetadata } from "./normalizePipeline";
+import {
+  normalizePipelineForEditor,
+  omitEditorMetadata,
+} from "./pipelineMapping";
 
 const emptyPipeline: PipelineExpression = Object.freeze({
   __type__: "pipeline",
@@ -54,7 +57,7 @@ describe("normalizePipeline", () => {
   test("should add instance id to every block in pipeline", () => {
     const pipeline = [echoBlockConfig, teapotBlockConfig];
 
-    const actual = normalizePipeline(pipeline);
+    const actual = normalizePipelineForEditor(pipeline);
     for (const config of actual) {
       expect(config.instanceId).toBeDefined();
     }
@@ -71,7 +74,7 @@ describe("normalizePipeline", () => {
       },
     ];
 
-    const actual = normalizePipeline(pipeline) as any;
+    const actual = normalizePipelineForEditor(pipeline) as any;
 
     // Checking the loop config
     const loopConfig = actual[0].config.body;
@@ -93,7 +96,7 @@ describe("normalizePipeline", () => {
       },
     ];
 
-    const actual = normalizePipeline(pipeline) as any;
+    const actual = normalizePipelineForEditor(pipeline) as any;
 
     // Checking IF branch
     const ifConfig = actual[0].config.if;
@@ -121,7 +124,7 @@ describe("normalizePipeline", () => {
       },
     ];
 
-    const actual = normalizePipeline(pipeline) as any;
+    const actual = normalizePipelineForEditor(pipeline) as any;
 
     // Checking IF branch
     const ifConfig = actual[0].config.if;
@@ -147,7 +150,7 @@ describe("normalizePipeline", () => {
       },
     ];
 
-    const actual = normalizePipeline(pipeline) as any;
+    const actual = normalizePipelineForEditor(pipeline) as any;
 
     // Checking TRY branch
     const tryConfig = actual[0].config.try;
@@ -174,7 +177,7 @@ describe("normalizePipeline", () => {
       },
     ];
 
-    const actual = normalizePipeline(pipeline) as any;
+    const actual = normalizePipelineForEditor(pipeline) as any;
 
     // Checking TRY branch
     const tryConfig = actual[0].config.try;
@@ -206,7 +209,7 @@ describe("normalizePipeline", () => {
       ]),
     ];
 
-    const actual = normalizePipeline(pipeline) as any;
+    const actual = normalizePipelineForEditor(pipeline) as any;
 
     // 1st level - root
     expect(actual[0].instanceId).toBeDefined();

--- a/src/pageEditor/extensionPoints/pipelineMapping.ts
+++ b/src/pageEditor/extensionPoints/pipelineMapping.ts
@@ -75,7 +75,9 @@ function normalizePipelineDraft(pipeline: WritableDraft<BlockPipeline>) {
  * Enrich a BlockPipeline with instanceIds for use in tracing
  * and normalize sub pipelines
  */
-export function normalizePipeline(pipeline: BlockPipeline): BlockPipeline {
+export function normalizePipelineForEditor(
+  pipeline: BlockPipeline
+): BlockPipeline {
   return produce(pipeline, normalizePipelineDraft);
 }
 

--- a/src/pageEditor/extensionPoints/pipelineMapping.ts
+++ b/src/pageEditor/extensionPoints/pipelineMapping.ts
@@ -24,49 +24,38 @@ import { isPipelineExpression } from "@/runtime/mapArgs";
 import { produce } from "immer";
 import { WritableDraft } from "immer/dist/types/types-external";
 
-/**
- * Normalize the Block and invoke normalization for the sub pipelines
- */
-function normalizeBlockDraft(
-  block: WritableDraft<BlockConfig>,
-  pipelineProps: string[] = []
-) {
-  block.instanceId = uuidv4();
+function getPipelinePropNames(block: BlockConfig) {
+  switch (block.id) {
+    case ForEach.BLOCK_ID:
+      return ["body"];
 
-  for (const prop of pipelineProps) {
-    const pipeline = block.config[prop];
-    if (isPipelineExpression(pipeline)) {
-      normalizePipelineDraft(pipeline.__value__);
-    } else {
-      // Normalizing am empty pipeline
-      block.config[prop] = {
-        __type__: "pipeline",
-        __value__: [],
-      };
-    }
+    case IfElse.BLOCK_ID:
+      return ["if", "else"];
+
+    case TryExcept.BLOCK_ID:
+      return ["try", "except"];
+
+    default:
+      return [];
   }
 }
 
-/**
- * Find the sub pipelines in every block of the given pipeline
- */
 function normalizePipelineDraft(pipeline: WritableDraft<BlockPipeline>) {
   for (const block of pipeline) {
-    switch (block.id) {
-      case ForEach.BLOCK_ID:
-        normalizeBlockDraft(block, ["body"]);
-        break;
+    block.instanceId = uuidv4();
 
-      case IfElse.BLOCK_ID:
-        normalizeBlockDraft(block, ["if", "else"]);
-        break;
-
-      case TryExcept.BLOCK_ID:
-        normalizeBlockDraft(block, ["try", "except"]);
-        break;
-
-      default:
-        normalizeBlockDraft(block);
+    const pipelineProps = getPipelinePropNames(block);
+    for (const prop of pipelineProps) {
+      const pipeline = block.config[prop];
+      if (isPipelineExpression(pipeline)) {
+        normalizePipelineDraft(pipeline.__value__);
+      } else {
+        // Normalizing am empty pipeline
+        block.config[prop] = {
+          __type__: "pipeline",
+          __value__: [],
+        };
+      }
     }
   }
 }
@@ -81,43 +70,16 @@ export function normalizePipelineForEditor(
   return produce(pipeline, normalizePipelineDraft);
 }
 
-/**
- * Omit the Block's meta and invoke normalization for the sub pipelines
- */
-function omitMetaInBlockDraft(
-  block: WritableDraft<BlockConfig>,
-  pipelineProps: string[] = []
-) {
-  delete block.instanceId;
-
-  for (const prop of pipelineProps) {
-    const pipeline = block.config[prop];
-    if (isPipelineExpression(pipeline)) {
-      omitMetaInPipelineDraft(pipeline.__value__);
-    }
-  }
-}
-
-/**
- * Find the sub pipelines in every block of the given pipeline
- */
 function omitMetaInPipelineDraft(pipeline: WritableDraft<BlockPipeline>) {
   for (const block of pipeline) {
-    switch (block.id) {
-      case ForEach.BLOCK_ID:
-        omitMetaInBlockDraft(block, ["body"]);
-        break;
+    delete block.instanceId;
 
-      case IfElse.BLOCK_ID:
-        omitMetaInBlockDraft(block, ["if", "else"]);
-        break;
-
-      case TryExcept.BLOCK_ID:
-        omitMetaInBlockDraft(block, ["try", "except"]);
-        break;
-
-      default:
-        omitMetaInBlockDraft(block);
+    const pipelineProps = getPipelinePropNames(block);
+    for (const prop of pipelineProps) {
+      const pipeline = block.config[prop];
+      if (isPipelineExpression(pipeline)) {
+        omitMetaInPipelineDraft(pipeline.__value__);
+      }
     }
   }
 }

--- a/src/pageEditor/extensionPoints/quickBar.tsx
+++ b/src/pageEditor/extensionPoints/quickBar.tsx
@@ -31,7 +31,7 @@ import {
   removeEmptyValues,
   selectIsAvailable,
 } from "@/pageEditor/extensionPoints/base";
-import { omitEditorMetadata } from "./normalizePipeline";
+import { omitEditorMetadata } from "./pipelineMapping";
 import { uuidv4 } from "@/types/helpers";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import { getDomain } from "@/permissions/patterns";

--- a/src/pageEditor/extensionPoints/quickBar.tsx
+++ b/src/pageEditor/extensionPoints/quickBar.tsx
@@ -27,11 +27,11 @@ import {
   makeInitialBaseState,
   makeIsAvailable,
   extensionWithNormalizedPipeline,
-  omitEditorMetadata,
   PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
   removeEmptyValues,
   selectIsAvailable,
 } from "@/pageEditor/extensionPoints/base";
+import { omitEditorMetadata } from "./normalizePipeline";
 import { uuidv4 } from "@/types/helpers";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import { getDomain } from "@/permissions/patterns";

--- a/src/pageEditor/extensionPoints/sidebar.tsx
+++ b/src/pageEditor/extensionPoints/sidebar.tsx
@@ -26,12 +26,12 @@ import {
   makeInitialBaseState,
   makeIsAvailable,
   extensionWithNormalizedPipeline,
-  omitEditorMetadata,
   PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
   readerTypeHack,
   removeEmptyValues,
   selectIsAvailable,
 } from "@/pageEditor/extensionPoints/base";
+import { omitEditorMetadata } from "./normalizePipeline";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import {
   SidebarConfig,

--- a/src/pageEditor/extensionPoints/sidebar.tsx
+++ b/src/pageEditor/extensionPoints/sidebar.tsx
@@ -31,7 +31,7 @@ import {
   removeEmptyValues,
   selectIsAvailable,
 } from "@/pageEditor/extensionPoints/base";
-import { omitEditorMetadata } from "./normalizePipeline";
+import { omitEditorMetadata } from "./pipelineMapping";
 import { ExtensionPointConfig } from "@/extensionPoints/types";
 import {
   SidebarConfig,

--- a/src/pageEditor/extensionPoints/trigger.tsx
+++ b/src/pageEditor/extensionPoints/trigger.tsx
@@ -26,12 +26,12 @@ import {
   lookupExtensionPoint,
   makeInitialBaseState,
   makeIsAvailable,
-  omitEditorMetadata,
   PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
   readerTypeHack,
   removeEmptyValues,
   selectIsAvailable,
 } from "@/pageEditor/extensionPoints/base";
+import { omitEditorMetadata } from "./normalizePipeline";
 import { uuidv4 } from "@/types/helpers";
 import {
   TriggerConfig,

--- a/src/pageEditor/extensionPoints/trigger.tsx
+++ b/src/pageEditor/extensionPoints/trigger.tsx
@@ -31,7 +31,7 @@ import {
   removeEmptyValues,
   selectIsAvailable,
 } from "@/pageEditor/extensionPoints/base";
-import { omitEditorMetadata } from "./normalizePipeline";
+import { omitEditorMetadata } from "./pipelineMapping";
 import { uuidv4 } from "@/types/helpers";
 import {
   TriggerConfig,


### PR DESCRIPTION
## What does this PR do?

- Part of #3491
- Removes `instanceId` from the sub pipeline blocks.

## Discussion

- Naming suggestions are very welcome.

## Checklist

- [x] Add tests
- [ ] Designate a primary reviewer
