### PR TITLE
#3492: trace sub-pipelines in control flow and document builder

### DIFF
--- a/src/blocks/renderers/documentView/DocumentView.tsx
+++ b/src/blocks/renderers/documentView/DocumentView.tsx
@@ -32,6 +32,11 @@ const DocumentView: React.FC<DocumentViewProps> = ({ body, options, meta }) => {
     throw new Error("meta.runId is required for DocumentView");
   }
 
+  if (!meta?.extensionId) {
+    // The sidebar panel should dynamically pass the prop through
+    throw new Error("meta.extensionId is required for DocumentView");
+  }
+
   return (
     // Wrap in a React context provider that passes BlockOptions down to any embedded bricks
     // ReactShadowRoot needs to be inside an HTMLElement to attach to something

--- a/src/blocks/renderers/documentView/DocumentView.tsx
+++ b/src/blocks/renderers/documentView/DocumentView.tsx
@@ -21,15 +21,21 @@ import ReactShadowRoot from "react-shadow-root";
 import BootstrapStylesheet from "@/blocks/renderers/BootstrapStylesheet";
 import { DocumentViewProps } from "./DocumentViewProps";
 import DocumentContext from "@/components/documentBuilder/render/DocumentContext";
+import { joinElementName } from "@/components/documentBuilder/utils";
 
-const DocumentView: React.FC<DocumentViewProps> = ({ body, options }) => {
+const DocumentView: React.FC<DocumentViewProps> = ({ body, options, meta }) => {
   // Track style loading to avoid a FOUC
   const [styleLoaded, setStyleLoaded] = useState(false);
+
+  if (!meta?.runId) {
+    // The sidebar panel should dynamically pass the prop through
+    throw new Error("meta.runId is required for DocumentView");
+  }
 
   return (
     // Wrap in a React context provider that passes BlockOptions down to any embedded bricks
     // ReactShadowRoot needs to be inside an HTMLElement to attach to something
-    <DocumentContext.Provider value={{ options }}>
+    <DocumentContext.Provider value={{ options, meta }}>
       <div className="h-100">
         <ReactShadowRoot>
           <BootstrapStylesheet
@@ -39,7 +45,10 @@ const DocumentView: React.FC<DocumentViewProps> = ({ body, options }) => {
           />
           {styleLoaded &&
             body.map((documentElement, index) => {
-              const { Component, props } = buildDocumentBranch(documentElement);
+              const { Component, props } = buildDocumentBranch(
+                documentElement,
+                { staticId: joinElementName("body", "children"), branches: [] }
+              );
               return <Component key={index} {...props} />;
             })}
         </ReactShadowRoot>

--- a/src/blocks/renderers/documentView/DocumentViewProps.tsx
+++ b/src/blocks/renderers/documentView/DocumentViewProps.tsx
@@ -1,7 +1,11 @@
 import { DocumentElement } from "@/components/documentBuilder/documentBuilderTypes";
-import { BlockArgContext, BlockOptions } from "@/core";
+import { BlockArgContext, BlockOptions, UUID } from "@/core";
 
 export type DocumentViewProps = {
   body: DocumentElement[];
   options: BlockOptions<BlockArgContext>;
+  meta: {
+    runId: UUID;
+    extensionId: UUID;
+  };
 };

--- a/src/blocks/transformers/controlFlow/ForEach.ts
+++ b/src/blocks/transformers/controlFlow/ForEach.ts
@@ -78,11 +78,15 @@ class ForEach extends Transformer {
   ): Promise<unknown> {
     let last: unknown;
 
-    for (const element of elements) {
+    for (const [index, element] of elements.entries()) {
       // eslint-disable-next-line no-await-in-loop -- synchronous for-loop brick
-      last = await options.runPipeline(bodyPipeline.__value__, {
-        [`@${elementKey}`]: element,
-      });
+      last = await options.runPipeline(
+        bodyPipeline.__value__,
+        { key: "body", counter: index },
+        {
+          [`@${elementKey}`]: element,
+        }
+      );
     }
 
     return last;

--- a/src/blocks/transformers/controlFlow/ForEachElement.ts
+++ b/src/blocks/transformers/controlFlow/ForEachElement.ts
@@ -21,6 +21,7 @@ import { propertiesToSchema } from "@/validators/generic";
 import { PipelineExpression } from "@/runtime/mapArgs";
 import { validateRegistryId } from "@/types/helpers";
 import { $safeFind } from "@/helpers";
+import { castArray } from "lodash";
 
 class ForEachElement extends Transformer {
   static BLOCK_ID = validateRegistryId("@pixiebrix/for-each-element");
@@ -72,9 +73,14 @@ class ForEachElement extends Transformer {
 
     let last: unknown;
 
-    for (const element of elements.get()) {
+    for (const [index, element] of castArray(elements.get()).entries()) {
       // eslint-disable-next-line no-await-in-loop -- synchronous for-loop brick
-      last = await options.runPipeline(bodyPipeline.__value__, {}, element);
+      last = await options.runPipeline(
+        bodyPipeline.__value__,
+        { key: "body", counter: index },
+        {},
+        element
+      );
     }
 
     return last;

--- a/src/blocks/transformers/controlFlow/IfElse.ts
+++ b/src/blocks/transformers/controlFlow/IfElse.ts
@@ -78,9 +78,17 @@ class IfElse extends Transformer {
 
     options.logger.debug("Condition", { condition, rawCondition });
 
-    return options.runPipeline(
-      condition ? ifPipeline.__value__ : elsePipeline?.__value__ ?? []
-    );
+    if (condition) {
+      return options.runPipeline(ifPipeline.__value__, {
+        key: "if",
+        counter: 0,
+      });
+    }
+
+    return options.runPipeline(elsePipeline.__value__, {
+      key: "else",
+      counter: 0,
+    });
   }
 }
 

--- a/src/blocks/transformers/controlFlow/IfElse.ts
+++ b/src/blocks/transformers/controlFlow/IfElse.ts
@@ -76,16 +76,14 @@ class IfElse extends Transformer {
   ): Promise<unknown> {
     const condition = boolean(rawCondition);
 
-    options.logger.debug("Condition", { condition, rawCondition });
-
     if (condition) {
-      return options.runPipeline(ifPipeline.__value__, {
+      return options.runPipeline(ifPipeline.__value__ ?? [], {
         key: "if",
         counter: 0,
       });
     }
 
-    return options.runPipeline(elsePipeline.__value__, {
+    return options.runPipeline(elsePipeline?.__value__ ?? [], {
       key: "else",
       counter: 0,
     });

--- a/src/blocks/transformers/controlFlow/Retry.ts
+++ b/src/blocks/transformers/controlFlow/Retry.ts
@@ -84,7 +84,10 @@ class Retry extends Transformer {
 
       try {
         // eslint-disable-next-line no-await-in-loop -- retry loop
-        return await options.runPipeline(bodyPipeline.__value__);
+        return await options.runPipeline(bodyPipeline.__value__, {
+          key: "branch",
+          counter: retryCount,
+        });
       } catch (error) {
         lastError = error;
       }

--- a/src/blocks/transformers/controlFlow/TryExcept.ts
+++ b/src/blocks/transformers/controlFlow/TryExcept.ts
@@ -76,13 +76,20 @@ class TryExcept extends Transformer {
     options: BlockOptions
   ): Promise<unknown> {
     try {
-      return await options.runPipeline(tryPipeline.__value__);
+      return await options.runPipeline(tryPipeline.__value__, {
+        key: "try",
+        counter: 0,
+      });
     } catch (error: unknown) {
       options.logger.debug("Caught error", { error });
 
-      return options.runPipeline(exceptPipeline?.__value__ ?? [], {
-        [`@${errorKey}`]: serializeError(error, { useToJSON: false }),
-      });
+      return options.runPipeline(
+        exceptPipeline?.__value__ ?? [],
+        { key: "catch", counter: 0 },
+        {
+          [`@${errorKey}`]: serializeError(error, { useToJSON: false }),
+        }
+      );
     }
   }
 }

--- a/src/blocks/transformers/randomNumber.ts
+++ b/src/blocks/transformers/randomNumber.ts
@@ -31,6 +31,8 @@ export class RandomNumber extends Transformer {
     );
   }
 
+  defaultOutputKey = "random";
+
   override async isPure(): Promise<boolean> {
     return false;
   }

--- a/src/blocks/types.ts
+++ b/src/blocks/types.ts
@@ -198,3 +198,13 @@ export type BlockConfig = {
  * A pipeline of blocks to execute sequentially
  */
 export type BlockPipeline = BlockConfig[];
+
+/**
+ * A control flow branch, for tracing. The array of branches is used to correlate runs of the same block in a pipeline
+ * @see TraceMetadata.blockInstanceId
+ * @see TraceMetadata.branches
+ */
+export type Branch = {
+  key: string;
+  counter: number;
+};

--- a/src/components/documentBuilder/documentBuilderTypes.ts
+++ b/src/components/documentBuilder/documentBuilderTypes.ts
@@ -97,6 +97,10 @@ export type DocumentComponent = {
   props?: UnknownObject | undefined;
 };
 
+/**
+ * Document path information for keep tracking of brick call sites/calls for tracing
+ * @since 1.7.0
+ */
 export type DynamicPath = {
   /**
    * The static path to the element in the pre-document.

--- a/src/components/documentBuilder/documentBuilderTypes.ts
+++ b/src/components/documentBuilder/documentBuilderTypes.ts
@@ -97,4 +97,22 @@ export type DocumentComponent = {
   props?: UnknownObject | undefined;
 };
 
-export type BuildDocumentBranch = (root: DocumentElement) => DocumentComponent;
+export type DynamicPath = {
+  /**
+   * The static path to the element in the pre-document.
+   */
+  staticId: string;
+
+  /**
+   * The branches to reach the element in the rendered document
+   */
+  branches: Array<{
+    staticId: string;
+    index: number;
+  }>;
+};
+
+export type BuildDocumentBranch = (
+  root: DocumentElement,
+  tracePath: DynamicPath
+) => DocumentComponent;

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -44,7 +44,10 @@ describe("When rendered in panel", () => {
   });
 
   const renderDocument = (config: any) => {
-    const { Component, props } = buildDocumentBranch(config);
+    const { Component, props } = buildDocumentBranch(config, {
+      staticId: "body",
+      branches: [],
+    });
     return render(<Component {...props} />);
   };
 

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -23,9 +23,12 @@ import blockRegistry from "@/blocks/registry";
 import { MarkdownRenderer } from "@/blocks/renderers/markdown";
 import * as backgroundAPI from "@/background/messenger/api";
 import * as contentScriptAPI from "@/contentScript/messenger/api";
-import { uuidv4 } from "@/types/helpers";
+import { UNSET_UUID, uuidv4 } from "@/types/helpers";
 import { buildDocumentBranch } from "./documentTree";
 import { DocumentElementType } from "./documentBuilderTypes";
+import DocumentContext, {
+  initialValue,
+} from "@/components/documentBuilder/render/DocumentContext";
 
 // Mock the recordX trace methods. Otherwise they'll fail and Jest will have unhandled rejection errors since we call
 // them with `void` instead of awaiting them in the reducePipeline methods
@@ -48,7 +51,19 @@ describe("When rendered in panel", () => {
       staticId: "body",
       branches: [],
     });
-    return render(<Component {...props} />);
+    return render(
+      <DocumentContext.Provider
+        value={{
+          ...initialValue,
+          meta: {
+            extensionId: UNSET_UUID,
+            runId: UNSET_UUID,
+          },
+        }}
+      >
+        <Component {...props} />
+      </DocumentContext.Provider>
+    );
   };
 
   test.each`

--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -181,7 +181,7 @@ export const buildDocumentBranch: BuildDocumentBranch = (root, tracePath) => {
   if (root.children?.length > 0) {
     componentDefinition.props.children = root.children.map((child, index) => {
       const { Component, props } = buildDocumentBranch(child, {
-        staticId: joinElementName(staticId, "children"),
+        staticId: joinElementName(staticId, root.type, "children"),
         branches: [...branches, { staticId, index }],
       });
       return <Component key={index} {...props} />;

--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -25,10 +25,12 @@ import {
   BuildDocumentBranch,
   DocumentComponent,
   DocumentElement,
+  DynamicPath,
 } from "./documentBuilderTypes";
 import ButtonElement from "@/components/documentBuilder/render/ButtonElement";
 import ListElement from "@/components/documentBuilder/render/ListElement";
 import { BusinessError } from "@/errors/businessErrors";
+import { joinElementName } from "@/components/documentBuilder/utils";
 
 const headerComponents = {
   header_1: "h1",
@@ -49,7 +51,8 @@ const UnknownType: React.FC<{ componentType: string }> = ({
 );
 
 export function getComponentDefinition(
-  element: DocumentElement
+  element: DocumentElement,
+  tracePath: DynamicPath
 ): DocumentComponent {
   const componentType = element.type;
   const config = get(element, "config", {} as UnknownObject);
@@ -122,6 +125,7 @@ export function getComponentDefinition(
         Component: BlockElement,
         props: {
           pipeline: pipeline.__value__,
+          tracePath,
         },
       };
     }
@@ -141,6 +145,7 @@ export function getComponentDefinition(
         props: {
           children: title,
           onClick: onClick.__value__,
+          tracePath,
           ...props,
         },
       };
@@ -151,6 +156,7 @@ export function getComponentDefinition(
         array: config.array,
         elementKey: config.elementKey,
         config: config.element,
+        tracePath,
         buildDocumentBranch,
       };
 
@@ -169,11 +175,15 @@ export function getComponentDefinition(
   }
 }
 
-export const buildDocumentBranch: BuildDocumentBranch = (root) => {
-  const componentDefinition = getComponentDefinition(root);
+export const buildDocumentBranch: BuildDocumentBranch = (root, tracePath) => {
+  const { staticId, branches } = tracePath;
+  const componentDefinition = getComponentDefinition(root, tracePath);
   if (root.children?.length > 0) {
     componentDefinition.props.children = root.children.map((child, index) => {
-      const { Component, props } = buildDocumentBranch(child);
+      const { Component, props } = buildDocumentBranch(child, {
+        staticId: joinElementName(staticId, "children"),
+        branches: [...branches, { staticId, index }],
+      });
       return <Component key={index} {...props} />;
     });
   }

--- a/src/components/documentBuilder/preview/getPreviewComponentDefinition.tsx
+++ b/src/components/documentBuilder/preview/getPreviewComponentDefinition.tsx
@@ -19,6 +19,7 @@ import documentTreeStyles from "./documentTree.module.scss";
 import {
   DocumentComponent,
   DocumentElement,
+  DynamicPath,
   PipelineDocumentConfig,
 } from "@/components/documentBuilder/documentBuilderTypes";
 import { get, isEmpty } from "lodash";
@@ -41,6 +42,10 @@ type PreviewComponentProps = {
   onMouseLeave: React.MouseEventHandler<HTMLDivElement>;
 };
 
+// Bookkeeping trace paths for preview is not necessary. But, we need to provide a value for the previews that use
+// getComponentDefinition under the hood
+const DUMMY_TRACE_PATH: DynamicPath = { staticId: "preview", branches: [] };
+
 function getPreviewComponentDefinition(
   element: DocumentElement
 ): DocumentComponent {
@@ -52,7 +57,10 @@ function getPreviewComponentDefinition(
     case "header_2":
     case "header_3":
     case "text": {
-      const { Component, props } = getComponentDefinition(element);
+      const { Component, props } = getComponentDefinition(
+        element,
+        DUMMY_TRACE_PATH
+      );
       const PreviewComponent: React.FC<PreviewComponentProps> = ({
         children,
         className,
@@ -77,7 +85,10 @@ function getPreviewComponentDefinition(
     }
 
     case "image": {
-      let { Component, props } = getComponentDefinition(element);
+      let { Component, props } = getComponentDefinition(
+        element,
+        DUMMY_TRACE_PATH
+      );
 
       // If it's not a valid URL, show a placeholder
       if (
@@ -116,7 +127,10 @@ function getPreviewComponentDefinition(
     case "container":
     case "row":
     case "column": {
-      const { Component, props } = getComponentDefinition(element);
+      const { Component, props } = getComponentDefinition(
+        element,
+        DUMMY_TRACE_PATH
+      );
       props.className = cx(props.className, documentTreeStyles.container);
       if (!element.children?.length) {
         props.children = <span className="text-muted">{componentType}</span>;
@@ -153,7 +167,10 @@ function getPreviewComponentDefinition(
         },
       };
 
-      const { Component, props } = getComponentDefinition(previewElement);
+      const { Component, props } = getComponentDefinition(
+        previewElement,
+        DUMMY_TRACE_PATH
+      );
       const PreviewComponent: React.FC<PreviewComponentProps> = ({
         children,
         className,
@@ -273,7 +290,7 @@ function getPreviewComponentDefinition(
     }
 
     default: {
-      return getComponentDefinition(element);
+      return getComponentDefinition(element, DUMMY_TRACE_PATH);
     }
   }
 }

--- a/src/components/documentBuilder/render/BlockElement.tsx
+++ b/src/components/documentBuilder/render/BlockElement.tsx
@@ -27,14 +27,20 @@ import PanelBody from "@/sidebar/PanelBody";
 import { RendererPayload } from "@/runtime/runtimeTypes";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { serializeError } from "serialize-error";
+import { DynamicPath } from "@/components/documentBuilder/documentBuilderTypes";
+import { mapPathToTraceBranches } from "@/components/documentBuilder/utils";
 
-type BlockElementProps = { pipeline: BlockPipeline };
+type BlockElementProps = {
+  pipeline: BlockPipeline;
+  tracePath: DynamicPath;
+};
 
 /**
- * A React component that messages the contentScript to run a pipeline and then shows the result
+ * A React component that messages the contentScript to run a pipeline and then displays the result
  */
-const BlockElement: React.FC<BlockElementProps> = ({ pipeline }) => {
+const BlockElement: React.FC<BlockElementProps> = ({ pipeline, tracePath }) => {
   const {
+    meta,
     options: { ctxt, logger },
   } = useContext(DocumentContext);
 
@@ -50,6 +56,11 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline }) => {
         context: ctxt,
         pipeline,
         // TODO: pass runtime version via DocumentContext instead of hard-coding it. This will break for v4+
+        meta: {
+          ...meta,
+          // The pipeline is static, so don't need to maintain run counter on branches
+          branches: mapPathToTraceBranches(tracePath),
+        },
         options: apiVersionOptions("v3"),
       });
     }, [pipeline]);
@@ -65,6 +76,7 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline }) => {
         payload={{
           key: `error-${getErrorMessage(error)}`,
           error: serializeError(error),
+          runId: meta.runId,
         }}
       />
     );

--- a/src/components/documentBuilder/render/BlockElement.tsx
+++ b/src/components/documentBuilder/render/BlockElement.tsx
@@ -76,7 +76,7 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline, tracePath }) => {
         payload={{
           key: `error-${getErrorMessage(error)}`,
           error: serializeError(error),
-          runId: meta.runId,
+          ...meta,
         }}
       />
     );

--- a/src/components/documentBuilder/render/ButtonElement.tsx
+++ b/src/components/documentBuilder/render/ButtonElement.tsx
@@ -40,6 +40,10 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
   const context = useContext(DocumentContext);
   const [counter, setCounter] = useState(0);
 
+  if (!context.meta.extensionId) {
+    throw new Error("ButtonElement requires meta.extensionId");
+  }
+
   const handler = async () => {
     const currentCounter = counter;
     setCounter((previous) => previous + 1);

--- a/src/components/documentBuilder/render/ButtonElement.tsx
+++ b/src/components/documentBuilder/render/ButtonElement.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useContext } from "react";
+import React, { useContext, useState } from "react";
 import { BlockPipeline } from "@/blocks/types";
 import AsyncButton, { AsyncButtonProps } from "@/components/AsyncButton";
 import { whoAmI } from "@/background/messenger/api";
@@ -24,18 +24,26 @@ import { uuidv4 } from "@/types/helpers";
 import DocumentContext from "@/components/documentBuilder/render/DocumentContext";
 import { Except } from "type-fest";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
+import { DynamicPath } from "@/components/documentBuilder/documentBuilderTypes";
 
 type ButtonElementProps = Except<AsyncButtonProps, "onClick"> & {
   onClick: BlockPipeline;
+  elementName: string;
+  tracePath: DynamicPath;
 };
 
 const ButtonElement: React.FC<ButtonElementProps> = ({
   onClick,
+  tracePath,
   ...restProps
 }) => {
   const context = useContext(DocumentContext);
+  const [counter, setCounter] = useState(0);
 
-  const handler = useCallback(async () => {
+  const handler = async () => {
+    const currentCounter = counter;
+    setCounter((previous) => previous + 1);
+
     const me = await whoAmI();
     // We currently only support associating the sidebar with the content script in the top-level frame (frameId: 0)
     return runEffectPipeline(
@@ -46,9 +54,19 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
         pipeline: onClick,
         // TODO: pass runtime version via DocumentContext instead of hard-coding it. This will break for v4+
         options: apiVersionOptions("v3"),
+        meta: {
+          ...context.meta,
+          branches: [
+            ...tracePath.branches.map(({ staticId, index }) => ({
+              key: staticId,
+              counter: index,
+            })),
+            { key: "onClick", counter: currentCounter },
+          ],
+        },
       }
     );
-  }, [onClick, context]);
+  };
 
   return <AsyncButton onClick={handler} {...restProps} />;
 };

--- a/src/components/documentBuilder/render/DocumentContext.tsx
+++ b/src/components/documentBuilder/render/DocumentContext.tsx
@@ -16,11 +16,15 @@
  */
 
 import React from "react";
-import { BlockArgContext, BlockOptions } from "@/core";
+import { BlockArgContext, BlockOptions, UUID } from "@/core";
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import { BusinessError } from "@/errors/businessErrors";
 
 type DocumentState = {
+  meta: {
+    runId: UUID;
+    extensionId: UUID;
+  };
   options: BlockOptions<BlockArgContext>;
 };
 
@@ -30,6 +34,10 @@ const blankContext = {
 } as BlockArgContext;
 
 const initialValue: DocumentState = {
+  meta: {
+    runId: null,
+    extensionId: null,
+  },
   options: {
     ctxt: blankContext,
     // The root should correspond to the host page's content script. If we passed document here, it would end up being

--- a/src/components/documentBuilder/render/DocumentContext.tsx
+++ b/src/components/documentBuilder/render/DocumentContext.tsx
@@ -33,7 +33,7 @@ const blankContext = {
   "@options": {},
 } as BlockArgContext;
 
-const initialValue: DocumentState = {
+export const initialValue: DocumentState = {
   meta: {
     runId: null,
     extensionId: null,

--- a/src/components/documentBuilder/render/ListElement.tsx
+++ b/src/components/documentBuilder/render/ListElement.tsx
@@ -128,7 +128,7 @@ const ListElementInternal: React.FC<DocumentListProps> = ({
         const { Component, props } = buildDocumentBranch(
           documentElement as DocumentElement,
           {
-            staticId: joinElementName(staticId, "children"),
+            staticId: joinElementName(staticId, "list", "children"),
             branches: [...branches, { staticId, index }],
           }
         );

--- a/src/components/documentBuilder/render/ListElement.tsx
+++ b/src/components/documentBuilder/render/ListElement.tsx
@@ -24,6 +24,7 @@ import Loader from "@/components/Loader";
 import {
   BuildDocumentBranch,
   DocumentElement,
+  DynamicPath,
 } from "@/components/documentBuilder/documentBuilderTypes";
 import { produce } from "immer";
 import ErrorBoundary from "@/components/ErrorBoundary";
@@ -32,12 +33,14 @@ import { runMapArgs } from "@/contentScript/messenger/api";
 import { isNullOrBlank } from "@/utils";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { whoAmI } from "@/background/messenger/api";
+import { joinElementName } from "@/components/documentBuilder/utils";
 
 type DocumentListProps = {
   array: UnknownObject[];
   elementKey?: string;
   config: Args;
   buildDocumentBranch: BuildDocumentBranch;
+  tracePath: DynamicPath;
 };
 
 const ListElementInternal: React.FC<DocumentListProps> = ({
@@ -45,8 +48,11 @@ const ListElementInternal: React.FC<DocumentListProps> = ({
   elementKey,
   config,
   buildDocumentBranch,
+  tracePath,
 }) => {
-  // Should be 'element' for any falsy value including empty string.
+  const { staticId, branches } = tracePath;
+
+  // Should be "element" for any falsy value including empty string.
   elementKey = isNullOrBlank(elementKey) ? "element" : elementKey;
 
   const documentContext = useContext(DocumentContext);
@@ -120,7 +126,11 @@ const ListElementInternal: React.FC<DocumentListProps> = ({
     <>
       {rootDefinitions.map(({ documentElement, elementContext }, index) => {
         const { Component, props } = buildDocumentBranch(
-          documentElement as DocumentElement
+          documentElement as DocumentElement,
+          {
+            staticId: joinElementName(staticId, "children"),
+            branches: [...branches, { staticId, index }],
+          }
         );
         return (
           <DocumentContext.Provider key={index} value={elementContext}>

--- a/src/contentScript/pageEditor.ts
+++ b/src/contentScript/pageEditor.ts
@@ -117,7 +117,9 @@ export async function runBlock({
     headless: true,
     logValues: false,
     logger: new ConsoleLogger(),
+    // Excluding runId will prevent the run from being stored in traces
     runId: null,
+    extensionId: null,
   };
 
   // Exclude the outputKey so that `output` is the output of the brick. Alternatively we could have taken then

--- a/src/contentScript/pageEditor.ts
+++ b/src/contentScript/pageEditor.ts
@@ -113,6 +113,7 @@ export async function runBlock({
 
   const options: ReduceOptions = {
     ...versionOptions,
+    branches: [],
     headless: true,
     logValues: false,
     logger: new ConsoleLogger(),

--- a/src/contentScript/pipelineProtocol.ts
+++ b/src/contentScript/pipelineProtocol.ts
@@ -82,8 +82,7 @@ export async function runRendererPipeline({
         blockId: error.blockId,
         args: error.args,
         ctxt: error.ctxt,
-        runId: meta.runId,
-        extensionId: meta.extensionId,
+        ...meta,
       };
     }
 

--- a/src/contentScript/pipelineProtocol.ts
+++ b/src/contentScript/pipelineProtocol.ts
@@ -1,4 +1,4 @@
-import { BlockPipeline } from "@/blocks/types";
+import { BlockPipeline, Branch } from "@/blocks/types";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { BlockArgContext, ServiceContext, UserOptions, UUID } from "@/core";
 import ConsoleLogger from "@/utils/ConsoleLogger";
@@ -11,11 +11,27 @@ import { UnknownObject } from "@/types";
 import { ApiVersionOptions } from "@/runtime/apiVersionOptions";
 import { BusinessError } from "@/errors/businessErrors";
 
+type RunMetadata = {
+  /**
+   * The extension id
+   */
+  extensionId: UUID;
+  /**
+   * The extension runId
+   */
+  runId: UUID;
+  /**
+   * The accumulated trace branches
+   */
+  branches: Branch[];
+};
+
 type RunPipelineParams = {
   nonce: UUID;
   pipeline: BlockPipeline;
   context: BlockArgContext;
   options: ApiVersionOptions;
+  meta: RunMetadata;
 };
 
 /**
@@ -24,14 +40,16 @@ type RunPipelineParams = {
  * @param context the context, including @input, @options, and services
  * @param nonce a nonce to help the caller correlate requests/responses. (This shouldn't be necessary in practice though
  *  because the messaging framework takes care of the correlation. In this case we're just using it as a key on
- *  RendererPayload
+ *  RendererPayload)
  * @param options pipeline options to pass to reducePipeline
+ * @param meta run/trace metadata
  */
 export async function runRendererPipeline({
   pipeline,
   context,
   nonce,
   options,
+  meta,
 }: RunPipelineParams): Promise<RendererPayload> {
   expectContext("contentScript");
 
@@ -42,7 +60,7 @@ export async function runRendererPipeline({
         input: context["@input"] ?? {},
         optionsArgs: (context["@options"] ?? {}) as UserOptions,
         // Pass null here to force the runtime to handle correctly. Passing `document` here wouldn't make sense because
-        // it would be the page that contains the react tree (i.e., the frame of the sidebar)
+        // it would be the page that contains the React tree (i.e., the frame of the sidebar)
         root: null,
         // `reducePipeline` just spreads the serviceContext. If we needed to pick out the actual services we could do the
         // following. However, we actually want to pass through the rest of the context and we don't have an affordance
@@ -54,6 +72,7 @@ export async function runRendererPipeline({
         logger: new ConsoleLogger(),
         headless: true,
         ...options,
+        ...meta,
       }
     );
   } catch (error) {
@@ -63,6 +82,8 @@ export async function runRendererPipeline({
         blockId: error.blockId,
         args: error.args,
         ctxt: error.ctxt,
+        runId: meta.runId,
+        extensionId: meta.extensionId,
       };
     }
 
@@ -76,6 +97,7 @@ export async function runEffectPipeline({
   pipeline,
   context,
   options,
+  meta,
 }: RunPipelineParams): Promise<void> {
   expectContext("contentScript");
 
@@ -95,6 +117,7 @@ export async function runEffectPipeline({
     },
     {
       ...options,
+      ...meta,
       logger: new ConsoleLogger(),
       headless: true,
     }

--- a/src/core.ts
+++ b/src/core.ts
@@ -278,6 +278,11 @@ export type BlockOptions<
     // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/3477
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- brick is responsible for providing shape
     pipeline: any,
+    // The branch for tracing. Used to determine order of pipeline runs
+    branch: {
+      key: string;
+      counter: number;
+    },
     // Should be UnknownObject, but can't use to introduce a circular dependency
     extraContext?: Record<string, unknown>,
     root?: ReaderRoot

--- a/src/extensionPoints/sidebarExtension.ts
+++ b/src/extensionPoints/sidebarExtension.ts
@@ -188,6 +188,8 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
     readerContext: ReaderOutput,
     extension: ResolvedExtension<SidebarConfig>
   ) {
+    const runId = uuidv4();
+
     const extensionLogger = this.logger.childLogger(
       selectExtensionContext(extension)
     );
@@ -213,6 +215,7 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
         headless: true,
         logger: extensionLogger,
         ...apiVersionOptions(extension.apiVersion),
+        runId,
       });
       // We're expecting a HeadlessModeError (or other error) to be thrown in the line above
       // noinspection ExceptionCaughtLocallyJS
@@ -227,15 +230,19 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
       if (error instanceof HeadlessModeError) {
         upsertPanel(ref, heading, {
           blockId: error.blockId,
+          extensionId: extension.id,
           key: uuidv4(),
           ctxt: error.ctxt,
           args: error.args,
+          runId,
         });
       } else {
         extensionLogger.error(error);
         upsertPanel(ref, heading, {
           key: uuidv4(),
+          extensionId: extension.id,
           error: serializeError(error),
+          runId,
         });
       }
     }

--- a/src/extensionPoints/sidebarExtension.ts
+++ b/src/extensionPoints/sidebarExtension.ts
@@ -188,6 +188,7 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
     readerContext: ReaderOutput,
     extension: ResolvedExtension<SidebarConfig>
   ) {
+    // Generate our own run id so that we know it (to pass to upsertPanel)
     const runId = uuidv4();
 
     const extensionLogger = this.logger.childLogger(
@@ -227,22 +228,25 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
         blueprintId: extension._recipe?.id,
       };
 
+      const meta = {
+        runId,
+        extensionId: extension.id,
+      };
+
       if (error instanceof HeadlessModeError) {
         upsertPanel(ref, heading, {
           blockId: error.blockId,
-          extensionId: extension.id,
           key: uuidv4(),
           ctxt: error.ctxt,
           args: error.args,
-          runId,
+          ...meta,
         });
       } else {
         extensionLogger.error(error);
         upsertPanel(ref, heading, {
           key: uuidv4(),
-          extensionId: extension.id,
           error: serializeError(error),
-          runId,
+          ...meta,
         });
       }
     }

--- a/src/pageEditor/hooks/useExtensionTrace.ts
+++ b/src/pageEditor/hooks/useExtensionTrace.ts
@@ -29,7 +29,7 @@ const { setExtensionTrace } = runtimeSlice.actions;
 const TRACE_RELOAD_MILLIS = 350;
 
 /**
- * Select sufficient data from trace to determine if two traces include the same data (i.e., they include both they
+ * Select minimal set of data from trace to determine if two traces include the same data (i.e., they include both they
  * entry and exit data).
  */
 function selectTraceMetadata(record: TraceRecord) {

--- a/src/pageEditor/hooks/useExtensionTrace.ts
+++ b/src/pageEditor/hooks/useExtensionTrace.ts
@@ -37,6 +37,7 @@ function selectTraceMetadata(record: TraceRecord) {
     runId: record.runId,
     timestamp: record.timestamp,
     isFinal: record.isFinal,
+    callId: record.callId,
   };
 }
 
@@ -63,6 +64,7 @@ function useExtensionTrace() {
         extensionTrace.map((x) => selectTraceMetadata(x))
       )
     ) {
+      console.debug("Updating extension trace in Redux slice: %s", extensionId);
       dispatch(setExtensionTrace({ extensionId, records: lastRun }));
     }
 

--- a/src/pageEditor/hooks/usePipelineField.ts
+++ b/src/pageEditor/hooks/usePipelineField.ts
@@ -16,15 +16,14 @@
  */
 
 import { useSelector } from "react-redux";
-import { selectTraceError } from "@/pageEditor/slices/runtimeSelectors";
+import { selectTraceErrors } from "@/pageEditor/slices/runtimeSelectors";
 import { useCallback } from "react";
 import { BlockPipeline } from "@/blocks/types";
 import { useField, useFormikContext, setNestedObjectValues } from "formik";
-import { TraceError } from "@/telemetry/trace";
 import { useAsyncEffect } from "use-async-effect";
 import validateOutputKey from "@/pageEditor/validation/validateOutputKey";
 import validateRenderers from "@/pageEditor/validation/validateRenderers";
-import applyTraceError from "@/pageEditor/validation/applyTraceError";
+import applyTraceErrors from "@/pageEditor/validation/applyTraceError";
 import { isEmpty } from "lodash";
 import {
   FormikError,
@@ -34,6 +33,7 @@ import { TypedBlockMap } from "@/blocks/registry";
 import { ExtensionPointType } from "@/extensionPoints/types";
 import validateStringTemplates from "@/pageEditor/validation/validateStringTemplates";
 import { PIPELINE_BLOCKS_FIELD_NAME } from "@/pageEditor/consts";
+import type { TraceError } from "@/telemetry/trace";
 
 function usePipelineField(
   allBlocks: TypedBlockMap,
@@ -41,9 +41,9 @@ function usePipelineField(
 ): {
   blockPipeline: BlockPipeline;
   blockPipelineErrors: FormikError;
-  errorTraceEntry: TraceError;
+  traceErrors: TraceError[];
 } {
-  const errorTraceEntry = useSelector(selectTraceError);
+  const traceErrors = useSelector(selectTraceErrors);
 
   const validatePipelineBlocks = useCallback(
     (pipeline: BlockPipeline): void | FormikErrorTree => {
@@ -52,11 +52,11 @@ function usePipelineField(
       validateOutputKey(formikErrors, pipeline, allBlocks);
       validateRenderers(formikErrors, pipeline, allBlocks, extensionPointType);
       validateStringTemplates(formikErrors, pipeline);
-      applyTraceError(formikErrors, errorTraceEntry, pipeline);
+      applyTraceErrors(formikErrors, traceErrors, pipeline);
 
       return isEmpty(formikErrors) ? undefined : formikErrors;
     },
-    [allBlocks, extensionPointType, errorTraceEntry]
+    [allBlocks, extensionPointType, traceErrors]
   );
 
   const [{ value: blockPipeline }, { error: blockPipelineErrors }] =
@@ -78,13 +78,13 @@ function usePipelineField(
         formikContext.setTouched(setNestedObjectValues(validationErrors, true));
       }
     },
-    [errorTraceEntry]
+    [traceErrors]
   );
 
   return {
     blockPipeline,
     blockPipelineErrors,
-    errorTraceEntry,
+    traceErrors,
   };
 }
 

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -118,8 +118,10 @@ const EditTab: React.FC<{
       []
     );
 
-  const { blockPipeline, blockPipelineErrors, errorTraceEntry } =
-    usePipelineField(allBlocks, extensionPointType);
+  const { blockPipeline, blockPipelineErrors, traceErrors } = usePipelineField(
+    allBlocks,
+    extensionPointType
+  );
 
   const activeNodeId = useSelector(selectActiveNodeId);
   const { blockId, path: fieldName } = useSelector(selectActiveNodeInfo) ?? {};
@@ -185,7 +187,7 @@ const EditTab: React.FC<{
                 relevantBlocksForRootPipeline={relevantBlocksForRootPipeline}
                 pipeline={blockPipeline}
                 pipelineErrors={blockPipelineErrors}
-                errorTraceEntry={errorTraceEntry}
+                traceErrors={traceErrors}
                 extensionPointLabel={extensionPointLabel}
                 extensionPointIcon={extensionPointIcon}
                 addBlock={addBlock}

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
@@ -24,7 +24,7 @@ import PipelineHeaderNode, {
 import PipelineFooterNode, {
   PipelineFooterNodeProps,
 } from "@/pageEditor/tabs/editTab/editorNodes/PipelineFooterNode";
-import { BlockPipeline } from "@/blocks/types";
+import { BlockPipeline, Branch } from "@/blocks/types";
 import {
   BrickNodeContentProps,
   BrickNodeProps,
@@ -55,7 +55,7 @@ import BrickIcon from "@/components/BrickIcon";
 import { Except } from "type-fest";
 import { FOUNDATION_NODE_ID } from "@/pageEditor/uiState/uiState";
 import { PIPELINE_BLOCKS_FIELD_NAME } from "@/pageEditor/consts";
-import { getLatestCall } from "@/telemetry/traceHelpers";
+import { filterTracesByCall, getLatestCall } from "@/telemetry/traceHelpers";
 
 const ADD_MESSAGE = "Add more bricks with the plus button";
 
@@ -170,7 +170,8 @@ const EditorNodeLayout: React.FC<EditorNodeLayoutProps> = ({
     const isRootPipeline = pipelinePath === PIPELINE_BLOCKS_FIELD_NAME;
     const relevantBlocks = isRootPipeline
       ? relevantBlocksForRootPipeline
-      : allBlocksAsRelevant;
+      : // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/3629
+        allBlocksAsRelevant;
 
     const lastIndex = pipeline.length - 1;
     // eslint-disable-next-line security/detect-object-injection -- just created the index
@@ -180,15 +181,44 @@ const EditorNodeLayout: React.FC<EditorNodeLayoutProps> = ({
 
     const nodes: EditorNodeProps[] = [];
 
+    // Determine which execution of the pipeline to show. Currently, getting the latest execution
+    let latestPipelineCall: Branch[];
+    if (pipeline.length > 0) {
+      // XXX: there seems to be a bug (race condition) where sometimes this isn't seeing the latest click of a
+      // button in the render document brick
+      latestPipelineCall = getLatestCall(
+        traces.filter(
+          // Use first block in pipeline to determine the latest run
+          (trace) => trace.blockInstanceId === pipeline[0].instanceId
+        )
+      )?.branches;
+    }
+
     for (const [index, blockConfig] of pipeline.entries()) {
       const subPipelines: SubPipeline[] = [];
       const block = allBlocks.get(blockConfig.id)?.block;
       const nodeIsActive = blockConfig.instanceId === activeNodeId;
-      const traceRecord = getLatestCall(
+
+      const traceRecords = filterTracesByCall(
         traces.filter(
           (trace) => trace.blockInstanceId === blockConfig.instanceId
-        )
+        ),
+        latestPipelineCall
       );
+
+      if (traceRecords.length > 1) {
+        console.warn(
+          "filterTracesByCall for %s returned multiple trace records",
+          blockConfig.instanceId,
+          {
+            traces,
+            instanceId: blockConfig.instanceId,
+            lastPipelineCall: latestPipelineCall,
+          }
+        );
+      }
+
+      const traceRecord = traceRecords[0];
 
       if (traceRecord != null) {
         // The runtime doesn't directly trace the extension point. However, if there's a trace from a brick, we

--- a/src/pageEditor/tabs/editTab/useReportTraceError.ts
+++ b/src/pageEditor/tabs/editTab/useReportTraceError.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { selectTraceError } from "@/pageEditor/slices/runtimeSelectors";
+import { selectTraceErrors } from "@/pageEditor/slices/runtimeSelectors";
 import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 import { reportEvent } from "@/telemetry/events";
 import { useEffect } from "react";
@@ -23,17 +23,19 @@ import { useSelector } from "react-redux";
 
 function useReportTraceError() {
   const sessionId = useSelector(selectSessionId);
-  const errorTraceEntry = useSelector(selectTraceError);
-  const runId = errorTraceEntry?.runId ?? null;
+  const traceErrors = useSelector(selectTraceErrors);
+
+  const traceError = traceErrors.find((x) => x.runId);
+  const runId = traceError?.runId ?? null;
 
   useEffect(() => {
-    if (errorTraceEntry) {
+    if (traceError) {
       reportEvent("PageEditorExtensionError", {
         sessionId,
-        extensionId: errorTraceEntry.extensionId,
+        extensionId: traceError.extensionId,
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- errorTraceEntry is not required, runId is sufficient
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- traceError is not required, runId is sufficient
   }, [runId, sessionId]);
 }
 

--- a/src/pageEditor/validation/applyTraceError.ts
+++ b/src/pageEditor/validation/applyTraceError.ts
@@ -21,25 +21,27 @@ import applyTraceBlockError from "./applyTraceBlockError";
 import applyTraceInputError from "./applyTraceInputError";
 import { FormikErrorTree } from "@/pageEditor/tabs/editTab/editTabTypes";
 
-function applyTraceError(
+function applyTraceErrors(
   pipelineErrors: FormikErrorTree,
-  errorTraceEntry: TraceError,
+  traceErrors: TraceError[],
   pipeline: BlockPipeline
 ) {
-  if (!errorTraceEntry) {
+  if (traceErrors.length === 0) {
     return;
   }
 
-  const { blockInstanceId } = errorTraceEntry;
-  const blockIndex = pipeline.findIndex(
-    (block) => block.instanceId === blockInstanceId
-  );
-  if (blockIndex === -1) {
-    return;
-  }
+  for (const traceError of traceErrors) {
+    const { blockInstanceId } = traceError;
+    const blockIndex = pipeline.findIndex(
+      (block) => block.instanceId === blockInstanceId
+    );
+    if (blockIndex === -1) {
+      return;
+    }
 
-  applyTraceInputError(pipelineErrors, errorTraceEntry, blockIndex);
-  applyTraceBlockError(pipelineErrors, errorTraceEntry, blockIndex);
+    applyTraceInputError(pipelineErrors, traceError, blockIndex);
+    applyTraceBlockError(pipelineErrors, traceError, blockIndex);
+  }
 }
 
-export default applyTraceError;
+export default applyTraceErrors;

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -10,6 +10,7 @@ import {
   PipelineExpression,
 } from "@/runtime/mapArgs";
 import { BusinessError } from "@/errors/businessErrors";
+import { UNSET_UUID } from "@/types/helpers";
 
 const logger = new ConsoleLogger();
 
@@ -224,6 +225,7 @@ export function simpleInput(input: UnknownObject): InitialValues {
 export function testOptions(version: ApiVersion) {
   return {
     logger,
+    extensionId: UNSET_UUID,
     ...apiVersionOptions(version),
   };
 }

--- a/src/runtime/pipelineTests/trace.test.ts
+++ b/src/runtime/pipelineTests/trace.test.ts
@@ -27,7 +27,7 @@ import {
 } from "./pipelineTestHelpers";
 import { uuidv4 } from "@/types/helpers";
 
-// Mock the recordX trace methods. Otherwise they'll fail and Jest will have unhandledrejection errors since we call
+// Mock the recordX trace methods. Otherwise, they'll fail and Jest will have unhandledrejection errors since we call
 // them with `void` instead of awaiting them in the reducePipeline methods
 import * as logging from "@/background/messenger/api";
 import { traces } from "@/background/messenger/api";
@@ -231,6 +231,7 @@ describe("Trace normal execution", () => {
     const meta: TraceRecordMeta = {
       extensionId,
       runId,
+      branches: [],
       blockInstanceId: instanceId,
       blockId: echoBlock.id,
     };
@@ -249,6 +250,7 @@ describe("Trace normal execution", () => {
       outputKey: undefined,
       output: { message: "hello" },
       skippedRun: false,
+      isRenderer: false,
       isFinal: true,
     };
 
@@ -293,6 +295,7 @@ describe("Trace normal execution", () => {
     const meta: TraceRecordMeta = {
       extensionId,
       runId,
+      branches: [],
       blockInstanceId: instanceId,
       blockId: echoBlock.id,
     };
@@ -302,6 +305,7 @@ describe("Trace normal execution", () => {
       outputKey,
       output: { message: "hello" },
       skippedRun: false,
+      isRenderer: false,
       isFinal: true,
     };
 
@@ -345,6 +349,7 @@ describe("Trace normal execution", () => {
     const meta: TraceRecordMeta = {
       extensionId,
       runId,
+      branches: [],
       blockInstanceId: instanceId,
       blockId: throwBlock.id,
     };

--- a/src/runtime/pipelineTests/trace.test.ts
+++ b/src/runtime/pipelineTests/trace.test.ts
@@ -226,6 +226,7 @@ describe("Trace normal execution", () => {
       ...testOptions("v2"),
       runId,
       logger,
+      extensionId,
     });
 
     const meta: TraceRecordMeta = {

--- a/src/runtime/runtimeTypes.ts
+++ b/src/runtime/runtimeTypes.ts
@@ -16,7 +16,7 @@
  */
 
 import { BlockConfig } from "@/blocks/types";
-import { BlockArg, IBlock, OutputKey, RegistryId } from "@/core";
+import { BlockArg, IBlock, OutputKey, RegistryId, UUID } from "@/core";
 
 export type BlockType = "reader" | "effect" | "transform" | "renderer";
 /**
@@ -38,6 +38,15 @@ export type RendererPayload = {
    * The registry id of the renderer block, e.g., @pixiebrix/table
    */
   blockId: RegistryId;
+  /**
+   * The extension run that produced the payload
+   * @since 1.7.0
+   */
+  runId: UUID;
+  /**
+   * The extension the produced the payload.
+   */
+  extensionId: UUID;
   /**
    * A unique id for the content, used control re-rendering (similar to `key` in React)
    */

--- a/src/sidebar/FormBody.tsx
+++ b/src/sidebar/FormBody.tsx
@@ -27,7 +27,7 @@ type FormBodyProps = {
 };
 
 /**
- * JSON Schema form for embedding in an sidebar tab
+ * JSON Schema form for embedding in a sidebar tab
  * @param form the form definition and extension metadata
  * @constructor
  */

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -18,7 +18,6 @@
 import React, { useReducer } from "react";
 import Loader from "@/components/Loader";
 import blockRegistry from "@/blocks/registry";
-import ConsoleLogger from "@/utils/ConsoleLogger";
 import ReactShadowRoot from "react-shadow-root";
 import { getErrorMessage, selectSpecificError } from "@/errors/errorHelpers";
 import { BlockArg, MessageContext, RegistryId, RendererOutput } from "@/core";
@@ -31,6 +30,7 @@ import GridLoader from "react-spinners/GridLoader";
 import styles from "./PanelBody.module.scss";
 import RootCancelledPanel from "@/sidebar/components/RootCancelledPanel";
 import RootErrorPanel from "@/sidebar/components/RootErrorPanel";
+import BackgroundLogger from "@/telemetry/BackgroundLogger";
 
 type BodyProps = {
   blockId: RegistryId;
@@ -131,17 +131,17 @@ const PanelBody: React.FunctionComponent<{
       // In most cases reactivate would have already been called for the payload == null branch. But confirm it here
       dispatch(slice.actions.reactivate());
 
-      const { blockId, ctxt, args } = payload;
+      const { blockId, ctxt, args, runId, extensionId } = payload;
 
       console.debug("Running panel body for panel payload", payload);
 
       const block = await blockRegistry.lookup(blockId);
+      // In the future, the renderer brick should run in the contentScript, not the panel frame
       // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/1939
       const body = await block.run(args as BlockArg, {
         ctxt,
         root: null,
-        // TODO: use the correct logger here so the errors show up in the logs
-        logger: new ConsoleLogger({
+        logger: new BackgroundLogger({
           ...context,
           blockId,
         }),
@@ -152,12 +152,18 @@ const PanelBody: React.FunctionComponent<{
         },
       });
 
+      if (!runId || !extensionId) {
+        console.warn("PanelBody requires runId in RendererPayload", {
+          payload,
+        });
+      }
+
       dispatch(
         slice.actions.success({
           data: {
             blockId,
             body: body as RendererOutput,
-            meta: { runId: payload.runId, extensionId: payload.extensionId },
+            meta: { runId, extensionId },
           },
         })
       );

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -22,7 +22,7 @@ import ConsoleLogger from "@/utils/ConsoleLogger";
 import ReactShadowRoot from "react-shadow-root";
 import { getErrorMessage, selectSpecificError } from "@/errors/errorHelpers";
 import { BlockArg, MessageContext, RegistryId, RendererOutput } from "@/core";
-import { PanelPayload } from "@/sidebar/types";
+import { PanelPayload, PanelRunMeta } from "@/sidebar/types";
 import RendererComponent from "@/sidebar/RendererComponent";
 import { BusinessError, CancelError } from "@/errors/businessErrors";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
@@ -35,12 +35,14 @@ import RootErrorPanel from "@/sidebar/components/RootErrorPanel";
 type BodyProps = {
   blockId: RegistryId;
   body: RendererOutput;
+  meta: PanelRunMeta;
 };
 
 const BodyContainer: React.FC<BodyProps & { isFetching: boolean }> = ({
   blockId,
   body,
   isFetching,
+  meta,
 }) => (
   <>
     {isFetching && (
@@ -51,7 +53,7 @@ const BodyContainer: React.FC<BodyProps & { isFetching: boolean }> = ({
 
     <div className="full-height" data-block-id={blockId}>
       <ReactShadowRoot>
-        <RendererComponent body={body} />
+        <RendererComponent body={body} meta={meta} />
       </ReactShadowRoot>
     </div>
   </>
@@ -152,7 +154,11 @@ const PanelBody: React.FunctionComponent<{
 
       dispatch(
         slice.actions.success({
-          data: { blockId, body: body as RendererOutput },
+          data: {
+            blockId,
+            body: body as RendererOutput,
+            meta: { runId: payload.runId, extensionId: payload.extensionId },
+          },
         })
       );
     } catch (error) {

--- a/src/sidebar/RendererComponent.tsx
+++ b/src/sidebar/RendererComponent.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo } from "react";
 import { RendererOutput } from "@/core";
+import { UnknownObject } from "@/types";
+import { PanelRunMeta } from "@/sidebar/types";
 
 /**
  * React component to display the output of a renderer brick
@@ -7,7 +9,8 @@ import { RendererOutput } from "@/core";
  */
 const RendererComponent: React.FunctionComponent<{
   body: RendererOutput;
-}> = ({ body }) =>
+  meta: PanelRunMeta;
+}> = ({ body, meta }) =>
   useMemo(() => {
     if (typeof body === "string") {
       // This is safe because if body is a string it's a SafeHTML value
@@ -20,7 +23,9 @@ const RendererComponent: React.FunctionComponent<{
     }
 
     const { Component, props } = body;
-    return <Component {...props} />;
-  }, [body]);
+    // Enrich with metadata about the run
+    const enrichedProps: UnknownObject = { ...props, meta };
+    return <Component {...enrichedProps} />;
+  }, [body, meta]);
 
 export default RendererComponent;

--- a/src/sidebar/types.ts
+++ b/src/sidebar/types.ts
@@ -29,6 +29,11 @@ export type RendererError = {
    */
   // TypeScript was having problems handling the type SerializedError here
   error: unknown;
+  /**
+   * The extension run id.
+   * @since 1.7.0
+   */
+  runId: UUID;
 };
 
 /**
@@ -120,7 +125,7 @@ export type ActivatePanelOptions = {
   /**
    * Refresh the panel content (default=true).
    *
-   * Has not effect if the sidebar is not already showing
+   * Has no effect if the sidebar is not already showing
    *
    * @since 1.7.0
    */
@@ -145,4 +150,13 @@ export type ActivatePanelOptions = {
    * @since 1.6.5
    */
   panelHeading?: string;
+};
+
+/**
+ * Metadata about the extension that produced the panel content
+ * @since 1.7.0
+ */
+export type PanelRunMeta = {
+  runId: UUID;
+  extensionId: UUID;
 };

--- a/src/sidebar/types.ts
+++ b/src/sidebar/types.ts
@@ -34,6 +34,11 @@ export type RendererError = {
    * @since 1.7.0
    */
   runId: UUID;
+  /**
+   * The extension id that produced the error
+   * @since 1.7.0
+   */
+  extensionId: UUID;
 };
 
 /**

--- a/src/telemetry/traceHelpers.test.ts
+++ b/src/telemetry/traceHelpers.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { traceRecordFactory } from "@/testUtils/factories";
+import { getLatestCall, hasBranchPrefix } from "@/telemetry/traceHelpers";
+
+describe("getLatestCall", () => {
+  it("sorts by single branch", () => {
+    const latest = traceRecordFactory({
+      branches: [{ key: "foo", counter: 2 }],
+    });
+
+    const traces = [
+      traceRecordFactory({ branches: [{ key: "foo", counter: 0 }] }),
+      latest,
+      traceRecordFactory({ branches: [{ key: "foo", counter: 1 }] }),
+    ];
+
+    expect(getLatestCall(traces)).toStrictEqual(latest);
+  });
+
+  it("sorts by second branch", () => {
+    const latest = traceRecordFactory({
+      branches: [
+        { key: "foo", counter: 0 },
+        { key: "bar", counter: 2 },
+      ],
+    });
+
+    const traces = [
+      traceRecordFactory({
+        branches: [
+          { key: "foo", counter: 0 },
+          { key: "bar", counter: 0 },
+        ],
+      }),
+      latest,
+      traceRecordFactory({
+        branches: [
+          { key: "foo", counter: 0 },
+          { key: "bar", counter: 1 },
+        ],
+      }),
+    ];
+
+    expect(getLatestCall(traces)).toStrictEqual(latest);
+  });
+
+  it("sorts by first branch", () => {
+    const latest = traceRecordFactory({
+      branches: [
+        { key: "foo", counter: 1 },
+        { key: "bar", counter: 0 },
+      ],
+    });
+
+    const traces = [
+      traceRecordFactory({
+        branches: [
+          { key: "foo", counter: 0 },
+          { key: "bar", counter: 1 },
+        ],
+      }),
+      latest,
+      traceRecordFactory({
+        branches: [
+          { key: "foo", counter: 0 },
+          { key: "bar", counter: 2 },
+        ],
+      }),
+    ];
+
+    expect(getLatestCall(traces)).toStrictEqual(latest);
+  });
+});
+
+describe("hasBranchPrefix", () => {
+  it("empty prefix", () => {
+    const record = traceRecordFactory({
+      branches: [{ key: "foo", counter: 0 }],
+    });
+    expect(hasBranchPrefix([], record)).toBeTrue();
+  });
+
+  it("matches", () => {
+    const prefix = { key: "foo", counter: 0 };
+    const record = traceRecordFactory({
+      branches: [prefix, { key: "bar", counter: 0 }],
+    });
+    expect(hasBranchPrefix([prefix], record)).toBeTrue();
+  });
+
+  it("rejects", () => {
+    const prefix = { key: "foo", counter: 0 };
+    const record = traceRecordFactory({
+      branches: [{ ...prefix, counter: 1 }],
+    });
+    expect(hasBranchPrefix([prefix], record)).toBeFalse();
+  });
+});

--- a/src/telemetry/traceHelpers.ts
+++ b/src/telemetry/traceHelpers.ts
@@ -15,21 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DynamicPath } from "@/components/documentBuilder/documentBuilderTypes";
-import { Branch } from "@/blocks/types";
+import { TraceRecord } from "@/telemetry/trace";
+import { reverse, sortBy } from "lodash";
 
 /**
- * Join parts of a document builder element name, ignoring null/blank parts.
- * @param nameParts the parts of the name
+ * Given records for a single runId and blockInstanceId, return the latest call to a given blockInstanceId.
+ * @param records the trace records
  */
-export function joinElementName(...nameParts: Array<string | number>): string {
-  // Don't use lodash.compact and lodash.isEmpty since they treat 0 as falsy
-  return nameParts.filter((x) => x != null && x !== "").join(".");
-}
-
-export function mapPathToTraceBranches(tracePath: DynamicPath): Branch[] {
-  return tracePath.branches.map(({ staticId, index }) => ({
-    key: staticId,
-    counter: index,
-  }));
+export function getLatestCall(records: TraceRecord[]): TraceRecord | null {
+  return reverse(sortBy(records, (x) => x.branches))[0];
 }

--- a/src/telemetry/traceHelpers.ts
+++ b/src/telemetry/traceHelpers.ts
@@ -34,16 +34,20 @@ export function hasBranchPrefix(
   prefix: Branch[],
   record: TraceRecord
 ): boolean {
-  // eslint-disable-next-line security/detect-object-injection -- index is a number
   return prefix.every(
     (branch, index) =>
+      // eslint-disable-next-line security/detect-object-injection -- index is a number
       index < record.branches.length && isEqual(branch, record.branches[index])
   );
 }
 
 export function filterTracesByCall(
   records: TraceRecord[],
-  callBranches: Branch[]
+  callBranches: Branch[] | null
 ): TraceRecord[] {
+  if (callBranches == null) {
+    return [];
+  }
+
   return records.filter((record) => hasBranchPrefix(callBranches, record));
 }

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -79,6 +79,7 @@ import {
   OrganizationAuthState,
 } from "@/auth/authTypes";
 import { JsonObject } from "type-fest";
+import objectHash from "object-hash";
 
 // UUID sequence generator that's predictable across runs. A couple characters can't be 0
 // https://stackoverflow.com/a/19989922/402560
@@ -246,9 +247,14 @@ export const traceRecordFactory = define<TraceRecord>({
   timestamp: timestampFactory,
   extensionId: uuidSequence,
   runId: uuidSequence,
+  branches(): TraceRecord["branches"] {
+    return [];
+  },
+  // XXX: callId should be derived from branches
+  callId: objectHash([]),
   blockInstanceId: uuidSequence,
   blockId: TEST_BLOCK_ID,
-  templateContext(): JsonObject {
+  templateContext(): TraceRecord["templateContext"] {
     return {};
   },
   renderedArgs(): RenderedArgs {
@@ -263,11 +269,14 @@ export const traceRecordFactory = define<TraceRecord>({
   },
 });
 
-export const traceErrorFactory = (config?: FactoryConfig<TraceError>) =>
+export const traceErrorFactory = (config?: FactoryConfig<TraceRecord>) =>
   traceRecordFactory({
     error: {
       message: "Trace error for tests",
     },
+    skippedRun: false,
+    isFinal: true,
+    isRenderer: false,
     ...config,
   }) as TraceError;
 

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -31,6 +31,9 @@ export function isUUID(uuid: string): uuid is UUID {
   return validate(uuid);
 }
 
+// Sentinel UUID
+export const UNSET_UUID = validateUUID("00000000-0000-4000-A000-000000000000");
+
 export function validateUUID(uuid: string): UUID {
   if (uuid == null) {
     // We don't have strictNullChecks on, so null values will find there way here. We should pass them along. Eventually


### PR DESCRIPTION
## What does this PR do?

- Closes #3492
- Introduces a `callId` into the trace database to deterministically sort calls to the same blockInstanceId
- Those are tracked in pipelines through keeping track of branches (where the same brick can result in multiple runs of the same blockInstanceId)
- Support more than 1 error at a time in the Page Editor
- Create a trace exit record for renderers once the the values that are passed to the renderer are computed (this isn't ideal, as the renderer could still error. But that would at least be not confusing)

## Demo

![image](https://user-images.githubusercontent.com/1879821/173487876-39d8d3cc-85a9-4f65-9e98-b42136e6efe0.png)

## Discussion

- The Page Editor will show the latest run/iteration of the pipeline
- The work with respect to callId is forward looking on giving some ability to inspect particular iterations of the pipeline instead of just the last one

## Work remaining

- [x] extensionId is not flowing through with button click traces currently
- [x] Show loops correctly in page editor. (E.g., if there's an error on the 2nd iteration, don't show any badged from the first iteration)
- [x] Test on the control flow bricks
- [x] Update tests

## Known Issues

- Sometimes the trace data is stale for multiple runs successive runs of pipeline (e.g., rapid button clicks in a document). I think that's an issue with our useTraces hook

## Future Work

- Improve the error status for renderer bricks that error during rendering. Might be able to use the render error prop here
- Improve branch key names from the document builder (current names are fine, because they just need to be unique within branch names for a given blockInstanceId)

## Checklist

- [ ] Add tests
- [X] Designate a primary reviewer: @BALEHOK 
