### PR TITLE
Speed up tag grouping in brick modal

### DIFF
--- a/src/components/brickModal/BrickModal.test.ts
+++ b/src/components/brickModal/BrickModal.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  groupListingsByTag,
+  POPULAR_BRICK_TAG_ID,
+} from "@/components/brickModal/BrickModal";
+import {
+  marketplaceListingFactory,
+  marketplaceTagFactory,
+} from "@/testUtils/factories";
+
+describe("groupListingsByTag", () => {
+  it("groups tags", () => {
+    const popular = marketplaceTagFactory({
+      subtype: "generic",
+      id: POPULAR_BRICK_TAG_ID,
+      name: "Popular",
+    });
+    const category = marketplaceTagFactory({ subtype: "role", name: "Other" });
+    const other = marketplaceTagFactory({
+      subtype: "service",
+      name: "Cat Facts",
+    });
+
+    const popularListing = marketplaceListingFactory({
+      tags: [popular, category, other],
+    });
+
+    const { taggedBrickIds, popularBrickIds } = groupListingsByTag(
+      [popular, other, category],
+      { [popularListing.package.name]: popularListing }
+    );
+
+    expect(taggedBrickIds).toStrictEqual({
+      [category.name]: new Set([popularListing.package.name]),
+    });
+
+    expect(popularBrickIds).toStrictEqual(
+      new Set([popularListing.package.name])
+    );
+  });
+});

--- a/src/components/brickModal/BrickModal.tsx
+++ b/src/components/brickModal/BrickModal.tsx
@@ -55,7 +55,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 const TAG_ALL = "All Categories";
 
