### PR TITLE
#4485 Send slow Page Editor times to rollbar

### DIFF
--- a/src/background/logging.ts
+++ b/src/background/logging.ts
@@ -312,6 +312,27 @@ export async function recordError(
   }
 }
 
+export async function recordWarning(
+  context: MessageContext | null,
+  message: string,
+  data?: JsonObject
+) {
+  forbidContext(
+    "contentScript",
+    "contentScript does not have CSP access to Rollbar"
+  );
+
+  void recordLog(context, "warn", message, data);
+
+  if (!(await allowsTrack())) {
+    warnAboutDisabledDNT();
+    return;
+  }
+
+  const rollbar = await getRollbar();
+  rollbar.warning(message, data);
+}
+
 export async function recordLog(
   context: MessageContext,
   level: MessageLevel,

--- a/src/pageEditor/pageEditor.tsx
+++ b/src/pageEditor/pageEditor.tsx
@@ -30,6 +30,9 @@ import Panel from "@/pageEditor/Panel";
 import { watchNavigation } from "@/pageEditor/protocol";
 import initGoogle from "@/contrib/google/initGoogle";
 import { initToaster } from "@/utils/notify";
+import { markAppStart } from "@/utils/performance";
+
+markAppStart();
 
 registerMessenger();
 void initGoogle();

--- a/src/pageEditor/sidebar/SidebarExpanded.tsx
+++ b/src/pageEditor/sidebar/SidebarExpanded.tsx
@@ -16,7 +16,7 @@
  */
 
 import styles from "./Sidebar.module.scss";
-import React, { FormEvent, useMemo, useState } from "react";
+import React, { FormEvent, useEffect, useMemo, useState } from "react";
 import { sortBy } from "lodash";
 import { getRecipeById } from "@/utils";
 import { Accordion, Button, Form, ListGroup } from "react-bootstrap";
@@ -47,11 +47,19 @@ import ReloadButton from "./ReloadButton";
 import AddExtensionPointButton from "./AddExtensionPointButton";
 import ExtensionEntry from "./ExtensionEntry";
 import { actions } from "@/pageEditor/slices/editorSlice";
+import { measurePerformanceFromAppStart } from "@/utils/performance";
 
 const SidebarExpanded: React.FunctionComponent<{
   collapseSidebar: () => void;
 }> = ({ collapseSidebar }) => {
-  const { data: allRecipes } = useGetRecipesQuery();
+  const { data: allRecipes, isLoading: isAllRecipesLoading } =
+    useGetRecipesQuery();
+
+  useEffect(() => {
+    if (!isAllRecipesLoading) {
+      measurePerformanceFromAppStart("sidebarExpanded:allRecipesLoaded");
+    }
+  }, [isAllRecipesLoading]);
 
   const dispatch = useDispatch();
   const activeElementId = useSelector(selectActiveElementId);

--- a/src/pageEditor/sidebar/SidebarExpanded.tsx
+++ b/src/pageEditor/sidebar/SidebarExpanded.tsx
@@ -47,7 +47,7 @@ import ReloadButton from "./ReloadButton";
 import AddExtensionPointButton from "./AddExtensionPointButton";
 import ExtensionEntry from "./ExtensionEntry";
 import { actions } from "@/pageEditor/slices/editorSlice";
-import { measurePerformanceFromAppStart } from "@/utils/performance";
+import { measureDurationFromAppStart } from "@/utils/performance";
 
 const SidebarExpanded: React.FunctionComponent<{
   collapseSidebar: () => void;
@@ -57,7 +57,7 @@ const SidebarExpanded: React.FunctionComponent<{
 
   useEffect(() => {
     if (!isAllRecipesLoading) {
-      measurePerformanceFromAppStart("sidebarExpanded:allRecipesLoaded");
+      measureDurationFromAppStart("sidebarExpanded:allRecipesLoaded");
     }
   }, [isAllRecipesLoading]);
 

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -30,7 +30,7 @@ export function markAppStart() {
  * @param action String message to log. A pattern to follow is <Place of measurement>:<Action>. For example, "sidebarExpanded:allRecipesLoaded"
  * @param reportThreshold The threshold in milliseconds to report the measurement as warning to rollbar. Pass null to not report
  */
-export function measurePerformanceFromAppStart(
+export function measureDurationFromAppStart(
   action: string,
   reportThreshold: number | null = 5000
 ) {

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -16,11 +16,13 @@
  */
 import { recordWarning } from "@/background/logging";
 
+const APP_START_ACTION = "app:start";
+
 /**
  * Adds a performance mark for the initialization of an app
  */
 export function markAppStart() {
-  performance.mark("app-start");
+  performance.mark(APP_START_ACTION);
 }
 
 /**
@@ -32,7 +34,7 @@ export function measurePerformanceFromAppStart(
   action: string,
   reportThreshold: number | null = 5000
 ) {
-  const { duration } = performance.measure("app-start");
+  const { duration } = performance.measure(APP_START_ACTION);
   const message = `Performance: "${action}" took ${Math.round(duration)}ms`;
   const data = {
     duration,

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { recordWarning } from "@/background/logging";
+
+/**
+ * Adds a performance mark for the initialization of an app
+ */
+export function markAppStart() {
+  performance.mark("app-start");
+}
+
+/**
+ * Measures the time between the app start and the current time
+ * @param action String message to log. A pattern to follow is <Place of measurement>:<Action>. For example, "sidebarExpanded:allRecipesLoaded"
+ * @param reportThreshold The threshold in milliseconds to report the measurement as warning to rollbar. Pass null to not report
+ */
+export function measurePerformanceFromAppStart(
+  action: string,
+  reportThreshold: number | null = 5000
+) {
+  const { duration } = performance.measure("app-start");
+  const message = `Performance: "${action}" took ${Math.round(duration)}ms`;
+  const data = {
+    duration,
+    threshold: reportThreshold,
+    timestamp: new Date().toISOString(),
+  };
+  console.debug(message, data);
+
+  if (reportThreshold != null && duration > reportThreshold) {
+    void recordWarning(null, message, data);
+  }
+}


### PR DESCRIPTION
## What does this PR do?

- Part of #4485 
- Sending performance metrics from Page Editor to Rollbar

## Demo

Rollbar event
<img width="1773" alt="Screenshot 2022-11-02 at 5 19 41 PM" src="https://user-images.githubusercontent.com/3116723/199544745-715aacd8-7f68-4f00-968d-e8b92d26e134.png">


## Checklist

- [ ] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer @BLoe 
