### PR TITLE
#4869: Detect mistaken polyfill import in pageScript.js

### DIFF
--- a/.github/actions/upload-zipped-artifact/action.yml
+++ b/.github/actions/upload-zipped-artifact/action.yml
@@ -35,7 +35,7 @@ runs:
         directory: ${{ inputs.directory }}
         exclusions: ${{ inputs.exclusions }}
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.name }}-artifact
         path: ${{ inputs.directory }}/${{ inputs.name }}.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           attempt_delay: 15000
           attempt_limit: 40
 
-  build-stage:
+  build:
     runs-on: ubuntu-latest
     env:
       SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com
@@ -79,10 +79,14 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
+      # The polyfill cannot be used outside the extension context
+      - run: "! grep 'loaded in a browser extension' dist/pageScript.js"
+        name: Detect browser-polyfill in pageScript.js
+
       - uses: actions/upload-artifact@v3
         name: Save report.html
         with:
-          name: staging-build-size
+          name: build-staging-bundle-dependency-report
           path: report.html
           retention-days: 5
           if-no-files-found: error

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isExtensionContext } from "webext-detect-page";
 import { forbidContext } from "@/utils/expectContext";
 import { type JsonValue } from "type-fest";
 import { type UnknownObject } from "@/types";
@@ -39,10 +38,6 @@ export type ManualStorageKey = string & {
 export type ReduxStorageKey = string & {
   _reduxStorageKeyBrand: never;
 };
-
-export function isBrowserSidebar(): boolean {
-  return isExtensionContext() && location.pathname === "/sidebar.html";
-}
 
 export function setChromeExtensionId(extensionId = ""): void {
   forbidContext("extension");

--- a/src/utils/expectContext.ts
+++ b/src/utils/expectContext.ts
@@ -15,13 +15,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isBrowserSidebar } from "@/chrome";
 import {
   isBackground,
   isContentScript,
   isExtensionContext,
   isWebPage,
 } from "webext-detect-page";
+
+export function isBrowserSidebar(): boolean {
+  return isExtensionContext() && location.pathname === "/sidebar.html";
+}
 
 /**
  * Accepts 'This is my error' | new Error('This is my error') | Error;


### PR DESCRIPTION
## What does this PR do?

- Avoids importing the polyfill in pageScript.js
- Adds a simple detection on CI to avoid the same issue in the future

### Issues

- Permanently fixes #4869 
- Related to https://github.com/pixiebrix/pixiebrix-extension/pull/2671

## Review suggestions

Notice how the first commit fails because it correctly detects the existing issue and how the second one passes because the issue has been fixed.


## Future Work

If we ever get around to full automatic code splitting, a grep-based approach will no longer be enough:

- https://github.com/pixiebrix/pixiebrix-extension/pull/2676
