### PR TITLE
Add support for integrations using HTTP basic auth

### DIFF
--- a/contrib/services/greenhouse.yaml
+++ b/contrib/services/greenhouse.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: service
+metadata:
+  id: greenhouse/api
+  version: 1.0.0
+  name: Greenhouse ATS API
+  description: The Greenhouse Harvest API
+inputSchema:
+  $schema: "https://json-schema.org/draft/2019-09/schema#"
+  type: object
+  properties:
+    apiToken:
+      $ref: "https://app.pixiebrix.com/schemas/key#"
+      description: Your Greenhouse API token
+  required:
+    - apiToken
+authentication:
+  baseURL: "https://harvest.greenhouse.io"
+  basic:
+    # https://developers.greenhouse.io/harvest.html#authentication
+    username: "{{{ apiToken }}}"
+    password: ""

--- a/schemas/service.json
+++ b/schemas/service.json
@@ -145,6 +145,26 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "basic": {
+              "type": "object",
+              "required": ["username", "password"],
+              "properties": {
+                "username": {
+                  "type": "string"
+                },
+                "password": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["basic"]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
             "oauth2": {
               "type": "object",
               "properties": {

--- a/schemas/service.json
+++ b/schemas/service.json
@@ -145,6 +145,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "baseURL": {
+              "type": "string",
+              "description": "The base URL of the API, as a URL literal or Mustache template"
+            },
             "basic": {
               "type": "object",
               "required": ["username", "password"],

--- a/src/core.ts
+++ b/src/core.ts
@@ -961,7 +961,7 @@ export interface IService<
    * True if service uses basic access authentication to authenticate
    * https://en.wikipedia.org/wiki/Basic_access_authentication
    */
-  isBasic: boolean;
+  isBasicHttpAuth: boolean;
 
   getOrigins: (serviceConfig: TSanitized) => string[];
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -957,6 +957,12 @@ export interface IService<
 
   isToken: boolean;
 
+  /**
+   * True if service uses basic access authentication to authenticate
+   * https://en.wikipedia.org/wiki/Basic_access_authentication
+   */
+  isBasic: boolean;
+
   getOrigins: (serviceConfig: TSanitized) => string[];
 
   getOAuth2Context: (serviceConfig: TSecret) => OAuth2Context;

--- a/src/services/factory.test.ts
+++ b/src/services/factory.test.ts
@@ -17,9 +17,11 @@
 
 import automationAnywhere from "@contrib/services/automation-anywhere.yaml";
 import automationAnywhereOAuth2 from "@contrib/services/automation-anywhere-oauth2.yaml";
+import greenhouse from "@contrib/services/greenhouse.yaml";
 import { fromJS } from "@/services/factory";
 import { type ServiceDefinition } from "@/types/definitions";
-import { type SanitizedConfig } from "@/core";
+import { type SanitizedConfig, ServiceConfig } from "@/core";
+import { BusinessError } from "@/errors/businessErrors";
 
 describe("LocalDefinedService", () => {
   test("includes version", () => {
@@ -55,5 +57,37 @@ describe("LocalDefinedService", () => {
       "https://oauthconfigapp.automationanywhere.digital/client/oauth/authorize?hosturl=&audience=https://controlroom",
       "https://oauthconfigapp.automationanywhere.digital/client/oauth/token",
     ]);
+  });
+});
+
+describe("LocalDefinedService.authenticateBasicRequest", () => {
+  it("adds authorization header", () => {
+    const service = fromJS(greenhouse as unknown as ServiceDefinition);
+
+    expect(service.isBasic).toBeTrue();
+
+    const config = service.authenticateRequest(
+      { apiToken: "topsecret" } as unknown as ServiceConfig,
+      { url: "/v1/candidates/", method: "get" }
+    );
+
+    expect(config.baseURL).toEqual("https://harvest.greenhouse.io");
+
+    expect(config.headers).toStrictEqual({
+      Authorization: `Basic ${btoa("topsecret:")}`,
+    });
+  });
+
+  it("requires value", () => {
+    const service = fromJS(greenhouse as unknown as ServiceDefinition);
+
+    expect(service.isBasic).toBeTrue();
+
+    expect(() =>
+      service.authenticateRequest(
+        { notTheKey: "topsecret" } as unknown as ServiceConfig,
+        { url: "/v1/candidates/", method: "get" }
+      )
+    ).toThrow(BusinessError);
   });
 });

--- a/src/services/factory.test.ts
+++ b/src/services/factory.test.ts
@@ -20,7 +20,7 @@ import automationAnywhereOAuth2 from "@contrib/services/automation-anywhere-oaut
 import greenhouse from "@contrib/services/greenhouse.yaml";
 import { fromJS } from "@/services/factory";
 import { type ServiceDefinition } from "@/types/definitions";
-import { type SanitizedConfig, ServiceConfig } from "@/core";
+import { type SanitizedConfig, type ServiceConfig } from "@/core";
 import { BusinessError } from "@/errors/businessErrors";
 
 describe("LocalDefinedService", () => {
@@ -64,7 +64,7 @@ describe("LocalDefinedService.authenticateBasicRequest", () => {
   it("adds authorization header", () => {
     const service = fromJS(greenhouse as unknown as ServiceDefinition);
 
-    expect(service.isBasic).toBeTrue();
+    expect(service.isBasicHttpAuth).toBeTrue();
 
     const config = service.authenticateRequest(
       { apiToken: "topsecret" } as unknown as ServiceConfig,
@@ -81,7 +81,7 @@ describe("LocalDefinedService.authenticateBasicRequest", () => {
   it("requires value", () => {
     const service = fromJS(greenhouse as unknown as ServiceDefinition);
 
-    expect(service.isBasic).toBeTrue();
+    expect(service.isBasicHttpAuth).toBeTrue();
 
     expect(() =>
       service.authenticateRequest(

--- a/src/services/factory.ts
+++ b/src/services/factory.ts
@@ -102,7 +102,7 @@ class LocalDefinedService<
    * Return true if service uses basic authentication
    * @since 1.7.16
    */
-  get isBasic(): boolean {
+  get isBasicHttpAuth(): boolean {
     return (
       this._definition.authentication != null &&
       "basic" in this._definition.authentication
@@ -352,7 +352,7 @@ class LocalDefinedService<
       );
     }
 
-    if (this.isBasic) {
+    if (this.isBasicHttpAuth) {
       return this.authenticateBasicRequest(serviceConfig, requestConfig);
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,7 @@ export abstract class Service<
 
   abstract get isToken(): boolean;
 
-  abstract get isBasic(): boolean;
+  abstract get isBasicHttpAuth(): boolean;
 
   protected constructor(
     public id: RegistryId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,8 @@ export abstract class Service<
 
   abstract get isToken(): boolean;
 
+  abstract get isBasic(): boolean;
+
   protected constructor(
     public id: RegistryId,
     public name: string,

--- a/src/types/definitions.ts
+++ b/src/types/definitions.ts
@@ -197,6 +197,15 @@ export interface TokenAuthenticationDefinition {
   headers: Record<string, string>;
 }
 
+export interface BasicAuthenticationDefinition {
+  baseURL?: string;
+  basic: {
+    username: string;
+    password: string;
+  };
+  headers: Record<string, string>;
+}
+
 export interface OAuth2AuthenticationDefinition {
   baseURL?: string;
   oauth2: {
@@ -218,8 +227,9 @@ export interface ServiceDefinition<
   TAuth =
     | KeyAuthenticationDefinition
     | OAuth2AuthenticationDefinition
-    | TokenAuthenticationDefinition
     | OAuth2AuthorizationGrantDefinition
+    | TokenAuthenticationDefinition
+    | BasicAuthenticationDefinition
 > {
   metadata: Metadata;
   inputSchema: Schema;


### PR DESCRIPTION
## What does this PR do?

- Adds support for integrations that use basic auth

## Discussion

- This PR assembles the header manually. Could have probably alternatively have passed in axios's `auth` property

## Future Work

- Create a corresponding PR in the app repository

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @fregante 
