### PR TITLE
#4256: Drop `undefined` error reporting in `initGoogle`

### DIFF
--- a/src/contrib/google/initGoogle.ts
+++ b/src/contrib/google/initGoogle.ts
@@ -16,12 +16,11 @@
  */
 
 import reportError from "@/telemetry/reportError";
-
-const API_KEY = process.env.GOOGLE_API_KEY;
-
 import { DISCOVERY_DOCS as SHEETS_DOCS } from "./sheets/handlers";
 import { DISCOVERY_DOCS as BIGQUERY_DOCS } from "./bigquery/handlers";
 import { isChrome } from "webext-detect-page";
+
+const API_KEY = process.env.GOOGLE_API_KEY;
 
 declare global {
   interface Window {
@@ -64,9 +63,6 @@ function initGoogle(): void {
 
   const script = document.createElement("script");
   script.src = "https://apis.google.com/js/client.js?onload=onGAPILoad";
-  script.addEventListener("error", (event) => {
-    reportError(event.error);
-  });
   document.head.append(script);
 }
 

--- a/src/errors/networkErrorHelpers.ts
+++ b/src/errors/networkErrorHelpers.ts
@@ -50,8 +50,8 @@ export const NO_RESPONSE_MESSAGE =
 export function selectNetworkErrorMessage(error: unknown): string | null {
   if (
     (isAxiosError(error) && error.response == null) ||
-    (typeof (error as any).message === "string" &&
-      (error as { message: string }).message.toLowerCase() === "network error")
+    // Do not use isErrorObject nor getErrorMessage, that'd be a cyclical dependency
+    (isObject(error) && String(error.message).toLowerCase() === "network error")
   ) {
     if (!navigator.onLine) {
       return NO_INTERNET_MESSAGE;


### PR DESCRIPTION
## What does this PR do?

- Part of #4256
- Drops an error reporting that results in hundreds of  `Error: undefined` reports on Rollbar: https://rollbar.com/pixiebrix/pixiebrix/items/5867/
- The line does not report any other type of error, as seen with a file search on Rollbar.com: https://rollbar.com/pixiebrix/all/items/?sort=%5Bobject%20Object%5D&status=all&enc_query=70snXhaSQm4u%2FiYsgMPNW0fbSikCwBVTrCSdcGR8p8OTjzt%2FaPyMpvKXyqMXF8NH&date_from=08-11-2022%2019%3A00%3A00&date_to=&environments=production&activated_to=&timezone=Europe%2FLisbon&framework=&levels=40&levels=50&activated_from=&offset=0&query=file%3AinitGoogle.ts&assigned_user=&date_filtering=seen&projects=395009

## Discussion

- Opened on notification by Johnny regarding the high amount of bug reports on Rollbar

## Confidence level

High

## As Seen On TV

_AKA Related_ 

- https://github.com/pixiebrix/pixiebrix-extension/pull/4194#discussion_r959390771
- https://github.com/pixiebrix/pixiebrix-extension/issues/3914

## Checklist

- 🌧  Add tests
- [x] Designate a primary reviewer: @BLoe because you added this piece of code
