### PR TITLE
Removing unused customFields and customWidgets properties from SchemaFieldContext

### DIFF
--- a/src/components/fields/schemaFields/SchemaFieldContext.tsx
+++ b/src/components/fields/schemaFields/SchemaFieldContext.tsx
@@ -53,8 +53,6 @@ export function defaultFieldFactory(
  * Context defining custom fields and widgets for schema-based fields.
  */
 const SchemaFieldContext = createContext<CustomFieldDefinitions>({
-  customFields: [],
-  customWidgets: [],
   customToggleModes: [],
 });
 

--- a/src/components/fields/schemaFields/schemaFieldTypes.ts
+++ b/src/components/fields/schemaFields/schemaFieldTypes.ts
@@ -16,29 +16,12 @@
  */
 
 import { Schema } from "@/core";
-import { SchemaFieldComponent } from "@/components/fields/schemaFields/propTypes";
 import { InputModeOption } from "@/components/fields/schemaFields/widgets/templateToggleWidgetTypes";
 
-/**
- * A form field, including label, error message, etc.
- */
-type CustomField = {
-  match: (fieldSchema: Schema) => boolean;
-  Component: SchemaFieldComponent;
-};
-/**
- * An individual form control (excluding label, error message, etc.)
- */
-type CustomWidget = {
-  match: (fieldSchema: Schema) => boolean;
-  Component: SchemaFieldComponent;
-};
 export type CustomFieldToggleMode = {
   match: (fieldSchema: Schema) => boolean;
   option: InputModeOption;
 };
 export type CustomFieldDefinitions = {
-  customFields: CustomField[];
-  customWidgets: CustomWidget[];
   customToggleModes: CustomFieldToggleMode[];
 };

--- a/src/pageEditor/fields/devtoolFieldOverrides.tsx
+++ b/src/pageEditor/fields/devtoolFieldOverrides.tsx
@@ -16,14 +16,11 @@
  */
 
 import React from "react";
-import SelectorSelectorField from "@/components/fields/schemaFields/SelectorSelectorField";
 import SelectorSelectorWidget from "@/pageEditor/fields/SelectorSelectorWidget";
-import { createTypePredicate } from "@/components/fields/fieldUtils";
 import { Schema } from "@/core";
 import { isTemplateExpression } from "@/runtime/mapArgs";
 import OptionIcon from "@/components/fields/schemaFields/optionIcon/OptionIcon";
 import { CustomFieldDefinitions } from "@/components/fields/schemaFields/schemaFieldTypes";
-import CssClassWidget from "@/components/fields/schemaFields/widgets/CssClassWidget";
 
 export const ClearableSelectorWidget: React.FunctionComponent<{
   name: string;
@@ -32,27 +29,7 @@ export const ClearableSelectorWidget: React.FunctionComponent<{
 const isSelectorField = (schema: Schema) =>
   schema.type === "string" && schema.format === "selector";
 
-const hasAnySelectorField = createTypePredicate(isSelectorField);
-
 const devtoolFieldOverrides: CustomFieldDefinitions = {
-  customFields: [
-    {
-      match: hasAnySelectorField,
-      Component: SelectorSelectorField,
-    },
-  ],
-  customWidgets: [
-    {
-      match: hasAnySelectorField,
-      Component: ClearableSelectorWidget,
-    },
-    {
-      // See getElementEditSchemas.ts:getClassNameEdit
-      match: (schema) =>
-        schema.type === "string" && schema.format === "bootstrap-class",
-      Component: CssClassWidget,
-    },
-  ],
   customToggleModes: [
     {
       match: isSelectorField,


### PR DESCRIPTION
## What does this PR do?

- Drops the unused customFields and customWidgets properties from SchemaFieldContext

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer @twschiller 
