### PR TITLE
#5176: fix await element performance regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,7 @@
       },
       "devDependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.36",
+        "@shopify/jest-dom-mocks": "^4.1.0",
         "@sindresorhus/tsconfig": "^3.0.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@storybook/addon-actions": "^6.5.15",
@@ -4790,6 +4791,32 @@
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+    },
+    "node_modules/@shopify/async": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@shopify/async/-/async-4.0.1.tgz",
+      "integrity": "sha512-Vy9nBUXDqtJ4kqUc0GOt2jZPMQ6I2FoMXFG+yslPOGGEuT1KfhTvEgywm/OqbxAWfl2jNCyliEizq7AYK4y4bg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@shopify/jest-dom-mocks": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shopify/jest-dom-mocks/-/jest-dom-mocks-4.1.0.tgz",
+      "integrity": "sha512-2a2bnkpiJMvOkcO4j2C0KqoNdEabwkBiEcSr367KnXhRCf84nxapCEvNazVn4m7KqNkdRjo7hKmlyFVSB99K/Q==",
+      "dev": true,
+      "dependencies": {
+        "@shopify/async": "^4.0.1",
+        "@types/fetch-mock": "^7.3.3",
+        "@types/lolex": "^2.1.3",
+        "fetch-mock": "^9.11.0",
+        "lolex": "^2.7.5",
+        "promise": "^8.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.21",
@@ -11982,6 +12009,12 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
+    "node_modules/@types/fetch-mock": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@types/fetch-mock/-/fetch-mock-7.3.5.tgz",
+      "integrity": "sha512-sLecm9ohBdGIpYUP9rWk5/XIKY2xHMYTBJIcJuBBM8IJWnYoQ1DAj8F4OVjnfD0API1drlkWEV0LPNk+ACuhsg==",
+      "dev": true
+    },
     "node_modules/@types/filesystem": {
       "version": "0.0.32",
       "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
@@ -12285,6 +12318,12 @@
       "dependencies": {
         "@types/lodash": "*"
       }
+    },
+    "node_modules/@types/lolex": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/lolex/-/lolex-2.1.3.tgz",
+      "integrity": "sha512-nEipOLYyZJ4RKHCg7tlR37ewFy91oggmip2MBzPdVQ8QhTFqjcRhE8R0t4tfpDnSlxGWHoEGJl0UCC4kYhqoiw==",
+      "dev": true
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -20326,6 +20365,65 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "funding": {
+        "type": "charity",
+        "url": "https://www.justgiving.com/refugee-support-europe"
+      },
+      "peerDependencies": {
+        "node-fetch": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-mock/node_modules/path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
+    "node_modules/fetch-mock/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/fetch-mock/node_modules/whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
     "node_modules/fetch-retry": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.3.tgz",
@@ -22997,6 +23095,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
+      "dev": true
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
@@ -27355,6 +27459,12 @@
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "dev": true
     },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true
+    },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
@@ -27432,6 +27542,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lolex": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+      "dev": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -30523,6 +30639,15 @@
       "version": "2.0.1",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "node_modules/promise": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+      "dev": true,
+      "dependencies": {
+        "asap": "~2.0.6"
+      }
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -40119,6 +40244,26 @@
         }
       }
     },
+    "@shopify/async": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@shopify/async/-/async-4.0.1.tgz",
+      "integrity": "sha512-Vy9nBUXDqtJ4kqUc0GOt2jZPMQ6I2FoMXFG+yslPOGGEuT1KfhTvEgywm/OqbxAWfl2jNCyliEizq7AYK4y4bg==",
+      "dev": true
+    },
+    "@shopify/jest-dom-mocks": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shopify/jest-dom-mocks/-/jest-dom-mocks-4.1.0.tgz",
+      "integrity": "sha512-2a2bnkpiJMvOkcO4j2C0KqoNdEabwkBiEcSr367KnXhRCf84nxapCEvNazVn4m7KqNkdRjo7hKmlyFVSB99K/Q==",
+      "dev": true,
+      "requires": {
+        "@shopify/async": "^4.0.1",
+        "@types/fetch-mock": "^7.3.3",
+        "@types/lolex": "^2.1.3",
+        "fetch-mock": "^9.11.0",
+        "lolex": "^2.7.5",
+        "promise": "^8.0.3"
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.25.21",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
@@ -45459,6 +45604,12 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
+    "@types/fetch-mock": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@types/fetch-mock/-/fetch-mock-7.3.5.tgz",
+      "integrity": "sha512-sLecm9ohBdGIpYUP9rWk5/XIKY2xHMYTBJIcJuBBM8IJWnYoQ1DAj8F4OVjnfD0API1drlkWEV0LPNk+ACuhsg==",
+      "dev": true
+    },
     "@types/filesystem": {
       "version": "0.0.32",
       "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
@@ -45748,6 +45899,12 @@
       "requires": {
         "@types/lodash": "*"
       }
+    },
+    "@types/lolex": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/lolex/-/lolex-2.1.3.tgz",
+      "integrity": "sha512-nEipOLYyZJ4RKHCg7tlR37ewFy91oggmip2MBzPdVQ8QhTFqjcRhE8R0t4tfpDnSlxGWHoEGJl0UCC4kYhqoiw==",
+      "dev": true
     },
     "@types/mdast": {
       "version": "3.0.10",
@@ -51925,6 +52082,52 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+          "dev": true
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
     "fetch-retry": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.3.tgz",
@@ -53886,6 +54089,12 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.4",
@@ -57226,6 +57435,12 @@
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
@@ -57281,6 +57496,12 @@
           }
         }
       }
