### PR TITLE
Drop vendors bundle

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,7 +22,7 @@
   "content_scripts": [
     {
       "matches": ["https://*.pixiebrix.com/*"],
-      "js": ["vendors.js", "contentScript.js"],
+      "js": ["contentScript.js"],
       "css": ["contentScript.css"],
       "run_at": "document_idle"
     }
@@ -79,7 +79,7 @@
     }
   },
   "background": {
-    "scripts": ["grayIconWhileLoading.js", "vendors.js", "background.js"]
+    "scripts": ["grayIconWhileLoading.js", "background.js"]
   },
   "options_ui": {
     "page": "options.html",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -36,7 +36,6 @@
       <div class="global-loading-message">Loading PixieBrix Options 🚀</div>
     </div>
     <script src="loadingScreen.js"></script>
-    <script src="vendors.js"></script>
     <script src="options.js"></script>
   </body>
 </html>

--- a/src/pageEditor/pageEditor.html
+++ b/src/pageEditor/pageEditor.html
@@ -29,7 +29,6 @@
       <div class="global-loading-message">Loading PixieBrix Editor 🚀</div>
     </div>
     <script src="loadingScreen.js"></script>
-    <script src="vendors.js"></script>
     <script src="pageEditor.js"></script>
   </body>
 </html>

--- a/src/sidebar/sidebar.html
+++ b/src/sidebar/sidebar.html
@@ -30,7 +30,6 @@
       <div class="global-loading-message">Loading PixieBrix 🚀</div>
     </div>
     <script src="loadingScreen.js"></script>
-    <script src="vendors.js"></script>
     <script src="sidebar.js"></script>
   </body>
 </html>

--- a/src/tinyPages/ephemeralForm.html
+++ b/src/tinyPages/ephemeralForm.html
@@ -26,7 +26,6 @@
   </head>
   <body>
     <div id="container"></div>
-    <script src="vendors.js"></script>
     <script src="ephemeralForm.js"></script>
   </body>
 </html>

--- a/src/tinyPages/permissionsPopup.html
+++ b/src/tinyPages/permissionsPopup.html
@@ -32,7 +32,6 @@
       <div class="global-loading-message">Loading PixieBrix 🚀</div>
     </div>
     <script src="loadingScreen.js"></script>
-    <script src="vendors.js"></script>
     <script src="permissionsPopup.js"></script>
   </body>
 </html>

--- a/static/background.worker.js
+++ b/static/background.worker.js
@@ -1,6 +1,2 @@
 // Don't include `background.worker.js` in webpack, there's no advantage in doing so
-self.importScripts(
-  "./grayIconWhileLoading.js",
-  "./vendors.js",
-  "./background.js"
-);
+self.importScripts("./grayIconWhileLoading.js", "./background.js");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -303,9 +303,7 @@ module.exports = (env, options) =>
           excludeAssets: /svg-icons/,
         }),
 
-      new NodePolyfillPlugin({
-        excludeAliases: ["console"],
-      }),
+      new NodePolyfillPlugin(),
       new WebExtensionTarget(),
       new webpack.ProvidePlugin({
         $: "jquery",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -214,40 +214,24 @@ module.exports = (env, options) =>
       },
     },
 
-    entry: {
-      // All of these entries require the `vendors.js` file to be included first
-      ...Object.fromEntries(
-        [
-          "background/background",
-          "contentScript/contentScript",
-          "pageEditor/pageEditor",
-          "options/options",
-          "sidebar/sidebar",
-          "tinyPages/ephemeralForm",
-          "tinyPages/permissionsPopup",
-        ].map((name) => [
-          path.basename(name),
-          { import: `./src/${name}`, dependOn: "vendors" },
-        ])
-      ),
+    entry: Object.fromEntries(
+      [
+        "background/background",
+        "contentScript/contentScript",
+        "pageEditor/pageEditor",
+        "options/options",
+        "sidebar/sidebar",
+        "tinyPages/ephemeralForm",
+        "tinyPages/permissionsPopup",
 
-      // This creates a `vendors.js` file that must be included together with the bundles generated above
-      vendors: [
-        "react",
-        "react-dom",
-        "jquery",
-        "lodash-es",
-        "@rjsf/bootstrap-4",
-        "@fortawesome/free-solid-svg-icons",
-      ],
+        // Tiny files without imports
+        "tinyPages/frame",
+        "tinyPages/devtools",
 
-      // Tiny files without imports, no vendors needed
-      frame: "./src/tinyPages/frame",
-      devtools: "./src/tinyPages/devtools",
-
-      // The script that gets injected into the host page should not have a vendor chunk
-      pageScript: "./src/pageScript/pageScript",
-    },
+        // The script that gets injected into the host page
+        "pageScript/pageScript",
+      ].map((name) => [path.basename(name), `./src/${name}`])
+    ),
 
     resolve: {
       alias: {
@@ -319,7 +303,9 @@ module.exports = (env, options) =>
           excludeAssets: /svg-icons/,
         }),
 
-      new NodePolyfillPlugin(),
+      new NodePolyfillPlugin({
+        excludeAliases: ["console"],
+      }),
       new WebExtensionTarget(),
       new webpack.ProvidePlugin({
         $: "jquery",


### PR DESCRIPTION
I think at this point the vendors bundle isn't saving much space anymore. I think we'd get better returns by looking into better tree-shaking somehow. I found that the vendor bundle somewhat conflicts with the logic expected in my other PR since the vendor is re-injected unconditionally, unlike the rest of the regular CS:

- #3915 

## Future work

- [ ] fix icons usage globally as described in https://github.com/pixiebrix/pixiebrix-extension/issues/2019
- [ ] tree-shake `@rjsf/bootstrap-4` and its `react-icons` dependency
- [ ] potentially https://github.com/pixiebrix/pixiebrix-extension/pull/2676