### PR TITLE
#4921: remove export blueprint action

### DIFF
--- a/src/options/pages/blueprints/BlueprintActions.tsx
+++ b/src/options/pages/blueprints/BlueprintActions.tsx
@@ -21,7 +21,6 @@ import EllipsisMenu, {
 } from "@/components/ellipsisMenu/EllipsisMenu";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faDownload,
   faList,
   faShare,
   faStore,
@@ -70,15 +69,6 @@ const BlueprintActions: React.FunctionComponent<{
         ),
         action: actions.viewShare,
         hide: !actions.viewShare,
-      },
-      {
-        title: (
-          <>
-            <FontAwesomeIcon icon={faDownload} /> Export
-          </>
-        ),
-        action: actions.exportBlueprint,
-        hide: !actions.exportBlueprint,
       },
       {
         title: (

--- a/src/options/pages/blueprints/useInstallableViewItemActions.test.tsx
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.test.tsx
@@ -119,13 +119,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: actions },
     } = renderHook(() => useInstallableViewItemActions(cloudExtensionItem));
     expectActions(
-      [
-        "viewPublish",
-        "viewShare",
-        "activate",
-        "deleteExtension",
-        "exportBlueprint",
-      ],
+      ["viewPublish", "viewShare", "activate", "deleteExtension"],
       actions
     );
   });
@@ -142,7 +136,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: actions },
     } = renderHook(() => useInstallableViewItemActions(personalExtensionItem));
     expectActions(
-      ["viewPublish", "viewShare", "uninstall", "viewLogs", "exportBlueprint"],
+      ["viewPublish", "viewShare", "uninstall", "viewLogs"],
       actions
     );
   });
@@ -159,14 +153,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: actions },
     } = renderHook(() => useInstallableViewItemActions(personalBlueprintItem));
     expectActions(
-      [
-        "viewPublish",
-        "viewShare",
-        "uninstall",
-        "viewLogs",
-        "exportBlueprint",
-        "reinstall",
-      ],
+      ["viewPublish", "viewShare", "uninstall", "viewLogs", "reinstall"],
       actions
     );
   });
@@ -182,10 +169,7 @@ describe("useInstallableViewItemActions", () => {
     const {
       result: { current: actions },
     } = renderHook(() => useInstallableViewItemActions(personalBlueprintItem));
-    expectActions(
-      ["viewPublish", "viewShare", "activate", "exportBlueprint"],
-      actions
-    );
+    expectActions(["viewPublish", "viewShare", "activate"], actions);
   });
 
   test("active team blueprint", () => {
@@ -200,14 +184,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: actions },
     } = renderHook(() => useInstallableViewItemActions(teamBlueprintItem));
     expectActions(
-      [
-        "viewPublish",
-        "viewShare",
-        "uninstall",
-        "viewLogs",
-        "exportBlueprint",
-        "reinstall",
-      ],
+      ["viewPublish", "viewShare", "uninstall", "viewLogs", "reinstall"],
       actions
     );
   });
@@ -223,10 +200,7 @@ describe("useInstallableViewItemActions", () => {
     const {
       result: { current: actions },
     } = renderHook(() => useInstallableViewItemActions(teamBlueprintItem));
-    expectActions(
-      ["viewPublish", "viewShare", "activate", "exportBlueprint"],
-      actions
-    );
+    expectActions(["viewPublish", "viewShare", "activate"], actions);
   });
 
   test("public blueprint", () => {
@@ -241,14 +215,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: actions },
     } = renderHook(() => useInstallableViewItemActions(publicBlueprintItem));
     expectActions(
-      [
-        "viewPublish",
-        "viewShare",
-        "reinstall",
-        "exportBlueprint",
-        "viewLogs",
-        "uninstall",
-      ],
+      ["viewPublish", "viewShare", "reinstall", "viewLogs", "uninstall"],
       actions
     );
   });
@@ -299,7 +266,6 @@ describe("useInstallableViewItemActions", () => {
         "uninstall",
         "viewLogs",
         "requestPermissions",
-        "exportBlueprint",
         "reinstall",
       ],
       actions
@@ -361,14 +327,7 @@ describe("useInstallableViewItemActions", () => {
         result: { current: actions },
       } = renderHook(() => useInstallableViewItemActions(blueprintItem));
       expectActions(
-        [
-          "viewPublish",
-          "viewShare",
-          "uninstall",
-          "viewLogs",
-          "exportBlueprint",
-          "reinstall",
-        ],
+        ["viewPublish", "viewShare", "uninstall", "viewLogs", "reinstall"],
         actions
       );
     });
