### PR TITLE
#3659: allow users to skip panel rendering

### DIFF
--- a/src/components/documentBuilder/render/BlockElement.tsx
+++ b/src/components/documentBuilder/render/BlockElement.tsx
@@ -26,6 +26,7 @@ import { uuidv4 } from "@/types/helpers";
 import PanelBody from "@/sidebar/PanelBody";
 import { RendererPayload } from "@/runtime/runtimeTypes";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
+import { serializeError } from "serialize-error";
 
 type BlockElementProps = { pipeline: BlockPipeline };
 
@@ -62,7 +63,7 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline }) => {
       <PanelBody
         payload={{
           key: `error-${getErrorMessage(error)}`,
-          error: getErrorMessage(error),
+          error: serializeError(error),
         }}
       />
     );

--- a/src/extensionPoints/sidebarExtension.ts
+++ b/src/extensionPoints/sidebarExtension.ts
@@ -55,7 +55,6 @@ import {
 } from "@/contentScript/sidebarController";
 import Mustache from "mustache";
 import { uuidv4 } from "@/types/helpers";
-import { getErrorMessage } from "@/errors/errorHelpers";
 import { HeadlessModeError } from "@/blocks/errors";
 import { selectExtensionContext } from "@/extensionPoints/helpers";
 import { cloneDeep, debounce } from "lodash";
@@ -66,6 +65,7 @@ import { makeServiceContext } from "@/services/serviceUtils";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import { BusinessError } from "@/errors/businessErrors";
+import { serializeError } from "serialize-error";
 
 export type SidebarConfig = {
   heading: string;
@@ -225,7 +225,7 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
         extensionLogger.error(error);
         upsertPanel(ref, heading, {
           key: uuidv4(),
-          error: getErrorMessage(error as Error),
+          error: serializeError(error),
         });
       }
     }

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -55,6 +55,31 @@ import { get } from "lodash";
 import Loader from "@/components/Loader";
 import { UnconfiguredQuickBarAlert } from "@/pageEditor/extensionPoints/quickBar";
 import { BlockType } from "@/runtime/runtimeTypes";
+import { validateRegistryId } from "@/types/helpers";
+
+function getRelevantBlocksForRootPipeline(
+  allBlocks: TypedBlockMap,
+  extensionPointType: string
+) {
+  const alwaysShow = new Set([
+    // Cancel/Error provide meaningful control flow for all bricks
+    validateRegistryId("@pixiebrix/cancel"),
+    validateRegistryId("@pixiebrix/error"),
+  ]);
+
+  const excludeType: BlockType = ["actionPanel", "panel"].includes(
+    extensionPointType
+  )
+    ? "effect"
+    : "renderer";
+
+  return [...allBlocks.values()]
+    .filter(
+      ({ type, block }) =>
+        (type != null && type !== excludeType) || alwaysShow.has(block.id)
+    )
+    .map(({ block }) => block);
+}
 
 const EditTab: React.FC<{
   eventKey: string;
@@ -87,17 +112,8 @@ const EditTab: React.FC<{
 
   const [relevantBlocksForRootPipeline, isLoadingRelevantBlocks] =
     useAsyncState(
-      async () => {
-        const excludeType: BlockType = ["actionPanel", "panel"].includes(
-          extensionPointType
-        )
-          ? "effect"
-          : "renderer";
-
-        return [...allBlocks.values()]
-          .filter(({ type }) => type != null && type !== excludeType)
-          .map(({ block }) => block);
-      },
+      async () =>
+        getRelevantBlocksForRootPipeline(allBlocks, extensionPointType),
       [allBlocks, extensionPointType],
       []
     );

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -20,11 +20,11 @@ import Loader from "@/components/Loader";
 import blockRegistry from "@/blocks/registry";
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import ReactShadowRoot from "react-shadow-root";
-import { getErrorMessage } from "@/errors/errorHelpers";
+import { getErrorMessage, selectSpecificError } from "@/errors/errorHelpers";
 import { BlockArg, RegistryId, RendererOutput } from "@/core";
 import { PanelPayload } from "@/sidebar/types";
 import RendererComponent from "@/sidebar/RendererComponent";
-import { BusinessError } from "@/errors/businessErrors";
+import { BusinessError, CancelError } from "@/errors/businessErrors";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { useAsyncEffect } from "use-async-effect";
 import GridLoader from "react-spinners/GridLoader";
@@ -158,6 +158,21 @@ const PanelBody: React.FunctionComponent<{ payload: PanelPayload }> = ({
   }
 
   if (state.error) {
+    if (selectSpecificError(state.error, CancelError)) {
+      return (
+        <>
+          {state.isFetching && (
+            <span className={styles.loader}>
+              <GridLoader size={8} />
+            </span>
+          )}
+          <div className="text-muted">
+            This panel is not available: {getErrorMessage(state.error)}
+          </div>
+        </>
+      );
+    }
+
     return (
       <>
         {state.isFetching && (

--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -123,7 +123,6 @@ const sidebarSlice = createSlice({
     removeForm(state, action: PayloadAction<UUID>) {
       const nonce = action.payload;
       state.forms = state.forms.filter((x) => x.nonce !== nonce);
-      // @ts-expect-error -- getting instantiation is excessively deep and possibly infinite
       state.activeKey = defaultEventKey(state);
     },
     // In the future, we might want to have ActivatePanelOptions support a "enqueue" prop for controlling whether the

--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -123,6 +123,7 @@ const sidebarSlice = createSlice({
     removeForm(state, action: PayloadAction<UUID>) {
       const nonce = action.payload;
       state.forms = state.forms.filter((x) => x.nonce !== nonce);
+      // @ts-expect-error -- getting instantiation is excessively deep and possibly infinite
       state.activeKey = defaultEventKey(state);
     },
     // In the future, we might want to have ActivatePanelOptions support a "enqueue" prop for controlling whether the

--- a/src/sidebar/types.ts
+++ b/src/sidebar/types.ts
@@ -18,6 +18,7 @@
 import { RegistryId, UUID } from "@/core";
 import { FormDefinition } from "@/blocks/transformers/ephemeralForm/formTypes";
 import { RendererPayload } from "@/runtime/runtimeTypes";
+import { ErrorObject } from "serialize-error";
 
 export type RendererError = {
   /**
@@ -27,7 +28,7 @@ export type RendererError = {
   /**
    * The error message to show in the panel
    */
-  error: string;
+  error: ErrorObject;
 };
 
 /**

--- a/src/sidebar/types.ts
+++ b/src/sidebar/types.ts
@@ -18,7 +18,6 @@
 import { RegistryId, UUID } from "@/core";
 import { FormDefinition } from "@/blocks/transformers/ephemeralForm/formTypes";
 import { RendererPayload } from "@/runtime/runtimeTypes";
-import { ErrorObject } from "serialize-error";
 
 export type RendererError = {
   /**
@@ -28,7 +27,8 @@ export type RendererError = {
   /**
    * The error message to show in the panel
    */
-  error: ErrorObject;
+  // TypeScript was having problems handling the type SerializedError here
+  error: unknown;
 };
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Part of #3659 
- Makes the cancel and business error bricks available in sidebar panel root pipeline
- Passes the full serialized error to the panel

## Future Work

- Make the cancel/error states of the panel look better
- Improve the naming/description of the cancel brick to make more sense in panel extensions

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @BLoe 
