### PR TITLE
Use document context reader for URL in new mods so `@input.url` is the current URL

### DIFF
--- a/src/pageEditor/extensionPoints/base.test.ts
+++ b/src/pageEditor/extensionPoints/base.test.ts
@@ -22,6 +22,8 @@ import {
 } from "./base";
 import { extensionPointDefinitionFactory } from "@/testUtils/factories";
 import { type ExtensionPointType } from "@/extensionPoints/types";
+import { ReaderConfig } from "@/blocks/types";
+import { validateRegistryId } from "@/types/helpers";
 
 describe("removeEmptyValues()", () => {
   test("removes empty non-expression values", () => {
@@ -91,6 +93,7 @@ describe("getImplicitReader", () => {
   it.each([
     ["menuItem"],
     ["quickBar"],
+    ["quickBarProvider"],
     ["contextMenu"],
     ["trigger"],
     ["panel"],
@@ -101,14 +104,43 @@ describe("getImplicitReader", () => {
     );
   });
 
-  it.each([["menuItem"], ["quickBar"], ["contextMenu"], ["trigger"]])(
-    "includes element reader for %s",
+  it.each([
+    ["menuItem"],
+    ["quickBar"],
+    ["quickBarProvider"],
+    ["contextMenu"],
+    ["trigger"],
+    ["panel"],
+    ["sidePanel"],
+  ])(
+    "overrides url from metadata reader with current URL from context reader",
     (type: ExtensionPointType) => {
-      expect(getImplicitReader(type)).toContainEqual({
-        element: "@pixiebrix/html/element",
-      });
+      const readerArray = getImplicitReader(type) as ReaderConfig[];
+
+      const metadataIndex = readerArray.indexOf(
+        validateRegistryId("@pixiebrix/document-metadata")
+      );
+      const contextIndex = readerArray.indexOf(
+        validateRegistryId("@pixiebrix/document-context")
+      );
+
+      expect(metadataIndex).toBeGreaterThan(-1);
+      expect(contextIndex).toBeGreaterThan(-1);
+      expect(contextIndex).toBeGreaterThan(metadataIndex);
     }
   );
+
+  it.each([
+    ["menuItem"],
+    ["quickBar"],
+    ["quickBarProvider"],
+    ["contextMenu"],
+    ["trigger"],
+  ])("includes element reader for %s", (type: ExtensionPointType) => {
+    expect(getImplicitReader(type)).toContainEqual({
+      element: "@pixiebrix/html/element",
+    });
+  });
 
   it.each([["panel"], ["sidePanel"]])(
     "does not include element reader for %s",

--- a/src/pageEditor/extensionPoints/base.test.ts
+++ b/src/pageEditor/extensionPoints/base.test.ts
@@ -22,7 +22,7 @@ import {
 } from "./base";
 import { extensionPointDefinitionFactory } from "@/testUtils/factories";
 import { type ExtensionPointType } from "@/extensionPoints/types";
-import { ReaderConfig } from "@/blocks/types";
+import { type ReaderConfig } from "@/blocks/types";
 import { validateRegistryId } from "@/types/helpers";
 
 describe("removeEmptyValues()", () => {

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -384,38 +384,42 @@ export function removeEmptyValues<T extends object>(obj: T): T {
 export function getImplicitReader(
   type: ExtensionPointType
 ): SingleLayerReaderConfig {
+  // Reminder: when providing a composite array reader, the later entries override the earlier ones
+
+  const base = [
+    validateRegistryId("@pixiebrix/document-metadata"),
+    // Include @pixiebrix/document-context because it reads the current URL, instead of the original URL on the page.
+    // Necessary to avoid confusion when working with SPAs
+    validateRegistryId("@pixiebrix/document-context"),
+  ] as ReaderConfig[];
+
+  const elementAddons = [
+    { element: validateRegistryId("@pixiebrix/html/element") },
+  ] as const;
+
   if (type === "trigger") {
-    return readerTypeHack([
-      validateRegistryId("@pixiebrix/document-metadata"),
-      { element: validateRegistryId("@pixiebrix/html/element") },
-    ]);
+    return readerTypeHack([...base, ...elementAddons]);
   }
 
   if (type === "quickBar" || type === "quickBarProvider") {
     return readerTypeHack([
-      validateRegistryId("@pixiebrix/document-metadata"),
+      ...base,
+      ...elementAddons,
       validateRegistryId("@pixiebrix/selection"),
-      { element: validateRegistryId("@pixiebrix/html/element") },
     ]);
   }
 
   if (type === "contextMenu") {
     // NOTE: we don't need to provide "@pixiebrix/context-menu-data" here because it's automatically attached by
     // the contextMenu extension point.
-    return readerTypeHack([
-      validateRegistryId("@pixiebrix/document-metadata"),
-      { element: validateRegistryId("@pixiebrix/html/element") },
-    ]);
+    return readerTypeHack([...base, ...elementAddons]);
   }
 
   if (type === "menuItem") {
-    return readerTypeHack([
-      validateRegistryId("@pixiebrix/document-metadata"),
-      { element: validateRegistryId("@pixiebrix/html/element") },
-    ]);
+    return readerTypeHack([...base, ...elementAddons]);
   }
 
-  return [validateRegistryId("@pixiebrix/document-metadata")];
+  return readerTypeHack(base);
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Modifies the Page Editor to use Document Context reader for new mods
- This avoids the confusing case when modding SPAs where the trigger sees the original URL

## Discussion

- Modifying the behavior of `@pixiebrix/document-metadata` would not be backward compatible
- See the old URL generation code here: https://github.com/mozilla/page-metadata-parser/blob/master/parser.js#L152

## Demo

- https://www.loom.com/share/5a929d390d954f1ea8af36af65bc3d58

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
