### PR TITLE
#4100: Defer loading of Google Fonts

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -37,5 +37,10 @@
     </div>
     <script src="loadingScreen.js"></script>
     <script src="options.js"></script>
+    <!-- Must be at the bottom https://github.com/pixiebrix/pixiebrix-extension/issues/4100 -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700&display=swap"
+      rel="stylesheet"
+    />
   </body>
 </html>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -39,7 +39,7 @@
     <script src="options.js"></script>
     <!-- Must be at the bottom https://github.com/pixiebrix/pixiebrix-extension/issues/4100 -->
     <link
-      href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
       rel="stylesheet"
     />
   </body>

--- a/src/sidebar/sidebar.html
+++ b/src/sidebar/sidebar.html
@@ -33,7 +33,7 @@
     <script src="sidebar.js"></script>
     <!-- Must be at the bottom https://github.com/pixiebrix/pixiebrix-extension/issues/4100 -->
     <link
-      href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
       rel="stylesheet"
     />
   </body>

--- a/src/sidebar/sidebar.html
+++ b/src/sidebar/sidebar.html
@@ -31,5 +31,10 @@
     </div>
     <script src="loadingScreen.js"></script>
     <script src="sidebar.js"></script>
+    <!-- Must be at the bottom https://github.com/pixiebrix/pixiebrix-extension/issues/4100 -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700&display=swap"
+      rel="stylesheet"
+    />
   </body>
 </html>

--- a/src/vendors/theme/app/app.scss
+++ b/src/vendors/theme/app/app.scss
@@ -21,7 +21,6 @@
 //@import "~compass-mixins/lib/compass";
 @import "~compass-mixins/lib/animate";
 @import "~bootstrap/scss/bootstrap";
-@import "../assets/styles/fonts";
 @import "../assets/styles/functions";
 
 /* === Icon fonts === */

--- a/src/vendors/theme/assets/styles/_fonts.scss
+++ b/src/vendors/theme/assets/styles/_fonts.scss
@@ -1,1 +1,0 @@
-@import url("https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700&display=swap");


### PR DESCRIPTION
## What does this PR do?

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/4100

## Discussion



Most [solutions](https://web.dev/defer-non-critical-css/) suggest `rel=preload` and an `onload` listener, but since our HTML is local and tiny this doesn't give any speed advantage over this:

- move the import to the bottom of the page

The stylesheets only delay the first paint of the page **if they come before the content**. By placing them after the JS, we ensure they don't delay anything (except the `document.onload` event, which we don't care about.)

## Demo

In this demo, I placed 

- options.html: `<style>* {font-family: Roboto;}</style>` in the `head`
- options.html: `<link href="https://deelay.me/10000/https://fonts.googleapis.com/css2?family=Roboto:wght@500&display=swap" rel="stylesheet"/>` after `options.js`
- manifest.json: added `https://deelay.me` to the CSP

https://user-images.githubusercontent.com/1402241/186377350-854a1be8-2606-4ae1-b2e0-5a9d88aa3e9e.mov


## Checklist

- [x] Designate a primary reviewer @twschiller 
