### PR TITLE
Cleanup some copyright notices

### DIFF
--- a/selenium/environment.js
+++ b/selenium/environment.js
@@ -1,18 +1,18 @@
 /*
- * Copyright (C) 2021 Pixie Brix, LLC
+ * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 const zipdir = require("zip-dir");

--- a/src/auth/useRequiredPartnerAuth.test.tsx
+++ b/src/auth/useRequiredPartnerAuth.test.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import React from "react";
 import { renderHook } from "@testing-library/react-hooks";
 import useRequiredPartnerAuth from "@/auth/useRequiredPartnerAuth";

--- a/src/blocks/effects/attachAutocomplete.ts
+++ b/src/blocks/effects/attachAutocomplete.ts
@@ -1,18 +1,18 @@
 /*
- * Copyright (C) 2021 Pixie Brix, LLC
+ * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import { Effect } from "@/types";

--- a/src/blocks/readers/ImageReader.ts
+++ b/src/blocks/readers/ImageReader.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import { Reader } from "@/types";
 import { Schema } from "@/core";
 

--- a/src/blocks/renderers/documentView/DocumentViewProps.tsx
+++ b/src/blocks/renderers/documentView/DocumentViewProps.tsx
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { DocumentElement } from "@/components/documentBuilder/documentBuilderTypes";
 import { BlockArgContext, BlockOptions, UUID } from "@/core";
 

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import React, {
   useCallback,
   useState,

--- a/src/components/LinkButton.module.scss
+++ b/src/components/LinkButton.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/LinkButton.tsx
+++ b/src/components/LinkButton.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import styles from "./LinkButton.module.scss";
 import React from "react";
 import { Button, ButtonProps } from "react-bootstrap";

--- a/src/components/Loader.module.scss
+++ b/src/components/Loader.module.scss
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 .root {
   margin: auto; // Center
   padding: 20px;

--- a/src/components/UnstyledButton.module.scss
+++ b/src/components/UnstyledButton.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/addBlockModal/BlockGridItem.module.scss
+++ b/src/components/addBlockModal/BlockGridItem.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/addBlockModal/QuickAdd.module.scss
+++ b/src/components/addBlockModal/QuickAdd.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/addBlockModal/TagList.module.scss
+++ b/src/components/addBlockModal/TagList.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/addBlockModal/TagSearchInput.module.scss
+++ b/src/components/addBlockModal/TagSearchInput.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/addBlockModal/addBlockModalVariables.scss
+++ b/src/components/addBlockModal/addBlockModalVariables.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/banner/Banner.module.scss
+++ b/src/components/banner/Banner.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 .root {
   text-align: center;
   padding: 10px;

--- a/src/components/brickModalNoTags/QuickAdd.module.scss
+++ b/src/components/brickModalNoTags/QuickAdd.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/documentBuilder/outline/DocumentOutline.module.scss
+++ b/src/components/documentBuilder/outline/DocumentOutline.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/documentBuilder/preview/AddElementAction.module.scss
+++ b/src/components/documentBuilder/preview/AddElementAction.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/documentBuilder/preview/DocumentPreview.module.scss
+++ b/src/components/documentBuilder/preview/DocumentPreview.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/documentBuilder/preview/ElementPreview.module.scss
+++ b/src/components/documentBuilder/preview/ElementPreview.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/documentBuilder/preview/documentTree.module.scss
+++ b/src/components/documentBuilder/preview/documentTree.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/ellipsisMenu/EllipsisMenu.module.scss
+++ b/src/components/ellipsisMenu/EllipsisMenu.module.scss
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .toggle:global(.dropdown-toggle)::after {
   display: none;
 }

--- a/src/components/errors/ErrorDetail.module.scss
+++ b/src/components/errors/ErrorDetail.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/fields/schemaFields/optionIcon/OptionIcon.module.scss
+++ b/src/components/fields/schemaFields/optionIcon/OptionIcon.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.module.scss
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/form/FieldTemplate.module.scss
+++ b/src/components/form/FieldTemplate.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/form/lockedLabel/LockedExtensionPointLabel.module.scss
+++ b/src/components/form/lockedLabel/LockedExtensionPointLabel.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/form/popoverInfoLabel/PopoverInfoLabel.module.scss
+++ b/src/components/form/popoverInfoLabel/PopoverInfoLabel.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/form/widgets/RegistryIdWidget.module.scss
+++ b/src/components/form/widgets/RegistryIdWidget.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/formBuilder/FormBuilder.module.scss
+++ b/src/components/formBuilder/FormBuilder.module.scss
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .root {
   display: flex;
 }

--- a/src/components/formBuilder/preview/FormPreviewBooleanField.module.scss
+++ b/src/components/formBuilder/preview/FormPreviewBooleanField.module.scss
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .root {
   :global(.form-group) {
     margin-bottom: 0 !important;

--- a/src/components/formBuilder/preview/FormPreviewFieldTemplate.module.scss
+++ b/src/components/formBuilder/preview/FormPreviewFieldTemplate.module.scss
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 $color-active: #007bff;
 .root {
   padding: 5px;

--- a/src/components/formBuilder/preview/FormPreviewStringField.module.scss
+++ b/src/components/formBuilder/preview/FormPreviewStringField.module.scss
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .root {
   :global(.form-group) {
     margin-bottom: 0 !important;

--- a/src/components/formBuilder/schemaFieldNames.ts
+++ b/src/components/formBuilder/schemaFieldNames.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 export const UI_ORDER = "ui:order";
 export const UI_SCHEMA_ACTIVE = "ui:active";
 export const UI_WIDGET = "ui:widget";

--- a/src/components/jsonTree/JsonTree.module.scss
+++ b/src/components/jsonTree/JsonTree.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/logViewer/EntryRow.module.scss
+++ b/src/components/logViewer/EntryRow.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/logViewer/LogTable.module.scss
+++ b/src/components/logViewer/LogTable.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/onboarding/OnboardingChecklistCard.module.scss
+++ b/src/components/onboarding/OnboardingChecklistCard.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/quickBar/QuickBarApp.module.scss
+++ b/src/components/quickBar/QuickBarApp.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/schemaTree/SchemaTree.module.scss
+++ b/src/components/schemaTree/SchemaTree.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/selectionToolPopover/SelectionToolPopover.module.scss
+++ b/src/components/selectionToolPopover/SelectionToolPopover.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/sidebar/ActionMenu.module.scss
+++ b/src/components/sidebar/ActionMenu.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/components/tabLayout/EditorTabLayout.module.scss
+++ b/src/components/tabLayout/EditorTabLayout.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/contentScript/nativeEditor/elementPicker.ts
+++ b/src/contentScript/nativeEditor/elementPicker.ts
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import Overlay from "@/vendors/Overlay";
 import {
   expandedCssSelector,

--- a/src/contrib/google/sheets/sheetsHelpers.ts
+++ b/src/contrib/google/sheets/sheetsHelpers.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 export function normalizeHeader(header: string): string {
   return header.toLowerCase().trim();
 }

--- a/src/hooks/title.ts
+++ b/src/hooks/title.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import { useEffect, useMemo } from "react";
 
 const SUFFIX = " | PixieBrix";

--- a/src/hooks/useQuickbarShortcut.ts
+++ b/src/hooks/useQuickbarShortcut.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { useEffect, useState } from "react";
 
 function useQuickbarShortcut(): {

--- a/src/hooks/useRefresh.ts
+++ b/src/hooks/useRefresh.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import { useAsyncEffect } from "use-async-effect";
 import extensionPointRegistry from "@/extensionPoints/registry";
 import blockRegistry from "@/blocks/registry";

--- a/src/icons/Icon.module.scss
+++ b/src/icons/Icon.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/icons/list.ts
+++ b/src/icons/list.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 /* eslint-disable unicorn/prefer-module -- There's no module equivalent to require.context */
 
 import { IconLibrary } from "@/core";