-const POPULAR_BRICK_TAG_ID = "35367896-b38f-447e-9444-ecfecb258468";
+export const POPULAR_BRICK_TAG_ID = "35367896-b38f-447e-9444-ecfecb258468";
 
 type BrickOption<T extends IBrick = IBlock> = {
   data: T;
@@ -212,7 +212,7 @@ const defaultAddCaption = (
   </span>
 );
 
-function groupListingsByTag(
+export function groupListingsByTag(
   marketplaceTags: MarketplaceTag[],
   listings: Record<RegistryId, MarketplaceListing>
 ): {

--- a/src/components/brickModal/BrickModal.tsx
+++ b/src/components/brickModal/BrickModal.tsx
@@ -48,7 +48,7 @@ import {
   useGetMarketplaceListingsQuery,
   useGetMarketplaceTagsQuery,
 } from "@/services/api";
-import { MarketplaceListing } from "@/types/contract";
+import { MarketplaceListing, MarketplaceTag } from "@/types/contract";
 import BrickDetail from "@/components/brickModal/BrickDetail";
 import Loader from "@/components/Loader";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
@@ -212,17 +212,48 @@ const defaultAddCaption = (
   </span>
 );
 
-type BrickIdMemoResult = {
+function groupListingsByTag(
+  marketplaceTags: MarketplaceTag[],
+  listings: Record<RegistryId, MarketplaceListing>
+): {
   /**
-   * A record with tag names as the keys, and a set of applicable brick ids as the values
+   * A record with tag names as the keys, and a set of applicable brick registry ids as the values
    */
-  taggedBrickIds: Record<string, Set<string>>;
+  taggedBrickIds: Record<string, Set<RegistryId>>;
 
   /**
    * A set of brick ids that have been tagged as "popular"
    */
-  popularBrickIds: Set<string>;
-};
+  popularBrickIds: Set<RegistryId>;
+} {
+  if (isEmpty(marketplaceTags) || isEmpty(listings)) {
+    return {
+      taggedBrickIds: {},
+      popularBrickIds: new Set<RegistryId>(),
+    };
+  }
+
+  const categoryTags = marketplaceTags.filter((tag) => tag.subtype === "role");
+
+  const taggedBrickIds = Object.fromEntries(
+    categoryTags.map((tag) => [tag.name, new Set<RegistryId>()])
+  );
+  const popularBrickIds = new Set<RegistryId>();
+
+  for (const [id, listing] of Object.entries(listings)) {
+    const registryId = id as RegistryId;
+
+    for (const listingTag of listing.tags) {
+      if (listingTag.id === POPULAR_BRICK_TAG_ID) {
+        popularBrickIds.add(registryId);
+      }
+
+      taggedBrickIds[listingTag.name]?.add(registryId);
+    }
+  }
+
+  return { taggedBrickIds, popularBrickIds };
+}
 
 type State = {
   query: string;
@@ -306,35 +337,10 @@ function ActualModal<T extends IBrick>({
     isLoading: isLoadingListings,
   } = useGetMarketplaceListingsQuery();
 
-  const { taggedBrickIds, popularBrickIds } = useMemo<BrickIdMemoResult>(() => {
-    if (isEmpty(marketplaceTags) || isEmpty(listings)) {
-      return {
-        taggedBrickIds: {},
-        popularBrickIds: new Set<string>(),
-      };
-    }
-
-    const tags = marketplaceTags.filter((tag) => tag.subtype === "role");
-
-    const taggedBrickIds: BrickIdMemoResult["taggedBrickIds"] =
-      Object.fromEntries(tags.map((tag) => [tag.name, new Set<string>()]));
-    const popularBrickIds: BrickIdMemoResult["popularBrickIds"] =
-      new Set<string>();
-
-    for (const [id, listing] of Object.entries(listings)) {
-      for (const tag of tags) {
-        if (listing.tags.some((lTag) => lTag.id === tag.id)) {
-          taggedBrickIds[tag.name]?.add(id);
-        }
-      }
-
-      if (listing.tags.some((tag) => tag.id === POPULAR_BRICK_TAG_ID)) {
-        popularBrickIds.add(id);
-      }
-    }
-
-    return { taggedBrickIds, popularBrickIds };
-  }, [marketplaceTags, listings]);
+  const { taggedBrickIds, popularBrickIds } = useMemo(
+    () => groupListingsByTag(marketplaceTags, listings),
+    [marketplaceTags, listings]
+  );
 
   const tagItems: TagItem[] = [
     { tag: TAG_ALL },

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -66,7 +66,13 @@ import {
   FrameConnectionState,
 } from "@/pageEditor/context";
 import { TypedBlock, TypedBlockMap } from "@/blocks/registry";
-import { CloudExtension, Deployment, UserRole } from "@/types/contract";
+import {
+  CloudExtension,
+  Deployment,
+  MarketplaceListing,
+  MarketplaceTag,
+  UserRole,
+} from "@/types/contract";
 import { ButtonSelectionResult } from "@/contentScript/nativeEditor/types";
 import getType from "@/runtime/getType";
 import { FormState } from "@/pageEditor/pageEditorTypes";
@@ -670,4 +676,27 @@ export const formStateWithTraceDataFactory = define<{
       });
     });
   }, "formState"),
+});
+
+export const marketplaceTagFactory = define<MarketplaceTag>({
+  id: uuidSequence,
+  name: (n: number) => `Tag ${n}`,
+  slug: (n: number) => `tag-${n}`,
+  subtype: "generic",
+  fa_icon: "fab abacus",
+});
+
+export const marketplaceListingFactory = define<MarketplaceListing>({
+  id: uuidSequence,
+  fa_icon: "fab abacus",
+  image: (n: number) => ({
+    url: `https://marketplace.dev/${n}`,
+  }),
+  assets: () => [] as MarketplaceListing["assets"],
+  tags: () => [] as MarketplaceListing["tags"],
+  package: (n: number) =>
+    ({
+      id: uuidSequence,
+      name: `@test/test-${n}`,
+    } as unknown as MarketplaceListing["package"]),
 });


### PR DESCRIPTION
## What does this PR do?

- Makes types more specific on tag grouping
- Eliminated unnecessary iteration in tag grouping
- Extracts grouping method outside of component

## Checklist

- [x] Add tests
- [X] Designate a primary reviewer: @BLoe 
