### PR TITLE
AddBlockModal: Drop redundant "Show details" text + use simple components

### DIFF
--- a/src/components/addBlockModal/BlockGridItem.module.scss
+++ b/src/components/addBlockModal/BlockGridItem.module.scss
@@ -38,6 +38,7 @@
   }
 
   &:focus {
+    outline: none;
     border: 1px solid #3e66fb !important;
     box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
   }

--- a/src/components/addBlockModal/BlockGridItem.module.scss
+++ b/src/components/addBlockModal/BlockGridItem.module.scss
@@ -18,29 +18,23 @@
 @import "@/components/addBlockModal/addBlockModalVariables.scss";
 
 .root {
-  border: none;
-  padding: $verticalSpacing $horizontalSpacing;
-}
-
-.card {
   cursor: pointer;
+  display: flex;
+  border: 1px solid rgba(0, 0, 0, 0.125);
   border-radius: 4px;
   padding: 12px; // Need to use exact px for fixed height grid items
-  flex-direction: row; // override card default
   align-items: center;
+  margin: $verticalSpacing;
 
   &:hover {
     background: #ebebf1;
 
-    .actions {
-      display: flex;
-      justify-content: flex-end;
-      align-items: center;
-    }
-
     .popularIcon {
       display: none;
     }
+  }
+  &:not(:hover) .addButton {
+    display: none;
   }
 
   &:focus {
@@ -57,7 +51,7 @@
   margin-bottom: 6px; // Need to use exact px for fixed height grid items
 }
 
-.cardContent {
+.content {
   flex-grow: 1;
   display: flex;
   flex-direction: column;
@@ -89,16 +83,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   color: #4c4c4c;
-}
-
-.actions {
-  display: none;
-  gap: 12px;
-}
-
-.viewDetails {
-  white-space: nowrap;
-  color: #3e66fb;
 }
 
 .addButton {

--- a/src/components/addBlockModal/BlockGridItem.tsx
+++ b/src/components/addBlockModal/BlockGridItem.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from "react";
-import { Button, Card, ListGroup } from "react-bootstrap";
+import { Button } from "react-bootstrap";
 import BrickIcon from "@/components/BrickIcon";
 import styles from "./BlockGridItem.module.scss";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
@@ -37,45 +37,44 @@ const BlockGridItem: React.VFC<BlockItemProps> = ({
   onSelect,
   onShowDetail,
 }) => (
-  <ListGroup.Item onClick={onShowDetail} className={styles.root}>
-    <Card className={styles.card}>
-      {/* Main Content */}
-      <div className={styles.cardContent}>
-        <div className={styles.nameRow}>
-          <BrickIcon brick={block} faIconClass={styles.icon} />
-          <span className={styles.name}>{block.name}</span>
-          {block.isPopular && (
-            <Icon
-              icon="icon-sparkles"
-              library="custom"
-              className={styles.popularIcon}
-            />
-          )}
-        </div>
-        {block.description ? (
-          <div className={styles.description}>{block.description}</div>
-        ) : (
-          <small className="text-muted font-italic">
-            No description provided.
-          </small>
+  <div
+    onClick={onShowDetail}
+    onKeyPress={onShowDetail}
+    tabIndex={0}
+    role="button"
+    className={styles.root}
+  >
+    <div className={styles.content}>
+      <div className={styles.nameRow}>
+        <BrickIcon brick={block} faIconClass={styles.icon} />
+        <span className={styles.name}>{block.name}</span>
+        {block.isPopular && (
+          <Icon
+            icon="icon-sparkles"
+            library="custom"
+            className={styles.popularIcon}
+          />
         )}
       </div>
+      {block.description ? (
+        <div className={styles.description}>{block.description}</div>
+      ) : (
+        <small className="text-muted font-italic">
+          No description provided.
+        </small>
+      )}
+    </div>
 
-      {/* Hover Actions */}
-      <div className={styles.actions}>
-        <span className={styles.viewDetails}>View Details</span>
-        <Button
-          variant="primary"
-          onClick={() => {
-            onSelect();
-          }}
-          className={styles.addButton}
-        >
-          <FontAwesomeIcon icon={faPlus} /> Add
-        </Button>
-      </div>
-    </Card>
-  </ListGroup.Item>
+    <Button
+      variant="primary"
+      onClick={() => {
+        onSelect();
+      }}
+      className={styles.addButton}
+    >
+      <FontAwesomeIcon icon={faPlus} /> Add
+    </Button>
+  </div>
 );
 
 export default BlockGridItem;

--- a/src/components/addBlockModal/BlockGridItem.tsx
+++ b/src/components/addBlockModal/BlockGridItem.tsx
@@ -39,7 +39,11 @@ const BlockGridItem: React.VFC<BlockItemProps> = ({
 }) => (
   <div
     onClick={onShowDetail}
-    onKeyPress={onShowDetail}
+    onKeyPress={(event) => {
+      if (event.key === "Enter") {
+        onShowDetail();
+      }
+    }}
     tabIndex={0}
     role="button"
     className={styles.root}

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -212,7 +212,7 @@ async function addABlock(addButton: Element, blockName: string) {
 
   await immediateUserEvent.click(
     screen.getAllByRole("button", {
-      name: /add/i,
+      name: /^Add/,
     })[0]
   );
 

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -211,9 +211,9 @@ async function addABlock(addButton: Element, blockName: string) {
   });
 
   await immediateUserEvent.click(
-    screen.getAllByRole("button", {
+    screen.getByRole("button", {
       name: /^Add/,
-    })[0]
+    })
   );
 
   // Run validation


### PR DESCRIPTION
I'm happy that most of the issues described in https://github.com/pixiebrix/pixiebrix-extension/issues/3574 were fixed 🎉 

## What does this PR do?

Closes https://github.com/pixiebrix/pixiebrix-extension/issues/3574

- addresses the last point about the hover state  text (removing it)
- avoids using BS components unnecessarily
	- `ListGroup.Item` did nothing and was not wrapped by `ListGroup`
	- `Card` was being used only for its border
	- both component’s styles were being specifically overridden by local styles
- adds focusability to the element (a11y), actually allowing the `:focus` style that was defined but unused

## Discussion

- I wanted to make the Add button smaller and always visible, but I'm sure you wouldn't have liked it, so I left it unchanged
- I equalized the x/y spacing of the cards

## Reviewing tips

- Best reviewed [without whitespace](https://github.com/pixiebrix/pixiebrix-extension/pull/3923/files?w=1)

## Before

<img width="924" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/182014681-67125f0e-b99e-4e83-8d0c-3c1293080ef6.png">


## After

<img width="924" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/182014683-dd49ef7e-8d62-4918-b7eb-0d84adbd4678.png">

## Future Work

- [ ] Turn into one column in small windows
