### PR TITLE
#3553: add selectionchange trigger

### DIFF
--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -59,6 +59,9 @@ import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import pluralize from "@/utils/pluralize";
 import { BusinessError, PromiseCancelled } from "@/errors";
 import { JsonObject } from "type-fest";
+import selectionController, {
+  guessSelectedElement,
+} from "@/utils/selectionController";
 
 export type TriggerConfig = {
   action: BlockPipeline | BlockConfig;
@@ -100,13 +103,15 @@ export type Trigger =
   | "keydown"
   | "keyup"
   | "keypress"
-  | "change";
+  | "change"
+  // https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event
+  | "selectionchange";
 
 /**
  * Triggers considered user actions for the purpose of defaulting the reportMode if not provided.
  *
  * Currently, includes mouse events and input blur. Keyboard events, e.g., "keydown", are not included because single
- * key events do not convery user intent.
+ * key events do not convey user intent.
  *
  * @see ReportMode
  * @see getDefaultReportModeForTrigger
@@ -197,6 +202,15 @@ function pickEventProperties(nativeEvent: Event): JsonObject {
       altKey,
       shiftKey,
       ctrlKey,
+    };
+  }
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event
+  if (nativeEvent.type === "selectionchange") {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Selection
+    return {
+      // Match the behavior for contextMenu and quickBar
+      selectionText: selectionController.get(),
     };
   }
 
@@ -415,6 +429,10 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     });
 
     let element: HTMLElement | Document = event.target;
+
+    if (this.trigger === "selectionchange") {
+      element = guessSelectedElement() ?? document;
+    }
 
     if (this.targetMode === "root") {
       element = $(event.target).closest(this.triggerSelector).get(0);
@@ -646,6 +664,21 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     });
   }
 
+  private attachSelectionTrigger(): void {
+    const $document = $(document);
+
+    $document.off(this.trigger, this.boundEventHandler);
+
+    // Install the DOM trigger
+    $document.on(this.trigger, this.boundEventHandler);
+
+    this.installedEvents.add(this.trigger);
+
+    this.addCancelHandler(() => {
+      $document.off(this.trigger, this.boundEventHandler);
+    });
+  }
+
   private attachDOMTrigger(
     $element: JQuery,
     { watch = false }: { watch?: boolean }
@@ -730,6 +763,11 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
       case "appear": {
         this.assertElement($root);
         this.attachAppearTrigger($root);
+        break;
+      }
+
+      case "selectionchange": {
+        this.attachSelectionTrigger();
         break;
       }
 

--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
@@ -40,7 +40,7 @@ import SwitchButtonWidget, {
 import MatchRulesSection from "@/pageEditor/tabs/MatchRulesSection";
 
 function supportsSelector(trigger: Trigger) {
-  return !["load", "interval"].includes(trigger);
+  return !["load", "interval", "selectionchange"].includes(trigger);
 }
 
 function supportsTargetMode(trigger: Trigger) {
@@ -85,6 +85,15 @@ const TriggerConfiguration: React.FC<{
       getDefaultReportModeForTrigger(nextTrigger)
     );
 
+    if (nextTrigger === "selectionchange" && debounce == null) {
+      // Add debounce by default, because the selection event fires for every event when clicking and dragging
+      setFieldValue(fieldName("debounce"), {
+        waitMillis: 250,
+        leading: false,
+        trailing: true,
+      });
+    }
+
     setFieldValue(fieldName("trigger"), currentTarget.value);
   };
 
@@ -106,6 +115,7 @@ const TriggerConfiguration: React.FC<{
           <option value="dblclick">Double Click</option>
           <option value="blur">Blur</option>
           <option value="mouseover">Mouseover</option>
+          <option value="selectionchange">Selection Change</option>
           <option value="keydown">Keydown</option>
           <option value="keyup">Keyup</option>
           <option value="keypress">Keypress</option>


### PR DESCRIPTION
## What does this PR do?

- Closes #3553 
- Adds a selectionchange trigger, and makes it available in the Page Editor

## Checklist

- 😢  Add tests: we don't have testing harnesses for triggers
- [X] Designate a primary reviewer: @BLoe 
