### PR TITLE
#4210: fix AA partner control room setup flow

### DIFF
--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -96,10 +96,10 @@ export async function getAuthHeaders(): Promise<UnknownObject | null> {
 
   if (partnerAuth?.token) {
     return {
-      ...partnerAuth?.extraHeaders,
+      ...partnerAuth.extraHeaders,
       // Put Authorization second to avoid overriding Authorization header. (Is defensive for now, currently
       // the extra headers are hard-coded)
-      Authorization: `Bearer ${partnerAuth?.token}`,
+      Authorization: `Bearer ${partnerAuth.token}`,
     };
   }
 

--- a/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
+++ b/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
@@ -73,7 +73,7 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
               serviceId: CONTROL_ROOM_OAUTH_SERVICE_ID,
               label: "Primary AARI Account",
               config: {
-                controlRoom: values.controlRoomUrl,
+                controlRoomUrl: values.controlRoomUrl,
               },
             })
           );

--- a/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
+++ b/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
@@ -88,11 +88,13 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
           config: configurationId,
         });
 
+        console.debug("Required permissions", requiredPermissions);
+
         await requestPermissions(requiredPermissions);
 
         await launchAuthIntegration({ serviceId: authServiceId });
       } catch (error) {
-        helpers.setStatus({ status: getErrorMessage(error) });
+        helpers.setStatus(getErrorMessage(error));
       }
     },
     [dispatch, configuredServices, authServiceId]

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -25,6 +25,7 @@ import { mergePermissions, requestPermissions } from "@/utils/permissions";
 import { resolveDefinitions } from "@/registry/internal";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import { locateWithRetry } from "@/services/serviceUtils";
+import { expectContext } from "@/utils/expectContext";
 
 // Copied from the permissions section of manifest.json
 const MANDATORY_PERMISSIONS = new Set([
@@ -118,6 +119,8 @@ export async function collectPermissions(
 export async function serviceOriginPermissions(
   dependency: ServiceAuthPair
 ): Promise<Permissions.Permissions> {
+  expectContext("extension");
+
   if (dependency.id === PIXIEBRIX_SERVICE_ID) {
     // Already included in the required permissions for the extension
     return { origins: [] };

--- a/src/services/factory.test.ts
+++ b/src/services/factory.test.ts
@@ -16,11 +16,43 @@
  */
 
 import automationAnywhere from "@contrib/services/automation-anywhere.yaml";
+import automationAnywhereOAuth2 from "@contrib/services/automation-anywhere-oauth2.yaml";
 import { fromJS } from "@/services/factory";
+import { ServiceDefinition } from "@/types/definitions";
+import { SanitizedConfig } from "@/core";
 
 describe("LocalDefinedService", () => {
   test("includes version", () => {
-    const service = fromJS(automationAnywhere as any);
+    const service = fromJS(automationAnywhere as unknown as ServiceDefinition);
     expect(service.version).toBe("1.0.0");
+  });
+
+  test("get origins for oauth2 service", () => {
+    const service = fromJS(
+      automationAnywhereOAuth2 as unknown as ServiceDefinition
+    );
+    const origins = service.getOrigins({
+      controlRoomUrl: "https://controlroom.example.com",
+    } as unknown as SanitizedConfig);
+
+    expect(origins).toEqual([
+      "https://controlroom.example.com/*",
+      "https://dev-5ufv3jh0.us.auth0.com/authorize?organization=org_55te9GGDwlzAS1PB&audience=https://dev-5ufv3jh0.us.auth0.com/userinfo",
+      "https://dev-5ufv3jh0.us.auth0.com/oauth/token",
+    ]);
+  });
+
+  test("excludes invalid base URL", () => {
+    const service = fromJS(
+      automationAnywhereOAuth2 as unknown as ServiceDefinition
+    );
+    const origins = service.getOrigins({
+      controlRoomUrl: "",
+    } as unknown as SanitizedConfig);
+
+    expect(origins).toEqual([
+      "https://dev-5ufv3jh0.us.auth0.com/authorize?organization=org_55te9GGDwlzAS1PB&audience=https://dev-5ufv3jh0.us.auth0.com/userinfo",
+      "https://dev-5ufv3jh0.us.auth0.com/oauth/token",
+    ]);
   });
 });


### PR DESCRIPTION
## What does this PR do?

- Closes #4210 
- Closes #4209

## Reviewer Notes
- The getOrigins method for services does include the `/token` and `/authorize` URLs for OAuth2 integrations (along with the base URL): https://github.com/pixiebrix/pixiebrix-extension/blob/8802f394eb6e7f71c519078c4e20e5139070ae17/src/services/factory.ts#L134-L134

## Blockers
- https://github.com/pixiebrix/pixiebrix-app/issues/2228

## Checklist

- [X] Manually test onboarding flow. I verified the login flow and that it's properly including the headers post login
- [X] 😐  Add tests
- [X] Designate a primary reviewer: @johnnymetz 
