### PR TITLE
#4542: make auth mode option explicit in advance settings

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (0.47.3).
+ * Mock Service Worker (0.47.4).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -48,6 +48,9 @@ type RequireAuthProps = {
   ignoreApiError?: boolean;
 };
 
+/**
+ * Hook to determine authentication status. Authentication can be via native PixieBrix token, or partner Bearer JWT.
+ */
 export const useRequiredAuth = () => {
   const dispatch = useDispatch();
 

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -81,6 +81,10 @@ export async function setPartnerAuth(data: PartnerAuthData): Promise<void> {
 
 /**
  * Return PixieBrix API authentication headers, or null if not authenticated.
+ *
+ * Headers can either be:
+ * - Native PixieBrix token
+ * - Partner Bearer JWT
  */
 export async function getAuthHeaders(): Promise<UnknownObject | null> {
   const [nativeToken, partnerAuth] = await Promise.all([

--- a/src/auth/useRequiredPartnerAuth.test.tsx
+++ b/src/auth/useRequiredPartnerAuth.test.tsx
@@ -85,6 +85,7 @@ describe("useRequiredPartnerAuth", () => {
       settings: {
         ...settingsSlice.getInitialState(),
         authServiceId: CONTROL_ROOM_OAUTH_SERVICE_ID,
+        authMethod: "partner-oauth2",
       },
     });
 

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -77,7 +77,7 @@ const Layout = () => {
     <div>
       <Navbar logo={logo} />
       <Container fluid className="page-body-wrapper">
-        {/* It is guaranteed that under RequireAuth the user has a valid API token. */}
+        {/* It is guaranteed that under RequireAuth the user has a valid API token (either PixieBrix token or partner JWT). */}
         <ErrorBoundary>
           <RequireAuth LoginPage={SetupPage}>
             <RefreshBricks />

--- a/src/options/pages/onboarding/SetupPage.tsx
+++ b/src/options/pages/onboarding/SetupPage.tsx
@@ -23,8 +23,6 @@ import DefaultSetupCard from "@/options/pages/onboarding/DefaultSetupCard";
 import { getBaseURL } from "@/services/baseService";
 import { useSelector } from "react-redux";
 import { selectSettings } from "@/store/settingsSelectors";
-import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
-import { isEmpty } from "lodash";
 import Loader from "@/components/Loader";
 import useRequiredPartnerAuth from "@/auth/useRequiredPartnerAuth";
 import PartnerSetupCard from "@/options/pages/onboarding/partner/PartnerSetupCard";
@@ -35,15 +33,24 @@ const Layout: React.FunctionComponent = ({ children }) => (
   </Row>
 );
 
+/**
+ * Extension Setup Page, guiding user to link to PixieBrix or connect via partner authentication.
+ *
+ * See SettingsPage user-controlled settings
+ *
+ * @see SettingsPage
+ */
 const SetupPage: React.FunctionComponent = () => {
   useTitle("Setup");
+
+  // Local override for authentication method
+  const { authMethod } = useSelector(selectSettings);
+
   const {
     isLoading: isPartnerLoading,
     hasPartner,
     hasConfiguredIntegration,
   } = useRequiredPartnerAuth();
-
-  const { authServiceId } = useSelector(selectSettings);
 
   const [baseURL, baseURLPending] = useAsyncState(getBaseURL, []);
 
@@ -57,9 +64,14 @@ const SetupPage: React.FunctionComponent = () => {
 
   let setupCard = <DefaultSetupCard installURL={baseURL} />;
 
-  if (
-    (!isEmpty(authServiceId) && authServiceId !== PIXIEBRIX_SERVICE_ID) ||
-    (hasPartner && !hasConfiguredIntegration)
+  if (authMethod === "pixiebrix-token") {
+    // NOP -- user has overridden to use PixieBrix token even though they might be connected to an organization
+    // that uses a Control Room
+  } else if (
+    (hasPartner && !hasConfiguredIntegration) ||
+    // The user has overridden to use the partner auth even though they might be linked via PixieBrix token
+    authMethod === "partner-token" ||
+    authMethod === "partner-oauth2"
   ) {
     setupCard = <PartnerSetupCard />;
   }

--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -40,7 +40,7 @@ const SAVING_URL_TIMEOUT_MS = 4000;
 const AdvancedSettings: React.FunctionComponent = () => {
   const dispatch = useDispatch();
   const { restrict, permit } = useFlags();
-  const { partnerId, authServiceId } = useSelector(selectSettings);
+  const { partnerId, authServiceId, authMethod } = useSelector(selectSettings);
 
   const [serviceURL, setServiceURL] = useConfiguredHost();
 
@@ -197,6 +197,25 @@ const AdvancedSettings: React.FunctionComponent = () => {
               }}
             />
             <Form.Text muted>The partner id of a PixieBrix partner</Form.Text>
+          </Form.Group>
+
+          <Form.Group controlId="authMethod">
+            <Form.Label>Authentication Method</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="default"
+              defaultValue={authMethod ?? "default"}
+              onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
+                dispatch(
+                  settingsSlice.actions.setAuthMethod({
+                    authMethod: event.target.value,
+                  })
+                );
+              }}
+            />
+            <Form.Text muted>
+              Provide an authentication type to force authentication
+            </Form.Text>
           </Form.Group>
         </Form>
       </Card.Body>

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -32,6 +32,13 @@ export function withoutTrailingSlash(url: string): string {
   return url.replace(/\/$/, "");
 }
 
+/**
+ * Return the base URL of the PixieBrix service.
+ *
+ * Can be overriden by:
+ * - Settings on the SettingsPage
+ * - Managed storage (configured by Enterprise IT)
+ */
 export async function getBaseURL(): Promise<string> {
   if (isExtensionContext()) {
     const configured = await readStorage<ConfiguredHost>(SERVICE_STORAGE_KEY);

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -16,7 +16,11 @@
  */
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { SettingsState, SkunkworksSettings } from "@/store/settingsTypes";
+import {
+  AUTH_METHODS,
+  SettingsState,
+  SkunkworksSettings,
+} from "@/store/settingsTypes";
 import reportError from "@/telemetry/reportError";
 import { once } from "lodash";
 import { DEFAULT_THEME } from "@/options/types";
@@ -29,6 +33,7 @@ export const initialSettingsState: SettingsState = {
   suggestElements: false,
   browserWarningDismissed: false,
   partnerId: null,
+  authMethod: null,
   authServiceId: null,
   theme: DEFAULT_THEME,
   updatePromptTimestamp: null,
@@ -70,6 +75,17 @@ const settingsSlice = createSlice({
       { payload: { serviceId } }: { payload: { serviceId: RegistryId } }
     ) {
       state.authServiceId = serviceId;
+    },
+    setAuthMethod(
+      state,
+      { payload: { authMethod } }: { payload: { authMethod: string } }
+    ) {
+      // Ignore invalid values
+      if (AUTH_METHODS.includes(authMethod as SettingsState["authMethod"])) {
+        state.authMethod = authMethod as SettingsState["authMethod"];
+      } else {
+        state.authMethod = null;
+      }
     },
     recordUpdatePromptTimestamp(state) {
       // Don't overwrite the old timestamp

--- a/src/store/settingsTypes.ts
+++ b/src/store/settingsTypes.ts
@@ -20,6 +20,13 @@ import { RegistryId } from "@/core";
 
 export type InstallMode = "local" | "remote";
 
+export const AUTH_METHODS = [
+  "default",
+  "pixiebrix-token",
+  "partner-token",
+  "partner-oauth2",
+] as const;
+
 export type SettingsState = SkunkworksSettings & {
   /**
    * Whether the extension is synced to the app for provisioning.
@@ -65,6 +72,16 @@ export type SettingsState = SkunkworksSettings & {
    * @since 1.7.5
    */
   authServiceId: RegistryId | null;
+
+  /**
+   * Force a particular authentication method. Will force user to authenticate, even if the user is authenticated via
+   * another method.
+   *
+   * Use "default" to infer based on primary organization, etc.
+   *
+   * @since 1.7.12
+   */
+  authMethod: typeof AUTH_METHODS[number] | null;
 
   /**
    * Theme name for the extension


### PR DESCRIPTION
## What does this PR do?

- Workaround of #4542
- Trying to unblock partner, so exposing Settings > Advance Settings Options to force which authentication method is used by the extension

## Discussion

- Mode Options
  - pixiebrix-token
  - partner-oauth2
  - partner-token: user still authenticates using PixieBrix token, but they also have to have a integration configuration installed for the Control Room

## Checklist

- 😢  Add tests - on time deadline, will circle back
- 😢  Add tests Run Storybook and manually confirm that all stories are working - on time deadline, will circle back
- [X] Designate a primary reviewer: @mnholtz or @johnnymetz whoever is available
