### PR TITLE
#5160: fix type error in localRegistry

### DIFF
--- a/src/registry/localRegistry.ts
+++ b/src/registry/localRegistry.ts
@@ -126,14 +126,21 @@ export async function clear(): Promise<void> {
   await db.clear(BRICK_STORE);
 }
 
-async function latestTimestamp(): Promise<Date> {
+/**
+ * Return the timestamp of the most recent package in the local DB.
+ */
+async function latestTimestamp(): Promise<Date | null> {
   const db = await getBrickDB();
   const tx = db.transaction(BRICK_STORE, "readonly");
   // Iterate from most recent to least recent and take first
   const cursor = tx.store.index("timestamp").iterate(null, "prev");
   const result = await cursor.next();
   await tx.done;
-  return result.value?.value.timestamp;
+
+  // https://github.com/pixiebrix/pixiebrix-extension/issues/5160 -- can sometimes come back as string
+  const timestamp: Date | string | null = result.value?.value.timestamp;
+
+  return timestamp ? new Date(timestamp) : null;
 }
 
 /**

--- a/src/registry/localRegistry.ts
+++ b/src/registry/localRegistry.ts
@@ -137,9 +137,8 @@ async function latestTimestamp(): Promise<Date | null> {
   const result = await cursor.next();
   await tx.done;
 
-  // https://github.com/pixiebrix/pixiebrix-extension/issues/5160 -- can sometimes come back as string
+  // https://github.com/pixiebrix/pixiebrix-extension/issues/5160 -- can come back as string on some versions
   const timestamp: Date | string | null = result.value?.value.timestamp;
-
   return timestamp ? new Date(timestamp) : null;
 }
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #5160 
- Fixes a type error in localRegistry when timestamp was persisted as a string

## Discussion

Old code saved in registry as date: https://github.com/pixiebrix/pixiebrix-extension/pull/5136/files#diff-ca01f9a58613d030266309c55fc73cf815e9be92274cb3efbf121b1a699b2095L252

![image](https://user-images.githubusercontent.com/1879821/217349508-554c08f0-72f6-4dbe-a119-3932b00a0876.png)

Not sure how, but my local machine somehow had string for timestamp:
![image](https://user-images.githubusercontent.com/1879821/217350642-302ed91a-2a54-4a21-a017-ffdd43e78ff0.png)

## Checklist

- [x] Add tests: changed type signature
- [x] Designate a primary reviewer: @BLoe 
