### PR TITLE
Replace occurrences of the word "extension" in non-chrome browser contexts

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -408,7 +408,7 @@ exports[`Storyshots Blueprints/OnboardingView Default 1`] = `
           className="d-flex justify-content-center flex-column text-center col"
         >
           <p>
-            Learn how to create your own extensions in minutes by following our
+            Learn how to create your own mods in minutes by following our
              
             <span
               className="text-primary"
@@ -5510,7 +5510,7 @@ exports[`Storyshots Fields/UrlMatchPatternField Default 1`] = `
         className="text-muted form-text"
       >
         <span>
-          URL match patterns permitting the extension to run on a site. If PixieBrix does not already have access to a site, your browser will prompt you to grant access. See
+          URL match patterns permitting the starter brick to run on a site. If PixieBrix does not already have access to a site, your browser will prompt you to grant access. See
            
           <a
             href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/"
@@ -5571,7 +5571,7 @@ exports[`Storyshots Fields/UrlPatternField Default 1`] = `
         className="text-muted form-text"
       >
         <span>
-          URL pattern rules restricting when the extension runs. If provided, at least one of the rules must match for the extension to run. See
+          URL pattern rules restricting when the starter brick runs. If provided, at least one of the rules must match for the starter brick to run. See
            
           <a
             href="https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API"
@@ -8551,7 +8551,7 @@ exports[`Storyshots Panels/RootErrorPanel No Renderer Error Example 1`] = `
       </div>
       <div>
         <small>
-          Add a renderer brick to the extension.
+          Add a renderer brick to the starter brick.
         </small>
       </div>
     </div>

--- a/src/analysis/analysisVisitors/renderersAnalysis.ts
+++ b/src/analysis/analysisVisitors/renderersAnalysis.ts
@@ -25,7 +25,7 @@ import { PipelineFlavor } from "@/pageEditor/pageEditorTypes";
 import { AnnotationType } from "@/types";
 
 export const MULTIPLE_RENDERERS_ERROR_MESSAGE =
-  "A panel can only have one renderer. There are one or more other renderers configured for this extension.";
+  "A panel can only have one renderer. There are one or more other renderers configured for this mod.";
 const RENDERER_MUST_BE_LAST_BLOCK_ERROR_MESSAGE =
   "A renderer must be the last brick.";
 

