### PR TITLE
#3785 Custom Form in document shows previous/stale data if record doesn't exist

### DIFF
--- a/src/blocks/readers/PageMetadataReader.ts
+++ b/src/blocks/readers/PageMetadataReader.ts
@@ -41,13 +41,7 @@ export class PageMetadataReader extends Reader {
     const { getMetadata } = await import(
       /* webpackChunkName: "page-metadata-parser" */ "page-metadata-parser"
     );
-
-    // The function getMetadata returns canonical URL of the page, reads it from document
-    // This value doesn't change when a navigation event (in SPA) happens
-    return {
-      ...getMetadata(document, location.href),
-      url: String(location.href),
-    };
+    return getMetadata(document, location.href);
   }
 
   override outputSchema: Schema = {

--- a/src/blocks/readers/PageMetadataReader.ts
+++ b/src/blocks/readers/PageMetadataReader.ts
@@ -41,7 +41,13 @@ export class PageMetadataReader extends Reader {
     const { getMetadata } = await import(
       /* webpackChunkName: "page-metadata-parser" */ "page-metadata-parser"
     );
-    return getMetadata(document, location.href);
+
+    // The function getMetadata returns canonical URL of the page, reads it from document
+    // This value doesn't change when a navigation event (in SPA) happens
+    return {
+      ...getMetadata(document, location.href),
+      url: String(location.href),
+    };
   }
 
   override outputSchema: Schema = {

--- a/src/blocks/renderers/__snapshots__/customForm.test.tsx.snap
+++ b/src/blocks/renderers/__snapshots__/customForm.test.tsx.snap
@@ -1,0 +1,150 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`form data normalization renders normalized data 1`] = `
+<DocumentFragment>
+  <form
+    class="rjsf"
+  >
+    <div
+      class="form-group"
+    >
+      <div
+        class="p-0 container-fluid"
+      >
+        <div
+          class="row"
+          style="margin-bottom: 10px;"
+        >
+          <div
+            class="col-12"
+          >
+             
+            <div
+              class="form-group"
+            >
+              <div
+                class="mb-0 form-group"
+              >
+                <label
+                  class="form-label"
+                >
+                  name
+                </label>
+                <input
+                  class="form-control"
+                  id="root_name"
+                  placeholder=""
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="row"
+          style="margin-bottom: 10px;"
+        >
+          <div
+            class="col-12"
+          >
+             
+            <div
+              class="form-group"
+            >
+              <div
+                class="mb-0 form-group"
+              >
+                <label
+                  class="form-label"
+                >
+                  age
+                </label>
+                <input
+                  class="form-control"
+                  id="root_age"
+                  placeholder=""
+                  type="integer"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="row"
+          style="margin-bottom: 10px;"
+        >
+          <div
+            class="col-12"
+          >
+             
+            <div
+              class="form-group"
+            >
+              <div
+                class="checkbox  form-group"
+              >
+                <div
+                  class="form-check"
+                >
+                  <input
+                    class="form-check-input"
+                    id="root_isAdmin"
+                    type="checkbox"
+                  />
+                  <label
+                    class="form-check-label"
+                    for="root_isAdmin"
+                    title=""
+                  >
+                    isAdmin
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="row"
+          style="margin-bottom: 10px;"
+        >
+          <div
+            class="col-12"
+          >
+             
+            <div
+              class="form-group"
+            >
+              <div
+                class="mb-0 form-group"
+              >
+                <label
+                  class="form-label"
+                >
+                  rating
+                </label>
+                <input
+                  class="form-control"
+                  id="root_rating"
+                  placeholder=""
+                  type="number"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        class="btn btn-primary"
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;

--- a/src/blocks/renderers/customForm.test.tsx
+++ b/src/blocks/renderers/customForm.test.tsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { Schema } from "@/core";
+import { render } from "@testing-library/react";
+import ImageCropWidget from "@/components/formBuilder/ImageCropWidget";
+// eslint-disable-next-line import/no-named-as-default -- need default export here
+import DescriptionField from "@/components/formBuilder/DescriptionField";
+import FieldTemplate from "@/components/formBuilder/FieldTemplate";
+import JsonSchemaForm from "@rjsf/bootstrap-4";
+import {
+  normalizeIncomingFormData,
+  normalizeOutgoingFormData,
+} from "./customForm";
+import { waitForEffect } from "@/testUtils/testHelpers";
+import userEvent from "@testing-library/user-event";
+
+describe("form data normalization", () => {
+  test("normalizes non-empty incoming data", () => {
+    const schema: Schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "integer" },
+        isAdmin: { type: "boolean" },
+        rating: { type: "number" },
+      },
+    };
+
+    const data = {
+      name: "John",
+      age: 30,
+      isAdmin: true,
+      rating: 4.8,
+    };
+
+    const normalizedData = normalizeIncomingFormData(schema, data);
+    const expectedData = {
+      name: "John",
+      age: 30,
+      isAdmin: true,
+      rating: 4.8,
+    };
+
+    expect(normalizedData).toStrictEqual(expectedData);
+  });
+
+  test("normalizes empty incoming data", () => {
+    const schema: Schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "integer" },
+        isAdmin: { type: "boolean" },
+        rating: { type: "number" },
+      },
+    };
+
+    const data = {};
+
+    const normalizedData = normalizeIncomingFormData(schema, data);
+    const expectedData = {
+      name: "",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- relaxed type checking in test
+    } as any;
+
+    expect(normalizedData).toStrictEqual(expectedData);
+  });
+  test("normalizes non-empty outgoing data", () => {
+    const schema: Schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "integer" },
+        isAdmin: { type: "boolean" },
+        rating: { type: "number" },
+      },
+    };
+
+    const data = {
+      name: "John",
+      age: 30,
+      isAdmin: true,
+      rating: 4.8,
+    };
+
+    const normalizedData = normalizeOutgoingFormData(schema, data);
+    const expectedData = {
+      name: "John",
+      age: 30,
+      isAdmin: true,
+      rating: 4.8,
+    };
+
+    expect(normalizedData).toStrictEqual(expectedData);
+  });
+
+  test("normalizes empty outgoing data", () => {
+    const schema: Schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "integer" },
+        isAdmin: { type: "boolean" },
+        rating: { type: "number" },
+      },
+    };
+
+    const data = {};
+
+    const normalizedData = normalizeOutgoingFormData(schema, data);
+    const expectedData = {
+      name: null,
+      age: null,
+      isAdmin: null,
+      rating: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- relaxed type checking in test
+    } as any;
+
+    expect(normalizedData).toStrictEqual(expectedData);
+  });
+
+  test("renders normalized data", async () => {
+    // A common data flow is:
+    // 1. Collect form data and run through normalizeOutgoingFormData
+    // 2. Send normalized data to the server
+    // 3. Get data from the server
+    // 4. Run through normalizeIncomingFormData and feed the form
+
+    const schema: Schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "integer" },
+        isAdmin: { type: "boolean" },
+        rating: { type: "number" },
+      },
+    };
+
+    const data = {};
+
+    // This is what we'd send to server
+    const outgoingData = normalizeOutgoingFormData(schema, data);
+
+    // This is what we feed to the form
+    const normalizedData = normalizeIncomingFormData(schema, outgoingData);
+
+    const fields = {
+      DescriptionField,
+    };
+    const uiWidgets = {
+      imageCrop: ImageCropWidget,
+    };
+
+    const rendered = render(
+      <JsonSchemaForm
+        schema={schema}
+        formData={normalizedData}
+        fields={fields}
+        widgets={uiWidgets}
+        FieldTemplate={FieldTemplate}
+      />
+    );
+
+    await waitForEffect();
+
+    // Make sure the form renders the data without errors
+    expect(rendered.asFragment()).toMatchSnapshot();
+
+    // Submit and make sure there're no validation errors
+    await userEvent.click(
+      rendered.getByRole("button", {
+        name: "Submit",
+      })
+    );
+
+    expect(rendered.queryByText("Error")).not.toBeInTheDocument();
+  });
+});

--- a/src/blocks/renderers/customForm.tsx
+++ b/src/blocks/renderers/customForm.tsx
@@ -173,7 +173,9 @@ async function setData(
         data: {
           id: recordId,
           data: cleanValues,
-          // Using shallow strategy to support partial data views
+          // Using shallow strategy to support partial data forms
+          // In case when a form contains (and submits) only a subset of all the fields of a record,
+          // the fields missing in the form will not be removed from the DB record
           merge_strategy: "shallow",
         },
       });
@@ -189,7 +191,6 @@ async function setData(
         {
           namespace: storage.namespace ?? "blueprint",
           data: cleanValues,
-          // Using shallow strategy to support partial data views
           mergeStrategy: "shallow",
           extensionId,
           blueprintId,
@@ -288,7 +289,7 @@ export const customFormRendererSchema = {
   required: ["schema"],
 };
 
-// Initialize all empty string fields to empty string
+// Ensure that all string fields contain string values (can be empty string "", but not null or undefined)
 // so the form updates the displayed values of the input correctly
 export function normalizeIncomingFormData(schema: Schema, data: UnknownObject) {
   const normalizedData: UnknownObject = {};
@@ -310,8 +311,8 @@ export function normalizeIncomingFormData(schema: Schema, data: UnknownObject) {
   return normalizedData;
 }
 
-// Setting all the empty fields to null to override the values on the server
-// b/c the server uses shallow merge strategy and ignores undefined values returned for empty fields from the form
+// The server uses a shallow merge strategy that ignores undefined values,
+// so we need to make all the undefined field values null instead, so that the server will clear those fields instead of ignoring them
 export function normalizeOutgoingFormData(schema: Schema, data: UnknownObject) {
   const normalizedData = { ...data };
   for (const key of Object.keys(schema.properties)) {

--- a/src/blocks/renderers/customForm.tsx
+++ b/src/blocks/renderers/customForm.tsx
@@ -286,6 +286,22 @@ export const customFormRendererSchema = {
   required: ["schema"],
 };
 
+function normalizeDataForForm(schema: Schema, data: UnknownObject) {
+  const normalizedData = { ...data };
+  for (const [key, property] of Object.entries(schema.properties)) {
+    if (
+      typeof property === "object" &&
+      property.type === "string" &&
+      isEmpty(property.default) &&
+      isEmpty(normalizedData[key])
+    ) {
+      normalizedData[key] = "";
+    }
+  }
+
+  return normalizedData;
+}
+
 export class CustomFormRenderer extends Renderer {
   static BLOCK_ID = validateRegistryId("@pixiebrix/form");
   constructor() {
@@ -339,15 +355,19 @@ export class CustomFormRenderer extends Renderer {
       extensionId,
     });
 
+    const normalizedData = normalizeDataForForm(schema, initialData);
+
     console.debug("Initial data for form", {
+      recordId,
       initialData,
+      normalizedData,
     });
 
     return {
       Component: CustomFormComponent,
       props: {
         recordId,
-        formData: initialData,
+        formData: normalizedData,
         schema,
         uiSchema,
         submitCaption,

--- a/src/components/documentBuilder/render/BlockElement.tsx
+++ b/src/components/documentBuilder/render/BlockElement.tsx
@@ -55,12 +55,12 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline, tracePath }) => {
         nonce: uuidv4(),
         context: ctxt,
         pipeline,
-        // TODO: pass runtime version via DocumentContext instead of hard-coding it. This will break for v4+
         meta: {
           ...meta,
           // The pipeline is static, so don't need to maintain run counter on branches
           branches: mapPathToTraceBranches(tracePath),
         },
+        // TODO: pass runtime version via DocumentContext instead of hard-coding it. This will break for v4+
         options: apiVersionOptions("v3"),
       });
     }, [pipeline]);


### PR DESCRIPTION
## What does this PR do?

- Fixes #3785
- Ensures the URL in the context changes with navigation
- Sets empty strings to the form fields that have no data (null or undefined)

This PR does not address the issue when the cleared value is not removed from the database.

## Demo

https://www.loom.com/share/b30ebe22cec94f34b9c330661b94d8c0

## Checklist

- [ ] Designate a primary reviewer @BLoe 
