### PR TITLE
#3557: document builder formatting widget

### DIFF
--- a/src/components/documentBuilder/edit/getElementEditSchemas.ts
+++ b/src/components/documentBuilder/edit/getElementEditSchemas.ts
@@ -22,7 +22,7 @@ import { DocumentElementType } from "@/components/documentBuilder/documentBuilde
 export function getClassNameEdit(elementName: string): SchemaFieldProps {
   return {
     name: joinName(elementName, "config", "className"),
-    schema: { type: "string" },
+    schema: { type: "string", format: "bootstrap-class" },
     label: "CSS Class",
   };
 }

--- a/src/components/documentBuilder/edit/useElementOptions.tsx
+++ b/src/components/documentBuilder/edit/useElementOptions.tsx
@@ -27,6 +27,7 @@ import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import getElementEditSchemas from "@/components/documentBuilder/edit/getElementEditSchemas";
 import PipelineOptions from "@/components/documentBuilder/edit/PipelineOptions";
 import ButtonOptions from "@/components/documentBuilder/edit/ButtonOptions";
+import CssClassField from "@/components/fields/schemaFields/CssClassField";
 
 const useElementOptions = (
   element: DocumentElement,
@@ -56,14 +57,19 @@ const useElementOptions = (
     const editSchemas = getElementEditSchemas(elementType, elementName);
     const OptionsFields: React.FC = () => (
       <>
-        {editSchemas.map((editSchema) => (
-          <SchemaField key={editSchema.name} {...editSchema} />
-        ))}
+        {editSchemas.map((editSchema) =>
+          editSchema.schema.type === "string" &&
+          editSchema.schema.format === "bootstrap-class" ? (
+            <CssClassField key={editSchema.name} {...editSchema} />
+          ) : (
+            <SchemaField key={editSchema.name} {...editSchema} />
+          )
+        )}
       </>
     );
 
     return OptionsFields;
-  }, [elementType, elementName]);
+  }, [element, elementType, elementName]);
 
   return ElementOptions;
 };

--- a/src/components/fields/schemaFields/CssClassField.tsx
+++ b/src/components/fields/schemaFields/CssClassField.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useMemo } from "react";
+import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFieldContext";
+import CssClassWidget from "@/components/fields/schemaFields/widgets/CssClassWidget";
+import { getToggleOptions } from "@/components/fields/schemaFields/getToggleOptions";
+import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
+
+const RawCssClassField = defaultFieldFactory(CssClassWidget);
+
+// Can't be constant because getToggleOptions needs the widgets registry to be initialized
+export const getCssClassInputFieldOptions = () =>
+  getToggleOptions({
+    fieldSchema: {
+      type: "string",
+    },
+    isRequired: false,
+    customToggleModes: [],
+    isArrayItem: false,
+    isObjectProperty: false,
+    allowExpressions: true,
+  });
+
+const CssClassField: React.VFC<SchemaFieldProps> = (props) => {
+  const cssClassInputFieldOptions = useMemo(
+    () => getCssClassInputFieldOptions(),
+    []
+  );
+
+  const enrichedProps = {
+    ...props,
+    inputModeOptions: cssClassInputFieldOptions,
+  } as SchemaFieldProps;
+
+  return <RawCssClassField {...enrichedProps} />;
+};
+
+export default CssClassField;

--- a/src/components/fields/schemaFields/propTypes.ts
+++ b/src/components/fields/schemaFields/propTypes.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import * as PropTypes from "prop-types";
 import { Schema, UiSchema } from "@/core";
 import React from "react";
 import { FieldInputMode } from "./fieldInputMode";
@@ -23,13 +22,6 @@ import { FieldInputMode } from "./fieldInputMode";
 // https://json-schema.org/understanding-json-schema/reference/generic.html
 
 export type SchemaFieldComponent = React.FunctionComponent<SchemaFieldProps>;
