### PR TITLE
#3791: browser extension/deployment update countdown timer

### DIFF
--- a/src/auth/authConstants.ts
+++ b/src/auth/authConstants.ts
@@ -27,4 +27,5 @@ export const anonAuth: AuthState = Object.freeze({
   flags: [],
   organizations: [],
   groups: [],
+  enforceUpdateMillis: null,
 });

--- a/src/auth/authTypes.ts
+++ b/src/auth/authTypes.ts
@@ -60,12 +60,18 @@ export type UserData = Partial<{
     name: string;
   }>;
   /**
-   * Groups the user is a member of
+   * Groups the user is a member of.
    */
   groups: Array<{
     id: UUID;
     name: string;
   }>;
+  /**
+   * Number of milliseconds after which to enforce browser extension and manual deployment updates, or `null` to
+   * allow the user to snooze updates.
+   * @since 1.7.1
+   */
+  enforceUpdateMillis: number | null;
 }>;
 
 // Exclude tenant information in updates (these are only updated on linking)
@@ -78,6 +84,7 @@ export const USER_DATA_UPDATE_KEYS: Array<keyof UserDataUpdate> = [
   "organizations",
   "groups",
   "flags",
+  "enforceUpdateMillis",
 ];
 
 export interface TokenAuthData extends UserData {
@@ -154,6 +161,16 @@ export type AuthState = {
   readonly flags: string[];
 
   readonly partner?: Me["partner"];
+
+  /**
+   * Number of milliseconds after which to enforce browser extension and manual deployment updates, or `null` to
+   * allow the user to snooze updates.
+   *
+   * NOTE: applies to both deployments and browser extension updates.
+   *
+   * @since 1.7.1
+   */
+  readonly enforceUpdateMillis: number | null;
 };
 
 export type AuthRootState = {

--- a/src/auth/authUtils.ts
+++ b/src/auth/authUtils.ts
@@ -52,7 +52,7 @@ export function selectUserDataUpdate({
   organization_memberships: organizationMemberships = [],
   group_memberships = [],
   flags = [],
-  enforceUpdateMillis,
+  enforce_update_millis: enforceUpdateMillis,
 }: Me): UserDataUpdate {
   const organizations = selectOrganizations(organizationMemberships);
   const groups = group_memberships.map(({ id, name }) => ({ id, name }));
@@ -77,7 +77,7 @@ export function selectExtensionAuthState({
   flags = [],
   organization_memberships: organizationMemberships = [],
   group_memberships = [],
-  enforceUpdateMillis,
+  enforce_update_millis: enforceUpdateMillis,
 }: Me): AuthState {
   const organizations = selectOrganizations(organizationMemberships);
   const groups = group_memberships.map(({ id, name }) => ({ id, name }));

--- a/src/auth/authUtils.ts
+++ b/src/auth/authUtils.ts
@@ -52,6 +52,7 @@ export function selectUserDataUpdate({
   organization_memberships: organizationMemberships = [],
   group_memberships = [],
   flags = [],
+  enforceUpdateMillis,
 }: Me): UserDataUpdate {
   const organizations = selectOrganizations(organizationMemberships);
   const groups = group_memberships.map(({ id, name }) => ({ id, name }));
@@ -63,6 +64,7 @@ export function selectUserDataUpdate({
     flags,
     organizations,
     groups,
+    enforceUpdateMillis,
   };
 }
 
@@ -75,6 +77,7 @@ export function selectExtensionAuthState({
   flags = [],
   organization_memberships: organizationMemberships = [],
   group_memberships = [],
+  enforceUpdateMillis,
 }: Me): AuthState {
   const organizations = selectOrganizations(organizationMemberships);
   const groups = group_memberships.map(({ id, name }) => ({ id, name }));
@@ -90,5 +93,6 @@ export function selectExtensionAuthState({
     organizations,
     groups,
     flags,
+    enforceUpdateMillis,
   };
 }

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -114,9 +114,10 @@ export async function updateUserData(update: UserDataUpdate): Promise<void> {
   const updated = await readAuthData();
 
   for (const key of USER_DATA_UPDATE_KEYS) {
-    // Intentionally overwrite values with null/undefined from the update
+    // Intentionally overwrite values with null/undefined from the update. For some reason TypeScript was complaining
+    // about assigning any to never. It's not clear why update[key] was being typed as never
     // eslint-disable-next-line security/detect-object-injection,@typescript-eslint/no-explicit-any -- keys from compile-time constant
-    updated[key] = update[key] as any;
+    (updated[key] as any) = update[key] as any;
   }
 
   await setStorage(STORAGE_EXTENSION_KEY, updated);

--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -334,10 +334,14 @@ describe("updateDeployments", () => {
     expect(refreshRegistriesMock.mock.calls.length).toBe(0);
   });
 
-  // FIXME: double check this
-  test("open options page on update if enforce_update_millis is set", async () => {
+  test("open options page on update if enforce_update_millis is set even if snoozed", async () => {
     isLinkedMock.mockResolvedValue(true);
     isUpdateAvailableMock.mockReturnValue(true);
+
+    getSettingsStateMock.mockResolvedValue({
+      nextUpdate: Date.now() + 1_000_000,
+      updatePromptTimestamp: null,
+    });
 
     axiosMock.onGet().reply(200, {
       flags: [],
@@ -348,7 +352,7 @@ describe("updateDeployments", () => {
 
     await updateDeployments();
 
-    expect(isUpdateAvailableMock.mock.calls.length).toBe(1);
+    expect(isUpdateAvailableMock.mock.calls.length).toBe(0);
     expect(openOptionsPageMock.mock.calls.length).toBe(1);
     expect(refreshRegistriesMock.mock.calls.length).toBe(0);
   });

--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -35,6 +35,7 @@ const axiosMock = new MockAdapter(axios);
 
 jest.mock("@/store/settingsStorage", () => ({
   getSettingsState: jest.fn(),
+  saveSettingsState: jest.fn(),
 }));
 
 jest.mock("@/hooks/useRefresh", () => ({
@@ -99,7 +100,7 @@ jest.mock("@/background/installer", () => ({
 import { isLinked, readAuthData } from "@/auth/token";
 import { refreshRegistries } from "@/hooks/useRefresh";
 import { isUpdateAvailable } from "@/background/installer";
-import { getSettingsState } from "@/store/settingsStorage";
+import { getSettingsState, saveSettingsState } from "@/store/settingsStorage";
 
 const isLinkedMock = isLinked as jest.Mock;
 const readAuthDataMock = readAuthData as jest.Mock;
@@ -110,6 +111,7 @@ const containsPermissionsMock = browser.permissions.contains as jest.Mock;
 const refreshRegistriesMock = refreshRegistries as jest.Mock;
 const isUpdateAvailableMock = isUpdateAvailable as jest.Mock;
 const getSettingsStateMock = getSettingsState as jest.Mock;
+const saveSettingsStateMock = saveSettingsState as jest.Mock;
 
 beforeEach(async () => {
   jest.resetModules();
@@ -123,6 +125,7 @@ beforeEach(async () => {
   readAuthDataMock.mockClear();
 
   getSettingsStateMock.mockClear();
+  saveSettingsStateMock.mockClear();
 
   getSettingsStateMock.mockResolvedValue({
     nextUpdate: undefined,
@@ -192,6 +195,7 @@ describe("updateDeployments", () => {
     const { extensions } = await loadOptions();
 
     expect(extensions.length).toBe(1);
+    expect(saveSettingsStateMock).toHaveBeenCalledTimes(1);
   });
 
   test("ignore other user extensions", async () => {
@@ -293,6 +297,7 @@ describe("updateDeployments", () => {
 
     expect((uninstallAllDeployments as jest.Mock).mock.calls.length).toBe(0);
     expect(refreshRegistriesMock.mock.calls.length).toBe(0);
+    expect(saveSettingsStateMock).toHaveBeenCalledTimes(0);
   });
 
   test("do not open options page on update if restricted-version flag not set", async () => {
@@ -329,6 +334,7 @@ describe("updateDeployments", () => {
     expect(refreshRegistriesMock.mock.calls.length).toBe(0);
   });
 
+  // FIXME: double check this
   test("open options page on update if enforce_update_millis is set", async () => {
     isLinkedMock.mockResolvedValue(true);
     isUpdateAvailableMock.mockReturnValue(true);

--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -352,8 +352,31 @@ describe("updateDeployments", () => {
 
     await updateDeployments();
 
-    expect(isUpdateAvailableMock.mock.calls.length).toBe(0);
+    expect(isUpdateAvailableMock.mock.calls.length).toBe(1);
     expect(openOptionsPageMock.mock.calls.length).toBe(1);
+    expect(refreshRegistriesMock.mock.calls.length).toBe(0);
+  });
+
+  test("do not open options page if enforce_update_millis is set but no updates available", async () => {
+    isLinkedMock.mockResolvedValue(true);
+    isUpdateAvailableMock.mockReturnValue(false);
+
+    getSettingsStateMock.mockResolvedValue({
+      nextUpdate: Date.now() + 1_000_000,
+      updatePromptTimestamp: null,
+    });
+
+    axiosMock.onGet().reply(200, {
+      flags: [],
+      enforce_update_millis: 5000,
+    });
+
+    axiosMock.onPost().reply(201, []);
+
+    await updateDeployments();
+
+    expect(isUpdateAvailableMock.mock.calls.length).toBe(1);
+    expect(openOptionsPageMock.mock.calls.length).toBe(0);
     expect(refreshRegistriesMock.mock.calls.length).toBe(0);
   });
 

--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -329,6 +329,24 @@ describe("updateDeployments", () => {
     expect(refreshRegistriesMock.mock.calls.length).toBe(0);
   });
 
+  test("open options page on update if enforce_update_millis is set", async () => {
+    isLinkedMock.mockResolvedValue(true);
+    isUpdateAvailableMock.mockReturnValue(true);
+
+    axiosMock.onGet().reply(200, {
+      flags: [],
+      enforce_update_millis: 5000,
+    });
+
+    axiosMock.onPost().reply(201, []);
+
+    await updateDeployments();
+
+    expect(isUpdateAvailableMock.mock.calls.length).toBe(1);
+    expect(openOptionsPageMock.mock.calls.length).toBe(1);
+    expect(refreshRegistriesMock.mock.calls.length).toBe(0);
+  });
+
   test("skip update if snoozed", async () => {
     isLinkedMock.mockResolvedValue(true);
     isUpdateAvailableMock.mockReturnValue(true);

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -22,6 +22,7 @@ import { getUID } from "@/background/messenger/api";
 import { DNT_STORAGE_KEY, allowsTrack } from "@/telemetry/dnt";
 import { gt } from "semver";
 import { getInstallURL } from "@/services/baseService";
+import { getSettingsState, saveSettingsState } from "@/store/settingsStorage";
 
 const UNINSTALL_URL = "https://www.pixiebrix.com/uninstall/";
 
@@ -94,10 +95,28 @@ async function setUninstallURL(): Promise<void> {
   await browser.runtime.setUninstallURL(url.href);
 }
 
+/**
+ * Reset the update countdown timer on startup.
+ *
+ * - If there was a Browser Extension update, it would have been applied
+ * - We don't currently separately track timestamps for showing an update modal for deployments vs. browser extension
+ * upgrades. However, in enterprise scenarios where enforceUpdateMillis is set, the IT policy is generally such
+ * that IT can't reset the extension.
+ */
+async function initUpdatePromptTimestamp() {
+  // There could be a race here, but unlikely because this is run on startup
+  const settings = await getSettingsState();
+  await saveSettingsState({
+    ...settings,
+    updatePromptTimestamp: null,
+  });
+}
+
 function initInstaller() {
   browser.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
   browser.runtime.onInstalled.addListener(install);
   browser.runtime.onStartup.addListener(initTelemetry);
+  browser.runtime.onStartup.addListener(initUpdatePromptTimestamp);
 
   browser.storage.onChanged.addListener((changes) => {
     if (DNT_STORAGE_KEY in changes) {

--- a/src/hooks/useDeployments.ts
+++ b/src/hooks/useDeployments.ts
@@ -38,6 +38,7 @@ import {
   checkExtensionUpdateRequired,
   makeUpdatedFilter,
 } from "@/utils/deployment";
+import settingsSlice from "@/store/settingsSlice";
 
 const { actions } = extensionsSlice;
 
@@ -169,6 +170,10 @@ function useDeployments(): DeploymentState {
   }, [restrict, installedExtensions, deployments]);
 
   const handleUpdate = useCallback(async () => {
+    // Always reset. So even if there's an error, the user at least has a grace period before PixieBrix starts
+    // notifying them to update again
+    dispatch(settingsSlice.actions.resetUpdatePromptTimestamp());
+
     if (deployments == null) {
       notify.error("Deployments have not been fetched");
       return;

--- a/src/options/pages/deployments/CountdownTimer.stories.tsx
+++ b/src/options/pages/deployments/CountdownTimer.stories.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { CountdownTimer } from "@/options/pages/deployments/DeploymentModal";
+import { action } from "@storybook/addon-actions";
+
+export default {
+  title: "Options/CountdownTimer",
+  component: CountdownTimer,
+} as ComponentMeta<typeof CountdownTimer>;
+
+const Template: ComponentStory<typeof CountdownTimer> = (args) => (
+  <CountdownTimer {...args} />
+);
+
+export const Running = Template.bind({});
+Running.args = {
+  start: Date.now() - 5000,
+  duration: 60 * 60 * 1000,
+  onFinish: action("finish"),
+};
+
+export const Completed = Template.bind({});
+Completed.args = {
+  start: Date.now() - 5000,
+  duration: 0,
+  onFinish: action("finish"),
+};

--- a/src/options/pages/deployments/DeploymentModal.stories.tsx
+++ b/src/options/pages/deployments/DeploymentModal.stories.tsx
@@ -24,7 +24,6 @@ import { configureStore } from "@reduxjs/toolkit";
 import extensionsSlice from "@/store/extensionsSlice";
 import settingsSlice from "@/store/settingsSlice";
 import { authSlice } from "@/auth/authSlice";
-import { SettingsState } from "@/store/settingsTypes";
 
 export default {
   title: "Options/DeploymentModal",
@@ -34,13 +33,13 @@ export default {
 type StoryType = ComponentProps<typeof DeploymentModal> & {
   updateAvailable?: boolean;
   enforceUpdateMillis?: number | null;
-  updatePromptTimestamps?: SettingsState["updatePromptTimestamps"];
+  updatePromptTimestamp?: number | null;
 };
 
 const Template: Story<StoryType> = ({
   extensionUpdateRequired,
   enforceUpdateMillis,
-  updatePromptTimestamps,
+  updatePromptTimestamp,
 }) => {
   const extensionsStore = configureStore({
     reducer: {
@@ -50,7 +49,7 @@ const Template: Story<StoryType> = ({
     },
     preloadedState: {
       options: extensionsSlice.getInitialState(),
-      settings: { ...settingsSlice.getInitialState(), updatePromptTimestamps },
+      settings: { ...settingsSlice.getInitialState(), updatePromptTimestamp },
       auth: { ...authSlice.getInitialState(), enforceUpdateMillis },
     },
   });

--- a/src/options/pages/deployments/DeploymentModal.stories.tsx
+++ b/src/options/pages/deployments/DeploymentModal.stories.tsx
@@ -37,6 +37,7 @@ const extensionsStore = configureStore({
       browserWarningDismissed: false,
       theme: undefined,
       partnerId: null,
+      updatePromptTimestamps: null,
     },
   },
 });

--- a/src/options/pages/deployments/DeploymentModal.stories.tsx
+++ b/src/options/pages/deployments/DeploymentModal.stories.tsx
@@ -23,24 +23,8 @@ import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import extensionsSlice from "@/store/extensionsSlice";
 import settingsSlice from "@/store/settingsSlice";
-
-const extensionsStore = configureStore({
-  reducer: {
-    options: extensionsSlice.reducer,
-    settings: settingsSlice.reducer,
-  },
-  preloadedState: {
-    options: { extensions: [] },
-    settings: {
-      mode: "remote",
-      nextUpdate: null,
-      browserWarningDismissed: false,
-      theme: undefined,
-      partnerId: null,
-      updatePromptTimestamps: null,
-    },
-  },
-});
+import { authSlice } from "@/auth/authSlice";
+import { SettingsState } from "@/store/settingsTypes";
 
 export default {
   title: "Options/DeploymentModal",
@@ -49,23 +33,42 @@ export default {
 
 type StoryType = ComponentProps<typeof DeploymentModal> & {
   updateAvailable?: boolean;
+  enforceUpdateMillis?: number | null;
+  updatePromptTimestamps?: SettingsState["updatePromptTimestamps"];
 };
 
-const Template: Story<StoryType> = ({ extensionUpdateRequired }) => (
-  <Provider store={extensionsStore}>
-    <DeploymentModal
-      update={async () => {
-        action("update");
-      }}
-      extensionUpdateRequired={extensionUpdateRequired}
-      updateExtension={async () => {
-        action("updateExtension");
-      }}
-    />
-  </Provider>
-);
+const Template: Story<StoryType> = ({
+  extensionUpdateRequired,
+  enforceUpdateMillis,
+  updatePromptTimestamps,
+}) => {
+  const extensionsStore = configureStore({
+    reducer: {
+      options: extensionsSlice.reducer,
+      settings: settingsSlice.reducer,
+      auth: authSlice.reducer,
+    },
+    preloadedState: {
+      options: extensionsSlice.getInitialState(),
+      settings: { ...settingsSlice.getInitialState(), updatePromptTimestamps },
+      auth: { ...authSlice.getInitialState(), enforceUpdateMillis },
+    },
+  });
 
-// TODO: add story for upgrade modal
+  return (
+    <Provider store={extensionsStore}>
+      <DeploymentModal
+        extensionUpdateRequired={extensionUpdateRequired}
+        update={async () => {
+          action("update");
+        }}
+        updateExtension={async () => {
+          action("updateExtension");
+        }}
+      />
+    </Provider>
+  );
+};
 
 export const ExtensionUpdateRequired = Template.bind({});
 ExtensionUpdateRequired.args = {

--- a/src/options/pages/deployments/DeploymentModal.test.tsx
+++ b/src/options/pages/deployments/DeploymentModal.test.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from "react";
+import { render } from "@testing-library/react";
+import DeploymentModal from "@/options/pages/deployments/DeploymentModal";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import settingsSlice, { initialSettingsState } from "@/store/settingsSlice";
+import MockDate from "mockdate";
+import { SettingsState } from "@/store/settingsTypes";
+import { authSlice } from "@/auth/authSlice";
+import { useUpdateAvailable } from "@/options/pages/UpdateBanner";
+
+jest.mock("@/options/pages/UpdateBanner", () => ({
+  useUpdateAvailable: jest.fn(),
+}));
+
+const useUpdateAvailableMock = useUpdateAvailable as jest.Mock;
+
+const renderModal = (
+  { extensionUpdateRequired }: { extensionUpdateRequired: boolean },
+  settings: SettingsState
+) => {
+  const store = configureStore({
+    reducer: {
+      settings: settingsSlice.reducer,
+      auth: authSlice.reducer,
+    },
+    preloadedState: {
+      settings,
+      auth: authSlice.getInitialState(),
+    },
+  });
+
+  return render(
+    <Provider store={store}>
+      <DeploymentModal
+        update={jest.fn()}
+        extensionUpdateRequired={extensionUpdateRequired}
+        updateExtension={jest.fn()}
+      />
+    </Provider>
+  );
+};
+
+describe("DeploymentModal", () => {
+  it("should not render when snoozed", async () => {
+    // Tonight I'm going to party like it's 1999
+    const date = new Date("12/31/1998");
+    MockDate.set(date);
+
+    (useUpdateAvailable as jest.Mock).mockReturnValue(true);
+
+    const rendered = renderModal(
+      {
+        extensionUpdateRequired: false,
+      },
+      {
+        ...initialSettingsState,
+        nextUpdate: date.getTime() + 1,
+      }
+    );
+
+    expect(rendered.asFragment()).toMatchSnapshot();
+  });
+
+  it("should render modal when snooze expired", async () => {
+    const snoozeDate = new Date("12/31/1998");
+    MockDate.set(new Date(snoozeDate.getTime() + 1));
+
+    useUpdateAvailableMock.mockReturnValue(true);
+
+    const rendered = renderModal(
+      {
+        extensionUpdateRequired: false,
+      },
+      {
+        ...initialSettingsState,
+        nextUpdate: snoozeDate.getTime(),
+      }
+    );
+
+    expect(rendered.asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/options/pages/deployments/DeploymentModal.test.tsx
+++ b/src/options/pages/deployments/DeploymentModal.test.tsx
@@ -114,7 +114,7 @@ describe("DeploymentModal", () => {
     expect(screen.getByText("Remind Me Later")).not.toBeDisabled();
   });
 
-  it("should render when browser extension update is enforced", async () => {
+  it("should render when is enforced", async () => {
     // Tonight I'm going to party like it's 1999
     const date = new Date("12/31/1998");
     MockDate.set(date);
@@ -129,10 +129,7 @@ describe("DeploymentModal", () => {
         ...initialSettingsState,
         // It is snoozed
         nextUpdate: date.getTime() + 1,
-        updatePromptTimestamps: {
-          browserExtension: new Date(date.getTime() - 2).getTime(),
-          deployments: null,
-        },
+        updatePromptTimestamp: new Date(date.getTime() - 2).getTime(),
       },
       { enforceUpdateMillis: 1 }
     );
@@ -157,10 +154,7 @@ describe("DeploymentModal", () => {
         ...initialSettingsState,
         // It is snoozed
         nextUpdate: date.getTime() + 1,
-        updatePromptTimestamps: {
-          browserExtension: null,
-          deployments: new Date(date.getTime() - 2).getTime(),
-        },
+        updatePromptTimestamp: new Date(date.getTime() - 2).getTime(),
       },
       { enforceUpdateMillis: 1 }
     );
@@ -185,10 +179,7 @@ describe("DeploymentModal", () => {
         ...initialSettingsState,
         // It is snoozed
         nextUpdate: date.getTime() + 1,
-        updatePromptTimestamps: {
-          browserExtension: null,
-          deployments: new Date(date.getTime() - 2).getTime(),
-        },
+        updatePromptTimestamp: new Date(date.getTime() - 2).getTime(),
       },
       { enforceUpdateMillis: 1 }
     );

--- a/src/options/pages/deployments/DeploymentModal.test.tsx
+++ b/src/options/pages/deployments/DeploymentModal.test.tsx
@@ -88,6 +88,30 @@ describe("DeploymentModal", () => {
     expect(screen.queryAllByRole("dialog")).toHaveLength(0);
   });
 
+  it("should render if snoozed if not shown to user yet", async () => {
+    // Tonight I'm going to party like it's 1999
+    const date = new Date("12/31/1998");
+    MockDate.set(date);
+
+    (useUpdateAvailable as jest.Mock).mockReturnValue(true);
+
+    renderModal(
+      {
+        extensionUpdateRequired: false,
+      },
+      {
+        ...initialSettingsState,
+        nextUpdate: date.getTime() + 1,
+        updatePromptTimestamp: null,
+      },
+      {
+        enforceUpdateMillis: 1,
+      }
+    );
+
+    expect(screen.queryAllByRole("dialog")).toHaveLength(1);
+  });
+
   it("should render modal when snooze expired", async () => {
     const snoozeDate = new Date("12/31/1998");
     MockDate.set(new Date(snoozeDate.getTime() + 1));

--- a/src/options/pages/deployments/DeploymentModal.tsx
+++ b/src/options/pages/deployments/DeploymentModal.tsx
@@ -18,7 +18,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { DeploymentState } from "@/hooks/useDeployments";
 import AsyncButton from "@/components/AsyncButton";
-import { Dropdown, DropdownButton, Modal } from "react-bootstrap";
+import { Alert, Dropdown, DropdownButton, Modal } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
 import settingsSlice from "@/store/settingsSlice";
 import notify from "@/utils/notify";
@@ -30,13 +30,17 @@ import {
   selectUpdatePromptState,
   StateWithSettings,
 } from "@/store/settingsSelectors";
+import pluralize from "@/utils/pluralize";
 
 const FIFTEEN_MINUTES_MILLIS = 900_000;
 const ONE_HOUR_MILLIS = FIFTEEN_MINUTES_MILLIS * 4;
 const ONE_DAY_MILLIS = ONE_HOUR_MILLIS * 24;
 const MINUTES_TO_MILLIS = 60 * 1000;
 
-const CountdownTimer: React.FunctionComponent<{
+/**
+ * Countdown time that automatically calls `onFinish` on countdown.
+ */
+export const CountdownTimer: React.FunctionComponent<{
   duration: number;
   start: number;
   onFinish?: () => void;
@@ -68,16 +72,17 @@ const CountdownTimer: React.FunctionComponent<{
       (remaining - minutes * MINUTES_TO_MILLIS) / 1000
     );
     return (
-      <div>
-        You have {minutes} minute(s) and {seconds} second(s) to update.
-      </div>
+      <Alert variant="info">
+        You have {minutes} {pluralize(minutes, "minute")} and {seconds}{" "}
+        {pluralize(seconds, "second")} remaining to update.
+      </Alert>
     );
   }
 
   return (
-    <div>
-      Your Admin has set a policy requiring you to update within 30 minutes.
-    </div>
+    <Alert variant="info">
+      Your team admin has set a policy requiring you to apply updates.
+    </Alert>
   );
 };
 
@@ -159,7 +164,7 @@ const DeploymentModal: React.FC<
     [dispatch]
   );
 
-  if (isSnoozed && !(isDeploymentUpdateOverdue || isDeploymentUpdateOverdue)) {
+  if (isSnoozed && !(isDeploymentUpdateOverdue || isBrowserExtensionOverdue)) {
     // Snoozed
     return null;
   }

--- a/src/options/pages/deployments/DeploymentModal.tsx
+++ b/src/options/pages/deployments/DeploymentModal.tsx
@@ -150,10 +150,21 @@ const DeploymentModal: React.FC<
       selectUpdatePromptState(state, { now: currentTime, enforceUpdateMillis })
   );
 
+  // Need to track the initial value because the useEffect is potentially overriding it
+  const [initialUpdatePromptTimestamp] = useState(updatePromptTimestamp);
+
+  // When an update is available and a time period is enabled, always show the modal once
+  const hideModal =
+    isSnoozed &&
+    !isUpdateOverdue &&
+    !(enforceUpdateMillis && initialUpdatePromptTimestamp == null);
+
   useEffect(() => {
     // The modal is only rendered if there is something to update
-    dispatch(settingsSlice.actions.recordUpdatePromptTimestamp());
-  }, [dispatch, hasUpdatesAvailable, extensionUpdateRequired]);
+    if (!hideModal) {
+      dispatch(settingsSlice.actions.recordUpdatePromptTimestamp());
+    }
+  }, [hideModal, dispatch]);
 
   const snooze = useCallback(
     (durationMillis: number) => {
@@ -164,7 +175,7 @@ const DeploymentModal: React.FC<
     [dispatch]
   );
 
-  if (isSnoozed && !isUpdateOverdue) {
+  if (hideModal) {
     return null;
   }
 

--- a/src/options/pages/deployments/DeploymentModal.tsx
+++ b/src/options/pages/deployments/DeploymentModal.tsx
@@ -145,23 +145,15 @@ const DeploymentModal: React.FC<
 
   const currentTime = Date.now();
 
-  const {
-    isSnoozed,
-    isBrowserExtensionOverdue,
-    isDeploymentUpdateOverdue,
-    deploymentsTimestamp,
-    browserExtensionTimestamp,
-  } = useSelector((state: StateWithSettings) =>
-    selectUpdatePromptState(state, { now: currentTime, enforceUpdateMillis })
+  const { isSnoozed, isUpdateOverdue, updatePromptTimestamp } = useSelector(
+    (state: StateWithSettings) =>
+      selectUpdatePromptState(state, { now: currentTime, enforceUpdateMillis })
   );
 
   useEffect(() => {
-    if (hasUpdatesAvailable || extensionUpdateRequired) {
-      dispatch(settingsSlice.actions.updateBrowserExtensionPromptTimestamp());
-    } else {
-      dispatch(settingsSlice.actions.updateDeploymentsPromptTimestamp());
-    }
-  }, [dispatch, hasUpdatesAvailable, extensionUpdateRequired, isSnoozed]);
+    // The modal is only rendered if there is something to update
+    dispatch(settingsSlice.actions.recordUpdatePromptTimestamp());
+  }, [dispatch, hasUpdatesAvailable, extensionUpdateRequired]);
 
   const snooze = useCallback(
     (durationMillis: number) => {
@@ -172,7 +164,7 @@ const DeploymentModal: React.FC<
     [dispatch]
   );
 
-  if (isSnoozed) {
+  if (isSnoozed && !isUpdateOverdue) {
     return null;
   }
 
@@ -192,7 +184,7 @@ const DeploymentModal: React.FC<
           <Modal.Body>
             <CountdownTimer
               duration={enforceUpdateMillis}
-              start={browserExtensionTimestamp}
+              start={updatePromptTimestamp}
               onFinish={() => {
                 browser.runtime.reload();
               }}
@@ -201,7 +193,7 @@ const DeploymentModal: React.FC<
         )}
 
         <Modal.Footer>
-          <SnoozeButton disabled={isBrowserExtensionOverdue} snooze={snooze} />
+          <SnoozeButton disabled={isUpdateOverdue} snooze={snooze} />
 
           <AsyncButton variant="primary" onClick={updateExtension}>
             Update
@@ -227,7 +219,7 @@ const DeploymentModal: React.FC<
           <Modal.Body>
             <CountdownTimer
               duration={enforceUpdateMillis}
-              start={deploymentsTimestamp}
+              start={updatePromptTimestamp}
               onFinish={() => {
                 browser.runtime.reload();
               }}
@@ -236,7 +228,7 @@ const DeploymentModal: React.FC<
         )}
 
         <Modal.Footer>
-          <SnoozeButton disabled={isDeploymentUpdateOverdue} snooze={snooze} />
+          <SnoozeButton disabled={isUpdateOverdue} snooze={snooze} />
           <AsyncButton variant="primary" onClick={updateExtension}>
             Update
           </AsyncButton>
@@ -256,13 +248,13 @@ const DeploymentModal: React.FC<
         <Modal.Body>
           <CountdownTimer
             duration={enforceUpdateMillis}
-            start={deploymentsTimestamp}
+            start={updatePromptTimestamp}
           />
         </Modal.Body>
       )}
 
       <Modal.Footer>
-        <SnoozeButton disabled={isDeploymentUpdateOverdue} snooze={snooze} />
+        <SnoozeButton disabled={isUpdateOverdue} snooze={snooze} />
         <AsyncButton variant="primary" onClick={update}>
           Activate
         </AsyncButton>

--- a/src/options/pages/deployments/DeploymentModal.tsx
+++ b/src/options/pages/deployments/DeploymentModal.tsx
@@ -147,13 +147,21 @@ const DeploymentModal: React.FC<
 
   const {
     isSnoozed,
-    isDeploymentUpdateOverdue,
     isBrowserExtensionOverdue,
+    isDeploymentUpdateOverdue,
     deploymentsTimestamp,
     browserExtensionTimestamp,
   } = useSelector((state: StateWithSettings) =>
     selectUpdatePromptState(state, { now: currentTime, enforceUpdateMillis })
   );
+
+  useEffect(() => {
+    if (hasUpdatesAvailable || extensionUpdateRequired) {
+      dispatch(settingsSlice.actions.updateBrowserExtensionPromptTimestamp());
+    } else {
+      dispatch(settingsSlice.actions.updateDeploymentsPromptTimestamp());
+    }
+  }, [dispatch, hasUpdatesAvailable, extensionUpdateRequired, isSnoozed]);
 
   const snooze = useCallback(
     (durationMillis: number) => {
@@ -164,8 +172,7 @@ const DeploymentModal: React.FC<
     [dispatch]
   );
 
-  if (isSnoozed && !(isDeploymentUpdateOverdue || isBrowserExtensionOverdue)) {
-    // Snoozed
+  if (isSnoozed) {
     return null;
   }
 

--- a/src/options/pages/deployments/__snapshots__/DeploymentModal.test.tsx.snap
+++ b/src/options/pages/deployments/__snapshots__/DeploymentModal.test.tsx.snap
@@ -173,7 +173,6 @@ Array [
           class="modal-footer"
         >
           <div
-            aria-disabled="false"
             class="dropdown"
           >
             <button
@@ -199,7 +198,7 @@ Array [
 ]
 `;
 
-exports[`DeploymentModal should render when browser extension update is enforced 1`] = `
+exports[`DeploymentModal should render when is enforced 1`] = `
 Array [
   <div
     aria-modal="true"

--- a/src/options/pages/deployments/__snapshots__/DeploymentModal.test.tsx.snap
+++ b/src/options/pages/deployments/__snapshots__/DeploymentModal.test.tsx.snap
@@ -2,10 +2,270 @@
 
 exports[`DeploymentModal should not render when snoozed 1`] = `<div />`;
 
-exports[`DeploymentModal should render modal when snooze expired 1`] = `
-<div
-  aria-hidden="true"
-/>
+exports[`DeploymentModal should reload browser extension if extension update required for deployment 1`] = `
+Array [
+  <div
+    aria-modal="true"
+    class="fade modal show"
+    role="dialog"
+    style="display: block;"
+    tabindex="-1"
+  >
+    <div
+      class="modal-dialog"
+    >
+      <div
+        class="modal-content"
+      >
+        <div
+          class="modal-header"
+        >
+          <div
+            class="modal-title h4"
+          >
+            Update Available
+          </div>
+        </div>
+        <div
+          class="modal-body"
+        >
+          Update the PixieBrix Browser Extension to activate team deployments. After updating, you will need need to reload any pages where PixieBrix is running
+        </div>
+        <div
+          class="modal-body"
+        >
+          <div
+            class="fade alert alert-info show"
+            role="alert"
+          >
+            Your team admin has set a policy requiring you to apply updates.
+          </div>
+        </div>
+        <div
+          class="modal-footer"
+        >
+          <div
+            aria-disabled="true"
+            class="dropdown"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="dropdown-toggle btn btn-info"
+              disabled=""
+              id="dropdown-snooze"
+              type="button"
+            >
+              Remind Me Later
+            </button>
+          </div>
+          <button
+            class="btn btn-primary"
+            type="button"
+          >
+            Update
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
 `;
 
-exports[`DeploymentModal should render when snooze expired 1`] = `<div />`;
+exports[`DeploymentModal should render deployment update if update is enforced 1`] = `
+Array [
+  <div
+    aria-modal="true"
+    class="fade modal show"
+    role="dialog"
+    style="display: block;"
+    tabindex="-1"
+  >
+    <div
+      class="modal-dialog"
+    >
+      <div
+        class="modal-content"
+      >
+        <div
+          class="modal-header"
+        >
+          <div
+            class="modal-title h4"
+          >
+            Team Deployments Available
+          </div>
+        </div>
+        <div
+          class="modal-body"
+        >
+          Team deployments are ready to activate
+        </div>
+        <div
+          class="modal-body"
+        >
+          <div
+            class="fade alert alert-info show"
+            role="alert"
+          >
+            Your team admin has set a policy requiring you to apply updates.
+          </div>
+        </div>
+        <div
+          class="modal-footer"
+        >
+          <div
+            aria-disabled="true"
+            class="dropdown"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="dropdown-toggle btn btn-info"
+              disabled=""
+              id="dropdown-snooze"
+              type="button"
+            >
+              Remind Me Later
+            </button>
+          </div>
+          <button
+            class="btn btn-primary"
+            type="button"
+          >
+            Activate
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`DeploymentModal should render modal when snooze expired 1`] = `
+Array [
+  <div
+    aria-modal="true"
+    class="fade modal show"
+    role="dialog"
+    style="display: block;"
+    tabindex="-1"
+  >
+    <div
+      class="modal-dialog"
+    >
+      <div
+        class="modal-content"
+      >
+        <div
+          class="modal-header"
+        >
+          <div
+            class="modal-title h4"
+          >
+            Update Available
+          </div>
+        </div>
+        <div
+          class="modal-body"
+        >
+          An update to the PixieBrix browser extension is available. After updating, you will need need to reload any pages where PixieBrix is running.
+        </div>
+        <div
+          class="modal-footer"
+        >
+          <div
+            class="dropdown"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="dropdown-toggle btn btn-info"
+              id="dropdown-snooze"
+              type="button"
+            >
+              Remind Me Later
+            </button>
+          </div>
+          <button
+            class="btn btn-primary"
+            type="button"
+          >
+            Update
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`DeploymentModal should render when browser extension update is enforced 1`] = `
+Array [
+  <div
+    aria-modal="true"
+    class="fade modal show"
+    role="dialog"
+    style="display: block;"
+    tabindex="-1"
+  >
+    <div
+      class="modal-dialog"
+    >
+      <div
+        class="modal-content"
+      >
+        <div
+          class="modal-header"
+        >
+          <div
+            class="modal-title h4"
+          >
+            Update Available
+          </div>
+        </div>
+        <div
+          class="modal-body"
+        >
+          An update to the PixieBrix browser extension is available. After updating, you will need need to reload any pages where PixieBrix is running.
+        </div>
+        <div
+          class="modal-body"
+        >
+          <div
+            class="fade alert alert-info show"
+            role="alert"
+          >
+            Your team admin has set a policy requiring you to apply updates.
+          </div>
+        </div>
+        <div
+          class="modal-footer"
+        >
+          <div
+            aria-disabled="true"
+            class="dropdown"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="dropdown-toggle btn btn-info"
+              disabled=""
+              id="dropdown-snooze"
+              type="button"
+            >
+              Remind Me Later
+            </button>
+          </div>
+          <button
+            class="btn btn-primary"
+            type="button"
+          >
+            Update
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/src/options/pages/deployments/__snapshots__/DeploymentModal.test.tsx.snap
+++ b/src/options/pages/deployments/__snapshots__/DeploymentModal.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeploymentModal should not render when snoozed 1`] = `<div />`;
+
+exports[`DeploymentModal should render modal when snooze expired 1`] = `
+<div
+  aria-hidden="true"
+/>
+`;
+
+exports[`DeploymentModal should render when snooze expired 1`] = `<div />`;

--- a/src/options/pages/deployments/__snapshots__/DeploymentModal.test.tsx.snap
+++ b/src/options/pages/deployments/__snapshots__/DeploymentModal.test.tsx.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DeploymentModal should not render when snoozed 1`] = `<div />`;
-
 exports[`DeploymentModal should reload browser extension if extension update required for deployment 1`] = `
 Array [
   <div
@@ -175,6 +173,7 @@ Array [
           class="modal-footer"
         >
           <div
+            aria-disabled="false"
             class="dropdown"
           >
             <button

--- a/src/store/settingsSelectors.test.ts
+++ b/src/store/settingsSelectors.test.ts
@@ -21,26 +21,7 @@ import settingsSlice from "@/store/settingsSlice";
 import { SettingsState } from "@/store/settingsTypes";
 
 describe("selectUpdatePromptState", () => {
-  it("handles null timestamp state from previous versions", () => {
-    const settings: SettingsState = {
-      ...settingsSlice.getInitialState(),
-      updatePromptTimestamps: null,
-    };
-
-    const result = selectUpdatePromptState(
-      { settings },
-      { now: Date.now(), enforceUpdateMillis: 1 }
-    );
-    expect(result).toStrictEqual({
-      isSnoozed: false,
-      isBrowserExtensionOverdue: false,
-      isDeploymentUpdateOverdue: false,
-      deploymentsTimestamp: null,
-      browserExtensionTimestamp: null,
-    });
-  });
-
-  it("snooze considers deployment enforcement", () => {
+  it("snooze independent of deployment enforcement", () => {
     const now = Date.now();
 
     MockDate.set(now);
@@ -50,37 +31,7 @@ describe("selectUpdatePromptState", () => {
     const settings: SettingsState = {
       ...settingsSlice.getInitialState(),
       nextUpdate: now + 3,
-      updatePromptTimestamps: {
-        deployments: timestamp,
-        browserExtension: null,
-      },
-    };
-
-    const result = selectUpdatePromptState(
-      { settings },
-      { now, enforceUpdateMillis: 1 }
-    );
-    expect(result).toStrictEqual({
-      isSnoozed: false,
-      isBrowserExtensionOverdue: false,
-      isDeploymentUpdateOverdue: true,
-      deploymentsTimestamp: timestamp,
-      browserExtensionTimestamp: null,
-    });
-  });
-
-  it("snoozes", () => {
-    const now = Date.now();
-
-    MockDate.set(now);
-
-    const settings: SettingsState = {
-      ...settingsSlice.getInitialState(),
-      nextUpdate: now + 3,
-      updatePromptTimestamps: {
-        deployments: null,
-        browserExtension: null,
-      },
+      updatePromptTimestamp: timestamp,
     };
 
     const result = selectUpdatePromptState(
@@ -89,10 +40,30 @@ describe("selectUpdatePromptState", () => {
     );
     expect(result).toStrictEqual({
       isSnoozed: true,
-      isBrowserExtensionOverdue: false,
-      isDeploymentUpdateOverdue: false,
-      deploymentsTimestamp: null,
-      browserExtensionTimestamp: null,
+      updatePromptTimestamp: timestamp,
+      isUpdateOverdue: true,
+    });
+  });
+
+  it("no snooze or previous prompt", () => {
+    const now = Date.now();
+
+    MockDate.set(now);
+
+    const settings: SettingsState = {
+      ...settingsSlice.getInitialState(),
+      nextUpdate: null,
+      updatePromptTimestamp: null,
+    };
+
+    const result = selectUpdatePromptState(
+      { settings },
+      { now, enforceUpdateMillis: 1 }
+    );
+    expect(result).toStrictEqual({
+      isSnoozed: false,
+      updatePromptTimestamp: null,
+      isUpdateOverdue: false,
     });
   });
 });

--- a/src/store/settingsSelectors.test.ts
+++ b/src/store/settingsSelectors.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import MockDate from "mockdate";
+import { selectUpdatePromptState } from "@/store/settingsSelectors";
+import settingsSlice from "@/store/settingsSlice";
+import { SettingsState } from "@/store/settingsTypes";
+
+describe("selectUpdatePromptState", () => {
+  it("handles null timestamp state from previous versions", () => {
+    const settings: SettingsState = {
+      ...settingsSlice.getInitialState(),
+      updatePromptTimestamps: null,
+    };
+
+    const result = selectUpdatePromptState(
+      { settings },
+      { now: Date.now(), enforceUpdateMillis: 1 }
+    );
+    expect(result).toStrictEqual({
+      isSnoozed: false,
+      isBrowserExtensionOverdue: false,
+      isDeploymentUpdateOverdue: false,
+      deploymentsTimestamp: null,
+      browserExtensionTimestamp: null,
+    });
+  });
+
+  it("snooze considers deployment enforcement", () => {
+    const now = Date.now();
+
+    MockDate.set(now);
+
+    const timestamp = now - 2;
+
+    const settings: SettingsState = {
+      ...settingsSlice.getInitialState(),
+      nextUpdate: now + 3,
+      updatePromptTimestamps: {
+        deployments: timestamp,
+        browserExtension: null,
+      },
+    };
+
+    const result = selectUpdatePromptState(
+      { settings },
+      { now, enforceUpdateMillis: 1 }
+    );
+    expect(result).toStrictEqual({
+      isSnoozed: false,
+      isBrowserExtensionOverdue: false,
+      isDeploymentUpdateOverdue: true,
+      deploymentsTimestamp: timestamp,
+      browserExtensionTimestamp: null,
+    });
+  });
+
+  it("snoozes", () => {
+    const now = Date.now();
+
+    MockDate.set(now);
+
+    const settings: SettingsState = {
+      ...settingsSlice.getInitialState(),
+      nextUpdate: now + 3,
+      updatePromptTimestamps: {
+        deployments: null,
+        browserExtension: null,
+      },
+    };
+
+    const result = selectUpdatePromptState(
+      { settings },
+      { now, enforceUpdateMillis: 1 }
+    );
+    expect(result).toStrictEqual({
+      isSnoozed: true,
+      isBrowserExtensionOverdue: false,
+      isDeploymentUpdateOverdue: false,
+      deploymentsTimestamp: null,
+      browserExtensionTimestamp: null,
+    });
+  });
+});

--- a/src/store/settingsSelectors.ts
+++ b/src/store/settingsSelectors.ts
@@ -31,31 +31,17 @@ export const selectUpdatePromptState = createSelector(
     ) => args,
   ],
   (state, { now, enforceUpdateMillis }) => {
-    const { nextUpdate, updatePromptTimestamps } = state;
-    const {
-      deployments: deploymentsTimestamp = null,
-      browserExtension: browserExtensionTimestamp = null,
-    } = updatePromptTimestamps ?? {};
+    const { nextUpdate, updatePromptTimestamp } = state;
 
-    const isDeploymentUpdateOverdue =
-      deploymentsTimestamp != null &&
+    const isUpdateOverdue =
+      updatePromptTimestamp != null &&
       enforceUpdateMillis &&
-      now - deploymentsTimestamp > enforceUpdateMillis;
-
-    const isBrowserExtensionOverdue =
-      browserExtensionTimestamp != null &&
-      enforceUpdateMillis &&
-      now - browserExtensionTimestamp > enforceUpdateMillis;
+      now - updatePromptTimestamp > enforceUpdateMillis;
 
     return {
-      isSnoozed:
-        nextUpdate != null &&
-        nextUpdate > now &&
-        !(isDeploymentUpdateOverdue || isDeploymentUpdateOverdue),
-      isBrowserExtensionOverdue,
-      isDeploymentUpdateOverdue,
-      deploymentsTimestamp,
-      browserExtensionTimestamp,
+      isSnoozed: nextUpdate != null && nextUpdate > now,
+      isUpdateOverdue,
+      updatePromptTimestamp,
     };
   }
 );

--- a/src/store/settingsSelectors.ts
+++ b/src/store/settingsSelectors.ts
@@ -26,3 +26,13 @@ export const selectSettings = ({ settings }: StateWithSettings) => settings;
 export const selectBrowserWarningDismissed = ({
   settings,
 }: StateWithSettings) => settings.browserWarningDismissed;
+
+export const selectPromptTimestamps = ({
+  settings,
+}: StateWithSettings): {
+  updateDeploymentsTimestamp: SettingsState["updatePromptTimestamps"]["deployments"];
+  updateExtensionTimestamp: SettingsState["updatePromptTimestamps"]["browserExtension"];
+} => ({
+  updateDeploymentsTimestamp: settings.updatePromptTimestamps?.deployments,
+  updateExtensionTimestamp: settings.updatePromptTimestamps?.browserExtension,
+});

--- a/src/store/settingsSelectors.ts
+++ b/src/store/settingsSelectors.ts
@@ -33,21 +33,25 @@ export const selectUpdatePromptState = createSelector(
   (state, { now, enforceUpdateMillis }) => {
     const { nextUpdate, updatePromptTimestamps } = state;
     const {
-      deployments: deploymentsTimestamp,
-      browserExtension: browserExtensionTimestamp,
+      deployments: deploymentsTimestamp = null,
+      browserExtension: browserExtensionTimestamp = null,
     } = updatePromptTimestamps ?? {};
 
     const isDeploymentUpdateOverdue =
-      deploymentsTimestamp &&
+      deploymentsTimestamp != null &&
       enforceUpdateMillis &&
       now - deploymentsTimestamp > enforceUpdateMillis;
+
     const isBrowserExtensionOverdue =
-      browserExtensionTimestamp &&
+      browserExtensionTimestamp != null &&
       enforceUpdateMillis &&
       now - browserExtensionTimestamp > enforceUpdateMillis;
 
     return {
-      isSnoozed: nextUpdate && nextUpdate > now,
+      isSnoozed:
+        nextUpdate != null &&
+        nextUpdate > now &&
+        !(isDeploymentUpdateOverdue || isDeploymentUpdateOverdue),
       isBrowserExtensionOverdue,
       isDeploymentUpdateOverdue,
       deploymentsTimestamp,

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -22,7 +22,7 @@ import { once } from "lodash";
 import { DEFAULT_THEME } from "@/options/types";
 import { isValidTheme } from "@/utils/themeUtils";
 
-const initialSettingsState: SettingsState = {
+export const initialSettingsState: SettingsState = {
   mode: "remote",
   nextUpdate: null as number,
   suggestElements: false,

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -66,6 +66,30 @@ const settingsSlice = createSlice({
     ) {
       state.partnerId = partnerId;
     },
+    updateBrowserExtensionPromptTimestamp(state) {
+      if (state.updatePromptTimestamps == null) {
+        state.updatePromptTimestamps = {
+          deployments: null,
+          browserExtension: null,
+        };
+      }
+
+      if (state.updatePromptTimestamps.browserExtension == null) {
+        state.updatePromptTimestamps.browserExtension = Date.now();
+      }
+    },
+    updateDeploymentsPromptTimestamp(state) {
+      if (state.updatePromptTimestamps == null) {
+        state.updatePromptTimestamps = {
+          deployments: null,
+          browserExtension: null,
+        };
+      }
+
+      if (state.updatePromptTimestamps.deployments == null) {
+        state.updatePromptTimestamps.deployments = Date.now();
+      }
+    },
     setTheme(state, { payload: { theme } }: { payload: { theme: string } }) {
       if (isValidTheme(theme)) {
         state.theme = theme;

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -29,6 +29,10 @@ const initialSettingsState: SettingsState = {
   browserWarningDismissed: false,
   partnerId: null,
   theme: DEFAULT_THEME,
+  updatePromptTimestamps: {
+    browserExtension: null,
+    deployments: null,
+  },
 };
 
 const settingsSlice = createSlice({

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -29,10 +29,7 @@ export const initialSettingsState: SettingsState = {
   browserWarningDismissed: false,
   partnerId: null,
   theme: DEFAULT_THEME,
-  updatePromptTimestamps: {
-    browserExtension: null,
-    deployments: null,
-  },
+  updatePromptTimestamp: null,
 };
 
 const settingsSlice = createSlice({
@@ -66,29 +63,14 @@ const settingsSlice = createSlice({
     ) {
       state.partnerId = partnerId;
     },
-    updateBrowserExtensionPromptTimestamp(state) {
-      if (state.updatePromptTimestamps == null) {
-        state.updatePromptTimestamps = {
-          deployments: null,
-          browserExtension: null,
-        };
-      }
-
-      if (state.updatePromptTimestamps.browserExtension == null) {
-        state.updatePromptTimestamps.browserExtension = Date.now();
+    recordUpdatePromptTimestamp(state) {
+      // Don't overwrite the old timestamp
+      if (state.updatePromptTimestamp == null) {
+        state.updatePromptTimestamp = Date.now();
       }
     },
-    updateDeploymentsPromptTimestamp(state) {
-      if (state.updatePromptTimestamps == null) {
-        state.updatePromptTimestamps = {
-          deployments: null,
-          browserExtension: null,
-        };
-      }
-
-      if (state.updatePromptTimestamps.deployments == null) {
-        state.updatePromptTimestamps.deployments = Date.now();
-      }
+    resetUpdatePromptTimestamp(state) {
+      state.updatePromptTimestamp = null;
     },
     setTheme(state, { payload: { theme } }: { payload: { theme: string } }) {
       if (isValidTheme(theme)) {

--- a/src/store/settingsStorage.ts
+++ b/src/store/settingsStorage.ts
@@ -16,7 +16,7 @@
  */
 
 import { localStorage } from "redux-persist-webextension-storage";
-import { readReduxStorage, ReduxStorageKey } from "@/chrome";
+import { readReduxStorage, ReduxStorageKey, setReduxStorage } from "@/chrome";
 import { SettingsState } from "@/store/settingsTypes";
 import { mapValues } from "lodash";
 
@@ -38,6 +38,16 @@ export async function getSettingsState(): Promise<SettingsState> {
   return parsedSettings;
 }
 
+/**
+ * Save extension options to local storage (without going through redux-persistor).
+ */
+export async function saveSettingsState(state: SettingsState): Promise<void> {
+  // `persist` library expects values as stringified values
+  await setReduxStorage(
+    SETTINGS_STORAGE_KEY,
+    mapValues(state, (value) => JSON.stringify(value))
+  );
+}
 export const persistSettingsConfig = {
   key: "settings",
   storage: localStorage,

--- a/src/store/settingsStorage.ts
+++ b/src/store/settingsStorage.ts
@@ -39,7 +39,7 @@ export async function getSettingsState(): Promise<SettingsState> {
 }
 
 /**
- * Save extension options to local storage (without going through redux-persistor).
+ * Save settings to local storage (without going through redux-persistor).
  */
 export async function saveSettingsState(state: SettingsState): Promise<void> {
   // `persist` library expects values as stringified values
@@ -48,6 +48,7 @@ export async function saveSettingsState(state: SettingsState): Promise<void> {
     mapValues(state, (value) => JSON.stringify(value))
   );
 }
+
 export const persistSettingsConfig = {
   key: "settings",
   storage: localStorage,

--- a/src/store/settingsTypes.ts
+++ b/src/store/settingsTypes.ts
@@ -21,7 +21,7 @@ export type InstallMode = "local" | "remote";
 
 export type SettingsState = SkunkworksSettings & {
   /**
-   * Whether the extension is synced to the app for provisioning.*
+   * Whether the extension is synced to the app for provisioning.
    *
    * NOTE: `local` is broken in many places. The only current valid value is remote.
    */
@@ -33,6 +33,28 @@ export type SettingsState = SkunkworksSettings & {
    * The banners still show, however no modals will be shown for the browser extension or team deployments.
    */
   nextUpdate: number | null;
+
+  /**
+   * Timestamps the update modal was first shown. Used to calculate time remaining for enforceUpdateMillis
+   *
+   * @since 1.7.1
+   * @see AuthState.enforceUpdateMillis
+   */
+  updatePromptTimestamps: {
+    /**
+     * Time (in milliseconds from the epoch) that the update deployment modal was first shown
+     *
+     * Reset when no deployment check indicates no deployment updates are available.
+     */
+    deployments: number | null;
+
+    /**
+     * Time (in milliseconds from the epoch) that the update PixieBrix browser extension modal was first shown
+     *
+     * Reset when extension check indicates no browser extension update is available.
+     */
+    browserExtension: number | null;
+  };
 
   /**
    * Whether the non-Chrome browser warning has been dismissed.

--- a/src/store/settingsTypes.ts
+++ b/src/store/settingsTypes.ts
@@ -40,21 +40,7 @@ export type SettingsState = SkunkworksSettings & {
    * @since 1.7.1
    * @see AuthState.enforceUpdateMillis
    */
-  updatePromptTimestamps: {
-    /**
-     * Time (in milliseconds from the epoch) that the update deployment modal was first shown
-     *
-     * Reset when no deployment check indicates no deployment updates are available.
-     */
-    deployments: number | null;
-
-    /**
-     * Time (in milliseconds from the epoch) that the update PixieBrix browser extension modal was first shown
-     *
-     * Reset when extension check indicates no browser extension update is available.
-     */
-    browserExtension: number | null;
-  };
+  updatePromptTimestamp: number | null;
 
   /**
    * Whether the non-Chrome browser warning has been dismissed.

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -113,6 +113,7 @@ export const authStateFactory = define<AuthState>({
   isLoggedIn: true,
   isOnboarded: true,
   extension: true,
+  enforceUpdateMillis: null,
   organizations() {
     return [
       organizationFactory({

--- a/src/types/swagger.ts
+++ b/src/types/swagger.ts
@@ -1050,7 +1050,7 @@ export interface components {
           id?: string;
           /**
            * Format: uri
-           * @description The control room url
+           * @description The Control Room URL
            */
           url: string;
         };
@@ -1065,7 +1065,7 @@ export interface components {
           id?: string;
           /**
            * Format: uri
-           * @description The control room url
+           * @description The Control Room URL
            */
           url: string;
         };
@@ -1084,7 +1084,7 @@ export interface components {
           id?: string;
           /**
            * Format: uri
-           * @description The control room url
+           * @description The Control Room URL
            */
           url: string;
         };
@@ -1106,6 +1106,7 @@ export interface components {
         /** Format: uri */
         documentation_url?: string | null;
       };
+      enforce_update_millis?: number;
     };
     Membership: {
       id?: number;
@@ -1287,7 +1288,7 @@ export interface components {
       id?: string;
       /**
        * Format: uri
-       * @description The control room url
+       * @description The Control Room URL
        */
       url: string;
     };
@@ -1296,7 +1297,7 @@ export interface components {
       id?: string;
       /**
        * Format: uri
-       * @description The control room url
+       * @description The Control Room URL
        */
       url: string;
       /** Format: uuid */


### PR DESCRIPTION
## What does this PR do?

- Closes #3791
- Corresponding api PR: https://github.com/pixiebrix/pixiebrix-app/pull/1950
- Tracks when the user was last shown an modal
- Enforces organization policy to update


## Demo

![image](https://user-images.githubusercontent.com/1879821/176787714-a923a08d-413c-435c-824d-422247a1e13f.png)

![image](https://user-images.githubusercontent.com/1879821/176787921-0b440045-283a-449a-ba2d-da491bcca991.png)

## Tasks Remaining

- [X] Reset timestamps on extension startup and deployment install
- [X] Add tests for deployment modal
- [X] Add storybook stories that include the timer, and expired timer

## Future Work

- Need to get Storybook working with mocks for the browser runtime... I just story booked the countdown timer separately to get more storybook coverage

## Checklist

- [x] Designate a primary reviewer: @BLoe 
