### PR TITLE
#5135: remove actions from quick bar on update

### DIFF
--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -18,17 +18,15 @@
 import React, { useEffect } from "react";
 import ReactDOM from "react-dom";
 import {
-  type Action,
   KBarAnimator,
+  KBarPortal,
   KBarPositioner,
   KBarProvider,
-  KBarPortal,
   KBarSearch,
   useKBar,
   VisualState,
 } from "kbar";
 import ReactShadowRoot from "react-shadow-root";
-import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import faStyleSheet from "@fortawesome/fontawesome-svg-core/styles.css?loadAsUrl";
 import { expectContext } from "@/utils/expectContext";
 import { once } from "lodash";
@@ -39,6 +37,7 @@ import selection from "@/utils/selectionController";
 import { animatorStyle, searchStyle } from "./quickBarTheme";
 import QuickBarResults from "./QuickBarResults";
 import useActionGenerators from "@/components/quickBar/useActionGenerators";
+import useActions from "@/components/quickBar/useActions";
 
 /**
  * Set to true if the KBar should be displayed on initial mount (i.e., because it was triggered by the
@@ -50,35 +49,6 @@ let autoShow = false;
  * Window event name to programmatically trigger quick bar
  */
 const QUICKBAR_EVENT_NAME = "pixiebrix-quickbar";
-
-function useActions(): void {
-  // The useActions hook is included in KBarComponent, which mounts/unmounts when the kbar is toggled
-
-  const { query } = useKBar();
-  const uninstallActionsRef = React.useRef<() => void | null>(null);
-
-  // Listen for changes while the kbar is mounted:
-  // - The user is making edits in the Page Editor
-  // - Generators are producing new actions in response to the search query changing
-  useEffect(() => {
-    const handler = (nextActions: Action[]) => {
-      uninstallActionsRef.current?.();
-      // Potential improvement: to avoid flickering, we could register actions individually and keep track of
-      // their uninstall handlers by id.
-      uninstallActionsRef.current = query.registerActions(nextActions);
-    };
-
-    // Don't use useRegisterActions, because then we aren't able to unregister actions that were around
-    // from the initial mount
-    handler(quickBarRegistry.currentActions);
-
-    quickBarRegistry.addListener(handler);
-    return () => {
-      quickBarRegistry.removeListener(handler);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- the query is available on initial mount
-  }, []);
-}
 
 function useAutoShow(): void {
   const { query } = useKBar();

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -55,6 +55,8 @@ const QUICKBAR_EVENT_NAME = "pixiebrix-quickbar";
 function useActions(): void {
   // The useActions hook is included in KBarComponent, which mounts/unmounts when the kbar is toggled
 
+  const uninstallRef = React.useRef<() => void | null>(null);
+
   // The kbar useRegisterActions hook uses an "unregister" affordance that's not available in the types
   // https://github.com/timc1/kbar/blob/main/src/useStore.tsx#L63
   // https://github.com/timc1/kbar/blob/main/src/useRegisterActions.tsx#L19
@@ -67,7 +69,8 @@ function useActions(): void {
   // - Generators are producing new actions in response to the search query changing
   useEffect(() => {
     const handler = (nextActions: Action[]) => {
-      query.registerActions(nextActions);
+      uninstallRef.current?.();
+      uninstallRef.current = query.registerActions(nextActions);
     };
 
     quickBarRegistry.addListener(handler);

--- a/src/components/quickBar/quickBarRegistry.ts
+++ b/src/components/quickBar/quickBarRegistry.ts
@@ -78,7 +78,8 @@ class QuickBarRegistry {
    * Get the current actions registered with the Quick Bar.
    */
   get currentActions(): CustomAction[] {
-    return this.actions;
+    // Return a copy, since this.actions is mutated in-place
+    return [...this.actions];
   }
 
   /**

--- a/src/components/quickBar/quickBarRegistry.ts
+++ b/src/components/quickBar/quickBarRegistry.ts
@@ -66,8 +66,11 @@ class QuickBarRegistry {
    * @private
    */
   private notifyListeners() {
+    // Need to copy the array because the registry mutates the array in-place, and listeners might be keeping a
+    // reference to the argument passed to them
+    const copy = [...this.actions];
     for (const listener of this.listeners) {
-      listener(this.actions);
+      listener(copy);
     }
   }
 

--- a/src/components/quickBar/useActions.test.tsx
+++ b/src/components/quickBar/useActions.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { act, renderHook } from "@testing-library/react-hooks";
+import useActions from "@/components/quickBar/useActions";
+import { KBarProvider, useKBar } from "kbar";
+import defaultActions from "@/components/quickBar/defaultActions";
+import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
+
+describe("useActions", () => {
+  test("should return the default actions", () => {
+    const hook = renderHook(
+      () => {
+        useActions();
+        return useKBar(({ actions }) => ({ actions }));
+      },
+      {
+        wrapper: ({ children }) => <KBarProvider>{children}</KBarProvider>,
+      }
+    );
+
+    expect(Object.keys(hook.result.current.actions)).toHaveLength(
+      defaultActions.length
+    );
+  });
+
+  test("should add/remove action", async () => {
+    const hook = renderHook(
+      () => {
+        useActions();
+        return useKBar(({ actions }) => ({ actions }));
+      },
+      {
+        wrapper: ({ children }) => <KBarProvider>{children}</KBarProvider>,
+      }
+    );
+
+    await act(async () => {
+      quickBarRegistry.addAction({
+        id: "test",
+        name: "Test Action",
+      });
+    });
+
+    expect(Object.keys(hook.result.current.actions)).toHaveLength(
+      defaultActions.length + 1
+    );
+
+    await act(async () => {
+      quickBarRegistry.removeAction("test");
+    });
+
+    expect(Object.keys(hook.result.current.actions)).toHaveLength(
+      defaultActions.length
+    );
+  });
+});

--- a/src/components/quickBar/useActions.ts
+++ b/src/components/quickBar/useActions.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type Action, useKBar } from "kbar";
+import React, { useEffect } from "react";
+import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
+
+function useActions(): void {
+  // The useActions hook is included in KBarComponent, which mounts/unmounts when the kbar is toggled
+
+  const { query } = useKBar();
+  const uninstallActionsRef = React.useRef<() => void | null>(null);
+
+  // Listen for changes while the kbar is mounted:
+  // - The user is making edits in the Page Editor
+  // - Generators are producing new actions in response to the search query changing
+  useEffect(() => {
+    const handler = (nextActions: Action[]) => {
+      uninstallActionsRef.current?.();
+      // Potential improvement: to avoid flickering, we could register actions individually and keep track of
+      // their uninstall handlers by id.
+      uninstallActionsRef.current = query.registerActions(nextActions);
+    };
+
+    // Don't use useRegisterActions, because then we aren't able to unregister actions that were around
+    // from the initial mount
+    handler(quickBarRegistry.currentActions);
+
+    quickBarRegistry.addListener(handler);
+    return () => {
+      quickBarRegistry.removeListener(handler);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- the query is available on initial mount
+  }, []);
+}
+
+export default useActions;


### PR DESCRIPTION
## What does this PR do?

- Closes #4501: this issue would be caused by the items by the actions being in the wrong order in the actions array
- There was a bug in the `useActions` hook where actions would be removed, only added

## Remaining Work

- [ ] Double-check this also solves the problem in the ticket where you get duplicate entries when you re-activate a Quick Bar blueprint in the Extension Console

## Demo

- https://www.loom.com/share/770b8dcd0a0145899edc9aebc841f61b

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
