### PR TITLE
#4025: show error if the form modal is used in a renderer branch

### DIFF
--- a/src/analysis/analysisVisitors/formBrickAnalysis.ts
+++ b/src/analysis/analysisVisitors/formBrickAnalysis.ts
@@ -19,6 +19,7 @@ import { AnalysisVisitor } from "./baseAnalysisVisitors";
 import { AnnotationType } from "@/analysis/analysisTypes";
 import { BlockConfig, BlockPosition } from "@/blocks/types";
 import { VisitBlockExtra } from "@/blocks/PipelineVisitor";
+import { FORM_MODAL_ID } from "@/pageEditor/fields/FormModalOptions";
 
 class FormBrickAnalysis extends AnalysisVisitor {
   get id() {
@@ -40,7 +41,7 @@ class FormBrickAnalysis extends AnalysisVisitor {
 
     if (
       extra.pipelineFlavor === "noEffect" &&
-      blockConfig.id === "@pixiebrix/form-modal"
+      blockConfig.id === FORM_MODAL_ID
     ) {
       this.annotations.push({
         position,

--- a/src/analysis/analysisVisitors/formBrickAnalysis.ts
+++ b/src/analysis/analysisVisitors/formBrickAnalysis.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AnalysisVisitor } from "./baseAnalysisVisitors";
+import { AnnotationType } from "@/analysis/analysisTypes";
+import { BlockConfig, BlockPosition } from "@/blocks/types";
+import { VisitBlockExtra } from "@/blocks/PipelineVisitor";
+
+class FormBrickAnalysis extends AnalysisVisitor {
+  get id() {
+    return "form";
+  }
+
+  override visitBlock(
+    position: BlockPosition,
+    blockConfig: BlockConfig,
+    extra: VisitBlockExtra
+  ) {
+    super.visitBlock(position, blockConfig, extra);
+
+    // In the future, we'll want to use the isPure property to generalize the rule. However, the isPure property
+    // conflates two things: 1) bricks that read state or have implicit state, so may return a different result, and
+    // 2) bricks that has UI or other side effects so are not safe to rerun.
+
+    // The other direction (not placing the renderer form in an action, is already handled by brickTypeAnalysis.ts)
+
+    if (
+      extra.pipelineFlavor === "noEffect" &&
+      blockConfig.id === "@pixiebrix/form-modal"
+    ) {
+      this.annotations.push({
+        position,
+        message:
+          "The modal form brick shows a temporary form, and therefore can only be used in actions. Instead, use the Custom Form brick.",
+        analysisId: this.id,
+        type: AnnotationType.Error,
+      });
+    }
+  }
+}
+
+export default FormBrickAnalysis;

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -31,12 +31,13 @@ import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 import runtimeSlice from "./slices/runtimeSlice";
 import { isAnyOf } from "@reduxjs/toolkit";
 import RequestPermissionAnalysis from "@/analysis/analysisVisitors/requestPermissionAnalysis";
+import FormBrickAnalysis from "@/analysis/analysisVisitors/formBrickAnalysis";
 
 const runtimeActions = runtimeSlice.actions;
 
 const pageEditorAnalysisManager = new ReduxAnalysisManager();
 
-// These actions will be used with every analysis so the annotation path is up to date
+// These actions will be used with every analysis so the annotation path is up-to-date
 // with the node position in the pipeline
 const nodeListMutationActions = [
   editorActions.addNode,
@@ -70,6 +71,16 @@ pageEditorAnalysisManager.registerAnalysisEffect(
 
 pageEditorAnalysisManager.registerAnalysisEffect(
   () => new BlockTypeAnalysis(),
+  {
+    // Only needed on editorActions.addNode,
+    // but the block path can change on move or remove
+    // @ts-expect-error: spreading the array as args
+    matcher: isAnyOf(...nodeListMutationActions),
+  }
+);
+
+pageEditorAnalysisManager.registerAnalysisEffect(
+  () => new FormBrickAnalysis(),
   {
     // Only needed on editorActions.addNode,
     // but the block path can change on move or remove


### PR DESCRIPTION
## What does this PR do?

- Closes #4025 
- Adds an analysis rule to error if the form modal is used in a renderer location

## Checklist

- [x] Designate a primary reviewer: @BALEHOK 
