### PR TITLE
#3858: add brick id to registry error message

### DIFF
--- a/src/baseRegistry.ts
+++ b/src/baseRegistry.ts
@@ -32,7 +32,7 @@ export class DoesNotExistError extends Error {
   public readonly id: string;
 
   constructor(id: string) {
-    super("Registry item does not exist");
+    super(`Registry item does not exist: ${id}`);
     this.id = id;
   }
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #3858 
- Adds the missing registry id to the error message to assist with debugging

## Checklist

- N/A: Add tests:
- [x] Designate a primary reviewer: @BLoe 
