### PR TITLE
#3554: add statechange trigger

### DIFF
--- a/src/blocks/renderers/customForm.tsx
+++ b/src/blocks/renderers/customForm.tsx
@@ -237,6 +237,7 @@ export const customFormRendererSchema = {
               const: "state",
             },
             namespace: {
+              type: "string",
               description:
                 "The namespace for the storage, to avoid conflicts. If set to blueprint and the extension is not part of a blueprint, defaults to shared",
               enum: ["blueprint", "extension", "shared"],
@@ -315,6 +316,10 @@ export class CustomFormRenderer extends Renderer {
     }>,
     { logger }: BlockOptions
   ): Promise<ComponentRef> {
+    if (logger.context.extensionId == null) {
+      throw new Error("extensionId is required");
+    }
+
     if (
       isEmpty(recordId) &&
       ["database", "localStorage"].includes(storage.type)

--- a/src/components/documentBuilder/render/BlockElement.tsx
+++ b/src/components/documentBuilder/render/BlockElement.tsx
@@ -35,7 +35,7 @@ type BlockElementProps = { pipeline: BlockPipeline };
  */
 const BlockElement: React.FC<BlockElementProps> = ({ pipeline }) => {
   const {
-    options: { ctxt },
+    options: { ctxt, logger },
   } = useContext(DocumentContext);
 
   const [payload, isLoading, error] =
@@ -55,12 +55,13 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline }) => {
     }, [pipeline]);
 
   if (isLoading) {
-    return <PanelBody payload={null} />;
+    return <PanelBody payload={null} context={logger.context} />;
   }
 
   if (error) {
     return (
       <PanelBody
+        context={logger.context}
         payload={{
           key: `error-${getErrorMessage(error)}`,
           error: serializeError(error),
@@ -69,7 +70,7 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline }) => {
     );
   }
 
-  return <PanelBody payload={payload} />;
+  return <PanelBody context={logger.context} payload={payload} />;
 };
 
 export default BlockElement;

--- a/src/pageEditor/fields/FormRendererOptions.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.tsx
@@ -82,7 +82,11 @@ const FormRendererOptions: React.FC<{
   useEffect(() => {
     if (storageType !== previousStorageType) {
       // Clear out any other values the user might have configured
-      setStorageValue({ type: "database" } as Storage);
+      if (storageType === "state") {
+        setStorageValue({ type: "state", namespace: "blueprint" } as Storage);
+      } else {
+        setStorageValue({ type: storageType } as Storage);
+      }
 
       if (previousStorageType === "database") {
         // I was a bit surprised this works. I would have thought the pruneDependencies call would have seen
@@ -125,9 +129,10 @@ const FormRendererOptions: React.FC<{
       {storageType === "state" && (
         <SchemaField
           name={makeName("storage", "namespace")}
+          isRequired
           schema={
             customFormRendererSchema.properties.storage.oneOf[1].properties
-              .namespace
+              .namespace as Schema
           }
         />
       )}

--- a/src/pageEditor/tabs/sidebar/SidebarConfiguration.tsx
+++ b/src/pageEditor/tabs/sidebar/SidebarConfiguration.tsx
@@ -93,6 +93,7 @@ const SidebarConfiguration: React.FC<{
         >
           <option value="load">Page Load / Navigation</option>
           <option value="selectionchange">Selection Change</option>
+          <option value="statechange">State Change</option>
           <option value="custom">Custom Event</option>
           <option value="manual">Manual</option>
         </ConnectedFieldTemplate>

--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
@@ -36,7 +36,9 @@ import DebounceFieldSet from "@/pageEditor/tabs/trigger/DebounceFieldSet";
 import { DebounceOptions } from "@/extensionPoints/types";
 
 function supportsSelector(trigger: Trigger) {
-  return !["load", "interval", "selectionchange"].includes(trigger);
+  return !["load", "interval", "selectionchange", "statechange"].includes(
+    trigger
+  );
 }
 
 function supportsTargetMode(trigger: Trigger) {
@@ -122,6 +124,7 @@ const TriggerConfiguration: React.FC<{
           <option value="keyup">Keyup</option>
           <option value="keypress">Keypress</option>
           <option value="change">Change</option>
+          <option value="statechange">State Change</option>
           <option value="custom">Custom Event</option>
         </ConnectedFieldTemplate>
 

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -101,7 +101,14 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
                 eventKey={mapTabEventKey("panel", panel)}
               >
                 <ErrorBoundary>
-                  <PanelBody payload={panel.payload} />
+                  <PanelBody
+                    payload={panel.payload}
+                    context={{
+                      extensionId: panel.extensionId,
+                      extensionPointId: panel.extensionPointId,
+                      blueprintId: panel.blueprintId,
+                    }}
+                  />
                 </ErrorBoundary>
               </Tab.Pane>
             ))}


### PR DESCRIPTION
## What does this PR do?

- Closes #3554 
- Adds a "stagechange" trigger for triggers and sidebar panel render
- Fixes a bug in the custom renderer where state was being set on shared state instead of the blueprint state because no context want being passed through

## Discussion

- It's using CustomEvent currently. In the future we might use browser messaging instead to have a private channel
- It's not configurable yet, it just triggers for all extension/blueprint state changes

## Checklist

- 😞 Add tests: manually QA'd
- [X] Designate a primary reviewer: @BLoe 
