### PR TITLE
#4181: detect AA token invalidation

### DIFF
--- a/src/background/proxyService.test.ts
+++ b/src/background/proxyService.test.ts
@@ -29,6 +29,7 @@ import enrichAxiosErrors from "@/utils/enrichAxiosErrors";
 import { sanitizedServiceConfigurationFactory } from "@/testUtils/factories";
 import { ContextError } from "@/errors/genericErrors";
 import { RemoteServiceError } from "@/errors/clientRequestErrors";
+import { getToken } from "@/background/auth";
 
 const axiosMock = new MockAdapter(axios);
 const mockIsBackground = isBackground as jest.MockedFunction<
@@ -42,6 +43,11 @@ mockIsExtensionContext.mockImplementation(() => true);
 
 browser.permissions.contains = jest.fn().mockResolvedValue(true);
 
+jest.mock("@/background/auth", () => ({
+  getCachedAuthData: jest.fn().mockResolvedValue(null),
+  getToken: jest.fn().mockResolvedValue({ token: "iamatoken" }),
+  deleteCachedAuthData: jest.fn().mockResolvedValue(undefined),
+}));
 jest.mock("@/auth/token");
 jest.mock("webext-detect-page");
 jest.mock("@/services/locator");
@@ -63,6 +69,7 @@ const { pixieServiceFactory } = jest.requireActual("@/services/locator");
 (locator.pixieServiceFactory as jest.Mock) = pixieServiceFactory;
 
 const EXAMPLE_SERVICE_API = validateRegistryId("example/api");
