### PR TITLE
#4489 Don't report context-invalidated errors to rollbar

### DIFF
--- a/src/pageEditor/tabState/tabStateSlice.ts
+++ b/src/pageEditor/tabState/tabStateSlice.ts
@@ -134,7 +134,6 @@ export const tabStateSlice = createSlice({
           "PixieBrix was updated or restarted. Reload the Page Editor to continue."
         );
         state.error = serializeError(error);
-        reportError(error);
       });
   },
 });


### PR DESCRIPTION
## What does this PR do?

- Follow up from #4489 
- "context invalidated" errors should not be reported to rollbar

## Checklist

- [ ] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer - @fregante 
