### PR TITLE
Optimistically display Blueprints UI

### DIFF
--- a/src/options/pages/blueprints/BlueprintsCard.tsx
+++ b/src/options/pages/blueprints/BlueprintsCard.tsx
@@ -150,10 +150,6 @@ const BlueprintsCard: React.FunctionComponent<{
     useSortBy
   );
 
-  if (isLoading) {
-    return <Loader />;
-  }
-
   return (
     <BootstrapRow className={styles.root}>
       <ListFilters teamFilters={teamFilters} tableInstance={tableInstance} />
@@ -161,15 +157,19 @@ const BlueprintsCard: React.FunctionComponent<{
         <BlueprintsToolbar tableInstance={tableInstance} />
         {/* This wrapper prevents AutoSizer overflow in a flex box container */}
         <div style={{ flex: "1 1 auto" }}>
-          <AutoSizer defaultHeight={500}>
-            {({ height, width }) => (
-              <BlueprintsView
-                tableInstance={tableInstance}
-                width={width}
-                height={height}
-              />
-            )}
-          </AutoSizer>
+          {isLoading ? (
+            <Loader />
+          ) : (
+            <AutoSizer defaultHeight={500}>
+              {({ height, width }) => (
+                <BlueprintsView
+                  tableInstance={tableInstance}
+                  width={width}
+                  height={height}
+                />
+              )}
+            </AutoSizer>
+          )}
         </div>
       </Col>
     </BootstrapRow>

--- a/src/options/pages/blueprints/BlueprintsPage.tsx
+++ b/src/options/pages/blueprints/BlueprintsPage.tsx
@@ -30,14 +30,13 @@ import {
   selectShowShareContext,
 } from "@/options/pages/blueprints/modals/blueprintModalsSelectors";
 import { useTitle } from "@/hooks/title";
-import Loader from "@/components/Loader";
 import { ErrorDisplay } from "@/layout/ErrorDisplay";
 import ConvertToRecipeModal from "./modals/ConvertToRecipeModal";
 import ShareRecipeModal from "./modals/ShareRecipeModal/ShareRecipeModal";
 
 const BlueprintsPage: React.FunctionComponent = () => {
   useTitle("Blueprints");
-  const { installables, isLoading, error } = useInstallables();
+  const { installables, error } = useInstallables();
   const showLogsContext = useSelector<RootState, LogsContext>(
     selectShowLogsContext
   );
@@ -46,16 +45,12 @@ const BlueprintsPage: React.FunctionComponent = () => {
   );
 
   const body = useMemo(() => {
-    if (isLoading) {
-      return <Loader />;
-    }
-
     if (error) {
       return <ErrorDisplay error={error} />;
     }
 
     return <BlueprintsCard installables={installables} />;
-  }, [installables, isLoading, error]);
+  }, [installables, error]);
 
   return (
     <div className="h-100">


### PR DESCRIPTION
## What does this PR do?

Since [the API may be slow to respond](https://github.com/pixiebrix/pixiebrix-app/issues/2184), we can try to display most of the UI available so far to avoid having the user wait on an empty page without a title with only a loader for several seconds.

This concept is the same one behind the ["loading skeletons"](https://betterprogramming.pub/the-what-why-and-how-of-using-a-skeleton-loading-screen-e68809d7f702)  mentioned on Slack before.

## Before


https://user-images.githubusercontent.com/1402241/186395997-e696ef0c-41e7-4458-ba15-a66bfcda5d9e.mov


## After

https://user-images.githubusercontent.com/1402241/186395953-11006026-0289-4cc6-88da-bd463fa30549.mov


## Future Work

- [ ] Potentially move `<Loader>` inside `<BlueprintsView>` to use its white background style or move the background style outside `<BlueprintsView>`

## Checklist

- 🥲 Add tests
- [x] Designate a primary reviewer @mnholtz 
