### PR TITLE
#4730: sandbox nunjucks and handlebars calls from runtime

### DIFF
--- a/src/__mocks__/@/sandbox/messenger/api.ts
+++ b/src/__mocks__/@/sandbox/messenger/api.ts
@@ -15,5 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Skip the sandbox messenger
-export { renderNunjucksTemplate, applyJq } from "@/sandbox/messenger/executor";
+// Skip the sandbox messenger during tests
+export {
+  renderNunjucksTemplate,
+  renderHandlebarsTemplate,
+  applyJq,
+} from "@/sandbox/messenger/executor";

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -538,18 +538,18 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
       const serviceContext = await makeServiceContext(extension.services);
       const extensionContext = { ...ctxt, ...serviceContext };
 
-      html = renderMustache(this.getTemplate(), {
+      html = (await renderMustache(this.getTemplate(), {
         caption: (await mapArgs(caption, extensionContext, {
           implicitRender,
           autoescape: versionOptions.autoescape,
         })) as string,
         icon: icon ? await getSvgIcon(icon) : null,
-      }) as string;
+      })) as string;
     } else {
-      html = renderMustache(this.getTemplate(), {
+      html = (await renderMustache(this.getTemplate(), {
         caption,
         icon: icon ? await getSvgIcon(icon) : null,
-      }) as string;
+      })) as string;
     }
 
     const $menuItem = this.makeItem(html, extension);

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -493,7 +493,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
 
     const implicitRender = versionOptions.explicitRender
       ? null
-      : await engineRenderer(
+      : engineRenderer(
           extension.templateEngine ?? DEFAULT_IMPLICIT_TEMPLATE_ENGINE,
           versionOptions
         );
@@ -531,7 +531,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
       }
     }
 
