### PR TITLE
5126: Update rainforest workflow to run for releases and nightly on main

### DIFF
--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -5,6 +5,7 @@ name: Rainforest QA Run
 # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 # https://frontside.com/blog/2020-05-26-github-actions-pull_request/
 on:
+  workflow_dispatch
   push:
     branches:
       - release/*

--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -5,7 +5,7 @@ name: Rainforest QA Run
 # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 # https://frontside.com/blog/2020-05-26-github-actions-pull_request/
 on:
-  workflow_dispatch
+  workflow_dispatch:
   push:
     branches:
       - release/*

--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -4,7 +4,12 @@ name: Rainforest QA Run
 # event triggers in the future. These will require potentially cleanly dealing with concurrent runs
 # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 # https://frontside.com/blog/2020-05-26-github-actions-pull_request/
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - release/*
+  schedule:
+    - cron: "0 8 * * *" # 8am UTC -> 3am EST
 
 jobs:
   rainforestqa:


### PR DESCRIPTION
## What does this PR do?

- Closes #5126 
- Sets up cron job to run rainforest qa on main nightly(3am EST)
- Sets up running on release branches

## Discussion

- [x] Ensure release build artifact creation is not blocked by the workflow
- [x] Double-check that the Rainforest tests in this run group are idempotent with respect to the tests accounts used

## Checklist

- [x] Designate a primary reviewer
