### PR TITLE
Adds test that redux serializableCheck fails

### DIFF
--- a/src/options/pages/blueprints/BlueprintsPageLayout.test.tsx
+++ b/src/options/pages/blueprints/BlueprintsPageLayout.test.tsx
@@ -237,6 +237,10 @@ describe("Serializable Data Test", () => {
     });
 
     await waitForEffect();
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("A non-serializable value was detected"),
+      expect.toBeFunction(),
+      expect.toBeString()
+    );
   });
 });

--- a/src/options/pages/blueprints/BlueprintsPageLayout.test.tsx
+++ b/src/options/pages/blueprints/BlueprintsPageLayout.test.tsx
@@ -222,3 +222,21 @@ describe("BlueprintsPageLayout", () => {
     expect(screen.getByTestId("bot-games-blueprint-tab")).toHaveClass("active");
   });
 });
+
+describe("Serializable Data Test", () => {
+  test("Pushes unserializable data to redux", async () => {
+    const spy = jest.spyOn(console, "error");
+    render(<BlueprintsPageLayout installables={installables} />, {
+      setupRedux(dispatch) {
+        dispatch(
+          blueprintsSlice.actions.setSearchQuery(
+            (() => {}) as unknown as string
+          )
+        );
+      },
+    });
+
+    await waitForEffect();
+    expect(spy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

-  Closes #4962 

## Discussion

- I have tried to assert that the console.error function has been called with a string matching part of the error output, but it doesn't match correctly. 
    - I believe it's because the error output derives from objects, but I can't match them correctly / I don't think this is the correct way to go.
    - I attempted: 
    ```javascript 
         expect(spy).toHaveBeenCalledWith(
              expect.stringContaining("A non-serializable value was detected")
         );
    ```
    - and received: 
![image](https://user-images.githubusercontent.com/22874911/214432430-2aab85f3-3f16-4222-9c87-693180457763.png)
- I also attempted using functions:
    - .toThrowError()
    - .toHaveErrorMessage()
    - .toReturnWith()
    - .toContain()
    - ... all of which do not work because of what I described above or the fact that console.error() does not throw exceptions or return a value
    - ~Any ideas or guidance is much appreciated~
- The above has since been resolved

## Checklist

- [x] Designate a primary reviewer
