### PR TITLE
#3828: mute rollbar sourcemap upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,14 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
-      - run: bash scripts/upload-sourcemaps.sh
-        if: ${{ fromJSON(env.PUBLIC_RELEASE)}}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.SOURCEMAP_USER_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.SOURCEMAP_USER_KEY }}
-          AWS_DEFAULT_REGION: "us-east-2"
-          ROLLBAR_POST_SERVER_ITEM_TOKEN: ${{ secrets.ROLLBAR_POST_SERVER_ITEM_TOKEN }}
+  # Slow, and we don't use currently
+  #      - run: bash scripts/upload-sourcemaps.sh
+  #        if: ${{ fromJSON(env.PUBLIC_RELEASE)}}
+  #        env:
+  #          AWS_ACCESS_KEY_ID: ${{ secrets.SOURCEMAP_USER_ID }}
+  #          AWS_SECRET_ACCESS_KEY: ${{ secrets.SOURCEMAP_USER_KEY }}
+  #          AWS_DEFAULT_REGION: "us-east-2"
+  #          ROLLBAR_POST_SERVER_ITEM_TOKEN: ${{ secrets.ROLLBAR_POST_SERVER_ITEM_TOKEN }}
 
   generate-headers:
     runs-on: ubuntu-latest

--- a/scripts/upload-sourcemaps.sh
+++ b/scripts/upload-sourcemaps.sh
@@ -40,13 +40,15 @@ sed s/dist\\/// | \
 # etc
 #
 # `curl` automatically retries if the server is busy. --fail throws on HTTP errors
+# https://github.com/pixiebrix/pixiebrix-extension/issues/3828 -- ignore errors since they appear to be transient
 parallel curl https://api.rollbar.com/api/1/sourcemap/download \
 	--fail \
 	--no-progress-meter \
   --max-time 10 \
 	-F version="$SOURCE_VERSION" \
 	-F access_token="$ROLLBAR_POST_SERVER_ITEM_TOKEN" \
-	-F minified_url="$SOURCE_MAP_URL_BASE/$SOURCE_MAP_PATH/{}"
+	-F minified_url="$SOURCE_MAP_URL_BASE/$SOURCE_MAP_PATH/{}" \
+	|| true
 
 # TODO: Replace --fail with --fail-with-body when curl is updated on GitHub Actions (min 7.76.0)
 # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md


### PR DESCRIPTION
## What does this PR do?

- Part of #3828 
- Turns off sourcemap upload on staging
- Ignores sourcemap upload errors to Rollbar

## Checklist

- [X] Add tests - tested on 1.7.1-beta.1 branch
- [X] Designate a primary reviewer: @johnnymetz 
