### PR TITLE
#4289 Hide UiPath bricks for AA users

### DIFF
--- a/src/components/addBlockModal/AddBlockModal.test.tsx
+++ b/src/components/addBlockModal/AddBlockModal.test.tsx
@@ -39,6 +39,9 @@ jest.mock("@/services/api");
 jest.mock("@/components/asyncIcon", () => ({
   useAsyncIcon: jest.fn(),
 }));
+jest.mock("@/hooks/useTheme", () => ({
+  useGetTheme: jest.fn(),
+}));
 
 beforeAll(() => {
   const tags = array(marketplaceTagFactory, 3)({ subtype: "role" });

--- a/src/components/addBlockModal/AddBlockModal.tsx
+++ b/src/components/addBlockModal/AddBlockModal.tsx
@@ -171,7 +171,7 @@ const AddBlockModal: React.FC = () => {
     isLoading: isLoadingListings,
   } = useGetMarketplaceListingsQuery();
 
-  const { taggedBrickIds, popularBrickIds } = useMemo(
+  const taggedBrickIds = useMemo(
     () => groupListingsByTag(marketplaceTags, listings),
     [marketplaceTags, listings]
   );
@@ -226,7 +226,7 @@ const AddBlockModal: React.FC = () => {
     const regular: BlockOption[] = [];
 
     for (const blockOption of searchResults) {
-      if (popularBrickIds.has(blockOption.blockResult.id)) {
+      if (taggedBrickIds.Popular.has(blockOption.blockResult.id)) {
         // Use immer to keep the class prototype and it's methods. There are downstream calls to runtime/getType which
         // depend on certain methods (e.g., transform, etc.) being present on the brick
         const newOption = produce(blockOption, (draft) => {
@@ -244,7 +244,7 @@ const AddBlockModal: React.FC = () => {
     }
 
     return [...popular, ...regular];
-  }, [popularBrickIds, searchResults, state.query]);
+  }, [searchResults, state.query, taggedBrickIds.Popular]);
 
   const [invalidBlockMessages] = useAsyncState<Map<RegistryId, string>>(
     async () =>

--- a/src/components/addBlockModal/AddBlockModal.tsx
+++ b/src/components/addBlockModal/AddBlockModal.tsx
@@ -62,6 +62,8 @@ import {
 import { getItemKey } from "@/components/addBlockModal/addBlockModalHelpers";
 import useAddBlock from "@/components/addBlockModal/useAddBlock";
 import { useAsyncState } from "@/hooks/common";
+import { useGetTheme } from "@/hooks/useTheme";
+import { AUTOMATION_ANYWHERE_PARTNER_KEY } from "@/services/constants";
 
 type State = {
   query: string;
@@ -184,16 +186,32 @@ const AddBlockModal: React.FC = () => {
       })),
   ];
 
-  const safeAllBlocks = useMemo<IBlock[]>(() => {
-    if (isLoadingAllBlocks || isEmpty(allBlocks)) {
+  const partnerKey = useGetTheme();
+
+  const filteredBlocks = useMemo<IBlock[]>(() => {
+    if (isLoadingAllBlocks || isLoadingTags || isEmpty(allBlocks)) {
       return [];
     }
 
-    return [...allBlocks.values()].map(({ block }) => block);
-  }, [allBlocks, isLoadingAllBlocks]);
+    let typedBlocks = [...allBlocks.values()];
+
+    if (partnerKey === AUTOMATION_ANYWHERE_PARTNER_KEY) {
+      typedBlocks = typedBlocks.filter(
+        (typed) => !taggedBrickIds.UiPath.has(typed.block.id)
+      );
+    }
+
+    return typedBlocks.map(({ block }) => block);
+  }, [
+    allBlocks,
+    isLoadingAllBlocks,
+    isLoadingTags,
+    partnerKey,
+    taggedBrickIds.UiPath,
+  ]);
 
   const searchResults = useBlockSearch(
-    safeAllBlocks,
+    filteredBlocks,
     taggedBrickIds,
     state.query,
     state.searchTag

--- a/src/components/addBlockModal/AddBlockModal.tsx
+++ b/src/components/addBlockModal/AddBlockModal.tsx
@@ -65,6 +65,9 @@ import { useAsyncState } from "@/hooks/common";
 import { useGetTheme } from "@/hooks/useTheme";
 import { AUTOMATION_ANYWHERE_PARTNER_KEY } from "@/services/constants";
 
+const TAG_POPULAR = "Popular";
+const TAG_UIPATH = "UiPath";
+
 type State = {
   query: string;
   searchTag: string;
@@ -197,7 +200,8 @@ const AddBlockModal: React.FC = () => {
 
     if (partnerKey === AUTOMATION_ANYWHERE_PARTNER_KEY) {
       typedBlocks = typedBlocks.filter(
-        (typed) => !taggedBrickIds.UiPath.has(typed.block.id)
+        // eslint-disable-next-line security/detect-object-injection -- constant
+        (typed) => !taggedBrickIds[TAG_UIPATH]?.has(typed.block.id)
       );
     }
 
@@ -207,7 +211,7 @@ const AddBlockModal: React.FC = () => {
     isLoadingAllBlocks,
     isLoadingTags,
     partnerKey,
-    taggedBrickIds.UiPath,
+    taggedBrickIds,
   ]);
 
   const searchResults = useBlockSearch(
@@ -226,7 +230,8 @@ const AddBlockModal: React.FC = () => {
     const regular: BlockOption[] = [];
 
     for (const blockOption of searchResults) {
-      if (taggedBrickIds.Popular?.has(blockOption.blockResult.id)) {
+      // eslint-disable-next-line security/detect-object-injection -- constant
+      if (taggedBrickIds[TAG_POPULAR]?.has(blockOption.blockResult.id)) {
         // Use immer to keep the class prototype and it's methods. There are downstream calls to runtime/getType which
         // depend on certain methods (e.g., transform, etc.) being present on the brick
         const newOption = produce(blockOption, (draft) => {
@@ -244,7 +249,7 @@ const AddBlockModal: React.FC = () => {
     }
 
     return [...popular, ...regular];
-  }, [searchResults, state.query, taggedBrickIds.Popular]);
+  }, [searchResults, state.query, taggedBrickIds]);
 
   const [invalidBlockMessages] = useAsyncState<Map<RegistryId, string>>(
     async () =>

--- a/src/components/addBlockModal/AddBlockModal.tsx
+++ b/src/components/addBlockModal/AddBlockModal.tsx
@@ -226,7 +226,7 @@ const AddBlockModal: React.FC = () => {
     const regular: BlockOption[] = [];
 
     for (const blockOption of searchResults) {
-      if (taggedBrickIds.Popular.has(blockOption.blockResult.id)) {
+      if (taggedBrickIds.Popular?.has(blockOption.blockResult.id)) {
         // Use immer to keep the class prototype and it's methods. There are downstream calls to runtime/getType which
         // depend on certain methods (e.g., transform, etc.) being present on the brick
         const newOption = produce(blockOption, (draft) => {

--- a/src/components/addBlockModal/addBlockModalConstants.ts
+++ b/src/components/addBlockModal/addBlockModalConstants.ts
@@ -17,4 +17,3 @@
 
 export const TAG_ALL = "All Categories";
 export const BLOCK_RESULT_COLUMN_COUNT = 2;
-export const POPULAR_BRICK_TAG_ID = "35367896-b38f-447e-9444-ecfecb258468";

--- a/src/components/addBlockModal/groupListingsByTag.test.ts
+++ b/src/components/addBlockModal/groupListingsByTag.test.ts
@@ -19,14 +19,12 @@ import {
   marketplaceListingFactory,
   marketplaceTagFactory,
 } from "@/testUtils/factories";
-import { POPULAR_BRICK_TAG_ID } from "@/components/addBlockModal/addBlockModalConstants";
 import groupListingsByTag from "@/components/addBlockModal/groupListingsByTag";
 
 describe("groupListingsByTag", () => {
   it("groups tags", () => {
     const popular = marketplaceTagFactory({
       subtype: "generic",
-      id: POPULAR_BRICK_TAG_ID,
       name: "Popular",
     });
     const category = marketplaceTagFactory({ subtype: "role", name: "Other" });
@@ -45,14 +43,11 @@ describe("groupListingsByTag", () => {
       tags: [other],
     });
 
-    const { taggedBrickIds, popularBrickIds } = groupListingsByTag(
-      [popular, other, category],
-      {
-        [popularListing.package.name]: popularListing,
-        [regularListing.package.name]: regularListing,
-        [otherListing.package.name]: otherListing,
-      }
-    );
+    const taggedBrickIds = groupListingsByTag([popular, other, category], {
+      [popularListing.package.name]: popularListing,
+      [regularListing.package.name]: regularListing,
+      [otherListing.package.name]: otherListing,
+    });
 
     expect(taggedBrickIds).toStrictEqual({
       [popular.name]: new Set([popularListing.package.name]),
@@ -62,9 +57,5 @@ describe("groupListingsByTag", () => {
       ]),
       [other.name]: new Set([otherListing.package.name]),
     });
-
-    expect(popularBrickIds).toStrictEqual(
-      new Set([popularListing.package.name])
-    );
   });
 });

--- a/src/components/addBlockModal/groupListingsByTag.test.ts
+++ b/src/components/addBlockModal/groupListingsByTag.test.ts
@@ -36,16 +36,31 @@ describe("groupListingsByTag", () => {
     });
 
     const popularListing = marketplaceListingFactory({
-      tags: [popular, category, other],
+      tags: [popular, category],
+    });
+    const regularListing = marketplaceListingFactory({
+      tags: [category],
+    });
+    const otherListing = marketplaceListingFactory({
+      tags: [other],
     });
 
     const { taggedBrickIds, popularBrickIds } = groupListingsByTag(
       [popular, other, category],
-      { [popularListing.package.name]: popularListing }
+      {
+        [popularListing.package.name]: popularListing,
+        [regularListing.package.name]: regularListing,
+        [otherListing.package.name]: otherListing,
+      }
     );
 
     expect(taggedBrickIds).toStrictEqual({
-      [category.name]: new Set([popularListing.package.name]),
+      [popular.name]: new Set([popularListing.package.name]),
+      [category.name]: new Set([
+        popularListing.package.name,
+        regularListing.package.name,
+      ]),
+      [other.name]: new Set([otherListing.package.name]),
     });
 
     expect(popularBrickIds).toStrictEqual(

--- a/src/components/addBlockModal/groupListingsByTag.ts
+++ b/src/components/addBlockModal/groupListingsByTag.ts
@@ -18,50 +18,40 @@
 import { MarketplaceListing, MarketplaceTag } from "@/types/contract";
 import { RegistryId } from "@/core";
 import { isEmpty } from "lodash";
-import { POPULAR_BRICK_TAG_ID } from "@/components/addBlockModal/addBlockModalConstants";
 
 const EMPTY_TAGGED_BRICK_IDS: Record<string, Set<RegistryId>> = {};
-const EMPTY_POPULAR_BRICK_IDS = new Set<RegistryId>();
 
+/**
+ * Groups marketplace listings by their tags
+ * @param marketplaceTags The tags to use as grouping keys
+ * @param listings The listings to group
+ * @returns Record<string, Set<RegistryId>> A record with the tag names as keys, and sets of listings as the values
+ */
 function groupListingsByTag(
   marketplaceTags: MarketplaceTag[],
   listings: Record<RegistryId, MarketplaceListing>
-): {
-  /**
-   * A record with tag names as the keys, and a set of applicable brick registry ids as the values
-   */
-  taggedBrickIds: Record<string, Set<RegistryId>>;
-
-  /**
-   * A set of brick ids that have been tagged as "popular"
-   */
-  popularBrickIds: Set<RegistryId>;
-} {
+): Record<string, Set<RegistryId>> {
   if (isEmpty(marketplaceTags) || isEmpty(listings)) {
-    return {
-      taggedBrickIds: EMPTY_TAGGED_BRICK_IDS,
-      popularBrickIds: EMPTY_POPULAR_BRICK_IDS,
-    };
+    return EMPTY_TAGGED_BRICK_IDS;
   }
 
+  // Create the Record with tag name keys and empty Set values
   const taggedBrickIds = Object.fromEntries(
     marketplaceTags.map((tag) => [tag.name, new Set<RegistryId>()])
   );
-  const popularBrickIds = new Set<RegistryId>();
 
+  // Populate the Record value Sets with listings that apply to each tag
   for (const [id, listing] of Object.entries(listings)) {
     const registryId = id as RegistryId;
 
     for (const listingTag of listing.tags) {
-      if (listingTag.id === POPULAR_BRICK_TAG_ID) {
-        popularBrickIds.add(registryId);
-      }
-
+      // The null-safe access (.?) here is just for safety in case the api
+      // endpoints for listings and tags get out of sync somehow
       taggedBrickIds[listingTag.name]?.add(registryId);
     }
   }
 
-  return { taggedBrickIds, popularBrickIds };
+  return taggedBrickIds;
 }
 
 export default groupListingsByTag;

--- a/src/components/addBlockModal/groupListingsByTag.ts
+++ b/src/components/addBlockModal/groupListingsByTag.ts
@@ -44,10 +44,8 @@ function groupListingsByTag(
     };
   }
 
-  const categoryTags = marketplaceTags.filter((tag) => tag.subtype === "role");
-
   const taggedBrickIds = Object.fromEntries(
-    categoryTags.map((tag) => [tag.name, new Set<RegistryId>()])
+    marketplaceTags.map((tag) => [tag.name, new Set<RegistryId>()])
   );
   const popularBrickIds = new Set<RegistryId>();
 

--- a/src/components/addBlockModal/groupListingsByTag.ts
+++ b/src/components/addBlockModal/groupListingsByTag.ts
@@ -45,7 +45,7 @@ function groupListingsByTag(
     const registryId = id as RegistryId;
 
     for (const listingTag of listing.tags) {
-      // The null-safe access (.?) here is just for safety in case the api
+      // The null-safe access (?.) here is just for safety in case the api
       // endpoints for listings and tags get out of sync somehow
       taggedBrickIds[listingTag.name]?.add(registryId);
     }

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -100,6 +100,9 @@ jest.mock("@/background/messenger/api", () => ({
 }));
 // Mock to support hook usage in the subtree, not relevant to UI tests here
 jest.mock("@/hooks/useRefresh");
+jest.mock("@/hooks/useTheme", () => ({
+  useGetTheme: jest.fn(),
+}));
 
 jest.setTimeout(30_000); // This test is flaky with the default timeout of 5000 ms
 


### PR DESCRIPTION
## What does this PR do?

- Closes #4289

## Future Work

- Using the tag names as Record keys is sketchy, but alright for now. Keys with spaces and stuff can still be accessed using bracket notation, and we're not hard-coding any tag names with spaces. We should probably refactor the `taggedBrickIds` Record to a different data structure at some point.

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
