### PR TITLE
Split the Upload to CodeCov CI step into a separate job and add retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
   PUBLIC_RELEASE: ${{ github.ref == 'refs/heads/main' }}
 
 jobs:
-  test:
+  run-tests:
     runs-on: ubuntu-latest
 
     steps:
@@ -18,11 +18,28 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run test -- --coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - uses: actions/upload-artifact@v3
         with:
-          fail_ci_if_error: true
-          verbose: true
+          name: extension-test-coverage
+          path: coverage/coverage-final.json
+
+  upload-to-codecov:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: extension-test-coverage
+      - name: Upload coverage to Codecov
+        uses: Wandalen/wretry.action@master
+        with:
+          action: codecov/codecov-action@v3
+          with: |
+            fail_ci_if_error: true
+            verbose: true
+          attempt_limit: 3
+          attempt_delay: 2000
 
   build-stage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR do?

- I found [this example](https://github.com/codecov/example-actions-bundled/blob/main/.github/workflows/ci.yml) of using the upload/download artifact actions to split the "upload to codecov" step into it's own job
- Used [this retry action](https://github.com/Wandalen/wretry.action) to add retry logic to the separate codecov upload job

## Discussion

- _Were there multiple approaches you were deciding between?_
f
## Demo

- _Paste a screenshot or demo video here_
