### PR TITLE
#3946: Add Salesforce selector hints

### DIFF
--- a/src/contentScript/nativeEditor/elementPicker.ts
+++ b/src/contentScript/nativeEditor/elementPicker.ts
@@ -282,7 +282,6 @@ export async function selectElement({
 
     case "element": {
       const selector = safeCssSelector(elements[0], {
-        selectors: [],
         root: rootElement,
         excludeRandomClasses,
       });

--- a/src/contentScript/nativeEditor/elementPicker.ts
+++ b/src/contentScript/nativeEditor/elementPicker.ts
@@ -293,6 +293,11 @@ export async function selectElement({
       const element = requireSingleElement(selector);
 
       // We're using pageScript getElementInfo only when specific framework is used.
+
+      // On Salesforce we were running into an issue where certain selectors weren't finding any elements when
+      // run from the pageScript. It might have something to do with the custom web components Salesforce uses?
+      // In any case, the pageScript is not necessary if framework is not specified, because selectElement
+      // only needs to return the selector alternatives.
       if (framework) {
         return pageScript.getElementInfo({
           selector,

--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -35,6 +35,12 @@ export const BUTTON_TAGS: string[] = [
 ];
 const MENU_TAGS = ["ul", "tbody"];
 
+export const SALESFORCE_UNIQUE_ATTRIBUTES: string[] = [
+  "data-aura-rendered-by",
+  "data-component-id",
+  "data-aura-class",
+];
+
 export const UNIQUE_ATTRIBUTES: string[] = [
   "id",
   "name",
@@ -45,7 +51,10 @@ export const UNIQUE_ATTRIBUTES: string[] = [
   "data-id",
   "data-test",
   "data-test-id",
+  // Salesforce good selector attributes
+  ...SALESFORCE_UNIQUE_ATTRIBUTES,
 ];
+
 // eslint-disable-next-line security/detect-non-literal-regexp -- Not user-provided
 const UNIQUE_ATTRIBUTES_REGEX = new RegExp(
   UNIQUE_ATTRIBUTES.map((attribute) => `^\\[${attribute}=`).join("|")

--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -38,20 +38,20 @@ export const BUTTON_TAGS: string[] = [
 ];
 const MENU_TAGS = ["ul", "tbody"];
 
-export interface SITE_SELECTOR_HINT {
-  SITE_NAME: string;
+export interface SiteSelectorHint {
+  siteName: string;
   siteValidator: (element?: HTMLElement) => boolean;
-  BAD_PATTERNS: CssSelectorMatch[];
-  UNIQUE_ATTRIBUTES: string[];
-  STABLE_ANCHORS: CssSelectorMatch[];
+  badPatterns: CssSelectorMatch[];
+  uniqueAttributes: string[];
+  stableAnchors: CssSelectorMatch[];
 }
 
-const SELECTOR_HINTS: SITE_SELECTOR_HINT[] = [
+const SELECTOR_HINTS: SiteSelectorHint[] = [
   {
-    SITE_NAME: "Salesforce",
+    siteName: "Salesforce",
     siteValidator: (element) =>
       $(element).closest("[data-aura-rendered-by]").length > 0,
-    BAD_PATTERNS: [
+    badPatterns: [
       getAttributeSelectorRegex(
         // Salesforce Aura component tracking
         "data-aura-rendered-by"
@@ -63,8 +63,8 @@ const SELECTOR_HINTS: SITE_SELECTOR_HINT[] = [
       /.*\.not-selected.*/,
       /^\[name='leftsidebar'] */,
     ],
-    UNIQUE_ATTRIBUTES: ["data-component-id"],
-    STABLE_ANCHORS: [
+    uniqueAttributes: ["data-component-id"],
+    stableAnchors: [
       ".consoleRelatedRecord",
       /\.consoleRelatedRecord\d+/,
       ".navexWorkspaceManager",
@@ -87,7 +87,7 @@ export const UNIQUE_ATTRIBUTES: string[] = [
   "data-test-id",
 
   // Register UNIQUE_ATTRIBUTES from all hints because we can't check site rules in this usage.
-  ...SELECTOR_HINTS.flatMap((hint) => hint.UNIQUE_ATTRIBUTES),
+  ...SELECTOR_HINTS.flatMap((hint) => hint.uniqueAttributes),
 ];
 
 // eslint-disable-next-line security/detect-non-literal-regexp -- Not user-provided
@@ -114,17 +114,17 @@ const UNSTABLE_SELECTORS = [
   ),
 ];
 
-function getSiteSelectorHint(element: HTMLElement): SITE_SELECTOR_HINT {
+function getSiteSelectorHint(element: HTMLElement): SiteSelectorHint {
   let siteSelectorHint = SELECTOR_HINTS.find((hint) =>
     hint.siteValidator(element)
   );
   if (!siteSelectorHint) {
     siteSelectorHint = {
-      SITE_NAME: "",
+      siteName: "",
       siteValidator: () => false,
-      BAD_PATTERNS: [],
-      UNIQUE_ATTRIBUTES: [],
-      STABLE_ANCHORS: [],
+      badPatterns: [],
+      uniqueAttributes: [],
+      stableAnchors: [],
     };
   }
 
@@ -133,7 +133,7 @@ function getSiteSelectorHint(element: HTMLElement): SITE_SELECTOR_HINT {
 
 function getUniqueAttributeSelectors(
   element: HTMLElement,
-  siteSelectorHint: SITE_SELECTOR_HINT
+  siteSelectorHint: SiteSelectorHint
 ): string[] {
   return UNIQUE_ATTRIBUTES.map((attribute) =>
     getAttributeSelector(attribute, element.getAttribute(attribute))
@@ -142,7 +142,7 @@ function getUniqueAttributeSelectors(
       !matchesAnyPattern(selector, [
         ...UNSTABLE_SELECTORS,
         // We need to include salesforce BAD_PATTERNS here as well since this function is used to get inferSelectorsIncludingStableAncestors
-        ...siteSelectorHint.BAD_PATTERNS,
+        ...siteSelectorHint.badPatterns,
       ])
   );
 }
@@ -282,7 +282,7 @@ export function safeCssSelector(
 
   const blacklist = [
     ...UNSTABLE_SELECTORS,
-    ...siteSelectorHint.BAD_PATTERNS,
+    ...siteSelectorHint.badPatterns,
 
     excludeRandomClasses
       ? (selector: string) => {
@@ -298,7 +298,7 @@ export function safeCssSelector(
   ];
   const whitelist = [
     getAttributeSelectorRegex(...UNIQUE_ATTRIBUTES),
-    ...siteSelectorHint.STABLE_ANCHORS,
+    ...siteSelectorHint.stableAnchors,
   ];
 
   const selector = getCssSelector(element, {

--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -38,16 +38,24 @@ export const BUTTON_TAGS: string[] = [
 ];
 const MENU_TAGS = ["ul", "tbody"];
 
-export interface SiteSelectorHint {
+export type SiteSelectorHint = {
+  /**
+   * Name for the rule hint-set.
+   */
   siteName: string;
+  /**
+   * Return true if the these hints apply to the current site.
+   */
   siteValidator: (element?: HTMLElement) => boolean;
   badPatterns: CssSelectorMatch[];
   uniqueAttributes: string[];
   stableAnchors: CssSelectorMatch[];
-}
+};
 
 const SELECTOR_HINTS: SiteSelectorHint[] = [
   {
+    // Matches all sites using Salesforce's Lightning framework
+    // https://developer.salesforce.com/docs/atlas.en-us.lightning.meta/lightning/intro_components.htm
     siteName: "Salesforce",
     siteValidator: (element) =>
       $(element).closest("[data-aura-rendered-by]").length > 0,

--- a/src/pageEditor/fields/SelectorSelectorWidget.tsx
+++ b/src/pageEditor/fields/SelectorSelectorWidget.tsx
@@ -185,7 +185,6 @@ const SelectorSelectorWidget: React.FC<SelectorSelectorProps> = ({
       setElement(selected);
 
       const selectors = selected.selectors ?? [];
-
       const [firstSelector] = sort ? sortBySelector(selectors) : selectors;
 
       console.debug("Setting selector", { selected, firstSelector });


### PR DESCRIPTION
## What does this PR do?

- Closes #3946 

## Demo
We implemented Site Selector Hint logic in selectorInference file so that you can easily define and attach bad/good patterns for specific site easily.

For example, `Salesforce` is using light web component and `data-component-id` attribute can be good selector. 
There are also several other good anchors : `.consoleRelatedRecord`, `.oneConsoleTab` and etc...
`data-aura-rendered-by` is typical attribute that salesforce lighting web component is using but it's bad pattern since it's value is changing. 

![Screen Shot 2022-09-02 at 3 37 48 PM](https://user-images.githubusercontent.com/10625864/188084284-76ccfcf6-af76-42d5-b44a-71f6b7d9ee9e.png)

In this PR, we're able to define several good anchors and patterns, make selector working.

Before: 
![Screen Shot 2022-09-02 at 3 46 11 PM](https://user-images.githubusercontent.com/10625864/188085741-ae311842-f0c2-43af-9a5b-1724893793fd.png)

After: 
![Screen Shot 2022-09-02 at 3 41 25 PM](https://user-images.githubusercontent.com/10625864/188085049-6430a2ed-c6d1-4a16-b953-4592029e16ae.png)


## Discussion

@fregante Is there any specific reason that you added `data-aura-rendered-by` to `UNSTABLE_SELECTORS` list [here](https://github.com/pixiebrix/pixiebrix-extension/blob/main/src/contentScript/nativeEditor/selectorInference.ts#L67)? 

## Checklist

- [ ] Designate a primary reviewer