--- a/src/analysis/analysisVisitors/requestPermissionAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/requestPermissionAnalysis.test.ts
@@ -109,7 +109,7 @@ describe("requestPermissionAnalysis", () => {
         analysisId: "requestPermission",
         type: "error",
         message:
-          "Insufficient browser permissions to make request. Specify an Integration to access the API, or add an Extra Permissions rule to the extension.",
+          "Insufficient browser permissions to make request. Specify an Integration to access the API, or add an Extra Permissions rule to the starter brick.",
         position: {
           path: "extension.blockPipeline.0.config.url",
         },

--- a/src/analysis/analysisVisitors/requestPermissionAnalysis.ts
+++ b/src/analysis/analysisVisitors/requestPermissionAnalysis.ts
@@ -112,7 +112,7 @@ class RequestPermissionAnalysis extends AnalysisVisitor {
             this.annotations.push({
               position: nestedPosition(position, "config.url"),
               message:
-                "Insufficient browser permissions to make request. Specify an Integration to access the API, or add an Extra Permissions rule to the extension.",
+                "Insufficient browser permissions to make request. Specify an Integration to access the API, or add an Extra Permissions rule to the starter brick.",
               analysisId: this.id,
               type: AnnotationType.Error,
               actions: [

--- a/src/auth/ScopeSettings.tsx
+++ b/src/auth/ScopeSettings.tsx
@@ -152,7 +152,7 @@ const ScopeSettings: React.VoidFunctionComponent<ScopeSettingsProps> = ({
       <Alert variant="info" className="mt-2">
         <p>
           <FontAwesomeIcon icon={faEyeSlash} /> You account alias will not be
-          visible to anyone unless you choose to share a brick or extension.
+          visible to anyone unless you choose to share a brick or mod.
         </p>
       </Alert>
 

--- a/src/components/errors/NetworkErrorDetail.tsx
+++ b/src/components/errors/NetworkErrorDetail.tsx
@@ -91,7 +91,7 @@ const NetworkErrorDetail: React.FunctionComponent<{
           <div className="text-warning">
             <FontAwesomeIcon icon={faExclamationTriangle} /> PixieBrix does not
             have permission to access {absoluteUrl}. Specify an Integration to
-            access the API, or add an Extra Permissions rule to the extension.
+            access the API, or add an Extra Permissions rule to the mod.
           </div>
         )}
         {permissionsReady && hasPermissions && (

--- a/src/components/errors/__snapshots__/getErrorDetails.test.tsx.snap
+++ b/src/components/errors/__snapshots__/getErrorDetails.test.tsx.snap
@@ -268,7 +268,7 @@ exports[`Network error 1`] = `
             fill="currentColor"
           />
         </svg>
-         PixieBrix does not have permission to access https://fail.com. Specify an Integration to access the API, or add an Extra Permissions rule to the extension.
+         PixieBrix does not have permission to access https://fail.com. Specify an Integration to access the API, or add an Extra Permissions rule to the mod.
       </div>
       <div>
         <div>

--- a/src/components/logViewer/LogToolbar.tsx
+++ b/src/components/logViewer/LogToolbar.tsx
@@ -52,10 +52,10 @@ const LogToolbar: React.FunctionComponent<{
   const onClear = () => {
     try {
       clear();
-      notify.success("Cleared the log entries for this extension");
+      notify.success("Cleared the log entries for this mod");
     } catch (error) {
       notify.error({
-        message: "Error clearing log entries for extension",
+        message: "Error clearing log entries for mod",
         error,
       });
     }

--- a/src/contentScript/pageEditor.ts
+++ b/src/contentScript/pageEditor.ts
@@ -73,7 +73,7 @@ export async function runBlock({
 
   if (!versionOptions.explicitDataFlow) {
     throw new BusinessError(
-      "Preview only supported for extensions using runtime v2 or later"
+      "Preview only supported for mods using runtime v2 or later"
     );
   }
 

--- a/src/extensionPoints/factory.ts
+++ b/src/extensionPoints/factory.ts
@@ -45,9 +45,7 @@ export function fromJS(config: ExtensionPointConfig): IExtensionPoint {
   }
 
   if (!Object.hasOwn(TYPE_MAP, config.definition.type)) {
-    throw new Error(
-      `Unexpected extension point type: ${config.definition.type}`
-    );
+    throw new Error(`Unexpected starter brick type: ${config.definition.type}`);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- the factory methods perform validation

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -414,7 +414,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
         extensionId: this.instanceId,
       });
       throw new Error(
-        "Cannot install menu item because extension point was uninstalled"
+        "Cannot install menu item because starter brick was uninstalled"
       );
     }
 
@@ -478,7 +478,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
     extension: ResolvedExtension<MenuItemExtensionConfig>
   ) {
     if (!extension.id) {
-      this.logger.error(`Refusing to run extension without id for ${this.id}`);
+      this.logger.error(`Refusing to run mod without id for ${this.id}`);
       return;
     }
 

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -701,9 +701,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
         : this.trigger;
 
     if (!domTrigger) {
-      throw new BusinessError(
-        "No trigger event configured for extension point"
-      );
+      throw new BusinessError("No trigger event configured for starter brick");
     }
 
     // Avoid duplicate events caused by:
@@ -827,7 +825,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
           this.attachDOMTrigger($root, { watch: this.attachMode === "watch" });
         } else {
           throw new BusinessError(
-            "No trigger event configured for extension point"
+            "No trigger event configured for starter brick"
           );
         }
       }

--- a/src/options/App.tsx
+++ b/src/options/App.tsx
@@ -96,6 +96,7 @@ const Layout = () => {
               <div className="content-wrapper">
                 <ErrorBoundary>
                   <Switch>
+                    {/* TODO: What should we do about these urls? */}
                     <Route
                       exact
                       path="/extensions/install/:extensionId"

--- a/src/options/Sidebar.tsx
+++ b/src/options/Sidebar.tsx
@@ -49,9 +49,7 @@ const Sidebar: React.FunctionComponent = () => {
             title="Mods"
             icon={faCubes}
             isActive={(match, location) =>
-              Boolean(match) ||
-              location.pathname === "/" ||
-              location.pathname.startsWith("/extensions/")
+              Boolean(match) || location.pathname === "/"
             }
           />
 

--- a/src/options/pages/activateExtension/ActivateForm.tsx
+++ b/src/options/pages/activateExtension/ActivateForm.tsx
@@ -87,10 +87,10 @@ const ActivateForm: React.FunctionComponent<{
             extension: { ...extension, ...values },
           })
         );
-        notify.success("Activated extension");
+        notify.success("Activated mod");
         dispatch(push("/mods"));
       } catch (error) {
-        notify.error({ message: "Error activating extension", error });
+        notify.error({ message: "Error activating mod", error });
       } finally {
         helpers.setSubmitting(false);
       }

--- a/src/options/pages/activateExtension/ActivatePage.tsx
+++ b/src/options/pages/activateExtension/ActivatePage.tsx
@@ -42,7 +42,7 @@ const ActivatePage: React.FunctionComponent = () => {
 
   return (
     <Page
-      title="Activate Extension"
+      title="Activate Mod"
       icon={faCloudDownloadAlt}
       error={error}
       isPending={isLoading || authOptions == null}

--- a/src/options/pages/blueprints/modals/convertToRecipeModal/__snapshots__/ConvertToRecipeModal.test.tsx.snap
+++ b/src/options/pages/blueprints/modals/convertToRecipeModal/__snapshots__/ConvertToRecipeModal.test.tsx.snap
@@ -348,7 +348,7 @@ exports[`it renders requires user scope 1`] = `
                 fill="currentColor"
               />
             </svg>
-             You account alias will not be visible to anyone unless you choose to share a brick or extension.
+             You account alias will not be visible to anyone unless you choose to share a brick or mod.
           </p>
         </div>
         <div

--- a/src/options/pages/blueprints/onboardingView/OnboardingView.tsx
+++ b/src/options/pages/blueprints/onboardingView/OnboardingView.tsx
@@ -95,7 +95,7 @@ const ContactTeamAdminColumn: React.VoidFunctionComponent = () => (
 const UnaffiliatedColumn: React.VoidFunctionComponent = () => (
   <Col className="d-flex justify-content-center flex-column text-center">
     <p>
-      Learn how to create your own extensions in minutes by following our{" "}
+      Learn how to create your own mods in minutes by following our{" "}
       <span className="text-primary">step-by-step guide</span>.
     </p>
     <div className="align-self-center">
@@ -115,8 +115,8 @@ const CreateBrickColumn: React.VoidFunctionComponent = () => (
   <Col>
     <h4>Create your Own</h4>
     <p>
-      Learn how to create your own extensions in minutes by following our
-      step-by-step guide.
+      Learn how to create your own mods in minutes by following our step-by-step
+      guide.
     </p>
     <a
       className="btn btn-info btn-sm"
@@ -177,7 +177,7 @@ const OnboardingView: React.VoidFunctionComponent<{
 
       default: {
         if (filter === "personal") {
-          return "Create your own extensions";
+          return "Create your own mods";
         }
 
         if (filter === "public") {

--- a/src/options/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.ts
@@ -174,10 +174,8 @@ function useInstallableViewItemActions(
       await deleteCloudExtension({ extensionId: installable.id }).unwrap();
     },
     {
-      successMessage: `Deleted extension ${getLabel(
-        installable
-      )} from your account`,
-      errorMessage: `Error deleting extension ${getLabel(
+      successMessage: `Deleted mod ${getLabel(installable)} from your account`,
+      errorMessage: `Error deleting mod ${getLabel(
         installable
       )} from your account`,
       event: "ExtensionCloudDelete",

--- a/src/options/pages/deployments/DeploymentModal.tsx
+++ b/src/options/pages/deployments/DeploymentModal.tsx
@@ -172,7 +172,7 @@ const DeploymentModal: React.FC<
 
   const snooze = useCallback(
     (durationMillis: number) => {
-      notify.success("Snoozed extensions and deployment updates");
+      notify.success("Snoozed mod and deployment updates");
       reportEvent("SnoozeUpdates", {
         durationMillis,
       });

--- a/src/options/pages/marketplace/__snapshots__/ActivateWizard.test.tsx.snap
+++ b/src/options/pages/marketplace/__snapshots__/ActivateWizard.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`ActivateWizard activate blueprint with missing required blueprint optio
         >
           <div>
             <h4>
-              Extensions Contained
+              Starter Bricks Contained
             </h4>
           </div>
           <div>
@@ -393,7 +393,7 @@ exports[`ActivateWizard renders 1`] = `
         >
           <div>
             <h4>
-              Extensions Contained
+              Starter Bricks Contained
             </h4>
           </div>
           <div>

--- a/src/options/pages/marketplace/useWizard.ts
+++ b/src/options/pages/marketplace/useWizard.ts
@@ -34,7 +34,11 @@ const STEPS: WizardStep[] = [
     }>,
   },
   { key: "services", label: "Integrations", Component: ServicesBody },
-  { key: "review", label: "Extensions Contained", Component: ExtensionsBody },
+  {
+    key: "review",
+    label: "Starter Bricks Contained",
+    Component: ExtensionsBody,
+  },
   { key: "activate", label: "Permissions & URLs", Component: PermissionsBody },
 ];
 

--- a/src/pageEditor/extensionPoints/adapter.ts
+++ b/src/pageEditor/extensionPoints/adapter.ts
@@ -58,11 +58,11 @@ export async function selectType(
 
   const brick = await registry.find(extension.extensionPointId);
   if (!brick) {
-    console.error("Cannot find extension point", {
+    console.error("Cannot find starter brick", {
       extensionPointId: extension.extensionPointId,
       extension,
     });
-    throw new Error("Cannot find extension point");
+    throw new Error("Cannot find starter brick");
   }
 
   const extensionPoint = brick.config as unknown as ExtensionPointConfig;

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -296,14 +296,14 @@ export async function lookupExtensionPoint<
   const brick = await registry.find(config.extensionPointId);
   if (!brick) {
     throw new Error(
-      `Cannot find extension point definition: ${config.extensionPointId}`
+      `Cannot find starter brick definition: ${config.extensionPointId}`
     );
   }
 
   const extensionPoint =
     brick.config as unknown as ExtensionPointConfig<TDefinition>;
   if (extensionPoint.definition.type !== type) {
-    throw new Error(`Expected ${type} extension point type`);
+    throw new Error(`Expected ${type} starter brick type`);
   }
 
   return extensionPoint as ExtensionPointConfig<TDefinition> & {

--- a/src/pageEditor/extensionPoints/contextMenu.tsx
+++ b/src/pageEditor/extensionPoints/contextMenu.tsx
@@ -171,7 +171,7 @@ async function fromExtensionPoint(
   extensionPoint: ExtensionPointConfig<MenuDefinition>
 ): Promise<ContextMenuFormState> {
   if (extensionPoint.definition.type !== "contextMenu") {
-    throw new Error("Expected contextMenu extension point type");
+    throw new Error("Expected contextMenu starter brick type");
   }
 
   const {

--- a/src/pageEditor/extensionPoints/menuItem.ts
+++ b/src/pageEditor/extensionPoints/menuItem.ts
@@ -140,7 +140,7 @@ async function fromExtensionPoint(
   extensionPoint: ExtensionPointConfig<MenuDefinition>
 ): Promise<ActionFormState> {
   if (extensionPoint.definition.type !== "menuItem") {
-    throw new Error("Expected menuItem extension point type");
+    throw new Error("Expected menuItem starter brick type");
   }
 
   return {

--- a/src/pageEditor/extensionPoints/panel.ts
+++ b/src/pageEditor/extensionPoints/panel.ts
@@ -138,7 +138,7 @@ async function fromExtensionPoint(
   extensionPoint: ExtensionPointConfig<PanelDefinition>
 ): Promise<PanelFormState> {
   if (extensionPoint.definition.type !== "panel") {
-    throw new Error("Expected panel extension point type");
+    throw new Error("Expected panel starter brick type");
   }
 
   const { heading = "Custom Panel", collapsible = false } =

--- a/src/pageEditor/extensionPoints/quickBar.tsx
+++ b/src/pageEditor/extensionPoints/quickBar.tsx
@@ -176,7 +176,7 @@ async function fromExtensionPoint(
   extensionPoint: ExtensionPointConfig<QuickBarDefinition>
 ): Promise<QuickBarFormState> {
   if (extensionPoint.definition.type !== "quickBar") {
-    throw new Error("Expected quickBar extension point type");
+    throw new Error("Expected quickBar starter brick type");
   }
 
   const {

--- a/src/pageEditor/extensionPoints/quickBarProvider.ts
+++ b/src/pageEditor/extensionPoints/quickBarProvider.ts
@@ -159,7 +159,7 @@ async function fromExtensionPoint(
   extensionPoint: ExtensionPointConfig<QuickBarProviderDefinition>
 ): Promise<QuickBarProviderFormState> {
   if (extensionPoint.definition.type !== "quickBarProvider") {
-    throw new Error("Expected quickBarProvider extension point type");
+    throw new Error("Expected quickBarProvider starter brick type");
   }
 
   const {

--- a/src/pageEditor/extensionPoints/sidebar.tsx
+++ b/src/pageEditor/extensionPoints/sidebar.tsx
@@ -133,7 +133,7 @@ export async function fromExtensionPoint(
   extensionPoint: ExtensionPointConfig<PanelDefinition>
 ): Promise<SidebarFormState> {
   if (extensionPoint.definition.type !== "actionPanel") {
-    throw new Error("Expected actionPanel extension point type");
+    throw new Error("Expected actionPanel starter brick type");
   }
 
   const heading = `${getDomain(url)} side panel`;

--- a/src/pageEditor/extensionPoints/tour.ts
+++ b/src/pageEditor/extensionPoints/tour.ts
@@ -118,7 +118,7 @@ async function fromExtensionPoint(
   extensionPoint: ExtensionPointConfig<TourDefinition>
 ): Promise<TourFormState> {
   if (extensionPoint.definition.type !== "tour") {
-    throw new Error("Expected tour extension point type");
+    throw new Error("Expected tour starter brick type");
   }
 
   const { type, reader } = extensionPoint.definition;

--- a/src/pageEditor/extensionPoints/trigger.tsx
+++ b/src/pageEditor/extensionPoints/trigger.tsx
@@ -150,7 +150,7 @@ async function fromExtensionPoint(
   extensionPoint: ExtensionPointConfig<TriggerDefinition>
 ): Promise<TriggerFormState> {
   if (extensionPoint.definition.type !== "trigger") {
-    throw new Error("Expected trigger extension point type");
+    throw new Error("Expected trigger starter brick type");
   }
 
   const {

--- a/src/pageEditor/fields/SelectorMatchField.tsx
+++ b/src/pageEditor/fields/SelectorMatchField.tsx
@@ -28,8 +28,9 @@ type SelectorMatchFieldProps = {
 
 const defaultDescription = (
   <span>
-    Selectors restricting when the extension runs. If provided, at least one of
-    the selectors must match <i>on page load</i> for the extension to run.
+    Selectors restricting when the starter brick runs. If provided, at least one
+    of the selectors must match <i>on page load</i> for the starter brick to
+    run.
   </span>
 );
 

--- a/src/pageEditor/fields/UrlMatchPatternField.tsx
+++ b/src/pageEditor/fields/UrlMatchPatternField.tsx
@@ -31,9 +31,9 @@ export type UrlMatchPatternFieldProps = {
 
 const defaultDescription = (
   <span>
-    URL match patterns permitting the extension to run on a site. If PixieBrix
-    does not already have access to a site, your browser will prompt you to
-    grant access. See{" "}
+    URL match patterns permitting the starter brick to run on a site. If
+    PixieBrix does not already have access to a site, your browser will prompt
+    you to grant access. See{" "}
     <a
       href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/"
       target="_blank"

--- a/src/pageEditor/fields/UrlPatternField.tsx
+++ b/src/pageEditor/fields/UrlPatternField.tsx
@@ -30,8 +30,8 @@ export type UrlPatternFieldProps = {
 
 const defaultDescription = (
   <span>
-    URL pattern rules restricting when the extension runs. If provided, at least
-    one of the rules must match for the extension to run. See{" "}
+    URL pattern rules restricting when the starter brick runs. If provided, at
+    least one of the rules must match for the starter brick to run. See{" "}
     <a
       href="https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API"
       target="_blank"

--- a/src/pageEditor/hooks/useCreate.ts
+++ b/src/pageEditor/hooks/useCreate.ts
@@ -222,7 +222,7 @@ function useCreate(): CreateCallback {
 
       reactivateEveryTab();
 
-      notify.success("Saved extension");
+      notify.success("Saved");
       return null;
     },
     [dispatch, editablePackages, sessionId]
@@ -235,10 +235,10 @@ function useCreate(): CreateCallback {
       } catch (error) {
         console.error("Error saving extension", { error });
         notify.error({
-          message: "Error saving extension",
+          message: "Save error",
           error,
         });
-        return "Error saving extension";
+        return "Save error";
       }
     },
     [saveElement]

--- a/src/pageEditor/hooks/useRemoveExtension.ts
+++ b/src/pageEditor/hooks/useRemoveExtension.ts
@@ -44,9 +44,8 @@ function useRemoveExtension(): (useRemoveConfig: Config) => Promise<void> {
 
       if (shouldShowConfirmation) {
         const confirm = await showConfirmation({
-          title: "Remove Extension?",
-          message:
-            "You can reactivate extensions and mods from the PixieBrix Options page",
+          title: "Remove Mod?",
+          message: "You can reactivate mods from the PixieBrix Options page",
           submitCaption: "Remove",
         });
 

--- a/src/pageEditor/hooks/useRemoveRecipe.ts
+++ b/src/pageEditor/hooks/useRemoveRecipe.ts
@@ -47,8 +47,7 @@ function useRemoveRecipe(): (useRemoveConfig: Config) => Promise<void> {
       if (shouldShowConfirmation) {
         const confirmed = await showConfirmation({
           title: "Remove Mod?",
-          message:
-            "You can reactivate extensions and mods from the PixieBrix Options page",
+          message: "You can reactivate mods from the PixieBrix Options page",
           submitCaption: "Remove",
         });
 

--- a/src/pageEditor/hooks/useResetRecipe.ts
+++ b/src/pageEditor/hooks/useResetRecipe.ts
@@ -34,7 +34,7 @@ function useResetRecipe(): (recipeId: RegistryId) => Promise<void> {
       const confirmed = await showConfirmation({
         title: "Reset Mod?",
         message:
-          "Unsaved changes to extensions within this mod, or to mod options and metadata, will be lost.",
+          "Unsaved changes to this mod, or to mod options and metadata, will be lost.",
         submitCaption: "Reset",
       });
       if (!confirmed) {

--- a/src/pageEditor/panes/BetaPane.tsx
+++ b/src/pageEditor/panes/BetaPane.tsx
@@ -33,8 +33,8 @@ const BetaPane: React.FunctionComponent = () => (
       </p>
 
       <p>
-        In the meantime, you can create extensions that depend on this feature
-        in the Workshop.
+        In the meantime, you can create mods that depend on this feature in the
+        Workshop.
       </p>
     </div>
   </Centered>

--- a/src/pageEditor/panes/NoExtensionSelectedPane.tsx
+++ b/src/pageEditor/panes/NoExtensionSelectedPane.tsx
@@ -23,13 +23,13 @@ import IntroButtons from "./IntroButtons";
 
 const NoExtensionSelectedPane: React.FunctionComponent = () => (
   <Centered>
-    <div className={styles.title}>No extension selected</div>
+    <div className={styles.title}>No mod selected</div>
 
     <div className="text-left">
-      <p>Select an extension in the sidebar to edit</p>
+      <p>Select a mod in the sidebar to edit</p>
       <p>
         Or, click the <span className="text-info">Add</span> button in the
-        sidebar to add an extension to the page.
+        sidebar to add an starter brick to the page.
       </p>
 
       <IntroButtons />

--- a/src/pageEditor/panes/NoExtensionsPane.tsx
+++ b/src/pageEditor/panes/NoExtensionsPane.tsx
@@ -25,7 +25,7 @@ const NoExtensionsPane: React.FunctionComponent<{
   unavailableCount: number;
 }> = ({ unavailableCount }) => (
   <Centered isScrollable>
-    <div className={styles.title}>No custom extensions on the page</div>
+    <div className={styles.title}>No custom mods on the page</div>
 
     <div className="text-left">
       <p>
@@ -35,8 +35,7 @@ const NoExtensionsPane: React.FunctionComponent<{
 
       <p>
         Check the &ldquo;Show {unavailableCount ?? 1} unavailable&rdquo; box to
-        list extensions that are activated but aren&apos;t available on this
-        page.
+        list mods that are activated but aren&apos;t available on this page.
       </p>
 
       <IntroButtons />

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -855,7 +855,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                         class="text-muted form-text"
                       >
                         <span>
-                          URL match patterns permitting the extension to run on a site. If PixieBrix does not already have access to a site, your browser will prompt you to grant access. See 
+                          URL match patterns permitting the starter brick to run on a site. If PixieBrix does not already have access to a site, your browser will prompt you to grant access. See 
                           <a
                             href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/"
                             rel="noreferrer"
@@ -1070,7 +1070,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                         class="text-muted form-text"
                       >
                         <span>
-                          URL pattern rules restricting when the extension runs. If provided, at least one of the rules must match for the extension to run. See 
+                          URL pattern rules restricting when the starter brick runs. If provided, at least one of the rules must match for the starter brick to run. See 
                           <a
                             href="https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API"
                             rel="noreferrer"
@@ -1125,11 +1125,11 @@ exports[`renders an extension with sub pipeline 1`] = `
                         class="text-muted form-text"
                       >
                         <span>
-                          Selectors restricting when the extension runs. If provided, at least one of the selectors must match 
+                          Selectors restricting when the starter brick runs. If provided, at least one of the selectors must match 
                           <i>
                             on page load
                           </i>
-                           for the extension to run.
+                           for the starter brick to run.
                         </span>
                       </small>
                     </div>
@@ -1199,7 +1199,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                         class="text-muted form-text"
                       >
                         <div>
-                          URL match patterns permitting the extension to run on a site or call an API. Provide URL match patterns here if the extension either 1) calls an API without using an Integration, or 2) performs actions on a target tab not included in the Site match patterns
+                          URL match patterns permitting the starter brick to run on a site or call an API. Provide URL match patterns here if the starter brick either 1) calls an API without using an Integration, or 2) performs actions on a target tab not included in the Site match patterns
                         </div>
                       </small>
                     </div>

--- a/src/pageEditor/panes/insert/GenericInsertPane.tsx
+++ b/src/pageEditor/panes/insert/GenericInsertPane.tsx
@@ -91,7 +91,7 @@ const GenericInsertPane: React.FunctionComponent<{
           )) as FormState
         );
       } catch (error) {
-        notify.error({ message: "Error using existing foundation", error });
+        notify.error({ message: "Error using existing starter brick", error });
       }
     },
     [start, config]

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -100,13 +100,13 @@ function findRecipeIndex(
 
   if (labelMatches.length === 0) {
     throw new Error(
-      `There are no extensions in the mod with label "${extension.label}". You must edit the mod in the Workshop`
+      `There are no starter bricks in the mod with label "${extension.label}". You must edit the mod in the Workshop`
     );
   }
 
   if (labelMatches.length > 1) {
     throw new Error(
-      `There are multiple extensions in the mod with label "${extension.label}". You must edit the mod in the Workshop`
+      `There are multiple starter bricks in the mod with label "${extension.label}". You must edit the mod in the Workshop`
     );
   }
 
@@ -141,7 +141,7 @@ export function replaceRecipeExtension(
 
   if (installedExtension == null) {
     throw new Error(
-      `Could not find local copy of recipe extension: ${element.uuid}`
+      `Could not find local copy of starter brick: ${element.uuid}`
     );
   }
 
@@ -163,7 +163,7 @@ export function replaceRecipeExtension(
         }
       } else {
         throw new Error(
-          `Element's API Version (${element.apiVersion}) does not match recipe's API Version (${sourceRecipe.apiVersion}) and recipe's API Version cannot be updated`
+          `Element's API Version (${element.apiVersion}) does not match mod's API Version (${sourceRecipe.apiVersion}) and mod's API Version cannot be updated`
         );
       }
     }
@@ -347,13 +347,13 @@ export function buildRecipe({
 
     if (badApiVersion) {
       throw new Error(
-        `Mod extensions have inconsistent API Versions (${itemsApiVersion}/${badApiVersion}). All extensions in a mod must have the same API Version.`
+        `Mod bricks have inconsistent API Versions (${itemsApiVersion}/${badApiVersion}). All bricks in a mod must have the same API Version.`
       );
     }
 
     if (itemsApiVersion !== recipe.apiVersion) {
       throw new Error(
-        `Mod has API Version ${recipe.apiVersion}, but it's extensions have version ${itemsApiVersion}. Please use the Workshop to edit this mod.`
+        `Mod uses API Version ${recipe.apiVersion}, but it's bricks have version ${itemsApiVersion}. Please use the Workshop to edit this mod.`
       );
     }
 

--- a/src/pageEditor/sidebar/modals/AddToRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/AddToRecipeModal.tsx
@@ -159,7 +159,7 @@ const AddToRecipeModal: React.FC = () => {
         hideLabel
         as={RadioItemListWidget}
         items={radioItems}
-        header="Move or copy the extension?"
+        header="Move or copy the starter brick?"
       />
     </Modal.Body>
   );

--- a/src/pageEditor/sidebar/modals/RemoveFromRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/RemoveFromRecipeModal.tsx
@@ -81,7 +81,7 @@ const RemoveFromRecipeModal: React.FC = () => {
 
   const radioItems: RadioItem[] = [
     {
-      label: "Move the extension to a stand-alone extension",
+      label: "Move the starter brick to stand-alone",
       value: "move",
     },
     {
@@ -96,12 +96,12 @@ const RemoveFromRecipeModal: React.FC = () => {
         name="moveOrRemove"
         as={RadioItemListWidget}
         items={radioItems}
-        header="Move or remove the extension?"
+        header="Move or remove the starter brick?"
       />
       {values.moveOrRemove === "remove" && (
         <Alert variant="warning">
           <FontAwesomeIcon icon={faExclamationTriangle} />
-          &nbsp;This will delete the extension. To restore it, use the reset
+          &nbsp;This will delete the starter brick. To restore it, use the reset
           button.
         </Alert>
       )}

--- a/src/pageEditor/tabs/ExtraPermissionsSection.tsx
+++ b/src/pageEditor/tabs/ExtraPermissionsSection.tsx
@@ -27,10 +27,10 @@ const ExtraPermissionsSection: React.FunctionComponent = () => (
       addButtonCaption="Add Allowed Origin"
       description={
         <div>
-          URL match patterns permitting the extension to run on a site or call
-          an API. Provide URL match patterns here if the extension either 1)
-          calls an API without using an Integration, or 2) performs actions on a
-          target tab not included in the Site match patterns
+          URL match patterns permitting the starter brick to run on a site or
+          call an API. Provide URL match patterns here if the starter brick
+          either 1) calls an API without using an Integration, or 2) performs
+          actions on a target tab not included in the Site match patterns
         </div>
       }
     />

--- a/src/pageEditor/tabs/__snapshots__/ExtraPermissionsSection.test.tsx.snap
+++ b/src/pageEditor/tabs/__snapshots__/ExtraPermissionsSection.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`ExtraPermissionsSection render empty section 1`] = `
             class="text-muted form-text"
           >
             <div>
-              URL match patterns permitting the extension to run on a site or call an API. Provide URL match patterns here if the extension either 1) calls an API without using an Integration, or 2) performs actions on a target tab not included in the Site match patterns
+              URL match patterns permitting the starter brick to run on a site or call an API. Provide URL match patterns here if the starter brick either 1) calls an API without using an Integration, or 2) performs actions on a target tab not included in the Site match patterns
             </div>
           </small>
         </div>
@@ -202,7 +202,7 @@ exports[`ExtraPermissionsSection render populated section 1`] = `
             class="text-muted form-text"
           >
             <div>
-              URL match patterns permitting the extension to run on a site or call an API. Provide URL match patterns here if the extension either 1) calls an API without using an Integration, or 2) performs actions on a target tab not included in the Site match patterns
+              URL match patterns permitting the starter brick to run on a site or call an API. Provide URL match patterns here if the starter brick either 1) calls an API without using an Integration, or 2) performs actions on a target tab not included in the Site match patterns
             </div>
           </small>
         </div>

--- a/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
+++ b/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`MatchRulesSection render empty section 1`] = `
             class="text-muted form-text"
           >
             <span>
-              URL pattern rules restricting when the extension runs. If provided, at least one of the rules must match for the extension to run. See 
+              URL pattern rules restricting when the starter brick runs. If provided, at least one of the rules must match for the starter brick to run. See 
               <a
                 href="https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API"
                 rel="noreferrer"
@@ -76,11 +76,11 @@ exports[`MatchRulesSection render empty section 1`] = `
             class="text-muted form-text"
           >
             <span>
-              Selectors restricting when the extension runs. If provided, at least one of the selectors must match 
+              Selectors restricting when the starter brick runs. If provided, at least one of the selectors must match 
               <i>
                 on page load
               </i>
-               for the extension to run.
+               for the starter brick to run.
             </span>
           </small>
         </div>
@@ -455,7 +455,7 @@ exports[`MatchRulesSection render populated section 1`] = `
             class="text-muted form-text"
           >
             <span>
-              URL pattern rules restricting when the extension runs. If provided, at least one of the rules must match for the extension to run. See 
+              URL pattern rules restricting when the starter brick runs. If provided, at least one of the rules must match for the starter brick to run. See 
               <a
                 href="https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API"
                 rel="noreferrer"
@@ -542,11 +542,11 @@ exports[`MatchRulesSection render populated section 1`] = `
             class="text-muted form-text"
           >
             <span>
-              Selectors restricting when the extension runs. If provided, at least one of the selectors must match 
+              Selectors restricting when the starter brick runs. If provided, at least one of the selectors must match 
               <i>
                 on page load
               </i>
-               for the extension to run.
+               for the starter brick to run.
             </span>
           </small>
         </div>

--- a/src/pageEditor/tabs/editTab/UnsupportedApiV1.tsx
+++ b/src/pageEditor/tabs/editTab/UnsupportedApiV1.tsx
@@ -30,7 +30,7 @@ const UnsupportedApiV1: React.FC = () => (
         the Page Editor.
       </Alert>
       <p>
-        Use the Workshop to edit this brick/extension.{" "}
+        Use the Workshop to edit this mod.{" "}
         <a
           href="https://docs.pixiebrix.com/runtime"
           target="_blank"

--- a/src/pageEditor/tabs/editTab/UpgradedToApiV3.tsx
+++ b/src/pageEditor/tabs/editTab/UpgradedToApiV3.tsx
@@ -42,8 +42,8 @@ const UpgradedToApiV3: React.FC = () => {
         />
         <p>
           The Page Editor no longer supports editing bricks created for runtime
-          API v2. We&apos;ve attempted to automatically convert this extension
-          to runtime API v3.{" "}
+          API v2. We&apos;ve attempted to automatically convert this mod to
+          runtime API v3.{" "}
           <a
             href="https://docs.pixiebrix.com/runtime"
             target="_blank"

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -364,7 +364,7 @@ const DataPanel: React.FC = () => {
               </ErrorBoundary>
             ) : (
               <div className="text-muted">
-                Run the extension once to enable live preview
+                Run the mod once to enable live preview
               </div>
             )}
           </DataTab>

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
@@ -50,7 +50,7 @@ const PageStateTab: React.VFC = () => {
         getPageState(thisTab, { namespace: "shared", ...context }),
         activeElement.recipe
           ? getPageState(thisTab, { namespace: "blueprint", ...context })
-          : Promise.resolve("Extension is not in a blueprint"),
+          : Promise.resolve("Starter brick is not in a mod"),
         getPageState(thisTab, { namespace: "extension", ...context }),
       ]);
 

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/PageStateTab.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/PageStateTab.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`PageStateTab it renders with orphan extension 1`] = `
               <span
                 style="color: rgb(64, 175, 108);"
               >
-                "Extension is not in a blueprint"
+                "Extension is not in a mod"
               </span>
             </li>
             <li

--- a/src/sidebar/LoginPanel.tsx
+++ b/src/sidebar/LoginPanel.tsx
@@ -50,8 +50,7 @@ const PartnerAuth: React.FunctionComponent = () => {
     <Col className="text-center">
       <h4 className="display-6">Connect your AARI account</h4>
       <p>
-        Authenticate with Automation Anywhere to continue using your team
-        extensions
+        Authenticate with Automation Anywhere to continue using your team mods
       </p>
       <Button
         className="mt-4"

--- a/src/sidebar/__snapshots__/ConnectedSidebar.test.tsx.snap
+++ b/src/sidebar/__snapshots__/ConnectedSidebar.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`SidebarApp renders not connected partner view 1`] = `
             Connect your AARI account
           </h4>
           <p>
-            Authenticate with Automation Anywhere to continue using your team extensions
+            Authenticate with Automation Anywhere to continue using your team mods
           </p>
           <a
             class="mt-4 btn btn-primary"

--- a/src/sidebar/components/RootErrorPanel.tsx
+++ b/src/sidebar/components/RootErrorPanel.tsx
@@ -39,7 +39,7 @@ const RootErrorPanel: React.VoidFunctionComponent<{ error: unknown }> = ({
           </h1>
           <div className="mb-2">No renderer found</div>
           <div>
-            <small>Add a renderer brick to the extension.</small>
+            <small>Add a renderer brick to the starter brick.</small>
           </div>
         </div>
       </div>

--- a/src/sidebar/components/__snapshots__/RootErrorPanel.test.tsx.snap
+++ b/src/sidebar/components/__snapshots__/RootErrorPanel.test.tsx.snap
@@ -307,7 +307,7 @@ exports[`RootErrorPanel should render no renderer error 1`] = `
           </div>
           <div>
             <small>
-              Add a renderer brick to the extension.
+              Add a renderer brick to the starter brick.
             </small>
           </div>
         </div>
@@ -347,7 +347,7 @@ exports[`RootErrorPanel should render no renderer error 1`] = `
         </div>
         <div>
           <small>
-            Add a renderer brick to the extension.
+            Add a renderer brick to the starter brick.
           </small>
         </div>
       </div>


### PR DESCRIPTION
## What does this PR do?
- Part of https://github.com/pixiebrix/pixiebrix-extension/pull/5238
- Continues our efforts in our terminology switchover by replacing all user-facing occurrences of the word "extension" to describe PixieBrix mods

## Reviewer Tips

- This is a large diff - mostly looking for feedback on appropriate grammar/Page Editor context

## Discussion

- I changed some custom `Error` messages thrown throughout. I figured that these might crop-up into user-facing interfaces? I'd like a second 👀 at this to make sure these changes make sense

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
