### PR TITLE
#3673: add retry and random bricks

### DIFF
--- a/src/blocks/transformers/controlFlow/Retry.test.ts
+++ b/src/blocks/transformers/controlFlow/Retry.test.ts
@@ -55,9 +55,9 @@ describe("Retry", () => {
       },
     };
 
-    expect(
+    return expect(
       reducePipeline(pipeline, simpleInput({}), testOptions("v3"))
-    ).rejects.toReject();
+    ).rejects.toThrow();
   });
 
   test("returns result on success", async () => {

--- a/src/blocks/transformers/controlFlow/Retry.test.ts
+++ b/src/blocks/transformers/controlFlow/Retry.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import blockRegistry from "@/blocks/registry";
+import {
+  echoBlock,
+  simpleInput,
+  testOptions,
+  throwBlock,
+} from "@/runtime/pipelineTests/pipelineTestHelpers";
+import { reducePipeline } from "@/runtime/reducePipeline";
+import * as logging from "@/background/messenger/api";
+import { makePipelineExpression } from "@/testUtils/expressionTestHelpers";
+import Retry from "@/blocks/transformers/controlFlow/Retry";
+
+(logging.getLoggingConfig as any) = jest.fn().mockResolvedValue({
+  logValues: true,
+});
+
+const retryBlock = new Retry();
+
+beforeEach(() => {
+  blockRegistry.clear();
+  blockRegistry.register(throwBlock, echoBlock, retryBlock);
+});
+
+describe("Retry", () => {
+  test("throws error if retries fail", async () => {
+    const pipeline = {
+      id: retryBlock.id,
+      config: {
+        maxRetries: 2,
+        body: makePipelineExpression([
+          {
+            id: throwBlock.id,
+            config: {
+              message: "This is an error message!",
+            },
+          },
+        ]),
+      },
+    };
+
+    expect(
+      reducePipeline(pipeline, simpleInput({}), testOptions("v3"))
+    ).rejects.toReject();
+  });
+
+  test("returns result on success", async () => {
+    const pipeline = {
+      id: retryBlock.id,
+      config: {
+        maxRetries: 2,
+        body: makePipelineExpression([
+          {
+            id: echoBlock.id,
+            config: {
+              message: "Hello, world!",
+            },
+          },
+        ]),
+      },
+    };
+
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      testOptions("v3")
+    );
+
+    expect(result).toStrictEqual({
+      message: "Hello, world!",
+    });
+  });
+});

--- a/src/blocks/transformers/controlFlow/Retry.ts
+++ b/src/blocks/transformers/controlFlow/Retry.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Transformer } from "@/types";
+import { BlockArg, BlockOptions, Schema } from "@/core";
+import { propertiesToSchema } from "@/validators/generic";
+import { PipelineExpression } from "@/runtime/mapArgs";
+import { validateRegistryId } from "@/types/helpers";
+import { sleep } from "@/utils";
+import { BusinessError } from "@/errors/businessErrors";
+
+class Retry extends Transformer {
+  static BLOCK_ID = validateRegistryId("@pixiebrix/retry");
+  defaultOutputKey = "retryOutput";
+
+  constructor() {
+    super(Retry.BLOCK_ID, "Retry", "Retry bricks on error");
+  }
+
+  override async isPure(): Promise<boolean> {
+    // Safe default -- need to be able to inspect the inputs to determine if pure
+    return false;
+  }
+
+  override async isRootAware(): Promise<boolean> {
+    // Safe default -- need to be able to inspect the inputs to determine if any sub-calls are root aware
+    return true;
+  }
+
+  inputSchema: Schema = propertiesToSchema(
+    {
+      body: {
+        $ref: "https://app.pixiebrix.com/schemas/pipeline#",
+        description: "The bricks to execute",
+      },
+      intervalMillis: {
+        type: "number",
+        description: "Number of milliseconds to wait between retries",
+      },
+      maxRetries: {
+        type: "number",
+        description:
+          "The maximum number of retries (not including the initial run)",
+        default: 3,
+      },
+    },
+    ["body"]
+  );
+
+  async transform(
+    {
+      body: bodyPipeline,
+      maxRetries = Number.MAX_SAFE_INTEGER,
+      intervalMillis,
+    }: BlockArg<{
+      body: PipelineExpression;
+      intervalMillis?: number;
+      maxRetries?: number;
+    }>,
+    options: BlockOptions
+  ): Promise<unknown> {
+    let lastError: unknown;
+    let retryCount = 0;
+
+    while (retryCount < maxRetries) {
+      if (retryCount > 0) {
+        await sleep(intervalMillis);
+      }
+
+      try {
+        // eslint-disable-next-line no-await-in-loop -- retry loop
+        return await options.runPipeline(bodyPipeline.__value__);
+      } catch (error) {
+        lastError = error;
+      }
+
+      retryCount++;
+    }
+
+    if (!lastError) {
+      // In practice, lastError will always be set. But throw just in case
+      throw new BusinessError("Maximum number of retries exceeded");
+    }
+
+    throw lastError;
+  }
+}
+
+export default Retry;

