### PR TITLE
#4994: Make links in Field descriptions clickable

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -18,7 +18,7 @@
     "^.+\\.txt$": "<rootDir>/src/testUtils/rawJestTransformer.mjs"
   },
   "transformIgnorePatterns": [
-    "node_modules/(?!@cfworker|escape-string-regex|filename-reserved-regex|filenamify|idb|webext-|p-timeout|p-retry|p-defer|p-memoize|serialize-error|strip-outer|trim-repeated|mimic-fn|urlpattern-polyfill|url-join|uuid|nanoid|use-debounce|copy-text-to-clipboard)"
+    "node_modules/(?!@cfworker|escape-string-regex|filename-reserved-regex|filenamify|idb|webext-|p-timeout|p-retry|p-defer|p-memoize|serialize-error|strip-outer|trim-repeated|mimic-fn|urlpattern-polyfill|url-join|uuid|nanoid|use-debounce|copy-text-to-clipboard|linkify-urls|create-html-element|stringify-attributes|escape-goat)"
   ],
   "setupFiles": [
     "dotenv/config",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "json-stringify-safe": "^5.0.1",
         "jsonpath-plus": "^7.0.0",
         "kbar": "^0.1.0-beta.39",
+        "linkify-urls": "^4.0.0",
         "lodash-es": "^4.17.21",
         "marked": "^4.2.5",
         "mustache": "^4.2.0",
@@ -17191,6 +17192,34 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/create-html-element": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/create-html-element/-/create-html-element-4.0.1.tgz",
+      "integrity": "sha512-K/wr7TGTPh4v2m5JpxNWQ/W4/lHkVjun7rTmg8ycNjbJE0ngjxvVYSiYzgq4iiJ+H5zq2FcPu6ZehCZHHcZtfA==",
+      "dependencies": {
+        "escape-goat": "^4.0.0",
+        "html-tags": "^3.1.0",
+        "stringify-attributes": "^3.0.0",
+        "type-fest": "^2.5.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/create-html-element/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
@@ -18819,6 +18848,17 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escape-html": {
@@ -22088,7 +22128,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
       "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -27330,6 +27369,20 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/linkify-urls": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-urls/-/linkify-urls-4.0.0.tgz",
+      "integrity": "sha512-Kjj+9gZtj+Yf93LL1UPND6F/F5hcZAINuBfS4AKiOUh5mmfVjSiZWBg75ebCJ8onkf0lIMJhiOQXF3BCBBmCtw==",
+      "dependencies": {
+        "create-html-element": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/load-json-file": {
       "version": "1.1.0",
@@ -33954,6 +34007,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stringify-attributes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-attributes/-/stringify-attributes-3.0.0.tgz",
+      "integrity": "sha512-tJKiThlLfog6ljT7ZTihlMh0iAtjKlu/ss9DMmBE5oOosbMqOMcuxc7zDfxP2lGzSb2Bwvbd3gQTqTSCmXyySw==",
+      "dependencies": {
+        "escape-goat": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stringify-attributes/node_modules/escape-goat": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
+      "integrity": "sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-ansi": {
@@ -49790,6 +49868,24 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-html-element": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/create-html-element/-/create-html-element-4.0.1.tgz",
+      "integrity": "sha512-K/wr7TGTPh4v2m5JpxNWQ/W4/lHkVjun7rTmg8ycNjbJE0ngjxvVYSiYzgq4iiJ+H5zq2FcPu6ZehCZHHcZtfA==",
+      "requires": {
+        "escape-goat": "^4.0.0",
+        "html-tags": "^3.1.0",
+        "stringify-attributes": "^3.0.0",
+        "type-fest": "^2.5.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
@@ -50967,6 +51063,11 @@
       "version": "3.1.1",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
+    },
+    "escape-goat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -53433,8 +53534,7 @@
     "html-tags": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
-      "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
-      "dev": true
+      "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg=="
     },
     "html-void-elements": {
       "version": "1.0.5",
@@ -57372,6 +57472,14 @@
     "lines-and-columns": {
       "version": "1.2.4",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "linkify-urls": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-urls/-/linkify-urls-4.0.0.tgz",
+      "integrity": "sha512-Kjj+9gZtj+Yf93LL1UPND6F/F5hcZAINuBfS4AKiOUh5mmfVjSiZWBg75ebCJ8onkf0lIMJhiOQXF3BCBBmCtw==",
+      "requires": {
+        "create-html-element": "^4.0.1"
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -62532,6 +62640,21 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.19.5"
+      }
+    },
+    "stringify-attributes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-attributes/-/stringify-attributes-3.0.0.tgz",
+      "integrity": "sha512-tJKiThlLfog6ljT7ZTihlMh0iAtjKlu/ss9DMmBE5oOosbMqOMcuxc7zDfxP2lGzSb2Bwvbd3gQTqTSCmXyySw==",
+      "requires": {
+        "escape-goat": "^3.0.0"
+      },
+      "dependencies": {
+        "escape-goat": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
+          "integrity": "sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw=="
+        }
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "json-stringify-safe": "^5.0.1",
     "jsonpath-plus": "^7.0.0",
     "kbar": "^0.1.0-beta.39",
+    "linkify-urls": "^4.0.0",
     "lodash-es": "^4.17.21",
     "marked": "^4.2.5",
     "mustache": "^4.2.0",

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -59,7 +59,13 @@ exports[`Storyshots ActivateWizard/OptionsBody Text Field 1`] = `
       <small
         className="text-muted form-text"
       >
-        This is a basic required text field.
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "This is a basic required text field.",
+            }
+          }
+        />
       </small>
     </div>
   </div>
@@ -3795,7 +3801,13 @@ exports[`Storyshots Fields/ChildObjectField Primitive Value 1`] = `
               <small
                 className="text-muted form-text"
               >
-                This is a description for the field
+                <span
+                  dangerouslySetInnerHTML={
+                    {
+                      "__html": "This is a description for the field",
+                    }
+                  }
+                />
               </small>
             </div>
           </div>
@@ -5130,7 +5142,13 @@ exports[`Storyshots Fields/SchemaField Password 1`] = `
       <small
         className="text-muted form-text"
       >
-        A secret field
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "A secret field",
+            }
+          }
+        />
       </small>
     </div>
   </div>
@@ -5809,7 +5827,13 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
             <small
               className="text-muted form-text"
             >
-              Enter a name to refer to this value in the output later
+              <span
+                dangerouslySetInnerHTML={
+                  {
+                    "__html": "Enter a name to refer to this value in the output later",
+                  }
+                }
+              />
             </small>
           </div>
         </div>
@@ -5868,7 +5892,13 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
             <small
               className="text-muted form-text"
             >
-              The user-visible label for this field
+              <span
+                dangerouslySetInnerHTML={
+                  {
+                    "__html": "The user-visible label for this field",
+                  }
+                }
+              />
             </small>
           </div>
         </div>
@@ -5927,7 +5957,13 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
             <small
               className="text-muted form-text"
             >
-              The user-visible description for the field
+              <span
+                dangerouslySetInnerHTML={
+                  {
+                    "__html": "The user-visible description for the field",
+                  }
+                }
+              />
             </small>
           </div>
         </div>
@@ -6631,7 +6667,13 @@ exports[`Storyshots Forms/Formik All Fields 1`] = `
       <small
         className="text-muted form-text"
       >
-        A name
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "A name",
+            }
+          }
+        />
       </small>
     </div>
   </div>
@@ -6659,7 +6701,13 @@ exports[`Storyshots Forms/Formik All Fields 1`] = `
       <small
         className="text-muted form-text"
       >
-        Tell me your story
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "Tell me your story",
+            }
+          }
+        />
       </small>
     </div>
   </div>
@@ -6781,7 +6829,13 @@ exports[`Storyshots Forms/Formik All Fields 1`] = `
       <small
         className="text-muted form-text"
       >
-        Demonstration dropdown
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "Demonstration dropdown",
+            }
+          }
+        />
       </small>
     </div>
   </div>
@@ -6903,7 +6957,13 @@ exports[`Storyshots Forms/Formik All Fields 1`] = `
       <small
         className="text-muted form-text"
       >
-        Creatable
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "Creatable",
+            }
+          }
+        />
       </small>
     </div>
   </div>
@@ -7001,7 +7061,13 @@ exports[`Storyshots Forms/Formik All Fields 1`] = `
       <small
         className="text-muted form-text"
       >
-        You can use a FormControl as a wrapped Widget
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "You can use a FormControl as a wrapped Widget",
+            }
+          }
+        />
       </small>
     </div>
   </div>
