### PR TITLE
#3478: put inline panel behind feature flag

### DIFF
--- a/src/pageEditor/extensionPoints/panel.ts
+++ b/src/pageEditor/extensionPoints/panel.ts
@@ -222,6 +222,7 @@ const config: ElementConfig<PanelSelectionResult, PanelFormState> = {
   icon: faWindowMaximize,
   baseClass: PanelExtensionPoint,
   selectNativeElement: insertPanel,
+  flag: "page-editor-extension-panel",
   EditorNode: PanelConfiguration,
   fromNativeElement,
   asDynamicElement,


### PR DESCRIPTION
## What does this PR do?

- Closes #3478
- Puts inline panel behind a feature flag `page-editor-extension-panel`

## Checklist

- [X] Add tests: N/A
- [X] Designate a primary reviewer: @BLoe 
