### PR TITLE
#5172: isolate quickbar from host page hot-keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "react-bootstrap": "^1.6.1",
         "react-dom": "^17.0.2",
         "react-draggable": "^4.4.5",
+        "react-focus-lock": "^2.9.3",
         "react-hot-toast": "^2.4.0",
         "react-hotkeys": "^2.0.0",
         "react-image-crop": "^10.0.6",
@@ -18072,6 +18073,11 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "node_modules/detect-package-manager": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-package-manager/-/detect-package-manager-2.0.1.tgz",
@@ -20646,6 +20652,17 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/focus-lock": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.5.tgz",
+      "integrity": "sha512-1mTr6pl9HBpJ8CqY7hRc38MCrcuTZIeYAkBD1gBTzbx5/to+bRBaBYtJ68iDq7ryTzAAbKrG3dVKjkrWTaaEaw==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/follow-redirects": {
@@ -30931,6 +30948,17 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/react-clientside-effect": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-docgen": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.4.3.tgz",
@@ -31043,6 +31071,28 @@
     "node_modules/react-fast-compare": {
       "version": "2.0.4",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/react-focus-lock": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.3.tgz",
+      "integrity": "sha512-cGNkz9p5Fpqio6hBHlkKxzRYrBYtcPosFOL6Q3N/LSbHjwP/PTBqHpvbgaOYoE7rWfzw8qXPKTB3Tk/VPgw4NQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.11.5",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-hot-toast": {
       "version": "2.4.0",
@@ -34588,8 +34638,7 @@
     },
     "node_modules/tslib": {
       "version": "2.3.1",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -35318,6 +35367,26 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-debounce": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-9.0.3.tgz",
@@ -35347,6 +35416,27 @@
       "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {
@@ -50182,6 +50272,11 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "detect-package-manager": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-package-manager/-/detect-package-manager-2.0.1.tgz",
@@ -52160,6 +52255,14 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "focus-lock": {
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.5.tgz",
+      "integrity": "sha512-1mTr6pl9HBpJ8CqY7hRc38MCrcuTZIeYAkBD1gBTzbx5/to+bRBaBYtJ68iDq7ryTzAAbKrG3dVKjkrWTaaEaw==",
+      "requires": {
+        "tslib": "^2.0.3"
       }
     },
     "follow-redirects": {
@@ -59962,6 +60065,14 @@
         "warning": "^4.0.3"
       }
     },
+    "react-clientside-effect": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "requires": {
+        "@babel/runtime": "^7.12.13"
+      }
+    },
     "react-docgen": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.4.3.tgz",
@@ -60048,6 +60159,19 @@
     "react-fast-compare": {
       "version": "2.0.4",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "react-focus-lock": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.3.tgz",
+      "integrity": "sha512-cGNkz9p5Fpqio6hBHlkKxzRYrBYtcPosFOL6Q3N/LSbHjwP/PTBqHpvbgaOYoE7rWfzw8qXPKTB3Tk/VPgw4NQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.11.5",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      }
     },
     "react-hot-toast": {
       "version": "2.4.0",
@@ -62808,8 +62932,7 @@
     },
     "tslib": {
       "version": "2.3.1",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -63351,6 +63474,14 @@
       "resolved": "https://registry.npmjs.org/use-async-effect/-/use-async-effect-2.2.7.tgz",
       "integrity": "sha512-Vq94tKPyo/9Nok4LOapV0GoGgZPhbeDW/bP6bulLPV4+lIoftaBRBBbGjTbM+j5W1Bm2EkUHJgapeu5YnQvKEA=="
     },
+    "use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "use-debounce": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-9.0.3.tgz",
@@ -63364,6 +63495,15 @@
     "use-memo-one": {
       "version": "1.1.2",
       "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
+    },
+    "use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      }
     },
     "use-sync-external-store": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "react-bootstrap": "^1.6.1",
     "react-dom": "^17.0.2",
     "react-draggable": "^4.4.5",
