### PR TITLE
Support uiSchema for bricks/services and sort YAML-brick input fields if no uiSchema present

### DIFF
--- a/schemas/component.json
+++ b/schemas/component.json
@@ -19,6 +19,18 @@
     "inputSchema": {
       "$ref": "http://json-schema.org/draft-07/schema#"
     },
+    "uiSchema": {
+      "type": "object",
+      "description": "An RJSF UI schema for the inputSchema",
+      "properties": {
+        "ui:order": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "outputSchema": {
       "$ref": "http://json-schema.org/draft-07/schema#"
     },

--- a/schemas/component.json
+++ b/schemas/component.json
@@ -29,7 +29,8 @@
             "type": "string"
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "outputSchema": {
       "$ref": "http://json-schema.org/draft-07/schema#"

--- a/schemas/service.json
+++ b/schemas/service.json
@@ -42,6 +42,19 @@
     },
     "metadata": { "$ref": "https://app.pixiebrix.com/schemas/metadata#" },
     "inputSchema": { "$ref": "http://json-schema.org/draft-07/schema#" },
+    "uiSchema": {
+      "type": "object",
+      "description": "An RJSF UI schema for the inputSchema",
+      "properties": {
+        "ui:order": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "isAvailable": {
       "type": "object",
       "properties": {

--- a/src/blocks/transformers/blockFactory.test.js
+++ b/src/blocks/transformers/blockFactory.test.js
@@ -19,7 +19,7 @@ import nytimes from "@contrib/blocks/nytimes-org.yaml";
 import trelloReader from "@contrib/readers/trello-card-reader.yaml";
 import { fromJS } from "@/blocks/transformers/blockFactory";
 import { InvalidDefinitionError } from "@/errors/businessErrors";
-import { isUserDefinedBlock } from "../../core";
+import { isUserDefinedBlock } from "@/core";
 import { MappingTransformer } from "./mapping";
 
 test("two plus two is four", () => {

--- a/src/blocks/transformers/blockFactory.test.js
+++ b/src/blocks/transformers/blockFactory.test.js
@@ -19,6 +19,8 @@ import nytimes from "@contrib/blocks/nytimes-org.yaml";
 import trelloReader from "@contrib/readers/trello-card-reader.yaml";
 import { fromJS } from "@/blocks/transformers/blockFactory";
 import { InvalidDefinitionError } from "@/errors/businessErrors";
+import { isUserDefinedBlock } from "../../core";
+import { MappingTransformer } from "./mapping";
 
 test("two plus two is four", () => {
   expect(2 + 2).toBe(4);
@@ -54,4 +56,14 @@ test("reject invalid fixture fixture", async () => {
   } catch (error) {
     expect(error).toBeInstanceOf(InvalidDefinitionError);
   }
+});
+
+describe("isUserDefinedBlock", () => {
+  test("is detected as user-defined block", () => {
+    expect(isUserDefinedBlock(fromJS(nytimes))).toBe(true);
+  });
+
+  test("is detected as built-in block", () => {
+    expect(isUserDefinedBlock(new MappingTransformer())).toBe(false);
+  });
 });

--- a/src/blocks/transformers/blockFactory.ts
+++ b/src/blocks/transformers/blockFactory.ts
@@ -33,6 +33,7 @@ import {
   type RegistryId,
   type Schema,
   type SemVerString,
+  type UiSchema,
 } from "@/core";
 import { dereference } from "@/validators/generic";
 import blockSchema from "@schemas/component.json";
@@ -50,7 +51,16 @@ type ComponentConfig = {
   defaultOptions: Record<string, string>;
   pipeline: BlockConfig | BlockPipeline;
   inputSchema: Schema;
+  /**
+   * An optional RJSF uiSchema for inputs.
+   *
+   * Currently only supports the ui:order property.
+   *
+   * @since 1.7.16
+   */
+  uiSchema?: UiSchema;
   outputSchema?: Schema;
+
   // Mapping from `key` -> `serviceId`
   services?: Record<string, RegistryId>;
 };
@@ -84,6 +94,8 @@ class ExternalBlock extends Block {
 
   readonly inputSchema: Schema;
 
+  readonly uiSchema?: UiSchema;
+
   readonly version: SemVerString;
 
   constructor(component: ComponentConfig) {
@@ -92,6 +104,7 @@ class ExternalBlock extends Block {
     this.apiVersion = component.apiVersion ?? "v1";
     this.component = component;
     this.inputSchema = this.component.inputSchema;
+    this.uiSchema = this.component.uiSchema;
     this.outputSchema = this.component.outputSchema;
     this.version = version;
   }

--- a/src/components/fields/schemaFields/genericOptionsFactory.test.ts
+++ b/src/components/fields/schemaFields/genericOptionsFactory.test.ts
@@ -68,7 +68,8 @@ describe("sortedFields", () => {
     ).toStrictEqual(["bbb", "aaa"]);
   });
 
-  test("it sorts by uiSchema order", () => {
+  test("it sorts by uiSchema order with missing entry", () => {
+    // Unlike RFSJ, don't throw an error if an entry is missing. Just throw it at the end
     expect(
       sortedFields(
         {
@@ -87,6 +88,27 @@ describe("sortedFields", () => {
         }
       ).map((x) => x.prop)
     ).toStrictEqual(["bbb", "aaa", "ccc"]);
+  });
+
+  test("it sorts by uiSchema *", () => {
+    expect(
+      sortedFields(
+        {
+          aaa: {
+            type: "string",
+          },
+          ccc: {
+            type: "string",
+          },
+          bbb: {
+            type: "string",
+          },
+        } as Schema,
+        {
+          "ui:order": ["*", "aaa"],
+        }
+      ).map((x) => x.prop)
+    ).toStrictEqual(["bbb", "ccc", "aaa"]);
   });
 
   test("it sorts optional fields", () => {

--- a/src/components/fields/schemaFields/genericOptionsFactory.test.ts
+++ b/src/components/fields/schemaFields/genericOptionsFactory.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { sortedFields } from "@/components/fields/schemaFields/genericOptionsFactory";
+import { type Schema } from "@/core";
+
+describe("sortedFields", () => {
+  test("it sorts by type first", () => {
+    expect(
+      sortedFields(
+        {
+          aaa: {
+            type: "string",
+          },
+          zzz: {
+            $ref: "https://app.pixiebrix.com/schemas/services/serpapi/api",
+          },
+        } as Schema,
+        {}
+      ).map((x) => x.prop)
+    ).toStrictEqual(["zzz", "aaa"]);
+  });
+
+  test("it sorts by database type first", () => {
+    expect(
+      sortedFields(
+        {
+          aaa: {
+            type: "string",
+          },
+          zzz: {
+            $ref: "https://app.pixiebrix.com/schemas/database#",
+          },
+        } as Schema,
+        {}
+      ).map((x) => x.prop)
+    ).toStrictEqual(["zzz", "aaa"]);
+  });
+
+  test("it prefers title", () => {
+    expect(
+      sortedFields(
+        {
+          aaa: {
+            type: "string",
+            title: "ZZZ",
+          },
+          bbb: {
+            type: "string",
+          },
+        } as Schema,
+        {}
+      ).map((x) => x.prop)
+    ).toStrictEqual(["bbb", "aaa"]);
+  });
+
+  test("it sorts by uiSchema order", () => {
+    expect(
+      sortedFields(
+        {
+          aaa: {
+            type: "string",
+          },
+          ccc: {
+            type: "string",
+          },
+          bbb: {
+            type: "string",
+          },
+        } as Schema,
+        {
+          "ui:order": ["bbb", "aaa"],
+        }
+      ).map((x) => x.prop)
+    ).toStrictEqual(["bbb", "aaa", "ccc"]);
+  });
+
+  test("it sorts optional fields", () => {
+    expect(
+      sortedFields(
+        {
+          type: "object",
+          required: ["ccc"],
+          properties: {
+            aaa: {
+              type: "string",
+            },
+            ccc: {
+              type: "string",
+            },
+            bbb: {
+              type: "string",
+              default: "foo",
+            },
+          },
+        } as Schema,
+        {}
+      ).map((x) => x.prop)
+    ).toStrictEqual(["bbb", "ccc", "aaa"]);
+  });
+
+  it("preserveSchemaOrder", () => {
+    expect(
+      sortedFields(
+        {
+          ccc: {
+            type: "string",
+          },
+          aaa: {
+            type: "string",
+          },
+        } as Schema,
+        {},
+        { preserveSchemaOrder: true }
+      ).map((x) => x.prop)
+    ).toStrictEqual(["ccc", "aaa"]);
+  });
+});

--- a/src/components/fields/schemaFields/genericOptionsFactory.tsx
+++ b/src/components/fields/schemaFields/genericOptionsFactory.tsx
@@ -134,7 +134,7 @@ function genericOptionsFactory(
     return NoOptions;
   }
 
-  const sortedFieldsConfig = sortedFields(optionSchema, uiSchema, {
+  const sortedFieldsConfig = sortedFields(schema, uiSchema, {
     preserveSchemaOrder,
   });
 

--- a/src/components/fields/schemaFields/genericOptionsFactory.tsx
+++ b/src/components/fields/schemaFields/genericOptionsFactory.tsx
@@ -18,10 +18,14 @@
 import React from "react";
 import { inputProperties } from "@/helpers";
 import { type Schema, type UiSchema } from "@/core";
-import { isEmpty } from "lodash";
+import { isEmpty, sortBy } from "lodash";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { joinName } from "@/utils";
 import pipelineSchema from "@schemas/pipeline.json";
+import {
+  isDatabaseField,
+  isServiceField,
+} from "@/components/fields/schemaFields/fieldTypeCheckers";
 
 export type BlockOptionProps = {
   /**
@@ -40,19 +44,55 @@ const NoOptions: React.FunctionComponent = () => (
   <div>No options available</div>
 );
 
-/**
- * Return the Options fields for configuring a block with the given schema.
- */
-function genericOptionsFactory(
-  schema: Schema,
-  uiSchema?: UiSchema
-): React.FunctionComponent<BlockOptionProps> {
-  const optionSchema = inputProperties(schema);
-  if (isEmpty(optionSchema)) {
-    return NoOptions;
-  }
+type FieldConfig = {
+  prop: string;
+  isRequired: boolean;
+  fieldSchema: Schema;
+  propUiSchema: unknown;
+};
 
-  const fieldsConfig = Object.entries(optionSchema)
+export function sortedFields(
+  schema: Schema,
+  uiSchema: UiSchema | null,
+  { preserveSchemaOrder = false }: { preserveSchemaOrder?: boolean } = {}
+): FieldConfig[] {
+  const optionSchema = inputProperties(schema);
+
+  const order = uiSchema?.["ui:order"] ?? ["*"];
+  const asteriskIndex = order.indexOf("*");
+
+  const uiSchemaOrder = (field: FieldConfig) => {
+    // https://react-jsonschema-form.readthedocs.io/en/docs/usage/objects/#specifying-property-order
+    const propIndex = order.indexOf(field.prop);
+    const index = propIndex === -1 ? asteriskIndex : propIndex;
+    return index === -1 ? order.length : index;
+  };
+
+  const fieldTypeOrder = (field: FieldConfig) => {
+    // Integration configurations
+    if (isServiceField(field.fieldSchema)) {
+      return 0;
+    }
+
+    // Databases
+    if (isDatabaseField(field.fieldSchema)) {
+      return 1;
+    }
+
+    // Required fields, and fields that will have input values pre-filled
+    if (field.isRequired || field.fieldSchema.default != null) {
+      return 2;
+    }
+
+    // Optional fields that are excluded by default
+    return Number.MAX_SAFE_INTEGER;
+  };
+
+  // Order by label
+  const labelOrder = (field: FieldConfig) =>
+    (field.fieldSchema.title ?? field.prop).toLowerCase();
+
+  const fields: FieldConfig[] = Object.entries(optionSchema)
     .filter(
       ([, fieldSchema]) =>
         typeof fieldSchema === "object" &&
@@ -65,23 +105,52 @@ function genericOptionsFactory(
 
       return {
         prop,
-        fieldSchema,
+        isRequired: schema.required?.includes(prop),
+        // The fieldSchema type has been filtered so its safe to assume it is Schema
+        fieldSchema: fieldSchema as Schema,
         propUiSchema,
       };
     });
 
+  return preserveSchemaOrder && isEmpty(uiSchema)
+    ? fields
+    : sortBy(fields, uiSchemaOrder, fieldTypeOrder, labelOrder);
+}
+
+/**
+ * Return the Options fields for configuring a block with the given schema.
+ *
+ * @param schema the JSONSchema for the block configuration
+ * @param uiSchema an optional RJSF UISchema for the block configuration
+ * @param preserveSchemaOrder if true, preserve order of the schema properties if no uiSchema is provided
+ */
+function genericOptionsFactory(
+  schema: Schema,
+  uiSchema: UiSchema = {},
+  { preserveSchemaOrder = false }: { preserveSchemaOrder?: boolean } = {}
+): React.FunctionComponent<BlockOptionProps> {
+  const optionSchema = inputProperties(schema);
+  if (isEmpty(optionSchema)) {
+    return NoOptions;
+  }
+
+  const sortedFieldsConfig = sortedFields(optionSchema, uiSchema, {
+    preserveSchemaOrder,
+  });
+
   const OptionsFields = ({ name, configKey }: BlockOptionProps) => (
     <>
-      {fieldsConfig.map(({ prop, fieldSchema, propUiSchema }) => (
-        <SchemaField
-          key={prop}
-          name={joinName(name, configKey, prop)}
-          // The fieldSchema type has been filtered and is safe to assume it is Schema
-          schema={fieldSchema as Schema}
-          isRequired={schema.required?.includes(prop)}
-          uiSchema={propUiSchema}
-        />
-      ))}
+      {sortedFieldsConfig.map(
+        ({ prop, fieldSchema, propUiSchema, isRequired }) => (
+          <SchemaField
+            key={prop}
+            name={joinName(name, configKey, prop)}
+            schema={fieldSchema}
+            isRequired={isRequired}
+            uiSchema={propUiSchema}
+          />
+        )
+      )}
     </>
   );
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -945,6 +945,12 @@ export interface IService<
 > extends Metadata {
   schema: Schema;
 
+  /**
+   * A uiSchema for the service configuration.
+   * @since 1.7.16
+   */
+  uiSchema?: UiSchema;
+
   isOAuth2: boolean;
 
   isAuthorizationGrant: boolean;

--- a/src/core.ts
+++ b/src/core.ts
@@ -747,6 +747,15 @@ export interface IBlock extends Metadata {
   /** A JSON schema of the inputs for the block */
   inputSchema: Schema;
 
+  /**
+   * An optional UiSchema for the inputs for the block
+   *
+   * Currently only ui:order is supported.
+   *
+   * @since 1.7.16
+   */
+  uiSchema?: UiSchema;
+
   /** An optional a JSON schema for the output of the block */
   outputSchema?: Schema;
 
@@ -799,6 +808,17 @@ export interface IBlock extends Metadata {
   defaultOutputKey?: string;
 
   run: (value: BlockArg, options: BlockOptions) => Promise<unknown>;
+}
+
+/**
+ * Returns `true` if block is a user-defined block (i.e., defined in YAML not JS).
+ * @param block the block
+ * @see ExternalBlock
+ */
+export function isUserDefinedBlock(block: IBlock): boolean {
+  // YAML-defined blocks have a .component property added by the ExternalBlock class
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- don't want to introduce circular dependency
+  return Boolean((block as any)?.component);
 }
 
 export type ReaderOutput = Record<string, unknown>;

--- a/src/hooks/useBlockOptions.ts
+++ b/src/hooks/useBlockOptions.ts
@@ -20,7 +20,7 @@ import { useMemo, useState } from "react";
 import genericOptionsFactory, {
   type BlockOptionProps,
 } from "@/components/fields/schemaFields/genericOptionsFactory";
-import { type IBlock, type RegistryId } from "@/core";
+import { type IBlock, isUserDefinedBlock, type RegistryId } from "@/core";
 import blockRegistry from "@/blocks/registry";
 import { useAsyncEffect } from "use-async-effect";
 import reportError from "@/telemetry/reportError";
@@ -61,11 +61,17 @@ function useBlockOptions(
     // or the config parameters of the past block will become part of the configuration of the new block.
     if (id === block?.id) {
       const registered = optionsRegistry.get(block.id);
-      return registered ?? genericOptionsFactory(block.inputSchema);
+      return (
+        registered ??
+        genericOptionsFactory(block.inputSchema, block.uiSchema, {
+          // Preserve order for JS-based bricks. We can trust the order because JS literals preserve dictionary order
+          preserveSchemaOrder: !isUserDefinedBlock(block),
+        })
+      );
     }
 
     return null;
-  }, [id, block?.id, block?.inputSchema]);
+  }, [id, block]);
 
   return [{ block, error }, BlockOptions];
 }

--- a/src/options/pages/services/ServiceEditorModal.tsx
+++ b/src/options/pages/services/ServiceEditorModal.tsx
@@ -78,7 +78,7 @@ const ServiceEditorModal: React.FunctionComponent<OwnProps> = ({
       return optionsRegistry.get(service.id);
     }
 
-    return genericOptionsFactory(service.schema);
+    return genericOptionsFactory(service.schema, service.uiSchema);
   }, [service]);
 
   const schemaPromise = useMemo(


### PR DESCRIPTION
## What does this PR do?

- Implementation of https://www.notion.so/pixiebrix/Brick-Configuration-Input-Ordering-b09c9a93c3d64f98b463ddafd6e395fb
- Add support for uiSchema field with `ui:order` in brick definitions and service definitions
- If no `ui:order` provided for a YAML brick, apply default input field order rules

## Remaining Tasks

- [x] Fix existing test snapshots

## Demo

- https://www.loom.com/share/3d199ce41d4146fb9434efc38160c339

## Future Work

- Create an app PR to support uiSchema on bricks and services. (Requires JSON Schema update): https://github.com/pixiebrix/pixiebrix-app/pull/2813
- Update the app front-end to use service uiSchema for the ServiceEditorModal

## Checklist

- [x] Add tests
- [x] Run Storybook and manually confirm that all stories are working
- [x] Designate a primary reviewer: @BLoe 
