### PR TITLE
#3724: Avoid screenshotting the quickbar

### DIFF
--- a/src/blocks/transformers/screenshotTab.ts
+++ b/src/blocks/transformers/screenshotTab.ts
@@ -54,7 +54,7 @@ export class ScreenshotTab extends Transformer {
       };
     } catch (error) {
       if (getErrorMessage(error).includes("activeTab")) {
-        // Event if PixieBrix has access to a host, PixieBrix needs activeTab. So the user must have done one of the
+        // Even if PixieBrix has access to a host, PixieBrix needs activeTab. So the user must have done one of the
         // following. https://developer.chrome.com/docs/extensions/mv3/manifest/activeTab/#invoking-activeTab. We'll
         // give an error message that ensures one of these must have been true:
         // - Executing an action

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -137,8 +137,8 @@ const KBarComponent: React.FC = () => {
 const QuickBarApp: React.FC = () => (
   <ReactShadowRoot mode="closed">
     <Stylesheet href={faStyleSheet}>
-      {/* Disable exit animation due to #3724 */}
-      <KBarProvider options={{ animations: { exitMs: 0 } }}>
+      {/* Disable exit animation due to #3724. `enterMs` is required too */}
+      <KBarProvider options={{ animations: { enterMs: 300, exitMs: 0 } }}>
         <AutoShow />
         <KBarToggle>
           <KBarComponent />

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -137,7 +137,8 @@ const KBarComponent: React.FC = () => {
 const QuickBarApp: React.FC = () => (
   <ReactShadowRoot mode="closed">
     <Stylesheet href={faStyleSheet}>
-      <KBarProvider>
+      {/* Disable exit animation due to #3724 */}
+      <KBarProvider options={{ animations: { exitMs: 0 } }}>
         <AutoShow />
         <KBarToggle>
           <KBarComponent />


### PR DESCRIPTION
This PR disables the exit animation of the QuickBar to ensure it does not appear when taking a screenshot.

- Fixes #3724


## Alternative solutions

- Add a `await sleep(200)` before every screenshot, which makes it feel less instantaneous
	-  100ms is the default https://github.com/timc1/kbar/blob/a232f3d8976a61eeeb844152dea25a23a76ad368/src/useStore.tsx#L20
- Only disable the exit animation if the action contains a screenshot, which seems difficult (but I don't know)

The last one would be ideal, but probably out of my reach for a couple of reasons 😬 

## Demo


You can see the screenshot being added to the top of the page. None of them include the quickbar:

https://user-images.githubusercontent.com/1402241/182339583-b1edcdf7-fecb-4623-8f60-37b947c66cf2.mov


