### PR TITLE
#2453: partner oauth2 login fixes

### DIFF
--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -69,7 +69,18 @@ export async function getExtensionToken(): Promise<string | undefined> {
 }
 
 /**
+ * Clear authentication data when using the partner JWT to authenticate.
+ *
+ * @see setPartnerAuth
+ */
+export async function clearPartnerAuth(): Promise<void> {
+  return setStorage(STORAGE_PARTNER_TOKEN, {});
+}
+
+/**
  * Set authentication data when using the partner JWT to authenticate.
+ *
+ * @see clearPartnerAuth
  */
 export async function setPartnerAuth(data: PartnerAuthData): Promise<void> {
   if (!isEmpty(data.authId) && isEmpty(data.token)) {

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -29,6 +29,7 @@ import { expectContext } from "@/utils/expectContext";
 import { isEmpty, omit, remove } from "lodash";
 import { UnknownObject } from "@/types";
 
+// `chrome.storage.local` keys
 const STORAGE_EXTENSION_KEY = "extensionKey" as ManualStorageKey;
 const STORAGE_PARTNER_TOKEN = "partnerToken" as ManualStorageKey;
 

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -52,10 +52,6 @@ export async function readAuthData(): Promise<
   return readStorage(STORAGE_EXTENSION_KEY, {});
 }
 
-export async function readPartnerAuthData(): Promise<Partial<PartnerAuthData>> {
-  return readStorage(STORAGE_PARTNER_TOKEN, {});
-}
-
 export async function flagOn(flag: string): Promise<boolean> {
   const authData = await readAuthData();
   return authData.flags?.includes(flag);
@@ -69,13 +65,8 @@ export async function getExtensionToken(): Promise<string | undefined> {
   return token;
 }
 
-/**
- * Clear authentication data when using the partner JWT to authenticate.
- *
- * @see setPartnerAuth
- */
-export async function clearPartnerAuth(): Promise<void> {
-  return setStorage(STORAGE_PARTNER_TOKEN, {});
+export async function readPartnerAuthData(): Promise<Partial<PartnerAuthData>> {
+  return readStorage(STORAGE_PARTNER_TOKEN, {});
 }
 
 /**
@@ -85,10 +76,20 @@ export async function clearPartnerAuth(): Promise<void> {
  */
 export async function setPartnerAuth(data: PartnerAuthData): Promise<void> {
   if (!isEmpty(data.authId) && isEmpty(data.token)) {
+    // Should use clearPartnerAuth for clearing the partner integration JWT
     throw new Error("Received null/blank token for partner integration");
   }
 
   return setStorage(STORAGE_PARTNER_TOKEN, data);
+}
+
+/**
+ * Clear authentication data when using the partner JWT to authenticate.
+ *
+ * @see setPartnerAuth
+ */
+export async function clearPartnerAuth(): Promise<void> {
+  return setStorage(STORAGE_PARTNER_TOKEN, {});
 }
 
 /**
@@ -157,12 +158,16 @@ export async function getExtensionAuth(): Promise<
 }
 
 /**
- * Clear the extension state. The options page will show as "unlinked" and prompt the user to link their account.
+ * Clear the cached extension authentication secrets.
+ *
+ * The options page will show as "unlinked" and prompt the user to link their account.
  */
-export async function clearExtensionAuth(): Promise<void> {
+export async function clearCachedAuthSecrets(): Promise<void> {
   console.debug("Clearing extension auth");
-  await browser.storage.local.remove(STORAGE_EXTENSION_KEY);
-  await browser.storage.local.remove(STORAGE_PARTNER_TOKEN);
+  await Promise.all([
+    browser.storage.local.remove(STORAGE_EXTENSION_KEY),
+    browser.storage.local.remove(STORAGE_PARTNER_TOKEN),
+  ]);
   Cookies.remove("csrftoken");
   Cookies.remove("sessionid");
 }

--- a/src/auth/useLinkState.ts
+++ b/src/auth/useLinkState.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useAsyncState } from "@/hooks/common";
+import {
+  addListener as addAuthListener,
+  isLinked,
+  removeListener as removeAuthListener,
+} from "@/auth/token";
+import { useEffect } from "react";
+
+type LinkState = {
+  hasToken: boolean | undefined;
+  tokenLoading: boolean;
+  tokenError: unknown;
+};
+
+/**
+ * Hook to get link state, and automatically update if extension becomes linked/unlinked.
+ *
+ * TODO: this should use Redux to ensure UI is in sync, as it is referenced by multiple place. OK for now because the
+ *   isLinked check is fast and side-effect free.
+ *
+ * @see isLinked
+ */
+function useLinkState(): LinkState {
+  // See component documentation for why both isLinked and useGetMeQuery are required
+  // hasToken is true for either native PixieBrix token, or partner Bearer JWT
+  const [hasToken, tokenLoading, tokenError, refreshTokenState] = useAsyncState(
+    isLinked,
+    []
+  );
+
+  useEffect(() => {
+    // Listen for token invalidation
+    const handler = async () => {
+      console.debug("Auth state changed, checking for token");
+      void refreshTokenState();
+    };
+
+    addAuthListener(handler);
+
+    return () => {
+      removeAuthListener(handler);
+    };
+  }, [refreshTokenState]);
+
+  return {
+    hasToken,
+    tokenLoading,
+    tokenError,
+  };
+}
+
+export default useLinkState;

--- a/src/auth/useRequiredPartnerAuth.ts
+++ b/src/auth/useRequiredPartnerAuth.ts
@@ -122,8 +122,11 @@ function useRequiredPartnerAuth(): RequiredPartnerState {
   // Prefer the most recent /api/me/ data from the server
   const { isLoading, data: me, error } = useGetMeQuery();
   const localAuth = useSelector(selectAuth);
-  const { authServiceId: authServiceIdOverride, authMethod } =
-    useSelector(selectSettings);
+  const {
+    authServiceId: authServiceIdOverride,
+    authMethod,
+    partnerId: partnerIdOverride,
+  } = useSelector(selectSettings);
   const configuredServices = useSelector(selectConfiguredServices);
 
   const [managedControlRoomUrl] = useAsyncState(
@@ -142,12 +145,18 @@ function useRequiredPartnerAuth(): RequiredPartnerState {
   // the organization will be null on result of useGetMeQuery
   const hasControlRoom =
     Boolean(organization?.control_room?.id) || Boolean(managedControlRoomUrl);
-  const hasPartner = Boolean(partner) || Boolean(managedPartnerId);
+  const hasPartner =
+    Boolean(partner) || Boolean(managedPartnerId) || hasControlRoom;
+  const partnerId =
+    partnerIdOverride ??
+    managedPartnerId ??
+    partner?.theme ??
+    (hasControlRoom ? "automation-anywhere" : null);
 
   const partnerServiceIds = decidePartnerServiceIds({
     authServiceIdOverride,
     authMethod,
-    partnerId: managedPartnerId ?? partner?.theme,
+    partnerId,
   });
 
   const partnerConfiguration = configuredServices.find((service) =>

--- a/src/background/partnerIntegrations.ts
+++ b/src/background/partnerIntegrations.ts
@@ -114,6 +114,10 @@ export async function launchAuthIntegration({
       throw new Error("controlRoomUrl is missing on configuration");
     }
 
+    console.info(
+      "Setting partner auth for Control Room %s",
+      config.config.controlRoomUrl
+    );
     await setPartnerAuth({
       authId: config.id,
       token: data.access_token,

--- a/src/options/__snapshots__/Navbar.test.tsx.snap
+++ b/src/options/__snapshots__/Navbar.test.tsx.snap
@@ -77,7 +77,30 @@ exports[`Navbar renders 1`] = `
       </div>
       <ul
         class="navbar-nav navbar-nav-right flex-grow-1 justify-content-end"
-      />
+      >
+        <a
+          class="px-3 nav-link"
+          href="https://app.pixiebrix.com"
+          target="_blank"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-external-link-alt fa-w-16 mr-1"
+            data-icon="external-link-alt"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              fill="currentColor"
+            />
+          </svg>
+          Open Admin Console
+        </a>
+      </ul>
     </div>
   </nav>
 </DocumentFragment>

--- a/src/options/pages/onboarding/SetupPage.test.tsx
+++ b/src/options/pages/onboarding/SetupPage.test.tsx
@@ -29,6 +29,8 @@ import settingsSlice from "@/store/settingsSlice";
 import { CONTROL_ROOM_OAUTH_SERVICE_ID } from "@/services/constants";
 import { uuidv4 } from "@/types/helpers";
 import { readStorage } from "@/chrome";
+import { HashRouter } from "react-router-dom";
+import { createHashHistory } from "history";
 
 function optionsStore(initialState?: any) {
   return configureStore({
@@ -119,25 +121,16 @@ describe("SetupPage", () => {
       data: {},
     }));
 
-    (global as any).window = Object.create(window);
+    const history = createHashHistory();
+    history.push("/start?hostname=https://mycontrolroom.com");
 
-    const url = new URL(
-      "chrome-extension://abc/options.html?hostname=https://mycontrolroom.com#/start"
-    );
-
-    Object.defineProperty(window, "location", {
-      value: {
-        href: url.href,
-        hash: url.hash,
-        search: url.search,
-      },
-    });
-
+    // Needs to use HashRouter instead of MemoryRouter for the useLocation calls in the components to work correctly
+    // given the URL structure above
     render(
       <Provider store={optionsStore({})}>
-        <MemoryRouter>
+        <HashRouter>
           <SetupPage />
-        </MemoryRouter>
+        </HashRouter>
       </Provider>
     );
 

--- a/src/options/pages/onboarding/SetupPage.tsx
+++ b/src/options/pages/onboarding/SetupPage.tsx
@@ -26,6 +26,7 @@ import { selectSettings } from "@/store/settingsSelectors";
 import Loader from "@/components/Loader";
 import useRequiredPartnerAuth from "@/auth/useRequiredPartnerAuth";
 import PartnerSetupCard from "@/options/pages/onboarding/partner/PartnerSetupCard";
+import { useLocation } from "react-router";
 
 const Layout: React.FunctionComponent = ({ children }) => (
   <Row className="w-100 mx-0">
@@ -42,6 +43,7 @@ const Layout: React.FunctionComponent = ({ children }) => (
  */
 const SetupPage: React.FunctionComponent = () => {
   useTitle("Setup");
+  const location = useLocation();
 
   // Local override for authentication method
   const { authMethod } = useSelector(selectSettings);
@@ -52,7 +54,7 @@ const SetupPage: React.FunctionComponent = () => {
     hasConfiguredIntegration,
   } = useRequiredPartnerAuth();
 
-  const isStartUrl = location.hash.startsWith("#/start");
+  const isStartUrl = location.pathname.startsWith("/start");
 
   const [baseURL, baseURLPending] = useAsyncState(getBaseURL, []);
 

--- a/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
+++ b/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
@@ -33,6 +33,7 @@ import { getErrorMessage } from "@/errors/errorHelpers";
 import { serviceOriginPermissions } from "@/permissions";
 import { requestPermissions } from "@/utils/permissions";
 import { isEmpty } from "lodash";
+import { util as apiUtil } from "@/services/api";
 
 const { updateServiceConfig } = servicesSlice.actions;
 
@@ -104,6 +105,11 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
         await requestPermissions(requiredPermissions);
 
         await launchAuthIntegration({ serviceId: authServiceId });
+
+        // Refresh auth state so that 1) the user appears as logged in the UI in the navbar, and 2) the Admin Console
+        // link in the navbar links to the URL required for JWT hand-off.
+        // See useRequiredAuth hook for more details
+        dispatch(apiUtil.resetApiState());
       } catch (error) {
         helpers.setStatus(getErrorMessage(error));
       }

--- a/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
+++ b/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
@@ -41,8 +41,13 @@ export type ControlRoomConfiguration = {
 };
 
 const validationSchema = Yup.object().shape({
-  // Leave off .url() because it doesn't allow localhost (which is needed for using mock-server for testing)
-  controlRoomUrl: Yup.string().required(),
+  controlRoomUrl: Yup.string()
+    .required()
+    .when([], {
+      // Yup url check doesn't allow localhost. Allow localhost during development
+      is: () => process.env.NODE_ENV === "development",
+      otherwise: (schema) => schema.url(),
+    }),
 });
 
 const ControlRoomOAuthForm: React.FunctionComponent<{

--- a/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
+++ b/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
@@ -32,6 +32,7 @@ import { FormikHelpers } from "formik";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { serviceOriginPermissions } from "@/permissions";
 import { requestPermissions } from "@/utils/permissions";
+import { isEmpty } from "lodash";
 
 const { updateServiceConfig } = servicesSlice.actions;
 
@@ -40,7 +41,8 @@ export type ControlRoomConfiguration = {
 };
 
 const validationSchema = Yup.object().shape({
-  controlRoomUrl: Yup.string().url().required(),
+  // Leave off .url() because it doesn't allow localhost (which is needed for using mock-server for testing)
+  controlRoomUrl: Yup.string().required(),
 });
 
 const ControlRoomOAuthForm: React.FunctionComponent<{
@@ -49,8 +51,12 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
   const dispatch = useDispatch();
   const configuredServices = useSelector(selectConfiguredServices);
 
-  const { authServiceId = CONTROL_ROOM_OAUTH_SERVICE_ID } =
-    useSelector(selectSettings);
+  const { authServiceId: authServiceIdOverride } = useSelector(selectSettings);
+
+  // `authServiceIdOverride` can be null/empty, so defaulting in the settings destructuring doesn't work
+  const authServiceId = isEmpty(authServiceIdOverride)
+    ? CONTROL_ROOM_OAUTH_SERVICE_ID
+    : authServiceIdOverride;
 
   const connect = useCallback(
     async (

--- a/src/options/pages/onboarding/partner/PartnerSetupCard.tsx
+++ b/src/options/pages/onboarding/partner/PartnerSetupCard.tsx
@@ -109,10 +109,12 @@ const PartnerSetupCard: React.FunctionComponent = () => {
   const [controlRoomUrl] = useAsyncState(
     async () => {
       try {
-        return await readStorage(
-          CONTROL_ROOM_URL_MANAGED_KEY,
-          undefined,
-          "managed"
+        return (
+          (await readStorage(
+            CONTROL_ROOM_URL_MANAGED_KEY,
+            undefined,
+            "managed"
+          )) ?? fallbackControlRoomUrl
         );
       } catch {
         return fallbackControlRoomUrl;

--- a/src/options/pages/onboarding/partner/PartnerSetupCard.tsx
+++ b/src/options/pages/onboarding/partner/PartnerSetupCard.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { useEffect } from "react";
 import OnboardingChecklistCard, {
   OnboardingStep,
 } from "@/components/onboarding/OnboardingChecklistCard";
@@ -31,6 +31,7 @@ import { faLink } from "@fortawesome/free-solid-svg-icons";
 import { useAsyncState } from "@/hooks/common";
 import { getBaseURL } from "@/services/baseService";
 import settingsSlice from "@/store/settingsSlice";
+import { ManualStorageKey, readStorage } from "@/chrome";
 
 function useInstallUrl() {
   const { data: me } = useGetMeQuery();
@@ -86,32 +87,55 @@ function usePartnerLoginMode(): "token" | "oauth2" {
   }
 }
 
+const CONTROL_ROOM_URL_MANAGED_KEY = "controlRoomUrl" as ManualStorageKey;
+
 /**
  * A card to set up a required partner integration.
  *
  * Currently, supports the Automation Anywhere partner integration.
  */
 const PartnerSetupCard: React.FunctionComponent = () => {
-  const mode = usePartnerLoginMode();
   const dispatch = useDispatch();
-  const hostname = new URLSearchParams(location.search).get("hostname");
-
+  const mode = usePartnerLoginMode();
   const { data: me } = useGetMeQuery();
   const { installURL } = useInstallUrl();
 
-  // TODO: prefer managed storage for the Control Room URL
-  const controlRoomUrl = hostname ?? me?.organization?.control_room?.url ?? "";
+  // Hostname passed from manual flow during manual setup initiated via Control Room link
+  const hostname = new URLSearchParams(location.search).get("hostname");
+
+  // Prefer controlRoomUrl set by IT for force-installed extensions
+  const fallbackControlRoomUrl =
+    hostname ?? me?.organization?.control_room?.url ?? "";
+  const [controlRoomUrl] = useAsyncState(
+    async () => {
+      try {
+        return await readStorage(
+          CONTROL_ROOM_URL_MANAGED_KEY,
+          undefined,
+          "managed"
+        );
+      } catch {
+        return fallbackControlRoomUrl;
+      }
+    },
+    [fallbackControlRoomUrl],
+    fallbackControlRoomUrl
+  );
+
   const initialValues = {
     controlRoomUrl,
     username: "",
     password: "",
   };
 
-  dispatch(
-    settingsSlice.actions.setPartnerId({
-      partnerId: "automation-anywhere",
-    })
-  );
+  useEffect(() => {
+    // Ensure the partner branding is applied
+    dispatch(
+      settingsSlice.actions.setPartnerId({
+        partnerId: "automation-anywhere",
+      })
+    );
+  }, [dispatch]);
 
   if (mode === "oauth2") {
     // For OAuth2, there's only 2 steps because the AA JWT is also used to communicate with the PixieBrix server
@@ -123,7 +147,10 @@ const PartnerSetupCard: React.FunctionComponent = () => {
           completed
         />
         <OnboardingStep number={2} title="Connect your AARI account" active>
-          <ControlRoomOAuthForm initialValues={initialValues} />
+          <ControlRoomOAuthForm
+            initialValues={initialValues}
+            key={controlRoomUrl}
+          />
         </OnboardingStep>
       </OnboardingChecklistCard>
     );
@@ -164,7 +191,10 @@ const PartnerSetupCard: React.FunctionComponent = () => {
         completed
       />
       <OnboardingStep number={3} title="Connect your AARI account" active>
-        <ControlRoomTokenForm initialValues={initialValues} />
+        <ControlRoomTokenForm
+          initialValues={initialValues}
+          key={controlRoomUrl}
+        />
       </OnboardingStep>
     </OnboardingChecklistCard>
   );

--- a/src/options/pages/onboarding/partner/PartnerSetupCard.tsx
+++ b/src/options/pages/onboarding/partner/PartnerSetupCard.tsx
@@ -32,6 +32,7 @@ import { useAsyncState } from "@/hooks/common";
 import { getBaseURL } from "@/services/baseService";
 import settingsSlice from "@/store/settingsSlice";
 import { ManualStorageKey, readStorage } from "@/chrome";
+import { useLocation } from "react-router";
 
 function useInstallUrl() {
   const { data: me } = useGetMeQuery();
@@ -96,6 +97,8 @@ const CONTROL_ROOM_URL_MANAGED_KEY = "controlRoomUrl" as ManualStorageKey;
  */
 const PartnerSetupCard: React.FunctionComponent = () => {
   const dispatch = useDispatch();
+  // Make sure to use useLocation because the location.search are on the hash route
+  const location = useLocation();
   const mode = usePartnerLoginMode();
   const { data: me } = useGetMeQuery();
   const { installURL } = useInstallUrl();

--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -20,7 +20,7 @@ import styles from "./AdvancedSettings.module.scss";
 import { Button, Card, Form } from "react-bootstrap";
 import { DEFAULT_SERVICE_URL, useConfiguredHost } from "@/services/baseService";
 import React, { useCallback } from "react";
-import { clearExtensionAuth, clearPartnerAuth } from "@/auth/token";
+import { clearCachedAuthSecrets, clearPartnerAuth } from "@/auth/token";
 import notify from "@/utils/notify";
 import useFlags from "@/hooks/useFlags";
 import settingsSlice from "@/store/settingsSlice";
@@ -46,7 +46,7 @@ const AdvancedSettings: React.FunctionComponent = () => {
   const [serviceURL, setServiceURL] = useConfiguredHost();
 
   const clear = useCallback(async () => {
-    await clearExtensionAuth();
+    await clearCachedAuthSecrets();
     // The success message will just flash up, because the page reloads on the next line
     notify.success(
       "Cleared the browser extension token. Visit the web app to set it again"

--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -20,7 +20,7 @@ import styles from "./AdvancedSettings.module.scss";
 import { Button, Card, Form } from "react-bootstrap";
 import { DEFAULT_SERVICE_URL, useConfiguredHost } from "@/services/baseService";
 import React, { useCallback } from "react";
-import { clearExtensionAuth } from "@/auth/token";
+import { clearExtensionAuth, clearPartnerAuth } from "@/auth/token";
 import notify from "@/utils/notify";
 import useFlags from "@/hooks/useFlags";
 import settingsSlice from "@/store/settingsSlice";
@@ -33,6 +33,7 @@ import chromeP from "webext-polyfill-kinda";
 import useUserAction from "@/hooks/useUserAction";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import { isEmpty } from "lodash";
+import { util as apiUtil } from "@/services/api";
 
 const SAVING_URL_NOTIFICATION_ID = uuidv4();
 const SAVING_URL_TIMEOUT_MS = 4000;
@@ -61,6 +62,10 @@ const AdvancedSettings: React.FunctionComponent = () => {
       // https://developer.chrome.com/docs/extensions/reference/identity/#method-clearAllCachedAuthTokens
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see documentation link
       await (chromeP.identity as any).clearAllCachedAuthTokens();
+
+      // Force /me query refresh, as user will now not be logged in
+      await clearPartnerAuth();
+      apiUtil.invalidateTags(["Me"]);
     },
     {
       successMessage: "Cleared all cached OAuth2 tokens",

--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -63,15 +63,16 @@ const AdvancedSettings: React.FunctionComponent = () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see documentation link
       await (chromeP.identity as any).clearAllCachedAuthTokens();
 
-      // Force /me query refresh, as user will now not be logged in
+      // Force reset of all queries, and partner bearer JWT will no longer be present.
+      // NOTE: currently the Navbar will show the user information, as it falls back to cached auth
       await clearPartnerAuth();
-      apiUtil.invalidateTags(["Me"]);
+      dispatch(apiUtil.resetApiState());
     },
     {
       successMessage: "Cleared all cached OAuth2 tokens",
       errorMessage: "Error clearing cached OAuth2 tokens",
     },
-    []
+    [dispatch]
   );
 
   const reload = useCallback(() => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -469,4 +469,5 @@ export const {
   useListPackageVersionsQuery,
   useUpdateScopeMutation,
   useGetStarterBlueprintsQuery,
+  util,
 } = appApi;

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -22,10 +22,11 @@ import {
   SkunkworksSettings,
 } from "@/store/settingsTypes";
 import reportError from "@/telemetry/reportError";
-import { once } from "lodash";
+import { isEmpty, once } from "lodash";
 import { DEFAULT_THEME } from "@/options/types";
 import { isValidTheme } from "@/utils/themeUtils";
 import { RegistryId } from "@/core";
+import { isRegistryId } from "@/types/helpers";
 
 export const initialSettingsState: SettingsState = {
   mode: "remote",
@@ -75,7 +76,9 @@ const settingsSlice = createSlice({
       state,
       { payload: { serviceId } }: { payload: { serviceId: RegistryId } }
     ) {
-      state.authServiceId = serviceId;
+      // Ensure valid data for authServiceId
+      state.authServiceId =
+        !isEmpty(serviceId) && isRegistryId(serviceId) ? serviceId : null;
     },
     setAuthMethod(
       state,

--- a/static/managedStorageSchema.json
+++ b/static/managedStorageSchema.json
@@ -9,6 +9,11 @@
       "type": "string",
       "description": "PixieBrix partner ID"
     },
+    "controlRoomUrl": {
+      "type": "string",
+      "format": "uri",
+      "description": "Automation Anywhere Control Room URL, including scheme"
+    },
     "campaignIds": {
       "type": "array",
       "description": "Campaign IDs the extension is associated with",


### PR DESCRIPTION
## What does this PR do?

- Part of #2453
- Fixes: https://github.com/pixiebrix/pixiebrix-extension/issues/4594
- Fixes: https://github.com/pixiebrix/pixiebrix-extension/issues/4628
- Add `controlRoomUrl` field to `managedStorageSchema.json` for enterprise IT departments to set as part of enterprise rollout
- PartnerSetupCard: Check and use configured `controlRoomUrl` in managed storage
- ControlRoomOAuthForm: fix `null` value handling for `settingsSlice.authServiceId`
- useRequiredPartnerAuth: check for  configured `controlRoomUrl` in managed storage, fix partner JWT check

## Remaining Work

- [x] Refresh AuthState from /api/me endpoint after OAuth2 login
- [x] When going round trip -- back to Extension Console from Admin Console, showing Login with AA screen. And every visit to Admin Console shows "Successfully linked the Browser Extension to your PixieBrix account"

## Demo

- [x] Loom demo: https://www.loom.com/share/2456bffe6c2842979700b9d8532a23e6

## Future Work / Out of Scope

- Check actual Control Room URL in cached partner auth data matches expected Control Room URL. (Unlikely for now that enterprise rollout users would need to switch)

## Team Coordination

- [X] This PR requires a documentation change (link to old docs): update documentation: https://docs.pixiebrix.com/integrations/automation-anywhere/aari-extensions-enterprise-it-guide#ddba78e8db8042afb230058e98ec563c

## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @johnnymetz 
