### PR TITLE
#4731: redirect to blueprints screen after /start URL

### DIFF
--- a/src/options/pages/onboarding/SetupPage.test.tsx
+++ b/src/options/pages/onboarding/SetupPage.test.tsx
@@ -31,6 +31,8 @@ import { uuidv4 } from "@/types/helpers";
 import { readStorage } from "@/chrome";
 import { HashRouter } from "react-router-dom";
 import { createHashHistory } from "history";
+import userEvent from "@testing-library/user-event";
+import { waitForEffect } from "@/testUtils/testHelpers";
 
 function optionsStore(initialState?: any) {
   return configureStore({
@@ -49,6 +51,13 @@ jest.mock("@/chrome", () => ({
 
 jest.mock("@/services/api", () => ({
   useGetMeQuery: jest.fn(),
+  util: {
+    resetApiState: jest.fn().mockReturnValue({ type: "notarealreset" }),
+  },
+}));
+
+jest.mock("@/background/messenger/api", () => ({
+  launchAuthIntegration: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock("@/services/baseService", () => ({
@@ -59,6 +68,14 @@ jest.mock("@/options/store", () => ({
   persistor: {
     flush: jest.fn(),
   },
+}));
+
+jest.mock("@/utils/permissions", () => ({
+  requestPermissions: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock("@/permissions", () => ({
+  serviceOriginPermissions: jest.fn().mockResolvedValue({ origins: [] }),
 }));
 
 describe("SetupPage", () => {
@@ -114,7 +131,9 @@ describe("SetupPage", () => {
     expect(screen.getByText("Connect your AARI account")).not.toBeNull();
   });
 
-  test("Start URL", async () => {
+  test("Start URL for OAuth2 flow", async () => {
+    const user = userEvent.setup();
+
     // User will be unauthenticated
     (useGetMeQuery as jest.Mock).mockImplementation(() => ({
       isLoading: false,
@@ -124,6 +143,12 @@ describe("SetupPage", () => {
     const history = createHashHistory();
     // Hostname comes as hostname, not URL
     history.push("/start?hostname=mycontrolroom.com");
+
+    // Not sure why, but listening here is necessary to get the final `history.location.pathname` assertion to
+    // pass :shrug:
+    history.listen((location) => {
+      console.debug(location);
+    });
 
     // Needs to use HashRouter instead of MemoryRouter for the useLocation calls in the components to work correctly
     // given the URL structure above
@@ -144,6 +169,13 @@ describe("SetupPage", () => {
       screen.getByLabelText("Control Room URL").getAttribute("value")
       // Schema get pre-pended automatically
     ).toStrictEqual("https://mycontrolroom.com");
+
+    const button = screen.getByText("Connect AARI");
+    await user.click(button);
+
+    await waitForEffect();
+
+    expect(history.location.pathname).toStrictEqual("/");
   });
 
   test("Start URL with Community Edition hostname if user is unauthenticated", async () => {

--- a/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
+++ b/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
@@ -34,6 +34,7 @@ import { serviceOriginPermissions } from "@/permissions";
 import { requestPermissions } from "@/utils/permissions";
 import { isEmpty } from "lodash";
 import { util as apiUtil } from "@/services/api";
+import { useHistory } from "react-router";
 
 const { updateServiceConfig } = servicesSlice.actions;
 
@@ -55,6 +56,7 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
   initialValues: ControlRoomConfiguration;
 }> = ({ initialValues }) => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const configuredServices = useSelector(selectConfiguredServices);
 
   const { authServiceId: authServiceIdOverride } = useSelector(selectSettings);
@@ -106,6 +108,9 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
 
         await launchAuthIntegration({ serviceId: authServiceId });
 
+        // Redirect to blueprints screen. The SetupPage always shows a login screen for the "/start" URL
+        history.push("/");
+
         // Refresh auth state so that 1) the user appears as logged in the UI in the navbar, and 2) the Admin Console
         // link in the navbar links to the URL required for JWT hand-off.
         // See useRequiredAuth hook for more details
@@ -114,7 +119,7 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
         helpers.setStatus(getErrorMessage(error));
       }
     },
-    [dispatch, configuredServices, authServiceId]
+    [dispatch, history, configuredServices, authServiceId]
   );
 
   const renderBody: RenderBody = () => (

--- a/src/options/pages/onboarding/partner/ControlRoomTokenForm.tsx
+++ b/src/options/pages/onboarding/partner/ControlRoomTokenForm.tsx
@@ -27,6 +27,7 @@ import Form, { RenderBody, RenderSubmit } from "@/components/form/Form";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import { Button } from "react-bootstrap";
 import { CONTROL_ROOM_SERVICE_ID } from "@/services/constants";
+import { useHistory } from "react-router";
 
 type ControlRoomConfiguration = {
   controlRoomUrl: string;
@@ -48,6 +49,7 @@ const ControlRoomTokenForm: React.FunctionComponent<{
 }> = ({ initialValues }) => {
   const { updateServiceConfig } = servicesSlice.actions;
   const dispatch = useDispatch();
+  const history = useHistory();
 
   const handleSubmit = async (formValues: ControlRoomConfiguration) => {
     dispatch(
@@ -65,6 +67,9 @@ const ControlRoomTokenForm: React.FunctionComponent<{
 
     try {
       await services.refresh();
+
+      // Redirect to blueprints screen. The SetupPage will always show a login screen for the "/start" URL
+      history.push("/");
     } catch (error) {
       notify.error({
         message:
@@ -82,11 +87,17 @@ const ControlRoomTokenForm: React.FunctionComponent<{
         type="text"
         description="Your Automation Anywhere Control Room URL, including https://"
       />
-      <ConnectedFieldTemplate name="username" label="Username" type="text" />
+      <ConnectedFieldTemplate
+        name="username"
+        label="Username"
+        type="text"
+        autoComplete="off"
+      />
       <ConnectedFieldTemplate
         name="password"
         label="Password"
         type="password"
+        autoComplete="off"
       />
     </>
   );


### PR DESCRIPTION
## What does this PR do?

- Closes #4731 

## Discussion

- Required due to /start URL logic in SetupPage

## Checklist

- [x] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @mnholtz 
