### PR TITLE
Improve notification readability

### DIFF
--- a/src/utils/notify.module.scss
+++ b/src/utils/notify.module.scss
@@ -1,5 +1,6 @@
 .message {
   align-self: center;
+  overflow-wrap: anywhere;
 
   // Space out multiple lines and make them less prominent
   & > :nth-child(n + 2) {

--- a/src/utils/notify.module.scss
+++ b/src/utils/notify.module.scss
@@ -1,5 +1,12 @@
 .message {
   align-self: center;
+
+  // Space out multiple lines and make them less prominent
+  & > :nth-child(n + 2) {
+    margin-top: 0.3em;
+    font-size: 0.9em;
+    opacity: 0.8;
+  }
 }
 
 .closeButton {

--- a/src/utils/notify.tsx
+++ b/src/utils/notify.tsx
@@ -72,7 +72,11 @@ const Message: React.VoidFunctionComponent<{
   dismissable: boolean;
 }> = ({ message, id, dismissable }) => (
   <>
-    <span className={styles.message}>{message}</span>
+    <div className={styles.message}>
+      {message.split("\n").map((line, number) => (
+        <div key={number}>{line}</div>
+      ))}
+    </div>
     {dismissable ? (
       <button
         className={styles.closeButton}
@@ -119,7 +123,7 @@ export function showNotification({
     if (!message) {
       message = getErrorMessage(error);
     } else if (includeErrorDetails) {
-      message = message.replace(/[\s.:]$/, "") + ": " + getErrorMessage(error);
+      message += "\n" + getErrorMessage(error);
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Error messages in notifications can be pretty long. Seeing a message like this can be overwhelming.



<img width="463" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1879821/183075222-ddb81ae9-e5eb-47a4-be3c-d78eb1bd6a99.png">

Adding a line break and automatically using a lighter color for the error message makes it easier to follow.

> <img width="406" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/183398672-7af678b7-fa69-4f2b-8aeb-0ea7d89db0fe.png">


This is particularly important because the concatenated error is generally a lower-level error.

## Other examples

<img width="357" alt="Screen Shot 12" src="https://user-images.githubusercontent.com/1402241/183399587-f6cbb6fb-6e68-43cf-87e2-0c14e3d022df.png">

<img width="376" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/183399625-f92a3ce3-a8f6-4115-b4e8-1184fd6fe275.png">

<img width="369" alt="Screen Shot 13" src="https://user-images.githubusercontent.com/1402241/183399677-0efa9b94-47a6-4f01-84b5-b74316353e07.png">

<img width="380" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/183399956-6da7fc5c-a912-44b3-8e5a-4375aebb88cf.png">

<img width="428" alt="Screen Shot 14" src="https://user-images.githubusercontent.com/1402241/183400005-830bc3dd-58f6-4ae1-a22e-9eed386883f4.png">

This last one has an additional visual bug. Fixed:

<img width="394" alt="Screen Shot 16" src="https://user-images.githubusercontent.com/1402241/183402735-d647b457-5fa6-4751-9e30-bd9cded46b7d.png">





## Related

- https://github.com/pixiebrix/pixiebrix-extension/issues/3961