### PR TITLE
Remove deprecated npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -192,7 +192,6 @@
         "@types/redux-persist-webextension-storage": "^1.0.0",
         "@types/selenium-webdriver": "^4.0.15",
         "@types/semver": "^7.3.8",
-        "@types/simple-icons": "^5.0.1",
         "@types/uuid": "^8.3.1",
         "@types/webextension-polyfill": "^0.9.0",
         "@types/webpack": "^5.28.0",
@@ -11676,15 +11675,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/simple-icons": {
-      "version": "5.21.1",
-      "integrity": "sha512-exnKcr2DxKe0UsGIjvw/hv88OAWkxwPped5iq7YlgC9flaxAJHHvsjmq45Sr7FYjjyrwJI8VFh85xzY6k+L5WQ==",
-      "deprecated": "This is a stub types definition. simple-icons provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "simple-icons": "*"
       }
     },
     "node_modules/@types/sizzle": {
@@ -44353,14 +44343,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/simple-icons": {
-      "version": "5.21.1",
-      "integrity": "sha512-exnKcr2DxKe0UsGIjvw/hv88OAWkxwPped5iq7YlgC9flaxAJHHvsjmq45Sr7FYjjyrwJI8VFh85xzY6k+L5WQ==",
-      "dev": true,
-      "requires": {
-        "simple-icons": "*"
       }
     },
     "@types/sizzle": {

--- a/package.json
+++ b/package.json
@@ -213,7 +213,6 @@
     "@types/redux-persist-webextension-storage": "^1.0.0",
     "@types/selenium-webdriver": "^4.0.15",
     "@types/semver": "^7.3.8",
-    "@types/simple-icons": "^5.0.1",
     "@types/uuid": "^8.3.1",
     "@types/webextension-polyfill": "^0.9.0",
     "@types/webpack": "^5.28.0",


### PR DESCRIPTION
## What does this PR do?

@types/yup is deprecated: https://www.npmjs.com/package/@types/simple-icons

According to the npm page:

> This is a stub types definition. simple-icons provides its own type definitions, so you do not need this installed.

Looks like we can delete this package.