### PR TITLE
Restore `@/icons/list` mock

### DIFF
--- a/src/__mocks__/@/icons/list.ts
+++ b/src/__mocks__/@/icons/list.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { IconLibrary } from "@/core";
+
+// https://raw.githubusercontent.com/twbs/icons/main/icons/exclamation-triangle.svg -- bootstrap icon triangle
+const icon =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-triangle" viewBox="0 0 16 16">\n' +
+  '  <path d="M7.938 2.016A.13.13 0 0 1 8.002 2a.13.13 0 0 1 .063.016.146.146 0 0 1 .054.057l6.857 11.667c.036.06.035.124.002.183a.163.163 0 0 1-.054.06.116.116 0 0 1-.066.017H1.146a.115.115 0 0 1-.066-.017.163.163 0 0 1-.054-.06.176.176 0 0 1 .002-.183L7.884 2.073a.147.147 0 0 1 .054-.057zm1.044-.45a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566z"/>\n' +
+  '  <path d="M7.002 12a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 5.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995z"/>\n' +
+  "</svg>";
+
+export const icons = new Map<IconLibrary, Map<string, string>>();
+icons.set(
+  "bootstrap",
+  new Map([["box", "data:image/svg+xml;base64," + btoa(icon)]])
+);


### PR DESCRIPTION
Restores the mock deleted in https://github.com/pixiebrix/pixiebrix-extension/pull/3934 and that was causing issues in https://github.com/pixiebrix/pixiebrix-app/pull/2779

It was introduced to speed up the build(s), sometimes on demand: 

https://github.com/pixiebrix/pixiebrix-extension/blob/6279fbd3322406d94621dbe559090dc231dd5ea9/webpack.config.js#L240-L246