### PR TITLE
#5072: Marketplace Activation Followup: bug fix and types cleanup

### DIFF
--- a/src/blocks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
+++ b/src/blocks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
@@ -340,7 +340,7 @@ class DisplayTemporaryInfo extends Transformer {
     }>,
     {
       logger: {
-        context: { extensionId, blueprintId, extensionPointId },
+        context: { extensionId },
       },
       root,
       ctxt,

--- a/src/blocks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
+++ b/src/blocks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
@@ -32,7 +32,7 @@ import {
   showTemporarySidebarPanel,
   updateTemporarySidebarPanel,
 } from "@/contentScript/sidebarController";
-import { type PanelEntry, type PanelPayload } from "@/sidebar/types";
+import { type PanelPayload, type TemporaryPanelEntry } from "@/sidebar/types";
 import {
   cancelTemporaryPanels,
   cancelTemporaryPanelsForExtension,
@@ -52,6 +52,7 @@ import { updateTemporaryOverlayPanel } from "@/contentScript/ephemeralPanelContr
 import { once } from "lodash";
 import { AbortPanelAction, ClosePanelAction } from "@/blocks/errors";
 import { isSpecificError } from "@/errors/errorHelpers";
+import { type Except } from "type-fest";
 
 type Location = "panel" | "modal" | "popover";
 // Match naming of the sidebar panel extension point triggers
@@ -70,11 +71,15 @@ export async function createFrameSource(
   return frameSource;
 }
 
+export type GetPanelEntry = () => Promise<
+  Except<TemporaryPanelEntry, "type" | "nonce">
+>;
+
 export type TemporaryDisplayInputs = {
   /**
-   * The initial panel entry.
+   * Factory method to generate the temporary panel entry.
    */
-  entry: PanelEntry;
+  getPanelEntry: GetPanelEntry;
   /**
    * The location to display the panel.
    */
@@ -92,11 +97,6 @@ export type TemporaryDisplayInputs = {
    * An optional trigger to trigger a panel refresh.
    */
   refreshTrigger?: RefreshTrigger;
-
-  /**
-   * Factory method to refresh the panel.
-   */
-  refreshEntry?: () => Promise<PanelEntry>;
 
   /**
    * Handler when the user clicks outside the modal/popover.
@@ -121,28 +121,27 @@ export type TemporaryDisplayInputs = {
 
 /**
  * Display a brick in a temporary panel: sidebar, modal, or popover.
- * @param entry the panel entry
+ * @param getPanelEntry factory to generate the panel entry
  * @param location the location to show the panel
  * @param signal abort signal
  * @param target target element, if location is popover
- * @param refreshEntry factory to re-generate the panel entry
  * @param refreshTrigger optional trigger to refresh the panel
  * @param popoverOptions optional popover options
  * @param onOutsideClick optional callback to invoke when the user clicks outside the popover/modal
  * @param onCloseClick optional callback to invoke when the user clicks the close button on the popover/modal
  */
 export async function displayTemporaryInfo({
-  entry,
+  getPanelEntry,
   location,
   signal,
   target,
-  refreshEntry,
   refreshTrigger,
   popoverOptions,
   onOutsideClick,
   onCloseClick,
 }: TemporaryDisplayInputs): Promise<UnknownObject> {
   const nonce = uuidv4();
+  const entry = await getPanelEntry();
   let onReady: () => void;
 
   const controller = new AbortController();
@@ -229,7 +228,7 @@ export async function displayTemporaryInfo({
 
   const rerender = async () => {
     try {
-      const newEntry = { ...(await refreshEntry()), nonce };
+      const newEntry = { ...(await getPanelEntry()), nonce };
       // Force a re-render by changing the key
       newEntry.payload.key = uuidv4();
 
@@ -357,7 +356,7 @@ class DisplayTemporaryInfo extends Transformer {
     // Counter for tracking branch execution
     let counter = 0;
 
-    const refreshEntry = async () => {
+    const getPanelEntry: GetPanelEntry = async () => {
       const payload = (await runRendererPipeline(
         bodyPipeline?.__value__ ?? [],
         {
@@ -374,19 +373,14 @@ class DisplayTemporaryInfo extends Transformer {
         heading: title,
         payload,
         extensionId,
-        blueprintId,
-        extensionPointId,
       };
     };
 
-    const initialEntry = await refreshEntry();
-
     return displayTemporaryInfo({
-      entry: initialEntry,
+      getPanelEntry,
       location,
       signal: abortSignal,
       target,
-      refreshEntry,
       refreshTrigger,
     });
   }

--- a/src/blocks/transformers/temporaryInfo/EphemeralPanel.test.tsx
+++ b/src/blocks/transformers/temporaryInfo/EphemeralPanel.test.tsx
@@ -25,6 +25,7 @@ import {
   cancelTemporaryPanel,
   resolveTemporaryPanel,
 } from "@/contentScript/messenger/api";
+import { sidebarEntryFactory } from "@/testUtils/factories";
 
 jest.mock(
   "@/blocks/transformers/temporaryInfo/useTemporaryPanelDefinition",
@@ -110,13 +111,10 @@ describe("EphemeralPanel", () => {
 
       useTemporaryPanelDefinitionMock.mockReturnValue({
         panelNonce,
-        entry: {
+        entry: sidebarEntryFactory("temporaryPanel", {
           nonce: panelNonce,
-          extensionId: uuidv4(),
-          heading: "Test Title",
-          payload: null as any,
           actions: [{ type: "testClick", variant: "light" }],
-        },
+        }),
         error: null,
         isLoading: null,
       });

--- a/src/blocks/transformers/temporaryInfo/__snapshots__/EphemeralPanel.test.tsx.snap
+++ b/src/blocks/transformers/temporaryInfo/__snapshots__/EphemeralPanel.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`EphemeralPanel renders action buttons: modal 1`] = `
       <div
         class="modal-title h4"
       >
-        Test Title
+        Temporary Panel Test 1
       </div>
       <button
         class="close"
@@ -63,7 +63,7 @@ exports[`EphemeralPanel renders action buttons: popover 1`] = `
     <div
       class="popover-header"
     >
-      Test Title
+      Temporary Panel Test 2
       <button
         class="close btn btn-primary"
         data-dismiss="alert"

--- a/src/blocks/transformers/temporaryInfo/temporaryPanelProtocol.test.ts
+++ b/src/blocks/transformers/temporaryInfo/temporaryPanelProtocol.test.ts
@@ -35,11 +35,11 @@ describe("temporaryPanelProtocol", () => {
 
   it("stopWaitingForTemporaryPanels resolves promise", async () => {
     const nonce = uuidv4();
-    const entry = sidebarEntryFactory("temporaryPanel", { nonce });
+    const definition = sidebarEntryFactory("temporaryPanel", { nonce });
 
-    const promise = waitForTemporaryPanel(nonce, entry);
+    const promise = waitForTemporaryPanel(nonce, definition);
 
-    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(entry);
+    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(definition);
 
     await stopWaitingForTemporaryPanels([nonce]);
 
@@ -48,11 +48,11 @@ describe("temporaryPanelProtocol", () => {
 
   it("resolveTemporaryPanel resolves promise", async () => {
     const nonce = uuidv4();
-    const entry = sidebarEntryFactory("temporaryPanel", { nonce });
+    const definition = sidebarEntryFactory("temporaryPanel", { nonce });
 
-    const promise = waitForTemporaryPanel(nonce, entry);
+    const promise = waitForTemporaryPanel(nonce, definition);
 
-    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(entry);
+    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(definition);
 
     const action = { type: "submit", detail: { foo: "bar" } };
 
@@ -63,11 +63,11 @@ describe("temporaryPanelProtocol", () => {
 
   it("cancelTemporaryPanels rejects promise", async () => {
     const nonce = uuidv4();
-    const entry = sidebarEntryFactory("temporaryPanel", { nonce });
+    const definition = sidebarEntryFactory("temporaryPanel", { nonce });
 
-    const promise = waitForTemporaryPanel(nonce, entry);
+    const promise = waitForTemporaryPanel(nonce, definition);
 
-    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(entry);
+    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(definition);
 
     await cancelTemporaryPanels([nonce]);
 

--- a/src/blocks/transformers/temporaryInfo/temporaryPanelProtocol.test.ts
+++ b/src/blocks/transformers/temporaryInfo/temporaryPanelProtocol.test.ts
@@ -23,8 +23,8 @@ import {
   resolveTemporaryPanel,
 } from "@/blocks/transformers/temporaryInfo/temporaryPanelProtocol";
 import { uuidv4 } from "@/types/helpers";
-import { type TemporaryPanelEntry } from "@/sidebar/types";
 import { CancelError } from "@/errors/businessErrors";
+import { sidebarEntryFactory } from "@/testUtils/factories";
 
 describe("temporaryPanelProtocol", () => {
   it("getPanelDefinition if panel is not defined", async () => {
@@ -35,17 +35,11 @@ describe("temporaryPanelProtocol", () => {
 
   it("stopWaitingForTemporaryPanels resolves promise", async () => {
     const nonce = uuidv4();
-    const extensionId = uuidv4();
-    const definition: TemporaryPanelEntry = {
-      nonce,
-      heading: "Test",
-      extensionId,
-      payload: {} as any,
-    };
+    const entry = sidebarEntryFactory("temporaryPanel", { nonce });
 
-    const promise = waitForTemporaryPanel(nonce, definition);
+    const promise = waitForTemporaryPanel(nonce, entry);
 
-    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(definition);
+    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(entry);
 
     await stopWaitingForTemporaryPanels([nonce]);
 
@@ -54,17 +48,11 @@ describe("temporaryPanelProtocol", () => {
 
   it("resolveTemporaryPanel resolves promise", async () => {
     const nonce = uuidv4();
-    const extensionId = uuidv4();
-    const definition: TemporaryPanelEntry = {
-      nonce,
-      heading: "Test",
-      extensionId,
-      payload: {} as any,
-    };
+    const entry = sidebarEntryFactory("temporaryPanel", { nonce });
 
-    const promise = waitForTemporaryPanel(nonce, definition);
+    const promise = waitForTemporaryPanel(nonce, entry);
 
-    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(definition);
+    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(entry);
 
     const action = { type: "submit", detail: { foo: "bar" } };
 
@@ -75,17 +63,11 @@ describe("temporaryPanelProtocol", () => {
 
   it("cancelTemporaryPanels rejects promise", async () => {
     const nonce = uuidv4();
-    const extensionId = uuidv4();
-    const definition: TemporaryPanelEntry = {
-      nonce,
-      heading: "Test",
-      extensionId,
-      payload: {} as any,
-    };
+    const entry = sidebarEntryFactory("temporaryPanel", { nonce });
 
-    const promise = waitForTemporaryPanel(nonce, definition);
+    const promise = waitForTemporaryPanel(nonce, entry);
 
-    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(definition);
+    await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(entry);
 
     await cancelTemporaryPanels([nonce]);
 

--- a/src/blocks/transformers/temporaryInfo/temporaryPanelProtocol.ts
+++ b/src/blocks/transformers/temporaryInfo/temporaryPanelProtocol.ts
@@ -21,9 +21,10 @@ import { expectContext } from "@/utils/expectContext";
 import { type PanelAction, type TemporaryPanelEntry } from "@/sidebar/types";
 import { ClosePanelAction } from "@/blocks/errors";
 import { CancelError } from "@/errors/businessErrors";
+import { type Except } from "type-fest";
 
 type RegisteredPanel = {
-  entry: TemporaryPanelEntry;
+  entry: Except<TemporaryPanelEntry, "type">;
   registration: DeferredPromise<PanelAction | null>;
 };
 
@@ -46,7 +47,7 @@ export async function getPanelDefinition(
     throw new Error("Panel definition not found");
   }
 
-  return panel.entry;
+  return { type: "temporaryPanel", ...panel.entry };
 }
 
 /**
@@ -54,7 +55,9 @@ export async function getPanelDefinition(
  * panel definition.
  * @param entry the panel definition
  */
-export function updatePanelDefinition(entry: TemporaryPanelEntry): void {
+export function updatePanelDefinition(
+  entry: Except<TemporaryPanelEntry, "type">
+): void {
   expectContext("contentScript");
 
   const panel = panels.get(entry.nonce);
@@ -79,7 +82,7 @@ export function updatePanelDefinition(entry: TemporaryPanelEntry): void {
  */
 export async function waitForTemporaryPanel(
   nonce: UUID,
-  entry: TemporaryPanelEntry,
+  entry: Except<TemporaryPanelEntry, "type">,
   { onRegister }: { onRegister?: () => void } = {}
 ): Promise<PanelAction | null> {
   expectContext("contentScript");

--- a/src/blocks/transformers/tourStep/tourStep.ts
+++ b/src/blocks/transformers/tourStep/tourStep.ts
@@ -29,7 +29,7 @@ import { isEmpty, noop } from "lodash";
 import { awaitElement } from "@/blocks/effects/wait";
 import {
   displayTemporaryInfo,
-  GetPanelEntry,
+  type GetPanelEntry,
   type RefreshTrigger,
   type TemporaryDisplayInputs,
 } from "@/blocks/transformers/temporaryInfo/DisplayTemporaryInfo";

--- a/src/blocks/transformers/tourStep/tourStep.ts
+++ b/src/blocks/transformers/tourStep/tourStep.ts
@@ -29,6 +29,7 @@ import { isEmpty, noop } from "lodash";
 import { awaitElement } from "@/blocks/effects/wait";
 import {
   displayTemporaryInfo,
+  GetPanelEntry,
   type RefreshTrigger,
   type TemporaryDisplayInputs,
 } from "@/blocks/transformers/temporaryInfo/DisplayTemporaryInfo";
@@ -328,7 +329,7 @@ export class TourStepTransformer extends Transformer {
       removeOverlay = addOverlay(element as HTMLElement);
     }
 
-    const refreshEntry = async () => {
+    const getPanelEntry: GetPanelEntry = async () => {
       const payload = (await runRendererPipeline(
         (body as PipelineExpression)?.__value__ ?? [],
         {
@@ -351,8 +352,6 @@ export class TourStepTransformer extends Transformer {
 
       return {
         extensionId,
-        extensionPointId,
-        blueprintId,
         heading: title,
         payload,
         actions,
@@ -385,12 +384,11 @@ export class TourStepTransformer extends Transformer {
 
     try {
       return await displayTemporaryInfo({
-        entry: await refreshEntry(),
+        getPanelEntry,
         target: element,
         location,
         signal: abortSignal,
         refreshTrigger: appearance.refreshTrigger,
-        refreshEntry,
         onOutsideClick,
         onCloseClick,
         popoverOptions: appearance.popover,

--- a/src/contentScript/ephemeralPanelController.tsx
+++ b/src/contentScript/ephemeralPanelController.tsx
@@ -19,6 +19,7 @@ import { type TemporaryPanelEntry } from "@/sidebar/types";
 import { expectContext } from "@/utils/expectContext";
 import panelInThisTab from "@/blocks/transformers/temporaryInfo/messenger/api";
 import { type UUID } from "@/core";
+import { type Except } from "type-fest";
 
 /**
  * Sequence number for ensuring render requests are handled in order
@@ -33,11 +34,16 @@ let renderSequenceNumber = 0;
  * @param entry the new panel content
  * @see updateTemporarySidebarPanel
  */
-export function updateTemporaryOverlayPanel(entry: TemporaryPanelEntry): void {
+export function updateTemporaryOverlayPanel(
+  entry: Except<TemporaryPanelEntry, "type">
+): void {
   expectContext("contentScript");
 
   const sequence = renderSequenceNumber++;
-  panelInThisTab.updateTemporaryPanel(sequence, entry);
+  panelInThisTab.updateTemporaryPanel(sequence, {
+    type: "temporaryPanel",
+    ...entry,
+  });
 }
 
 export function setTemporaryOverlayPanel(args: {

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -43,6 +43,7 @@ import {
   isSidebarFrameVisible,
   removeSidebarFrame,
 } from "./sidebarDomControllerLite";
+import { type Except } from "type-fest";
 
 export const PANEL_HIDING_EVENT = "pixiebrix:hideSidebar";
 
@@ -183,7 +184,7 @@ function renderPanelsIfVisible(): void {
   }
 }
 
-export function showSidebarForm(entry: FormEntry): void {
+export function showSidebarForm(entry: Except<FormEntry, "type">): void {
   expectContext("contentScript");
 
   if (!isSidebarFrameVisible()) {
@@ -192,7 +193,7 @@ export function showSidebarForm(entry: FormEntry): void {
 
   const seqNum = renderSequenceNumber;
   renderSequenceNumber++;
-  void sidebarInThisTab.showForm(seqNum, entry);
+  void sidebarInThisTab.showForm(seqNum, { type: "form", ...entry });
 }
 
 export function hideSidebarForm(nonce: UUID): void {
@@ -208,7 +209,9 @@ export function hideSidebarForm(nonce: UUID): void {
   void sidebarInThisTab.hideForm(seqNum, nonce);
 }
 
-export function showTemporarySidebarPanel(entry: TemporaryPanelEntry): void {
+export function showTemporarySidebarPanel(
+  entry: Except<TemporaryPanelEntry, "type">
+): void {
   expectContext("contentScript");
 
   if (!isSidebarFrameVisible()) {
@@ -218,10 +221,15 @@ export function showTemporarySidebarPanel(entry: TemporaryPanelEntry): void {
   }
 
   const sequence = renderSequenceNumber++;
-  void sidebarInThisTab.showTemporaryPanel(sequence, entry);
+  void sidebarInThisTab.showTemporaryPanel(sequence, {
+    type: "temporaryPanel",
+    ...entry,
+  });
 }
 
-export function updateTemporarySidebarPanel(entry: TemporaryPanelEntry): void {
+export function updateTemporarySidebarPanel(
+  entry: Except<TemporaryPanelEntry, "type">
+): void {
   expectContext("contentScript");
 
   if (!isSidebarFrameVisible()) {
@@ -231,7 +239,10 @@ export function updateTemporarySidebarPanel(entry: TemporaryPanelEntry): void {
   }
 
   const sequence = renderSequenceNumber++;
-  sidebarInThisTab.updateTemporaryPanel(sequence, entry);
+  sidebarInThisTab.updateTemporaryPanel(sequence, {
+    type: "temporaryPanel",
+    ...entry,
+  });
 }
 
 export function hideTemporarySidebarPanel(nonce: UUID): void {
@@ -294,6 +305,7 @@ export function reservePanels(refs: ExtensionRef[]): void {
   for (const { extensionId, extensionPointId, blueprintId } of refs) {
     if (!current.has(extensionId)) {
       const entry: PanelEntry = {
+        type: "panel",
         extensionId,
         extensionPointId,
         blueprintId,
@@ -365,6 +377,7 @@ export function upsertPanel(
       }
     );
     panels.push({
+      type: "panel",
       extensionId,
       extensionPointId,
       blueprintId,
@@ -376,7 +389,9 @@ export function upsertPanel(
   renderPanelsIfVisible();
 }
 
-export function showActivateRecipeInSidebar(entry: ActivateRecipeEntry): void {
+export function showActivateRecipeInSidebar(
+  entry: Except<ActivateRecipeEntry, "type">
+): void {
   expectContext("contentScript");
 
   if (!isSidebarFrameVisible()) {
@@ -386,7 +401,10 @@ export function showActivateRecipeInSidebar(entry: ActivateRecipeEntry): void {
   }
 
   const sequence = renderSequenceNumber++;
-  void sidebarInThisTab.showActivateRecipe(sequence, entry);
+  void sidebarInThisTab.showActivateRecipe(sequence, {
+    type: "activateRecipe",
+    ...entry,
+  });
 }
 
 export function hideActivateRecipeInSidebar(recipeId: RegistryId): void {

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -17,7 +17,7 @@
 
 import React, { useCallback, useEffect } from "react";
 import { type PanelEntry, type SidebarEntries } from "@/sidebar/types";
-import { mapTabEventKey } from "@/sidebar/utils";
+import { eventKeyForEntry } from "@/sidebar/utils";
 import { type UUID } from "@/core";
 import { reportEvent } from "@/telemetry/events";
 import { CloseButton, Nav, Tab } from "react-bootstrap";
@@ -88,7 +88,7 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
           {panels.map((panel) => (
             <Nav.Link
               key={panel.extensionId}
-              eventKey={mapTabEventKey("panel", panel)}
+              eventKey={eventKeyForEntry(panel)}
               className={styles.tabHeader}
             >
               <span className={styles.tabTitle}>
@@ -99,7 +99,7 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
           {forms.map((form) => (
             <Nav.Link
               key={form.extensionId}
-              eventKey={mapTabEventKey("form", form)}
+              eventKey={eventKeyForEntry(form)}
               className={styles.tabHeader}
             >
               <span className={styles.tabTitle}>
@@ -110,7 +110,7 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
           {temporaryPanels.map((panel) => (
             <Nav.Link
               key={panel.nonce}
-              eventKey={mapTabEventKey("temporaryPanel", panel)}
+              eventKey={eventKeyForEntry(panel)}
               className={styles.tabHeader}
             >
               <span className={styles.tabTitle}>{panel.heading}</span>
@@ -124,7 +124,7 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
           {recipeToActivate && (
             <Nav.Link
               key={recipeToActivate.recipeId}
-              eventKey={`activate-${recipeToActivate.recipeId}`}
+              eventKey={eventKeyForEntry(recipeToActivate)}
               className={styles.tabHeader}
             >
               <span className={styles.tabTitle}>
@@ -138,7 +138,7 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
             <Tab.Pane
               className={cx("full-height flex-grow", styles.paneOverrides)}
               key={panel.extensionId}
-              eventKey={mapTabEventKey("panel", panel)}
+              eventKey={eventKeyForEntry(panel)}
             >
               <ErrorBoundary>
                 <PanelBody
@@ -158,7 +158,7 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
             <Tab.Pane
               className="full-height flex-grow"
               key={form.nonce}
-              eventKey={mapTabEventKey("form", form)}
+              eventKey={eventKeyForEntry(form)}
             >
               <ErrorBoundary>
                 <FormBody form={form} />
@@ -169,7 +169,7 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
             <Tab.Pane
               className={cx("h-100", styles.paneOverrides)}
               key={panel.nonce}
-              eventKey={mapTabEventKey("temporaryPanel", panel)}
+              eventKey={eventKeyForEntry(panel)}
             >
               <ErrorBoundary>
                 <PanelBody
@@ -187,7 +187,7 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
             <Tab.Pane
               className={cx("h-100", styles.paneOverrides)}
               key={recipeToActivate.recipeId}
-              eventKey={`activate-${recipeToActivate.recipeId}`}
+              eventKey={eventKeyForEntry(recipeToActivate)}
             >
               <ErrorBoundary>
                 <ActivateRecipePanel recipeId={recipeToActivate.recipeId} />

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
@@ -21,13 +21,13 @@ import { useGetMarketplaceListingsQuery } from "@/services/api";
 import {
   marketplaceListingFactory,
   recipeDefinitionFactory,
+  sidebarEntryFactory,
 } from "@/testUtils/factories";
 import { type UseCachedQueryResult } from "@/core";
 import { uuidv4 } from "@/types/helpers";
 import { render } from "@/sidebar/testHelpers";
 import ActivateRecipePanel from "@/sidebar/activateRecipe/ActivateRecipePanel";
 import sidebarSlice from "@/sidebar/sidebarSlice";
-import { type ActivateRecipeEntry } from "@/sidebar/types";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { propertiesToSchema } from "@/validators/generic";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
@@ -138,10 +138,10 @@ describe("ActivateRecipePanel", () => {
       refetch: jest.fn(),
     });
 
-    const entry: ActivateRecipeEntry = {
+    const entry = sidebarEntryFactory("activateRecipe", {
       recipeId: recipe.metadata.id,
       heading: "Activate Blueprint",
-    };
+    });
 
     const rendered = render(
       <ActivateRecipePanel recipeId={recipe.metadata.id} />,

--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -22,19 +22,21 @@ import {
   type ActivatePanelOptions,
   type TemporaryPanelEntry,
   type ActivateRecipeEntry,
+  type SidebarEntry,
 } from "@/sidebar/types";
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { type UUID } from "@/core";
-import { defaultEventKey, mapTabEventKey } from "@/sidebar/utils";
+import { defaultEventKey, eventKeyForEntry } from "@/sidebar/utils";
 import {
   cancelForm,
   cancelTemporaryPanel,
   closeTemporaryPanel,
   resolveTemporaryPanel,
 } from "@/contentScript/messenger/api";
-import { partition, sortBy } from "lodash";
+import { partition, remove, sortBy } from "lodash";
 import { getTopLevelFrame } from "webext-messenger";
 import { type SubmitPanelAction } from "@/blocks/errors";
+import { type WritableDraft } from "immer/dist/types/types-external";
 
 export type SidebarState = SidebarEntries & {
   activeKey: string;
@@ -57,13 +59,16 @@ const emptySidebarState: SidebarState = {
   pendingActivePanel: null,
 };
 
-function eventKeyExists(state: SidebarState, query: string): boolean {
+function eventKeyExists(state: SidebarState, query: string | null): boolean {
+  if (query == null) {
+    return false;
+  }
+
   return (
-    state.forms.some((x) => mapTabEventKey("form", x) === query) ||
-    state.temporaryPanels.some(
-      (x) => mapTabEventKey("temporaryPanel", x) === query
-    ) ||
-    state.panels.some((x) => mapTabEventKey("panel", x) === query)
+    state.forms.some((x) => eventKeyForEntry(x) === query) ||
+    state.temporaryPanels.some((x) => eventKeyForEntry(x) === query) ||
+    state.panels.some((x) => eventKeyForEntry(x) === query) ||
+    eventKeyForEntry(state.recipeToActivate) === query
   );
 }
 
@@ -78,21 +83,21 @@ function findNextActiveKey(
       (x) => x.extensionId === extensionId
     );
     if (extensionForm) {
-      return mapTabEventKey("form", extensionForm);
+      return eventKeyForEntry(extensionForm);
     }
 
     const extensionTemporaryPanel = state.temporaryPanels.find(
       (x) => x.extensionId === extensionId
     );
     if (extensionTemporaryPanel) {
-      return mapTabEventKey("temporaryPanel", extensionTemporaryPanel);
+      return eventKeyForEntry(extensionTemporaryPanel);
     }
 
     const extensionPanel = state.panels.find(
       (x) => x.extensionId === extensionId
     );
     if (extensionPanel) {
-      return mapTabEventKey("panel", extensionPanel);
+      return eventKeyForEntry(extensionPanel);
     }
   }
 
@@ -102,7 +107,7 @@ function findNextActiveKey(
       .filter((x) => blueprintId == null || x.blueprintId === blueprintId)
       .find((x) => x.heading === panelHeading);
     if (extensionPanel) {
-      return mapTabEventKey("panel", extensionPanel);
+      return eventKeyForEntry(extensionPanel);
     }
   }
 
@@ -112,7 +117,7 @@ function findNextActiveKey(
       (x) => x.blueprintId === blueprintId
     );
     if (blueprintPanel) {
-      return mapTabEventKey("panel", blueprintPanel);
+      return eventKeyForEntry(blueprintPanel);
     }
   }
 
@@ -151,6 +156,16 @@ async function resolvePanel(
   resolveTemporaryPanel(topLevelFrame, nonce, action);
 }
 
+function fixActiveTabOnRemove(
+  state: WritableDraft<SidebarState>,
+  removedEntry: SidebarEntry
+) {
+  // Only update the active panel if the panel needs to change
+  if (state.activeKey === eventKeyForEntry(removedEntry)) {
+    state.activeKey = defaultEventKey(state);
+  }
+}
+
 const sidebarSlice = createSlice({
   initialState: emptySidebarState,
   name: "sidebar",
@@ -180,12 +195,14 @@ const sidebarSlice = createSlice({
         // Unlike panels which are sorted, forms are like a "stack", will show the latest form available
         form,
       ];
-      state.activeKey = mapTabEventKey("form", form);
+      state.activeKey = eventKeyForEntry(form);
     },
     removeForm(state, action: PayloadAction<UUID>) {
       const nonce = action.payload;
-      state.forms = state.forms.filter((x) => x.nonce !== nonce);
-      state.activeKey = defaultEventKey(state);
+
+      const entry = remove(state.forms, (form) => form.nonce === nonce)[0];
+
+      fixActiveTabOnRemove(state, entry);
     },
     updateTemporaryPanel(
       state,
@@ -217,25 +234,19 @@ const sidebarSlice = createSlice({
       );
 
       state.temporaryPanels = [...otherTemporaryPanels, panel];
-      state.activeKey = mapTabEventKey("temporaryPanel", panel);
+      state.activeKey = eventKeyForEntry(panel);
     },
     removeTemporaryPanel(state, action: PayloadAction<UUID>) {
       const nonce = action.payload;
 
-      state.temporaryPanels = state.temporaryPanels.filter(
-        (panel) => panel.nonce !== nonce
-      );
+      const entry = remove(
+        state.temporaryPanels,
+        (panel) => panel.nonce === nonce
+      )[0];
 
       void closePanels([nonce]);
 
-      // Only update the active panel if the panel needs to change
-      // Temporary panels use nonce instead of extensionId, so can pass null for extensionId
-      if (
-        state.activeKey ===
-        mapTabEventKey("temporaryPanel", { nonce, extensionId: undefined })
-      ) {
-        state.activeKey = defaultEventKey(state);
-      }
+      fixActiveTabOnRemove(state, entry);
     },
     resolveTemporaryPanel(
       state,
@@ -243,20 +254,14 @@ const sidebarSlice = createSlice({
     ) {
       const { nonce, action: panelAction } = action.payload;
 
-      state.temporaryPanels = state.temporaryPanels.filter(
-        (panel) => panel.nonce !== nonce
-      );
+      const entry = remove(
+        state.temporaryPanels,
+        (panel) => panel.nonce === nonce
+      )[0];
 
       void resolvePanel(nonce, panelAction);
 
-      // Only update the active panel if the panel needs to change
-      // Temporary panels use nonce instead of extensionId, so can pass null for extensionId
-      if (
-        state.activeKey ===
-        mapTabEventKey("temporaryPanel", { nonce, extensionId: undefined })
-      ) {
-        state.activeKey = defaultEventKey(state);
-      }
+      fixActiveTabOnRemove(state, entry);
     },
     // In the future, we might want to have ActivatePanelOptions support a "enqueue" prop for controlling whether the
     // or not a miss here is queued. We added pendingActivePanel to handle race condition on the initial sidebar
@@ -297,23 +302,19 @@ const sidebarSlice = createSlice({
       }
 
       // If a panel is no longer available, reset the current tab to a valid tab
-      if (
-        state.activeKey == null ||
-        (state.activeKey.startsWith("panel-") &&
-          !state.panels.some(
-            (x) => mapTabEventKey("panel", x) === state.activeKey
-          ))
-      ) {
+      if (!eventKeyExists(state, state.activeKey)) {
         state.activeKey = defaultEventKey(state);
       }
     },
     showActivateRecipe(state, action: PayloadAction<ActivateRecipeEntry>) {
-      state.recipeToActivate = action.payload;
-      state.activeKey = `activate-${action.payload.recipeId}`;
+      const entry = action.payload;
+      state.recipeToActivate = entry;
+      state.activeKey = eventKeyForEntry(entry);
     },
     hideActivateRecipe(state) {
+      const { recipeToActivate: entry } = state;
       state.recipeToActivate = null;
-      state.activeKey = defaultEventKey(state);
+      fixActiveTabOnRemove(state, entry);
     },
   },
 });

--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -158,10 +158,10 @@ async function resolvePanel(
 
 function fixActiveTabOnRemove(
   state: WritableDraft<SidebarState>,
-  removedEntry: SidebarEntry
+  removedEntry: SidebarEntry | null
 ) {
   // Only update the active panel if the panel needs to change
-  if (state.activeKey === eventKeyForEntry(removedEntry)) {
+  if (removedEntry && state.activeKey === eventKeyForEntry(removedEntry)) {
     state.activeKey = defaultEventKey(state);
   }
 }

--- a/src/sidebar/types.ts
+++ b/src/sidebar/types.ts
@@ -49,8 +49,10 @@ export type RendererError = {
  *
  * @see PanelEntry
  * @see FormEntry
+ * @see TemporaryPanelEntry
+ * @see ActivateRecipeEntry
  */
-export type EntryType = "panel" | "form" | "temporaryPanel";
+export type EntryType = "panel" | "form" | "temporaryPanel" | "activateRecipe";
 
 /**
  * The information required to run the renderer of a pipeline, or error information if the pipeline run errored.
@@ -89,6 +91,10 @@ export type PanelButton = PanelAction & {
 };
 
 type BasePanelEntry = {
+  type: EntryType;
+};
+
+export type BaseExtensionPanelEntry = BasePanelEntry & {
   /**
    * The id of the extension that added the panel
    */
@@ -113,7 +119,8 @@ type BasePanelEntry = {
  * A panel added by an extension attached to an SidebarExtensionPoint
  * @see SidebarExtensionPoint
  */
-export type PanelEntry = BasePanelEntry & {
+export type PanelEntry = BaseExtensionPanelEntry & {
+  type: "panel";
   /**
    * The blueprint associated with the extension that added the panel.
    *
@@ -132,7 +139,8 @@ export type PanelEntry = BasePanelEntry & {
 /**
  * An ephemeral panel to show in the sidebar. Only one temporary panel can be shown from an extension at a time.
  */
-export type TemporaryPanelEntry = BasePanelEntry & {
+export type TemporaryPanelEntry = BaseExtensionPanelEntry & {
+  type: "temporaryPanel";
   /**
    * Unique identifier for the temporary panel instance. Used to correlate panel-close action.
    */
@@ -149,7 +157,8 @@ export type TemporaryPanelEntry = BasePanelEntry & {
  * An ephemeral form to show in the sidebar. Only one form can be shown from an extension at a time.
  * @see ModalTransformer
  */
-export type FormEntry = {
+export type FormEntry = BasePanelEntry & {
+  type: "form";
   /**
    * The extension that created the form
    */
@@ -164,10 +173,17 @@ export type FormEntry = {
   form: FormDefinition;
 };
 
-export type ActivateRecipeEntry = {
+export type ActivateRecipeEntry = BasePanelEntry & {
+  type: "activateRecipe";
   recipeId: RegistryId;
   heading: string;
 };
+
+export type SidebarEntry =
+  | PanelEntry
+  | FormEntry
+  | TemporaryPanelEntry
+  | ActivateRecipeEntry;
 
 /**
  * The entries currently added to the sidebar

--- a/src/sidebar/utils.test.ts
+++ b/src/sidebar/utils.test.ts
@@ -15,9 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { defaultEventKey, mapTabEventKey } from "@/sidebar/utils";
-import { uuidv4 } from "@/types/helpers";
+import { defaultEventKey, eventKeyForEntry } from "@/sidebar/utils";
+import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { type FormEntry, type TemporaryPanelEntry } from "@/sidebar/types";
+import { sidebarEntryFactory } from "@/testUtils/factories";
 
 describe("defaultEventKey", () => {
   it("returns null no content", () => {
@@ -38,7 +39,7 @@ describe("defaultEventKey", () => {
       panels: [{ extensionId: uuidv4() }],
     } as any;
 
-    expect(defaultEventKey(args)).toBe(mapTabEventKey("form", args.forms[1]));
+    expect(defaultEventKey(args)).toBe(eventKeyForEntry(args.forms[1]));
     expect(defaultEventKey(args)).not.toBe("form-undefined");
   });
 
@@ -53,7 +54,7 @@ describe("defaultEventKey", () => {
     } as any;
 
     expect(defaultEventKey(args)).toBe(
-      mapTabEventKey("temporaryPanel", args.temporaryPanels[1])
+      eventKeyForEntry(args.temporaryPanels[1])
     );
     expect(defaultEventKey(args)).not.toBe("temporaryPanel-undefined");
   });
@@ -65,27 +66,45 @@ describe("defaultEventKey", () => {
       panels: [{ extensionId: uuidv4() }, { extensionId: uuidv4() }],
     } as any;
 
-    expect(defaultEventKey(args)).toBe(mapTabEventKey("panel", args.panels[0]));
+    expect(defaultEventKey(args)).toBe(eventKeyForEntry(args.panels[0]));
     expect(defaultEventKey(args)).not.toBe("panel-undefined");
   });
 });
 
-describe("mapTabEventKey", () => {
+describe("eventKeyForEntry", () => {
   it.each([[undefined, null]])("returns null for %s", (value) => {
-    expect(mapTabEventKey("form", value)).toBe(null);
+    expect(eventKeyForEntry(value)).toBe(null);
   });
 
-  it("prefers nonce", () => {
-    const nonce = uuidv4();
-    expect(mapTabEventKey("form", { nonce, extensionId: uuidv4() })).toBe(
-      `form-${nonce}`
-    );
+  it("uses recipeId for activateRecipe", () => {
+    const recipeId = validateRegistryId("@test/test-recipe");
+    const entry = sidebarEntryFactory("activateRecipe", { recipeId });
+    expect(eventKeyForEntry(entry)).toBe(`activate-${recipeId}`);
   });
 
-  it("uses extension id", () => {
+  it("uses extensionId for panel", () => {
     const extensionId = uuidv4();
-    expect(mapTabEventKey("panel", { extensionId })).toBe(
-      `panel-${extensionId}`
+    const extensionPointId = validateRegistryId("@test/test-extension-point");
+    const entry = sidebarEntryFactory("panel", {
+      extensionId,
+      extensionPointId,
+    });
+    expect(eventKeyForEntry(entry)).toBe(`panel-${extensionId}`);
+  });
+
+  it("uses nonce for forms and temporary panels", () => {
+    const extensionId = uuidv4();
+    const nonce = uuidv4();
+
+    const formEntry = sidebarEntryFactory("form", { extensionId, nonce });
+    expect(eventKeyForEntry(formEntry)).toBe(`form-${nonce}`);
+
+    const temporaryPanelEntry = sidebarEntryFactory("temporaryPanel", {
+      extensionId,
+      nonce,
+    });
+    expect(eventKeyForEntry(temporaryPanelEntry)).toBe(
+      `temporaryPanel-${nonce}`
     );
   });
 });

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -95,6 +95,15 @@ import { type Permissions } from "webextension-polyfill";
 import quickBar from "@/pageEditor/extensionPoints/quickBar";
 import contextMenu from "@/pageEditor/extensionPoints/contextMenu";
 import sidebar from "@/pageEditor/extensionPoints/sidebar";
+import {
+  type ActivateRecipeEntry,
+  type EntryType,
+  type FormEntry,
+  type PanelEntry,
+  type SidebarEntry,
+  type TemporaryPanelEntry,
+} from "@/sidebar/types";
+import { type FormDefinition } from "@/blocks/transformers/ephemeralForm/formTypes";
 
 // UUID sequence generator that's predictable across runs. A couple characters can't be 0
 // https://stackoverflow.com/a/19989922/402560
@@ -768,3 +777,87 @@ export const marketplaceListingFactory = define<MarketplaceListing>({
       name: `@test/test-${n}`,
     } as unknown as MarketplaceListing["package"]),
 });
+
+const activateRecipeEntryFactory = define<ActivateRecipeEntry>({
+  type: "activateRecipe",
+  recipeId: (n: number) =>
+    validateRegistryId(`@test/activate-recipe-test-${n}`),
+  heading: (n: number) => `Activate Recipe Test ${n}`,
+});
+
+const formDefinitionFactory = define<FormDefinition>({
+  schema: () => ({}),
+  uiSchema: () => ({}),
+  cancelable: true,
+  submitCaption: "Submit",
+});
+
+const formEntryFactory = define<FormEntry>({
+  type: "form",
+  extensionId: uuidSequence,
+  nonce: uuidSequence,
+  form: formDefinitionFactory,
+});
+
+const temporaryPanelEntryFactory = define<TemporaryPanelEntry>({
+  type: "temporaryPanel",
+  extensionId: uuidSequence,
+  heading: (n: number) => `Temporary Panel Test ${n}`,
+  payload: null,
+  nonce: uuidSequence,
+});
+
+const panelEntryFactory = define<PanelEntry>({
+  type: "panel",
+  extensionId: uuidSequence,
+  heading: (n: number) => `Panel Test ${n}`,
+  payload: null,
+  blueprintId: (n: number) =>
+    validateRegistryId(`@test/panel-recipe-test-${n}`),
+  extensionPointId: (n: number) =>
+    validateRegistryId(`@test/panel-extensionPoint-test-${n}`),
+});
+
+export function sidebarEntryFactory(
+  type: "panel",
+  override?: FactoryConfig<PanelEntry>
+): PanelEntry;
+export function sidebarEntryFactory(
+  type: "temporaryPanel",
+  override?: FactoryConfig<TemporaryPanelEntry>
+): TemporaryPanelEntry;
+export function sidebarEntryFactory(
+  type: "form",
+  override?: FactoryConfig<FormEntry>
+): FormEntry;
+export function sidebarEntryFactory(
+  type: "activateRecipe",
+  override?: FactoryConfig<ActivateRecipeEntry>
+): ActivateRecipeEntry;
+export function sidebarEntryFactory(
+  type: EntryType,
+  override?: FactoryConfig<SidebarEntry>
+): SidebarEntry {
+  if (type === "activateRecipe") {
+    return activateRecipeEntryFactory(
+      override as FactoryConfig<ActivateRecipeEntry>
+    );
+  }
+
+  if (type === "form") {
+    return formEntryFactory(override as FactoryConfig<FormEntry>);
+  }
+
+  if (type === "temporaryPanel") {
+    return temporaryPanelEntryFactory(
+      override as FactoryConfig<TemporaryPanelEntry>
+    );
+  }
+
+  if (type === "panel") {
+    return panelEntryFactory(override as FactoryConfig<PanelEntry>);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- allow never, future-proof for new types
+  throw new Error(`Unknown entry type: ${type}`);
+}


### PR DESCRIPTION
## What does this PR do?

- Part of #5072, fixing a bug with the activate recipe sidebar tab when there are other tabs in the sidebar
- Cleans up some stuff with types across the whole sidebar app

## Reviewer Tips

Main changes are:
- `type SidebarEntry = PanelEntry | TemporaryPanelEntry | FormEntry | ActivateRecipeEntry`
- `PanelEntry`, `TemporaryPanelEntry`, `FormEntry`, and `ActivateRecipeEntry` have a `type` field now to differentiate them
  - Test factories set up to generate SidebarEntry instances, tests refactored
- `mapTabEventKey()` renamed to `eventKeyForEntry()`, updated to handle activate-recipe tabs as well
- In `sidebarSlice`, `eventKeyExists()` updated to include activate-recipe keys to fix activate tab bug in the UI
- `displayTemporaryInfo()`
  - Typing fixed to use `TemporaryPanelEntry` instead of `PanelEntry` throughout
  - `entry/refreshEntry()` props condensed into `getPanelEntry()` since the usage is consistent at both call-sites, a factory function is created and then called to generate the entry prop in both places, so move this inside the display function.

## Checklist

- [x] Add tests
- [ ] Designate a primary reviewer
