### PR TITLE
#4280: monkeypatch JQuery calls to QSA use non-native :has

### DIFF
--- a/src/contentScript/contentScript.ts
+++ b/src/contentScript/contentScript.ts
@@ -28,6 +28,8 @@ import {
 } from "@/contentScript/ready";
 import { logPromiseDuration } from "@/utils";
 import { onContextInvalidated } from "@/errors/contextInvalidated";
+// eslint-disable-next-line import/no-unassigned-import -- monkey patching import
+import "@/utils/jqueryHack";
 
 // See note in `@/contentScript/ready.ts` for further details about the lifecycle of content scripts
 async function initContentScript() {

--- a/src/pageScript/pageScript.ts
+++ b/src/pageScript/pageScript.ts
@@ -20,6 +20,8 @@
  */
 
 import { uuidv4 } from "@/types/helpers";
+// eslint-disable-next-line import/no-unassigned-import -- monkey patching import
+import "@/utils/jqueryHack";
 
 const JQUERY_WINDOW_PROP = "$$jquery";
 const PAGESCRIPT_SYMBOL = Symbol.for("pixiebrix-page-script");

--- a/src/utils/jqueryHack.ts
+++ b/src/utils/jqueryHack.ts
@@ -1,0 +1,51 @@
+/* eslint-disable unicorn/prefer-reflect-apply,prefer-rest-params -- copied code from maintainer */
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Chrome 105 introduced native support for :has, but has a "bug" that breaks support for JQuery pseudo-selectors
+// Implementation adapted from: https://github.com/jquery/jquery/issues/5098#issuecomment-1232952901
+
+const originalQSA = document.querySelectorAll;
+// @ts-expect-error -- internal callable object
+const originalFind = $.find;
+
+function patchedQSA(selectors: string) {
+  if (selectors.includes(":has")) {
+    // Force use of JQuery for :has
+    throw new DOMException();
+  }
+
+  return originalQSA(selectors);
+}
+
+// @ts-expect-error -- internal callable object
+$.find = Object.assign(function () {
+  document.querySelectorAll = patchedQSA;
+  Element.prototype.querySelectorAll = patchedQSA;
+
+  let result;
+
+  try {
+    // @ts-expect-error -- Typescript can't infer `this`
+    result = originalFind.apply(this, arguments);
+  } finally {
+    document.querySelectorAll = originalQSA;
+    Element.prototype.querySelectorAll = originalQSA;
+  }
+
+  return result;
+}, originalFind);


### PR DESCRIPTION
## What does this PR do?

- Closes #4280 
- Monkey patches QSA calls from JQuery to avoid regression in Chrome 105

## Discussion

- The content script runs in it's own VM
- The page script has it's own copy of jquery

## Demo

![image](https://user-images.githubusercontent.com/1879821/190025545-9761616c-dd0a-48be-b282-843f2b4a5c81.png)

## Checklist

- [ ] Add tests: no way to automatically test 😢 
- [x] Designate a primary reviewer: @fregante 
