### PR TITLE
#4910: make selector for Set Input Value optional if root is field

### DIFF
--- a/src/blocks/effects/forms.test.ts
+++ b/src/blocks/effects/forms.test.ts
@@ -37,7 +37,7 @@ import ConsoleLogger from "@/utils/ConsoleLogger";
 import { uuidSequence } from "@/testUtils/factories";
 import { type BlockOptions } from "@/core";
 import { FormFill, SetInputValue } from "@/blocks/effects/forms";
-import { NoElementsFoundError } from "@/errors/businessErrors";
+import { BusinessError, NoElementsFoundError } from "@/errors/businessErrors";
 
 const setInputValueBrick = new SetInputValue();
 const formFillBrick = new FormFill();
@@ -104,6 +104,50 @@ describe("SetInputValue", () => {
     );
 
     expect(document.querySelector("[name='name']")).toHaveValue("Bob Smith");
+  });
+
+  test("accepts field root and blank selector", async () => {
+    await setInputValueBrick.run(
+      unsafeAssumeValidArg({
+        inputs: [{ value: "Bob Smith" }],
+        isRootAware: true,
+      }),
+      {
+        root: document.querySelector("input"),
+        logger,
+      } as unknown as BlockOptions
+    );
+
+    expect(document.querySelector("[name='name']")).toHaveValue("Bob Smith");
+  });
+
+  test("requires selector for document root", async () => {
+    const promise = setInputValueBrick.run(
+      unsafeAssumeValidArg({
+        inputs: [{ value: "Bob Smith" }],
+        isRootAware: false,
+      }),
+      {
+        logger,
+      } as unknown as BlockOptions
+    );
+
+    await expect(promise).rejects.toThrow(BusinessError);
+  });
+
+  test("rejects non-field root", async () => {
+    const promise = setInputValueBrick.run(
+      unsafeAssumeValidArg({
+        inputs: [{ value: "Bob Smith" }],
+        isRootAware: true,
+      }),
+      {
+        logger,
+        root: document.querySelector("div"),
+      } as unknown as BlockOptions
+    );
+
+    await expect(promise).rejects.toThrow(BusinessError);
   });
 });
 

--- a/src/blocks/effects/forms.ts
+++ b/src/blocks/effects/forms.ts
@@ -34,6 +34,7 @@ import {
   $safeFindElementsWithRootMode,
   IS_ROOT_AWARE_BRICK_PROPS,
 } from "@/blocks/rootModeHelpers";
