### PR TITLE
Update `webext-dynamic-content-scripts` to enable MV3 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,7 @@
         "webext-base-css": "^1.4.1",
         "webext-content-scripts": "^1.0.1",
         "webext-detect-page": "^4.0.1",
-        "webext-dynamic-content-scripts": "^8.1.1",
+        "webext-dynamic-content-scripts": "^9.0.0-0",
         "webext-messenger": "^0.20.1",
         "webext-patterns": "^1.1.1",
         "webext-polyfill-kinda": "^0.10.0",
@@ -35088,12 +35088,13 @@
       "integrity": "sha512-Y9Skw6/Uj0dGwOIidc1XqZ3neEbmuuT4BlkL/J4JHAo6fVznHIZq6/MWDsPGOA/jnNowiSXtHHh4S/TOxbl6bQ=="
     },
     "node_modules/webext-dynamic-content-scripts": {
-      "version": "8.1.1",
-      "integrity": "sha512-raVyQFZOGPU15V+O2vbWlsiQlL54hq+y57AqEqgqLkWntYbcx2x+EaKtL/faAj9Ytw4Mm73JDebyoEH3A4JeqA==",
+      "version": "9.0.0-0",
+      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-9.0.0-0.tgz",
+      "integrity": "sha512-bjv3Oucuuy1nsEHDVhIiHGTwTACLhKLy1GTHWvxzw2234tsQo7kiTe7Jyh6vnp921nKiAuUnhMZ3t+qbdihc0w==",
       "dependencies": {
         "content-scripts-register-polyfill": "^3.2.2",
         "webext-additional-permissions": "^2.3.0",
-        "webext-content-scripts": "^1.0.1"
+        "webext-content-scripts": "^1.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/fregante"
@@ -62036,12 +62037,13 @@
       "integrity": "sha512-Y9Skw6/Uj0dGwOIidc1XqZ3neEbmuuT4BlkL/J4JHAo6fVznHIZq6/MWDsPGOA/jnNowiSXtHHh4S/TOxbl6bQ=="
     },
     "webext-dynamic-content-scripts": {
-      "version": "8.1.1",
-      "integrity": "sha512-raVyQFZOGPU15V+O2vbWlsiQlL54hq+y57AqEqgqLkWntYbcx2x+EaKtL/faAj9Ytw4Mm73JDebyoEH3A4JeqA==",
+      "version": "9.0.0-0",
+      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-9.0.0-0.tgz",
+      "integrity": "sha512-bjv3Oucuuy1nsEHDVhIiHGTwTACLhKLy1GTHWvxzw2234tsQo7kiTe7Jyh6vnp921nKiAuUnhMZ3t+qbdihc0w==",
       "requires": {
         "content-scripts-register-polyfill": "^3.2.2",
         "webext-additional-permissions": "^2.3.0",
-        "webext-content-scripts": "^1.0.1"
+        "webext-content-scripts": "^1.0.2"
       }
     },
     "webext-messenger": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "webext-base-css": "^1.4.1",
     "webext-content-scripts": "^1.0.1",
     "webext-detect-page": "^4.0.1",
-    "webext-dynamic-content-scripts": "^8.1.1",
+    "webext-dynamic-content-scripts": "^9.0.0-0",
     "webext-messenger": "^0.20.1",
     "webext-patterns": "^1.1.1",
     "webext-polyfill-kinda": "^0.10.0",


### PR DESCRIPTION
## What does this PR do?

- Includes https://github.com/fregante/webext-dynamic-content-scripts/pull/38

The update preserves MV2 compatibility but should add support for MV3. 

Since I'll be testing the extension on MV3, we need to start making sure that every component works as we switch between MV2 and MV3 during testing phase.

From preliminary testing, everything seems to work:

- adding a new permission via page editor
- opening the sidebar on a new website
- opening the quickbar on a new website
- detecting activeTab in the page editor
- running bricks in a newly-created "target" tab from another tab

## Future Work

- [ ] #287 

## Merge notice

We should make sure that the logic was not broken so it's best to merge this at a convenient time, right **after** a release, so we can test it further during development (but I don't expect issues)