### PR TITLE
Add support for passing an explicit element to root-aware bricks

### DIFF
--- a/schemas/element.json
+++ b/schemas/element.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://app.pixiebrix.com/schemas/element#",
+  "type": "string",
+  "format": "uuid"
+}

--- a/src/blocks/readers/ElementReader.test.ts
+++ b/src/blocks/readers/ElementReader.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ElementReader } from "@/blocks/readers/ElementReader";
+import { validateUUID } from "@/types/helpers";
+
+const reader = new ElementReader();
+
+describe("ElementReader", () => {
+  test("it produces valid element reference", async () => {
+    const div = document.createElement("div");
+    const { ref } = await reader.read(div);
+    expect(validateUUID(ref)).not.toBeNull();
+  });
+});

--- a/src/blocks/readers/ElementReader.ts
+++ b/src/blocks/readers/ElementReader.ts
@@ -18,6 +18,7 @@
 import { Reader } from "@/types";
 import { type ReaderRoot, type Schema } from "@/core";
 import { isHTMLElement } from "@/blocks/readers/frameworkReader";
+import { getReferenceForElement } from "@/contentScript/elementReference";
 
 /**
  * Read attributes, text, etc. from an HTML element.
@@ -40,9 +41,11 @@ export class ElementReader extends Reader {
     const element = isHTMLElement(elementOrDocument)
       ? elementOrDocument
       : document.body;
+
     const $elements = $(element);
 
     return {
+      ref: getReferenceForElement(element),
       tagName: element.tagName,
       attrs: Object.fromEntries(
         Object.values(element.attributes).map((x) => [x.name, x.value])
@@ -60,6 +63,9 @@ export class ElementReader extends Reader {
     $schema: "https://json-schema.org/draft/2019-09/schema#",
     type: "object",
     properties: {
+      ref: {
+        $ref: "https://app.pixiebrix.com/schemas/element#",
+      },
       tagName: {
         type: "string",
       },
@@ -77,7 +83,7 @@ export class ElementReader extends Reader {
         additionalProperties: true,
       },
     },
-    required: ["tagName", "attrs", "data", "text"],
+    required: ["tagName", "attrs", "data", "text", "ref"],
     additionalProperties: false,
   };
 

--- a/src/blocks/transformers/controlFlow/ForEachElement.ts
+++ b/src/blocks/transformers/controlFlow/ForEachElement.ts
@@ -22,6 +22,9 @@ import { type PipelineExpression } from "@/runtime/mapArgs";
 import { validateRegistryId } from "@/types/helpers";
 import { $safeFind } from "@/helpers";
 import { castArray } from "lodash";
+import { getReferenceForElement } from "@/contentScript/elementReference";
+import { validateOutputKey } from "@/runtime/runtimeTypes";
+import { PropError } from "@/errors/businessErrors";
 
 class ForEachElement extends Transformer {
   static BLOCK_ID = validateRegistryId("@pixiebrix/for-each-element");
@@ -55,6 +58,12 @@ class ForEachElement extends Transformer {
         $ref: "https://app.pixiebrix.com/schemas/pipeline#",
         description: "The bricks to execute for each element",
       },
+      elementKey: {
+        type: "string",
+        default: "element",
+        description:
+          "The element key/variable for the body of the loop, without the leading @",
+      },
     },
     ["selector", "body"]
   );
@@ -63,22 +72,44 @@ class ForEachElement extends Transformer {
     {
       selector,
       body: bodyPipeline,
+      // For backward compatibility, don't default to "element"
+      elementKey,
     }: BlockArg<{
       selector: string;
       body: PipelineExpression;
+      elementKey?: string;
     }>,
     options: BlockOptions
   ): Promise<unknown> {
+    if (elementKey) {
+      try {
+        validateOutputKey(elementKey);
+      } catch {
+        throw new PropError(
+          "Invalid value for elementKey",
+          this.id,
+          "elementKey",
+          null
+        );
+      }
+    }
+
     const elements = $safeFind(selector, options.root ?? document);
 
     let last: unknown;
 
     for (const [index, element] of castArray(elements.get()).entries()) {
+      const extraContext = elementKey
+        ? {
+            [`@${elementKey}`]: getReferenceForElement(element),
+          }
+        : {};
+
       // eslint-disable-next-line no-await-in-loop -- synchronous for-loop brick
       last = await options.runPipeline(
         bodyPipeline.__value__,
         { key: "body", counter: index },
-        {},
+        extraContext,
         element
       );
     }

--- a/src/blocks/transformers/registerTransformers.ts
+++ b/src/blocks/transformers/registerTransformers.ts
@@ -47,6 +47,7 @@ import ForEachElement from "@/blocks/transformers/controlFlow/ForEachElement";
 import { RandomNumber } from "@/blocks/transformers/randomNumber";
 import Retry from "@/blocks/transformers/controlFlow/Retry";
 import DisplayTemporaryInfo from "@/blocks/transformers/temporaryInfo/DisplayTemporaryInfo";
+import TraverseElements from "@/blocks/transformers/traverseElements";
 
 function registerTransformers() {
   registerBlock(new JQTransformer());
@@ -75,6 +76,7 @@ function registerTransformers() {
   registerBlock(new ParseDate());
   registerBlock(new ScreenshotTab());
   registerBlock(new RandomNumber());
+  registerBlock(new TraverseElements());
 
   // Control Flow Bricks
   registerBlock(new ForEach());

--- a/src/blocks/transformers/traverseElements.test.ts
+++ b/src/blocks/transformers/traverseElements.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { uuidv4, validateRegistryId } from "@/types/helpers";
+import TraverseElements from "@/blocks/transformers/traverseElements";
+import ConsoleLogger from "@/utils/ConsoleLogger";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { type BlockOptions } from "@/core";
+import { getReferenceForElement } from "@/contentScript/elementReference";
+
+const brick = new TraverseElements();
+
+const logger = new ConsoleLogger({
+  extensionId: uuidv4(),
+  blueprintId: validateRegistryId("test/123"),
+});
+
+describe("TraverseElements", () => {
+  test("find", async () => {
+    const div = document.createElement("div");
+    document.body.append(div);
+    const result = await brick.run(
+      unsafeAssumeValidArg({
+        selector: "div",
+        traversal: "find",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(result).toStrictEqual({
+      elements: [getReferenceForElement(div)],
+      count: 1,
+    });
+  });
+
+  test("closest finds self", async () => {
+    const div = document.createElement("div");
+    document.body.append(div);
+    const result = await brick.run(
+      unsafeAssumeValidArg({
+        selector: "div",
+        traversal: "closest",
+      }),
+      { logger, root: div } as unknown as BlockOptions
+    );
+
+    expect(result).toStrictEqual({
+      elements: [getReferenceForElement(div)],
+      count: 1,
+    });
+  });
+});

--- a/src/blocks/transformers/traverseElements.ts
+++ b/src/blocks/transformers/traverseElements.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Transformer } from "@/types";
+import {
+  type BlockArg,
+  type BlockOptions,
+  type Schema,
+  type ElementReference,
+} from "@/core";
+import { getReferenceForElement } from "@/contentScript/elementReference";
+import { propertiesToSchema } from "@/validators/generic";
+
+export class TraverseElements extends Transformer {
+  override async isPure(): Promise<boolean> {
+    return true;
+  }
+
+  override async isRootAware(): Promise<boolean> {
+    return true;
+  }
+
+  constructor() {
+    super(
+      "@pixiebrix/html/traverse",
+      "Traverse Elements",
+      "Traverse elements in an HTML document using a selector/filter",
+      "faCode"
+    );
+  }
+
+  inputSchema: Schema = propertiesToSchema({
+    selector: {
+      type: "string",
+      format: "selector",
+      description: "The selector/filter for the traversal",
+    },
+    traversal: {
+      type: "string",
+      description:
+        "jQuery traversal type: https://api.jquery.com/category/traversing/tree-traversal/",
+      default: "find",
+      enum: [
+        "closest",
+        "children",
+        "find",
+        "next",
+        "nextAll",
+        "nextUntil",
+        "parent",
+        "parents",
+        "parentsUntil",
+        "prev",
+        "prevAll",
+        "prevUntil",
+        "siblings",
+      ],
+    },
+  });
+
+  override outputSchema: Schema = {
+    $schema: "https://json-schema.org/draft/2019-09/schema#",
+    type: "object",
+    properties: {
+      elements: {
+        type: "array",
+        description: "The array of element references found",
+        items: {
+          $ref: "https://app.pixiebrix.com/schemas/element#",
+        },
+      },
+      count: {
+        type: "integer",
+        description: "The number of elements found",
+      },
+    },
+    required: ["elements", "count"],
+    additionalProperties: false,
+  };
+
+  async transform(
+    {
+      selector,
+      traversal = "find",
+    }: BlockArg<{
+      selector: string;
+      traversal: string;
+    }>,
+    { ctxt, root }: BlockOptions
+  ): Promise<{
+    elements: ElementReference[];
+    count: number;
+  }> {
+    // @ts-expect-error -- indexing method of jQuery
+    // eslint-disable-next-line security/detect-object-injection -- input validated
+    const elements = $(root)[traversal](selector) as JQuery;
+    const elementRefs = elements
+      .get()
+      .map((element) => getReferenceForElement(element));
+
+    return {
+      elements: elementRefs,
+      count: elementRefs.length,
+    };
+  }
+}
+
+export default TraverseElements;

--- a/src/blocks/types.ts
+++ b/src/blocks/types.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  type ElementReference,
   type Expression,
   type OutputKey,
   type RegistryId,
@@ -169,15 +170,18 @@ export type BlockConfig = {
    * @see root
    * @since 1.4.0
    */
