### PR TITLE
#4506:  Add Jest test cases for commonCssSelector

### DIFF
--- a/src/contentScript/nativeEditor/selectorInference.test.ts
+++ b/src/contentScript/nativeEditor/selectorInference.test.ts
@@ -264,8 +264,33 @@ describe("commonCssSelector", () => {
     const elements = [...document.body.querySelectorAll(selector)] as [
       HTMLElement
     ];
-    const inferredSelector = commonCssSelector(elements);
-    expect(inferredSelector).toBe(selector);
+    const commonSelector = commonCssSelector(elements);
+    expect(commonSelector).toBe(selector);
+  };
+
+  const expectSimilarElements = (
+    selector1: string,
+    selector2: string,
+    selector3: string,
+    body: string
+  ) => {
+    document.body.innerHTML = body;
+    const element1 = document.body.querySelector(selector1);
+    const element2 = document.body.querySelector(selector2);
+    const element3 = document.body.querySelector(selector3);
+
+    const commonSelector = commonCssSelector([
+      element1 as HTMLElement,
+      element2 as HTMLElement,
+    ]);
+    const commonElements = [
+      ...document.body.querySelectorAll(commonSelector),
+    ] as [HTMLElement];
+    expect(commonElements).toBeArray();
+    expect(commonElements).toHaveLength(3);
+    expect(commonElements).toContain(element1);
+    expect(commonElements).toContain(element2);
+    expect(commonElements).toContain(element3);
   };
 
   const body = html`
@@ -302,6 +327,18 @@ describe("commonCssSelector", () => {
             <span class="titleline"><a href="#">Almost</a> </span>
           </div>
         </div>
+        <div>extra text</div>
+        <div class="spacer" style="height:5px"></div>
+        <div class="athing">
+          <div valign="top" class="votelinks">
+            <a id="up_33239255" href="#"
+              ><div class="votearrow" title="upvote"></div
+            ></a>
+          </div>
+          <div class="title">
+            <span class="titleline"><a href="#">Nearly</a> </span>
+          </div>
+        </div>
       </div>
     </div>
   `;
@@ -318,6 +355,14 @@ describe("commonCssSelector", () => {
     expectSelector(".itemlist .title .titleline", body);
   });
 
+  test("pass two similar elements should return another similar elements", () => {
+    expectSimilarElements(
+      "#up_33240341 .votearrow",
+      "#up_33239220 .votearrow",
+      "#up_33239255 .votearrow",
+      body
+    );
+  });
   /* eslint-enable jest/expect-expect */
 });
 

--- a/src/contentScript/nativeEditor/selectorInference.test.ts
+++ b/src/contentScript/nativeEditor/selectorInference.test.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  commonCssSelector,
   generateSelector,
   getAttributeSelector,
   getAttributeSelectorRegex,
@@ -250,6 +251,71 @@ describe("safeCssSelector", () => {
         </ul>
       `
     );
+  });
+
+  /* eslint-enable jest/expect-expect */
+});
+
+describe("commonCssSelector", () => {
+  /* eslint-disable jest/expect-expect -- Custom expectSelector */
+  const expectSelector = (selector: string, body: string) => {
+    document.body.innerHTML = body;
+
+    const elements = [...document.body.querySelectorAll(selector)] as [
+      HTMLElement
+    ];
+    const inferredSelector = commonCssSelector(elements);
+    expect(inferredSelector).toBe(selector);
+  };
+
+  const body = html`
+    <div>
+      <div>
+        <div>Hello</div>
+        <div class="title"></div>
+        <span class="titleline"><a href="#">GitHub</a></span>
+      </div>
+      <div class="itemlist">
+        <span class="titleline"><a href="#">Almost</a> </span>
+        <div class="athing">
+          <div class="title">
+            <span class="rank">1.</span>
+          </div>
+          <div valign="top" class="votelinks">
+            <a id="up_33240341" href="#">
+              <div class="votearrow" title="upvote"></div>
+            </a>
+          </div>
+          <div class="title">
+            <span class="titleline"><a href="#">GitHub</a></span>
+          </div>
+        </div>
+        <div>extra text</div>
+        <div class="spacer" style="height:5px"></div>
+        <div class="athing">
+          <div valign="top" class="votelinks">
+            <a id="up_33239220" href="#"
+              ><div class="votearrow" title="upvote"></div
+            ></a>
+          </div>
+          <div class="title">
+            <span class="titleline"><a href="#">Almost</a> </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+
+  test("common ancester classname, parent classname, element tag", () => {
+    expectSelector(".itemlist .titleline > a", body);
+  });
+
+  test("common ancester classname, common element classname", () => {
+    expectSelector(".itemlist .votearrow", body);
+  });
+
+  test("common ancester classname, common parent classname, common element classname", () => {
+    expectSelector(".itemlist .title .titleline", body);
   });
 
   /* eslint-enable jest/expect-expect */

--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -396,12 +396,7 @@ export function commonCssSelector(
   if (commonAncestor) {
     // Get common class of elements
     const [commonClassName] = intersection(
-      ...elements.map((element) => element.className)
-    );
-
-    // Get first common class of ancestor of elements
-    const [commonAncestorClassName] = intersection(
-      ...ancestors.map((list) => list.map((element) => element.className))
+      ...elements.map((element) => element.className.split(" "))
     );
 
     // Get selector of common ancestor
@@ -416,6 +411,15 @@ export function commonCssSelector(
 
     // If elements have comment class we can easily select them
     if (commonClassName) {
+      // Make sure to not include the elements with same classname but in different parent class
+      if (commonParentClassName) {
+        return [
+          commonAncestorSelector,
+          getSelectorFromClass(commonParentClassName),
+          getSelectorFromClass(commonClassName),
+        ].join(" ");
+      }
+
       return [
         commonAncestorSelector,
         getSelectorFromClass(commonClassName),
@@ -431,27 +435,9 @@ export function commonCssSelector(
       ].join(" ");
     }
 
-    if (commonAncestorClassName) {
-      // If not, we use common ancestor's class
-
-      if (
-        intersection(
-          $(commonAncestorSelector),
-          $(getSelectorFromClass(commonAncestorClassName))
-        ).length > 0
-      ) {
-        // Make sure that commonAncestorClassName is not duplicated with commonAncestorSelector
-        return [commonAncestorSelector, elements[0].tagName.toLowerCase()].join(
-          " "
-        );
-      }
-
-      return [
-        commonAncestorSelector,
-        getSelectorFromClass(commonAncestorClassName),
-        elements[0].tagName.toLowerCase(),
-      ].join(" ");
-    }
+    return [commonAncestorSelector, elements[0].tagName.toLowerCase()].join(
+      " "
+    );
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #4506 
- Fix some logic of commonCssSelector found while doing tests.

## Reviewer Tips

- fixed getting common classname of elements

## Checklist

- [ ] Add tests