+const EXAMPLE_SERVICE_TOKEN_API = validateRegistryId("example/token");
 
 serviceRegistry.register({
   id: PIXIEBRIX_SERVICE_ID,
@@ -80,6 +87,15 @@ serviceRegistry.register({
   ) => requestConfig,
 } as any);
 
+serviceRegistry.register({
+  id: EXAMPLE_SERVICE_TOKEN_API,
+  authenticateRequest: (
+    serviceConfig: ServiceConfig,
+    requestConfig: AxiosRequestConfig
+  ) => requestConfig,
+  isToken: true,
+} as any);
+
 const requestConfig: AxiosRequestConfig = {
   url: "https://www.example.com",
   method: "get",
@@ -88,6 +104,11 @@ const requestConfig: AxiosRequestConfig = {
 const directServiceConfig = sanitizedServiceConfigurationFactory({
   proxy: false,
   serviceId: EXAMPLE_SERVICE_API,
+});
+
+const directTokenServiceConfig = sanitizedServiceConfigurationFactory({
+  proxy: false,
+  serviceId: EXAMPLE_SERVICE_TOKEN_API,
 });
 
 const proxiedServiceConfig = sanitizedServiceConfigurationFactory({
@@ -236,5 +257,38 @@ describe("proxy service requests", () => {
         message: expect.stringMatching(/^No response received/),
       },
     });
+  });
+});
+
+describe("Retry token request", () => {
+  beforeEach(() => {
+    jest
+      .spyOn(Locator.prototype, "locate")
+      .mockResolvedValue(directTokenServiceConfig);
+    jest
+      .spyOn(Locator.prototype, "getLocalConfig")
+      .mockResolvedValue(
+        directTokenServiceConfig as unknown as RawServiceConfiguration
+      );
+  });
+
+  it("Handles expired token", async () => {
+    const mockGetToken = getToken as jest.Mock;
+    axiosMock.onGet(requestConfig.url).reply(401, {});
+    const response = proxyService(directTokenServiceConfig, requestConfig);
+    await expect(response).rejects.toThrow(ContextError);
+    // Once on the intial call b/c no cached auth data, and once for the retry
+    expect(mockGetToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("Handles expired AA token", async () => {
+    const mockGetToken = getToken as jest.Mock;
+    axiosMock
+      .onGet(requestConfig.url)
+      .reply(400, { message: "Access Token has expired" });
+    const response = proxyService(directTokenServiceConfig, requestConfig);
+    await expect(response).rejects.toThrow(ContextError);
+    // Once on the intial call b/c no cached auth data, and once for the retry
+    expect(mockGetToken).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -237,25 +237,26 @@ const UNAUTHORIZED_STATUS_CODES = new Set([401, 403]);
 export function isAuthenticationError(
   error: Pick<AxiosError, "response">
 ): boolean {
-  if (error.response != null) {
-    // Technically 403 is an authorization error and re-authenticating as the same user won't help. However, there is
-    // a case where the user just needs an updated JWT that contains the most up-to-date entitlements
-    if (UNAUTHORIZED_STATUS_CODES.has(error.response.status)) {
-      return true;
-    }
-
-    // Handle Automation Anywhere's Control Room expired JWT response. They'll return this from any endpoint instead
-    // of a proper error code.
-    if (
-      error.response.status === 400 &&
-      isObject(error.response.data) &&
-      error.response.data.message === "Access Token has expired"
-    ) {
-      return true;
-    }
+  // Response should be an object, but be defensive
+  if (error.response == null || !isObject(error.response)) {
+    return false;
   }
 
-  return false;
+  // Technically 403 is an authorization error and re-authenticating as the same user won't help. However, there is
+  // a case where the user just needs an updated JWT that contains the most up-to-date entitlements
+  if (UNAUTHORIZED_STATUS_CODES.has(error.response.status)) {
+    return true;
+  }
+
+  // Handle Automation Anywhere's Control Room expired JWT response. They'll return this from any endpoint instead
+  // of a proper error code.
+  if (
+    error.response.status === 400 &&
+    isObject(error.response.data) &&
+    error.response.data.message === "Access Token has expired"
+  ) {
+    return true;
+  }
 }
 
 async function performConfiguredRequest(

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -15,7 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import axios, { AxiosRequestConfig, AxiosResponse, Method } from "axios";
+import axios, {
+  AxiosError,
+  AxiosRequestConfig,
+  AxiosResponse,
+  Method,
+} from "axios";
 import {
   IService,
   MessageContext,
@@ -33,7 +38,7 @@ import {
   getToken,
   launchOAuth2Flow,
 } from "@/background/auth";
-import { isAbsoluteUrl } from "@/utils";
+import { isAbsoluteUrl, isObject } from "@/utils";
 import { expectContext } from "@/utils/expectContext";
 import { absoluteApiUrl } from "@/services/apiClient";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
@@ -229,6 +234,30 @@ async function proxyRequest<T>(
 
 const UNAUTHORIZED_STATUS_CODES = new Set([401, 403]);
 
+export function isAuthenticationError(
+  error: Pick<AxiosError, "response">
+): boolean {
+  if (error.response != null) {
+    // Technically 403 is an authorization error and re-authenticating as the same user won't help. However, there is
+    // a case where the user just needs an updated JWT that contains the most up-to-date entitlements
+    if (UNAUTHORIZED_STATUS_CODES.has(error.response.status)) {
+      return true;
+    }
+
+    // Handle Automation Anywhere's Control Room expired JWT response. They'll return this from any endpoint instead
+    // of a proper error code.
+    if (
+      error.response.status === 400 &&
+      isObject(error.response.data) &&
+      error.response.data.message === "Access Token has expired"
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 async function performConfiguredRequest(
   serviceConfig: SanitizedServiceConfiguration,
   requestConfig: AxiosRequestConfig
@@ -247,10 +276,7 @@ async function performConfiguredRequest(
 
     const axiosError = selectAxiosError(error);
 
-    if (
-      axiosError &&
-      UNAUTHORIZED_STATUS_CODES.has(axiosError.response?.status)
-    ) {
+    if (axiosError && isAuthenticationError(axiosError)) {
       const service = await serviceRegistry.lookup(serviceConfig.serviceId);
       if (service.isOAuth2 || service.isToken) {
         await deleteCachedAuthData(serviceConfig.id);


### PR DESCRIPTION
## What does this PR do?

- Closes #4181 
- Specially handles AA token invalidation because the CR API doesn't use 401 to indicate invalid authentication

## Checklist

- [X] Add tests
- [X] Designate a primary reviewer: @fregante 
