### PR TITLE
Allow cross-origin image URLs in form field

### DIFF
--- a/src/components/formBuilder/ImageCropWidget.tsx
+++ b/src/components/formBuilder/ImageCropWidget.tsx
@@ -99,7 +99,12 @@ const ImageCropWidget: React.VFC<WidgetProps> = ({
             onComplete={onCropComplete}
             onChange={onCropChange}
           >
-            <img src={source} alt="Item being cropped" onLoad={onImageLoaded} />
+            <img
+              crossOrigin="anonymous"
+              src={source}
+              alt="Item being cropped"
+              onLoad={onImageLoaded}
+            />
           </ReactCrop>
         </Stylesheets>
       )}


### PR DESCRIPTION
## What does this PR do?

- Fixes the issue discovered in https://github.com/pixiebrix/pixiebrix-extension/pull/4024#pullrequestreview-1072315858
- Avoids the silent error caused by painting a cross-origin image onto the canvas


## Discussion

- This change is non-breaking because it the ability to load non-`data:` images, which was previously impossible

## Demo

Uses the URL:

```
https://cdn.pixabay.com/photo/2015/10/01/17/17/car-967387__480.png
```


<img width="881" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/184939563-fe0dad31-2e47-4e56-bbaa-af8638a987c5.png">


## Future Work

- [ ] Add error messaging for when the image fails to load, like:
```
https://images.freeimages.com/images/large-previews/566/green-frog-1361810.jpg
```


