### PR TITLE
#5084: support auto save in custom form brick

### DIFF
--- a/src/blocks/renderers/customForm.test.tsx
+++ b/src/blocks/renderers/customForm.test.tsx
@@ -16,18 +16,33 @@
  */
 
 import React from "react";
-import { type Schema } from "@/core";
+import { type BlockOptions, type Schema } from "@/core";
 import { render } from "@testing-library/react";
 import ImageCropWidget from "@/components/formBuilder/ImageCropWidget";
 import DescriptionField from "@/components/formBuilder/DescriptionField";
 import FieldTemplate from "@/components/formBuilder/FieldTemplate";
 import JsonSchemaForm from "@rjsf/bootstrap-4";
 import {
+  CustomFormRenderer,
   normalizeIncomingFormData,
   normalizeOutgoingFormData,
 } from "./customForm";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import userEvent from "@testing-library/user-event";
+import ConsoleLogger from "@/utils/ConsoleLogger";
+import { uuidv4 } from "@/types/helpers";
+
+import { dataStore } from "@/background/messenger/api";
+
+jest.mock("@/background/messenger/api", () => ({
+  dataStore: {
+    get: jest.fn(),
+  },
+}));
+
+const dataStoreGetMock = dataStore.get as jest.MockedFunction<
+  typeof dataStore.get
+>;
 
 describe("form data normalization", () => {
   const normalizationTestCases = [
@@ -181,7 +196,7 @@ describe("form data normalization", () => {
     // Make sure the form renders the data without errors
     expect(rendered.asFragment()).toMatchSnapshot();
 
-    // Submit and make sure there're no validation errors
+    // Submit and make sure there are no validation errors
     await userEvent.click(
       rendered.getByRole("button", {
         name: "Submit",
@@ -189,5 +204,37 @@ describe("form data normalization", () => {
     );
 
     expect(rendered.queryByText("Error")).not.toBeInTheDocument();
+  });
+});
+
+describe("CustomFormRenderer", () => {
+  test("Render autosaved form", async () => {
+    const brick = new CustomFormRenderer();
+
+    dataStoreGetMock.mockResolvedValue({});
+
+    const { Component, props } = await brick.render(
+      {
+        storage: { type: "localStorage" },
+        autoSave: true,
+        recordId: "test",
+        schema: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+          },
+        },
+      } as any,
+      {
+        logger: new ConsoleLogger({
+          extensionId: uuidv4(),
+        }),
+      } as BlockOptions
+    );
+
+    const rendered = render(<Component {...props} />);
+
+    expect(rendered.queryByText("Submit")).toBeNull();
+    expect(rendered.container.querySelector("#root_name")).not.toBeNull();
   });
 });

--- a/src/pageEditor/fields/FormRendererOptions.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.tsx
@@ -89,6 +89,8 @@ const FormRendererOptions: React.FC<{
     editorActions.setNodePreviewActiveElement
   );
 
+  const [{ value: autoSave }] = useField<boolean>(makeName("autoSave"));
+
   const [{ value: storage }, , { setValue: setStorageValue }] =
     useField<Storage>(makeName("storage"));
   const storageType = storage?.type;
@@ -174,11 +176,13 @@ const FormRendererOptions: React.FC<{
         schema={customFormRendererSchema.properties.autoSave as Schema}
       />
 
-      <SchemaField
-        name={makeName("submitCaption")}
-        label="Submit Caption"
-        schema={customFormRendererSchema.properties.submitCaption as Schema}
-      />
+      {!autoSave && (
+        <SchemaField
+          name={makeName("submitCaption")}
+          label="Submit Caption"
+          schema={customFormRendererSchema.properties.submitCaption as Schema}
+        />
+      )}
 
       <SchemaField
         name={makeName("successMessage")}

--- a/src/pageEditor/fields/FormRendererOptions.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.tsx
@@ -169,6 +169,12 @@ const FormRendererOptions: React.FC<{
       )}
 
       <SchemaField
+        name={makeName("autoSave")}
+        label="Auto Save"
+        schema={customFormRendererSchema.properties.autoSave as Schema}
+      />
+
+      <SchemaField
         name={makeName("submitCaption")}
         label="Submit Caption"
         schema={customFormRendererSchema.properties.submitCaption as Schema}


### PR DESCRIPTION
## What does this PR do?

- Closes #5084
- Adds an `autoSave` option to the Custom Form brick to support filtering/search use cases

## Discussion

- When I had originally tried this last week, I was hitting issues with the field losing focus as I type. Now it appears to be working 🤷 

## Demo

- https://www.loom.com/share/21c4b62a335b4c548a4f9e7d81687fb1

## Future Work

- Get rid of loading indicator flicker. On sub bricks of document reader, likely need way to provide option to keep the old component while waiting for the next value

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BALEHOK 
