### PR TITLE
#3725 Fix nested header colors in node layout

### DIFF
--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -52,7 +52,6 @@ import useReportTraceError from "./useReportTraceError";
 import devtoolFieldOverrides from "@/pageEditor/fields/devtoolFieldOverrides";
 import SchemaFieldContext from "@/components/fields/schemaFields/SchemaFieldContext";
 import { get } from "lodash";
-import Loader from "@/components/Loader";
 import { UnconfiguredQuickBarAlert } from "@/pageEditor/extensionPoints/quickBar";
 import { BlockType } from "@/runtime/runtimeTypes";
 import { validateRegistryId } from "@/types/helpers";
@@ -104,19 +103,17 @@ const EditTab: React.FC<{
     EditorNode,
   } = useMemo(() => ADAPTERS.get(extensionPointType), [extensionPointType]);
 
-  const [allBlocks, isLoadingAllBlocks] = useAsyncState<TypedBlockMap>(
+  const [allBlocks] = useAsyncState<TypedBlockMap>(
     async () => blockRegistry.allTyped(),
     [],
     new Map()
   );
 
-  const [relevantBlocksForRootPipeline, isLoadingRelevantBlocks] =
-    useAsyncState(
-      async () =>
-        getRelevantBlocksForRootPipeline(allBlocks, extensionPointType),
-      [allBlocks, extensionPointType],
-      []
-    );
+  const [relevantBlocksForRootPipeline] = useAsyncState(
+    async () => getRelevantBlocksForRootPipeline(allBlocks, extensionPointType),
+    [allBlocks, extensionPointType],
+    []
+  );
 
   const { blockPipeline, blockPipelineErrors, traceErrors } = usePipelineField(
     allBlocks,
@@ -179,23 +176,19 @@ const EditTab: React.FC<{
             />
           </div>
           <div className={styles.nodeLayout}>
-            {isLoadingAllBlocks || isLoadingRelevantBlocks ? (
-              <Loader />
-            ) : (
-              <EditorNodeLayout
-                allBlocks={allBlocks}
-                relevantBlocksForRootPipeline={relevantBlocksForRootPipeline}
-                pipeline={blockPipeline}
-                pipelineErrors={blockPipelineErrors}
-                traceErrors={traceErrors}
-                extensionPointLabel={extensionPointLabel}
-                extensionPointIcon={extensionPointIcon}
-                addBlock={addBlock}
-                moveBlockUp={moveBlockUp}
-                moveBlockDown={moveBlockDown}
-                pasteBlock={pasteBlock}
-              />
-            )}
+            <EditorNodeLayout
+              allBlocks={allBlocks}
+              relevantBlocksForRootPipeline={relevantBlocksForRootPipeline}
+              pipeline={blockPipeline}
+              pipelineErrors={blockPipelineErrors}
+              traceErrors={traceErrors}
+              extensionPointLabel={extensionPointLabel}
+              extensionPointIcon={extensionPointIcon}
+              addBlock={addBlock}
+              moveBlockUp={moveBlockUp}
+              moveBlockDown={moveBlockDown}
+              pasteBlock={pasteBlock}
+            />
           </div>
         </div>
         <div className={styles.configPanel}>

--- a/src/pageEditor/tabs/editTab/editTabVariables.scss
+++ b/src/pageEditor/tabs/editTab/editTabVariables.scss
@@ -24,7 +24,7 @@ $contentOffset: calc(
 );
 
 // Colors
-$selectedListItemBackgroundColor: #007bff;
-$headerBackgroundColor: #ebebf1;
-$activeHeaderBackgroundColor: #b8dbf6;
-$parentActiveBackgroundColor: #e8f3fc;
+$activeListItemColor: #007bff;
+$defaultHeaderColor: #ebebf1;
+$activeHeaderColor: #b8dbf6;
+$nestedActiveColor: #e8f3fc;

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
@@ -425,7 +425,8 @@ const EditorNodeLayout: React.FC<EditorNodeLayoutProps> = ({
             headerLabel,
             nestingLevel,
             nodeActions: headerActions,
-            active: nodeIsActive || parentIsActive,
+            active: nodeIsActive,
+            nestedActive: parentIsActive,
           };
 
           nodes.push(
@@ -450,7 +451,7 @@ const EditorNodeLayout: React.FC<EditorNodeLayoutProps> = ({
           trailingMessage,
           nestingLevel,
           active: nodeIsActive,
-          parentIsActive,
+          nestedActive: parentIsActive,
           hovered,
           onHoverChange,
           onClick,

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineFooterNode.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineFooterNode.module.scss
@@ -26,11 +26,11 @@ $pipeLineFooterWidth: 17px;
   cursor: pointer;
 
   &.active {
-    background-color: $selectedListItemBackgroundColor;
+    background-color: $activeListItemColor;
   }
 
-  &.parentIsActive {
-    background-color: $parentActiveBackgroundColor;
+  &.nestedActive {
+    background-color: $nestedActiveColor;
   }
 
   &.hovered {

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineFooterNode.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineFooterNode.tsx
@@ -33,7 +33,7 @@ export type PipelineFooterNodeProps = {
   trailingMessage?: string;
   nestingLevel: number;
   active?: boolean;
-  parentIsActive?: boolean;
+  nestedActive?: boolean;
   hovered?: boolean;
   onHoverChange: (hovered: boolean) => void;
   onClick: () => void;
@@ -46,7 +46,7 @@ const PipelineFooterNode: React.VFC<PipelineFooterNodeProps> = ({
   trailingMessage,
   nestingLevel,
   active,
-  parentIsActive,
+  nestedActive,
   hovered,
   onHoverChange,
   onClick,
@@ -62,7 +62,7 @@ const PipelineFooterNode: React.VFC<PipelineFooterNodeProps> = ({
       }}
       className={cx(styles.footer, {
         [styles.active]: active,
-        [styles.parentIsActive]: parentIsActive,
+        [styles.nestedActive]: nestedActive,
         [styles.hovered]: hovered,
       })}
       onMouseOver={() => {
@@ -83,14 +83,14 @@ const PipelineFooterNode: React.VFC<PipelineFooterNodeProps> = ({
       <div className={styles.pipelineContainer}>
         <div
           className={cx(styles.pipelineEnd, {
-            [styles.active]: active && !parentIsActive,
+            [styles.active]: active && !nestedActive,
           })}
         />
       </div>
       <OutputKeyView
         outputKey={outputKey}
         className={cx(styles.outputKey, {
-          [styles.active]: active && !parentIsActive,
+          [styles.active]: active && !nestedActive,
         })}
       />
     </div>

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
@@ -29,11 +29,15 @@ $headerPipeLineHeight: 4px;
 .header {
   flex-grow: 1;
   position: relative; // Allow children to position relative to this element
-  background: $headerBackgroundColor;
+  background: $defaultHeaderColor;
   padding: $headerOffsetY 0 0 $headerOffsetX;
 
   &.active {
-    background-color: $activeHeaderBackgroundColor;
+    background-color: $activeHeaderColor;
+  }
+
+  &.nestedActive {
+    background-color: $nestedActiveColor;
   }
 }
 

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
@@ -28,6 +28,7 @@ export type PipelineHeaderNodeProps = {
   nestingLevel: number;
   nodeActions: NodeAction[];
   active?: boolean;
+  nestedActive?: boolean;
 };
 
 const PipelineHeaderNode: React.VFC<PipelineHeaderNodeProps> = ({
@@ -35,15 +36,21 @@ const PipelineHeaderNode: React.VFC<PipelineHeaderNodeProps> = ({
   nestingLevel,
   nodeActions,
   active,
+  nestedActive,
 }) => (
   <>
     <div className={styles.root}>
       <PipelineOffsetView
         nestingLevel={nestingLevel}
-        parentIsActive={active}
-        isHeader
+        nestedActive={active || nestedActive} // Color for this offset-view is chosen using the header flag
+        isHeader={!nestedActive} // Don't color deeply-nested pipeline headers as active headers
       />
-      <div className={cx(styles.header, { [styles.active]: active })}>
+      <div
+        className={cx(styles.header, {
+          [styles.active]: active,
+          [styles.nestedActive]: nestedActive,
+        })}
+      >
         <div className={styles.headerPipeLineTop} />
         <div className={styles.subPipelineLabel}>{headerLabel}</div>
         <div className={styles.headerPipeLineBottom} />

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.module.scss
@@ -27,11 +27,15 @@
     border-color: white;
   }
 
-  &.parentIsActive {
-    background-color: $activeHeaderBackgroundColor;
+  &.nestedActive {
+    background-color: $nestedActiveColor;
   }
 
-  &.isHeader:not(.parentIsActive) {
-    background-color: $headerBackgroundColor;
+  &.isHeader {
+    background-color: $defaultHeaderColor;
+
+    &.nestedActive {
+      background-color: $activeHeaderColor;
+    }
   }
 }

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.tsx
@@ -23,14 +23,14 @@ import styles from "./PipelineOffsetView.module.scss";
 type PipelineOffsetViewProps = {
   nestingLevel: number;
   active?: boolean;
-  parentIsActive?: boolean;
+  nestedActive?: boolean;
   isHeader?: boolean;
 };
 
 const PipelineOffsetView: React.VFC<PipelineOffsetViewProps> = ({
   nestingLevel,
   active,
-  parentIsActive,
+  nestedActive,
   isHeader,
 }) => (
   <>
@@ -40,7 +40,7 @@ const PipelineOffsetView: React.VFC<PipelineOffsetViewProps> = ({
           key={n}
           className={cx(styles.pipeLine, {
             [styles.active]: active,
-            [styles.parentIsActive]: parentIsActive,
+            [styles.nestedActive]: nestedActive,
             [styles.isHeader]: isHeader,
           })}
         />

--- a/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.module.scss
@@ -34,7 +34,8 @@ $openHandleHeight: 20px;
   }
 
   &.parentIsActive {
-    background-color: $parentActiveBackgroundColor;
+    background-color: $nestedActiveColor;
+    border-bottom: 1px solid lightgrey !important; // override expanded state for nested nodes
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #3725 
- Removes an unnecessary loading indicator on top of the entire node layout when adding/removing bricks

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer - @BALEHOK 