### PR TITLE
#3513: Align icons in Blueprints sidebar

### DIFF
--- a/src/options/pages/blueprints/ListFilters.module.scss
+++ b/src/options/pages/blueprints/ListFilters.module.scss
@@ -6,4 +6,8 @@
     font-size: 0.8rem;
     color: #bba8bff5;
   }
+
+  :global .nav-link {
+    padding-inline: 0.7rem; // Reduce horizontal padding
+  }
 }

--- a/src/options/pages/blueprints/ListFilters.tsx
+++ b/src/options/pages/blueprints/ListFilters.tsx
@@ -1,6 +1,6 @@
 import styles from "./ListFilters.module.scss";
 
-import { Col, Form, Nav } from "react-bootstrap";
+import { Col, Form, Nav, NavLinkProps } from "react-bootstrap";
 import React, { useEffect, useState } from "react";
 import useReduxState from "@/hooks/useReduxState";
 import { selectActiveTab } from "./blueprintsSelectors";
@@ -20,6 +20,10 @@ import { TableInstance } from "react-table";
 import { InstallableViewItem } from "@/options/pages/blueprints/blueprintsTypes";
 import useFlags from "@/hooks/useFlags";
 import { useGetMeQuery, useGetStarterBlueprintsQuery } from "@/services/api";
+import { IconProp } from "@fortawesome/fontawesome-svg-core";
+
+// eslint-disable-next-line no-restricted-imports -- Type only
+import type { BsPrefixRefForwardingComponent } from "react-bootstrap/esm/helpers";
 
 type ListFiltersProps = {
   teamFilters: string[];
@@ -65,6 +69,16 @@ export const BLUEPRINTS_PAGE_TABS: BlueprintTabMap = {
     filters: [],
   },
 };
