### PR TITLE
Data panel state

### DIFF
--- a/src/pageEditor/slices/editorSelectors.ts
+++ b/src/pageEditor/slices/editorSelectors.ts
@@ -23,6 +23,7 @@ import { flatMap, isEmpty, uniqBy } from "lodash";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
 import {
   ElementUIState,
+  ErrorMap,
   NodeUIState,
   TabUIState,
 } from "@/pageEditor/uiState/uiStateTypes";
@@ -249,10 +250,9 @@ export const selectErrorMap = createSelector(
 );
 
 export const selectActiveNodeError = createSelector(
-  selectActiveElementUIState,
+  selectErrorMap,
   selectActiveNodeId,
-  (uiState: ElementUIState, activeNodeId: UUID) =>
-    uiState.errorMap[activeNodeId]
+  (errorMap: ErrorMap, activeNodeId: UUID) => errorMap[activeNodeId]
 );
 
 export const selectAddBlockLocation = ({ editor }: RootState) =>

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -26,8 +26,6 @@ import BlockPreview, {
   usePreviewInfo,
 } from "@/pageEditor/tabs/effect/BlockPreview";
 import useReduxState from "@/hooks/useReduxState";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useSelector } from "react-redux";
 import { selectExtensionTrace } from "@/pageEditor/slices/runtimeSelectors";
 import { JsonObject } from "type-fest";
@@ -44,7 +42,6 @@ import {
   selectActiveElement,
   selectActiveNodeId,
   selectActiveNodeInfo,
-  selectErrorMap,
   selectNodePreviewActiveElement,
 } from "@/pageEditor/slices/editorSelectors";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
@@ -54,6 +51,8 @@ import { FormTransformer } from "@/blocks/transformers/ephemeralForm/formTransfo
 import { DocumentRenderer } from "@/blocks/renderers/document";
 import DocumentOutline from "@/components/documentBuilder/outline/DocumentOutline";
 import useAllBlocks from "@/pageEditor/hooks/useAllBlocks";
+import StateTab from "./tabs/StateTab";
+import ConfigurationTab from "./tabs/ConfigurationTab";
 
 /**
  * Exclude irrelevant top-level keys.
@@ -78,7 +77,6 @@ const DataPanel: React.FC = () => {
   const { flagOn } = useFlags();
   const showDeveloperTabs = flagOn("page-editor-developer");
 
-  const errors = useSelector(selectErrorMap);
   const activeElement = useSelector(selectActiveElement);
 
   const {
@@ -204,7 +202,7 @@ const DataPanel: React.FC = () => {
           {showDeveloperTabs && (
             <>
               <Nav.Item className={dataPanelStyles.tabNav}>
-                <Nav.Link eventKey={DataPanelTabKey.Formik}>Formik</Nav.Link>
+                <Nav.Link eventKey={DataPanelTabKey.Formik}>State</Nav.Link>
               </Nav.Item>
               <Nav.Item className={dataPanelStyles.tabNav}>
                 <Nav.Link eventKey={DataPanelTabKey.BlockConfig}>
@@ -250,29 +248,8 @@ const DataPanel: React.FC = () => {
           )}
           {showDeveloperTabs && (
             <>
-              <DataTab eventKey={DataPanelTabKey.Formik}>
-                <div className="text-info">
-                  <FontAwesomeIcon icon={faInfoCircle} /> This tab is only
-                  visible to developers
-                </div>
-                <DataTabJsonTree
-                  data={{ activeElement, errors }}
-                  searchable
-                  tabKey={DataPanelTabKey.Formik}
-                  label="Formik State"
-                />
-              </DataTab>
-              <DataTab eventKey={DataPanelTabKey.BlockConfig}>
-                <div className="text-info">
-                  <FontAwesomeIcon icon={faInfoCircle} /> This tab is only
-                  visible to developers
-                </div>
-                <DataTabJsonTree
-                  data={blockConfig ?? {}}
-                  tabKey={DataPanelTabKey.BlockConfig}
-                  label="Configuration"
-                />
-              </DataTab>
+              <StateTab />
+              <ConfigurationTab config={blockConfig} />
             </>
           )}
           <DataTab eventKey={DataPanelTabKey.Rendered} isTraceEmpty={!record}>

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -202,7 +202,7 @@ const DataPanel: React.FC = () => {
           {showDeveloperTabs && (
             <>
               <Nav.Item className={dataPanelStyles.tabNav}>
-                <Nav.Link eventKey={DataPanelTabKey.Formik}>State</Nav.Link>
+                <Nav.Link eventKey={DataPanelTabKey.State}>State</Nav.Link>
               </Nav.Item>
               <Nav.Item className={dataPanelStyles.tabNav}>
                 <Nav.Link eventKey={DataPanelTabKey.BlockConfig}>

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -17,9 +17,7 @@
  */
 
 import React, { useMemo } from "react";
-import { FormState } from "@/pageEditor/pageEditorTypes";
 import { isEmpty, isEqual, pickBy } from "lodash";
