### PR TITLE
#5210 replace "blueprint" with "mod" in the Extension Console and Page Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PixieBrix is a browser extension and platform for safely extending your favorite
 with low/no-code.
 
 In addition to the extension, we maintain [pixiebrix.com](https://www.pixiebrix.com/), a
-registry of bricks and pre-made blueprints. You can create a PixieBrix account to enable
+registry of bricks and pre-made mods. You can create a PixieBrix account to enable
 support for team features, such as shared integration configurations and team bricks.
 
 <table>

--- a/schemas/recipe.json
+++ b/schemas/recipe.json
@@ -3,7 +3,7 @@
   "$id": "https://app.pixiebrix.com/schemas/recipe#",
   "type": "object",
   "title": "PixieBrix Recipe",
-  "description": "A PixieBrix blueprint for one or more installed bricks",
+  "description": "A PixieBrix mod for one or more installed bricks",
   "properties": {
     "apiVersion": {
       "type": "string",

--- a/schemas/recipe.json
+++ b/schemas/recipe.json
@@ -3,7 +3,7 @@
   "$id": "https://app.pixiebrix.com/schemas/recipe#",
   "type": "object",
   "title": "PixieBrix Recipe",
-  "description": "A PixieBrix mod for one or more installed bricks",
+  "description": "A PixieBrix mod containing one or more installed bricks",
   "properties": {
     "apiVersion": {
       "type": "string",

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -85,7 +85,7 @@ exports[`Storyshots Blueprints/GetStartedView Activate Blueprint 1`] = `
       className="col"
     >
       <h4>
-        Want to create a new Blueprint?
+        Want to create a new Mod?
       </h4>
       <ul>
         <li>
@@ -110,7 +110,7 @@ exports[`Storyshots Blueprints/GetStartedView Activate Blueprint 1`] = `
            and start editing your page.
         </li>
         <li>
-          Save your Blueprint in the Page Editor, and you'll see it here as a personal Blueprint.
+          Save your Mod in the Page Editor, and you'll see it here as a personal Mod.
         </li>
       </ul>
     </div>
@@ -239,7 +239,7 @@ exports[`Storyshots Blueprints/GetStartedView Default 1`] = `
       className="col"
     >
       <h4>
-        Want to create a new Blueprint?
+        Want to create a new Mod?
       </h4>
       <ul>
         <li>
@@ -264,7 +264,7 @@ exports[`Storyshots Blueprints/GetStartedView Default 1`] = `
            and start editing your page.
         </li>
         <li>
-          Save your Blueprint in the Page Editor, and you'll see it here as a personal Blueprint.
+          Save your Mod in the Page Editor, and you'll see it here as a personal Mod.
         </li>
       </ul>
     </div>

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -85,7 +85,7 @@ exports[`Storyshots Blueprints/GetStartedView Activate Blueprint 1`] = `
       className="col"
     >
       <h4>
-        Want to create a new Mod?
+        Want to create a new mod?
       </h4>
       <ul>
         <li>
@@ -110,7 +110,7 @@ exports[`Storyshots Blueprints/GetStartedView Activate Blueprint 1`] = `
            and start editing your page.
         </li>
         <li>
-          Save your Mod in the Page Editor, and you'll see it here as a personal Mod.
+          Save your mod in the Page Editor, and you'll see it here as a personal mod.
         </li>
       </ul>
     </div>
@@ -239,7 +239,7 @@ exports[`Storyshots Blueprints/GetStartedView Default 1`] = `
       className="col"
     >
       <h4>
-        Want to create a new Mod?
+        Want to create a new mod?
       </h4>
       <ul>
         <li>
@@ -264,7 +264,7 @@ exports[`Storyshots Blueprints/GetStartedView Default 1`] = `
            and start editing your page.
         </li>
         <li>
-          Save your Mod in the Page Editor, and you'll see it here as a personal Mod.
+          Save your mod in the Page Editor, and you'll see it here as a personal mod.
         </li>
       </ul>
     </div>

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -28,7 +28,7 @@ const ERR_UNABLE_TO_OPEN =
   "PixieBrix was unable to open the Sidebar. Try refreshing the page.";
 
 const keyboardShortcut = isMac() ? "Cmd+Opt+C" : "Ctrl+Shift+C";
-const MSG_NO_SIDEBAR_ON_OPTIONS_PAGE = `PixieBrix Tip 💜\n If you want to create a new blueprint, first navigate to the page you want to modify, then open PixieBrix in the DevTools (${keyboardShortcut}).`;
+const MSG_NO_SIDEBAR_ON_OPTIONS_PAGE = `PixieBrix Tip 💜\n If you want to create a new mod, first navigate to the page you want to modify, then open PixieBrix in the DevTools (${keyboardShortcut}).`;
 
 // The sidebar is always injected to into the top level frame
 const TOP_LEVEL_FRAME_ID = 0;

--- a/src/blocks/effects/runSubTour.ts
+++ b/src/blocks/effects/runSubTour.ts
@@ -27,7 +27,7 @@ export class RunSubTourEffect extends Effect {
     super(
       "@pixiebrix/tour/run",
       "Run Sub-tour",
-      "Run a tour from the same blueprint"
+      "Run a tour from the same mod"
     );
   }
 
@@ -46,7 +46,7 @@ export class RunSubTourEffect extends Effect {
     { logger }: BlockOptions
   ): Promise<void> {
     if (isEmpty(logger.context.blueprintId)) {
-      throw new BusinessError("Can only run sub-tours in the same blueprint");
+      throw new BusinessError("Can only run sub-tours in the same mod");
     }
 
     // XXX: do we need affordance cancel this using abortSignal from BlockOptions? Probably not for now, because

--- a/src/blocks/effects/sidebar.ts
+++ b/src/blocks/effects/sidebar.ts
@@ -40,7 +40,7 @@ export class ShowSidebar extends Effect {
       panelHeading: {
         type: "string",
         description:
-          "The panel to show in the sidebar. If not provided, defaults to a sidebar panel in this extension's mod",
+          "The panel to show in the sidebar. If not provided, defaults to a sidebar panel in this mod",
       },
       forcePanel: {
         type: "boolean",

--- a/src/blocks/effects/sidebar.ts
+++ b/src/blocks/effects/sidebar.ts
@@ -40,7 +40,7 @@ export class ShowSidebar extends Effect {
       panelHeading: {
         type: "string",
         description:
-          "The panel to show in the sidebar. If not provided, defaults to a sidebar panel in this extension's blueprint",
+          "The panel to show in the sidebar. If not provided, defaults to a sidebar panel in this extension's mod",
       },
       forcePanel: {
         type: "boolean",

--- a/src/components/fields/schemaFields/widgets/varPopup/SourceLabel.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/SourceLabel.tsx
@@ -27,7 +27,7 @@ const SourceLabel: React.FunctionComponent<SourceLabelProps> = ({
       }
 
       case KnownSources.OPTIONS: {
-        label = "Blueprint Options";
+        label = "Mod Options";
         break;
       }
 

--- a/src/options/Sidebar.tsx
+++ b/src/options/Sidebar.tsx
@@ -45,8 +45,8 @@ const Sidebar: React.FunctionComponent = () => {
       <nav className="sidebar sidebar-offcanvas" id={SIDEBAR_ID}>
         <ul className="nav">
           <SidebarLink
-            route="/blueprints"
-            title="Blueprints"
+            route="/mods"
+            title="Mods"
             icon={faCubes}
             isActive={(match, location) =>
               Boolean(match) ||

--- a/src/options/pages/activateExtension/ActivateForm.tsx
+++ b/src/options/pages/activateExtension/ActivateForm.tsx
@@ -88,7 +88,7 @@ const ActivateForm: React.FunctionComponent<{
           })
         );
         notify.success("Activated extension");
-        dispatch(push("/blueprints"));
+        dispatch(push("/mods"));
       } catch (error) {
         notify.error({ message: "Error activating extension", error });
       } finally {

--- a/src/options/pages/blueprints/BlueprintsPage.tsx
+++ b/src/options/pages/blueprints/BlueprintsPage.tsx
@@ -24,7 +24,7 @@ import { reportEvent } from "@/telemetry/events";
 import Modals from "./modals/Modals";
 
 const BlueprintsPage: React.FunctionComponent = () => {
-  useTitle("Blueprints");
+  useTitle("Mods");
   const { installables, error } = useInstallables();
 
   useEffect(() => {

--- a/src/options/pages/blueprints/BlueprintsPageSidebar.tsx
+++ b/src/options/pages/blueprints/BlueprintsPageSidebar.tsx
@@ -52,22 +52,22 @@ type BlueprintTabMap = {
 export const BLUEPRINTS_PAGE_TABS: BlueprintTabMap = {
   active: {
     key: "Active",
-    tabTitle: "Active Blueprints",
+    tabTitle: "Active Mods",
     filters: [{ id: "status", value: "Active" }],
   },
   all: {
     key: "All",
-    tabTitle: "All Blueprints",
+    tabTitle: "All Mods",
     filters: [],
   },
   personal: {
     key: "Personal",
-    tabTitle: "Personal Blueprints",
+    tabTitle: "Personal Mods",
     filters: [{ id: "sharing.source.label", value: "Personal" }],
   },
   public: {
     key: "Public",
-    tabTitle: "Public Blueprints",
+    tabTitle: "Public Mods",
     filters: [{ id: "sharing.source.label", value: "Public" }],
   },
   getStarted: {
@@ -253,7 +253,7 @@ const BlueprintsPageSidebar: React.FunctionComponent<
       <Form>
         <Form.Control
           id="query"
-          placeholder="Search all blueprints"
+          placeholder="Search all mods"
           size="sm"
           value={searchInput}
           onChange={({ target }) => {
@@ -300,7 +300,7 @@ const BlueprintsPageSidebar: React.FunctionComponent<
         />
         <ListItem
           icon={faAsterisk}
-          label="All Blueprints"
+          label="All Mods"
           eventKey="All"
           onClick={() => {
             setActiveTab(BLUEPRINTS_PAGE_TABS.all);
@@ -336,7 +336,7 @@ const BlueprintsPageSidebar: React.FunctionComponent<
             onClick={() => {
               setActiveTab({
                 key: filter,
-                tabTitle: `${filter} Blueprints`,
+                tabTitle: `${filter} Mods`,
                 filters: [{ id: "sharing.source.label", value: filter }],
               });
             }}

--- a/src/options/pages/blueprints/BotGamesView.tsx
+++ b/src/options/pages/blueprints/BotGamesView.tsx
@@ -132,8 +132,7 @@ const BotGamesView: React.VoidFunctionComponent<{
                 <p>
                   Click to open the Bot Games challenge page. Chrome will prompt
                   you to allow PixieBrix to enhance the challenge page.
-                  Additionally, PixieBrix will activate the challenge hints
-                  blueprint.
+                  Additionally, PixieBrix will activate the challenge hints mod.
                 </p>
                 <span>
                   <AsyncButton onClick={installBotGamesBlueprint}>

--- a/src/options/pages/blueprints/GetStartedView.tsx
+++ b/src/options/pages/blueprints/GetStartedView.tsx
@@ -94,8 +94,8 @@ const GetStartedView: React.VoidFunctionComponent<{
             </h4>
             <ul>
               <li>
-                Time to try this Mod in the wild! You can navigate to a webpage
-                this Mod enhances to see it in action.
+                Time to try this mod in the wild! You can navigate to a webpage
+                this mod enhances to see it in action.
               </li>
               <li>
                 Check out the &quot;How to Use&quot; section for{" "}
@@ -103,7 +103,7 @@ const GetStartedView: React.VoidFunctionComponent<{
                   linkText={`${onboardingBlueprintListing.package.verbose_name}`}
                   url={marketplaceUrl}
                 />{" "}
-                in the Marketplace for more details about how to use this Mod.
+                in the Marketplace for more details about how to use this mod.
               </li>
             </ul>
           </Col>
@@ -111,7 +111,7 @@ const GetStartedView: React.VoidFunctionComponent<{
       )}
       <Row className={styles.infoRow}>
         <Col>
-          <h4>Want to create a new Mod?</h4>
+          <h4>Want to create a new mod?</h4>
           <ul>
             <li>
               Start by opening a new browser tab and navigating to the webpage
@@ -128,8 +128,8 @@ const GetStartedView: React.VoidFunctionComponent<{
               or <kbd>F12</kbd> and start editing your page.
             </li>
             <li>
-              Save your Mod in the Page Editor, and you&apos;ll see it here as a
-              personal Mod.
+              Save your mod in the Page Editor, and you&apos;ll see it here as a
+              personal mod.
             </li>
           </ul>
         </Col>

--- a/src/options/pages/blueprints/GetStartedView.tsx
+++ b/src/options/pages/blueprints/GetStartedView.tsx
@@ -94,8 +94,8 @@ const GetStartedView: React.VoidFunctionComponent<{
             </h4>
             <ul>
               <li>
-                Time to try this Blueprint in the wild! You can navigate to a
-                webpage this Blueprint enhances to see it in action.
+                Time to try this Mod in the wild! You can navigate to a webpage
+                this Mod enhances to see it in action.
               </li>
               <li>
                 Check out the &quot;How to Use&quot; section for{" "}
@@ -103,8 +103,7 @@ const GetStartedView: React.VoidFunctionComponent<{
                   linkText={`${onboardingBlueprintListing.package.verbose_name}`}
                   url={marketplaceUrl}
                 />{" "}
-                in the Marketplace for more details about how to use this
-                Blueprint.
+                in the Marketplace for more details about how to use this Mod.
               </li>
             </ul>
           </Col>
@@ -112,7 +111,7 @@ const GetStartedView: React.VoidFunctionComponent<{
       )}
       <Row className={styles.infoRow}>
         <Col>
-          <h4>Want to create a new Blueprint?</h4>
+          <h4>Want to create a new Mod?</h4>
           <ul>
             <li>
               Start by opening a new browser tab and navigating to the webpage
@@ -129,8 +128,8 @@ const GetStartedView: React.VoidFunctionComponent<{
               or <kbd>F12</kbd> and start editing your page.
             </li>
             <li>
-              Save your Blueprint in the Page Editor, and you&apos;ll see it
-              here as a personal Blueprint.
+              Save your Mod in the Page Editor, and you&apos;ll see it here as a
+              personal Mod.
             </li>
           </ul>
         </Col>

--- a/src/options/pages/blueprints/__snapshots__/BlueprintsPageLayout.test.tsx.snap
+++ b/src/options/pages/blueprints/__snapshots__/BlueprintsPageLayout.test.tsx.snap
@@ -230,7 +230,7 @@ exports[`BlueprintsPageLayout renders 1`] = `
               class="col"
             >
               <h4>
-                Want to create a new Mod?
+                Want to create a new mod?
               </h4>
               <ul>
                 <li>
@@ -252,7 +252,7 @@ exports[`BlueprintsPageLayout renders 1`] = `
                    and start editing your page.
                 </li>
                 <li>
-                  Save your Mod in the Page Editor, and you'll see it here as a personal Mod.
+                  Save your mod in the Page Editor, and you'll see it here as a personal mod.
                 </li>
               </ul>
             </div>

--- a/src/options/pages/blueprints/__snapshots__/BlueprintsPageLayout.test.tsx.snap
+++ b/src/options/pages/blueprints/__snapshots__/BlueprintsPageLayout.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`BlueprintsPageLayout renders 1`] = `
         <input
           class="form-control form-control-sm"
           id="query"
-          placeholder="Search all blueprints"
+          placeholder="Search all mods"
           value=""
         />
       </form>
@@ -85,7 +85,7 @@ exports[`BlueprintsPageLayout renders 1`] = `
         <a
           class="media nav-link"
           data-rb-event-key="All"
-          data-testid="all-blueprints-blueprint-tab"
+          data-testid="all-mods-blueprint-tab"
           href="#"
           role="button"
         >
@@ -107,7 +107,7 @@ exports[`BlueprintsPageLayout renders 1`] = `
           <span
             class="media-body ml-2"
           >
-            All Blueprints
+            All Mods
           </span>
         </a>
         <a

--- a/src/options/pages/blueprints/__snapshots__/BlueprintsPageLayout.test.tsx.snap
+++ b/src/options/pages/blueprints/__snapshots__/BlueprintsPageLayout.test.tsx.snap
@@ -230,7 +230,7 @@ exports[`BlueprintsPageLayout renders 1`] = `
               class="col"
             >
               <h4>
-                Want to create a new Blueprint?
+                Want to create a new Mod?
               </h4>
               <ul>
                 <li>
@@ -252,7 +252,7 @@ exports[`BlueprintsPageLayout renders 1`] = `
                    and start editing your page.
                 </li>
                 <li>
-                  Save your Blueprint in the Page Editor, and you'll see it here as a personal Blueprint.
+                  Save your Mod in the Page Editor, and you'll see it here as a personal Mod.
                 </li>
               </ul>
             </div>

--- a/src/options/pages/blueprints/emptyView/EmptyView.tsx
+++ b/src/options/pages/blueprints/emptyView/EmptyView.tsx
@@ -46,9 +46,9 @@ const EmptyView: React.VoidFunctionComponent<{
         <Card.Body>
           <div className={styles.suggestions}>
             <img src={workshopImage} alt="Workshop" width={300} />
-            <h3>No blueprints found {filterName && `in "${filterName}"`}</h3>
+            <h3>No mods found {filterName && `in "${filterName}"`}</h3>
             <div className="mb-4">
-              There {"weren't"} any blueprints with a name, description, or id
+              There {"weren't"} any mods with a name, description, or id
               containing your search term <strong>{`"${globalFilter}"`}</strong>
               .
             </div>

--- a/src/options/pages/blueprints/labels/SharingLabel.tsx
+++ b/src/options/pages/blueprints/labels/SharingLabel.tsx
@@ -48,11 +48,11 @@ const SharingLabel: React.VoidFunctionComponent<{
     overlay={
       <Popover id="sharingLabelPopover">
         <Popover.Content>
-          {sharing.type === "Personal" && "You created this blueprint."}
+          {sharing.type === "Personal" && "You created this mod."}
           {sharing.type === "Team" &&
-            `This blueprint was shared with you by "${sharing.label}" team.`}
+            `This mod was shared with you by "${sharing.label}" team.`}
           {sharing.type === "Public" &&
-            "You activated this blueprint from the public marketplace."}
+            "You activated this mod from the public marketplace."}
         </Popover.Content>
       </Popover>
     }

--- a/src/options/pages/blueprints/modals/convertToRecipeModal/ConvertToRecipeModal.tsx
+++ b/src/options/pages/blueprints/modals/convertToRecipeModal/ConvertToRecipeModal.tsx
@@ -38,10 +38,10 @@ const ConvertToRecipeModal: React.FunctionComponent = () => {
   return (
     <ModalLayout
       show={showConvertToRecipeModal}
-      title="Name your blueprint"
+      title="Name your mod"
       onHide={closeModal}
     >
-      <RequireScope scopeSettingsDescription="To publish a blueprint, you must first set an account alias for your PixieBrix account">
+      <RequireScope scopeSettingsDescription="To publish a mod, you must first set an account alias for your PixieBrix account">
         <ConvertToRecipeModalBody />
       </RequireScope>
     </ModalLayout>

--- a/src/options/pages/blueprints/modals/convertToRecipeModal/ConvertToRecipeModalBody.tsx
+++ b/src/options/pages/blueprints/modals/convertToRecipeModal/ConvertToRecipeModalBody.tsx
@@ -250,7 +250,7 @@ const ConvertToRecipeModalBody: React.FunctionComponent = () => {
         <Modal.Body>
           <ConnectedFieldTemplate
             name="blueprintId"
-            label="Blueprint ID"
+            label="Mod ID"
             description={FieldDescriptions.BLUEPRINT_ID}
             as={RegistryIdWidget}
             selectStyles={selectStylesOverride}

--- a/src/options/pages/blueprints/modals/convertToRecipeModal/ConvertToRecipeModalBody.tsx
+++ b/src/options/pages/blueprints/modals/convertToRecipeModal/ConvertToRecipeModalBody.tsx
@@ -224,7 +224,7 @@ const ConvertToRecipeModalBody: React.FunctionComponent = () => {
   };
 
   return (
-    <RequireScope scopeSettingsDescription="To share a blueprint, you must first set an account alias for your PixieBrix account">
+    <RequireScope scopeSettingsDescription="To share a mod, you must first set an account alias for your PixieBrix account">
       <Form
         validationSchema={validationSchema}
         initialValues={initialValues}

--- a/src/options/pages/blueprints/modals/convertToRecipeModal/__snapshots__/ConvertToRecipeModal.test.tsx.snap
+++ b/src/options/pages/blueprints/modals/convertToRecipeModal/__snapshots__/ConvertToRecipeModal.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`it renders default state 1`] = `
               class="label form-label col-form-label col-xl-2 col-lg-3"
               for="blueprintId"
             >
-              Blueprint ID
+              Mod ID
             </label>
             <div
               class="col-xl-10 col-lg-9"
@@ -150,7 +150,7 @@ exports[`it renders default state 1`] = `
                 class="text-muted form-text"
               >
                 <span>
-                  A unique id for the blueprint
+                  A unique id for the mod
                 </span>
               </small>
             </div>
@@ -177,7 +177,7 @@ exports[`it renders default state 1`] = `
                 class="text-muted form-text"
               >
                 <span>
-                  A display name for the blueprint
+                  A display name for the mod
                 </span>
               </small>
             </div>
@@ -204,7 +204,7 @@ exports[`it renders default state 1`] = `
                 class="text-muted form-text"
               >
                 <span>
-                  The current blueprint version
+                  The current mod version
                 </span>
               </small>
             </div>
@@ -231,7 +231,7 @@ exports[`it renders default state 1`] = `
                 class="text-muted form-text"
               >
                 <span>
-                  A short description of the blueprint
+                  A short description of the mod
                 </span>
               </small>
             </div>

--- a/src/options/pages/blueprints/modals/convertToRecipeModal/__snapshots__/ConvertToRecipeModal.test.tsx.snap
+++ b/src/options/pages/blueprints/modals/convertToRecipeModal/__snapshots__/ConvertToRecipeModal.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`it renders default state 1`] = `
         <div
           class="modal-title h4"
         >
-          Name your blueprint
+          Name your mod
         </div>
         <button
           class="close"
@@ -279,7 +279,7 @@ exports[`it renders requires user scope 1`] = `
         <div
           class="modal-title h4"
         >
-          Name your blueprint
+          Name your mod
         </div>
         <button
           class="close"
@@ -303,7 +303,7 @@ exports[`it renders requires user scope 1`] = `
         <div
           class="font-weight-bold"
         >
-          To publish a blueprint, you must first set an account alias for your PixieBrix account
+          To publish a mod, you must first set an account alias for your PixieBrix account
         </div>
         <div
           class="fade mt-2 alert alert-info show"

--- a/src/options/pages/blueprints/modals/shareModals/CancelPublishContent.tsx
+++ b/src/options/pages/blueprints/modals/shareModals/CancelPublishContent.tsx
@@ -96,7 +96,7 @@ const CancelPublishContent: React.FunctionComponent = () => {
 
         <p>
           Your marketplace submission will not be published and the public link
-          to your blueprint will no longer work.
+          to your mod will no longer work.
         </p>
       </Modal.Body>
       <Modal.Footer>

--- a/src/options/pages/blueprints/modals/shareModals/EditPublishContent.tsx
+++ b/src/options/pages/blueprints/modals/shareModals/EditPublishContent.tsx
@@ -45,8 +45,8 @@ const EditPublishContent: React.FunctionComponent = () => {
           <a href={MARKETPLACE_URL} target="blank" rel="noreferrer noopener">
             PixieBrix Marketplace
           </a>{" "}
-          admin team is working on publishing your blueprint. You&apos;ll
-          receive an email when it is live in the Marketplace. Contact{" "}
+          admin team is working on publishing your mod. You&apos;ll receive an
+          email when it is live in the Marketplace. Contact{" "}
           <a href="mailto:support@pixiebrix.com">support@pixiebrix.com</a> if
           you need help.
         </p>

--- a/src/options/pages/blueprints/modals/shareModals/PublishContentLayout.tsx
+++ b/src/options/pages/blueprints/modals/shareModals/PublishContentLayout.tsx
@@ -117,7 +117,7 @@ const PublishContentLayout: React.FunctionComponent<
       <Modal.Header closeButton>
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>
-      <RequireScope scopeSettingsDescription="To publish a blueprint, you must first set an account alias for your PixieBrix account">
+      <RequireScope scopeSettingsDescription="To publish a mod, you must first set an account alias for your PixieBrix account">
         {body}
       </RequireScope>
     </>

--- a/src/options/pages/blueprints/modals/shareModals/PublishRecipeContent.tsx
+++ b/src/options/pages/blueprints/modals/shareModals/PublishRecipeContent.tsx
@@ -95,12 +95,11 @@ const PublishRecipeContent: React.FunctionComponent = () => {
         {error && <div className="text-danger p-3">{error}</div>}
 
         <p>
-          On Submit, the public link to this blueprint will be shared with the{" "}
+          On Submit, the public link to this mod will be shared with the{" "}
           <a href={MARKETPLACE_URL} target="blank" rel="noreferrer noopener">
             PixieBrix Marketplace
           </a>{" "}
-          admin team, who will review your submission and publish your
-          blueprint.
+          admin team, who will review your submission and publish your mod.
         </p>
         <p>
           As soon as you Submit, the public link below will work for anyone, so

--- a/src/options/pages/blueprints/modals/shareModals/PublishedContent.tsx
+++ b/src/options/pages/blueprints/modals/shareModals/PublishedContent.tsx
@@ -28,7 +28,7 @@ const PublishedContent: React.FunctionComponent = (props) => {
   return (
     <PublishContentLayout title="Published">
       <Modal.Body>
-        <p>The blueprint has been published to the Marketplace.</p>
+        <p>The mod has been published to the Marketplace.</p>
         <p className="mb-1">Public link to share:</p>
         <ActivationLink blueprintId={blueprintId} />
       </Modal.Body>

--- a/src/options/pages/blueprints/modals/shareModals/ShareRecipeModal.tsx
+++ b/src/options/pages/blueprints/modals/shareModals/ShareRecipeModal.tsx
@@ -37,7 +37,7 @@ const ShareRecipeModal: React.FunctionComponent = () => {
       title="Share with Teams"
       onHide={closeModal}
     >
-      <RequireScope scopeSettingsDescription="To share a blueprint, you must first set an account alias for your PixieBrix account">
+      <RequireScope scopeSettingsDescription="To share a mod, you must first set an account alias for your PixieBrix account">
         <ShareRecipeModalBody />
       </RequireScope>
     </ModalLayout>

--- a/src/options/pages/blueprints/modals/shareModals/ShareRecipeModalBody.tsx
+++ b/src/options/pages/blueprints/modals/shareModals/ShareRecipeModalBody.tsx
@@ -285,7 +285,7 @@ const ShareRecipeModalBody: React.FunctionComponent = () => {
       <Modal.Body>
         <h4>Link to share:</h4>
         <p className="mb-1">
-          People with access can activate the blueprint with this link
+          People with access can activate the mod with this link
         </p>
         <ActivationLink blueprintId={blueprintId} />
       </Modal.Body>

--- a/src/options/pages/blueprints/modals/shareModals/__snapshots__/PublishRecipeModals.test.tsx.snap
+++ b/src/options/pages/blueprints/modals/shareModals/__snapshots__/PublishRecipeModals.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`renders cancel publish modal 1`] = `
         class="modal-body"
       >
         <p>
-          Your marketplace submission will not be published and the public link to your blueprint will no longer work.
+          Your marketplace submission will not be published and the public link to your mod will no longer work.
         </p>
       </div>
       <div
@@ -118,7 +118,7 @@ exports[`renders edit publish modal 1`] = `
             PixieBrix Marketplace
           </a>
            
-          admin team is working on publishing your blueprint. You'll receive an email when it is live in the Marketplace. Contact
+          admin team is working on publishing your mod. You'll receive an email when it is live in the Marketplace. Contact
            
           <a
             href="mailto:support@pixiebrix.com"
@@ -233,7 +233,7 @@ exports[`renders publish modal 1`] = `
         class="modal-body"
       >
         <p>
-          On Submit, the public link to this blueprint will be shared with the
+          On Submit, the public link to this mod will be shared with the
            
           <a
             href="https://www.pixiebrix.com/marketplace/"
@@ -243,7 +243,7 @@ exports[`renders publish modal 1`] = `
             PixieBrix Marketplace
           </a>
            
-          admin team, who will review your submission and publish your blueprint.
+          admin team, who will review your submission and publish your mod.
         </p>
         <p>
           As soon as you Submit, the public link below will work for anyone, so you can start sharing right away!

--- a/src/options/pages/blueprints/onboardingView/OnboardingView.tsx
+++ b/src/options/pages/blueprints/onboardingView/OnboardingView.tsx
@@ -33,8 +33,7 @@ const ActivateFromMarketplaceColumn: React.VoidFunctionComponent = () => (
   <Col className="d-flex justify-content-center flex-column text-center">
     <p>
       <span className="text-primary">Not sure what to build?</span> Activate a
-      pre-made blueprints from the public marketplace, or just peruse for
-      inspiration.
+      pre-made mod from the public marketplace, or just peruse for inspiration.
     </p>
     <div className="align-self-center">
       <a
@@ -55,10 +54,10 @@ const ActivateTeamBlueprintsColumn: React.VoidFunctionComponent = () => {
 
   return (
     <Col xs={6}>
-      <h4>Activate Team Blueprints</h4>
+      <h4>Activate Team Mods</h4>
       <p>
-        You can browse blueprints shared with you using the category filters on
-        this page.
+        You can browse mods shared with you using the category filters on this
+        page.
       </p>
       <Button
         size="sm"
@@ -66,7 +65,7 @@ const ActivateTeamBlueprintsColumn: React.VoidFunctionComponent = () => {
           dispatch(setActiveTab(BLUEPRINTS_PAGE_TABS.all));
         }}
       >
-        View my blueprints
+        View my mods
       </Button>
     </Col>
   );
@@ -77,8 +76,8 @@ const ActivateFromDeploymentBannerColumn: React.VoidFunctionComponent = () => (
     <p>
       Click the <strong className="text-primary">Activate</strong> button in the{" "}
       <strong className="text-info">blue banner above</strong> to start using
-      your team blueprints. You will see this banner every time your team
-      deploys new or updated blueprints for you to use.
+      your team mods. You will see this banner every time your team deploys new
+      or updated mods for you to use.
     </p>
   </Col>
 );
@@ -86,9 +85,9 @@ const ActivateFromDeploymentBannerColumn: React.VoidFunctionComponent = () => (
 const ContactTeamAdminColumn: React.VoidFunctionComponent = () => (
   <Col>
     <p>
-      It looks like your team hasn&apos;t made any blueprints available to you
-      yet. <strong>Contact your team admin</strong> to get access to your
-      team&apos;s blueprints.
+      It looks like your team hasn&apos;t made any mods available to you yet.{" "}
+      <strong>Contact your team admin</strong> to get access to your team&apos;s
+      mods.
     </p>
   </Col>
 );
@@ -182,7 +181,7 @@ const OnboardingView: React.VoidFunctionComponent<{
         }
 
         if (filter === "public") {
-          return "Discover pre-made blueprints in the public marketplace";
+          return "Discover pre-made mods in the public marketplace";
         }
 
         return "Welcome to PixieBrix! Ready to get started?";

--- a/src/options/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.ts
@@ -113,7 +113,7 @@ function useInstallableViewItemActions(
       // This should never happen, because the hook will return `reinstall: null` for installables with no
       // associated blueprint
       notify.error({
-        error: new Error("Cannot reinstall item with no associated blueprint"),
+        error: new Error("Cannot reinstall item with no associated mod"),
       });
     }
   };
@@ -208,8 +208,8 @@ function useInstallableViewItemActions(
       }
     },
     {
-      successMessage: `Deactivated blueprint: ${getLabel(installable)}`,
-      errorMessage: `Error deactivating blueprint: ${getLabel(installable)}`,
+      successMessage: `Deactivated mod: ${getLabel(installable)}`,
+      errorMessage: `Error deactivating mod: ${getLabel(installable)}`,
     },
     [installable, extensionsFromInstallable]
   );

--- a/src/options/pages/blueprints/utils/exportBlueprint.ts
+++ b/src/options/pages/blueprints/utils/exportBlueprint.ts
@@ -42,7 +42,7 @@ function inferOptionsSchema(optionsArgs: UserOptions): OptionsDefinition {
     // The install flow supports passing in an object of properties, or a full schema where the top-level has
     // `type: object` and a `properties` field. The following will output the full schema instead of the short-hand.
     // This avoids a corner-case where we're using the short-hand version but one of the property names is "properties"
-    schema: GenerateSchema.json("Blueprint Options", optionsArgs) as Schema,
+    schema: GenerateSchema.json("Mod Options", optionsArgs) as Schema,
   };
 }
 

--- a/src/options/pages/blueprints/utils/useInstall.ts
+++ b/src/options/pages/blueprints/utils/useInstall.ts
@@ -129,7 +129,7 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
 
         reactivateEveryTab();
 
-        dispatch(push("/blueprints"));
+        dispatch(push("/mods"));
       } catch (error) {
         notify.error({
           message: `Error installing ${recipe.metadata.name}`,

--- a/src/options/pages/brickEditor/EditPage.tsx
+++ b/src/options/pages/brickEditor/EditPage.tsx
@@ -159,7 +159,7 @@ const EditForm: React.FC<{ id: UUID; data: Package }> = ({ id, data }) => {
                     {isBlueprint && isInstalled && (
                       <div className="mr-4 my-auto">
                         <BooleanWidget name="reactivate" />
-                        <span className="ml-2">Re-activate Blueprint</span>
+                        <span className="ml-2">Re-activate Mod</span>
                       </div>
                     )}
                     <div>

--- a/src/options/pages/deployments/DeploymentBanner.tsx
+++ b/src/options/pages/deployments/DeploymentBanner.tsx
@@ -37,7 +37,7 @@ const DeploymentBanner: React.FunctionComponent = () => {
   // to show the banner on other pages with an activate button (e.g., the marketplace wizard, in the workshop, etc.)
   const matchRoot = useRouteMatch({ path: "/", exact: true });
   const matchInstalled = useRouteMatch({ path: "/installed", exact: true });
-  const matchMarketplace = useRouteMatch({ path: "/blueprints", exact: true });
+  const matchMarketplace = useRouteMatch({ path: "/mods", exact: true });
 
   if (!hasUpdate) {
     return null;

--- a/src/options/pages/marketplace/ActivateBlueprintPage.tsx
+++ b/src/options/pages/marketplace/ActivateBlueprintPage.tsx
@@ -68,11 +68,11 @@ const ActivateBlueprintPage: React.FunctionComponent = () => {
       // show an error message if not a valid blueprint
       return (
         <Card>
-          <Card.Header>Invalid Blueprint</Card.Header>
+          <Card.Header>Invalid Mod</Card.Header>
           <Card.Body>
             <p className="text-danger">
-              Error: {decodeURIComponent(blueprintId)} is not a valid blueprint.
-              Please verify the link you received to activate the blueprint
+              Error: {decodeURIComponent(blueprintId)} is not a valid mod.
+              Please verify the link you received to activate the mod
             </p>
 
             <Link to="/marketplace" className="btn btn-info">
@@ -90,7 +90,7 @@ const ActivateBlueprintPage: React.FunctionComponent = () => {
 
   return (
     <Page
-      title={`${action} Blueprint`}
+      title={`${action} Mod`}
       icon={faStoreAlt}
       isPending={fetchingBlueprint}
       error={fetchError}

--- a/src/options/pages/marketplace/ActivateWizard.test.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.test.tsx
@@ -95,7 +95,7 @@ describe("ActivateWizard", () => {
           blueprint={recipeDefinitionFactory({
             metadata: recipeMetadataFactory({
               id: "test/blueprint-with-required-options" as RegistryId,
-              name: "Blueprint with Required Options",
+              name: "Mod with Required Options",
             }),
             options: {
               schema: {
@@ -113,7 +113,7 @@ describe("ActivateWizard", () => {
             },
             extensionPoints: [
               extensionPointConfigFactory({
-                label: "Extension Point for Blueprint with Required Options",
+                label: "Extension Point for Mod with Required Options",
               }),
             ],
           })}

--- a/src/options/pages/marketplace/PermissionsBody.tsx
+++ b/src/options/pages/marketplace/PermissionsBody.tsx
@@ -42,8 +42,8 @@ export function useSelectedAuths(): ServiceAuthPair[] {
 
 const QuickBarAlert = () => (
   <Alert variant="warning">
-    <FontAwesomeIcon icon={faExclamationTriangle} /> This blueprint contains a
-    Quick Bar action, but you have not{" "}
+    <FontAwesomeIcon icon={faExclamationTriangle} /> This mod contains a Quick
+    Bar action, but you have not{" "}
     <a
       href="chrome://extensions/shortcuts"
       onClick={(event) => {

--- a/src/options/pages/marketplace/__snapshots__/ActivateWizard.test.tsx.snap
+++ b/src/options/pages/marketplace/__snapshots__/ActivateWizard.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`ActivateWizard activate blueprint with missing required blueprint optio
                   <div
                     class="card-title h5"
                   >
-                    Blueprint with Required Options
+                    Mod with Required Options
                   </div>
                   <code
                     class="packageId"
@@ -104,7 +104,7 @@ exports[`ActivateWizard activate blueprint with missing required blueprint optio
         >
           <div>
             <h4>
-              Configure Blueprint
+              Configure Mod
             </h4>
           </div>
           <div
@@ -257,7 +257,7 @@ exports[`ActivateWizard activate blueprint with missing required blueprint optio
                   fill="currentColor"
                 />
               </svg>
-               Extension Point for Blueprint with Required Options
+               Extension Point for Mod with Required Options
             </span>
           </div>
         </div>

--- a/src/options/pages/marketplace/useWizard.ts
+++ b/src/options/pages/marketplace/useWizard.ts
@@ -28,7 +28,7 @@ const STEPS: WizardStep[] = [
   // to realize it's OK to pass in a whole RecipeDefinition for something that just needs the options prop
   {
     key: "options",
-    label: "Configure Blueprint",
+    label: "Configure Mod",
     Component: OptionsBody as React.FunctionComponent<{
       blueprint: RecipeDefinition;
     }>,

--- a/src/options/pages/workshop/WorkshopPage.tsx
+++ b/src/options/pages/workshop/WorkshopPage.tsx
@@ -235,8 +235,8 @@ const WorkshopPage: React.FunctionComponent<NavigateProps> = ({ navigate }) => (
       icon={faHammer}
       description={
         <p>
-          Text-based editor for advanced users to create and edit bricks.
-          Blueprints created in the Page Editor can also be edited here.
+          Text-based editor for advanced users to create and edit bricks. Mods
+          created in the Page Editor can also be edited here.
         </p>
       }
       toolbar={

--- a/src/pageEditor/NonScriptablePage.tsx
+++ b/src/pageEditor/NonScriptablePage.tsx
@@ -26,8 +26,7 @@ const GetStarted: React.FunctionComponent = () => (
   <>
     <h4 className={styles.callout}>Get started with PixieBrix</h4>
     <p>
-      This is the PixieBrix Page Editor where you can create and modify
-      Blueprints.
+      This is the PixieBrix Page Editor where you can create and modify mods.
     </p>
     <p>To get started, try navigating to a page you&apos;d like to edit.</p>
     <p>

--- a/src/pageEditor/NonScriptablePage.tsx
+++ b/src/pageEditor/NonScriptablePage.tsx
@@ -26,9 +26,13 @@ const GetStarted: React.FunctionComponent = () => (
   <>
     <h4 className={styles.callout}>Get started with PixieBrix</h4>
     <p>
-      This is the PixieBrix Page Editor where you can create and modify mods.
+      This is the PixieBrix Page Editor. Use the Page Editor to create web page
+      modifications, called mods.
     </p>
-    <p>To get started, try navigating to a page you&apos;d like to edit.</p>
+    <p>
+      To start, navigate to a web page that you&apos;d like to modify and then
+      click the &quot;Add&quot; button.
+    </p>
     <p>
       Try the{" "}
       <a

--- a/src/pageEditor/hooks/useRemoveExtension.ts
+++ b/src/pageEditor/hooks/useRemoveExtension.ts
@@ -46,7 +46,7 @@ function useRemoveExtension(): (useRemoveConfig: Config) => Promise<void> {
         const confirm = await showConfirmation({
           title: "Remove Extension?",
           message:
-            "You can reactivate extensions and blueprints from the PixieBrix Options page",
+            "You can reactivate extensions and mods from the PixieBrix Options page",
           submitCaption: "Remove",
         });
 

--- a/src/pageEditor/hooks/useRemoveRecipe.ts
+++ b/src/pageEditor/hooks/useRemoveRecipe.ts
@@ -46,9 +46,9 @@ function useRemoveRecipe(): (useRemoveConfig: Config) => Promise<void> {
     async ({ recipeId, shouldShowConfirmation = true }) => {
       if (shouldShowConfirmation) {
         const confirmed = await showConfirmation({
-          title: "Remove Blueprint?",
+          title: "Remove Mod?",
           message:
-            "You can reactivate extensions and blueprints from the PixieBrix Options page",
+            "You can reactivate extensions and mods from the PixieBrix Options page",
           submitCaption: "Remove",
         });
 

--- a/src/pageEditor/hooks/useResetRecipe.ts
+++ b/src/pageEditor/hooks/useResetRecipe.ts
@@ -32,9 +32,9 @@ function useResetRecipe(): (recipeId: RegistryId) => Promise<void> {
   return useCallback(
     async (recipeId: RegistryId) => {
       const confirmed = await showConfirmation({
-        title: "Reset Blueprint?",
+        title: "Reset Mod?",
         message:
-          "Unsaved changes to extensions within this blueprint, or to blueprint options and metadata, will be lost.",
+          "Unsaved changes to extensions within this mod, or to mod options and metadata, will be lost.",
         submitCaption: "Reset",
       });
       if (!confirmed) {

--- a/src/pageEditor/hooks/useSaveRecipe.ts
+++ b/src/pageEditor/hooks/useSaveRecipe.ts
@@ -116,7 +116,7 @@ function useSaveRecipe(): RecipeSaver {
 
     const confirm = await showConfirmation({
       title: "Save Mod?",
-      message: "All changes to the mod and its extensions will be saved",
+      message: "All changes to the mod will be saved",
       submitCaption: "Save",
       submitVariant: "primary",
     });

--- a/src/pageEditor/hooks/useSaveRecipe.ts
+++ b/src/pageEditor/hooks/useSaveRecipe.ts
@@ -105,7 +105,7 @@ function useSaveRecipe(): RecipeSaver {
     const recipe = recipes?.find((recipe) => recipe.metadata.id === recipeId);
     if (recipe == null) {
       throw new Error(
-        "You no longer have edit permissions for the blueprint. Please reload the Editor."
+        "You no longer have edit permissions for the mod. Please reload the Editor."
       );
     }
 
@@ -115,8 +115,8 @@ function useSaveRecipe(): RecipeSaver {
     }
 
     const confirm = await showConfirmation({
-      title: "Save Blueprint?",
-      message: "All changes to the blueprint and its extensions will be saved",
+      title: "Save Mod?",
+      message: "All changes to the mod and its extensions will be saved",
       submitCaption: "Save",
       submitVariant: "primary",
     });
@@ -217,11 +217,11 @@ function useSaveRecipe(): RecipeSaver {
     try {
       const success = await save(recipeId);
       if (success) {
-        notify.success("Saved blueprint");
+        notify.success("Saved mod");
       }
     } catch (error: unknown) {
       notify.error({
-        message: "Failed saving blueprint",
+        message: "Failed saving mod",
         error,
       });
     } finally {

--- a/src/pageEditor/hooks/useSaveRecipe.ts
+++ b/src/pageEditor/hooks/useSaveRecipe.ts
@@ -105,7 +105,7 @@ function useSaveRecipe(): RecipeSaver {
     const recipe = recipes?.find((recipe) => recipe.metadata.id === recipeId);
     if (recipe == null) {
       throw new Error(
-        "You no longer have edit permissions for the mod. Please reload the Editor."
+        "You no longer have edit permissions for the mod. Please reload the Page Editor."
       );
     }
 

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -627,7 +627,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                   class="label form-label col-form-label col-xl-2 col-lg-3"
                   for="label"
                 >
-                  Extension Name
+                  Name
                 </label>
                 <div
                   class="col-xl-10 col-lg-9"
@@ -1292,7 +1292,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                 <div
                   class="text-muted"
                 >
-                  A foundation is the first step in the execution flow, they do not receive inputs
+                  This is the first step in the execution flow, so it does not receive inputs from any other brick.
                 </div>
               </div>
               <div
@@ -1303,7 +1303,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                 <div
                   class="text-muted"
                 >
-                  A foundation is the first step in the execution flow, they do not receive inputs
+                  This is the first step in the execution flow, so it does not receive inputs from any other brick.
                 </div>
               </div>
               <div
@@ -2141,7 +2141,7 @@ exports[`renders the first selected node 1`] = `
                   <div
                     class="text-muted"
                   >
-                    No trace available, run the extension to generate data
+                    No trace available. Run the mod to generate data
                   </div>
                 </div>
               </div>

--- a/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`NonScriptablePage it renders 1`] = `
             Get started with PixieBrix
           </h4>
           <p>
-            This is the PixieBrix Page Editor where you can create and modify Blueprints.
+            This is the PixieBrix Page Editor where you can create and modify mods.
           </p>
           <p>
             To get started, try navigating to a page you'd like to edit.

--- a/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
@@ -20,10 +20,10 @@ exports[`NonScriptablePage it renders 1`] = `
             Get started with PixieBrix
           </h4>
           <p>
-            This is the PixieBrix Page Editor where you can create and modify mods.
+            This is the PixieBrix Page Editor. Use the Page Editor to create web page modifications, called mods.
           </p>
           <p>
-            To get started, try navigating to a page you'd like to edit.
+            To start, navigate to a web page that you'd like to modify and then click the "Add" button.
           </p>
           <p>
             Try the 

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -100,13 +100,13 @@ function findRecipeIndex(
 
   if (labelMatches.length === 0) {
     throw new Error(
-      `There are no extensions in the blueprint with label "${extension.label}". You must edit the blueprint in the Workshop`
+      `There are no extensions in the mod with label "${extension.label}". You must edit the mod in the Workshop`
     );
   }
 
   if (labelMatches.length > 1) {
     throw new Error(
-      `There are multiple extensions in the blueprint with label "${extension.label}". You must edit the blueprint in the Workshop`
+      `There are multiple extensions in the mod with label "${extension.label}". You must edit the mod in the Workshop`
     );
   }
 
@@ -347,13 +347,13 @@ export function buildRecipe({
 
     if (badApiVersion) {
       throw new Error(
-        `Blueprint extensions have inconsistent API Versions (${itemsApiVersion}/${badApiVersion}). All extensions in a blueprint must have the same API Version.`
+        `Mod extensions have inconsistent API Versions (${itemsApiVersion}/${badApiVersion}). All extensions in a mod must have the same API Version.`
       );
     }
 
     if (itemsApiVersion !== recipe.apiVersion) {
       throw new Error(
-        `Blueprint has API Version ${recipe.apiVersion}, but it's extensions have version ${itemsApiVersion}. Please use the Workshop to edit this blueprint.`
+        `Mod has API Version ${recipe.apiVersion}, but it's extensions have version ${itemsApiVersion}. Please use the Workshop to edit this mod.`
       );
     }
 

--- a/src/pageEditor/panes/save/useSavingWizard.test.tsx
+++ b/src/pageEditor/panes/save/useSavingWizard.test.tsx
@@ -461,7 +461,7 @@ describe("saving a Recipe Extension", () => {
       await updatingRecipePromise;
       await savingPromise;
     } catch (error) {
-      expect(error).toBe("Failed to update the Mod");
+      expect(error).toBe("Failed to update the mod");
     }
 
     // Wizard closes on error

--- a/src/pageEditor/panes/save/useSavingWizard.test.tsx
+++ b/src/pageEditor/panes/save/useSavingWizard.test.tsx
@@ -378,7 +378,7 @@ describe("saving a Recipe Extension", () => {
       await creatingRecipePromise;
       await savingPromise;
     } catch (error) {
-      expect(error).toBe("Failed to create new Blueprint");
+      expect(error).toBe("Failed to create new Mod");
     }
 
     // Wizard closes on error
@@ -461,7 +461,7 @@ describe("saving a Recipe Extension", () => {
       await updatingRecipePromise;
       await savingPromise;
     } catch (error) {
-      expect(error).toBe("Failed to update the Blueprint");
+      expect(error).toBe("Failed to update the Mod");
     }
 
     // Wizard closes on error

--- a/src/pageEditor/panes/save/useSavingWizard.test.tsx
+++ b/src/pageEditor/panes/save/useSavingWizard.test.tsx
@@ -378,7 +378,7 @@ describe("saving a Recipe Extension", () => {
       await creatingRecipePromise;
       await savingPromise;
     } catch (error) {
-      expect(error).toBe("Failed to create new Mod");
+      expect(error).toBe("Failed to create new mod");
     }
 
     // Wizard closes on error

--- a/src/pageEditor/panes/save/useSavingWizard.ts
+++ b/src/pageEditor/panes/save/useSavingWizard.ts
@@ -96,7 +96,7 @@ const useSavingWizard = () => {
       const recipe = recipes.find((x) => x.metadata.id === element.recipe.id);
       if (!recipe) {
         notify.error(
-          "You no longer have edit permissions for the blueprint. Please reload the Editor."
+          "You no longer have edit permissions for the mod. Please reload the Editor."
         );
         return;
       }
@@ -158,7 +158,7 @@ const useSavingWizard = () => {
     const recipe = recipes.find((x) => x.metadata.id === elementRecipeMeta.id);
 
     if (recipeMeta.id === recipe.metadata.id) {
-      closeWizard("You must provide a new id for the Blueprint");
+      closeWizard("You must provide a new id for the Mod");
       return;
     }
 
@@ -182,7 +182,7 @@ const useSavingWizard = () => {
     });
 
     if ("error" in createRecipeResponse) {
-      const errorMessage = "Failed to create new Blueprint";
+      const errorMessage = "Failed to create new Mod";
       notify.error({
         message: errorMessage,
         error: createRecipeResponse.error,
@@ -240,7 +240,7 @@ const useSavingWizard = () => {
     });
 
     if ("error" in updateRecipeResponse) {
-      const errorMessage = "Failed to update the Blueprint";
+      const errorMessage = "Failed to update the Mod";
       notify.error({
         message: errorMessage,
         error: updateRecipeResponse.error,

--- a/src/pageEditor/panes/save/useSavingWizard.ts
+++ b/src/pageEditor/panes/save/useSavingWizard.ts
@@ -182,7 +182,7 @@ const useSavingWizard = () => {
     });
 
     if ("error" in createRecipeResponse) {
-      const errorMessage = "Failed to create new Mod";
+      const errorMessage = "Failed to create new mod";
       notify.error({
         message: errorMessage,
         error: createRecipeResponse.error,

--- a/src/pageEditor/panes/save/useSavingWizard.ts
+++ b/src/pageEditor/panes/save/useSavingWizard.ts
@@ -96,7 +96,7 @@ const useSavingWizard = () => {
       const recipe = recipes.find((x) => x.metadata.id === element.recipe.id);
       if (!recipe) {
         notify.error(
-          "You no longer have edit permissions for the mod. Please reload the Editor."
+          "You no longer have edit permissions for the mod. Please reload the Page Editor."
         );
         return;
       }

--- a/src/pageEditor/panes/save/useSavingWizard.ts
+++ b/src/pageEditor/panes/save/useSavingWizard.ts
@@ -240,7 +240,7 @@ const useSavingWizard = () => {
     });
 
     if ("error" in updateRecipeResponse) {
-      const errorMessage = "Failed to update the Mod";
+      const errorMessage = "Failed to update the mod";
       notify.error({
         message: errorMessage,
         error: updateRecipeResponse.error,

--- a/src/pageEditor/panes/save/useSavingWizard.ts
+++ b/src/pageEditor/panes/save/useSavingWizard.ts
@@ -158,7 +158,7 @@ const useSavingWizard = () => {
     const recipe = recipes.find((x) => x.metadata.id === elementRecipeMeta.id);
 
     if (recipeMeta.id === recipe.metadata.id) {
-      closeWizard("You must provide a new id for the Mod");
+      closeWizard("You must provide a new id for the mod");
       return;
     }
 

--- a/src/pageEditor/sidebar/ActionMenu.tsx
+++ b/src/pageEditor/sidebar/ActionMenu.tsx
@@ -79,7 +79,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
             fixedWidth
             className={styles.addIcon}
           />{" "}
-          Add to blueprint
+          Add to mod
         </>
       ),
       hide: !onAddToRecipe,
@@ -94,7 +94,7 @@ const ActionMenu: React.FC<ActionMenuProps> = ({
             fixedWidth
             className={styles.removeIcon}
           />{" "}
-          Remove from blueprint
+          Remove from mod
         </>
       ),
       hide: !onRemoveFromRecipe,

--- a/src/pageEditor/sidebar/RecipeEntry.test.tsx
+++ b/src/pageEditor/sidebar/RecipeEntry.test.tsx
@@ -107,7 +107,7 @@ test("renders the warning icon when has update", () => {
   });
 
   const warningIcon = rendered.getByTitle(
-    "You are editing version 1.0.0 of this blueprint, the latest version is 2.0.0."
+    "You are editing version 1.0.0 of this mod, the latest version is 2.0.0."
   );
 
   expect(warningIcon).toBeInTheDocument();

--- a/src/pageEditor/sidebar/RecipeEntry.tsx
+++ b/src/pageEditor/sidebar/RecipeEntry.tsx
@@ -115,7 +115,7 @@ const RecipeEntry: React.FC<RecipeEntryProps> = ({
         {hasUpdate && (
           <span className={cx(styles.icon, "text-warning")}>
             <RecipeHasUpdateIcon
-              title={`You are editing version ${installedVersion} of this blueprint, the latest version is ${latestRecipeVersion}.`}
+              title={`You are editing version ${installedVersion} of this mod, the latest version is ${latestRecipeVersion}.`}
             />
           </span>
         )}

--- a/src/pageEditor/sidebar/modals/AddToRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/AddToRecipeModal.tsx
@@ -117,7 +117,7 @@ const AddToRecipeModal: React.FC = () => {
       }
 
       notify.error({
-        message: "Problem adding extension to mod",
+        message: "Problem adding to mod",
         error,
       });
     } finally {

--- a/src/pageEditor/sidebar/modals/AddToRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/AddToRecipeModal.tsx
@@ -117,7 +117,7 @@ const AddToRecipeModal: React.FC = () => {
       }
 
       notify.error({
-        message: "Problem adding extension to blueprint",
+        message: "Problem adding extension to mod",
         error,
       });
     } finally {
@@ -126,7 +126,7 @@ const AddToRecipeModal: React.FC = () => {
   };
 
   const selectOptions = [
-    { label: "➕ Create new blueprint...", value: NEW_RECIPE_ID },
+    { label: "➕ Create new mod...", value: NEW_RECIPE_ID },
     ...recipeMetadatas.map((metadata) => ({
       label: metadata.name,
       value: metadata.id,
@@ -135,11 +135,11 @@ const AddToRecipeModal: React.FC = () => {
 
   const radioItems: RadioItem[] = [
     {
-      label: "Move the extension into the blueprint",
+      label: "Move the extension into the mod",
       value: "move",
     },
     {
-      label: "Create a copy of the extension in the blueprint",
+      label: "Create a copy of the extension in the mod",
       value: "copy",
     },
   ];
@@ -149,7 +149,7 @@ const AddToRecipeModal: React.FC = () => {
       <ConnectedFieldTemplate
         name="recipeId"
         hideLabel
-        description="Choose a blueprint"
+        description="Choose a mod"
         as={SelectWidget}
         options={selectOptions}
         widerLabel
@@ -187,7 +187,7 @@ const AddToRecipeModal: React.FC = () => {
     <Modal show={show} onHide={hideModal}>
       <Modal.Header closeButton>
         <Modal.Title>
-          Add <em>{activeElement?.label}</em> to a blueprint
+          Add <em>{activeElement?.label}</em> to a mod
         </Modal.Title>
       </Modal.Header>
       <Form

--- a/src/pageEditor/sidebar/modals/AddToRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/AddToRecipeModal.tsx
@@ -139,7 +139,7 @@ const AddToRecipeModal: React.FC = () => {
       value: "move",
     },
     {
-      label: "Create a copy of the extension in the mod",
+      label: "Create a copy in the selected mod",
       value: "copy",
     },
   ];

--- a/src/pageEditor/sidebar/modals/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/CreateRecipeModal.tsx
@@ -308,10 +308,10 @@ function useFormSchema() {
     id: string()
       .matches(
         PACKAGE_REGEX,
-        "Blueprint ID is required, and may only include lowercase letters, numbers, and the symbols - _ ~"
+        "Mod ID is required, and may only include lowercase letters, numbers, and the symbols - _ ~"
       )
-      .notOneOf(allRecipeIds, "Blueprint ID is already in use")
-      .required("Blueprint ID is required"),
+      .notOneOf(allRecipeIds, "Mod ID is already in use")
+      .required("Mod ID is required"),
     name: string().required("Name is required"),
     version: string()
       .test(
@@ -361,7 +361,7 @@ const CreateRecipeModalBody: React.FC = () => {
       } else {
         // Should not happen in practice
         // noinspection ExceptionCaughtLocallyJS
-        throw new Error("Expected either active element or blueprint");
+        throw new Error("Expected either active element or mod");
       }
 
       hideModal();
@@ -372,7 +372,7 @@ const CreateRecipeModalBody: React.FC = () => {
       }
 
       notify.error({
-        message: "Error creating blueprint",
+        message: "Error creating mod",
         error,
       });
     } finally {
@@ -384,7 +384,7 @@ const CreateRecipeModalBody: React.FC = () => {
     <Modal.Body>
       <ConnectedFieldTemplate
         name="id"
-        label="Blueprint ID"
+        label="Mod ID"
         description={FieldDescriptions.BLUEPRINT_ID}
         widerLabel
         as={RegistryIdWidget}
@@ -426,7 +426,7 @@ const CreateRecipeModalBody: React.FC = () => {
   );
 
   return (
-    <RequireScope scopeSettingsDescription="To create a blueprint, you must first set an account alias for your PixieBrix account">
+    <RequireScope scopeSettingsDescription="To create a mod, you must first set an account alias for your PixieBrix account">
       {isRecipeFetching ? (
         <Loader />
       ) : (
@@ -455,7 +455,7 @@ const CreateRecipeModal: React.FunctionComponent = () => {
   }, [dispatch]);
 
   return (
-    <ModalLayout title="Create new blueprint" show={show} onHide={hideModal}>
+    <ModalLayout title="Create new mod" show={show} onHide={hideModal}>
       <CreateRecipeModalBody />
     </ModalLayout>
   );

--- a/src/pageEditor/sidebar/modals/RemoveFromRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/RemoveFromRecipeModal.tsx
@@ -85,7 +85,7 @@ const RemoveFromRecipeModal: React.FC = () => {
       value: "move",
     },
     {
-      label: "Remove the extension from the mod",
+      label: "Remove from the mod",
       value: "remove",
     },
   ];

--- a/src/pageEditor/sidebar/modals/RemoveFromRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/RemoveFromRecipeModal.tsx
@@ -69,7 +69,7 @@ const RemoveFromRecipeModal: React.FC = () => {
         hideModal();
       } catch (error: unknown) {
         notify.error({
-          message: "Problem removing extension from mod",
+          message: "Problem removing from mod",
           error,
         });
       } finally {

--- a/src/pageEditor/sidebar/modals/RemoveFromRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/RemoveFromRecipeModal.tsx
@@ -69,7 +69,7 @@ const RemoveFromRecipeModal: React.FC = () => {
         hideModal();
       } catch (error: unknown) {
         notify.error({
-          message: "Problem removing extension from blueprint",
+          message: "Problem removing extension from mod",
           error,
         });
       } finally {
@@ -85,7 +85,7 @@ const RemoveFromRecipeModal: React.FC = () => {
       value: "move",
     },
     {
-      label: "Remove the extension from the blueprint",
+      label: "Remove the extension from the mod",
       value: "remove",
     },
   ];
@@ -127,7 +127,7 @@ const RemoveFromRecipeModal: React.FC = () => {
     <Modal show={show} onHide={hideModal}>
       <Modal.Header closeButton>
         <Modal.Title>
-          Remove <em>{activeElement?.label}</em> from blueprint{" "}
+          Remove <em>{activeElement?.label}</em> from mod{" "}
           <em>{activeElement?.recipe?.name}</em>?
         </Modal.Title>
       </Modal.Header>

--- a/src/pageEditor/sidebar/modals/SaveAsNewRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/SaveAsNewRecipeModal.tsx
@@ -32,7 +32,7 @@ const SaveAsNewRecipeModal: React.FC = () => {
 
   const recipeId = useSelector(selectActiveRecipeId);
   const { data: recipe, isFetching } = useRecipe(recipeId);
-  const recipeName = recipe?.metadata?.name ?? "this blueprint";
+  const recipeName = recipe?.metadata?.name ?? "this mod";
 
   const dispatch = useDispatch();
 
@@ -48,11 +48,11 @@ const SaveAsNewRecipeModal: React.FC = () => {
   return (
     <Modal show={show} onHide={hideModal}>
       <Modal.Header closeButton>
-        <Modal.Title>Save as new blueprint?</Modal.Title>
+        <Modal.Title>Save as new mod?</Modal.Title>
       </Modal.Header>
       <Modal.Body>
         You do not have permissions to edit <em>{recipeName}</em>. Save as a new
-        blueprint?
+        mod?
       </Modal.Body>
       <Modal.Footer>
         <Button variant="info" onClick={hideModal}>

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -587,7 +587,7 @@ export const editorSlice = createSlice({
       );
       if (elementIndex < 0) {
         throw new Error(
-          "Unable to add extension to blueprint, extension form state not found"
+          "Unable to add extension to mod, extension form state not found"
         );
       }
 
@@ -628,7 +628,7 @@ export const editorSlice = createSlice({
       );
       if (elementIndex < 0) {
         throw new Error(
-          "Unable to remove extension from blueprint, extension form state not found"
+          "Unable to remove extension from mod, extension form state not found"
         );
       }
 

--- a/src/pageEditor/tabs/editRecipeTab/EditRecipe.tsx
+++ b/src/pageEditor/tabs/editRecipeTab/EditRecipe.tsx
@@ -117,25 +117,25 @@ const EditRecipe: React.VoidFunctionComponent = () => {
       <Effect values={values} onChange={updateRedux} delayMillis={100} />
 
       <Card>
-        <Card.Header>Blueprint Metadata</Card.Header>
+        <Card.Header>Mod Metadata</Card.Header>
         <Card.Body>
           {showOldRecipeWarning && (
             <Alert variant="warning">
-              You are editing version {installedRecipeVersion} of this
-              blueprint, the latest version is {latestRecipeVersion}. To get the
-              latest version,{" "}
+              You are editing version {installedRecipeVersion} of this mod, the
+              latest version is {latestRecipeVersion}. To get the latest
+              version,{" "}
               <a
-                href="/options.html#/blueprints"
+                href="/options.html#/mods"
                 target="_blank"
-                title="Re-activate the blueprint"
+                title="Re-activate the mod"
               >
-                re-activate the blueprint
+                re-activate the mod
               </a>
             </Alert>
           )}
           <ConnectedFieldTemplate
             name="id"
-            label="Blueprint ID"
+            label="Mod ID"
             description={FieldDescriptions.BLUEPRINT_ID}
             // Blueprint IDs may not be changed after creation
             readOnly

--- a/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
@@ -46,7 +46,7 @@ const FoundationNodeConfigPanel: React.FC = () => {
       {extensionPoint.definition.type === "quickBar" && (
         <UnconfiguredQuickBarAlert />
       )}
-      <ConnectedFieldTemplate name="label" label="Extension Name" />
+      <ConnectedFieldTemplate name="label" label="Name" />
       {showVersionField && <ApiVersionField />}
       <UpgradedToApiV3 />
       <SchemaFieldContext.Provider value={devtoolFieldOverrides}>

--- a/src/pageEditor/tabs/editTab/dataPanel/DataTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataTab.tsx
@@ -38,7 +38,7 @@ const DataTab: React.FC<TabPaneProps & TabStateProps> = ({
     contents = (
       <>
         <div className="text-muted">
-          No trace available, run the extension to generate data
+          No trace available. Run the mod to generate data
         </div>
 
         <div className="text-info mt-2">
@@ -51,7 +51,7 @@ const DataTab: React.FC<TabPaneProps & TabStateProps> = ({
   } else if (isTraceEmpty) {
     contents = (
       <div className="text-muted">
-        No trace available, run the extension to generate data
+        No trace available. Run the mod to generate data
       </div>
     );
   } else {

--- a/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
@@ -86,8 +86,8 @@ const FoundationDataPanel: React.FC = () => {
           className={dataPanelStyles.tabPane}
         >
           <div className="text-muted">
-            A foundation is the first step in the execution flow, they do not
-            receive inputs
+            This is the first step in the execution flow, so it does not receive
+            inputs from any other brick.
           </div>
         </Tab.Pane>
         {showDeveloperTabs && (
@@ -101,8 +101,8 @@ const FoundationDataPanel: React.FC = () => {
           className={dataPanelStyles.tabPane}
         >
           <div className="text-muted">
-            A foundation is the first step in the execution flow, they do not
-            receive inputs
+            This is the first step in the execution flow, so it does not receive
+            inputs from any other brick.
           </div>
         </Tab.Pane>
         <Tab.Pane
@@ -121,8 +121,8 @@ const FoundationDataPanel: React.FC = () => {
             />
           ) : (
             <div className="text-muted">
-              No trace available, add a brick and run the extension to see the
-              data produced by the foundation
+              This is the first step in the execution flow, so it does not
+              receive inputs from any other brick.
             </div>
           )}
         </Tab.Pane>

--- a/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/FoundationDataPanel.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/FoundationDataPanel.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`FoundationDataPanel it renders with form state and trace data 1`] = `
         <div
           class="text-muted"
         >
-          A foundation is the first step in the execution flow, they do not receive inputs
+          This is the first step in the execution flow, so it does not receive inputs from any other brick.
         </div>
       </div>
       <div
@@ -97,7 +97,7 @@ exports[`FoundationDataPanel it renders with form state and trace data 1`] = `
         <div
           class="text-muted"
         >
-          A foundation is the first step in the execution flow, they do not receive inputs
+          This is the first step in the execution flow, so it does not receive inputs from any other brick.
         </div>
       </div>
       <div

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
@@ -50,7 +50,7 @@ const PageStateTab: React.VFC = () => {
         getPageState(thisTab, { namespace: "shared", ...context }),
         activeElement.recipe
           ? getPageState(thisTab, { namespace: "blueprint", ...context })
-          : Promise.resolve("Extension is not in a mod"),
+          : Promise.resolve("Extension is not in a blueprint"),
         getPageState(thisTab, { namespace: "extension", ...context }),
       ]);
 

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
@@ -50,7 +50,7 @@ const PageStateTab: React.VFC = () => {
         getPageState(thisTab, { namespace: "shared", ...context }),
         activeElement.recipe
           ? getPageState(thisTab, { namespace: "blueprint", ...context })
-          : Promise.resolve("Extension is not in a blueprint"),
+          : Promise.resolve("Extension is not in a mod"),
         getPageState(thisTab, { namespace: "extension", ...context }),
       ]);
 

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/PageStateTab.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/PageStateTab.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`PageStateTab it renders with orphan extension 1`] = `
               <span
                 style="color: rgb(64, 175, 108);"
               >
-                "Extension is not in a mod"
+                "Extension is not in a blueprint"
               </span>
             </li>
             <li

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/PageStateTab.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/PageStateTab.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`PageStateTab it renders with orphan extension 1`] = `
               <span
                 style="color: rgb(64, 175, 108);"
               >
-                "Extension is not in a blueprint"
+                "Extension is not in a mod"
               </span>
             </li>
             <li

--- a/src/pageEditor/tabs/recipeOptionsDefinitions/RecipeOptionsDefinition.tsx
+++ b/src/pageEditor/tabs/recipeOptionsDefinitions/RecipeOptionsDefinition.tsx
@@ -131,11 +131,11 @@ const RecipeOptionsDefinition: React.VFC = () => {
 
               <div className={styles.configPanel}>
                 <Card>
-                  <Card.Header>Advanced: Blueprint Options</Card.Header>
+                  <Card.Header>Advanced: Mod Options</Card.Header>
                   <Card.Body>
                     {noOptions && (
                       <div className="mb-3">
-                        No options defined for this Blueprint
+                        No options defined for this mod
                       </div>
                     )}
 

--- a/src/pageEditor/tabs/recipeOptionsValues/RecipeOptionsValues.tsx
+++ b/src/pageEditor/tabs/recipeOptionsValues/RecipeOptionsValues.tsx
@@ -114,7 +114,7 @@ const RecipeOptionsValuesContent: React.FC = () => {
     <>
       <Effect values={values} onChange={updateRedux} delayMillis={300} />
       <Card>
-        <Card.Header>Blueprint Input Options</Card.Header>
+        <Card.Header>Mod Input Options</Card.Header>
         <Card.Body>
           <FieldRuntimeContext.Provider value={OPTIONS_FIELD_RUNTIME_CONTEXT}>
             <OptionsFieldGroup name="" />

--- a/src/pageEditor/tabs/recipeOptionsValues/__snapshots__/RecipeOptionsValues.test.tsx.snap
+++ b/src/pageEditor/tabs/recipeOptionsValues/__snapshots__/RecipeOptionsValues.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`ActivationOptions renders blueprint options 1`] = `
             <div
               class="card-header"
             >
-              Blueprint Input Options
+              Mod Input Options
             </div>
             <div
               class="card-body"
@@ -339,7 +339,7 @@ exports[`ActivationOptions renders empty options 1`] = `
             <div
               class="card-header"
             >
-              Blueprint Input Options
+              Mod Input Options
             </div>
             <div
               class="card-body"

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
@@ -159,7 +159,7 @@ describe("ActivateRecipePanel", () => {
 
     const entry = sidebarEntryFactory("activateRecipe", {
       recipeId: recipe.metadata.id,
-      heading: "Activate Blueprint",
+      heading: "Activate Mod",
     });
 
     const rendered = render(

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
@@ -72,9 +72,7 @@ const ActivateRecipePanel: React.FC<ActivateRecipePanelProps> = ({
   }
 
   const recipeName =
-    listing?.package?.verbose_name ??
-    listing?.package?.name ??
-    "Unnamed blueprint";
+    listing?.package?.verbose_name ?? listing?.package?.name ?? "Unnamed mod";
   const recipeNameComponent = (
     <div className={styles.recipeName}>{recipeName}</div>
   );
@@ -143,7 +141,7 @@ const ActivateRecipePanel: React.FC<ActivateRecipePanelProps> = ({
               {recipeNameComponent}
               <div>is ready to use!</div>
               <br />
-              <div>Go try it out now, or activate another blueprint.</div>
+              <div>Go try it out now, or activate another mod.</div>
             </div>
           </div>
           <div className={styles.footer}>
@@ -160,7 +158,7 @@ const ActivateRecipePanel: React.FC<ActivateRecipePanelProps> = ({
               {recipeNameComponent}
               <p>
                 {
-                  "We're almost there. This blueprint has a few settings to configure before using. You can always change these later."
+                  "We're almost there. This mod has a few settings to configure before using. You can always change these later."
                 }
               </p>
             </>

--- a/src/sidebar/activateRecipe/__snapshots__/ActivateRecipePanel.test.tsx.snap
+++ b/src/sidebar/activateRecipe/__snapshots__/ActivateRecipePanel.test.tsx.snap
@@ -18,11 +18,11 @@ exports[`ActivateRecipePanel it renders with options, permissions info, and quic
           My Test Listing
         </div>
         <p>
-          We're almost there. This blueprint has a few settings to configure before using. You can always change these later.
+          We're almost there. This mod has a few settings to configure before using. You can always change these later.
         </p>
         <div>
           <h4>
-            Configure Blueprint
+            Configure Mod
           </h4>
         </div>
         <div

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -22,8 +22,8 @@
 export const MARKETPLACE_URL = process.env.MARKETPLACE_URL;
 
 export const FieldDescriptions = {
-  BLUEPRINT_ID: "A unique id for the blueprint",
-  BLUEPRINT_NAME: "A display name for the blueprint",
-  BLUEPRINT_DESCRIPTION: "A short description of the blueprint",
-  BLUEPRINT_VERSION: "The current blueprint version",
+  BLUEPRINT_ID: "A unique id for the mod",
+  BLUEPRINT_NAME: "A display name for the mod",
+  BLUEPRINT_DESCRIPTION: "A short description of the mod",
+  BLUEPRINT_VERSION: "The current mod version",
 };


### PR DESCRIPTION
## What does this PR do?

- Closes #5210 and #5170
- Replaces all user-facing occurrences of the word "blueprint" with "mod" in the extension console and page editor

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @BLoe 
