### PR TITLE
#4358: Use standard memoize instead of custom storage logic

### DIFF
--- a/src/background/auth.test.ts
+++ b/src/background/auth.test.ts
@@ -18,7 +18,7 @@
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import { getToken } from "./auth";
-import { IService, RawServiceConfiguration } from "@/core";
+import { UUID } from "@/core";
 import { uuidv4 } from "@/types/helpers";
 
 const axiosMock = new MockAdapter(axios);
@@ -26,10 +26,11 @@ const axiosMock = new MockAdapter(axios);
 const getOneToken = async (id: UUID) =>
   getToken(
     {
-      isToken: true,
+      // @ts-expect-error The result isn't necessary at this time
       getTokenContext: () => ({}),
-    } as unknown as IService,
-    { id } as RawServiceConfiguration
+      isToken: true,
+    },
+    { id }
   );
 
 describe("getToken", () => {

--- a/src/background/auth.test.ts
+++ b/src/background/auth.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import { getToken } from "./auth";
+import { IService, RawServiceConfiguration } from "@/core";
+import { uuidv4 } from "@/types/helpers";
+
+const axiosMock = new MockAdapter(axios);
+
+const getOneToken = async (id: UUID) =>
+  getToken(
+    {
+      isToken: true,
+      getTokenContext: () => ({}),
+    } as unknown as IService,
+    { id } as RawServiceConfiguration
+  );
+
+describe("getToken", () => {
+  test("multiple requests are temporarily memoized", async () => {
+    let userId = 0;
+    axiosMock.onPost().reply(200, {
+      userId: userId++, // Increase ID at every request
+    });
+
+    const id1 = uuidv4();
+    // Consecutive calls should make new requests
+    expect(await getOneToken(id1)).toBe(0);
+    expect(await getOneToken(id1)).toBe(1);
+
+    // Parallel calls should make one request
+    expect(
+      await Promise.all([getOneToken(id1), getOneToken(id1)])
+    ).toStrictEqual([2, 2]);
+
+    // Parallel calls but with different auth.id’s should make multiple requests
+    const id2 = uuidv4();
+    expect(
+      await Promise.all([getOneToken(id1), getOneToken(id2)])
+    ).toStrictEqual([3, 4]);
+  });
+});

--- a/src/background/auth.test.ts
+++ b/src/background/auth.test.ts
@@ -36,9 +36,7 @@ const getOneToken = async (id: UUID) =>
 describe("getToken", () => {
   test("multiple requests are temporarily memoized", async () => {
     let userId = 0;
-    axiosMock.onPost().reply(200, {
-      userId: userId++, // Increase ID at every request
-    });
+    axiosMock.onPost().reply(() => [200, userId++]); // Increase ID at every request
 
     const id1 = uuidv4();
     // Consecutive calls should make new requests

--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -33,6 +33,7 @@ import { getErrorMessage } from "@/errors/errorHelpers";
 import { expectContext } from "@/utils/expectContext";
 import { UnknownObject } from "@/types";
 import { BusinessError } from "@/errors/businessErrors";
+import { memoizeUntilSettled } from "@/utils";
 
 const OAUTH2_STORAGE_KEY = "OAUTH2" as ManualStorageKey;
 
@@ -98,18 +99,29 @@ export async function deleteCachedAuthData(serviceAuthId: UUID): Promise<void> {
     );
   }
 }
-
-// In-progress token requests to coalesce multiple requests for the same token. NOTE: this is not a cache, it only
-// contains in-progress requests.
-const tokenRequests = new Map<UUID, Promise<AuthData>>();
-
 /**
- * @see getToken
+ * Exchange credentials for a token, and cache the token response.
+ *
+ * If a request for the token is already in progress, return the existing promise.
+ *
+ * @param service
+ * @param auth
  */
-export async function _getToken(
+
+export const getToken = memoizeUntilSettled(_getToken, {
+  cacheKey: ([, auth]) => auth.id,
+});
+
+async function _getToken(
   service: IService,
   auth: RawServiceConfiguration
 ): Promise<AuthData> {
+  expectContext("background");
+
+  if (!service.isToken) {
+    throw new Error(`Service ${service.id} does not use token authentication`);
+  }
+
   const { url, data: tokenData } = service.getTokenContext(auth.config);
 
   const {
@@ -125,36 +137,6 @@ export async function _getToken(
   await setCachedAuthData(auth.id, responseData);
 
   return responseData;
-}
-
-/**
- * Exchange credentials for a token, and cache the token response.
- *
- * If a request for the token is already in progress, return the existing promise.
- *
- * @param service
- * @param auth
- */
-export async function getToken(
-  service: IService,
-  auth: RawServiceConfiguration
-): Promise<AuthData> {
-  expectContext("background");
-
-  if (!service.isToken) {
-    throw new Error(`Service ${service.id} does not use token authentication`);
-  }
-
-  const existing = tokenRequests.get(auth.id);
-  if (existing != null) {
-    return existing;
-  }
-
-  const tokenPromise = _getToken(service, auth);
-  tokenRequests.set(auth.id, tokenPromise);
-  // eslint-disable-next-line promise/prefer-await-to-then -- returning the promise outside this method
-  tokenPromise.finally(() => tokenRequests.delete(auth.id));
-  return tokenPromise;
 }
 
 function parseResponseParams(url: URL): UnknownObject {
@@ -204,7 +186,7 @@ async function implicitGrantFlow(
   });
 
   const responseUrl = await browser.identity.launchWebAuthFlow({
-    url: authorizeURL.toString(),
+    url: authorizeURL.href,
     interactive: true,
   });
 
@@ -279,7 +261,7 @@ async function codeGrantFlow(
   }
 
   const responseUrl = await browser.identity.launchWebAuthFlow({
-    url: authorizeURL.toString(),
+    url: authorizeURL.href,
     interactive: true,
   });
 
@@ -327,7 +309,7 @@ async function codeGrantFlow(
   let tokenResponse: AxiosResponse;
 
   try {
-    tokenResponse = await axios.post(tokenURL.toString(), tokenParams, {
+    tokenResponse = await axios.post(tokenURL.href, tokenParams, {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
       },

--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -103,9 +103,6 @@ export async function deleteCachedAuthData(serviceAuthId: UUID): Promise<void> {
  * Exchange credentials for a token, and cache the token response.
  *
  * If a request for the token is already in progress, return the existing promise.
- *
- * @param service
- * @param auth
  */
 
 export const getToken = memoizeUntilSettled(_getToken, {

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -18,9 +18,8 @@
 import { ensureContentScript } from "@/background/contentScript";
 import { rehydrateSidebar } from "@/contentScript/messenger/api";
 import { executeScript } from "webext-content-scripts";
-import pMemoize from "p-memoize";
 import webextAlert from "./webextAlert";
-import { isMac } from "@/utils";
+import { memoizeUntilSettled, isMac } from "@/utils";
 import { notify } from "@/options/messenger/api";
 import { browserAction, Tab } from "@/mv3/api";
 import { isScriptableUrl } from "@/utils/permissions";
@@ -34,12 +33,7 @@ const MSG_NO_SIDEBAR_ON_OPTIONS_PAGE = `PixieBrix Tip 💜\n If you want to crea
 // The sidebar is always injected to into the top level frame
 const TOP_LEVEL_FRAME_ID = 0;
 
-// Avoid triggering multiple requests at once and causing multiple error alerts.
-// This patterns "debounces" calls while the promise is pending:
-// https://github.com/sindresorhus/promise-fun/issues/15
-const toggleSidebar = pMemoize(_toggleSidebar, {
-  cache: false,
-});
+const toggleSidebar = memoizeUntilSettled(_toggleSidebar);
 
 // Don't accept objects here as they're not easily memoizable
 async function _toggleSidebar(tabId: number, tabUrl: string): Promise<void> {

--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -104,10 +104,7 @@ async function dispatchMenu(
 }
 
 function menuListener(info: Menus.OnClickData, tab: Tabs.Tab) {
-  if (
-    typeof info.menuItemId === "string" &&
-    info.menuItemId.startsWith(MENU_PREFIX)
-  ) {
+  if (String(info.menuItemId).startsWith(MENU_PREFIX)) {
     void dispatchMenu(info, tab);
   } else {
     console.debug(`Ignoring menu item: ${info.menuItemId}`);
@@ -166,6 +163,7 @@ async function _ensureContextMenu({
   } catch {
     // WARNING: Do not remove `chromeP`
     // The standard `contextMenus.create` does not return a Promise in any browser
+    // https://github.com/w3c/webextensions/issues/188#issuecomment-1112436359
     // eslint-disable-next-line @typescript-eslint/await-thenable -- The types don't really match `chromeP`
     await chromeP.contextMenus.create({
       ...updateProperties,

--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -17,9 +17,9 @@
 
 import pTimeout from "p-timeout";
 import { Menus, Tabs } from "webextension-polyfill";
-import { getErrorMessage, hasSpecificErrorCause } from "@/errors/errorHelpers";
+import chromeP from "webext-polyfill-kinda";
+import { hasSpecificErrorCause } from "@/errors/errorHelpers";
 import reportError from "@/telemetry/reportError";
-import { noop } from "lodash";
 import { handleMenuAction, notify } from "@/contentScript/messenger/api";
 import { ensureContentScript } from "@/background/contentScript";
 import { reportEvent } from "@/telemetry/events";
@@ -32,16 +32,8 @@ import {
 } from "@/extensionPoints/contextMenu";
 import { loadOptions } from "@/store/extensionsStorage";
 import { resolveDefinitions } from "@/registry/internal";
-import { allSettledValues } from "@/utils";
+import { allSettledValues, memoizeUntilSettled } from "@/utils";
 import { CancelError } from "@/errors/businessErrors";
-
-type ExtensionId = UUID;
-// This is the type the browser API has for menu ids. In practice they should be strings because that's what we're
-// creating via `makeMenuId`
-type MenuItemId = number | string;
-
-const extensionMenuItems = new Map<ExtensionId, MenuItemId>();
-const pendingRegistration = new Set<ExtensionId>();
 
 const MENU_PREFIX = "pixiebrix-";
 
@@ -132,16 +124,7 @@ export async function uninstallContextMenu({
   extensionId: UUID;
 }): Promise<boolean> {
   try {
-    const menuItemId = extensionMenuItems.get(extensionId);
-
-    if (menuItemId) {
-      extensionMenuItems.delete(extensionId);
-      await browser.contextMenus.remove(menuItemId);
-    } else {
-      // Our bookkeeping in `extensionMenuItems` might be off. Try removing the expected menuId just in case.
-      await browser.contextMenus.remove(makeMenuId(extensionId));
-    }
-
+    await browser.contextMenus.remove(makeMenuId(extensionId));
     console.debug(`Uninstalled context menu ${extensionId}`);
     return true;
   } catch (error) {
@@ -154,7 +137,10 @@ export async function uninstallContextMenu({
   }
 }
 
-export async function ensureContextMenu({
+export const ensureContextMenu = memoizeUntilSettled(_ensureContextMenu, {
+  cacheKey: ([{ extensionId }]) => extensionId,
+});
+async function _ensureContextMenu({
   extensionId,
   contexts,
   title,
@@ -166,16 +152,6 @@ export async function ensureContextMenu({
     throw new Error("extensionId is required");
   }
 
-  // Handle the thundering herd of re-registrations when a contentScript.reactivate is broadcast
-  if (pendingRegistration.has(extensionId)) {
-    console.debug("contextMenu registration pending for %s", extensionId);
-
-    // Is it OK to return immediately? Or do we need to track the common promise that all callers should see?
-    return;
-  }
-
-  pendingRegistration.add(extensionId);
-
   const updateProperties: Menus.UpdateUpdatePropertiesType = {
     type: "normal",
     title,
@@ -184,60 +160,17 @@ export async function ensureContextMenu({
   };
 
   const expectedMenuId = makeMenuId(extensionId);
-
   try {
-    let menuId = extensionMenuItems.get(extensionId);
-
-    if (menuId) {
-      try {
-        await browser.contextMenus.update(menuId, updateProperties);
-        return;
-      } catch (error) {
-        console.debug("Cannot update context menu", { error });
-      }
-    } else {
-      // Just to be safe if our `extensionMenuItems` bookkeeping is off, remove any stale menu item
-      await browser.contextMenus.remove(expectedMenuId).catch(noop);
-    }
-
-    // The update failed, or this is a new context menu
-    extensionMenuItems.delete(extensionId);
-
-    // The types of browser.contextMenus.create are wacky. I verified on Chrome that the method does take a callback
-    // even when using the browser polyfill
-    let createdMenuId: string | number;
-    menuId = await new Promise((resolve, reject) => {
-      // `browser.contextMenus.create` returns immediately with the assigned menu id
-      createdMenuId = browser.contextMenus.create(
-        {
-          ...updateProperties,
-          id: makeMenuId(extensionId),
-        },
-        () => {
-          if (browser.runtime.lastError) {
-            reject(new Error(browser.runtime.lastError.message));
-          }
-
-          resolve(createdMenuId);
-        }
-      );
+    // Try updating it first. It will fail if missing, so we attempt to create it instead
+    await browser.contextMenus.update(expectedMenuId, updateProperties);
+  } catch {
+    // WARNING: Do not remove `chromeP`
+    // The standard `contextMenus.create` does not return a Promise in any browser
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- The types don't really match `chromeP`
+    await chromeP.contextMenus.create({
+      ...updateProperties,
+      id: expectedMenuId,
     });
-
-    extensionMenuItems.set(extensionId, menuId);
-  } catch (error) {
-    if (
-      getErrorMessage(error).includes("Cannot create item with duplicate id")
-    ) {
-      // Likely caused by a concurrent update. In practice, our `pendingRegistration` set and `extensionMenuItems`
-      // should prevent this from happening
-      console.debug("Error registering context menu item", { error });
-      return;
-    }
-
-    console.error("Error registering context menu item", { error });
-    throw error;
-  } finally {
-    pendingRegistration.delete(extensionId);
   }
 }
 

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -24,8 +24,8 @@ import { queueReactivateTab } from "@/contentScript/messenger/api";
 import { ExtensionOptionsState } from "@/store/extensionsTypes";
 import reportError from "@/telemetry/reportError";
 import { debounce } from "lodash";
-import pMemoize from "p-memoize";
 import { refreshRegistries } from "./refreshRegistries";
+import { memoizeUntilSettled } from "@/utils";
 
 const { reducer, actions } = extensionsSlice;
 
@@ -143,9 +143,7 @@ const _installStarterBlueprints = async (): Promise<boolean> => {
 };
 
 const debouncedInstallStarterBlueprints = debounce(
-  pMemoize(_installStarterBlueprints, {
-    cache: false,
-  }),
+  memoizeUntilSettled(_installStarterBlueprints),
   BLUEPRINT_INSTALLATION_DEBOUNCE_MS,
   {
     leading: true,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -24,6 +24,7 @@ import {
   makeURL,
   getScopeAndId,
   smartAppendPeriod,
+  memoizeUntilSettled,
 } from "@/utils";
 import type { RegistryId, SafeString } from "@/core";
 import { BusinessError } from "@/errors/businessErrors";
@@ -190,7 +191,7 @@ describe("makeURL", () => {
     );
   });
 
-  test("override existing search parameters if requested", () => {
+  test("override existing search parameters if called", () => {
     const origin = "https://pixiebrix.com?a=ORIGINAL&b=ORIGINAL&c=ORIGINAL";
     expect(makeURL(origin, { a: null, c: null })).toBe(
       "https://pixiebrix.com/?b=ORIGINAL"
@@ -270,4 +271,16 @@ describe("smartAppendPeriod", () => {
       }
     }
   });
+});
+
+// From https://github.com/sindresorhus/p-memoize/blob/52fe6052ff2287f528c954c4c67fc5a61ff21360/test.ts#LL198
+test("memoizeUntilSettled", async () => {
+  let index = 0;
+
+  const memoized = memoizeUntilSettled(async () => index++);
+
+  expect(await memoized()).toBe(0);
+  expect(await memoized()).toBe(1);
+  expect(await memoized()).toBe(2);
+  expect(await Promise.all([memoized(), memoized()])).toStrictEqual([3, 3]);
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,6 +44,7 @@ import { ApiVersion, RegistryId, SafeString } from "@/core";
 import { UnknownObject } from "@/types";
 import { RecipeDefinition } from "@/types/definitions";
 import safeJsonStringify from "json-stringify-safe";
+import pMemoize from "p-memoize";
 
 const specialCharsRegex = /[.[\]]/;
 
@@ -269,7 +270,7 @@ export function clearObject(obj: Record<string, unknown>): void {
   for (const member in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, member)) {
       // Checking to ensure own property
-      // eslint-disable-next-line security/detect-object-injection
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete,security/detect-object-injection
       delete obj[member];
     }
   }
@@ -652,3 +653,23 @@ export function isValidUrl(
     return false;
   }
 }
+
+/**
+ * Ignores calls made with the same arguments while the first call is pending
+ * @example
+ *   const memFetch = ignoreRepeatedCalls(fetch)
+ *   await Promise([memFetch('/time'), memFetch('/time')])
+ *   // => both will return the exact same Promise
+ *   await memFetch('/time')
+ *   // => no concurrent calls at this time, so another request made
+ *
+ * @see https://github.com/sindresorhus/promise-fun/issues/15
+ */
+export const memoizeUntilSettled: typeof pMemoize = (
+  functionToMemoize,
+  options
+) =>
+  pMemoize(functionToMemoize, {
+    ...options,
+    cache: false,
+  });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -250,10 +250,6 @@ export function boolean(value: unknown): boolean {
   return false;
 }
 
-export function clone<T extends Record<string, unknown>>(object: T): T {
-  return Object.assign(Object.create(null), object);
-}
-
 export function isObject(value: unknown): value is Record<string, unknown> {
   return value && typeof value === "object";
 }
@@ -264,16 +260,6 @@ export function ensureJsonObject(value: Record<string, unknown>): JsonObject {
   }
 
   return JSON.parse(safeJsonStringify(value)) as JsonObject;
-}
-
-export function clearObject(obj: Record<string, unknown>): void {
-  for (const member in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, member)) {
-      // Checking to ensure own property
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete,security/detect-object-injection
-      delete obj[member];
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

- part of https://github.com/pixiebrix/pixiebrix-extension/issues/4358

I'm looking for and replacing all instances of data that should be stored in `chrome.storage.session`. This brought me to replace a couple of patterns around `getToken` and `ensureContextMenus`

## Checklist

- [x] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @twschiller 