+
+const ListItem: BsPrefixRefForwardingComponent<
+  "a",
+  NavLinkProps & { label: string; icon: IconProp }
+> = ({ label, icon, ...otherProps }) => (
+  <Nav.Link className="media" {...otherProps}>
+    <FontAwesomeIcon className="align-self-center" icon={icon} />
+    <span className="media-body ml-2">{label}</span>
+  </Nav.Link>
+);
 
 const ListFilters: React.FunctionComponent<ListFiltersProps> = ({
   teamFilters,
@@ -157,7 +171,7 @@ const ListFilters: React.FunctionComponent<ListFiltersProps> = ({
 
   return (
     <Col sm={12} md={3} xl={2} className={styles.root}>
-      <Form className="mr-3">
+      <Form>
         <Form.Control
           id="query"
           placeholder="Search all blueprints"
@@ -175,91 +189,79 @@ const ListFilters: React.FunctionComponent<ListFiltersProps> = ({
         activeKey={activeTab.key}
       >
         {showGetStartedTab && (
-          <Nav.Item className="mt-3">
-            <Nav.Link
-              eventKey="Get Started"
-              onClick={() => {
-                setActiveTab(BLUEPRINTS_PAGE_TABS.getStarted);
-              }}
-            >
-              <FontAwesomeIcon icon={faRocket} /> Get Started
-            </Nav.Link>
-          </Nav.Item>
+          <ListItem
+            className="mt-3"
+            icon={faRocket}
+            label="Get Started"
+            eventKey="Get Started"
+            onClick={() => {
+              setActiveTab(BLUEPRINTS_PAGE_TABS.getStarted);
+            }}
+          />
         )}
         <h5 className="mt-3">Category Filters</h5>
-        <Nav.Item>
-          <Nav.Link
-            eventKey="Active"
-            onClick={() => {
-              setActiveTab(BLUEPRINTS_PAGE_TABS.active);
-            }}
-          >
-            <FontAwesomeIcon icon={faCheck} /> Active
-          </Nav.Link>
-        </Nav.Item>
-        <Nav.Item>
-          <Nav.Link
-            eventKey="All"
-            onClick={() => {
-              setActiveTab(BLUEPRINTS_PAGE_TABS.all);
-            }}
-          >
-            <FontAwesomeIcon icon={faAsterisk} /> All Blueprints
-          </Nav.Link>
-        </Nav.Item>
+        <ListItem
+          icon={faCheck}
+          label="Active"
+          eventKey="Active"
+          onClick={() => {
+            setActiveTab(BLUEPRINTS_PAGE_TABS.active);
+          }}
+        />
+        <ListItem
+          icon={faAsterisk}
+          label="All Blueprints"
+          eventKey="All"
+          onClick={() => {
+            setActiveTab(BLUEPRINTS_PAGE_TABS.all);
+          }}
+        />
         {permit("marketplace") && (
           <>
-            <Nav.Item>
-              <Nav.Link
-                eventKey="Personal"
-                onClick={() => {
-                  setActiveTab(BLUEPRINTS_PAGE_TABS.personal);
-                }}
-              >
-                <FontAwesomeIcon icon={faUser} /> Personal
-              </Nav.Link>
-            </Nav.Item>
-            <Nav.Item>
-              <Nav.Link
-                eventKey="Public"
-                onClick={() => {
-                  setActiveTab(BLUEPRINTS_PAGE_TABS.public);
-                }}
-              >
-                <FontAwesomeIcon icon={faGlobe} /> Public Marketplace
-              </Nav.Link>
-            </Nav.Item>
+            <ListItem
+              icon={faUser}
+              label="Personal"
+              eventKey="Personal"
+              onClick={() => {
+                setActiveTab(BLUEPRINTS_PAGE_TABS.personal);
+              }}
+            />
+            <ListItem
+              icon={faGlobe}
+              label="Public Marketplace"
+              eventKey="Public"
+              onClick={() => {
+                setActiveTab(BLUEPRINTS_PAGE_TABS.public);
+              }}
+            />
           </>
         )}
         {teamFilters.length > 0 && <h5 className="mt-3">Shared with Me</h5>}
         {teamFilters.map((filter) => (
-          <Nav.Item key={filter}>
-            <Nav.Link
-              eventKey={filter}
-              onClick={() => {
-                setActiveTab({
-                  key: filter,
-                  tabTitle: `${filter} Blueprints`,
-                  filters: [{ id: "sharing.source.label", value: filter }],
-                });
-              }}
-            >
-              <FontAwesomeIcon icon={faUsers} /> {filter}
-            </Nav.Link>
-          </Nav.Item>
+          <ListItem
+            key={filter}
+            icon={faUsers}
+            label={filter}
+            eventKey={filter}
+            onClick={() => {
+              setActiveTab({
+                key: filter,
+                tabTitle: `${filter} Blueprints`,
+                filters: [{ id: "sharing.source.label", value: filter }],
+              });
+            }}
+          />
         ))}
       </Nav>
       <Nav className="flex-column">
         <h5>Explore</h5>
-        <Nav.Item>
-          <Nav.Link
-            href="https://www.pixiebrix.com/marketplace"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <FontAwesomeIcon icon={faExternalLinkAlt} /> Open Public Marketplace
-          </Nav.Link>
-        </Nav.Item>
+        <ListItem
+          icon={faExternalLinkAlt}
+          label="Open Public Marketplace"
+          href="https://www.pixiebrix.com/marketplace"
+          target="_blank"
+          rel="noopener noreferrer"
+        />
       </Nav>
     </Col>
   );

--- a/src/options/pages/blueprints/__snapshots__/BlueprintsCard.test.tsx.snap
+++ b/src/options/pages/blueprints/__snapshots__/BlueprintsCard.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`BlueprintsCard renders 1`] = `
       class="root col-xl-2 col-md-3 col-sm-12"
     >
       <form
-        class="mr-3"
+        class=""
       >
         <input
           class="form-control form-control-sm"
@@ -21,146 +21,146 @@ exports[`BlueprintsCard renders 1`] = `
       <div
         class="flex-column nav nav-pills"
       >
-        <div
-          class="mt-3 nav-item"
+        <a
+          class="mt-3 nav-link active"
+          data-rb-event-key="Get Started"
+          href="#"
+          role="button"
         >
-          <a
-            class="nav-link active"
-            data-rb-event-key="Get Started"
-            href="#"
-            role="button"
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-rocket fa-w-16 align-self-center"
+            data-icon="rocket"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-rocket fa-w-16 "
-              data-icon="rocket"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M505.12019,19.09375c-1.18945-5.53125-6.65819-11-12.207-12.1875C460.716,0,435.507,0,410.40747,0,307.17523,0,245.26909,55.20312,199.05238,128H94.83772c-16.34763.01562-35.55658,11.875-42.88664,26.48438L2.51562,253.29688A28.4,28.4,0,0,0,0,264a24.00867,24.00867,0,0,0,24.00582,24H127.81618l-22.47457,22.46875c-11.36521,11.36133-12.99607,32.25781,0,45.25L156.24582,406.625c11.15623,11.1875,32.15619,13.15625,45.27726,0l22.47457-22.46875V488a24.00867,24.00867,0,0,0,24.00581,24,28.55934,28.55934,0,0,0,10.707-2.51562l98.72834-49.39063c14.62888-7.29687,26.50776-26.5,26.50776-42.85937V312.79688c72.59753-46.3125,128.03493-108.40626,128.03493-211.09376C512.07526,76.5,512.07526,51.29688,505.12019,19.09375ZM384.04033,168A40,40,0,1,1,424.05,128,40.02322,40.02322,0,0,1,384.04033,168Z"
-                fill="currentColor"
-              />
-            </svg>
-             Get Started
-          </a>
-        </div>
+            <path
+              d="M505.12019,19.09375c-1.18945-5.53125-6.65819-11-12.207-12.1875C460.716,0,435.507,0,410.40747,0,307.17523,0,245.26909,55.20312,199.05238,128H94.83772c-16.34763.01562-35.55658,11.875-42.88664,26.48438L2.51562,253.29688A28.4,28.4,0,0,0,0,264a24.00867,24.00867,0,0,0,24.00582,24H127.81618l-22.47457,22.46875c-11.36521,11.36133-12.99607,32.25781,0,45.25L156.24582,406.625c11.15623,11.1875,32.15619,13.15625,45.27726,0l22.47457-22.46875V488a24.00867,24.00867,0,0,0,24.00581,24,28.55934,28.55934,0,0,0,10.707-2.51562l98.72834-49.39063c14.62888-7.29687,26.50776-26.5,26.50776-42.85937V312.79688c72.59753-46.3125,128.03493-108.40626,128.03493-211.09376C512.07526,76.5,512.07526,51.29688,505.12019,19.09375ZM384.04033,168A40,40,0,1,1,424.05,128,40.02322,40.02322,0,0,1,384.04033,168Z"
+              fill="currentColor"
+            />
+          </svg>
+          <span
+            class="media-body ml-2"
+          >
+            Get Started
+          </span>
+        </a>
         <h5
           class="mt-3"
         >
           Category Filters
         </h5>
-        <div
-          class="nav-item"
+        <a
+          class="media nav-link"
+          data-rb-event-key="Active"
+          href="#"
+          role="button"
         >
-          <a
-            class="nav-link"
-            data-rb-event-key="Active"
-            href="#"
-            role="button"
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-check fa-w-16 align-self-center"
+            data-icon="check"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-check fa-w-16 "
-              data-icon="check"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
-                fill="currentColor"
-              />
-            </svg>
-             Active
-          </a>
-        </div>
-        <div
-          class="nav-item"
+            <path
+              d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+              fill="currentColor"
+            />
+          </svg>
+          <span
+            class="media-body ml-2"
+          >
+            Active
+          </span>
+        </a>
+        <a
+          class="media nav-link"
+          data-rb-event-key="All"
+          href="#"
+          role="button"
         >
-          <a
-            class="nav-link"
-            data-rb-event-key="All"
-            href="#"
-            role="button"
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-asterisk fa-w-16 align-self-center"
+            data-icon="asterisk"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-asterisk fa-w-16 "
-              data-icon="asterisk"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M478.21 334.093L336 256l142.21-78.093c11.795-6.477 15.961-21.384 9.232-33.037l-19.48-33.741c-6.728-11.653-21.72-15.499-33.227-8.523L296 186.718l3.475-162.204C299.763 11.061 288.937 0 275.48 0h-38.96c-13.456 0-24.283 11.061-23.994 24.514L216 186.718 77.265 102.607c-11.506-6.976-26.499-3.13-33.227 8.523l-19.48 33.741c-6.728 11.653-2.562 26.56 9.233 33.037L176 256 33.79 334.093c-11.795 6.477-15.961 21.384-9.232 33.037l19.48 33.741c6.728 11.653 21.721 15.499 33.227 8.523L216 325.282l-3.475 162.204C212.237 500.939 223.064 512 236.52 512h38.961c13.456 0 24.283-11.061 23.995-24.514L296 325.282l138.735 84.111c11.506 6.976 26.499 3.13 33.227-8.523l19.48-33.741c6.728-11.653 2.563-26.559-9.232-33.036z"
-                fill="currentColor"
-              />
-            </svg>
-             All Blueprints
-          </a>
-        </div>
-        <div
-          class="nav-item"
+            <path
+              d="M478.21 334.093L336 256l142.21-78.093c11.795-6.477 15.961-21.384 9.232-33.037l-19.48-33.741c-6.728-11.653-21.72-15.499-33.227-8.523L296 186.718l3.475-162.204C299.763 11.061 288.937 0 275.48 0h-38.96c-13.456 0-24.283 11.061-23.994 24.514L216 186.718 77.265 102.607c-11.506-6.976-26.499-3.13-33.227 8.523l-19.48 33.741c-6.728 11.653-2.562 26.56 9.233 33.037L176 256 33.79 334.093c-11.795 6.477-15.961 21.384-9.232 33.037l19.48 33.741c6.728 11.653 21.721 15.499 33.227 8.523L216 325.282l-3.475 162.204C212.237 500.939 223.064 512 236.52 512h38.961c13.456 0 24.283-11.061 23.995-24.514L296 325.282l138.735 84.111c11.506 6.976 26.499 3.13 33.227-8.523l19.48-33.741c6.728-11.653 2.563-26.559-9.232-33.036z"
+              fill="currentColor"
+            />
+          </svg>
+          <span
+            class="media-body ml-2"
+          >
+            All Blueprints
+          </span>
+        </a>
+        <a
+          class="media nav-link"
+          data-rb-event-key="Personal"
+          href="#"
+          role="button"
         >
-          <a
-            class="nav-link"
-            data-rb-event-key="Personal"
-            href="#"
-            role="button"
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-user fa-w-14 align-self-center"
+            data-icon="user"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-user fa-w-14 "
-              data-icon="user"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M224 256c70.7 0 128-57.3 128-128S294.7 0 224 0 96 57.3 96 128s57.3 128 128 128zm89.6 32h-16.7c-22.2 10.2-46.9 16-72.9 16s-50.6-5.8-72.9-16h-16.7C60.2 288 0 348.2 0 422.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-41.6c0-74.2-60.2-134.4-134.4-134.4z"
-                fill="currentColor"
-              />
-            </svg>
-             Personal
-          </a>
-        </div>
-        <div
-          class="nav-item"
+            <path
+              d="M224 256c70.7 0 128-57.3 128-128S294.7 0 224 0 96 57.3 96 128s57.3 128 128 128zm89.6 32h-16.7c-22.2 10.2-46.9 16-72.9 16s-50.6-5.8-72.9-16h-16.7C60.2 288 0 348.2 0 422.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-41.6c0-74.2-60.2-134.4-134.4-134.4z"
+              fill="currentColor"
+            />
+          </svg>
+          <span
+            class="media-body ml-2"
+          >
+            Personal
+          </span>
+        </a>
+        <a
+          class="media nav-link"
+          data-rb-event-key="Public"
+          href="#"
+          role="button"
         >
-          <a
-            class="nav-link"
-            data-rb-event-key="Public"
-            href="#"
-            role="button"
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-globe fa-w-16 align-self-center"
+            data-icon="globe"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 496 512"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-globe fa-w-16 "
-              data-icon="globe"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 496 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"
-                fill="currentColor"
-              />
-            </svg>
-             Public Marketplace
-          </a>
-        </div>
+            <path
+              d="M336.5 160C322 70.7 287.8 8 248 8s-74 62.7-88.5 152h177zM152 256c0 22.2 1.2 43.5 3.3 64h185.3c2.1-20.5 3.3-41.8 3.3-64s-1.2-43.5-3.3-64H155.3c-2.1 20.5-3.3 41.8-3.3 64zm324.7-96c-28.6-67.9-86.5-120.4-158-141.6 24.4 33.8 41.2 84.7 50 141.6h108zM177.2 18.4C105.8 39.6 47.8 92.1 19.3 160h108c8.7-56.9 25.5-107.8 49.9-141.6zM487.4 192H372.7c2.1 21 3.3 42.5 3.3 64s-1.2 43-3.3 64h114.6c5.5-20.5 8.6-41.8 8.6-64s-3.1-43.5-8.5-64zM120 256c0-21.5 1.2-43 3.3-64H8.6C3.2 212.5 0 233.8 0 256s3.2 43.5 8.6 64h114.6c-2-21-3.2-42.5-3.2-64zm39.5 96c14.5 89.3 48.7 152 88.5 152s74-62.7 88.5-152h-177zm159.3 141.6c71.4-21.2 129.4-73.7 158-141.6h-108c-8.8 56.9-25.6 107.8-50 141.6zM19.3 352c28.6 67.9 86.5 120.4 158 141.6-24.4-33.8-41.2-84.7-50-141.6h-108z"
+              fill="currentColor"
+            />
+          </svg>
+          <span
+            class="media-body ml-2"
+          >
+            Public Marketplace
+          </span>
+        </a>
       </div>
       <div
         class="flex-column nav"
@@ -168,34 +168,34 @@ exports[`BlueprintsCard renders 1`] = `
         <h5>
           Explore
         </h5>
-        <div
-          class="nav-item"
+        <a
+          class="media nav-link"
+          data-rb-event-key="https://www.pixiebrix.com/marketplace"
+          href="https://www.pixiebrix.com/marketplace"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          <a
-            class="nav-link"
-            data-rb-event-key="https://www.pixiebrix.com/marketplace"
-            href="https://www.pixiebrix.com/marketplace"
-            rel="noopener noreferrer"
-            target="_blank"
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-external-link-alt fa-w-16 align-self-center"
+            data-icon="external-link-alt"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-external-link-alt fa-w-16 "
-              data-icon="external-link-alt"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-                fill="currentColor"
-              />
-            </svg>
-             Open Public Marketplace
-          </a>
-        </div>
+            <path
+              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              fill="currentColor"
+            />
+          </svg>
+          <span
+            class="media-body ml-2"
+          >
+            Open Public Marketplace
+          </span>
+        </a>
       </div>
     </div>
     <div


### PR DESCRIPTION
## What does this PR do?

- Reduces wrapping by using space better
- Avoids wrapping of text _below_ the icon
- Part of https://github.com/pixiebrix/pixiebrix-extension/issues/3513

## Before / After

<img width="152" alt="Screen Shot 36" src="https://user-images.githubusercontent.com/1402241/195824936-b41391c8-1aa8-4645-9e4c-e97eaab48743.png"> <img width="152" alt="Screen Shot 35" src="https://user-images.githubusercontent.com/1402241/195824947-ffc1d2f2-8cb1-41bd-81b2-63f8341ebd98.png">


## Checklist

- [x] https://github.com/pixiebrix/pixiebrix-extension/issues/4456
- [x] Designate a primary reviewer: @mnholtz 
