### PR TITLE
#3545: fix anchoring to stable selectors

### DIFF
--- a/src/contentScript/nativeEditor/selectorInference.test.ts
+++ b/src/contentScript/nativeEditor/selectorInference.test.ts
@@ -366,7 +366,9 @@ describe("inferSelectorsIncludingStableAncestors", () => {
 
     // The provided selector list should match the inferred list
     const inferredSelectors = inferSelectorsIncludingStableAncestors(
-      userSelectedElements[0]
+      userSelectedElements[0],
+      document.body,
+      true
     );
     expect(inferredSelectors).toEqual(selectors);
   };
@@ -375,7 +377,29 @@ describe("inferSelectorsIncludingStableAncestors", () => {
     expectSelectors(
       ["h2"],
       html`
-        <div id="#ember33">
+        <div id="ember33">
+          <h2>I am a header</h2>
+        </div>
+      `
+    );
+  });
+
+  test("include stable id attribute", () => {
+    expectSelectors(
+      ["#thisisgoodid h2", "h2"],
+      html`
+        <div id="thisisgoodid">
+          <h2>I am a header</h2>
+        </div>
+      `
+    );
+  });
+
+  test("include stable data-id attribute", () => {
+    expectSelectors(
+      ['[data-id="thisisgoodid"] h2', "h2"],
+      html`
+        <div data-id="thisisgoodid">
           <h2>I am a header</h2>
         </div>
       `

--- a/src/contentScript/nativeEditor/selectorInference.test.ts
+++ b/src/contentScript/nativeEditor/selectorInference.test.ts
@@ -397,7 +397,7 @@ describe("inferSelectorsIncludingStableAncestors", () => {
 
   test("include stable data-id attribute", () => {
     expectSelectors(
-      ['[data-id="thisisgoodid"] h2', "h2"],
+      ["[data-id='thisisgoodid'] h2", "h2"],
       html`
         <div data-id="thisisgoodid">
           <h2>I am a header</h2>

--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -79,7 +79,7 @@ const UNSTABLE_SELECTORS = [
 function getUniqueAttributeSelectors(element: HTMLElement): string[] {
   return UNIQUE_ATTRIBUTES.map((attribute) =>
     getAttributeSelector(attribute, element.getAttribute(attribute))
-  ).filter((selector) => matchesAnyPattern(selector, UNSTABLE_SELECTORS));
+  ).filter((selector) => !matchesAnyPattern(selector, UNSTABLE_SELECTORS));
 }
 
 /** ID selectors and certain other attributes can uniquely identify items */


### PR DESCRIPTION
## What does this PR do?

- Closes #3545
- Moves selectorInference.test.ts to peer directory
- Adds inferSelectorsIncludingStableAncestors test
- [x] Fixes bug in inferSelectorsIncludingStableAncestors

## Checklist

- [X] Add tests
- [X] Designate a primary reviewer: @fregante 
