### PR TITLE
#3513: Avoid repeating dropdown labels in Blueprints

### DIFF
--- a/src/options/pages/blueprints/BlueprintsCard.tsx
+++ b/src/options/pages/blueprints/BlueprintsCard.tsx
@@ -158,25 +158,23 @@ const BlueprintsCard: React.FunctionComponent<{
         <BlueprintsToolbar tableInstance={tableInstance} />
         {/* This wrapper prevents AutoSizer overflow in a flex box container */}
         <div style={{ flex: "1 1 auto" }}>
-          <AutoSizer defaultHeight={500}>
-            {({ height, width }) =>
-              isLoading ? (
-                <div style={{ height: `${height}px`, width: `${width}px` }}>
-                  <Card>
-                    <Card.Body>
-                      <Loader />
-                    </Card.Body>
-                  </Card>
-                </div>
-              ) : (
+          {isLoading ? (
+            <Card>
+              <Card.Body>
+                <Loader />
+              </Card.Body>
+            </Card>
+          ) : (
+            <AutoSizer defaultHeight={500}>
+              {({ height, width }) => (
                 <BlueprintsView
                   tableInstance={tableInstance}
                   width={width}
                   height={height}
                 />
-              )
-            }
-          </AutoSizer>
+              )}
+            </AutoSizer>
+          )}
         </div>
       </Col>
     </BootstrapRow>

--- a/src/options/pages/blueprints/BlueprintsCard.tsx
+++ b/src/options/pages/blueprints/BlueprintsCard.tsx
@@ -17,7 +17,7 @@
 
 import styles from "./BlueprintsCard.module.scss";
 
-import { Col, Row as BootstrapRow } from "react-bootstrap";
+import { Card, Col, Row as BootstrapRow } from "react-bootstrap";
 import React, { useMemo } from "react";
 import {
   Column,
@@ -158,19 +158,25 @@ const BlueprintsCard: React.FunctionComponent<{
         <BlueprintsToolbar tableInstance={tableInstance} />
         {/* This wrapper prevents AutoSizer overflow in a flex box container */}
         <div style={{ flex: "1 1 auto" }}>
-          {isLoading ? (
-            <Loader />
-          ) : (
-            <AutoSizer defaultHeight={500}>
-              {({ height, width }) => (
+          <AutoSizer defaultHeight={500}>
+            {({ height, width }) =>
+              isLoading ? (
+                <div style={{ height: `${height}px`, width: `${width}px` }}>
+                  <Card>
+                    <Card.Body>
+                      <Loader />
+                    </Card.Body>
+                  </Card>
+                </div>
+              ) : (
                 <BlueprintsView
                   tableInstance={tableInstance}
                   width={width}
                   height={height}
                 />
-              )}
-            </AutoSizer>
-          )}
+              )
+            }
+          </AutoSizer>
         </div>
       </Col>
     </BootstrapRow>

--- a/src/options/pages/blueprints/BlueprintsToolbar.tsx
+++ b/src/options/pages/blueprints/BlueprintsToolbar.tsx
@@ -97,7 +97,6 @@ const BlueprintsToolbar: React.FunctionComponent<{
     <div className="d-flex justify-content-between align-items-center mb-3">
       <h3 className={styles.filterTitle}>{tabContentTitle}</h3>
       <span className="d-flex align-items-center small">
-        <span className="ml-3 mr-2">Group by:</span>
         <Select
           isClearable
           placeholder="Group by"
@@ -107,10 +106,16 @@ const BlueprintsToolbar: React.FunctionComponent<{
             setGroupBy(value);
           }}
           value={groupByOptions.find((opt) => opt.value === groupBy[0])}
+          formatOptionLabel={({ label }, { context }) => (
+            <>
+              {context === "value" && <strong>Group by: </strong>}
+              {label}
+            </>
+          )}
         />
 
-        <span className="ml-3 mr-2">Sort by:</span>
         <Select
+          className="ml-3"
           isClearable
           placeholder="Sort by"
           options={sortByOptions}
@@ -120,6 +125,12 @@ const BlueprintsToolbar: React.FunctionComponent<{
             setSortBy(value);
           }}
           value={sortByOptions.find((opt) => opt.value === sortBy[0]?.id)}
+          formatOptionLabel={({ label }, { context }) => (
+            <>
+              {context === "value" && <strong>Sort by: </strong>}
+              {label}
+            </>
+          )}
         />
 
         {isSorted && (

--- a/src/options/pages/blueprints/BlueprintsToolbar.tsx
+++ b/src/options/pages/blueprints/BlueprintsToolbar.tsx
@@ -98,6 +98,7 @@ const BlueprintsToolbar: React.FunctionComponent<{
       <h3 className={styles.filterTitle}>{tabContentTitle}</h3>
       <span className="d-flex align-items-center small">
         <Select
+          className="ml-2"
           isClearable
           placeholder="Group by"
           options={groupByOptions}

--- a/src/options/pages/blueprints/Status.tsx
+++ b/src/options/pages/blueprints/Status.tsx
@@ -82,7 +82,7 @@ const Status: React.VoidFunctionComponent<{
   }
 
   return (
-    <div className="text-success w-100">
+    <div className="text-success">
       <div className={styles.root}>
         <FontAwesomeIcon icon={faCheck} />
         <span className={styles.textStatus}>

--- a/src/options/pages/blueprints/Status.tsx
+++ b/src/options/pages/blueprints/Status.tsx
@@ -65,7 +65,7 @@ const Status: React.VoidFunctionComponent<{
 
   if (status === "Paused") {
     return (
-      <div className="text-muted w-100">
+      <div className="text-muted">
         <div className={styles.root}>
           <FontAwesomeIcon icon={faPause} />
           <span className={styles.textStatus}>

--- a/src/options/pages/blueprints/__snapshots__/BlueprintsCard.test.tsx.snap
+++ b/src/options/pages/blueprints/__snapshots__/BlueprintsCard.test.tsx.snap
@@ -212,11 +212,6 @@ exports[`BlueprintsCard renders 1`] = `
         <span
           class="d-flex align-items-center small"
         >
-          <span
-            class="ml-3 mr-2"
-          >
-            Group by:
-          </span>
           <div
             class=" css-b62m3t-container"
           >
@@ -291,13 +286,8 @@ exports[`BlueprintsCard renders 1`] = `
               </div>
             </div>
           </div>
-          <span
-            class="ml-3 mr-2"
-          >
-            Sort by:
-          </span>
           <div
-            class=" css-b62m3t-container"
+            class="ml-3 css-b62m3t-container"
           >
             <span
               class="css-1f43avz-a11yText-A11yText"

--- a/src/options/pages/blueprints/__snapshots__/BlueprintsCard.test.tsx.snap
+++ b/src/options/pages/blueprints/__snapshots__/BlueprintsCard.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`BlueprintsCard renders 1`] = `
           class="d-flex align-items-center small"
         >
           <div
-            class=" css-b62m3t-container"
+            class="ml-2 css-b62m3t-container"
           >
             <span
               class="css-1f43avz-a11yText-A11yText"

--- a/src/options/pages/blueprints/listView/ListItem.module.scss
+++ b/src/options/pages/blueprints/listView/ListItem.module.scss
@@ -84,7 +84,6 @@
 .status {
   padding: 0 20px;
   display: flex;
-  justify-content: center;
-  flex-basis: 150px;
+  flex-basis: 130px;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## What does this PR do?

- Avoids repetition
- Avoids unnecessary wrapping in tighter windows
- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/3513

## Before/after pairs

<img width="582" alt="Screen Shot 20" src="https://user-images.githubusercontent.com/1402241/195821100-114b7415-6be9-4843-9086-6e1d11b68822.png"><img width="582" alt="Screen Shot 25" src="https://user-images.githubusercontent.com/1402241/195821123-9afb2d7b-ee04-47a9-8427-3532c8e2378e.png">

<img width="644" alt="Screen Shot 18" src="https://user-images.githubusercontent.com/1402241/195820422-69b9a6d2-703c-447a-8c86-d4cee8605786.png"><img width="644" alt="Screen Shot 14" src="https://user-images.githubusercontent.com/1402241/195820475-e17b32fa-d599-448d-84e9-9ffb8e508ed3.png">

<img width="644" alt="Screen Shot 19" src="https://user-images.githubusercontent.com/1402241/195820409-be46262b-f0ee-46a3-aad6-7941178d6e11.png"><img width="644" alt="Screen Shot 15" src="https://user-images.githubusercontent.com/1402241/195820467-4983a6b5-dbee-4860-af34-453248696ba4.png">

<img width="644" alt="Screen Shot 17" src="https://user-images.githubusercontent.com/1402241/195820428-84cc5cf7-fefb-434d-9af7-32ec9b14baf0.png"><img width="644" alt="Screen Shot 16" src="https://user-images.githubusercontent.com/1402241/195820480-0859847a-73e2-4070-b9c8-d5313fd47637.png">

## Checklist

- [x] https://github.com/pixiebrix/pixiebrix-extension/issues/4456
- [x] Designate a primary reviewer: @mnholtz 
