### PR TITLE
Avoid flash after selecting any extension

### DIFF
--- a/src/pageEditor/Editor.tsx
+++ b/src/pageEditor/Editor.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-else-return -- TODO: Fix later */
 /*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
@@ -103,6 +104,7 @@ const Editor: React.FunctionComponent = () => {
     isCreateRecipeModalVisible,
   } = useSelector(selectEditorModalVisibilities);
 
+  const isModalInsert = inserting === "menuItem" || inserting === "panel";
   const body = useMemo(() => {
     if (restrict("page-editor")) {
       return <RestrictedPane />;
@@ -119,21 +121,15 @@ const Editor: React.FunctionComponent = () => {
       return <BetaPane />;
     }
 
-    if (inserting) {
-      switch (inserting) {
-        case "menuItem":
-          return <InsertMenuItemPane cancel={cancelInsert} />;
-        case "panel":
-          return <InsertPanelPane cancel={cancelInsert} />;
-        default:
-          return (
-            <GenericInsertPane
-              cancel={cancelInsert}
-              config={ADAPTERS.get(inserting)}
-            />
-          );
-      }
-    } else if (editorError) {
+    if (inserting === "menuItem") {
+      return <InsertMenuItemPane cancel={cancelInsert} />;
+    }
+
+    if (inserting === "panel") {
+      return <InsertPanelPane cancel={cancelInsert} />;
+    }
+
+    if (editorError) {
       return (
         <div className="p-2">
           <span className="text-danger">{editorError}</span>
@@ -174,8 +170,14 @@ const Editor: React.FunctionComponent = () => {
 
   return (
     <>
+      {inserting && !isModalInsert && (
+        <GenericInsertPane
+          cancel={cancelInsert}
+          config={ADAPTERS.get(inserting)}
+        />
+      )}
       <div className={styles.root}>
-        {!(inserting || restrict("page-editor")) && <Sidebar />}
+        {!(isModalInsert || restrict("page-editor")) && <Sidebar />}
         {body}
       </div>
 

--- a/src/pageEditor/Editor.tsx
+++ b/src/pageEditor/Editor.tsx
@@ -58,7 +58,7 @@ const Editor: React.FunctionComponent = () => {
   const { tabState, connecting } = useContext(PageEditorTabContext);
   const installed = useSelector(selectExtensions);
   const dispatch = useDispatch();
-  const { restrict } = useFlags();
+  const { restrict, flagOn } = useFlags();
 
   const sessionId = useSelector(selectSessionId);
   useEffect(() => {
@@ -104,7 +104,11 @@ const Editor: React.FunctionComponent = () => {
     isCreateRecipeModalVisible,
   } = useSelector(selectEditorModalVisibilities);
 
-  const isModalInsert = inserting === "menuItem" || inserting === "panel";
+  const showMarketplace = true;
+  const isModalInsert =
+    inserting === "menuItem" ||
+    inserting === "panel" ||
+    (inserting && showMarketplace);
   const body = useMemo(() => {
     if (restrict("page-editor")) {
       return <RestrictedPane />;

--- a/src/pageEditor/panes/insert/GenericInsertPane.tsx
+++ b/src/pageEditor/panes/insert/GenericInsertPane.tsx
@@ -38,7 +38,6 @@ import {
 import { FormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { getExampleBlockPipeline } from "@/pageEditor/exampleExtensionConfig";
 import useFlags from "@/hooks/useFlags";
-import Loader from "@/components/Loader";
 
 const { addElement } = editorSlice.actions;
 
@@ -130,7 +129,7 @@ const GenericInsertPane: React.FunctionComponent<{
 
   if (!showMarketplace) {
     // The insert pane will flash up quickly while the addNew is running.
-    return <Loader />;
+    return null;
   }
 
   return (


### PR DESCRIPTION
## What does this PR do?

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/3942

## Discussion

- It's a small change to avoid unnecessary full-screen flashes when the user is adding almost any extension

## Demo

https://user-images.githubusercontent.com/1402241/187660489-33fef381-234e-4f45-9a2b-f3567e5c33ee.mov

## Alternative

- [ ] Never replace the main content, just show a modal

