### PR TITLE
#4130: Keep sidebar below QuickBar

### DIFF
--- a/src/contentScript/sidebarDomControllerLite.ts
+++ b/src/contentScript/sidebarDomControllerLite.ts
@@ -78,7 +78,8 @@ export function insertSidebarFrame(): boolean {
     position: "fixed",
     top: 0,
     right: 0,
-    zIndex: MAX_Z_INDEX,
+    // `-1` keeps it under the QuickBar #4130
+    zIndex: MAX_Z_INDEX - 1,
     width: CSS.px(SIDEBAR_WIDTH_PX),
     height: "100%",
     border: 0,


### PR DESCRIPTION
## What does this PR do?

- Fixes #4130


## Before

<img width="973" alt="Screen Shot 43" src="https://user-images.githubusercontent.com/1402241/195831631-5b421df4-d826-4278-b066-5986b980771c.png">

## After


<img width="973" alt="Screen Shot 44" src="https://user-images.githubusercontent.com/1402241/195831655-6778fad9-8cbd-4ecb-8f4e-1b13cc8f219b.png">

 

## Future

The upcoming Popups API will likely solve all of our z-index related issues:

https://developer.chrome.com/blog/pop-ups-theyre-making-a-resurgence/
