### PR TITLE
#4286 Limit sidebar tab header names to one line and ellipsize the text overflow

### DIFF
--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -19,3 +19,9 @@
 .paneOverrides {
   text-align: initial;
 }
+
+.tabHeader {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -81,6 +81,7 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
               <Nav.Link
                 key={panel.extensionId}
                 eventKey={mapTabEventKey("panel", panel)}
+                className={styles.tabHeader}
               >
                 {panel.heading ?? <FontAwesomeIcon icon={faSpinner} />}
               </Nav.Link>
@@ -89,6 +90,7 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
               <Nav.Link
                 key={form.extensionId}
                 eventKey={mapTabEventKey("form", form)}
+                className={styles.tabHeader}
               >
                 {form.form.schema.title ?? "Form"}
               </Nav.Link>


### PR DESCRIPTION
## What does this PR do?

- Closes #4286 

## Demo

Before:
<img width="430" alt="image" src="https://user-images.githubusercontent.com/2801308/191593216-9a6efbe1-a34f-4d57-8cb0-4fe39868b460.png">


After:
<img width="438" alt="image" src="https://user-images.githubusercontent.com/2801308/191592322-8e888a3b-84a5-46aa-8c3f-39ad286e73fd.png">

## Future Work

- Will be followed by #4290 

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