--- a/src/blocks/transformers/controlFlow/Retry.ts
+++ b/src/blocks/transformers/controlFlow/Retry.ts
@@ -78,6 +78,7 @@ class Retry extends Transformer {
 
     while (retryCount < maxRetries) {
       if (retryCount > 0) {
+        // eslint-disable-next-line no-await-in-loop -- retry loop
         await sleep(intervalMillis);
       }
 

--- a/src/blocks/transformers/randomNumber.test.ts
+++ b/src/blocks/transformers/randomNumber.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { RandomNumber } from "@/blocks/transformers/randomNumber";
+
+describe("random number", () => {
+  it("returns a random integer", async () => {
+    const { value } = await new RandomNumber().transform(
+      unsafeAssumeValidArg({ lower: 0, upper: 5 })
+    );
+    expect(value).toBeInteger();
+  });
+
+  it("returns a random float", async () => {
+    const { value } = await new RandomNumber().transform(
+      unsafeAssumeValidArg({ lower: 0, upper: 5, floating: true })
+    );
+    expect(value).not.toBeInteger();
+    expect(value).toBeNumber();
+  });
+});

--- a/src/blocks/transformers/randomNumber.ts
+++ b/src/blocks/transformers/randomNumber.ts
@@ -19,6 +19,7 @@ import { Transformer } from "@/types";
 import { propertiesToSchema } from "@/validators/generic";
 import { BlockArg } from "@/core";
 import { random } from "lodash";
+import { BusinessError } from "@/errors/businessErrors";
 
 export class RandomNumber extends Transformer {
   constructor() {
@@ -38,17 +39,18 @@ export class RandomNumber extends Transformer {
     {
       lower: {
         type: "number",
-        description: "The lower bound",
+        description: "The lower bound (inclusive)",
         default: 0,
       },
       upper: {
         type: "number",
-        description: "The upper bound",
+        description: "The upper bound (exclusive)",
         default: 1,
       },
       floating: {
         type: "boolean",
-        description: "Specify returning a floating-point number.",
+        description:
+          "Flag to return a decimal (floating point) number instead of an integer.",
       },
     },
     []
@@ -69,6 +71,10 @@ export class RandomNumber extends Transformer {
     upper?: number;
     floating?: boolean;
   }>): Promise<{ value: number }> {
+    if (lower > upper) {
+      throw new BusinessError("lower bound cannot be greater than upper bound");
+    }
+
     return {
       value: random(lower, upper, floating),
     };

--- a/src/blocks/transformers/randomNumber.ts
+++ b/src/blocks/transformers/randomNumber.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Transformer } from "@/types";
+import { propertiesToSchema } from "@/validators/generic";
+import { BlockArg } from "@/core";
+import { random } from "lodash";
+
+export class RandomNumber extends Transformer {
+  constructor() {
+    super(
+      "@pixiebrix/random",
+      "Random Number",
+      "Generate a random number",
+      "faCode"
+    );
+  }
+
+  override async isPure(): Promise<boolean> {
+    return false;
+  }
+
+  inputSchema = propertiesToSchema(
+    {
+      lower: {
+        type: "number",
+        description: "The lower bound",
+        default: 0,
+      },
+      upper: {
+        type: "number",
+        description: "The upper bound",
+        default: 1,
+      },
+      floating: {
+        type: "boolean",
+        description: "Specify returning a floating-point number.",
+      },
+    },
+    []
+  );
+
+  override outputSchema = propertiesToSchema({
+    value: {
+      type: "number",
+    },
+  });
+
+  async transform({
+    lower = 0,
+    upper = 1,
+    floating = false,
+  }: BlockArg<{
+    lower?: number;
+    upper?: number;
+    floating?: boolean;
+  }>): Promise<{ value: number }> {
+    return {
+      value: random(lower, upper, floating),
+    };
+  }
+}

--- a/src/blocks/transformers/registerTransformers.ts
+++ b/src/blocks/transformers/registerTransformers.ts
@@ -44,6 +44,8 @@ import ForEach from "./controlFlow/ForEach";
 import IfElse from "./controlFlow/IfElse";
 import TryExcept from "./controlFlow/TryExcept";
 import ForEachElement from "@/blocks/transformers/controlFlow/ForEachElement";
+import { RandomNumber } from "@/blocks/transformers/randomNumber";
+import Retry from "@/blocks/transformers/controlFlow/Retry";
 
 function registerTransformers() {
   registerBlock(new JQTransformer());
@@ -71,12 +73,14 @@ function registerTransformers() {
   registerBlock(new ParseDataUrl());
   registerBlock(new ParseDate());
   registerBlock(new ScreenshotTab());
+  registerBlock(new RandomNumber());
 
   // Control Flow Bricks
   registerBlock(new ForEach());
   registerBlock(new IfElse());
   registerBlock(new TryExcept());
   registerBlock(new ForEachElement());
+  registerBlock(new Retry());
 }
 
 export default registerTransformers;

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -19,7 +19,7 @@ import fs from "fs";
 import blockRegistry from "@/blocks/registry";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 102;
+const EXPECTED_HEADER_COUNT = 104;
 
 // Import for side-effects (these modules register the blocks)
 // NOTE: we don't need to also include extensionPoints because we got rid of all the legacy hard-coded extension points

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -30,6 +30,7 @@ import {
 } from "@/components/documentBuilder/documentBuilderTypes";
 import { joinElementName } from "@/components/documentBuilder/utils";
 import ForEachElement from "@/blocks/transformers/controlFlow/ForEachElement";
+import Retry from "@/blocks/transformers/controlFlow/Retry";
 
 export async function getCurrentURL(): Promise<string> {
   if (!browser.devtools) {
@@ -65,6 +66,10 @@ export function getRecipeIdForElement(
 export function getPipelinePropNames(block: BlockConfig): string[] {
   switch (block.id) {
     case ForEach.BLOCK_ID: {
+      return ["body"];
+    }
+
+    case Retry.BLOCK_ID: {
       return ["body"];
     }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #3673 
- Adds a Retry brick
- Add a random number brick

## Discussion

- I chose to implement "Retry" instead of "wait until" b/c it's a bit more natural way of framing the more control flow (e.g., retrying network requests). A user can implement "wait until" by raising a business/cancel error if their condition is not met

## Future Work

- The retry brick shows as successful even if all the tries fail. Might be fixed by https://github.com/pixiebrix/pixiebrix-extension/pull/3670

## Checklist

- [X] Add tests
- [X] Designate a primary reviewer: @BLoe 
