### PR TITLE
Live and complete permission list in options

### DIFF
--- a/src/hooks/useExtensionPermissions.test.ts
+++ b/src/hooks/useExtensionPermissions.test.ts
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook, act } from "@testing-library/react-hooks";
 import useExtensionPermissions from "./useExtensionPermissions";
 import { selectAdditionalPermissionsSync } from "webext-additional-permissions";
-import { getChromeEventMocks, waitForEffect } from "@/testUtils/testHelpers";
+import { getChromeEventMocks } from "@/testUtils/testHelpers";
 
 browser.permissions.getAll = jest.fn();
 browser.permissions.onAdded = getChromeEventMocks();
@@ -50,7 +50,7 @@ describe("useExtensionPermissions", () => {
     mockOrigins();
     const { result } = renderHook(useExtensionPermissions);
     expect(result.current).toMatchInlineSnapshot("[]");
-    await waitForEffect();
+    await act(async () => {});
     expect(result.current).toMatchInlineSnapshot(`
       [
         {
@@ -66,7 +66,7 @@ describe("useExtensionPermissions", () => {
   test("includes additional permissions", async () => {
     mockOrigins("https://added.example.com/*", "https://more.example.com/*");
     const { result } = renderHook(useExtensionPermissions);
-    await waitForEffect();
+    await act(async () => {});
     expect(result.current).toMatchInlineSnapshot(`
       [
         {
@@ -94,7 +94,7 @@ describe("useExtensionPermissions", () => {
   test("detects overlapping permissions", async () => {
     mockOrigins("https://added.example.com/*", "https://*.example.com/*");
     const { result } = renderHook(useExtensionPermissions);
-    await waitForEffect();
+    await act(async () => {});
     expect(result.current).toMatchInlineSnapshot(`
       [
         {

--- a/src/hooks/useExtensionPermissions.test.ts
+++ b/src/hooks/useExtensionPermissions.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { renderHook, act } from "@testing-library/react-hooks";
+import useExtensionPermissions from "./useExtensionPermissions";
+import { selectAdditionalPermissionsSync } from "webext-additional-permissions";
+
+browser.permissions.getAll = jest.fn();
+(browser.permissions.onAdded as any) = {
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+};
+(browser.permissions.onRemoved as any) = {
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+};
+
+const getAllMock = jest.mocked(browser.permissions.getAll);
+const selectAdditionalMock = jest.mocked(selectAdditionalPermissionsSync);
+
+jest.mock("webext-additional-permissions", () => ({
+  ...jest.requireActual("webext-additional-permissions"),
+  selectAdditionalPermissionsSync: jest.fn(),
+}));
+
+const manifestPermission = "https://p.com/*";
+
+function mockOrigins(...additional: string[]): void {
+  getAllMock.mockResolvedValueOnce({
+    permissions: [],
+    origins: [manifestPermission, ...additional],
+  });
+  selectAdditionalMock.mockReturnValueOnce({
+    permissions: [],
+    origins: additional,
+  });
+}
+
+describe("useExtensionPermissions", () => {
+  test("reads manifest", async () => {
+    mockOrigins();
+    const { result } = renderHook(useExtensionPermissions);
+    expect(result.current).toMatchInlineSnapshot("[]");
+    await act(async () => {});
+    expect(result.current).toMatchInlineSnapshot(`
+      [
+        {
+          "isAdditional": false,
+          "isOrigin": true,
+          "isUnique": true,
+          "name": "https://p.com/*",
+        },
+      ]
+    `);
+  });
+
+  test("includes additional permissions", async () => {
+    mockOrigins("https://added.example.com/*", "https://more.example.com/*");
+    const { result } = renderHook(useExtensionPermissions);
+    await act(async () => {});
+    expect(result.current).toMatchInlineSnapshot(`
+      [
+        {
+          "isAdditional": true,
+          "isOrigin": true,
+          "isUnique": true,
+          "name": "https://added.example.com/*",
+        },
+        {
+          "isAdditional": true,
+          "isOrigin": true,
+          "isUnique": true,
+          "name": "https://more.example.com/*",
+        },
+        {
+          "isAdditional": false,
+          "isOrigin": true,
+          "isUnique": true,
+          "name": "https://p.com/*",
+        },
+      ]
+    `);
+  });
+
+  test("detects overlapping permissions", async () => {
+    mockOrigins("https://added.example.com/*", "https://*.example.com/*");
+    const { result } = renderHook(useExtensionPermissions);
+    await act(async () => {});
+    expect(result.current).toMatchInlineSnapshot(`
+      [
+        {
+          "isAdditional": true,
+          "isOrigin": true,
+          "isUnique": true,
+          "name": "https://*.example.com/*",
+        },
+        {
+          "isAdditional": true,
+          "isOrigin": true,
+          "isUnique": false,
+          "name": "https://added.example.com/*",
+        },
+        {
+          "isAdditional": false,
+          "isOrigin": true,
+          "isUnique": true,
+          "name": "https://p.com/*",
+        },
+      ]
+    `);
+  });
+});

--- a/src/hooks/useExtensionPermissions.test.ts
+++ b/src/hooks/useExtensionPermissions.test.ts
@@ -18,17 +18,11 @@
 import { renderHook } from "@testing-library/react-hooks";
 import useExtensionPermissions from "./useExtensionPermissions";
 import { selectAdditionalPermissionsSync } from "webext-additional-permissions";
-import { waitForEffect } from "@/testUtils/testHelpers";
+import { getChromeEventMocks, waitForEffect } from "@/testUtils/testHelpers";
 
 browser.permissions.getAll = jest.fn();
-(browser.permissions.onAdded as any) = {
-  addListener: jest.fn(),
-  removeListener: jest.fn(),
-};
-(browser.permissions.onRemoved as any) = {
-  addListener: jest.fn(),
-  removeListener: jest.fn(),
-};
+browser.permissions.onAdded = getChromeEventMocks();
+browser.permissions.onRemoved = getChromeEventMocks();
 
 const getAllMock = jest.mocked(browser.permissions.getAll);
 const selectAdditionalMock = jest.mocked(selectAdditionalPermissionsSync);

--- a/src/hooks/useExtensionPermissions.test.ts
+++ b/src/hooks/useExtensionPermissions.test.ts
@@ -15,9 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook, act } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react-hooks";
 import useExtensionPermissions from "./useExtensionPermissions";
 import { selectAdditionalPermissionsSync } from "webext-additional-permissions";
+import { waitForEffect } from "@/testUtils/testHelpers";
 
 browser.permissions.getAll = jest.fn();
 (browser.permissions.onAdded as any) = {
@@ -55,7 +56,7 @@ describe("useExtensionPermissions", () => {
     mockOrigins();
     const { result } = renderHook(useExtensionPermissions);
     expect(result.current).toMatchInlineSnapshot("[]");
-    await act(async () => {});
+    await waitForEffect();
     expect(result.current).toMatchInlineSnapshot(`
       [
         {
@@ -71,7 +72,7 @@ describe("useExtensionPermissions", () => {
   test("includes additional permissions", async () => {
     mockOrigins("https://added.example.com/*", "https://more.example.com/*");
     const { result } = renderHook(useExtensionPermissions);
-    await act(async () => {});
+    await waitForEffect();
     expect(result.current).toMatchInlineSnapshot(`
       [
         {
@@ -99,7 +100,7 @@ describe("useExtensionPermissions", () => {
   test("detects overlapping permissions", async () => {
     mockOrigins("https://added.example.com/*", "https://*.example.com/*");
     const { result } = renderHook(useExtensionPermissions);
-    await act(async () => {});
+    await waitForEffect();
     expect(result.current).toMatchInlineSnapshot(`
       [
         {

--- a/src/hooks/useExtensionPermissions.ts
+++ b/src/hooks/useExtensionPermissions.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from "react";
+
+type Permissions = chrome.permissions.Permissions;
+
+export default function useExtensionPermissions(): Permissions {
+  const [permissions, setPermissions] = useState<Permissions>({
+    permissions: [],
+    origins: [],
+  });
+  console.log({ permissions });
+
+  const update = async () => {
+    const { permissions, origins } = await browser.permissions.getAll();
+    setPermissions({
+      permissions: permissions.sort(),
+      origins: origins.sort(),
+    });
+  };
+
+  useEffect(() => {
+    browser.permissions.onAdded.addListener(update);
+    browser.permissions.onRemoved.addListener(update);
+    void update();
+    return () => {
+      browser.permissions.onAdded.removeListener(update);
+      browser.permissions.onRemoved.removeListener(update);
+    };
+  }, []);
+
+  return permissions;
+}

--- a/src/options/pages/settings/PermissionsSettings.tsx
+++ b/src/options/pages/settings/PermissionsSettings.tsx
@@ -57,10 +57,6 @@ const PermissionRow: React.FunctionComponent<{
 const PermissionsSettings: React.FunctionComponent = () => {
   const permissions = useExtensionPermissions();
 
-  // `devtools` is actually a required permission that gets added automatically
-  // https://github.com/fregante/webext-additional-permissions/issues/6
-  remove(permissions, ({ name }) => name === "devtools");
-
   const removeOrigin = useCallback(async (origin: string) => {
     await browser.permissions.remove({ origins: [origin] });
     notify.success(`Removed permission for ${origin}`);
@@ -82,12 +78,15 @@ const PermissionsSettings: React.FunctionComponent = () => {
       <ListGroup variant="flush">
         {permissions.map(
           ({ name, isUnique, isOrigin, isAdditional }) =>
+            // Only show removable permissions
             isAdditional &&
+            // Exclude overlapping permissions, unless it's a dev build
             (isUnique || IS_DEV) && (
               <PermissionRow
                 key={name}
                 value={name}
                 remove={
+                  // Removing a non-unique permission does nothing, so don't show the button
                   isUnique ? (isOrigin ? removeOrigin : removePermission) : null
                 }
               />

--- a/src/options/pages/settings/PermissionsSettings.tsx
+++ b/src/options/pages/settings/PermissionsSettings.tsx
@@ -18,7 +18,6 @@
 import React, { useCallback } from "react";
 import notify from "@/utils/notify";
 import { type Manifest } from "webextension-polyfill";
-import { remove } from "lodash";
 import { Badge, Button, Card, ListGroup } from "react-bootstrap";
 import useExtensionPermissions from "@/hooks/useExtensionPermissions";
 

--- a/src/testUtils/testHelpers.tsx
+++ b/src/testUtils/testHelpers.tsx
@@ -51,6 +51,17 @@ export const neverPromise = async (...args: unknown[]): Promise<never> => {
   throw new Error("This method should not have been called");
 };
 
+/**
+ * Generate mocked listeners for browser.*.onEvent objects
+ * @example browser.permissions.onAdded = getChromeEventMocks();
+ */
+export const getChromeEventMocks = () => ({
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  hasListener: jest.fn(),
+  hasListeners: jest.fn(),
+});
+
 export const waitForEffect = async () =>
   act(async () => {
     // Awaiting the async state update


### PR DESCRIPTION
## What does this PR do?

- The permission list in the options page now automatically updates when permissions are added or removed. 

This means we won't show a stale view to the user anymore. This change is akin to the Page Editor’s ability to detect other open sessions.


https://user-images.githubusercontent.com/1402241/213497923-05740793-5e5f-4388-b261-a5337a6cee8b.mov

also on loom: https://www.loom.com/share/84e53912d68a4c0ea09d9a244d893c89

## Changes for DEV builds only

- the permission list is complete again, also showing overlapping permissions
	- Partially undoes https://github.com/pixiebrix/pixiebrix-extension/pull/2778
	- Lets us see the real permissions list without opening the console https://github.com/pixiebrix/pixiebrix-extension/issues/4863#issuecomment-1380751741

"Overlapping" or _shadowed_ permission is an origin permission granted before a broader one. The overlapping permission cannot be revoked because the broader one will still cover it. We hid these permissions in https://github.com/pixiebrix/pixiebrix-extension/pull/2778 but they're still there, so it's useful to see them during development.


<img width="400" alt="Screenshot 3" src="https://user-images.githubusercontent.com/1402241/213499111-c0e621b1-d359-446a-b453-8b74f2fe0c90.png">

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: 
