### PR TITLE
Add Design System color variables file

### DIFF
--- a/src/vendors/theme/assets/styles/_colors.scss
+++ b/src/vendors/theme/assets/styles/_colors.scss
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+* Base Tokens
+*
+* The following color variables are Base Color Tokens defined in our Figma Foundation documents
+* https://www.figma.com/file/LiShRwQlnRG5zNl38oGCKl/%F0%9F%94%91-Foundation?node-id=359%3A11872&t=clXjxbSfhvEFAlPW-0
+*/
+
+// Neutral
+$N400: #675c7c;
+$N600: #3b2e53;
+$N800: #241c32;
+
+// Pixie
+$P100: #ccb8f4;
+$P900: #260b5c;


### PR DESCRIPTION
## What does this PR do?

- As part of kicking off incremental design system improvement work, we decided to start by creating a color variables file to define variables for colors that we are already hard-coding in our css modules

## How we propose using this new file

1. Whenever implementing or touching an existing css file, take stock of existing hard-coded color hex codes
2. For each hard-coded hex code, find the matching variable for it in `_colors.scss`
4. Otherwise, define a new color variable in `_colors.scss`
  a. If the color is defined as a token in our Figma design system document here: https://www.figma.com/file/LiShRwQlnRG5zNl38oGCKl/%F0%9F%94%91-Foundation?node-id=359%3A11872&t=clXjxbSfhvEFAlPW-0, use the token name
  b. Otherwise, come up with a good, descriptive name for the color
3. Import variables at the top of your css module `@import "@/vendors/theme/assets/styles/_colors";` and replace the hex value with the variable

## Discussion

- The goal with this file for the time being is to collect _all_ colors, not exclusively ones that are part of a system (we are shooting for reusability, not perfection), although we'd like to start using variable names that are defined in our Figma design files where applicable
- Out of scope is defining "themable" color variables, with e.g. css variables

## Demo

- See https://github.com/pixiebrix/pixiebrix-app/blob/7265695bf7a573e358873b8807826ae8f90978ce/pixiebrix-app/src/pages/onboarding/BotGamesLogin.module.scss for an example of the variables usage from this PR

## Future Work

- [ ] We will probably want to follow-up closely with a wiki/documentation update

- I noticed that color variables imported this way are not recognized by my IDE. It would be nice to be able to fix this for dev ergonomics purposes.

## Checklist

- [x] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer @BLoe 
