### PR TITLE
#4127: add maximum wait option for AA bot

### DIFF
--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -18,7 +18,10 @@
 import React, { useMemo } from "react";
 import { partial } from "lodash";
 import { BlockOptionProps } from "@/components/fields/schemaFields/genericOptionsFactory";
-import { COMMON_PROPERTIES } from "@/contrib/automationanywhere/RunBot";
+import {
+  COMMON_PROPERTIES,
+  ENTERPRISE_EDITION_PROPERTIES,
+} from "@/contrib/automationanywhere/RunBot";
 import { Schema } from "@/core";
 import { useField } from "formik";
 import { useAsyncState } from "@/hooks/common";
@@ -42,6 +45,7 @@ import BooleanWidget from "@/components/fields/schemaFields/widgets/BooleanWidge
 import RemoteMultiSelectWidget from "@/components/form/widgets/RemoteMultiSelectWidget";
 import SelectWidget from "@/components/form/widgets/SelectWidget";
 import { useAsyncEffect } from "use-async-effect";
+import SchemaField from "@/components/fields/schemaFields/SchemaField";
 
 const WORKSPACE_OPTIONS = [
   { value: "public", label: "Public" },
@@ -62,6 +66,10 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
     useField<string>(configName("workspaceType"));
 
   const [{ value: fileId }] = useField<string>(configName("fileId"));
+
+  const [{ value: awaitResult }] = useField<boolean | null>(
+    configName("awaitResult")
+  );
 
   // Default the workspaceType based on the file id
   useAsyncEffect(async () => {
@@ -169,6 +177,13 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
                 description="Wait for the bot to run and return the output"
                 as={BooleanWidget}
               />
+              {awaitResult && (
+                <SchemaField
+                  label="Result Timeout (Milliseconds)"
+                  name={configName("maxWaitMillis")}
+                  schema={ENTERPRISE_EDITION_PROPERTIES.maxWaitMillis as Schema}
+                />
+              )}
             </>
           )}
 

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -182,6 +182,8 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
                   label="Result Timeout (Milliseconds)"
                   name={configName("maxWaitMillis")}
                   schema={ENTERPRISE_EDITION_PROPERTIES.maxWaitMillis as Schema}
+                  // Mark as required so the widget defaults to showing the number entry
+                  isRequired
                 />
               )}
             </>

--- a/src/contrib/automationanywhere/RunBot.ts
+++ b/src/contrib/automationanywhere/RunBot.ts
@@ -20,6 +20,7 @@ import { BlockArg, BlockOptions, Schema, SchemaProperties } from "@/core";
 import { validateRegistryId } from "@/types/helpers";
 import { isCommunityControlRoom } from "@/contrib/automationanywhere/aaUtils";
 import {
+  DEFAULT_MAX_WAIT_MILLIS,
   pollEnterpriseResult,
   runCommunityBot,
   runEnterpriseBot,
@@ -69,7 +70,7 @@ const COMMUNITY_EDITION_PROPERTIES: SchemaProperties = {
   },
 };
 
-const ENTERPRISE_EDITION_PROPERTIES: SchemaProperties = {
+export const ENTERPRISE_EDITION_PROPERTIES: SchemaProperties = {
   runAsUsers: {
     type: "array",
     description: "The user(s) to run the bot",
@@ -87,6 +88,12 @@ const ENTERPRISE_EDITION_PROPERTIES: SchemaProperties = {
     type: "boolean",
     default: false,
     description: "Wait for the bot to complete and return the output",
+  },
+  maxWaitMillis: {
+    type: "number",
+    default: DEFAULT_MAX_WAIT_MILLIS,
+    description:
+      "Maximum time (in milliseconds) to wait for the process to complete when awaiting result.",
   },
 };
 
@@ -129,7 +136,11 @@ export class RunBot extends Transformer {
     args: BlockArg<BotArgs>,
     { logger }: BlockOptions
   ): Promise<UnknownObject> {
-    const { awaitResult, service } = args;
+    const {
+      awaitResult,
+      maxWaitMillis = DEFAULT_MAX_WAIT_MILLIS,
+      service,
+    } = args;
 
     if (isCommunityControlRoom(service.config.controlRoomUrl)) {
       if (!("deviceId" in args)) {
@@ -173,6 +184,7 @@ export class RunBot extends Transformer {
       service,
       deploymentId: deployment.deploymentId,
       logger,
+      maxWaitMillis,
     });
   }
 }

--- a/src/contrib/automationanywhere/RunBot.ts
+++ b/src/contrib/automationanywhere/RunBot.ts
@@ -93,7 +93,7 @@ export const ENTERPRISE_EDITION_PROPERTIES: SchemaProperties = {
     type: "number",
     default: DEFAULT_MAX_WAIT_MILLIS,
     description:
-      "Maximum time (in milliseconds) to wait for the process to complete when awaiting result.",
+      "Maximum time (in milliseconds) to wait for the bot to complete when awaiting result.",
   },
 };
 

--- a/src/contrib/automationanywhere/aaApi.ts
+++ b/src/contrib/automationanywhere/aaApi.ts
@@ -45,7 +45,7 @@ import {
 import { BusinessError } from "@/errors/businessErrors";
 import { RemoteResponse } from "@/types/contract";
 
-const MAX_WAIT_MILLIS = 60_000;
+export const DEFAULT_MAX_WAIT_MILLIS = 60_000;
 const POLL_MILLIS = 2000;
 
 /**
@@ -257,10 +257,12 @@ export async function pollEnterpriseResult({
   service,
   deploymentId,
   logger,
+  maxWaitMillis = DEFAULT_MAX_WAIT_MILLIS,
 }: {
   service: SanitizedServiceConfiguration;
   deploymentId: string;
   logger: Logger;
+  maxWaitMillis?: number;
 }) {
   const poll = async () => {
     // Sleep first because it's unlikely it will be completed immediately after the running the bot
@@ -318,7 +320,7 @@ export async function pollEnterpriseResult({
 
   const result = await pollUntilTruthy(poll, {
     intervalMillis: 0, // Already covered by the inline `sleep`
-    maxWaitMillis: MAX_WAIT_MILLIS,
+    maxWaitMillis,
   });
 
   if (result) {
@@ -326,6 +328,6 @@ export async function pollEnterpriseResult({
   }
 
   throw new BusinessError(
-    `Bot did not finish in ${MAX_WAIT_MILLIS / 1000} seconds`
+    `Bot did not finish in ${Math.round(maxWaitMillis / 1000)} seconds`
   );
 }

--- a/src/contrib/automationanywhere/aaTypes.ts
+++ b/src/contrib/automationanywhere/aaTypes.ts
@@ -35,4 +35,5 @@ export type EnterpriseBotArgs = {
 
 export type BotArgs = (CommunityBotArgs | EnterpriseBotArgs) & {
   awaitResult: boolean;
+  maxWaitMillis: number;
 };


### PR DESCRIPTION
## What does this PR do?

- Closes #4127 (is the AA side of the ticket)
- Exposes a maxWaitMillis argument on the AA Remote Bot brick

## Demo

![image](https://user-images.githubusercontent.com/1879821/187036593-a674351f-d006-442e-b949-2461f7cf9a72.png)

## Discussion

- Currently if the field is left off, the default (currently 1 minute will be used). We could consider having the default be no timeout if the value is not provided

## Checklist

- 🕐  Add tests: will be added in follow up PR addressing AA option combinations
- [X] Designate a primary reviewer: @BLoe 