--- a/src/options/options.scss
+++ b/src/options/options.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/blueprints/BlueprintsCard.module.scss
+++ b/src/options/pages/blueprints/BlueprintsCard.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 .root {
   height: 100%;
 }

--- a/src/options/pages/blueprints/GetStartedView.module.scss
+++ b/src/options/pages/blueprints/GetStartedView.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/blueprints/GetStartedView.tsx
+++ b/src/options/pages/blueprints/GetStartedView.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import styles from "./GetStartedView.module.scss";
 
 import React from "react";

--- a/src/options/pages/blueprints/ListFilters.module.scss
+++ b/src/options/pages/blueprints/ListFilters.module.scss
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .root {
   font-size: 0.9rem;
 

--- a/src/options/pages/blueprints/Status.module.scss
+++ b/src/options/pages/blueprints/Status.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/blueprints/emptyView/EmptyView.module.scss
+++ b/src/options/pages/blueprints/emptyView/EmptyView.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/blueprints/labels/LastUpdatedLabel.tsx
+++ b/src/options/pages/blueprints/labels/LastUpdatedLabel.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import styles from "./SharingLabel.module.scss";
 
 import { OverlayTrigger, Popover } from "react-bootstrap";

--- a/src/options/pages/blueprints/labels/SharingLabel.module.scss
+++ b/src/options/pages/blueprints/labels/SharingLabel.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/blueprints/labels/SharingLabel.tsx
+++ b/src/options/pages/blueprints/labels/SharingLabel.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import styles from "./SharingLabel.module.scss";
 
 import React from "react";

--- a/src/options/pages/blueprints/listView/ListItem.module.scss
+++ b/src/options/pages/blueprints/listView/ListItem.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 .root {
   display: flex;
   align-items: center;

--- a/src/options/pages/blueprints/onboardingView/OnboardingView.module.scss
+++ b/src/options/pages/blueprints/onboardingView/OnboardingView.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/brickEditor/BrickHistory.module.scss
+++ b/src/options/pages/brickEditor/BrickHistory.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 :global(.codeMarker) {
   background: #fff677;
   position: absolute;

--- a/src/options/pages/brickEditor/referenceTab/BlockResult.module.scss
+++ b/src/options/pages/brickEditor/referenceTab/BlockResult.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/brickEditor/referenceTab/BrickReference.module.scss
+++ b/src/options/pages/brickEditor/referenceTab/BrickReference.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/deployments/DeploymentModal.test.tsx
+++ b/src/options/pages/deployments/DeploymentModal.test.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import DeploymentModal from "@/options/pages/deployments/DeploymentModal";

--- a/src/options/pages/marketplace/ActivateWizard.module.scss
+++ b/src/options/pages/marketplace/ActivateWizard.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/marketplace/AuthWidget.module.scss
+++ b/src/options/pages/marketplace/AuthWidget.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/marketplace/ExtensionsBody.module.scss
+++ b/src/options/pages/marketplace/ExtensionsBody.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/marketplace/ServiceDescriptor.tsx
+++ b/src/options/pages/marketplace/ServiceDescriptor.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import styles from "./ServicesBody.module.scss";
 
 import React, { useMemo } from "react";

--- a/src/options/pages/marketplace/ServicesBody.module.scss
+++ b/src/options/pages/marketplace/ServicesBody.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/marketplace/useWizard.test.tsx
+++ b/src/options/pages/marketplace/useWizard.test.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import * as redux from "react-redux";
 import { recipeDefinitionFactory } from "@/testUtils/factories";
 import useWizard from "@/options/pages/marketplace/useWizard";

--- a/src/options/pages/services/PrivateServicesCard.module.scss
+++ b/src/options/pages/services/PrivateServicesCard.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/services/ServiceEditorModal.module.scss
+++ b/src/options/pages/services/ServiceEditorModal.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/options/pages/workshop/CustomBricksCard.module.scss
+++ b/src/options/pages/workshop/CustomBricksCard.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/EditorContent.module.scss
+++ b/src/pageEditor/EditorContent.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/ElementWizard.module.scss
+++ b/src/pageEditor/ElementWizard.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/extensionPoints/elementConfig.ts
+++ b/src/pageEditor/extensionPoints/elementConfig.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import React from "react";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import {

--- a/src/pageEditor/fields/FieldSection.module.scss
+++ b/src/pageEditor/fields/FieldSection.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/fields/FieldSection.tsx
+++ b/src/pageEditor/fields/FieldSection.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import React from "react";
 import { Card } from "react-bootstrap";
 import styles from "./FieldSection.module.scss";

--- a/src/pageEditor/fields/SelectorSelectorWidget.module.scss
+++ b/src/pageEditor/fields/SelectorSelectorWidget.module.scss
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 .root {
   display: flex;
   align-items: stretch;

--- a/src/pageEditor/fields/creatableAutosuggest/CreatableAutosuggest.module.scss
+++ b/src/pageEditor/fields/creatableAutosuggest/CreatableAutosuggest.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/panes/CantModifyPane.module.scss
+++ b/src/pageEditor/panes/CantModifyPane.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/panes/CantModifyPane.tsx
+++ b/src/pageEditor/panes/CantModifyPane.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import styles from "./CantModifyPane.module.scss";
 
 import React from "react";

--- a/src/pageEditor/panes/Pane.module.scss
+++ b/src/pageEditor/panes/Pane.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/panes/RecipePane.module.scss
+++ b/src/pageEditor/panes/RecipePane.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/panes/insert/GenericInsertPane.module.scss
+++ b/src/pageEditor/panes/insert/GenericInsertPane.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/panes/save/useSavingWizard.test.tsx
+++ b/src/pageEditor/panes/save/useSavingWizard.test.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 /* eslint-disable promise/prefer-await-to-then */
 
 import { configureStore, Store } from "@reduxjs/toolkit";

--- a/src/pageEditor/sidebar/ActionButtons.module.scss
+++ b/src/pageEditor/sidebar/ActionButtons.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/sidebar/SaveButton.module.scss
+++ b/src/pageEditor/sidebar/SaveButton.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/RecipeOptions.module.scss
+++ b/src/pageEditor/tabs/RecipeOptions.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/dataPanelTabs.module.scss
+++ b/src/pageEditor/tabs/dataPanelTabs.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editRecipeTab/EditRecipe.module.scss
+++ b/src/pageEditor/tabs/editRecipeTab/EditRecipe.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/EditTab.module.scss
+++ b/src/pageEditor/tabs/editTab/EditTab.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/UpgradedToApiV3.module.scss
+++ b/src/pageEditor/tabs/editTab/UpgradedToApiV3.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/dataPanel/ErrorDisplay.module.scss
+++ b/src/pageEditor/tabs/editTab/dataPanel/ErrorDisplay.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/editTabVariables.scss
+++ b/src/pageEditor/tabs/editTab/editTabVariables.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/editorNodes/OutputKeyView.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/OutputKeyView.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineFooterNode.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineFooterNode.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/editorNodes/TrailingMessage.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/TrailingMessage.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNodeContent.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNodeContent.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/editorNodes/brickNode/MoveBrickControl.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/brickNode/MoveBrickControl.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/editTab/editorNodes/nodeActions/NodeActionsView.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/nodeActions/NodeActionsView.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/pageEditor/tabs/effect/AdvancedLinks.module.scss
+++ b/src/pageEditor/tabs/effect/AdvancedLinks.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/recipes/registry.ts
+++ b/src/recipes/registry.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import BaseRegistry from "@/baseRegistry";
 import { RegistryId, Schema, SchemaProperties, UiSchema } from "@/core";
 import { OptionsDefinition, RecipeDefinition } from "@/types/definitions";

--- a/src/runtime/brickYaml.test.ts
+++ b/src/runtime/brickYaml.test.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import { loadBrickYaml, dumpBrickYaml } from "@/runtime/brickYaml";
 
 describe("loadYaml", () => {

--- a/src/sidebar/DefaultPanel.module.scss
+++ b/src/sidebar/DefaultPanel.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/sidebar/components/RootCancelledPanel.test.tsx
+++ b/src/sidebar/components/RootCancelledPanel.test.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import React from "react";
 
 import { render } from "@testing-library/react";

--- a/src/sidebar/components/RootErrorPanel.test.tsx
+++ b/src/sidebar/components/RootErrorPanel.test.tsx
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import React from "react";
 
 import { render } from "@testing-library/react";

--- a/src/sidebar/sidebar.scss
+++ b/src/sidebar/sidebar.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { CloudExtension, Deployment } from "@/types/contract";
 import { reportEvent } from "@/telemetry/events";

--- a/src/store/servicesSlice.ts
+++ b/src/store/servicesSlice.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 import { RawServiceConfiguration, UUID } from "@/core";
 import { localStorage } from "redux-persist-webextension-storage";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";

--- a/src/tinyPages/alert.scss
+++ b/src/tinyPages/alert.scss
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 @import "webext-base-css";
 
 body {

--- a/src/tinyPages/alert.ts
+++ b/src/tinyPages/alert.ts
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/tinyPages/ephemeralForm.scss
+++ b/src/tinyPages/ephemeralForm.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/utils/layout.scss
+++ b/src/utils/layout.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/src/utils/notify.module.scss
+++ b/src/utils/notify.module.scss
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .message {
   align-self: center;
   overflow-wrap: anywhere;

--- a/src/vendors/overrides.scss
+++ b/src/vendors/overrides.scss
@@ -1,18 +1,18 @@
-/*!
- * Copyright (C) 2020 Pixie Brix, LLC
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 span.page-title-icon {

--- a/src/vendors/theme/assets/styles/_themes.scss
+++ b/src/vendors/theme/assets/styles/_themes.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify

--- a/static/loadingScreen.js
+++ b/static/loadingScreen.js
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (C) 2022 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## What does this PR do?

- Adds some missing copyright notices
- Updates a handful of notices that still report Pixie Brix, LLC
- Always add two line breaks after the notice
- Drop `!` from start from some files (not useful in this context)

## Future work

I think that there are like 50 more files without notice, but that requires _some_ review if I automate it, so I skipped it for now.