### PR TITLE
#4142: fix AA attended bot behavior for EE

### DIFF
--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -178,6 +178,15 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
             <>
               {workspaceType === "public" && (
                 <>
+                  {isAttended && (
+                    <Alert variant="info">
+                      <FontAwesomeIcon icon={faInfoCircle} /> In attended mode,
+                      the bot will run using the authenticated user&apos;s
+                      credentials. You will not be able to run the bot using a
+                      Bot Creator license. Switch to unattended mode to test
+                      using a Bot Creator license.
+                    </Alert>
+                  )}
                   <ConnectedFieldTemplate
                     label="Attended"
                     name={configName("isAttended")}

--- a/src/contrib/automationanywhere/RunBot.test.ts
+++ b/src/contrib/automationanywhere/RunBot.test.ts
@@ -62,6 +62,7 @@ const CE_CONTROL_ROOM_URL =
 const EE_CONTROL_ROOM_URL = "https://custom.dev";
 const FILE_ID = "456";
 const DEVICE_ID = "123";
+const DEVICE_POOL_ID = "012";
 const CONTROL_ROOM_USER_ID = 999;
 const UNATTENDED_RUN_AS_USER_ID = 1000;
 const DEPLOYMENT_ID = "789";
@@ -124,7 +125,7 @@ describe("Automation Anywhere - RunBot", () => {
     expect(values).toStrictEqual({});
   });
 
-  it("runs private Enterprise Edition bot using token configuration", async () => {
+  it("runs private unattended Enterprise Edition bot using token authentication", async () => {
     proxyServiceMock.mockResolvedValue({
       status: 201,
       statusText: "Created",
@@ -150,7 +151,72 @@ describe("Automation Anywhere - RunBot", () => {
           },
         },
         workspaceType: "private",
-        deviceId: DEVICE_ID,
+        poolIds: [DEVICE_POOL_ID],
+        fileId: FILE_ID,
+        runAsUserIds: [UNATTENDED_RUN_AS_USER_ID],
+        data: {},
+      }),
+      { logger } as BlockOptions
+    );
+
+    expect(getCachedAuthDataMock).not.toHaveBeenCalled();
+
+    expect(proxyServiceMock).toHaveBeenCalledWith(
+      {
+        config: {
+          controlRoomUrl: EE_CONTROL_ROOM_URL,
+        },
+        id: tokenAuthId,
+        proxy: false,
+        serviceId: CONTROL_ROOM_SERVICE_ID,
+      },
+      {
+        data: {
+          botInput: {},
+          fileId: FILE_ID,
+          numOfRunAsUsersToUse: 1,
+          overrideDefaultDevice: true,
+          poolIds: [DEVICE_POOL_ID],
+          runAsUserIds: [UNATTENDED_RUN_AS_USER_ID],
+        },
+        method: "post",
+        url: "/v3/automations/deploy",
+      }
+    );
+
+    // CE returns blank object
+    expect(values).toStrictEqual({
+      deploymentId: DEPLOYMENT_ID,
+    });
+  });
+
+  it("runs public attended Enterprise Edition bot using token configuration", async () => {
+    proxyServiceMock.mockResolvedValue({
+      status: 201,
+      statusText: "Created",
+      data: {
+        deploymentId: DEPLOYMENT_ID,
+      },
+      $$proxied: false,
+    });
+
+    getCachedAuthDataMock.mockResolvedValue({
+      user: { id: CONTROL_ROOM_USER_ID },
+      _oauthBrand: undefined,
+    } as AuthData);
+
+    const values = await brick.run(
+      unsafeAssumeValidArg({
+        service: {
+          id: tokenAuthId,
+          proxy: false,
+          serviceId: CONTROL_ROOM_SERVICE_ID,
+          config: {
+            controlRoomUrl: EE_CONTROL_ROOM_URL,
+          },
+        },
+        workspaceType: "public",
+        isAttended: true,
         fileId: FILE_ID,
         data: {},
       }),
@@ -188,7 +254,7 @@ describe("Automation Anywhere - RunBot", () => {
     });
   });
 
-  it("runs public Enterprise Edition bot using token configuration", async () => {
+  it("runs unattended public Enterprise Edition bot using token authentication", async () => {
     proxyServiceMock.mockResolvedValue({
       status: 201,
       statusText: "Created",
@@ -250,7 +316,7 @@ describe("Automation Anywhere - RunBot", () => {
     });
   });
 
-  it("runs Enterprise Edition bot in attended mode", async () => {
+  it("runs Enterprise Edition bot in attended mode using oauth2 configuration", async () => {
     proxyServiceMock.mockResolvedValue({
       status: 201,
       statusText: "Created",

--- a/src/contrib/automationanywhere/RunBot.ts
+++ b/src/contrib/automationanywhere/RunBot.ts
@@ -170,7 +170,6 @@ export class RunBot extends Transformer {
       awaitResult,
       maxWaitMillis = DEFAULT_MAX_WAIT_MILLIS,
       service,
-      workspaceType,
     } = args;
 
     if (isCommunityControlRoom(service.config.controlRoomUrl)) {
@@ -202,9 +201,11 @@ export class RunBot extends Transformer {
 
     let runAsUserIds: number[] = enterpriseBotArgs.runAsUserIds ?? [];
     if (
-      (enterpriseBotArgs.isAttended || workspaceType === "private") &&
+      enterpriseBotArgs.isAttended &&
       service.serviceId === CONTROL_ROOM_OAUTH_SERVICE_ID
     ) {
+      // Attended mode uses the authenticated user id as a runAsUserId
+
       const { partnerPrincipals = [] } = await getUserData();
 
       const principal = partnerPrincipals.find(
@@ -222,11 +223,11 @@ export class RunBot extends Transformer {
       runAsUserIds = [principal.control_room_user_id];
       enterpriseBotArgs.poolIds = [];
     } else if (
-      (workspaceType === "private" ||
-        workspaceType == null ||
-        enterpriseBotArgs.isAttended) &&
+      enterpriseBotArgs.isAttended &&
       service.serviceId === CONTROL_ROOM_SERVICE_ID
     ) {
+      // Attended mode uses the authenticated user id as a runAsUserId
+
       // Get the user id from the cached token data. AA doesn't have any endpoints for retrieving the user id that
       // we could automatically fetch in the Page Editor
       const userData = (await getCachedAuthData(service.id)) as unknown as {


### PR DESCRIPTION
## What does this PR do?

- Closes #4142 
- Adds an information message about being unable to run a bot in attended mode using a Bot Creator license
- Switches "private" folder bots to use the authenticated user only if isAttended is set. Previously, private folder bots would always run the authenticated user as the runAsUser

## Demo

- TODO

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
