### PR TITLE
#4732: refresh partner auth token in the background

### DIFF
--- a/contrib/services/automation-anywhere-oauth2.yaml
+++ b/contrib/services/automation-anywhere-oauth2.yaml
@@ -2,14 +2,13 @@ apiVersion: v1
 kind: service
 metadata:
   id: "automation-anywhere/oauth2"
-  version: 1.0.0
+  version: 3.0.0
   name: Automation Anywhere OAuth2 (Preview)
-  description: Automation Anywhere OAuth2
+  description: Preview/test integration of OAuth2 authentication for Automation Anywhere
 inputSchema:
   $schema: "https://json-schema.org/draft/2019-09/schema#"
   type: object
   properties:
-    # Needs match the property name in automation-anywhere/control-room
     controlRoomUrl:
       type: string
       description: "The Control Room URL, including https://"
@@ -19,10 +18,10 @@ inputSchema:
 authentication:
   baseURL: "{{{ controlRoomUrl }}}"
   oauth2:
-    authorizeUrl: "https://dev-5ufv3jh0.us.auth0.com/authorize?organization=org_55te9GGDwlzAS1PB&audience=https://dev-5ufv3jh0.us.auth0.com/userinfo"
-    tokenUrl: "https://dev-5ufv3jh0.us.auth0.com/oauth/token"
+    authorizeUrl: "https://oauthconfigapp.automationanywhere.digital/client/oauth/authorize?hosturl={{{ controlRoomUrl }}}&audience=https://controlroom"
+    tokenUrl: "https://oauthconfigapp.automationanywhere.digital/client/oauth/token"
     code_challenge_method: S256
-    scope: "openid email userprofile"
-    client_id: "tfnmiN5uWd4gw2slYVbjSHAF5o8a2pms"
+    scope: "openid userprofile offline_access"
+    client_id: "g2qrB2fvyLYbotkb3zi9wwO5qjmje3eM"
   headers:
     Authorization: "Bearer {{{ access_token }}}"