+    },
+    "lolex": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -59663,6 +59884,15 @@
       "version": "2.0.1",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "promise": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.6"
+      }
     },
     "promise-inflight": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
   },
   "devDependencies": {
     "@fortawesome/fontawesome-common-types": "^0.2.36",
+    "@shopify/jest-dom-mocks": "^4.1.0",
     "@sindresorhus/tsconfig": "^3.0.1",
     "@sinonjs/fake-timers": "^10.0.2",
     "@storybook/addon-actions": "^6.5.15",

--- a/src/blocks/effects/wait.test.ts
+++ b/src/blocks/effects/wait.test.ts
@@ -21,6 +21,15 @@ import { uuidSequence } from "@/testUtils/factories";
 import { type BlockOptions } from "@/core";
 import { WaitElementEffect } from "@/blocks/effects/wait";
 import { BusinessError } from "@/errors/businessErrors";
+import { ensureMocksReset, requestIdleCallback } from "@shopify/jest-dom-mocks";
+
+beforeAll(() => {
+  requestIdleCallback.mock();
+});
+
+beforeEach(() => {
+  ensureMocksReset();
+});
 
 const brick = new WaitElementEffect();
 

--- a/src/blocks/transformers/tourStep/tourStep.test.ts
+++ b/src/blocks/transformers/tourStep/tourStep.test.ts
@@ -28,6 +28,15 @@ import { tick } from "@/extensionPoints/extensionPointTestUtils";
 import { MultipleElementsFoundError } from "@/errors/businessErrors";
 import { showModal } from "@/blocks/transformers/ephemeralForm/modalUtils";
 import { showPopover } from "@/blocks/transformers/temporaryInfo/popoverUtils";
+import { ensureMocksReset, requestIdleCallback } from "@shopify/jest-dom-mocks";
+
+beforeAll(() => {
+  requestIdleCallback.mock();
+});
+
+beforeEach(() => {
+  ensureMocksReset();
+});
 
 Element.prototype.scrollIntoView = jest.fn();
 browser.runtime.getURL = jest
@@ -278,6 +287,8 @@ describe("tourStep", () => {
 
     // :initialize:
     document.body.innerHTML = '<div id="foo">Foo</div>';
+
+    requestIdleCallback.runIdleCallbacks();
 
     await tick();
 

--- a/src/blocks/transformers/tourStep/tourStep.test.ts
+++ b/src/blocks/transformers/tourStep/tourStep.test.ts
@@ -289,7 +289,8 @@ describe("tourStep", () => {
     document.body.innerHTML = '<div id="foo">Foo</div>';
 
     requestIdleCallback.runIdleCallbacks();
-
+    // Ticks to allow the setInterval to run
+    await tick();
     await tick();
 
     cancelAllTours();

--- a/src/extensionPoints/helpers.test.ts
+++ b/src/extensionPoints/helpers.test.ts
@@ -17,6 +17,15 @@
 
 import { getDocument } from "@/extensionPoints/extensionPointTestUtils";
 import { awaitElementOnce } from "@/extensionPoints/helpers";
+import { ensureMocksReset, requestIdleCallback } from "@shopify/jest-dom-mocks";
+
+beforeAll(() => {
+  requestIdleCallback.mock();
+});
+
+beforeEach(() => {
+  ensureMocksReset();
+});
 
 describe("awaitElementOnce", () => {
   it("finds change in ancestor", async () => {
@@ -25,6 +34,9 @@ describe("awaitElementOnce", () => {
     ).body.innerHTML;
     const [promise] = awaitElementOnce(".newClass #menu");
     document.querySelector("#root").classList.add("newClass");
+
+    requestIdleCallback.runIdleCallbacks();
+
     await expect(promise).resolves.toHaveLength(1);
   });
 
@@ -34,6 +46,9 @@ describe("awaitElementOnce", () => {
     ).body.innerHTML;
     const [promise] = awaitElementOnce('#root:has(h1:contains("Bar")) #menu');
     document.querySelector("h1").textContent = "Bar";
+
+    requestIdleCallback.runIdleCallbacks();
+
     await expect(promise).resolves.toHaveLength(1);
   });
 });

--- a/src/extensionPoints/helpers.test.ts
+++ b/src/extensionPoints/helpers.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getDocument } from "@/extensionPoints/extensionPointTestUtils";
+import { getDocument, tick } from "@/extensionPoints/extensionPointTestUtils";
 import { awaitElementOnce } from "@/extensionPoints/helpers";
 import { ensureMocksReset, requestIdleCallback } from "@shopify/jest-dom-mocks";
 
@@ -36,6 +36,7 @@ describe("awaitElementOnce", () => {
     document.querySelector("#root").classList.add("newClass");
 
     requestIdleCallback.runIdleCallbacks();
+    await tick();
 
     await expect(promise).resolves.toHaveLength(1);
   });
@@ -48,6 +49,7 @@ describe("awaitElementOnce", () => {
     document.querySelector("h1").textContent = "Bar";
 
     requestIdleCallback.runIdleCallbacks();
+    await tick();
 
     await expect(promise).resolves.toHaveLength(1);
   });

--- a/src/extensionPoints/triggerExtension.test.ts
+++ b/src/extensionPoints/triggerExtension.test.ts
@@ -36,6 +36,15 @@ import {
 import { getReferenceForElement } from "@/contentScript/elementReference";
 import userEvent from "@testing-library/user-event";
 import { waitForEffect } from "@/testUtils/testHelpers";
+import { ensureMocksReset, requestIdleCallback } from "@shopify/jest-dom-mocks";
+
+beforeAll(() => {
+  requestIdleCallback.mock();
+});
+
+beforeEach(() => {
+  ensureMocksReset();
+});
 
 jest.mock("@/telemetry/logging", () => {
   const actual = jest.requireActual("@/telemetry/logging");
@@ -152,6 +161,8 @@ describe("triggerExtension", () => {
       document.body.innerHTML = getDocument(
         "<button>Click Me</button>"
       ).body.innerHTML;
+
+      requestIdleCallback.runIdleCallbacks();
 
       // Give the mutation observer time to run
       await tick();

--- a/src/extensionPoints/triggerExtension.test.ts
+++ b/src/extensionPoints/triggerExtension.test.ts
@@ -166,10 +166,12 @@ describe("triggerExtension", () => {
 
       // Give the mutation observer time to run
       await tick();
+      await tick();
 
       // Check click handler was not re-attached
       document.querySelector("button").click();
       await tick();
+
       expect(rootReader.readCount).toBe(attachMode === "watch" ? 2 : 1);
 
       extensionPoint.uninstall();

--- a/src/vendors/initialize.js
+++ b/src/vendors/initialize.js
@@ -73,14 +73,17 @@ msobservers.initialize = function (selector, callback, options) {
   var callbackOnce = function () {
     if (!seen.has(this)) {
       seen.add(this);
-      $(this).each(callback);
+      $(this).each(() => {
+        // Don't block the page transition/animation frame
+        setTimeout(callback, 0);
+      });
     }
   };
 
-  let idleCallbackHandle = null;
-
+  // Fall back handler to check the entire page for the selector
   // Try to choose timeouts that are long enough to avoid performance bottlenecks, but short enough to provide
   // responsiveness for triggers that depend on ancestor/sibling elements changing
+  let idleCallbackHandle = null;
   var throttledCheckTarget = throttle(
     () => {
       if (isMatchinInProgress) {

--- a/src/vendors/initialize.js
+++ b/src/vendors/initialize.js
@@ -73,9 +73,9 @@ msobservers.initialize = function (selector, callback, options) {
   var callbackOnce = function () {
     if (!seen.has(this)) {
       seen.add(this);
-      $(this).each(() => {
+      $(this).each((index, element) => {
         // Don't block the page transition/animation frame
-        setTimeout(callback, 0);
+        setTimeout(() => callback(index, element), 0);
       });
     }
   };

--- a/src/vendors/initialize.js
+++ b/src/vendors/initialize.js
@@ -95,11 +95,6 @@ msobservers.initialize = function (selector, callback, options) {
       // Wrap in requestIdleCallback to prevent impacting performance
       idleCallbackHandle = requestIdleCallback(
         () => {
-          console.debug(
-            "requestIdleCallback: checking target for matches",
-            selector
-          );
-
           requestAnimationFrame(() => {
             $safeFind(selector, options.target).each(callbackOnce);
             idleCallbackHandle = null;


### PR DESCRIPTION
## What does this PR do?

- Closes #5176 
- Use requestIdleCallback and requestAnimationFrame to avoid performance regressions when watching whole page for a selector

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
