### PR TITLE
Feature/remove show detail marketplace listings

### DIFF
--- a/src/components/BrickIcon.tsx
+++ b/src/components/BrickIcon.tsx
@@ -39,7 +39,7 @@ import { SidebarExtensionPoint } from "@/extensionPoints/sidebarExtension";
 import { appApi } from "@/services/api";
 import { useAsyncState } from "@/hooks/common";
 import { useAsyncIcon } from "@/components/asyncIcon";
-import { MarketplaceListing } from "@/types/contract";
+import { IconStringDefinition, MarketplaceListing } from "@/types/contract";
 import getType from "@/runtime/getType";
 import { BlockType } from "@/runtime/runtimeTypes";
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -258,7 +258,7 @@ export const appApi = createApi({
       void
     >({
       query: () => ({
-        url: "/api/marketplace/listings/?show_detail=true",
+        url: "/api/marketplace/listings/",
         method: "get",
         // Returns public marketplace
         requireLinked: false,

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -182,20 +182,15 @@ export type BlueprintResponse = {
 // The fa_icon database value is a string with Font Awesome prefix and name, e.g. "fas fa-coffee"
 export type IconStringDefinition = `${IconPrefix} ${IconName}`;
 
-/**
- * @See components["schemas"]["Tag"]
- */
-export type MarketplaceTag = {
-  id?: UUID;
-  name: string;
-  slug?: string;
-  fa_icon: IconStringDefinition | null;
-  subtype: components["schemas"]["Tag"]["subtype"];
-  created_at?: string;
-  updated_at?: string;
-};
+export type MarketplaceTag = components["schemas"]["Tag"];
 
-export type MarketplaceListing = components["schemas"]["MarketplaceListing"];
+export type MarketplaceListing = Omit<
+  components["schemas"]["MarketplaceListing"],
+  "fa_icon"
+> & {
+  // See IconStringDefinition for type explanation
+  fa_icon: IconStringDefinition | null;
+};
 
 export type ProxyResponseSuccessData = {
   json: unknown;

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -195,23 +195,7 @@ export type MarketplaceTag = {
   updated_at?: string;
 };
 
-/**
- * Detailed MarketplaceListing
- * TODO: generate type using swagger
- */
-export type MarketplaceListing = {
-  id: string;
-  package: Record<string, unknown>;
-  fa_icon: IconStringDefinition | null;
-  icon_color: string;
-  image?: {
-    url: string;
-    alt_text: string;
-  };
-  instructions: string;
-  assets: unknown[];
-  tags: MarketplaceTag[];
-};
+export type MarketplaceListing = components["schemas"]["MarketplaceListing"];
 
 export type ProxyResponseSuccessData = {
   json: unknown;


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-app/issues/1796
- Back-end implementation: https://github.com/pixiebrix/pixiebrix-app/pull/1806
- This removes the `show_detail` parameter on the `marketplace/listings` endpoint and refactors the `MarketplaceListing` type as a result.

## Reviewer Tips

Not much refactoring was needed to make this change. Mostly just take a look at the type issue in the discussion below.

## Discussion

Notice the need for the `Omit` on the `MarketplaceListing` type in order to produce the proper type for `fa_icon`. This is needed because the type for `fa_icon` coming from swagger is `string`, but `useAsyncIcon` [expects type `IconStringDefinition`](https://github.com/pixiebrix/pixiebrix-extension/blob/055e22d71c6ef4a005d5f871be3a09b956398ca9/src/components/asyncIcon.ts#L77-L78).

The quickest solution is the one I implemented - simply changing the type of `fa_icon`. However, this cast could potentially result in type errors, because `fa_icon` coming from the database is user-inputted, and could potentially be wrong. It really should be type `string`. However, implementing a function that will check the type would involve creating an array of all the fontawesome icons, which feels a little cumbersome to me. Any thoughts here?

## Checklist

- [ ] Add tests (n/a)
- [ ] Designate a primary reviewer
