### PR TITLE
Bump webext-messenger from 0.20.1 to 0.21.0-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,7 @@
         "webext-content-scripts": "^1.0.1",
         "webext-detect-page": "^4.0.1",
         "webext-dynamic-content-scripts": "^8.1.1",
-        "webext-messenger": "^0.20.1",
+        "webext-messenger": "^0.21.0-0",
         "webext-patterns": "^1.1.1",
         "webext-polyfill-kinda": "^0.10.0",
         "webext-tools": "^1.0.0",
@@ -35093,9 +35093,9 @@
       }
     },
     "node_modules/webext-messenger": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.20.1.tgz",
-      "integrity": "sha512-HuIZ0zqAyFw1S9Muo/idOIW3hrEn1yj2kVfLKIDe+eRxvBdXmqH+LlkTigiYEifh4fVbk87DP9plWaz4LUETlA==",
+      "version": "0.21.0-0",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.21.0-0.tgz",
+      "integrity": "sha512-lF6mZ8MP9s+AIF44Tk450TzyFdiHsNg8RVoB1iHI8SIHAHmyCsVeXiGQa3uNMy7j3vPtSgMfmDsnS5oFy6X8MA==",
       "dependencies": {
         "p-retry": "^5.1.1",
         "serialize-error": "^11.0.0",
@@ -62031,9 +62031,9 @@
       }
     },
     "webext-messenger": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.20.1.tgz",
-      "integrity": "sha512-HuIZ0zqAyFw1S9Muo/idOIW3hrEn1yj2kVfLKIDe+eRxvBdXmqH+LlkTigiYEifh4fVbk87DP9plWaz4LUETlA==",
+      "version": "0.21.0-0",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.21.0-0.tgz",
+      "integrity": "sha512-lF6mZ8MP9s+AIF44Tk450TzyFdiHsNg8RVoB1iHI8SIHAHmyCsVeXiGQa3uNMy7j3vPtSgMfmDsnS5oFy6X8MA==",
       "requires": {
         "p-retry": "^5.1.1",
         "serialize-error": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "webext-content-scripts": "^1.0.1",
     "webext-detect-page": "^4.0.1",
     "webext-dynamic-content-scripts": "^8.1.1",
-    "webext-messenger": "^0.20.1",
+    "webext-messenger": "^0.21.0-0",
     "webext-patterns": "^1.1.1",
     "webext-polyfill-kinda": "^0.10.0",
     "webext-tools": "^1.0.0",


### PR DESCRIPTION
## What does this PR do?

- Includes https://github.com/pixiebrix/webext-messenger/pull/84

## Discussion

- It shouldn't have any real user-facing changes except better errors. I just need to try to cause these errors and see if we were catching the old errors somewhere.

## Checklist

- [x] Test
- [x] Designate a primary reviewer: @twschiller 
