### PR TITLE
Data panel button to copy JSON

### DIFF
--- a/src/components/jsonTree/JsonTree.tsx
+++ b/src/components/jsonTree/JsonTree.tsx
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import styles from "./JsonTree.module.scss";
 import { JSONTree } from "react-json-tree";
 import { jsonTreeTheme as theme } from "@/themes/light";
 import React, {
@@ -42,6 +41,14 @@ import {
 import { Primitive } from "type-fest";
 import { produce } from "immer";
 import { Styling, Theme } from "react-base16-styling";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCode } from "@fortawesome/free-solid-svg-icons";
+import cx from "classnames";
+import copy from "copy-to-clipboard";
+import notify from "@/utils/notify";
+import safeJsonStringify from "json-stringify-safe";
+import { Button } from "react-bootstrap";
+import styles from "./JsonTree.module.scss";
 
 const SEARCH_DEBOUNCE_MS = 100;
 
@@ -137,6 +144,25 @@ const jsonTreeTheme: Theme = {
   }),
 };
 
+const CopyDataButton: React.FunctionComponent<{ data: unknown }> = ({
+  data,
+}) => (
+  <Button
+    variant="text"
+    className={cx(styles.copyPath, "p-0")}
+    aria-label="copy data"
+    href="#"
+    onClick={(event) => {
+      copy(safeJsonStringify(data));
+      event.preventDefault();
+      event.stopPropagation();
+      notify.info("Copied data to the clipboard");
+    }}
+  >
+    <FontAwesomeIcon icon={faCode} aria-hidden />
+  </Button>
+);
+
 /**
  * Internally a memoised component is used, be mindful about the reference equality of the props
  */
@@ -229,7 +255,12 @@ const JsonTree: React.FunctionComponent<JsonTreeProps> = ({
           fitLabelWidth
         />
       )}
