### PR TITLE
#4078: Instant sidebar loading via browserAction

### DIFF
--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -28,12 +28,11 @@ export const resetTab = getNotifier("RESET_TAB");
 
 export const toggleQuickBar = getMethod("TOGGLE_QUICK_BAR");
 export const handleMenuAction = getMethod("HANDLE_MENU_ACTION");
-export const toggleSidebar = getMethod("TOGGLE_SIDEBAR");
+export const rehydrateSidebar = getMethod("REHYDRATE_SIDEBAR");
 export const showSidebar = getMethod("SHOW_SIDEBAR");
 export const hideSidebar = getMethod("HIDE_SIDEBAR");
 export const reloadSidebar = getMethod("RELOAD_SIDEBAR");
 export const removeSidebar = getMethod("REMOVE_SIDEBAR");
-export const getSidebarEntries = getMethod("GET_SIDEBAR_ENTRIES");
 export const insertPanel = getMethod("INSERT_PANEL");
 export const insertButton = getMethod("INSERT_BUTTON");
 

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -34,9 +34,8 @@ import {
 import {
   hideSidebar,
   showSidebar,
-  toggleSidebar,
+  rehydrateSidebar,
   removeExtension as removeSidebar,
-  getSidebarEntries,
   reloadSidebar,
 } from "@/contentScript/sidebarController";
 import { insertPanel } from "@/contentScript/nativeEditor/insertPanel";
@@ -87,12 +86,11 @@ declare global {
 
     TOGGLE_QUICK_BAR: typeof toggleQuickBar;
     HANDLE_MENU_ACTION: typeof handleMenuAction;
-    TOGGLE_SIDEBAR: typeof toggleSidebar;
+    REHYDRATE_SIDEBAR: typeof rehydrateSidebar;
     SHOW_SIDEBAR: typeof showSidebar;
     HIDE_SIDEBAR: typeof hideSidebar;
     RELOAD_SIDEBAR: typeof reloadSidebar;
     REMOVE_SIDEBAR: typeof removeSidebar;
-    GET_SIDEBAR_ENTRIES: typeof getSidebarEntries;
 
     INSERT_PANEL: typeof insertPanel;
     INSERT_BUTTON: typeof insertButton;
@@ -145,12 +143,11 @@ export default function registerMessenger(): void {
 
     TOGGLE_QUICK_BAR: toggleQuickBar,
     HANDLE_MENU_ACTION: handleMenuAction,
-    TOGGLE_SIDEBAR: toggleSidebar,
+    REHYDRATE_SIDEBAR: rehydrateSidebar,
     SHOW_SIDEBAR: showSidebar,
     HIDE_SIDEBAR: hideSidebar,
     RELOAD_SIDEBAR: reloadSidebar,
     REMOVE_SIDEBAR: removeSidebar,
-    GET_SIDEBAR_ENTRIES: getSidebarEntries,
 
     INSERT_PANEL: insertPanel,
     INSERT_BUTTON: insertButton,

--- a/src/contentScript/sidebarDomControllerLite.ts
+++ b/src/contentScript/sidebarDomControllerLite.ts
@@ -35,8 +35,6 @@ function storeOriginalCSSOnce() {
 }
 
 export function isSidebarFrameVisible(): boolean {
-  // expectContext("contentScript");
-
   return Boolean(document.querySelector(PANEL_CONTAINER_SELECTOR));
 }
 

--- a/src/contentScript/sidebarDomControllerLite.ts
+++ b/src/contentScript/sidebarDomControllerLite.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file This file MUST not have dependencies as it's meant to be tiny
+ * and imported by browserActionInstantHandler.ts
+ */
+
+import { MAX_Z_INDEX, PANEL_FRAME_ID } from "@/common";
+
+export const SIDEBAR_WIDTH_CSS_PROPERTY = "--pb-sidebar-margin-right";
+
+let originalMarginRight: number;
+const SIDEBAR_WIDTH_PX = 400;
+const PANEL_CONTAINER_SELECTOR = "#" + PANEL_FRAME_ID;
+
+function storeOriginalCSSOnce() {
+  originalMarginRight ??= Number.parseFloat(
+    getComputedStyle(document.documentElement).getPropertyValue("margin-right")
+  );
+}
+
+export function isSidebarFrameVisible(): boolean {
+  // expectContext("contentScript");
+
+  return Boolean(document.querySelector(PANEL_CONTAINER_SELECTOR));
+}
+
+/** Removes the element; Returns false if no element was found */
+export function removeSidebarFrame(): boolean {
+  if (!isSidebarFrameVisible()) {
+    return false;
+  }
+
+  $(PANEL_CONTAINER_SELECTOR).remove();
+
+  $("html")
+    .css(SIDEBAR_WIDTH_CSS_PROPERTY, "")
+    .css("margin-right", originalMarginRight);
+
+  return true;
+}
+
+/** Inserts the element; Returns false if it already existed */
+export function insertSidebarFrame(): boolean {
+  if (isSidebarFrameVisible()) {
+    return false;
+  }
+
+  console.debug("SidePanel is not on the page, attaching side panel");
+
+  storeOriginalCSSOnce();
+  const nonce = crypto.randomUUID();
+  const actionURL = browser.runtime.getURL("sidebar.html");
+
+  $("html")
+    .css(SIDEBAR_WIDTH_CSS_PROPERTY, originalMarginRight + SIDEBAR_WIDTH_PX)
+    .css("margin-right", `var(${SIDEBAR_WIDTH_CSS_PROPERTY})`);
+
+  $("<iframe>")
+    .attr({
+      id: PANEL_FRAME_ID,
+      src: `${actionURL}?nonce=${nonce}`,
+      "data-nonce": nonce, // Don't use jQuery.data because we need this as an HTML attribute to target with selector
+    })
+    .css({
+      position: "fixed",
+      top: 0,
+      right: 0,
+      zIndex: MAX_Z_INDEX,
+      width: SIDEBAR_WIDTH_PX,
+      height: "100%",
+      border: 0,
+      borderLeft: "1px solid lightgray",
+      background: "#f2edf3",
+    })
+    .appendTo("body");
+
+  return false;
+}
+
+export function toggleSidebarFrame(): boolean {
+  if (isSidebarFrameVisible()) {
+    removeSidebarFrame();
+    return false;
+  }
+
+  insertSidebarFrame();
+  return true;
+}

--- a/src/extensionPoints/sidebarExtension.ts
+++ b/src/extensionPoints/sidebarExtension.ts
@@ -45,7 +45,6 @@ import { Permissions } from "webextension-polyfill";
 import { checkAvailable } from "@/blocks/available";
 import notify from "@/utils/notify";
 import {
-  isSidebarVisible,
   removeExtensionPoint,
   reservePanels,
   ShowCallback,
@@ -69,6 +68,7 @@ import { mergeReaders } from "@/blocks/readers/readerUtils";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import { NoRendererError } from "@/errors/businessErrors";
 import { serializeError } from "serialize-error";
+import { isSidebarFrameVisible } from "@/contentScript/sidebarDomControllerLite";
 
 export type SidebarConfig = {
   heading: string;
@@ -352,7 +352,7 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
       return;
     }
 
-    if (!isSidebarVisible()) {
+    if (!isSidebarFrameVisible()) {
       console.debug(
         "Skipping run for %s because sidebar is not visible",
         this.id

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -52,12 +52,6 @@ export function inputProperties(inputSchema: Schema): SchemaProperties {
 }
 
 /**
- * True if the script is executing in a web browser context.
- */
-export const IS_BROWSER =
-  typeof window !== "undefined" && typeof window.document !== "undefined";
-
-/**
  * Find an element(s) by its jQuery selector. A safe alternative to $(selector), which constructs an element it it's
  * passed HTML.
  * @param selector a jQuery selector

--- a/src/tinyPages/browserActionInstantHandler.ts
+++ b/src/tinyPages/browserActionInstantHandler.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file This file MUST be lightweight and free of any logic and dependencies, it's meant to be instant */
+import { toggleSidebarFrame } from "@/contentScript/sidebarDomControllerLite";
+
+toggleSidebarFrame();

--- a/src/utils/notify.tsx
+++ b/src/utils/notify.tsx
@@ -26,7 +26,7 @@ import reportError from "@/telemetry/reportError";
 import { Except, RequireAtLeastOne } from "type-fest";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { truncate } from "lodash";
-import { SIDEBAR_WIDTH_CSS_PROPERTY } from "@/contentScript/sidebarController";
+import { SIDEBAR_WIDTH_CSS_PROPERTY } from "@/contentScript/sidebarDomControllerLite";
 
 const MINIMUM_NOTIFICATION_DURATION = 2000;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -223,6 +223,7 @@ module.exports = (env, options) =>
         "sidebar/sidebar",
         "tinyPages/ephemeralForm",
         "tinyPages/permissionsPopup",
+        "tinyPages/browserActionInstantHandler",
 
         // Tiny files without imports
         "tinyPages/frame",


### PR DESCRIPTION
## What does this PR do?

- Part of #4078

## Reviewer Tips

- Before trying this PR, open your PB sidebar to see a slow-responding browser action for the last time [^1]

    [^1]: For best effects, use on hosts without permissions. It does not affect the actual sidebar.html loading time. Contact your doctor if page loads take longer than 4 hours.

## Discussion

- Further readability improvements were possible but I tried to keep this PR slim



## Demo

### Before


https://user-images.githubusercontent.com/1402241/185910211-271490e8-8b59-473b-8302-aa30eaa12d34.mov

### After



https://user-images.githubusercontent.com/1402241/185910234-83ac4931-8cb8-4380-808b-d2531c95f793.mov



## Future Work

- [ ] Merge `ensureSidebar` into `showSidebar`
- [ ] Extract `showSidebar` side effects out of it, its logic is hard to follow and it's doing two things at once.
- [ ] Rename `hideSidebar`/`showSidebar` with `unloadSidebar`/`loadSidebar` for clarity
- [ ] Drop jQuery from `sidebarDomControllerLite` to make it smaller and avoid issues with it

## Checklist

- [x] Designate a primary reviewer: @twschiller 
