### PR TITLE
#4409 Fix bug with non-serializable tab state error being stored in redux

### DIFF
--- a/src/pageEditor/tabState/tabStateTypes.ts
+++ b/src/pageEditor/tabState/tabStateTypes.ts
@@ -52,7 +52,7 @@ export type TabState = {
    * The error connecting to the content script, or undefined.
    * @see connectToContentScript
    */
-  error?: unknown;
+  error: string | null;
 };
 
 export type TabStateRootState = {


### PR DESCRIPTION
## What does this PR do?

- Fixes #4409

## Discussion

- Pretty straightforward, just store the string message not the error object. We were just creating an `Error` with a hard-coded message anyway.

## Checklist

- [ ] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer - @BALEHOK 