-
-export const schemaPropTypes = {
-  type: PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired,
-  description: PropTypes.string,
-  default: PropTypes.any,
-  enum: PropTypes.array,
-};
 
 export interface SchemaFieldProps {
   /**

--- a/src/components/fields/schemaFields/widgets/ClassClassWidget.test.tsx
+++ b/src/components/fields/schemaFields/widgets/ClassClassWidget.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import CssClassWidget from "@/components/fields/schemaFields/widgets/CssClassWidget";
+import { Formik } from "formik";
+import React from "react";
+import { Expression } from "@/core";
+import { noop } from "lodash";
+import { render } from "@testing-library/react";
+import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
+import { getCssClassInputFieldOptions } from "@/components/fields/schemaFields/CssClassField";
+
+const renderWidget = (value: string | Expression) =>
+  render(
+    <Formik initialValues={{ cssClass: value }} onSubmit={noop}>
+      <CssClassWidget
+        inputModeOptions={getCssClassInputFieldOptions()}
+        schema={{
+          type: "string",
+        }}
+        name="cssClass"
+      />
+    </Formik>
+  );
+
+beforeAll(() => {
+  console.debug("Registering widgets");
+  registerDefaultWidgets();
+});
+
+describe("CssClassWidget", () => {
+  it("should render blank literal", () => {
+    const result = renderWidget("");
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/components/fields/schemaFields/widgets/CssClassWidget.stories.tsx
+++ b/src/components/fields/schemaFields/widgets/CssClassWidget.stories.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { ComponentMeta, Story } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import CssClassWidget, { parseValue } from "./CssClassWidget";
+import { Formik, useField } from "formik";
+import { Expression } from "@/core";
+import { getCssClassInputFieldOptions } from "@/components/fields/schemaFields/CssClassField";
+
+export default {
+  title: "Widgets/CssClassWidget",
+  component: CssClassWidget,
+} as ComponentMeta<typeof CssClassWidget>;
+
+const Preview: React.VFC = () => {
+  const [{ value }] = useField("cssClass");
+
+  const { classes, isVar, includesTemplate } = parseValue(value);
+
+  if (isVar || includesTemplate) {
+    return <div>Preview not supported</div>;
+  }
+
+  return (
+    <div className={classes.join(" ")}>
+      The quick brown fox jumps over the lazy dog
+    </div>
+  );
+};
+
+const Template: Story<
+  typeof CssClassWidget & { initialValues: { cssClass: string | Expression } }
+> = ({ initialValues }) => {
+  return (
+    <Formik initialValues={initialValues} onSubmit={action("submit")}>
+      <>
+        <div className="mb-4">
+          <Preview />
+        </div>
+
+        <div>
+          <CssClassWidget
+            inputModeOptions={getCssClassInputFieldOptions()}
+            schema={{
+              type: "string",
+            }}
+            name="cssClass"
+          />
+        </div>
+      </>
+    </Formik>
+  );
+};
+
+export const BlankLiteral = Template.bind({});
+BlankLiteral.args = {
+  initialValues: {
+    cssClass: "",
+  },
+};
+
+export const Omitted = Template.bind({});
+Omitted.args = {
+  initialValues: {
+    cssClass: null,
+  },
+};
+
+export const BlankExpression = Template.bind({});
+BlankExpression.args = {
+  initialValues: {
+    cssClass: {
+      __type__: "nunjucks",
+      __value__: "",
+    },
+  },
+};
+
+export const VariableExpression = Template.bind({});
+VariableExpression.args = {
+  initialValues: {
+    cssClass: {
+      __type__: "var",
+      __value__: "@cssClasses",
+    },
+  },
+};

--- a/src/components/fields/schemaFields/widgets/CssClassWidget.stories.tsx
+++ b/src/components/fields/schemaFields/widgets/CssClassWidget.stories.tsx
@@ -46,27 +46,25 @@ const Preview: React.VFC = () => {
 
 const Template: Story<
   typeof CssClassWidget & { initialValues: { cssClass: string | Expression } }
-> = ({ initialValues }) => {
-  return (
-    <Formik initialValues={initialValues} onSubmit={action("submit")}>
-      <>
-        <div className="mb-4">
-          <Preview />
-        </div>
+> = ({ initialValues }) => (
+  <Formik initialValues={initialValues} onSubmit={action("submit")}>
+    <>
+      <div className="mb-4">
+        <Preview />
+      </div>
 
-        <div>
-          <CssClassWidget
-            inputModeOptions={getCssClassInputFieldOptions()}
-            schema={{
-              type: "string",
-            }}
-            name="cssClass"
-          />
-        </div>
-      </>
-    </Formik>
-  );
-};
+      <div>
+        <CssClassWidget
+          inputModeOptions={getCssClassInputFieldOptions()}
+          schema={{
+            type: "string",
+          }}
+          name="cssClass"
+        />
+      </div>
+    </>
+  </Formik>
+);
 
 export const BlankLiteral = Template.bind({});
 BlankLiteral.args = {

--- a/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
@@ -1,0 +1,341 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useCallback, useMemo } from "react";
+import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
+import { Button, ButtonGroup, Dropdown, DropdownButton } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faAlignCenter,
+  faAlignJustify,
+  faAlignLeft,
+  faAlignRight,
+  faBold,
+  faFont,
+  faItalic,
+} from "@fortawesome/free-solid-svg-icons";
+import { useField } from "formik";
+import { Expression, TemplateEngine } from "@/core";
+import { isTemplateExpression, isVarExpression } from "@/runtime/mapArgs";
+import { uniq } from "lodash";
+import TemplateToggleWidget from "@/components/fields/schemaFields/widgets/TemplateToggleWidget";
+import { InputModeOption } from "@/components/fields/schemaFields/widgets/templateToggleWidgetTypes";
+
+/**
+ * An independent class name
+ */
+type ClassFlag = {
+  /**
+   * The Bootstrap 4 class name
+   */
+  className: string;
+
+  /**
+   * Title node to render for the element (in a button/dropdown)
+   */
+  title: React.ReactNode;
+};
+
+const flags = {
+  bold: {
+    className: "font-weight-bold",
+    title: <FontAwesomeIcon icon={faBold} />,
+  },
+  italic: {
+    className: "font-italic",
+    title: <FontAwesomeIcon icon={faItalic} />,
+  },
+};
+
+const optionsGroups = {
+  textAlign: [
+    { className: "text-left", title: <FontAwesomeIcon icon={faAlignLeft} /> },
+    {
+      className: "text-center",
+      title: <FontAwesomeIcon icon={faAlignCenter} />,
+    },
+    { className: "text-right", title: <FontAwesomeIcon icon={faAlignRight} /> },
+    {
+      className: "text-justify",
+      title: <FontAwesomeIcon icon={faAlignJustify} />,
+    },
+  ],
+  textVariant: [
+    {
+      className: "text-default",
+      title: <span className="text-default">Default</span>,
+    },
+    {
+      className: "text-primary",
+      title: <span className="text-primary">Primary</span>,
+    },
+    { className: "text-info", title: <span className="text-info">Info</span> },
+    {
+      className: "text-warning",
+      title: <span className="text-warning">Warning</span>,
+    },
+    {
+      className: "text-danger",
+      title: <span className="text-danger">Danger</span>,
+    },
+    {
+      className: "text-success",
+      title: <span className="text-success">Success</span>,
+    },
+  ],
+};
+
+type Value = string | Expression;
+
+const FlagButton: React.VFC<
+  ClassFlag & {
+    disabled: boolean;
+    classes: string[];
+    toggleClass: (className: string, on: boolean, group?: ClassFlag[]) => void;
+    group?: ClassFlag[];
+  }
+> = ({ className, classes, title, toggleClass, group, disabled }) => {
+  const active = classes.includes(className);
+
+  return (
+    <Button
+      disabled={disabled}
+      variant="light"
+      size="sm"
+      active={active}
+      onClick={() => {
+        toggleClass(className, !active, group);
+      }}
+    >
+      {title}
+    </Button>
+  );
+};
+
+const FlagItem: React.VFC<
+  ClassFlag & {
+    classes: string[];
+    toggleClass: (className: string, on: boolean, group?: ClassFlag[]) => void;
+    group?: ClassFlag[];
+  }
+> = ({ className, classes, title, toggleClass, group }) => {
+  const active = classes.includes(className);
+
+  return (
+    <Dropdown.Item
+      active={active}
+      onClick={() => {
+        toggleClass(className, !active, group);
+      }}
+    >
+      {title}
+    </Dropdown.Item>
+  );
+};
+
+/**
+ * Return utility classes from the value
+ * @param value
+ */
+export function parseValue(value: Value): {
+  classes: string[];
+  isVar: boolean;
+  isTemplate: boolean;
+  includesTemplate: boolean;
+} {
+  if (value == null) {
+    return {
+      classes: [],
+      isVar: false,
+      isTemplate: false,
+      includesTemplate: false,
+    };
+  }
+
+  if (isVarExpression(value)) {
+    return {
+      classes: [],
+      isVar: true,
+      isTemplate: false,
+      includesTemplate: false,
+    };
+  }
+
+  if (isTemplateExpression(value)) {
+    if (value.__value__.includes("{{") || value.__value__.includes("{%")) {
+      return {
+        classes: value.__value__.split(" "),
+        isVar: false,
+        isTemplate: true,
+        includesTemplate: true,
+      };
+    }
+
+    return {
+      classes: value.__value__.split(" "),
+      isVar: false,
+      isTemplate: true,
+      includesTemplate: false,
+    };
+  }
+
+  if (typeof value === "string") {
+    return {
+      classes: value.split(" "),
+      isVar: false,
+      isTemplate: false,
+      includesTemplate: false,
+    };
+  }
+
+  throw new Error("Unexpected value");
+}
+
+function calculateNextValue(
+  previousValue: Value,
+  className: string,
+  on: boolean,
+  group?: ClassFlag[]
+): Value {
+  const { isVar, isTemplate, classes, includesTemplate } =
+    parseValue(previousValue);
+
+  if (isVar || includesTemplate) {
+    throw new Error("Not supported");
+  }
+
+  let nextClasses;
+
+  if (on && group) {
+    const inactiveClasses = group
+      .map((x) => x.className)
+      .filter((x) => x !== className);
+    nextClasses = [
+      ...classes.filter((x) => !inactiveClasses.includes(x)),
+      className,
+    ];
+  } else if (on) {
+    nextClasses = [...classes, className];
+  } else {
+    nextClasses = classes.filter((x) => x !== className);
+  }
+
+  const nextValue = uniq(nextClasses).join(" ");
+
+  if (isTemplate) {
+    return {
+      __type__: (previousValue as Expression).__type__ as TemplateEngine,
+      __value__: nextValue,
+    };
+  }
+
+  return nextValue;
+}
+
+/**
+ * A widget for customizing Bootstrap 4 utility classes.
+ *
+ * CSS classes are available in the document builder.
+ */
+const CssClassWidget: React.VFC<
+  SchemaFieldProps & { inputModeOptions: InputModeOption[] }
+> = (props) => {
+  const [{ value }, , { setValue }] = useField<Value>(props.name);
+
+  const { classes, isVar, includesTemplate } = useMemo(
+    () => parseValue(value),
+    [value]
+  );
+
+  const toggleClass = useCallback(
+    (className: string, on: boolean, group?: ClassFlag[]) => {
+      setValue(calculateNextValue(value, className, on, group));
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Formik bug where setValue changes on each render
+    [value]
+  );
+
+  const disableControls = isVar || includesTemplate;
+
+  return (
+    <div>
+      <TemplateToggleWidget
+        {...props}
+        defaultType="string"
+        setFieldDescription={() => "CSS class names for the element"}
+      />
+
+      <div className="mt-2">
+        <ButtonGroup>
+          {optionsGroups.textAlign.map((flag) => (
+            <FlagButton
+              key={flag.className}
+              disabled={disableControls}
+              {...flag}
+              classes={classes}
+              toggleClass={toggleClass}
+              group={optionsGroups.textAlign}
+            />
+          ))}
+        </ButtonGroup>
+
+        <ButtonGroup className="mx-2">
+          {[flags.bold, flags.italic].map((flag) => (
+            <FlagButton
+              key={flag.className}
+              {...flag}
+              disabled={disableControls}
+              classes={classes}
+              toggleClass={toggleClass}
+            />
+          ))}
+        </ButtonGroup>
+
+        <ButtonGroup className="mx-2">
+          <DropdownButton
+            title={
+              <span
+                className={
+                  optionsGroups.textVariant.find((x) =>
+                    classes.includes(x.className)
+                  )?.className
+                }
+              >
+                <FontAwesomeIcon icon={faFont} />
+              </span>
+            }
+            disabled={disableControls}
+            variant="light"
+            size="sm"
+          >
+            {optionsGroups.textVariant.map((flag) => (
+              <FlagItem
+                key={flag.className}
+                {...flag}
+                classes={classes}
+                toggleClass={toggleClass}
+                group={optionsGroups.textVariant}
+              />
+            ))}
+          </DropdownButton>
+        </ButtonGroup>
+      </div>
+    </div>
+  );
+};
+
+export default CssClassWidget;

--- a/src/components/fields/schemaFields/widgets/__snapshots__/ClassClassWidget.test.tsx.snap
+++ b/src/components/fields/schemaFields/widgets/__snapshots__/ClassClassWidget.test.tsx.snap
@@ -1,0 +1,468 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CssClassWidget should render blank literal 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div>
+        <div
+          class="root"
+        >
+          <div
+            class="field"
+          >
+            <textarea
+              class="form-control"
+              name="cssClass"
+              rows="1"
+            />
+          </div>
+          <div
+            class="dropdown dropdown"
+            data-test-selected="Text"
+            data-testid="toggle-cssClass"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="dropdown-toggle btn btn-link"
+              type="button"
+            >
+              <span
+                class="symbol"
+              >
+                <test-file-stub
+                  classname="root"
+                />
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="mt-2"
+        >
+          <div
+            class="btn-group"
+            role="group"
+          >
+            <button
+              class="btn btn-light btn-sm"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-align-left fa-w-14 "
+                data-icon="align-left"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12.83 352h262.34A12.82 12.82 0 0 0 288 339.17v-38.34A12.82 12.82 0 0 0 275.17 288H12.83A12.82 12.82 0 0 0 0 300.83v38.34A12.82 12.82 0 0 0 12.83 352zm0-256h262.34A12.82 12.82 0 0 0 288 83.17V44.83A12.82 12.82 0 0 0 275.17 32H12.83A12.82 12.82 0 0 0 0 44.83v38.34A12.82 12.82 0 0 0 12.83 96zM432 160H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0 256H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <button
+              class="btn btn-light btn-sm"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-align-center fa-w-14 "
+                data-icon="align-center"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M432 160H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0 256H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM108.1 96h231.81A12.09 12.09 0 0 0 352 83.9V44.09A12.09 12.09 0 0 0 339.91 32H108.1A12.09 12.09 0 0 0 96 44.09V83.9A12.1 12.1 0 0 0 108.1 96zm231.81 256A12.09 12.09 0 0 0 352 339.9v-39.81A12.09 12.09 0 0 0 339.91 288H108.1A12.09 12.09 0 0 0 96 300.09v39.81a12.1 12.1 0 0 0 12.1 12.1z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <button
+              class="btn btn-light btn-sm"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-align-right fa-w-14 "
+                data-icon="align-right"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16 224h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16zm416 192H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm3.17-384H172.83A12.82 12.82 0 0 0 160 44.83v38.34A12.82 12.82 0 0 0 172.83 96h262.34A12.82 12.82 0 0 0 448 83.17V44.83A12.82 12.82 0 0 0 435.17 32zm0 256H172.83A12.82 12.82 0 0 0 160 300.83v38.34A12.82 12.82 0 0 0 172.83 352h262.34A12.82 12.82 0 0 0 448 339.17v-38.34A12.82 12.82 0 0 0 435.17 288z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <button
+              class="btn btn-light btn-sm"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-align-justify fa-w-14 "
+                data-icon="align-justify"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M432 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="mx-2 btn-group"
+            role="group"
+          >
+            <button
+              class="btn btn-light btn-sm"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-bold fa-w-12 "
+                data-icon="bold"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 384 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M333.49 238a122 122 0 0 0 27-65.21C367.87 96.49 308 32 233.42 32H34a16 16 0 0 0-16 16v48a16 16 0 0 0 16 16h31.87v288H34a16 16 0 0 0-16 16v48a16 16 0 0 0 16 16h209.32c70.8 0 134.14-51.75 141-122.4 4.74-48.45-16.39-92.06-50.83-119.6zM145.66 112h87.76a48 48 0 0 1 0 96h-87.76zm87.76 288h-87.76V288h87.76a56 56 0 0 1 0 112z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <button
+              class="btn btn-light btn-sm"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-italic fa-w-10 "
+                data-icon="italic"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 320 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M320 48v32a16 16 0 0 1-16 16h-62.76l-80 320H208a16 16 0 0 1 16 16v32a16 16 0 0 1-16 16H16a16 16 0 0 1-16-16v-32a16 16 0 0 1 16-16h62.76l80-320H112a16 16 0 0 1-16-16V48a16 16 0 0 1 16-16h192a16 16 0 0 1 16 16z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="mx-2 btn-group"
+            role="group"
+          >
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-light btn-sm"
+                type="button"
+              >
+                <span>
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-font fa-w-14 "
+                    data-icon="font"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div>
+      <div
+        class="root"
+      >
+        <div
+          class="field"
+        >
+          <textarea
+            class="form-control"
+            name="cssClass"
+            rows="1"
+          />
+        </div>
+        <div
+          class="dropdown dropdown"
+          data-test-selected="Text"
+          data-testid="toggle-cssClass"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="true"
+            class="dropdown-toggle btn btn-link"
+            type="button"
+          >
+            <span
+              class="symbol"
+            >
+              <test-file-stub
+                classname="root"
+              />
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="mt-2"
+      >
+        <div
+          class="btn-group"
+          role="group"
+        >
+          <button
+            class="btn btn-light btn-sm"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-align-left fa-w-14 "
+              data-icon="align-left"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12.83 352h262.34A12.82 12.82 0 0 0 288 339.17v-38.34A12.82 12.82 0 0 0 275.17 288H12.83A12.82 12.82 0 0 0 0 300.83v38.34A12.82 12.82 0 0 0 12.83 352zm0-256h262.34A12.82 12.82 0 0 0 288 83.17V44.83A12.82 12.82 0 0 0 275.17 32H12.83A12.82 12.82 0 0 0 0 44.83v38.34A12.82 12.82 0 0 0 12.83 96zM432 160H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0 256H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+          <button
+            class="btn btn-light btn-sm"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-align-center fa-w-14 "
+              data-icon="align-center"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M432 160H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0 256H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM108.1 96h231.81A12.09 12.09 0 0 0 352 83.9V44.09A12.09 12.09 0 0 0 339.91 32H108.1A12.09 12.09 0 0 0 96 44.09V83.9A12.1 12.1 0 0 0 108.1 96zm231.81 256A12.09 12.09 0 0 0 352 339.9v-39.81A12.09 12.09 0 0 0 339.91 288H108.1A12.09 12.09 0 0 0 96 300.09v39.81a12.1 12.1 0 0 0 12.1 12.1z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+          <button
+            class="btn btn-light btn-sm"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-align-right fa-w-14 "
+              data-icon="align-right"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 224h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16zm416 192H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm3.17-384H172.83A12.82 12.82 0 0 0 160 44.83v38.34A12.82 12.82 0 0 0 172.83 96h262.34A12.82 12.82 0 0 0 448 83.17V44.83A12.82 12.82 0 0 0 435.17 32zm0 256H172.83A12.82 12.82 0 0 0 160 300.83v38.34A12.82 12.82 0 0 0 172.83 352h262.34A12.82 12.82 0 0 0 448 339.17v-38.34A12.82 12.82 0 0 0 435.17 288z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+          <button
+            class="btn btn-light btn-sm"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-align-justify fa-w-14 "
+              data-icon="align-justify"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M432 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          class="mx-2 btn-group"
+          role="group"
+        >
+          <button
+            class="btn btn-light btn-sm"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-bold fa-w-12 "
+              data-icon="bold"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 384 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M333.49 238a122 122 0 0 0 27-65.21C367.87 96.49 308 32 233.42 32H34a16 16 0 0 0-16 16v48a16 16 0 0 0 16 16h31.87v288H34a16 16 0 0 0-16 16v48a16 16 0 0 0 16 16h209.32c70.8 0 134.14-51.75 141-122.4 4.74-48.45-16.39-92.06-50.83-119.6zM145.66 112h87.76a48 48 0 0 1 0 96h-87.76zm87.76 288h-87.76V288h87.76a56 56 0 0 1 0 112z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+          <button
+            class="btn btn-light btn-sm"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-italic fa-w-10 "
+              data-icon="italic"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 320 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M320 48v32a16 16 0 0 1-16 16h-62.76l-80 320H208a16 16 0 0 1 16 16v32a16 16 0 0 1-16 16H16a16 16 0 0 1-16-16v-32a16 16 0 0 1 16-16h62.76l80-320H112a16 16 0 0 1-16-16V48a16 16 0 0 1 16-16h192a16 16 0 0 1 16 16z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          class="mx-2 btn-group"
+          role="group"
+        >
+          <div
+            class="dropdown"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="dropdown-toggle btn btn-light btn-sm"
+              type="button"
+            >
+              <span>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-font fa-w-14 "
+                  data-icon="font"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M432 416h-23.41L277.88 53.69A32 32 0 0 0 247.58 32h-47.16a32 32 0 0 0-30.3 21.69L39.41 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16h-19.58l23.3-64h152.56l23.3 64H304a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h128a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zM176.85 272L224 142.51 271.15 272z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/components/fields/schemaFields/widgets/registerDefaultWidgets.ts
+++ b/src/components/fields/schemaFields/widgets/registerDefaultWidgets.ts
@@ -30,8 +30,21 @@ import UnsupportedWidget from "./UnsupportedWidget";
 import widgetsRegistry from "./widgetsRegistry";
 import WorkshopMessageWidget from "./WorkshopMessageWidget";
 import SelectorMatchWidget from "@/pageEditor/components/SelectorMatchWidget";
+import CssClassWidget from "@/components/fields/schemaFields/widgets/CssClassWidget";
 
 function registerDefaultWidgets() {
+  if (typeof TextWidget === "undefined" || TextWidget == null) {
+    throw new Error(
+      "Error registering default widgets. TextWidget is undefined. Is there a circular dependency?"
+    );
+  }
+
+  if (typeof OmitFieldWidget === "undefined" || OmitFieldWidget == null) {
+    throw new Error(
+      "Error registering default widgets. OmitFieldWidget is undefined. Is there a circular dependency?"
+    );
+  }
+
   widgetsRegistry.ArrayWidget = ArrayWidget;
   widgetsRegistry.BooleanWidget = BooleanWidget;
   widgetsRegistry.IntegerWidget = IntegerWidget;
@@ -45,6 +58,7 @@ function registerDefaultWidgets() {
   widgetsRegistry.UrlMatchPatternWidget = UrlMatchPatternWidget;
   widgetsRegistry.UrlPatternWidget = UrlPatternWidget;
   widgetsRegistry.SelectorMatchWidget = SelectorMatchWidget;
+  widgetsRegistry.CssClassWidget = CssClassWidget;
   widgetsRegistry.WorkshopMessageWidget = WorkshopMessageWidget;
 }
 

--- a/src/components/fields/schemaFields/widgets/widgetsRegistry.ts
+++ b/src/components/fields/schemaFields/widgets/widgetsRegistry.ts
@@ -35,6 +35,7 @@ type Widgets = {
   SchemaSelectWidget: React.VFC<SchemaFieldProps>;
   TemplateToggleWidget: React.VFC<TemplateToggleWidgetProps>;
   TextWidget: React.VFC<SchemaFieldProps & FormControlProps>;
+  CssClassWidget: React.VFC<SchemaFieldProps>;
   UnsupportedWidget: React.VFC<SchemaFieldProps>;
   UrlMatchPatternWidget: React.VFC<SchemaFieldProps & FormControlProps>;
   UrlPatternWidget: React.VFC<SchemaFieldProps>;
@@ -42,11 +43,15 @@ type Widgets = {
   WorkshopMessageWidget: React.VFC<Partial<SchemaFieldProps>>;
 };
 
-const UnsetWidget: React.VFC = () => {
-  throw new Error(
-    "An input widget not set. Did you forget to register it in registerDefaultWidgets?"
-  );
-};
+function unsetWidgetFactory(label: string): React.VFC {
+  const UnsetWidget: React.VFC = () => {
+    throw new Error(
+      `Input widget ${label} not set. Did you forget to register it in registerDefaultWidgets?`
+    );
+  };
+
+  return UnsetWidget;
+}
 
 /**
  * The container that holds references to all the widgets.
@@ -54,20 +59,21 @@ const UnsetWidget: React.VFC = () => {
  * When you add a new widget, add it here, register in the `registerDefaultWidgets` function.
  */
 const widgetsRegistry: Widgets = {
-  ArrayWidget: UnsetWidget,
-  BooleanWidget: UnsetWidget,
-  IntegerWidget: UnsetWidget,
-  NumberWidget: UnsetWidget,
-  ObjectWidget: UnsetWidget,
-  OmitFieldWidget: UnsetWidget,
-  SchemaSelectWidget: UnsetWidget,
-  TemplateToggleWidget: UnsetWidget,
-  TextWidget: UnsetWidget,
-  UnsupportedWidget: UnsetWidget,
-  UrlMatchPatternWidget: UnsetWidget,
-  UrlPatternWidget: UnsetWidget,
-  SelectorMatchWidget: UnsetWidget,
-  WorkshopMessageWidget: UnsetWidget,
+  ArrayWidget: unsetWidgetFactory("ArrayWidget"),
+  BooleanWidget: unsetWidgetFactory("BooleanWidget"),
+  IntegerWidget: unsetWidgetFactory("IntegerWidget"),
+  NumberWidget: unsetWidgetFactory("NumberWidget"),
+  ObjectWidget: unsetWidgetFactory("ObjectWidget"),
+  OmitFieldWidget: unsetWidgetFactory("OmitFieldWidget"),
+  SchemaSelectWidget: unsetWidgetFactory("SchemaSelectWidget"),
+  TemplateToggleWidget: unsetWidgetFactory("TemplateToggleWidget"),
+  TextWidget: unsetWidgetFactory("TextWidget"),
+  CssClassWidget: unsetWidgetFactory("CssClassWidget"),
+  UnsupportedWidget: unsetWidgetFactory("UnsupportedWidget"),
+  UrlMatchPatternWidget: unsetWidgetFactory("UrlMatchPatternWidget"),
+  UrlPatternWidget: unsetWidgetFactory("UrlPatternWidget"),
+  SelectorMatchWidget: unsetWidgetFactory("SelectorMatchWidget"),
+  WorkshopMessageWidget: unsetWidgetFactory("WorkshopMessageWidget"),
 };
 
 export default widgetsRegistry;

--- a/src/pageEditor/fields/ConfigErrorBoundary.tsx
+++ b/src/pageEditor/fields/ConfigErrorBoundary.tsx
@@ -21,6 +21,10 @@ import reportError from "@/telemetry/reportError";
 import { UnknownObject } from "@/types";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { isEmpty } from "lodash";
+
+// eslint-disable-next-line prefer-destructuring -- process.env substitution
+const DEBUG = process.env.DEBUG;
 
 interface State {
   hasError: boolean;
@@ -59,6 +63,29 @@ class ConfigErrorBoundary extends Component<UnknownObject, State> {
             are not currently supported in the Page Editor. Please visit the
             Workshop to modify the configuration
           </div>
+
+          {DEBUG && (
+            <div>
+              <h4 className="my-4">Debug-Mode Information</h4>
+              {!isEmpty(this.state.errorMessage) && (
+                <div className="text-danger">
+                  <p>{this.state.errorMessage}</p>
+                </div>
+              )}
+              {this.state.stack && (
+                <pre className="mt-2 small text-secondary">
+                  {this.state.stack
+                    // In the app
+                    .replaceAll(location.origin + "/", "")
+                    // In the content script
+                    .replaceAll(
+                      `chrome-extension://${process.env.CHROME_EXTENSION_ID}/`,
+                      ""
+                    )}
+                </pre>
+              )}
+            </div>
+          )}
         </div>
       );
     }

--- a/src/pageEditor/fields/SelectorSelectorField.tsx
+++ b/src/pageEditor/fields/SelectorSelectorField.tsx
@@ -27,7 +27,7 @@ const SelectorSelectorField: React.FunctionComponent<
   SelectorSelectorProps & { name?: string }
 > = (props) => {
   // Some properties (e.g., the menuItem's container prop) support providing an array of selectors.
-  // See awaitElementOnce for for the difference in the semantics vs. nested CSS selectors
+  // See awaitElementOnce for the difference in the semantics vs. nested CSS selectors
   const [field] = useField<string | string[]>(props.name);
 
   const isArray = Array.isArray(field.value);

--- a/src/pageEditor/fields/devtoolFieldOverrides.tsx
+++ b/src/pageEditor/fields/devtoolFieldOverrides.tsx
@@ -23,6 +23,7 @@ import { Schema } from "@/core";
 import { isTemplateExpression } from "@/runtime/mapArgs";
 import OptionIcon from "@/components/fields/schemaFields/optionIcon/OptionIcon";
 import { CustomFieldDefinitions } from "@/components/fields/schemaFields/schemaFieldTypes";
+import CssClassWidget from "@/components/fields/schemaFields/widgets/CssClassWidget";
 
 export const ClearableSelectorWidget: React.FunctionComponent<{
   name: string;
@@ -44,6 +45,12 @@ const devtoolFieldOverrides: CustomFieldDefinitions = {
     {
       match: hasAnySelectorField,
       Component: ClearableSelectorWidget,
+    },
+    {
+      // See getElementEditSchemas.ts:getClassNameEdit
+      match: (schema) =>
+        schema.type === "string" && schema.format === "bootstrap-class",
+      Component: CssClassWidget,
     },
   ],
   customToggleModes: [


### PR DESCRIPTION
## What does this PR do?

- Initial part of #3557 
- Creates a CssClassWidget and CssClassField for adding bootstrap utility classes

## Discussion

- The `text-justify` class doesn't seem do anything. Might only be valid for `p` tags?
- If the value is a variable or includes template syntax, the controls are disabled. Will work to clean up the messaging on that
- Had do a bit of hack to get it to show up in the Document Builder. The Document Builder uses Schema Fields directly instead of using the options factory

## Demo

![image](https://user-images.githubusercontent.com/1879821/173195769-78c266d7-2eb5-4d55-83b0-eca0f8a92167.png)

## Future Work

- Support the layout utility classes (`p`, `m`, etc.). These require different handling because there are multiple in the family, e.g., `m`, `mx`, and `my`

## Checklist

- [ ] Add tests
- [X] Designate a primary reviewer: @BALEHOK 
