### PR TITLE
[JSFIX] Major version upgrade of react-redux from version 7.2.4 to 8.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "react-image-crop": "^9.0.5",
         "react-json-tree": "^0.16.1",
         "react-outside-click-handler": "^1.3.0",
-        "react-redux": "^7.2.4",
+        "react-redux": "^8.0.2",
         "react-router": "5.3.1",
         "react-router-dom": "5.3.1",
         "react-select": "^5.2.1",
@@ -12442,7 +12442,7 @@
       "version": "17.0.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz",
       "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -12670,6 +12670,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
@@ -31296,6 +31301,35 @@
         "react-dom": "^16.8.5 || ^17.0.0"
       }
     },
+    "node_modules/react-beautiful-dnd/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-beautiful-dnd/node_modules/react-redux": {
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-bootstrap": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.5.tgz",
@@ -31633,33 +31667,47 @@
       "dev": true
     },
     "node_modules/react-redux": {
-      "version": "7.2.8",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
-      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
         "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18"
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
         "react-dom": {
           "optional": true
         },
         "react-native": {
           "optional": true
+        },
+        "redux": {
+          "optional": true
         }
       }
     },
     "node_modules/react-redux/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -36602,6 +36650,14 @@
       "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {
@@ -47464,7 +47520,7 @@
       "version": "17.0.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz",
       "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/react": "*"
       }
@@ -47685,6 +47741,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/uuid": {
       "version": "8.3.4",
@@ -62129,6 +62190,26 @@
         "react-redux": "^7.2.0",
         "redux": "^4.0.4",
         "use-memo-one": "^1.1.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        },
+        "react-redux": {
+          "version": "7.2.8",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+          "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+          "requires": {
+            "@babel/runtime": "^7.15.4",
+            "@types/react-redux": "^7.1.20",
+            "hoist-non-react-statics": "^3.3.2",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.7.2",
+            "react-is": "^17.0.2"
+          }
+        }
       }
     },
     "react-bootstrap": {
@@ -62396,22 +62477,22 @@
       }
     },
     "react-redux": {
-      "version": "7.2.8",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
-      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
       "requires": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
         "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
       },
       "dependencies": {
         "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         }
       }
     },
@@ -66323,6 +66404,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
       "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
+      "requires": {}
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "requires": {}
     },
     "util": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "react-image-crop": "^9.0.5",
     "react-json-tree": "^0.16.1",
     "react-outside-click-handler": "^1.3.0",
-    "react-redux": "^7.2.4",
+    "react-redux": "^8.0.2",
     "react-router": "5.3.1",
     "react-router-dom": "5.3.1",
     "react-select": "^5.2.1",


### PR DESCRIPTION
This pull request was created by [mtorp](https://github.com/mtorp) using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It upgrades react-redux to version 8.0.2.

The JSFIX tool used advanced program analysis to determine how react-redux is used by pixiebrix-extension and how it is affected by breaking changes in react-redux version 8.0.2 (see details below). JSFIX checked for the 3 breaking changes affecting react-redux version 8.0.2 and found 1 occurrences in pixiebrix-extension. 1 of the occurrences must be manually audited. 

<strong>Install the [JSFIX GitHub app](https://github.com/apps/jsfix-updater) to receive other package updates from JSFIX.</strong>

***

<h3>Breaking change details</h3>

<details open><summary><strong> 🚧 - Not automatically fixed breaking changes (please check before merging)</strong></summary><blockquote class="pr-blockquote"><details open>
<summary>Affects all applications (not related to specific API usages in your code).</summary>

* If you are using Typescript, React-Redux is now written in TS and includes its own types. You should remove any dependencies on @types/react-redux.
</details>

</blockquote></details><details>
<summary><strong> 🚧 - Files JSFIX failed to analyze (carefully check that no source files are in this list before merging)</strong></summary>

* src/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx (TypeError) - emessage: Cannot read properties of null (reading 'startsWith').

</details>

<details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* The connectAdvanced API is now deprecated 
* The pure option for connect has been removed.
</details>



***

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.