### PR TITLE
#4196: update API endpoints for awaiting result

### DIFF
--- a/src/contrib/automationanywhere/RunBot.test.ts
+++ b/src/contrib/automationanywhere/RunBot.test.ts
@@ -382,6 +382,8 @@ describe("Automation Anywhere - RunBot", () => {
   });
 
   it("awaits Enterprise Edition result", async () => {
+    const activityId = "288bf36b-e902-4ed2-a5bf-b5534eca137e_6bb3be11a848a48b";
+
     proxyServiceMock.mockImplementation(async (service, request) => {
       if (request.url.includes("deploy")) {
         return {
@@ -394,30 +396,43 @@ describe("Automation Anywhere - RunBot", () => {
         };
       }
 
-      if (request.url.includes("activity")) {
+      if (request.url.endsWith("/v3/activity/list")) {
         return {
           status: 200,
           statusText: "Success",
           data: {
             list: [
               {
+                id: activityId,
                 status: "COMPLETED",
-                botOutVariables: {
-                  values: {
-                    foo: {
-                      type: "STRING",
-                      string: "bar",
-                      number: "",
-                      boolean: "",
-                    },
-                  },
-                },
               },
             ],
           },
           $$proxied: false,
         };
       }
+
+      if (request.url.endsWith(`/v3/activity/execution/${activityId}`)) {
+        return {
+          status: 200,
+          statusText: "Success",
+          data: {
+            id: activityId,
+            botOutVariables: {
+              values: {
+                foo: {
+                  type: "STRING",
+                  string: "bar",
+                  number: "",
+                  boolean: "",
+                },
+              },
+            },
+          },
+        };
+      }
+
+      throw new Error("Unexpected request");
     });
 
     getCachedAuthDataMock.mockResolvedValue({

--- a/src/contrib/automationanywhere/aaApi.ts
+++ b/src/contrib/automationanywhere/aaApi.ts
@@ -391,13 +391,6 @@ export async function pollEnterpriseResult({
     const { data: execution } = await proxyService<Execution>(service, {
       url: `/v3/activity/execution/${completedActivity.id}`,
       method: "get",
-      data: {
-        filter: {
-          operator: "eq",
-          field: "deploymentId",
-          value: deploymentId,
-        },
-      },
     });
 
     return selectBotOutput(execution);

--- a/src/contrib/automationanywhere/aaUtils.test.ts
+++ b/src/contrib/automationanywhere/aaUtils.test.ts
@@ -4,7 +4,7 @@ import {
   isCommunityControlRoom,
   selectBotOutput,
 } from "@/contrib/automationanywhere/aaUtils";
-import { type Activity } from "@/contrib/automationanywhere/contract";
+import { type Execution } from "@/contrib/automationanywhere/contract";
 
 describe("isCommunityControlRoom", () => {
   test.each([
@@ -129,8 +129,7 @@ describe("interfaceToInputSchema", () => {
 
 describe("selectBotOutput", () => {
   test("select outputs", () => {
-    const activity: Activity = {
-      status: "COMPLETED",
+    const activity: Execution = {
       botOutVariables: {
         values: {
           out_String: {

--- a/src/contrib/automationanywhere/aaUtils.ts
+++ b/src/contrib/automationanywhere/aaUtils.ts
@@ -18,7 +18,7 @@
 import { boolean } from "@/utils";
 import { type Schema } from "@/core";
 import {
-  type Activity,
+  type Execution,
   type Interface,
   type OutputValue,
   type Variable,
@@ -168,8 +168,10 @@ export function mapBotOutput(value: OutputValue): Primitive {
   }
 }
 
-export function selectBotOutput(activity: Activity): Record<string, Primitive> {
-  return mapValues(activity.botOutVariables?.values ?? {}, (value) =>
+export function selectBotOutput(
+  execution: Pick<Execution, "botOutVariables">
+): Record<string, Primitive> {
+  return mapValues(execution.botOutVariables?.values ?? {}, (value) =>
     mapBotOutput(value)
   );
 }

--- a/src/contrib/automationanywhere/contract.ts
+++ b/src/contrib/automationanywhere/contract.ts
@@ -121,7 +121,18 @@ export type OutputValue = {
 };
 
 export type Activity = {
+  /**
+   * The id of the activity
+   */
+  id: string;
   status: string;
+  /**
+   * The id of the deployment
+   */
+  deploymentId: string;
+};
+
+export type Execution = {
   botOutVariables?: {
     values: Record<string, OutputValue>;
   };


### PR DESCRIPTION
## What does this PR do?

- Closes #4196 
- Switches to `/v3/activity/list` and `/v3/activity/execution/:activityId` endpoints

## Discussion

- We'll also manually QA once we cut a release build with it
- I confirmed the requests are working against our 0.26 CR

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
