### PR TITLE
#3574: Fix extra scrollbar outside the brick modal

### DIFF
--- a/src/components/brickModal/BrickModal.module.scss
+++ b/src/components/brickModal/BrickModal.module.scss
@@ -19,10 +19,10 @@ $maxHeight: calc(100vh - 100px);
 $bootstrapPadding: 15px;
 
 .root {
-  display: grid;
+  display: grid !important;
   place-content: center center;
   & > :first-child {
-    margin: 20px auto;
+    margin: auto;
     width: 89vw;
     max-width: 1220px; // Fits 3 "recommended bricks" columns
   }


### PR DESCRIPTION
## What does this PR do?

- Point 1 of #3574 

## Demo

The difference is subtle: the explicit `margin` on the left pushes the modal lower, so it lengthens the document

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="272" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/172526941-21ff5cd4-0550-446d-82a8-28412109f0d2.png">
	<td><img width="292" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/172526948-cf61086d-0fb5-4be6-b053-8236b62caa2c.png">
</table>
