### PR TITLE
#3951 Fix crash on save when using the Translate brick

### DIFF
--- a/src/pageEditor/Panel.tsx
+++ b/src/pageEditor/Panel.tsx
@@ -23,8 +23,6 @@ import Editor from "@/pageEditor/Editor";
 import store, { persistor } from "./store";
 import { PersistGate } from "redux-persist/integration/react";
 import { Provider } from "react-redux";
-import { useAsyncEffect } from "use-async-effect";
-import blockRegistry from "@/blocks/registry";
 import { ModalProvider } from "@/components/ConfirmationModal";
 import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
@@ -33,6 +31,7 @@ import ErrorBanner from "@/pageEditor/ErrorBanner";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import RequireAuth from "@/auth/RequireAuth";
 import LoginCard from "./components/LoginCard";
+import useRefresh from "@/hooks/useRefresh";
 
 // Register the built-in bricks
 registerEditors();
@@ -45,9 +44,8 @@ registerDefaultWidgets();
 const Panel: React.VoidFunctionComponent = () => {
   const context = useDevConnection();
 
-  useAsyncEffect(async () => {
-    await blockRegistry.fetch();
-  }, []);
+  // Refresh the brick registry on mount
+  useRefresh({ refreshOnMount: true });
 
   return (
     <Provider store={store}>

--- a/src/pageEditor/hooks/useCreate.ts
+++ b/src/pageEditor/hooks/useCreate.ts
@@ -134,7 +134,7 @@ function useCreate(): CreateCallback {
 
       try {
         try {
-          // Make sure the pages have the latest blocks for when we reactivate below
+          // Make sure the pages have the latest bricks for when we reactivate below
           // NOTE: This must run before the permissions check (below), because we
           // need to look up service definitions as part of checking permissions.
           await refreshRegistries();

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -23,12 +23,12 @@ import {
 } from "@/types/definitions";
 import { Permissions } from "webextension-polyfill";
 import { castArray, compact, uniq } from "lodash";
-import { locator } from "@/background/locator";
 import registry from "@/services/registry";
 import { mergePermissions, requestPermissions } from "@/utils/permissions";
 import { Deployment } from "@/types/contract";
 import { resolveDefinitions, resolveRecipe } from "@/registry/internal";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
+import { locateWithRetry } from "@/services/serviceUtils";
 
 // Copied from the permissions section of manifest.json
 const MANDATORY_PERMISSIONS = new Set([
@@ -150,7 +150,9 @@ export async function serviceOriginPermissions(
     return { origins: [] };
   }
 
-  const localConfig = await locator.locate(dependency.id, dependency.config);
+  const localConfig = await locateWithRetry(dependency.id, dependency.config, {
+    retry: true,
+  });
 
   if (localConfig.proxy) {
     // Don't need permissions to access the pixiebrix API proxy server because they're already granted on

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -33,7 +33,7 @@ import { inputProperties } from "@/helpers";
 import { fetch } from "@/hooks/fetch";
 import { validateRegistryId } from "@/types/helpers";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
-import { forbidContext } from "@/utils/expectContext";
+import { expectContext, forbidContext } from "@/utils/expectContext";
 import { ExtensionNotLinkedError } from "@/errors/genericErrors";
 import {
   MissingConfigurationError,
@@ -237,6 +237,11 @@ class LazyLocatorFactory {
     serviceId: RegistryId,
     authId: UUID
   ): Promise<SanitizedServiceConfiguration> {
+    expectContext(
+      "background",
+      "The service locator must run in the background worker"
+    );
+
     if (!this.initialized) {
       await this.refresh();
     }

--- a/src/services/serviceUtils.ts
+++ b/src/services/serviceUtils.ts
@@ -58,7 +58,7 @@ export function extractServiceIds(schema: Schema): RegistryId[] {
   throw new Error("Expected $ref or anyOf in schema for service");
 }
 
-async function locateWithRetry(
+export async function locateWithRetry(
   serviceId: RegistryId,
   authId: UUID,
   { retry = true }: { retry: boolean }


### PR DESCRIPTION
## What does this PR do?

- Fixes #3951 
- Adds a guard rail to the `locator.locate()` function to make sure it's only called from the background context
- Refreshes all bricks (blocks, extensionPoints, readers, services) on `Panel` mount in the page editor, instead of just bricks

## Discussion

- Does it make sense to refresh all the brick types like this in either/both places? Or should I make the minimum change possible and just have the create function refresh services before the permissions check?
- Should we look at any other places where only one brick type is fetched and convert everything to refresh the whole registry in each place? This seems more robust, especially to changes in the future, but not sure of, e.g. performance, ramifications of a change like this.

## Team Coordination

- [ ] This PR requires security review

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer - @twschiller 
