### PR TITLE
Don't show error when user stops the element picker

### DIFF
--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -28,7 +28,7 @@ import {
   getErrorMessage,
   hasSpecificErrorCause,
   IGNORED_ERROR_PATTERNS,
-  isContextError,
+  isSpecificError,
 } from "@/errors/errorHelpers";
 import { expectContext, forbidContext } from "@/utils/expectContext";
 import { matchesAnyPattern } from "@/utils";
@@ -37,6 +37,7 @@ import {
   selectExtraContext,
 } from "@/services/errorService";
 import { BusinessError } from "@/errors/businessErrors";
+import { ContextError } from "@/errors/genericErrors";
 
 const STORAGE_KEY = "LOG";
 const ENTRY_OBJECT_STORE = "entries";
@@ -209,7 +210,7 @@ function flattenContext(
   error: Error | SerializedError,
   context: MessageContext
 ): MessageContext {
-  if (isContextError(error)) {
+  if (isSpecificError(error, ContextError)) {
     const currentContext =
       typeof error.context === "object" ? error.context : {};
     const innerContext = flattenContext(

--- a/src/contentScript/nativeEditor/elementPicker.ts
+++ b/src/contentScript/nativeEditor/elementPicker.ts
@@ -31,6 +31,7 @@ import {
   SelectionHandlerType,
   showSelectionToolPopover,
 } from "@/components/selectionToolPopover/SelectionToolPopover";
+import { CancelError } from "@/errors/businessErrors";
 
 let overlay: Overlay | null = null;
 let expandOverlay: Overlay | null = null;
@@ -271,7 +272,7 @@ export async function userSelectElement({
 
     function cancel() {
       stopInspectingNative();
-      reject(new Error("Selection cancelled"));
+      reject(new CancelError("Selection cancelled"));
     }
 
     function registerListenersOnWindow(window: Window) {

--- a/src/errors/errorHelpers.ts
+++ b/src/errors/errorHelpers.ts
@@ -19,7 +19,6 @@ import { deserializeError, ErrorObject } from "serialize-error";
 import { isObject, smartAppendPeriod } from "@/utils";
 import safeJsonStringify from "json-stringify-safe";
 import { truncate } from "lodash";
-import type { ContextError } from "@/errors/genericErrors";
 import {
   isAxiosError,
   selectNetworkErrorMessage,
@@ -73,10 +72,6 @@ export const IGNORED_ERROR_PATTERNS = [
 export function isErrorObject(error: unknown): error is ErrorObject {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a type guard function and it uses ?.
   return typeof (error as any)?.message === "string";
-}
-
-export function isContextError(error: unknown): error is ContextError {
-  return isErrorObject(error) && error.name === "ContextError";
 }
 
 export function isSpecificError<

--- a/src/errors/networkErrorHelpers.ts
+++ b/src/errors/networkErrorHelpers.ts
@@ -29,17 +29,13 @@ export type SerializableAxiosError = Except<AxiosError, "toJSON">;
 
 // Copy of axios.isAxiosError, without risking to import the whole untreeshakeable axios library
 export function isAxiosError(error: unknown): error is SerializableAxiosError {
-  if (
+  return (
     isObject(error) &&
     // To deal with original AxiosError as well as a serialized error
     // we check 'isAxiosError' property for a non-serialized Error and 'name' for serialized object
     // Related issue to revisit RTKQ error handling: https://github.com/pixiebrix/pixiebrix-extension/issues/4032
     (Boolean(error.isAxiosError) || error.name === "AxiosError")
-  ) {
-    return true;
-  }
-
-  return false;
+  );
 }
 
 export const NO_INTERNET_MESSAGE =

--- a/src/pageEditor/fields/SelectorSelectorWidget.tsx
+++ b/src/pageEditor/fields/SelectorSelectorWidget.tsx
@@ -42,6 +42,7 @@ import { SettingsState } from "@/store/settingsTypes";
 
 // eslint-disable-next-line import/no-restricted-paths -- Not ideal, but webpack should be able to treeshake the file. Maybe move to @/utils ?
 import { sortBySelector } from "@/contentScript/nativeEditor/selectorInference";
+import { getErrorMessage } from "@/errors/errorHelpers";
 
 interface ElementSuggestion extends SuggestionTypeBase {
   value: string;
@@ -198,6 +199,10 @@ const SelectorSelectorWidget: React.FC<SelectorSelectorProps> = ({
       console.debug("Setting selector", { selected, firstSelector });
       setValue(firstSelector);
     } catch (error) {
+      if (getErrorMessage(error) === "Selection cancelled") {
+        return;
+      }
+
       notify.error({
         message: "Error selecting element",
         error,

--- a/src/pageEditor/fields/SelectorSelectorWidget.tsx
+++ b/src/pageEditor/fields/SelectorSelectorWidget.tsx
@@ -42,7 +42,8 @@ import { SettingsState } from "@/store/settingsTypes";
 
 // eslint-disable-next-line import/no-restricted-paths -- Not ideal, but webpack should be able to treeshake the file. Maybe move to @/utils ?
 import { sortBySelector } from "@/contentScript/nativeEditor/selectorInference";
-import { isErrorObject } from "@/errors/errorHelpers";
+import { isSpecificError } from "@/errors/errorHelpers";
+import { CancelError } from "@/errors/businessErrors";
 
 interface ElementSuggestion extends SuggestionTypeBase {
   value: string;
@@ -199,7 +200,7 @@ const SelectorSelectorWidget: React.FC<SelectorSelectorProps> = ({
       console.debug("Setting selector", { selected, firstSelector });
       setValue(firstSelector);
     } catch (error) {
-      if (isErrorObject(error) && error.name === "CancelError") {
+      if (isSpecificError(error, CancelError)) {
         return;
       }
 

--- a/src/pageEditor/fields/SelectorSelectorWidget.tsx
+++ b/src/pageEditor/fields/SelectorSelectorWidget.tsx
@@ -42,7 +42,6 @@ import { SettingsState } from "@/store/settingsTypes";
 
 // eslint-disable-next-line import/no-restricted-paths -- Not ideal, but webpack should be able to treeshake the file. Maybe move to @/utils ?
 import { sortBySelector } from "@/contentScript/nativeEditor/selectorInference";
-import { CancelError } from "@/errors/businessErrors";
 import { isErrorObject } from "@/errors/errorHelpers";
 
 interface ElementSuggestion extends SuggestionTypeBase {

--- a/src/pageEditor/fields/SelectorSelectorWidget.tsx
+++ b/src/pageEditor/fields/SelectorSelectorWidget.tsx
@@ -42,7 +42,8 @@ import { SettingsState } from "@/store/settingsTypes";
 
 // eslint-disable-next-line import/no-restricted-paths -- Not ideal, but webpack should be able to treeshake the file. Maybe move to @/utils ?
 import { sortBySelector } from "@/contentScript/nativeEditor/selectorInference";
-import { getErrorMessage } from "@/errors/errorHelpers";
+import { CancelError } from "@/errors/businessErrors";
+import { isErrorObject } from "@/errors/errorHelpers";
 
 interface ElementSuggestion extends SuggestionTypeBase {
   value: string;
@@ -199,7 +200,7 @@ const SelectorSelectorWidget: React.FC<SelectorSelectorProps> = ({
       console.debug("Setting selector", { selected, firstSelector });
       setValue(firstSelector);
     } catch (error) {
-      if (getErrorMessage(error) === "Selection cancelled") {
+      if (isErrorObject(error) && error.name === "CancelError") {
         return;
       }
 

--- a/src/pageEditor/hooks/useAddElement.ts
+++ b/src/pageEditor/hooks/useAddElement.ts
@@ -20,7 +20,7 @@ import { useCallback } from "react";
 import notify from "@/utils/notify";
 import { actions } from "@/pageEditor/slices/editorSlice";
 import { internalExtensionPointMetaFactory } from "@/pageEditor/extensionPoints/base";
-import { getErrorMessage } from "@/errors/errorHelpers";
+import { getErrorMessage, isErrorObject } from "@/errors/errorHelpers";
 import { ElementConfig } from "@/pageEditor/extensionPoints/elementConfig";
 import { getCurrentURL, thisTab } from "@/pageEditor/utils";
 import { updateDynamicElement } from "@/contentScript/messenger/api";
@@ -29,6 +29,7 @@ import useFlags from "@/hooks/useFlags";
 import { FormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { selectFrameState } from "@/pageEditor/tabState/tabStateSelectors";
 import { reportEvent } from "@/telemetry/events";
+import { CancelError } from "@/errors/businessErrors";
 
 type AddElement = (config: ElementConfig) => void;
 
@@ -83,7 +84,7 @@ function useAddElement(): AddElement {
           type: config.elementType,
         });
       } catch (error) {
-        if (getErrorMessage(error) === "Selection cancelled") {
+        if (isErrorObject(error) && error.name === "CancelError") {
           return;
         }
 

--- a/src/pageEditor/hooks/useAddElement.ts
+++ b/src/pageEditor/hooks/useAddElement.ts
@@ -20,7 +20,7 @@ import { useCallback } from "react";
 import notify from "@/utils/notify";
 import { actions } from "@/pageEditor/slices/editorSlice";
 import { internalExtensionPointMetaFactory } from "@/pageEditor/extensionPoints/base";
-import { isErrorObject } from "@/errors/errorHelpers";
+import { isSpecificError } from "@/errors/errorHelpers";
 import { ElementConfig } from "@/pageEditor/extensionPoints/elementConfig";
 import { getCurrentURL, thisTab } from "@/pageEditor/utils";
 import { updateDynamicElement } from "@/contentScript/messenger/api";
@@ -29,6 +29,7 @@ import useFlags from "@/hooks/useFlags";
 import { FormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { selectFrameState } from "@/pageEditor/tabState/tabStateSelectors";
 import { reportEvent } from "@/telemetry/events";
+import { CancelError } from "@/errors/businessErrors";
 
 type AddElement = (config: ElementConfig) => void;
 
@@ -83,7 +84,7 @@ function useAddElement(): AddElement {
           type: config.elementType,
         });
       } catch (error) {
-        if (isErrorObject(error) && error.name === "CancelError") {
+        if (isSpecificError(error, CancelError)) {
           return;
         }
 

--- a/src/pageEditor/hooks/useAddElement.ts
+++ b/src/pageEditor/hooks/useAddElement.ts
@@ -20,7 +20,7 @@ import { useCallback } from "react";
 import notify from "@/utils/notify";
 import { actions } from "@/pageEditor/slices/editorSlice";
 import { internalExtensionPointMetaFactory } from "@/pageEditor/extensionPoints/base";
-import { getErrorMessage, isErrorObject } from "@/errors/errorHelpers";
+import { isErrorObject } from "@/errors/errorHelpers";
 import { ElementConfig } from "@/pageEditor/extensionPoints/elementConfig";
 import { getCurrentURL, thisTab } from "@/pageEditor/utils";
 import { updateDynamicElement } from "@/contentScript/messenger/api";
@@ -29,7 +29,6 @@ import useFlags from "@/hooks/useFlags";
 import { FormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { selectFrameState } from "@/pageEditor/tabState/tabStateSelectors";
 import { reportEvent } from "@/telemetry/events";
-import { CancelError } from "@/errors/businessErrors";
 
 type AddElement = (config: ElementConfig) => void;
 

--- a/src/pageEditor/tabState/tabStateSlice.ts
+++ b/src/pageEditor/tabState/tabStateSlice.ts
@@ -17,14 +17,14 @@
 
 import pTimeout from "p-timeout";
 import { FrameworkMeta } from "@/messaging/constants";
-import { getErrorMessage, isErrorObject } from "@/errors/errorHelpers";
+import { getErrorMessage, isSpecificError } from "@/errors/errorHelpers";
 import reportError from "@/telemetry/reportError";
 import { uuidv4 } from "@/types/helpers";
 import { thisTab } from "@/pageEditor/utils";
 import { detectFrameworks } from "@/contentScript/messenger/api";
 import { ensureContentScript } from "@/background/messenger/api";
 import { canAccessTab } from "webext-tools";
-import { sleep } from "@/utils";
+import { sleep, TimeoutError } from "@/utils";
 import { onContextInvalidated } from "@/errors/contextInvalidated";
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import {
@@ -77,10 +77,9 @@ const connectToContentScript = createAsyncThunk<
   try {
     await contentScript;
   } catch (error) {
-    const errorMessage =
-      isErrorObject(error) && error.name === "TimeoutError"
-        ? "The Page Editor could not establish a connection to the content script"
-        : getErrorMessage(error);
+    const errorMessage = isSpecificError(error, TimeoutError)
+      ? "The Page Editor could not establish a connection to the content script"
+      : getErrorMessage(error);
     reportError(error);
     throw new Error(errorMessage, { cause: error });
   }

--- a/src/services/serviceUtils.ts
+++ b/src/services/serviceUtils.ts
@@ -26,7 +26,8 @@ import {
 import { services } from "@/background/messenger/api";
 import { pickBy } from "lodash";
 import { resolveObj } from "@/utils";
-import { isErrorLike } from "serialize-error";
+import { isSpecificError } from "@/errors/errorHelpers";
+import { MissingConfigurationError } from "@/errors/businessErrors";
 
 export const SERVICE_FIELD_REFS = [
   "https://app.pixiebrix.com/schemas/service#/definitions/configuredServiceOrVar",
@@ -66,11 +67,7 @@ export async function locateWithRetry(
   try {
     return await services.locate(serviceId, authId);
   } catch (error) {
-    if (
-      retry &&
-      isErrorLike(error) &&
-      error.name === "MissingConfigurationError"
-    ) {
+    if (retry && isSpecificError(error, MissingConfigurationError)) {
       // Retry
     } else {
       throw error;


### PR DESCRIPTION
## What does this PR do?

- Stops showing an error when the user cancels an element selection

## Discussion

This matches existing behavior in `useAddElement`:

https://github.com/pixiebrix/pixiebrix-extension/blob/e60ad1ad95f8ac7bda6f0bf4377dbf5bd0ffb2f5/src/pageEditor/hooks/useAddElement.ts#L85-L93

## Before

![gif](https://user-images.githubusercontent.com/1402241/195788434-dd1e033f-6eb0-4ceb-a639-7467dedc4033.gif)

## After

![gif](https://user-images.githubusercontent.com/1402241/195788332-8c89b109-63c8-4968-9234-42330992ca9f.gif)


## Checklist

- [x] Designate a primary reviewer: @jcforest 


## Related

- https://github.com/pixiebrix/pixiebrix-extension/pull/4451