### PR TITLE
#4322: Remove useOnboarding hook loader

### DIFF
--- a/src/options/pages/blueprints/BlueprintsView.tsx
+++ b/src/options/pages/blueprints/BlueprintsView.tsx
@@ -25,10 +25,8 @@ import {
 } from "@/options/pages/blueprints/blueprintsSelectors";
 import { BlueprintListViewProps } from "@/options/pages/blueprints/blueprintsTypes";
 import OnboardingView from "@/options/pages/blueprints/onboardingView/OnboardingView";
-import useOnboarding from "@/options/pages/blueprints/onboardingView/useOnboarding";
 import EmptyView from "@/options/pages/blueprints/emptyView/EmptyView";
 import GetStartedView from "@/options/pages/blueprints/GetStartedView";
-import Loader from "@/components/Loader";
 
 const BlueprintsView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
   tableInstance,
@@ -37,7 +35,6 @@ const BlueprintsView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
 }) => {
   const view = useSelector(selectView);
   const activeTab = useSelector(selectActiveTab);
-  const { onboardingType, onboardingFilter, isLoading } = useOnboarding();
 
   const {
     state: { globalFilter },
@@ -48,10 +45,6 @@ const BlueprintsView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
 
   if (activeTab.key === "Get Started") {
     return <GetStartedView width={width} height={height} />;
-  }
-
-  if (isLoading) {
-    return <Loader />;
   }
 
   if (rows.length > 0) {
@@ -70,15 +63,7 @@ const BlueprintsView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
     );
   }
 
-  return (
-    <OnboardingView
-      onboardingType={onboardingType}
-      isLoading={isLoading}
-      filter={onboardingFilter}
-      width={width}
-      height={height}
-    />
-  );
+  return <OnboardingView width={width} height={height} />;
 };
 
 export default BlueprintsView;

--- a/src/options/pages/blueprints/BlueprintsView.tsx
+++ b/src/options/pages/blueprints/BlueprintsView.tsx
@@ -27,6 +27,7 @@ import { BlueprintListViewProps } from "@/options/pages/blueprints/blueprintsTyp
 import OnboardingView from "@/options/pages/blueprints/onboardingView/OnboardingView";
 import EmptyView from "@/options/pages/blueprints/emptyView/EmptyView";
 import GetStartedView from "@/options/pages/blueprints/GetStartedView";
+import useOnboarding from "@/options/pages/blueprints/onboardingView/useOnboarding";
 
 const BlueprintsView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
   tableInstance,
@@ -35,6 +36,7 @@ const BlueprintsView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
 }) => {
   const view = useSelector(selectView);
   const activeTab = useSelector(selectActiveTab);
+  const { onboardingType, onboardingFilter, isLoading } = useOnboarding();
 
   const {
     state: { globalFilter },
@@ -63,7 +65,15 @@ const BlueprintsView: React.VoidFunctionComponent<BlueprintListViewProps> = ({
     );
   }
 
-  return <OnboardingView width={width} height={height} />;
+  return (
+    <OnboardingView
+      onboardingType={onboardingType}
+      isLoading={isLoading}
+      filter={onboardingFilter}
+      width={width}
+      height={height}
+    />
+  );
 };
 
 export default BlueprintsView;

--- a/src/options/pages/blueprints/onboardingView/OnboardingView.tsx
+++ b/src/options/pages/blueprints/onboardingView/OnboardingView.tsx
@@ -22,7 +22,7 @@ import { Button, Card, Col, Row } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import marketplaceImage from "@img/marketplace.svg";
-import { OnboardingType } from "@/options/pages/blueprints/onboardingView/useOnboarding";
+import useOnboarding from "@/options/pages/blueprints/onboardingView/useOnboarding";
 import blueprintsSlice from "@/options/pages/blueprints/blueprintsSlice";
 import { useDispatch } from "react-redux";
 import workshopImage from "@img/workshop.svg";
@@ -135,12 +135,15 @@ const CreateBrickColumn: React.VoidFunctionComponent = () => (
 );
 
 const OnboardingView: React.VoidFunctionComponent<{
-  onboardingType: OnboardingType;
-  isLoading: boolean;
-  filter?: string;
   width: number;
   height: number;
-}> = ({ onboardingType, filter, isLoading, width, height }) => {
+}> = ({ width, height }) => {
+  const {
+    onboardingType,
+    onboardingFilter: filter,
+    isLoading,
+  } = useOnboarding();
+
   const onBoardingInformation = useMemo(() => {
     if (!(onboardingType === "restricted") && filter === "public") {
       return <ActivateFromMarketplaceColumn />;

--- a/src/options/pages/blueprints/onboardingView/OnboardingView.tsx
+++ b/src/options/pages/blueprints/onboardingView/OnboardingView.tsx
@@ -22,9 +22,7 @@ import { Button, Card, Col, Row } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import marketplaceImage from "@img/marketplace.svg";
-import useOnboarding, {
-  OnboardingType,
-} from "@/options/pages/blueprints/onboardingView/useOnboarding";
+import { OnboardingType } from "@/options/pages/blueprints/onboardingView/useOnboarding";
 import blueprintsSlice from "@/options/pages/blueprints/blueprintsSlice";
 import { useDispatch } from "react-redux";
 import workshopImage from "@img/workshop.svg";

--- a/src/options/pages/blueprints/onboardingView/OnboardingView.tsx
+++ b/src/options/pages/blueprints/onboardingView/OnboardingView.tsx
@@ -22,7 +22,9 @@ import { Button, Card, Col, Row } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import marketplaceImage from "@img/marketplace.svg";
-import useOnboarding from "@/options/pages/blueprints/onboardingView/useOnboarding";
+import useOnboarding, {
+  OnboardingType,
+} from "@/options/pages/blueprints/onboardingView/useOnboarding";
 import blueprintsSlice from "@/options/pages/blueprints/blueprintsSlice";
 import { useDispatch } from "react-redux";
 import workshopImage from "@img/workshop.svg";
@@ -135,15 +137,12 @@ const CreateBrickColumn: React.VoidFunctionComponent = () => (
 );
 
 const OnboardingView: React.VoidFunctionComponent<{
+  onboardingType: OnboardingType;
+  isLoading: boolean;
+  filter?: string;
   width: number;
   height: number;
-}> = ({ width, height }) => {
-  const {
-    onboardingType,
-    onboardingFilter: filter,
-    isLoading,
-  } = useOnboarding();
-
+}> = ({ onboardingType, filter, isLoading, width, height }) => {
   const onBoardingInformation = useMemo(() => {
     if (!(onboardingType === "restricted") && filter === "public") {
       return <ActivateFromMarketplaceColumn />;


### PR DESCRIPTION
## What does this PR do?

- Fixes #4322
- This removes the Loader on the `BlueprintsView` component, because the `isLoading` state for the `useOnboarding` hook is only relevant in the situation where there is an OnboardingView.

## Discussion

I had originally moved the `useOnboarding` hook into the `OnboardingView` entirely, but this would cause me to mock things in the OnboardingView story, which is out of scope for now.

## Demo

https://user-images.githubusercontent.com/36575242/191343104-5f2d5a85-15a2-425a-9dbc-fa8a95c3a628.mov


## Future Work

- There is a PR open for adding tests to the BlueprintsPage: https://github.com/pixiebrix/pixiebrix-extension/issues/4316
- Please see this PR for why adding tests is momentarily blocked (I'm prioritizing fixing this immediate bug at the moment)

## Checklist

- [x] Add tests - see future work
- [x] Designate a primary reviewer @BLoe / @twschiller 
