### PR TITLE
#4356: Add MV3 build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,7 @@
         "webext-base-css": "^1.4.1",
         "webext-content-scripts": "^1.0.1",
         "webext-detect-page": "^4.0.1",
-        "webext-dynamic-content-scripts": "^9.0.0-0",
+        "webext-dynamic-content-scripts": "^9.0.0-1",
         "webext-messenger": "^0.21.0-0",
         "webext-patterns": "^1.1.1",
         "webext-polyfill-kinda": "^0.10.0",
@@ -36006,9 +36006,9 @@
       "integrity": "sha512-Y9Skw6/Uj0dGwOIidc1XqZ3neEbmuuT4BlkL/J4JHAo6fVznHIZq6/MWDsPGOA/jnNowiSXtHHh4S/TOxbl6bQ=="
     },
     "node_modules/webext-dynamic-content-scripts": {
-      "version": "9.0.0-0",
-      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-9.0.0-0.tgz",
-      "integrity": "sha512-bjv3Oucuuy1nsEHDVhIiHGTwTACLhKLy1GTHWvxzw2234tsQo7kiTe7Jyh6vnp921nKiAuUnhMZ3t+qbdihc0w==",
+      "version": "9.0.0-1",
+      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-9.0.0-1.tgz",
+      "integrity": "sha512-Il/9I7KLv+kknTboEOW/jCe5sCBBMSstR3CCg/6p0PDAfHqYc86HWMK2HuIDvAhe3vKhsj6mmFpEwbm0rBio5A==",
       "dependencies": {
         "content-scripts-register-polyfill": "^3.2.2",
         "webext-additional-permissions": "^2.3.0",
@@ -63762,9 +63762,9 @@
       "integrity": "sha512-Y9Skw6/Uj0dGwOIidc1XqZ3neEbmuuT4BlkL/J4JHAo6fVznHIZq6/MWDsPGOA/jnNowiSXtHHh4S/TOxbl6bQ=="
     },
     "webext-dynamic-content-scripts": {
-      "version": "9.0.0-0",
-      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-9.0.0-0.tgz",
-      "integrity": "sha512-bjv3Oucuuy1nsEHDVhIiHGTwTACLhKLy1GTHWvxzw2234tsQo7kiTe7Jyh6vnp921nKiAuUnhMZ3t+qbdihc0w==",
+      "version": "9.0.0-1",
+      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-9.0.0-1.tgz",
+      "integrity": "sha512-Il/9I7KLv+kknTboEOW/jCe5sCBBMSstR3CCg/6p0PDAfHqYc86HWMK2HuIDvAhe3vKhsj6mmFpEwbm0rBio5A==",
       "requires": {
         "content-scripts-register-polyfill": "^3.2.2",
         "webext-additional-permissions": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "webext-base-css": "^1.4.1",
     "webext-content-scripts": "^1.0.1",
     "webext-detect-page": "^4.0.1",
-    "webext-dynamic-content-scripts": "^9.0.0-0",
+    "webext-dynamic-content-scripts": "^9.0.0-1",
     "webext-messenger": "^0.21.0-0",
     "webext-patterns": "^1.1.1",
     "webext-polyfill-kinda": "^0.10.0",

--- a/src/background/activeTab.ts
+++ b/src/background/activeTab.ts
@@ -3,12 +3,13 @@
 import { Tabs } from "webextension-polyfill";
 import { updatePageEditor } from "@/pageEditor/messenger/api";
 import { canReceiveContentScript } from "@/utils/permissions";
+import { browserAction } from "@/mv3/api";
 
 type TabId = number;
 type Origin = string;
 export const possiblyActiveTabs = new Map<TabId, Origin>();
 
-function track(tab: Tabs.Tab): void {
+function track(tab: Tabs.Tab | chrome.tabs.Tab): void {
   if (tab.url && canReceiveContentScript(tab.url)) {
     console.debug("ActiveTab added:", tab.id, tab.url);
     possiblyActiveTabs.set(tab.id, new URL(tab.url).origin);
@@ -19,7 +20,7 @@ function track(tab: Tabs.Tab): void {
 }
 
 export default function initActiveTabTracking() {
-  browser.browserAction.onClicked.addListener(track);
+  browserAction.onClicked.addListener(track);
   browser.contextMenus.onClicked.addListener((_, tab) => {
     track(tab);
   });

--- a/src/background/activeTab.ts
+++ b/src/background/activeTab.ts
@@ -1,15 +1,14 @@
 /** @file It's possible that some of these tabs might lose the permission in the meantime, we can't track that exactly */
 
-import { Tabs } from "webextension-polyfill";
 import { updatePageEditor } from "@/pageEditor/messenger/api";
 import { canReceiveContentScript } from "@/utils/permissions";
-import { browserAction } from "@/mv3/api";
+import { browserAction, Tab } from "@/mv3/api";
 
 type TabId = number;
 type Origin = string;
 export const possiblyActiveTabs = new Map<TabId, Origin>();
 
-function track(tab: Tabs.Tab | chrome.tabs.Tab): void {
+function track(tab: Tab): void {
   if (tab.url && canReceiveContentScript(tab.url)) {
     console.debug("ActiveTab added:", tab.id, tab.url);
     possiblyActiveTabs.set(tab.id, new URL(tab.url).origin);

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -22,8 +22,7 @@ import "@/development/autoreload";
 import "@/development/errorsBadge";
 
 // Required for MV3; Service Workers don't have XMLHttpRequest
-// TODO: Disabled due to https://github.com/pixiebrix/pixiebrix-extension/issues/3020
-// import "@/background/axiosFetch";
+import "@/background/axiosFetch";
 
 import "webext-dynamic-content-scripts";
 

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -16,14 +16,13 @@
  */
 
 import { ensureContentScript } from "@/background/util";
-import { Tabs } from "webextension-polyfill";
 import { rehydrateSidebar } from "@/contentScript/messenger/api";
 import { executeScript, isScriptableUrl } from "webext-content-scripts";
 import pMemoize from "p-memoize";
 import webextAlert from "./webextAlert";
 import { isMac } from "@/utils";
 import { notify } from "@/options/messenger/api";
-import { browserAction } from "@/mv3/api";
+import { browserAction, Tab } from "@/mv3/api";
 
 const ERR_UNABLE_TO_OPEN =
   "PixieBrix was unable to open the Sidebar. Try refreshing the page.";
@@ -77,9 +76,7 @@ async function _toggleSidebar(tabId: number, tabUrl: string): Promise<void> {
   });
 }
 
-async function handleBrowserAction(
-  tab: Tabs.Tab | chrome.tabs.Tab
-): Promise<void> {
+async function handleBrowserAction(tab: Tab): Promise<void> {
   // The URL might not be available in certain circumstances. This silences these
   // cases and just treats them as "not allowed on this page"
   const url = String(tab.url);

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -23,6 +23,7 @@ import pMemoize from "p-memoize";
 import webextAlert from "./webextAlert";
 import { isMac } from "@/utils";
 import { notify } from "@/options/messenger/api";
+import { browserAction } from "@/mv3/api";
 
 const ERR_UNABLE_TO_OPEN =
   "PixieBrix was unable to open the Sidebar. Try refreshing the page.";
@@ -76,7 +77,9 @@ async function _toggleSidebar(tabId: number, tabUrl: string): Promise<void> {
   });
 }
 
-async function handleBrowserAction(tab: Tabs.Tab): Promise<void> {
+async function handleBrowserAction(
+  tab: Tabs.Tab | chrome.tabs.Tab
+): Promise<void> {
   // The URL might not be available in certain circumstances. This silences these
   // cases and just treats them as "not allowed on this page"
   const url = String(tab.url);
@@ -96,7 +99,6 @@ async function handleBrowserAction(tab: Tabs.Tab): Promise<void> {
 }
 
 export default function initBrowserAction() {
-  // Handle namespace change between MV2/MV3
-  const action = browser.browserAction ?? browser.action;
-  action.onClicked.addListener(handleBrowserAction);
+  // Handle namespace change between MV2/MV3\
+  browserAction.onClicked.addListener(handleBrowserAction);
 }

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -96,6 +96,5 @@ async function handleBrowserAction(tab: Tab): Promise<void> {
 }
 
 export default function initBrowserAction() {
-  // Handle namespace change between MV2/MV3\
   browserAction.onClicked.addListener(handleBrowserAction);
 }

--- a/src/background/initBrowserCommands.ts
+++ b/src/background/initBrowserCommands.ts
@@ -16,15 +16,13 @@
  */
 
 import { toggleQuickBar } from "@/contentScript/messenger/api";
+import { Tab } from "@/mv3/api";
 import { Target } from "@/types";
 import { expectContext } from "@/utils/expectContext";
 import { canReceiveContentScript } from "@/utils/permissions";
 import { ensureContentScript } from "./util";
 
-async function handleCommand(
-  command: string,
-  tab: chrome.tabs.Tab
-): Promise<void> {
+async function handleCommand(command: string, tab: Tab): Promise<void> {
   if (command !== "toggle-quick-bar" || !canReceiveContentScript(tab.url)) {
     return;
   }
@@ -40,6 +38,5 @@ async function handleCommand(
 
 export default function initBrowserCommands(): void {
   expectContext("background");
-  // TODO: Use browser.* when its types are fixed https://github.com/Lusito/webextension-polyfill-ts/issues/70
-  chrome.commands.onCommand.addListener(handleCommand);
+  browser.commands.onCommand.addListener(handleCommand);
 }

--- a/src/background/partnerTheme.ts
+++ b/src/background/partnerTheme.ts
@@ -19,6 +19,7 @@ import { getSettingsState } from "@/store/settingsStorage";
 import { getThemeLogo } from "@/utils/themeUtils";
 import activateBrowserActionIcon from "@/background/activateBrowserActionIcon";
 import { DEFAULT_THEME } from "@/options/types";
+import { browserAction } from "@/mv3/api";
 
 async function setToolbarIcon(): Promise<void> {
   const { theme } = await getSettingsState();
@@ -29,7 +30,7 @@ async function setToolbarIcon(): Promise<void> {
   }
 
   const themeLogo = getThemeLogo(theme);
-  (chrome.browserAction ?? chrome.action).setIcon({ path: themeLogo.small });
+  browserAction.setIcon({ path: themeLogo.small });
 }
 
 export default function initPartnerTheme() {

--- a/src/contrib/google/initGoogle.ts
+++ b/src/contrib/google/initGoogle.ts
@@ -24,6 +24,7 @@ import { DISCOVERY_DOCS as BIGQUERY_DOCS } from "./bigquery/handlers";
 import { isChrome } from "webext-detect-page";
 import pMemoize from "p-memoize";
 import injectScriptTag from "@/utils/injectScriptTag";
+import { isMV3 } from "@/mv3/api";
 
 declare global {
   interface Window {
@@ -49,7 +50,7 @@ async function onGAPILoad(): Promise<void> {
 }
 
 async function _initGoogle(): Promise<boolean> {
-  if (!isChrome() || browser.runtime.getManifest().manifest_version === 3) {
+  if (!isChrome() || isMV3()) {
     // TODO: Use feature detection instead of sniffing the user agent
     console.info(
       "Google API not enabled because it's not supported by this browser"

--- a/src/contrib/google/initGoogle.ts
+++ b/src/contrib/google/initGoogle.ts
@@ -49,7 +49,7 @@ async function onGAPILoad(): Promise<void> {
 }
 
 async function _initGoogle(): Promise<boolean> {
-  if (!isChrome() || typeof document === "undefined" /* MV3 exclusion */) {
+  if (!isChrome() || browser.runtime.getManifest().manifest_version === 3) {
     // TODO: Use feature detection instead of sniffing the user agent
     console.info(
       "Google API not enabled because it's not supported by this browser"

--- a/src/development/errorsBadge.ts
+++ b/src/development/errorsBadge.ts
@@ -16,19 +16,20 @@
  */
 
 import { getErrorMessage } from "@/errors/errorHelpers";
+import { browserAction } from "@/mv3/api";
 import { uncaughtErrorHandlers } from "@/telemetry/reportUncaughtErrors";
 
 let counter = 0;
 let timer: NodeJS.Timeout;
 
 function updateBadge(errorMessage: string | null): void {
-  void chrome.browserAction.setTitle({
+  void browserAction.setTitle({
     title: errorMessage ?? "Unknown error (no error message provided)",
   });
-  void chrome.browserAction.setBadgeText({
+  void browserAction.setBadgeText({
     text: counter ? String(counter) : undefined,
   });
-  void chrome.browserAction.setBadgeBackgroundColor({ color: "#F00" });
+  void browserAction.setBadgeBackgroundColor({ color: "#F00" });
 }
 
 function backgroundErrorsBadge(_: unknown, error: unknown) {

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -117,11 +117,6 @@ declare module "@/vendors/initialize" {
   export default initialize;
 }
 
-// Missing from TS types, but it's a standard
-interface HTMLDialogElement extends HTMLElement {
-  showModal(): void;
-}
-
 // `useUnknownInCatchVariables` for .catch method https://github.com/microsoft/TypeScript/issues/45602
 interface Promise<T> {
   /**

--- a/src/mv3/api.ts
+++ b/src/mv3/api.ts
@@ -15,10 +15,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { browserAction } from "@/mv3/api";
-
-export default function activateBrowserActionIcon() {
-  // This re-sets the colored manifest icons
-  const { icons: path } = browser.runtime.getManifest();
-  browserAction.setIcon({ path });
-}
+export const browserAction = chrome.browserAction ?? chrome.action;

--- a/src/mv3/api.ts
+++ b/src/mv3/api.ts
@@ -19,5 +19,7 @@
 
 import { Tabs } from "webextension-polyfill";
 
+export const isMV3 = (): boolean =>
+  browser.runtime.getManifest().manifest_version === 3;
 export const browserAction = chrome.browserAction ?? chrome.action;
 export type Tab = Tabs.Tab | chrome.tabs.Tab;

--- a/src/mv3/api.ts
+++ b/src/mv3/api.ts
@@ -15,4 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Tabs } from "webextension-polyfill";
+
 export const browserAction = chrome.browserAction ?? chrome.action;
+export type Tab = Tabs.Tab | chrome.tabs.Tab;

--- a/src/mv3/api.ts
+++ b/src/mv3/api.ts
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/** @file Temporary helpers useful for the MV3 transition */
+
 import { Tabs } from "webextension-polyfill";
 
 export const browserAction = chrome.browserAction ?? chrome.action;

--- a/src/telemetry/reportUncaughtErrors.ts
+++ b/src/telemetry/reportUncaughtErrors.ts
@@ -67,5 +67,5 @@ export const uncaughtErrorHandlers = [ignoreKnownPatterns];
 // When imported, the file will be executed immediately, whereas if it exports
 // an `init` function will be called after every top-level imports (and their deps)
 // has been executed.
-window.addEventListener("error", errorListener);
-window.addEventListener("unhandledrejection", errorListener);
+self.addEventListener("error", errorListener);
+self.addEventListener("unhandledrejection", errorListener);

--- a/src/utils/preventNativeFormSubmission.ts
+++ b/src/utils/preventNativeFormSubmission.ts
@@ -21,13 +21,13 @@
  * https://github.com/pixiebrix/pixiebrix-extension/issues/3879
  * https://github.com/pixiebrix/pixiebrix-extension/issues/4122
  */
-import { isWebPage } from "webext-detect-page";
+import { isBackgroundWorker, isWebPage } from "webext-detect-page";
 
 function preventDefault(event: Event): void {
   event.preventDefault();
   console.debug("The native submission of the form has been prevented");
 }
 
-if (!isWebPage()) {
+if (!isWebPage() && !isBackgroundWorker()) {
   document.addEventListener("submit", preventDefault);
 }


### PR DESCRIPTION
## What does this PR do?

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/4356
- Part of #287
- Continues https://github.com/pixiebrix/pixiebrix-extension/pull/2107
- Includes updates to https://github.com/fregante/webext-dynamic-content-scripts/pull/38

PixieBrix seems to work for the most part. I'm only seeing an issue related to https://github.com/pixiebrix/pixiebrix-extension/issues/4387 and one likely due to the worker recycling. Reloading the extension fixes the latter

## Review tips

Initial failures can only be debugged by checking the first checkbox on this page: 
```
chrome://serviceworker-internals/?devtools
```

## Discussion

The build alters the manifest on request:

```sh
MV=3 nr build
MV=3 nr watch
```

`web-ext` commands are unchanged, the folder is the same.

## Future Work

- Add MV3 artifact in CI?
- https://github.com/pixiebrix/pixiebrix-extension/issues/4387
- https://github.com/pixiebrix/pixiebrix-extension/issues/4358

## Team Coordination

- [x] This PR requires a documentation change: https://github.com/pixiebrix/pixiebrix-extension/wiki/Development-commands

## Checklist

- [x] Designate a primary reviewer: @twschiller 

