### PR TITLE
Drop mistaken `*://*/*` in MV3

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -140,7 +140,7 @@ function updateManifestToV3(manifest) {
   // Extract host permissions
   pull(manifest.permissions, "https://*.pixiebrix.com/*");
   pull(manifest.optional_permissions, "*://*/*");
-  manifest.host_permissions = ["https://*.pixiebrix.com/*", "*://*/*"];
+  manifest.host_permissions = ["https://*.pixiebrix.com/*"];
   manifest.permissions.push("scripting");
 
   // Update format


### PR DESCRIPTION
This was picked up from the original MV3 PR, initially added because that's how optional permissions were supposed to work.