### PR TITLE
Feature/3570 eliminate flickering

### DIFF
--- a/src/blocks/effects/sidebar.ts
+++ b/src/blocks/effects/sidebar.ts
@@ -16,8 +16,9 @@
  */
 
 import { Effect } from "@/types";
-import { Schema } from "@/core";
-import { hideSidebar, showSidebar } from "@/contentScript/sidebar";
+import { BlockArg, BlockOptions, Schema } from "@/core";
+import { hideSidebar, showSidebar } from "@/contentScript/sidebarController";
+import { propertiesToSchema } from "@/validators/generic";
 
 const NO_PARAMS: Schema = {
   $schema: "https://json-schema.org/draft/2019-09/schema#",
@@ -34,10 +35,40 @@ export class ShowSidebar extends Effect {
     );
   }
 
-  inputSchema: Schema = NO_PARAMS;
+  inputSchema: Schema = propertiesToSchema(
+    {
+      panelHeading: {
+        type: "string",
+        description:
+          "The panel to show in the sidebar. If not provided, defaults to a sidebar panel in the blueprint",
+      },
+      force: {
+        type: "boolean",
+        description:
+          "If the sidebar is already showing a panel, force switch the active panel",
+        default: false,
+      },
+    },
+    []
+  );
 
-  async effect(): Promise<void> {
-    showSidebar();
+  async effect(
+    {
+      panelHeading,
+      force = false,
+    }: BlockArg<{
+      panelHeading?: string;
+      force?: boolean;
+    }>,
+    { logger }: BlockOptions
+  ): Promise<void> {
+    // Don't pass extensionId here because the extensionId in showOptions refers to the extensionId of the panel,
+    // not the extensionId of the extension toggling the sidebar
+    showSidebar({
+      force,
+      panelHeading,
+      blueprintId: logger.context.blueprintId,
+    });
   }
 }
 

