### PR TITLE
#4441: Stop inspecting after dev tool is closed

### DIFF
--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -59,6 +59,7 @@ export const handleNavigate = getNotifier("HANDLE_NAVIGATE");
 export const runBrick = getMethod("RUN_BRICK");
 export const cancelSelect = getMethod("CANCEL_SELECT_ELEMENT");
 export const selectElement = getMethod("SELECT_ELEMENT");
+export const stopInspectingNative = getNotifier("STOP_INSPECTING_NATIVE");
 
 export const runRendererPipeline = getMethod("RUN_RENDERER_PIPELINE");
 export const runEffectPipeline = getMethod("RUN_EFFECT_PIPELINE");

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -65,6 +65,7 @@ import { runBrick } from "@/contentScript/executor";
 import {
   cancelSelect,
   selectElement,
+  stopInspectingNativeHandler,
 } from "@/contentScript/nativeEditor/elementPicker";
 import {
   runEffectPipeline,
@@ -119,6 +120,7 @@ declare global {
     RUN_BRICK: typeof runBrick;
     CANCEL_SELECT_ELEMENT: typeof cancelSelect;
     SELECT_ELEMENT: typeof selectElement;
+    STOP_INSPECTING_NATIVE: typeof stopInspectingNativeHandler;
 
     RUN_RENDERER_PIPELINE: typeof runRendererPipeline;
     RUN_EFFECT_PIPELINE: typeof runEffectPipeline;
@@ -177,6 +179,7 @@ export default function registerMessenger(): void {
     RUN_BRICK: runBrick,
     CANCEL_SELECT_ELEMENT: cancelSelect,
     SELECT_ELEMENT: selectElement,
+    STOP_INSPECTING_NATIVE: stopInspectingNativeHandler,
 
     RUN_RENDERER_PIPELINE: runRendererPipeline,
     RUN_EFFECT_PIPELINE: runEffectPipeline,

--- a/src/contentScript/nativeEditor/elementPicker.ts
+++ b/src/contentScript/nativeEditor/elementPicker.ts
@@ -37,6 +37,7 @@ let expandOverlay: Overlay | null = null;
 let styleElement: HTMLStyleElement = null;
 let multiSelectionToolElement: HTMLElement = null;
 let selectionHandler: SelectionHandlerType;
+let stopInspectingNative: () => void;
 
 function setSelectionHandler(handler: SelectionHandlerType) {
   selectionHandler = handler;
@@ -48,6 +49,12 @@ export function hideOverlay(): void {
     overlay = null;
     expandOverlay.remove();
     expandOverlay = null;
+  }
+}
+
+export function stopInspectingNativeHandler(): void {
+  if (stopInspectingNative) {
+    stopInspectingNative();
   }
 }
 
@@ -122,16 +129,6 @@ export async function userSelectElement({
       }
 
       prehiglightItems();
-    }
-
-    function stopInspectingNative() {
-      hideOverlay();
-      _cancelSelect = null;
-      removeListenersOnWindow(window);
-      removeInspectingModeStyles();
-      if (enableSelectionTools) {
-        removeMultiSelectionTool();
-      }
     }
 
     function handleDone(target?: HTMLElement) {
@@ -367,6 +364,18 @@ export async function userSelectElement({
     }
 
     startInspectingNative();
+
+    stopInspectingNative = () => {
+      hideOverlay();
+      _cancelSelect = null;
+      removeListenersOnWindow(window);
+      removeInspectingModeStyles();
+      if (enableSelectionTools) {
+        removeMultiSelectionTool();
+      }
+
+      stopInspectingNative = null;
+    };
   });
 }
 

--- a/src/pageEditor/protocol.ts
+++ b/src/pageEditor/protocol.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { resetTab } from "@/contentScript/messenger/api";
+import { resetTab, stopInspectingNative } from "@/contentScript/messenger/api";
 import { thisTab } from "./utils";
 import { Target } from "@/types";
 import { updatePageEditor } from "./events";
@@ -38,6 +38,7 @@ async function onNavigation(target: Target): Promise<void> {
 
 function onEditorClose(): void {
   resetTab(thisTab);
+  stopInspectingNative(thisTab);
 }
 
 export function watchNavigation(): void {


### PR DESCRIPTION
## What does this PR do?

- Closes #4441 

## Reviewer Tips

- we're using `beforeunload` event listener to catch dev tool closing event.
