### PR TITLE
#4027: Avoid duplicate error reporting in `ErrorBoundary`

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -17,11 +17,9 @@
 
 import React, { Component } from "react";
 import { Button } from "react-bootstrap";
-import { isExtensionContext } from "webext-detect-page";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faRedo } from "@fortawesome/free-solid-svg-icons";
 import { getErrorMessage } from "@/errors/errorHelpers";
-import reportError from "@/telemetry/reportError";
 import { UnknownObject } from "@/types";
 import { isEmpty } from "lodash";
 
@@ -51,12 +49,6 @@ class ErrorBoundary extends Component<Props, State> {
       errorMessage: getErrorMessage(error),
       stack: error.stack,
     };
-  }
-
-  override componentDidCatch(error: Error): void {
-    if (isExtensionContext()) {
-      reportError(error);
-    }
   }
 
   override render(): React.ReactNode {

--- a/src/sidebar/ErrorBoundary.tsx
+++ b/src/sidebar/ErrorBoundary.tsx
@@ -16,9 +16,7 @@
  */
 
 import React, { Component } from "react";
-import { isExtensionContext } from "webext-detect-page";
 import { getErrorMessage } from "@/errors/errorHelpers";
-import reportError from "@/telemetry/reportError";
 import { UnknownObject } from "@/types";
 import { isEmpty } from "lodash";
 import { faRedo } from "@fortawesome/free-solid-svg-icons";
@@ -46,12 +44,6 @@ class ErrorBoundary extends Component<UnknownObject, State> {
       errorMessage: getErrorMessage(error),
       stack: error.stack,
     };
-  }
-
-  override componentDidCatch(error: Error): void {
-    if (isExtensionContext()) {
-      reportError(error);
-    }
   }
 
   async reloadSidebar() {


### PR DESCRIPTION
## What does this PR do?

- Fixe #4027 

## Discussion

- [x] _Confirmed_ ~~Is this the correct behavior in every situation? I saw this issue in the sidebar, I have not confirmed the issue in other contexts yet~~



## Demo

You can see that there's only one error report now:

<img width="631" alt="Screen Shot 8" src="https://user-images.githubusercontent.com/1402241/184587904-016de6f7-f467-4bd5-b3ec-d4318f021fff.png">
