### PR TITLE
#4465 Autocomplete Slice 1: write visitor to determine values that may exist for each input

### DIFF
--- a/src/analysis/analysisSelectors.ts
+++ b/src/analysis/analysisSelectors.ts
@@ -28,3 +28,7 @@ export function selectExtensionAnnotations(
     // eslint-disable-next-line security/detect-object-injection -- extensionId is supposed to be UUID, not from user input
     analysis.extensionAnnotations[extensionId] ?? emptyAnnotations;
 }
+
+export function selectKnownVars(): (state: AnalysisRootState) => any {
+  return ({ analysis }: AnalysisRootState) => analysis.knownVars;
+}

--- a/src/analysis/analysisSlice.ts
+++ b/src/analysis/analysisSlice.ts
@@ -21,6 +21,7 @@ import { UUID } from "@/core";
 
 const initialState: AnalysisState = {
   extensionAnnotations: {},
+  knownVars: {},
 };
 
 const analysisSlice = createSlice({
@@ -57,6 +58,9 @@ const analysisSlice = createSlice({
         ...state.extensionAnnotations[extensionId],
         ...annotations,
       ];
+    },
+    setKnownVars(state, action: PayloadAction<any>) {
+      state.knownVars = action.payload;
     },
   },
 });

--- a/src/analysis/analysisTypes.ts
+++ b/src/analysis/analysisTypes.ts
@@ -68,6 +68,7 @@ export interface Analysis {
 
 export type AnalysisState = {
   extensionAnnotations: Record<UUID, Annotation[]>;
+  knownVars: any;
 };
 
 export type AnalysisRootState = {

--- a/src/analysis/analysisVisitors/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis.test.ts
@@ -21,7 +21,6 @@ import { services } from "@/background/messenger/api";
 import { validateRegistryId } from "@/types/helpers";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import IfElse from "@/blocks/transformers/controlFlow/IfElse";
-import { toExpression } from "@/testUtils/testHelpers";
 import ForEach from "@/blocks/transformers/controlFlow/ForEach";
 import {
   makePipelineExpression,
@@ -247,7 +246,8 @@ describe("VarAnalysis", () => {
 
     test("adds for-each output after the brick", async () => {
       expect(
-        analysis.knownVars
+        analysis
+          .getKnownVars()
           .get("extension.blockPipeline.1")
           .get("@forEachOutput")
       ).toBe(VarExistence.DEFINITELY);
@@ -273,7 +273,8 @@ describe("VarAnalysis", () => {
 
     test("adds the element key to the sub pipeline", async () => {
       expect(
-        analysis.knownVars
+        analysis
+          .getKnownVars()
           .get("extension.blockPipeline.0.config.body.__value__.0")
           .get("@element")
       ).toBe(VarExistence.DEFINITELY);

--- a/src/analysis/analysisVisitors/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getVarsFromObject } from "./varAnalysis";
+
+describe("getVarsFromObject", () => {
+  test("gets all the root keys", () => {
+    const obj = {
+      foo: "bar",
+      baz: "qux",
+    };
+    expect(getVarsFromObject(obj)).toEqual(["foo", "baz"]);
+  });
+
+  test("gets all the nested keys", () => {
+    const obj = {
+      foo: {
+        bar: "baz",
+      },
+    };
+    expect(getVarsFromObject(obj)).toEqual(["foo", "foo.bar"]);
+  });
+});

--- a/src/analysis/analysisVisitors/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis.test.ts
@@ -85,9 +85,9 @@ describe("VarAnalysis", () => {
     const analysis = new VarAnalysis();
     await analysis.run(extension);
 
-    expect(analysis.knownVars.size).toBe(1);
+    expect(analysis.getKnownVars().size).toBe(1);
     expect([
-      ...analysis.knownVars.get("extension.blockPipeline.0").keys(),
+      ...analysis.getKnownVars().get("extension.blockPipeline.0").keys(),
     ]).toEqual([
       "@pixiebrix",
       "@pixiebrix.__service",
@@ -100,9 +100,9 @@ describe("VarAnalysis", () => {
       "@options.foo",
     ]);
     expect(
-      [...analysis.knownVars.get("extension.blockPipeline.0").values()].every(
-        (x) => x === VarExistence.DEFINITELY
-      )
+      [
+        ...analysis.getKnownVars().get("extension.blockPipeline.0").values(),
+      ].every((x) => x === VarExistence.DEFINITELY)
     ).toBeTrue();
   });
 
@@ -118,14 +118,14 @@ describe("VarAnalysis", () => {
     await analysis.run(extension);
 
     expect(
-      analysis.knownVars.get("extension.blockPipeline.0").get("@foo")
+      analysis.getKnownVars().get("extension.blockPipeline.0").get("@foo")
     ).toBeUndefined();
 
     expect(
-      analysis.knownVars.get("extension.blockPipeline.1").get("@foo")
+      analysis.getKnownVars().get("extension.blockPipeline.1").get("@foo")
     ).toBe(VarExistence.DEFINITELY);
     expect(
-      analysis.knownVars.get("extension.blockPipeline.1").get("@foo.*")
+      analysis.getKnownVars().get("extension.blockPipeline.1").get("@foo.*")
     ).toBe(VarExistence.MAYBE);
   });
 
@@ -142,14 +142,14 @@ describe("VarAnalysis", () => {
     await analysis.run(extension);
 
     expect(
-      analysis.knownVars.get("extension.blockPipeline.0").get("@foo")
+      analysis.getKnownVars().get("extension.blockPipeline.0").get("@foo")
     ).toBeUndefined();
 
     expect(
-      analysis.knownVars.get("extension.blockPipeline.1").get("@foo")
+      analysis.getKnownVars().get("extension.blockPipeline.1").get("@foo")
     ).toBe(VarExistence.MAYBE);
     expect(
-      analysis.knownVars.get("extension.blockPipeline.1").get("@foo.*")
+      analysis.getKnownVars().get("extension.blockPipeline.1").get("@foo.*")
     ).toBe(VarExistence.MAYBE);
   });
 
@@ -187,7 +187,10 @@ describe("VarAnalysis", () => {
 
     test("adds if-else output after the brick", async () => {
       expect(
-        analysis.knownVars.get("extension.blockPipeline.1").get("@ifOutput")
+        analysis
+          .getKnownVars()
+          .get("extension.blockPipeline.1")
+          .get("@ifOutput")
       ).toBe(VarExistence.DEFINITELY);
     });
 
@@ -200,17 +203,17 @@ describe("VarAnalysis", () => {
       "doesn't add if-else output to sub pipelines (%s)",
       async (blockPath) => {
         expect(
-          analysis.knownVars.get(blockPath).get("@ifOutput")
+          analysis.getKnownVars().get(blockPath).get("@ifOutput")
         ).toBeUndefined();
       }
     );
 
     test("doesn't leak sub pipeline outputs", async () => {
       expect(
-        analysis.knownVars.get("extension.blockPipeline.1").get("@foo")
+        analysis.getKnownVars().get("extension.blockPipeline.1").get("@foo")
       ).toBeUndefined();
       expect(
-        analysis.knownVars.get("extension.blockPipeline.1").get("@bar")
+        analysis.getKnownVars().get("extension.blockPipeline.1").get("@bar")
       ).toBeUndefined();
     });
   });
@@ -257,14 +260,14 @@ describe("VarAnalysis", () => {
       "doesn't add for-each output to sub pipelines (%s)",
       async (blockPath) => {
         expect(
-          analysis.knownVars.get(blockPath).get("@forEachOutput")
+          analysis.getKnownVars().get(blockPath).get("@forEachOutput")
         ).toBeUndefined();
       }
     );
 
     test("doesn't leak sub pipeline outputs", async () => {
       expect(
-        analysis.knownVars.get("extension.blockPipeline.1").get("@foo")
+        analysis.getKnownVars().get("extension.blockPipeline.1").get("@foo")
       ).toBeUndefined();
     });
 
@@ -278,7 +281,7 @@ describe("VarAnalysis", () => {
 
     test("doesn't leak the sub pipeline element key", async () => {
       expect(
-        analysis.knownVars.get("extension.blockPipeline.1").get("@element")
+        analysis.getKnownVars().get("extension.blockPipeline.1").get("@element")
       ).toBeUndefined();
     });
   });

--- a/src/analysis/analysisVisitors/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis.test.ts
@@ -15,7 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getVarsFromObject } from "./varAnalysis";
+import { blockConfigFactory, formStateFactory } from "@/testUtils/factories";
+import VarAnalysis, { getVarsFromObject } from "./varAnalysis";
 
 describe("getVarsFromObject", () => {
   test("gets all the root keys", () => {
@@ -33,5 +34,30 @@ describe("getVarsFromObject", () => {
       },
     };
     expect(getVarsFromObject(obj)).toEqual(["foo", "foo.bar"]);
+  });
+});
+
+describe("VarAnalysis", () => {
+  test("gets the context vars", async () => {
+    // TODO add @options
+    const extension = formStateFactory(
+      {
+        // mock getting services
+        services: [
+          {
+            outputKey: "pixiebrix",
+            id: "@pixiebrix/api",
+          },
+        ],
+      },
+      [blockConfigFactory()]
+    );
+    const analysis = new VarAnalysis();
+    await analysis.run(extension);
+
+    expect(analysis.knownVars.size).toBe(1);
+    expect([
+      ...analysis.knownVars.get("extension.blockPipeline.0").keys(),
+    ]).toEqual(["@input", "@input.icon", "@input.title", "@input.url"]);
   });
 });

--- a/src/analysis/analysisVisitors/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis.ts
@@ -36,12 +36,16 @@ type PreviousVisitedBlock = {
   output: BlockVars | null;
 };
 class VarAnalysis extends AnalysisVisitor {
-  knownVars: ExtensionVars = new Map<string, BlockVars>();
-  previousVisitedBlock: PreviousVisitedBlock = null;
-  contextStack: PreviousVisitedBlock[] = [];
+  private readonly knownVars: ExtensionVars = new Map<string, BlockVars>();
+  private previousVisitedBlock: PreviousVisitedBlock = null;
+  private readonly contextStack: PreviousVisitedBlock[] = [];
 
   get id() {
     return "var";
+  }
+
+  getKnownVars() {
+    return this.knownVars;
   }
 
   override visitBlock(

--- a/src/analysis/analysisVisitors/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis.ts
@@ -55,10 +55,13 @@ class VarAnalysis extends AnalysisVisitor {
     const currentBlockOutput = new Map<string, VarExistence>();
 
     if (blockConfig.outputKey) {
-      currentBlockOutput.set(blockConfig.outputKey, VarExistence.DEFINITELY);
+      currentBlockOutput.set(
+        `@${blockConfig.outputKey}`,
+        blockConfig.if == null ? VarExistence.DEFINITELY : VarExistence.MAYBE
+      );
 
       // TODO: revisit the wildcard/regex format of MAYBE vars
-      currentBlockOutput.set(`${blockConfig.outputKey}.*`, VarExistence.MAYBE);
+      currentBlockOutput.set(`@${blockConfig.outputKey}.*`, VarExistence.MAYBE);
     }
 
     this.previousVisitedBlock = {

--- a/src/analysis/analysisVisitors/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis.ts
@@ -22,7 +22,7 @@ import { FormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { makeServiceContext } from "@/services/serviceUtils";
 import { AnalysisVisitor } from "./baseAnalysisVisitors";
 
-enum VarExistence {
+export enum VarExistence {
   MAYBE = "MAYBE",
   DEFINITELY = "DEFINITELY",
 }

--- a/src/analysis/analysisVisitors/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { VisitBlockExtra } from "@/blocks/PipelineVisitor";
+import { BlockPosition, BlockConfig } from "@/blocks/types";
+import { AnalysisVisitor } from "./baseAnalysisVisitors";
+
+class VarAnalysis extends AnalysisVisitor {
+  get id() {
+    return "var";
+  }
+
+  override visitBlock(
+    position: BlockPosition,
+    blockConfig: BlockConfig,
+    extra: VisitBlockExtra
+  ) {
+    super.visitBlock(position, blockConfig, extra);
+
+    if (blockConfig.outputKey) {
+      console.log("block", {
+        blockConfig,
+        outputKey: blockConfig.outputKey,
+      });
+    }
+  }
+}
+
+export default VarAnalysis;

--- a/src/blocks/PipelineVisitor.ts
+++ b/src/blocks/PipelineVisitor.ts
@@ -56,7 +56,8 @@ export type VisitResolvedBlockExtra = VisitBlockExtra & {
 };
 export type VisitPipelineExtra = {
   flavor: PipelineFlavor;
-  parentNodeId?: UUID | undefined;
+  parentNode?: BlockConfig | undefined;
+  pipelinePropName?: string | undefined;
 };
 export type VisitRootPipelineExtra = {
   extensionPointType: ExtensionPointType;
@@ -95,7 +96,8 @@ class PipelineVisitor {
         );
         this.visitPipeline(pipelinePosition, value.__value__, {
           flavor: pipelineFlavor,
-          parentNodeId: blockConfig.instanceId,
+          parentNode: blockConfig,
+          pipelinePropName: prop,
         });
       }
     }
@@ -121,7 +123,7 @@ class PipelineVisitor {
         );
         this.visitPipeline(pipelinePosition, subPipeline, {
           flavor: pipelineFlavor,
-          parentNodeId: blockConfig.instanceId,
+          parentNode: blockConfig,
         });
       }
     }
@@ -130,12 +132,12 @@ class PipelineVisitor {
   public visitPipeline(
     position: BlockPosition,
     pipeline: BlockConfig[],
-    { flavor, parentNodeId }: VisitPipelineExtra
+    { flavor, parentNode }: VisitPipelineExtra
   ): void {
     for (const [index, blockConfig] of pipeline.entries()) {
       this.visitBlock(nestedPosition(position, String(index)), blockConfig, {
         index,
-        parentNodeId,
+        parentNodeId: parentNode?.instanceId,
         pipeline,
         pipelinePosition: position,
         pipelineFlavor: flavor,

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -131,7 +131,11 @@ pageEditorAnalysisManager.registerAnalysisEffect(
 pageEditorAnalysisManager.registerAnalysisEffect(() => new VarAnalysis(), {
   // Only needed on editorActions.editElement,
   // but the block path can change when node tree is mutated
-  matcher: isAnyOf(editorActions.editElement, ...nodeListMutationActions),
+  matcher: isAnyOf(
+    editorActions.editElement,
+    runtimeActions.setExtensionTrace,
+    ...nodeListMutationActions
+  ),
 });
 
 export default pageEditorAnalysisManager;

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -32,6 +32,7 @@ import { isAnyOf } from "@reduxjs/toolkit";
 import RequestPermissionAnalysis from "@/analysis/analysisVisitors/requestPermissionAnalysis";
 import FormBrickAnalysis from "@/analysis/analysisVisitors/formBrickAnalysis";
 import { selectExtensionTrace } from "./slices/runtimeSelectors";
+import VarAnalysis from "@/analysis/analysisVisitors/varAnalysis";
 
 const runtimeActions = runtimeSlice.actions;
 
@@ -126,5 +127,11 @@ pageEditorAnalysisManager.registerAnalysisEffect(
     matcher: isAnyOf(editorActions.editElement, ...nodeListMutationActions),
   }
 );
+
+pageEditorAnalysisManager.registerAnalysisEffect(() => new VarAnalysis(), {
+  // Only needed on editorActions.editElement,
+  // but the block path can change when node tree is mutated
+  matcher: isAnyOf(editorActions.editElement, ...nodeListMutationActions),
+});
 
 export default pageEditorAnalysisManager;

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -33,6 +33,7 @@ import RequestPermissionAnalysis from "@/analysis/analysisVisitors/requestPermis
 import FormBrickAnalysis from "@/analysis/analysisVisitors/formBrickAnalysis";
 import { selectExtensionTrace } from "./slices/runtimeSelectors";
 import VarAnalysis from "@/analysis/analysisVisitors/varAnalysis";
+import analysisSlice from "@/analysis/analysisSlice";
 
 const runtimeActions = runtimeSlice.actions;
 
@@ -136,6 +137,11 @@ pageEditorAnalysisManager.registerAnalysisEffect(() => new VarAnalysis(), {
     runtimeActions.setExtensionTrace,
     ...nodeListMutationActions
   ),
+  postAnalysisAction(analysis, listenerApi) {
+    listenerApi.dispatch(
+      analysisSlice.actions.setKnownVars(analysis.getKnownVars())
+    );
+  },
 });
 
 export default pageEditorAnalysisManager;

--- a/src/pageEditor/store.ts
+++ b/src/pageEditor/store.ts
@@ -78,9 +78,8 @@ const store = configureStore({
     return getDefaultMiddleware({
       // See https://github.com/rt2zz/redux-persist/issues/988#issuecomment-654875104
       serializableCheck: {
-        ignoredActions: ["persist/PERSIST"],
-        // Actions are also checked, filter out the "payload" path
-        ignoredPaths: ["payload", "analysis.knownVars"],
+        ignoredActions: ["persist/PERSIST", "analysis/setKnownVars"],
+        ignoredPaths: ["analysis.knownVars"],
       },
       // With RTK we're effectively using Immer, no need for extra check
       immutableCheck: false,

--- a/src/pageEditor/store.ts
+++ b/src/pageEditor/store.ts
@@ -44,16 +44,16 @@ const persistSettingsConfig = {
 };
 
 const conditionalMiddleware: Middleware[] = [];
-if (typeof createLogger === "function") {
-  // Allow tree shaking of logger in production
-  // https://github.com/LogRocket/redux-logger/issues/6
-  conditionalMiddleware.push(
-    createLogger({
-      // Do not log polling actions (they happen too often)
-      predicate: (getState, action) => !action.type.includes("logs/polling"),
-    })
-  );
-}
+// if (typeof createLogger === "function") {
+//   // Allow tree shaking of logger in production
+//   // https://github.com/LogRocket/redux-logger/issues/6
+//   conditionalMiddleware.push(
+//     createLogger({
+//       // Do not log polling actions (they happen too often)
+//       predicate: (getState, action) => !action.type.includes("logs/polling"),
+//     })
+//   );
+// }
 
 const store = configureStore({
   reducer: {

--- a/src/pageEditor/store.ts
+++ b/src/pageEditor/store.ts
@@ -44,16 +44,16 @@ const persistSettingsConfig = {
 };
 
 const conditionalMiddleware: Middleware[] = [];
-// if (typeof createLogger === "function") {
-//   // Allow tree shaking of logger in production
-//   // https://github.com/LogRocket/redux-logger/issues/6
-//   conditionalMiddleware.push(
-//     createLogger({
-//       // Do not log polling actions (they happen too often)
-//       predicate: (getState, action) => !action.type.includes("logs/polling"),
-//     })
-//   );
-// }
+if (typeof createLogger === "function") {
+  // Allow tree shaking of logger in production
+  // https://github.com/LogRocket/redux-logger/issues/6
+  conditionalMiddleware.push(
+    createLogger({
+      // Do not log polling actions (they happen too often)
+      predicate: (getState, action) => !action.type.includes("logs/polling"),
+    })
+  );
+}
 
 const store = configureStore({
   reducer: {
@@ -79,7 +79,11 @@ const store = configureStore({
       // See https://github.com/rt2zz/redux-persist/issues/988#issuecomment-654875104
       serializableCheck: {
         ignoredActions: ["persist/PERSIST"],
+        // Actions are also checked, filter out the "payload" path
+        ignoredPaths: ["payload", "analysis.knownVars"],
       },
+      // With RTK we're effectively using Immer, no need for extra check
+      immutableCheck: false,
     })
       .concat(appApi.middleware)
       .concat(pageEditorAnalysisManager.middleware)


### PR DESCRIPTION
## What does this PR do?

- Closes #4465 
- Collects available vars for extension and stores them in Redux
- Traces are not implemented yet


## Discussion

- Data structure to store the vars: full names as strings or tree-like structure where each part of the var will be a key for an inner object (`{ "@foo.bar": DEFINITELY }` vs `{ "@foo": { bar: DEFINITELY } }`). The later probably gives more flexibility and will help with `*` (see the next point)
- How to treat the properties that may have children but we don't know the exact schema (ex. the `@ifElseOutput` below)

## Demo

- Extension config and trace output
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/3116723/197865362-1ffce26b-63cd-49c9-90c5-87b121cc9fe1.png">

- Collected vars for the block. `payload` is a Map where keys are block paths and values are Maps of available vars for the block. A var with `.*` means it can have properties, but we are not certain about their names (ex. `@ifElseOutput.*` works for `@ifElseOutput.props`).
<img width="920" alt="image" src="https://user-images.githubusercontent.com/3116723/197865529-e6c9f49c-9704-4beb-bd27-5496210cc5ab.png">



## Checklist

- [x] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [ ] Designate a primary reviewer
