### PR TITLE
Adjust injection expectations in `connectToContentScript`

### DIFF
--- a/src/background/activeTab.ts
+++ b/src/background/activeTab.ts
@@ -39,3 +39,11 @@ export async function getTabsWithAccess(): Promise<TabId[]> {
   const tabs = await browser.tabs.query({ url: origins });
   return [...tabs.map((x) => x.id), ...possiblyActiveTabs.keys()];
 }
+
+export async function forEachTab<
+  TCallback extends (target: { tabId: number }) => void
+>(callback: TCallback): Promise<void> {
+  for (const tabId of await getTabsWithAccess()) {
+    callback({ tabId });
+  }
+}

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ensureContentScript } from "@/background/util";
+import { ensureContentScript } from "@/background/contentScript";
 import { rehydrateSidebar } from "@/contentScript/messenger/api";
 import { executeScript, isScriptableUrl } from "webext-content-scripts";
 import pMemoize from "p-memoize";

--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -21,7 +21,7 @@ import { getErrorMessage, hasSpecificErrorCause } from "@/errors/errorHelpers";
 import reportError from "@/telemetry/reportError";
 import { noop } from "lodash";
 import { handleMenuAction, notify } from "@/contentScript/messenger/api";
-import { ensureContentScript } from "@/background/util";
+import { ensureContentScript } from "@/background/contentScript";
 import { reportEvent } from "@/telemetry/events";
 import { UUID, IExtension, ResolvedExtension } from "@/core";
 import { expectContext } from "@/utils/expectContext";

--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -42,7 +42,7 @@ jest.mock("@/hooks/useRefresh", () => ({
   refreshRegistries: jest.fn(),
 }));
 
