### PR TITLE
#4657: fix partner login storybook stories

### DIFF
--- a/src/options/pages/onboarding/partner/PartnerSetupCard.stories.tsx
+++ b/src/options/pages/onboarding/partner/PartnerSetupCard.stories.tsx
@@ -31,6 +31,7 @@ import { appApi } from "@/services/api";
 import { rest } from "msw";
 import { HashRouter } from "react-router-dom";
 import { createHashHistory } from "history";
+import { addThemeClassToDocumentRoot } from "@/utils/themeUtils";
 
 export default {
   title: "Onboarding/Setup/PartnerSetupCard",
@@ -70,6 +71,8 @@ const Template: Story<{
 
   const history = createHashHistory();
   history.push("/");
+
+  addThemeClassToDocumentRoot("automation-anywhere");
 
   return (
     <Provider store={templateStore}>

--- a/src/options/pages/onboarding/partner/PartnerSetupCard.stories.tsx
+++ b/src/options/pages/onboarding/partner/PartnerSetupCard.stories.tsx
@@ -41,6 +41,7 @@ const Template: Story<{
   auth: AuthState;
   configuredServiceId: RegistryId | null;
 }> = ({ auth }) => {
+  // Store that doesn't persist the data
   const templateStore = configureStore({
     reducer: {
       options: extensionsSlice.reducer,
@@ -113,7 +114,7 @@ TokenUnlinked.parameters = {
 
 export const TokenLinked = Template.bind({});
 TokenLinked.args = {
-  auth: { ...authSlice.getInitialState(), isLoggedIn: true },
+  auth: { ...authSlice.getInitialState(), isLoggedIn: true, userId: uuidv4() },
 };
 TokenLinked.storyName = "Token (Linked Extension)";
 TokenLinked.parameters = {

--- a/src/options/pages/onboarding/partner/PartnerSetupCard.stories.tsx
+++ b/src/options/pages/onboarding/partner/PartnerSetupCard.stories.tsx
@@ -29,6 +29,8 @@ import PartnerSetupCard from "@/options/pages/onboarding/partner/PartnerSetupCar
 import { AuthState } from "@/auth/authTypes";
 import { appApi } from "@/services/api";
 import { rest } from "msw";
+import { HashRouter } from "react-router-dom";
+import { createHashHistory } from "history";
 
 export default {
   title: "Onboarding/Setup/PartnerSetupCard",
@@ -65,9 +67,14 @@ const Template: Story<{
     },
   });
 
+  const history = createHashHistory();
+  history.push("/");
+
   return (
     <Provider store={templateStore}>
-      <PartnerSetupCard />
+      <HashRouter>
+        <PartnerSetupCard />
+      </HashRouter>
     </Provider>
   );
 };

--- a/src/options/pages/onboarding/partner/PartnerSetupCard.stories.tsx
+++ b/src/options/pages/onboarding/partner/PartnerSetupCard.stories.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { useEffect } from "react";
 import { ComponentMeta, Story } from "@storybook/react";
 import { configureStore } from "@reduxjs/toolkit";
 import extensionsSlice from "@/store/extensionsSlice";
@@ -37,6 +37,18 @@ export default {
   title: "Onboarding/Setup/PartnerSetupCard",
   component: PartnerSetupCard,
 } as ComponentMeta<typeof PartnerSetupCard>;
+
+const PartnerThemeEffect: React.FunctionComponent = () => {
+  useEffect(() => {
+    addThemeClassToDocumentRoot("automation-anywhere");
+
+    return () => {
+      addThemeClassToDocumentRoot("default");
+    };
+  }, []);
+
+  return null;
+};
 
 const Template: Story<{
   auth: AuthState;
@@ -72,10 +84,9 @@ const Template: Story<{
   const history = createHashHistory();
   history.push("/");
 
-  addThemeClassToDocumentRoot("automation-anywhere");
-
   return (
     <Provider store={templateStore}>
+      <PartnerThemeEffect />
       <HashRouter>
         <PartnerSetupCard />
       </HashRouter>


### PR DESCRIPTION
## What does this PR do?

- Closes #4657 
- Wraps partner onboarding stories in HashRouter to support inner useLocation call
- Applies partner theme colors to the stories

## Checklist

- [X] Add tests: N/A
- [X] Run Storybook and manually confirm that all stories are working
- [X] Designate a primary reviewer: @mnholtz 
