### PR TITLE
#3812 Display node error message

### DIFF
--- a/src/pageEditor/hooks/usePipelineErrors.ts
+++ b/src/pageEditor/hooks/usePipelineErrors.ts
@@ -25,24 +25,14 @@ import validateOutputKey from "@/pageEditor/validation/validateOutputKey";
 import validateRenderers from "@/pageEditor/validation/validateRenderers";
 import applyTraceErrors from "@/pageEditor/validation/applyTraceError";
 import { isEmpty } from "lodash";
-import {
-  FormikError,
-  FormikErrorTree,
-} from "@/pageEditor/tabs/editTab/editTabTypes";
-import { TypedBlockMap } from "@/blocks/registry";
+import { FormikErrorTree } from "@/pageEditor/tabs/editTab/editTabTypes";
 import { ExtensionPointType } from "@/extensionPoints/types";
 import validateStringTemplates from "@/pageEditor/validation/validateStringTemplates";
 import { PIPELINE_BLOCKS_FIELD_NAME } from "@/pageEditor/consts";
-import type { TraceError } from "@/telemetry/trace";
+import useAllBlocks from "./useAllBlocks";
 
-function usePipelineField(
-  allBlocks: TypedBlockMap,
-  extensionPointType: ExtensionPointType
-): {
-  blockPipeline: BlockPipeline;
-  blockPipelineErrors: FormikError;
-  traceErrors: TraceError[];
-} {
+function usePipelineErrors(extensionPointType: ExtensionPointType) {
+  const [allBlocks] = useAllBlocks();
   const traceErrors = useSelector(selectTraceErrors);
   const formikContext = useFormikContext();
 
@@ -60,12 +50,11 @@ function usePipelineField(
     [allBlocks, extensionPointType, traceErrors]
   );
 
-  const [{ value: blockPipeline }, { error: blockPipelineErrors }] =
-    useField<BlockPipeline>({
-      name: PIPELINE_BLOCKS_FIELD_NAME,
-      // @ts-expect-error working with nested errors
-      validate: validatePipelineBlocks,
-    });
+  useField<BlockPipeline>({
+    name: PIPELINE_BLOCKS_FIELD_NAME,
+    // @ts-expect-error working with nested errors
+    validate: validatePipelineBlocks,
+  });
 
   useAsyncEffect(
     async (isMounted) => {
@@ -75,17 +64,14 @@ function usePipelineField(
       }
 
       if (Object.keys(validationErrors).length > 0) {
-        formikContext.setTouched(setNestedObjectValues(validationErrors, true));
+        formikContext.setTouched(
+          setNestedObjectValues(validationErrors, true),
+          false
+        );
       }
     },
     [traceErrors]
   );
-
-  return {
-    blockPipeline,
-    blockPipelineErrors,
-    traceErrors,
-  };
 }
 
-export default usePipelineField;
+export default usePipelineErrors;

--- a/src/pageEditor/hooks/usePipelineErrors.ts
+++ b/src/pageEditor/hooks/usePipelineErrors.ts
@@ -26,15 +26,16 @@ import validateRenderers from "@/pageEditor/validation/validateRenderers";
 import applyTraceErrors from "@/pageEditor/validation/applyTraceError";
 import { isEmpty } from "lodash";
 import { FormikErrorTree } from "@/pageEditor/tabs/editTab/editTabTypes";
-import { ExtensionPointType } from "@/extensionPoints/types";
 import validateStringTemplates from "@/pageEditor/validation/validateStringTemplates";
 import { PIPELINE_BLOCKS_FIELD_NAME } from "@/pageEditor/consts";
+import { FormState } from "@/pageEditor/pageEditorTypes";
 import useAllBlocks from "./useAllBlocks";
 
-function usePipelineErrors(extensionPointType: ExtensionPointType) {
+function usePipelineErrors() {
   const [allBlocks] = useAllBlocks();
   const traceErrors = useSelector(selectTraceErrors);
-  const formikContext = useFormikContext();
+  const formikContext = useFormikContext<FormState>();
+  const extensionPointType = formikContext.values.type;
 
   const validatePipelineBlocks = useCallback(
     (pipeline: BlockPipeline): void | FormikErrorTree => {

--- a/src/pageEditor/slices/editorSelectors.ts
+++ b/src/pageEditor/slices/editorSelectors.ts
@@ -19,7 +19,7 @@ import { RecipeMetadata, RegistryId, UUID } from "@/core";
 import { createSelector } from "reselect";
 import { EditorState } from "@/pageEditor/pageEditorTypes";
 import { selectExtensions } from "@/store/extensionsSelectors";
-import { flatMap, isEmpty, uniqBy } from "lodash";
+import { flatMap, get, isEmpty, uniqBy } from "lodash";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
 import {
   ElementUIState,
@@ -211,7 +211,7 @@ export const selectActiveNodeInfo = createSelector(
   selectActiveElementUIState,
   selectActiveNodeId,
   (uiState: ElementUIState, activeNodeId: UUID) =>
-    uiState.pipelineMap[activeNodeId]
+    get(uiState.pipelineMap, activeNodeId)
 );
 
 export const selectActiveNode: (rootState: RootState) => BlockConfig =

--- a/src/pageEditor/slices/editorSelectors.ts
+++ b/src/pageEditor/slices/editorSelectors.ts
@@ -19,7 +19,7 @@ import { RecipeMetadata, RegistryId, UUID } from "@/core";
 import { createSelector } from "reselect";
 import { EditorState } from "@/pageEditor/pageEditorTypes";
 import { selectExtensions } from "@/store/extensionsSelectors";
-import { flatMap, get, isEmpty, uniqBy } from "lodash";
+import { flatMap, isEmpty, uniqBy } from "lodash";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
 import {
   ElementUIState,
@@ -211,7 +211,7 @@ export const selectActiveNodeInfo = createSelector(
   selectActiveElementUIState,
   selectActiveNodeId,
   (uiState: ElementUIState, activeNodeId: UUID) =>
-    get(uiState.pipelineMap, activeNodeId)
+    uiState.pipelineMap[activeNodeId]
 );
 
 export const selectActiveNode: (rootState: RootState) => BlockConfig =

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -51,6 +51,7 @@ import devtoolFieldOverrides from "@/pageEditor/fields/devtoolFieldOverrides";
 import SchemaFieldContext from "@/components/fields/schemaFields/SchemaFieldContext";
 import { get } from "lodash";
 import { UnconfiguredQuickBarAlert } from "@/pageEditor/extensionPoints/quickBar";
+import { FormikError } from "./editTabTypes";
 
 const EditTab: React.FC<{
   eventKey: string;
@@ -144,7 +145,7 @@ const EditTab: React.FC<{
           <div className={styles.nodeLayout}>
             <EditorNodeLayout
               pipeline={blockPipeline}
-              errors={errors}
+              errors={errors as FormikError}
               extensionPointType={extensionPointType}
               extensionPointLabel={extensionPointLabel}
               extensionPointIcon={extensionPointIcon}

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -27,7 +27,7 @@ import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import DataPanel from "@/pageEditor/tabs/editTab/dataPanel/DataPanel";
 import useExtensionTrace from "@/pageEditor/hooks/useExtensionTrace";
 import FoundationDataPanel from "@/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel";
-import usePipelineField from "@/pageEditor/hooks/usePipelineField";
+import usePipelineErrors from "@/pageEditor/hooks/usePipelineErrors";
 import { useSelector } from "react-redux";
 import { FOUNDATION_NODE_ID } from "@/pageEditor/uiState/uiState";
 import {
@@ -51,7 +51,7 @@ import devtoolFieldOverrides from "@/pageEditor/fields/devtoolFieldOverrides";
 import SchemaFieldContext from "@/components/fields/schemaFields/SchemaFieldContext";
 import { get } from "lodash";
 import { UnconfiguredQuickBarAlert } from "@/pageEditor/extensionPoints/quickBar";
-import useAllBlocks from "@/pageEditor/hooks/useAllBlocks";
+import { FormikError } from "./editTabTypes";
 
 const EditTab: React.FC<{
   eventKey: string;
@@ -59,8 +59,19 @@ const EditTab: React.FC<{
   useExtensionTrace();
   useReportTraceError();
 
-  const { values, setValues: setFormValues } = useFormikContext<FormState>();
-  const { extensionPoint, type: extensionPointType } = values;
+  const {
+    values,
+    setValues: setFormValues,
+    errors,
+  } = useFormikContext<FormState>();
+
+  const {
+    extensionPoint,
+    type: extensionPointType,
+    extension: { blockPipeline },
+  } = values;
+
+  usePipelineErrors(extensionPointType);
 
   // For now, don't allow modifying extensionPoint packages via the Page Editor.
   const isLocked = useMemo(
@@ -76,13 +87,6 @@ const EditTab: React.FC<{
     EditorNode,
   } = useMemo(() => ADAPTERS.get(extensionPointType), [extensionPointType]);
 
-  const [allBlocks] = useAllBlocks();
-
-  const { blockPipeline, blockPipelineErrors, traceErrors } = usePipelineField(
-    allBlocks,
-    extensionPointType
-  );
-
   const activeNodeId = useSelector(selectActiveNodeId);
   const { blockId, path: fieldName } = useSelector(selectActiveNodeInfo) ?? {};
   const pipelineMap = useSelector(selectPipelineMap);
@@ -97,7 +101,7 @@ const EditTab: React.FC<{
   } = useBlockPipelineActions(pipelineMap, values, setFormValues);
 
   // The value of formikErrorForBlock can be object or string.
-  const formikErrorForBlock = get(blockPipelineErrors, fieldName);
+  const formikErrorForBlock = get(errors, fieldName);
   // If formikErrorForBlock is a string, it means that this exact block has an error.
   const blockError: string =
     typeof formikErrorForBlock === "string" ? formikErrorForBlock : null;
@@ -140,10 +144,8 @@ const EditTab: React.FC<{
           </div>
           <div className={styles.nodeLayout}>
             <EditorNodeLayout
-              allBlocks={allBlocks}
               pipeline={blockPipeline}
-              pipelineErrors={blockPipelineErrors}
-              traceErrors={traceErrors}
+              errors={errors}
               extensionPointType={extensionPointType}
               extensionPointLabel={extensionPointLabel}
               extensionPointIcon={extensionPointIcon}

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -51,7 +51,6 @@ import devtoolFieldOverrides from "@/pageEditor/fields/devtoolFieldOverrides";
 import SchemaFieldContext from "@/components/fields/schemaFields/SchemaFieldContext";
 import { get } from "lodash";
 import { UnconfiguredQuickBarAlert } from "@/pageEditor/extensionPoints/quickBar";
-import { FormikError } from "./editTabTypes";
 
 const EditTab: React.FC<{
   eventKey: string;

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -71,7 +71,7 @@ const EditTab: React.FC<{
     extension: { blockPipeline },
   } = values;
 
-  usePipelineErrors(extensionPointType);
+  usePipelineErrors();
 
   // For now, don't allow modifying extensionPoint packages via the Page Editor.
   const isLocked = useMemo(

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
@@ -110,7 +110,6 @@ function decideBlockStatus(
   blockError: FormikError,
   traceRecord: TraceRecord
 ): RunStatus {
-  // If blockPipelineErrors is a string, it means the error is on the pipeline level
   if (blockError) {
     return RunStatus.ERROR;
   }
@@ -127,7 +126,6 @@ function decideBlockStatus(
     return RunStatus.SKIPPED;
   }
 
-  // We already checked for errors
   if (traceRecord.isFinal) {
     return RunStatus.SUCCESS;
   }

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
@@ -31,9 +31,9 @@ import {
   FormikError,
   RunStatus,
 } from "@/pageEditor/tabs/editTab/editTabTypes";
-import { TraceError, TraceRecord } from "@/telemetry/trace";
+import { TraceRecord } from "@/telemetry/trace";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
-import { TypedBlock, TypedBlockMap } from "@/blocks/registry";
+import { TypedBlock } from "@/blocks/registry";
 import { IBlock, OutputKey, UUID } from "@/core";
 import { useDispatch, useSelector } from "react-redux";
 import { selectExtensionTrace } from "@/pageEditor/slices/runtimeSelectors";
@@ -61,6 +61,7 @@ import {
   IsBlockAllowedPredicate,
   makeIsAllowedForRootPipeline,
 } from "@/pageEditor/tabs/editTab/blockFilterHelpers";
+import useAllBlocks from "@/pageEditor/hooks/useAllBlocks";
 
 const ADD_MESSAGE = "Add more bricks with the plus button";
 
@@ -70,11 +71,9 @@ type EditorNodeProps =
   | (PipelineFooterNodeProps & { type: "footer"; key: string });
 
 type EditorNodeLayoutProps = {
-  allBlocks: TypedBlockMap;
   extensionPointType: ExtensionPointType;
   pipeline: BlockPipeline;
-  pipelineErrors: FormikError;
-  traceErrors: TraceError[];
+  errors: FormikError;
   extensionPointLabel: string;
   extensionPointIcon: IconProp;
   addBlock: (
@@ -107,18 +106,12 @@ type SubPipeline = {
   isBlockAllowed: IsBlockAllowedPredicate;
 };
 
-function decideBrickStatus({
-  index,
-  pipelineErrors,
-  traceRecord,
-}: {
-  index: number;
-  pipelineErrors: FormikError;
-  traceRecord: TraceRecord;
-}): RunStatus {
+function decideBlockStatus(
+  blockError: FormikError,
+  traceRecord: TraceRecord
+): RunStatus {
   // If blockPipelineErrors is a string, it means the error is on the pipeline level
-  // eslint-disable-next-line security/detect-object-injection -- index is a number
-  if (typeof pipelineErrors !== "string" && Boolean(pipelineErrors?.[index])) {
+  if (blockError) {
     return RunStatus.ERROR;
   }
 
@@ -134,7 +127,7 @@ function decideBrickStatus({
     return RunStatus.SKIPPED;
   }
 
-  // We already checked for errors from pipelineErrors
+  // We already checked for errors
   if (traceRecord.isFinal) {
     return RunStatus.SUCCESS;
   }
@@ -143,10 +136,9 @@ function decideBrickStatus({
 }
 
 const EditorNodeLayout: React.FC<EditorNodeLayoutProps> = ({
-  allBlocks,
   extensionPointType,
   pipeline,
-  pipelineErrors,
+  errors,
   extensionPointLabel,
   extensionPointIcon,
   addBlock,
@@ -157,6 +149,7 @@ const EditorNodeLayout: React.FC<EditorNodeLayoutProps> = ({
   const dispatch = useDispatch();
   const isApiAtLeastV2 = useApiVersionAtLeast("v2");
   const showPaste = pasteBlock && isApiAtLeastV2;
+  const [allBlocks] = useAllBlocks();
   const activeNodeId = useSelector(selectActiveNodeId);
   const traces = useSelector(selectExtensionTrace);
 
@@ -174,6 +167,7 @@ const EditorNodeLayout: React.FC<EditorNodeLayoutProps> = ({
 
   let foundationRunStatus: RunStatus = RunStatus.NONE;
 
+  // eslint-disable-next-line complexity
   function mapPipelineToNodes({
     pipeline,
     pipelinePath = PIPELINE_BLOCKS_FIELD_NAME,
@@ -371,13 +365,13 @@ const EditorNodeLayout: React.FC<EditorNodeLayoutProps> = ({
       };
 
       if (block) {
+        const blockError = get(
+          errors,
+          joinElementName(pipelinePath, String(index))
+        );
         contentProps = {
           icon: <BrickIcon brick={block} size="2x" inheritColor />,
-          runStatus: decideBrickStatus({
-            index,
-            pipelineErrors,
-            traceRecord,
-          }),
+          runStatus: decideBlockStatus(blockError, traceRecord),
           brickLabel: isNullOrBlank(blockConfig.label)
             ? block?.name
             : blockConfig.label,

--- a/src/pageEditor/uiState/uiStateTypes.ts
+++ b/src/pageEditor/uiState/uiStateTypes.ts
@@ -24,7 +24,7 @@ type PipelineMapBlock = {
   blockId: RegistryId;
 
   /**
-   * The property name path relative to the pipeline root
+   * The property name path relative to the Formik root
    */
   path: string;
 
@@ -36,7 +36,7 @@ type PipelineMapBlock = {
   index: number;
 
   /**
-   * The path of the pipeline relative to the pipeline root
+   * The path of the pipeline relative to the Formik root
    */
   pipelinePath: string;
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #3812 
- the `usePipelineField` is changed to only apply the errors

## Demo

<img width="792" alt="image" src="https://user-images.githubusercontent.com/3116723/176681299-80161c93-9229-42e7-85d6-16e000e843ce.png">


## Future Work

- Loop over the nested pipelines to apply trace errors to the error state

## Checklist

- [x] Designate a primary reviewer @BLoe 
