### PR TITLE
#4732: save refreshed token in token cache

### DIFF
--- a/src/background/auth.ts
+++ b/src/background/auth.ts
@@ -37,7 +37,7 @@ import { memoizeUntilSettled } from "@/utils";
 
 const OAUTH2_STORAGE_KEY = "OAUTH2" as ManualStorageKey;
 
-async function setCachedAuthData<TAuthData extends Partial<AuthData>>(
+export async function setCachedAuthData<TAuthData extends Partial<AuthData>>(
   serviceAuthId: UUID,
   data: TAuthData
 ): Promise<void> {

--- a/src/background/partnerIntegrations.test.ts
+++ b/src/background/partnerIntegrations.test.ts
@@ -31,6 +31,7 @@ import {
 } from "@/services/constants";
 import { uuidv4 } from "@/types/helpers";
 import { readPartnerAuthData, setPartnerAuth } from "@/auth/token";
+import { setCachedAuthData } from "@/background/auth";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 
@@ -79,6 +80,10 @@ jest.mock("@/hooks/fetch", () => ({
   fetch: jest.fn(),
 }));
 
+jest.mock("@/background/auth", () => ({
+  setCachedAuthData: jest.fn().mockResolvedValue(undefined),
+}));
+
 const axiosMock = new MockAdapter(axios);
 
 afterEach(() => {
@@ -90,6 +95,7 @@ const readRawConfigurationsMock = readRawConfigurations as jest.Mock;
 const fetchMock = fetch as jest.Mock;
 const setPartnerAuthMock = setPartnerAuth as jest.Mock;
 const readPartnerAuthDataMock = readPartnerAuthData as jest.Mock;
+const setCachedAuthDataMock = setCachedAuthData as jest.Mock;
 
 describe("getPartnerPrincipals", () => {
   beforeEach(() => {
@@ -200,6 +206,11 @@ describe("refresh partner token", () => {
       extraHeaders: {
         "X-Control-Room": "https://controlroom.com",
       },
+    });
+
+    expect(setCachedAuthDataMock).toHaveBeenCalledWith(authId, {
+      access_token: "notatoken2",
+      refresh_token: "notarefreshtoken2",
     });
   });
 

--- a/src/background/partnerIntegrations.ts
+++ b/src/background/partnerIntegrations.ts
@@ -20,7 +20,7 @@ import { flatten, isEmpty } from "lodash";
 import { expectContext } from "@/utils/expectContext";
 import { safeParseUrl } from "@/utils";
 import { type RegistryId } from "@/core";
-import { launchOAuth2Flow } from "@/background/auth";
+import { launchOAuth2Flow, setCachedAuthData } from "@/background/auth";
 import { readPartnerAuthData, setPartnerAuth } from "@/auth/token";
 import serviceRegistry from "@/services/registry";
 
@@ -167,6 +167,10 @@ export async function _refreshPartnerToken(): Promise<void> {
       headers: { Authorization: `Basic ${btoa(context.client_id)} ` },
     });
 
+    // Store for use direct calls to the partner API
+    await setCachedAuthData(config.id, data);
+
+    // Store for use with the PixieBrix API
     await setPartnerAuth({
       authId: config.id,
       token: data.access_token,


### PR DESCRIPTION
## What does this PR do?

- Part of #4732
- Fixes bug where the refreshed token wasn't being saved in the oauth2 token cache

## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working: N/A
- [x] Designate a primary reviewer: @johnnymetz 
