### PR TITLE
#5049: ensure YAML bricks are shown in add brick modal

### DIFF
--- a/src/background/deployment.test.ts
+++ b/src/background/deployment.test.ts
@@ -29,7 +29,7 @@ import axios from "axios";
 import { updateDeployments } from "@/background/deployment";
 import { reportEvent } from "@/telemetry/events";
 import { isLinked, readAuthData } from "@/auth/token";
-import { refreshRegistries } from "@/hooks/useRefresh";
+import { refreshRegistries } from "@/hooks/useRefreshRegistries";
 import { isUpdateAvailable } from "@/background/installer";
 import { getSettingsState, saveSettingsState } from "@/store/settingsStorage";
 
@@ -44,7 +44,7 @@ jest.mock("@/store/settingsStorage", () => ({
   saveSettingsState: jest.fn(),
 }));
 
-jest.mock("@/hooks/useRefresh", () => ({
+jest.mock("@/hooks/useRefreshRegistries", () => ({
   refreshRegistries: jest.fn(),
 }));
 

--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -26,7 +26,7 @@ import {
 } from "@/chrome";
 import { isLinked, readAuthData, updateUserData } from "@/auth/token";
 import { reportEvent } from "@/telemetry/events";
-import { refreshRegistries } from "@/hooks/useRefresh";
+import { refreshRegistries } from "@/hooks/useRefreshRegistries";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import { type RegistryId, type UUID } from "@/core";
 import { maybeGetLinkedApiClient } from "@/services/apiClient";

--- a/src/blocks/registry.ts
+++ b/src/blocks/registry.ts
@@ -60,7 +60,7 @@ export class BlocksRegistry extends BaseRegistry<RegistryId, IBlock> {
 
     console.debug("Computing block types for %d block(s)", items.length);
 
-    await Promise.allSettled(
+    const typePromises = await Promise.allSettled(
       items.map(async (item) => {
         // XXX: will we run into problems with circular dependency between getType and the registry exported from
         //  this module? getType references the blockRegistry in order to calculate the type for composite bricks
@@ -71,6 +71,13 @@ export class BlocksRegistry extends BaseRegistry<RegistryId, IBlock> {
         });
       })
     );
+
+    const failureCount = typePromises.filter(
+      (x) => x.status === "rejected"
+    ).length;
+    if (failureCount > 0) {
+      console.warn("Failed to compute type for %d block(s)", failureCount);
+    }
 
     return typeCache;
   }

--- a/src/hooks/useDeployments.ts
+++ b/src/hooks/useDeployments.ts
@@ -25,7 +25,7 @@ import { selectExtensions } from "@/store/extensionsSelectors";
 import notify from "@/utils/notify";
 import { getUID, services } from "@/background/messenger/api";
 import { getExtensionVersion, reloadIfNewVersionIsReady } from "@/chrome";
-import { refreshRegistries } from "@/hooks/useRefresh";
+import { refreshRegistries } from "@/hooks/useRefreshRegistries";
 import { type Dispatch } from "redux";
 import { type IExtension } from "@/core";
 import { maybeGetLinkedApiClient } from "@/services/apiClient";

--- a/src/hooks/useRefreshRegistries.ts
+++ b/src/hooks/useRefreshRegistries.ts
@@ -68,7 +68,7 @@ const throttledRefreshRegistries = throttle(
  * Hook to refresh brick registries.
  * @param options hook options, e.g., whether to refresh the registries on initial hook mount.
  */
-function useRefresh(options?: {
+function useRefreshRegistries(options?: {
   refreshOnMount: boolean;
 }): [boolean, () => Promise<void>] {
   const { refreshOnMount } = {
@@ -105,4 +105,4 @@ function useRefresh(options?: {
   return [loaded, refresh];
 }
 
-export default useRefresh;
+export default useRefreshRegistries;

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -34,7 +34,7 @@ import { ConnectedRouter } from "connected-react-router";
 import EnvironmentBanner from "@/layout/EnvironmentBanner";
 import ActivateBlueprintPage from "@/options/pages/marketplace/ActivateBlueprintPage";
 import ActivateExtensionPage from "@/options/pages/activateExtension/ActivatePage";
-import useRefresh from "@/hooks/useRefresh";
+import useRefreshRegistries from "@/hooks/useRefreshRegistries";
 import SetupPage from "@/options/pages/onboarding/SetupPage";
 import UpdateBanner from "@/options/pages/UpdateBanner";
 import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
@@ -62,7 +62,7 @@ registerDefaultWidgets();
 const RefreshBricks: React.VFC = () => {
   const dispatch = useDispatch();
   // Get the latest brick definitions. Defined as a component to put inside the RequireAuth gate in the layout.
-  useRefresh();
+  useRefreshRegistries();
 
   useEffect(() => {
     // Start polling logs

--- a/src/options/pages/brickEditor/useSubmitBrick.ts
+++ b/src/options/pages/brickEditor/useSubmitBrick.ts
@@ -22,7 +22,7 @@ import { push } from "connected-react-router";
 import { useDispatch } from "react-redux";
 import { type EditorValues } from "./Editor";
 import { type BrickValidationResult, validateSchema } from "./validate";
-import useRefresh from "@/hooks/useRefresh";
+import useRefreshRegistries from "@/hooks/useRefreshRegistries";
 import {
   type Definition,
   type UnsavedRecipeDefinition,
@@ -57,7 +57,7 @@ type SubmitCallbacks = {
 };
 
 function useSubmitBrick({ create = false }: SubmitOptions): SubmitCallbacks {
-  const [, refresh] = useRefresh({ refreshOnMount: false });
+  const [, refresh] = useRefreshRegistries({ refreshOnMount: false });
   const reinstall = useReinstall();
   const history = useHistory();
   const dispatch = useDispatch();

--- a/src/pageEditor/EditorContent.test.tsx
+++ b/src/pageEditor/EditorContent.test.tsx
@@ -60,7 +60,7 @@ jest.mock("@/background/messenger/api", () => ({
   containsPermissions: jest.fn().mockResolvedValue(true),
 }));
 // Mock to support hook usage in the subtree, not relevant to UI tests here
-jest.mock("@/hooks/useRefresh");
+jest.mock("@/hooks/useRefreshRegistries");
 jest.mock("@/hooks/useTheme", () => ({
   useGetTheme: jest.fn(),
 }));

--- a/src/pageEditor/Panel.tsx
+++ b/src/pageEditor/Panel.tsx
@@ -22,7 +22,7 @@ import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 import registerEditors from "@/contrib/editors";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
-import useRefresh from "@/hooks/useRefresh";
+import useRefreshRegistries from "@/hooks/useRefreshRegistries";
 import PanelContent from "@/pageEditor/PanelContent";
 
 // Register the built-in bricks
@@ -35,7 +35,7 @@ registerDefaultWidgets();
 
 const Panel: React.VoidFunctionComponent = () => {
   // Refresh the brick registry on mount
-  useRefresh({ refreshOnMount: true });
+  useRefreshRegistries({ refreshOnMount: true });
 
   return (
     <Provider store={store}>

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -115,7 +115,7 @@ jest.mock("@/background/messenger/api", () => ({
   containsPermissions: jest.fn().mockResolvedValue(true),
 }));
 // Mock to support hook usage in the subtree, not relevant to UI tests here
-jest.mock("@/hooks/useRefresh");
+jest.mock("@/hooks/useRefreshRegistries");
 jest.mock("@/hooks/useTheme", () => ({
   useGetTheme: jest.fn(),
 }));


### PR DESCRIPTION
## What does this PR do?

- Fixes: #5049 
- There was a bug in the registry fetch method where it would remove the items from the cache and save them to IDB, but not re-register them
- Renames useRefresh to useRefreshRegistries

## Checklist

- 😞  Add tests: we don't have unit tests for baseRegistry yet. I'll add some after we cut a beta with this PR
- [x] Designate a primary reviewer: @BALEHOK 
