### PR TITLE
Add highlight text brick

### DIFF
--- a/src/blocks/effects/highlightText.test.ts
+++ b/src/blocks/effects/highlightText.test.ts
@@ -166,4 +166,22 @@ describe("ReplaceTextEffect", () => {
       '<div><mark style="background-color: yellow;">foo</mark>bar<mark style="background-color: yellow;">foo</mark></div>'
     );
   });
+
+  test("sanitize HTML", async () => {
+    const document = getDocument("<div>foobar</div>");
+    const brick = new HighlightText();
+
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "[fo]+",
+        isRegex: true,
+        color: '"<script>alert("xss")</script>',
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toEqual(
+      '<div><mark style="background-color:">alert("xss");"&gt;foo</mark>bar</div>'
+    );
+  });
 });

--- a/src/blocks/effects/highlightText.test.ts
+++ b/src/blocks/effects/highlightText.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { JSDOM } from "jsdom";
+import ConsoleLogger from "@/utils/ConsoleLogger";
+import { uuidv4 } from "@/types/helpers";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import HighlightText from "@/blocks/effects/highlightText";
+import { type BlockOptions } from "@/core";
+
+function getDocument(html: string): Document {
+  return new JSDOM(html).window.document;
+}
+
+const logger = new ConsoleLogger({
+  extensionId: uuidv4(),
+});
+
+describe("ReplaceTextEffect", () => {
+  test.each([[undefined], ["yellow"]])(
+    "replace text beginning of div with color: %s",
+    async (color) => {
+      const document = getDocument("<div>foobar</div>");
+      const brick = new HighlightText();
+      await brick.run(
+        unsafeAssumeValidArg({
+          pattern: "foo",
+          color,
+        }),
+        { logger, root: document } as BlockOptions
+      );
+
+      expect(document.body.innerHTML).toEqual(
+        '<div><mark style="background-color: yellow;">foo</mark>bar</div>'
+      );
+    }
+  );
+
+  test("replace text end of div", async () => {
+    const document = getDocument("<div>foobar</div>");
+    const brick = new HighlightText();
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "bar",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toEqual(
+      '<div>foo<mark style="background-color: yellow;">bar</mark></div>'
+    );
+  });
+
+  test("replace middle of div", async () => {
+    const document = getDocument("<div>foobar</div>");
+    const brick = new HighlightText();
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "oba",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toEqual(
+      '<div>fo<mark style="background-color: yellow;">oba</mark>r</div>'
+    );
+  });
+
+  test("don't re-highlight text", async () => {
+    const document = getDocument("<div>foobar</div>");
+    const brick = new HighlightText();
+
+    for (let i = 0; i < 2; i++) {
+      // eslint-disable-next-line no-await-in-loop -- running in sequence
+      await brick.run(
+        unsafeAssumeValidArg({
+          pattern: "foo",
+        }),
+        { logger, root: document } as BlockOptions
+      );
+    }
+
+    expect(document.body.innerHTML).toEqual(
+      '<div><mark style="background-color: yellow;">foo</mark>bar</div>'
+    );
+  });
+
+  test("don't re-highlight text with selector matching multiple levels", async () => {
+    const document = getDocument("<div><div>foobar</div></div>");
+    const brick = new HighlightText();
+
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "foo",
+        selector: "div",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toEqual(
+      '<div><div><mark style="background-color: yellow;">foo</mark>bar</div></div>'
+    );
+  });
+
+  test("highlight regex", async () => {
+    const document = getDocument("<div>foobar</div>");
+    const brick = new HighlightText();
+
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "[fo]+",
+        isRegex: true,
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toEqual(
+      '<div><mark style="background-color: yellow;">foo</mark>bar</div>'
+    );
+  });
+
+  test("highlight with hex code", async () => {
+    const document = getDocument("<div>foobar</div>");
+    const brick = new HighlightText();
+
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "foo",
+        color: "#A020F0",
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toEqual(
+      '<div><mark style="background-color: #A020F0;">foo</mark>bar</div>'
+    );
+  });
+
+  test("highlight multiple regex", async () => {
+    const document = getDocument("<div>foobarfoo</div>");
+    const brick = new HighlightText();
+
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "[fo]+",
+        isRegex: true,
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toEqual(
+      '<div><mark style="background-color: yellow;">foo</mark>bar<mark style="background-color: yellow;">foo</mark></div>'
+    );
+  });
+});