-    const renderMustache = await engineRenderer("mustache", versionOptions);
+    const renderMustache = engineRenderer("mustache", versionOptions);
 
     if (dynamicCaption) {
       const ctxt = await ctxtPromise;

--- a/src/runtime/mapArgs.test.ts
+++ b/src/runtime/mapArgs.test.ts
@@ -101,18 +101,18 @@ describe("exclude null", () => {
 });
 
 describe("renderImplicit", () => {
-  test("prefer path to renderer", () => {
-    expect(
+  test("prefer path to renderer", async () => {
+    await expect(
       renderImplicit({ foo: "array.0" }, { array: ["bar"] }, Mustache.render)
-    ).toEqual({
+    ).resolves.toEqual({
       foo: "bar",
     });
   });
 
-  test("render path as string if it doesn't exist in the context", () => {
-    expect(
+  test("render path as string if it doesn't exist in the context", async () => {
+    await expect(
       renderImplicit({ foo: "array.0" }, { otherVar: ["bar"] }, Mustache.render)
-    ).toEqual({
+    ).resolves.toEqual({
       foo: "array.0",
     });
   });
@@ -120,13 +120,13 @@ describe("renderImplicit", () => {
 
 describe("handlebars", () => {
   test("render array item", async () => {
-    expect(
+    await expect(
       renderImplicit(
         { foo: "{{ obj.prop }}" },
         { obj: { prop: 42 } },
-        await engineRenderer("handlebars", apiVersionOptions("v3"))
+        engineRenderer("handlebars", apiVersionOptions("v3"))
       )
-    ).toEqual({
+    ).resolves.toEqual({
       foo: "42",
     });
   });
@@ -134,13 +134,13 @@ describe("handlebars", () => {
   // NOTE: Handlebars doesn't work with @-prefixed variable because it uses @ to denote data variables
   // see: https://handlebarsjs.com/api-reference/data-variables.html
   test("cannot render @-prefixed variable", async () => {
-    expect(
+    await expect(
       renderImplicit(
         { foo: "{{ obj.prop }}" },
         { "@obj": { prop: 42 } },
-        await engineRenderer("handlebars", apiVersionOptions("v3"))
+        engineRenderer("handlebars", apiVersionOptions("v3"))
       )
-    ).toEqual({
+    ).resolves.toEqual({
       foo: "",
     });
   });

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -447,7 +447,7 @@ async function renderBlockArg(
 
   const implicitRender = explicitRender
     ? null
-    : await engineRenderer(
+    : engineRenderer(
         config.templateEngine ?? DEFAULT_IMPLICIT_TEMPLATE_ENGINE,
         { autoescape }
       );

--- a/src/runtime/runtimeUtils.ts
+++ b/src/runtime/runtimeUtils.ts
@@ -113,7 +113,7 @@ export async function shouldRunBlock(
   if (blockConfig.if !== undefined) {
     const render = explicitRender
       ? null
-      : await engineRenderer(
+      : engineRenderer(
           blockConfig.templateEngine ?? DEFAULT_IMPLICIT_TEMPLATE_ENGINE,
           { autoescape }
         );

--- a/src/sandbox/messenger/api.ts
+++ b/src/sandbox/messenger/api.ts
@@ -40,17 +40,25 @@ export async function ping() {
   });
 }
 
-export type NunjucksRenderPayload = {
+export type TemplateRenderPayload = {
   template: string;
   context: JsonObject;
   autoescape: boolean;
 };
 
-export async function renderNunjucksTemplate(payload: NunjucksRenderPayload) {
+export async function renderNunjucksTemplate(payload: TemplateRenderPayload) {
   return postMessage({
     recipient: await loadSandbox(),
     payload,
     type: "RENDER_NUNJUCKS",
+  });
+}
+
+export async function renderHandlebarsTemplate(payload: TemplateRenderPayload) {
+  return postMessage({
+    recipient: await loadSandbox(),
+    payload,
+    type: "RENDER_HANDLEBARS",
   });
 }
 

--- a/src/sandbox/messenger/executor.ts
+++ b/src/sandbox/messenger/executor.ts
@@ -16,29 +16,18 @@
  */
 
 import { type ApplyJqPayload, type TemplateRenderPayload } from "./api";
-import { once } from "lodash";
 import { isErrorObject } from "@/errors/errorHelpers";
 import { InvalidTemplateError } from "@/errors/businessErrors";
-
-const ensureNunjucks = once(async () => {
-  const { default: nunjucks } = await import(
-    /* webpackChunkName: "nunjucks" */ "nunjucks"
-  );
-  return nunjucks;
-});
-
-const ensureHandlebars = once(async () => {
-  const { default: handlebars } = await import(
-    /* webpackChunkName: "handlebars" */ "handlebars"
-  );
-  return handlebars;
-});
 
 export async function renderNunjucksTemplate(
   payload: TemplateRenderPayload
 ): Promise<string> {
   const { template, context, autoescape } = payload;
-  const nunjucks = await ensureNunjucks();
+
+  // Webpack caches the module import, so doesn't need to cache via lodash's `once`
+  const { default: nunjucks } = await import(
+    /* webpackChunkName: "nunjucks" */ "nunjucks"
+  );
 
   nunjucks.configure({ autoescape });
   try {
@@ -54,7 +43,12 @@ export async function renderHandlebarsTemplate(
   payload: TemplateRenderPayload
 ): Promise<string> {
   const { template, context, autoescape } = payload;
-  const handlebars = await ensureHandlebars();
+
+  // Webpack caches the module import, so doesn't need to cache via lodash's `once`
+  const { default: handlebars } = await import(
+    /* webpackChunkName: "handlebars" */ "handlebars"
+  );
+
   const compiledTemplate = handlebars.compile(template, {
     noEscape: !autoescape,
   });

--- a/src/sandbox/messenger/registration.ts
+++ b/src/sandbox/messenger/registration.ts
@@ -18,10 +18,15 @@
 /** @file It doesn't actually use the Messenger but this file tries to replicate the pattern */
 
 import { addPostMessageListener } from "@/utils/postMessage";
-import { applyJq, renderNunjucksTemplate } from "./executor";
+import {
+  applyJq,
+  renderHandlebarsTemplate,
+  renderNunjucksTemplate,
+} from "./executor";
 
 export default function registerMessenger(): void {
   addPostMessageListener("SANDBOX_PING", async (payload) => "pong");
   addPostMessageListener("RENDER_NUNJUCKS", renderNunjucksTemplate);
+  addPostMessageListener("RENDER_HANDLEBARS", renderHandlebarsTemplate);
   addPostMessageListener("APPLY_JQ", applyJq);
 }

--- a/src/utils/postMessage.ts
+++ b/src/utils/postMessage.ts
@@ -105,14 +105,24 @@ export function addPostMessageListener(
       return;
     }
 
+    // Only log with process.env.WEBEXT_MESSENGER_LOGGING to avoid large logging payloads
     try {
-      console.debug("SANDBOX:", type, "Received payload:", data.payload);
+      if (process.env.WEBEXT_MESSENGER_LOGGING) {
+        console.debug("SANDBOX:", type, "Received payload:", data.payload);
+      }
+
       const response = await listener(data.payload);
 
-      console.debug("SANDBOX:", type, "Responding with", response);
+      if (process.env.WEBEXT_MESSENGER_LOGGING) {
+        console.debug("SANDBOX:", type, "Responding with", response);
+      }
+
       source.postMessage({ response } satisfies ResponsePacket);
     } catch (error) {
-      console.debug("SANDBOX:", type, "Throwing", error);
+      if (process.env.WEBEXT_MESSENGER_LOGGING) {
+        console.debug("SANDBOX:", type, "Throwing", error);
+      }
+
       source.postMessage({
         error: serializeError(error),
       } satisfies ResponsePacket);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const path = require("path");
+const path = require("node:path");
 const dotenv = require("dotenv");
 const webpack = require("webpack");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
@@ -32,16 +32,26 @@ const mergeWithShared = require("./webpack.sharedConfig.js");
 
 function parseEnv(value) {
   switch (String(value).toLowerCase()) {
-    case "undefined":
+    case "undefined": {
       return;
-    case "null":
+    }
+
+    case "null": {
       return null;
-    case "false":
+    }
+
+    case "false": {
       return false;
-    case "true":
+    }
+
+    case "true": {
       return true;
-    case "":
+    }
+
+    case "": {
       return "";
+    }
+
     default:
   }
 
@@ -79,7 +89,7 @@ console.log(
 );
 
 if (!process.env.SOURCE_VERSION) {
-  process.env.SOURCE_VERSION = require("child_process")
+  process.env.SOURCE_VERSION = require("node:child_process")
     .execSync("git rev-parse --short HEAD")
     .toString()
     .trim();


### PR DESCRIPTION
## What does this PR do?

- Part of #4730
- Uses Chrome sandbox for calls to nunjucks and handlebars from runtime

## Demo

- No user-facing changes

## Remaining Work

- Update Nunjucks constructor call in variable analysis framework. Might need to shift work to sandbox?

## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @fregante 
