### PR TITLE
#4010: provide toggle for default success message on menu item extensions

### DIFF
--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -135,7 +135,7 @@ export type MenuItemExtensionConfig = {
   /**
    * (Experimental) message to show on success when running the extension
    */
-  onSuccess?: MessageConfig;
+  onSuccess?: MessageConfig | boolean;
 };
 
 export const actionSchema: Schema = {
@@ -569,10 +569,16 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
 
         extensionLogger.info("Successfully ran menu action");
 
-        showNotification({
-          ...DEFAULT_ACTION_RESULTS.success,
-          ...pick(onSuccess, "message", "type"),
-        });
+        if (onSuccess) {
+          if (typeof onSuccess === "boolean") {
+            showNotification(DEFAULT_ACTION_RESULTS.success);
+          } else {
+            showNotification({
+              ...DEFAULT_ACTION_RESULTS.success,
+              ...pick(onSuccess, "message", "type"),
+            });
+          }
+        }
       } catch (error) {
         if (hasSpecificErrorCause(error, CancelError)) {
           showNotification({

--- a/src/pageEditor/extensionPoints/menuItem.ts
+++ b/src/pageEditor/extensionPoints/menuItem.ts
@@ -116,7 +116,7 @@ function selectExtension(
       ? extension.blockPipeline
       : omitEditorMetadata(extension.blockPipeline),
     dynamicCaption: extension.dynamicCaption,
-    onSuccess: extension.onSuccess ?? true,
+    onSuccess: extension.onSuccess,
   };
   return removeEmptyValues({
     ...baseSelectExtension(state),
@@ -188,12 +188,7 @@ async function fromExtension(
   return {
     ...base,
 
-    extension: {
-      ...extension,
-      // Explicitly set the default value. (Alternatively could set the defaultValue in MenuItemConfiguration for the
-      // ConnectedFieldTemplate, but that wasn't working for some reason
-      onSuccess: extension.onSuccess ?? true,
-    },
+    extension,
 
     // `containerInfo` only populated on initial creation session
     containerInfo: null,

--- a/src/pageEditor/extensionPoints/menuItem.ts
+++ b/src/pageEditor/extensionPoints/menuItem.ts
@@ -79,6 +79,7 @@ function fromNativeElement(
       caption: button.item.caption,
       blockPipeline: [],
       dynamicCaption: false,
+      onSuccess: true,
     },
   };
 }
@@ -115,6 +116,7 @@ function selectExtension(
       ? extension.blockPipeline
       : omitEditorMetadata(extension.blockPipeline),
     dynamicCaption: extension.dynamicCaption,
+    onSuccess: extension.onSuccess ?? true,
   };
   return removeEmptyValues({
     ...baseSelectExtension(state),
@@ -146,6 +148,7 @@ async function fromExtensionPoint(
       caption:
         extensionPoint.definition.defaultOptions?.caption ?? "Custom Action",
       blockPipeline: [],
+      onSuccess: true,
     },
 
     // There's no containerInfo for the page because the user did not select it during the session
@@ -185,7 +188,12 @@ async function fromExtension(
   return {
     ...base,
 
-    extension,
+    extension: {
+      ...extension,
+      // Explicitly set the default value. (Alternatively could set the defaultValue in MenuItemConfiguration for the
+      // ConnectedFieldTemplate, but that wasn't working for some reason
+      onSuccess: extension.onSuccess ?? true,
+    },
 
     // `containerInfo` only populated on initial creation session
     containerInfo: null,

--- a/src/pageEditor/tabs/menuItem/MenuItemConfiguration.tsx
+++ b/src/pageEditor/tabs/menuItem/MenuItemConfiguration.tsx
@@ -93,7 +93,7 @@ const MenuItemConfiguration: React.FC<{
           {...makeLockableFieldProps("Template", isLocked)}
         />
 
-        {typeof onSuccess === "boolean" && (
+        {(typeof onSuccess === "boolean" || onSuccess == null) && (
           // Punt on object-based configuration for now. Enterprise customers are just asking to turn off the message.
           // If they want a custom message they can add an alert brick.
           <ConnectedFieldTemplate
@@ -101,7 +101,7 @@ const MenuItemConfiguration: React.FC<{
             label="Show Success Message"
             as={SwitchButtonWidget}
             description="Show the default success message when run"
-            defaultValue={true}
+            blankValue={true}
           />
         )}
       </FieldSection>

--- a/src/pageEditor/tabs/menuItem/MenuItemConfiguration.tsx
+++ b/src/pageEditor/tabs/menuItem/MenuItemConfiguration.tsx
@@ -27,6 +27,8 @@ import SelectWidget, { Option } from "@/components/form/widgets/SelectWidget";
 import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
 import MatchRulesSection from "@/pageEditor/tabs/MatchRulesSection";
 import ExtraPermissionsSection from "@/pageEditor/tabs/ExtraPermissionsSection";
+import { useField } from "formik";
+import SwitchButtonWidget from "@/components/form/widgets/switchButton/SwitchButtonWidget";
 
 const menuSnippets: Snippet[] = [
   { label: "caption", value: "{{{caption}}}" },
@@ -41,58 +43,74 @@ const positionOptions: Option[] = [
 
 const MenuItemConfiguration: React.FC<{
   isLocked: boolean;
-}> = ({ isLocked = false }) => (
-  <Card>
-    <FieldSection title="Configuration">
-      <ConnectedFieldTemplate
-        name="extension.caption"
-        label="Caption"
-        description="Button caption"
-      />
+}> = ({ isLocked = false }) => {
+  const [{ value: onSuccess }] = useField("extension.onSuccess");
 
-      <ConnectedFieldTemplate
-        name="extensionPoint.definition.containerSelector"
-        as={LocationWidget}
-        description="Location on the page"
-        {...makeLockableFieldProps("Location", isLocked)}
-      />
+  return (
+    <Card>
+      <FieldSection title="Configuration">
+        <ConnectedFieldTemplate
+          name="extension.caption"
+          label="Caption"
+          description="Button caption"
+        />
 
-      <UrlMatchPatternField
-        name="extensionPoint.definition.isAvailable.matchPatterns"
-        {...makeLockableFieldProps("Sites", isLocked)}
-      />
-    </FieldSection>
+        <ConnectedFieldTemplate
+          name="extensionPoint.definition.containerSelector"
+          as={LocationWidget}
+          description="Location on the page"
+          {...makeLockableFieldProps("Location", isLocked)}
+        />
 
-    <FieldSection title="Advanced: Item Options">
-      <ConnectedFieldTemplate
-        name="extension.icon"
-        label="Icon"
-        as={IconWidget}
-        description="Icon to place in the icon placeholder of the template"
-      />
+        <UrlMatchPatternField
+          name="extensionPoint.definition.isAvailable.matchPatterns"
+          {...makeLockableFieldProps("Sites", isLocked)}
+        />
+      </FieldSection>
 
-      <ConnectedFieldTemplate
-        name="extensionPoint.definition.position"
-        description="Position relative to other menu items/buttons"
-        as={SelectWidget}
-        blankValue={null}
-        options={positionOptions}
-        {...makeLockableFieldProps("Order/Position", isLocked)}
-      />
+      <FieldSection title="Advanced: Item Options">
+        <ConnectedFieldTemplate
+          name="extension.icon"
+          label="Icon"
+          as={IconWidget}
+          description="Icon to place in the icon placeholder of the template"
+        />
 
-      <ConnectedFieldTemplate
-        name="extensionPoint.definition.template"
-        as={TemplateWidget}
-        description="A template for the item, with a placeholder for the caption and/or icon"
-        snippets={menuSnippets}
-        {...makeLockableFieldProps("Template", isLocked)}
-      />
-    </FieldSection>
+        <ConnectedFieldTemplate
+          name="extensionPoint.definition.position"
+          description="Position relative to other menu items/buttons"
+          as={SelectWidget}
+          blankValue={null}
+          options={positionOptions}
+          {...makeLockableFieldProps("Order/Position", isLocked)}
+        />
 
-    <MatchRulesSection isLocked={isLocked} />
+        <ConnectedFieldTemplate
+          name="extensionPoint.definition.template"
+          as={TemplateWidget}
+          description="A template for the item, with a placeholder for the caption and/or icon"
+          snippets={menuSnippets}
+          {...makeLockableFieldProps("Template", isLocked)}
+        />
 
-    <ExtraPermissionsSection />
-  </Card>
-);
+        {typeof onSuccess === "boolean" && (
+          // Punt on object-based configuration for now. Enterprise customers are just asking to turn off the message.
+          // If they want a custom message they can add an alert brick.
+          <ConnectedFieldTemplate
+            name="extension.onSuccess"
+            label="Show Success Message"
+            as={SwitchButtonWidget}
+            description="Show the default success message when run"
+            defaultValue={true}
+          />
+        )}
+      </FieldSection>
+
+      <MatchRulesSection isLocked={isLocked} />
+
+      <ExtraPermissionsSection />
+    </Card>
+  );
+};
 
 export default MenuItemConfiguration;


### PR DESCRIPTION
## What does this PR do?

- Closes #4010 
- Provides toggle to turn off default success message for menu item

## Coordination
- 😢  Add tests - we don't have extension point test framework yet
- [x] Designate a primary reviewer: @BALEHOK 