-      {labelText && <span>{labelText}</span>}
+      {labelText && (
+        <span>
+          {labelText}&nbsp;
+          <CopyDataButton data={searchResults} />
+        </span>
+      )}
       {searchResults === undefined ? (
         <Loader />
       ) : (

--- a/src/components/jsonTree/JsonTree.tsx
+++ b/src/components/jsonTree/JsonTree.tsx
@@ -153,7 +153,7 @@ const CopyDataButton: React.FunctionComponent<{ data: unknown }> = ({
     aria-label="copy data"
     href="#"
     onClick={(event) => {
-      copy(safeJsonStringify(data));
+      copy(safeJsonStringify(data, null, 2));
       event.preventDefault();
       event.stopPropagation();
       notify.info("Copied data to the clipboard");
@@ -164,7 +164,7 @@ const CopyDataButton: React.FunctionComponent<{ data: unknown }> = ({
 );
 
 /**
- * Internally a memoised component is used, be mindful about the reference equality of the props
+ * Internally a memoized component is used, be mindful about the reference equality of the props
  */
 const JsonTree: React.FunctionComponent<JsonTreeProps> = ({
   copyable = false,

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -20,7 +20,7 @@ import React, { useMemo } from "react";
 import { FormState } from "@/pageEditor/pageEditorTypes";
 import { isEmpty, isEqual, pickBy } from "lodash";
 import { useFormikContext } from "formik";
-import { Button, Nav, Tab } from "react-bootstrap";
+import { Nav, Tab } from "react-bootstrap";
 import dataPanelStyles from "@/pageEditor/tabs/dataPanelTabs.module.scss";
 import FormPreview from "@/components/formBuilder/preview/FormPreview";
 import ErrorBoundary from "@/components/ErrorBoundary";
@@ -37,7 +37,6 @@ import { RJSFSchema } from "@/components/formBuilder/formBuilderTypes";
 import DataTab from "./DataTab";
 import useDataPanelActiveTabKey from "@/pageEditor/tabs/editTab/dataPanel/useDataPanelActiveTabKey";
 import DocumentPreview from "@/components/documentBuilder/preview/DocumentPreview";
-import copy from "copy-to-clipboard";
 import useFlags from "@/hooks/useFlags";
 import ErrorDisplay from "./ErrorDisplay";
 import PageStateTab from "./PageStateTab";
@@ -232,6 +231,7 @@ const DataPanel: React.FC = () => {
               copyable
               searchable
               tabKey={DataPanelTabKey.Context}
+              label="Context"
             />
           </DataTab>
           {showPageState && (
@@ -250,6 +250,7 @@ const DataPanel: React.FC = () => {
                   data={{ ...activeElement, ...formikErrors }}
                   searchable
                   tabKey={DataPanelTabKey.Formik}
+                  label="Formik State"
                 />
               </DataTab>
               <DataTab eventKey={DataPanelTabKey.BlockConfig}>
@@ -260,15 +261,8 @@ const DataPanel: React.FC = () => {
                 <DataTabJsonTree
                   data={blockConfig ?? {}}
                   tabKey={DataPanelTabKey.BlockConfig}
+                  label="Configuration"
                 />
-                <Button
-                  onClick={() => {
-                    copy(JSON.stringify(blockConfig, undefined, 2));
-                  }}
-                  size="sm"
-                >
-                  Copy JSON
-                </Button>
               </DataTab>
             </>
           )}
@@ -328,7 +322,7 @@ const DataPanel: React.FC = () => {
                   copyable
                   searchable
                   tabKey={DataPanelTabKey.Output}
-                  label="Data"
+                  label="Output Data"
                 />
               </>
             )}

--- a/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
@@ -107,6 +107,7 @@ const FoundationDataPanel: React.FC<{
                 data={formState ?? {}}
                 searchable
                 tabKey={DataPanelTabKey.Formik}
+                label="Formik State"
               />
             </Tab.Pane>
             <Tab.Pane
@@ -122,6 +123,7 @@ const FoundationDataPanel: React.FC<{
               <DataTabJsonTree
                 data={extensionPoint}
                 tabKey={DataPanelTabKey.BlockConfig}
+                label="Configuration"
               />
             </Tab.Pane>
           </>
@@ -147,7 +149,7 @@ const FoundationDataPanel: React.FC<{
               copyable
               searchable
               tabKey={DataPanelTabKey.Output}
-              label="Data"
+              label="Output Data"
             />
           ) : (
             <div className="text-muted">

--- a/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/DataPanel.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/DataPanel.test.tsx.snap
@@ -97,6 +97,31 @@ exports[`DataPanel it renders with form state and trace data 1`] = `
                 />
               </div>
             </div>
+            <span>
+              Context 
+              <a
+                aria-label="copy data"
+                class="copyPath p-0 btn btn-text"
+                href="#"
+                role="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-code fa-w-20 "
+                  data-icon="code"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 640 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M278.9 511.5l-61-17.7c-6.4-1.8-10-8.5-8.2-14.9L346.2 8.7c1.8-6.4 8.5-10 14.9-8.2l61 17.7c6.4 1.8 10 8.5 8.2 14.9L293.8 503.3c-1.9 6.4-8.5 10.1-14.9 8.2zm-114-112.2l43.5-46.4c4.6-4.9 4.3-12.7-.8-17.2L117 256l90.6-79.7c5.1-4.5 5.5-12.3.8-17.2l-43.5-46.4c-4.5-4.8-12.1-5.1-17-.5L3.8 247.2c-5.1 4.7-5.1 12.8 0 17.5l144.1 135.1c4.9 4.6 12.5 4.4 17-.5zm327.2.6l144.1-135.1c5.1-4.7 5.1-12.8 0-17.5L492.1 112.1c-4.8-4.5-12.4-4.3-17 .5L431.6 159c-4.6 4.9-4.3 12.7.8 17.2L523 256l-90.6 79.7c-5.1 4.5-5.5 12.3-.8 17.2l43.5 46.4c4.5 4.9 12.1 5.1 17 .6z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </a>
+            </span>
             <ul
               style="border: 0px; padding: 0px; margin: 0.5em 0px 0.5em 0.125em; list-style: none; background-color: rgb(253, 255, 255);"
             >

--- a/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/FoundationDataPanel.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/FoundationDataPanel.test.tsx.snap
@@ -130,7 +130,29 @@ exports[`FoundationDataPanel it renders with form state and trace data 1`] = `
             </div>
           </div>
           <span>
-            Data
+            Output Data 
+            <a
+              aria-label="copy data"
+              class="copyPath p-0 btn btn-text"
+              href="#"
+              role="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-code fa-w-20 "
+                data-icon="code"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 640 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M278.9 511.5l-61-17.7c-6.4-1.8-10-8.5-8.2-14.9L346.2 8.7c1.8-6.4 8.5-10 14.9-8.2l61 17.7c6.4 1.8 10 8.5 8.2 14.9L293.8 503.3c-1.9 6.4-8.5 10.1-14.9 8.2zm-114-112.2l43.5-46.4c4.6-4.9 4.3-12.7-.8-17.2L117 256l90.6-79.7c5.1-4.5 5.5-12.3.8-17.2l-43.5-46.4c-4.5-4.8-12.1-5.1-17-.5L3.8 247.2c-5.1 4.7-5.1 12.8 0 17.5l144.1 135.1c4.9 4.6 12.5 4.4 17-.5zm327.2.6l144.1-135.1c5.1-4.7 5.1-12.8 0-17.5L492.1 112.1c-4.8-4.5-12.4-4.3-17 .5L431.6 159c-4.6 4.9-4.3 12.7.8 17.2L523 256l-90.6 79.7c-5.1 4.5-5.5 12.3-.8 17.2l43.5 46.4c4.5 4.9 12.1 5.1 17 .6z"
+                  fill="currentColor"
+                />
+              </svg>
+            </a>
           </span>
           <ul
             style="border: 0px; padding: 0px; margin: 0.5em 0px 0.5em 0.125em; list-style: none; background-color: rgb(253, 255, 255);"

--- a/src/pageEditor/tabs/effect/BlockPreview.tsx
+++ b/src/pageEditor/tabs/effect/BlockPreview.tsx
@@ -281,6 +281,7 @@ const BlockPreview: React.FunctionComponent<{
           searchable
           copyable
           tabKey={DataPanelTabKey.Preview}
+          label="Output Preview"
         />
       )}
 

--- a/src/pageEditor/tabs/effect/ExtensionPointPreview.tsx
+++ b/src/pageEditor/tabs/effect/ExtensionPointPreview.tsx
@@ -168,6 +168,7 @@ const ExtensionPointPreview: React.FunctionComponent<{
         searchable
         copyable
         tabKey={DataPanelTabKey.Preview}
+        label="Output Preview"
       />
     </div>
   );


### PR DESCRIPTION
## What does this PR do?

- Adds a button next to JSON tree for output and preview to copy data as JSON to the clipboard
- Helpful for getting the data for playing around in jqplay, etc

## Considerations

- This adds it to all of our JSON trees

## Demo

![image](https://user-images.githubusercontent.com/1879821/172913057-0c74de48-9017-4a0c-9523-bd7485b6f91a.png)

## Checklist

- [ ] Designate a primary reviewer: @BALEHOK 
