### PR TITLE
#4102 Add element dropdown gets cuts off inside list element preview in Document Builder

### DIFF
--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -20,7 +20,7 @@ import BlockElement from "@/components/documentBuilder/render/BlockElement";
 import { isPipelineExpression } from "@/runtime/mapArgs";
 import { UnknownObject } from "@/types";
 import { get } from "lodash";
-import { Card, Col, Container, Row, Image } from "react-bootstrap";
+import { Col, Container, Row, Image } from "react-bootstrap";
 import {
   BuildDocumentBranch,
   ButtonDocumentConfig,
@@ -33,8 +33,8 @@ import ButtonElement from "@/components/documentBuilder/render/ButtonElement";
 import ListElement from "@/components/documentBuilder/render/ListElement";
 import { BusinessError } from "@/errors/businessErrors";
 import { joinPathParts } from "@/utils";
-import cx from "classnames";
 import Markdown from "@/components/Markdown";
+import CardElement from "./render/CardElement";
 
 const headerComponents = {
   header_1: "h1",
@@ -123,23 +123,8 @@ export function getComponentDefinition(
     case "card": {
       const props = { ...config };
 
-      // The bodyClassName is for internal use,
-      // it allows to set CSS class needed in preview to the body
-      const Component: React.FC<UnknownObject> = ({
-        heading,
-        children,
-        bodyClassName,
-        ...cardProps
-      }) => (
-        <Card {...cardProps}>
-          <Card.Header>{heading}</Card.Header>
-          <Card.Body className={cx(bodyClassName, "overflow-auto")}>
-            {children}
-          </Card.Body>
-        </Card>
-      );
       return {
-        Component,
+        Component: CardElement,
         props,
       };
     }

--- a/src/components/documentBuilder/preview/__snapshots__/ElementPreview.test.tsx.snap
+++ b/src/components/documentBuilder/preview/__snapshots__/ElementPreview.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`can preview default card 1`] = `
           Header
         </div>
         <div
-          class="container overflow-auto card-body"
+          class="container cardBody overflow-auto card-body"
         >
           <div
             class="addElement dropdown"

--- a/src/components/documentBuilder/preview/elementsPreview/Card.module.scss
+++ b/src/components/documentBuilder/preview/elementsPreview/Card.module.scss
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+:global(.card) .cardBody {
+  // With 'overflow: auto;' set for the CardElement render component
+  // the ellipses menu gets cut. Overriding the rule.
+  // We expect no issues since in Preview most of the custom content classes are filtered
+  overflow: visible !important;
+}

--- a/src/components/documentBuilder/preview/elementsPreview/Card.tsx
+++ b/src/components/documentBuilder/preview/elementsPreview/Card.tsx
@@ -24,6 +24,7 @@ import {
 import cx from "classnames";
 import documentTreeStyles from "@/components/documentBuilder/preview/documentTree.module.scss";
 import Flaps from "@/components/documentBuilder/preview/flaps/Flaps";
+import styles from "./Card.module.scss";
 
 type CardProps = PreviewComponentProps & {
   element: DocumentElement;
@@ -40,21 +41,29 @@ const Card: React.FunctionComponent<CardProps> = ({
   documentBodyName,
   elementName,
   ...restPreviewProps
-}) => (
-  <div
-    className={cx(documentTreeStyles.shiftRightWrapper, className)}
-    {...restPreviewProps}
-  >
-    <Flaps
-      className={documentTreeStyles.flapShiftRight}
-      elementType={element.type}
-      documentBodyName={documentBodyName}
-      elementName={elementName}
-      isHovered={isHovered}
-      isActive={isActive}
-    />
-    <Component {...props}>{children}</Component>
-  </div>
-);
+}) => {
+  const { bodyClassName, ...restCardProps } = props;
+  return (
+    <div
+      className={cx(documentTreeStyles.shiftRightWrapper, className)}
+      {...restPreviewProps}
+    >
+      <Flaps
+        className={documentTreeStyles.flapShiftRight}
+        elementType={element.type}
+        documentBodyName={documentBodyName}
+        elementName={elementName}
+        isHovered={isHovered}
+        isActive={isActive}
+      />
+      <Component
+        {...restCardProps}
+        bodyClassName={cx(bodyClassName, styles.cardBody)}
+      >
+        {children}
+      </Component>
+    </div>
+  );
+};
 
 export default Card;

--- a/src/components/documentBuilder/render/CardElement.tsx
+++ b/src/components/documentBuilder/render/CardElement.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { Card, CardProps } from "react-bootstrap";
+import cx from "classnames";
+
+type CardElementProps = CardProps & {
+  heading: string;
+
+  // The bodyClassName is for internal use,
+  // it allows to set CSS class needed in preview to the body
+  bodyClassName?: string;
+};
+
+const CardElement: React.FunctionComponent<CardElementProps> = ({
+  heading,
+  children,
+  bodyClassName,
+  ...cardProps
+}) => (
+  <Card {...cardProps}>
+    <Card.Header>{heading}</Card.Header>
+    <Card.Body className={cx(bodyClassName, "overflow-auto")}>
+      {children}
+    </Card.Body>
+  </Card>
+);
+
+export default CardElement;


### PR DESCRIPTION
## What does this PR do?

- Fixes #4102


## Demo
<img width="1325" alt="Screen Shot 2022-08-26 at 3 08 05 PM" src="https://user-images.githubusercontent.com/3116723/186924875-d4b7dd7d-0a6d-4a67-b06c-697f00342b93.png">


## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer @BLoe 
