### PR TITLE
Installs swc/core, fixing jest issue for M1 Mac users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -150,7 +150,7 @@
         "@storybook/manager-webpack5": "^6.5.15",
         "@storybook/react": "^6.5.15",
         "@svgr/webpack": "^6.5.1",
-        "@swc/core": "^1.3.26",
+        "@swc/core": "^1.3.28",
         "@swc/jest": "^0.2.24",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.5",
@@ -11465,9 +11465,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.27.tgz",
-      "integrity": "sha512-praRNgpeYGvwDIm/Cl6JU+yHMvwVraL0U6ejMgGyzvpcm1FVsZd1/EYXGqzbBJ0ALv7Gx4eK56h4GnwV6d4L0w==",
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.28.tgz",
+      "integrity": "sha512-yzc61HbAIjHeOYTUW/IgXAywlSviMFymnUiLY7dNUELGHjMVxSp0XnIlPQN4v5UekYbwLEV8+KChaoQRACiQCw==",
       "dev": true,
       "hasInstallScript": true,
       "engines": {
@@ -11478,22 +11478,38 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.27",
-        "@swc/core-darwin-x64": "1.3.27",
-        "@swc/core-linux-arm-gnueabihf": "1.3.27",
-        "@swc/core-linux-arm64-gnu": "1.3.27",
-        "@swc/core-linux-arm64-musl": "1.3.27",
-        "@swc/core-linux-x64-gnu": "1.3.27",
-        "@swc/core-linux-x64-musl": "1.3.27",
-        "@swc/core-win32-arm64-msvc": "1.3.27",
-        "@swc/core-win32-ia32-msvc": "1.3.27",
-        "@swc/core-win32-x64-msvc": "1.3.27"
+        "@swc/core-darwin-arm64": "1.3.28",
+        "@swc/core-darwin-x64": "1.3.28",
+        "@swc/core-linux-arm-gnueabihf": "1.3.28",
+        "@swc/core-linux-arm64-gnu": "1.3.28",
+        "@swc/core-linux-arm64-musl": "1.3.28",
+        "@swc/core-linux-x64-gnu": "1.3.28",
+        "@swc/core-linux-x64-musl": "1.3.28",
+        "@swc/core-win32-arm64-msvc": "1.3.28",
+        "@swc/core-win32-ia32-msvc": "1.3.28",
+        "@swc/core-win32-x64-msvc": "1.3.28"
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.28.tgz",
+      "integrity": "sha512-f1ph5DDIOX6bvjhlOuWz8ZDiTghhq144Sy9gaRi+DjK3gdnftc4p5AyZHA4Xb03MZ+fd0mj8q6/znco5aBMi1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.27.tgz",
-      "integrity": "sha512-MtabZIhFf/dL3vs6UMbd+vJsjIkm2NaFqulGV0Jofy2bfVZPTj/b5pXeOlUsTWy7JcH1uixjdx4RvJRyvqJxQA==",
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.28.tgz",
+      "integrity": "sha512-5dB5Z4Ry45UTXXAxhwagCYfh57njffkdIJkjid1f+Qt4i7cOznOaIiD4wobGD7xHCATEcs8F23yWkAmvrbacew==",
       "cpu": [
         "x64"
       ],
@@ -11501,6 +11517,134 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.28.tgz",
+      "integrity": "sha512-VmtAQAENJ5SHBXTKxXNlnnM34xGOtJpHYva83zeZM/2epdoz1BJ6Ny3gTBXDftaWgAj2SRwVIjMR3/c71aJysQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.28.tgz",
+      "integrity": "sha512-KIJ1SHGbusM6W2rxue1f+IN/iuzmspgMY9qP/qW5Z43Mm9mrHdzDmhsMoEH1y2gPUsu/ZZnkXlODJ0M0454JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.28.tgz",
+      "integrity": "sha512-Zz2DZj8ncSvVEAsol8gtoXrVLP8e+IYSx6o8txYVR0p0pviJBzeuYGaLe5sbQdQnVVS2M5N90LX28P6/mQb6sQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.28.tgz",
+      "integrity": "sha512-Za3uowhcP74qSCNqjZLBx3nAmjIFYNbB0nGBKwkLBopbMcpO0BjvnsdzmoWqv2Uq41vaeVk/o9vATQMojfHHQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.28.tgz",
+      "integrity": "sha512-i3BAkmrf19VXybbjuS9Jnlnx5Ie4vukLMCQRfXCQqIqaiSw3QzubjolYo07sGtzoVI3nBscDt3i8T+oxTPOMkw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.28.tgz",
+      "integrity": "sha512-DdNxKP/P0/OFqX1dtl9Ubrd567QPMSeJvp9iDtMdgCBWN2N6HXvyMj623WIA0y9FIcA7wexz0Hh3gS+G9Jof+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.28.tgz",
+      "integrity": "sha512-/jZWBIgaNkKTlKiZ7DXmMJzW0n1ychDKS1bYRuNLrtTRthMP5M3LRZXITz0AcvPl0mIA0IXeMQbE4ZMUc7LAFg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.28.tgz",
+      "integrity": "sha512-HKhE0LznEwTP/qi6EVclmJzfNdykzuK6sjYMTjcDqNJOuuRNMu+IJzPzCPuakgljymWGFmddnuuubd9Y+kl3eg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -44823,27 +44967,90 @@
       }
     },
     "@swc/core": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.27.tgz",
