### PR TITLE
#3557: Fix default text alignment in sidebar panel

### DIFF
--- a/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
@@ -27,6 +27,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faAlignCenter,
+  faAlignJustify,
   faAlignLeft,
   faAlignRight,
   faBold,
@@ -94,11 +95,10 @@ export const optionsGroups = {
       title: <FontAwesomeIcon icon={faAlignCenter} />,
     },
     { className: "text-right", title: <FontAwesomeIcon icon={faAlignRight} /> },
-    // Justify doesn't seem to do anything - it might be the default for p?
-    // {
-    //   className: "text-justify",
-    //   title: <FontAwesomeIcon icon={faAlignJustify} />,
-    // },
+    {
+      className: "text-justify",
+      title: <FontAwesomeIcon icon={faAlignJustify} />,
+    },
   ],
   textVariant: [
     {

--- a/src/components/fields/schemaFields/widgets/__snapshots__/ClassClassWidget.test.tsx.snap
+++ b/src/components/fields/schemaFields/widgets/__snapshots__/ClassClassWidget.test.tsx.snap
@@ -73,6 +73,26 @@ Object {
                 />
               </svg>
             </button>
+            <button
+              class="btn btn-light btn-sm"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-align-justify fa-w-14 "
+                data-icon="align-justify"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M432 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
           </div>
           <div
             class="mx-2 btn-group"
@@ -440,6 +460,26 @@ Object {
             >
               <path
                 d="M16 224h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16zm416 192H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm3.17-384H172.83A12.82 12.82 0 0 0 160 44.83v38.34A12.82 12.82 0 0 0 172.83 96h262.34A12.82 12.82 0 0 0 448 83.17V44.83A12.82 12.82 0 0 0 435.17 32zm0 256H172.83A12.82 12.82 0 0 0 160 300.83v38.34A12.82 12.82 0 0 0 172.83 352h262.34A12.82 12.82 0 0 0 448 339.17v-38.34A12.82 12.82 0 0 0 435.17 288z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+          <button
+            class="btn btn-light btn-sm"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-align-justify fa-w-14 "
+              data-icon="align-justify"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M432 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
                 fill="currentColor"
               />
             </svg>

--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -1,0 +1,21 @@
+/*!
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Overrides for Bootstraps opinionated styling of tab content
+.paneOverrides {
+  text-align: initial;
+}

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -29,6 +29,9 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import PanelBody from "@/sidebar/PanelBody";
 import FormBody from "@/sidebar/FormBody";
 
+import styles from "./Tabs.module.scss";
+import cx from "classnames";
+
 type SidebarTabsProps = SidebarEntries & {
   activeKey: string;
   onSelectTab: (eventKey: string) => void;
@@ -96,7 +99,7 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
           <Tab.Content className="p-0 border-0 full-height">
             {panels.map((panel: PanelEntry) => (
               <Tab.Pane
-                className="full-height flex-grow"
+                className={cx(styles.paneOverrides, "full-height flex-grow")}
                 key={panel.extensionId}
                 eventKey={mapTabEventKey("panel", panel)}
               >


### PR DESCRIPTION
## What does this PR do?

- Part of #3557
- Disables text-justify that's applied to bootstrap tab panes by default
- Adds justify style option in CSS widget

## Checklist

- 😞  Add tests
- [X] Designate a primary reviewer: @BALEHOK 
