### PR TITLE
#4812: Drop "check storybook" checkbox from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,5 +35,4 @@ _Leave all that are relevant and check off as completed_
 ## Checklist
 
 - [ ] Add tests
-- [ ] Run Storybook and manually confirm that all stories are working
 - [ ] Designate a primary reviewer


### PR DESCRIPTION
Should we drop this from the PR checklist thanks to:

- #4812