-      "integrity": "sha512-praRNgpeYGvwDIm/Cl6JU+yHMvwVraL0U6ejMgGyzvpcm1FVsZd1/EYXGqzbBJ0ALv7Gx4eK56h4GnwV6d4L0w==",
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.28.tgz",
+      "integrity": "sha512-yzc61HbAIjHeOYTUW/IgXAywlSviMFymnUiLY7dNUELGHjMVxSp0XnIlPQN4v5UekYbwLEV8+KChaoQRACiQCw==",
       "dev": true,
       "requires": {
-        "@swc/core-darwin-arm64": "1.3.27",
-        "@swc/core-darwin-x64": "1.3.27",
-        "@swc/core-linux-arm-gnueabihf": "1.3.27",
-        "@swc/core-linux-arm64-gnu": "1.3.27",
-        "@swc/core-linux-arm64-musl": "1.3.27",
-        "@swc/core-linux-x64-gnu": "1.3.27",
-        "@swc/core-linux-x64-musl": "1.3.27",
-        "@swc/core-win32-arm64-msvc": "1.3.27",
-        "@swc/core-win32-ia32-msvc": "1.3.27",
-        "@swc/core-win32-x64-msvc": "1.3.27"
+        "@swc/core-darwin-arm64": "1.3.28",
+        "@swc/core-darwin-x64": "1.3.28",
+        "@swc/core-linux-arm-gnueabihf": "1.3.28",
+        "@swc/core-linux-arm64-gnu": "1.3.28",
+        "@swc/core-linux-arm64-musl": "1.3.28",
+        "@swc/core-linux-x64-gnu": "1.3.28",
+        "@swc/core-linux-x64-musl": "1.3.28",
+        "@swc/core-win32-arm64-msvc": "1.3.28",
+        "@swc/core-win32-ia32-msvc": "1.3.28",
+        "@swc/core-win32-x64-msvc": "1.3.28"
       }
     },
+    "@swc/core-darwin-arm64": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.28.tgz",
+      "integrity": "sha512-f1ph5DDIOX6bvjhlOuWz8ZDiTghhq144Sy9gaRi+DjK3gdnftc4p5AyZHA4Xb03MZ+fd0mj8q6/znco5aBMi1A==",
+      "dev": true,
+      "optional": true
+    },
     "@swc/core-darwin-x64": {
-      "version": "1.3.27",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.27.tgz",
-      "integrity": "sha512-MtabZIhFf/dL3vs6UMbd+vJsjIkm2NaFqulGV0Jofy2bfVZPTj/b5pXeOlUsTWy7JcH1uixjdx4RvJRyvqJxQA==",
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.28.tgz",
+      "integrity": "sha512-5dB5Z4Ry45UTXXAxhwagCYfh57njffkdIJkjid1f+Qt4i7cOznOaIiD4wobGD7xHCATEcs8F23yWkAmvrbacew==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.28.tgz",
+      "integrity": "sha512-VmtAQAENJ5SHBXTKxXNlnnM34xGOtJpHYva83zeZM/2epdoz1BJ6Ny3gTBXDftaWgAj2SRwVIjMR3/c71aJysQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.28.tgz",
+      "integrity": "sha512-KIJ1SHGbusM6W2rxue1f+IN/iuzmspgMY9qP/qW5Z43Mm9mrHdzDmhsMoEH1y2gPUsu/ZZnkXlODJ0M0454JNQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.28.tgz",
+      "integrity": "sha512-Zz2DZj8ncSvVEAsol8gtoXrVLP8e+IYSx6o8txYVR0p0pviJBzeuYGaLe5sbQdQnVVS2M5N90LX28P6/mQb6sQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.28.tgz",
+      "integrity": "sha512-Za3uowhcP74qSCNqjZLBx3nAmjIFYNbB0nGBKwkLBopbMcpO0BjvnsdzmoWqv2Uq41vaeVk/o9vATQMojfHHQg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.28.tgz",
+      "integrity": "sha512-i3BAkmrf19VXybbjuS9Jnlnx5Ie4vukLMCQRfXCQqIqaiSw3QzubjolYo07sGtzoVI3nBscDt3i8T+oxTPOMkw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.28.tgz",
+      "integrity": "sha512-DdNxKP/P0/OFqX1dtl9Ubrd567QPMSeJvp9iDtMdgCBWN2N6HXvyMj623WIA0y9FIcA7wexz0Hh3gS+G9Jof+Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.28.tgz",
+      "integrity": "sha512-/jZWBIgaNkKTlKiZ7DXmMJzW0n1ychDKS1bYRuNLrtTRthMP5M3LRZXITz0AcvPl0mIA0IXeMQbE4ZMUc7LAFg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.28.tgz",
+      "integrity": "sha512-HKhE0LznEwTP/qi6EVclmJzfNdykzuK6sjYMTjcDqNJOuuRNMu+IJzPzCPuakgljymWGFmddnuuubd9Y+kl3eg==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "@storybook/manager-webpack5": "^6.5.15",
     "@storybook/react": "^6.5.15",
     "@svgr/webpack": "^6.5.1",
-    "@swc/core": "^1.3.26",
+    "@swc/core": "^1.3.28",
     "@swc/jest": "^0.2.24",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",


### PR DESCRIPTION
## What does this PR do?

- Adds the updated package.json and package-lock.json to the repo after running `npm install @swc/core` 
- Issues with running tests (bindings not found) like shown below do not occur now for M1 Mac users
![image](https://user-images.githubusercontent.com/22874911/214381096-c806a8de-3f71-426b-a510-c9f35672b82b.png)