-  rootMode?: "inherit" | "document";
+  rootMode?: "inherit" | "document" | "element";
 
   /**
-   * (Optional) root jQuery/CSS selector. The selector is relative to the `root` that is passed to the pipeline/stage.
+   * (Optional) root jQuery/CSS selector or element reference.
    *
-   * An error is thrown at runtime if the selector doesn't match exactly one element
+   * For rootMode of "inherit" and "document", interpreted as a jQuery/CSS selector. The selector is relative to the
+   * `root` that is passed to the pipeline/stage. An error is thrown at runtime if the selector doesn't match exactly
+   * one element
+   *
    * @see rootMode
    */
-  root?: string;
+  root?: string | ElementReference | Expression;
 
   /**
    * (Optional) template language to use for rendering the `if` and `config` properties (default=`mustache`)

--- a/src/blocks/types.ts
+++ b/src/blocks/types.ts
@@ -167,6 +167,8 @@ export type BlockConfig = {
    * (Optional) whether the block should inherit the current root element, or if it should use the document
    * (default=`inherit`)
    *
+   * `element` rootMode added in 1.7.16
+   *
    * @see root
    * @since 1.4.0
    */

--- a/src/contentScript/elementReference.test.ts
+++ b/src/contentScript/elementReference.test.ts
@@ -21,7 +21,7 @@ import {
 } from "@/contentScript/elementReference";
 import { uuidv4 } from "@/types/helpers";
 import { BusinessError } from "@/errors/businessErrors";
