### PR TITLE
#2783: Hide page editor sidebar while adding a new extension

### DIFF
--- a/src/pageEditor/Editor.tsx
+++ b/src/pageEditor/Editor.tsx
@@ -173,7 +173,7 @@ const Editor: React.FunctionComponent = () => {
   return (
     <>
       <div className={styles.root}>
-        <Sidebar />
+        {inserting ? null : <Sidebar />}
         {body}
       </div>
 

--- a/src/pageEditor/sidebar/Sidebar.tsx
+++ b/src/pageEditor/sidebar/Sidebar.tsx
@@ -166,9 +166,6 @@ const SidebarExpanded: React.VoidFunctionComponent<{
   const { data: allRecipes, isLoading: isLoadingRecipes } =
     useGetRecipesQuery();
 
-  const isInsertingElement = useSelector((state: EditorState) =>
-    Boolean(state.inserting)
-  );
   const activeElementId = useSelector(selectActiveElementId);
   const activeRecipeId = useSelector(selectActiveRecipeId);
   const expandedRecipeId = useSelector(selectExpandedRecipeId);
@@ -348,7 +345,7 @@ const SidebarExpanded: React.VoidFunctionComponent<{
               <Logo />
             </a>
             <DropdownButton
-              disabled={isInsertingElement || !hasPermissions}
+              disabled={!hasPermissions}
               variant="info"
               size="sm"
               title="Add"

--- a/src/pageEditor/sidebar/Sidebar.tsx
+++ b/src/pageEditor/sidebar/Sidebar.tsx
@@ -65,7 +65,7 @@ import {
   selectIsAddToRecipeModalVisible,
 } from "@/pageEditor/slices/editorSelectors";
 import { useDispatch, useSelector } from "react-redux";
-import { EditorState, FormState } from "@/pageEditor/pageEditorTypes";
+import { FormState } from "@/pageEditor/pageEditorTypes";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import { useGetRecipesQuery } from "@/services/api";
 import { getIdForElement, getRecipeIdForElement } from "@/pageEditor/utils";


### PR DESCRIPTION
## What does this PR do?

- Fixes #2783

## Discussion

This solves several issues that appear when showing the sidebar while "inserting":

- the extensions in the sidebar are still selectable, but nothing happens
- new extensions can be "added" before the current one is done

**This sidebar-less view may look strange at first but the exact look can be improved later**

## Before 

The user can roam the extension while the "inserting" state is active

https://user-images.githubusercontent.com/1402241/172535060-d0304ef1-150c-49c6-9b5e-bad934904c9d.mov

## After

Inserting is now "modal" (i.e. no other operations are available) so you must act on it (add or cancel) before moving onto other operations


https://user-images.githubusercontent.com/1402241/172535252-802f344e-c574-4b0f-aacd-3fa158ba033e.mov
