### PR TITLE
#3641: fix page script loading; fix button insertion

### DIFF
--- a/src/errors/errorHelpers.ts
+++ b/src/errors/errorHelpers.ts
@@ -25,7 +25,12 @@ import {
   selectNetworkErrorMessage,
   selectServerErrorMessage,
 } from "@/errors/networkErrorHelpers";
-import { errorTabDoesntExist, errorTargetClosedEarly } from "webext-messenger";
+
+// From "webext-messenger". Cannot import because the webextension polyfill can only run in an extension context
+// TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/3641
+const errorTargetClosedEarly =
+  "The target was closed before receiving a response";
+const errorTabDoesntExist = "The tab doesn't exist";
 
 const DEFAULT_ERROR_MESSAGE = "Unknown error";
 


### PR DESCRIPTION
## What does this PR do?

- Closes #3641
- Fixes a dependency on webext-messenger in errorHelpers that was causes the pageScript module to error on initialization
- Fix button insertion

## Future Work

- Add linter rule to prevent webext-messenger imports in non-extension directories

## Checklist

- [X] Designate a primary reviewer: @fregante 
