### PR TITLE
#4815: fix jq compile error annotation and status badge

### DIFF
--- a/src/analysis/analysisVisitors/traceAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/traceAnalysis.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import TraceAnalysis from "@/analysis/analysisVisitors/traceAnalysis";
+import { serializeError } from "serialize-error";
+import { throwIfInvalidInput } from "@/runtime/runtimeUtils";
+import { JQTransformer } from "@/blocks/transformers/jq";
+
+describe("TraceAnalysis.mapErrorAnnotations", () => {
+  test("handles invalid field value", async () => {
+    let inputError;
+    try {
+      await throwIfInvalidInput(new JQTransformer(), { filter: 42 } as any);
+      expect.fail("Invalid test, expected validateInput to throw");
+    } catch (error) {
+      inputError = serializeError(error);
+    }
+
+    const annotations = new TraceAnalysis([]).mapErrorAnnotations(
+      { path: "" },
+      inputError
+    );
+
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0].position).toEqual({ path: "config.filter" });
+  });
+});

--- a/src/blocks/transformers/jq.ts
+++ b/src/blocks/transformers/jq.ts
@@ -90,9 +90,9 @@ export class JQTransformer extends Transformer {
         { filter, data: input },
         [
           {
-            keyword: "filter",
-            keywordLocation: "#/filter",
-            instanceLocation: "#",
+            keyword: "format",
+            keywordLocation: "#/properties/filter/format",
+            instanceLocation: "#/filter",
             error: error.stack,
           },
         ]


### PR DESCRIPTION
## What does this PR do?

- Fixes #4815 
- Fixes a bug in the `instanceLocation` of jq compile errors translated to runtime InputValidationErrors
- Fixes bug in TraceAnalysis where if no matching instanceLocations were found, no annotations would be added

## Demo

![image](https://user-images.githubusercontent.com/1879821/210185435-8a666e2d-edbc-4e0d-b652-1e53c11a3ab5.png)

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BALEHOK 
