### PR TITLE
Pin node on CI to 16.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          # 16.15.1 was having problems with peer dependency conflicts
+          # https://github.com/pixiebrix/pixiebrix-extension/pull/3598#issuecomment-1148930727
+          node-version: "16.15.0"
           cache: npm
       - run: npm ci
       - run: npm run build:webpack
@@ -82,7 +84,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          # 16.15.1 was having problems with peer dependency conflicts
+          # https://github.com/pixiebrix/pixiebrix-extension/pull/3598#issuecomment-1148930727
+          node-version: "16.15.0"
           cache: npm
       - run: npm ci
       - run: npm run build:scripts
@@ -103,7 +107,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          # 16.15.1 was having problems with peer dependency conflicts
+          # https://github.com/pixiebrix/pixiebrix-extension/pull/3598#issuecomment-1148930727
+          node-version: "16.15.0"
           cache: npm
       - run: npm ci
       - run: npm run build:typescript
@@ -115,7 +121,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          # 16.15.1 was having problems with peer dependency conflicts
+          # https://github.com/pixiebrix/pixiebrix-extension/pull/3598#issuecomment-1148930727
+          node-version: "16.15.0"
           cache: npm
       - run: npm ci
       - run: npm run lint -- --quiet
@@ -127,7 +135,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          # 16.15.1 was having problems with peer dependency conflicts
+          # https://github.com/pixiebrix/pixiebrix-extension/pull/3598#issuecomment-1148930727
+          node-version: "16.15.0"
           cache: npm
       # Fixed version to avoid random breaks. Not in package.json due to #1084
       - run: npm install --global madge@5.0.1

--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          # 16.15.1 was having problems with peer dependency conflicts
+          # https://github.com/pixiebrix/pixiebrix-extension/pull/3598#issuecomment-1148930727
+          node-version: "16.15.0"
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          # 16.15.1 was having problems with peer dependency conflicts
+          # https://github.com/pixiebrix/pixiebrix-extension/pull/3598#issuecomment-1148930727
+          node-version: "16.15.0"
           cache: npm
       - run: npm ci
       - run: npm run build
@@ -55,7 +57,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          # 16.15.1 was having problems with peer dependency conflicts
+          # https://github.com/pixiebrix/pixiebrix-extension/pull/3598#issuecomment-1148930727
+          node-version: "16.15.0"
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -10,7 +10,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          # 16.15.1 was having problems with peer dependency conflicts
+          # https://github.com/pixiebrix/pixiebrix-extension/pull/3598#issuecomment-1148930727
+          node-version: "16.15.0"
           cache: npm
       - run: npm ci
       - run: npm run build-storybook


### PR DESCRIPTION
## What does this PR do?

- Pins node to 16.15.0 because 16.15.1 was erroring due to dependency conflicts during npm install
- Node 16.15.1 uses npm 8.11.0 vs. 8.5.5
- https://github.com/pixiebrix/pixiebrix-extension/pull/3598#issuecomment-1148930727