+import { isEmpty } from "lodash";
 
 type SetValueData = RequireExactlyOne<
   {
@@ -48,6 +49,68 @@ type SetValueData = RequireExactlyOne<
 >;
 
 const optionFields = ["checkbox", "radio"];
+
+type FieldElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
+
+function isFieldElement(element: HTMLElement): boolean {
+  return (
+    element.isContentEditable ||
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement ||
+    element instanceof HTMLSelectElement
+  );
+}
+
+function setFieldValue(
+  field: FieldElement,
+  value: unknown,
+  { dispatchEvent, isOption }: { dispatchEvent: boolean; isOption: boolean }
+): void {
+  if (field.isContentEditable) {
+    // Field needs to be focused first
+    field.focus();
+
+    // `insertText` acts as a "paste", so if no text is selected it's just appended
+    document.execCommand("selectAll");
+
+    // It automatically triggers an `input` event
+    document.execCommand("insertText", false, String(value));
+
+    return;
+  }
+
+  // `instanceof` is there as a type guard only
+  if (
+    !optionFields.includes(field.type) ||
+    field instanceof HTMLTextAreaElement ||
+    field instanceof HTMLSelectElement
+  ) {
+    // Plain text field
+    field.value = String(value);
+  } else if (isOption) {
+    // Value-based radio/checkbox
+    field.checked = field.value === value;
+  } else {
+    // Boolean checkbox
+    field.checked = boolean(value);
+  }
+
+  if (dispatchEvent) {
+    if (
+      !(optionFields.includes(field.type) || field instanceof HTMLSelectElement)
+    ) {
+      // Browsers normally fire these text events while typing
+      field.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true }));
+      field.dispatchEvent(new KeyboardEvent("keypress", { bubbles: true }));
+      field.dispatchEvent(new CompositionEvent("textInput", { bubbles: true }));
+      field.dispatchEvent(new InputEvent("input", { bubbles: true }));
+      field.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
+    }
+
+    // Browsers normally fire this on `blur` if it's a text field, otherwise immediately
+    field.dispatchEvent(new KeyboardEvent("change", { bubbles: true }));
+  }
+}
 
 /**
  * Set the value of an input, doing the right thing for check boxes, etc.
@@ -65,11 +128,7 @@ function setValue({
     .find<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>(selector)
     .toArray()
     .filter((element) => {
-      const isField =
-        element.isContentEditable ||
-        element instanceof HTMLInputElement ||
-        element instanceof HTMLTextAreaElement ||
-        element instanceof HTMLSelectElement;
+      const isField = isFieldElement(element);
       if (!isField) {
         logger.warn(
           "The selected element is not an input field nor an editable element",
@@ -98,55 +157,7 @@ function setValue({
     );
 
   for (const field of fields) {
-    if (field.isContentEditable) {
-      // Field needs to be focused first
-      field.focus();
-
-      // `insertText` acts as a "paste", so if no text is selected it's just appended
-      document.execCommand("selectAll");
-
-      // It automatically triggers an `input` event
-      document.execCommand("insertText", false, String(value));
-
-      continue;
-    }
-
-    // `instanceof` is there as a type guard only
-    if (
-      !optionFields.includes(field.type) ||
-      field instanceof HTMLTextAreaElement ||
-      field instanceof HTMLSelectElement
-    ) {
-      // Plain text field
-      field.value = String(value);
-    } else if (isOption) {
-      // Value-based radio/checkbox
-      field.checked = field.value === value;
-    } else {
-      // Boolean checkbox
-      field.checked = boolean(value);
-    }
-
-    if (dispatchEvent) {
-      if (
-        !(
-          optionFields.includes(field.type) ||
-          field instanceof HTMLSelectElement
-        )
-      ) {
-        // Browsers normally fire these text events while typing
-        field.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true }));
-        field.dispatchEvent(new KeyboardEvent("keypress", { bubbles: true }));
-        field.dispatchEvent(
-          new CompositionEvent("textInput", { bubbles: true })
-        );
-        field.dispatchEvent(new InputEvent("input", { bubbles: true }));
-        field.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
-      }
-
-      // Browsers normally fire this on `blur` if it's a text field, otherwise immediately
-      field.dispatchEvent(new KeyboardEvent("change", { bubbles: true }));
-    }
+    setFieldValue(field, value, { dispatchEvent, isOption });
   }
 }
 
@@ -174,6 +185,8 @@ export class SetInputValue extends Effect {
             selector: {
               type: "string",
               format: "selector",
+              description:
+                "jQuery selector for the input(s), or exclude to use target element",
             },
             value: {
               oneOf: [
@@ -203,7 +216,24 @@ export class SetInputValue extends Effect {
   ): Promise<void> {
     const form = isRootAware ? root : document;
     for (const { selector, value } of inputs) {
-      setValue({ selector, value, logger, dispatchEvent: true, form });
+      if (isEmpty(selector)) {
+        if (form == null || form === document) {
+          throw new BusinessError("Selector required when called on document");
+        }
+
+        if (!isFieldElement(form as HTMLElement)) {
+          throw new BusinessError(
+            "Field is not a input field or editable element"
+          );
+        }
+
+        setFieldValue(form as FieldElement, value, {
+          dispatchEvent: true,
+          isOption: false,
+        });
+      } else {
+        setValue({ selector, value, logger, dispatchEvent: true, form });
+      }
     }
   }
 }

--- a/src/blocks/effects/forms.ts
+++ b/src/blocks/effects/forms.ts
@@ -214,25 +214,32 @@ export class SetInputValue extends Effect {
     }>,
     { logger, root }: BlockOptions
   ): Promise<void> {
-    const form = isRootAware ? root : document;
+    const target = isRootAware ? root : document;
     for (const { selector, value } of inputs) {
       if (isEmpty(selector)) {
-        if (form == null || form === document) {
+        if (target == null || target === document) {
           throw new BusinessError("Selector required when called on document");
         }
 
-        if (!isFieldElement(form as HTMLElement)) {
+        if (!isFieldElement(target as HTMLElement)) {
           throw new BusinessError(
             "Field is not a input field or editable element"
           );
         }
 
-        setFieldValue(form as FieldElement, value, {
+        setFieldValue(target as FieldElement, value, {
           dispatchEvent: true,
           isOption: false,
         });
       } else {
-        setValue({ selector, value, logger, dispatchEvent: true, form });
+        // `setValue` works on any element that contains fields, not just forms
+        setValue({
+          selector,
+          value,
+          logger,
+          dispatchEvent: true,
+          form: target,
+        });
       }
     }
   }

--- a/src/pageEditor/exampleBlockConfigs.ts
+++ b/src/pageEditor/exampleBlockConfigs.ts
@@ -113,6 +113,13 @@ export function getExampleBlockConfig(
     };
   }
 
+  if (blockId === "@pixiebrix/forms/set") {
+    return {
+      isRootAware: true,
+      inputs: [{ selector: null, value: "" }],
+    };
+  }
+
   if (blockId === DisplayTemporaryInfo.BLOCK_ID) {
     return {
       title: "Example Info",


### PR DESCRIPTION
## What does this PR do?

- Part of #4910
- Makes `selector` optional for Set Input Value brick if the target element is a field
- Includes an input entry by default when adding the brick

## Demo

- https://www.loom.com/share/0174c5a1480a45b5a7a21f6e993636d6

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
