### PR TITLE
Optionally disable debug output in tests

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -21,6 +21,7 @@
     "node_modules/(?!@cfworker|escape-string-regex|filename-reserved-regex|filenamify|idb|webext-|p-timeout|p-retry|p-defer|p-memoize|serialize-error|strip-outer|trim-repeated|mimic-fn|urlpattern-polyfill|url-join|uuid|nanoid|use-debounce|copy-text-to-clipboard)"
   ],
   "setupFiles": [
+    "dotenv/config",
     "<rootDir>/src/testUtils/testEnv.js",
     "<rootDir>/src/development/cryptoNodePolyfill.js",
     "jest-webextension-mock",

--- a/src/testUtils/testEnv.js
+++ b/src/testUtils/testEnv.js
@@ -34,6 +34,6 @@ global.PromiseRejectionEvent = class PromiseRejectionEvent extends Event {
   }
 };
 
-if (process.env.NO_DEBUG_OUTPUT_IN_TESTS === "true") {
+if (process.env.JEST_CONSOLE_DEBUG === "false") {
   console.debug = () => {};
 }

--- a/src/testUtils/testEnv.js
+++ b/src/testUtils/testEnv.js
@@ -33,3 +33,7 @@ global.PromiseRejectionEvent = class PromiseRejectionEvent extends Event {
     this.reason = init.reason;
   }
 };
+
+if (process.env.NO_DEBUG_OUTPUT_IN_TESTS === "true") {
+  console.debug = () => {};
+}


### PR DESCRIPTION
## What does this PR do?

- Allows to mute `console.debug` output in tests while you can still use `console.log` while debugging unit tests.
- To mite debug messages, add `NO_DEBUG_OUTPUT_IN_TESTS=true` to your `.env` file

## Discussion

- We use `console.debug` extensively. This creates a lot of noise when working on unit tests.

## Demo

Before:
<img width="670" alt="Screenshot 2022-12-08 at 11 39 08 AM" src="https://user-images.githubusercontent.com/3116723/206756606-2ae6ab9a-c9c1-4c7c-b202-a87d07388228.png">

Same test after:
<img width="665" alt="Screenshot 2022-12-08 at 11 39 49 AM" src="https://user-images.githubusercontent.com/3116723/206756632-7ebfc1f1-b8b7-4521-8d62-2218b756e55e.png">


## Checklist

- [ ] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [ ] Designate a primary reviewer
