### PR TITLE
link back to start url on PartnerSetupCard

### DIFF
--- a/src/options/pages/onboarding/PartnerSetupCard.tsx
+++ b/src/options/pages/onboarding/PartnerSetupCard.tsx
@@ -127,6 +127,10 @@ const PartnerSetupCard: React.FunctionComponent<{
     password: "",
   };
 
+  const startUrl = new URL(`${installURL}start`);
+  startUrl.searchParams.set("hostname", me?.organization?.control_room?.url);
+  startUrl.searchParams.set("partner", "automation-anywhere");
+
   return (
     <OnboardingChecklistCard title="Set up your account">
       <OnboardingStep
@@ -142,7 +146,9 @@ const PartnerSetupCard: React.FunctionComponent<{
         <Button
           role="button"
           className="btn btn-primary mt-2"
-          href={installURL}
+          href={
+            me?.organization?.control_room?.url ? startUrl.href : installURL
+          }
         >
           <FontAwesomeIcon icon={faLink} /> Create/link PixieBrix account
         </Button>

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -54,7 +54,6 @@ export async function getBaseURL(): Promise<string> {
 
 export async function getInstallURL(): Promise<string> {
   const url = new URL(await getBaseURL());
-  url.searchParams.set("install", "1");
   return url.href;
 }
 


### PR DESCRIPTION
## What does this PR do?

- Fixes a leg of the Partner End User onboarding flow where they would see the enterprise success modal instead of screens for Partner Onboarding by linking back to a non-start url.
- Also removes the `install` search param from the Install url which is unused.

## Reviewer Tips

- The start url is reconstructed from the control room on the user's primary organization.

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer @twschiller 
