### PR TITLE
Update / fix broken rainforestqa CI tests

### DIFF
--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -4,7 +4,7 @@ name: Rainforest QA Run
 # event triggers in the future. These will require potentially cleanly dealing with concurrent runs
 # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 # https://frontside.com/blog/2020-05-26-github-actions-pull_request/
-on: workflow_dispatch
+on: [push]
 
 jobs:
   rainforestqa:

--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -53,7 +53,7 @@ jobs:
         #   they're all using the same server
         # Use --fail-fast so that we're not using GitHub build minutes if not necessary
         run: |
-          ./rainforest run --fail-fast --description "CI automatic run" --run-group $RUN_GROUP --release "${{ github.sha }}" --conflict abort-all --custom-url "https://pixiebrix-extension-builds.s3.us-east-2.amazonaws.com/$BUILD_PATH"
+          ./rainforest run --fail-fast --description "CI automatic run" --run-group $RUN_GROUP --release "${{ github.sha }}" --conflict cancel-all --custom-url "https://pixiebrix-extension-builds.s3.us-east-2.amazonaws.com/$BUILD_PATH"
         env:
           RAINFOREST_API_TOKEN: ${{ secrets.RAINFORESTQA_TOKEN }}
           # The run group for tests to run during CI


### PR DESCRIPTION
## What does this PR do?

- Part of / Closes #4960 
- Makes rainforest workflow / [tests](https://app.rainforestqa.com/run_groups/9732) run on push, rather than by manual dispatch

## Discussion

- In the old/broken versions of the [tests](https://app.rainforestqa.com/run_groups/9732), an old link to the pixiebrix playground was used. In my updates, I instead use [wikipedia.org](https://wikipedia.org) and [bill.com](https://bill.com) to showcase similar functionality.
    - I chose these sites based on the assumption and in part observation that they change infrequently, so we shouldn't need to update the tests because of them often or hopefully at all. 
    - I did not use the new pixiebrix tutorial / onboarding walkthrough on the advice of @mnholtz, for now. See Future Work 

## Future Work

- This [smoke test](https://app.rainforestqa.com/tests/300849) should / will be fixed in the future when a plan to handle onboarding in CI is devised

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer
