### PR TITLE
#4507: Check for common tag type when generating selector for expanded selection

### DIFF
--- a/src/contentScript/nativeEditor/selectorInference.test.ts
+++ b/src/contentScript/nativeEditor/selectorInference.test.ts
@@ -315,7 +315,7 @@ describe("commonCssSelector", () => {
   });
 
   test("common ancester classname, common parent classname, common element classname", () => {
-    expectSelector(".itemlist .title .titleline", body);
+    expectSelector(".itemlist .title > .titleline", body);
   });
 
   /* eslint-enable jest/expect-expect */

--- a/src/contentScript/nativeEditor/selectorInference.test.ts
+++ b/src/contentScript/nativeEditor/selectorInference.test.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  commonCssSelector,
   generateSelector,
   getAttributeSelector,
   getAttributeSelectorRegex,
@@ -250,6 +251,71 @@ describe("safeCssSelector", () => {
         </ul>
       `
     );
+  });
+
+  /* eslint-enable jest/expect-expect */
+});
+
+describe("commonCssSelector", () => {
+  /* eslint-disable jest/expect-expect -- Custom expectSelector */
+  const expectSelector = (selector: string, body: string) => {
+    document.body.innerHTML = body;
+
+    const elements = [...document.body.querySelectorAll(selector)] as [
+      HTMLElement
+    ];
+    const inferredSelector = commonCssSelector(elements);
+    expect(inferredSelector).toBe(selector);
+  };
+
+  const body = html`
+    <div>
+      <div>
+        <div>Hello</div>
+        <div class="title"></div>
+        <span class="titleline"><a href="#">GitHub</a></span>
+      </div>
+      <div class="itemlist">
+        <span class="titleline"><a href="#">Almost</a> </span>
+        <div class="athing">
+          <div class="title">
+            <span class="rank">1.</span>
+          </div>
+          <div valign="top" class="votelinks">
+            <a id="up_33240341" href="#">
+              <div class="votearrow" title="upvote"></div>
+            </a>
+          </div>
+          <div class="title">
+            <span class="titleline"><a href="#">GitHub</a></span>
+          </div>
+        </div>
+        <div>extra text</div>
+        <div class="spacer" style="height:5px"></div>
+        <div class="athing">
+          <div valign="top" class="votelinks">
+            <a id="up_33239220" href="#"
+              ><div class="votearrow" title="upvote"></div
+            ></a>
+          </div>
+          <div class="title">
+            <span class="titleline"><a href="#">Almost</a> </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+
+  test("common ancester classname, parent classname, element tag", () => {
+    expectSelector(".itemlist .titleline > a", body);
+  });
+
+  test("common ancester classname, common element classname", () => {
+    expectSelector(".itemlist .votearrow", body);
+  });
+
+  test("common ancester classname, common parent classname, common element classname", () => {
+    expectSelector(".itemlist .title .titleline", body);
   });
 
   /* eslint-enable jest/expect-expect */

--- a/src/contentScript/nativeEditor/selectorInference.ts
+++ b/src/contentScript/nativeEditor/selectorInference.ts
@@ -396,12 +396,7 @@ export function commonCssSelector(
   if (commonAncestor) {
     // Get common class of elements
     const [commonClassName] = intersection(
-      ...elements.map((element) => element.className)
-    );
-
-    // Get first common class of ancestor of elements
-    const [commonAncestorClassName] = intersection(
-      ...ancestors.map((list) => list.map((element) => element.className))
+      ...elements.map((element) => element.className.split(" "))
     );
 
     // Get selector of common ancestor
@@ -416,6 +411,15 @@ export function commonCssSelector(
 
     // If elements have comment class we can easily select them
     if (commonClassName) {
+      // Make sure to not include the elements with same classname but in different parent class
+      if (commonParentClassName) {
+        return [
+          commonAncestorSelector,
+          getSelectorFromClass(commonParentClassName),
+          getSelectorFromClass(commonClassName),
+        ].join(" ");
+      }
+
       return [
         commonAncestorSelector,
         getSelectorFromClass(commonClassName),
@@ -431,27 +435,9 @@ export function commonCssSelector(
       ].join(" ");
     }
 
-    if (commonAncestorClassName) {
-      // If not, we use common ancestor's class
-
-      if (
-        intersection(
-          $(commonAncestorSelector),
-          $(getSelectorFromClass(commonAncestorClassName))
-        ).length > 0
-      ) {
-        // Make sure that commonAncestorClassName is not duplicated with commonAncestorSelector
-        return [commonAncestorSelector, elements[0].tagName.toLowerCase()].join(
-          " "
-        );
-      }
-
-      return [
-        commonAncestorSelector,
-        getSelectorFromClass(commonAncestorClassName),
-        elements[0].tagName.toLowerCase(),
-      ].join(" ");
-    }
+    return [commonAncestorSelector, elements[0].tagName.toLowerCase()].join(
+      " "
+    );
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #4507 

## Reviewer Tips

- This PR is based off from #4532 
- Fix and Optimize the logic for commonCssSelector.

## Checklist
