### PR TITLE
#4864: add replace text brick

### DIFF
--- a/src/blocks/effects/registerEffects.ts
+++ b/src/blocks/effects/registerEffects.ts
@@ -43,6 +43,7 @@ import { DisableEffect } from "./disable";
 import { EnableEffect } from "./enable";
 import InsertHtml from "@/blocks/effects/insertHtml";
 import CustomEventEffect from "@/blocks/effects/customEvent";
+import ReplaceTextEffect from "@/blocks/effects/replaceText";
 
 function registerEffects(): void {
   registerBlock(new LogEffect());
@@ -78,6 +79,7 @@ function registerEffects(): void {
   registerBlock(new DisableEffect());
   registerBlock(new InsertHtml());
   registerBlock(new CustomEventEffect());
+  registerBlock(new ReplaceTextEffect());
 }
 
 export default registerEffects;

--- a/src/blocks/effects/replaceText.test.ts
+++ b/src/blocks/effects/replaceText.test.ts
@@ -138,6 +138,7 @@ describe("ReplaceTextEffect", () => {
       unsafeAssumeValidArg({
         pattern: "^(\\+\\d{1,2}\\s)?\\(?\\d{3}\\)?[\\s.-]\\d{3}[\\s.-]\\d{4}",
         replacement: "###-###-####",
+        isRegex: true,
       }),
       { logger, root: document } as BlockOptions
     );
@@ -150,6 +151,7 @@ describe("ReplaceTextEffect", () => {
       unsafeAssumeValidArg({
         pattern: "(?<numbers>[0-9]+)[a-z]+",
         replacement: "$<numbers>",
+        isRegex: true,
       }),
       { logger, root: document } as BlockOptions
     );
@@ -162,7 +164,6 @@ describe("ReplaceTextEffect", () => {
       unsafeAssumeValidArg({
         pattern: "^(\\+\\d{1,2}\\s)?\\(?\\d{3}\\)?[\\s.-]\\d{3}[\\s.-]\\d{4}",
         replacement: "###-###-####",
-        isRegex: false,
       }),
       { logger, root: document } as BlockOptions
     );

--- a/src/blocks/effects/replaceText.test.ts
+++ b/src/blocks/effects/replaceText.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import ConsoleLogger from "@/utils/ConsoleLogger";
+import { uuidv4, validateRegistryId } from "@/types/helpers";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { type BlockOptions } from "@/core";
+import { JSDOM } from "jsdom";
+import ReplaceTextEffect from "@/blocks/effects/replaceText";
+
+beforeEach(() => {
+  // Isolate extension state between test
+  jest.resetModules();
+});
+
+function getDocument(html: string): Document {
+  return new JSDOM(html).window.document;
+}
+
+const brick = new ReplaceTextEffect();
+
+const logger = new ConsoleLogger({
+  extensionId: uuidv4(),
+  blueprintId: validateRegistryId("test/123"),
+});
+
+describe("ReplaceTextEffect", () => {
+  test("replace text shallow document", async () => {
+    const document = getDocument("<div>foo</div>");
+    const brick = new ReplaceTextEffect();
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "foo",
+        replacement: "bar",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toBe("<div>bar</div>");
+  });
+
+  test("replace all matches in node", async () => {
+    const document = getDocument("<div>foofoo</div>");
+    const brick = new ReplaceTextEffect();
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "foo",
+        replacement: "bar",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toBe("<div>barbar</div>");
+  });
+
+  test("replace text recursively in document", async () => {
+    const document = getDocument("<div>foo <span>foo</span></div>");
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "foo",
+        replacement: "bar",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+    expect(document.body.innerHTML).toBe("<div>bar <span>bar</span></div>");
+  });
+
+  test("use selector", async () => {
+    const document = getDocument("<div>foo <span>foo</span></div>");
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "foo",
+        replacement: "bar",
+        selector: "span",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+    expect(document.body.innerHTML).toBe("<div>foo <span>bar</span></div>");
+  });
+
+  test("apply pattern once", async () => {
+    const document = getDocument("<div>foo <div>foo</div></div>");
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "foo",
+        replacement: "foobar",
+        selector: "div",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+    expect(document.body.innerHTML).toBe("<div>foobar <div>foobar</div></div>");
+  });
+
+  test("apply relative to root", async () => {
+    const document = getDocument("<div>foo <span>foo</span></div>");
+    const span = document.querySelector("span");
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "foo",
+        replacement: "bar",
+      }),
+      { logger, root: span } as BlockOptions
+    );
+    expect(document.body.innerHTML).toBe("<div>foo <span>bar</span></div>");
+  });
+
+  test("mask phone number regex", async () => {
+    const document = getDocument("<div>123-456-7890</div>");
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "^(\\+\\d{1,2}\\s)?\\(?\\d{3}\\)?[\\s.-]\\d{3}[\\s.-]\\d{4}",
+        replacement: "###-###-####",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+    expect(document.body.innerHTML).toBe("<div>###-###-####</div>");
+  });
+
+  test("supports replacement pattern", async () => {
+    const document = getDocument("<div>123abc</div>");
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "(?<numbers>[0-9]+)[a-z]+",
+        replacement: "$<numbers>",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+    expect(document.body.innerHTML).toBe("<div>123</div>");
+  });
+
+  test("isRegex false", async () => {
+    const document = getDocument("<div>123-456-7890</div>");
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "^(\\+\\d{1,2}\\s)?\\(?\\d{3}\\)?[\\s.-]\\d{3}[\\s.-]\\d{4}",
+        replacement: "###-###-####",
+        isRegex: false,
+      }),
+      { logger, root: document } as BlockOptions
+    );
+    expect(document.body.innerHTML).toBe("<div>123-456-7890</div>");
+  });
+});

