### PR TITLE
Don't rerun sidebar panels on selection in Page Editor

### DIFF
--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -138,15 +138,17 @@ export function showSidebar(
     nonce = insertSidebar();
   }
 
-  // Run the extension points available on the page. If the sidebar is already in the page, running
-  // all the callbacks ensures the content is up-to-date
-  for (const callback of callbacks) {
-    try {
-      callback({ reason: RunReason.MANUAL });
-    } catch (error) {
-      // The callbacks should each have their own error handling. But wrap in a try-catch to ensure running
-      // the callbacks does not interfere prevent showing the sidebar
-      reportError(error);
+  if (!isShowing || (activateOptions.refresh ?? true)) {
+    // Run the extension points available on the page. If the sidebar is already in the page, running
+    // all the callbacks ensures the content is up-to-date
+    for (const callback of callbacks) {
+      try {
+        callback({ reason: RunReason.MANUAL });
+      } catch (error) {
+        // The callbacks should each have their own error handling. But wrap in a try-catch to ensure running
+        // the callbacks does not interfere prevent showing the sidebar
+        reportError(error);
+      }
     }
   }
 

--- a/src/pageEditor/sidebar/DynamicEntry.tsx
+++ b/src/pageEditor/sidebar/DynamicEntry.tsx
@@ -93,7 +93,13 @@ const DynamicEntry: React.FunctionComponent<{
         dispatch(actions.selectElement(item.uuid));
 
         if (item.type === "actionPanel") {
-          void showSidebar(thisTab, { extensionId: item.uuid, force: true });
+          // Switch the sidepanel over to the panel. However, don't refresh because the user might be switching
+          // frequently between extensions within the same blueprint.
+          void showSidebar(thisTab, {
+            extensionId: item.uuid,
+            force: true,
+            refresh: false,
+          });
         }
       }}
     >

--- a/src/pageEditor/sidebar/InstalledEntry.tsx
+++ b/src/pageEditor/sidebar/InstalledEntry.tsx
@@ -97,8 +97,13 @@ const InstalledEntry: React.FunctionComponent<{
         dispatch(actions.selectInstalled(state));
 
         if (type === "actionPanel") {
-          // Switch the sidepanel over to the panel
-          void showSidebar(thisTab, { extensionId: extension.id, force: true });
+          // Switch the sidepanel over to the panel. However, don't refresh because the user might be switching
+          // frequently between extensions within the same blueprint.
+          void showSidebar(thisTab, {
+            extensionId: extension.id,
+            force: true,
+            refresh: false,
+          });
         }
       } catch (error) {
         reportError(error);

--- a/src/sidebar/types.ts
+++ b/src/sidebar/types.ts
@@ -116,6 +116,16 @@ export type ActivatePanelOptions = {
    * @since 1.6.5
    */
   force?: boolean;
+
+  /**
+   * Refresh the panel content (default=true).
+   *
+   * Has not effect if the sidebar is not already showing
+   *
+   * @since 1.7.0
+   */
+  refresh?: boolean;
+
   /**
    * The id of the extension panel to show. Included so the Page Editor can request a specific panel to show when
    * editing the extension


### PR DESCRIPTION
## What does this PR do?

- Don't re-run panels when switching between them in Page Editor
- Running panels unnecessarily is a problem when using throttled APIs

## Checklist

- 😞 Add tests
- [x] Designate a primary reviewer: @BALEHOK 
