### PR TITLE
Avoid error class name mangling in webpack

### DIFF
--- a/src/errors/errorHelpers.test.ts
+++ b/src/errors/errorHelpers.test.ts
@@ -39,7 +39,6 @@ import {
 } from "@/errors/businessErrors";
 import { ContextError } from "@/errors/genericErrors";
 import {
-  ClientNetworkPermissionError,
   ClientRequestError,
   RemoteServiceError,
 } from "@/errors/clientRequestErrors";
@@ -498,51 +497,5 @@ describe("serialization", () => {
     };
 
     expect(hasSpecificErrorCause(error, CancelError)).toBeTrue();
-  });
-});
-
-describe("robust to name mangling", () => {
-  it("handles namespaced business errors", () => {
-    class businessErrors_BusinessError extends Error {
-      // The name that webpack will produce during optimize.concatenateModules
-      override name = "businessErrors_BusinessError";
-    }
-
-    expect(
-      hasSpecificErrorCause(
-        new CancelError("test"),
-        businessErrors_BusinessError
-      )
-    ).toBeTrue();
-  });
-
-  it("handles namespaced business errors in a context error", () => {
-    class businessErrors_BusinessError extends Error {
-      // The name that webpack will produce during optimize.concatenateModules
-      override name = "businessErrors_BusinessError";
-    }
-
-    const error = new ContextError("foo", {
-      cause: new CancelError("test"),
-      context: {},
-    });
-
-    expect(
-      hasSpecificErrorCause(error, businessErrors_BusinessError)
-    ).toBeTrue();
-  });
-
-  it("handles namespaced client request errors", () => {
-    class clientRequestErrors_ClientRequestError extends Error {
-      // The name that webpack will produce during optimize.concatenateModules
-      override name = "clientRequestErrors_ClientRequestError";
-    }
-
-    expect(
-      hasSpecificErrorCause(
-        new ClientNetworkPermissionError("test", { cause: null }),
-        clientRequestErrors_ClientRequestError
-      )
-    ).toBeTrue();
   });
 });

