### PR TITLE
#4863: consider tab/frame when handling ENSURE_CONTENT_SCRIPT_READY message

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -43,6 +43,7 @@ import initActiveTabTracking from "@/background/activeTab";
 import initPartnerTheme from "@/background/partnerTheme";
 import initStarterBlueprints from "@/background/starterBlueprints";
 import { initPartnerTokenRefresh } from "@/background/partnerIntegrations";
+import { initContentScriptReadyListener } from "@/background/contentScript";
 
 void initLocator();
 registerMessenger();
@@ -53,6 +54,7 @@ initNavigation();
 initExecutor();
 void initGoogle();
 initContextMenus();
+initContentScriptReadyListener();
 initBrowserCommands();
 initDeploymentUpdater();
 initFirefoxCompat();

--- a/src/background/contentScript.test.ts
+++ b/src/background/contentScript.test.ts
@@ -18,6 +18,7 @@
 import {
   ensureContentScript,
   initContentScriptReadyListener,
+  makeSenderKey,
 } from "@/background/contentScript";
 import { getTargetState } from "@/contentScript/ready";
 import { injectContentScript } from "webext-content-scripts";
@@ -250,5 +251,11 @@ describe("ensureContentScript", () => {
     expect(secondFrameReady).toBe(true);
 
     await Promise.all([firstFrame, secondFrame]);
+  });
+});
+
+describe("makeSenderKey", () => {
+  it("handles non-tab message", () => {
+    expect(makeSenderKey({ id: RUNTIME_ID })).toBe("{}");
   });
 });

--- a/src/background/contentScript.ts
+++ b/src/background/contentScript.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import pDefer from "p-defer";
+import pDefer, { type DeferredPromise } from "p-defer";
 import { injectContentScript } from "webext-content-scripts";
 import { getAdditionalPermissions } from "webext-additional-permissions";
 import { patternToRegex } from "webext-patterns";
@@ -26,6 +26,8 @@ import pTimeout from "p-timeout";
 import type { Target } from "@/types";
 import { getTargetState } from "@/contentScript/ready";
 import { memoizeUntilSettled } from "@/utils";
