### PR TITLE
#4256: Avoid reporting user cancellation errors to Rollbar

### DIFF
--- a/src/errors/errorHelpers.ts
+++ b/src/errors/errorHelpers.ts
@@ -56,6 +56,8 @@ export const CONTEXT_INVALIDATED_ERROR = "Extension context invalidated.";
 export const IGNORED_ERROR_PATTERNS = [
   "ResizeObserver loop limit exceeded",
   "Promise was cancelled",
+  "Action cancelled",
+  "User cancelled the action",
   "Uncaught Error: PixieBrix contentScript already installed",
   "Could not establish connection. Receiving end does not exist.",
   "The frame was removed.",


### PR DESCRIPTION
## What does this PR do?

- Part of #4256
- Stops reports of cancelled actions to [Rollbar](https://rollbar.com/pixiebrix/all/items/?sort=%5Bobject%20Object%5D&status=all&date_from=08-11-2022%2019%3A00%3A00&date_to=&environments=production&activated_to=&framework=&levels=40&levels=50&activated_from=&offset=0&timezone=Europe%2FLisbon&assigned_user=&date_filtering=seen&projects=395009&query=cancelled&enc_query=jZ2v2aRYpQxVXZqWlvLbNp11FlZxk9oGPFoq94gzQUU%3D)

## Discussion

- We're already ignoring the more generic "Promise cancelled" error, so the specific "User cancelled action" feels like it should be ignored too

## Confidence level

High

## Checklist

- 🤫 Add tests
- [x] Designate a primary reviewer: @johnnymetz 

## Related

- #4253 