### PR TITLE
#4964: disable template and jq sandboxing

### DIFF
--- a/src/blocks/transformers/jq.ts
+++ b/src/blocks/transformers/jq.ts
@@ -22,7 +22,6 @@ import { isNullOrBlank } from "@/utils";
 import { InputValidationError } from "@/blocks/errors";
 import { isErrorObject } from "@/errors/errorHelpers";
 import { BusinessError } from "@/errors/businessErrors";
-import { applyJq } from "@/sandbox/messenger/api";
 
 const jqStacktraceRegexp = /jq: error \(at <stdin>:0\): (?<message>.*)/;
 
@@ -63,7 +62,12 @@ export class JQTransformer extends Transformer {
     logger.debug("Running jq transform", { filter, data, ctxt, input });
 
     try {
-      return await applyJq({ input, filter });
+      const { default: jq } = await import(
+        /* webpackChunkName: "jq-web" */ "jq-web"
+      );
+
+      // eslint-disable-next-line @typescript-eslint/return-await -- missing promise type
+      return await jq.promised.json(input, filter);
     } catch (error) {
       // The message length check is there because the JQ error message sometimes is cut and if it is we try to parse the stacktrace
       // See https://github.com/pixiebrix/pixiebrix-extension/issues/3216

--- a/src/blocks/transformers/jq.ts
+++ b/src/blocks/transformers/jq.ts
@@ -22,6 +22,7 @@ import { isNullOrBlank } from "@/utils";
 import { InputValidationError } from "@/blocks/errors";
 import { isErrorObject } from "@/errors/errorHelpers";
 import { BusinessError } from "@/errors/businessErrors";
+import { applyJq } from "@/sandbox/messenger/executor";
 
 const jqStacktraceRegexp = /jq: error \(at <stdin>:0\): (?<message>.*)/;
 
@@ -62,12 +63,7 @@ export class JQTransformer extends Transformer {
     logger.debug("Running jq transform", { filter, data, ctxt, input });
 
     try {
-      const { default: jq } = await import(
-        /* webpackChunkName: "jq-web" */ "jq-web"
-      );
-
-      // eslint-disable-next-line @typescript-eslint/return-await -- missing promise type
-      return await jq.promised.json(input, filter);
+      return await applyJq({ input, filter });
     } catch (error) {
       // The message length check is there because the JQ error message sometimes is cut and if it is we try to parse the stacktrace
       // See https://github.com/pixiebrix/pixiebrix-extension/issues/3216

--- a/src/runtime/renderers.ts
+++ b/src/runtime/renderers.ts
@@ -20,10 +20,11 @@ import Mustache from "mustache";
 import { identity, mapKeys } from "lodash";
 import { getPropByPath } from "@/runtime/pathHelpers";
 import { type UnknownObject } from "@/types";
-import { type TemplateRenderPayload } from "@/sandbox/messenger/api";
 import { type JsonObject } from "type-fest";
-import { isErrorObject } from "@/errors/errorHelpers";
-import { InvalidTemplateError } from "@/errors/businessErrors";
+import {
+  renderHandlebarsTemplate,
+  renderNunjucksTemplate,
+} from "@/sandbox/messenger/executor";
 
 export type AsyncTemplateRenderer = (
   template: string,
@@ -41,48 +42,6 @@ export type RendererOptions = {
  */
 export function containsTemplateExpression(literalOrTemplate: string): boolean {
   return literalOrTemplate.includes("{{") || literalOrTemplate.includes("{%");
-}
-
-// XXX: https://github.com/pixiebrix/pixiebrix-extension/issues/4964
-// Copied from the sandbox handler
-async function renderNunjucksTemplate({
-  autoescape,
-  template,
-  context,
-}: TemplateRenderPayload): Promise<string> {
-  // Webpack caches the module import, so doesn't need to cache via lodash's `once`
-  const { default: nunjucks } = await import(
-    /* webpackChunkName: "nunjucks" */ "nunjucks"
-  );
-
-  nunjucks.configure({ autoescape });
-  try {
-    return nunjucks.renderString(template, context);
-  } catch (error) {
-    if (isErrorObject(error) && error.name === "Template render error") {
-      throw new InvalidTemplateError(error.message, template);
-    }
-
-    throw error;
-  }
-}
-
-// XXX: https://github.com/pixiebrix/pixiebrix-extension/issues/4964
-// Copied from the sandbox handler
-async function renderHandlebarsTemplate({
-  autoescape,
-  template,
-  context,
-}: TemplateRenderPayload): Promise<string> {
-  // Webpack caches the module import, so doesn't need to cache via lodash's `once`
-  const { default: handlebars } = await import(
-    /* webpackChunkName: "handlebars" */ "handlebars"
-  );
-
-  const compiledTemplate = handlebars.compile(template, {
-    noEscape: !autoescape,
-  });
-  return compiledTemplate(context);
 }
 
 export function engineRenderer(


### PR DESCRIPTION
## What does this PR do?

- Part of #4964 
- For 1.7.16 we're disabling template sandboxing while we investigate the runtime crash

## Discussion

- I left the sandbox in there (including the ping/pong). I just bypassed it for template and jq rendering
- I confirmed the problematic brick is not erroring out with this PR

## Future Work

- Figure out what's causing the issue. Potentially put being a skunkworks flag

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @fregante 
