### PR TITLE
#4031: add sidebar router to support auth hooks

### DIFF
--- a/src/sidebar/SidebarApp.tsx
+++ b/src/sidebar/SidebarApp.tsx
@@ -22,12 +22,17 @@ import Loader from "@/components/Loader";
 import { PersistGate } from "redux-persist/integration/react";
 import ConnectedSidebar from "./ConnectedSidebar";
 import Header from "./Header";
+import { MemoryRouter } from "react-router";
 
+// Include MemoryRouter because some of our authentication-gate hooks use useLocation. However, there's currently no
+// navigation in the SidebarApp
 const SidebarApp: React.FunctionComponent = () => (
   <Provider store={store}>
     <PersistGate loading={<Loader />} persistor={persistor}>
-      <Header />
-      <ConnectedSidebar />
+      <MemoryRouter>
+        <Header />
+        <ConnectedSidebar />
+      </MemoryRouter>
     </PersistGate>
   </Provider>
 );


### PR DESCRIPTION
## What does this PR do?

- Closes #4031 
- Adds MemoryRouter to SidebarApp. Our RequireAuth does a location check to support ignoring the gate on settings page, so it needs a router in the tree: https://github.com/pixiebrix/pixiebrix-extension/blob/851aa40bd03e448af32199c5818ee81b881fc7b7/src/auth/RequireAuth.tsx#L163-L163

## Checklist

- 😢  Add tests
- [X] Designate a primary reviewer: @fregante 