@@ -7061,7 +7127,13 @@ exports[`Storyshots Forms/Formik Custom Submit 1`] = `
       <small
         className="text-muted form-text"
       >
-        A name
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "A name",
+            }
+          }
+        />
       </small>
     </div>
   </div>
@@ -7088,7 +7160,13 @@ exports[`Storyshots Forms/Formik Custom Submit 1`] = `
       <small
         className="text-muted form-text"
       >
-        Your age
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "Your age",
+            }
+          }
+        />
       </small>
     </div>
   </div>
@@ -7147,7 +7225,13 @@ exports[`Storyshots Forms/Formik With FormikField 1`] = `
       <small
         className="text-muted form-text"
       >
-        A name
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "A name",
+            }
+          }
+        />
       </small>
     </div>
   </div>
@@ -7174,7 +7258,13 @@ exports[`Storyshots Forms/Formik With FormikField 1`] = `
       <small
         className="text-muted form-text"
       >
-        Your age
+        <span
+          dangerouslySetInnerHTML={
+            {
+              "__html": "Your age",
+            }
+          }
+        />
       </small>
     </div>
   </div>

--- a/src/components/LinkifiedString.test.tsx
+++ b/src/components/LinkifiedString.test.tsx
@@ -25,41 +25,19 @@ describe("LinkifiedString", () => {
       <LinkifiedString>https://example.com and more</LinkifiedString>
     );
 
-    expect(rendered.asFragment()).toMatchInlineSnapshot(`
-      <DocumentFragment>
-        <span>
-          <a
-            href="https://example.com"
-            target="_blank"
-          >
-            https://example.com
-          </a>
-           and more
-        </span>
-      </DocumentFragment>
-    `);
+    expect(rendered.asFragment()).toMatchSnapshot();
   });
   test("ignores string without links", async () => {
     const rendered = render(
       <LinkifiedString>Here’s regular text</LinkifiedString>
     );
 
-    expect(rendered.asFragment()).toMatchInlineSnapshot(`
-      <DocumentFragment>
-        <span>
-          Here’s regular text
-        </span>
-      </DocumentFragment>
-    `);
+    expect(rendered.asFragment()).toMatchSnapshot();
   });
   test("ignores empty string", async () => {
     const rendered = render(<LinkifiedString>{""}</LinkifiedString>);
 
-    expect(rendered.asFragment()).toMatchInlineSnapshot(`
-      <DocumentFragment>
-        <span />
-      </DocumentFragment>
-    `);
+    expect(rendered.asFragment()).toMatchSnapshot();
   });
   test("ignores non-string children", async () => {
     const rendered = render(
@@ -68,20 +46,11 @@ describe("LinkifiedString", () => {
       </LinkifiedString>
     );
 
-    expect(rendered.asFragment()).toMatchInlineSnapshot(`
-      <DocumentFragment>
-        Half
-        <a
-          href="https://example.com"
-        >
-          linked
-        </a>
-      </DocumentFragment>
-    `);
+    expect(rendered.asFragment()).toMatchSnapshot();
   });
   test("ignores missing children", async () => {
     const rendered = render(<LinkifiedString />);
 
-    expect(rendered.asFragment()).toMatchInlineSnapshot("<DocumentFragment />");
+    expect(rendered.asFragment()).toMatchSnapshot();
   });
 });

