### PR TITLE
Fix starter blueprint installation bug when user has an installed extension with no _recipe property

### DIFF
--- a/src/background/starterBlueprints.test.ts
+++ b/src/background/starterBlueprints.test.ts
@@ -155,4 +155,35 @@ describe("installStarterBlueprints", () => {
     expect(extensions.length).toBe(1);
     expect(openPlaygroundPage.mock.calls).toHaveLength(0);
   });
+
+  test("extension with no _recipe doesn't throw undefined error", async () => {
+    isLinkedMock.mockResolvedValue(true);
+
+    const recipe = recipeFactory();
+
+    const extension = extensionFactory({
+      _recipe: undefined,
+    }) as PersistedExtension;
+    await saveOptions({
+      extensions: [extension],
+    });
+
+    axiosMock
+      .onGet("/api/onboarding/starter-blueprints/install/")
+      .reply(200, { install_starter_blueprints: true });
+
+    axiosMock.onGet("/api/onboarding/starter-blueprints/").reply(200, [
+      {
+        extensionPoints: [extension],
+        ...recipe,
+      },
+    ]);
+
+    axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
+
+    await firstTimeInstallStarterBlueprints();
+    const { extensions } = await loadOptions();
+
+    expect(extensions.length).toBe(2);
+  });
 });

--- a/src/background/starterBlueprints.test.ts
+++ b/src/background/starterBlueprints.test.ts
@@ -159,8 +159,6 @@ describe("installStarterBlueprints", () => {
   test("extension with no _recipe doesn't throw undefined error", async () => {
     isLinkedMock.mockResolvedValue(true);
 
-    const recipe = recipeFactory();
-
     const extension = extensionFactory({
       _recipe: undefined,
     }) as PersistedExtension;
@@ -172,13 +170,9 @@ describe("installStarterBlueprints", () => {
       .onGet("/api/onboarding/starter-blueprints/install/")
       .reply(200, { install_starter_blueprints: true });
 
-    axiosMock.onGet("/api/onboarding/starter-blueprints/").reply(200, [
-      {
-        extensionPoints: [extension],
-        ...recipe,
-      },
-    ]);
-
+    axiosMock
+      .onGet("/api/onboarding/starter-blueprints/")
+      .reply(200, [recipeFactory()]);
     axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
 
     await firstTimeInstallStarterBlueprints();

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -56,7 +56,7 @@ async function installBlueprints(
   let extensionsState = await loadOptions();
   for (const blueprint of blueprints) {
     const blueprintAlreadyInstalled = extensionsState.extensions.some(
-      (extension) => extension._recipe.id === blueprint.metadata.id
+      (extension) => extension._recipe?.id === blueprint.metadata.id
     );
 
     if (!blueprintAlreadyInstalled) {


### PR DESCRIPTION
## What does this PR do?

- Fixes a bug @orliesaurus was seeing when visiting the Playground page and expecting starter blueprints to install. They were not installing.

## Reviewer Tips

- The added test should clarify the cause of the problem, which was accessing the `id` property on an `undefined` `_recipe`.

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @BLoe 
