### PR TITLE
#4705: show root mode for menuItem and quickBar

### DIFF
--- a/src/pageEditor/tabs/effect/BlockConfiguration.test.tsx
+++ b/src/pageEditor/tabs/effect/BlockConfiguration.test.tsx
@@ -95,10 +95,16 @@ test("renders", async () => {
 });
 
 describe("shows root mode", () => {
-  test("shows root mode for trigger", async () => {
+  test.each([
+    ["trigger", triggerFormStateFactory],
+    ["quickBar", quickbarFormStateFactory],
+    ["contextMenu", contextMenuFormStateFactory],
+    // `menuItem` must show root mode because root mode is used if the location matches multiple elements on the page
+    ["menuItem", menuItemFormStateFactory],
+  ])("shows root mode for %s", async (type, factory) => {
     const block = echoBlock;
     blockRegistry.register(block);
-    const initialState = triggerFormStateFactory({ apiVersion: "v3" }, [
+    const initialState = factory({ apiVersion: "v3" }, [
       blockConfigFactory({ id: block.id }),
     ]);
     renderBlockConfiguration(
@@ -112,69 +118,6 @@ describe("shows root mode", () => {
     await waitForEffect();
 
     const rootModeSelect = screen.getByLabelText("Root Mode");
-
-    expect(rootModeSelect).not.toBeNull();
-  });
-
-  test("shows root mode for quickBar", async () => {
-    const block = echoBlock;
-    blockRegistry.register(block);
-    const initialState = quickbarFormStateFactory({ apiVersion: "v3" }, [
-      blockConfigFactory({ id: block.id }),
-    ]);
-    renderBlockConfiguration(
-      <BlockConfiguration
-        name="extension.blockPipeline[0]"
-        blockId={block.id}
-      />,
-      initialState
-    );
-
-    await waitForEffect();
-
-    const rootModeSelect = screen.getByLabelText("Root Mode");
-
-    expect(rootModeSelect).not.toBeNull();
-  });
-
-  test("shows root mode for contextMenu", async () => {
-    const block = echoBlock;
-    blockRegistry.register(block);
-    const initialState = contextMenuFormStateFactory({ apiVersion: "v3" }, [
-      blockConfigFactory({ id: block.id }),
-    ]);
-    renderBlockConfiguration(
-      <BlockConfiguration
-        name="extension.blockPipeline[0]"
-        blockId={block.id}
-      />,
-      initialState
-    );
-
-    await waitForEffect();
-
-    const rootModeSelect = screen.getByLabelText("Root Mode");
-
-    expect(rootModeSelect).not.toBeNull();
-  });
-
-  test("show root mode for menuItem", async () => {
-    const block = echoBlock;
-    blockRegistry.register(block);
-    const initialState = menuItemFormStateFactory({ apiVersion: "v3" }, [
-      blockConfigFactory({ id: block.id }),
-    ]);
-    renderBlockConfiguration(
-      <BlockConfiguration
-        name="extension.blockPipeline[0]"
-        blockId={block.id}
-      />,
-      initialState
-    );
-
-    await waitForEffect();
-
-    const rootModeSelect = screen.queryByLabelText("Root Mode");
 
     expect(rootModeSelect).not.toBeNull();
   });

--- a/src/pageEditor/tabs/effect/BlockConfiguration.test.tsx
+++ b/src/pageEditor/tabs/effect/BlockConfiguration.test.tsx
@@ -22,6 +22,10 @@ import {
   blockFactory,
   formStateFactory,
   triggerFormStateFactory,
+  quickbarFormStateFactory,
+  menuItemFormStateFactory,
+  contextMenuFormStateFactory,
+  sidebarPanelFormStateFactory,
 } from "@/testUtils/factories";
 import blockRegistry from "@/blocks/registry";
 import { echoBlock } from "@/runtime/pipelineTests/pipelineTestHelpers";
@@ -90,22 +94,111 @@ test("renders", async () => {
   expect(rendered.asFragment()).toMatchSnapshot();
 });
 
-test("shows root mode for trigger", async () => {
-  const block = echoBlock;
-  blockRegistry.register(block);
-  const initialState = triggerFormStateFactory({ apiVersion: "v3" }, [
-    blockConfigFactory({ id: block.id }),
-  ]);
-  renderBlockConfiguration(
-    <BlockConfiguration name="extension.blockPipeline[0]" blockId={block.id} />,
-    initialState
-  );
+describe("shows root mode", () => {
+  test("shows root mode for trigger", async () => {
+    const block = echoBlock;
+    blockRegistry.register(block);
+    const initialState = triggerFormStateFactory({ apiVersion: "v3" }, [
+      blockConfigFactory({ id: block.id }),
+    ]);
+    renderBlockConfiguration(
+      <BlockConfiguration
+        name="extension.blockPipeline[0]"
+        blockId={block.id}
+      />,
+      initialState
+    );
 
-  await waitForEffect();
+    await waitForEffect();
 
-  const rootModeSelect = screen.getByLabelText("Root Mode");
+    const rootModeSelect = screen.getByLabelText("Root Mode");
 
-  expect(rootModeSelect).not.toBeNull();
+    expect(rootModeSelect).not.toBeNull();
+  });
+
+  test("shows root mode for quickBar", async () => {
+    const block = echoBlock;
+    blockRegistry.register(block);
+    const initialState = quickbarFormStateFactory({ apiVersion: "v3" }, [
+      blockConfigFactory({ id: block.id }),
+    ]);
+    renderBlockConfiguration(
+      <BlockConfiguration
+        name="extension.blockPipeline[0]"
+        blockId={block.id}
+      />,
+      initialState
+    );
+
+    await waitForEffect();
+
+    const rootModeSelect = screen.getByLabelText("Root Mode");
+
+    expect(rootModeSelect).not.toBeNull();
+  });
+
+  test("shows root mode for contextMenu", async () => {
+    const block = echoBlock;
+    blockRegistry.register(block);
+    const initialState = contextMenuFormStateFactory({ apiVersion: "v3" }, [
+      blockConfigFactory({ id: block.id }),
+    ]);
+    renderBlockConfiguration(
+      <BlockConfiguration
+        name="extension.blockPipeline[0]"
+        blockId={block.id}
+      />,
+      initialState
+    );
+
+    await waitForEffect();
+
+    const rootModeSelect = screen.getByLabelText("Root Mode");
+
+    expect(rootModeSelect).not.toBeNull();
+  });
+
+  test("show root mode for menuItem", async () => {
+    const block = echoBlock;
+    blockRegistry.register(block);
+    const initialState = menuItemFormStateFactory({ apiVersion: "v3" }, [
+      blockConfigFactory({ id: block.id }),
+    ]);
+    renderBlockConfiguration(
+      <BlockConfiguration
+        name="extension.blockPipeline[0]"
+        blockId={block.id}
+      />,
+      initialState
+    );
+
+    await waitForEffect();
+
+    const rootModeSelect = screen.queryByLabelText("Root Mode");
+
+    expect(rootModeSelect).not.toBeNull();
+  });
+
+  test("don't show root mode for sidebar panel", async () => {
+    const block = echoBlock;
+    blockRegistry.register(block);
+    const initialState = sidebarPanelFormStateFactory({ apiVersion: "v3" }, [
+      blockConfigFactory({ id: block.id }),
+    ]);
+    renderBlockConfiguration(
+      <BlockConfiguration
+        name="extension.blockPipeline[0]"
+        blockId={block.id}
+      />,
+      initialState
+    );
+
+    await waitForEffect();
+
+    const rootModeSelect = screen.queryByLabelText("Root Mode");
+
+    expect(rootModeSelect).toBeNull();
+  });
 });
 
 test.each`

--- a/src/pageEditor/tabs/effect/BlockConfiguration.tsx
+++ b/src/pageEditor/tabs/effect/BlockConfiguration.tsx
@@ -93,10 +93,15 @@ const BlockConfiguration: React.FunctionComponent<{
     [configName]
   );
 
-  // Only show if necessary. Currently, only the trigger extension point passes the element
-  // that triggered the event through for the reader root
+  // Only show if the extension point supports a target mode. menuItem implicitly supports target mode, because
+  // it's root-aware if multiple menu items are added to the page.
+  // Technically trigger/quickBar/etc. allow the user to pick the target mode. But for now, show the field even if
+  // the user has configured the extension point to use the document as the target.
   const showRootMode =
-    isRootAware && ["trigger", "contextMenu"].includes(context.values.type);
+    isRootAware &&
+    ["trigger", "contextMenu", "quickBar", "menuItem"].includes(
+      context.values.type
+    );
   const showIfAndTarget = blockType && blockType !== "renderer";
   const noAdvancedOptions = !showRootMode && !showIfAndTarget;
 

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -48,7 +48,10 @@ import trigger from "@/pageEditor/extensionPoints/trigger";
 import menuItem from "@/pageEditor/extensionPoints/menuItem";
 import {
   ActionFormState,
+  ContextMenuFormState,
   FormState,
+  QuickBarFormState,
+  SidebarFormState,
   TriggerFormState,
 } from "@/pageEditor/extensionPoints/formStateTypes";
 import {
@@ -83,6 +86,9 @@ import { JsonObject } from "type-fest";
 import objectHash from "object-hash";
 import { makeEmptyPermissions } from "@/utils/permissions";
 import { Permissions } from "webextension-polyfill";
+import quickBar from "@/pageEditor/extensionPoints/quickBar";
+import contextMenu from "@/pageEditor/extensionPoints/contextMenu";
+import sidebar from "@/pageEditor/extensionPoints/sidebar";
 
 // UUID sequence generator that's predictable across runs. A couple characters can't be 0
 // https://stackoverflow.com/a/19989922/402560
@@ -596,6 +602,73 @@ export const triggerFormStateFactory = (
     } as any,
     pipelineOverride
   ) as TriggerFormState;
+};
+
+export const sidebarPanelFormStateFactory = (
+  override?: FactoryConfig<SidebarFormState>,
+  pipelineOverride?: BlockPipeline
+) => {
+  const defaultTriggerProps = sidebar.fromNativeElement(
+    "https://test.com",
+    recipeMetadataFactory({
+      id: (n: number) => validateRegistryId(`test/extension-point-${n}`),
+      name: (n: number) => `Extension Point ${n}`,
+    }),
+    // TypeScript complains if the 3rd positional argument is left off
+    undefined as never
+  );
+
+  return formStateFactory(
+    {
+      ...defaultTriggerProps,
+      ...override,
+    } as any,
+    pipelineOverride
+  ) as SidebarFormState;
+};
+
+export const contextMenuFormStateFactory = (
+  override?: FactoryConfig<ContextMenuFormState>,
+  pipelineOverride?: BlockPipeline
+) => {
+  const defaultTriggerProps = contextMenu.fromNativeElement(
+    "https://test.com",
+    recipeMetadataFactory({
+      id: (n: number) => validateRegistryId(`test/extension-point-${n}`),
+      name: (n: number) => `Extension Point ${n}`,
+    }),
+    null
+  );
+
+  return formStateFactory(
+    {
+      ...defaultTriggerProps,
+      ...override,
+    } as any,
+    pipelineOverride
+  ) as ContextMenuFormState;
+};
+
+export const quickbarFormStateFactory = (
+  override?: FactoryConfig<QuickBarFormState>,
+  pipelineOverride?: BlockPipeline
+) => {
+  const defaultTriggerProps = quickBar.fromNativeElement(
+    "https://test.com",
+    recipeMetadataFactory({
+      id: (n: number) => validateRegistryId(`test/extension-point-${n}`),
+      name: (n: number) => `Extension Point ${n}`,
+    }),
+    null
+  );
+
+  return formStateFactory(
+    {
+      ...defaultTriggerProps,
+      ...override,
+    } as any,
+    pipelineOverride
+  ) as QuickBarFormState;
 };
 
 export const menuItemFormStateFactory = (


### PR DESCRIPTION
## What does this PR do?

- Closes #4705 
- Modified BlockConfiguration to show Root Mode field for menuItem and quickBar

## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working: N/A
- [x] Designate a primary reviewer: @BLoe 
