### PR TITLE
#4320 Fix bug with Panel type incorrectly appearing in the add-extension dropdown menu

### DIFF
--- a/src/pageEditor/sidebar/AddExtensionPointButton.tsx
+++ b/src/pageEditor/sidebar/AddExtensionPointButton.tsx
@@ -25,6 +25,7 @@ import { sortBy } from "lodash";
 import useAddElement from "@/pageEditor/hooks/useAddElement";
 import { useSelector } from "react-redux";
 import { selectTabHasPermissions } from "@/pageEditor/tabState/tabStateSelectors";
+import { useAsyncState } from "@/hooks/common";
 
 const sortedExtensionPoints = sortBy(
   [...ADAPTERS.values()],
@@ -56,6 +57,37 @@ const AddExtensionPointButton: React.FunctionComponent = () => {
 
   const addElement = useAddElement();
 
+  const [entries] = useAsyncState<React.ReactNode>(
+    async () => {
+      const results = await Promise.all(
+        sortedExtensionPoints.map((config) => {
+          if (!config.flag) {
+            return true;
+          }
+
+          return flagOn(config.flag);
+        })
+      );
+
+      // eslint-disable-next-line security/detect-object-injection -- array index
+      return sortedExtensionPoints
+        .filter((_, index) => results[index])
+        .map((config) => (
+          <DropdownEntry
+            key={config.elementType}
+            caption={config.label}
+            icon={config.icon}
+            beta={Boolean(config.flag)}
+            onClick={() => {
+              addElement(config);
+            }}
+          />
+        ));
+    },
+    [],
+    []
+  );
+
   return (
     <DropdownButton
       disabled={!tabHasPermissions}
@@ -64,19 +96,7 @@ const AddExtensionPointButton: React.FunctionComponent = () => {
       title="Add"
       id="add-extension-point"
     >
-      {sortedExtensionPoints
-        .filter((element) => !element.flag || flagOn(element.flag))
-        .map((element) => (
-          <DropdownEntry
-            key={element.elementType}
-            caption={element.label}
-            icon={element.icon}
-            beta={Boolean(element.flag)}
-            onClick={() => {
-              addElement(element);
-            }}
-          />
-        ))}
+      {entries}
     </DropdownButton>
   );
 };

--- a/src/pageEditor/sidebar/AddExtensionPointButton.tsx
+++ b/src/pageEditor/sidebar/AddExtensionPointButton.tsx
@@ -69,20 +69,22 @@ const AddExtensionPointButton: React.FunctionComponent = () => {
         })
       );
 
-      // eslint-disable-next-line security/detect-object-injection -- array index
-      return sortedExtensionPoints
-        .filter((_, index) => results[index])
-        .map((config) => (
-          <DropdownEntry
-            key={config.elementType}
-            caption={config.label}
-            icon={config.icon}
-            beta={Boolean(config.flag)}
-            onClick={() => {
-              addElement(config);
-            }}
-          />
-        ));
+      return (
+        sortedExtensionPoints
+          // eslint-disable-next-line security/detect-object-injection -- array index
+          .filter((_, index) => results[index])
+          .map((config) => (
+            <DropdownEntry
+              key={config.elementType}
+              caption={config.label}
+              icon={config.icon}
+              beta={Boolean(config.flag)}
+              onClick={() => {
+                addElement(config);
+              }}
+            />
+          ))
+      );
     },
     [],
     []


### PR DESCRIPTION
## What does this PR do?

- Fixes #4320 

## Discussion

- Second time this week I've run into an issue related to improper `async` usage that wasn't caught at all by eslint/TS
  - Is there any way to catch these edge cases with another lint rule or something?
  - Should we try to check every usage of `async` closely in PRs from now on?
  - Any other ideas here? Maybe it's not that big a deal...

## Checklist

- [ ] Add tests - I really don't feel like figuring out auth data/feature-flag mocking right now... 🥲 
- [x] Designate a primary reviewer
