### PR TITLE
Dependabot: update package.json + also keep GHA up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,16 @@ updates:
       interval: weekly
       time: "08:42"
       timezone: "Etc/UTC"
+    versioning-strategy: increase # Update package.json too https://stackoverflow.com/a/66819358/288906
+    open-pull-requests-limit: 20
+    reviewers:
+      - "fregante"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "08:42"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 20
     reviewers:
       - "fregante"


### PR DESCRIPTION
## Context

Dependabot will update the lockfile but not package.json in most cases. This means that even if we update a dependency here, the app still sees the old version in package.json and isn't forced to update it.

- https://github.com/dependabot/dependabot-core/issues/310#issuecomment-373328152

I wonder if this is what caused this `IgnorePlugin` issue:

- https://github.com/pixiebrix/pixiebrix-app/pull/2148#discussion_r952628451

## What does this PR do?

- Forces Dependabot to update package.json
- Enables dependabot to update GitHub Actions too