-import { useFormikContext } from "formik";
 import { Nav, Tab } from "react-bootstrap";
 import dataPanelStyles from "@/pageEditor/tabs/dataPanelTabs.module.scss";
 import FormPreview from "@/components/formBuilder/preview/FormPreview";
@@ -46,6 +44,7 @@ import {
   selectActiveElement,
   selectActiveNodeId,
   selectActiveNodeInfo,
+  selectErrorMap,
   selectNodePreviewActiveElement,
 } from "@/pageEditor/slices/editorSelectors";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
@@ -79,7 +78,7 @@ const DataPanel: React.FC = () => {
   const { flagOn } = useFlags();
   const showDeveloperTabs = flagOn("page-editor-developer");
 
-  const { errors: formikErrors } = useFormikContext<FormState>();
+  const errors = useSelector(selectErrorMap);
   const activeElement = useSelector(selectActiveElement);
 
   const {
@@ -257,7 +256,7 @@ const DataPanel: React.FC = () => {
                   visible to developers
                 </div>
                 <DataTabJsonTree
-                  data={{ ...activeElement, ...formikErrors }}
+                  data={{ activeElement, errors }}
                   searchable
                   tabKey={DataPanelTabKey.Formik}
                   label="Formik State"

--- a/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
@@ -57,7 +57,7 @@ const FoundationDataPanel: React.FC<{
         {showDeveloperTabs && (
           <>
             <Nav.Item className={dataPanelStyles.tabNav}>
-              <Nav.Link eventKey={DataPanelTabKey.Formik}>State</Nav.Link>
+              <Nav.Link eventKey={DataPanelTabKey.State}>State</Nav.Link>
             </Nav.Item>
             <Nav.Item className={dataPanelStyles.tabNav}>
               <Nav.Link eventKey={DataPanelTabKey.BlockConfig}>

--- a/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
@@ -21,8 +21,6 @@ import { UUID } from "@/core";
 import { useSelector } from "react-redux";
 import { makeSelectBlockTrace } from "@/pageEditor/slices/runtimeSelectors";
 import { Nav, Tab } from "react-bootstrap";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import dataPanelStyles from "@/pageEditor/tabs/dataPanelTabs.module.scss";
 import ExtensionPointPreview from "@/pageEditor/tabs/effect/ExtensionPointPreview";
 import useDataPanelActiveTabKey from "@/pageEditor/tabs/editTab/dataPanel/useDataPanelActiveTabKey";
@@ -31,6 +29,8 @@ import { FormState } from "@/pageEditor/pageEditorTypes";
 import PageStateTab from "./PageStateTab";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
 import DataTabJsonTree from "./DataTabJsonTree";
+import StateTab from "./tabs/StateTab";
+import ConfigurationTab from "./tabs/ConfigurationTab";
 
 const FoundationDataPanel: React.FC<{
   firstBlockInstanceId?: UUID;
@@ -59,7 +59,7 @@ const FoundationDataPanel: React.FC<{
         {showDeveloperTabs && (
           <>
             <Nav.Item className={dataPanelStyles.tabNav}>
-              <Nav.Link eventKey={DataPanelTabKey.Formik}>Formik</Nav.Link>
+              <Nav.Link eventKey={DataPanelTabKey.Formik}>State</Nav.Link>
             </Nav.Item>
             <Nav.Item className={dataPanelStyles.tabNav}>
               <Nav.Link eventKey={DataPanelTabKey.BlockConfig}>
@@ -93,39 +93,8 @@ const FoundationDataPanel: React.FC<{
         </Tab.Pane>
         {showDeveloperTabs && (
           <>
-            <Tab.Pane
-              eventKey={DataPanelTabKey.Formik}
-              className={dataPanelStyles.tabPane}
-              mountOnEnter
-              unmountOnExit
-            >
-              <div className="text-info">
-                <FontAwesomeIcon icon={faInfoCircle} /> This tab is only visible
-                to developers
-              </div>
-              <DataTabJsonTree
-                data={formState ?? {}}
-                searchable
-                tabKey={DataPanelTabKey.Formik}
-                label="Formik State"
-              />
-            </Tab.Pane>
-            <Tab.Pane
-              eventKey={DataPanelTabKey.BlockConfig}
-              className={dataPanelStyles.tabPane}
-              mountOnEnter
-              unmountOnExit
-            >
-              <div className="text-info">
-                <FontAwesomeIcon icon={faInfoCircle} /> This tab is only visible
-                to developers
-              </div>
-              <DataTabJsonTree
-                data={extensionPoint}
-                tabKey={DataPanelTabKey.BlockConfig}
-                label="Configuration"
-              />
-            </Tab.Pane>
+            <StateTab />
+            <ConfigurationTab config={extensionPoint} />
           </>
         )}
         <Tab.Pane

--- a/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
@@ -16,7 +16,6 @@
  */
 
 import React from "react";
-import { useFormikContext } from "formik";
 import { UUID } from "@/core";
 import { useSelector } from "react-redux";
 import { makeSelectBlockTrace } from "@/pageEditor/slices/runtimeSelectors";
@@ -25,12 +24,12 @@ import dataPanelStyles from "@/pageEditor/tabs/dataPanelTabs.module.scss";
 import ExtensionPointPreview from "@/pageEditor/tabs/effect/ExtensionPointPreview";
 import useDataPanelActiveTabKey from "@/pageEditor/tabs/editTab/dataPanel/useDataPanelActiveTabKey";
 import useFlags from "@/hooks/useFlags";
-import { FormState } from "@/pageEditor/pageEditorTypes";
 import PageStateTab from "./PageStateTab";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
 import DataTabJsonTree from "./DataTabJsonTree";
 import StateTab from "./tabs/StateTab";
 import ConfigurationTab from "./tabs/ConfigurationTab";
+import { selectActiveElement } from "@/pageEditor/slices/editorSelectors";
 
 const FoundationDataPanel: React.FC<{
   firstBlockInstanceId?: UUID;
@@ -38,9 +37,8 @@ const FoundationDataPanel: React.FC<{
   const { flagOn } = useFlags();
   const showDeveloperTabs = flagOn("page-editor-developer");
 
-  const { values: formState } = useFormikContext<FormState>();
-
-  const { extensionPoint } = formState;
+  const activeElement = useSelector(selectActiveElement);
+  const { extensionPoint } = activeElement;
 
   const { record: firstBlockTraceRecord } = useSelector(
     makeSelectBlockTrace(firstBlockInstanceId)
@@ -133,7 +131,7 @@ const FoundationDataPanel: React.FC<{
           mountOnEnter
           unmountOnExit
         >
-          <ExtensionPointPreview element={formState} />
+          <ExtensionPointPreview element={activeElement} />
         </Tab.Pane>
         <Tab.Pane
           eventKey={DataPanelTabKey.PageState}

--- a/src/pageEditor/tabs/editTab/dataPanel/dataPanelTypes.ts
+++ b/src/pageEditor/tabs/editTab/dataPanel/dataPanelTypes.ts
@@ -18,7 +18,7 @@
 export enum DataPanelTabKey {
   Context = "context",
   PageState = "pageState",
-  Formik = "formik",
+  State = "state",
   BlockConfig = "blockConfig",
   Rendered = "rendered",
   Output = "output",

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/ConfigurationTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/ConfigurationTab.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React from "react";
+import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
+import DataTab from "@/pageEditor/tabs/editTab/dataPanel/DataTab";
+import DataTabJsonTree from "@/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree";
+
+const ConfigurationTab: React.FC<{ config: unknown }> = ({ config }) => (
+  <DataTab eventKey={DataPanelTabKey.BlockConfig}>
+    <div className="text-info">
+      <FontAwesomeIcon icon={faInfoCircle} /> This tab is only visible to
+      developers
+    </div>
+    <DataTabJsonTree
+      data={config ?? {}}
+      tabKey={DataPanelTabKey.BlockConfig}
+      label="Configuration"
+    />
+  </DataTab>
+);
+
+export default ConfigurationTab;

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/StateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/StateTab.tsx
@@ -32,7 +32,7 @@ const StateTab: React.FC = () => {
   const activeElement = useSelector(selectActiveElement);
 
   return (
-    <DataTab eventKey={DataPanelTabKey.Formik}>
+    <DataTab eventKey={DataPanelTabKey.State}>
       <div className="text-info">
         <FontAwesomeIcon icon={faInfoCircle} /> This tab is only visible to
         developers
@@ -40,7 +40,7 @@ const StateTab: React.FC = () => {
       <DataTabJsonTree
         data={{ activeElement, errors }}
         searchable
-        tabKey={DataPanelTabKey.Formik}
+        tabKey={DataPanelTabKey.State}
         label="Element State"
       />
     </DataTab>

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/StateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/StateTab.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  selectErrorMap,
+  selectActiveElement,
+} from "@/pageEditor/slices/editorSelectors";
+import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React from "react";
+import { useSelector } from "react-redux";
+import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
+import DataTab from "@/pageEditor/tabs/editTab/dataPanel/DataTab";
+import DataTabJsonTree from "@/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree";
+
+const StateTab: React.FC = () => {
+  const errors = useSelector(selectErrorMap);
+  const activeElement = useSelector(selectActiveElement);
+
+  return (
+    <DataTab eventKey={DataPanelTabKey.Formik}>
+      <div className="text-info">
+        <FontAwesomeIcon icon={faInfoCircle} /> This tab is only visible to
+        developers
+      </div>
+      <DataTabJsonTree
+        data={{ activeElement, errors }}
+        searchable
+        tabKey={DataPanelTabKey.Formik}
+        label="Element State"
+      />
+    </DataTab>
+  );
+};
+
+export default StateTab;


### PR DESCRIPTION
## What does this PR do?

- Converts Data Panel dev tabs into reusable components
- Renames Formik tab to State
- Drops usage of Formik by Data Panel


## Demo

<img width="321" alt="image" src="https://user-images.githubusercontent.com/3116723/179537477-9f322828-44ed-471c-954b-b05a3f0610f2.png">


## Checklist

- [x] Designate a primary reviewer @BLoe 
