### PR TITLE
#4492: Rename "menu item extension" to "button extension"

### DIFF
--- a/src/components/BrickIcon.tsx
+++ b/src/components/BrickIcon.tsx
@@ -32,7 +32,7 @@ import {
   faWindowMaximize,
 } from "@fortawesome/free-solid-svg-icons";
 import { TriggerExtensionPoint } from "@/extensionPoints/triggerExtension";
-import { MenuItemExtensionPoint } from "@/extensionPoints/menuItemExtension";
+import { ButtonExtensionPoint } from "@/extensionPoints/buttonExtension";
 import { ContextMenuExtensionPoint } from "@/extensionPoints/contextMenu";
 import { PanelExtensionPoint } from "@/extensionPoints/panelExtension";
 import { SidebarExtensionPoint } from "@/extensionPoints/sidebarExtension";
@@ -77,7 +77,7 @@ export function getDefaultBrickIcon(
     return faBolt;
   }
 
-  if (brick instanceof MenuItemExtensionPoint) {
+  if (brick instanceof ButtonExtensionPoint) {
     return faMousePointer;
   }
 

--- a/src/contentScript/nativeEditor/types.ts
+++ b/src/contentScript/nativeEditor/types.ts
@@ -29,8 +29,8 @@ import {
 } from "@/extensionPoints/panelExtension";
 import {
   type MenuDefinition,
-  type MenuItemExtensionConfig,
-} from "@/extensionPoints/menuItemExtension";
+  type ButtonExtensionConfig,
+} from "@/extensionPoints/buttonExtension";
 
 export interface ElementInfo {
   selectors: string[];
@@ -62,11 +62,11 @@ export type PanelSelectionResult = {
 };
 export type ButtonDefinition = DynamicDefinition<
   MenuDefinition,
-  MenuItemExtensionConfig
+  ButtonExtensionConfig
 >;
 export type ButtonSelectionResult = {
   uuid: UUID;
   menu: Except<MenuDefinition, "defaultOptions" | "isAvailable" | "reader">;
-  item: Pick<MenuItemExtensionConfig, "caption">;
+  item: Pick<ButtonExtensionConfig, "caption">;
   containerInfo: ElementInfo;
 };

--- a/src/contrib/automationanywhere/BotOptions.test.tsx
+++ b/src/contrib/automationanywhere/BotOptions.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from "react";
-import { menuItemFormStateFactory } from "@/testUtils/factories";
+import { buttonFormStateFactory } from "@/testUtils/factories";
 import { type IService, type OutputKey } from "@/core";
 import { type FormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { render } from "@/options/testHelpers";
@@ -53,7 +53,7 @@ jest.mock("@/contentScript/messenger/api");
 jest.mock("@/background/messenger/api");
 
 function makeBaseState() {
-  const baseFormState = menuItemFormStateFactory();
+  const baseFormState = buttonFormStateFactory();
   baseFormState.services = [
     {
       id: CONTROL_ROOM_SERVICE_ID,

--- a/src/contrib/uipath/LocalProcessOptions.test.tsx
+++ b/src/contrib/uipath/LocalProcessOptions.test.tsx
@@ -20,7 +20,7 @@ import { render } from "@testing-library/react";
 import LocalProcessOptions from "@/contrib/uipath/LocalProcessOptions";
 import * as contentScriptApi from "@/contentScript/messenger/api";
 import { Formik } from "formik";
-import { menuItemFormStateFactory } from "@/testUtils/factories";
+import { buttonFormStateFactory } from "@/testUtils/factories";
 import { UIPATH_ID } from "@/contrib/uipath/localProcess";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
@@ -76,7 +76,7 @@ jest.mock("@/components/form/widgets/RemoteSelectWidget", () => {
 const serviceId = validateRegistryId("@uipath/cloud");
 
 function makeBaseState() {
-  const baseFormState = menuItemFormStateFactory();
+  const baseFormState = buttonFormStateFactory();
   baseFormState.services = [
     { id: serviceId, outputKey: "uipath" as OutputKey },
   ];

--- a/src/contrib/uipath/ProcessOptions.test.tsx
+++ b/src/contrib/uipath/ProcessOptions.test.tsx
@@ -18,7 +18,7 @@
 import React from "react";
 import { render } from "@/options/testHelpers";
 import { Formik } from "formik";
-import { menuItemFormStateFactory } from "@/testUtils/factories";
+import { buttonFormStateFactory } from "@/testUtils/factories";
 import { UIPATH_ID } from "@/contrib/uipath/localProcess";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { validateRegistryId } from "@/types/helpers";
@@ -78,7 +78,7 @@ jest.mock("@/components/form/widgets/RemoteSelectWidget", () => {
 const serviceId = validateRegistryId("@uipath/cloud");
 
 function makeBaseState() {
-  const baseFormState = menuItemFormStateFactory();
+  const baseFormState = buttonFormStateFactory();
   baseFormState.services = [
     { id: serviceId, outputKey: "uipath" as OutputKey },
   ];

--- a/src/core.ts
+++ b/src/core.ts
@@ -667,7 +667,7 @@ export enum RunReason {
   /**
    * Experimental: a declared dependency of the extension point changed.
    *
-   * See MenuItemExtensionPoint
+   * See ButtonExtensionPoint
    */
   DEPENDENCY_CHANGED = 4,
   /**

--- a/src/extensionPoints/factory.ts
+++ b/src/extensionPoints/factory.ts
@@ -16,7 +16,7 @@
  */
 
 import { fromJS as deserializePanel } from "@/extensionPoints/panelExtension";
-import { fromJS as deserializeMenuItem } from "@/extensionPoints/menuItemExtension";
+import { fromJS as deserializeButton } from "@/extensionPoints/buttonExtension";
 import { fromJS as deserializeTrigger } from "@/extensionPoints/triggerExtension";
 import { fromJS as deserializeContextMenu } from "@/extensionPoints/contextMenu";
 import { fromJS as deserializeSidebar } from "@/extensionPoints/sidebarExtension";
@@ -26,7 +26,7 @@ import { type ExtensionPointConfig } from "@/extensionPoints/types";
 
 const TYPE_MAP = {
   panel: deserializePanel,
-  menuItem: deserializeMenuItem,
+  menuItem: deserializeButton,
   trigger: deserializeTrigger,
   contextMenu: deserializeContextMenu,
   actionPanel: deserializeSidebar,

--- a/src/pageEditor/extensionPoints/adapter.ts
+++ b/src/pageEditor/extensionPoints/adapter.ts
@@ -21,7 +21,7 @@ import {
   type ExtensionPointConfig,
   type ExtensionPointType,
 } from "@/extensionPoints/types";
-import menuItemExtension from "@/pageEditor/extensionPoints/menuItem";
+import buttonExtension from "@/pageEditor/extensionPoints/button";
 import quickBarExtension from "@/pageEditor/extensionPoints/quickBar";
 import triggerExtension from "@/pageEditor/extensionPoints/trigger";
 import panelExtension from "@/pageEditor/extensionPoints/panel";
@@ -36,7 +36,7 @@ export const ADAPTERS = new Map<ExtensionPointType, ElementConfig>([
   ["panel", panelExtension],
   ["contextMenu", contextMenuExtension],
   ["actionPanel", sidebarExtension],
-  ["menuItem", menuItemExtension],
+  ["menuItem", buttonExtension],
   ["quickBar", quickBarExtension],
 ]);
 

--- a/src/pageEditor/extensionPoints/button.ts
+++ b/src/pageEditor/extensionPoints/button.ts
@@ -33,16 +33,16 @@ import {
 import { omitEditorMetadata } from "./pipelineMapping";
 import {
   type MenuDefinition,
-  type MenuItemExtensionConfig,
-  MenuItemExtensionPoint,
-} from "@/extensionPoints/menuItemExtension";
+  type ButtonExtensionConfig,
+  ButtonExtensionPoint,
+} from "@/extensionPoints/buttonExtension";
 import { type ExtensionPointConfig } from "@/extensionPoints/types";
 import { identity, pickBy } from "lodash";
 import { uuidv4 } from "@/types/helpers";
 import { getDomain } from "@/permissions/patterns";
 import { faMousePointer } from "@fortawesome/free-solid-svg-icons";
 import { type ElementConfig } from "@/pageEditor/extensionPoints/elementConfig";
-import MenuItemConfiguration from "@/pageEditor/tabs/menuItem/MenuItemConfiguration";
+import ButtonConfiguration from "@/pageEditor/tabs/button/ButtonConfiguration";
 import { insertButton } from "@/contentScript/messenger/api";
 import {
   type ButtonDefinition,
@@ -108,9 +108,9 @@ function selectExtensionPoint(
 function selectExtension(
   state: ActionFormState,
   options: { includeInstanceIds?: boolean } = {}
-): IExtension<MenuItemExtensionConfig> {
+): IExtension<ButtonExtensionConfig> {
   const { extension } = state;
-  const config: MenuItemExtensionConfig = {
+  const config: ButtonExtensionConfig = {
     caption: extension.caption,
     icon: extension.icon,
     action: options.includeInstanceIds
@@ -174,11 +174,11 @@ async function fromExtensionPoint(
 }
 
 async function fromExtension(
-  config: IExtension<MenuItemExtensionConfig>
+  config: IExtension<ButtonExtensionConfig>
 ): Promise<ActionFormState> {
   const extensionPoint = await lookupExtensionPoint<
     MenuDefinition,
-    MenuItemExtensionConfig,
+    ButtonExtensionConfig,
     "menuItem"
   >(config, "menuItem");
 
@@ -220,8 +220,8 @@ const config: ElementConfig<ButtonSelectionResult, ActionFormState> = {
   elementType: "menuItem",
   label: "Button",
   icon: faMousePointer,
-  baseClass: MenuItemExtensionPoint,
-  EditorNode: MenuItemConfiguration,
+  baseClass: ButtonExtensionPoint,
+  EditorNode: ButtonConfiguration,
   selectNativeElement: insertButton,
   fromExtensionPoint,
   fromNativeElement,

--- a/src/pageEditor/extensionPoints/formStateTypes.ts
+++ b/src/pageEditor/extensionPoints/formStateTypes.ts
@@ -23,9 +23,9 @@ import {
   type MenuDefaultOptions as ContextMenuDefaultOptions,
 } from "@/extensionPoints/contextMenu";
 import {
-  type MenuItemExtensionConfig,
+  type ButtonExtensionConfig,
   type MenuPosition,
-} from "@/extensionPoints/menuItemExtension";
+} from "@/extensionPoints/buttonExtension";
 import { type PanelConfig } from "@/extensionPoints/panelExtension";
 import {
   type QuickBarConfig,
@@ -58,7 +58,7 @@ import {
 
 // ActionFormState
 type ActionExtensionState = BaseExtensionState &
-  Except<MenuItemExtensionConfig, "action">;
+  Except<ButtonExtensionConfig, "action">;
 type ActionExtensionPointState = BaseExtensionPointState & {
   definition: {
     type: ExtensionPointType;

--- a/src/pageEditor/panes/insert/InsertButtonPane.tsx
+++ b/src/pageEditor/panes/insert/InsertButtonPane.tsx
@@ -18,12 +18,12 @@
 import styles from "@/pageEditor/panes/Pane.module.scss";
 
 import React from "react";
-import config from "@/pageEditor/extensionPoints/menuItem";
+import config from "@/pageEditor/extensionPoints/button";
 import useAvailableExtensionPoints from "@/pageEditor/hooks/useAvailableExtensionPoints";
 import {
   type MenuDefinition,
-  MenuItemExtensionPoint,
-} from "@/extensionPoints/menuItemExtension";
+  ButtonExtensionPoint,
+} from "@/extensionPoints/buttonExtension";
 import Centered from "@/components/Centered";
 import { Alert, Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -38,18 +38,17 @@ import { type ExtensionPointConfig } from "@/extensionPoints/types";
 import useAddExisting from "@/pageEditor/panes/insert/useAddExisting";
 import useFlags from "@/hooks/useFlags";
 
-type MenuItemWithConfig = MenuItemExtensionPoint & {
+type ButtonWithConfig = ButtonExtensionPoint & {
   rawConfig: ExtensionPointConfig<MenuDefinition>;
 };
 
-const InsertMenuItemPane: React.FunctionComponent<{ cancel: () => void }> = ({
+const InsertButtonPane: React.FunctionComponent<{ cancel: () => void }> = ({
   cancel,
 }) => {
   const { flagOn } = useFlags();
 
-  const menuItemExtensionPoints = useAvailableExtensionPoints(
-    MenuItemExtensionPoint
-  );
+  const buttonExtensionPoints =
+    useAvailableExtensionPoints(ButtonExtensionPoint);
 
   const addExisting = useAddExisting(config, cancel);
 
@@ -76,18 +75,18 @@ const InsertMenuItemPane: React.FunctionComponent<{ cancel: () => void }> = ({
       <div>
         {flagOn("page-editor-extension-point-marketplace") && (
           <BrickModal
-            bricks={menuItemExtensionPoints ?? []}
+            bricks={buttonExtensionPoints ?? []}
             caption="Select button foundation"
             renderButton={(onClick) => (
               <Button
                 variant="info"
                 onClick={onClick}
-                disabled={!menuItemExtensionPoints?.length}
+                disabled={!buttonExtensionPoints?.length}
               >
                 <FontAwesomeIcon icon={faSearch} /> Search Marketplace
               </Button>
             )}
-            onSelect={async (block) => addExisting(block as MenuItemWithConfig)}
+            onSelect={async (block) => addExisting(block as ButtonWithConfig)}
           />
         )}
 
@@ -99,4 +98,4 @@ const InsertMenuItemPane: React.FunctionComponent<{ cancel: () => void }> = ({
   );
 };
 
-export default InsertMenuItemPane;
+export default InsertButtonPane;

--- a/src/pageEditor/panes/insert/InsertPane.tsx
+++ b/src/pageEditor/panes/insert/InsertPane.tsx
@@ -17,7 +17,7 @@
 
 import React, { useCallback } from "react";
 import { type ExtensionPointType } from "@/extensionPoints/types";
-import InsertMenuItemPane from "@/pageEditor/panes/insert/InsertMenuItemPane";
+import InsertButtonPane from "@/pageEditor/panes/insert/InsertButtonPane";
 import InsertPanelPane from "@/pageEditor/panes/insert/InsertPanelPane";
 import GenericInsertPane from "@/pageEditor/panes/insert/GenericInsertPane";
 import { ADAPTERS } from "@/pageEditor/extensionPoints/adapter";
@@ -42,7 +42,7 @@ const InsertPane: React.FC<{ inserting: ExtensionPointType }> = ({
 
   switch (inserting) {
     case "menuItem": {
-      return <InsertMenuItemPane cancel={cancelInsert} />;
+      return <InsertButtonPane cancel={cancelInsert} />;
     }
 
     case "panel": {

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -32,7 +32,7 @@ import {
   extensionFactory,
   typedBlockFactory,
 } from "@/testUtils/factories";
-import menuItemExtensionAdapter from "@/pageEditor/extensionPoints/menuItem";
+import buttonExtensionAdapter from "@/pageEditor/extensionPoints/button";
 import { type UnknownObject } from "@/types";
 import {
   internalExtensionPointMetaFactory,
@@ -43,7 +43,7 @@ import { produce } from "immer";
 import { makeInternalId } from "@/registry/internal";
 import { cloneDeep, range, uniq } from "lodash";
 import { type InnerDefinitionRef, type UnresolvedExtension } from "@/core";
-import { type MenuDefinition } from "@/extensionPoints/menuItemExtension";
+import { type MenuDefinition } from "@/extensionPoints/buttonExtension";
 import extensionsSlice from "@/store/extensionsSlice";
 import {
   getMinimalSchema,
@@ -117,7 +117,7 @@ describe("replaceRecipeExtension round trip", () => {
 
     (lookupExtensionPoint as jest.Mock).mockResolvedValue(extensionPoint);
 
-    const element = await menuItemExtensionAdapter.fromExtension(
+    const element = await buttonExtensionAdapter.fromExtension(
       state.extensions[0]
     );
     element.label = "New Label";
@@ -161,7 +161,7 @@ describe("replaceRecipeExtension round trip", () => {
 
     (lookupExtensionPoint as jest.Mock).mockResolvedValue(extensionPoint);
 
-    const element = await menuItemExtensionAdapter.fromExtension(
+    const element = await buttonExtensionAdapter.fromExtension(
       state.extensions[0]
     );
     element.label = "New Label";
@@ -204,7 +204,7 @@ describe("replaceRecipeExtension round trip", () => {
       },
     });
 
-    const element = await menuItemExtensionAdapter.fromExtension(
+    const element = await buttonExtensionAdapter.fromExtension(
       state.extensions[0]
     );
 
@@ -254,7 +254,7 @@ describe("replaceRecipeExtension round trip", () => {
       },
     });
 
-    const element = await menuItemExtensionAdapter.fromExtension(
+    const element = await buttonExtensionAdapter.fromExtension(
       state.extensions[0]
     );
 
@@ -314,7 +314,7 @@ describe("replaceRecipeExtension round trip", () => {
       },
     });
 
-    const element = await menuItemExtensionAdapter.fromExtension(
+    const element = await buttonExtensionAdapter.fromExtension(
       state.extensions[0]
     );
 
@@ -363,7 +363,7 @@ describe("replaceRecipeExtension round trip", () => {
 
     (lookupExtensionPoint as jest.Mock).mockResolvedValue(extensionPoint);
 
-    const element = await menuItemExtensionAdapter.fromExtension({
+    const element = await buttonExtensionAdapter.fromExtension({
       ...state.extensions[0],
       apiVersion: "v3",
     });
@@ -412,7 +412,7 @@ describe("replaceRecipeExtension round trip", () => {
 
     (lookupExtensionPoint as jest.Mock).mockResolvedValue(extensionPoint);
 
-    const element = await menuItemExtensionAdapter.fromExtension({
+    const element = await buttonExtensionAdapter.fromExtension({
       ...state.extensions[0],
       apiVersion: "v3",
     });
@@ -448,7 +448,7 @@ describe("blueprint options", () => {
       })
     );
 
-    const element = await menuItemExtensionAdapter.fromExtension(
+    const element = await buttonExtensionAdapter.fromExtension(
       state.extensions[0]
     );
 

--- a/src/pageEditor/panes/save/useSavingWizard.test.tsx
+++ b/src/pageEditor/panes/save/useSavingWizard.test.tsx
@@ -26,7 +26,7 @@ import { savingExtensionSlice } from "./savingExtensionSlice";
 import useSavingWizard from "./useSavingWizard";
 import {
   formStateFactory,
-  menuItemFormStateFactory,
+  buttonFormStateFactory,
   recipeMetadataFactory,
   recipeFactory,
   installedRecipeMetadataFactory,
@@ -40,7 +40,7 @@ import {
 } from "@/services/api";
 import { selectElements } from "@/pageEditor/slices/editorSelectors";
 import { uuidv4 } from "@/types/helpers";
-import menuItem from "@/pageEditor/extensionPoints/menuItem";
+import button from "@/pageEditor/extensionPoints/button";
 import pDefer from "p-defer";
 import { pick } from "lodash";
 import extensionsSlice from "@/store/extensionsSlice";
@@ -183,7 +183,7 @@ describe("saving a Recipe Extension", () => {
     });
 
     const extensionLabel = recipe.extensionPoints[0].label;
-    const element = menuItemFormStateFactory({
+    const element = buttonFormStateFactory({
       label: extensionLabel,
       recipe: {
         ...recipe.metadata,
@@ -192,7 +192,7 @@ describe("saving a Recipe Extension", () => {
       },
       optionsDefinition: recipeOptions,
     });
-    const extension = menuItem.selectExtension(element);
+    const extension = button.selectExtension(element);
     extension._recipe = element.recipe;
     const store = createStore({
       options: {

--- a/src/pageEditor/sidebar/arrangeElements.test.ts
+++ b/src/pageEditor/sidebar/arrangeElements.test.ts
@@ -18,7 +18,7 @@
 import {
   extensionFactory,
   installedRecipeMetadataFactory,
-  menuItemFormStateFactory,
+  buttonFormStateFactory,
   recipeDefinitionFactory,
   recipeMetadataFactory,
 } from "@/testUtils/factories";
@@ -56,7 +56,7 @@ const installedFooA: IExtension = extensionFactory({
 });
 
 const ID_FOO_B = uuidv4();
-const dynamicFooB: ActionFormState = menuItemFormStateFactory({
+const dynamicFooB: ActionFormState = buttonFormStateFactory({
   uuid: ID_FOO_B,
   label: "B",
   recipe: installedRecipeMetadataFactory({
@@ -65,7 +65,7 @@ const dynamicFooB: ActionFormState = menuItemFormStateFactory({
 });
 
 const ID_ORPHAN_C = uuidv4();
-const dynamicOrphanC: ActionFormState = menuItemFormStateFactory({
+const dynamicOrphanC: ActionFormState = buttonFormStateFactory({
   uuid: ID_ORPHAN_C,
   label: "C",
 });
@@ -80,7 +80,7 @@ const installedBarD: IExtension = extensionFactory({
 });
 
 const ID_BAR_E = uuidv4();
-const dynamicBarE: ActionFormState = menuItemFormStateFactory({
+const dynamicBarE: ActionFormState = buttonFormStateFactory({
   uuid: ID_BAR_E,
   label: "E",
   recipe: installedRecipeMetadataFactory({
@@ -109,7 +109,7 @@ const installedOrphanH: IExtension = extensionFactory({
   label: "H",
 });
 
-const dynamicOrphanH: ActionFormState = menuItemFormStateFactory({
+const dynamicOrphanH: ActionFormState = buttonFormStateFactory({
   uuid: ID_ORPHAN_H,
   label: "H",
 });

--- a/src/pageEditor/tabs/button/ButtonConfiguration.tsx
+++ b/src/pageEditor/tabs/button/ButtonConfiguration.tsx
@@ -45,7 +45,7 @@ const positionOptions: Option[] = [
   { value: "prepend", label: "Start" },
 ];
 
-const MenuItemConfiguration: React.FC<{
+const ButtonConfiguration: React.FC<{
   isLocked: boolean;
 }> = ({ isLocked = false }) => {
   const [{ value: onSuccess }] = useField("extension.onSuccess");
@@ -124,4 +124,4 @@ const MenuItemConfiguration: React.FC<{
   );
 };
 
-export default MenuItemConfiguration;
+export default ButtonConfiguration;

--- a/src/pageEditor/tabs/effect/BlockConfiguration.test.tsx
+++ b/src/pageEditor/tabs/effect/BlockConfiguration.test.tsx
@@ -23,7 +23,7 @@ import {
   formStateFactory,
   triggerFormStateFactory,
   quickbarFormStateFactory,
-  buttonFormStateFactory as buttonFormStateFactory,
+  buttonFormStateFactory,
   contextMenuFormStateFactory,
   sidebarPanelFormStateFactory,
 } from "@/testUtils/factories";

--- a/src/pageEditor/tabs/effect/BlockConfiguration.test.tsx
+++ b/src/pageEditor/tabs/effect/BlockConfiguration.test.tsx
@@ -23,7 +23,7 @@ import {
   formStateFactory,
   triggerFormStateFactory,
   quickbarFormStateFactory,
-  menuItemFormStateFactory,
+  buttonFormStateFactory as buttonFormStateFactory,
   contextMenuFormStateFactory,
   sidebarPanelFormStateFactory,
 } from "@/testUtils/factories";
@@ -100,7 +100,7 @@ describe("shows root mode", () => {
     ["quickBar", quickbarFormStateFactory],
     ["contextMenu", contextMenuFormStateFactory],
     // `menuItem` must show root mode because root mode is used if the location matches multiple elements on the page
-    ["menuItem", menuItemFormStateFactory],
+    ["menuItem", buttonFormStateFactory],
   ])("shows root mode for %s", async (type, factory) => {
     const block = echoBlock;
     blockRegistry.register(block);

--- a/src/store/checkActiveElementAvailability.test.ts
+++ b/src/store/checkActiveElementAvailability.test.ts
@@ -21,7 +21,7 @@ import { type EditorRootState } from "@/pageEditor/pageEditorTypes";
 import { type ExtensionsRootState } from "@/store/extensionsTypes";
 import { actions, editorSlice } from "@/pageEditor/slices/editorSlice";
 import extensionsSlice from "@/store/extensionsSlice";
-import { buttonFormStateFactory as buttonFormStateFactory } from "@/testUtils/factories";
+import { buttonFormStateFactory } from "@/testUtils/factories";
 import { validateRegistryId } from "@/types/helpers";
 import { type RegistryId } from "@/core";
 import { checkAvailable } from "@/contentScript/messenger/api";

--- a/src/store/checkActiveElementAvailability.test.ts
+++ b/src/store/checkActiveElementAvailability.test.ts
@@ -21,7 +21,7 @@ import { type EditorRootState } from "@/pageEditor/pageEditorTypes";
 import { type ExtensionsRootState } from "@/store/extensionsTypes";
 import { actions, editorSlice } from "@/pageEditor/slices/editorSlice";
 import extensionsSlice from "@/store/extensionsSlice";
-import { menuItemFormStateFactory } from "@/testUtils/factories";
+import { buttonFormStateFactory as buttonFormStateFactory } from "@/testUtils/factories";
 import { validateRegistryId } from "@/types/helpers";
 import { type RegistryId } from "@/core";
 import { checkAvailable } from "@/contentScript/messenger/api";
@@ -54,7 +54,7 @@ describe("checkActiveElementAvailability", () => {
       },
     });
 
-    const availableDynamicExtension = menuItemFormStateFactory({
+    const availableDynamicExtension = buttonFormStateFactory({
       extensionPoint: {
         metadata: {
           id: validateRegistryId("test/available-button"),
@@ -72,7 +72,7 @@ describe("checkActiveElementAvailability", () => {
       },
     });
 
-    const unavailableDynamicExtension = menuItemFormStateFactory({
+    const unavailableDynamicExtension = buttonFormStateFactory({
       extensionPoint: {
         metadata: {
           id: validateRegistryId("test/unavailable-button"),

--- a/src/store/checkAvailableDynamicElements.test.ts
+++ b/src/store/checkAvailableDynamicElements.test.ts
@@ -18,7 +18,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { type EditorRootState } from "@/pageEditor/pageEditorTypes";
 import { actions, editorSlice } from "@/pageEditor/slices/editorSlice";
-import { menuItemFormStateFactory } from "@/testUtils/factories";
+import { buttonFormStateFactory } from "@/testUtils/factories";
 import { type RegistryId } from "@/core";
 import { validateRegistryId } from "@/types/helpers";
 import { selectExtensionAvailability } from "@/pageEditor/slices/editorSelectors";
@@ -53,7 +53,7 @@ describe("checkAvailableDynamicElements", () => {
       },
     });
 
-    const availableDynamicExtension = menuItemFormStateFactory({
+    const availableDynamicExtension = buttonFormStateFactory({
       extensionPoint: {
         metadata: {
           id: validateRegistryId("test/available-button"),
@@ -71,7 +71,7 @@ describe("checkAvailableDynamicElements", () => {
       },
     });
 
-    const unavailableDynamicExtension = menuItemFormStateFactory({
+    const unavailableDynamicExtension = buttonFormStateFactory({
       extensionPoint: {
         metadata: {
           id: validateRegistryId("test/unavailable-button"),

--- a/src/store/checkAvailableInstalledExtensions.test.ts
+++ b/src/store/checkAvailableInstalledExtensions.test.ts
@@ -31,8 +31,8 @@ import { getCurrentURL } from "@/pageEditor/utils";
 import { validateRegistryId } from "@/types/helpers";
 import {
   type MenuDefinition,
-  RemoteMenuItemExtensionPoint,
-} from "@/extensionPoints/menuItemExtension";
+  RemoteButtonExtensionPoint,
+} from "@/extensionPoints/buttonExtension";
 import { type ExtensionPointConfig } from "@/extensionPoints/types";
 import { type Metadata } from "@/core";
 import {
@@ -92,7 +92,7 @@ describe("checkAvailableInstalledExtensions", () => {
         },
       }
     ) as ExtensionPointConfig<MenuDefinition>;
-    const availableButtonExtensionPoint = new RemoteMenuItemExtensionPoint(
+    const availableButtonExtensionPoint = new RemoteButtonExtensionPoint(
       availableButtonExtensionPointConfig
     );
 

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -51,7 +51,7 @@ import {
 } from "@/types/helpers";
 import { type BaseExtensionState } from "@/pageEditor/extensionPoints/elementConfig";
 import trigger from "@/pageEditor/extensionPoints/trigger";
-import menuItem from "@/pageEditor/extensionPoints/menuItem";
+import menuItem from "@/pageEditor/extensionPoints/button";
 import {
   type ActionFormState,
   type ContextMenuFormState,
@@ -677,7 +677,7 @@ export const quickbarFormStateFactory = (
   ) as QuickBarFormState;
 };
 
-export const menuItemFormStateFactory = (
+export const buttonFormStateFactory = (
   override?: FactoryConfig<ActionFormState>,
   pipelineOverride?: BlockPipeline
 ) => {


### PR DESCRIPTION
## What does this PR do?

- Closes #4492

See the issue for background information.

## Discussion

I'm a bit conflicted on this one. On one hand:

- it resolves the confusion between context menus (which sometimes have a "menuItemId") and regular button extensions

but this change:

- leaves "menuItem" as the actual underlying name
- uses a less specific name ("button"), which makes it more difficult to search

These drawbacks could be avoided if:

- we found a less generic name 
- we also change the "menuItem" name in the schema, which would likely require a migration or aliasing

## Checklist

- [ ] Add tests
- [ ] Run Storybook and manually confirm that all stories are working
- [X] Designate a primary reviewer: @BLoe 
