### PR TITLE
Avoid Messenger roundtrip when fetching current tab data

### DIFF
--- a/__mocks__/webext-messenger.js
+++ b/__mocks__/webext-messenger.js
@@ -17,3 +17,6 @@
 
 export const getMethod = jest.fn(() => jest.fn());
 export const getNotifier = jest.fn(() => jest.fn());
+
+export const getTopLevelFrame = async () => ({ tabId: 1234, frameId: 0 });
+export const getThisFrame = getTopLevelFrame;

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,7 @@
         "webext-content-scripts": "^1.0.1",
         "webext-detect-page": "^4.0.1",
         "webext-dynamic-content-scripts": "^9.0.0-1",
-        "webext-messenger": "^0.21.0-0",
+        "webext-messenger": "^0.22.0",
         "webext-patterns": "^1.1.1",
         "webext-polyfill-kinda": "^0.10.0",
         "webext-tools": "^1.1.1",
@@ -34143,7 +34143,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.2.0.tgz",
       "integrity": "sha512-Il3wdLRzWvbAEtocgxGQA9YOoRVeVUGOMBtel5LdEpNeEAol6GJTLw8GbX6Z8EIMfvfhoOXs2bwOijtAZdK5og==",
-      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -35379,26 +35378,15 @@
       }
     },
     "node_modules/webext-messenger": {
-      "version": "0.21.0-0",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.21.0-0.tgz",
-      "integrity": "sha512-lF6mZ8MP9s+AIF44Tk450TzyFdiHsNg8RVoB1iHI8SIHAHmyCsVeXiGQa3uNMy7j3vPtSgMfmDsnS5oFy6X8MA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.22.0.tgz",
+      "integrity": "sha512-NMsu7ug8Tr9jVR4OipJMe1U8GvJUDhxrED5ZNq3XALzP+AJzVZuU3nP2iwztLoAknHlEIBcu2+MAoJJXvDZrhA==",
       "dependencies": {
         "p-retry": "^5.1.1",
         "serialize-error": "^11.0.0",
-        "type-fest": "^2.13.0",
+        "type-fest": "^3.2.0",
         "webext-detect-page": "^4.0.1",
         "webext-tools": "^1.1.0"
-      }
-    },
-    "node_modules/webext-messenger/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/webext-patterns": {
@@ -61686,8 +61674,7 @@
     "type-fest": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.2.0.tgz",
-      "integrity": "sha512-Il3wdLRzWvbAEtocgxGQA9YOoRVeVUGOMBtel5LdEpNeEAol6GJTLw8GbX6Z8EIMfvfhoOXs2bwOijtAZdK5og==",
-      "dev": true
+      "integrity": "sha512-Il3wdLRzWvbAEtocgxGQA9YOoRVeVUGOMBtel5LdEpNeEAol6GJTLw8GbX6Z8EIMfvfhoOXs2bwOijtAZdK5og=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -62646,22 +62633,15 @@
       }
     },
     "webext-messenger": {
-      "version": "0.21.0-0",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.21.0-0.tgz",
-      "integrity": "sha512-lF6mZ8MP9s+AIF44Tk450TzyFdiHsNg8RVoB1iHI8SIHAHmyCsVeXiGQa3uNMy7j3vPtSgMfmDsnS5oFy6X8MA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.22.0.tgz",
+      "integrity": "sha512-NMsu7ug8Tr9jVR4OipJMe1U8GvJUDhxrED5ZNq3XALzP+AJzVZuU3nP2iwztLoAknHlEIBcu2+MAoJJXvDZrhA==",
       "requires": {
         "p-retry": "^5.1.1",
         "serialize-error": "^11.0.0",
-        "type-fest": "^2.13.0",
+        "type-fest": "^3.2.0",
         "webext-detect-page": "^4.0.1",
         "webext-tools": "^1.1.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
-        }
       }
     },
     "webext-patterns": {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "webext-content-scripts": "^1.0.1",
     "webext-detect-page": "^4.0.1",
     "webext-dynamic-content-scripts": "^9.0.0-1",
-    "webext-messenger": "^0.21.0-0",
+    "webext-messenger": "^0.22.0",
     "webext-patterns": "^1.1.1",
     "webext-polyfill-kinda": "^0.10.0",
     "webext-tools": "^1.1.1",

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Runtime, Tabs } from "webextension-polyfill";
+import { Tabs } from "webextension-polyfill";
 import { expectContext } from "@/utils/expectContext";
 import { asyncForEach } from "@/utils";
 import { getLinkedApiClient } from "@/services/apiClient";
