### PR TITLE
#2359: Cleanup sidebar "context invalidated" state

### DIFF
--- a/.github/workflows/loom-slack.yml
+++ b/.github/workflows/loom-slack.yml
@@ -33,16 +33,25 @@ jobs:
     if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     steps:
+      - name: Get PR status
+        run: |
+          STATUS=$(
+            gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json state --jq .state
+          )
+          echo STATUS=$STATUS >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Post loom if present
         uses: marocchino/sticky-pull-request-comment@v2
-        if: ${{ needs.search.outputs.link }}
+        if: ${{ needs.search.outputs.link && env.STATUS == 'OPEN' }}
         with:
           message: |
             When the PR is merged, the [first loom link found on this PR](${{ needs.search.outputs.link }}) will be posted to `#sprint-demo` on Slack. _Do not edit this comment manually._
 
       - name: Remind to post loom if missing
         uses: marocchino/sticky-pull-request-comment@v2
-        if: ${{ ! needs.search.outputs.link }}
+        if: ${{ ! needs.search.outputs.link && env.STATUS == 'OPEN' }}
         with:
           message: |
             No loom links were found in the first post. Please add one there if you'd like to it to appear on Slack. _Do not edit this comment manually._

--- a/src/__mocks__/@/hooks/useContextInvalidated.ts
+++ b/src/__mocks__/@/hooks/useContextInvalidated.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export default () => false;

--- a/src/hooks/useContextInvalidated.ts
+++ b/src/hooks/useContextInvalidated.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState } from "react";
+import useAsyncEffect from "use-async-effect";
+import {
+  onContextInvalidated,
+  wasContextInvalidated,
+} from "@/errors/contextInvalidated";
+
+export default function useContextInvalidated(): boolean {
+  const [invalidated, setInvalidated] = useState(wasContextInvalidated());
+  useAsyncEffect(async (isMounted) => {
+    await onContextInvalidated();
+
+    if (isMounted()) {
+      setInvalidated(true);
+    }
+  });
+
+  return invalidated;
+}

--- a/src/sidebar/ErrorBanner.tsx
+++ b/src/sidebar/ErrorBanner.tsx
@@ -19,8 +19,8 @@ import React from "react";
 import useContextInvalidated from "@/hooks/useContextInvalidated";
 
 // Note, it's currently impossible to have a "Reload sidebar" button because it can
