### PR TITLE
#4763: account for error class name namespacing/hoisting in production bundles

### DIFF
--- a/src/errors/errorHelpers.test.ts
+++ b/src/errors/errorHelpers.test.ts
@@ -516,7 +516,7 @@ describe("robust to name mangling", () => {
     ).toBeTrue();
   });
 
-  it("handles namespaced business errors", () => {
+  it("handles namespaced business errors in a context error", () => {
     class businessErrors_BusinessError extends Error {
       // The name that webpack will produce during optimize.concatenateModules
       override name = "businessErrors_BusinessError";

--- a/src/errors/errorHelpers.test.ts
+++ b/src/errors/errorHelpers.test.ts
@@ -39,6 +39,7 @@ import {
 } from "@/errors/businessErrors";
 import { ContextError } from "@/errors/genericErrors";
 import {
+  ClientNetworkPermissionError,
   ClientRequestError,
   RemoteServiceError,
 } from "@/errors/clientRequestErrors";
@@ -497,5 +498,51 @@ describe("serialization", () => {
     };
 
     expect(hasSpecificErrorCause(error, CancelError)).toBeTrue();
+  });
+});
+
+describe("robust to name mangling", () => {
+  it("handles namespaced business errors", () => {
+    class businessErrors_BusinessError extends Error {
+      // The name that webpack will produce during optimize.concatenateModules
+      override name = "businessErrors_BusinessError";
+    }
+
+    expect(
+      hasSpecificErrorCause(
+        new CancelError("test"),
+        businessErrors_BusinessError
+      )
+    ).toBeTrue();
+  });
+
+  it("handles namespaced business errors", () => {
+    class businessErrors_BusinessError extends Error {
+      // The name that webpack will produce during optimize.concatenateModules
+      override name = "businessErrors_BusinessError";
+    }
+
+    const error = new ContextError("foo", {
+      cause: new CancelError("test"),
+      context: {},
+    });
+
+    expect(
+      hasSpecificErrorCause(error, businessErrors_BusinessError)
+    ).toBeTrue();
+  });
+
+  it("handles namespaced client request errors", () => {
+    class clientRequestErrors_ClientRequestError extends Error {
+      // The name that webpack will produce during optimize.concatenateModules
+      override name = "clientRequestErrors_ClientRequestError";
+    }
+
+    expect(
+      hasSpecificErrorCause(
+        new ClientNetworkPermissionError("test", { cause: null }),
+        clientRequestErrors_ClientRequestError
+      )
+    ).toBeTrue();
   });
 });

--- a/src/errors/errorHelpers.ts
+++ b/src/errors/errorHelpers.ts
@@ -174,7 +174,15 @@ const BUSINESS_ERROR_NAMES = new Set([
   "InvalidSelectorError",
 ]);
 
-function isErrorTypeNameMatch(
+/**
+ * Returns true if errorName matches at least one of classNames.
+ *
+ * Accounts for name-mangling by webpack in optimized code for the class names in classNames.
+ *
+ * @param errorName the query error name
+ * @param classNames the class names to match against
+ */
+export function isErrorTypeNameMatch(
   errorName: string,
   classNames: Iterable<string>
 ): boolean {
@@ -185,6 +193,11 @@ function isErrorTypeNameMatch(
 
   // Also note that keep_classnames must be set in webpack's TerserPlugin configuration to preserve the error
   // class names for the name check to work
+
+  // Defensive check because some call sites cast from unknown
+  if (typeof errorName !== "string") {
+    return false;
+  }
 
   return (
     errorName &&

--- a/src/errors/errorHelpers.ts
+++ b/src/errors/errorHelpers.ts
@@ -194,13 +194,10 @@ export function isErrorTypeNameMatch(
   // Also note that keep_classnames must be set in webpack's TerserPlugin configuration to preserve the error
   // class names for the name check to work
 
-  // Defensive check because some call sites cast from unknown
-  if (typeof errorName !== "string") {
-    return false;
-  }
-
   return (
     errorName &&
+    // Defensive check because some call sites cast from unknown
+    typeof errorName === "string" &&
     [...classNames].some(
       (className) =>
         errorName === className || errorName.endsWith(`_${className}`)

--- a/src/errors/networkErrorHelpers.ts
+++ b/src/errors/networkErrorHelpers.ts
@@ -20,6 +20,7 @@ import { type Except } from "type-fest";
 import { type AxiosError, type AxiosResponse } from "axios";
 import { isEmpty, isPlainObject } from "lodash";
 import { getReasonPhrase } from "http-status-codes";
+import { isErrorTypeNameMatch } from "@/errors/errorHelpers";
 
 /**
  * Axios offers its own serialization method, but it doesn't include the response.
@@ -34,7 +35,8 @@ export function isAxiosError(error: unknown): error is SerializableAxiosError {
     // To deal with original AxiosError as well as a serialized error
     // we check 'isAxiosError' property for a non-serialized Error and 'name' for serialized object
     // Related issue to revisit RTKQ error handling: https://github.com/pixiebrix/pixiebrix-extension/issues/4032
-    (Boolean(error.isAxiosError) || error.name === "AxiosError")
+    (Boolean(error.isAxiosError) ||
+      isErrorTypeNameMatch(error.name as string, ["AxiosError"]))
   );
 }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #4763 
- Accounts for moduleName_className error class names in optimized code

## Post-Merge Checklist

- [ ] Verify logic works in release build

## Checklist

- [x] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @fregante 