--- a/src/blocks/effects/replaceText.test.ts
+++ b/src/blocks/effects/replaceText.test.ts
@@ -67,6 +67,20 @@ describe("ReplaceTextEffect", () => {
     expect(document.body.innerHTML).toBe("<div>barbar</div>");
   });
 
+  test("is case case-sensitive", async () => {
+    const document = getDocument("<div>FOO</div>");
+    const brick = new ReplaceTextEffect();
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "foo",
+        replacement: "bar",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toBe("<div>FOO</div>");
+  });
+
   test("replace text recursively in document", async () => {
     const document = getDocument("<div>foo <span>foo</span></div>");
     await brick.run(

--- a/src/blocks/effects/replaceText.ts
+++ b/src/blocks/effects/replaceText.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Effect } from "@/types";
+import { type BlockArg, type BlockOptions, type Schema } from "@/core";
+import { $safeFind } from "@/helpers";
+
+/**
+ * Recursively replace text in an element and its children, without modifying the structure of the document.
+ */
+export function replaceText({
+  node,
+  pattern,
+  replacement,
+  visited,
+}: {
+  node: Node;
+  pattern: string | RegExp;
+  replacement: string;
+  visited: WeakSet<Node>;
+}) {
+  if (visited.has(node)) {
+    // Avoid running replaceText on same node twice if selector passed to brick matches multiple nodes
+    // in the same subtree
+    return;
+  }
+
+  visited.add(node);
+
+  if (node.nodeType === Node.TEXT_NODE) {
+    node.textContent = node.textContent.replaceAll(pattern, replacement);
+    return;
+  }
+
+  for (const childNode of node.childNodes) {
+    replaceText({ node: childNode, pattern, replacement, visited });
+  }
+}
+
+class ReplaceTextEffect extends Effect {
+  constructor() {
+    super(
+      "@pixiebrix/html/replace-text",
+      "Replace Text",
+      "Replace text within an HTML document or subtree"
+    );
+  }
+
+  inputSchema: Schema = {
+    type: "object",
+    properties: {
+      pattern: {
+        type: "string",
+        description: "A string or regular expression to match",
+      },
+      replacement: {
+        type: "string",
+        description:
+          "A string or replacement pattern: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement",
+      },
+      isRegex: {
+        type: "boolean",
+        description: "Whether the pattern is a regular expression",
+        default: true,
+      },
+      selector: {
+        type: "string",
+        format: "selector",
+        description:
+          "An optional JQuery element selector to limit replacement to document subtree(s)",
+      },
+    },
+    required: ["pattern", "replacement"],
+  };
+
+  override async isRootAware(): Promise<boolean> {
+    return true;
+  }
+
+  async effect(
+    {
+      pattern,
+      replacement,
+      selector,
+      isRegex = true,
+    }: BlockArg<{
+      pattern: string;
+      replacement: string;
+      isRegex?: boolean;
+      selector?: string;
+    }>,
+    { root }: BlockOptions
+  ): Promise<void> {
+    const $elements = selector ? $safeFind(selector, root) : $(root);
+
+    const visited = new WeakSet<Node>();
+    const convertedPattern = isRegex ? new RegExp(pattern, "g") : pattern;
+
+    for (const element of $elements.get()) {
+      replaceText({
+        node: element,
+        pattern: convertedPattern,
+        replacement,
+        visited,
+      });
+    }
+  }
+}
+
+export default ReplaceTextEffect;

--- a/src/blocks/effects/replaceText.ts
+++ b/src/blocks/effects/replaceText.ts
@@ -75,7 +75,7 @@ class ReplaceTextEffect extends Effect {
       isRegex: {
         type: "boolean",
         description: "Whether the pattern is a regular expression",
-        default: true,
+        default: false,
       },
       selector: {
         type: "string",
@@ -96,7 +96,7 @@ class ReplaceTextEffect extends Effect {
       pattern,
       replacement,
       selector,
-      isRegex = true,
+      isRegex = false,
     }: BlockArg<{
       pattern: string;
       replacement: string;

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -27,7 +27,7 @@ import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 105;
+const EXPECTED_HEADER_COUNT = 106;
 
 registerBuiltinBlocks();
 registerContribBlocks();


### PR DESCRIPTION
## What does this PR do?

- Closes #4864 
- Adds a new brick that replaces text within elements

## Discussion

- The brick default isRegex to `false` if not provided
- To expose case insensitive mode in the future, can use https://www.npmjs.com/package/regex-escape to convert a string to a regex and then pass the `i` flag to the regex 

## Demo

- https://www.loom.com/share/f1e8535eaf344304b1977d329d03253f

## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working: N/A
- [x] Designate a primary reviewer: @fregante 
