### PR TITLE
#3493: use quiet default for keyboard events

### DIFF
--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -103,18 +103,19 @@ export type Trigger =
   | "change";
 
 /**
- * Triggers considered user actions for the purpose of defaulting the reportMode if not provided
+ * Triggers considered user actions for the purpose of defaulting the reportMode if not provided.
+ *
+ * Currently, includes mouse events and input blur. Keyboard events, e.g., "keydown", are not included because single
+ * key events do not convery user intent.
+ *
  * @see ReportMode
  * @see getDefaultReportModeForTrigger
  */
 export const USER_ACTION_TRIGGERS: Trigger[] = [
   "click",
-  "blur",
   "dblclick",
+  "blur",
   "mouseover",
-  "keydown",
-  "keyup",
-  "keypress",
 ];
 
 type IntervalArgs = {


### PR DESCRIPTION
## What does this PR do?

- Part of #3493
- Use "report once" mode by default for keyboard events

## Checklist

- [ ] Add tests: N/A
- [ ] Designate a primary reviewer:  @BLoe 
