### PR TITLE
#3134: add onboarding tests

### DIFF
--- a/src/auth/RequireAuth.test.tsx
+++ b/src/auth/RequireAuth.test.tsx
@@ -24,10 +24,13 @@ import { useGetMeQuery } from "@/services/api";
 import { Provider } from "react-redux";
 import { authSlice, persistAuthConfig } from "@/auth/authSlice";
 import servicesSlice, { persistServicesConfig } from "@/store/servicesSlice";
+import { connectRouter } from "connected-react-router";
+import { hashHistory } from "@/options/store";
 
 function optionsStore(initialState?: any) {
   return configureStore({
     reducer: {
+      router: connectRouter(hashHistory),
       auth: persistReducer(persistAuthConfig, authSlice.reducer),
       services: persistReducer(persistServicesConfig, servicesSlice.reducer),
     },
@@ -74,6 +77,9 @@ describe("RequireAuth", () => {
     );
 
     expect(screen.getByText("Login")).not.toBeNull();
+    expect(
+      screen.queryByText("Only authenticated users should see me!")
+    ).toBeNull();
   });
 
   test("loading state does not flash content", () => {
@@ -90,5 +96,8 @@ describe("RequireAuth", () => {
     );
 
     expect(screen.getByTestId("loader")).not.toBeNull();
+    expect(
+      screen.queryByText("Only authenticated users should see me!")
+    ).toBeNull();
   });
 });

--- a/src/auth/RequireAuth.test.tsx
+++ b/src/auth/RequireAuth.test.tsx
@@ -24,13 +24,10 @@ import { useGetMeQuery } from "@/services/api";
 import { Provider } from "react-redux";
 import { authSlice, persistAuthConfig } from "@/auth/authSlice";
 import servicesSlice, { persistServicesConfig } from "@/store/servicesSlice";
-import { connectRouter } from "connected-react-router";
-import { hashHistory } from "@/options/store";
 
 function optionsStore(initialState?: any) {
   return configureStore({
     reducer: {
-      router: connectRouter(hashHistory),
       auth: persistReducer(persistAuthConfig, authSlice.reducer),
       services: persistReducer(persistServicesConfig, servicesSlice.reducer),
     },

--- a/src/auth/RequireAuth.test.tsx
+++ b/src/auth/RequireAuth.test.tsx
@@ -55,6 +55,7 @@ describe("RequireAuth", () => {
       </Provider>
     );
 
+    expect(screen.queryByTestId("loader")).toBeNull();
     expect(
       screen.getByText("Only authenticated users should see me!")
     ).not.toBeNull();
@@ -73,6 +74,7 @@ describe("RequireAuth", () => {
       </Provider>
     );
 
+    expect(screen.queryByTestId("loader")).toBeNull();
     expect(screen.getByText("Login")).not.toBeNull();
     expect(
       screen.queryByText("Only authenticated users should see me!")

--- a/src/background/partnerTheme.ts
+++ b/src/background/partnerTheme.ts
@@ -15,11 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { getSettingsState } from "@/store/settingsStorage";
 import { getThemeLogo } from "@/utils/themeUtils";
 import activateBrowserActionIcon from "@/background/activateBrowserActionIcon";
-import { DEFAULT_THEME, Theme } from "@/options/types";
+import { DEFAULT_THEME } from "@/options/types";
 
-async function setToolbarIcon(theme: Theme): Promise<void> {
+async function setToolbarIcon(): Promise<void> {
+  const { theme } = await getSettingsState();
+
   if (theme === DEFAULT_THEME) {
     activateBrowserActionIcon();
     return;
@@ -29,6 +32,6 @@ async function setToolbarIcon(theme: Theme): Promise<void> {
   (chrome.browserAction ?? chrome.action).setIcon({ path: themeLogo.small });
 }
 
-export default function initPartnerTheme(theme: Theme) {
-  void setToolbarIcon(theme);
+export default function initPartnerTheme() {
+  void setToolbarIcon();
 }

--- a/src/background/partnerTheme.ts
+++ b/src/background/partnerTheme.ts
@@ -15,14 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getSettingsState } from "@/store/settingsStorage";
 import { getThemeLogo } from "@/utils/themeUtils";
 import activateBrowserActionIcon from "@/background/activateBrowserActionIcon";
-import { DEFAULT_THEME } from "@/options/types";
+import { DEFAULT_THEME, Theme } from "@/options/types";
 
-async function setToolbarIcon(): Promise<void> {
-  const { theme } = await getSettingsState();
-
+async function setToolbarIcon(theme: Theme): Promise<void> {
   if (theme === DEFAULT_THEME) {
     activateBrowserActionIcon();
     return;
@@ -32,6 +29,6 @@ async function setToolbarIcon(): Promise<void> {
   (chrome.browserAction ?? chrome.action).setIcon({ path: themeLogo.small });
 }
 
-export default function initPartnerTheme() {
-  void setToolbarIcon();
+export default function initPartnerTheme(theme: Theme) {
+  void setToolbarIcon(theme);
 }

--- a/src/hooks/useTheme.test.tsx
+++ b/src/hooks/useTheme.test.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { persistReducer } from "redux-persist";
+import { authSlice, persistAuthConfig } from "@/auth/authSlice";
+import { persistSettingsConfig } from "@/store/settingsStorage";
+import settingsSlice from "@/store/settingsSlice";
+import { renderHook } from "@testing-library/react-hooks";
+import { useGetTheme } from "@/hooks/useTheme";
+import { Provider } from "react-redux";
+import { DEFAULT_THEME } from "@/options/types";
+import { useGetMeQuery } from "@/services/api";
+
+jest.mock("@/options/store", () => ({
+  persistor: {
+    flush: jest.fn(),
+  },
+}));
+
+jest.mock("@/services/api", () => ({
+  useGetMeQuery: jest.fn(),
+}));
+
+function optionsStore(initialState?: any) {
+  return configureStore({
+    reducer: {
+      auth: persistReducer(persistAuthConfig, authSlice.reducer),
+      settings: persistReducer(persistSettingsConfig, settingsSlice.reducer),
+    },
+    preloadedState: initialState,
+  });
+}
+
+describe("useGetTheme", () => {
+  test("has no partner", () => {
+    (useGetMeQuery as jest.Mock).mockImplementation(() => ({
+      isLoading: false,
+      partner: null,
+    }));
+
+    const {
+      result: { current: theme },
+    } = renderHook(() => useGetTheme(), {
+      wrapper: ({ children }) => (
+        <Provider store={optionsStore()}>{children}</Provider>
+      ),
+    });
+
+    expect(theme).toBe(DEFAULT_THEME);
+  });
+
+  test("has partnerId and no me partner", () => {
+    (useGetMeQuery as jest.Mock).mockImplementation(() => ({
+      isLoading: false,
+      partner: null,
+    }));
+
+    const {
+      result: { current: theme },
+    } = renderHook(() => useGetTheme(), {
+      wrapper: ({ children }) => (
+        <Provider
+          store={optionsStore({
+            settings: { partnerId: "automation-anywhere" },
+          })}
+        >
+          {children}
+        </Provider>
+      ),
+    });
+
+    expect(theme).toBe("automation-anywhere");
+  });
+
+  test("has theme, but no partnerId and no me partner", () => {
+    (useGetMeQuery as jest.Mock).mockImplementation(() => ({
+      isLoading: false,
+      partner: null,
+    }));
+
+    const {
+      result: { current: theme },
+    } = renderHook(() => useGetTheme(), {
+      wrapper: ({ children }) => (
+        <Provider
+          store={optionsStore({ settings: { theme: "automation-anywhere" } })}
+        >
+          {children}
+        </Provider>
+      ),
+    });
+
+    expect(theme).toBe(DEFAULT_THEME);
+  });
+
+  test("has cached partner, but no me partner", () => {
+    (useGetMeQuery as jest.Mock).mockImplementation(() => ({
+      isLoading: false,
+      partner: null,
+    }));
+
+    const {
+      result: { current: theme },
+    } = renderHook(() => useGetTheme(), {
+      wrapper: ({ children }) => (
+        <Provider
+          store={optionsStore({
+            auth: {
+              partner: {
+                theme: "automation-anywhere",
+              },
+            },
+          })}
+        >
+          {children}
+        </Provider>
+      ),
+    });
+
+    expect(theme).toBe("automation-anywhere");
+  });
+
+  test("has partnerId, and me partner", () => {
+    (useGetMeQuery as jest.Mock).mockImplementation(() => ({
+      isLoading: false,
+      data: {
+        partner: {
+          theme: "automation-anywhere",
+        },
+      },
+    }));
+
+    const {
+      result: { current: theme },
+    } = renderHook(() => useGetTheme(), {
+      wrapper: ({ children }) => (
+        <Provider store={optionsStore({ settings: { partnerId: "default" } })}>
+          {children}
+        </Provider>
+      ),
+    });
+
+    expect(theme).toBe("automation-anywhere");
+  });
+
+  test("has me partner, and different cached partner", () => {
+    (useGetMeQuery as jest.Mock).mockImplementation(() => ({
+      isLoading: false,
+      data: {
+        partner: {
+          theme: "automation-anywhere",
+        },
+      },
+    }));
+
+    const {
+      result: { current: theme },
+    } = renderHook(() => useGetTheme(), {
+      wrapper: ({ children }) => (
+        <Provider
+          store={optionsStore({ auth: { partner: { theme: "default" } } })}
+        >
+          {children}
+        </Provider>
+      ),
+    });
+
+    expect(theme).toBe("automation-anywhere");
+  });
+});

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -36,10 +36,10 @@ import { selectAuth } from "@/auth/authSelectors";
 
 const MANAGED_PARTNER_ID_KEY = "partnerId" as ManualStorageKey;
 
-const activateBackgroundTheme = async (theme: Theme): Promise<void> => {
+const activateBackgroundTheme = async (): Promise<void> => {
   // Flush the Redux state to localStorage to ensure the background page sees the latest state
   await persistor.flush();
-  await activatePartnerTheme(theme);
+  await activatePartnerTheme();
 };
 
 export const useGetTheme = (): Theme => {
@@ -89,7 +89,7 @@ const useTheme = (theme?: Theme): { logo: ThemeLogo } => {
   const inferredTheme = useGetTheme();
 
   useEffect(() => {
-    void activateBackgroundTheme(theme ?? inferredTheme);
+    void activateBackgroundTheme();
     addThemeClassToDocumentRoot(theme ?? inferredTheme);
     setThemeFavicon(theme ?? inferredTheme);
   }, [theme, inferredTheme]);

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -36,16 +36,16 @@ import { selectAuth } from "@/auth/authSelectors";
 
 const MANAGED_PARTNER_ID_KEY = "partnerId" as ManualStorageKey;
 
-const activateBackgroundTheme = async (): Promise<void> => {
+const activateBackgroundTheme = async (theme: Theme): Promise<void> => {
   // Flush the Redux state to localStorage to ensure the background page sees the latest state
   await persistor.flush();
-  await activatePartnerTheme();
+  await activatePartnerTheme(theme);
 };
 
 export const useGetTheme = (): Theme => {
   const { theme, partnerId } = useSelector(selectSettings);
   const { data: me } = useGetMeQuery();
-  const { partner: cachedParnter } = useSelector(selectAuth);
+  const { partner: cachedPartner } = useSelector(selectAuth);
   const dispatch = useDispatch();
 
   const partnerTheme = useMemo(() => {
@@ -53,8 +53,8 @@ export const useGetTheme = (): Theme => {
       return isValidTheme(me.partner?.theme) ? me.partner?.theme : null;
     }
 
-    return isValidTheme(cachedParnter?.theme) ? cachedParnter?.theme : null;
-  }, [me, cachedParnter?.theme]);
+    return isValidTheme(cachedPartner?.theme) ? cachedPartner?.theme : null;
+  }, [me, cachedPartner?.theme]);
 
   const [managedPartnerId, isLoading] = useAsyncState(
     readStorage(MANAGED_PARTNER_ID_KEY, undefined, "managed"),
@@ -84,14 +84,15 @@ export const useGetTheme = (): Theme => {
   return theme;
 };
 
-const useTheme = (theme: Theme): { logo: ThemeLogo } => {
+const useTheme = (theme?: Theme): { logo: ThemeLogo } => {
   const themeLogo = getThemeLogo(theme);
+  const inferredTheme = useGetTheme();
 
   useEffect(() => {
-    void activateBackgroundTheme();
-    addThemeClassToDocumentRoot(theme);
-    setThemeFavicon(theme);
-  }, [theme]);
+    void activateBackgroundTheme(theme ?? inferredTheme);
+    addThemeClassToDocumentRoot(theme ?? inferredTheme);
+    setThemeFavicon(theme ?? inferredTheme);
+  }, [theme, inferredTheme]);
 
   return {
     logo: themeLogo,

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -51,7 +51,7 @@ import BrowserBanner from "./pages/BrowserBanner";
 import useFlags from "@/hooks/useFlags";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import RequireAuth from "@/auth/RequireAuth";
-import useTheme, { useGetTheme } from "@/hooks/useTheme";
+import useTheme from "@/hooks/useTheme";
 
 // Register the built-in bricks
 registerEditors();
@@ -68,8 +68,7 @@ const RefreshBricks: React.VFC = () => {
 };
 
 const Layout = () => {
-  const theme = useGetTheme();
-  useTheme(theme);
+  useTheme();
   const { permit } = useFlags();
 
   return (

--- a/src/options/pages/onboarding/SetupPage.test.tsx
+++ b/src/options/pages/onboarding/SetupPage.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import SetupPage from "@/options/pages/onboarding/SetupPage";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { configureStore } from "@reduxjs/toolkit";
+import { persistReducer } from "redux-persist";
+import { authSlice, persistAuthConfig } from "@/auth/authSlice";
+import servicesSlice, { persistServicesConfig } from "@/store/servicesSlice";
+import { Provider } from "react-redux";
+import { useGetMeQuery } from "@/services/api";
+
+function optionsStore(initialState?: any) {
+  return configureStore({
+    reducer: {
+      auth: persistReducer(persistAuthConfig, authSlice.reducer),
+      services: persistReducer(persistServicesConfig, servicesSlice.reducer),
+    },
+    preloadedState: initialState,
+  });
+}
+
+jest.mock("@/services/api", () => ({
+  useGetMeQuery: jest.fn(),
+}));
+
+jest.mock("@/options/store", () => ({
+  persistor: {
+    flush: jest.fn(),
+  },
+}));
+
+describe("SetupPage", () => {
+  test("typical user", async () => {
+    (useGetMeQuery as jest.Mock).mockImplementation(() => ({
+      isLoading: false,
+      partner: null,
+    }));
+
+    render(
+      <Provider store={optionsStore()}>
+        <MemoryRouter>
+          <SetupPage />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("loader")).toBeNull();
+    });
+
+    expect(screen.queryByText("Connect your AARI account")).toBeNull();
+  });
+
+  test("partner user", async () => {
+    (useGetMeQuery as jest.Mock).mockImplementation(() => ({
+      isLoading: false,
+      data: {
+        partner: {
+          id: "",
+          name: "Test Partner",
+          theme: "automation-anywhere",
+        },
+      },
+    }));
+
+    render(
+      <Provider store={optionsStore()}>
+        <MemoryRouter>
+          <SetupPage />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("loader")).toBeNull();
+    });
+
+    expect(screen.getByText("Connect your AARI account")).not.toBeNull();
+  });
+});

--- a/src/options/pages/onboarding/SetupPage.tsx
+++ b/src/options/pages/onboarding/SetupPage.tsx
@@ -51,6 +51,7 @@ const SetupPage: React.FunctionComponent = () => {
     await browser.tabs.remove(accountTabs.map((tab) => tab.id));
     return accountTabs.length > 0;
   }, []);
+
   const [installURL, installURLPending] = useAsyncState(async () => {
     const url = new URL(await getBaseURL());
     url.searchParams.set("install", "1");

--- a/src/sidebar/SidebarApp.tsx
+++ b/src/sidebar/SidebarApp.tsx
@@ -37,7 +37,7 @@ import sidebarSlice, { SidebarState } from "./sidebarSlice";
 import { AnyAction } from "redux";
 import { hideSidebar } from "@/contentScript/messenger/api";
 import { whoAmI } from "@/background/messenger/api";
-import useTheme, { useGetTheme } from "@/hooks/useTheme";
+import useTheme from "@/hooks/useTheme";
 
 /**
  * Listeners to update the Sidebar's Redux state upon receiving messages from the contentScript.
@@ -59,7 +59,7 @@ function getConnectedListener(dispatch: Dispatch<AnyAction>): SidebarListener {
 const selectState = ({ sidebar }: { sidebar: SidebarState }) => sidebar;
 
 const ConnectedSidebar: React.VFC = () => {
-  const { logo } = useTheme(useGetTheme());
+  const { logo } = useTheme();
   const dispatch = useDispatch();
   const sidebarState = useSelector(selectState);
 


### PR DESCRIPTION
## What does this PR do?

- Adds tests for `SetupPage` and `useTheme` as a follow-up for https://github.com/pixiebrix/pixiebrix-extension/issues/3134

## Reviewer Tips

- Take a look at test files for `SetupPage` and `useTheme` first - make sure these tests cover a sufficient number of cases
- Not relevant to the tests was a small refactor for optional query parameter on `useTheme`

## Discussion
Not a huge issue, but I realized while I was refactoring `useTheme` that when using `useTheme` with a theme that's different than the one in redux (e.g. when manually setting the partner theme before the user is authenticated), the toolbar logo won't use the proper theme. This is because the background function `initPartnerTheme` background function doesn't take any parameters.

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @twschiller 
