### PR TITLE
Restore `getTargetState`

### DIFF
--- a/src/background/contentScript.ts
+++ b/src/background/contentScript.ts
@@ -24,7 +24,7 @@ import { isRemoteProcedureCallRequest } from "@/messaging/protocol";
 import { expectContext } from "@/utils/expectContext";
 import pTimeout from "p-timeout";
 import type { Target } from "@/types";
-import { getReadyState } from "@/contentScript/messenger/api";
+import { getTargetState } from "@/contentScript/ready";
 
 /** Checks whether a URL will have the content scripts automatically injected */
 export async function isContentScriptRegistered(url: string): Promise<boolean> {
@@ -107,7 +107,7 @@ async function ensureContentScriptWithoutTimeout(
   // `webext-dynamic-content-scripts` might have already injected the content script
   const readyNotificationPromise = onReadyNotification(signal);
 
-  const result = await getReadyState(target); // It will throw if we don't have permissions
+  const result = await getTargetState(target); // It will throw if we don't have permissions
 
   if (result.ready) {
     console.debug("ensureContentScript: already exists and is ready", target);

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -18,7 +18,6 @@
 /* Do not use `registerMethod` in this file */
 import { getMethod, getNotifier } from "webext-messenger";
 
-export const getReadyState = getMethod("GET_READY_STATE");
 export const getFormDefinition = getMethod("FORM_GET_DEFINITION");
 export const resolveForm = getMethod("FORM_RESOLVE");
 export const cancelForm = getNotifier("FORM_CANCEL");

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -76,14 +76,11 @@ import {
 import { toggleQuickBar } from "@/components/quickBar/QuickBarApp";
 import { getPageState, setPageState } from "@/contentScript/pageState";
 import { stopWaitingForTemporaryPanels } from "@/blocks/transformers/temporaryInfo/temporaryPanelProtocol";
-import { getReadyState } from "@/contentScript/ready";
 
 expectContext("contentScript");
 
 declare global {
   interface MessengerMethods {
-    GET_READY_STATE: typeof getReadyState;
-
     FORM_GET_DEFINITION: typeof getFormDefinition;
     FORM_RESOLVE: typeof resolveForm;
     FORM_CANCEL: typeof cancelForm;
@@ -144,8 +141,6 @@ declare global {
 
 export default function registerMessenger(): void {
   registerMethods({
-    GET_READY_STATE: getReadyState,
-
     FORM_GET_DEFINITION: getFormDefinition,
     FORM_RESOLVE: resolveForm,
     FORM_CANCEL: cancelForm,


### PR DESCRIPTION
## What does this PR do?

- Reverts one file from https://github.com/pixiebrix/pixiebrix-extension/pull/4728
- Brings `executeFunction` back because we have different expectations around retries (and probably other issues that are causing the page editor to break)

My editor still worked before this PR, so I don't know if this fixes it.

- [x] Tested
	- It seems to work for me. This reverts the relevant change from the PR

