### PR TITLE
#3722: fix keep_classnames regex

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -282,7 +282,7 @@ module.exports = (env, options) =>
           terserOptions: {
             // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
             // Keep error classnames because we perform name comparison (see selectSpecificError)
-            keep_classnames: ".*Error",
+            keep_classnames: /.*Error/,
           },
         }),
         new CssMinimizerPlugin(),


### PR DESCRIPTION
## What does this PR do?

- #3722 
- Fixes keep_classnames regex for errors during minimization

## Demo

![image](https://user-images.githubusercontent.com/1879821/173968264-f62ffe79-8082-4e33-898e-d6b232fcc7df.png)

## Testing

Can verify count of CancelError in a production build: 
```
sed 's/CancelError/CancelError\n/g' dist/contentScript.js | grep -c "CancelError"
```

## Checklist

- [X] Designate a primary reviewer: @fregante 