+import { Runtime } from "webextension-polyfill";
+import MessageSender = Runtime.MessageSender;
 
 /** Checks whether a URL will have the content scripts automatically injected */
 export async function isContentScriptRegistered(url: string): Promise<boolean> {
@@ -44,28 +46,75 @@ export async function isContentScriptRegistered(url: string): Promise<boolean> {
   return patternToRegex(...origins, ...manifestScriptsOrigins).test(url);
 }
 
-export async function onReadyNotification(signal: AbortSignal): Promise<void> {
-  const { resolve, promise: readyNotification } = pDefer();
+/**
+ * @see makeSenderKey
+ */
+const targetReadyPromiseMap = new Map<string, DeferredPromise<Event>>();
 
-  const onMessage = (message: unknown) => {
-    if (
-      isRemoteProcedureCallRequest(message) &&
-      message.type === ENSURE_CONTENT_SCRIPT_READY
-    ) {
-      resolve();
+function makeSenderKey(sender: MessageSender): string {
+  return JSON.stringify({ tabId: sender.tab.id, frameId: sender.frameId });
+}
+
+function makeTargetKey(target: Target): string {
+  return JSON.stringify({ tabId: target.tabId, frameId: target.frameId });
+}
+
+/**
+ * Runtime message handler to handle ENSURE_CONTENT_SCRIPT_READY messages sent from the contentScript
+ */
+function onContentScriptReadyMessage(
+  message: unknown,
+  sender: MessageSender
+): null | undefined {
+  if (
+    isRemoteProcedureCallRequest(message) &&
+    message.type === ENSURE_CONTENT_SCRIPT_READY &&
+    sender.id === browser.runtime.id
+  ) {
+    const key = makeSenderKey(sender);
+
+    try {
+      targetReadyPromiseMap.get(key)?.resolve();
+    } catch (error) {
+      console.error("Error resolving contentScript ready promise", error);
+    } finally {
+      targetReadyPromiseMap.delete(key);
     }
-  };
+
+    // Don't value to indicate we handled the message
+    return null;
+  }
+
+  // Don't return anything to indicate this didn't handle the message
+}
+
+export async function onReadyNotification(
+  target: Target,
+  signal: AbortSignal
+): Promise<void> {
+  // Track if this thread is created the promise, so it can be the one to delete it from the map
+  let isLeader = false;
+  const key = makeTargetKey(target);
+
+  let deferredPromise = targetReadyPromiseMap.get(key);
+  if (!deferredPromise) {
+    isLeader = true;
+    deferredPromise = pDefer<Event>();
+    targetReadyPromiseMap.set(key, deferredPromise);
+  }
 
   // `onReadyNotification` is not expected to throw. It resolves on `abort` simply to
   // clean up the listeners, but by then nothing is awaiting this promise anyway.
-  browser.runtime.onMessage.addListener(onMessage);
-  signal.addEventListener("abort", resolve);
+  signal.addEventListener("abort", deferredPromise.resolve);
 
   try {
-    await readyNotification;
+    await deferredPromise.promise;
   } finally {
-    browser.runtime.onMessage.removeListener(onMessage);
-    signal.removeEventListener("abort", resolve);
+    signal.removeEventListener("abort", deferredPromise.resolve);
+    if (isLeader) {
+      // Avoid race condition where another task has created a new promise
+      targetReadyPromiseMap.delete(key);
+    }
   }
 }
 
@@ -106,7 +155,7 @@ async function ensureContentScriptWithoutTimeout(
 ): Promise<void> {
   // Start waiting for the notification as early as possible,
   // `webext-dynamic-content-scripts` might have already injected the content script
-  const readyNotificationPromise = onReadyNotification(signal);
+  const readyNotificationPromise = onReadyNotification(target, signal);
 
   const result = await getTargetState(target); // It will throw if we don't have permissions
 
@@ -146,4 +195,8 @@ async function ensureContentScriptWithoutTimeout(
 
   await injectContentScript(target, scripts);
   await readyNotificationPromise;
+}
+
+export function initContentScriptReadyListener() {
+  browser.runtime.onMessage.addListener(onContentScriptReadyMessage);
 }

--- a/src/background/contentScript.ts
+++ b/src/background/contentScript.ts
@@ -48,11 +48,13 @@ export async function isContentScriptRegistered(url: string): Promise<boolean> {
 
 /**
  * @see makeSenderKey
+ * @see makeTargetKey
  */
 const targetReadyPromiseMap = new Map<string, DeferredPromise<Event>>();
 
 function makeSenderKey(sender: MessageSender): string {
-  return JSON.stringify({ tabId: sender.tab.id, frameId: sender.frameId });
+  // `tab?` to handle messages from other locations (so we can ignore instead of error)
+  return JSON.stringify({ tabId: sender.tab?.id, frameId: sender.frameId });
 }
 
 function makeTargetKey(target: Target): string {

--- a/src/background/contentScript.ts
+++ b/src/background/contentScript.ts
@@ -52,8 +52,8 @@ export async function isContentScriptRegistered(url: string): Promise<boolean> {
  */
 const targetReadyPromiseMap = new Map<string, DeferredPromise<Event>>();
 
-function makeSenderKey(sender: MessageSender): string {
-  // `tab?` to handle messages from other locations (so we can ignore instead of error)
+export function makeSenderKey(sender: MessageSender): string {
+  // Be defensive: `tab?` to handle messages from other locations (so we can ignore instead of error)
   return JSON.stringify({ tabId: sender.tab?.id, frameId: sender.frameId });
 }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #4863 
- Fixes `background/contentScript` to consider tab and frame when receiving contentScript ready messages

## Discussion

- One thing I'm not sure about is whether the memoized `ensureContentScript` should have the timeout embedded in it, or if each caller should be responsible for setting its own timeout. It's likely OK as-is -- the only potential downside is it prevents getting lucky on a 2nd call to ensureContentScript that's made at 3.99 seconds
- We may also want validate the origin URL to ensure the message being received is for the correct page altogether
- We may want to remove the entry when a tab is removed. To efficiently do that we'd use a nested map of `tab -> frame -> promise`. The memory leak isn't likely too bad though, because it'd only leak for tabs where ensureContentScript is called but the tab is closed before it resolves

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @fregante 
