### PR TITLE
Update Messenger pattern to clarify the messenger usage

### DIFF
--- a/src/sidebar/messenger/api.ts
+++ b/src/sidebar/messenger/api.ts
@@ -18,8 +18,13 @@
 /* Do not use `registerMethod` in this file */
 import { getMethod } from "webext-messenger";
 
-export const renderPanels = getMethod("SIDEBAR_RENDER_PANELS");
-export const activatePanel = getMethod("SIDEBAR_ACTIVATE_PANEL");
-export const showForm = getMethod("SIDEBAR_SHOW_FORM");
-export const hideForm = getMethod("SIDEBAR_HIDE_FORM");
-export const pingSidebar = getMethod("SIDEBAR_PING");
+const target = { tabId: "this", page: "/sidebar.html" } as const;
+const sidebarInThisTab = {
+  renderPanels: getMethod("SIDEBAR_RENDER_PANELS", target),
+  activatePanel: getMethod("SIDEBAR_ACTIVATE_PANEL", target),
+  showForm: getMethod("SIDEBAR_SHOW_FORM", target),
+  hideForm: getMethod("SIDEBAR_HIDE_FORM", target),
+  pingSidebar: getMethod("SIDEBAR_PING", target),
+};
+
+export default sidebarInThisTab;


### PR DESCRIPTION
## What does this PR do?

Something I forgot to do when I implemented this:

- Pre-binds sidebar messenger methods to the sidebar instead of having to specify `{ tabId: "this", page: "/sidebar.html" }` every time

And a proposal around the usage of Messenger methods:

- Always use `sidebar.method()` instead of `method()` to clarify that the method is related to the sidebar

I applied the proposal only to the sidebar, but once accepted we can change the background one too since it's also pre-bound:

```diff
- proxyService()
+ background.proxyService()
```

This does make it a little more verbose and explicit to call these methods, but maybe it helps readability.

The content script’s messenger isn't affected by this much considering that every call is followed by the target already:

```js
cancelForm(thisTab)
```