### PR TITLE
#1640: Turn SelectorSelectorWidget into a modal

### DIFF
--- a/src/pageEditor/components/Centered.tsx
+++ b/src/pageEditor/components/Centered.tsx
@@ -22,10 +22,11 @@ import cx from "classnames";
 const Centered: React.FunctionComponent<{
   isScrollable?: boolean;
   vertically?: boolean;
-}> = ({ isScrollable = false, vertically = false, children }) => (
+  className?: string;
+}> = ({ isScrollable = false, vertically = false, className, children }) => (
   <Container
     fluid
-    className={cx({
+    className={cx(className, {
       "h-100 pb-2 overflow-auto": isScrollable,
       "h-100": vertically,
     })}

--- a/src/pageEditor/fields/SelectorSelectorWidget.module.scss
+++ b/src/pageEditor/fields/SelectorSelectorWidget.module.scss
@@ -17,10 +17,6 @@
 .root {
   display: flex;
   align-items: stretch;
-  button {
-    border-bottom-right-radius: 0;
-    border-top-right-radius: 0;
-  }
   input {
     border-left: none;
     border-bottom-left-radius: 0;
@@ -29,4 +25,17 @@
   [role="combobox"] {
     flex-grow: 1;
   }
+}
+
+.selectButton {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.overlay {
+  position: fixed;
+  display: flex;
+  z-index: 1000;
+  inset: 0;
+  background: white;
 }

--- a/src/pageEditor/fields/SelectorSelectorWidget.test.tsx
+++ b/src/pageEditor/fields/SelectorSelectorWidget.test.tsx
@@ -15,8 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import React from "react";
 import { ElementInfo } from "@/contentScript/nativeEditor/types";
-import { getSuggestionsForElement } from "./SelectorSelectorWidget";
+import SelectorSelectorWidget, {
+  getSuggestionsForElement,
+} from "./SelectorSelectorWidget";
+import { render } from "@/pageEditor/testHelpers";
 
 test("getSuggestionsForElement", () => {
   const elementInfo = {
@@ -35,4 +39,14 @@ test("getSuggestionsForElement", () => {
     { value: ".a" },
     { value: "a" },
   ]);
+});
+
+describe("SelectorSelectorWidget", () => {
+  test("render base widget", () => {
+    expect(
+      render(<SelectorSelectorWidget name="Test" />, {
+        initialValues: {},
+      }).asFragment()
+    ).toMatchSnapshot();
+  });
 });

--- a/src/pageEditor/fields/SelectorSelectorWidget.tsx
+++ b/src/pageEditor/fields/SelectorSelectorWidget.tsx
@@ -228,11 +228,24 @@ const SelectorSelectorWidget: React.FC<SelectorSelectorProps> = ({
   return (
     // Do not replace this with `InputGroup` because that requires too many style overrides #2658 #2835
     <div className={styles.root}>
+      {isSelecting && (
+        <div className={styles.overlay}>
+          <button
+            className="btn btn-info m-auto"
+            onClick={() => {
+              setSelecting(false);
+            }}
+          >
+            Cancel selection
+          </button>
+        </div>
+      )}
       <Button
         onClick={select}
         disabled={isSelecting || disabled}
         variant="info"
         aria-label="Select element"
+        className={styles.selectButton}
       >
         <FontAwesomeIcon icon={faMousePointer} />
       </Button>

--- a/src/pageEditor/fields/__snapshots__/SelectorSelectorWidget.test.tsx.snap
+++ b/src/pageEditor/fields/__snapshots__/SelectorSelectorWidget.test.tsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SelectorSelectorWidget render base widget 1`] = `
+<DocumentFragment>
+  <form
+    action="#"
+  >
+    <div
+      class="root"
+    >
+      <button
+        aria-label="Select element"
+        class="selectButton btn btn-info"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-mouse-pointer fa-w-10 "
+          data-icon="mouse-pointer"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 320 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M302.189 329.126H196.105l55.831 135.993c3.889 9.428-.555 19.999-9.444 23.999l-49.165 21.427c-9.165 4-19.443-.571-23.332-9.714l-53.053-129.136-86.664 89.138C18.729 472.71 0 463.554 0 447.977V18.299C0 1.899 19.921-6.096 30.277 5.443l284.412 292.542c11.472 11.179 3.007 31.141-12.5 31.141z"
+            fill="currentColor"
+          />
+        </svg>
+      </button>
+      <div
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-owns="react-autowhatever-1"
+        role="combobox"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-controls="react-autowhatever-1"
+          autocomplete="off"
+          class="form-control input notClearable"
+          placeholder="Choose a selector..."
+          type="search"
+          value=""
+        />
+        <div
+          class="dropdown"
+          id="react-autowhatever-1"
+          role="listbox"
+        />
+      </div>
+    </div>
+    <button
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -710,7 +710,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                       >
                         <button
                           aria-label="Select element"
-                          class="btn btn-info"
+                          class="selectButton btn btn-info"
                           disabled=""
                           type="button"
                         >


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/1640
- Similar problem and solution as https://github.com/pixiebrix/pixiebrix-extension/issues/2783

This is a simple solution to this issue, it matches the experience offered by the initial "Add -> Button" feature:

## Add -> Button feature (pre-existing)

![gif](https://user-images.githubusercontent.com/1402241/195785303-0637add5-91b5-495d-9dcb-46ef8c5589f3.gif)

## SelectorSelectorWidget (This PR)

https://user-images.githubusercontent.com/1402241/195785491-73afe016-8c05-4d7e-9b79-5bd6b73f5783.mov


## Future Work

- [ ] Match style/wording of `InsertMenuItemPane` or merge into single component
- [ ] Move the multi-selector picker into this new overlay (avoids style conflicts + moves the focus back into the editor)
- [ ] https://github.com/pixiebrix/pixiebrix-extension/issues/3942#issuecomment-1236172382

Also:

- [ ] Rename to `SelectorPickerWidget`

## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @jcforest 
