### PR TITLE
#3985: ignore network errors in sidebar's authentication gate

### DIFF
--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -43,6 +43,11 @@ import { selectConfiguredServices } from "@/store/servicesSelectors";
 type RequireAuthProps = {
   /** Rendered in case of 401 response */
   LoginPage: React.VFC;
+  /**
+   * Ignore network/token errors. Set to 'false' to avoid prompting on login if there are intermittent network errors
+   * or PixieBrix service degradation.
+   */
+  ignoreError?: boolean;
 };
 
 const AA_CONTROL_ROOM_SERVICE_ID = "automation-anywhere/control-room";
@@ -169,7 +174,11 @@ export const useRequiredAuth = () => {
  *   token-based authentication.
  * - Therefore, also check the extension has the Authentication header token from the server.
  */
-const RequireAuth: React.FC<RequireAuthProps> = ({ children, LoginPage }) => {
+const RequireAuth: React.FC<RequireAuthProps> = ({
+  children,
+  LoginPage,
+  ignoreError = false,
+}) => {
   const {
     isAccountUnlinked,
     tokenError,
@@ -203,7 +212,7 @@ const RequireAuth: React.FC<RequireAuthProps> = ({ children, LoginPage }) => {
 
   // RequireAuth only knows how to handle auth errors. Rethrow any other errors
   const error = meError ?? tokenError;
-  if (error != null) {
+  if (error != null && !ignoreError) {
     throw error;
   }
 

--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -44,10 +44,10 @@ type RequireAuthProps = {
   /** Rendered in case of 401 response */
   LoginPage: React.VFC;
   /**
-   * Ignore network/token errors. Set to 'false' to avoid prompting on login if there are intermittent network errors
+   * Ignore network errors. Set to 'false' to avoid prompting on login if there are intermittent network errors
    * or PixieBrix service degradation.
    */
-  ignoreError?: boolean;
+  ignoreApiError?: boolean;
 };
 
 const AA_CONTROL_ROOM_SERVICE_ID = "automation-anywhere/control-room";
@@ -177,7 +177,7 @@ export const useRequiredAuth = () => {
 const RequireAuth: React.FC<RequireAuthProps> = ({
   children,
   LoginPage,
-  ignoreError = false,
+  ignoreApiError = false,
 }) => {
   const {
     isAccountUnlinked,
@@ -210,10 +210,13 @@ const RequireAuth: React.FC<RequireAuthProps> = ({
     return <Loader />;
   }
 
-  // RequireAuth only knows how to handle auth errors. Rethrow any other errors
-  const error = meError ?? tokenError;
-  if (error != null && !ignoreError) {
-    throw error;
+  // `useRequiredAuth` handles 401 and other auth-related errors. Rethrow any other errors, e.g., internal server error
+  if (meError && !ignoreApiError) {
+    throw meError;
+  }
+
+  if (tokenError) {
+    throw tokenError;
   }
 
   return <>{children}</>;

--- a/src/sidebar/ConnectedSidebar.tsx
+++ b/src/sidebar/ConnectedSidebar.tsx
@@ -77,8 +77,8 @@ const ConnectedSidebar: React.VFC = () => {
       <ErrorBoundary>
         <RequireAuth
           LoginPage={LoginPanel}
-          // Use ignoreError to avoid showing error on intermittent network issues or PixieBrix API degradation
-          ignoreError
+          // Use ignoreApiError to avoid showing error on intermittent network issues or PixieBrix API degradation
+          ignoreApiError
         >
           {sidebarState.panels?.length || sidebarState.forms?.length ? (
             <Tabs

--- a/src/sidebar/ConnectedSidebar.tsx
+++ b/src/sidebar/ConnectedSidebar.tsx
@@ -75,7 +75,11 @@ const ConnectedSidebar: React.VFC = () => {
   return (
     <div className="full-height">
       <ErrorBoundary>
-        <RequireAuth LoginPage={LoginPanel}>
+        <RequireAuth
+          LoginPage={LoginPanel}
+          // Use ignoreError to avoid showing error on intermittent network issues or PixieBrix API degradation
+          ignoreError
+        >
           {sidebarState.panels?.length || sidebarState.forms?.length ? (
             <Tabs
               {...sidebarState}


### PR DESCRIPTION
## What does this PR do?

- Closes #3985 3985

## Discussion

- I went with ignoreApiError rather than throwApiError to keep the default false

## Checklist

- [ ] Add tests
- [X] Designate a primary reviewer: @BALEHOK 