-import { ElementReference } from "@/core";
+import { type ElementReference } from "@/core";
 
 describe("elementReference", () => {
   test("get reference for element", () => {

--- a/src/contentScript/elementReference.test.ts
+++ b/src/contentScript/elementReference.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  getElementForReference,
+  getReferenceForElement,
+} from "@/contentScript/elementReference";
+import { uuidv4 } from "@/types/helpers";
+import { BusinessError } from "@/errors/businessErrors";
+import { ElementReference } from "@/core";
+
+describe("elementReference", () => {
+  test("get reference for element", () => {
+    const element = document.createElement("div");
+    const id = getReferenceForElement(element);
+    expect(id).toBeTruthy();
+  });
+
+  test("return same reference", () => {
+    const element = document.createElement("div");
+    const id = getReferenceForElement(element);
+    expect(getReferenceForElement(element)).toEqual(id);
+  });
+
+  test("lookup reference", () => {
+    const element = document.createElement("div");
+    const id = getReferenceForElement(element);
+    expect(getElementForReference(id)).toEqual(element);
+  });
+
+  test("unknown id throws error", () => {
+    expect(() => getElementForReference(uuidv4() as ElementReference)).toThrow(
+      BusinessError
+    );
+  });
+});

--- a/src/contentScript/elementReference.ts
+++ b/src/contentScript/elementReference.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { uuidv4 } from "@/types/helpers";
+import { type ElementReference } from "@/core";
+import { BusinessError } from "@/errors/businessErrors";
+
+const elementIds = new WeakMap<HTMLElement, ElementReference>();
+const elementReferences = new Map<ElementReference, WeakRef<HTMLElement>>();
+
+/**
+ * Returns a reference uuid for element. If a reference already exists, it is returned.
+ * @param element the element to generate a reference for
+ */
+export function getReferenceForElement(element: HTMLElement): ElementReference {
+  let id = elementIds.get(element);
+  if (id == null) {
+    id = uuidv4() as ElementReference;
+    elementIds.set(element, id);
+    elementReferences.set(id, new WeakRef(element));
+  }
+
+  return id;
+}
+
+/**
+ * Return the element for a given reference id.
+ * @param id the element reference
+ */
+export function getElementForReference(id: ElementReference): HTMLElement {
+  const elementReference = elementReferences.get(id);
+
+  if (elementReference == null) {
+    throw new BusinessError(
+      "Id is not a valid element reference for the document"
+    );
+  }
+
+  const element = elementReference.deref();
+
+  if (element == null) {
+    throw new BusinessError("Referenced element is no longer in the document");
+  }
+
+  return element;
+}

--- a/src/core.ts
+++ b/src/core.ts
@@ -974,6 +974,10 @@ export type SafeHTML = string & {
   _safeHTMLBrand: never;
 };
 
+export type ElementReference = UUID & {
+  _elementReferenceBrand: never;
+};
+
 export type ComponentRef = {
   Component: React.ComponentType;
   props: Record<string, unknown>;

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -27,7 +27,7 @@ import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 106;
+const EXPECTED_HEADER_COUNT = 107;
 
 registerBuiltinBlocks();
 registerContribBlocks();

--- a/src/pageEditor/exampleBlockConfigs.ts
+++ b/src/pageEditor/exampleBlockConfigs.ts
@@ -128,6 +128,8 @@ export function createNewBlock(
   return {
     id: blockId,
     instanceId: uuidv4(),
+    // @since 1.7.16 -- use "document" as the default root mode because it's the easiest to understand
+    rootMode: "document",
     config:
       getExampleBlockConfig(blockId) ??
       (blockInputSchema == null ? {} : defaultBlockConfig(blockInputSchema)),

--- a/src/pageEditor/extensionPoints/base.test.ts
+++ b/src/pageEditor/extensionPoints/base.test.ts
@@ -15,8 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { removeEmptyValues, selectIsAvailable } from "./base";
+import {
+  getImplicitReader,
+  removeEmptyValues,
+  selectIsAvailable,
+} from "./base";
 import { extensionPointDefinitionFactory } from "@/testUtils/factories";
+import { type ExtensionPointType } from "@/extensionPoints/types";
 
 describe("removeEmptyValues()", () => {
   test("removes empty non-expression values", () => {
@@ -80,4 +85,37 @@ describe("selectIsAvailable", () => {
     expect(normalized.selectors).toBeUndefined();
     expect(normalized.urlPatterns).toBeUndefined();
   });
+});
+
+describe("getImplicitReader", () => {
+  it.each([
+    ["menuItem"],
+    ["quickBar"],
+    ["contextMenu"],
+    ["trigger"],
+    ["panel"],
+    ["sidePanel"],
+  ])("includes metadata reader for %s", (type: ExtensionPointType) => {
+    expect(getImplicitReader(type)).toContainEqual(
+      "@pixiebrix/document-metadata"
+    );
+  });
+
+  it.each([["menuItem"], ["quickBar"], ["contextMenu"], ["trigger"]])(
+    "includes element reader for %s",
+    (type: ExtensionPointType) => {
+      expect(getImplicitReader(type)).toContainEqual({
+        element: "@pixiebrix/html/element",
+      });
+    }
+  );
+
+  it.each([["panel"], ["sidePanel"]])(
+    "does not include element reader for %s",
+    (type: ExtensionPointType) => {
+      expect(getImplicitReader(type)).not.toContainEqual({
+        element: "@pixiebrix/html/element",
+      });
+    }
+  );
 });

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -408,11 +408,26 @@ export function getImplicitReader(
     return readerTypeHack([
       validateRegistryId("@pixiebrix/document-metadata"),
       validateRegistryId("@pixiebrix/selection"),
+      { element: validateRegistryId("@pixiebrix/html/element") },
     ]);
   }
 
-  // NOTE: we don't need to provide "@pixiebrix/context-menu-data" here because it's automatically attached by
-  // the contextMenu extension point.
+  if (type === "contextMenu") {
+    // NOTE: we don't need to provide "@pixiebrix/context-menu-data" here because it's automatically attached by
+    // the contextMenu extension point.
+    return readerTypeHack([
+      validateRegistryId("@pixiebrix/document-metadata"),
+      { element: validateRegistryId("@pixiebrix/html/element") },
+    ]);
+  }
+
+  if (type === "menuItem") {
+    return readerTypeHack([
+      validateRegistryId("@pixiebrix/document-metadata"),
+      { element: validateRegistryId("@pixiebrix/html/element") },
+    ]);
+  }
+
   return [validateRegistryId("@pixiebrix/document-metadata")];
 }
 

--- a/src/pageEditor/tabs/effect/BlockConfiguration.test.tsx
+++ b/src/pageEditor/tabs/effect/BlockConfiguration.test.tsx
@@ -117,7 +117,7 @@ describe("shows root mode", () => {
 
     await waitForEffect();
 
-    const rootModeSelect = screen.getByLabelText("Root Mode");
+    const rootModeSelect = screen.getByLabelText("Target Root Mode");
 
     expect(rootModeSelect).not.toBeNull();
   });
@@ -138,7 +138,7 @@ describe("shows root mode", () => {
 
     await waitForEffect();
 
-    const rootModeSelect = screen.queryByLabelText("Root Mode");
+    const rootModeSelect = screen.queryByLabelText("Target Root Mode");
 
     expect(rootModeSelect).toBeNull();
   });
@@ -177,7 +177,7 @@ test.each`
     await waitForEffect();
 
     const conditionInput = screen.queryByLabelText("Condition");
-    const targetInput = screen.queryByLabelText("Target");
+    const targetInput = screen.queryByLabelText("Target Tab/Frame");
 
     if (expected) {
       expect(conditionInput).not.toBeNull();

--- a/src/pageEditor/tabs/effect/BlockConfiguration.tsx
+++ b/src/pageEditor/tabs/effect/BlockConfiguration.tsx
@@ -42,9 +42,9 @@ import { type FormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import ConfigurationTitle from "./ConfigurationTitle";
 
 const rootModeOptions = [
-  { label: "Inherit", value: "inherit" },
   { label: "Document", value: "document" },
   { label: "Element", value: "element" },
+  { label: "Inherit", value: "inherit" },
 ];
 
 const targetOptions: Array<Option<BlockWindow>> = [
@@ -94,8 +94,13 @@ const BlockConfiguration: React.FunctionComponent<{
     () => ({
       name: configName("root"),
       label: "Target Element",
-      description:
-        "The target element for the brick. Provide an element reference generated with the Element Reader, For Each Element, or Traverse Elements brick",
+      description: (
+        <span>
+          The target element for the brick. Provide element reference{" "}
+          <code>@input.element.ref</code>, or a reference generated with the
+          Element Reader, For-Each Element, or Traverse Elements brick
+        </span>
+      ),
       // If the field is visible, it's required
       isRequired: true,
       schema: {
@@ -171,7 +176,7 @@ const BlockConfiguration: React.FunctionComponent<{
               as={SelectWidget}
               options={rootModeOptions}
               blankValue="inherit"
-              description="The Root Mode controls which page element the brick targets. PixieBrix evaluates selectors relative to the root document/element"
+              description="The Root Mode controls the page element the brick targets. PixieBrix evaluates selectors relative to the root document/element"
             />
           )}
 

--- a/src/pageEditor/tabs/effect/BlockPreview.tsx
+++ b/src/pageEditor/tabs/effect/BlockPreview.tsx
@@ -157,6 +157,8 @@ const BlockPreview: React.FunctionComponent<{
 
   // This defaults to "inherit" as described in the doc, see BlockConfig.rootMode
   const blockRootMode = blockConfig.rootMode ?? "inherit";
+
+  // FIXME: this logic is wrong because For-Each Element can switch the root element
   const shouldUseExtensionPointRoot =
     blockInfo?.isRootAware &&
     blockRootMode === "inherit" &&
@@ -211,6 +213,14 @@ const BlockPreview: React.FunctionComponent<{
     return (
       <div className="text-muted">
         Output previews are not currently supported for renderers
+      </div>
+    );
+  }
+
+  if (blockConfig?.rootMode === "element") {
+    return (
+      <div className="text-muted">
+        Output Preview is not currently supported for Element Root Mode
       </div>
     );
   }

--- a/src/runtime/pipelineTests/root.test.ts
+++ b/src/runtime/pipelineTests/root.test.ts
@@ -179,7 +179,7 @@ describe.each([["v1"], ["v2"], ["v3"]])(
 
     test.each([rootBlock.id, rootReader.id])(
       "throw on multiple custom root matches: %s",
-      async () => {
+      async (blockId) => {
         const div = document.createElement("DIV");
         const element = document.createElement("IMG");
         div.append(element);
@@ -190,7 +190,7 @@ describe.each([["v1"], ["v2"], ["v3"]])(
         await expect(
           reducePipeline(
             // Force document as starting point for the selector
-            { id: rootBlock.id, config: {}, rootMode: "document", root: "img" },
+            { id: blockId, config: {}, rootMode: "document", root: "img" },
             { ...simpleInput({}), optionsArgs: {}, root: div },
             testOptions(apiVersion)
           )
@@ -200,11 +200,11 @@ describe.each([["v1"], ["v2"], ["v3"]])(
 
     test.each([rootBlock.id, rootReader.id])(
       "throw on no custom root matches: %s",
-      async () => {
+      async (blockId) => {
         await expect(
           reducePipeline(
             // Force document as starting point for the selector
-            { id: rootBlock.id, config: {}, rootMode: "document", root: "a" },
+            { id: blockId, config: {}, rootMode: "document", root: "a" },
             { ...simpleInput({}), optionsArgs: {} },
             testOptions(apiVersion)
           )
@@ -212,7 +212,7 @@ describe.each([["v1"], ["v2"], ["v3"]])(
       }
     );
 
-    test.each([rootBlock.id])("pass hard-coded root reference", async () => {
+    test("pass hard-coded root reference", async () => {
       const div = document.createElement("DIV");
       document.body.append(div);
 
@@ -231,7 +231,7 @@ describe.each([["v1"], ["v2"], ["v3"]])(
 );
 
 describe.each([["v3"]])("apiVersion: %s", (apiVersion: ApiVersion) => {
-  test.each([rootBlock.id])("pass templated root reference", async () => {
+  test("pass templated root reference", async () => {
     const div = document.createElement("DIV");
     document.body.append(div);
 

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -595,7 +595,12 @@ export async function blockReducer(
   };
 
   // Adjust the root according to the `root` and `rootMode` props on the blockConfig
-  const blockRoot = selectBlockRootElement(blockConfig, root);
+  const blockRoot = await selectBlockRootElement(
+    blockConfig,
+    root,
+    context,
+    options
+  );
 
   let renderedArgs: RenderedArgs;
   let renderError: unknown;

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -39,11 +39,15 @@ export function isUUID(uuid: string): uuid is UUID {
 // Sentinel UUID
 export const UNSET_UUID = validateUUID("00000000-0000-4000-A000-000000000000");
 
-export function validateUUID(uuid: string): UUID {
+export function validateUUID(uuid: unknown): UUID {
   if (uuid == null) {
     // We don't have strictNullChecks on, so null values will find there way here. We should pass them along. Eventually
     // we can remove this check as strictNullChecks will check the call site
     return uuid as UUID;
+  }
+
+  if (typeof uuid !== "string") {
+    throw new TypeError("Expected UUID to be a string");
   }
 
   if (isUUID(uuid)) {

--- a/src/validators/generic.ts
+++ b/src/validators/generic.ts
@@ -47,6 +47,7 @@ import refSchema from "@schemas/ref.json";
 import componentSchema from "@schemas/component.json";
 import pipelineSchema from "@schemas/pipeline.json";
 import databaseSchema from "@schemas/database.json";
+import elementSchema from "@schemas/element.json";
 import { resolveDefinitions } from "@/registry/internal";
 import type Lazy from "yup/lib/Lazy";
 import * as Yup from "yup";
@@ -74,6 +75,7 @@ const SCHEMA_URLS: Record<string, UnknownObject> = {
   "https://app.pixiebrix.com/schemas/ref": refSchema,
   "https://app.pixiebrix.com/schemas/innerDefinition": innerDefinitionSchema,
   "https://app.pixiebrix.com/schemas/database": databaseSchema,
+  "https://app.pixiebrix.com/schemas/element": elementSchema,
 };
 
 const BASE_SCHEMA_URI = "https://app.pixiebrix.com/schemas/";
@@ -117,6 +119,8 @@ export async function validateOutput(
 
   // @ts-expect-error: loading statically
   validator.addSchema(serviceSchema);
+  // @ts-expect-error: loading statically
+  validator.addSchema(elementSchema);
 
   return validator.validate(instance ?? null);
 }


### PR DESCRIPTION
## What does this PR do?

- Implementation of https://www.notion.so/pixiebrix/Explicitly-Referring-to-HTML-Elements-to-make-scraping-automation-use-cases-easier-df1415ba0cd149acb158bb0b9a0e395c

## What's Included

Phase 1
- [x] Slice 1a: element reference generation/record keeping
- [x] Slice 1b: adds element reference field to ElementReader
- [x] Slice 2: updates runtime to support `element` for rootMode
- [x] Slice 3: update inner extension points to provide the reader in `@input`
- [x] Slice 4: support `elementKey` in For Each Element brick
- [x] Slice 4: add unit tests for elementKey in For Each Element brick
- [x] Slice 5: add Element field to Page Editor
- [x] Slice 5: move rootMode fields next to target tab/frame field
- [x] Slice 5: show that preview is unavailable if root mode is element or inherit

Phase 2:
- [x] Slice 1: add Traverse Elements brick

## Discussion

- I turned off preview for "element" and "inherit" mode entirely. The "inherit" logic was not correct anymore because it didn't account for For-Each Element loops

## Future Work

- Re-enable preview pane for certain cases of "inherit" and "element"
- I was mistaken when writing the spec. The menu item extension point currently always passes the document as the reader root. So we're going to need to provide a way in the future to get which menu item was clicked: https://github.com/pixiebrix/pixiebrix-extension/blob/feature%2Fexplicit-element/src/extensionPoints/menuItemExtension.ts#L342-L342
- Update non-root aware bricks to be root-aware (e.g., show/hide, etc.). Draft spec here: https://www.notion.so/pixiebrix/Update-Non-Root-Aware-Bricks-to-be-Root-Aware-71011e4a523f41afa27dd84f085f7252

## Demo

- https://www.loom.com/share/a8e1d285a86b409c88b4ef118cf0cfe4

## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @BLoe 
