### PR TITLE
#3715: fix default output key for added bricks

### DIFF
--- a/src/components/brickModal/BrickModal.tsx
+++ b/src/components/brickModal/BrickModal.tsx
@@ -371,6 +371,8 @@ function ActualModal<T extends IBrick>({
     for (const result of searchResults) {
       if (popularBrickIds.has(result.data.id)) {
         popular.push(
+          // Use immer to keep the class prototype and it's methods. There are downstream calls to runtime/getType which
+          // depend on certain methods (e.g., transform, etc.) being present on the brick
           produce(result, (draft) => {
             const brickResult = draft.data as BrickResult<T>;
             brickResult.isPopular = true;

--- a/src/components/brickModal/BrickModal.tsx
+++ b/src/components/brickModal/BrickModal.tsx
@@ -52,6 +52,7 @@ import { MarketplaceListing, MarketplaceTag } from "@/types/contract";
 import BrickDetail from "@/components/brickModal/BrickDetail";
 import Loader from "@/components/Loader";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { castDraft, produce } from "immer";
 
 const TAG_ALL = "All Categories";
 
@@ -369,15 +370,15 @@ function ActualModal<T extends IBrick>({
 
     for (const result of searchResults) {
       if (popularBrickIds.has(result.data.id)) {
-        popular.push({
-          ...result,
-          data: {
-            ...result.data,
-            isPopular: true,
-          },
-        });
+        popular.push(
+          produce(result, (draft) => {
+            const brickResult = draft.data as BrickResult<T>;
+            brickResult.isPopular = true;
+            draft.data = castDraft(brickResult);
+          })
+        );
       } else {
-        regular.push(result);
+        regular.push(result as BrickOption<BrickResult<T>>);
       }
     }
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #3715 
- This popular brick code was removing the prototype on the `IBrick` items, and this change uses `immer` instead to avoid that.

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
