### PR TITLE
#2512: Only reload the browser if the extension has been updated

### DIFF
--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -141,3 +141,13 @@ export async function onTabClose(watchedTabId: number): Promise<void> {
     browser.tabs.onRemoved.addListener(listener);
   });
 }
+
+export async function tryUpdatingExtension(): Promise<chrome.runtime.RequestUpdateCheckStatus> {
+  const status = await browser.runtime.requestUpdateCheck();
+  if (status === "update_available") {
+    browser.runtime.reload();
+    // It will stop here
+  }
+
+  return status;
+}

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -18,6 +18,8 @@
 import { forbidContext } from "@/utils/expectContext";
 import { type JsonValue } from "type-fest";
 import { type UnknownObject } from "@/types";
+import { foreverPendingPromise } from "@/utils";
+import pTimeout from "p-timeout";
 
 // eslint-disable-next-line prefer-destructuring -- It breaks EnvironmentPlugin
 const CHROME_EXTENSION_ID = process.env.CHROME_EXTENSION_ID;
@@ -149,7 +151,12 @@ export async function reloadIfNewVersionIsReady(): Promise<
   const status = await browser.runtime.requestUpdateCheck();
   if (status === "update_available") {
     browser.runtime.reload();
-    // It will stop here
+
+    // This should be dead code
+    await pTimeout(foreverPendingPromise, {
+      message: "Extension did not reload as requested",
+      milliseconds: 1000,
+    });
   }
 
   return status as "throttled" | "no_update";

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -142,12 +142,15 @@ export async function onTabClose(watchedTabId: number): Promise<void> {
   });
 }
 
-export async function tryUpdatingExtension(): Promise<chrome.runtime.RequestUpdateCheckStatus> {
+/** If no update is available and downloaded yet, it will return a string explaining why */
+export async function reloadIfNewVersionIsReady(): Promise<
+  "throttled" | "no_update"
+> {
   const status = await browser.runtime.requestUpdateCheck();
   if (status === "update_available") {
     browser.runtime.reload();
     // It will stop here
   }
 
-  return status;
+  return status as "throttled" | "no_update";
 }

--- a/src/hooks/useDeployments.ts
+++ b/src/hooks/useDeployments.ts
@@ -24,7 +24,7 @@ import { reportEvent } from "@/telemetry/events";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import notify from "@/utils/notify";
 import { getUID, services } from "@/background/messenger/api";
-import { getExtensionVersion, tryUpdatingExtension } from "@/chrome";
+import { getExtensionVersion, reloadIfNewVersionIsReady } from "@/chrome";
 import { refreshRegistries } from "@/hooks/useRefresh";
 import { type Dispatch } from "redux";
 import { type IExtension } from "@/core";
@@ -243,7 +243,7 @@ function useDeployments(): DeploymentState {
   }, [deployments, dispatch, installedExtensions]);
 
   const updateExtension = useCallback(async () => {
-    await tryUpdatingExtension();
+    await reloadIfNewVersionIsReady();
     notify.info(
       "The extension update hasn't yet been downloaded. Try again in a few minutes."
     );

--- a/src/hooks/useDeployments.ts
+++ b/src/hooks/useDeployments.ts
@@ -24,7 +24,7 @@ import { reportEvent } from "@/telemetry/events";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import notify from "@/utils/notify";
 import { getUID, services } from "@/background/messenger/api";
-import { getExtensionVersion } from "@/chrome";
+import { getExtensionVersion, tryUpdatingExtension } from "@/chrome";
 import { refreshRegistries } from "@/hooks/useRefresh";
 import { type Dispatch } from "redux";
 import { type IExtension } from "@/core";
@@ -204,7 +204,7 @@ function useDeployments(): DeploymentState {
     }
 
     if (checkExtensionUpdateRequired(deployments)) {
-      await browser.runtime.requestUpdateCheck();
+      void browser.runtime.requestUpdateCheck();
       notify.warning(
         "You must update the PixieBrix browser extension to activate the deployment"
       );
@@ -243,8 +243,10 @@ function useDeployments(): DeploymentState {
   }, [deployments, dispatch, installedExtensions]);
 
   const updateExtension = useCallback(async () => {
-    await browser.runtime.requestUpdateCheck();
-    browser.runtime.reload();
+    await tryUpdatingExtension();
+    notify.info(
+      "The extension update hasn't yet been downloaded. Try again in a few minutes."
+    );
   }, []);
 
   return {

--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -34,6 +34,7 @@ import useUserAction from "@/hooks/useUserAction";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import { isEmpty } from "lodash";
 import { util as apiUtil } from "@/services/api";
+import { tryUpdatingExtension } from "@/chrome";
 
 const SAVING_URL_NOTIFICATION_ID = uuidv4();
 const SAVING_URL_TIMEOUT_MS = 4000;
@@ -78,10 +79,8 @@ const AdvancedSettings: React.FunctionComponent = () => {
   }, []);
 
   const requestExtensionUpdate = useCallback(async () => {
-    const status = await browser.runtime.requestUpdateCheck();
-    if (status === "update_available") {
-      browser.runtime.reload();
-    } else if (status === "throttled") {
+    const status = await tryUpdatingExtension();
+    if (status === "throttled") {
       notify.error({ message: "Too many update requests", reportError: false });
     } else {
       notify.info("No update available");

--- a/src/options/pages/settings/AdvancedSettings.tsx
+++ b/src/options/pages/settings/AdvancedSettings.tsx
@@ -34,7 +34,7 @@ import useUserAction from "@/hooks/useUserAction";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import { isEmpty } from "lodash";
 import { util as apiUtil } from "@/services/api";
-import { tryUpdatingExtension } from "@/chrome";
+import { reloadIfNewVersionIsReady } from "@/chrome";
 
 const SAVING_URL_NOTIFICATION_ID = uuidv4();
 const SAVING_URL_TIMEOUT_MS = 4000;
@@ -79,7 +79,7 @@ const AdvancedSettings: React.FunctionComponent = () => {
   }, []);
 
   const requestExtensionUpdate = useCallback(async () => {
-    const status = await tryUpdatingExtension();
+    const status = await reloadIfNewVersionIsReady();
     if (status === "throttled") {
       notify.error({ message: "Too many update requests", reportError: false });
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -658,3 +658,5 @@ export const memoizeUntilSettled: typeof pMemoize = (
     ...options,
     cache: false,
   });
+
+export const foreverPendingPromise = new Promise(() => {});


### PR DESCRIPTION

- Follows https://github.com/pixiebrix/pixiebrix-extension/pull/2512/files#r1059708642

## What this PR changes for the user

- If Chrome hasn't already downloaded the extension by the time they click "Update extension", the extension will no longer reload _the previous version_, it will just inform the user.

## Discussion

Assumptions:

- "available" means it's downloaded and ready, not simply available on CWS
- `requestUpdateCheck` does not wait for the extension to load (in our case it could take a minute), it only waits for the CWS API request to complete.

Here's how I suppose the API the works:

0. Extension is available on CWS, but Chrome hasn't checked
2. `requestUpdateCheck` causes the browser to contact CWS
	- if a version is available it will start downloading
3. `requestUpdateCheck`’s returned promise will resolve with `"no_update"` while the extension downloads
4. When the new version is ready to be installed, `onUpdateAvailable` is fired and a successive `requestUpdateCheck` will return `"update_available"`

## Documentation

- https://developer.chrome.com/docs/extensions/reference/runtime/#event-onUpdateAvailable (this backs at least some of my logic)
- https://developer.chrome.com/docs/extensions/reference/runtime/#method-requestUpdateCheck
