### PR TITLE
#3557: margin/padding utility class formatting

### DIFF
--- a/src/components/documentBuilder/edit/getElementEditSchemas.ts
+++ b/src/components/documentBuilder/edit/getElementEditSchemas.ts
@@ -23,7 +23,7 @@ export function getClassNameEdit(elementName: string): SchemaFieldProps {
   return {
     name: joinName(elementName, "config", "className"),
     schema: { type: "string", format: "bootstrap-class" },
-    label: "CSS Class",
+    label: "Layout/Style",
   };
 }
 

--- a/src/components/fields/schemaFields/widgets/ClassClassWidget.test.tsx
+++ b/src/components/fields/schemaFields/widgets/ClassClassWidget.test.tsx
@@ -15,7 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import CssClassWidget from "@/components/fields/schemaFields/widgets/CssClassWidget";
+import CssClassWidget, {
+  calculateNextSpacing,
+  calculateNextValue,
+  extractSpacing,
+  optionsGroups,
+} from "@/components/fields/schemaFields/widgets/CssClassWidget";
 import { Formik } from "formik";
 import React from "react";
 import { Expression } from "@/core";
@@ -46,5 +51,77 @@ describe("CssClassWidget", () => {
   it("should render blank literal", () => {
     const result = renderWidget("");
     expect(result).toMatchSnapshot();
+  });
+});
+
+describe("calculateNextValue", () => {
+  it("should toggle independent flag", () => {
+    expect(calculateNextValue("", "font-weight-bold", true)).toBe(
+      "font-weight-bold"
+    );
+    expect(
+      calculateNextValue(
+        "font-weight-bold font-italic",
+        "font-weight-bold",
+        false
+      )
+    ).toBe("font-italic");
+  });
+
+  it("should toggle flag group", () => {
+    expect(
+      calculateNextValue(
+        "text-left",
+        "text-right",
+        true,
+        optionsGroups.textAlign
+      )
+    ).toBe("text-right");
+  });
+
+  it("should toggle border group", () => {
+    expect(
+      calculateNextValue("border-left", "border", true, optionsGroups.borders)
+    ).toBe("border");
+    expect(
+      calculateNextValue("border", "border-left", true, optionsGroups.borders)
+    ).toBe("border border-left");
+    expect(
+      calculateNextValue(
+        "border border-left",
+        "border",
+        false,
+        optionsGroups.borders
+      )
+    ).toBe("border-left");
+  });
+});
+
+describe("calculateNextSpacing", () => {
+  it("should update size in place", () => {
+    expect(calculateNextSpacing("p-0", "p", { side: null, size: 1 })).toBe(
+      "p-1"
+    );
+  });
+
+  it("should ignore other classes", () => {
+    expect(
+      calculateNextSpacing("p-0 text-italic", "p", { side: null, size: 1 })
+    ).toBe("text-italic p-1");
+  });
+
+  it("should add new entry for size", () => {
+    expect(calculateNextSpacing("p-0", "p", { side: "b", size: 2 })).toBe(
+      "p-0 pb-2"
+    );
+  });
+});
+
+describe("extractSpacing", () => {
+  it("should extract spacing", () => {
+    expect(extractSpacing("p", ["p-1", "z-1", "pq-1", "px-2"])).toStrictEqual([
+      { side: null, size: 1 },
+      { side: "x", size: 2 },
+    ]);
   });
 });

--- a/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
@@ -589,7 +589,7 @@ const CssClassWidget: React.VFC<
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://getbootstrap.com/docs/4.6/utilities/borders/"
+            href="https://getbootstrap.com/docs/4.6/utilities/"
           >
             Bootstrap utilities
           </a>

--- a/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
@@ -15,23 +15,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
-import { Button, ButtonGroup, Dropdown, DropdownButton } from "react-bootstrap";
+import {
+  Button,
+  ButtonGroup,
+  Dropdown,
+  DropdownButton,
+  Form,
+} from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faAlignCenter,
-  faAlignJustify,
   faAlignLeft,
   faAlignRight,
   faBold,
+  faBorderStyle,
+  faCaretDown,
+  faCaretRight,
+  faCheck,
   faFont,
   faItalic,
 } from "@fortawesome/free-solid-svg-icons";
 import { useField } from "formik";
 import { Expression, TemplateEngine } from "@/core";
 import { isTemplateExpression, isVarExpression } from "@/runtime/mapArgs";
-import { uniq } from "lodash";
+import { compact, partition, uniq } from "lodash";
 import TemplateToggleWidget from "@/components/fields/schemaFields/widgets/TemplateToggleWidget";
 import { InputModeOption } from "@/components/fields/schemaFields/widgets/templateToggleWidgetTypes";
 
