### PR TITLE
#4256: Avoid reporting bare Network Errors to Rollbar

### DIFF
--- a/src/errors/errorHelpers.ts
+++ b/src/errors/errorHelpers.ts
@@ -55,6 +55,7 @@ export const CONTEXT_INVALIDATED_ERROR = "Extension context invalidated.";
  */
 export const IGNORED_ERROR_PATTERNS = [
   "ResizeObserver loop limit exceeded",
+  "Network Error",
   "Promise was cancelled",
   "Uncaught Error: PixieBrix contentScript already installed",
   "Could not establish connection. Receiving end does not exist.",


### PR DESCRIPTION
## What does this PR do?

- Stops reports of `Network Error` to Rollbar
- Part of #4256

## Discussion

- The browser does not add further information to these errors, they most likely are a consequence of user error (e.g. due to a flaky connection, wifi captive portal, wrong address, …)
- The aggregation of these errors however could lead to the discovery of new bugs when spikes occur — I'm not sure they'd be useful in that case either though
- Opened on notification by @johnnymetz regarding the high amount of bug reports on Rollbar

## Confidence level

Medium-high

## Checklist

- 😣 Add tests
- [x] Designate a primary reviewer: @johnnymetz 

