### PR TITLE
#4499 add PackageVersion to invalidated tags on updatePackage mutation

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -396,6 +396,7 @@ export const appApi = createApi({
         { type: "Package", id },
         "Recipes",
         "EditablePackages",
+        "PackageVersion",
       ],
     }),
     deletePackage: builder.mutation<void, { id: UUID }>({


### PR DESCRIPTION
## What does this PR do?

- Fixes #4499 
- Adds the `PackageVersion` RTK query tag to to the `updatePackage` mutation so that the diff viewer refreshes properly when updating a brick in the editor.

## Demo

https://user-images.githubusercontent.com/36575242/199361652-753bf7fc-b868-4c9a-be83-7f220e6394df.mov


## Checklist

- [ ] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer @BLoe 
