### PR TITLE
#3721 Minor document builder UI fixes

### DIFF
--- a/src/components/documentBuilder/edit/ButtonOptions.tsx
+++ b/src/components/documentBuilder/edit/ButtonOptions.tsx
@@ -19,7 +19,6 @@ import React, { useMemo } from "react";
 import { Col, Row } from "react-bootstrap";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import getElementEditSchemas from "@/components/documentBuilder/edit/getElementEditSchemas";
-import CssClassField from "@/components/fields/schemaFields/CssClassField";
 
 type ButtonOptionsProps = {
   elementName: string;
@@ -28,14 +27,9 @@ type ButtonOptionsProps = {
 const ButtonOptions: React.FC<ButtonOptionsProps> = ({ elementName }) => {
   const schemaFields = useMemo(
     () =>
-      getElementEditSchemas("button", elementName).map((editSchema) => {
-        const Field =
-          editSchema.schema.type === "string" &&
-          editSchema.schema.format === "bootstrap-class"
-            ? CssClassField
-            : SchemaField;
-        return <Field key={editSchema.name} {...editSchema} />;
-      }),
+      getElementEditSchemas("button", elementName).map((schema) => (
+        <SchemaField key={schema.name} {...schema} />
+      )),
     [elementName]
   );
 

--- a/src/components/documentBuilder/edit/ButtonOptions.tsx
+++ b/src/components/documentBuilder/edit/ButtonOptions.tsx
@@ -19,6 +19,7 @@ import React, { useMemo } from "react";
 import { Col, Row } from "react-bootstrap";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import getElementEditSchemas from "@/components/documentBuilder/edit/getElementEditSchemas";
+import CssClassField from "@/components/fields/schemaFields/CssClassField";
 
 type ButtonOptionsProps = {
   elementName: string;
@@ -27,9 +28,14 @@ type ButtonOptionsProps = {
 const ButtonOptions: React.FC<ButtonOptionsProps> = ({ elementName }) => {
   const schemaFields = useMemo(
     () =>
-      getElementEditSchemas("button", elementName).map((schema) => (
-        <SchemaField key={schema.name} {...schema} />
-      )),
+      getElementEditSchemas("button", elementName).map((editSchema) => {
+        const Field =
+          editSchema.schema.type === "string" &&
+          editSchema.schema.format === "bootstrap-class"
+            ? CssClassField
+            : SchemaField;
+        return <Field key={editSchema.name} {...editSchema} />;
+      }),
     [elementName]
   );
 

--- a/src/components/documentBuilder/edit/getElementEditSchemas.ts
+++ b/src/components/documentBuilder/edit/getElementEditSchemas.ts
@@ -19,7 +19,7 @@ import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import { joinName } from "@/utils";
 import { DocumentElementType } from "@/components/documentBuilder/documentBuilderTypes";
 
-export function getClassNameEdit(elementName: string): SchemaFieldProps {
+function getClassNameEdit(elementName: string): SchemaFieldProps {
   return {
     name: joinName(elementName, "config", "className"),
     schema: { type: "string", format: "bootstrap-class" },

--- a/src/components/documentBuilder/edit/useElementOptions.tsx
+++ b/src/components/documentBuilder/edit/useElementOptions.tsx
@@ -60,14 +60,14 @@ const useElementOptions = (
       const editSchemas = getElementEditSchemas(elementType, elementName);
       const OptionsFields: React.FC = () => (
         <>
-          {editSchemas.map((editSchema) =>
-            editSchema.schema.type === "string" &&
-            editSchema.schema.format === "bootstrap-class" ? (
-              <CssClassField key={editSchema.name} {...editSchema} />
-            ) : (
-              <SchemaField key={editSchema.name} {...editSchema} />
-            )
-          )}
+          {editSchemas.map((editSchema) => {
+            const Field =
+              editSchema.schema.type === "string" &&
+              editSchema.schema.format === "bootstrap-class"
+                ? CssClassField
+                : SchemaField;
+            return <Field key={editSchema.name} {...editSchema} />;
+          })}
         </>
       );
 

--- a/src/components/documentBuilder/edit/useElementOptions.tsx
+++ b/src/components/documentBuilder/edit/useElementOptions.tsx
@@ -27,7 +27,6 @@ import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import getElementEditSchemas from "@/components/documentBuilder/edit/getElementEditSchemas";
 import PipelineOptions from "@/components/documentBuilder/edit/PipelineOptions";
 import ButtonOptions from "@/components/documentBuilder/edit/ButtonOptions";
-import CssClassField from "@/components/fields/schemaFields/CssClassField";
 
 const useElementOptions = (
   element: DocumentElement,
@@ -60,14 +59,9 @@ const useElementOptions = (
       const editSchemas = getElementEditSchemas(elementType, elementName);
       const OptionsFields: React.FC = () => (
         <>
-          {editSchemas.map((editSchema) => {
-            const Field =
-              editSchema.schema.type === "string" &&
-              editSchema.schema.format === "bootstrap-class"
-                ? CssClassField
-                : SchemaField;
-            return <Field key={editSchema.name} {...editSchema} />;
-          })}
+          {editSchemas.map((editSchema) => (
+            <SchemaField key={editSchema.name} {...editSchema} />
+          ))}
         </>
       );
 

--- a/src/components/fields/schemaFields/CssClassField.tsx
+++ b/src/components/fields/schemaFields/CssClassField.tsx
@@ -20,8 +20,13 @@ import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFiel
 import CssClassWidget from "@/components/fields/schemaFields/widgets/CssClassWidget";
 import { getToggleOptions } from "@/components/fields/schemaFields/getToggleOptions";
 import { SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
+import { Schema } from "@/core";
 
 const RawCssClassField = defaultFieldFactory(CssClassWidget);
+
+export const isCssClassField = (fieldDefinition: Schema) =>
+  fieldDefinition.type === "string" &&
+  fieldDefinition.format === "bootstrap-class";
 
 // Can't be constant because getToggleOptions needs the widgets registry to be initialized
 export const getCssClassInputFieldOptions = () =>

--- a/src/components/fields/schemaFields/SchemaField.tsx
+++ b/src/components/fields/schemaFields/SchemaField.tsx
@@ -24,6 +24,7 @@ import ServiceField, {
 import AppServiceField, {
   isAppServiceField,
 } from "@/components/fields/schemaFields/AppServiceField";
+import CssClassField, { isCssClassField } from "./CssClassField";
 
 const SchemaField: SchemaFieldComponent = (props) => {
   const { schema } = props;
@@ -34,6 +35,10 @@ const SchemaField: SchemaFieldComponent = (props) => {
 
   if (isServiceField(schema)) {
     return <ServiceField {...props} />;
+  }
+
+  if (isCssClassField(schema)) {
+    return <CssClassField {...props} />;
   }
 
   return <BasicSchemaField {...props} />;

--- a/src/components/fields/schemaFields/widgets/CssClassWidget.module.scss
+++ b/src/components/fields/schemaFields/widgets/CssClassWidget.module.scss
@@ -21,3 +21,7 @@
   justify-content: space-between;
   margin-bottom: 0.25rem;
 }
+
+.flagButton:global(.btn.active):not(:focus) {
+  z-index: unset;
+}

--- a/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
@@ -349,8 +349,9 @@ const SpacingControl: React.VFC<{
   label: string;
   className?: string;
   classes: string[];
+  disabled: boolean;
   onUpdate: (update: Spacing) => void;
-}> = ({ prefix, label, className, classes, onUpdate }) => {
+}> = ({ prefix, label, className, classes, disabled, onUpdate }) => {
   const [expand, setExpand] = useState(false);
 
   const spacing = extractSpacing(prefix, classes);
@@ -377,6 +378,7 @@ const SpacingControl: React.VFC<{
             min="0"
             max="5"
             value={spacing.find((x) => x.side == null)?.size}
+            disabled={disabled}
             onChange={(event) => {
               onUpdate({
                 side: null,
@@ -402,6 +404,7 @@ const SpacingControl: React.VFC<{
                   min="0"
                   max="5"
                   value={spacing.find((x) => x.side === direction.side)?.size}
+                  disabled={disabled}
                   onChange={(event) => {
                     onUpdate({
                       side: direction.side,
@@ -665,6 +668,7 @@ const CssClassWidget: React.VFC<
           label="Margin"
           className="mr-2"
           classes={classes}
+          disabled={disableControls}
           onUpdate={(update) => {
             setValue(calculateNextSpacing(value, "m", update));
           }}
@@ -674,6 +678,7 @@ const CssClassWidget: React.VFC<
           label="Padding"
           className="mx-2"
           classes={classes}
+          disabled={disableControls}
           onUpdate={(update) => {
             setValue(calculateNextSpacing(value, "p", update));
           }}

--- a/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
@@ -218,6 +218,7 @@ const FlagButton: React.VFC<
 
   return (
     <Button
+      className={styles.flagButton}
       disabled={disabled}
       variant="light"
       size="sm"

--- a/src/components/fields/schemaFields/widgets/__snapshots__/ClassClassWidget.test.tsx.snap
+++ b/src/components/fields/schemaFields/widgets/__snapshots__/ClassClassWidget.test.tsx.snap
@@ -14,7 +14,7 @@ Object {
             role="group"
           >
             <button
-              class="btn btn-light btn-sm"
+              class="flagButton btn btn-light btn-sm"
               type="button"
             >
               <svg
@@ -34,7 +34,7 @@ Object {
               </svg>
             </button>
             <button
-              class="btn btn-light btn-sm"
+              class="flagButton btn btn-light btn-sm"
               type="button"
             >
               <svg
@@ -54,7 +54,7 @@ Object {
               </svg>
             </button>
             <button
-              class="btn btn-light btn-sm"
+              class="flagButton btn btn-light btn-sm"
               type="button"
             >
               <svg
@@ -74,7 +74,7 @@ Object {
               </svg>
             </button>
             <button
-              class="btn btn-light btn-sm"
+              class="flagButton btn btn-light btn-sm"
               type="button"
             >
               <svg
@@ -99,7 +99,7 @@ Object {
             role="group"
           >
             <button
-              class="btn btn-light btn-sm"
+              class="flagButton btn btn-light btn-sm"
               type="button"
             >
               <svg
@@ -119,7 +119,7 @@ Object {
               </svg>
             </button>
             <button
-              class="btn btn-light btn-sm"
+              class="flagButton btn btn-light btn-sm"
               type="button"
             >
               <svg
@@ -241,7 +241,7 @@ Object {
             role="group"
           >
             <button
-              class="btn btn-light btn-sm"
+              class="flagButton btn btn-light btn-sm"
               type="button"
             >
               <svg
@@ -409,7 +409,7 @@ Object {
           role="group"
         >
           <button
-            class="btn btn-light btn-sm"
+            class="flagButton btn btn-light btn-sm"
             type="button"
           >
             <svg
@@ -429,7 +429,7 @@ Object {
             </svg>
           </button>
           <button
-            class="btn btn-light btn-sm"
+            class="flagButton btn btn-light btn-sm"
             type="button"
           >
             <svg
@@ -449,7 +449,7 @@ Object {
             </svg>
           </button>
           <button
-            class="btn btn-light btn-sm"
+            class="flagButton btn btn-light btn-sm"
             type="button"
           >
             <svg
@@ -469,7 +469,7 @@ Object {
             </svg>
           </button>
           <button
-            class="btn btn-light btn-sm"
+            class="flagButton btn btn-light btn-sm"
             type="button"
           >
             <svg
@@ -494,7 +494,7 @@ Object {
           role="group"
         >
           <button
-            class="btn btn-light btn-sm"
+            class="flagButton btn btn-light btn-sm"
             type="button"
           >
             <svg
@@ -514,7 +514,7 @@ Object {
             </svg>
           </button>
           <button
-            class="btn btn-light btn-sm"
+            class="flagButton btn btn-light btn-sm"
             type="button"
           >
             <svg
@@ -636,7 +636,7 @@ Object {
           role="group"
         >
           <button
-            class="btn btn-light btn-sm"
+            class="flagButton btn btn-light btn-sm"
             type="button"
           >
             <svg


### PR DESCRIPTION
## What does this PR do?

- Fixes #3721
- Disables the margin/padding controls for vars and expressions
- Enables CssClassWidget for buttons
- Fixes the styles buttons appearing above selector popup
<img width="1025" alt="Screen Shot 2022-06-20 at 6 45 04 PM" src="https://user-images.githubusercontent.com/3116723/174649278-46e06aae-c898-4bed-a147-5857ad92b81c.png">


## Checklist

- [x] Designate a primary reviewer @BLoe 
