### PR TITLE
#3597: Ensure that long words don't break the UI

### DIFF
--- a/src/vendors/overrides.scss
+++ b/src/vendors/overrides.scss
@@ -18,3 +18,9 @@
 span.page-title-icon {
   line-height: 36px;
 }
+
+html {
+  /* Ensure that long words don't break the UI */
+  /* https://github.com/pixiebrix/pixiebrix-extension/issues/3597 */
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## What does this PR do?

- Fixes #3597

## Demo

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="485" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/172530179-3ddf6d58-71f3-4859-af6a-442532095eab.png">
	<td><img width="486" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/172530185-1eaa619c-10f1-49e1-bdf1-7005b6225774.png">

</table>