--- a/src/auth/authTypes.ts
+++ b/src/auth/authTypes.ts
@@ -114,6 +114,12 @@ export type PartnerAuthData = {
    */
   token: string | null;
   /**
+   * The refresh token, if `offline_access` was included in scope.
+   * @since 1.7.15
+   */
+  refreshToken: string | null;
+
+  /**
    * Extra HTTP headers to send with every request.
    */
   extraHeaders: Record<string, string> | null;

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -58,7 +58,7 @@ export async function flagOn(flag: string): Promise<boolean> {
 }
 
 /**
- * Return the PixieBrix API token (issued by the PixieBrix API).
+ * Return the native PixieBrix API token (issued by the PixieBrix API).
  */
 export async function getExtensionToken(): Promise<string | undefined> {
   const { token } = await readAuthData();

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -42,7 +42,7 @@ import activateBrowserActionIcon from "@/background/activateBrowserActionIcon";
 import initActiveTabTracking from "@/background/activeTab";
 import initPartnerTheme from "@/background/partnerTheme";
 import initStarterBlueprints from "@/background/starterBlueprints";
-import { initTokenRefresh } from "@/background/partnerIntegrations";
+import { initPartnerTokenRefresh } from "@/background/partnerIntegrations";
 
 void initLocator();
 registerMessenger();
@@ -60,4 +60,4 @@ activateBrowserActionIcon();
 initActiveTabTracking();
 initPartnerTheme();
 initStarterBlueprints();
-initTokenRefresh();
+initPartnerTokenRefresh();

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -42,6 +42,7 @@ import activateBrowserActionIcon from "@/background/activateBrowserActionIcon";
 import initActiveTabTracking from "@/background/activeTab";
 import initPartnerTheme from "@/background/partnerTheme";
 import initStarterBlueprints from "@/background/starterBlueprints";
+import { initTokenRefresh } from "@/background/partnerIntegrations";
 
 void initLocator();
 registerMessenger();
@@ -59,3 +60,4 @@ activateBrowserActionIcon();
 initActiveTabTracking();
 initPartnerTheme();
 initStarterBlueprints();
+initTokenRefresh();

--- a/src/background/partnerIntegrations.test.ts
+++ b/src/background/partnerIntegrations.test.ts
@@ -165,7 +165,7 @@ describe("refresh partner token", () => {
     expect(axiosMock.history.post).toHaveLength(0);
   });
 
-  it("it refreshes token", async () => {
+  it("refreshes token", async () => {
     const authId = uuidv4();
     readPartnerAuthDataMock.mockResolvedValue({
       authId,
@@ -203,7 +203,7 @@ describe("refresh partner token", () => {
     });
   });
 
-  it("it throws on authorization error", async () => {
+  it("throws on authorization error", async () => {
     const authId = uuidv4();
     readPartnerAuthDataMock.mockResolvedValue({
       authId,

--- a/src/background/partnerIntegrations.test.ts
+++ b/src/background/partnerIntegrations.test.ts
@@ -15,17 +15,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getPartnerPrincipals } from "@/background/partnerIntegrations";
+import {
+  _refreshPartnerToken,
+  getPartnerPrincipals,
+} from "@/background/partnerIntegrations";
 import serviceRegistry, { readRawConfigurations } from "@/services/registry";
-
 import { fetch } from "@/hooks/fetch";
-
 import controlRoomTokenService from "@contrib/services/automation-anywhere.yaml";
 import controlRoomOAuthService from "@contrib/services/automation-anywhere-oauth2.yaml";
 import { RawServiceConfiguration, RegistryId } from "@/core";
 import { locator as serviceLocator } from "@/background/locator";
-import { CONTROL_ROOM_SERVICE_ID } from "@/services/constants";
+import {
+  CONTROL_ROOM_OAUTH_SERVICE_ID,
+  CONTROL_ROOM_SERVICE_ID,
+} from "@/services/constants";
 import { uuidv4 } from "@/types/helpers";
+import { readPartnerAuthData, setPartnerAuth } from "@/auth/token";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
 
 const serviceMap = new Map([
   [(controlRoomTokenService as any).metadata.id, controlRoomTokenService],
@@ -34,6 +41,11 @@ const serviceMap = new Map([
 
 jest.mock("@/hooks/fetch", () => ({
   fetch: jest.fn(),
+}));
+
+jest.mock("@/auth/token", () => ({
+  readPartnerAuthData: jest.fn().mockResolvedValue({}),
+  setPartnerAuth: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock("@/services/registry", () => {
@@ -63,8 +75,21 @@ jest.mock("@/background/messenger/api", () => {
   };
 });
 
+jest.mock("@/hooks/fetch", () => ({
+  fetch: jest.fn(),
+}));
+
+const axiosMock = new MockAdapter(axios);
+
+afterEach(() => {
+  axiosMock.reset();
+  axiosMock.resetHistory();
+});
+
 const readRawConfigurationsMock = readRawConfigurations as jest.Mock;
 const fetchMock = fetch as jest.Mock;
+const setPartnerAuthMock = setPartnerAuth as jest.Mock;
+const readPartnerAuthDataMock = readPartnerAuthData as jest.Mock;
 
 describe("getPartnerPrincipals", () => {
   beforeEach(() => {
@@ -121,5 +146,87 @@ describe("getPartnerPrincipals", () => {
         principalId: "bot_creator",
       },
     ]);
+  });
+});
+
+describe("refresh partner token", () => {
+  it("nop if no token", async () => {
+    await _refreshPartnerToken();
+    expect(readPartnerAuthDataMock).toHaveBeenCalledOnce();
+  });
+
+  it("nop if no refresh token", async () => {
+    readPartnerAuthDataMock.mockResolvedValue({
+      authId: uuidv4(),
+      token: "notatoken",
+    });
+
+    await _refreshPartnerToken();
+    expect(axiosMock.history.post).toHaveLength(0);
+  });
+
+  it("it refreshes token", async () => {
+    const authId = uuidv4();
+    readPartnerAuthDataMock.mockResolvedValue({
+      authId,
+      token: "notatoken",
+      refreshToken: "notarefreshtoken",
+    });
+
+    readRawConfigurationsMock.mockResolvedValue([
+      {
+        id: authId,
+        serviceId: CONTROL_ROOM_OAUTH_SERVICE_ID,
+        config: {
+          controlRoomUrl: "https://controlroom.com",
+        },
+      } as unknown as RawServiceConfiguration,
+    ]);
+
+    axiosMock.onPost().reply(200, {
+      access_token: "notatoken2",
+      refresh_token: "notarefreshtoken2",
+    });
+
+    await serviceLocator.refreshLocal();
+
+    await _refreshPartnerToken();
+    expect(axiosMock.history.post).toHaveLength(1);
+    // `toHaveBeenCalledOnceWith` had the wrong types :shrug:
+    expect(setPartnerAuthMock).toHaveBeenCalledWith({
+      authId,
+      token: "notatoken2",
+      refreshToken: "notarefreshtoken2",
+      extraHeaders: {
+        "X-Control-Room": "https://controlroom.com",
+      },
+    });
+  });
+
+  it("it throws on authorization error", async () => {
+    const authId = uuidv4();
+    readPartnerAuthDataMock.mockResolvedValue({
+      authId,
+      token: "notatoken",
+      refreshToken: "notarefreshtoken",
+    });
+
+    readRawConfigurationsMock.mockResolvedValue([
+      {
+        id: authId,
+        serviceId: CONTROL_ROOM_OAUTH_SERVICE_ID,
+        config: {
+          controlRoomUrl: "https://controlroom.com",
+        },
+      } as unknown as RawServiceConfiguration,
+    ]);
+
+    axiosMock.onPost().reply(401);
+
+    await serviceLocator.refreshLocal();
+
+    await expect(_refreshPartnerToken()).rejects.toThrow(
+      "Request failed with status code 401"
+    );
   });
 });

--- a/src/background/partnerIntegrations.ts
+++ b/src/background/partnerIntegrations.ts
@@ -137,7 +137,7 @@ export async function launchAuthIntegration({
 }
 
 /**
- * Refresh an Automation Anywhere JWT. NOOP if a refresh token is not available.
+ * Refresh an Automation Anywhere JWT. NOOP if a JWT refresh token is not available.
  */
 export async function _refreshPartnerToken(): Promise<void> {
   const authData = await readPartnerAuthData();
@@ -188,8 +188,8 @@ export async function safeTokenRefresh(): Promise<void> {
 }
 
 /**
- * Refresh partner token every 10 minutes, if a refresh token is available.
+ * Refresh partner JWT every 10 minutes, if a refresh token is available.
  */
-export function initTokenRefresh(): void {
+export function initPartnerTokenRefresh(): void {
   setInterval(safeTokenRefresh, 1000 * 60 * 10);
 }

--- a/src/background/partnerIntegrations.ts
+++ b/src/background/partnerIntegrations.ts
@@ -21,12 +21,14 @@ import { expectContext } from "@/utils/expectContext";
 import { safeParseUrl } from "@/utils";
 import { RegistryId } from "@/core";
 import { launchOAuth2Flow } from "@/background/auth";
+import { readPartnerAuthData, setPartnerAuth } from "@/auth/token";
 import serviceRegistry from "@/services/registry";
-import { setPartnerAuth } from "@/auth/token";
+
 import {
   CONTROL_ROOM_OAUTH_SERVICE_ID,
   CONTROL_ROOM_SERVICE_ID,
 } from "@/services/constants";
+import axios from "axios";
 
 /**
  * A principal on a remote service, e.g., an Automation Anywhere Control Room.
@@ -121,6 +123,8 @@ export async function launchAuthIntegration({
     await setPartnerAuth({
       authId: config.id,
       token: data.access_token,
+      // `refresh_token` only returned if offline_access scope is requested
+      refreshToken: data.refresh_token,
       extraHeaders: {
         "X-Control-Room": config.config.controlRoomUrl,
       },
@@ -130,4 +134,62 @@ export async function launchAuthIntegration({
       `Support for login with integration not implemented: ${serviceId}`
     );
   }
+}
+
+/**
+ * Refresh an Automation Anywhere JWT. NOOP if a refresh token is not available.
+ */
+export async function _refreshPartnerToken(): Promise<void> {
+  const authData = await readPartnerAuthData();
+  if (authData.authId && authData.refreshToken) {
+    console.debug("Refreshing partner JWT");
+
+    const service = await serviceRegistry.lookup(CONTROL_ROOM_OAUTH_SERVICE_ID);
+    const config = await serviceLocator.getLocalConfig(authData.authId);
+    const context = service.getOAuth2Context(config.config);
+
+    if (isEmpty(config.config.controlRoomUrl)) {
+      // Fine to dump to console for debugging because CONTROL_ROOM_OAUTH_SERVICE_ID doesn't have any secret props.
+      console.warn("controlRoomUrl is missing on configuration", config);
+      throw new Error("controlRoomUrl is missing on configuration");
+    }
+
+    // https://axios-http.com/docs/urlencoded
+    const params = new URLSearchParams();
+    params.append("grant_type", "refresh_token");
+    params.append("client_id", context.client_id);
+    params.append("refresh_token", authData.refreshToken);
+    params.append("hosturl", config.config.controlRoomUrl);
+
+    // On 401, throw the error. In the future, we might consider clearing the partnerAuth. However, currently that
+    // would trigger a re-login, which may not be desirable at arbitrary times.
+    const { data } = await axios.post(context.tokenUrl, params, {
+      headers: { Authorization: `Basic ${btoa(context.client_id)} ` },
+    });
+
+    await setPartnerAuth({
+      authId: config.id,
+      token: data.access_token,
+      // `refresh_token` only returned if offline_access scope is requested
+      refreshToken: data.refresh_token,
+      extraHeaders: {
+        "X-Control-Room": config.config.controlRoomUrl,
+      },
+    });
+  }
+}
+
+export async function safeTokenRefresh(): Promise<void> {
+  try {
+    await _refreshPartnerToken();
+  } catch (error) {
+    console.warn("Failed to refresh partner token", error);
+  }
+}
+
+/**
+ * Refresh partner token every 10 minutes, if a refresh token is available.
+ */
+export function initTokenRefresh(): void {
+  setInterval(safeTokenRefresh, 1000 * 60 * 10);
 }

--- a/src/services/factory.test.ts
+++ b/src/services/factory.test.ts
@@ -37,8 +37,8 @@ describe("LocalDefinedService", () => {
 
     expect(origins).toEqual([
       "https://controlroom.example.com/*",
-      "https://dev-5ufv3jh0.us.auth0.com/authorize?organization=org_55te9GGDwlzAS1PB&audience=https://dev-5ufv3jh0.us.auth0.com/userinfo",
-      "https://dev-5ufv3jh0.us.auth0.com/oauth/token",
+      "https://oauthconfigapp.automationanywhere.digital/client/oauth/authorize?hosturl=https://controlroom.example.com&audience=https://controlroom",
+      "https://oauthconfigapp.automationanywhere.digital/client/oauth/token",
     ]);
   });
 
@@ -51,8 +51,9 @@ describe("LocalDefinedService", () => {
     } as unknown as SanitizedConfig);
 
     expect(origins).toEqual([
-      "https://dev-5ufv3jh0.us.auth0.com/authorize?organization=org_55te9GGDwlzAS1PB&audience=https://dev-5ufv3jh0.us.auth0.com/userinfo",
-      "https://dev-5ufv3jh0.us.auth0.com/oauth/token",
+      // `controlRoomUrl` not included because it's not a valid URL
+      "https://oauthconfigapp.automationanywhere.digital/client/oauth/authorize?hosturl=&audience=https://controlroom",
+      "https://oauthconfigapp.automationanywhere.digital/client/oauth/token",
     ]);
   });
 });

--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -198,8 +198,10 @@ class LazyLocatorFactory {
    * @param authId UUID of the integration configuration
    */
   async getLocalConfig(authId: UUID): Promise<RawServiceConfiguration | null> {
+    // The `initialized` flag gets set from _refresh, which covers both local and remote. For performance,
+    // we could split the initialized flag into two, but it's not worth it since refreshLocal is fast.
     if (!this.initialized) {
-      await this.refresh();
+      await this.refreshLocal();
     }
 
     return this.local.find((x) => x.id === authId);


### PR DESCRIPTION
## What does this PR do?

- Closes #4732 
- If using an AA JWT with a refresh_token, automatically refresh the token every 10 min

## Discussion

- On refresh failure (e.g., due to expiration), the code doesn't clear out the token state
- If the JWT is expired, the next time the JWT is used to authenticate against our API or the control room, it will be cleared out, prompting re-authentication

## Demo

- TBD

## TODO

- [ ] manually perform E2E test and create demo of network inspector

## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working: N/A
- [x] Designate a primary reviewer: @mnholtz 
