### PR TITLE
#4548 add disconnected Sidebar view for Partner users

### DIFF
--- a/src/sidebar/ConnectedSidebar.test.tsx
+++ b/src/sidebar/ConnectedSidebar.test.tsx
@@ -43,6 +43,8 @@ jest.mock("@/auth/token", () => {
     isLinked: jest.fn().mockResolvedValue(true),
   };
 });
+browser.runtime.getURL = (path: string) =>
+  `chrome-extension://example.url/${path}`;
 
 beforeAll(() => {
   jest.useFakeTimers();
@@ -58,6 +60,26 @@ describe("SidebarApp", () => {
     (useGetMeQuery as jest.Mock).mockReturnValue({
       isLoading: false,
       data: anonAuth,
+    });
+
+    const rendered = render(
+      <MemoryRouter>
+        <ConnectedSidebar />
+      </MemoryRouter>
+    );
+    await waitForEffect();
+
+    jest.runAllTimers();
+    expect(rendered.asFragment()).toMatchSnapshot();
+  });
+
+  test("renders not connected partner view", async () => {
+    (useGetMeQuery as jest.Mock).mockReturnValue({
+      isLoading: false,
+      data: {
+        partner: {},
+        ...anonAuth,
+      },
     });
 
     const rendered = render(

--- a/src/sidebar/LoginPanel.stories.tsx
+++ b/src/sidebar/LoginPanel.stories.tsx
@@ -19,14 +19,41 @@ import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import LoginPanel from "@/sidebar/LoginPanel";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+import settingsSlice from "@/store/settingsSlice";
+import servicesSlice from "@/store/servicesSlice";
+import { authSlice } from "@/auth/authSlice";
+import { appApi } from "@/services/api";
+import { createApi } from "@reduxjs/toolkit/query/react";
 
 export default {
   title: "Sidebar/LoginPanel",
   component: LoginPanel,
 } as ComponentMeta<typeof LoginPanel>;
 
+const baseQuery = () => ({ data: [] as any });
+
+function optionsStore(initialState?: any) {
+  return configureStore({
+    reducer: {
+      settings: settingsSlice.reducer,
+      services: servicesSlice.reducer,
+      auth: authSlice.reducer,
+      [appApi.reducerPath]: createApi({
+        reducerPath: "appApi",
+        baseQuery,
+        endpoints: (builder) => ({}),
+      }).reducer,
+    },
+    ...(initialState ?? { preloadedState: initialState }),
+  });
+}
+
 const Template: ComponentStory<typeof LoginPanel> = (args) => (
-  <LoginPanel {...args} />
+  <Provider store={optionsStore()}>
+    <LoginPanel {...args} />
+  </Provider>
 );
 
 export const Default = Template.bind({});

--- a/src/sidebar/LoginPanel.tsx
+++ b/src/sidebar/LoginPanel.tsx
@@ -23,6 +23,8 @@ import marketplaceImage from "@img/marketplace.svg";
 import useRequiredPartnerAuth from "@/auth/useRequiredPartnerAuth";
 import { useSelector } from "react-redux";
 import { selectSettings } from "@/store/settingsSelectors";
+import ControlRoomOAuthForm from "@/options/pages/onboarding/partner/ControlRoomOAuthForm";
+import ControlRoomTokenForm from "@/options/pages/onboarding/partner/ControlRoomTokenForm";
 
 // eslint-disable-next-line prefer-destructuring -- process.env variable
 const SERVICE_URL = process.env.SERVICE_URL;
@@ -45,7 +47,35 @@ const DefaultLogin: React.FunctionComponent = () => (
 );
 
 const PartnerAuth: React.FunctionComponent = () => {
+  const { authMethod } = useSelector(selectSettings);
   const extensionUrl = new URL(browser.runtime.getURL("options.html")).href;
+
+  let authBody = (
+    <Button
+      className="mt-4"
+      href={extensionUrl}
+      target="_blank"
+      variant="primary"
+    >
+      <FontAwesomeIcon icon={faSignInAlt} /> Connect Account
+    </Button>
+  );
+
+  if (authMethod === "partner-oauth2") {
+    authBody = <ControlRoomOAuthForm initialValues={{ controlRoomUrl: "" }} />;
+  }
+
+  if (authMethod === "partner-token") {
+    authBody = (
+      <ControlRoomTokenForm
+        initialValues={{
+          controlRoomUrl: "",
+          username: "",
+          password: "",
+        }}
+      />
+    );
+  }
 
   return (
     <Col className="text-center">
@@ -54,14 +84,7 @@ const PartnerAuth: React.FunctionComponent = () => {
         Authenticate with Automation Anywhere to continue using your team
         extensions
       </p>
-      <Button
-        className="mt-4"
-        href={extensionUrl}
-        target="_blank"
-        variant="primary"
-      >
-        <FontAwesomeIcon icon={faSignInAlt} /> Connect Account
-      </Button>
+      {authBody}
     </Col>
   );
 };

--- a/src/sidebar/LoginPanel.tsx
+++ b/src/sidebar/LoginPanel.tsx
@@ -20,6 +20,9 @@ import { Button, Col, Container, Row } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSignInAlt } from "@fortawesome/free-solid-svg-icons";
 import marketplaceImage from "@img/marketplace.svg";
+import useRequiredPartnerAuth from "@/auth/useRequiredPartnerAuth";
+import { useSelector } from "react-redux";
+import { selectSettings } from "@/store/settingsSelectors";
 
 // eslint-disable-next-line prefer-destructuring -- process.env variable
 const SERVICE_URL = process.env.SERVICE_URL;
@@ -43,6 +46,7 @@ const DefaultLogin: React.FunctionComponent = () => (
 
 const PartnerAuth: React.FunctionComponent = () => {
   const extensionUrl = new URL(browser.runtime.getURL("options.html")).href;
+
   return (
     <Col className="text-center">
       <h4 className="display-6">Connect your AARI account</h4>
@@ -63,11 +67,17 @@ const PartnerAuth: React.FunctionComponent = () => {
 };
 
 const LoginPanel: React.FunctionComponent = () => {
-  const partnerAuth = false;
+  const { authMethod } = useSelector(selectSettings);
+  const { hasPartner, hasConfiguredIntegration } = useRequiredPartnerAuth();
+
+  const showPartnerAuth =
+    (hasPartner && !hasConfiguredIntegration) ||
+    ["partner-oauth2", "partner-token"].includes(authMethod);
+
   return (
     <Container>
       <Row className="mt-4">
-        {partnerAuth ? <PartnerAuth /> : <DefaultLogin />}
+        {showPartnerAuth ? <PartnerAuth /> : <DefaultLogin />}
       </Row>
 
       <Row>

--- a/src/sidebar/LoginPanel.tsx
+++ b/src/sidebar/LoginPanel.tsx
@@ -24,33 +24,59 @@ import marketplaceImage from "@img/marketplace.svg";
 // eslint-disable-next-line prefer-destructuring -- process.env variable
 const SERVICE_URL = process.env.SERVICE_URL;
 
-const LoginPanel: React.FunctionComponent = () => (
-  <Container>
-    <Row className="mt-4">
-      <Col className="text-center">
-        <h4 className="display-6">Connect PixieBrix Account</h4>
+const DefaultLogin: React.FunctionComponent = () => (
+  <Col className="text-center">
+    <h4 className="display-6">Connect PixieBrix Account</h4>
 
-        <p>
-          Register/log-in to PixieBrix to access your personal and team bricks
-        </p>
+    <p>Register/log-in to PixieBrix to access your personal and team bricks</p>
 
-        <Button
-          className="mt-4"
-          href={SERVICE_URL}
-          target="_blank"
-          variant="primary"
-        >
-          <FontAwesomeIcon icon={faSignInAlt} /> Connect Account
-        </Button>
-      </Col>
-    </Row>
-
-    <Row>
-      <Col className="text-center">
-        <img src={marketplaceImage} alt="Marketplace" width={300} />
-      </Col>
-    </Row>
-  </Container>
+    <Button
+      className="mt-4"
+      href={SERVICE_URL}
+      target="_blank"
+      variant="primary"
+    >
+      <FontAwesomeIcon icon={faSignInAlt} /> Connect Account
+    </Button>
+  </Col>
 );
+
+const PartnerAuth: React.FunctionComponent = () => {
+  const extensionUrl = new URL(browser.runtime.getURL("options.html")).href;
+  return (
+    <Col className="text-center">
+      <h4 className="display-6">Connect your AARI account</h4>
+      <p>
+        Authenticate with Automation Anywhere to continue using your team
+        extensions
+      </p>
+      <Button
+        className="mt-4"
+        href={extensionUrl}
+        target="_blank"
+        variant="primary"
+      >
+        <FontAwesomeIcon icon={faSignInAlt} /> Connect Account
+      </Button>
+    </Col>
+  );
+};
+
+const LoginPanel: React.FunctionComponent = () => {
+  const partnerAuth = false;
+  return (
+    <Container>
+      <Row className="mt-4">
+        {partnerAuth ? <PartnerAuth /> : <DefaultLogin />}
+      </Row>
+
+      <Row>
+        <Col className="text-center">
+          <img src={marketplaceImage} alt="Marketplace" width={300} />
+        </Col>
+      </Row>
+    </Container>
+  );
+};
 
 export default LoginPanel;

--- a/src/sidebar/LoginPanel.tsx
+++ b/src/sidebar/LoginPanel.tsx
@@ -23,8 +23,6 @@ import marketplaceImage from "@img/marketplace.svg";
 import useRequiredPartnerAuth from "@/auth/useRequiredPartnerAuth";
 import { useSelector } from "react-redux";
 import { selectSettings } from "@/store/settingsSelectors";
-import ControlRoomOAuthForm from "@/options/pages/onboarding/partner/ControlRoomOAuthForm";
-import ControlRoomTokenForm from "@/options/pages/onboarding/partner/ControlRoomTokenForm";
 
 // eslint-disable-next-line prefer-destructuring -- process.env variable
 const SERVICE_URL = process.env.SERVICE_URL;
@@ -47,36 +45,7 @@ const DefaultLogin: React.FunctionComponent = () => (
 );
 
 const PartnerAuth: React.FunctionComponent = () => {
-  const { authMethod } = useSelector(selectSettings);
   const extensionUrl = new URL(browser.runtime.getURL("options.html")).href;
-
-  let authBody = (
-    <Button
-      className="mt-4"
-      href={extensionUrl}
-      target="_blank"
-      variant="primary"
-    >
-      <FontAwesomeIcon icon={faSignInAlt} /> Connect Account
-    </Button>
-  );
-
-  if (authMethod === "partner-oauth2") {
-    authBody = <ControlRoomOAuthForm initialValues={{ controlRoomUrl: "" }} />;
-  }
-
-  if (authMethod === "partner-token") {
-    authBody = (
-      <ControlRoomTokenForm
-        initialValues={{
-          controlRoomUrl: "",
-          username: "",
-          password: "",
-        }}
-      />
-    );
-  }
-
   return (
     <Col className="text-center">
       <h4 className="display-6">Connect your AARI account</h4>
@@ -84,7 +53,14 @@ const PartnerAuth: React.FunctionComponent = () => {
         Authenticate with Automation Anywhere to continue using your team
         extensions
       </p>
-      {authBody}
+      <Button
+        className="mt-4"
+        href={extensionUrl}
+        target="_blank"
+        variant="primary"
+      >
+        <FontAwesomeIcon icon={faSignInAlt} /> Connect Account
+      </Button>
     </Col>
   );
 };

--- a/src/sidebar/__snapshots__/ConnectedSidebar.test.tsx.snap
+++ b/src/sidebar/__snapshots__/ConnectedSidebar.test.tsx.snap
@@ -162,3 +162,67 @@ exports[`SidebarApp renders not connected 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`SidebarApp renders not connected partner view 1`] = `
+<DocumentFragment>
+  <div
+    class="full-height"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="mt-4 row"
+      >
+        <div
+          class="text-center col"
+        >
+          <h4
+            class="display-6"
+          >
+            Connect your AARI account
+          </h4>
+          <p>
+            Authenticate with Automation Anywhere to continue using your team extensions
+          </p>
+          <a
+            class="mt-4 btn btn-primary"
+            href="chrome-extension://example.url/options.html"
+            target="_blank"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-sign-in-alt fa-w-16 "
+              data-icon="sign-in-alt"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M416 448h-84c-6.6 0-12-5.4-12-12v-40c0-6.6 5.4-12 12-12h84c17.7 0 32-14.3 32-32V160c0-17.7-14.3-32-32-32h-84c-6.6 0-12-5.4-12-12V76c0-6.6 5.4-12 12-12h84c53 0 96 43 96 96v192c0 53-43 96-96 96zm-47-201L201 79c-15-15-41-4.5-41 17v96H24c-13.3 0-24 10.7-24 24v96c0 13.3 10.7 24 24 24h136v96c0 21.5 26 32 41 17l168-168c9.3-9.4 9.3-24.6 0-34z"
+                fill="currentColor"
+              />
+            </svg>
+             Connect Account
+          </a>
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <div
+          class="text-center col"
+        >
+          <img
+            alt="Marketplace"
+            src="test-file-stub"
+            width="300"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
## What does this PR do?

- Closes #4548
- This modifies the "disconnected" Sidebar view for the case where a partner user is disconnected either from an expired partner token or from never having authenticated before. In this case, the user will be directed back to the extension where they'll be prompted to reconnect via OAuth2.

## Discussion

- Due to some additional complexity copying the `ControlRoomOAuthForm` & testing, I am leaving authenticating within the Sidebar itself for future work.

## Demo
<img width="400" alt="Screen Shot 2022-11-01 at 3 18 49 PM" src="https://user-images.githubusercontent.com/36575242/199352672-89c56576-9538-46c0-84fa-77026025ed8b.png">

## Future Work

- Improve the UX for users that have expired tokens by allowing them to authenticate directly within the Sidebar, instead of being redirect back to the Extension Console https://github.com/pixiebrix/pixiebrix-extension/issues/4589

## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer @twschiller 
