### PR TITLE
#4792: fix workshop reset to original data on 400 error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -193,7 +193,7 @@
         "@types/webpack": "^5.28.0",
         "@types/webpack-env": "^1.16.2",
         "@types/whatwg-mimetype": "^3.0.0",
-        "axios-mock-adapter": "^1.19.0",
+        "axios-mock-adapter": "^1.21.2",
         "chromedriver": "^108.0.0",
         "compass-mixins": "^0.12.10",
         "concurrently": "^7.2.0",
@@ -13920,6 +13920,7 @@
     },
     "node_modules/axios": {
       "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
       "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
         "follow-redirects": "^1.14.9",
@@ -15573,9 +15574,9 @@
       }
     },
     "node_modules/chromedriver/node_modules/axios": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
-      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
+      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -47756,6 +47757,7 @@
     },
     "axios": {
       "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
       "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
         "follow-redirects": "^1.14.9",
@@ -49004,9 +49006,9 @@
       },
       "dependencies": {
         "axios": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
-          "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
+          "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
           "dev": true,
           "requires": {
             "follow-redirects": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "@types/webpack": "^5.28.0",
     "@types/webpack-env": "^1.16.2",
     "@types/whatwg-mimetype": "^3.0.0",
-    "axios-mock-adapter": "^1.19.0",
+    "axios-mock-adapter": "^1.21.2",
     "chromedriver": "^108.0.0",
     "compass-mixins": "^0.12.10",
     "concurrently": "^7.2.0",

--- a/src/errors/networkErrorHelpers.test.ts
+++ b/src/errors/networkErrorHelpers.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  isAxiosError,
+  isBadRequestObjectData,
+  isSingleObjectBadRequestError,
+} from "@/errors/networkErrorHelpers";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+
+const axiosMock = new MockAdapter(axios);
+
+const CONFIG_ERROR = {
+  config: [
+    "Cannot overwrite version of a published brick. Increment the version",
+  ],
+};
+
+describe("isBadRequestObjectData", () => {
+  test("detects config error", () => {
+    expect(isBadRequestObjectData(CONFIG_ERROR)).toBe(true);
+  });
+});
+
+describe("isSingleObjectBadRequestError", () => {
+  test("handles error-like object", async () => {
+    axiosMock.onPut().reply(400, CONFIG_ERROR);
+
+    try {
+      await axios.create().put("/", {});
+      expect.fail("Expected error");
+    } catch (error) {
+      expect(isAxiosError(error)).toBe(true);
+      expect(isSingleObjectBadRequestError(error)).toBe(true);
+    }
+  });
+});

--- a/src/errors/networkErrorHelpers.ts
+++ b/src/errors/networkErrorHelpers.ts
@@ -91,7 +91,9 @@ type ClientErrorData = {
   detail: string;
 };
 
-function isBadRequestObjectData(data: unknown): data is BadRequestObjectData {
+export function isBadRequestObjectData(
+  data: unknown
+): data is BadRequestObjectData {
   if (!isPlainObject(data)) {
     return false;
   }

--- a/src/hooks/useRefresh.ts
+++ b/src/hooks/useRefresh.ts
@@ -64,6 +64,10 @@ const throttledRefreshRegistries = throttle(
   }
 );
 
+/**
+ * Hook to refresh brick registries.
+ * @param options hook options, e.g., whether to refresh the registries on initial hook mount.
+ */
 function useRefresh(options?: {
   refreshOnMount: boolean;
 }): [boolean, () => Promise<void>] {

--- a/src/options/pages/brickEditor/useSubmitBrick.test.tsx
+++ b/src/options/pages/brickEditor/useSubmitBrick.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import useSubmitBrick from "@/options/pages/brickEditor/useSubmitBrick";
+import { renderHook } from "@testing-library/react-hooks";
+import { Provider } from "react-redux";
+import { type AuthState } from "@/auth/authTypes";
+import servicesSlice, { type ServicesState } from "@/store/servicesSlice";
+import { type SettingsState } from "@/store/settingsTypes";
+import { configureStore } from "@reduxjs/toolkit";
+import { authSlice } from "@/auth/authSlice";
+import settingsSlice from "@/store/settingsSlice";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+// FIXME: this is coming through as a module with default being a JSON object. (yaml-jest-transform is being applied)
+import pipedriveYaml from "@contrib/services/pipedrive.yaml?loadAsText";
+import { appApi } from "@/services/api";
+import { brickToYaml } from "@/utils/objToYaml";
+import { getLinkedApiClient } from "@/services/apiClient";
+import { act } from "react-dom/test-utils";
+
+const axiosMock = new MockAdapter(axios);
+
+jest.mock("@/options/pages/blueprints/utils/useReinstall", () => ({
+  __esModule: true,
+  useReinstall: jest.fn(),
+  default: jest.fn(),
+}));
+
+jest.mock("@/services/apiClient", () => ({
+  getLinkedApiClient: jest.fn(),
+}));
+
+const getLinkedApiClientMock = getLinkedApiClient as jest.Mock;
+
+getLinkedApiClientMock.mockResolvedValue(axios.create());
+
+function testStore(initialState?: {
+  auth: AuthState;
+  services: ServicesState;
+  settings: SettingsState;
+}) {
+  return configureStore({
+    reducer: {
+      auth: authSlice.reducer,
+      services: servicesSlice.reducer,
+      settings: settingsSlice.reducer,
+      [appApi.reducerPath]: appApi.reducer,
+    },
+    middleware(getDefaultMiddleware) {
+      // eslint-disable-next-line unicorn/prefer-spread -- use concat for proper type inference
+      return getDefaultMiddleware().concat(appApi.middleware);
+    },
+    preloadedState: initialState,
+  });
+}
+
+describe("useSubmitBrick", () => {
+  it("handles 400 error editing public listing", async () => {
+    const store = testStore();
+    const { result } = renderHook(() => useSubmitBrick({ create: false }), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+
+    const resetForm = jest.fn();
+    const setErrors = jest.fn();
+
+    const errorData = {
+      config: [
+        "Cannot overwrite version of a published brick. Increment the version",
+      ],
+    };
+
+    axiosMock.onPut().reply(400, errorData);
+
+    await act(async () => {
+      // `pipedriveYaml` actually comes through as an object. Jest is ignoring loadAsText
+      await result.current.submit(
+        {
+          config: brickToYaml(pipedriveYaml as any),
+          reactivate: false,
+          public: true,
+          organizations: [],
+        },
+        {
+          resetForm,
+          setErrors,
+        } as any
+      );
+    });
+
+    expect(setErrors).toHaveBeenCalledWith(errorData);
+    expect(resetForm).not.toHaveBeenCalled();
+  });
+});

--- a/src/options/pages/brickEditor/useSubmitBrick.test.tsx
+++ b/src/options/pages/brickEditor/useSubmitBrick.test.tsx
@@ -67,10 +67,13 @@ function testStore(initialState?: {
       [appApi.reducerPath]: appApi.reducer,
     },
     middleware(getDefaultMiddleware) {
-      // eslint-disable-next-line unicorn/prefer-spread -- use concat for proper type inference
-      return getDefaultMiddleware()
-        .concat(appApi.middleware)
-        .concat(testMiddleware);
+      return (
+        getDefaultMiddleware()
+          // eslint-disable-next-line unicorn/prefer-spread -- use concat for proper type inference
+          .concat(appApi.middleware)
+          // eslint-disable-next-line unicorn/prefer-spread -- use concat for proper type inference
+          .concat(testMiddleware)
+      );
     },
     preloadedState: initialState,
   });

--- a/src/options/pages/brickEditor/useSubmitBrick.ts
+++ b/src/options/pages/brickEditor/useSubmitBrick.ts
@@ -121,7 +121,7 @@ function useSubmitBrick({ create = false }: SubmitOptions): SubmitCallbacks {
             }
 
             if (kind === "service") {
-              // Flear the background page's service cache after refreshing so
+              // Clear the background page's service cache after refreshing so
               // it's forced to read the updated service definition.
               await clearServiceCache();
             }

--- a/src/services/api.test.tsx
+++ b/src/services/api.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import { getLinkedApiClient } from "@/services/apiClient";
+import { configureStore } from "@reduxjs/toolkit";
+import { appApi, useUpdatePackageMutation } from "@/services/api";
+import { renderHook } from "@testing-library/react-hooks";
+import { Provider } from "react-redux";
+import React from "react";
+import { isAxiosError } from "@/errors/networkErrorHelpers";
+import { uuidv4 } from "@/types/helpers";
+import { act } from "react-dom/test-utils";
+
+const axiosMock = new MockAdapter(axios);
+
+jest.mock("@/services/apiClient", () => ({
+  getLinkedApiClient: jest.fn(),
+}));
+
+const getLinkedApiClientMock = getLinkedApiClient as jest.Mock;
+
+getLinkedApiClientMock.mockResolvedValue(axios.create());
+
+function testStore() {
+  return configureStore({
+    reducer: {
+      [appApi.reducerPath]: appApi.reducer,
+    },
+    middleware(getDefaultMiddleware) {
+      // eslint-disable-next-line unicorn/prefer-spread -- use concat for proper type inference
+      return getDefaultMiddleware().concat(appApi.middleware);
+    },
+    preloadedState: {},
+  });
+}
+
+describe("appBaseQuery", () => {
+  test("RTK preserves AxiosError information", async () => {
+    axiosMock.onPut().reply(400, { config: ["Field error."] });
+
+    const store = testStore();
+
+    const { result } = renderHook(() => useUpdatePackageMutation(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+
+    const [update] = result.current;
+
+    try {
+      await act(async () => {
+        await update({ id: uuidv4() } as any).unwrap();
+      });
+
+      expect.fail("Expected error");
+    } catch (error) {
+      expect(isAxiosError(error)).toBe(true);
+      // `serializeError` doesn't serialize properties on the prototype
+      expect((error as any).isAxiosError).toBeUndefined();
+    }
+  });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -315,10 +315,14 @@ export const appApi = createApi({
           },
         };
       },
-      invalidatesTags: (result, error, { packageId }) => [
-        { type: "Package", id: packageId },
-        "EditablePackages",
-      ],
+      invalidatesTags(result, error, { packageId }) {
+        if (isAxiosError(error) && error.response?.status === 400) {
+          // Package is invalid, don't invalidate cache because no changes were made on the server.
+          return [];
+        }
+
+        return [{ type: "Package", id: packageId }, "EditablePackages"];
+      },
     }),
     getInvitations: builder.query<PendingInvitation[], void>({
       query: () => ({ url: "/api/invitations/me", method: "get" }),
@@ -349,11 +353,14 @@ export const appApi = createApi({
           data,
         };
       },
-      invalidatesTags: (result, error, { id }) => [
-        { type: "Package", id },
-        "EditablePackages",
-        "PackageVersion",
-      ],
+      invalidatesTags(result, error, { id }) {
+        if (isAxiosError(error) && error.response?.status === 400) {
+          // Package is invalid, don't invalidate cache because no changes were made on the server.
+          return [];
+        }
+
+        return [{ type: "Package", id }, "EditablePackages", "PackageVersion"];
+      },
     }),
     deletePackage: builder.mutation<void, { id: UUID }>({
       query({ id }) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -46,6 +46,7 @@ import { type components } from "@/types/swagger";
 import { dumpBrickYaml } from "@/runtime/brickYaml";
 import { serializeError } from "serialize-error";
 import { type UnknownObject } from "@/types";
+import { isAxiosError } from "@/errors/networkErrorHelpers";
 
 type QueryArgs = {
   /**
@@ -91,9 +92,19 @@ const appBaseQuery: BaseQueryFn<QueryArgs> = async ({
 
     return { data: result.data, meta };
   } catch (error) {
-    // Axios offers its own serialization method, but it reshapes the Error object (doesn't include the response, puts the status on the root level). `useToJSON: false` skips that.
+    if (isAxiosError(error)) {
+      // Was running into issues with AxiosError generation in axios-mock-adapter where the prototype was AxiosError
+      // but the Error name was Error and there was no isAxiosError present after serializeError
+      // See line here: https://github.com/axios/axios/blob/v0.27.2/lib/core/AxiosError.js#L79
+      error.name = "AxiosError";
+      return {
+        // Axios offers its own serialization method, but it reshapes the Error object (doesn't include the response, puts the status on the root level). `useToJSON: false` skips that.
+        error: serializeError(error, { useToJSON: false }),
+      };
+    }
+
     return {
-      error: serializeError(error, { useToJSON: false }),
+      error: serializeError(error),
     };
   }
 };

--- a/src/testUtils/testMiddleware.ts
+++ b/src/testUtils/testMiddleware.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type Middleware } from "@reduxjs/toolkit";
+import { type Action } from "redux";
+
+const actions: Action[] = [];
+
+// eslint-disable-next-line unicorn/consistent-function-scoping -- idiomatic redux
+const testMiddleware: Middleware = (store) => (next) => (action) => {
+  actions.push(action);
+  next(action);
+};
+
+export function resetTestMiddleware(): void {
+  actions.length = 0;
+}
+
+export function actionTypes(): string[] {
+  return actions.map((x) => x.type);
+}
+
+export default testMiddleware;


### PR DESCRIPTION
## What does this PR do?

- Closes #4792 
- Adds tests for Axis error handling: error shape from Axios and RTK base query
- Adds 400 error test for useSubmitBrick
- Disables cache invalidate on 400 error for updatePackage and updateRecipe endpoint

## Demo

![image](https://user-images.githubusercontent.com/1879821/206921376-bcb9bf18-a7e2-45fa-a865-40bb6905fb70.png)

## Remaining Work
- [x] Fix workshop reload to old data on 400 error

## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @BALEHOK 