@@ -385,7 +344,6 @@ describe("useInstallableViewItemActions", () => {
           "viewShare",
           "uninstall",
           "viewLogs",
-          "exportBlueprint",
           "reinstall",
         ],
         actions

--- a/src/options/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.ts
@@ -62,10 +62,6 @@ export type InstallableViewItemActions = {
   uninstall: ActionCallback | null;
   viewLogs: ActionCallback | null;
   requestPermissions: ActionCallback | null;
-
-  // XXX: this is one is not implemented like the others for some reason. It will always be defined but will show
-  // an error if the action is not available
-  exportBlueprint: ActionCallback;
 };
 
 // eslint-disable-next-line complexity
@@ -240,26 +236,6 @@ function useInstallableViewItemActions(
     );
   };
 
-  const exportBlueprint = useUserAction(
-    () => {
-      if (isInstallableBlueprint) {
-        throw new Error("Already a blueprint. Access in the Workshop");
-      }
-
-      if (extensionsFromInstallable.length === 0) {
-        throw new Error("Extension must be installed to export as blueprint");
-      }
-
-      exportBlueprintYaml(extensionsFromInstallable[0]);
-    },
-    {
-      successMessage: `Exported blueprint: ${getLabel(installable)}`,
-      errorMessage: `Error exporting blueprint: ${getLabel(installable)}`,
-      event: "ExtensionExport",
-    },
-    [installable, extensionsFromInstallable]
-  );
-
   const showPublishAction =
     // Deployment sharing is controlled via the Admin Console
     !isDeployment &&
@@ -286,8 +262,6 @@ function useInstallableViewItemActions(
     reinstall: hasBlueprint && isInstalled && !isRestricted ? reinstall : null,
     viewLogs: status === "Inactive" ? null : viewLogs,
     activate: status === "Inactive" ? activate : null,
-    // If a developer needs to access the underlying blueprint, they can access it in the workshop
-    exportBlueprint: isDeployment ? null : exportBlueprint,
     requestPermissions: hasPermissions ? null : requestPermissions,
   };
 }

--- a/src/options/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.ts
@@ -36,7 +36,6 @@ import {
 } from "@/options/pages/blueprints/modals/blueprintModalsSlice";
 import { selectExtensionContext } from "@/extensionPoints/helpers";
 import { push } from "connected-react-router";
-import { exportBlueprint as exportBlueprintYaml } from "@/options/pages/blueprints/utils/exportBlueprint";
 import { useDeleteCloudExtensionMutation } from "@/services/api";
 import extensionsSlice from "@/store/extensionsSlice";
 import useUserAction from "@/hooks/useUserAction";

--- a/src/options/pages/blueprints/utils/exportBlueprint.ts
+++ b/src/options/pages/blueprints/utils/exportBlueprint.ts
@@ -18,13 +18,10 @@
 import { isEmpty } from "lodash";
 import {
   type Metadata,
-  type RegistryId,
   type Schema,
   type UnresolvedExtension,
   type UserOptions,
 } from "@/core";
-import { objToYaml } from "@/utils/objToYaml";
-import { saveAs } from "file-saver";
 import {
   type OptionsDefinition,
   type UnsavedRecipeDefinition,
@@ -32,8 +29,6 @@ import {
 import { isNullOrBlank } from "@/utils";
 import GenerateSchema from "generate-schema";
 import { isInnerExtensionPoint } from "@/registry/internal";
-import filenamify from "filenamify";
-import { validateSemVerString } from "@/types/helpers";
 
 /**
  * Infer optionsSchema from the options provided to the extension.
@@ -94,17 +89,4 @@ export function makeBlueprint(
       },
     ],
   };
-}
-
-export function exportBlueprint(extension: UnresolvedExtension): void {
-  const blueprint = makeBlueprint(extension, {
-    id: "" as RegistryId,
-    name: extension.label,
-    description: "Blueprint exported from PixieBrix",
-    version: validateSemVerString("1.0.0"),
-  });
-
-  const blueprintYAML = objToYaml(blueprint);
-  const blob = new Blob([blueprintYAML], { type: "text/plain;charset=utf-8" });
-  saveAs(blob, [filenamify(extension.label), "yaml"].join("."));
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #4921 
- Removes "Export Blueprint" action from blueprint screen

## Discussion

- See comment here: https://github.com/pixiebrix/pixiebrix-extension/issues/4921#issuecomment-1368528626. Now that we have "Make a Copy" in the Page Editor, it's likely time to remove this export action altogether

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @mnholtz 
