### PR TITLE
Fix `openInstallPage` inconsistency

### DIFF
--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -22,6 +22,7 @@ import { getUID } from "@/background/messenger/api";
 import { DNT_STORAGE_KEY, allowsTrack } from "@/telemetry/dnt";
 import { gt } from "semver";
 import { getBaseURL } from "@/services/baseService";
+import { isLinked } from "@/auth/token";
 
 const UNINSTALL_URL = "https://www.pixiebrix.com/uninstall/";
 
@@ -34,30 +35,33 @@ const SERVICE_URL = process.env.SERVICE_URL;
 let _availableVersion: string | null = null;
 
 async function openInstallPage() {
-  const [accountTab] = await browser.tabs.query({
-    url: [
-      new URL("setup", SERVICE_URL).href,
-      new URL("start", SERVICE_URL).href,
-    ],
-  });
+  const [url, [accountTab]] = await Promise.all([
+    getBaseURL(),
+    browser.tabs.query({
+      url: [
+        new URL("setup", SERVICE_URL).href,
+        new URL("start", SERVICE_URL).href,
+      ],
+    }),
+  ]);
 
   if (accountTab) {
     // Automatically reuse the tab that is part of the onboarding flow
     // https://github.com/pixiebrix/pixiebrix-extension/pull/3506
-    await browser.tabs.update(accountTab.id, {
-      url: await getBaseURL(),
-    });
+    await browser.tabs.update(accountTab.id, { url });
   } else {
-    await browser.runtime.openOptionsPage();
+    await browser.tabs.create({ url });
   }
 }
 
-function install({ reason }: Runtime.OnInstalledDetailsType) {
+async function install({ reason }: Runtime.OnInstalledDetailsType) {
   if (reason === "install") {
-    void openInstallPage();
     reportEvent("PixieBrixInstall", {
       version: browser.runtime.getManifest().version,
     });
+    if (!(await isLinked())) {
+      void openInstallPage();
+    }
   } else if (reason === "update") {
     reportEvent("PixieBrixUpdate", {
       version: browser.runtime.getManifest().version,


### PR DESCRIPTION
## What does this PR do?

- Opens the correct install page even if no pixiebrix.com tabs are open
- Avoids opening a new tab when the extension is loaded via `web-ext`

## Checklist


- [x] Designate a primary reviewer: @mnholtz  
