### PR TITLE
Move messaging code out of `@/common`

### DIFF
--- a/src/blocks/readers/window.ts
+++ b/src/blocks/readers/window.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { withReadWindow } from "@/common";
+import { withReadWindow } from "@/messaging/protocol";
 import { ReaderOutput } from "@/core";
 import { registerFactory } from "@/blocks/readers/factory";
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -15,13 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { createSendScriptMessage } from "@/messaging/chrome";
-import {
-  DETECT_FRAMEWORK_VERSIONS,
-  FrameworkMeta,
-  READ_WINDOW,
-  SEARCH_WINDOW,
-} from "@/messaging/constants";
 import { CONTENT_SCRIPT_READY_ATTRIBUTE } from "@/contentScript/ready";
 
 export const NOTIFICATIONS_Z_INDEX = 2_147_483_647;
@@ -37,19 +30,3 @@ export const PRIVATE_ATTRIBUTES_SELECTOR = `
   [${CONTENT_SCRIPT_READY_ATTRIBUTE}],
   [${EXTENSION_POINT_DATA_ATTR}]
 `;
-
-type ReadSpec = <T extends Record<string, string>>(arg: {
-  pathSpec: T;
-  waitMillis?: number;
-}) => Promise<Record<keyof T, unknown>>;
-
-export const withReadWindow = createSendScriptMessage(
-  READ_WINDOW
-) as unknown as ReadSpec;
-
-export const withSearchWindow =
-  createSendScriptMessage<{ results: unknown[] }>(SEARCH_WINDOW);
-
-export const withDetectFrameworkVersions = createSendScriptMessage<
-  FrameworkMeta[]
->(DETECT_FRAMEWORK_VERSIONS);

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -49,7 +49,10 @@ import {
   updateDynamicElement,
 } from "@/contentScript/nativeEditor/dynamic";
 import { getProcesses, initRobot } from "@/contentScript/uipath";
-import { withDetectFrameworkVersions, withSearchWindow } from "@/common";
+import {
+  withDetectFrameworkVersions,
+  withSearchWindow,
+} from "@/messaging/protocol";
 import {
   runBlock,
   runReaderBlock,

--- a/src/contrib/pipedrive/readers.ts
+++ b/src/contrib/pipedrive/readers.ts
@@ -17,7 +17,7 @@
 
 import { Reader } from "@/types";
 import { startCase, mapValues } from "lodash";
-import { withReadWindow } from "@/common";
+import { withReadWindow } from "@/messaging/protocol";
 import { PathSpec } from "@/blocks/readers/window";
 
 export async function checkRoute(expectedRoute: string): Promise<boolean> {

--- a/src/messaging/protocol.ts
+++ b/src/messaging/protocol.ts
@@ -17,6 +17,13 @@
 
 import { ActionType, Message, SerializedError, Meta } from "@/core";
 import { serializeError } from "serialize-error";
+import { createSendScriptMessage } from "./chrome";
+import {
+  DETECT_FRAMEWORK_VERSIONS,
+  FrameworkMeta,
+  READ_WINDOW,
+  SEARCH_WINDOW,
+} from "./constants";
 
 // eslint-disable-next-line @typescript-eslint/ban-types -- Line can be dropped once we migrate to `webext-messenger`
 export type SerializableResponse = boolean | string | number | object | void;
@@ -64,3 +71,19 @@ export function isRemoteProcedureCallRequest(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a type guard function and it uses ?.
   return typeof (message as any)?.type === "string";
 }
+
+type ReadSpec = <T extends Record<string, string>>(arg: {
+  pathSpec: T;
+  waitMillis?: number;
+}) => Promise<Record<keyof T, unknown>>;
+
+export const withReadWindow = createSendScriptMessage(
+  READ_WINDOW
+) as unknown as ReadSpec;
+
+export const withSearchWindow =
+  createSendScriptMessage<{ results: unknown[] }>(SEARCH_WINDOW);
+
+export const withDetectFrameworkVersions = createSendScriptMessage<
+  FrameworkMeta[]
+>(DETECT_FRAMEWORK_VERSIONS);


### PR DESCRIPTION
## What does this PR do?


`@/common` is imported by every context via `notify.ts` and unsafe-messaging stuff shouldn't be part of it.


## Reviewer Tips

No changes made, just moving code

## Checklist

- [x] Designate a primary reviewer: @twschiller 


## Related

- https://github.com/pixiebrix/pixiebrix-extension/issues/669