### PR TITLE
Improve Page Editor brick searching by fixing search over `packageId` and `description`

### DIFF
--- a/src/components/addBlockModal/useBlockSearch.ts
+++ b/src/components/addBlockModal/useBlockSearch.ts
@@ -67,7 +67,7 @@ function useBlockSearch(
       (x) => x.label
     );
     const fuse = new Fuse<BlockOption>(blockOptions, {
-      keys: ["label", "data.id", "data.description"],
+      keys: ["label", "blockResult.description", "value"],
     });
 
     return { blockOptions, fuse };


### PR DESCRIPTION
## What does this PR do?

- This is a quick fix, part of https://github.com/pixiebrix/pixiebrix-extension/issues/4404
- I noticed while researching search behavior in the Page Editor that the keys used to initialize our fuzzy search algorithm don't match the shape of the actual data `BlockOption`. This was causing search results to only be conducted over the `label`, not the `packageId` or the `description`, as we had intended. Fixing this actually makes some improvements to problems we were seeing with search experiences in the past, like:
    - the search term _**automation anywhere**_ not producing Automation Anywhere brick results
    - the search term _**jq**_ producing the actual jq brick matching as the second search result, rather than first
    
## Discussion

- Search results that match the query string over all three keys, `packageId`, `label`, and `description`, will be scored higher than those that only match with one key
- This fix helps with the AA brick searching in particular because now the `packageId` is getting hit, many (or all?) of which have `automation-anywhere` in the id

## Demo

Before/after for the search term _**translate**_
<img width="865" alt="Screen Shot 2022-10-06 at 5 27 39 PM" src="https://user-images.githubusercontent.com/36575242/194441911-e3cebf7d-9fa9-4eb5-bc63-a69a1ec2188c.png">
<img width="861" alt="Screen Shot 2022-10-06 at 5 28 32 PM" src="https://user-images.githubusercontent.com/36575242/194441915-c2128233-0600-4a50-9b74-835958ccccb9.png">

Before/after for the search term **_automation anywhere_**

<img width="860" alt="Screen Shot 2022-10-06 at 5 25 03 PM" src="https://user-images.githubusercontent.com/36575242/194441962-1092d4ae-f1d0-4106-b51f-b64d418d18c9.png">

<img width="866" alt="Screen Shot 2022-10-06 at 5 28 08 PM" src="https://user-images.githubusercontent.com/36575242/194441978-ff5eb6b5-640b-4e69-b486-99db392b3e22.png">

Before/after for the search term **_jq_**
<img width="858" alt="Screen Shot 2022-10-06 at 5 25 17 PM" src="https://user-images.githubusercontent.com/36575242/194441999-0bee314b-f680-42d4-a14b-4d476ab39b26.png">
<img width="857" alt="Screen Shot 2022-10-06 at 5 28 16 PM" src="https://user-images.githubusercontent.com/36575242/194442010-38c9a16b-73bd-4bb7-be83-c809ae526af1.png">

## Checklist

- [ ] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [ ] Designate a primary reviewer @BLoe 
