### PR TITLE
#4773: normalize control room URLs during onboarding

### DIFF
--- a/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
+++ b/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
@@ -37,6 +37,7 @@ import { serviceOriginPermissions } from "@/permissions";
 import { requestPermissions } from "@/utils/permissions";
 import { isEmpty } from "lodash";
 import { util as apiUtil } from "@/services/api";
+import { normalizeControlRoomUrl } from "@/options/pages/onboarding/partner/partnerOnboardingUtils";
 import { useHistory } from "react-router";
 
 const { updateServiceConfig } = servicesSlice.actions;
@@ -90,7 +91,7 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
               serviceId: CONTROL_ROOM_OAUTH_SERVICE_ID,
               label: "Primary AARI Account",
               config: {
-                controlRoomUrl: values.controlRoomUrl,
+                controlRoomUrl: normalizeControlRoomUrl(values.controlRoomUrl),
               },
             })
           );

--- a/src/options/pages/onboarding/partner/ControlRoomTokenForm.tsx
+++ b/src/options/pages/onboarding/partner/ControlRoomTokenForm.tsx
@@ -31,6 +31,7 @@ import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import { Button } from "react-bootstrap";
 import { CONTROL_ROOM_SERVICE_ID } from "@/services/constants";
 import { useHistory } from "react-router";
+import { normalizeControlRoomUrl } from "@/options/pages/onboarding/partner/partnerOnboardingUtils";
 
 type ControlRoomConfiguration = {
   controlRoomUrl: string;
@@ -60,7 +61,10 @@ const ControlRoomTokenForm: React.FunctionComponent<{
         id: uuidv4(),
         serviceId: CONTROL_ROOM_SERVICE_ID,
         label: "Primary AA Control Room",
-        config: formValues,
+        config: {
+          ...formValues,
+          controlRoomUrl: normalizeControlRoomUrl(formValues.controlRoomUrl),
+        },
       })
     );
 

--- a/src/options/pages/onboarding/partner/partnerOnboardingUtils.test.ts
+++ b/src/options/pages/onboarding/partner/partnerOnboardingUtils.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { normalizeControlRoomUrl } from "@/options/pages/onboarding/partner/partnerOnboardingUtils";
+
+describe("test normalizeControlRoomUrl", () => {
+  it("removes trailing slash", () => {
+    expect(
+      normalizeControlRoomUrl(
+        "https://community2.cloud-2.automationanywhere.digital/"
+      )
+    ).toBe("https://community2.cloud-2.automationanywhere.digital");
+  });
+
+  it("preserves scheme", () => {
+    expect(
+      normalizeControlRoomUrl(
+        "http://community2.cloud-2.automationanywhere.digital"
+      )
+    ).toBe("http://community2.cloud-2.automationanywhere.digital");
+  });
+  it("allows localhost", () => {
+    expect(normalizeControlRoomUrl("http://localhost:8000")).toBe(
+      "http://localhost:8000"
+    );
+  });
+});

--- a/src/options/pages/onboarding/partner/partnerOnboardingUtils.ts
+++ b/src/options/pages/onboarding/partner/partnerOnboardingUtils.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Normalize a user-provided partner Control Room URL for use in an integration configuration.
+ * @param controlRoomUrl user-provided control room URL
+ */
+export function normalizeControlRoomUrl(controlRoomUrl: string): string {
+  const url = new URL(controlRoomUrl);
+  return url.origin;
+}


### PR DESCRIPTION
## What does this PR do?

- Fixes #4773 
- Uses the origin without trailing slash for control room URLs

## Checklist

- [x] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @mnholtz 
