### PR TITLE
#4331 Fix bug with add-extension dropdown menu overflowing

### DIFF
--- a/src/pageEditor/sidebar/Sidebar.module.scss
+++ b/src/pageEditor/sidebar/Sidebar.module.scss
@@ -13,8 +13,8 @@ $logoSize: 31px;
     align-items: center;
   }
   &.expanded {
-    flex: 0 0 260px;
-    width: 260px; // Preserve width during the transition
+    flex: 0 0 270px;
+    width: 270px; // Preserve width during the transition
     z-index: 1000; // Always on top of the collapsed one *and* of the content
     &.enter,
     &.exit.exitActive {


### PR DESCRIPTION
## What does this PR do?

- Fixes #4331 

## Demo

Menu places properly when scrollbars are enabled:
<img width="292" alt="image" src="https://user-images.githubusercontent.com/2801308/191553091-2962a07f-5398-4c64-904c-d1d6a756aeda.png">

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
