### PR TITLE
#3603: add trigger customization to sidebar panels

### DIFF
--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -17,7 +17,13 @@
 
 import { loadOptions } from "@/store/extensionsStorage";
 import extensionPointRegistry from "@/extensionPoints/registry";
-import { ResolvedExtension, IExtensionPoint, RegistryId, UUID } from "@/core";
+import {
+  IExtensionPoint,
+  RegistryId,
+  ResolvedExtension,
+  RunReason,
+  UUID,
+} from "@/core";
 import * as context from "@/contentScript/context";
 import * as sidebar from "@/contentScript/sidebarController";
 import { sleep } from "@/utils";
@@ -32,6 +38,7 @@ import { $safeFind } from "@/helpers";
 import { PromiseCancelled } from "@/errors/genericErrors";
 import { SidebarExtensionPoint } from "@/extensionPoints/sidebarExtension";
 
+let _initialLoadNavigation = true;
 let _scriptPromise: Promise<void> | undefined;
 const _dynamic: Map<UUID, IExtensionPoint> = new Map();
 const _frameHref: Map<number, string> = new Map();
@@ -66,6 +73,7 @@ async function installScriptOnce(): Promise<void> {
 
 async function runExtensionPoint(
   extensionPoint: IExtensionPoint,
+  reason: RunReason,
   isCancelled: () => boolean
 ): Promise<void> {
   let installed = false;
@@ -100,7 +108,7 @@ async function runExtensionPoint(
   console.debug(`Installed extension: ${extensionPoint.id}`);
   _installedExtensionPoints.push(extensionPoint);
 
-  await extensionPoint.run();
+  await extensionPoint.run({ reason });
 }
 
 export function getInstalled(): IExtensionPoint[] {
@@ -213,7 +221,11 @@ export async function runDynamic(
   }
 
   _dynamic.set(elementId, extensionPoint);
-  await runExtensionPoint(extensionPoint, makeCancelOnNavigate());
+  await runExtensionPoint(
+    extensionPoint,
+    RunReason.MANUAL,
+    makeCancelOnNavigate()
+  );
 }
 
 /**
@@ -318,12 +330,27 @@ async function waitLoaded(cancel: () => boolean): Promise<void> {
   }
 }
 
+function decideRunReason({ force }: { force: boolean }): RunReason {
+  if (force) {
+    return RunReason.MANUAL;
+  }
+
+  if (_initialLoadNavigation) {
+    return RunReason.INITIAL_LOAD;
+  }
+
+  return RunReason.NAVIGATE;
+}
+
 /**
  * Handle a website navigation, e.g., page load or a URL change in an SPA.
  */
 export async function handleNavigate({
   force,
 }: { force?: boolean } = {}): Promise<void> {
+  const runReason = decideRunReason({ force });
+  _initialLoadNavigation = false;
+
   if (context.frameId == null) {
     console.debug(
       "Ignoring handleNavigate because context.frameId is not set yet"
@@ -364,13 +391,15 @@ export async function handleNavigate({
       extensionPoints.map(async (extensionPoint) => {
         // Don't await each extension point since the extension point may never appear. For example, an
         // extension point that runs on the contact information modal on LinkedIn
-        const runPromise = runExtensionPoint(extensionPoint, cancel).catch(
-          (error) => {
-            console.error(`Error installing/running: ${extensionPoint.id}`, {
-              error,
-            });
-          }
-        );
+        const runPromise = runExtensionPoint(
+          extensionPoint,
+          runReason,
+          cancel
+        ).catch((error) => {
+          console.error(`Error installing/running: ${extensionPoint.id}`, {
+            error,
+          });
+        });
 
         if (extensionPoint.syncInstall) {
           await runPromise;

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -20,7 +20,7 @@ import { uuidv4 } from "@/types/helpers";
 import { IS_BROWSER } from "@/helpers";
 import { reportEvent } from "@/telemetry/events";
 import { expectContext } from "@/utils/expectContext";
-import { ExtensionRef, RegistryId, UUID } from "@/core";
+import { ExtensionRef, RegistryId, RunArgs, RunReason, UUID } from "@/core";
 import type {
   SidebarEntries,
   FormEntry,
@@ -50,7 +50,7 @@ export const SIDEBAR_WIDTH_CSS_PROPERTY = "--pb-sidebar-margin-right";
  */
 let renderSequenceNumber = 0;
 
-export type ShowCallback = () => void;
+export type ShowCallback = (args: RunArgs) => void;
 
 const panels: PanelEntry[] = [];
 const extensionCallbacks: ShowCallback[] = [];
@@ -142,7 +142,7 @@ export function showSidebar(
   // all the callbacks ensures the content is up-to-date
   for (const callback of callbacks) {
     try {
-      callback();
+      callback({ reason: RunReason.MANUAL });
     } catch (error) {
       // The callbacks should each have their own error handling. But wrap in a try-catch to ensure running
       // the callbacks does not interfere prevent showing the sidebar

--- a/src/core.ts
+++ b/src/core.ts
@@ -613,6 +613,56 @@ export type ResolvedExtension<T extends Config = EmptyConfig> = Except<
   _resolvedExtensionBrand: never;
 };
 
+/**
+ * The extension run reason.
+ * @since 1.6.5
+ */
+export enum RunReason {
+  // Skip 0 to avoid truthy/falsy conversion issues
+
+  /**
+   * The initial load/navigation of the page.
+   */
+  INITIAL_LOAD = 1,
+  /**
+   * The SPA navigated
+   */
+  NAVIGATE = 2,
+  /**
+   * A manual run request. One of:
+   * - Page Editor updated the extension
+   * - The user toggled the sidebar (sidebar extensions only)
+   * - A brick issued a reactivation event
+   * - PixieBrix issues a re-activate (e.g., on extension install/uninstall)
+   */
+  MANUAL = 3,
+  /**
+   * Experimental: a declared dependency of the extension point changed.
+   *
+   * See MenuItemExtensionPoint
+   */
+  DEPENDENCY_CHANGED = 4,
+  /**
+   * The SPA mutated without navigating
+   */
+  MUTATION = 5,
+}
+
+/**
+ * Arguments for running an IExtensionPoint
+ * @see IExtensionPoint.run
+ */
+export type RunArgs = {
+  /**
+   * The reason for running the extension point.
+   */
+  reason: RunReason;
+  /**
+   * If provided, only run the specified extensions.
+   */
+  extensionIds?: UUID[];
+};
+
 export interface IExtensionPoint extends Metadata {
   kind: string;
 
@@ -657,7 +707,7 @@ export interface IExtensionPoint extends Metadata {
   /**
    * Run the installed extensions for extension point.
    */
-  run(): Promise<void>;
+  run(args: RunArgs): Promise<void>;
 
   /**
    * Returns any blocks configured in extension.

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -20,6 +20,10 @@ import initialize from "@/vendors/initialize";
 import { MessageContext, ResolvedExtension } from "@/core";
 import { $safeFind } from "@/helpers";
 import { EXTENSION_POINT_DATA_ATTR } from "@/common";
+import { JsonObject } from "type-fest";
+import { ensureJsonObject, isObject } from "@/utils";
+import { BusinessError } from "@/errors/businessErrors";
+import selectionController from "@/utils/selectionController";
 
 export function isHost(hostname: string): boolean {
   return (
@@ -235,4 +239,44 @@ export function selectExtensionContext(
     blueprintId: extension._recipe?.id,
     blueprintVersion: extension._recipe?.version,
   };
+}
+
+export function pickEventProperties(nativeEvent: Event): JsonObject {
+  if (nativeEvent instanceof KeyboardEvent) {
+    // Can't use Object.entries because they're on the prototype. Can't use lodash's pick because the type isn't
+    // precise enough (per-picked property) to support the JsonObject return type.
+    const { key, keyCode, metaKey, altKey, shiftKey, ctrlKey } = nativeEvent;
+
+    return {
+      key,
+      keyCode,
+      metaKey,
+      altKey,
+      shiftKey,
+      ctrlKey,
+    };
+  }
+
+  if (nativeEvent instanceof CustomEvent) {
+    const { detail = {} } = nativeEvent;
+
+    if (isObject(detail)) {
+      // Ensure detail is a serialized/a JSON object. The custom trigger can also pick up JS custom event, which could
+      // have real JS data in them (vs. a JsonObject the user has provided via our @pixiebrix/event brick)
+      return ensureJsonObject(detail);
+    }
+
+    throw new BusinessError("Custom event detail is not an object");
+  }
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event
+  if (nativeEvent.type === "selectionchange") {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Selection
+    return {
+      // Match the behavior for contextMenu and quickBar
+      selectionText: selectionController.get(),
+    };
+  }
+
+  return {};
 }

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -438,7 +438,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
     }
   }
 
-  async run(extensionIds?: string[]): Promise<void> {
+  async run(): Promise<void> {
     if (!this.$container || this.extensions.length === 0) {
       return;
     }
@@ -453,10 +453,6 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
     const errors: unknown[] = [];
 
     for (const extension of this.extensions) {
-      if (extensionIds != null && !extensionIds.includes(extension.id)) {
-        continue;
-      }
-
       try {
         // Running in loop to ensure consistent placement. OK because `installBody` in runExtension is runs asynchronously
         // eslint-disable-next-line no-await-in-loop

--- a/src/extensionPoints/sidebarExtension.ts
+++ b/src/extensionPoints/sidebarExtension.ts
@@ -27,6 +27,8 @@ import {
   Metadata,
   ReaderOutput,
   ResolvedExtension,
+  RunArgs,
+  RunReason,
   Schema,
   UUID,
 } from "@/core";
@@ -53,8 +55,11 @@ import Mustache from "mustache";
 import { uuidv4 } from "@/types/helpers";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { HeadlessModeError } from "@/blocks/errors";
-import { selectExtensionContext } from "@/extensionPoints/helpers";
-import { cloneDeep } from "lodash";
+import {
+  pickEventProperties,
+  selectExtensionContext,
+} from "@/extensionPoints/helpers";
+import { cloneDeep, debounce } from "lodash";
 import { BlockConfig, BlockPipeline } from "@/blocks/types";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { blockList } from "@/blocks/util";
@@ -68,15 +73,89 @@ export type SidebarConfig = {
   body: BlockConfig | BlockPipeline;
 };
 
+/**
+ * Follows the semantics of lodash's debounce: https://lodash.com/docs/4.17.15#debounce
+ */
+export type DebounceOptions = {
+  /**
+   * The number of milliseconds to delay.
+   */
+  waitMillis?: number;
+
+  /**
+   * Specify invoking on the leading edge of the timeout.
+   */
+  leading?: boolean;
+
+  /**
+   *  Specify invoking on the trailing edge of the timeout.
+   */
+  trailing?: boolean;
+};
+
+/**
+ * Custom options for the `custom` trigger
+ * @since 1.6.5
+ */
+export type CustomEventOptions = {
+  /**
+   * The name of the event.
+   */
+  eventName: "string";
+};
+
+export type Trigger =
+  // `load` is page load/navigation (default for backward compatability)
+  | "load"
+  // https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event
+  | "selectionchange"
+  // Manually, e.g., via the Page Editor or Show Sidebar brick
+  | "manual"
+  // A custom event configured by the user
+  | "custom";
+
 export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig> {
+  abstract get trigger(): Trigger;
+
+  abstract get debounceOptions(): DebounceOptions;
+
+  abstract get customTriggerOptions(): CustomEventOptions;
+
   readonly permissions: Permissions.Permissions = {};
 
   readonly showCallback: ShowCallback;
 
+  /**
+   * Controller to drop all listeners and timers
+   * @private
+   */
+  private abortController = new AbortController();
+
+  private installedListeners = false;
+
+  /**
+   * A bound version of eventHandler
+   * @private
+   */
+  private readonly boundEventHandler: JQuery.EventHandler<unknown>;
+
   protected constructor(metadata: Metadata, logger: Logger) {
     super(metadata, logger);
     this.showCallback = SidebarExtensionPoint.prototype.run.bind(this);
+    // Bind so we can pass as callback
+    this.boundEventHandler = this.eventHandler.bind(this);
   }
+
+  /**
+   * Refresh all panels for the extension point
+   * @private
+   */
+  // Can't set in constructor because the constructor doesn't have access to debounceOptions
+  private debouncedRefreshPanelsAndNotify?: ({
+    nativeEvent,
+  }: {
+    nativeEvent: Event | null;
+  }) => Promise<void>;
 
   inputSchema: Schema = propertiesToSchema(
     {
@@ -117,6 +196,7 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
     this.removeExtensions();
     removeExtensionPoint(this.id);
     removeShowCallback(this.showCallback);
+    this.cancelListeners();
   }
 
   /**
@@ -187,15 +267,92 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
     }
   }
 
-  async run(extensionIds?: string[]): Promise<void> {
+  /**
+   * DO NOT CALL DIRECTLY - call debouncedRefreshPanels
+   */
+  private async refreshPanels(
+    // Force parameter to be included to make it explicit which types of triggers pass nativeEvent
+    { nativeEvent }: { nativeEvent: Event | null }
+  ): Promise<void> {
+    const reader = await this.defaultReader();
+
+    const readerContext = {
+      // The default reader overrides the event property
+      event: nativeEvent ? pickEventProperties(nativeEvent) : null,
+      ...(await reader.read(document)),
+    };
+
+    const errors: unknown[] = [];
+
+    // OK to run in parallel because we've fixed the order the panels appear in reservePanels
+    await Promise.all(
+      this.extensions.map(async (extension) => {
+        try {
+          await this.runExtension(readerContext, extension);
+        } catch (error) {
+          errors.push(error);
+          this.logger
+            .childLogger({
+              deploymentId: extension._deployment?.id,
+              extensionId: extension.id,
+            })
+            .error(error);
+        }
+      })
+    );
+
+    if (errors.length > 0) {
+      notify.error(`An error occurred adding ${errors.length} panels(s)`);
+    }
+  }
+
+  addCancelHandler(callback: () => void): void {
+    this.abortController.signal.addEventListener("abort", callback);
+  }
+
+  cancelListeners(): void {
+    // Inform registered listeners
+    this.abortController.abort();
+
+    // Allow new registrations
+    this.abortController = new AbortController();
+
+    this.installedListeners = false;
+  }
+
+  /**
+   * Shared event handler for DOM event triggers
+   */
+  private readonly eventHandler: JQuery.EventHandler<unknown> = async (
+    event
+  ) => {
+    const nativeEvent = event.originalEvent;
+    return this.debouncedRefreshPanelsAndNotify({ nativeEvent });
+  };
+
+  private attachEventTrigger(eventName: string): void {
+    const $document = $(document);
+
+    $document.off(eventName, this.boundEventHandler);
+
+    // Install the DOM trigger
+    $document.on(eventName, this.boundEventHandler);
+
+    this.addCancelHandler(() => {
+      $document.off(eventName, this.boundEventHandler);
+    });
+  }
+
+  async run({ reason }: RunArgs): Promise<void> {
     if (!(await this.isAvailable())) {
+      // Keep sidebar up-to-date regardless of trigger policy
       removeExtensionPoint(this.id);
       return;
     }
 
     if (this.extensions.length === 0) {
       console.debug(
-        "sidebar extension point %s has no installed extensions",
+        "Sidebar extension point %s has no installed extensions",
         this.id
       );
       return;
@@ -217,38 +374,25 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
       }))
     );
 
-    const reader = await this.defaultReader();
-
-    const readerContext = await reader.read(document);
-    if (readerContext == null) {
-      throw new Error("Reader returned null/undefined");
+    // On the initial run or a manual run, run directly
+    if (
+      this.trigger === "load" ||
+      [RunReason.MANUAL, RunReason.INITIAL_LOAD].includes(reason)
+    ) {
+      void this.debouncedRefreshPanelsAndNotify({ nativeEvent: null });
     }
 
-    const errors: unknown[] = [];
+    if (!this.installedListeners) {
+      if (this.trigger === "selectionchange") {
+        this.attachEventTrigger(this.trigger);
+      } else if (
+        this.trigger === "custom" &&
+        this.customTriggerOptions?.eventName
+      ) {
+        this.attachEventTrigger(this.customTriggerOptions?.eventName);
+      }
 
-    const toRun = this.extensions.filter(
-      (x) => extensionIds == null || extensionIds.includes(x.id)
-    );
-
-    // OK to run in parallel because we've fixed the order the panels appear in reservePanels
-    await Promise.all(
-      toRun.map(async (extension) => {
-        try {
-          await this.runExtension(readerContext, extension);
-        } catch (error) {
-          errors.push(error);
-          this.logger
-            .childLogger({
-              deploymentId: extension._deployment?.id,
-              extensionId: extension.id,
-            })
-            .error(error);
-        }
-      })
-    );
-
-    if (errors.length > 0) {
-      notify.error(`An error occurred adding ${errors.length} panels(s)`);
+      this.installedListeners = true;
     }
   }
 
@@ -260,11 +404,40 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
       removeExtensionPoint(this.id);
     }
 
+    const boundRefresh = this.refreshPanels.bind(this);
+
+    this.debouncedRefreshPanelsAndNotify = this.debounceOptions
+      ? debounce(boundRefresh, this.debounceOptions.waitMillis ?? 0, {
+          ...this.debounceOptions,
+        })
+      : boundRefresh;
+
     return available;
   }
 }
 
-export type PanelDefinition = ExtensionPointDefinition;
+export interface PanelDefinition extends ExtensionPointDefinition {
+  /**
+   * The trigger to refresh the panel
+   *
+   * @since 1.6.5
+   */
+  trigger?: Trigger;
+
+  /**
+   * For `custom` trigger, the custom event trigger options.
+   *
+   * @since 1.6.5
+   */
+  customEvent?: CustomEventOptions;
+
+  /**
+   * Options for debouncing the overall refresh of the panel
+   *
+   * @since 1.6.5
+   */
+  debounce?: DebounceOptions;
+}
 
 class RemotePanelExtensionPoint extends SidebarExtensionPoint {
   private readonly definition: PanelDefinition;
@@ -281,6 +454,19 @@ class RemotePanelExtensionPoint extends SidebarExtensionPoint {
 
   override async defaultReader(): Promise<IReader> {
     return mergeReaders(this.definition.reader);
+  }
+
+  get debounceOptions(): DebounceOptions | null {
+    return this.definition.debounce;
+  }
+
+  get customTriggerOptions(): CustomEventOptions | null {
+    return this.definition.customEvent;
+  }
+
+  get trigger(): Trigger {
+    // Default to load for backward compatability
+    return this.definition.trigger ?? "load";
   }
 
   async isAvailable(): Promise<boolean> {

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -21,13 +21,13 @@ import {
 } from "@/runtime/reducePipeline";
 import {
   IBlock,
-  ResolvedExtension,
   IExtensionPoint,
+  Logger,
+  Metadata,
   ReaderOutput,
   ReaderRoot,
+  ResolvedExtension,
   Schema,
-  Metadata,
-  Logger,
   UUID,
 } from "@/core";
 import { propertiesToSchema } from "@/validators/generic";
@@ -43,6 +43,7 @@ import reportError from "@/telemetry/reportError";
 import { reportEvent } from "@/telemetry/events";
 import {
   awaitElementOnce,
+  pickEventProperties,
   selectExtensionContext,
 } from "@/extensionPoints/helpers";
 import notify from "@/utils/notify";
@@ -52,17 +53,14 @@ import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { blockList } from "@/blocks/util";
 import { makeServiceContext } from "@/services/serviceUtils";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
-import { ensureJsonObject, isObject, sleep } from "@/utils";
+import { sleep } from "@/utils";
 import initialize from "@/vendors/initialize";
 import { $safeFind } from "@/helpers";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import pluralize from "@/utils/pluralize";
-import { JsonObject } from "type-fest";
 import { PromiseCancelled } from "@/errors/genericErrors";
 import { BusinessError } from "@/errors/businessErrors";
-import selectionController, {
-  guessSelectedElement,
-} from "@/utils/selectionController";
+import { guessSelectedElement } from "@/utils/selectionController";
 
 export type TriggerConfig = {
   action: BlockPipeline | BlockConfig;
@@ -190,46 +188,6 @@ async function interval({
   }
 
   console.debug("interval:completed");
-}
-
-function pickEventProperties(nativeEvent: Event): JsonObject {
-  if (nativeEvent instanceof KeyboardEvent) {
-    // Can't use Object.entries because they're on the prototype. Can't use lodash's pick because the type isn't
-    // precise enough (per-picked property) to support the JsonObject return type.
-    const { key, keyCode, metaKey, altKey, shiftKey, ctrlKey } = nativeEvent;
-
-    return {
-      key,
-      keyCode,
-      metaKey,
-      altKey,
-      shiftKey,
-      ctrlKey,
-    };
-  }
-
-  if (nativeEvent instanceof CustomEvent) {
-    const { detail = {} } = nativeEvent;
-
-    if (isObject(detail)) {
-      // Ensure detail is a serialized/a JSON object. The custom trigger can also pick up JS custom event, which could
-      // have real JS data in them (vs. a JsonObject the user has provided via our @pixiebrix/event brick)
-      return ensureJsonObject(detail);
-    }
-
-    throw new BusinessError("Custom event detail is not an object");
-  }
-
-  // https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event
-  if (nativeEvent.type === "selectionchange") {
-    // https://developer.mozilla.org/en-US/docs/Web/API/Selection
-    return {
-      // Match the behavior for contextMenu and quickBar
-      selectionText: selectionController.get(),
-    };
-  }
-
-  return {};
 }
 
 export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig> {

--- a/src/extensionPoints/types.ts
+++ b/src/extensionPoints/types.ts
@@ -26,6 +26,7 @@ import {
   Metadata,
   RegistryId,
   ResolvedExtension,
+  RunArgs,
   Schema,
   UUID,
 } from "@/core";
@@ -191,5 +192,5 @@ export abstract class ExtensionPoint<TConfig extends EmptyConfig>
     console.warn(`Uninstall not implemented for extension point: ${this.id}`);
   }
 
-  abstract run(): Promise<void>;
+  abstract run(args: RunArgs): Promise<void>;
 }

--- a/src/options/pages/brickEditor/referenceTab/BrickReference.tsx
+++ b/src/options/pages/brickEditor/referenceTab/BrickReference.tsx
@@ -26,7 +26,7 @@ import {
   ListGroup,
   Row,
 } from "react-bootstrap";
-import { IBlock, IService } from "@/core";
+import { IBlock, IExtensionPoint, IService } from "@/core";
 import Fuse from "fuse.js";
 import { sortBy } from "lodash";
 import Loader from "@/components/Loader";
@@ -77,7 +77,7 @@ const BrickReference: React.FunctionComponent<{
     return null;
   }, [selected]);
 
-  const fuse: Fuse<IBlock | IService> = useMemo(
+  const fuse: Fuse<IBlock | IService | IExtensionPoint> = useMemo(
     () =>
       new Fuse(sortedBricks, {
         // Prefer name, then id

--- a/src/pageEditor/extensionPoints/formStateTypes.ts
+++ b/src/pageEditor/extensionPoints/formStateTypes.ts
@@ -32,14 +32,17 @@ import {
   QuickBarDefaultOptions,
   QuickBarTargetMode,
 } from "@/extensionPoints/quickBarExtension";
-import { SidebarConfig } from "@/extensionPoints/sidebarExtension";
+import {
+  SidebarConfig,
+  Trigger as SidebarTrigger,
+} from "@/extensionPoints/sidebarExtension";
 import {
   AttachMode,
   CustomEventOptions,
   DebounceOptions,
   ReportMode,
   TargetMode,
-  Trigger,
+  Trigger as TriggerTrigger,
 } from "@/extensionPoints/triggerExtension";
 import { ExtensionPointType } from "@/extensionPoints/types";
 import { Except } from "type-fest";
@@ -79,7 +82,30 @@ export interface ActionFormState
 // SidebarFormState
 type SidebarExtensionState = BaseExtensionState & Except<SidebarConfig, "body">;
 
-export interface SidebarFormState extends BaseFormState<SidebarExtensionState> {
+export type SidebarExtensionPointState = BaseExtensionPointState & {
+  definition: BaseExtensionPointState["definition"] & {
+    /**
+     * Sidebar trigger (default="load")
+     * @since 1.6.5
+     */
+    trigger: SidebarTrigger;
+
+    /**
+     * Debouncing props
+     * @since 1.6.5
+     */
+    debounce: DebounceOptions | null;
+
+    /**
+     * Custom trigger props
+     * @since 1.6.5
+     */
+    customEvent: CustomEventOptions | null;
+  };
+};
+
+export interface SidebarFormState
+  extends BaseFormState<SidebarExtensionState, SidebarExtensionPointState> {
   type: "actionPanel";
 }
 
@@ -88,7 +114,7 @@ export type TriggerExtensionPointState = BaseExtensionPointState & {
   definition: {
     type: ExtensionPointType;
     rootSelector: string | null;
-    trigger: Trigger;
+    trigger: TriggerTrigger;
     reader: SingleLayerReaderConfig;
     attachMode: AttachMode;
     targetMode: TargetMode;

--- a/src/pageEditor/tabs/sidebar/SidebarConfiguration.tsx
+++ b/src/pageEditor/tabs/sidebar/SidebarConfiguration.tsx
@@ -22,26 +22,95 @@ import UrlMatchPatternField from "@/pageEditor/fields/UrlMatchPatternField";
 import FieldSection from "@/pageEditor/fields/FieldSection";
 import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
 import MatchRulesSection from "@/pageEditor/tabs/MatchRulesSection";
+import { partial } from "lodash";
+import { joinName } from "@/utils";
+import DebounceFieldSet from "@/pageEditor/tabs/trigger/DebounceFieldSet";
+import { DebounceOptions, Trigger } from "@/extensionPoints/sidebarExtension";
+import { useField, useFormikContext } from "formik";
+import { TriggerFormState } from "@/pageEditor/extensionPoints/formStateTypes";
 
 const SidebarConfiguration: React.FC<{
   isLocked: boolean;
-}> = ({ isLocked = false }) => (
-  <Card>
-    <FieldSection title="Configuration">
-      <ConnectedFieldTemplate
-        name="extension.heading"
-        label="Heading"
-        description="Panel heading to show in the sidebar"
-      />
+}> = ({ isLocked = false }) => {
+  const fieldName = partial(joinName, "extensionPoint.definition");
 
-      <UrlMatchPatternField
-        name="extensionPoint.definition.isAvailable.matchPatterns"
-        {...makeLockableFieldProps("Sites", isLocked)}
-      />
-    </FieldSection>
+  const [{ value: trigger }] = useField<Trigger>(fieldName("trigger"));
 
-    <MatchRulesSection isLocked={isLocked} />
-  </Card>
-);
+  const [{ value: debounce }] = useField<DebounceOptions | null>(
+    fieldName("debounce")
+  );
+
+  const { setFieldValue } = useFormikContext<TriggerFormState>();
+
+  const onTriggerChange = ({
+    currentTarget,
+  }: React.FormEvent<HTMLSelectElement>) => {
+    const nextTrigger = currentTarget.value as Trigger;
+
+    if (nextTrigger === "custom") {
+      setFieldValue(fieldName("customEvent"), { eventName: "" });
+    } else {
+      setFieldValue(fieldName("customEvent"), null);
+    }
+
+    if (nextTrigger !== "manual" && debounce == null) {
+      // Add debounce by default, because the selection event fires for every event when clicking and dragging
+      setFieldValue(fieldName("debounce"), {
+        waitMillis: 250,
+        leading: false,
+        trailing: true,
+      });
+    } else if (nextTrigger === "manual") {
+      setFieldValue(fieldName("debounce"), null);
+    }
+
+    setFieldValue(fieldName("trigger"), currentTarget.value);
+  };
+
+  return (
+    <Card>
+      <FieldSection title="Configuration">
+        <ConnectedFieldTemplate
+          name="extension.heading"
+          label="Heading"
+          description="Panel heading to show in the sidebar"
+        />
+
+        <UrlMatchPatternField
+          name="extensionPoint.definition.isAvailable.matchPatterns"
+          {...makeLockableFieldProps("Sites", isLocked)}
+        />
+      </FieldSection>
+
+      <FieldSection title="Panel Refresh">
+        <ConnectedFieldTemplate
+          name={fieldName("trigger")}
+          as="select"
+          description="Event to refresh the panel"
+          onChange={onTriggerChange}
+          {...makeLockableFieldProps("Trigger", isLocked)}
+        >
+          <option value="load">Page Load / Navigation</option>
+          <option value="selectionchange">Selection Change</option>
+          <option value="custom">Custom Event</option>
+          <option value="manual">Manual</option>
+        </ConnectedFieldTemplate>
+
+        {trigger === "custom" && (
+          <ConnectedFieldTemplate
+            title="Custom Event"
+            name={fieldName("customEvent", "eventName")}
+            description="The custom event name"
+            {...makeLockableFieldProps("Custom Event", isLocked)}
+          />
+        )}
+
+        <DebounceFieldSet isLocked={isLocked} />
+      </FieldSection>
+
+      <MatchRulesSection isLocked={isLocked} />
+    </Card>
+  );
+};
 
 export default SidebarConfiguration;

--- a/src/pageEditor/tabs/trigger/DebounceFieldSet.tsx
+++ b/src/pageEditor/tabs/trigger/DebounceFieldSet.tsx
@@ -1,0 +1,74 @@
+import React, { ChangeEvent } from "react";
+import FieldTemplate from "@/components/form/FieldTemplate";
+import SwitchButtonWidget, {
+  CheckBoxLike,
+} from "@/components/form/widgets/switchButton/SwitchButtonWidget";
+import { isEmpty, partial } from "lodash";
+import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
+import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
+import NumberWidget from "@/components/fields/schemaFields/widgets/NumberWidget";
+import BooleanWidget from "@/components/fields/schemaFields/widgets/BooleanWidget";
+import { useField, useFormikContext } from "formik";
+import { DebounceOptions } from "@/extensionPoints/triggerExtension";
+import { joinName } from "@/utils";
+import { TriggerFormState } from "@/pageEditor/extensionPoints/formStateTypes";
+
+const DebounceFieldSet: React.FC<{
+  isLocked: boolean;
+}> = ({ isLocked }) => {
+  const { setFieldValue } = useFormikContext<TriggerFormState>();
+
+  const fieldName = partial(joinName, "extensionPoint.definition");
+
+  const [{ value: debounce }] = useField<DebounceOptions | null>(
+    fieldName("debounce")
+  );
+
+  return (
+    <>
+      <FieldTemplate
+        as={SwitchButtonWidget}
+        description="Debounce the trigger"
+        name="debounce"
+        value={!isEmpty(debounce)}
+        onChange={({ target }: ChangeEvent<CheckBoxLike>) => {
+          if (target.value) {
+            setFieldValue(fieldName("debounce"), {
+              waitMillis: 250,
+              leading: false,
+              trailing: true,
+            });
+          } else {
+            setFieldValue(fieldName("debounce"), null);
+          }
+        }}
+        {...makeLockableFieldProps("Debounce", isLocked)}
+      />
+
+      {debounce && (
+        <>
+          <ConnectedFieldTemplate
+            name={fieldName("debounce", "waitMillis")}
+            as={NumberWidget}
+            description="The number of milliseconds to delay"
+            {...makeLockableFieldProps("Delay Millis", isLocked)}
+          />
+          <ConnectedFieldTemplate
+            name={fieldName("debounce", "leading")}
+            as={BooleanWidget}
+            description="Specify invoking on the leading edge of the debounced timeout."
+            {...makeLockableFieldProps("Leading", isLocked)}
+          />
+          <ConnectedFieldTemplate
+            name={fieldName("debounce", "trailing")}
+            as={BooleanWidget}
+            description="Specify invoking on the trailing edge of the debounced timeout."
+            {...makeLockableFieldProps("Trailing", isLocked)}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+export default DebounceFieldSet;

--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { ChangeEvent } from "react";
+import React from "react";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import { Card } from "react-bootstrap";
 import UrlMatchPatternField from "@/pageEditor/fields/UrlMatchPatternField";
@@ -30,14 +30,10 @@ import {
 } from "@/extensionPoints/triggerExtension";
 import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
 import BooleanWidget from "@/components/fields/schemaFields/widgets/BooleanWidget";
-import NumberWidget from "@/components/fields/schemaFields/widgets/NumberWidget";
-import FieldTemplate from "@/components/form/FieldTemplate";
-import { isEmpty, partial } from "lodash";
+import { partial } from "lodash";
 import { joinName } from "@/utils";
-import SwitchButtonWidget, {
-  CheckBoxLike,
-} from "@/components/form/widgets/switchButton/SwitchButtonWidget";
 import MatchRulesSection from "@/pageEditor/tabs/MatchRulesSection";
+import DebounceFieldSet from "@/pageEditor/tabs/trigger/DebounceFieldSet";
 
 function supportsSelector(trigger: Trigger) {
   return !["load", "interval", "selectionchange"].includes(trigger);
@@ -207,47 +203,7 @@ const TriggerConfiguration: React.FC<{
           </ConnectedFieldTemplate>
         )}
 
-        <FieldTemplate
-          as={SwitchButtonWidget}
-          description="Debounce the trigger"
-          name="debounce"
-          value={!isEmpty(debounce)}
-          onChange={({ target }: ChangeEvent<CheckBoxLike>) => {
-            if (target.value) {
-              setFieldValue(fieldName("debounce"), {
-                waitMillis: 250,
-                leading: false,
-                trailing: true,
-              });
-            } else {
-              setFieldValue(fieldName("debounce"), null);
-            }
-          }}
-          {...makeLockableFieldProps("Debounce", isLocked)}
-        />
-
-        {debounce && (
-          <>
-            <ConnectedFieldTemplate
-              name={fieldName("debounce", "waitMillis")}
-              as={NumberWidget}
-              description="The number of milliseconds to delay"
-              {...makeLockableFieldProps("Delay Millis", isLocked)}
-            />
-            <ConnectedFieldTemplate
-              name={fieldName("debounce", "leading")}
-              as={BooleanWidget}
-              description="Specify invoking on the leading edge of the debounced timeout."
-              {...makeLockableFieldProps("Leading", isLocked)}
-            />
-            <ConnectedFieldTemplate
-              name={fieldName("debounce", "trailing")}
-              as={BooleanWidget}
-              description="Specify invoking on the trailing edge of the debounced timeout."
-              {...makeLockableFieldProps("Trailing", isLocked)}
-            />
-          </>
-        )}
+        <DebounceFieldSet isLocked={isLocked} />
 
         <UrlMatchPatternField
           name={fieldName("isAvailable", "matchPatterns")}

--- a/src/runtime/getType.ts
+++ b/src/runtime/getType.ts
@@ -15,12 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { IBlock, IService } from "@/core";
+import { IBlock, IExtensionPoint, IService } from "@/core";
 import { BlockType } from "@/runtime/runtimeTypes";
 
 export default async function getType(
-  // HACK: including IService here is a hack to fix some call-sites. This method can only return block types
-  block: IBlock | IService
+  // HACK: including IService and IExtensionPoint here is a hack to fix some call-sites. This method can only return
+  // block types
+  block: IBlock | IService | IExtensionPoint
 ): Promise<BlockType | null> {
   if ("inferType" in block) {
     // For YAML-based blocks, can't use the method to determine the type because only the "run" method is available.


### PR DESCRIPTION
## What does this PR do?

- Closes #3603 
- Adds debounce support to sidebar panels
- Adds trigger customization to sidebar panels

## Reviewer Tips

Review order:
- Review sidebarExtension extension point runtime changes
- Review Page Editor form state adapter
- Review Page Editor configuration

## Discussion

- Selection change is a common enough event that it makes sense to support natively vs. having the user define a selection change trigger that refreshes the panel
- Does not pass the event data to the panel, because the panel may sometimes be run manually without an event context 

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer: @BALEHOK 
