### PR TITLE
#4971 Form Fill and Form Reader bricks should use selector input types

### DIFF
--- a/src/blocks/effects/forms.ts
+++ b/src/blocks/effects/forms.ts
@@ -235,7 +235,7 @@ export class FormFill extends Effect {
       submit: {
         description: "true to submit the form, or a jQuery selector to click",
         default: false,
-        oneOf: [{ type: "string" }, { type: "boolean" }],
+        oneOf: [{ type: "string", format: "selector" }, { type: "boolean" }],
       },
     },
     required: [],

--- a/src/blocks/transformers/FormData.ts
+++ b/src/blocks/transformers/FormData.ts
@@ -53,6 +53,7 @@ export class FormData extends Transformer {
     {
       selector: {
         type: "string",
+        format: "selector",
         description: "jQuery selector for the form",
       },
       ...IS_ROOT_AWARE_BRICK_PROPS,


### PR DESCRIPTION
## What does this PR do?

- Fixes #4971 

## Demo

https://www.loom.com/share/1bd0b8e67fa940f69971d40d856a5306

## Future Work

- Tracking the selectors for property _names_ in #4988

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer - @BALEHOK 
