### PR TITLE
#3989 Fix useInstallState NPE

### DIFF
--- a/src/pageEditor/context.ts
+++ b/src/pageEditor/context.ts
@@ -58,16 +58,23 @@ const initialFrameState: FrameConnectionState = {
   frameId: 0,
 };
 
-export interface Context {
+export type Context = {
   /**
-   * True if the a connection attempt is in process
+   * True if a connection attempt is in process
    */
   connecting: boolean;
 
+  /**
+   * The frame connection state, or initialFrameState if there was an error
+   */
   tabState: FrameConnectionState;
 
+  /**
+   * The error connecting to the frame, or undefined.
+   * @see connectToFrame
+   */
   error?: unknown;
-}
+};
 
 const initialValue: Context = {
   connecting: false,
@@ -158,6 +165,8 @@ export function useDevConnection(): Context {
   return {
     connecting: isConnecting,
     error: contextInvalidatedError ?? connectionError,
+    // `tabState` will be if null there's an error in useAsyncState. The caller is responsible for checking the
+    // connecting/error properties.
     tabState: tabState ?? initialFrameState,
   };
 }

--- a/src/pageEditor/context.ts
+++ b/src/pageEditor/context.ts
@@ -158,6 +158,6 @@ export function useDevConnection(): Context {
   return {
     connecting: isConnecting,
     error: contextInvalidatedError ?? connectionError,
-    tabState,
+    tabState: tabState ?? initialFrameState,
   };
 }


### PR DESCRIPTION
## What does this PR do?

- Fixes #3989 

## Discussion

- Does this make sense to return the initial `tabState`? The alternative would be to fix all the call-sites to null-coalesce the `tabState` property of `PageEditorTabContext` before destructuring the fields.
- Should I rename the const to `defaultFrameState` instead of `initial...`?

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer - @BALEHOK 