-jest.mock("@/background/util", () => ({
+jest.mock("@/chrome", () => ({
   forEachTab: jest.fn().mockResolvedValue(undefined),
 }));
 

--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -42,7 +42,7 @@ jest.mock("@/hooks/useRefresh", () => ({
   refreshRegistries: jest.fn(),
 }));
 
-jest.mock("@/chrome", () => ({
+jest.mock("@/background/activeTab", () => ({
   forEachTab: jest.fn().mockResolvedValue(undefined),
 }));
 

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -27,7 +27,7 @@ import { selectExtensions } from "@/store/extensionsSelectors";
 import { RegistryId, UUID } from "@/core";
 import { maybeGetLinkedApiClient } from "@/services/apiClient";
 import { queueReactivateTab } from "@/contentScript/messenger/api";
-import { forEachTab } from "./util";
+import { forEachTab } from "@/chrome";
 import { parse as parseSemVer, satisfies, SemVer } from "semver";
 import { ExtensionOptionsState } from "@/store/extensionsTypes";
 import extensionsSlice from "@/store/extensionsSlice";

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -27,7 +27,7 @@ import { selectExtensions } from "@/store/extensionsSelectors";
 import { RegistryId, UUID } from "@/core";
 import { maybeGetLinkedApiClient } from "@/services/apiClient";
 import { queueReactivateTab } from "@/contentScript/messenger/api";
-import { forEachTab } from "@/chrome";
+import { forEachTab } from "@/background/activeTab";
 import { parse as parseSemVer, satisfies, SemVer } from "semver";
 import { ExtensionOptionsState } from "@/store/extensionsTypes";
 import extensionsSlice from "@/store/extensionsSlice";

--- a/src/background/initBrowserCommands.ts
+++ b/src/background/initBrowserCommands.ts
@@ -20,7 +20,7 @@ import { Tab } from "@/mv3/api";
 import { Target } from "@/types";
 import { expectContext } from "@/utils/expectContext";
 import { canReceiveContentScript } from "@/utils/permissions";
-import { ensureContentScript } from "./util";
+import { ensureContentScript } from "./contentScript";
 
 async function handleCommand(command: string, tab: Tab): Promise<void> {
   if (command !== "toggle-quick-bar" || !canReceiveContentScript(tab.url)) {

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -38,7 +38,7 @@ import {
   requestRunInTop,
 } from "@/background/executor";
 import * as registry from "@/registry/localRegistry";
-import { ensureContentScript } from "@/background/util";
+import { ensureContentScript } from "@/background/contentScript";
 import serviceRegistry from "@/services/registry";
 import { deleteCachedAuthData, getCachedAuthData } from "@/background/auth";
 import { proxyService } from "@/background/requests";

--- a/src/background/navigation.ts
+++ b/src/background/navigation.ts
@@ -16,7 +16,7 @@
  */
 
 import { reactivateTab, handleNavigate } from "@/contentScript/messenger/api";
-import { forEachTab } from "@/background/util";
+import { forEachTab } from "@/chrome";
 import { canAccessTab } from "webext-tools";
 import { Target } from "@/types";
 

--- a/src/background/navigation.ts
+++ b/src/background/navigation.ts
@@ -16,7 +16,7 @@
  */
 
 import { reactivateTab, handleNavigate } from "@/contentScript/messenger/api";
-import { forEachTab } from "@/chrome";
+import { forEachTab } from "@/background/activeTab";
 import { canAccessTab } from "webext-tools";
 import { Target } from "@/types";
 

--- a/src/background/permissionPrompt.ts
+++ b/src/background/permissionPrompt.ts
@@ -18,23 +18,10 @@
 import { Tabs, Windows } from "webextension-polyfill";
 import { isFirefox } from "webext-detect-page";
 import { isMac } from "@/utils";
+import { onTabClose } from "@/chrome";
 
 const POPUP_WIDTH_PX = 400; // Makes the native prompt appear centered
 const POPUP_HEIGHT_PX = 215; // Includes titlebar height, must fit the content and error to avoid scrollbars
-
-async function onTabClose(tabId: number): Promise<void> {
-  return new Promise((resolve) => {
-    const handlePossibleClosure = (closeTabId: number) => {
-      if (closeTabId === tabId) {
-        // Remove listener first to ensure it's removed even if resolve throws
-        browser.tabs.onRemoved.removeListener(handlePossibleClosure);
-        resolve();
-      }
-    };
-
-    browser.tabs.onRemoved.addListener(handlePossibleClosure);
-  });
-}
 
 async function openTab(url: string, openerTabId: number): Promise<Tabs.Tab> {
   return browser.tabs.create({

--- a/src/background/starterBlueprints.test.ts
+++ b/src/background/starterBlueprints.test.ts
@@ -32,7 +32,7 @@ jest.mock("@/auth/token", () => ({
   isLinked: jest.fn().mockResolvedValue(true),
 }));
 
-jest.mock("@/chrome", () => ({
+jest.mock("@/background/activeTab", () => ({
   forEachTab: jest.fn().mockResolvedValue(undefined),
 }));
 

--- a/src/background/starterBlueprints.test.ts
+++ b/src/background/starterBlueprints.test.ts
@@ -32,7 +32,7 @@ jest.mock("@/auth/token", () => ({
   isLinked: jest.fn().mockResolvedValue(true),
 }));
 
-jest.mock("@/background/util", () => ({
+jest.mock("@/chrome", () => ({
   forEachTab: jest.fn().mockResolvedValue(undefined),
 }));
 

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -19,7 +19,7 @@ import extensionsSlice from "@/store/extensionsSlice";
 import { maybeGetLinkedApiClient } from "@/services/apiClient";
 import { loadOptions, saveOptions } from "@/store/extensionsStorage";
 import { RecipeDefinition } from "@/types/definitions";
-import { forEachTab } from "@/background/util";
+import { forEachTab } from "@/chrome";
 import { queueReactivateTab } from "@/contentScript/messenger/api";
 import { ExtensionOptionsState } from "@/store/extensionsTypes";
 import reportError from "@/telemetry/reportError";

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -19,7 +19,7 @@ import extensionsSlice from "@/store/extensionsSlice";
 import { maybeGetLinkedApiClient } from "@/services/apiClient";
 import { loadOptions, saveOptions } from "@/store/extensionsStorage";
 import { RecipeDefinition } from "@/types/definitions";
-import { forEachTab } from "@/chrome";
+import { forEachTab } from "@/background/activeTab";
 import { queueReactivateTab } from "@/contentScript/messenger/api";
 import { ExtensionOptionsState } from "@/store/extensionsTypes";
 import reportError from "@/telemetry/reportError";

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -18,7 +18,6 @@
 import { isExtensionContext } from "webext-detect-page";
 import { forbidContext } from "@/utils/expectContext";
 import { JsonValue } from "type-fest";
-import { getTabsWithAccess } from "@/background/activeTab";
 import { UnknownObject } from "@/types";
 
 // eslint-disable-next-line prefer-destructuring -- It breaks EnvironmentPlugin
@@ -152,12 +151,4 @@ export async function onTabClose(watchedTabId: number): Promise<void> {
 
     browser.tabs.onRemoved.addListener(listener);
   });
-}
-
-export async function forEachTab<
-  TCallback extends (target: { tabId: number }) => void
->(callback: TCallback): Promise<void> {
-  for (const tabId of await getTabsWithAccess()) {
-    callback({ tabId });
-  }
 }

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -18,6 +18,7 @@
 import { isExtensionContext } from "webext-detect-page";
 import { forbidContext } from "@/utils/expectContext";
 import { JsonValue } from "type-fest";
+import { getTabsWithAccess } from "@/background/activeTab";
 import { UnknownObject } from "@/types";
 
 // eslint-disable-next-line prefer-destructuring -- It breaks EnvironmentPlugin
@@ -151,4 +152,12 @@ export async function onTabClose(watchedTabId: number): Promise<void> {
 
     browser.tabs.onRemoved.addListener(listener);
   });
+}
+
+export async function forEachTab<
+  TCallback extends (target: { tabId: number }) => void
+>(callback: TCallback): Promise<void> {
+  for (const tabId of await getTabsWithAccess()) {
+    callback({ tabId });
+  }
 }

--- a/src/pageEditor/ErrorBanner.tsx
+++ b/src/pageEditor/ErrorBanner.tsx
@@ -17,9 +17,10 @@
 
 import React from "react";
 import { Button } from "react-bootstrap";
-import { getErrorMessage } from "@/errors/errorHelpers";
+import { getErrorMessage, isSpecificError } from "@/errors/errorHelpers";
 import { useSelector } from "react-redux";
 import { selectTabStateError } from "@/pageEditor/tabState/tabStateSelectors";
+import { TimeoutError } from "@/utils";
 
 /**
  * Error banner for Page Editor browser connection errors.
@@ -35,9 +36,13 @@ const ErrorBanner: React.VFC = () => {
     return null;
   }
 
+  const message = isSpecificError(error, TimeoutError)
+    ? "The Page Editor could not establish a connection to the page"
+    : getErrorMessage(error);
+
   return (
     <div className="d-flex p-2 align-items-center alert-danger flex-align-center">
-      <div className="flex-grow-1">{getErrorMessage(error)}</div>
+      <div className="flex-grow-1">{message}</div>
       <div>
         <Button
           className="ml-2"


### PR DESCRIPTION
## What does this PR do?

- Fixes the error message for the user
- Avoids unnecessary Error wrapping 
- Drops dead code (the 15s timeout was never reached)
- Wraps entire `ensureContentScript` into a single timeout
- Rename `@/background/utils` to `@/background/contentScript` to be more specific

## Future Work (slightly related)

- https://github.com/pixiebrix/pixiebrix-extension/issues/4189
- https://github.com/sindresorhus/p-timeout/issues/31

## Checklist

- [x] Designate a primary reviewer: @twschiller 