-// only be done from the content script + after context invalidation the page loses
-// all contact to the outside world (chrome.runtime and  chrome.tabs become undefined)
+// only be done from the content script + contact to the outside world is lost after
+// context invalidation (chrome.runtime and chrome.tabs become undefined)
 const ErrorBanner: React.VFC = () => {
   const wasContextInvalidated = useContextInvalidated();
 

--- a/src/sidebar/ErrorBanner.tsx
+++ b/src/sidebar/ErrorBanner.tsx
@@ -23,7 +23,6 @@ import useContextInvalidated from "@/hooks/useContextInvalidated";
 // context invalidation (chrome.runtime and chrome.tabs become undefined)
 const ErrorBanner: React.VFC = () => {
   const wasContextInvalidated = useContextInvalidated();
-
   if (!wasContextInvalidated) {
     return null;
   }

--- a/src/sidebar/ErrorBanner.tsx
+++ b/src/sidebar/ErrorBanner.tsx
@@ -15,28 +15,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Keep in order so precedence is preserved
-import "@/vendors/theme/app/app.scss";
-import "@/vendors/overrides.scss";
-import "@/utils/layout.scss";
-import "./sidebar.scss";
-
-import "@/extensionContext";
-
-import registerMessenger from "@/sidebar/messenger/registration";
-import App from "@/sidebar/SidebarApp";
-import ReactDOM from "react-dom";
 import React from "react";
-import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
-import registerContribBlocks from "@/contrib/registerContribBlocks";
-import { initToaster } from "@/utils/notify";
+import useContextInvalidated from "@/hooks/useContextInvalidated";
 
-function init(): void {
-  ReactDOM.render(<App />, document.querySelector("#container"));
-}
+// Note, it's currently impossible to have a "Reload sidebar" button because it can
+// only be done from the content script + after context invalidation the page loses
+// all contact to the outside world (chrome.runtime and  chrome.tabs become undefined)
+const ErrorBanner: React.VFC = () => {
+  const wasContextInvalidated = useContextInvalidated();
 
-registerMessenger();
-registerContribBlocks();
-registerBuiltinBlocks();
-initToaster();
-init();
+  if (!wasContextInvalidated) {
+    return null;
+  }
+
+  return (
+    <div className="p-3 alert-danger">
+      PixieBrix was updated or restarted. <br />
+      Close and reopen the sidebar to continue.
+    </div>
+  );
+};
+
+export default ErrorBanner;

--- a/src/sidebar/Header.tsx
+++ b/src/sidebar/Header.tsx
@@ -24,27 +24,31 @@ import { hideSidebar } from "@/contentScript/messenger/api";
 import { whoAmI } from "@/background/messenger/api";
 import useTheme, { useGetTheme } from "@/hooks/useTheme";
 import cx from "classnames";
+import useContextInvalidated from "@/hooks/useContextInvalidated";
 
 const Header: React.FunctionComponent = () => {
   const { logo, showSidebarLogo, customSidebarLogo } = useTheme();
   const theme = useGetTheme();
+  const wasContextInvalidated = useContextInvalidated();
 
   return (
     <div className="d-flex p-2 justify-content-between align-content-center">
-      <Button
-        className={cx(
-          styles.button,
-          theme === "default" ? styles.themeColorOverride : styles.themeColor
-        )}
-        onClick={async () => {
-          const sidebar = await whoAmI();
-          await hideSidebar({ tabId: sidebar.tab.id });
-        }}
-        size="sm"
-        variant="link"
-      >
-        <FontAwesomeIcon icon={faAngleDoubleRight} className="fa-lg" />
-      </Button>
+      {wasContextInvalidated || ( // /* The button doesn't work after invalidation #2359 */
+        <Button
+          className={cx(
+            styles.button,
+            theme === "default" ? styles.themeColorOverride : styles.themeColor
+          )}
+          onClick={async () => {
+            const sidebar = await whoAmI();
+            await hideSidebar({ tabId: sidebar.tab.id });
+          }}
+          size="sm"
+          variant="link"
+        >
+          <FontAwesomeIcon icon={faAngleDoubleRight} className="fa-lg" />
+        </Button>
+      )}
       {showSidebarLogo && (
         <div className="align-self-center">
           <img

--- a/src/sidebar/SidebarApp.test.tsx
+++ b/src/sidebar/SidebarApp.test.tsx
@@ -33,7 +33,6 @@ jest.mock("@/hooks/useContextInvalidated", () => ({
 
 describe("SidebarApp", () => {
   test("it renders", () => {
-    (useContextInvalidated as jest.Mock).mockReturnValue(false);
     const rendered = render(<SidebarApp />);
     expect(rendered.asFragment()).toMatchSnapshot();
   });

--- a/src/sidebar/SidebarApp.test.tsx
+++ b/src/sidebar/SidebarApp.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import SidebarApp from "@/sidebar/SidebarApp";
+import { render } from "@testing-library/react";
+import useContextInvalidated from "@/hooks/useContextInvalidated";
+
+jest.mock("@/options/store", () => ({
+  persistor: {
+    flush: jest.fn(),
+  },
+}));
+
+jest.mock("@/hooks/useContextInvalidated", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe("SidebarApp", () => {
+  test("it renders", () => {
+    (useContextInvalidated as jest.Mock).mockReturnValue(false);
+    const rendered = render(<SidebarApp />);
+    expect(rendered.asFragment()).toMatchSnapshot();
+  });
+
+  test("it renders error when context is invalidated", () => {
+    (useContextInvalidated as jest.Mock).mockReturnValue(true);
+    const rendered = render(<SidebarApp />);
+    expect(rendered.asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/sidebar/SidebarApp.tsx
+++ b/src/sidebar/SidebarApp.tsx
@@ -22,6 +22,7 @@ import Loader from "@/components/Loader";
 import { PersistGate } from "redux-persist/integration/react";
 import ConnectedSidebar from "./ConnectedSidebar";
 import Header from "./Header";
+import ErrorBanner from "./ErrorBanner";
 import { MemoryRouter } from "react-router";
 
 // Include MemoryRouter because some of our authentication-gate hooks use useLocation. However, there's currently no
@@ -30,6 +31,7 @@ const SidebarApp: React.FunctionComponent = () => (
   <Provider store={store}>
     <PersistGate loading={<Loader />} persistor={persistor}>
       <MemoryRouter>
+        <ErrorBanner />
         <Header />
         <ConnectedSidebar />
       </MemoryRouter>

--- a/src/sidebar/__snapshots__/SidebarApp.test.tsx.snap
+++ b/src/sidebar/__snapshots__/SidebarApp.test.tsx.snap
@@ -1,0 +1,232 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SidebarApp it renders 1`] = `
+<DocumentFragment>
+  <div
+    class="d-flex p-2 justify-content-between align-content-center"
+  >
+    <button
+      class="button themeColorOverride btn btn-link btn-sm"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="svg-inline--fa fa-angle-double-right fa-w-14 fa-lg"
+        data-icon="angle-double-right"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        viewBox="0 0 448 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+          fill="currentColor"
+        />
+      </svg>
+    </button>
+    <div
+      class="align-self-center"
+    >
+      <img
+        alt="PixieBrix logo"
+        class="logo"
+        data-testid="sidebarHeaderLogo"
+        src="test-file-stub"
+      />
+    </div>
+    <a
+      class="button themeColorOverride btn btn-link btn-sm"
+      href="/options.html"
+      target="_blank"
+    >
+      <span>
+        Options 
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-cog fa-w-16 "
+          data-icon="cog"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M487.4 315.7l-42.6-24.6c4.3-23.2 4.3-47 0-70.2l42.6-24.6c4.9-2.8 7.1-8.6 5.5-14-11.1-35.6-30-67.8-54.7-94.6-3.8-4.1-10-5.1-14.8-2.3L380.8 110c-17.9-15.4-38.5-27.3-60.8-35.1V25.8c0-5.6-3.9-10.5-9.4-11.7-36.7-8.2-74.3-7.8-109.2 0-5.5 1.2-9.4 6.1-9.4 11.7V75c-22.2 7.9-42.8 19.8-60.8 35.1L88.7 85.5c-4.9-2.8-11-1.9-14.8 2.3-24.7 26.7-43.6 58.9-54.7 94.6-1.7 5.4.6 11.2 5.5 14L67.3 221c-4.3 23.2-4.3 47 0 70.2l-42.6 24.6c-4.9 2.8-7.1 8.6-5.5 14 11.1 35.6 30 67.8 54.7 94.6 3.8 4.1 10 5.1 14.8 2.3l42.6-24.6c17.9 15.4 38.5 27.3 60.8 35.1v49.2c0 5.6 3.9 10.5 9.4 11.7 36.7 8.2 74.3 7.8 109.2 0 5.5-1.2 9.4-6.1 9.4-11.7v-49.2c22.2-7.9 42.8-19.8 60.8-35.1l42.6 24.6c4.9 2.8 11 1.9 14.8-2.3 24.7-26.7 43.6-58.9 54.7-94.6 1.5-5.5-.7-11.3-5.6-14.1zM256 336c-44.1 0-80-35.9-80-80s35.9-80 80-80 80 35.9 80 80-35.9 80-80 80z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+    </a>
+  </div>
+  <div
+    class="full-height"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="mt-4 row"
+      >
+        <div
+          class="text-center col"
+        >
+          <h4
+            class="display-6"
+          >
+            Connect PixieBrix Account
+          </h4>
+          <p>
+            Register/log-in to PixieBrix to access your personal and team bricks
+          </p>
+          <a
+            class="mt-4 btn btn-primary"
+            href="https://app.pixiebrix.com"
+            target="_blank"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-sign-in-alt fa-w-16 "
+              data-icon="sign-in-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M416 448h-84c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h84c17.7 0 32-14.3 32-32V160c0-17.7-14.3-32-32-32h-84c-6.6 0-12-5.4-12-12V76c0-6.6 5.4-12 12-12h84c53 0 96 43 96 96v192c0 53-43 96-96 96zm-47-201L201 79c-15-15-41-4.5-41 17v96H24c-13.3 0-24 10.7-24 24v96c0 13.3 10.7 24 24 24h136v96c0 21.5 26 32 41 17l168-168c9.3-9.4 9.3-24.6 0-34z"
+                fill="currentColor"
+              />
+            </svg>
+             Connect Account
+          </a>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="text-center col"
+        >
+          <img
+            alt="Marketplace"
+            src="test-file-stub"
+            width="300"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SidebarApp it renders error when context is invalidated 1`] = `
+<DocumentFragment>
+  <div
+    class="p-3 alert-danger"
+  >
+    PixieBrix was updated or restarted. 
+    <br />
+    Close and reopen the sidebar to continue.
+  </div>
+  <div
+    class="d-flex p-2 justify-content-between align-content-center"
+  >
+    <div
+      class="align-self-center"
+    >
+      <img
+        alt="PixieBrix logo"
+        class="logo"
+        data-testid="sidebarHeaderLogo"
+        src="test-file-stub"
+      />
+    </div>
+    <a
+      class="button themeColorOverride btn btn-link btn-sm"
+      href="/options.html"
+      target="_blank"
+    >
+      <span>
+        Options 
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-cog fa-w-16 "
+          data-icon="cog"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M487.4 315.7l-42.6-24.6c4.3-23.2 4.3-47 0-70.2l42.6-24.6c4.9-2.8 7.1-8.6 5.5-14-11.1-35.6-30-67.8-54.7-94.6-3.8-4.1-10-5.1-14.8-2.3L380.8 110c-17.9-15.4-38.5-27.3-60.8-35.1V25.8c0-5.6-3.9-10.5-9.4-11.7-36.7-8.2-74.3-7.8-109.2 0-5.5 1.2-9.4 6.1-9.4 11.7V75c-22.2 7.9-42.8 19.8-60.8 35.1L88.7 85.5c-4.9-2.8-11-1.9-14.8 2.3-24.7 26.7-43.6 58.9-54.7 94.6-1.7 5.4.6 11.2 5.5 14L67.3 221c-4.3 23.2-4.3 47 0 70.2l-42.6 24.6c-4.9 2.8-7.1 8.6-5.5 14 11.1 35.6 30 67.8 54.7 94.6 3.8 4.1 10 5.1 14.8 2.3l42.6-24.6c17.9 15.4 38.5 27.3 60.8 35.1v49.2c0 5.6 3.9 10.5 9.4 11.7 36.7 8.2 74.3 7.8 109.2 0 5.5-1.2 9.4-6.1 9.4-11.7v-49.2c22.2-7.9 42.8-19.8 60.8-35.1l42.6 24.6c4.9 2.8 11 1.9 14.8-2.3 24.7-26.7 43.6-58.9 54.7-94.6 1.5-5.5-.7-11.3-5.6-14.1zM256 336c-44.1 0-80-35.9-80-80s35.9-80 80-80 80 35.9 80 80-35.9 80-80 80z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+    </a>
+  </div>
+  <div
+    class="full-height"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="mt-4 row"
+      >
+        <div
+          class="text-center col"
+        >
+          <h4
+            class="display-6"
+          >
+            Connect PixieBrix Account
+          </h4>
+          <p>
+            Register/log-in to PixieBrix to access your personal and team bricks
+          </p>
+          <a
+            class="mt-4 btn btn-primary"
+            href="https://app.pixiebrix.com"
+            target="_blank"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-sign-in-alt fa-w-16 "
+              data-icon="sign-in-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M416 448h-84c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h84c17.7 0 32-14.3 32-32V160c0-17.7-14.3-32-32-32h-84c-6.6 0-12-5.4-12-12V76c0-6.6 5.4-12 12-12h84c53 0 96 43 96 96v192c0 53-43 96-96 96zm-47-201L201 79c-15-15-41-4.5-41 17v96H24c-13.3 0-24 10.7-24 24v96c0 13.3 10.7 24 24 24h136v96c0 21.5 26 32 41 17l168-168c9.3-9.4 9.3-24.6 0-34z"
+                fill="currentColor"
+              />
+            </svg>
+             Connect Account
+          </a>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="text-center col"
+        >
+          <img
+            alt="Marketplace"
+            src="test-file-stub"
+            width="300"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
- Continues from https://github.com/pixiebrix/pixiebrix-extension/pull/4117
- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/2359

[](https://github.com/pixiebrix/pixiebrix-extension/issues/4193)

I started this PR to add a "Reload Sidebar" to the "context invalidated" message but that's currently not possible:
- messaging is blocked after invalidation
- sidebar manager lives in the content script:  https://github.com/pixiebrix/pixiebrix-extension/blob/main/src/contentScript/sidebarController.tsx#L70-L95






## Before

<img width="399" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/197379061-f60085d5-6319-449b-82d1-0157740a2a45.png">

## After

<img width="399" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/197380345-d473de96-9529-4657-9fc9-98e4003230f0.png">



The style matches the bootstrap-native alert bar that we use in the editor as well:

<img width="708" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/197379186-fae1617a-18f5-4342-9e27-b898e8361f6e.png">


## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @BALEHOK because of [recent sidebar work](https://github.com/pixiebrix/pixiebrix-extension/pull/3962)
