### PR TITLE
Fix "unmounted component" warning in sidebar

### DIFF
--- a/src/blocks/effects/wait.ts
+++ b/src/blocks/effects/wait.ts
@@ -18,8 +18,9 @@
 import { Effect } from "@/types";
 import { type BlockArg, type BlockOptions, type Schema } from "@/core";
 import { awaitElementOnce } from "@/extensionPoints/helpers";
-import { runInMillis, sleep, TimeoutError } from "@/utils";
+import { sleep } from "@/utils";
 import { BusinessError } from "@/errors/businessErrors";
+import pTimeout, { TimeoutError } from "p-timeout";
 
 export class WaitEffect extends Effect {
   constructor() {
@@ -107,7 +108,7 @@ export class WaitElementEffect extends Effect {
     if (maxWaitMillis > 0) {
       const [promise, cancel] = awaitElementOnce(selector);
       try {
-        await runInMillis(async () => promise, maxWaitMillis);
+        await pTimeout(promise, { milliseconds: maxWaitMillis });
       } catch (error) {
         cancel();
 

--- a/src/components/DelayedRender.tsx
+++ b/src/components/DelayedRender.tsx
@@ -25,6 +25,8 @@ type Props = {
 /** Component used to reduce flashing */
 const DelayedRender: React.FC<Props> = ({ children, millis }) => {
   const isShown = useTimeoutState(millis);
+  // The hidden element allows us to preload the content (and images) while hidden.
+  // Replacing this with `null` defeats the purpose of this component
   return isShown ? <>{children}</> : <div hidden>{children}</div>;
 };
 

--- a/src/hooks/useTimeoutState.test.ts
+++ b/src/hooks/useTimeoutState.test.ts
@@ -15,17 +15,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useState } from "react";
+import { sleep } from "@/utils";
+import { renderHook, act } from "@testing-library/react-hooks";
+import useTimeoutState from "./useTimeoutState";
 
-export default function useTimeoutState(millis: number): boolean {
-  const [state, setState] = useState(false);
+test("useTimeoutState", async () => {
+  const { result } = renderHook(() => useTimeoutState(200));
 
-  useEffect(() => {
-    const timer = setTimeout(setState, millis, true);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [millis]);
-
-  return state;
-}
+  expect(result.current).toEqual(false);
+  await act(async () => sleep(30));
+  expect(result.current).toEqual(false);
+  await act(async () => sleep(300));
+  expect(result.current).toEqual(true);
+});

--- a/src/hooks/useTimeoutState.test.ts
+++ b/src/hooks/useTimeoutState.test.ts
@@ -15,16 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { sleep } from "@/utils";
-import { renderHook, act } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react-hooks";
 import useTimeoutState from "./useTimeoutState";
 
-test("useTimeoutState", async () => {
+jest.useFakeTimers();
+
+test("useTimeoutState", () => {
   const { result } = renderHook(() => useTimeoutState(200));
 
   expect(result.current).toEqual(false);
-  await act(async () => sleep(30));
+  jest.advanceTimersByTime(30);
   expect(result.current).toEqual(false);
-  await act(async () => sleep(300));
+  jest.advanceTimersByTime(300);
   expect(result.current).toEqual(true);
 });

--- a/src/hooks/useTimeoutState.ts
+++ b/src/hooks/useTimeoutState.ts
@@ -15,17 +15,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
-import useTimeoutState from "@/hooks/useTimeoutState";
+import { useEffect, useState } from "react";
 
-type Props = {
-  millis: number;
-};
+export default function useTimeoutState(millis: number): boolean {
+  const [state, setState] = useState(false);
 
-/** Component used to reduce flashing */
-const DelayedRender: React.FC<Props> = ({ children, millis }) => {
-  const isShown = useTimeoutState(millis);
-  return isShown ? <>{children}</> : <div hidden>{children}</div>;
-};
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setState(true);
+    }, millis);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [millis]);
 
-export default DelayedRender;
+  return state;
+}

--- a/src/pageEditor/ErrorBanner.tsx
+++ b/src/pageEditor/ErrorBanner.tsx
@@ -20,7 +20,7 @@ import { Button } from "react-bootstrap";
 import { getErrorMessage, isSpecificError } from "@/errors/errorHelpers";
 import { useSelector } from "react-redux";
 import { selectTabStateError } from "@/pageEditor/tabState/tabStateSelectors";
-import { TimeoutError } from "@/utils";
+import { TimeoutError } from "p-timeout";
 
 /**
  * Error banner for Page Editor browser connection errors.

--- a/src/pageScript/pageScript.ts
+++ b/src/pageScript/pageScript.ts
@@ -47,7 +47,7 @@ import {
   type WritePayload,
   initialize,
 } from "@/pageScript/protocol";
-import { awaitValue, TimeoutError } from "@/utils";
+import { awaitValue } from "@/utils";
 import {
   type ReadableComponentAdapter,
   traverse,
@@ -61,6 +61,7 @@ import {
   type ReadProxy,
 } from "@/runtime/pathHelpers";
 import { type UnknownObject } from "@/types";
+import { TimeoutError } from "p-timeout";
 
 const JQUERY_WINDOW_PROP = "$$jquery";
 const PAGESCRIPT_SYMBOL = Symbol.for("pixiebrix-page-script");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,7 @@ import { type UnknownObject } from "@/types";
 import { type RecipeDefinition } from "@/types/definitions";
 import safeJsonStringify from "json-stringify-safe";
 import pMemoize from "p-memoize";
+import { TimeoutError } from "p-timeout";
 
 const specialCharsRegex = /[\s.[\]]/;
 
@@ -165,10 +166,6 @@ export const sleep = async (milliseconds: number): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, milliseconds);
   });
-
-export class TimeoutError extends Error {
-  override name = "TimeoutError";
-}
 
 export async function awaitValue<T>(
   valueFactory: () => T,
@@ -475,23 +472,6 @@ export function getProperty<TResult = unknown>(
     // eslint-disable-next-line security/detect-object-injection
     return obj[property] as TResult;
   }
-}
-
-export async function runInMillis<TResult>(
-  factory: () => Promise<TResult>,
-  maxMillis: number
-): Promise<TResult> {
-  const timeout = Symbol("timeout");
-  const value = await Promise.race([
-    factory(),
-    sleep(maxMillis).then(() => timeout),
-  ]);
-
-  if (value === timeout) {
-    throw new TimeoutError(`Method did not complete in ${maxMillis}ms`);
-  }
-
-  return value as TResult;
 }
 
 /** Loop an iterable with the ability to place `await` in the loop itself */


### PR DESCRIPTION
Opening the sidebar causes this warning to appear in the console:

> Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function

I took the opportunity to:

- add `useTimeoutState` to implement this stuff the right way + add tests
- drop a duplicate timeout function

## Checklist

- [x] Add tests