--- a/src/blocks/effects/sidebar.ts
+++ b/src/blocks/effects/sidebar.ts
@@ -40,9 +40,9 @@ export class ShowSidebar extends Effect {
       panelHeading: {
         type: "string",
         description:
-          "The panel to show in the sidebar. If not provided, defaults to a sidebar panel in the blueprint",
+          "The panel to show in the sidebar. If not provided, defaults to a sidebar panel in this extension's blueprint",
       },
-      force: {
+      forcePanel: {
         type: "boolean",
         description:
           "If the sidebar is already showing a panel, force switch the active panel",
@@ -55,17 +55,17 @@ export class ShowSidebar extends Effect {
   async effect(
     {
       panelHeading,
-      force = false,
+      forcePanel = false,
     }: BlockArg<{
       panelHeading?: string;
-      force?: boolean;
+      forcePanel?: boolean;
     }>,
     { logger }: BlockOptions
   ): Promise<void> {
     // Don't pass extensionId here because the extensionId in showOptions refers to the extensionId of the panel,
     // not the extensionId of the extension toggling the sidebar
     showSidebar({
-      force,
+      force: forcePanel,
       panelHeading,
       blueprintId: logger.context.blueprintId,
     });

--- a/src/blocks/renderers/BootstrapStylesheet.tsx
+++ b/src/blocks/renderers/BootstrapStylesheet.tsx
@@ -15,11 +15,33 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import theme from "bootstrap/dist/css/bootstrap.min.css?loadAsUrl";
+import { noop } from "lodash";
 
-const BootstrapStylesheet: React.FC = () => (
-  <link rel="stylesheet" href={theme} />
-);
+type BootstrapStylesheetProps = {
+  // Allow parent to avoid a FOUC: https://webkit.org/blog/66/the-fouc-problem/ by waiting for the stylesheet to have
+  // had a chance to load.
+  // The load event fires once the stylesheet and all of its imported content has been loaded and parsed, and
+  // immediately before the styles start being applied to the content.
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#stylesheet_load_events
+  onLoad?: () => void;
+};
+
+const BootstrapStylesheet: React.FC<BootstrapStylesheetProps> = ({
+  onLoad = noop,
+}) => {
+  const linkRef = useRef<HTMLLinkElement>();
+
+  useEffect(() => {
+    linkRef.current.addEventListener("load", () => {
+      requestAnimationFrame(() => {
+        onLoad();
+      });
+    });
+  }, [onLoad]);
+
+  return <link rel="stylesheet" href={theme} ref={linkRef} />;
+};
 
 export default BootstrapStylesheet;

--- a/src/blocks/renderers/documentView/DocumentView.tsx
+++ b/src/blocks/renderers/documentView/DocumentView.tsx
@@ -16,26 +16,36 @@
  */
 
 import { buildDocumentBranch } from "@/components/documentBuilder/documentTree";
-import React from "react";
+import React, { useState } from "react";
 import ReactShadowRoot from "react-shadow-root";
 import BootstrapStylesheet from "@/blocks/renderers/BootstrapStylesheet";
 import { DocumentViewProps } from "./DocumentViewProps";
 import DocumentContext from "@/components/documentBuilder/render/DocumentContext";
 
-const DocumentView: React.FC<DocumentViewProps> = ({ body, options }) => (
-  // Wrap in a React context provider that passes BlockOptions down to any embedded bricks
-  // ReactShadowRoot needs to be inside an HTMLElement so it has something to attach to
-  <DocumentContext.Provider value={{ options }}>
-    <div className="h-100">
-      <ReactShadowRoot>
-        <BootstrapStylesheet />
-        {body.map((documentElement, i) => {
-          const { Component, props } = buildDocumentBranch(documentElement);
-          return <Component key={i} {...props} />;
-        })}
-      </ReactShadowRoot>
-    </div>
-  </DocumentContext.Provider>
-);
+const DocumentView: React.FC<DocumentViewProps> = ({ body, options }) => {
+  // Track style loading to avoid a FOUC
+  const [styleLoaded, setStyleLoaded] = useState(false);
+
+  return (
+    // Wrap in a React context provider that passes BlockOptions down to any embedded bricks
+    // ReactShadowRoot needs to be inside an HTMLElement to attach to something
+    <DocumentContext.Provider value={{ options }}>
+      <div className="h-100">
+        <ReactShadowRoot>
+          <BootstrapStylesheet
+            onLoad={() => {
+              setStyleLoaded(true);
+            }}
+          />
+          {styleLoaded &&
+            body.map((documentElement, index) => {
+              const { Component, props } = buildDocumentBranch(documentElement);
+              return <Component key={index} {...props} />;
+            })}
+        </ReactShadowRoot>
+      </div>
+    </DocumentContext.Provider>
+  );
+};
 
 export default DocumentView;

--- a/src/blocks/transformers/ephemeralForm/formTransformer.ts
+++ b/src/blocks/transformers/ephemeralForm/formTransformer.ts
@@ -29,7 +29,7 @@ import {
   hideSidebarForm,
   PANEL_HIDING_EVENT,
   showSidebarForm,
-} from "@/contentScript/sidebar";
+} from "@/contentScript/sidebarController";
 import { showModal } from "@/blocks/transformers/ephemeralForm/modalUtils";
 
 // The modes for createFrameSrc are different than the location argument for FormTransformer. The mode for the frame

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -19,7 +19,7 @@ import { loadOptions } from "@/store/extensionsStorage";
 import extensionPointRegistry from "@/extensionPoints/registry";
 import { ResolvedExtension, IExtensionPoint, RegistryId, UUID } from "@/core";
 import * as context from "@/contentScript/context";
-import * as sidebar from "@/contentScript/sidebar";
+import * as sidebar from "@/contentScript/sidebarController";
 import { sleep } from "@/utils";
 import { NAVIGATION_RULES } from "@/contrib/navigationRules";
 import { testMatchPatterns } from "@/blocks/available";

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -37,7 +37,7 @@ import {
   toggleSidebar,
   removeExtension as removeSidebar,
   getSidebarEntries,
-} from "@/contentScript/sidebar";
+} from "@/contentScript/sidebarController";
 import { insertPanel } from "@/contentScript/nativeEditor/insertPanel";
 import { insertButton } from "@/contentScript/nativeEditor/insertButton";
 import {

--- a/src/contentScript/nativeEditor/dynamic.ts
+++ b/src/contentScript/nativeEditor/dynamic.ts
@@ -179,7 +179,6 @@ export async function updateDynamicElement({
 
   if (extensionPoint.kind === "actionPanel") {
     await ensureSidebar();
-    // XXX: there's a race here on the initial show
     await activateExtensionPanel(extensionConfig.id);
   }
 }

--- a/src/contentScript/nativeEditor/dynamic.ts
+++ b/src/contentScript/nativeEditor/dynamic.ts
@@ -34,6 +34,10 @@ import { TriggerDefinition } from "@/extensionPoints/triggerExtension";
 import selection from "@/utils/selectionController";
 import { ContextMenuReader } from "@/extensionPoints/contextMenuReader";
 import type { DynamicDefinition } from "@/contentScript/nativeEditor/types";
+import {
+  activateExtensionPanel,
+  ensureSidebar,
+} from "@/contentScript/sidebarController";
 
 let _overlay: Overlay | null = null;
 const _temporaryExtensions: Map<string, IExtensionPoint> = new Map();
@@ -172,6 +176,12 @@ export async function updateDynamicElement({
 
   extensionPoint.addExtension(resolved);
   await runDynamic(extensionConfig.id, extensionPoint);
+
+  if (extensionPoint.kind === "actionPanel") {
+    await ensureSidebar();
+    // XXX: there's a race here on the initial show
+    await activateExtensionPanel(extensionConfig.id);
+  }
 }
 
 export async function enableOverlay(selector: string): Promise<void> {

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -110,7 +110,7 @@ function insertSidebar(): string {
 }
 
 /**
- * Add the sidebar to the page if it's not already on the page
+ * Attach the sidebar to the page if it's not already attached. Then re-renders all panels.
  * @param activateOptions options controlling the visible panel in the sidebar
  * @param callbacks callbacks to refresh the panels, leave blank to refresh all extension panels
  */
@@ -152,11 +152,20 @@ export function showSidebar(
   return nonce;
 }
 
+export async function activateExtensionPanel(extensionId: UUID): Promise<void> {
+  void activatePanel(
+    { tabId: "this", page: "/sidebar.html" },
+    { extensionId, force: true }
+  );
+}
+
 /**
  * Awaitable version of showSidebar which does not reload existing panels if the sidebar is already visible
  * @see showSidebar
  */
 export async function ensureSidebar(): Promise<void> {
+  expectContext("contentScript");
+
   const show = pDefer();
 
   if (!isSidebarVisible()) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -444,6 +444,11 @@ export type ExtensionRef = {
    * Registry id of the extension point.
    */
   extensionPointId: RegistryId;
+
+  /**
+   * Blueprint the extension is from.
+   */
+  blueprintId: RegistryId | null;
 };
 
 /**

--- a/src/extensionPoints/sidebarExtension.ts
+++ b/src/extensionPoints/sidebarExtension.ts
@@ -47,7 +47,7 @@ import {
   ShowCallback,
   updateHeading,
   upsertPanel,
-} from "@/contentScript/sidebar";
+} from "@/contentScript/sidebarController";
 import Mustache from "mustache";
 import { uuidv4 } from "@/types/helpers";
 import { getErrorMessage } from "@/errors/errorHelpers";
@@ -150,7 +150,11 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
       // noinspection ExceptionCaughtLocallyJS
       throw new BusinessError("No renderer brick attached to body");
     } catch (error) {
-      const ref = { extensionId: extension.id, extensionPointId: this.id };
+      const ref = {
+        extensionId: extension.id,
+        extensionPointId: this.id,
+        blueprintId: extension._recipe?.id,
+      };
 
       if (error instanceof HeadlessModeError) {
         upsertPanel(ref, heading, {
@@ -195,6 +199,7 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
       this.extensions.map((extension) => ({
         extensionId: extension.id,
         extensionPointId: this.id,
+        blueprintId: extension._recipe?.id,
       }))
     );
 

--- a/src/pageEditor/sidebar/DynamicEntry.tsx
+++ b/src/pageEditor/sidebar/DynamicEntry.tsx
@@ -27,7 +27,11 @@ import {
   UnsavedChangesIcon,
 } from "@/pageEditor/sidebar/ExtensionIcons";
 import { UUID } from "@/core";
-import { disableOverlay, enableOverlay } from "@/contentScript/messenger/api";
+import {
+  disableOverlay,
+  enableOverlay,
+  showSidebar,
+} from "@/contentScript/messenger/api";
 import { thisTab } from "@/pageEditor/utils";
 import cx from "classnames";
 import { reportEvent } from "@/telemetry/events";
@@ -87,6 +91,10 @@ const DynamicEntry: React.FunctionComponent<{
         });
 
         dispatch(actions.selectElement(item.uuid));
+
+        if (item.type === "actionPanel") {
+          void showSidebar(thisTab, { extensionId: item.uuid, force: true });
+        }
       }}
     >
       <span

--- a/src/pageEditor/sidebar/InstalledEntry.tsx
+++ b/src/pageEditor/sidebar/InstalledEntry.tsx
@@ -38,6 +38,7 @@ import {
   disableOverlay,
   enableOverlay,
   removeExtension,
+  showSidebar,
 } from "@/contentScript/messenger/api";
 import { thisTab } from "@/pageEditor/utils";
 import { resolveDefinitions } from "@/registry/internal";
@@ -94,12 +95,17 @@ const InstalledEntry: React.FunctionComponent<{
         // FIXME: is where we need to uninstall the extension because it will now be a dynamic element? Or should it
         //  be getting handled by lifecycle.ts? Need to add some logging to figure out how other ones work
         dispatch(actions.selectInstalled(state));
+
+        if (type === "actionPanel") {
+          // Switch the sidepanel over to the panel
+          void showSidebar(thisTab, { extensionId: extension.id, force: true });
+        }
       } catch (error) {
         reportError(error);
         dispatch(actions.adapterError({ uuid: extension.id, error }));
       }
     },
-    [dispatch, sessionId, recipes]
+    [dispatch, sessionId, recipes, type]
   );
 
   const isButton = type === "menuItem";

--- a/src/sidebar/PanelBody.module.scss
+++ b/src/sidebar/PanelBody.module.scss
@@ -1,0 +1,22 @@
+/*!
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.loader {
+  position: absolute;
+  top: 60px;
+  right: 5px;
+}

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -15,68 +15,151 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { useReducer } from "react";
 import Loader from "@/components/Loader";
 import blockRegistry from "@/blocks/registry";
-import { useAsyncState } from "@/hooks/common";
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import ReactShadowRoot from "react-shadow-root";
 import { getErrorMessage } from "@/errors/errorHelpers";
-import { BlockArg, RendererOutput } from "@/core";
+import { BlockArg, RegistryId, RendererOutput } from "@/core";
 import { PanelPayload } from "@/sidebar/types";
 import RendererComponent from "@/sidebar/RendererComponent";
 import { BusinessError } from "@/errors/businessErrors";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { useAsyncEffect } from "use-async-effect";
+import GridLoader from "react-spinners/GridLoader";
+import styles from "./PanelBody.module.scss";
+
+type BodyProps = {
+  blockId: RegistryId;
+  body: RendererOutput;
+};
+
+const BodyContainer: React.FC<BodyProps & { isFetching: boolean }> = ({
+  blockId,
+  body,
+  isFetching,
+}) => (
+  <>
+    {isFetching && (
+      <span className={styles.loader}>
+        <GridLoader size={8} />
+      </span>
+    )}
+
+    <div className="full-height" data-block-id={blockId}>
+      <ReactShadowRoot>
+        <RendererComponent body={body} />
+      </ReactShadowRoot>
+    </div>
+  </>
+);
+
+type State = {
+  component: BodyProps | null;
+  /**
+   * True if the panel is loading the first time
+   */
+  isLoading: boolean;
+  /**
+   * True if the panel is recalculating
+   */
+  isFetching: boolean;
+  error: unknown | null;
+};
+
+const initialPanelState: State = {
+  component: null,
+  isLoading: true,
+  isFetching: false,
+  error: null,
+};
+
+const slice = createSlice({
+  name: "panelSlice",
+  initialState: initialPanelState,
+  reducers: {
+    reactivate(state) {
+      // Don't clear out the component, because we want to keep showing the old component while the panel is reloading
+      state.isFetching = true;
+    },
+    run() {
+      // NOP
+    },
+    success(state, action: PayloadAction<{ data: BodyProps }>) {
+      state.isLoading = false;
+      state.isFetching = false;
+      state.component = action.payload.data;
+      state.error = null;
+    },
+    failure(state, action: PayloadAction<{ error: unknown }>) {
+      state.isLoading = false;
+      state.isFetching = false;
+      state.component = null;
+      state.error = action.payload.error ?? "Error rendering component";
+    },
+  },
+});
 
 const PanelBody: React.FunctionComponent<{ payload: PanelPayload }> = ({
   payload,
 }) => {
-  const [component, pending, error] = useAsyncState(async () => {
-    if (!payload) {
-      return null;
+  const [state, dispatch] = useReducer(slice.reducer, initialPanelState);
+
+  useAsyncEffect(async () => {
+    if (payload == null) {
+      dispatch(slice.actions.reactivate());
+      return;
     }
 
     if ("error" in payload) {
-      // Have useAsyncState return the error. PanelBody already knows how to render an error received from useAsyncState
-      const { error } = payload;
-      throw error;
+      dispatch(slice.actions.failure({ error: payload.error }));
+      return;
     }
 
-    // FIXME: https://github.com/pixiebrix/pixiebrix-extension/issues/1939
-    const { blockId, ctxt, args } = payload;
-    const block = await blockRegistry.lookup(blockId);
-    const body = await block.run(args as BlockArg, {
-      ctxt,
-      root: null,
-      // TODO: use the correct logger here so the errors show up in the logs
-      logger: new ConsoleLogger({ blockId }),
-      async runPipeline() {
-        throw new BusinessError(
-          "Support for running pipelines in panels not implemented"
-        );
-      },
-    });
-    return (
-      <div className="full-height" data-block-id={blockId}>
-        <ReactShadowRoot>
-          <RendererComponent body={body as RendererOutput} />
-        </ReactShadowRoot>
-      </div>
-    );
-  }, [payload?.key]);
+    try {
+      dispatch(slice.actions.run());
+      const { blockId, ctxt, args } = payload;
+      const block = await blockRegistry.lookup(blockId);
+      // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/1939
+      const body = await block.run(args as BlockArg, {
+        ctxt,
+        root: null,
+        // TODO: use the correct logger here so the errors show up in the logs
+        logger: new ConsoleLogger({ blockId }),
+        async runPipeline() {
+          throw new BusinessError(
+            "Support for running pipelines in panels not implemented"
+          );
+        },
+      });
 
-  if (error) {
-    return (
-      <div className="text-danger">
-        Error rendering panel: {getErrorMessage(error as Error)}
-      </div>
-    );
-  }
+      dispatch(
+        slice.actions.success({
+          data: { blockId, body: body as RendererOutput },
+        })
+      );
+    } catch (error) {
+      dispatch(slice.actions.failure({ error }));
+    }
+  }, [payload?.key, dispatch]);
 
-  if (pending || component == null) {
+  // Only show loader on initial render. Otherwise, just overlay a loading indicator over the other panel to
+  // avoid remounting the whole generated component. Some components maybe have long initialization times. E.g., our
+  // Document Builder loads Bootstrap into the Shadow DOM
+  if (state.isLoading) {
     return <Loader />;
   }
 
-  return component;
+  if (state.error) {
+    return (
+      <div className="text-danger">
+        Error rendering panel: {getErrorMessage(state.error)}
+      </div>
+    );
+  }
+
+  return <BodyContainer {...state.component} isFetching={state.isFetching} />;
 };
 
 export default PanelBody;

--- a/src/sidebar/SidebarApp.tsx
+++ b/src/sidebar/SidebarApp.tsx
@@ -31,7 +31,7 @@ import store, { persistor } from "@/sidebar/store";
 import { Provider, useDispatch, useSelector } from "react-redux";
 import Loader from "@/components/Loader";
 import { PersistGate } from "redux-persist/integration/react";
-import { FormEntry, PanelEntry } from "@/sidebar/types";
+import { ActivatePanelOptions, FormEntry, PanelEntry } from "@/sidebar/types";
 import Tabs from "@/sidebar/Tabs";
 import sidebarSlice, { SidebarState } from "./sidebarSlice";
 import { AnyAction } from "redux";
@@ -52,6 +52,9 @@ function getConnectedListener(dispatch: Dispatch<AnyAction>): SidebarListener {
     },
     onHideForm({ nonce }: Partial<FormEntry>) {
       dispatch(sidebarSlice.actions.removeForm(nonce));
+    },
+    onActivatePanel(options: ActivatePanelOptions) {
+      dispatch(sidebarSlice.actions.activatePanel(options));
     },
   };
 }

--- a/src/sidebar/messenger/registration.ts
+++ b/src/sidebar/messenger/registration.ts
@@ -17,7 +17,12 @@
 
 /* Do not use `getMethod` in this file; Keep only registrations here, not implementations */
 import { registerMethods } from "webext-messenger";
-import { hideForm, renderPanels, showForm } from "@/sidebar/protocol";
+import {
+  activatePanel,
+  hideForm,
+  renderPanels,
+  showForm,
+} from "@/sidebar/protocol";
 import { isBrowserSidebar } from "@/chrome";
 
 // TODO: Use `expectContext("sidebar")` when it’s supported
@@ -27,6 +32,7 @@ if (!isBrowserSidebar()) {
 
 declare global {
   interface MessengerMethods {
+    SIDEBAR_ACTIVATE_PANEL: typeof activatePanel;
     SIDEBAR_RENDER_PANELS: typeof renderPanels;
     SIDEBAR_SHOW_FORM: typeof showForm;
     SIDEBAR_HIDE_FORM: typeof hideForm;
@@ -35,6 +41,7 @@ declare global {
 
 export default function registerMessenger(): void {
   registerMethods({
+    SIDEBAR_ACTIVATE_PANEL: activatePanel,
     SIDEBAR_RENDER_PANELS: renderPanels,
     SIDEBAR_SHOW_FORM: showForm,
     SIDEBAR_HIDE_FORM: hideForm,

--- a/src/sidebar/protocol.tsx
+++ b/src/sidebar/protocol.tsx
@@ -51,8 +51,8 @@ function runListeners<Method extends keyof SidebarListener>(
   if (sequence < lastMessageSeen) {
     console.debug(
       "Skipping stale message (seq: %d, current: %d)",
-      lastMessageSeen,
       sequence,
+      lastMessageSeen,
       { data }
     );
     return;
@@ -83,10 +83,11 @@ export async function renderPanels(
 }
 
 export async function activatePanel(
+  sequence: number,
   options: ActivatePanelOptions
 ): Promise<void> {
-  // Activating a panel doesn't cause a re-render, so can use the lastMessageSeen
-  runListeners("onActivatePanel", lastMessageSeen, options);
+  // Activating a panel doesn't cause a rerender, so can use the lastMessageSeen
+  runListeners("onActivatePanel", sequence, options);
 }
 
 export async function showForm(sequence: number, entry: FormEntry) {

--- a/src/sidebar/protocol.tsx
+++ b/src/sidebar/protocol.tsx
@@ -16,15 +16,9 @@
  */
 
 import reportError from "@/telemetry/reportError";
-import { FormEntry, PanelEntry } from "@/sidebar/types";
+import { ActivatePanelOptions, FormEntry, PanelEntry } from "@/sidebar/types";
 import { FormDefinition } from "@/blocks/transformers/ephemeralForm/formTypes";
 import { UUID } from "@/core";
-
-export const MESSAGE_PREFIX = "@@pixiebrix/sidebar/";
-
-export const RENDER_PANELS_MESSAGE = `${MESSAGE_PREFIX}RENDER_PANELS`;
-export const SHOW_FORM_MESSAGE = `${MESSAGE_PREFIX}SHOW_FORM`;
-export const HIDE_FORM_MESSAGE = `${MESSAGE_PREFIX}HIDE_FORM`;
 
 let lastMessageSeen = -1;
 
@@ -32,6 +26,7 @@ export type SidebarListener = {
   onRenderPanels: (panels: PanelEntry[]) => void;
   onShowForm: (form: { nonce: UUID; form: FormDefinition }) => void;
   onHideForm: (form: { nonce: UUID }) => void;
+  onActivatePanel: (options: ActivatePanelOptions) => void;
 };
 
 const listeners: SidebarListener[] = [];
@@ -85,6 +80,13 @@ export async function renderPanels(
   panels: PanelEntry[]
 ): Promise<void> {
   runListeners("onRenderPanels", sequence, panels);
+}
+
+export async function activatePanel(
+  options: ActivatePanelOptions
+): Promise<void> {
+  // Activating a panel doesn't cause a re-render, so can use the lastMessageSeen
+  runListeners("onActivatePanel", lastMessageSeen, options);
 }
 
 export async function showForm(sequence: number, entry: FormEntry) {

--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -31,13 +31,67 @@ import { sortBy } from "lodash";
 
 export type SidebarState = SidebarEntries & {
   activeKey: string;
+
+  /**
+   * Pending panel activation request.
+   *
+   * Because there's a race condition between activatePanel and setPanels, etc. we need to keep track of the activation
+   * request in order to fulfill it once the panel is registered.
+   */
+  pendingActivePanel: ActivatePanelOptions | null;
 };
 
 export const emptySidebarState: SidebarState = {
   panels: [],
   forms: [],
   activeKey: null,
+  pendingActivePanel: null,
 };
+
+function findNextActiveKey(
+  state: SidebarState,
+  { extensionId, blueprintId, panelHeading }: ActivatePanelOptions
+): string {
+  // Try matching on extension
+  if (extensionId) {
+    // Prefer form to panel -- however, it would be unusual to target an ephemeral form when reshowing the sidebar
+    const extensionForm = state.forms.find(
+      (x) => x.extensionId === extensionId
+    );
+    if (extensionForm) {
+      return mapTabEventKey("form", extensionForm);
+    }
+
+    const extensionPanel = state.panels.find(
+      (x) => x.extensionId === extensionId
+    );
+    if (extensionPanel) {
+      return mapTabEventKey("panel", extensionPanel);
+    }
+  }
+
+  // Try matching on panel heading
+  if (panelHeading) {
+    const extensionPanel = state.panels
+      .filter((x) => blueprintId == null || x.blueprintId === blueprintId)
+      .find((x) => x.heading === panelHeading);
+    if (extensionPanel) {
+      return mapTabEventKey("panel", extensionPanel);
+    }
+  }
+
+  // Try matching on blueprint
+  if (blueprintId) {
+    const blueprintPanel = state.panels.find(
+      (x) => x.blueprintId === blueprintId
+    );
+    if (blueprintPanel) {
+      return mapTabEventKey("panel", blueprintPanel);
+    }
+  }
+
+  return null;
+}
 
 const sidebarSlice = createSlice({
   initialState: emptySidebarState,
@@ -45,6 +99,8 @@ const sidebarSlice = createSlice({
   reducers: {
     selectTab(state, action: PayloadAction<string>) {
       state.activeKey = action.payload;
+      // User manually selected a panel, so cancel any pending automatic panel activation
+      state.pendingActivePanel = null;
     },
     addForm(state, action: PayloadAction<{ form: FormEntry }>) {
       const { form } = action.payload;
@@ -69,54 +125,25 @@ const sidebarSlice = createSlice({
       state.forms = state.forms.filter((x) => x.nonce !== nonce);
       state.activeKey = defaultEventKey(state);
     },
-    activatePanel(
-      state,
-      {
-        payload: { extensionId, panelHeading, blueprintId, force },
-      }: PayloadAction<ActivatePanelOptions>
-    ) {
+    // In the future, we might want to have ActivatePanelOptions support a "enqueue" prop for controlling whether the
+    // or not a miss here is queued. We added pendingActivePanel to handle race condition on the initial sidebar
+    // loading. If we always set pendingActivePanel though, can hit a weird corner cases where a panel is activated
+    // significantly after the initial request.
+    activatePanel(state, { payload }: PayloadAction<ActivatePanelOptions>) {
+      state.pendingActivePanel = null;
+
       const hasActive = state.forms.length > 0 || state.panels.length > 0;
 
-      if (hasActive && !force) {
+      if (hasActive && !payload.force) {
         return;
       }
 
-      // Try matching on extension
-      if (extensionId) {
-        const extensionForm = state.forms.find(
-          (x) => x.extensionId === extensionId
-        );
-        if (extensionForm) {
-          state.activeKey = mapTabEventKey("form", extensionForm);
-          return;
-        }
+      const next = findNextActiveKey(state, payload);
 
-        const extensionPanel = state.panels.find(
-          (x) => x.extensionId === extensionId
-        );
-        if (extensionPanel) {
-          state.activeKey = mapTabEventKey("panel", extensionPanel);
-        }
-      }
-
-      // Try matching on panel heading
-      if (panelHeading) {
-        const extensionPanel = state.panels
-          .filter((x) => blueprintId == null || x.blueprintId === blueprintId)
-          .find((x) => x.heading === panelHeading);
-        if (extensionPanel) {
-          state.activeKey = mapTabEventKey("panel", extensionPanel);
-        }
-      }
-
-      // Try matching on blueprint
-      if (blueprintId) {
-        const blueprintPanel = state.panels.find(
-          (x) => x.blueprintId === blueprintId
-        );
-        if (blueprintPanel) {
-          state.activeKey = mapTabEventKey("panel", blueprintPanel);
-        }
+      if (next) {
+        state.activeKey = next;
+      } else {
+        state.pendingActivePanel = payload;
       }
     },
     setPanels(state, action: PayloadAction<{ panels: PanelEntry[] }>) {
@@ -125,6 +152,16 @@ const sidebarSlice = createSlice({
         action.payload.panels,
         (panel) => panel.extensionId
       );
+
+      // Try fulfilling the pendingActivePanel request
+      if (state.pendingActivePanel) {
+        const next = findNextActiveKey(state, state.pendingActivePanel);
+        if (next) {
+          state.activeKey = next;
+          state.pendingActivePanel = null;
+          return;
+        }
+      }
 
       // If a panel is no longer available, reset the current tab to a valid tab
       if (

--- a/src/sidebar/types.ts
+++ b/src/sidebar/types.ts
@@ -55,6 +55,14 @@ export type PanelEntry = {
    */
   extensionId: UUID;
   /**
+   * The blueprint associated with the extension that added the panel.
+   *
+   * Used to give preference to blueprint side panels when using the "Show Sidebar" brick.
+   *
+   * @since 1.6.5
+   */
+  blueprintId: RegistryId | null;
+  /**
    * The sidebar extension point
    * @see SidebarExtensionPoint
    */
@@ -94,4 +102,36 @@ export type FormEntry = {
 export type SidebarEntries = {
   panels: PanelEntry[];
   forms: FormEntry[];
+};
+
+/**
+ * A request to activate a panel in the sidebar
+ * @since 1.6.5
+ */
+export type ActivatePanelOptions = {
+  /**
+   * Force-activate the panel, even if the user is currently viewing a different panel that doesn't match the criteria
+   *
+   * @since 1.6.5
+   */
+  force?: boolean;
+  /**
+   * The id of the extension panel to show. Included so the Page Editor can request a specific panel to show when
+   * editing the extension
+   *
+   * @since 1.6.5
+   */
+  extensionId?: UUID;
+  /**
+   * The blueprint of the extension panel to show
+   *
+   * @since 1.6.5
+   */
+  blueprintId?: RegistryId;
+  /**
+   * A panel heading name to match
+   *
+   * @since 1.6.5
+   */
+  panelHeading?: string;
 };

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -15,10 +15,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* Do not use `registerMethod` in this file */
-import { getMethod } from "webext-messenger";
+export function getHTMLElement(): JQuery {
+  // Resolve html tag, which is more dominant than <body>
+  if (document.documentElement) {
+    return $(document.documentElement);
+  }
 
-export const renderPanels = getMethod("SIDEBAR_RENDER_PANELS");
-export const activatePanel = getMethod("SIDEBAR_ACTIVATE_PANEL");
-export const showForm = getMethod("SIDEBAR_SHOW_FORM");
-export const hideForm = getMethod("SIDEBAR_HIDE_FORM");
+  if (document.querySelector("html")) {
+    return $(document.querySelector("html"));
+  }
+
+  const $html = $("html");
+  if ($html.length > 0) {
+    return $html;
+  }
+
+  throw new Error("HTML node not found");
+}

--- a/src/utils/notify.tsx
+++ b/src/utils/notify.tsx
@@ -27,7 +27,7 @@ import reportError from "@/telemetry/reportError";
 import { Except, RequireAtLeastOne } from "type-fest";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { truncate } from "lodash";
-import { SIDEBAR_WIDTH_CSS_PROPERTY } from "@/contentScript/sidebar";
+import { SIDEBAR_WIDTH_CSS_PROPERTY } from "@/contentScript/sidebarController";
 
 const MINIMUM_NOTIFICATION_DURATION = 2000;
 


### PR DESCRIPTION
## What does this PR do?

- Closes #3570 
- Eliminates the FOUC in the document renderer (see DocumentView)
- Eliminates remount between panel states in PanelBody

## Reviewer Tips

- Review and merge https://github.com/pixiebrix/pixiebrix-extension/pull/3567 first

## Future Work

- [ ] When clicking "Render Panel" in the Page Editor, the the panel is removed + re-added. So there's a flickering of selected tab

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer: @BALEHOK
