### PR TITLE
#4058: fix race condition on tab load

### DIFF
--- a/src/contentScript/contentScript.ts
+++ b/src/contentScript/contentScript.ts
@@ -15,9 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// IMPORTANT: do not import anything that has a transitive dependency of the messenger.
+// See for more information: https://github.com/pixiebrix/pixiebrix-extension/issues/4058
 import "./contentScript.scss";
 import { uuidv4 } from "@/types/helpers";
-import { onContextInvalidated } from "@/errors/contextInvalidated";
 import {
   isInstalledInThisSession,
   isReadyInThisDocument,
@@ -47,17 +48,12 @@ async function initContentScript() {
 
   setInstalledInThisSession();
 
-  // eslint-disable-next-line promise/prefer-await-to-then -- It's an unrelated event listener
-  void onContextInvalidated().then(() => {
-    console.debug("contentScript: invalidated", uuid);
-  });
-
   // Keeping the import separate ensures that no side effects are run until this point
   const { init } = await logPromiseDuration(
     "contentScript: imported", // "imported" timing includes the parsing of the file, which can take 500-1000ms
     import(/* webpackChunkName: "contentScriptCore" */ "./contentScriptCore")
   );
-  await init();
+  await init(uuid);
   setReadyInThisDocument(uuid);
 }
 


### PR DESCRIPTION
## What does this PR do?

- Part of #4058 
- Moves the onContextInvalidated listener to the contentScriptCore to avoid the messenger registration race condition

Discussion
---
- @fregante there's still a race in the `init()` method. If you put a `await sleep(1000)` as the first line init method, you'll see that you still get the error. That's because the __getTabData method is loading synchronously with the module load, while the registerMessenger is running async. 
- I think we need to be able explicitly set the messenger as "ready". Otherwise you'll always run into race conditions with: 1) message registration, 2) brick registration, 3) other content script initialization, etc.

Coordination
---
- [x] Designate a primary reviewer: @fregante 
