### PR TITLE
Provide explicit default for list element in document builder

### DIFF
--- a/src/components/documentBuilder/createNewElement.ts
+++ b/src/components/documentBuilder/createNewElement.ts
@@ -91,6 +91,9 @@ export function createNewElement(elementType: DocumentElementType) {
     }
 
     case "list": {
+      // ListElement uses "element" as the default. But be explicit
+      element.config.elementKey = "element";
+
       element.config.element = {
         __type__: "defer",
         __value__: createNewElement("text"),

--- a/src/components/documentBuilder/edit/ListOptions.tsx
+++ b/src/components/documentBuilder/edit/ListOptions.tsx
@@ -45,6 +45,7 @@ const ListOptions: React.FC<ListOptionsProps> = ({ elementName }) => {
     name: joinName(elementName, "config", "array"),
     schema: { type: "array" },
     label: "Array",
+    description: "An array/list of elements to render in the document",
   };
 
   const onElementTypeChange: ChangeEventHandler<HTMLInputElement> = (event) => {
@@ -64,9 +65,10 @@ const ListOptions: React.FC<ListOptionsProps> = ({ elementName }) => {
     <>
       <SchemaField {...arraySourceEdit} />
       <ConnectedFieldTemplate
-        label="Element key"
+        label="Element Key"
         name={joinName(elementName, "config", "elementKey")}
         as={KeyNameWidget}
+        description="The variable name to use for each element in the array/list"
       />
       <FieldTemplate
         label="Item type"


### PR DESCRIPTION
## What does this PR do?

- Makes the element key for List Elements in the document builder explicit
- Improves documentation for the List Element fields

## Demo

![image](https://user-images.githubusercontent.com/1879821/221423678-9babce41-4bbd-48d1-8666-14113f08aecb.png)

## Checklist

- [x] Designate a primary reviewer: @BLoe 
