### PR TITLE
Add Storybook stories to PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,4 +35,5 @@ _Leave all that are relevant and check off as completed_
 ## Checklist
 
 - [ ] Add tests
+- [ ] Run Storybook and manually confirm that all stories are working
 - [ ] Designate a primary reviewer


### PR DESCRIPTION
## What does this PR do?

- Closes #2152
- This adds a PR checklist item to manually verify that no Storybook stories were broken from the feature. Unfortunately, we don't have a quick way to add automation to this task at this time because broken Storybook stories compile without errors.

## Discussion

- It sucks to have to verify Storybook stories manually. However, it also sucks that Storybook stories are always breaking and not available when we need them.

## Future Work

- There are broken stories on `main` at the moment. I'm leaving this for another PR so as to get this checklist item in.
- Potentially automating this process? https://github.com/pixiebrix/pixiebrix-extension/issues/2152#issuecomment-1261540166

## Checklist

- [x] Add tests n/a
- [x] Designate a primary reviewer. @twschiller 
