### PR TITLE
#4863: Make content script injection visible

### DIFF
--- a/src/contentScript/contentScript.ts
+++ b/src/contentScript/contentScript.ts
@@ -16,6 +16,7 @@
  */
 
 import "./contentScript.scss";
+import "@/development/visualInjection";
 import { uuidv4 } from "@/types/helpers";
 import {
   isInstalledInThisSession,

--- a/src/development/visualInjection.ts
+++ b/src/development/visualInjection.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { MAX_Z_INDEX } from "@/common";
+
+if (process.env.ENVIRONMENT === "development") {
+  const indicator = document.createElement("div");
+
+  // Hide on hover
+  indicator.addEventListener("mouseenter", indicator.remove);
+
+  Object.assign(indicator.style, {
+    position: "fixed",
+    top: 0,
+    height: "1px",
+    zIndex: MAX_Z_INDEX,
+
+    // Vary position to see multiple injections
+    left: `${Math.random() * 100}px`,
+
+    // Add contrast so it's visible no matter the background
+    borderLeft: "solid 5px white",
+    borderRight: "solid 5px black",
+  });
+  document.body.prepend(indicator);
+}


### PR DESCRIPTION
- For #4863

This makes it immediately visible if and when a content script is injected, and whether it's been injected multiple times.

Note: this indicates whether `contentScript/contentScript` was injected, not `contentScriptCore`

Here you can see multiple injections (caused by an extension reload):

<img width="282" alt="Screenshot 1" src="https://user-images.githubusercontent.com/1402241/211990399-49a06238-b70b-49e5-8038-1c9b69f5ba40.png">


This visual indicator could make it easier to detect issues even without opening the console.

Here you can see the indicator in frames too:

https://alt-ephiframe.vercel.app/?iframe=.test

<img width="437" alt="Screenshot 4" src="https://user-images.githubusercontent.com/1402241/212020008-ea7aa129-70c7-42ba-b10e-e79cf1765877.png">


And here you can see that the content screen wasn't injected:

https://alt-ephiframe.vercel.app/Outer?iframe=https://extra-ephiframe.vercel.app/Cross-domain-iframe

<img width="442" alt="Screenshot 5" src="https://user-images.githubusercontent.com/1402241/212020266-6b1ffe41-c4e7-477a-82e6-64a6f3a6fbd6.png">