--- a/src/components/LinkifiedString.test.tsx
+++ b/src/components/LinkifiedString.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import LinkifiedString from "./LinkifiedString";
+
+describe("LinkifiedString", () => {
+  test("linkifies string", async () => {
+    const rendered = render(
+      <LinkifiedString>https://example.com and more</LinkifiedString>
+    );
+
+    expect(rendered.asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <span>
+          <a
+            href="https://example.com"
+            target="_blank"
+          >
+            https://example.com
+          </a>
+           and more
+        </span>
+      </DocumentFragment>
+    `);
+  });
+  test("ignores string without links", async () => {
+    const rendered = render(
+      <LinkifiedString>Here’s regular text</LinkifiedString>
+    );
+
+    expect(rendered.asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <span>
+          Here’s regular text
+        </span>
+      </DocumentFragment>
+    `);
+  });
+  test("ignores empty string", async () => {
+    const rendered = render(<LinkifiedString>{""}</LinkifiedString>);
+
+    expect(rendered.asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        <span />
+      </DocumentFragment>
+    `);
+  });
+  test("ignores non-string children", async () => {
+    const rendered = render(
+      <LinkifiedString>
+        Half<a href="https://example.com">linked</a>
+      </LinkifiedString>
+    );
+
+    expect(rendered.asFragment()).toMatchInlineSnapshot(`
+      <DocumentFragment>
+        Half
+        <a
+          href="https://example.com"
+        >
+          linked
+        </a>
+      </DocumentFragment>
+    `);
+  });
+  test("ignores missing children", async () => {
+    const rendered = render(<LinkifiedString />);
+
+    expect(rendered.asFragment()).toMatchInlineSnapshot("<DocumentFragment />");
+  });
+});

--- a/src/components/LinkifiedString.tsx
+++ b/src/components/LinkifiedString.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import linkifyUrls from "linkify-urls";
+import React from "react";
+
+const LinkifiedString: React.FC = ({ children }) => {
+  if (typeof children !== "string") {
+    return <>{children}</>;
+  }
+
+  return (
+    <span
+      dangerouslySetInnerHTML={{
+        __html: linkifyUrls(children, {
+          attributes: {
+            target: "_blank",
+          },
+        }),
+      }}
+    />
+  );
+};
+
+export default LinkifiedString;

--- a/src/components/__snapshots__/LinkifiedString.test.tsx.snap
+++ b/src/components/__snapshots__/LinkifiedString.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LinkifiedString ignores empty string 1`] = `
+<DocumentFragment>
+  <span />
+</DocumentFragment>
+`;
+
+exports[`LinkifiedString ignores missing children 1`] = `<DocumentFragment />`;
+
+exports[`LinkifiedString ignores non-string children 1`] = `
+<DocumentFragment>
+  Half
+  <a
+    href="https://example.com"
+  >
+    linked
+  </a>
+</DocumentFragment>
+`;
+
+exports[`LinkifiedString ignores string without links 1`] = `
+<DocumentFragment>
+  <span>
+    Here’s regular text
+  </span>
+</DocumentFragment>
+`;
+
+exports[`LinkifiedString linkifies string 1`] = `
+<DocumentFragment>
+  <span>
+    <a
+      href="https://example.com"
+      target="_blank"
+    >
+      https://example.com
+    </a>
+     and more
+  </span>
+</DocumentFragment>
+`;

--- a/src/components/form/FieldTemplate.tsx
+++ b/src/components/form/FieldTemplate.tsx
@@ -29,7 +29,7 @@ import cx from "classnames";
 import { castArray, isPlainObject } from "lodash";
 import AnnotationAlert from "@/components/annotationAlert/AnnotationAlert";
 import { AnnotationType } from "@/analysis/analysisTypes";
-import LinkifiedString from "../LinkifiedString";
+import LinkifiedString from "@/components/LinkifiedString";
 
 export type FieldProps<As extends React.ElementType = React.ElementType> =
   FormControlProps &

--- a/src/components/form/FieldTemplate.tsx
+++ b/src/components/form/FieldTemplate.tsx
@@ -29,7 +29,7 @@ import cx from "classnames";
 import { castArray, isPlainObject } from "lodash";
 import AnnotationAlert from "@/components/annotationAlert/AnnotationAlert";
 import { AnnotationType } from "@/analysis/analysisTypes";
-import linkifyUrls from "linkify-urls";
+import LinkifiedString from "../LinkifiedString";
 
 export type FieldProps<As extends React.ElementType = React.ElementType> =
   FormControlProps &
@@ -223,16 +223,9 @@ const FieldTemplate: React.FC<FieldProps> = ({
       <Col {...colSize}>
         {formControl}
         {description && (
-          <BootstrapForm.Text
-            className="text-muted"
-            dangerouslySetInnerHTML={{
-              __html: linkifyUrls(description, {
-                attributes: {
-                  target: "_blank",
-                },
-              }),
-            }}
-          ></BootstrapForm.Text>
+          <BootstrapForm.Text className="text-muted">
+            <LinkifiedString>{description}</LinkifiedString>
+          </BootstrapForm.Text>
         )}
       </Col>
     </BootstrapForm.Group>

--- a/src/components/form/FieldTemplate.tsx
+++ b/src/components/form/FieldTemplate.tsx
@@ -29,6 +29,7 @@ import cx from "classnames";
 import { castArray, isPlainObject } from "lodash";
 import AnnotationAlert from "@/components/annotationAlert/AnnotationAlert";
 import { AnnotationType } from "@/analysis/analysisTypes";
+import linkifyUrls from "linkify-urls";
 
 export type FieldProps<As extends React.ElementType = React.ElementType> =
   FormControlProps &
@@ -222,9 +223,16 @@ const FieldTemplate: React.FC<FieldProps> = ({
       <Col {...colSize}>
         {formControl}
         {description && (
-          <BootstrapForm.Text className="text-muted">
-            {description}
-          </BootstrapForm.Text>
+          <BootstrapForm.Text
+            className="text-muted"
+            dangerouslySetInnerHTML={{
+              __html: linkifyUrls(description, {
+                attributes: {
+                  target: "_blank",
+                },
+              }),
+            }}
+          ></BootstrapForm.Text>
         )}
       </Col>
     </BootstrapForm.Group>

--- a/src/components/formBuilder/edit/__snapshots__/FormEditor.test.tsx.snap
+++ b/src/components/formBuilder/edit/__snapshots__/FormEditor.test.tsx.snap
@@ -367,7 +367,9 @@ exports[`FormEditor renders simple schema 1`] = `
           <small
             class="text-muted form-text"
           >
-            Enter a name to refer to this value in the output later
+            <span>
+              Enter a name to refer to this value in the output later
+            </span>
           </small>
         </div>
       </div>
@@ -422,7 +424,9 @@ exports[`FormEditor renders simple schema 1`] = `
           <small
             class="text-muted form-text"
           >
-            The user-visible label for this field
+            <span>
+              The user-visible label for this field
+            </span>
           </small>
         </div>
       </div>
@@ -476,7 +480,9 @@ exports[`FormEditor renders simple schema 1`] = `
           <small
             class="text-muted form-text"
           >
-            The user-visible description for the field
+            <span>
+              The user-visible description for the field
+            </span>
           </small>
         </div>
       </div>
@@ -937,7 +943,9 @@ exports[`FormEditor renders unknown field format 1`] = `
           <small
             class="text-muted form-text"
           >
-            Enter a name to refer to this value in the output later
+            <span>
+              Enter a name to refer to this value in the output later
+            </span>
           </small>
         </div>
       </div>
@@ -992,7 +1000,9 @@ exports[`FormEditor renders unknown field format 1`] = `
           <small
             class="text-muted form-text"
           >
-            The user-visible label for this field
+            <span>
+              The user-visible label for this field
+            </span>
           </small>
         </div>
       </div>
@@ -1046,7 +1056,9 @@ exports[`FormEditor renders unknown field format 1`] = `
           <small
             class="text-muted form-text"
           >
-            The user-visible description for the field
+            <span>
+              The user-visible description for the field
+            </span>
           </small>
         </div>
       </div>

--- a/src/contrib/uipath/__snapshots__/ProcessOptions.test.tsx.snap
+++ b/src/contrib/uipath/__snapshots__/ProcessOptions.test.tsx.snap
@@ -370,7 +370,9 @@ exports[`UiPath Options Render with selected dependency 1`] = `
         <small
           class="text-muted form-text"
         >
-          The UiPath release/process
+          <span>
+            The UiPath release/process
+          </span>
         </small>
       </div>
     </div>
@@ -506,7 +508,9 @@ exports[`UiPath Options Render with selected dependency 1`] = `
         <small
           class="text-muted form-text"
         >
-          How the process should be run
+          <span>
+            How the process should be run
+          </span>
         </small>
       </div>
     </div>
@@ -560,7 +564,9 @@ exports[`UiPath Options Render with selected dependency 1`] = `
         <small
           class="text-muted form-text"
         >
-          When using strategy JobsCount, the process will run x times where x is the value of the JobsCount field.
+          <span>
+            When using strategy JobsCount, the process will run x times where x is the value of the JobsCount field.
+          </span>
         </small>
       </div>
     </div>
@@ -628,7 +634,9 @@ exports[`UiPath Options Render with selected dependency 1`] = `
         <small
           class="text-muted form-text"
         >
-          Wait for the process to complete and output the results.
+          <span>
+            Wait for the process to complete and output the results.
+          </span>
         </small>
       </div>
     </div>

--- a/src/options/pages/blueprints/modals/convertToRecipeModal/__snapshots__/ConvertToRecipeModal.test.tsx.snap
+++ b/src/options/pages/blueprints/modals/convertToRecipeModal/__snapshots__/ConvertToRecipeModal.test.tsx.snap
@@ -149,7 +149,9 @@ exports[`it renders default state 1`] = `
               <small
                 class="text-muted form-text"
               >
-                A unique id for the blueprint
+                <span>
+                  A unique id for the blueprint
+                </span>
               </small>
             </div>
           </div>
@@ -174,7 +176,9 @@ exports[`it renders default state 1`] = `
               <small
                 class="text-muted form-text"
               >
-                A display name for the blueprint
+                <span>
+                  A display name for the blueprint
+                </span>
               </small>
             </div>
           </div>
@@ -199,7 +203,9 @@ exports[`it renders default state 1`] = `
               <small
                 class="text-muted form-text"
               >
-                The current blueprint version
+                <span>
+                  The current blueprint version
+                </span>
               </small>
             </div>
           </div>
@@ -224,7 +230,9 @@ exports[`it renders default state 1`] = `
               <small
                 class="text-muted form-text"
               >
-                A short description of the blueprint
+                <span>
+                  A short description of the blueprint
+                </span>
               </small>
             </div>
           </div>
@@ -372,7 +380,9 @@ exports[`it renders requires user scope 1`] = `
                 <small
                   class="text-muted form-text"
                 >
-                  Your @alias for publishing bricks, e.g. @peter-parker
+                  <span>
+                    Your @alias for publishing bricks, e.g. @peter-parker
+                  </span>
                 </small>
               </div>
             </div>

--- a/src/options/pages/services/__snapshots__/ServiceEditorModal.test.tsx.snap
+++ b/src/options/pages/services/__snapshots__/ServiceEditorModal.test.tsx.snap
@@ -67,7 +67,9 @@ exports[`ServiceEditorModal Can render Pipedrive configuration modal without exi
               <small
                 class="text-muted form-text"
               >
-                A label to help identify this integration
+                <span>
+                  A label to help identify this integration
+                </span>
               </small>
             </div>
           </div>
@@ -171,7 +173,9 @@ exports[`ServiceEditorModal Can render Pipedrive configuration modal without exi
               <small
                 class="text-muted form-text"
               >
-                Your Pipedrive API Key
+                <span>
+                  Your Pipedrive API Key
+                </span>
               </small>
             </div>
           </div>
@@ -225,7 +229,9 @@ exports[`ServiceEditorModal Can render Pipedrive configuration modal without exi
               <small
                 class="text-muted form-text"
               >
-                The subdomain of your Pipedrive instance URL
+                <span>
+                  The subdomain of your Pipedrive instance URL
+                </span>
               </small>
             </div>
           </div>

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -672,7 +672,9 @@ exports[`renders an extension with sub pipeline 1`] = `
                       <small
                         class="text-muted form-text"
                       >
-                        Panel heading
+                        <span>
+                          Panel heading
+                        </span>
                       </small>
                     </div>
                   </div>
@@ -756,7 +758,9 @@ exports[`renders an extension with sub pipeline 1`] = `
                       <small
                         class="text-muted form-text"
                       >
-                        Location on the page
+                        <span>
+                          Location on the page
+                        </span>
                       </small>
                     </div>
                   </div>
@@ -916,7 +920,9 @@ exports[`renders an extension with sub pipeline 1`] = `
                       <small
                         class="text-muted form-text"
                       >
-                        Render the panel as a collapsible drawer
+                        <span>
+                          Render the panel as a collapsible drawer
+                        </span>
                       </small>
                     </div>
                   </div>
@@ -960,7 +966,9 @@ exports[`renders an extension with sub pipeline 1`] = `
                       <small
                         class="text-muted form-text"
                       >
-                        Isolate the panel style with a Shadow DOM
+                        <span>
+                          Isolate the panel style with a Shadow DOM
+                        </span>
                       </small>
                     </div>
                   </div>
@@ -1005,7 +1013,9 @@ exports[`renders an extension with sub pipeline 1`] = `
                       <small
                         class="text-muted form-text"
                       >
-                        A template for the item, with a placeholder for the heading and body
+                        <span>
+                          A template for the item, with a placeholder for the heading and body
+                        </span>
                       </small>
                     </div>
                   </div>

--- a/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
+++ b/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
@@ -212,7 +212,9 @@ exports[`MatchRulesSection render populated section 1`] = `
                                     <small
                                       class="text-muted form-text"
                                     >
-                                      Pattern to match the hostname part of a URL.
+                                      <span>
+                                        Pattern to match the hostname part of a URL.
+                                      </span>
                                     </small>
                                   </div>
                                 </div>
@@ -273,7 +275,9 @@ exports[`MatchRulesSection render populated section 1`] = `
                                     <small
                                       class="text-muted form-text"
                                     >
-                                      Pattern to match the pathname part of a URL.
+                                      <span>
+                                        Pattern to match the pathname part of a URL.
+                                      </span>
                                     </small>
                                   </div>
                                 </div>
@@ -335,7 +339,9 @@ exports[`MatchRulesSection render populated section 1`] = `
                                     <small
                                       class="text-muted form-text"
                                     >
-                                      Pattern to match the hash part of a URL.
+                                      <span>
+                                        Pattern to match the hash part of a URL.
+                                      </span>
                                     </small>
                                   </div>
                                 </div>
@@ -396,7 +402,9 @@ exports[`MatchRulesSection render populated section 1`] = `
                                     <small
                                       class="text-muted form-text"
                                     >
-                                      Pattern to match the search part of a URL.
+                                      <span>
+                                        Pattern to match the search part of a URL.
+                                      </span>
                                     </small>
                                   </div>
                                 </div>


### PR DESCRIPTION
1. Visit https://app.pixiebrix.com/activate?id=@pixies/content-management-demo
2. Click "Configure"


<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/1402241/211462461-18f4e561-ec08-49ee-be45-870180e877d9.gif">
	<td><img src="https://user-images.githubusercontent.com/1402241/211462456-a3a314e7-4058-4908-8fe4-bb01f7885e6b.gif">
</table>


## Discussion

This is the lowest-level place I found. If you know of other parts that would benefit from linkification, let me know.

This change also applies to the page editor. Here it ignores any pre-existing links/dom:

<img width="662" alt="Screenshot 4" src="https://user-images.githubusercontent.com/1402241/211473676-61a15b20-b68e-45d0-a677-8ffcc82328b5.png">

An alternative solution with a broader impact would be to use a barebones "markdown" parser so we don't have to create JSX for this kind of content:

https://github.com/pixiebrix/pixiebrix-extension/blob/9dfc712805546a06a6ca05820e75d321fa82251a/src/pageEditor/tabs/quickBar/QuickBarConfiguration.tsx#L58-L68

However this requires further discussion and research so I skipped it for now. We just need support for `code` and `a`, not the whole `marked` module.


## Team Coordination

- [x] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BALEHOK 
