### PR TITLE
#4539: remove feature flag from partner id field

### DIFF
--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -39,7 +39,7 @@ const SAVING_URL_TIMEOUT_MS = 4000;
 
 const AdvancedSettings: React.FunctionComponent = () => {
   const dispatch = useDispatch();
-  const { restrict, permit, flagOn } = useFlags();
+  const { restrict, permit } = useFlags();
   const { partnerId, authServiceId } = useSelector(selectSettings);
 
   const [serviceURL, setServiceURL] = useConfiguredHost();
@@ -182,24 +182,22 @@ const AdvancedSettings: React.FunctionComponent = () => {
               API
             </Form.Text>
           </Form.Group>
-          {flagOn("partner-theming") && (
-            <Form.Group controlId="partnerId">
-              <Form.Label>Partner ID</Form.Label>
-              <Form.Control
-                type="text"
-                placeholder="my-company"
-                defaultValue={partnerId ?? ""}
-                onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
-                  dispatch(
-                    settingsSlice.actions.setPartnerId({
-                      partnerId: event.target.value,
-                    })
-                  );
-                }}
-              />
-              <Form.Text muted>The partner id of a PixieBrix partner</Form.Text>
-            </Form.Group>
-          )}
+          <Form.Group controlId="partnerId">
+            <Form.Label>Partner ID</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="my-company"
+              defaultValue={partnerId ?? ""}
+              onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
+                dispatch(
+                  settingsSlice.actions.setPartnerId({
+                    partnerId: event.target.value,
+                  })
+                );
+              }}
+            />
+            <Form.Text muted>The partner id of a PixieBrix partner</Form.Text>
+          </Form.Group>
         </Form>
       </Card.Body>
       <Card.Footer className={styles.cardFooter}>


### PR DESCRIPTION
## What does this PR do?

- Closes #4539
- Removes feature flag from Partner ID Advanced Setting so unauthenticated users can set the flag

## Checklist

- 😢  Add tests: N/A
- 😢  Run Storybook and manually confirm that all stories are working
- [X] Designate a primary reviewer: @johnnymetz 
