### PR TITLE
#3054: extra extension permissions in page editor

### DIFF
--- a/src/blocks/types.ts
+++ b/src/blocks/types.ts
@@ -60,7 +60,7 @@ export type Availability = {
 };
 
 /**
- * Availability with consistent shape (i.e., all fields are arrays if provded)
+ * Availability with consistent shape (i.e., all fields are arrays if provided)
  * @see Availability
  */
 export type NormalizedAvailability = {

--- a/src/components/errors/NetworkErrorDetail.tsx
+++ b/src/components/errors/NetworkErrorDetail.tsx
@@ -90,7 +90,8 @@ const NetworkErrorDetail: React.FunctionComponent<{
         {permissionsReady && !hasPermissions && (
           <div className="text-warning">
             <FontAwesomeIcon icon={faExclamationTriangle} /> PixieBrix does not
-            have permission to access {absoluteUrl}
+            have permission to access {absoluteUrl}. Specify an Integration to
+            access the API, or add an Extra Permissions rule to the extension.
           </div>
         )}
         {permissionsReady && hasPermissions && (

--- a/src/components/errors/__snapshots__/getErrorDetails.test.tsx.snap
+++ b/src/components/errors/__snapshots__/getErrorDetails.test.tsx.snap
@@ -268,7 +268,7 @@ exports[`Network error 1`] = `
             fill="currentColor"
           />
         </svg>
-         PixieBrix does not have permission to access https://fail.com
+         PixieBrix does not have permission to access https://fail.com. Specify an Integration to access the API, or add an Extra Permissions rule to the extension.
       </div>
       <div>
         <div>

--- a/src/pageEditor/components/UrlMatchPatternWidget.tsx
+++ b/src/pageEditor/components/UrlMatchPatternWidget.tsx
@@ -65,7 +65,12 @@ export const DEFAULT_SHORTCUTS: Shortcut[] = [
 const UrlMatchPatternWidget: React.VFC<UrlMatchPatternWidgetProps> = (
   props
 ) => {
-  const { name, disabled, shortcuts = DEFAULT_SHORTCUTS } = props;
+  const {
+    name,
+    disabled,
+    shortcuts = DEFAULT_SHORTCUTS,
+    addButtonCaption = "Add Site",
+  } = props;
 
   const { values: formState } = useFormikContext<FormState>();
   const [{ value }, , { setValue }] = useField<string[]>(name);
@@ -95,7 +100,7 @@ const UrlMatchPatternWidget: React.VFC<UrlMatchPatternWidgetProps> = (
       >
         <ArrayWidget
           schema={{ items: { type: "string" } }}
-          addButtonCaption="Add Site"
+          addButtonCaption={addButtonCaption}
           {...props}
         />
       </FieldRuntimeContext.Provider>

--- a/src/pageEditor/components/urlMatchPatternWidgetTypes.tsx
+++ b/src/pageEditor/components/urlMatchPatternWidgetTypes.tsx
@@ -26,4 +26,5 @@ export type Shortcut = {
 export type UrlMatchPatternWidgetProps = SchemaFieldProps &
   FormControlProps & {
     shortcuts: Shortcut[];
+    addButtonCaption?: string;
   };

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -65,6 +65,7 @@ import {
   isInnerExtensionPoint,
 } from "@/registry/internal";
 import { normalizePipelineForEditor } from "./pipelineMapping";
+import { Permissions } from "webextension-polyfill";
 
 export interface WizardStep {
   step: string;
@@ -107,6 +108,7 @@ export function baseFromExtension<T extends ExtensionPointType>(
   | "installed"
   | "label"
   | "services"
+  | "permissions"
   | "optionsArgs"
   | "recipe"
 > & { type: T } {
@@ -117,6 +119,7 @@ export function baseFromExtension<T extends ExtensionPointType>(
     label: config.label,
     // Normalize here because the fields aren't optional/nullable on the BaseFormState destination type.
     services: config.services ?? [],
+    permissions: config.permissions ?? {},
     optionsArgs: config.optionsArgs ?? {},
     type,
     recipe: config._recipe,
@@ -156,6 +159,7 @@ export function baseSelectExtension({
   label,
   optionsArgs,
   services,
+  permissions,
   extensionPoint,
   recipe,
 }: BaseFormState): Pick<
@@ -166,6 +170,7 @@ export function baseSelectExtension({
   | "_recipe"
   | "label"
   | "services"
+  | "permissions"
   | "optionsArgs"
 > {
   return {
@@ -175,6 +180,7 @@ export function baseSelectExtension({
     _recipe: recipe,
     label,
     services,
+    permissions,
     optionsArgs,
   };
 }
@@ -186,6 +192,7 @@ export function makeInitialBaseState(
     uuid,
     apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
     services: [],
+    permissions: {},
     optionsArgs: {},
     extension: {
       blockPipeline: [],
@@ -252,6 +259,16 @@ export function cleanIsAvailable({
     matchPatterns: matchPatterns.filter((x) => !isNullOrBlank(x)),
     urlPatterns: urlPatterns.filter((x) => isEmpty(x)),
     selectors: selectors.filter((x) => !isNullOrBlank(x)),
+  };
+}
+
+export function cleanExtraPermissions({
+  permissions = [],
+  origins = [],
+}: Permissions.Permissions = {}) {
+  return {
+    permissions: permissions.filter((x) => !isNullOrBlank(x)),
+    origins: origins.filter((x) => !isNullOrBlank(x)),
   };
 }
 

--- a/src/pageEditor/extensionPoints/contextMenu.tsx
+++ b/src/pageEditor/extensionPoints/contextMenu.tsx
@@ -186,6 +186,7 @@ async function fromExtensionPoint(
     label: `My ${getDomain(url)} context menu`,
 
     services: [],
+    permissions: {},
     optionsArgs: {},
 
     extension: {

--- a/src/pageEditor/extensionPoints/elementConfig.ts
+++ b/src/pageEditor/extensionPoints/elementConfig.ts
@@ -35,6 +35,7 @@ import { BlockPipeline, NormalizedAvailability } from "@/blocks/types";
 import { Target } from "@/types";
 import { OptionsDefinition } from "@/types/definitions";
 import type { DynamicDefinition } from "@/contentScript/nativeEditor/types";
+import type { Permissions } from "webextension-polyfill";
 
 /**
  * A simplified type for ReaderConfig to prevent TypeScript reporting problems with infinite type instantiation
@@ -105,6 +106,12 @@ export interface BaseFormState<
   optionsArgs: UserOptions;
 
   services: ServiceDependency[];
+
+  /**
+   * The extra permissions required by the extension
+   * @since 1.7.0
+   */
+  permissions: Permissions.Permissions;
 
   extensionPoint: TExtensionPoint;
 

--- a/src/pageEditor/extensionPoints/menuItem.ts
+++ b/src/pageEditor/extensionPoints/menuItem.ts
@@ -137,6 +137,7 @@ async function fromExtensionPoint(
     label: `My ${getDomain(url)} button`,
 
     services: [],
+    permissions: {},
 
     optionsArgs: {},
 

--- a/src/pageEditor/extensionPoints/panel.ts
+++ b/src/pageEditor/extensionPoints/panel.ts
@@ -151,6 +151,7 @@ async function fromExtensionPoint(
     label: `My ${getDomain(url)} panel`,
 
     services: [],
+    permissions: {},
 
     optionsArgs: {},
 

--- a/src/pageEditor/extensionPoints/quickBar.tsx
+++ b/src/pageEditor/extensionPoints/quickBar.tsx
@@ -191,6 +191,7 @@ async function fromExtensionPoint(
     label: `My ${getDomain(url)} quick bar item`,
 
     services: [],
+    permissions: {},
     optionsArgs: {},
 
     extension: {

--- a/src/pageEditor/extensionPoints/sidebar.tsx
+++ b/src/pageEditor/extensionPoints/sidebar.tsx
@@ -152,6 +152,7 @@ export async function fromExtensionPoint(
     label: heading,
 
     services: [],
+    permissions: {},
 
     optionsArgs: {},
 

--- a/src/pageEditor/extensionPoints/trigger.tsx
+++ b/src/pageEditor/extensionPoints/trigger.tsx
@@ -173,6 +173,7 @@ async function fromExtensionPoint(
     label: `My ${getDomain(url)} ${trigger} trigger`,
 
     services: [],
+    permissions: {},
 
     optionsArgs: {},
 

--- a/src/pageEditor/fields/UrlMatchPatternField.tsx
+++ b/src/pageEditor/fields/UrlMatchPatternField.tsx
@@ -26,6 +26,7 @@ export type UrlMatchPatternFieldProps = {
   label?: React.ReactNode;
   description?: React.ReactNode;
   shortcuts?: Shortcut[];
+  addButtonCaption?: string;
 };
 
 const defaultDescription = (
@@ -50,6 +51,7 @@ const UrlMatchPatternField: React.VFC<UrlMatchPatternFieldProps> = ({
   label = "Sites",
   description = defaultDescription,
   shortcuts,
+  addButtonCaption = "Add Site",
 }) => (
   <ConnectedFieldTemplate
     name={name}
@@ -58,6 +60,7 @@ const UrlMatchPatternField: React.VFC<UrlMatchPatternFieldProps> = ({
     label={label}
     description={description}
     shortcuts={shortcuts}
+    addButtonCaption={addButtonCaption}
   />
 );
 

--- a/src/pageEditor/tabs/ExtraPermissionsSection.test.tsx
+++ b/src/pageEditor/tabs/ExtraPermissionsSection.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render } from "@/pageEditor/testHelpers";
+import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
+import { set } from "lodash";
+import ExtraPermissionsSection from "./ExtraPermissionsSection";
+
+beforeEach(() => {
+  registerDefaultWidgets();
+});
+
+describe("ExtraPermissionsSection", () => {
+  test("render empty section", () => {
+    expect(
+      render(<ExtraPermissionsSection />, {
+        initialValues: set({}, "permissions", {
+          origins: [],
+          permissions: [],
+        }),
+      }).asFragment()
+    ).toMatchSnapshot();
+  });
+
+  test("render populated section", () => {
+    expect(
+      render(<ExtraPermissionsSection />, {
+        initialValues: set({}, "permissions", {
+          origins: [
+            "http://web.archive.org/web/20150905193945/http://www.hamsterdance.com/",
+          ],
+          permissions: [],
+        }),
+      }).asFragment()
+    ).toMatchSnapshot();
+  });
+});

--- a/src/pageEditor/tabs/ExtraPermissionsSection.tsx
+++ b/src/pageEditor/tabs/ExtraPermissionsSection.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import FieldSection from "@/pageEditor/fields/FieldSection";
+import React from "react";
+import UrlMatchPatternField from "@/pageEditor/fields/UrlMatchPatternField";
+
+const ExtraPermissionsSection: React.FunctionComponent = () => (
+  <FieldSection title="Advanced: Extra Permissions">
+    <UrlMatchPatternField
+      label="Sites/APIs"
+      name="permissions.origins"
+      addButtonCaption={"Add Origin"}
+      description={
+        <div>
+          URL match patterns permitting the extension to run on a site or call
+          an API. Provide URL match patterns here if the extension 1) calls an
+          API without using an Integration, or 2) performs actions on a target
+          tab not included in the Site match patterns
+        </div>
+      }
+    />
+  </FieldSection>
+);
+
+export default ExtraPermissionsSection;

--- a/src/pageEditor/tabs/ExtraPermissionsSection.tsx
+++ b/src/pageEditor/tabs/ExtraPermissionsSection.tsx
@@ -24,13 +24,13 @@ const ExtraPermissionsSection: React.FunctionComponent = () => (
     <UrlMatchPatternField
       label="Sites/APIs"
       name="permissions.origins"
-      addButtonCaption={"Add Origin"}
+      addButtonCaption={"Add Allowed Origin"}
       description={
         <div>
           URL match patterns permitting the extension to run on a site or call
-          an API. Provide URL match patterns here if the extension 1) calls an
-          API without using an Integration, or 2) performs actions on a target
-          tab not included in the Site match patterns
+          an API. Provide URL match patterns here if the extension either 1)
+          calls an API without using an Integration, or 2) performs actions on a
+          target tab not included in the Site match patterns
         </div>
       }
     />

--- a/src/pageEditor/tabs/__snapshots__/ExtraPermissionsSection.test.tsx.snap
+++ b/src/pageEditor/tabs/__snapshots__/ExtraPermissionsSection.test.tsx.snap
@@ -1,0 +1,218 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExtraPermissionsSection render empty section 1`] = `
+<DocumentFragment>
+  <form
+    action="#"
+  >
+    <div
+      class="cardHeader card-header"
+    >
+      Advanced: Extra Permissions
+    </div>
+    <div
+      class="cardBody card-body"
+    >
+      <div
+        class="formGroup form-group row"
+      >
+        <label
+          class="label form-label col-form-label col-xl-2 col-lg-3"
+          for="permissions.origins"
+        >
+          Sites/APIs
+        </label>
+        <div
+          class="col-xl-10 col-lg-9"
+        >
+          <div
+            class="small"
+          >
+            <span>
+              Shortcuts:
+            </span>
+            <button
+              class="root ml-2 btn btn-link"
+              type="button"
+            >
+              Site
+            </button>
+            <button
+              class="root ml-2 btn btn-link"
+              type="button"
+            >
+              Domain
+            </button>
+            <button
+              class="root ml-2 btn btn-link"
+              type="button"
+            >
+              HTTPS
+            </button>
+            <button
+              class="root ml-2 btn btn-link"
+              type="button"
+            >
+              All URLs
+            </button>
+          </div>
+          <ul
+            class="list-group mb-2"
+          />
+          <button
+            class="btn btn-primary"
+            type="button"
+          >
+            Add Allowed Origin
+          </button>
+          <small
+            class="text-muted form-text"
+          >
+            <div>
+              URL match patterns permitting the extension to run on a site or call an API. Provide URL match patterns here if the extension either 1) calls an API without using an Integration, or 2) performs actions on a target tab not included in the Site match patterns
+            </div>
+          </small>
+        </div>
+      </div>
+    </div>
+    <button
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`ExtraPermissionsSection render populated section 1`] = `
+<DocumentFragment>
+  <form
+    action="#"
+  >
+    <div
+      class="cardHeader card-header"
+    >
+      Advanced: Extra Permissions
+    </div>
+    <div
+      class="cardBody card-body"
+    >
+      <div
+        class="formGroup form-group row"
+      >
+        <label
+          class="label form-label col-form-label col-xl-2 col-lg-3"
+          for="permissions.origins"
+        >
+          Sites/APIs
+        </label>
+        <div
+          class="col-xl-10 col-lg-9"
+        >
+          <div
+            class="small"
+          >
+            <span>
+              Shortcuts:
+            </span>
+            <button
+              class="root ml-2 btn btn-link"
+              type="button"
+            >
+              Site
+            </button>
+            <button
+              class="root ml-2 btn btn-link"
+              type="button"
+            >
+              Domain
+            </button>
+            <button
+              class="root ml-2 btn btn-link"
+              type="button"
+            >
+              HTTPS
+            </button>
+            <button
+              class="root ml-2 btn btn-link"
+              type="button"
+            >
+              All URLs
+            </button>
+          </div>
+          <ul
+            class="list-group mb-2"
+          >
+            <li
+              class="list-group-item py-1"
+            >
+              <div
+                class="formGroup mb-0 form-group row"
+              >
+                <div
+                  class="col-xl-12 col-lg-12"
+                >
+                  <div
+                    class="root"
+                  >
+                    <div
+                      class="field"
+                    >
+                      <textarea
+                        class="form-control"
+                        id="permissions.origins.0"
+                        name="permissions.origins.0"
+                        rows="1"
+                      >
+                        http://web.archive.org/web/20150905193945/http://www.hamsterdance.com/
+                      </textarea>
+                    </div>
+                    <div
+                      class="dropdown dropdown"
+                      data-test-selected="Text"
+                      data-testid="toggle-permissions.origins.0"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        class="dropdown-toggle btn btn-link"
+                        type="button"
+                      >
+                        <span
+                          class="symbol"
+                        >
+                          <test-file-stub
+                            classname="root"
+                          />
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </li>
+          </ul>
+          <button
+            class="btn btn-primary"
+            type="button"
+          >
+            Add Allowed Origin
+          </button>
+          <small
+            class="text-muted form-text"
+          >
+            <div>
+              URL match patterns permitting the extension to run on a site or call an API. Provide URL match patterns here if the extension either 1) calls an API without using an Integration, or 2) performs actions on a target tab not included in the Site match patterns
+            </div>
+          </small>
+        </div>
+      </div>
+    </div>
+    <button
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;

--- a/src/pageEditor/tabs/contextMenu/ContextMenuConfiguration.tsx
+++ b/src/pageEditor/tabs/contextMenu/ContextMenuConfiguration.tsx
@@ -23,6 +23,7 @@ import UrlMatchPatternField from "@/pageEditor/fields/UrlMatchPatternField";
 import TemplateWidget, { Snippet } from "@/pageEditor/fields/TemplateWidget";
 import MultiSelectWidget from "@/pageEditor/fields/MultiSelectWidget";
 import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
+import ExtraPermissionsSection from "@/pageEditor/tabs/ExtraPermissionsSection";
 
 const menuSnippets: Snippet[] = [{ label: "selected text", value: "%s" }];
 
@@ -127,6 +128,8 @@ const ContextMenuConfiguration: React.FC<{
         {...makeLockableFieldProps("Automatic Permissions", isLocked)}
       />
     </FieldSection>
+
+    <ExtraPermissionsSection />
   </Card>
 );
 

--- a/src/pageEditor/tabs/effect/BlockConfiguration.tsx
+++ b/src/pageEditor/tabs/effect/BlockConfiguration.tsx
@@ -51,7 +51,8 @@ const targetOptions: Array<Option<BlockWindow>> = [
   { label: "Target Tab (target)", value: "target" },
   { label: "Top-level Frame (top)", value: "top" },
   { label: "All Tabs (broadcast)", value: "broadcast" },
-  { label: "Server (remote)", value: "remote" },
+  // Not currently generally available
+  // { label: "Server (remote)", value: "remote" },
 ];
 
 const BlockConfiguration: React.FunctionComponent<{
@@ -155,7 +156,7 @@ const BlockConfiguration: React.FunctionComponent<{
                 as={SelectWidget}
                 options={targetOptions}
                 blankValue={DEFAULT_WINDOW_VALUE}
-                description="Where to execute the brick."
+                description="The tab/frame to run the brick. To ensure PixieBrix has permission to run on the tab, add an Extra Permissions pattern that matches the target tab URL"
               />
             </>
           )}

--- a/src/pageEditor/tabs/menuItem/MenuItemConfiguration.tsx
+++ b/src/pageEditor/tabs/menuItem/MenuItemConfiguration.tsx
@@ -26,6 +26,7 @@ import LocationWidget from "@/pageEditor/fields/LocationWidget";
 import SelectWidget, { Option } from "@/components/form/widgets/SelectWidget";
 import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
 import MatchRulesSection from "@/pageEditor/tabs/MatchRulesSection";
+import ExtraPermissionsSection from "@/pageEditor/tabs/ExtraPermissionsSection";
 
 const menuSnippets: Snippet[] = [
   { label: "caption", value: "{{{caption}}}" },
@@ -89,6 +90,8 @@ const MenuItemConfiguration: React.FC<{
     </FieldSection>
 
     <MatchRulesSection isLocked={isLocked} />
+
+    <ExtraPermissionsSection />
   </Card>
 );
 

--- a/src/pageEditor/tabs/panel/PanelConfiguration.tsx
+++ b/src/pageEditor/tabs/panel/PanelConfiguration.tsx
@@ -25,6 +25,7 @@ import LocationWidget from "@/pageEditor/fields/LocationWidget";
 import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
 import SwitchButtonWidget from "@/components/form/widgets/switchButton/SwitchButtonWidget";
 import MatchRulesSection from "@/pageEditor/tabs/MatchRulesSection";
+import ExtraPermissionsSection from "@/pageEditor/tabs/ExtraPermissionsSection";
 
 const panelSnippets: Snippet[] = [
   { label: "heading", value: "{{{heading}}}" },
@@ -80,6 +81,8 @@ const PanelConfiguration: React.FC<{
     </FieldSection>
 
     <MatchRulesSection isLocked={isLocked} />
+
+    <ExtraPermissionsSection />
   </Card>
 );
 

--- a/src/pageEditor/tabs/quickBar/QuickBarConfiguration.tsx
+++ b/src/pageEditor/tabs/quickBar/QuickBarConfiguration.tsx
@@ -24,6 +24,7 @@ import MultiSelectWidget from "@/pageEditor/fields/MultiSelectWidget";
 import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
 import { contextOptions } from "@/pageEditor/tabs/contextMenu/ContextMenuConfiguration";
 import IconWidget from "@/components/fields/IconWidget";
+import ExtraPermissionsSection from "@/pageEditor/tabs/ExtraPermissionsSection";
 
 const QuickBarConfiguration: React.FC<{
   isLocked: boolean;
@@ -108,6 +109,8 @@ const QuickBarConfiguration: React.FC<{
         {...makeLockableFieldProps("Automatic Permissions", isLocked)}
       />
     </FieldSection>
+
+    <ExtraPermissionsSection />
   </Card>
 );
 

--- a/src/pageEditor/tabs/sidebar/SidebarConfiguration.tsx
+++ b/src/pageEditor/tabs/sidebar/SidebarConfiguration.tsx
@@ -29,6 +29,7 @@ import { Trigger } from "@/extensionPoints/sidebarExtension";
 import { useField, useFormikContext } from "formik";
 import { TriggerFormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { DebounceOptions } from "@/extensionPoints/types";
+import ExtraPermissionsSection from "@/pageEditor/tabs/ExtraPermissionsSection";
 
 const SidebarConfiguration: React.FC<{
   isLocked: boolean;
@@ -111,6 +112,8 @@ const SidebarConfiguration: React.FC<{
       </FieldSection>
 
       <MatchRulesSection isLocked={isLocked} />
+
+      <ExtraPermissionsSection />
     </Card>
   );
 };

--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
@@ -34,6 +34,7 @@ import { joinName } from "@/utils";
 import MatchRulesSection from "@/pageEditor/tabs/MatchRulesSection";
 import DebounceFieldSet from "@/pageEditor/tabs/trigger/DebounceFieldSet";
 import { DebounceOptions } from "@/extensionPoints/types";
+import ExtraPermissionsSection from "@/pageEditor/tabs/ExtraPermissionsSection";
 
 function supportsSelector(trigger: Trigger) {
   return !["load", "interval", "selectionchange", "statechange"].includes(
@@ -232,6 +233,8 @@ const TriggerConfiguration: React.FC<{
       </FieldSection>
 
       <MatchRulesSection isLocked={isLocked} />
+
+      <ExtraPermissionsSection />
     </Card>
   );
 };

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -182,9 +182,13 @@ type PermissionOptions = {
 
 /**
  * Returns browser permissions required to run the extension
+ * - Extension
  * - Blocks
  * - Services (optional, default=true)
  * - Extension point (optional, default=true)
+ *
+ * @see IExtension.permissions
+ * @see IExtensionPoint.permissions
  */
 export async function extensionPermissions(
   extension: IExtension,
@@ -214,6 +218,7 @@ export async function extensionPermissions(
 
   return mergePermissions(
     compact([
+      extension.permissions ?? {},
       includeExtensionPoint ? extensionPoint.permissions : null,
       ...servicePermissions,
       ...blockPermissions,

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -322,6 +322,7 @@ export const extensionPointConfigFactory = define<ExtensionPointConfig>({
   id: "extensionPoint" as InnerDefinitionRef,
   label: (n: number) => `Test Extension ${n}`,
   services: {},
+  permissions: {},
   config: () => ({
     caption: "Button",
     action: [] as BlockPipeline,
@@ -392,6 +393,7 @@ export const versionedExtensionPointRecipeFactory = ({
         id: extensionPointId ?? validateRegistryId("test/extension-point"),
         label: `Test Extension for Recipe ${n}`,
         services: {},
+        permissions: {},
         config: {
           caption: "Button",
           action: [] as BlockPipeline,


### PR DESCRIPTION
## What does this PR do?

- Closes #3054 
- Exposes the extension's `permissions.origins` field in the Page Editor
- Fixes a bug in extensionPermissions where `IExtension.permissions` wasn't being considered

## How to Review

- Start with the base adapter code for the Page Editor
- Review the UI changes
- Verify test snapshots are up to date
- Reminder: If you want to test permissions, you can revoke permissions on the Extension Console > Settings page

## Remaining Work

- [x] Provide help text for the user to configure that field if they're making an unauthenticated request or using the target tab functionality

## Demo

![image](https://user-images.githubusercontent.com/1879821/173258729-5da14165-48d8-473d-9164-e4c0e8bd341d.png)

![image](https://user-images.githubusercontent.com/1879821/173259310-16d985cc-49b5-4498-951b-40e9402a10e5.png)

![image](https://user-images.githubusercontent.com/1879821/173259775-30e6c589-4592-4e59-aa39-73dc0df417df.png)

## Future Work

- Detect situations where the extension is calling tabs/origins the extension creator has given access to, but is not in the declared origin list

## Checklist

- [X] Add tests
- [X] Designate a primary reviewer: @BLoe 
