### PR TITLE
#4694: Warn when shared modules import context-specific modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,4 @@
-const strictContexts = ["background"];
-
-const contexts = [
+const strictContexts = [
   "background",
   "contentScript",
   "pageEditor",
@@ -9,36 +7,16 @@ const contexts = [
   // "pageScript", // TODO: After Messenger migration
 ];
 
-const restrictedZones = [];
-for (const exporter of contexts) {
-  for (const importer of contexts) {
-    if (exporter !== importer && !strictContexts.includes(exporter)) {
-      restrictedZones.push({
-        target: `./src/${importer}`,
-        from: `./src/${exporter}`,
-        message: `Cross-context imports break expectations. Either use the Messenger to get data from ${exporter}, or move the imported item out of @/${exporter}`,
-        except: [
-          `../${exporter}/messenger/api.ts`,
-          `../${exporter}/types.ts`,
-          `../${exporter}/nativeEditor/types.ts`,
-        ],
-      });
-    }
-  }
-}
-
-for (const exporter of strictContexts) {
-  restrictedZones.push({
-    target: `./src/!(${exporter})/**/*`,
-    from: `./src/${exporter}`,
-    message: `Cross-context imports break expectations. Either use the Messenger to get data from ${exporter}, or move the imported item out of @/${exporter}`,
-    except: [
-      `../${exporter}/messenger`,
-      `../${exporter}/types.ts`,
-      `../${exporter}/nativeEditor/types.ts`,
-    ],
-  });
-}
+const restrictedZones = strictContexts.map((exporter) => ({
+  target: `./src/!(${exporter})/**/*`,
+  from: `./src/${exporter}`,
+  message: `Cross-context imports break expectations. Shared components should be in shared folders. Solution 1: keep both importer and imported modules in the same context (shared or @/${exporter}). Solution 2: Use the Messenger if they are in the correct context.`,
+  except: [
+    `../${exporter}/messenger`,
+    `../${exporter}/types.ts`,
+    `../${exporter}/nativeEditor/types.ts`,
+  ],
+}));
 
 module.exports = {
   root: true,
@@ -51,7 +29,7 @@ module.exports = {
     "@typescript-eslint/consistent-type-imports": "off",
 
     "import/no-restricted-paths": [
-      "error",
+      "warn",
       {
         zones: restrictedZones,
       },


### PR DESCRIPTION
## What does this PR do?

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/4694

## Context

Until now we blocked cross-context imports, like `@/options` was blocked from importing `@/background`. This is because code under `@/background` is expected to be used exclusively in the background page. If that's not the case, then the code is misplaced and should be moved out of `@/background`

This PR extends the block to any file outside context-specific folders, like `@/utils` can't import from `@/background` anymore. The logic is the same, but we didn't enforce it before because it requires a lot of changes.

This currently triggers 136 messages, but the changes necessary aren't straightforward, the author needs to decide where this code belongs. For this reason, I changed the lint to *warn* instead of *error*.

## Demo

This line for example triggers a warning:

> Unexpected path "@/contentScript/nativeEditor/selectorInference" imported in restricted zone. Cross-context imports break expectations. Shared components should be in shared folders. Solution 1: keep both importer and imported modules in the same context (shared or @/contentScript). Solution 2: Use the Messenger if they are in the correct context.

https://github.com/pixiebrix/pixiebrix-extension/blob/267d715a3c4f4bc2f92a3e8af07b8dad94a75afd/src/utils/selectionController.ts