### PR TITLE
#2614: Show extension list much earlier in page editor

### DIFF
--- a/.github/workflows/loom-slack.yml
+++ b/.github/workflows/loom-slack.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   search:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     # https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
     outputs:

--- a/.github/workflows/loom-slack.yml
+++ b/.github/workflows/loom-slack.yml
@@ -55,7 +55,9 @@ jobs:
         if: ${{ ! needs.search.outputs.link && env.STATUS == 'OPEN' }}
         with:
           message: |
-            No loom links were found in the first post. Please add one there if you'd like to it to appear on Slack. _Do not edit this comment manually._
+            No loom links were found in the first post. Please add one there if you'd like to it to appear on Slack.
+
+            _Do not edit this comment manually._
 
   slack:
     needs: search

--- a/src/pageEditor/sidebar/SidebarExpanded.tsx
+++ b/src/pageEditor/sidebar/SidebarExpanded.tsx
@@ -25,7 +25,6 @@ import hash from "object-hash";
 import { isExtension } from "@/pageEditor/sidebar/common";
 import { faAngleDoubleLeft } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
-import Loader from "@/components/Loader";
 import RecipeEntry from "@/pageEditor/sidebar/RecipeEntry";
 import useFlags from "@/hooks/useFlags";
 import arrangeElements from "@/pageEditor/sidebar/arrangeElements";
@@ -52,8 +51,7 @@ import { actions } from "@/pageEditor/slices/editorSlice";
 const SidebarExpanded: React.FunctionComponent<{
   collapseSidebar: () => void;
 }> = ({ collapseSidebar }) => {
-  const { data: allRecipes, isLoading: isLoadingRecipes } =
-    useGetRecipesQuery();
+  const { data: allRecipes } = useGetRecipesQuery();
 
   const dispatch = useDispatch();
   const activeElementId = useSelector(selectActiveElementId);
@@ -229,13 +227,9 @@ const SidebarExpanded: React.FunctionComponent<{
         ) : null}
       </div>
       <div className={styles.extensions}>
-        {isLoadingRecipes ? (
-          <Loader />
-        ) : (
-          <Accordion activeKey={expandedRecipeId}>
-            <ListGroup>{listItems}</ListGroup>
-          </Accordion>
-        )}
+        <Accordion activeKey={expandedRecipeId}>
+          <ListGroup>{listItems}</ListGroup>
+        </Accordion>
       </div>
     </div>
   );

--- a/src/pageEditor/sidebar/arrangeElements.ts
+++ b/src/pageEditor/sidebar/arrangeElements.ts
@@ -20,6 +20,7 @@ import { IExtension, RegistryId, UUID } from "@/core";
 import { RecipeDefinition } from "@/types/definitions";
 import { FormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { getRecipeById } from "@/utils";
+import { isExtension } from "@/pageEditor/sidebar/common";
 
 type ArrangeElementsArgs = {
   elements: FormState[];
@@ -105,7 +106,22 @@ function arrangeElements({
       if (Array.isArray(item)) {
         const recipeId = item[0];
         const recipe = getRecipeById(recipes, recipeId);
-        return lowerCase(recipe?.metadata?.name ?? "");
+        if (recipe) {
+          return lowerCase(recipe?.metadata?.name ?? "");
+        }
+
+        // Look for a recipe name in the elements/extensions in case recipes are still loading
+        for (const element of item[1]) {
+          if (isExtension(element)) {
+            if (element._recipe?.name) {
+              return element._recipe.name;
+            }
+          } else if (element.recipe?.name) {
+            return element.recipe.name;
+          }
+        }
+
+        return "";
       }
 
       return lowerCase(item.label);


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/2614
- Related to https://github.com/pixiebrix/pixiebrix-extension/issues/2657

## Discussion

- The UI is waiting to show "everything" when the necessary parts are already available and sub-components that require additional loading time already handle it

This specific piece of code was added in https://github.com/pixiebrix/pixiebrix-extension/pull/2495/files#diff-a49d57aac9f4c53630d736168e2ffb549d29ab3aa545f3e6f32faeba02601a45


## Before / After

![loader](https://user-images.githubusercontent.com/1402241/197389574-a4988050-ff74-4e50-a293-fdb6c1d34ac7.gif) ![gif](https://user-images.githubusercontent.com/1402241/197390199-ba541e4f-857e-49eb-8cae-412e37a89ea3.gif)

https://www.loom.com/share/fdec5eded32345a68b20573845c35959

## Checklist

- [x] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @BALEHOK 
