### PR TITLE
fix useTheme inferredTheme logo logic

### DIFF
--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -85,8 +85,8 @@ export const useGetTheme = (): Theme => {
 };
 
 const useTheme = (theme?: Theme): { logo: ThemeLogo } => {
-  const themeLogo = getThemeLogo(theme);
   const inferredTheme = useGetTheme();
+  const themeLogo = getThemeLogo(theme ?? inferredTheme);
 
   useEffect(() => {
     void activateBackgroundTheme();

--- a/src/options/Navbar.tsx
+++ b/src/options/Navbar.tsx
@@ -36,7 +36,7 @@ import { toggleSidebar } from "./toggleSidebar";
 import { SettingsState } from "@/store/settingsTypes";
 import cx from "classnames";
 import { selectAuth } from "@/auth/authSelectors";
-import useTheme, { useGetTheme } from "@/hooks/useTheme";
+import useTheme from "@/hooks/useTheme";
 
 const Navbar: React.FunctionComponent = () => {
   const { email, extension } = useSelector(selectAuth);
@@ -45,8 +45,7 @@ const Navbar: React.FunctionComponent = () => {
   const mode = useSelector<{ settings: SettingsState }, string>(
     ({ settings }) => settings.mode
   );
-  const theme = useGetTheme();
-  const { logo } = useTheme(theme);
+  const { logo } = useTheme();
 
   // Use `connectedPending` to optimistically show the toggle
   const showNavbarToggle = mode === "local" || connected || connectedPending;


### PR DESCRIPTION
## What does this PR do?

- Fixes 3710
- This fixes the theme logo from not showing up in the sidebar app. It was a mistake with the logo logic in `useTheme` and some code that was left un-refactored after a `useTheme` refactoring change.

## Demo

<img width="399" alt="Screen Shot 2022-06-15 at 11 18 22 AM" src="https://user-images.githubusercontent.com/36575242/173897262-639d6217-1b0e-4b65-93aa-1f45a7dc83d5.png">

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
