### PR TITLE
#2273: Existing interval trigger not deactivated when editing in Page Editor

### DIFF
--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -122,7 +122,10 @@ export function removeExtension(
   extensionPointId: RegistryId,
   extensionId: UUID
 ) {
-  const extensionPoint = _installedExtensionPoints.find((x) => x.id);
+  // We need to select correct extensionPoint with extensionId param
+  const extensionPoint = _installedExtensionPoints.find(
+    (x) => x.id === extensionPointId
+  );
   if (extensionPoint) {
     extensionPoint.removeExtension(extensionId);
   } else {

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -302,7 +302,6 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     // observers/handlers are installed for the extensionPoint itself, not the extensions. I.e., there's a single
     // load/click/etc. trigger that's shared by all extensions using this extension point.
     // We need to cancelObservers in order to stop the trigger when extension is selected.
-    this.cancelObservers();
     console.debug("triggerExtension:removeExtensions");
   }
 

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -301,6 +301,8 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     // NOP: the removeExtensions method doesn't need to unregister anything from the page because the
     // observers/handlers are installed for the extensionPoint itself, not the extensions. I.e., there's a single
     // load/click/etc. trigger that's shared by all extensions using this extension point.
+    // We need to cancelObservers in order to stop the trigger when extension is selected.
+    this.cancelObservers();
     console.debug("triggerExtension:removeExtensions");
   }
 

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -301,7 +301,6 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     // NOP: the removeExtensions method doesn't need to unregister anything from the page because the
     // observers/handlers are installed for the extensionPoint itself, not the extensions. I.e., there's a single
     // load/click/etc. trigger that's shared by all extensions using this extension point.
-    // We need to cancelObservers in order to stop the trigger when extension is selected.
     console.debug("triggerExtension:removeExtensions");
   }
 


### PR DESCRIPTION
removeExtensions method is called when user select the extension in the sidebar.

## What does this PR do?

- Closes #2273 

## Reviewer Tips

@twschiller left comment on `removeExtensions` method of TriggerExtensionPoint. However after some debugging, I found that when extension is removed, the triggered observers are not cleared in extensionPoint.

## Discussion

- Do we have any side-effects if we cancel observers in removeExtensions method? 
- Another thing to discuss is I found a case that when we remove trigger extension (which is already running) in the page editor, it clears extension and cancel Observers in the current tab. However it doesn't cancel observers in the different tabs. Thus trigger is still running on different tabs until refresh. Is this case that we need to fix? 

## Checklist

- [ ] Designate a primary reviewer @twschiller 
