### PR TITLE
#4730: rethrow non-nunjucks error in sandbox

### DIFF
--- a/src/sandbox/messenger/executor.test.ts
+++ b/src/sandbox/messenger/executor.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { renderNunjucksTemplate } from "@/sandbox/messenger/executor";
+import { InvalidTemplateError } from "@/errors/businessErrors";
+
+describe("renderNunjucksTemplate", () => {
+  it("handles template", async () => {
+    await expect(
+      renderNunjucksTemplate({
+        template: "{{ hello }}",
+        context: { hello: "world" },
+        autoescape: false,
+      })
+    ).resolves.toBe("world");
+  });
+
+  it("handles malformed template", async () => {
+    await expect(
+      renderNunjucksTemplate({
+        template: "{{ hello",
+        context: { hello: "world" },
+        autoescape: false,
+      })
+    ).rejects.toThrow(InvalidTemplateError);
+  });
+
+  it("handles non-nunjucks error", async () => {
+    jest.doMock("@/sandbox/messenger/executor", () => ({
+      renderString: jest.fn().mockImplementation(() => {
+        throw new Error("test");
+      }),
+    }));
+
+    await expect(
+      renderNunjucksTemplate({
+        template: "{{ hello",
+        context: { hello: "world" },
+        autoescape: false,
+      })
+    ).rejects.toThrow(Error);
+
+    jest.resetAllMocks();
+  });
+});

--- a/src/sandbox/messenger/executor.ts
+++ b/src/sandbox/messenger/executor.ts
@@ -36,6 +36,8 @@ export async function renderNunjucksTemplate(
     if (isErrorObject(error) && error.name === "Template render error") {
       throw new InvalidTemplateError(error.message, template);
     }
+
+    throw error;
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

- Follow up for #4730
- Add missing re-throw

## Checklist

- [x] Add tests: need to add tests for sandbox executors because there were no tests
- [x] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @fregante 
