### PR TITLE
#5163: fix brick cache initialization

### DIFF
--- a/src/baseRegistry.ts
+++ b/src/baseRegistry.ts
@@ -127,8 +127,8 @@ export class Registry<
 
     databaseChangeListeners.push({
       onChanged: () => {
-        this._cacheInitialized = false;
-        this.cache.clear();
+        // If database changes, clear the cache to force reloading user-defined bricks
+        this.clear();
       },
     });
   }
@@ -320,7 +320,8 @@ export class Registry<
   }
 
   /**
-   * Test-only method to completely reset the registry state.
+   * Test-only method to completely reset the registry state. Does NOT notify listeners
+   * @see clear
    */
   TEST_reset(): void {
     this._cacheInitialized = false;

--- a/src/baseRegistry.ts
+++ b/src/baseRegistry.ts
@@ -101,13 +101,13 @@ export class Registry<
    * Registered built-in items. Used to keep track of built-ins across cache clears.
    * @private
    */
-  private readonly builtins = new Map<RegistryId, Item>();
+  private readonly _builtins = new Map<RegistryId, Item>();
 
   /**
    * Cache of items in the registry. Contains both built-ins and remote items.
    * @private
    */
-  private readonly cache = new Map<RegistryId, Item>();
+  private readonly _cache = new Map<RegistryId, Item>();
 
   /**
    * Track the state of the cache
@@ -160,7 +160,7 @@ export class Registry<
    * @param id the registry id
    */
   async exists(id: Id): Promise<boolean> {
-    return this.cache.has(id) || (await backgroundRegistry.find(id)) != null;
+    return this._cache.has(id) || (await backgroundRegistry.find(id)) != null;
   }
 
   /**
@@ -174,13 +174,13 @@ export class Registry<
       throw new Error("id is required");
     }
 
-    const cached = this.cache.get(id);
+    const cached = this._cache.get(id);
 
     if (cached) {
       return cached;
     }
 
-    const builtin = this.builtins.get(id);
+    const builtin = this._builtins.get(id);
 
     if (builtin) {
       return builtin;
@@ -217,23 +217,30 @@ export class Registry<
   }
 
   /**
-   * Synchronously return all cached bricks.
-   * @deprecated needed for header generation; will be removed in future versions
+   * Return built-in JS bricks registered
+   */
+  get builtins(): Item[] {
+    return [...this._builtins.values()];
+  }
+
+  /**
+   * Synchronously return all cached bricks
+   * @deprecated requires all data to be parsed
    * @throws Error if the cache is not initialized
    * @see isCachedInitialized
    * @see all
    */
-  cached(): Item[] {
+  get cached(): Item[] {
     if (!this._cacheInitialized) {
       throw new Error("Cache not initialized");
     }
 
-    return [...this.cache.values()];
+    return [...this._cache.values()];
   }
 
   /**
    * Reloads all brick configurations from IDB, and returns all bricks in the registry.
-   * @deprecated requires all data to be fetched/parsed
+   * @deprecated requires all data to be parsed
    * @see cached
    */
   async all(): Promise<Item[]> {
@@ -251,7 +258,7 @@ export class Registry<
 
     // Perform as single call to register so listeners are notified once
     this.register(remoteItems, { source: "remote", notify: false });
-    this.register([...this.builtins.values()], {
+    this.register([...this._builtins.values()], {
       source: "builtin",
       notify: false,
     });
@@ -259,7 +266,7 @@ export class Registry<
 
     this._cacheInitialized = true;
 
-    return this.cached();
+    return this.cached;
   }
 
   /**
@@ -284,10 +291,10 @@ export class Registry<
       }
 
       if (source === "builtin") {
-        this.builtins.set(item.id, item);
+        this._builtins.set(item.id, item);
       }
 
-      this.cache.set(item.id, item);
+      this._cache.set(item.id, item);
       changed = true;
     }
 
@@ -315,7 +322,7 @@ export class Registry<
   clear(): void {
     // Need to clear the whole thing, including built-ins. Listeners will often can all() to repopulate the cache.
     this._cacheInitialized = false;
-    this.cache.clear();
+    this._cache.clear();
     this.notifyAll();
   }
 
@@ -326,7 +333,7 @@ export class Registry<
   TEST_reset(): void {
     this._cacheInitialized = false;
     this.clear();
-    this.builtins.clear();
+    this._builtins.clear();
   }
 }
 

--- a/src/blocks/registry.test.ts
+++ b/src/blocks/registry.test.ts
@@ -107,14 +107,14 @@ describe("blocksRegistry", () => {
   test("reads single JS block", async () => {
     blocksRegistry.register([echoBlock]);
     await expect(blocksRegistry.all()).resolves.toEqual([echoBlock]);
-    expect(blocksRegistry.cached()).toEqual([echoBlock]);
+    expect(blocksRegistry.cached).toEqual([echoBlock]);
   });
 
   test("preserves JS block on clear", async () => {
     blocksRegistry.register([echoBlock]);
     blocksRegistry.clear();
     await expect(blocksRegistry.all()).resolves.toEqual([echoBlock]);
-    expect(blocksRegistry.cached()).toEqual([echoBlock]);
+    expect(blocksRegistry.cached).toEqual([echoBlock]);
 
     blocksRegistry.clear();
     await expect(blocksRegistry.lookup(echoBlock.id)).resolves.toEqual(
@@ -126,7 +126,7 @@ describe("blocksRegistry", () => {
     blocksRegistry.register([echoBlock]);
     blocksRegistry.clear();
     expect(blocksRegistry.isCachedInitialized).toBe(false);
-    expect(() => blocksRegistry.cached()).toThrow("Cache not initialized");
+    expect(() => blocksRegistry.cached).toThrow("Cache not initialized");
   });
 
   test("cache invalid until all()", async () => {

--- a/src/blocks/registry.ts
+++ b/src/blocks/registry.ts
@@ -56,7 +56,7 @@ class BlocksRegistry extends BaseRegistry<RegistryId, IBlock> {
   private async inferAllTypes(): Promise<TypedBlockMap> {
     const typeCache: TypedBlockMap = new Map();
 
-    const items = this.cached().length > 0 ? this.cached() : await this.all();
+    const items = this.isCachedInitialized ? this.cached() : await this.all();
 
     console.debug("Computing block types for %d block(s)", items.length);
 

--- a/src/blocks/registry.ts
+++ b/src/blocks/registry.ts
@@ -56,7 +56,7 @@ class BlocksRegistry extends BaseRegistry<RegistryId, IBlock> {
   private async inferAllTypes(): Promise<TypedBlockMap> {
     const typeCache: TypedBlockMap = new Map();
 
-    const items = this.isCachedInitialized ? this.cached() : await this.all();
+    const items = this.isCachedInitialized ? this.cached : await this.all();
 
     console.debug("Computing block types for %d block(s)", items.length);
 

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -36,7 +36,7 @@ Error.stackTraceLimit = Number.POSITIVE_INFINITY;
 
 console.log(`version: ${process.env.NPM_PACKAGE_VERSION}`);
 
-const blockDefinitions = blockRegistry.cached().map((block) => ({
+const blockDefinitions = blockRegistry.builtins.map((block) => ({
   apiVersion: "v1",
   header: true,
   kind: "read" in block ? "reader" : "component",

--- a/src/pageEditor/extensionPoints/pipelineMapping.ts
+++ b/src/pageEditor/extensionPoints/pipelineMapping.ts
@@ -47,20 +47,30 @@ class NormalizePipelineVisitor extends PipelineVisitor {
 
     // Initialize empty sub pipelines
     const typedBlock = this.blockMap.get(blockConfig.id);
-    const propertiesSchema = typedBlock.block?.inputSchema?.properties ?? {};
-    const emptySubPipelineProperties = Object.entries(propertiesSchema)
-      .filter(
-        ([prop, fieldSchema]) =>
-          typeof fieldSchema === "object" &&
-          fieldSchema.$ref === pipelineSchema.$id &&
-          !isPipelineExpression(blockConfig.config[prop])
-      )
-      .map(([prop]) => prop);
-    for (const prop of emptySubPipelineProperties) {
-      blockConfig.config[prop] = {
-        __type__: "pipeline",
-        __value__: [],
-      };
+
+    if (typedBlock == null) {
+      console.warn(
+        "Block not found in block map: %s",
+        blockConfig.id,
+        this.blockMap
+      );
+    } else {
+      const propertiesSchema = typedBlock.block?.inputSchema?.properties ?? {};
+      const emptySubPipelineProperties = Object.entries(propertiesSchema)
+        .filter(
+          ([prop, fieldSchema]) =>
+            typeof fieldSchema === "object" &&
+            fieldSchema.$ref === pipelineSchema.$id &&
+            !isPipelineExpression(blockConfig.config[prop])
+        )
+        .map(([prop]) => prop);
+
+      for (const prop of emptySubPipelineProperties) {
+        blockConfig.config[prop] = {
+          __type__: "pipeline",
+          __value__: [],
+        };
+      }
     }
 
     super.visitBlock(position, blockConfig, extra);

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -115,6 +115,9 @@ jest.mock("@/permissions", () => {
 });
 jest.mock("@/background/messenger/api", () => ({
   containsPermissions: jest.fn().mockResolvedValue(true),
+  registry: {
+    getByKinds: jest.fn().mockResolvedValue([]),
+  },
 }));
 // Mock to support hook usage in the subtree, not relevant to UI tests here
 jest.mock("@/hooks/useRefreshRegistries");
@@ -133,7 +136,9 @@ const immediateUserEvent = userEvent.setup({ delay: null });
 
 beforeAll(async () => {
   registerDefaultWidgets();
+
   blockRegistry.clear();
+
   blockRegistry.register([
     echoBlock,
     teapotBlock,
@@ -143,6 +148,8 @@ beforeAll(async () => {
     markdownBlock,
     uiPathBlock,
   ]);
+
+  // Force block map to be created
   await blockRegistry.allTyped();
 
   const tags = [

--- a/src/registry/localRegistry.ts
+++ b/src/registry/localRegistry.ts
@@ -157,7 +157,9 @@ async function putAll(packages: Package[]): Promise<void> {
   await tx.done;
 }
 
-function parsePackage(item: RegistryPackage): Except<Package, "timestamp"> {
+export function parsePackage(
+  item: RegistryPackage
+): Except<Package, "timestamp"> {
   const [major, minor, patch] = item.metadata.version
     .split(".")
     .map((x) => Number.parseInt(x, 10));


### PR DESCRIPTION
## What does this PR do?

- Closes #5163 
- Fixes bug in baseRegistry/brick registry where it though registry cache was initialized before YAML brick were loaded from the local DB

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
