### PR TITLE
#3914: Clean GAPI script loading

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -51,7 +51,7 @@ initBrowserAction();
 initInstaller();
 initNavigation();
 initExecutor();
-initGoogle();
+void initGoogle();
 initContextMenus();
 initBrowserCommands();
 initDeploymentUpdater();

--- a/src/contrib/google/bigquery/handlers.ts
+++ b/src/contrib/google/bigquery/handlers.ts
@@ -28,13 +28,7 @@ export const DISCOVERY_DOCS: string[] = [
   "https://bigquery.googleapis.com/discovery/v1/apis/bigquery/v2/rest",
 ];
 
-const initialized = false;
-
 async function ensureBigQuery(): Promise<void> {
-  if (initialized) {
-    return;
-  }
-
   // https://github.com/google/google-api-javascript-client/blob/master/docs/reference.md
   try {
     await gapi.client.load("bigquery", "v2");

--- a/src/contrib/google/initGoogle.ts
+++ b/src/contrib/google/initGoogle.ts
@@ -22,6 +22,8 @@ const API_KEY = process.env.GOOGLE_API_KEY;
 import { DISCOVERY_DOCS as SHEETS_DOCS } from "./sheets/handlers";
 import { DISCOVERY_DOCS as BIGQUERY_DOCS } from "./bigquery/handlers";
 import { isChrome } from "webext-detect-page";
+import pMemoize from "p-memoize";
+import injectScriptTag from "@/utils/injectScriptTag";
 
 declare global {
   interface Window {
@@ -46,28 +48,29 @@ async function onGAPILoad(): Promise<void> {
   }
 }
 
-function initGoogle(): void {
+async function _initGoogle(): Promise<boolean> {
   if (!isChrome() || typeof document === "undefined" /* MV3 exclusion */) {
     // TODO: Use feature detection instead of sniffing the user agent
     console.info(
       "Google API not enabled because it's not supported by this browser"
     );
-    return;
+    return false;
   }
 
   if (!API_KEY) {
     console.info("Google API not enabled because the API key is not available");
-    return;
+    return false;
   }
 
   window.onGAPILoad = onGAPILoad;
 
-  const script = document.createElement("script");
-  script.src = "https://apis.google.com/js/client.js?onload=onGAPILoad";
-  script.addEventListener("error", (event) => {
-    reportError(event.error);
-  });
-  document.head.append(script);
+  await injectScriptTag(
+    "https://apis.google.com/js/client.js?onload=onGAPILoad"
+  );
+
+  return true;
 }
 
+// `pMemoize` will avoid multiple injections, while also allow retrying if the first injection fails
+const initGoogle = pMemoize(_initGoogle);
 export default initGoogle;

--- a/src/options/options.tsx
+++ b/src/options/options.tsx
@@ -34,6 +34,6 @@ function init(): void {
 }
 
 registerMessenger();
-initGoogle();
+void initGoogle();
 initToaster();
 init();

--- a/src/utils/injectScriptTag.tsx
+++ b/src/utils/injectScriptTag.tsx
@@ -15,25 +15,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import "bootstrap/dist/css/bootstrap.min.css";
-import "@/vendors/overrides.scss";
-import "@/utils/layout.scss";
-
-import "@/extensionContext";
-import "@/development/darkMode";
-
-import registerMessenger from "@/pageEditor/messenger/registration";
-
-import ReactDOM from "react-dom";
-import React from "react";
-import Panel from "@/pageEditor/Panel";
-import { watchNavigation } from "@/pageEditor/protocol";
-import initGoogle from "@/contrib/google/initGoogle";
-import { initToaster } from "@/utils/notify";
-
-registerMessenger();
-void initGoogle();
-watchNavigation();
-initToaster();
-
-ReactDOM.render(<Panel />, document.querySelector("#container"));
+/** Loads a script URL via `script` tag. Resolves with `script` tag or throws when it fails. */
+export default async function injectScriptTag(
+  source: string
+): Promise<HTMLScriptElement> {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = source;
+    script.addEventListener("error", (event) => {
+      // The cause will most likely be `undefined`
+      reject(new Error("Script failed loading", { cause: event.error }));
+    });
+    script.addEventListener("load", () => {
+      resolve(script);
+    });
+    (document.head ?? document.documentElement).append(script);
+  });
+}

--- a/src/utils/injectScriptTag.tsx
+++ b/src/utils/injectScriptTag.tsx
@@ -24,7 +24,9 @@ export default async function injectScriptTag(
     script.src = source;
     script.addEventListener("error", (event) => {
       // The cause will most likely be `undefined`
-      reject(new Error("Script failed loading", { cause: event.error }));
+      reject(
+        new Error(`Script failed loading: ${source}`, { cause: event.error })
+      );
     });
     script.addEventListener("load", () => {
       resolve(script);


### PR DESCRIPTION
## What does this PR do?


- Makes the GAPI script failure loud: script load errors don't bubble to our global handlers as [one’d expect](https://github.com/pixiebrix/pixiebrix-extension/pull/4018/files#r945211199); this PR throws a proper error when that happens
- Instead of reporting "undefined", it reports `Script failed loading: {url}`, with a cause with more information, if ever present
- Prepares initGoogle for retries, should we want to do that in the future
Also:

- cleans up/standardizes the loading code

### Related issues

- Part of https://github.com/pixiebrix/pixiebrix-extension/issues/3914
- Partially reverts https://github.com/pixiebrix/pixiebrix-extension/pull/4018/files
- Replaces/extends/closes https://github.com/pixiebrix/pixiebrix-extension/pull/4252


## Future Work

- [ ] Maybe retry loading the script if it fails

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @BLoe 
