### PR TITLE
#5197: fix submit panel action

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -323,7 +323,8 @@ module.exports = (env, options) =>
           terserOptions: {
             // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
             // Keep error classnames because we perform name comparison (see selectSpecificError)
-            keep_classnames: /.*Error/,
+            // We use Action for SubmitPanelAction, AbortPanelAction, etc.
+            keep_classnames: /.*(Error|Action)$/,
           },
         }),
         new CssMinimizerPlugin(),


### PR DESCRIPTION
## What does this PR do?

- Fixes #5197 🤞 
- Ensures Webpack doesn't mangle `*Action` classnames in prod builds

## Demo

Before:
![image](https://user-images.githubusercontent.com/1879821/218796662-0759900c-cb0d-4776-99b4-7947e973333f.png)

After:
![image](https://user-images.githubusercontent.com/1879821/218797183-c0389b1c-5f5b-45e2-8d96-f9c0b5bdc5ad.png)
## Remaining Work

- [x] Run a build locally and check for existence of Action classes in the minified JS

## Checklist

- [x] Add tests: N/A: can't test because it only impacts production builds that use the minimizer
- [x] Designate a primary reviewer: @BALEHOK 
