### PR TITLE
Add flag to starter blueprints request to accommodate older extension versions

### DIFF
--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -110,7 +110,8 @@ async function getStarterBlueprints(): Promise<RecipeDefinition[]> {
 
   try {
     const { data: starterBlueprints } = await client.get<RecipeDefinition[]>(
-      "/api/onboarding/starter-blueprints/"
+      "/api/onboarding/starter-blueprints/",
+      { params: { ignore_installed: true } }
     );
     return starterBlueprints;
   } catch (error) {

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -111,7 +111,7 @@ async function getStarterBlueprints(): Promise<RecipeDefinition[]> {
   try {
     const { data: starterBlueprints } = await client.get<RecipeDefinition[]>(
       "/api/onboarding/starter-blueprints/",
-      { params: { ignore_installed: true } }
+      { params: { ignore_user_state: true } }
     );
     return starterBlueprints;
   } catch (error) {


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-app/pull/2250
- This adds a flag to the starter blueprints request in order to accommodate older versions of the extension. This prevents older versions of the extension from installing starter blueprints for all users (even enterprise) on extension launch.

## Discussion

- An alternative approach is keeping everything as-is and simply waiting for a certain percentage of the new extension release to be adopted.

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @twschiller 