@@ -48,9 +57,19 @@ type ClassFlag = {
    * Title node to render for the element (in a button/dropdown)
    */
   title: React.ReactNode;
+
+  /**
+   * True if the flag is exclusive for it's group (default=true)
+   */
+  exclusive?: boolean;
+
+  /**
+   * Other flags in the same group that the flag implies
+   */
+  implies?: string[];
 };
 
-const flags = {
+export const flags = {
   bold: {
     className: "font-weight-bold",
     title: <FontAwesomeIcon icon={faBold} />,
@@ -61,7 +80,7 @@ const flags = {
   },
 };
 
-const optionsGroups = {
+export const optionsGroups = {
   textAlign: [
     { className: "text-left", title: <FontAwesomeIcon icon={faAlignLeft} /> },
     {
@@ -69,10 +88,11 @@ const optionsGroups = {
       title: <FontAwesomeIcon icon={faAlignCenter} />,
     },
     { className: "text-right", title: <FontAwesomeIcon icon={faAlignRight} /> },
-    {
-      className: "text-justify",
-      title: <FontAwesomeIcon icon={faAlignJustify} />,
-    },
+    // Justify doesn't seem to do anything - it might be the default for p?
+    // {
+    //   className: "text-justify",
+    //   title: <FontAwesomeIcon icon={faAlignJustify} />,
+    // },
   ],
   textVariant: [
     {
@@ -95,6 +115,34 @@ const optionsGroups = {
     {
       className: "text-success",
       title: <span className="text-success">Success</span>,
+    },
+  ],
+  borders: [
+    {
+      className: "border",
+      title: "All Borders",
+      implies: ["border-top", "border-right", "border-bottom", "border-left"],
+      exclusive: true,
+    },
+    {
+      className: "border-top",
+      title: "Border Top",
+      exclusive: false,
+    },
+    {
+      className: "border-right",
+      title: "Border Right",
+      exclusive: false,
+    },
+    {
+      className: "border-bottom",
+      title: "Border Bottom",
+      exclusive: false,
+    },
+    {
+      className: "border-left",
+      title: "Border Left",
+      exclusive: false,
     },
   ],
 };
@@ -142,7 +190,16 @@ const FlagItem: React.VFC<
         toggleClass(className, !active, group);
       }}
     >
-      {title}
+      {active ? (
+        <FontAwesomeIcon icon={faCheck} fixedWidth />
+      ) : (
+        <FontAwesomeIcon
+          icon={faCheck}
+          fixedWidth
+          style={{ visibility: "hidden" }}
+        />
+      )}
+      <span className="ml-2">{title}</span>
     </Dropdown.Item>
   );
 };
@@ -205,7 +262,150 @@ export function parseValue(value: Value): {
   throw new Error("Unexpected value");
 }
 
-function calculateNextValue(
+type Spacing = {
+  side: string | null;
+  size: number;
+};
+
+function createSpacingRegex(prefix: string): RegExp {
+  return new RegExp(`${prefix}(?<side>[tblrxy])?-(?<size>\\d)`);
+}
+
+export function extractSpacing(prefix: string, classes: string[]): Spacing[] {
+  const re = createSpacingRegex(prefix);
+
+  return compact(classes.map((x) => re.exec(x))).map((x) => ({
+    side: x.groups.side ?? null,
+    size: Number(x.groups.size),
+  })) as Spacing[];
+}
+
+const spacingSides = [
+  { label: "Top", side: "t" },
+  { label: "Right", side: "r" },
+  { label: "Bottom", side: "b" },
+  { label: "Left", side: "l" },
+];
+
+const SpacingControl: React.VFC<{
+  prefix: string;
+  label: string;
+  className?: string;
+  classes: string[];
+  onUpdate: (update: Spacing) => void;
+}> = ({ prefix, label, className, classes, onUpdate }) => {
+  const [expand, setExpand] = useState(false);
+
+  const spacing = extractSpacing(prefix, classes);
+
+  return (
+    <div className={className}>
+      <div className="d-flex align-items-center">
+        <div
+          role="button"
+          tabIndex={0}
+          onKeyPress={() => {
+            setExpand(!expand);
+          }}
+          onClick={() => {
+            setExpand(!expand);
+          }}
+        >
+          {label}&nbsp;
+          <FontAwesomeIcon icon={expand ? faCaretDown : faCaretRight} />
+        </div>
+        <div>
+          <Form.Control
+            type="number"
+            min="0"
+            max="5"
+            value={spacing.find((x) => x.side == null)?.size}
+            onChange={(event) => {
+              onUpdate({
+                side: null,
+                size: Number(event.target.value),
+              });
+            }}
+          />
+        </div>
+      </div>
+      {expand && (
+        <div>
+          {spacingSides.map((direction) => (
+            <div
+              key={direction.side}
+              className="ml-4 d-flex align-items-center"
+            >
+              <div>
+                {label} {direction.label}
+              </div>
+              <div>
+                <Form.Control
+                  type="number"
+                  min="0"
+                  max="5"
+                  value={spacing.find((x) => x.side === direction.side)?.size}
+                  onChange={(event) => {
+                    onUpdate({
+                      side: direction.side,
+                      size: Number(event.target.value),
+                    });
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export function calculateNextSpacing(
+  previousValue: Value,
+  prefix: string,
+  spacingUpdate: Spacing
+): Value {
+  const { isVar, isTemplate, classes, includesTemplate } =
+    parseValue(previousValue);
+
+  if (isVar || includesTemplate) {
+    throw new Error("Not supported");
+  }
+
+  const regex = createSpacingRegex(prefix);
+
+  const [spacingClasses, otherClasses] = partition(classes, (x) =>
+    regex.test(x)
+  );
+  const spacingRules = extractSpacing(prefix, spacingClasses);
+
+  // Don't try to be smart for now. Just update the rule
+  const existingRule = spacingRules.find((x) => x.side === spacingUpdate.side);
+  if (existingRule) {
+    existingRule.size = spacingUpdate.size;
+  } else {
+    spacingRules.push(spacingUpdate);
+  }
+
+  const nextClasses = [
+    ...otherClasses,
+    ...spacingRules.map((x) => `${prefix}${x.side ?? ""}-${x.size}`),
+  ];
+
+  const nextValue = compact(uniq(nextClasses)).join(" ");
+
+  if (isTemplate) {
+    return {
+      __type__: (previousValue as Expression).__type__ as TemplateEngine,
+      __value__: nextValue,
+    };
+  }
+
+  return nextValue;
+}
+
+export function calculateNextValue(
   previousValue: Value,
   className: string,
   on: boolean,
@@ -221,11 +421,24 @@ function calculateNextValue(
   let nextClasses;
 
   if (on && group) {
+    const rule = group.find((x) => x.className === className);
+
+    if (rule == null) {
+      throw new Error(`Class ${className} not found in group`);
+    }
+
+    const isExclusive = rule.exclusive ?? true;
+    const implies = rule.implies ?? [];
+
     const inactiveClasses = group
       .map((x) => x.className)
       .filter((x) => x !== className);
+
     nextClasses = [
-      ...classes.filter((x) => !inactiveClasses.includes(x)),
+      ...classes.filter(
+        (x) =>
+          (!isExclusive || !inactiveClasses.includes(x)) && !implies.includes(x)
+      ),
       className,
     ];
   } else if (on) {
@@ -234,7 +447,7 @@ function calculateNextValue(
     nextClasses = classes.filter((x) => x !== className);
   }
 
-  const nextValue = uniq(nextClasses).join(" ");
+  const nextValue = compact(uniq(nextClasses)).join(" ");
 
   if (isTemplate) {
     return {
@@ -273,12 +486,6 @@ const CssClassWidget: React.VFC<
 
   return (
     <div>
-      <TemplateToggleWidget
-        {...props}
-        defaultType="string"
-        setFieldDescription={() => "CSS class names for the element"}
-      />
-
       <div className="mt-2">
         <ButtonGroup>
           {optionsGroups.textAlign.map((flag) => (
@@ -333,6 +540,65 @@ const CssClassWidget: React.VFC<
             ))}
           </DropdownButton>
         </ButtonGroup>
+
+        <ButtonGroup className="mx-2">
+          <DropdownButton
+            title={<FontAwesomeIcon icon={faBorderStyle} />}
+            disabled={disableControls}
+            variant="light"
+            size="sm"
+          >
+            {optionsGroups.borders.map((flag) => (
+              <FlagItem
+                key={flag.className}
+                {...flag}
+                classes={classes}
+                toggleClass={toggleClass}
+                group={optionsGroups.borders}
+              />
+            ))}
+          </DropdownButton>
+        </ButtonGroup>
+      </div>
+
+      <div className="d-flex my-2">
+        <SpacingControl
+          prefix="m"
+          label="Margin"
+          className="mr-2"
+          classes={classes}
+          onUpdate={(update) => {
+            setValue(calculateNextSpacing(value, "m", update));
+          }}
+        />
+        <SpacingControl
+          prefix="p"
+          label="Padding"
+          className="mx-2"
+          classes={classes}
+          onUpdate={(update) => {
+            setValue(calculateNextSpacing(value, "p", update));
+          }}
+        />
+      </div>
+
+      <div>
+        <div className="text-muted">
+          Advanced: use a variable or text template to apply conditional
+          formatting. PixieBrix supports the{" "}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://getbootstrap.com/docs/4.6/utilities/borders/"
+          >
+            Bootstrap utilities
+          </a>
+        </div>
+        <TemplateToggleWidget
+          {...props}
+          defaultType="string"
+          setFieldDescription={() => "CSS class names for the element"}
+        />
       </div>
     </div>
   );

--- a/src/components/fields/schemaFields/widgets/__snapshots__/ClassClassWidget.test.tsx.snap
+++ b/src/components/fields/schemaFields/widgets/__snapshots__/ClassClassWidget.test.tsx.snap
@@ -7,39 +7,6 @@ Object {
     <div>
       <div>
         <div
-          class="root"
-        >
-          <div
-            class="field"
-          >
-            <textarea
-              class="form-control"
-              name="cssClass"
-              rows="1"
-            />
-          </div>
-          <div
-            class="dropdown dropdown"
-            data-test-selected="Text"
-            data-testid="toggle-cssClass"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              class="dropdown-toggle btn btn-link"
-              type="button"
-            >
-              <span
-                class="symbol"
-              >
-                <test-file-stub
-                  classname="root"
-                />
-              </span>
-            </button>
-          </div>
-        </div>
-        <div
           class="mt-2"
         >
           <div
@@ -102,26 +69,6 @@ Object {
               >
                 <path
                   d="M16 224h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16zm416 192H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm3.17-384H172.83A12.82 12.82 0 0 0 160 44.83v38.34A12.82 12.82 0 0 0 172.83 96h262.34A12.82 12.82 0 0 0 448 83.17V44.83A12.82 12.82 0 0 0 435.17 32zm0 256H172.83A12.82 12.82 0 0 0 160 300.83v38.34A12.82 12.82 0 0 0 172.83 352h262.34A12.82 12.82 0 0 0 448 339.17v-38.34A12.82 12.82 0 0 0 435.17 288z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
-            <button
-              class="btn btn-light btn-sm"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-align-justify fa-w-14 "
-                data-icon="align-justify"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M432 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
                   fill="currentColor"
                 />
               </svg>
@@ -205,45 +152,173 @@ Object {
               </button>
             </div>
           </div>
+          <div
+            class="mx-2 btn-group"
+            role="group"
+          >
+            <div
+              class="dropdown"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-light btn-sm"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-border-style fa-w-14 "
+                  data-icon="border-style"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M240 416h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm-96 0h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm192 0h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm96-192h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0 96h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0 96h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-288h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-96H32A32 32 0 0 0 0 64v400a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16V96h368a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          class="d-flex my-2"
+        >
+          <div
+            class="mr-2"
+          >
+            <div
+              class="d-flex align-items-center"
+            >
+              <div
+                role="button"
+                tabindex="0"
+              >
+                Margin
+                 
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-caret-right fa-w-6 "
+                  data-icon="caret-right"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 192 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </div>
+              <div>
+                <input
+                  class="form-control"
+                  max="5"
+                  min="0"
+                  type="number"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="mx-2"
+          >
+            <div
+              class="d-flex align-items-center"
+            >
+              <div
+                role="button"
+                tabindex="0"
+              >
+                Padding
+                 
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-caret-right fa-w-6 "
+                  data-icon="caret-right"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  viewBox="0 0 192 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </div>
+              <div>
+                <input
+                  class="form-control"
+                  max="5"
+                  min="0"
+                  type="number"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div
+            class="text-muted"
+          >
+            Advanced: use a variable or text template to apply conditional formatting. PixieBrix supports the
+             
+            <a
+              href="https://getbootstrap.com/docs/4.6/utilities/"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Bootstrap utilities
+            </a>
+          </div>
+          <div
+            class="root"
+          >
+            <div
+              class="field"
+            >
+              <textarea
+                class="form-control"
+                name="cssClass"
+                rows="1"
+              />
+            </div>
+            <div
+              class="dropdown dropdown"
+              data-test-selected="Text"
+              data-testid="toggle-cssClass"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-link"
+                type="button"
+              >
+                <span
+                  class="symbol"
+                >
+                  <test-file-stub
+                    classname="root"
+                  />
+                </span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
   </body>,
   "container": <div>
     <div>
-      <div
-        class="root"
-      >
-        <div
-          class="field"
-        >
-          <textarea
-            class="form-control"
-            name="cssClass"
-            rows="1"
-          />
-        </div>
-        <div
-          class="dropdown dropdown"
-          data-test-selected="Text"
-          data-testid="toggle-cssClass"
-        >
-          <button
-            aria-expanded="false"
-            aria-haspopup="true"
-            class="dropdown-toggle btn btn-link"
-            type="button"
-          >
-            <span
-              class="symbol"
-            >
-              <test-file-stub
-                classname="root"
-              />
-            </span>
-          </button>
-        </div>
-      </div>
       <div
         class="mt-2"
       >
@@ -307,26 +382,6 @@ Object {
             >
               <path
                 d="M16 224h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16zm416 192H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm3.17-384H172.83A12.82 12.82 0 0 0 160 44.83v38.34A12.82 12.82 0 0 0 172.83 96h262.34A12.82 12.82 0 0 0 448 83.17V44.83A12.82 12.82 0 0 0 435.17 32zm0 256H172.83A12.82 12.82 0 0 0 160 300.83v38.34A12.82 12.82 0 0 0 172.83 352h262.34A12.82 12.82 0 0 0 448 339.17v-38.34A12.82 12.82 0 0 0 435.17 288z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
-          <button
-            class="btn btn-light btn-sm"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-align-justify fa-w-14 "
-              data-icon="align-justify"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M432 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
                 fill="currentColor"
               />
             </svg>
@@ -406,6 +461,167 @@ Object {
                     fill="currentColor"
                   />
                 </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="mx-2 btn-group"
+          role="group"
+        >
+          <div
+            class="dropdown"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="dropdown-toggle btn btn-light btn-sm"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-border-style fa-w-14 "
+                data-icon="border-style"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240 416h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm-96 0h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm192 0h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm96-192h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0 96h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0 96h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-288h-32a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-96H32A32 32 0 0 0 0 64v400a16 16 0 0 0 16 16h32a16 16 0 0 0 16-16V96h368a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="d-flex my-2"
+      >
+        <div
+          class="mr-2"
+        >
+          <div
+            class="d-flex align-items-center"
+          >
+            <div
+              role="button"
+              tabindex="0"
+            >
+              Margin
+               
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-caret-right fa-w-6 "
+                data-icon="caret-right"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 192 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+            <div>
+              <input
+                class="form-control"
+                max="5"
+                min="0"
+                type="number"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="mx-2"
+        >
+          <div
+            class="d-flex align-items-center"
+          >
+            <div
+              role="button"
+              tabindex="0"
+            >
+              Padding
+               
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-caret-right fa-w-6 "
+                data-icon="caret-right"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 192 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M0 384.662V127.338c0-17.818 21.543-26.741 34.142-14.142l128.662 128.662c7.81 7.81 7.81 20.474 0 28.284L34.142 398.804C21.543 411.404 0 402.48 0 384.662z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+            <div>
+              <input
+                class="form-control"
+                max="5"
+                min="0"
+                type="number"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div
+          class="text-muted"
+        >
+          Advanced: use a variable or text template to apply conditional formatting. PixieBrix supports the
+           
+          <a
+            href="https://getbootstrap.com/docs/4.6/utilities/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Bootstrap utilities
+          </a>
+        </div>
+        <div
+          class="root"
+        >
+          <div
+            class="field"
+          >
+            <textarea
+              class="form-control"
+              name="cssClass"
+              rows="1"
+            />
+          </div>
+          <div
+            class="dropdown dropdown"
+            data-test-selected="Text"
+            data-testid="toggle-cssClass"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="dropdown-toggle btn btn-link"
+              type="button"
+            >
+              <span
+                class="symbol"
+              >
+                <test-file-stub
+                  classname="root"
+                />
               </span>
             </button>
           </div>


### PR DESCRIPTION
## What does this PR do?

- Part of #3557 
- Controls for updating the margin/padding of document elements

## Discussion

- The number spinners and collapse don't work well because on every change the component remounts: 1) the collapse state gets lost, 2) the spinner loses focus

## Demo

![image](https://user-images.githubusercontent.com/1879821/173201290-d4a33ba5-4fe4-41a6-bae1-c80fc648be22.png)

## Future Work

- Clean up the formatting and spacing using CSS grid. The inputs should be aligned
- Fix the re-mounting/focus issues
- Use placeholders to indicate to user what the implied size is for elements

## Checklist

- [X] Add tests
- [X] Designate a primary reviewer: @BALEHOK 