+    "react-focus-lock": "^2.9.3",
     "react-hot-toast": "^2.4.0",
     "react-hotkeys": "^2.0.0",
     "react-image-crop": "^10.0.6",

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -39,6 +39,8 @@ import QuickBarResults from "./QuickBarResults";
 import useActionGenerators from "@/components/quickBar/useActionGenerators";
 import useActions from "@/components/quickBar/useActions";
 
+import FocusLock from "react-focus-lock";
+
 /**
  * Set to true if the KBar should be displayed on initial mount (i.e., because it was triggered by the
  * shortcut giving the page activeTab).
@@ -89,16 +91,27 @@ const KBarComponent: React.FC = () => {
     selection.restore();
   }
 
+  // We're using the Shadow DOM to isolate the style. However, that also means keydown events look like they're
+  // coming from the div instead of the search input. Include div.contentEditable to indicate to hotkey libraries
+  // that the user is interacting with the quick bar
+  //
+  // Library references:
+  // hotkey: https://github.com/github/hotkey/blob/main/src/utils.ts#L1
+
   return (
     <KBarPortal>
       <KBarPositioner style={{ zIndex: MAX_Z_INDEX }}>
         <KBarAnimator style={animatorStyle}>
-          <ReactShadowRoot mode="open">
-            <Stylesheets href={faStyleSheet} mountOnLoad>
-              <KBarSearch style={searchStyle} />
-              <QuickBarResults />
-            </Stylesheets>
-          </ReactShadowRoot>
+          <div contentEditable suppressContentEditableWarning>
+            <ReactShadowRoot mode="closed">
+              <Stylesheets href={faStyleSheet} mountOnLoad>
+                <FocusLock>
+                  <KBarSearch style={searchStyle} />
+                  <QuickBarResults />
+                </FocusLock>
+              </Stylesheets>
+            </ReactShadowRoot>
+          </div>
         </KBarAnimator>
       </KBarPositioner>
     </KBarPortal>

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -92,17 +92,24 @@ const KBarComponent: React.FC = () => {
   }
 
   // We're using the Shadow DOM to isolate the style. However, that also means keydown events look like they're
-  // coming from the div instead of the search input. Include div.contentEditable to indicate to hotkey libraries
-  // that the user is interacting with the quick bar
+  // coming from the div instead of the search input.
+  //
+  // - Include div.contentEditable to indicate to hotkey libraries that the user is interacting with the quick bar
+  // - Salesforce looks for the `cke_editable` instead of contentEditable, so provide that class
   //
   // Library references:
-  // hotkey: https://github.com/github/hotkey/blob/main/src/utils.ts#L1
+  // - hotkey: https://github.com/github/hotkey/blob/main/src/utils.ts#L1
+  // - Salesforce: https://salesforce.stackexchange.com/questions/183771/disable-keyboard-shortcuts-in-lightning-experience
 
   return (
     <KBarPortal>
       <KBarPositioner style={{ zIndex: MAX_Z_INDEX }}>
         <KBarAnimator style={animatorStyle}>
-          <div contentEditable suppressContentEditableWarning>
+          <div
+            className="cke_editable"
+            contentEditable
+            suppressContentEditableWarning
+          >
             <ReactShadowRoot mode="closed">
               <Stylesheets href={faStyleSheet} mountOnLoad>
                 <FocusLock>


### PR DESCRIPTION
## What does this PR do?

- Closes #5172 🤞 
- Wraps the Quick Bar in a contentEditable (which the user can't actually target), so hot key libraries see typing in the Quick Bar as input-like events. 
- The contenEditable div is taken up fully by the Quick Bar, so the user can't actually type into the div itself. (At least I wasn't able to when I tried)
- Introduces focus lock library to ensure Quick Bar keeps focus while open

## Discussion

- Tested on GitHub, Zendesk, Trello, Salesforce. Not tested on Notion yet

## Demo

- https://www.loom.com/share/04b79d48c30e484896d76df8700be51b

## Checklist

- [x] Add tests: N/A - I didn't want to introduce dependency on hotkeys library just to test
- [x] Designate a primary reviewer: @BALEHOK 
