### PR TITLE
#3994 Fix issue with bricks not appearing

### DIFF
--- a/src/pageEditor/hooks/useAllBlocks.ts
+++ b/src/pageEditor/hooks/useAllBlocks.ts
@@ -56,7 +56,7 @@ function useAllBlocks(): {
     return () => {
       blockRegistry.removeListener(registryListener);
     };
-  }, [registryListener, reload]);
+  }, [registryListener]);
 
   return {
     allBlocks,


### PR DESCRIPTION
## What does this PR do?

- Fixes #3994 

## Discussion

- This causes `brickRegistry.all()` to get called twice on page editor startup, but it's just pulling from the background registry / IDB, so it's not fetching twice

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
