### PR TITLE
#4165: fix partner caching in Redux

### DIFF
--- a/src/auth/authSlice.ts
+++ b/src/auth/authSlice.ts
@@ -25,15 +25,19 @@ export const authSlice = createSlice({
   name: "auth",
   initialState: anonAuth,
   reducers: {
-    setAuth: (state, { payload }: PayloadAction<AuthState>) => ({
-      ...payload,
-      scope: isEmpty(payload.scope) ? null : payload.scope,
-      flags: Array.isArray(payload.flags) ? payload.flags : [],
-      organizations: Array.isArray(payload.organizations)
-        ? payload.organizations
-        : [],
-      groups: Array.isArray(payload.groups) ? payload.groups : [],
-    }),
+    setAuth(state, { payload }: PayloadAction<AuthState>) {
+      console.debug("authSlice:setAuth", payload);
+
+      return {
+        ...payload,
+        scope: isEmpty(payload.scope) ? null : payload.scope,
+        flags: Array.isArray(payload.flags) ? payload.flags : [],
+        organizations: Array.isArray(payload.organizations)
+          ? payload.organizations
+          : [],
+        groups: Array.isArray(payload.groups) ? payload.groups : [],
+      };
+    },
   },
 });
 

--- a/src/auth/authTypes.ts
+++ b/src/auth/authTypes.ts
@@ -153,10 +153,16 @@ export type AuthUserOrganization = {
 };
 
 export type AuthState = {
+  /**
+   * The PixieBrix userId, or null if the user is not authenticated
+   */
   readonly userId?: UUID | null;
 
   readonly email?: string | null;
 
+  /**
+   * The user's package scope.
+   */
   readonly scope?: string | null;
 
   /**
@@ -191,6 +197,9 @@ export type AuthState = {
    */
   readonly flags: string[];
 
+  /**
+   * The partner, controlling theme, documentation links, etc.
+   */
   readonly partner?: Me["partner"];
 
   /**

--- a/src/auth/authUtils.ts
+++ b/src/auth/authUtils.ts
@@ -79,6 +79,7 @@ export function selectExtensionAuthState({
   flags = [],
   organization_memberships: organizationMemberships = [],
   group_memberships = [],
+  partner,
   enforce_update_millis: enforceUpdateMillis,
 }: Me): AuthState {
   const organizations = selectOrganizations(organizationMemberships);
@@ -95,6 +96,7 @@ export function selectExtensionAuthState({
     organizations,
     groups,
     flags,
+    partner,
     enforceUpdateMillis,
   };
 }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -36,36 +36,38 @@ import { selectAuth } from "@/auth/authSelectors";
 
 const MANAGED_PARTNER_ID_KEY = "partnerId" as ManualStorageKey;
 
-const activateBackgroundTheme = async (): Promise<void> => {
+async function activateBackgroundTheme(): Promise<void> {
   // Flush the Redux state to localStorage to ensure the background page sees the latest state
   await persistor.flush();
   await activatePartnerTheme();
-};
+}
 
-export const useGetTheme = (): Theme => {
+export function useGetTheme(): Theme {
   const { theme, partnerId } = useSelector(selectSettings);
-  const { data: me } = useGetMeQuery();
   const { partner: cachedPartner } = useSelector(selectAuth);
+  const { data: me } = useGetMeQuery();
   const dispatch = useDispatch();
 
   const partnerTheme = useMemo(() => {
     if (me) {
-      return isValidTheme(me.partner?.theme) ? me.partner?.theme : null;
+      const meTheme = me.partner?.theme;
+      return isValidTheme(meTheme) ? meTheme : null;
     }
 
-    return isValidTheme(cachedPartner?.theme) ? cachedPartner?.theme : null;
+    const cachedTheme = cachedPartner?.theme;
+    return isValidTheme(cachedTheme) ? cachedTheme : null;
   }, [me, cachedPartner?.theme]);
 
   // Read from the browser's managed storage. The IT department can set as part of distributing the browser extension
   // so the correct theme is applied before authentication.
-  const [managedPartnerId, isLoading] = useAsyncState(
+  const [managedPartnerId, managedPartnerIdIsLoading] = useAsyncState(
     readStorage(MANAGED_PARTNER_ID_KEY, undefined, "managed"),
     [],
     null
   );
 
   useEffect(() => {
-    if (partnerId === null && !isLoading) {
+    if (partnerId === null && !managedPartnerIdIsLoading) {
       // Initialize initial partner id with the one in managed storage, if any
       dispatch(
         settingsSlice.actions.setPartnerId({
@@ -73,20 +75,29 @@ export const useGetTheme = (): Theme => {
         })
       );
     }
-  }, [partnerId, dispatch, isLoading, managedPartnerId]);
+  }, [partnerId, dispatch, managedPartnerIdIsLoading, managedPartnerId]);
 
   useEffect(() => {
+    // Update persisted Redux slice
     dispatch(
       settingsSlice.actions.setTheme({
         theme: partnerTheme ?? partnerId ?? DEFAULT_THEME,
       })
     );
-  }, [dispatch, me, partnerId, partnerTheme, theme]);
+  }, [dispatch, partnerId, partnerTheme, theme]);
 
   return theme;
+}
+
+type ThemeAssets = {
+  logo: ThemeLogo;
 };
 
-const useTheme = (theme?: Theme): { logo: ThemeLogo } => {
+/**
+ * Hook to activate the PixieBrix or partner theme.
+ * @param theme the theme to use, or nullish to automatically determine the theme.
+ */
+function useTheme(theme?: Theme): ThemeAssets {
   const inferredTheme = useGetTheme();
   const themeLogo = getThemeLogo(theme ?? inferredTheme);
 
@@ -99,6 +110,6 @@ const useTheme = (theme?: Theme): { logo: ThemeLogo } => {
   return {
     logo: themeLogo,
   };
-};
+}
 
 export default useTheme;

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -66,12 +66,12 @@ const RefreshBricks: React.VFC = () => {
 };
 
 const Layout = () => {
-  useTheme();
+  const { logo } = useTheme();
   const { permit } = useFlags();
 
   return (
     <div>
-      <Navbar />
+      <Navbar logo={logo} />
       <Container fluid className="page-body-wrapper">
         {/* It is guaranteed that under RequireAuth the user has a valid API token. */}
         <ErrorBoundary>

--- a/src/options/Navbar.tsx
+++ b/src/options/Navbar.tsx
@@ -36,16 +36,15 @@ import { toggleSidebar } from "./toggleSidebar";
 import { SettingsState } from "@/store/settingsTypes";
 import cx from "classnames";
 import { selectAuth } from "@/auth/authSelectors";
-import useTheme from "@/hooks/useTheme";
+import { ThemeLogo } from "@/utils/themeUtils";
 
-const Navbar: React.FunctionComponent = () => {
+const Navbar: React.FunctionComponent<{ logo: ThemeLogo }> = ({ logo }) => {
   const { email, extension } = useSelector(selectAuth);
   const [serviceURL] = useAsyncState<string>(getBaseURL);
   const [connected, connectedPending] = useAsyncState(isLinked);
   const mode = useSelector<{ settings: SettingsState }, string>(
     ({ settings }) => settings.mode
   );
-  const { logo } = useTheme();
 
   // Use `connectedPending` to optimistically show the toggle
   const showNavbarToggle = mode === "local" || connected || connectedPending;

--- a/src/options/Sidebar.tsx
+++ b/src/options/Sidebar.tsx
@@ -27,7 +27,6 @@ import {
   faSeedling,
   faStoreAlt,
 } from "@fortawesome/free-solid-svg-icons";
-import cx from "classnames";
 import { SidebarLink } from "./SidebarLink";
 import { closeSidebarOnSmallScreen, SIDEBAR_ID } from "./toggleSidebar";
 import useFlags from "@/hooks/useFlags";
@@ -38,6 +37,7 @@ const DEFAULT_DOCUMENTATION_URL = "https://docs.pixiebrix.com/";
 const Sidebar: React.FunctionComponent = () => {
   const { permit } = useFlags();
   const { data: me } = useGetMeQuery();
+  const hasPartner = Boolean(me?.partner);
 
   return (
     <OutsideClickHandler onOutsideClick={closeSidebarOnSmallScreen}>
@@ -74,7 +74,7 @@ const Sidebar: React.FunctionComponent = () => {
           </li>
 
           {permit("marketplace") && (
-            <li className={cx("nav-item")}>
+            <li className="nav-item">
               <a
                 href="https://www.pixiebrix.com/marketplace"
                 target="_blank"
@@ -86,20 +86,22 @@ const Sidebar: React.FunctionComponent = () => {
               </a>
             </li>
           )}
+          {!hasPartner && (
+            // Hide for partner users because we don't support custom community links yet
+            <li className="nav-item">
+              <a
+                href="https://community.pixiebrix.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="nav-link"
+              >
+                <span className="menu-title">Community</span>
+                <FontAwesomeIcon icon={faSeedling} className="menu-icon" />
+              </a>
+            </li>
+          )}
 
-          <li className={cx("nav-item")}>
-            <a
-              href="https://community.pixiebrix.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="nav-link"
-            >
-              <span className="menu-title">Community</span>
-              <FontAwesomeIcon icon={faSeedling} className="menu-icon" />
-            </a>
-          </li>
-
-          <li className={cx("nav-item")}>
+          <li className="nav-item">
             <a
               href={me?.partner?.documentation_url ?? DEFAULT_DOCUMENTATION_URL}
               target="_blank"


### PR DESCRIPTION
## What does this PR do?

- Closes #4165 
- Fixes `selectExtensionAuthState` to include the partner so it's cached in the persisted state

## Reviewer Notes

- Functional change: https://github.com/pixiebrix/pixiebrix-extension/pull/4166/files#diff-98ae72f5a9a3488b154dfa0eafc7aaa621ab92c69239263eef42f82ebd84cca5R82

## Checklist

- [ ] Add tests
- [X] Designate a primary reviewer: @mnholtz 
