### PR TITLE
#3536: add refresh for cached remote options

### DIFF
--- a/src/components/form/widgets/RemoteSelectWidget.tsx
+++ b/src/components/form/widgets/RemoteSelectWidget.tsx
@@ -26,6 +26,9 @@ import { CustomFieldWidgetProps } from "@/components/form/FieldTemplate";
 import isPromise from "is-promise";
 import useReportError from "@/hooks/useReportError";
 import { BusinessError } from "@/errors/businessErrors";
+import { Button } from "react-bootstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSync } from "@fortawesome/free-solid-svg-icons";
 
 export type OptionsFactory<T = unknown> = (
   config: SanitizedServiceConfiguration
@@ -70,7 +73,7 @@ const RemoteSelectWidget: React.FC<RemoteSelectWidgetProps> = ({
   optionsFactory,
   ...selectProps
 }) => {
-  const [options, isLoading, error] = useOptionsResolver(
+  const [options, isLoading, error, refreshOptions] = useOptionsResolver(
     config,
     optionsFactory
   );
@@ -78,12 +81,24 @@ const RemoteSelectWidget: React.FC<RemoteSelectWidgetProps> = ({
   useReportError(error);
 
   return (
-    <SelectWidget
-      options={options}
-      isLoading={isLoading}
-      loadError={error}
-      {...selectProps}
-    />
+    <div className="d-flex">
+      <div className="flex-grow-1">
+        <SelectWidget
+          options={options}
+          isLoading={isLoading}
+          loadError={error}
+          {...selectProps}
+        />
+      </div>
+
+      {!isPromise(optionsFactory) && (
+        <div>
+          <Button onClick={refreshOptions} variant="info" title="Refresh">
+            <FontAwesomeIcon icon={faSync} />
+          </Button>
+        </div>
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
## What does this PR do?

- Closes #3536 
- Adds a refresh button to RemoteSelectWidget if the optionsFactory is a function

## Demo

![image](https://user-images.githubusercontent.com/1879821/173256970-d39017dc-52ab-4535-b110-3e50c0b141b0.png)

## Checklist

- 😞 Add tests: manual QA
- [X] Designate a primary reviewer: @BLoe 