--- a/src/blocks/effects/highlightText.test.ts
+++ b/src/blocks/effects/highlightText.test.ts
@@ -167,6 +167,23 @@ describe("ReplaceTextEffect", () => {
     );
   });
 
+  test("multiple elements", async () => {
+    const document = getDocument("<div><div>foo</div><div>foo</div></div>");
+    const brick = new HighlightText();
+
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: "[fo]+",
+        isRegex: true,
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toEqual(
+      '<div><div><mark style="background-color: yellow;">foo</mark></div><div><mark style="background-color: yellow;">foo</mark></div></div>'
+    );
+  });
+
   test("sanitize HTML", async () => {
     const document = getDocument("<div>foobar</div>");
     const brick = new HighlightText();

--- a/src/blocks/effects/highlightText.test.ts
+++ b/src/blocks/effects/highlightText.test.ts
@@ -184,7 +184,7 @@ describe("ReplaceTextEffect", () => {
     );
   });
 
-  test("sanitize HTML", async () => {
+  test("sanitize color HTML", async () => {
     const document = getDocument("<div>foobar</div>");
     const brick = new HighlightText();
 
@@ -198,7 +198,27 @@ describe("ReplaceTextEffect", () => {
     );
 
     expect(document.body.innerHTML).toEqual(
-      '<div><mark style="background-color:">alert("xss");"&gt;foo</mark>bar</div>'
+      '<div><mark style="background-color: &quot;<script>alert(&quot;xss&quot;)</script>;">foo</mark>bar</div>'
+    );
+  });
+
+  test("sanitize HTML", async () => {
+    const document = getDocument("<div>foobar</div>");
+    document.querySelector("div").textContent = "<script>alert('xss')</script>";
+
+    const brick = new HighlightText();
+
+    await brick.run(
+      unsafeAssumeValidArg({
+        pattern: ".+",
+        isRegex: true,
+      }),
+      { logger, root: document } as BlockOptions
+    );
+
+    expect(document.body.innerHTML).toEqual(
+      // The text content was sanitized
+      '<div><mark style="background-color: yellow;"></mark></div>'
     );
   });
 });

--- a/src/blocks/effects/highlightText.ts
+++ b/src/blocks/effects/highlightText.ts
@@ -43,6 +43,8 @@ export function wrapText({
 
   let currentNode: Node | null;
 
+  const replacements = [];
+
   while ((currentNode = walker.nextNode())) {
     if (visited.has(currentNode)) {
       // Avoid running replaceText on same node twice if selector passed to brick matches multiple nodes
@@ -72,7 +74,18 @@ export function wrapText({
 
     div.innerHTML = sanitize(innerHTML);
     fragment.append(...div.childNodes);
-    currentNode.parentNode.replaceChild(fragment, currentNode);
+
+    // Can't replace in the treeWalker loop
+    replacements.push({
+      parentNode: currentNode.parentNode,
+      currentNode,
+      fragment,
+    });
+  }
+
+  for (const { parentNode, fragment, currentNode } of replacements) {
+    // eslint-disable-next-line unicorn/prefer-modern-dom-apis -- currentNode is text node not element
+    parentNode.replaceChild(fragment, currentNode);
   }
 }
 

--- a/src/blocks/effects/highlightText.ts
+++ b/src/blocks/effects/highlightText.ts
@@ -19,6 +19,7 @@ import { Effect } from "@/types";
 import { type BlockArg, type BlockOptions, type Schema } from "@/core";
 import { $safeFind } from "@/helpers";
 import { validateRegistryId } from "@/types/helpers";
+import sanitize from "@/utils/sanitize";
 
 const highlightId = validateRegistryId("@pixiebrix/html/highlight-text");
 
@@ -69,7 +70,7 @@ export function wrapText({
       continue;
     }
 
-    div.innerHTML = innerHTML;
+    div.innerHTML = sanitize(innerHTML);
     fragment.append(...div.childNodes);
     currentNode.parentNode.replaceChild(fragment, currentNode);
   }

--- a/src/blocks/effects/highlightText.ts
+++ b/src/blocks/effects/highlightText.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2022 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Effect } from "@/types";
+import { type BlockArg, type BlockOptions, type Schema } from "@/core";
+import { $safeFind } from "@/helpers";
+import { validateRegistryId } from "@/types/helpers";
+
+const highlightId = validateRegistryId("@pixiebrix/html/highlight-text");
+
+/**
+ * Recursively wrap text in an element and its children.
+ */
+export function wrapText({
+  node,
+  pattern,
+  color,
+  visited,
+}: {
+  node: Node;
+  pattern: string | RegExp;
+  color: string;
+  visited: WeakSet<Node>;
+}) {
+  // `ownerDocument` is null for documents
+  const nodeDocument = node.ownerDocument ?? (node as Document);
+  const walker = nodeDocument.createTreeWalker(node, NodeFilter.SHOW_TEXT);
+
+  let currentNode: Node | null;
+
+  while ((currentNode = walker.nextNode())) {
+    if (visited.has(currentNode)) {
+      // Avoid running replaceText on same node twice if selector passed to brick matches multiple nodes
+      // in the same subtree
+      continue;
+    }
+
+    visited.add(currentNode);
+
+    if ((currentNode.parentNode as HTMLElement)?.tagName === "MARK") {
+      // Don't highlight text that's already highlighted
+      continue;
+    }
+
+    const fragment = nodeDocument.createDocumentFragment();
+    const div = nodeDocument.createElement("div");
+
+    const innerHTML = currentNode.textContent.replaceAll(
+      pattern,
+      `<mark style="background-color: ${color};">$&</mark>`
+    );
+
+    if (innerHTML === currentNode.textContent) {
+      // No replacements made, avoid DOM manipulation
+      continue;
+    }
+
+    div.innerHTML = innerHTML;
+    fragment.append(...div.childNodes);
+    currentNode.parentNode.replaceChild(fragment, currentNode);
+  }
+}
+
+class HighlightText extends Effect {
+  constructor() {
+    super(
+      highlightId,
+      "Highlight Text",
+      "Highlight text within an HTML document or subtree"
+    );
+  }
+
+  inputSchema: Schema = {
+    type: "object",
+    properties: {
+      pattern: {
+        type: "string",
+        description: "A string or regular expression to match",
+      },
+      color: {
+        type: "string",
+        description:
+          "The highlight color value or hex code: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value",
+        default: "yellow",
+        examples: ["yellow", "red", "green"],
+      },
+      isRegex: {
+        type: "boolean",
+        description: "Whether the pattern is a regular expression",
+        default: false,
+      },
+      selector: {
+        type: "string",
+        format: "selector",
+        description:
+          "An optional JQuery element selector to limit replacement to document subtree(s)",
+      },
+    },
+    required: ["pattern"],
+  };
+
+  override async isRootAware(): Promise<boolean> {
+    return true;
+  }
+
+  async effect(
+    {
+      pattern,
+      color = "yellow",
+      selector,
+      isRegex = false,
+    }: BlockArg<{
+      pattern: string;
+      color?: string;
+      isRegex?: boolean;
+      selector?: string;
+    }>,
+    { root }: BlockOptions
+  ): Promise<void> {
+    const $elements = selector ? $safeFind(selector, root) : $(root);
+
+    const visited = new WeakSet<Node>();
+    const convertedPattern = isRegex ? new RegExp(pattern, "g") : pattern;
+
+    for (const element of $elements.get()) {
+      wrapText({
+        node: element,
+        pattern: convertedPattern,
+        color,
+        visited,
+      });
+    }
+  }
+}
+
+export default HighlightText;

--- a/src/blocks/effects/registerEffects.ts
+++ b/src/blocks/effects/registerEffects.ts
@@ -44,6 +44,7 @@ import { EnableEffect } from "./enable";
 import InsertHtml from "@/blocks/effects/insertHtml";
 import CustomEventEffect from "@/blocks/effects/customEvent";
 import ReplaceTextEffect from "@/blocks/effects/replaceText";
+import HighlightText from "@/blocks/effects/highlightText";
 
 function registerEffects(): void {
   registerBlock(new LogEffect());
@@ -80,6 +81,7 @@ function registerEffects(): void {
   registerBlock(new InsertHtml());
   registerBlock(new CustomEventEffect());
   registerBlock(new ReplaceTextEffect());
+  registerBlock(new HighlightText());
 }
 
 export default registerEffects;

--- a/src/blocks/effects/replaceText.ts
+++ b/src/blocks/effects/replaceText.ts
@@ -18,39 +18,45 @@
 import { Effect } from "@/types";
 import { type BlockArg, type BlockOptions, type Schema } from "@/core";
 import { $safeFind } from "@/helpers";
+import { uniq } from "lodash";
+
+// Adapted from https://github.com/refined-github/refined-github/blob/main/source/helpers/get-text-nodes.ts
+export function getTextNodes(roots: Node[]): Text[] {
+  const textNodes: Text[] = [];
+
+  for (const root of roots) {
+    // `ownerDocument` is null for documents
+    const nodeDocument = root.ownerDocument ?? (root as Document);
+    const walker = nodeDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+
+    let node;
+
+    do {
+      node = walker.nextNode();
+
+      if (node) {
+        textNodes.push(node as Text);
+      }
+    } while (node);
+  }
+
+  return uniq(textNodes);
+}
 
 /**
  * Recursively replace text in an element and its children, without modifying the structure of the document.
  */
 export function replaceText({
-  node,
+  nodes,
   pattern,
   replacement,
-  visited,
 }: {
-  node: Node;
+  nodes: Node[];
   pattern: string | RegExp;
   replacement: string;
-  visited: WeakSet<Node>;
 }) {
-  // `ownerDocument` is null for documents
-  const nodeDocument = node.ownerDocument ?? (node as Document);
-  const walker = nodeDocument.createTreeWalker(node, NodeFilter.SHOW_TEXT);
-
-  let currentNode: Node | null;
-
-  while ((currentNode = walker.nextNode())) {
-    if (visited.has(currentNode)) {
-      // Avoid running replaceText on same node twice if selector passed to brick matches multiple nodes
-      // in the same subtree
-      continue;
-    }
-
-    visited.add(currentNode);
-    currentNode.textContent = currentNode.textContent.replaceAll(
-      pattern,
-      replacement
-    );
+  for (const node of getTextNodes(nodes)) {
+    node.textContent = node.textContent.replaceAll(pattern, replacement);
   }
 }
 
@@ -110,17 +116,13 @@ class ReplaceTextEffect extends Effect {
   ): Promise<void> {
     const $elements = selector ? $safeFind(selector, root) : $(root);
 
-    const visited = new WeakSet<Node>();
     const convertedPattern = isRegex ? new RegExp(pattern, "g") : pattern;
 
-    for (const element of $elements.get()) {
-      replaceText({
-        node: element,
-        pattern: convertedPattern,
-        replacement,
-        visited,
-      });
-    }
+    replaceText({
+      nodes: $elements.get(),
+      pattern: convertedPattern,
+      replacement,
+    });
   }
 }
 

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -27,7 +27,7 @@ import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 107;
+const EXPECTED_HEADER_COUNT = 108;
 
 registerBuiltinBlocks();
 registerContribBlocks();


### PR DESCRIPTION
## What does this PR do?

- Adds a highlight text brick
- Walks text nodes and wraps matched text in `mark` tag

## Discussion

- If the text is already an immediate child of a `mark` tag, it does not re-highlight the text
- I'm just calling `sanitize` on the textContent and passing it as instead of manually re-assembling the text nodes. I don't think tags will appear in textContent on normal sites. (I think they'd have to have to have been programmatically added)

## Demo

- https://www.loom.com/share/0f929322091e48d98e98c034b06a4e39

## Future Work

- Expose an option for passing an arbitrary style for the element

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
