### PR TITLE
#4899: disable autosuggest in service configuration

### DIFF
--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
@@ -64,7 +64,12 @@ const TemplateToggleWidget: React.VFC<TemplateToggleWidgetProps> = ({
   useEffect(() => {
     setFocusInput(false);
     setFieldDescription(selectedOption?.description);
-  }, [inputMode, inputModeOptions, setFieldDescription]);
+  }, [
+    inputMode,
+    inputModeOptions,
+    setFieldDescription,
+    selectedOption?.description,
+  ]);
 
   const onModeChange = useCallback(
     (newInputMode: FieldInputMode) => {

--- a/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
@@ -26,6 +26,7 @@ import { useSelector } from "react-redux";
 import { selectSettings } from "@/store/settingsSelectors";
 import { joinName } from "@/utils";
 import fitTextarea from "fit-textarea";
+import { type UnknownObject } from "@/types";
 
 type VarPopupProps = {
   inputMode: FieldInputMode;
@@ -34,6 +35,11 @@ type VarPopupProps = {
   setValue: (value: string) => void;
 };
 
+// A bit of hack to determine if we're in a context where autosuggest is supported. Used to prevent autosuggest from
+// breaking service configuration.
+const selectAnalysisSliceExists = (state: UnknownObject) =>
+  Boolean(state.analysis);
+
 const VarPopup: React.FunctionComponent<VarPopupProps> = ({
   inputMode,
   inputElementRef,
@@ -41,9 +47,10 @@ const VarPopup: React.FunctionComponent<VarPopupProps> = ({
   setValue,
 }) => {
   const [showMenu, setShowMenu] = useState(false);
-
+  const analysisSliceExists = useSelector(selectAnalysisSliceExists);
   const { varAnalysis, varAutosuggest } = useSelector(selectSettings);
-  const autosuggestEnabled = varAnalysis && varAutosuggest;
+  const autosuggestEnabled =
+    varAnalysis && varAutosuggest && analysisSliceExists;
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## What does this PR do?

- Closes #4899 
- Disables variable autosuggest in locations where analysis is available (because VarPopup errors out when the user types a `@`)

## Discussion

- This could have alternatively checked to see if the component was running in the dev tools context. The check for an analysis slice is conceptually cleaner

## Checklist

- Add tests: @BALEHOK will need to add tests in the future for triggering the var popup
- [x] Designate a primary reviewer: @BLoe 