@@ -212,12 +212,6 @@ export async function activateTab(this: MessengerMeta): Promise<void> {
 export async function closeTab(this: MessengerMeta): Promise<void> {
   // Allow `closeTab` to return before closing the tab or else the Messenger won't be able to respond #2051
   setTimeout(async () => browser.tabs.remove(this.trace[0].tab.id), 100);
-}
-
-export async function whoAmI(
-  this: MessengerMeta
-): Promise<Runtime.MessageSender> {
-  return this.trace[0];
 }
 
 interface ServerResponse {

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -34,7 +34,6 @@ export const getAvailableVersion = getMethod("GET_AVAILABLE_VERSION", bg);
 export const ensureContentScript = getMethod("INJECT_SCRIPT", bg);
 export const openPopupPrompt = getMethod("OPEN_POPUP_PROMPT", bg);
 export const getUID = getMethod("GET_UID", bg);
-export const whoAmI = getMethod("ECHO_SENDER", bg);
 export const waitForTargetByUrl = getMethod("WAIT_FOR_TARGET_BY_URL", bg);
 
 export const activatePartnerTheme = getMethod("ACTIVATE_PARTNER_THEME", bg);

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -28,7 +28,6 @@ import { openPopupPrompt } from "@/background/permissionPrompt";
 import {
   activateTab,
   closeTab,
-  whoAmI,
   openTab,
   requestRunOnServer,
   requestRunInOpener,
@@ -102,7 +101,6 @@ declare global {
     LAUNCH_AUTH_INTEGRATION: typeof launchAuthIntegration;
 
     GET_UID: typeof uid;
-    ECHO_SENDER: typeof whoAmI;
     WAIT_FOR_TARGET_BY_URL: typeof waitForTargetByUrl;
 
     ACTIVATE_TAB: typeof activateTab;
@@ -179,7 +177,6 @@ export default function registerMessenger(): void {
     OPEN_POPUP_PROMPT: openPopupPrompt,
 
     GET_UID: uid,
-    ECHO_SENDER: whoAmI,
     WAIT_FOR_TARGET_BY_URL: waitForTargetByUrl,
 
     ACTIVATE_TAB: activateTab,

--- a/src/blocks/renderers/customForm.tsx
+++ b/src/blocks/renderers/customForm.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/core";
 import JsonSchemaForm from "@rjsf/bootstrap-4";
 import { JsonObject } from "type-fest";
-import { dataStore, proxyService, whoAmI } from "@/background/messenger/api";
+import { dataStore, proxyService } from "@/background/messenger/api";
 import notify from "@/utils/notify";
 import custom from "@/blocks/renderers/customForm.css?loadAsUrl";
 import ImageCropWidget from "@/components/formBuilder/ImageCropWidget";
@@ -44,6 +44,7 @@ import { getPageState, setPageState } from "@/contentScript/messenger/api";
 import safeJsonStringify from "json-stringify-safe";
 import { isEmpty, set } from "lodash";
 import { Stylesheets } from "@/components/Stylesheets";
+import { getTopLevelFrame } from "webext-messenger";
 
 const fields = {
   DescriptionField,
@@ -120,13 +121,14 @@ async function getInitialData(
 
     case "state": {
       const namespace = storage.namespace ?? "blueprint";
-      const me = await whoAmI();
+      const topLevelFrame = await getTopLevelFrame();
       // Target the top level frame. Inline panels aren't generally available, so the renderer will always be in the
       // sidebar which runs in the context of the top-level frame
-      return getPageState(
-        { tabId: me.tab.id, frameId: 0 },
-        { namespace, blueprintId, extensionId }
-      );
+      return getPageState(topLevelFrame, {
+        namespace,
+        blueprintId,
+        extensionId,
+      });
     }
 
     case "database": {
@@ -186,19 +188,16 @@ async function setData(
     }
 
     case "state": {
-      const me = await whoAmI();
+      const topLevelFrame = await getTopLevelFrame();
       // Target the top level frame. Inline panels aren't generally available, so the renderer will always be in the
       // sidebar which runs in the context of the top-level frame
-      await setPageState(
-        { tabId: me.tab.id, frameId: 0 },
-        {
-          namespace: storage.namespace ?? "blueprint",
-          data: cleanValues,
-          mergeStrategy: "shallow",
-          extensionId,
-          blueprintId,
-        }
-      );
+      await setPageState(topLevelFrame, {
+        namespace: storage.namespace ?? "blueprint",
+        data: cleanValues,
+        mergeStrategy: "shallow",
+        extensionId,
+        blueprintId,
+      });
       return;
     }
 

--- a/src/blocks/transformers/ephemeralForm/formTransformer.ts
+++ b/src/blocks/transformers/ephemeralForm/formTransformer.ts
@@ -23,7 +23,6 @@ import {
   registerForm,
 } from "@/contentScript/ephemeralFormProtocol";
 import { expectContext } from "@/utils/expectContext";
-import { whoAmI } from "@/background/messenger/api";
 import {
   ensureSidebar,
   hideSidebarForm,
@@ -31,6 +30,7 @@ import {
   showSidebarForm,
 } from "@/contentScript/sidebarController";
 import { showModal } from "@/blocks/transformers/ephemeralForm/modalUtils";
+import { getThisFrame } from "webext-messenger";
 
 // The modes for createFrameSrc are different than the location argument for FormTransformer. The mode for the frame
 // just determines the layout container of the form
@@ -40,14 +40,11 @@ export async function createFrameSource(
   nonce: string,
   mode: Mode
 ): Promise<URL> {
-  const { tab, frameId } = await whoAmI();
+  const target = await getThisFrame();
 
   const frameSource = new URL(browser.runtime.getURL("ephemeralForm.html"));
   frameSource.searchParams.set("nonce", nonce);
-  frameSource.searchParams.set(
-    "opener",
-    JSON.stringify({ tabId: tab.id, frameId })
-  );
+  frameSource.searchParams.set("opener", JSON.stringify(target));
   frameSource.searchParams.set("mode", mode);
   return frameSource;
 }

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -313,9 +313,6 @@ describe("When rendered in panel", () => {
 
   test("renders block", async () => {
     const markdown = "Pipeline text for card test.";
-    (backgroundAPI.whoAmI as jest.Mock).mockResolvedValueOnce({
-      tab: { id: 0 },
-    });
     (contentScriptAPI.runRendererPipeline as jest.Mock).mockResolvedValueOnce({
       blockId: markdownBlock.id,
       key: uuidv4(),

--- a/src/components/documentBuilder/render/BlockElement.tsx
+++ b/src/components/documentBuilder/render/BlockElement.tsx
@@ -21,7 +21,6 @@ import { useAsyncState } from "@/hooks/common";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import DocumentContext from "@/components/documentBuilder/render/DocumentContext";
 import { runRendererPipeline } from "@/contentScript/messenger/api";
-import { whoAmI } from "@/background/messenger/api";
 import { uuidv4 } from "@/types/helpers";
 import PanelBody from "@/sidebar/PanelBody";
 import { RendererPayload } from "@/runtime/runtimeTypes";
@@ -29,6 +28,7 @@ import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { serializeError } from "serialize-error";
 import { DynamicPath } from "@/components/documentBuilder/documentBuilderTypes";
 import { mapPathToTraceBranches } from "@/components/documentBuilder/utils";
+import { getTopLevelFrame } from "webext-messenger";
 
 type BlockElementProps = {
   pipeline: BlockPipeline;
@@ -46,12 +46,10 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline, tracePath }) => {
 
   const [payload, isLoading, error] =
     useAsyncState<RendererPayload>(async () => {
-      const me = await whoAmI();
-
       // We currently only support associating the sidebar with the content script in the top-level frame (frameId: 0)
-      const target = { tabId: me.tab.id, frameId: 0 };
+      const topLevelFrame = await getTopLevelFrame();
 
-      return runRendererPipeline(target, {
+      return runRendererPipeline(topLevelFrame, {
         nonce: uuidv4(),
         context: ctxt,
         pipeline,

--- a/src/components/documentBuilder/render/ButtonElement.tsx
+++ b/src/components/documentBuilder/render/ButtonElement.tsx
@@ -18,13 +18,13 @@
 import React, { useContext, useState } from "react";
 import { BlockPipeline } from "@/blocks/types";
 import AsyncButton, { AsyncButtonProps } from "@/components/AsyncButton";
-import { whoAmI } from "@/background/messenger/api";
 import { runEffectPipeline } from "@/contentScript/messenger/api";
 import { uuidv4 } from "@/types/helpers";
 import DocumentContext from "@/components/documentBuilder/render/DocumentContext";
 import { Except } from "type-fest";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { DynamicPath } from "@/components/documentBuilder/documentBuilderTypes";
+import { getTopLevelFrame } from "webext-messenger";
 
 type ButtonElementProps = Except<AsyncButtonProps, "onClick"> & {
   onClick: BlockPipeline;
@@ -51,29 +51,27 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
     const currentCounter = counter;
     setCounter((previous) => previous + 1);
 
-    const me = await whoAmI();
     // We currently only support associating the sidebar with the content script in the top-level frame (frameId: 0)
-    return runEffectPipeline(
-      { tabId: me.tab.id, frameId: 0 },
-      {
-        nonce: uuidv4(),
-        context: ctxt,
-        pipeline: onClick,
-        // TODO: pass runtime version via DocumentContext instead of hard-coding it. This will break for v4+
-        options: apiVersionOptions("v3"),
-        messageContext: logger.context,
-        meta: {
-          ...meta,
-          branches: [
-            ...tracePath.branches.map(({ staticId, index }) => ({
-              key: staticId,
-              counter: index,
-            })),
-            { key: "onClick", counter: currentCounter },
-          ],
-        },
-      }
-    );
+    const topLevelFrame = await getTopLevelFrame();
+
+    return runEffectPipeline(topLevelFrame, {
+      nonce: uuidv4(),
+      context: ctxt,
+      pipeline: onClick,
+      // TODO: pass runtime version via DocumentContext instead of hard-coding it. This will break for v4+
+      options: apiVersionOptions("v3"),
+      messageContext: logger.context,
+      meta: {
+        ...meta,
+        branches: [
+          ...tracePath.branches.map(({ staticId, index }) => ({
+            key: staticId,
+            counter: index,
+          })),
+          { key: "onClick", counter: currentCounter },
+        ],
+      },
+    });
   };
 
   return <AsyncButton onClick={handler} {...restProps} />;

--- a/src/components/documentBuilder/render/ListElement.tsx
+++ b/src/components/documentBuilder/render/ListElement.tsx
@@ -32,7 +32,7 @@ import { getErrorMessage } from "@/errors/errorHelpers";
 import { runMapArgs } from "@/contentScript/messenger/api";
 import { isNullOrBlank, joinPathParts } from "@/utils";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
-import { whoAmI } from "@/background/messenger/api";
+import { getTopLevelFrame } from "webext-messenger";
 
 type DocumentListProps = {
   array: UnknownObject[];
@@ -59,8 +59,7 @@ const ListElementInternal: React.FC<DocumentListProps> = ({
   const documentContext = useContext(DocumentContext);
 
   const [rootDefinitions, isLoading, error] = useAsyncState(async () => {
-    const me = await whoAmI();
-    const target = { tabId: me.tab.id, frameId: 0 };
+    const topLevelFrame = await getTopLevelFrame();
 
     const key = `@${elementKey}`;
 
@@ -83,7 +82,7 @@ const ListElementInternal: React.FC<DocumentListProps> = ({
 
         if (isDeferExpression(config)) {
           documentElement = (await runMapArgs(
-            target,
+            topLevelFrame,
             // TODO: pass runtime version via DocumentContext instead of hard-coding it. This is be wrong for v4+
             {
               config: config.__value__,

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -27,7 +27,7 @@ import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 import { handleNavigate } from "@/contentScript/lifecycle";
 import { updateTabInfo } from "@/contentScript/context";
-import { whoAmI, initTelemetry } from "@/background/messenger/api";
+import { initTelemetry } from "@/background/messenger/api";
 import { ENSURE_CONTENT_SCRIPT_READY } from "@/messaging/constants";
 // eslint-disable-next-line import/no-restricted-paths -- Custom devTools mechanism to transfer data
 import { addListenerForUpdateSelectedElement } from "@/pageEditor/getSelectedElement";
@@ -39,6 +39,7 @@ import {
 } from "@/errors/contextInvalidated";
 import { uncaughtErrorHandlers } from "@/telemetry/reportUncaughtErrors";
 import { UUID } from "@/core";
+import { getThisFrame } from "webext-messenger";
 
 function ignoreContextInvalidatedErrors(
   errorEvent: ErrorEvent | PromiseRejectionEvent
@@ -65,9 +66,8 @@ export async function init(uuid: UUID): Promise<void> {
   initTelemetry();
   initToaster();
 
-  const sender = await whoAmI();
-
-  updateTabInfo({ tabId: sender.tab.id, frameId: sender.frameId });
+  const { tabId, frameId } = await getThisFrame();
+  updateTabInfo({ tabId, frameId });
 
   await handleNavigate();
 

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -26,7 +26,6 @@ import registerMessenger from "@/contentScript/messenger/registration";
 import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 import { handleNavigate } from "@/contentScript/lifecycle";
-import { updateTabInfo } from "@/contentScript/context";
 import { initTelemetry } from "@/background/messenger/api";
 import { ENSURE_CONTENT_SCRIPT_READY } from "@/messaging/constants";
 // eslint-disable-next-line import/no-restricted-paths -- Custom devTools mechanism to transfer data
@@ -39,7 +38,6 @@ import {
 } from "@/errors/contextInvalidated";
 import { uncaughtErrorHandlers } from "@/telemetry/reportUncaughtErrors";
 import { UUID } from "@/core";
-import { getThisFrame } from "webext-messenger";
 
 function ignoreContextInvalidatedErrors(
   errorEvent: ErrorEvent | PromiseRejectionEvent
@@ -65,9 +63,6 @@ export async function init(uuid: UUID): Promise<void> {
   addListenerForUpdateSelectedElement();
   initTelemetry();
   initToaster();
-
-  const { tabId, frameId } = await getThisFrame();
-  updateTabInfo({ tabId, frameId });
 
   await handleNavigate();
 

--- a/src/contentScript/context.ts
+++ b/src/contentScript/context.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Target } from "@/types";
 import { uuidv4 } from "@/types/helpers";
 
 export const sessionId = uuidv4();
@@ -23,8 +22,6 @@ export const sessionTimestamp = new Date();
 
 export let navigationId = uuidv4();
 export let navigationTimestamp = new Date();
-
-export const thisTarget = {} as Target;
 
 /**
  * Set a unique id and timestamp for current navigation event.
@@ -39,11 +36,4 @@ export function updateNavigationId(): void {
  */
 export function getNavigationId(): string {
   return navigationId;
-}
-
-export function updateTabInfo(info: Target): void {
-  thisTarget.tabId = info.tabId;
-  thisTarget.frameId = info.frameId;
-
-  console.debug("updateTabInfo", thisTarget);
 }

--- a/src/contentScript/context.ts
+++ b/src/contentScript/context.ts
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Target } from "@/types";
 import { uuidv4 } from "@/types/helpers";
 
 export const sessionId = uuidv4();
@@ -23,8 +24,7 @@ export const sessionTimestamp = new Date();
 export let navigationId = uuidv4();
 export let navigationTimestamp = new Date();
 
-export let tabId: number;
-export let frameId: number;
+export const thisTarget = {} as Target;
 
 /**
  * Set a unique id and timestamp for current navigation event.
@@ -41,9 +41,9 @@ export function getNavigationId(): string {
   return navigationId;
 }
 
-export function updateTabInfo(info: { tabId: number; frameId: number }): void {
-  tabId = info.tabId;
-  frameId = info.frameId;
+export function updateTabInfo(info: Target): void {
+  thisTarget.tabId = info.tabId;
+  thisTarget.frameId = info.frameId;
 
-  console.debug("updateTabInfo", { tabId, frameId });
+  console.debug("updateTabInfo", thisTarget);
 }

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -24,7 +24,7 @@ import {
   RunReason,
   UUID,
 } from "@/core";
-import { thisTarget, updateNavigationId } from "@/contentScript/context";
+import { updateNavigationId } from "@/contentScript/context";
 import * as sidebar from "@/contentScript/sidebarController";
 import { pollUntilTruthy } from "@/utils";
 import { NAVIGATION_RULES } from "@/contrib/navigationRules";
@@ -38,6 +38,7 @@ import { $safeFind } from "@/helpers";
 import { PromiseCancelled } from "@/errors/genericErrors";
 import { SidebarExtensionPoint } from "@/extensionPoints/sidebarExtension";
 import injectScriptTag from "@/utils/injectScriptTag";
+import { getThisFrame } from "webext-messenger";
 
 let _initialLoadNavigation = true;
 const _dynamic = new Map<UUID, IExtensionPoint>();
@@ -342,7 +343,7 @@ export async function handleNavigate({
 }: { force?: boolean } = {}): Promise<void> {
   const runReason = decideRunReason({ force });
   _initialLoadNavigation = false;
-
+  const thisTarget = await getThisFrame();
   if (thisTarget.frameId == null) {
     console.debug(
       "Ignoring handleNavigate because thisTarget.frameId is not set yet"

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -24,7 +24,7 @@ import {
   RunReason,
   UUID,
 } from "@/core";
-import * as context from "@/contentScript/context";
+import { thisTarget, updateNavigationId } from "@/contentScript/context";
 import * as sidebar from "@/contentScript/sidebarController";
 import { pollUntilTruthy } from "@/utils";
 import { NAVIGATION_RULES } from "@/contrib/navigationRules";
@@ -343,31 +343,27 @@ export async function handleNavigate({
   const runReason = decideRunReason({ force });
   _initialLoadNavigation = false;
 
-  if (context.frameId == null) {
+  if (thisTarget.frameId == null) {
     console.debug(
-      "Ignoring handleNavigate because context.frameId is not set yet"
+      "Ignoring handleNavigate because thisTarget.frameId is not set yet"
     );
     return;
   }
 
   const { href } = location;
 
-  if (!force && _frameHref.get(context.frameId) === href) {
-    console.debug(
-      `Ignoring NOOP navigation to ${href} (tabId=${context.tabId}, frameId=${context.frameId})`
-    );
+  if (!force && _frameHref.get(thisTarget.frameId) === href) {
+    console.debug(`Ignoring NOOP navigation to ${href}`, thisTarget);
     return;
   }
 
-  _frameHref.set(context.frameId, href);
+  _frameHref.set(thisTarget.frameId, href);
 
-  console.debug(
-    `Handling navigation to ${href} (tabId=${context.tabId}, frameId=${context.frameId})`
-  );
+  console.debug(`Handling navigation to ${href}`, thisTarget);
 
   await installScriptOnce();
 
-  context.updateNavigationId();
+  updateNavigationId();
 
   const extensionPoints = await loadExtensionsOnce();
 

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -354,13 +354,13 @@ export async function handleNavigate({
   const { href } = location;
 
   if (!force && _frameHref.get(thisTarget.frameId) === href) {
-    console.debug(`Ignoring NOOP navigation to ${href}`, thisTarget);
+    console.debug("Ignoring NOOP navigation to %s", href, thisTarget);
     return;
   }
 
   _frameHref.set(thisTarget.frameId, href);
 
-  console.debug(`Handling navigation to ${href}`, thisTarget);
+  console.debug("Handling navigation to %s", href, thisTarget);
 
   await installScriptOnce();
 
@@ -385,7 +385,7 @@ export async function handleNavigate({
           runReason,
           cancel
         ).catch((error) => {
-          console.error(`Error installing/running: ${extensionPoint.id}`, {
+          console.error("Error installing/running: %s", extensionPoint.id, {
             error,
           });
         });

--- a/src/sidebar/ErrorBoundary.tsx
+++ b/src/sidebar/ErrorBoundary.tsx
@@ -22,8 +22,8 @@ import { isEmpty } from "lodash";
 import { faRedo } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Alert, Button } from "react-bootstrap";
-import { whoAmI } from "@/background/messenger/api";
 import { reloadSidebar } from "@/contentScript/messenger/api";
+import { getTopLevelFrame } from "webext-messenger";
 
 interface State {
   hasError: boolean;
@@ -47,8 +47,8 @@ class ErrorBoundary extends Component<UnknownObject, State> {
   }
 
   async reloadSidebar() {
-    const sidebar = await whoAmI();
-    await reloadSidebar({ tabId: sidebar.tab.id });
+    const topLevelFrame = await getTopLevelFrame();
+    await reloadSidebar(topLevelFrame);
   }
 
   override render(): React.ReactNode {

--- a/src/sidebar/Header.tsx
+++ b/src/sidebar/Header.tsx
@@ -21,10 +21,10 @@ import { Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDoubleRight, faCog } from "@fortawesome/free-solid-svg-icons";
 import { hideSidebar } from "@/contentScript/messenger/api";
-import { whoAmI } from "@/background/messenger/api";
 import useTheme, { useGetTheme } from "@/hooks/useTheme";
 import cx from "classnames";
 import useContextInvalidated from "@/hooks/useContextInvalidated";
+import { getTopLevelFrame } from "webext-messenger";
 
 const Header: React.FunctionComponent = () => {
   const { logo, showSidebarLogo, customSidebarLogo } = useTheme();
@@ -40,8 +40,8 @@ const Header: React.FunctionComponent = () => {
             theme === "default" ? styles.themeColorOverride : styles.themeColor
           )}
           onClick={async () => {
-            const sidebar = await whoAmI();
-            await hideSidebar({ tabId: sidebar.tab.id });
+            const topLevelFrame = await getTopLevelFrame();
+            await hideSidebar(topLevelFrame);
           }}
           size="sm"
           variant="link"

--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -26,8 +26,8 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { UUID } from "@/core";
 import { defaultEventKey, mapTabEventKey } from "@/sidebar/utils";
 import { cancelForm, closeTemporaryPanel } from "@/contentScript/messenger/api";
-import { whoAmI } from "@/background/messenger/api";
 import { partition, sortBy } from "lodash";
+import { getTopLevelFrame } from "webext-messenger";
 
 export type SidebarState = SidebarEntries & {
   activeKey: string;
@@ -95,15 +95,13 @@ function findNextActiveKey(
 }
 
 async function cancelPreexistingForms(forms: UUID[]): Promise<void> {
-  // TODO: Replace with `tabId: "this"` once implemented in the messenger
-  const sender = await whoAmI();
-  cancelForm({ tabId: sender.tab.id, frameId: 0 }, ...forms);
+  const topLevelFrame = await getTopLevelFrame();
+  cancelForm(topLevelFrame, ...forms);
 }
 
 async function resolvePanels(nonces: UUID[]): Promise<void> {
-  // TODO: Replace with `tabId: "this"` once implemented in the messenger
-  const { tab } = await whoAmI();
-  closeTemporaryPanel({ tabId: tab.id, frameId: 0 }, nonces);
+  const topLevelFrame = await getTopLevelFrame();
+  closeTemporaryPanel(topLevelFrame, nonces);
 }
 
 const sidebarSlice = createSlice({


### PR DESCRIPTION
## What does this PR do?

- Includes https://github.com/pixiebrix/webext-messenger/pull/89


## Discussion

- The messenger already knows its own tab as soon as the content script is executed
- Most of the time, we're fetching the current target only to know the top-level frame, so I exposed an API just for that
- There's a native API under discussion for this, however it might not be accepted anytime soon https://github.com/w3c/webextensions/issues/12

## Future Work


- In the future, I might just expose a `{tabId: "this", frameId: "top"}` object, but that requires extra logic in the sender

## Checklist

- [x] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @twschiller 
