### PR TITLE
Fix merge conflict

### DIFF
--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -23,7 +23,6 @@ import { render } from "@testing-library/react";
 import React from "react";
 import blockRegistry from "@/blocks/registry";
 import { MarkdownRenderer } from "@/blocks/renderers/markdown";
-import * as backgroundAPI from "@/background/messenger/api";
 import * as contentScriptAPI from "@/contentScript/messenger/api";
 import { UNSET_UUID, uuidv4 } from "@/types/helpers";
 import { buildDocumentBranch } from "./documentTree";


### PR DESCRIPTION
https://github.com/pixiebrix/pixiebrix-extension/pull/4696 and https://github.com/pixiebrix/pixiebrix-extension/pull/4699 each dropped a mock for the background API, so now it's not used by either