### PR TITLE
Silence Jest coverage CLI 1000-lines noise

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -31,6 +31,7 @@
     "<rootDir>/src/testUtils/testAfterEnv.js",
     "jest-extended/all"
   ],
+  "coverageReporters" : ["json"],
   "collectCoverageFrom": [
     "src/**/*.{ts,tsx}",
     "!src/**/*.stories.tsx",

--- a/jest.config.json
+++ b/jest.config.json
@@ -31,7 +31,7 @@
     "<rootDir>/src/testUtils/testAfterEnv.js",
     "jest-extended/all"
   ],
-  "coverageReporters" : ["json"],
+  "coverageReporters": ["json"],
   "collectCoverageFrom": [
     "src/**/*.{ts,tsx}",
     "!src/**/*.stories.tsx",


### PR DESCRIPTION
Finding the test error on CI takes too long because Jest outputs a list of _every file_ we have in the project. 

Example: https://github.com/pixiebrix/pixiebrix-extension/actions/runs/3872008390/jobs/6600357244

You might not have noticed due to this noise, but our test is producing a silent error and it's at the top of such list. I opened #4986 

## Before

![clicks](https://user-images.githubusercontent.com/1402241/211340403-02b3b180-fe0b-4c59-909a-43315c555fb4.gif)

## After

The error is shown right under the PASS list

<img width="930" alt="Screenshot 1" src="https://user-images.githubusercontent.com/1402241/211343208-2f328ac1-cbe7-4436-b8df-31f987b6f770.png">

