### PR TITLE
Avoid proxy revocation by optimizing cancelForm call

### DIFF
--- a/src/blocks/transformers/ephemeralForm/EphemeralForm.tsx
+++ b/src/blocks/transformers/ephemeralForm/EphemeralForm.tsx
@@ -100,7 +100,7 @@ const EphemeralForm: React.FC = () => {
             className="btn btn-primary"
             type="button"
             onClick={() => {
-              void cancelForm(target, nonce);
+              cancelForm(target, nonce);
             }}
           >
             Close
@@ -132,7 +132,7 @@ const EphemeralForm: React.FC = () => {
                 className="btn btn-link"
                 type="button"
                 onClick={() => {
-                  void cancelForm(target, nonce);
+                  cancelForm(target, nonce);
                 }}
               >
                 Cancel

--- a/src/contentScript/ephemeralFormProtocol.ts
+++ b/src/contentScript/ephemeralFormProtocol.ts
@@ -88,10 +88,12 @@ export async function resolveForm(
  * Cancel the form. Is a NOP if the form is no longer registered.
  * @param formNonce the form nonce
  */
-export async function cancelForm(formNonce: UUID): Promise<void> {
+export async function cancelForm(...formNonces: UUID[]): Promise<void> {
   expectContext("contentScript");
 
-  const form = forms.get(formNonce);
-  form?.registration.reject(new CancelError("User cancelled the action"));
-  unregisterForm(formNonce);
+  for (const formNonce of formNonces) {
+    const form = forms.get(formNonce);
+    form?.registration.reject(new CancelError("User cancelled the action"));
+    unregisterForm(formNonce);
+  }
 }

--- a/src/contentScript/ephemeralFormProtocol.ts
+++ b/src/contentScript/ephemeralFormProtocol.ts
@@ -85,8 +85,8 @@ export async function resolveForm(
 }
 
 /**
- * Cancel the form. Is a NOP if the form is no longer registered.
- * @param formNonce the form nonce
+ * Cancel some forms. Is a NOP if a form is no longer registered.
+ * @param formNonces the form nonces
  */
 export async function cancelForm(...formNonces: UUID[]): Promise<void> {
   expectContext("contentScript");

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -20,7 +20,7 @@ import { getMethod, getNotifier } from "webext-messenger";
 
 export const getFormDefinition = getMethod("FORM_GET_DEFINITION");
 export const resolveForm = getMethod("FORM_RESOLVE");
-export const cancelForm = getMethod("FORM_CANCEL");
+export const cancelForm = getNotifier("FORM_CANCEL");
 export const queueReactivateTab = getNotifier("QUEUE_REACTIVATE_TAB");
 export const reactivateTab = getNotifier("REACTIVATE_TAB");
 export const removeExtension = getNotifier("REMOVE_EXTENSION");

--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -110,16 +110,16 @@ const sidebarSlice = createSlice({
     addForm(state, action: PayloadAction<{ form: FormEntry }>) {
       const { form } = action.payload;
 
-      const [currentForms, notCurrentForms] = partition(
+      const [thisExtensionForms, otherForms] = partition(
         state.forms,
         (x) => x.extensionId === form.extensionId
       );
 
       // The UUID must be fetched synchronously to ensure the `form` Proxy element doesn't expire
-      void cancelPreexistingForms(currentForms.map((form) => form.nonce));
+      void cancelPreexistingForms(thisExtensionForms.map((form) => form.nonce));
 
       state.forms = [
-        ...notCurrentForms,
+        ...otherForms,
         // Unlike panels which are sorted, forms are like a "stack", will show the latest form available
         form,
       ];

--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -26,8 +26,7 @@ import { defaultEventKey, mapTabEventKey } from "@/sidebar/utils";
 import { UUID } from "@/core";
 import { cancelForm } from "@/contentScript/messenger/api";
 import { whoAmI } from "@/background/messenger/api";
-import { asyncForEach } from "@/utils";
-import { sortBy } from "lodash";
+import { partition, sortBy } from "lodash";
 
 export type SidebarState = SidebarEntries & {
   activeKey: string;
@@ -93,6 +92,12 @@ function findNextActiveKey(
   return null;
 }
 
+async function cancelPreexistingForms(forms: UUID[]): Promise<void> {
+  // TODO: Replace with `tabId: "this"` once implemented in the messenger
+  const sender = await whoAmI();
+  cancelForm({ tabId: sender.tab.id, frameId: 0 }, ...forms);
+}
+
 const sidebarSlice = createSlice({
   initialState: emptySidebarState,
   name: "sidebar",
@@ -105,19 +110,19 @@ const sidebarSlice = createSlice({
     addForm(state, action: PayloadAction<{ form: FormEntry }>) {
       const { form } = action.payload;
 
-      // Cancel pre-existing forms for the extension
-      void asyncForEach(state.forms, async (current) => {
-        if (current.extensionId === form.extensionId) {
-          const sender = await whoAmI();
-          await cancelForm({ tabId: sender.tab.id, frameId: 0 }, current.nonce);
-        }
-      });
-
-      state.forms = state.forms.filter(
-        (x) => x.extensionId !== form.extensionId
+      const [currentForms, notCurrentForms] = partition(
+        state.forms,
+        (x) => x.extensionId === form.extensionId
       );
-      // Unlike panels which are sorted, forms are like a "stack", will show the latest form available
-      state.forms.push(form);
+
+      // The UUID must be fetched synchronously to ensure the `form` Proxy element doesn't expire
+      void cancelPreexistingForms(currentForms.map((form) => form.nonce));
+
+      state.forms = [
+        ...notCurrentForms,
+        // Unlike panels which are sorted, forms are like a "stack", will show the latest form available
+        form,
+      ];
       state.activeKey = mapTabEventKey("form", form);
     },
     removeForm(state, action: PayloadAction<UUID>) {


### PR DESCRIPTION
## What does this PR do?

Presumably fixes this frequent error found on Rollbar.

```
Cannot perform 'get' on a proxy that has been revoked
```

## Discussion

- Opened on notification by @johnnymetz regarding the high amount of bug reports on Rollbar
- See review notes

## Checklist

- 📉 Add tests
- [x] Designate a primary reviewer: @BLoe 
