### PR TITLE
#4124: BrowserAction: notify failed clicks; debounce clicks

### DIFF
--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -72,6 +72,7 @@ async function _toggleSidebar(tabId: number, tabUrl: string): Promise<void> {
 
   // NOTE: at this point, the sidebar should already be visible on the page, even if not ready.
   // Avoid showing any alerts or notifications: further messaging can appear in the sidebar itself.
+  // Any errors are automatically reported by the global error handler.
   await contentScriptPromise;
   await rehydrateSidebar({
     tabId,

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -15,18 +15,29 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import reportError from "@/telemetry/reportError";
 import { ensureContentScript } from "@/background/util";
 import { Tabs } from "webextension-polyfill";
 import webextAlert from "./webextAlert";
 import { rehydrateSidebar } from "@/contentScript/messenger/api";
 import { executeScript, isScriptableUrl } from "webext-content-scripts";
+import pMemoize from "p-memoize";
+
+const ERR_UNABLE_TO_OPEN =
+  "PixieBrix was unable to open the sidebar. Try refreshing the page.";
 
 // The sidebar is always injected to into the top level frame
 const TOP_LEVEL_FRAME_ID = 0;
 
-async function handleBrowserAction(tab: Tabs.Tab): Promise<void> {
-  const url = String(tab.url);
+// Avoid triggering multiple requests at once and causing multiple error alerts.
+// This patterns "debounces" calls while the promise is pending:
+// https://github.com/sindresorhus/promise-fun/issues/15
+const toggleSidebar = pMemoize(_toggleSidebar, {
+  cache: false,
+});
+
+// Don't accept objects here as they're not easily memoizable
+async function _toggleSidebar(tabId: number, tabUrl: string): Promise<void> {
+  const url = String(tabUrl);
   if (!isScriptableUrl(url)) {
     webextAlert(
       "Extensions cannot run on web store and other special browser vendor pages"
@@ -40,27 +51,35 @@ async function handleBrowserAction(tab: Tabs.Tab): Promise<void> {
     return;
   }
 
-  try {
-    await Promise.all([
-      // Toggle the sidebar every time it's run
-      executeScript({
-        tabId: tab.id,
-        files: ["browserActionInstantHandler.js"],
-      }),
+  // Load the raw toggle script first, then the content script. The browser executes them
+  // in order but we don't need to use `Promise.all` to await them at the same time as we
+  // want to catch each error separately.
+  const sidebarTogglePromise = executeScript({
+    tabId,
+    files: ["browserActionInstantHandler.js"],
+  });
+  const contentScriptPromise = ensureContentScript({
+    tabId,
+    frameId: TOP_LEVEL_FRAME_ID,
+  });
 
-      // Run the usual content script unless it's already loaded
-      ensureContentScript({ tabId: tab.id, frameId: TOP_LEVEL_FRAME_ID }),
-    ]);
-    await rehydrateSidebar({
-      tabId: tab.id,
-    });
+  try {
+    await sidebarTogglePromise;
   } catch (error) {
-    // We no longer `showErrorInOptions` because it may appear several seconds later
-    // https://github.com/pixiebrix/pixiebrix-extension/issues/4021
-    reportError(
-      new Error("Error opening sidebar via browser action", { cause: error })
-    );
+    webextAlert(ERR_UNABLE_TO_OPEN);
+    throw error;
   }
+
+  // NOTE: at this point, the sidebar should already be visible on the page, even if not ready.
+  // Avoid showing any alerts or notifications: further messaging can appear in the sidebar itself.
+  await contentScriptPromise;
+  await rehydrateSidebar({
+    tabId,
+  });
+}
+
+async function handleBrowserAction(tab: Tabs.Tab): Promise<void> {
+  await toggleSidebar(tab.id, String(tab.url));
 }
 
 export default function initBrowserAction() {

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -23,7 +23,7 @@ import { executeScript, isScriptableUrl } from "webext-content-scripts";
 import pMemoize from "p-memoize";
 
 const ERR_UNABLE_TO_OPEN =
-  "PixieBrix was unable to open the sidebar. Try refreshing the page.";
+  "PixieBrix was unable to open the Sidebar. Try refreshing the page.";
 
 // The sidebar is always injected to into the top level frame
 const TOP_LEVEL_FRAME_ID = 0;

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -20,6 +20,7 @@ import { Tabs } from "webextension-polyfill";
 import { rehydrateSidebar } from "@/contentScript/messenger/api";
 import { executeScript, isScriptableUrl } from "webext-content-scripts";
 import pMemoize from "p-memoize";
+import webextAlert from "./webextAlert";
 
 const ERR_UNABLE_TO_OPEN =
   "PixieBrix was unable to open the Sidebar. Try refreshing the page.";


### PR DESCRIPTION
## What does this PR do?

- Avoids attempting multiple simultaneous injections in the same tab
- Shows an error when the sidebar was supposed to open, but failed
	- **Note:** this PR covers an actual failure to open the sidebar rather than "unable to edit special browser pages" like https://github.com/pixiebrix/pixiebrix-extension/pull/4188


Specifically:

- Closes #4124 
-  https://github.com/pixiebrix/pixiebrix-extension/issues/4125


## Discussion

- The "blank slate" design of the sidebar is being handled in other tickets. I think we can use the sidebar to display any _connection_ issues, rather than _injection_ (which at this point is unlikely)

## Future Work

- [ ] #4193

## Checklist

- [x] Designate a primary reviewer @twschiller 