--- a/src/errors/errorHelpers.ts
+++ b/src/errors/errorHelpers.ts
@@ -103,17 +103,15 @@ export function isSpecificError<
 >(error: unknown, errorType: ErrorType): error is InstanceType<ErrorType> {
   // Catch 2 common error subclass groups. Necessary until we drop support for serialized errors:
   // https://github.com/sindresorhus/serialize-error/issues/72
-  if (isErrorTypeNameMatch(errorType.name, ["ClientRequestError"])) {
+  if (errorType.name === "ClientRequestError") {
     return isClientRequestError(error);
   }
 
-  if (isErrorTypeNameMatch(errorType.name, ["BusinessError"])) {
+  if (errorType.name === "BusinessError") {
     return isBusinessError(error);
   }
 
-  return (
-    isErrorObject(error) && isErrorTypeNameMatch(error.name, [errorType.name])
-  );
+  return isErrorObject(error) && error.name === errorType.name;
 }
 
 export function selectSpecificError<
@@ -174,42 +172,8 @@ const BUSINESS_ERROR_NAMES = new Set([
   "InvalidSelectorError",
 ]);
 
-/**
- * Returns true if errorName matches at least one of classNames.
- *
- * Accounts for name-mangling by webpack in optimized code for the class names in classNames.
- *
- * @param errorName the query error name
- * @param classNames the class names to match against
- */
-export function isErrorTypeNameMatch(
-  errorName: string,
-  classNames: Iterable<string>
-): boolean {
-  // https://github.com/pixiebrix/pixiebrix-extension/issues/4763
-
-  // In production builds, webpack tries to hoist classes to the global scope. To do so, it namespaces the class name
-  // with the module name: https://webpack.js.org/configuration/optimization/#optimizationconcatenatemodules
-
-  // Also note that keep_classnames must be set in webpack's TerserPlugin configuration to preserve the error
-  // class names for the name check to work
-
-  return (
-    errorName &&
-    // Defensive check because some call sites cast from unknown
-    typeof errorName === "string" &&
-    [...classNames].some(
-      (className) =>
-        errorName === className || errorName.endsWith(`_${className}`)
-    )
-  );
-}
-
 export function isBusinessError(error: unknown): boolean {
-  return (
-    isErrorObject(error) &&
-    isErrorTypeNameMatch(error.name, BUSINESS_ERROR_NAMES)
-  );
+  return isErrorObject(error) && BUSINESS_ERROR_NAMES.has(error.name);
 }
 
 // List all ClientRequestError subclasses as text:
@@ -227,10 +191,7 @@ const CLIENT_REQUEST_ERROR_NAMES = new Set([
  * @see CLIENT_REQUEST_ERROR_NAMES
  */
 export function isClientRequestError(error: unknown): boolean {
-  return (
-    isErrorObject(error) &&
-    isErrorTypeNameMatch(error.name, CLIENT_REQUEST_ERROR_NAMES)
-  );
+  return isErrorObject(error) && CLIENT_REQUEST_ERROR_NAMES.has(error.name);
 }
 
 /**

--- a/src/errors/errorHelpers.ts
+++ b/src/errors/errorHelpers.ts
@@ -18,13 +18,15 @@
 import { deserializeError, type ErrorObject } from "serialize-error";
 import { isObject, matchesAnyPattern, smartAppendPeriod } from "@/utils";
 import safeJsonStringify from "json-stringify-safe";
-import { isEmpty, truncate } from "lodash";
+import { isEmpty, memoize, truncate } from "lodash";
 import {
   isAxiosError,
   selectNetworkErrorMessage,
   selectServerErrorMessage,
 } from "@/errors/networkErrorHelpers";
 import { type MessageContext } from "@/core";
+
+type ErrorConstructor = new (...args: unknown[]) => Error;
 
 // From "webext-messenger". Cannot import because the webextension polyfill can only run in an extension context
 // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/3641
@@ -98,25 +100,33 @@ export function isErrorObject(error: unknown): error is ErrorObject {
   return typeof (error as any)?.message === "string";
 }
 
-export function isSpecificError<
-  ErrorType extends new (...args: unknown[]) => Error
->(error: unknown, errorType: ErrorType): error is InstanceType<ErrorType> {
+export function isSpecificError<ErrorType extends ErrorConstructor>(
+  error: unknown,
+  errorType: ErrorType
+): error is InstanceType<ErrorType> {
+  if (!isErrorObject(error)) {
+    return false;
+  }
+
+  const errorTypeName = getErrorName(errorType);
+
   // Catch 2 common error subclass groups. Necessary until we drop support for serialized errors:
   // https://github.com/sindresorhus/serialize-error/issues/72
-  if (errorType.name === "ClientRequestError") {
+  if (errorTypeName === "ClientRequestError") {
     return isClientRequestError(error);
   }
 
-  if (errorType.name === "BusinessError") {
+  if (errorTypeName === "BusinessError") {
     return isBusinessError(error);
   }
 
-  return isErrorObject(error) && error.name === errorType.name;
+  return errorTypeName === error.name;
 }
 
-export function selectSpecificError<
-  ErrorType extends new (...args: unknown[]) => Error
->(error: unknown, errorType: ErrorType): InstanceType<ErrorType> | null {
+export function selectSpecificError<ErrorType extends ErrorConstructor>(
+  error: unknown,
+  errorType: ErrorType
+): InstanceType<ErrorType> | null {
   if (!isObject(error)) {
     return null;
   }
@@ -141,9 +151,17 @@ export function getRootCause(error: unknown): unknown {
   return error;
 }
 
-export function hasSpecificErrorCause<
-  ErrorType extends new (...args: unknown[]) => Error
->(error: unknown, errorType: ErrorType): boolean {
+const getErrorName = memoize(
+  (ErrorOrErrorConstructor: Error | ErrorConstructor): string =>
+    ErrorOrErrorConstructor instanceof Error
+      ? ErrorOrErrorConstructor.name
+      : new ErrorOrErrorConstructor().name
+);
+
+export function hasSpecificErrorCause<ErrorType extends ErrorConstructor>(
+  error: unknown,
+  errorType: ErrorType
+): boolean {
   return Boolean(selectSpecificError(error, errorType));
 }
 

--- a/src/errors/networkErrorHelpers.ts
+++ b/src/errors/networkErrorHelpers.ts
@@ -20,7 +20,6 @@ import { type Except } from "type-fest";
 import { type AxiosError, type AxiosResponse } from "axios";
 import { isEmpty, isPlainObject } from "lodash";
 import { getReasonPhrase } from "http-status-codes";
-import { isErrorTypeNameMatch } from "@/errors/errorHelpers";
 
 /**
  * Axios offers its own serialization method, but it doesn't include the response.
@@ -35,8 +34,7 @@ export function isAxiosError(error: unknown): error is SerializableAxiosError {
     // To deal with original AxiosError as well as a serialized error
     // we check 'isAxiosError' property for a non-serialized Error and 'name' for serialized object
     // Related issue to revisit RTKQ error handling: https://github.com/pixiebrix/pixiebrix-extension/issues/4032
-    (Boolean(error.isAxiosError) ||
-      isErrorTypeNameMatch(error.name as string, ["AxiosError"]))
+    (Boolean(error.isAxiosError) || error.name === "AxiosError")
   );
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -284,6 +284,9 @@ module.exports = (env, options) =>
     },
 
     optimization: {
+      // Module concatenation mangles class names https://github.com/pixiebrix/pixiebrix-extension/issues/4763
+      concatenateModules: false,
+
       // Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=1108199
       splitChunks: {
         automaticNameDelimiter: "-",


### PR DESCRIPTION
## What does this PR do?

- Reverts #4767
- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/4763
- Related to https://github.com/pixiebrix/pixiebrix-extension/pull/3731

## Discussion

Webpack is mangling the names due to `concatenateModules`, but we can't expect them to be stable. `concatenateModules` currently only saves a few KBs (1.09MB -> 1.05MB), so it's not worth keeping it.

Alternative solutions:

- use both a static and instance name: `Err {name = 'Err'; static name = 'Err'}`
	- TS complains
	- no way to enforce it
- extract the name from the constructor by instantiating it
	- some errors **require** additional arguments, so we can't safely call `new` on them 

Future solution:

- [ ] Deserialize errors into their correct instances; we're still paying the price for using a hack to avoid fixing it
	- https://github.com/sindresorhus/serialize-error/issues/72
	- https://github.com/pixiebrix/pixiebrix-extension/blob/65427ee747ec2df787167bd17cea1fedd9b3b47c/src/errors/errorHelpers.ts#L215-L217

## Checklist

- [ ] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer
