### PR TITLE
#4028: handle missing service definition

### DIFF
--- a/src/background/partnerIntegrations.ts
+++ b/src/background/partnerIntegrations.ts
@@ -53,7 +53,15 @@ export async function getPartnerPrincipals(): Promise<PartnerPrincipal[]> {
 
   const auths = flatten(
     await Promise.all(
-      partnerIds.map(async (id) => serviceLocator.locateAllForService(id))
+      partnerIds.map(async (id) => {
+        try {
+          return await serviceLocator.locateAllForService(id);
+        } catch {
+          // `serviceLocator` throws if the user doesn't have the service definition. Handle case where
+          // CONTROL_ROOM_OAUTH_SERVICE_ID hasn't been made available on the server yet
+          return [];
+        }
+      })
     )
   );
 


### PR DESCRIPTION
## What does this PR do?

- Closes #4028 
- Handles missing `automation-anywhere/oauth2` definition which is not publicly available on prod yet

## Discussion
- I didn't need to change useRequiredPartnerAuth because it loops over all services, https://github.com/pixiebrix/pixiebrix-extension/blob/2a808ea401e2a0f8a38f6702489f57488e4a0e31/src/auth/useRequiredPartnerAuth.ts#L100-L100

## Checklist

- 😢  Add tests
- [X] Designate a primary reviewer: @mnholtz 
