### PR TITLE
Update Library-Detector

### DIFF
--- a/src/vendors/libraryDetector/libraries.js
+++ b/src/vendors/libraryDetector/libraries.js
@@ -2,6 +2,15 @@
 // https://github.com/johnmichel/Library-Detector-for-Chrome/blob/master/library/libraries.js
 
 const UNKNOWN_VERSION = null;
+function _createTimeoutHelper() {
+  let timeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeout = setTimeout(() => reject(new Error("Timed out")), 5000);
+  });
+
+  return { timeoutPromise, clearTimeout: () => clearTimeout(timeout) };
+}
+
 export default {
   GWT: {
     id: "gwt",
@@ -185,6 +194,23 @@ export default {
       if (win.litElementVersions && win.litElementVersions.length) {
         // Get latest version if multiple versions are used
         var versions = [...win.litElementVersions].sort((a, b) =>
+          a.localeCompare(b, undefined, { numeric: true })
+        );
+        return { version: versions[versions.length - 1] };
+      }
+      return false;
+    },
+  },
+
+  "lit-html": {
+    id: "lit-html",
+    icon: "polymer",
+    url: "https://lit-html.polymer-project.org/",
+    npm: "lit-element",
+    test: function (win) {
+      if (win.litHtmlVersions && win.litHtmlVersions.length) {
+        // Get latest version if multiple versions are used
+        var versions = [...win.litHtmlVersions].sort((a, b) =>
           a.localeCompare(b, undefined, { numeric: true })
         );
         return { version: versions[versions.length - 1] };
@@ -428,6 +454,18 @@ export default {
         return { version: win.Ext.versions.core.version };
       } else if (win.Ext) {
         return { version: win.Ext.version || UNKNOWN_VERSION };
+      }
+      return false;
+    },
+  },
+
+  Ezoic: {
+    id: "ezoic",
+    icon: "ezoic",
+    url: "https://www.ezoic.com/",
+    test: function (win) {
+      if (win.__ez && win.__ez.template) {
+        return { version: UNKNOWN_VERSION };
       }
       return false;
     },
@@ -1425,7 +1463,11 @@ export default {
     url: "https://nuxtjs.org/",
     npm: "nuxt",
     test: function (win) {
-      if ((win.__NUXT__ && win.__NUXT__.data != null) || win.$nuxt) {
+      if (
+        win.__NUXT__ ||
+        win.$nuxt ||
+        [...win.document.querySelectorAll("*")].some((el) => el.__vue__?.nuxt)
+      ) {
         return { version: UNKNOWN_VERSION };
       }
       return false;
@@ -1791,8 +1833,13 @@ export default {
               }
               return false;
             });
+        })
+        /* fix for https://github.com/johnmichel/Library-Detector-for-Chrome/issues/178
+         * `TypeError: Cannot read property 'active' of undefined` on registration.active.scriptURL from failed serviceWorker where 'registration' is undefined above
+         */
+        .catch(function (err) {
+          return false;
         });
-
       return Promise.race([workerPromise, timeoutPromise])
         .catch(function (exception) {
           return false;
@@ -2002,6 +2049,35 @@ export default {
         return { version: UNKNOWN_VERSION };
       }
 
+      return false;
+    },
+  },
+  Sugar: {
+    id: "sugar",
+    icon: "sugar",
+    url: "https://sugarjs.com",
+    npm: "sugar",
+    test: function (win) {
+      if (win.Sugar) {
+        return { version: win.Sugar.VERSION || UNKNOWN_VERSION };
+      }
+
+      if (win.Array.SugarMethods) {
+        return { version: UNKNOWN_VERSION };
+      }
+
+      return false;
+    },
+  },
+  Bento: {
+    id: "bentojs",
+    icon: "bentojs",
+    url: "https://bentojs.dev",
+    npm: "https://www.npmjs.com/org/bentoproject",
+    test: function (win) {
+      if (win.BENTO && win.BENTO.push) {
+        return { version: UNKNOWN_VERSION };
+      }
       return false;
     },
   },


### PR DESCRIPTION
I was seeing some errors related to:

- the missing `_createTimeoutHelper` function
- https://github.com/johnmichel/Library-Detector-for-Chrome/issues/178

and while we wait/hope for https://togithub.com/johnmichel/Library-Detector-for-Chrome/issues/199 I thought I'd just copy-paste the file again.


### Question

Do we use anything other than these 4? 

https://github.com/pixiebrix/pixiebrix-extension/blob/ccd5ac79c1194c2570665cba9404225123b526b7/src/frameworks/adapters.ts#L32-L35

If not, we should probably only test for them instead of the entire thing:

https://github.com/pixiebrix/pixiebrix-extension/blob/ccd5ac79c1194c2570665cba9404225123b526b7/src/vendors/libraryDetector/detect.ts#L22-L27

Really we could just extract 4 test functions and skip loading the 2000-line file as well.