### PR TITLE
#2657: Avoid loader in PersistGate

### DIFF
--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -19,7 +19,6 @@ import React, { useEffect } from "react";
 import store, { hashHistory, persistor } from "./store";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
-import Loader from "@/components/Loader";
 import { Container } from "react-bootstrap";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import ServicesEditor from "@/options/pages/services/ServicesEditor";
@@ -148,7 +147,7 @@ const App: React.FunctionComponent = () => {
 
   return (
     <Provider store={store}>
-      <PersistGate loading={<Loader />} persistor={persistor}>
+      <PersistGate persistor={persistor}>
         <ConnectedRouter history={hashHistory}>
           <ModalProvider>
             <Layout />

--- a/src/pageEditor/Panel.tsx
+++ b/src/pageEditor/Panel.tsx
@@ -29,7 +29,6 @@ import { ModalProvider } from "@/components/ConfirmationModal";
 import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 import registerEditors from "@/contrib/editors";
-import Loader from "@/components/Loader";
 import ErrorBanner from "@/pageEditor/ErrorBanner";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import RequireAuth from "@/auth/RequireAuth";
@@ -52,7 +51,7 @@ const Panel: React.VoidFunctionComponent = () => {
 
   return (
     <Provider store={store}>
-      <PersistGate loading={<Loader />} persistor={persistor}>
+      <PersistGate persistor={persistor}>
         <PageEditorTabContext.Provider value={context}>
           <ModalProvider>
             <ErrorBoundary>


### PR DESCRIPTION
- Part of https://github.com/pixiebrix/pixiebrix-extension/issues/2657

From what I see, all data is persisted locally so there's no reason to show a loader since it's just **shown for a fraction of a second**, or maybe no time at all (I don't see a difference)

`RequireAuth`’s loader also seems to be instantaneous for me and I also suggest dropping it, but I didn't here. You can see how quickly it disappears in https://github.com/pixiebrix/pixiebrix-extension/pull/3611

> _For anything that takes less than 1 second to load, it is distracting to use a looped animation, because users cannot keep up with what happened and might feel anxious about whatever flashed on the screen._
> 
> From https://www.nngroup.com/articles/progress-indicators/


### Side experiment

Delete this line on your computer,  I bet the extension feel better and faster. This isn't practical everywhere, but it suggests loaders should be used sparingly.


https://github.com/pixiebrix/pixiebrix-extension/blob/e1c4679df66679a1d51e10100b18f69735f6a6e5/src/components/Loader.tsx#L29

