### PR TITLE
#5255: fix var analysis false positives and enable var analysis

### DIFF
--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -20,6 +20,7 @@ import {
   formStateFactory,
   installedRecipeMetadataFactory,
   recipeFactory,
+  triggerFormStateFactory,
 } from "@/testUtils/factories";
 import VarAnalysis, {
   INVALID_VARIABLE_GENERIC_MESSAGE,
@@ -134,7 +135,6 @@ describe("Collecting available vars", () => {
       expect(knownVars.size).toBe(1);
 
       const foundationKnownVars = knownVars.get("extension.blockPipeline.0");
-
       expect(foundationKnownVars.isVariableDefined("@input.title")).toBeTrue();
       expect(foundationKnownVars.isVariableDefined("@input.url")).toBeTrue();
       expect(foundationKnownVars.isVariableDefined("@input.lang")).toBeTrue();
@@ -1013,5 +1013,29 @@ describe("var expression annotations", () => {
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(1);
     expect(annotations[0].message).toEqual(INVALID_VARIABLE_GENERIC_MESSAGE);
+  });
+});
+
+describe("var analysis integration tests", () => {
+  it("should handle trigger event", async () => {
+    const extension = triggerFormStateFactory(undefined, [
+      {
+        id: EchoBlock.BLOCK_ID,
+        config: {
+          message: makeTemplateExpression(
+            "nunjucks",
+            "{{ @input.event.key }} was pressed"
+          ),
+        },
+      },
+    ]);
+
+    extension.extensionPoint.definition.trigger = "keypress";
+
+    const analysis = new VarAnalysis([]);
+    await analysis.run(extension);
+
+    const annotations = analysis.getAnnotations();
+    expect(annotations).toHaveLength(0);
   });
 });

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -24,6 +24,7 @@ import {
 import VarAnalysis, {
   INVALID_VARIABLE_GENERIC_MESSAGE,
   VARIABLE_SHOULD_START_WITH_AT_MESSAGE,
+  NO_VARIABLE_PROVIDED_MESSAGE,
 } from "./varAnalysis";
 import { validateRegistryId } from "@/types/helpers";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
@@ -40,6 +41,11 @@ import recipeRegistry from "@/recipes/registry";
 import blockRegistry from "@/blocks/registry";
 import { SELF_EXISTENCE, VarExistence } from "./varMap";
 import { type Schema } from "@/core";
+import TryExcept from "@/blocks/transformers/controlFlow/TryExcept";
+import ForEachElement from "@/blocks/transformers/controlFlow/ForEachElement";
+import { DocumentRenderer } from "@/blocks/renderers/document";
+import { createNewElement } from "@/components/documentBuilder/createNewElement";
+import { type ListDocumentElement } from "@/components/documentBuilder/documentBuilderTypes";
 
 jest.mock("@/background/messenger/api", () => ({
   __esModule: true,
@@ -648,6 +654,138 @@ describe("Collecting available vars", () => {
     });
   });
 
+  describe("document builder list element", () => {
+    beforeAll(async () => {
+      const listElement = createNewElement("list") as ListDocumentElement;
+      const textElement = createNewElement("text");
+      textElement.config.text = makeTemplateExpression(
+        "nunjucks",
+        "{{ @foo }} {{ @element }}"
+      );
+      listElement.config.element.__value__ = textElement;
+
+      const otherTextElement = createNewElement("text");
+      otherTextElement.config.text = makeTemplateExpression(
+        "nunjucks",
+        "{{ @element }}"
+      );
+
+      const documentRendererBrick = {
+        id: DocumentRenderer.BLOCK_ID,
+        config: {
+          body: [listElement, otherTextElement],
+        },
+      };
+
+      const extension = formStateFactory(undefined, [documentRendererBrick]);
+
+      analysis = new VarAnalysis([]);
+      await analysis.run(extension);
+    });
+
+    test("adds the list element key list body", () => {
+      const knownVars = analysis.getKnownVars();
+      const listElementVarMap = knownVars.get(
+        "extension.blockPipeline.0.config.body.0.config.element.__value__"
+      );
+
+      expect(listElementVarMap.isVariableDefined("@element")).toBeTrue();
+      expect(listElementVarMap.isVariableDefined("@foo")).toBeFalse();
+    });
+
+    test("adds annotations", () => {
+      const annotations = analysis.getAnnotations();
+      expect(annotations).toHaveLength(2);
+
+      // Check warning is generated for @foo but not @element
+      expect(annotations[0].message).toEqual(
+        'Variable "@foo" might not be defined'
+      );
+      expect(annotations[0].position.path).toEqual(
+        "extension.blockPipeline.0.config.body.0.config.element.__value__.config.text"
+      );
+
+      // Not available in to the peer element to the list
+      expect(annotations[1].message).toEqual(
+        'Variable "@element" might not be defined'
+      );
+      expect(annotations[1].position.path).toEqual(
+        "extension.blockPipeline.0.config.body.1.config.text"
+      );
+    });
+  });
+
+  describe("try-except brick", () => {
+    beforeAll(async () => {
+      const tryExceptBlock = {
+        id: TryExcept.BLOCK_ID,
+        outputKey: validateOutputKey("typeExcept"),
+        config: {
+          errorKey: "error",
+          try: makePipelineExpression([blockConfigFactory()]),
+          except: makePipelineExpression([blockConfigFactory()]),
+        },
+      };
+
+      const extension = formStateFactory(undefined, [
+        tryExceptBlock,
+        blockConfigFactory(),
+      ]);
+
+      analysis = new VarAnalysis([]);
+      await analysis.run(extension);
+    });
+
+    test("adds the error key to the except branch", () => {
+      expect(
+        analysis
+          .getKnownVars()
+          .get("extension.blockPipeline.0.config.except.__value__.0")
+          .isVariableDefined("@error")
+      ).toBeTrue();
+    });
+
+    test("does not add the error key to the try branch", () => {
+      expect(
+        analysis
+          .getKnownVars()
+          .get("extension.blockPipeline.0.config.try.__value__.0")
+          .isVariableDefined("@error")
+      ).toBeFalse();
+    });
+  });
+
+  describe("for-each element brick", () => {
+    beforeAll(async () => {
+      const forEachBlock = {
+        id: ForEachElement.BLOCK_ID,
+        outputKey: validateOutputKey("forEachOutput"),
+        config: {
+          elementKey: "element",
+          selector: "a",
+          body: makePipelineExpression([blockConfigFactory()]),
+        },
+      };
+
+      const extension = formStateFactory(undefined, [
+        forEachBlock,
+        blockConfigFactory(),
+      ]);
+
+      analysis = new VarAnalysis([]);
+      await analysis.run(extension);
+    });
+
+    test("adds the element key to the sub pipeline", () => {
+      expect(
+        analysis
+          .getKnownVars()
+          .get("extension.blockPipeline.0.config.body.__value__.0")
+          .isVariableDefined("@element")
+      ).toBeTrue();
+    });
+  });
+
   describe("for-each brick", () => {
     beforeAll(async () => {
       const forEachBlock = {
@@ -834,10 +972,29 @@ describe("var expression annotations", () => {
     const analysis = new VarAnalysis([]);
     await analysis.run(extension);
 
-    expect(analysis.getAnnotations()).toHaveLength(1);
-    expect(analysis.getAnnotations()[0].message).toEqual(
+    const annotations = analysis.getAnnotations();
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0].message).toEqual(
       VARIABLE_SHOULD_START_WITH_AT_MESSAGE
     );
+  });
+
+  test("annotates variable which is just whitespace", async () => {
+    const extension = formStateFactory(undefined, [
+      {
+        id: EchoBlock.BLOCK_ID,
+        config: {
+          message: makeVariableExpression("  "),
+        },
+      },
+    ]);
+
+    const analysis = new VarAnalysis([]);
+    await analysis.run(extension);
+
+    const annotations = analysis.getAnnotations();
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0].message).toEqual(NO_VARIABLE_PROVIDED_MESSAGE);
   });
 
   test("return a generic error message for a single @ character", async () => {
@@ -853,9 +1010,8 @@ describe("var expression annotations", () => {
     const analysis = new VarAnalysis([]);
     await analysis.run(extension);
 
-    expect(analysis.getAnnotations()).toHaveLength(1);
-    expect(analysis.getAnnotations()[0].message).toEqual(
-      INVALID_VARIABLE_GENERIC_MESSAGE
-    );
+    const annotations = analysis.getAnnotations();
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0].message).toEqual(INVALID_VARIABLE_GENERIC_MESSAGE);
   });
 });

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -95,22 +95,15 @@ async function setInputVars(
 
   const reader = await extensionPoint.defaultReader();
 
-  const readerProperties = reader?.outputSchema?.properties;
-  const readerKeys = Object.keys(readerProperties ?? {});
-
-  if (readerKeys.length === 0) {
-    return;
-  }
-
-  const inputContextShape: Record<string, boolean> = {};
-  for (const key of readerKeys) {
-    inputContextShape[key] = true;
-  }
-
-  contextVars.setExistenceFromValues({
+  setVarsFromSchema({
+    schema: reader?.outputSchema ?? {
+      type: "object",
+      properties: {},
+      additionalProperties: true,
+    },
+    contextVars,
     source: KnownSources.INPUT,
-    values: inputContextShape,
-    parentPath: "@input",
+    parentPath: ["@input"],
   });
 }
 

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -15,16 +15,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import PipelineExpressionVisitor from "@/blocks/PipelineExpressionVisitor";
+import PipelineExpressionVisitor, {
+  type VisitDocumentElementArgs,
+} from "@/blocks/PipelineExpressionVisitor";
 import {
+  nestedPosition,
   type VisitBlockExtra,
   type VisitPipelineExtra,
 } from "@/blocks/PipelineVisitor";
-import { type BlockPosition, type BlockConfig } from "@/blocks/types";
-import type { Schema, Expression, TemplateEngine } from "@/core";
+import { type BlockConfig, type BlockPosition } from "@/blocks/types";
+import type { Expression, Schema, TemplateEngine } from "@/core";
 import { type FormState } from "@/pageEditor/extensionPoints/formStateTypes";
-import { getInputKeyForSubPipeline } from "@/pageEditor/utils";
-import { isNunjucksExpression, isVarExpression } from "@/runtime/mapArgs";
+import { getVariableKeyForSubPipeline } from "@/pageEditor/utils";
+import {
+  isDeferExpression,
+  isExpression,
+  isNunjucksExpression,
+  isVarExpression,
+} from "@/runtime/mapArgs";
 import { makeServiceContext } from "@/services/serviceUtils";
 import { isEmpty } from "lodash";
 import {
@@ -38,8 +46,13 @@ import parseTemplateVariables from "./parseTemplateVariables";
 import recipesRegistry from "@/recipes/registry";
 import blockRegistry, { type TypedBlockMap } from "@/blocks/registry";
 import { AnnotationType } from "@/types";
+import { joinPathParts } from "@/utils";
+import { type ListDocumentElement } from "@/components/documentBuilder/documentBuilderTypes";
 
 export const INVALID_VARIABLE_GENERIC_MESSAGE = "Invalid variable name";
+
+export const NO_VARIABLE_PROVIDED_MESSAGE = "Variable is blank";
+
 export const VARIABLE_SHOULD_START_WITH_AT_MESSAGE =
   "Variable name should start with @";
 
@@ -202,7 +215,10 @@ function setVarsFromSchema({
   }
 }
 
-async function setOptionsVars(extension: FormState, contextVars: VarMap) {
+async function setOptionsVars(
+  extension: FormState,
+  contextVars: VarMap
+): Promise<void> {
   if (extension.recipe == null) {
     return;
   }
@@ -379,6 +395,8 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
       message = INVALID_VARIABLE_GENERIC_MESSAGE;
     } else if (varName.startsWith("@")) {
       message = `Variable "${varName}" might not be defined`;
+    } else if (varName.trim() === "") {
+      message = NO_VARIABLE_PROVIDED_MESSAGE;
     } else {
       message = VARIABLE_SHOULD_START_WITH_AT_MESSAGE;
     }
@@ -407,10 +425,10 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
     pipeline: BlockConfig[],
     extra: VisitPipelineExtra
   ) {
-    // Getting element key for sub pipeline if applicable (e.g. for a for-each block)
+    // Getting element key for sub pipeline if applicable (e.g. for a for-each, try-except, block)
     const subPipelineInput =
       extra.parentNode && extra.pipelinePropName
-        ? getInputKeyForSubPipeline(extra.parentNode, extra.pipelinePropName)
+        ? getVariableKeyForSubPipeline(extra.parentNode, extra.pipelinePropName)
         : null;
 
     // Before visiting the sub pipeline, we need to save the current context
@@ -458,6 +476,113 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
     this.visitRootPipeline(extension.extension.blockPipeline, {
       extensionPointType: extension.type,
     });
+  }
+
+  /**
+   * Visit a Document Builder ListElement body.
+   *
+   * The ListElement body is a deferred expression that is evaluated with the elementKey available on each rendering
+   * of an item.
+   *
+   * @param position the position of the document builder block
+   * @param blockConfig the block config of the document builder block
+   * @param element the ListElement within the document
+   * @param pathInBlock the path of the ListElement within the document config
+   */
+  visitListElementBody({
+    position,
+    blockConfig,
+    element,
+    pathInBlock,
+  }: VisitDocumentElementArgs) {
+    const variableName = element.config.elementKey ?? "element";
+    const listBodyExpression = element.config.element;
+
+    // `element` of ListElement should always be a deferred expression. But guard just in case.
+    if (isDeferExpression(listBodyExpression)) {
+      // Before visiting the deferred expression, we need to save the current context
+      this.contextStack.push(this.previousVisitedBlock);
+
+      let deferredExpressionVars: VarMap;
+      if (typeof variableName === "string") {
+        deferredExpressionVars = new VarMap();
+        deferredExpressionVars.setOutputKeyExistence({
+          source: position.path,
+          outputKey: `@${variableName}`,
+          existence: VarExistence.DEFINITELY,
+          // XXX: type should be derived from the known array item type from the list
+          allowAnyChild: true,
+        });
+      }
+
+      this.currentBlockKnownVars = this.previousVisitedBlock.vars.clone();
+      this.currentBlockKnownVars.addSourceMap(deferredExpressionVars);
+      this.knownVars.set(
+        joinPathParts(
+          position.path,
+          pathInBlock,
+          "config",
+          "element",
+          "__value__"
+        ),
+        this.currentBlockKnownVars
+      );
+
+      // Creating context for the sub-pipeline
+      this.previousVisitedBlock = {
+        vars: this.previousVisitedBlock.vars,
+        output: deferredExpressionVars,
+      };
+
+      this.visitDocumentElement({
+        position,
+        blockConfig,
+        element: (element as ListDocumentElement).config.element.__value__,
+        pathInBlock: joinPathParts(
+          pathInBlock,
+          "config",
+          "element",
+          "__value__"
+        ),
+      });
+
+      // Restoring the context of the parent pipeline
+      this.previousVisitedBlock = this.contextStack.pop();
+      this.currentBlockKnownVars = this.previousVisitedBlock.vars.clone();
+    }
+  }
+
+  override visitDocumentElement({
+    position,
+    blockConfig,
+    element,
+    pathInBlock,
+  }: VisitDocumentElementArgs) {
+    if (element.type === "list") {
+      for (const [prop, value] of Object.entries(element.config)) {
+        // ListElement provides an elementKey to the deferred expression in its body
+        if (prop === "element") {
+          this.visitListElementBody({
+            position,
+            blockConfig,
+            element,
+            pathInBlock,
+          });
+        } else if (isExpression(value)) {
+          this.visitExpression(
+            nestedPosition(position, pathInBlock, "config", prop),
+            value
+          );
+        }
+      }
+    } else {
+      super.visitDocumentElement({
+        position,
+        blockConfig,
+        element,
+        pathInBlock,
+      });
+    }
   }
 }
 

--- a/src/analysis/analysisVisitors/varAnalysis/varMap.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varMap.ts
@@ -133,7 +133,7 @@ function createNode(
   return node;
 }
 
-const numberReges = /^\d+$/;
+const numberRegex = /^\d+$/;
 
 class VarMap {
   private map: Record<string, ExistenceNode> = {};
@@ -269,7 +269,7 @@ class VarMap {
         const part = pathPartsCopy.shift();
 
         // Handle the array case (allow only numeric keys)
-        const isNumberPart = numberReges.test(part);
+        const isNumberPart = numberRegex.test(part);
         if (isNumberPart && bag[IS_ARRAY]) {
           // Dealing with array of primitives or array of unknown objects
           if (pathPartsCopy.length === 0 || bag[ALLOW_ANY_CHILD]) {

--- a/src/blocks/PipelineExpressionVisitor.ts
+++ b/src/blocks/PipelineExpressionVisitor.ts
@@ -25,10 +25,22 @@ import PipelineVisitor, {
 } from "./PipelineVisitor";
 import { type DocumentElement } from "@/components/documentBuilder/documentBuilderTypes";
 
-type VisitDocumentElementArgs = {
+export type VisitDocumentElementArgs = {
+  /**
+   * The position of document builder block within the mod
+   */
   position: BlockPosition;
+  /**
+   * The document builder config
+   */
   blockConfig: BlockConfig;
+  /**
+   * The element at path `pathInBlock` within the document builder config
+   */
   element: DocumentElement;
+  /**
+   * The path to the element within the document builder config
+   */
   pathInBlock: string;
 };
 

--- a/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
@@ -48,9 +48,8 @@ const VarPopup: React.FunctionComponent<VarPopupProps> = ({
 }) => {
   const [showMenu, setShowMenu] = useState(false);
   const analysisSliceExists = useSelector(selectAnalysisSliceExists);
-  const { varAnalysis, varAutosuggest } = useSelector(selectSettings);
-  const autosuggestEnabled =
-    varAnalysis && varAutosuggest && analysisSliceExists;
+  const { varAutosuggest } = useSelector(selectSettings);
+  const autosuggestEnabled = varAutosuggest && analysisSliceExists;
 
   useEffect(() => {
     if (

--- a/src/core.ts
+++ b/src/core.ts
@@ -696,7 +696,7 @@ export type RunArgs = {
   extensionIds?: UUID[];
 };
 
-export interface IExtensionPoint extends Metadata {
+export type IExtensionPoint = Metadata & {
   kind: string;
 
   inputSchema: Schema;
@@ -705,7 +705,20 @@ export interface IExtensionPoint extends Metadata {
 
   defaultOptions: Record<string, unknown>;
 
+  /**
+   * Return the IReader used by the extension point. This method should only be called for calculating availability
+   * and the schema, as it may include stub readers.
+   *
+   * @see IExtensionPoint.previewReader
+   */
   defaultReader: () => Promise<IReader>;
+
+  /**
+   * Return a IReader for generated an `@input` preview. The shape will correspond to defaultReader, but some
+   * properties may not be available
+   * @see defaultReader
+   */
+  previewReader: () => Promise<IReader>;
 
   isAvailable: () => Promise<boolean>;
 
@@ -746,7 +759,7 @@ export interface IExtensionPoint extends Metadata {
    * Returns any blocks configured in extension.
    */
   getBlocks: (extension: ResolvedExtension) => Promise<IBlock[]>;
-}
+};
 
 export interface IBlock extends Metadata {
   /** A JSON schema of the inputs for the block */

--- a/src/extensionPoints/contextMenu.test.ts
+++ b/src/extensionPoints/contextMenu.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type UnknownObject } from "@/types";
+import { define } from "cooky-cutter";
+import { type ExtensionPointConfig } from "@/extensionPoints/types";
+import { validateRegistryId } from "@/types/helpers";
+import { type Metadata, type ResolvedExtension } from "@/core";
+import { uuidSequence } from "@/testUtils/factories";
+import { type BlockPipeline } from "@/blocks/types";
+import { RootReader } from "@/extensionPoints/extensionPointTestUtils";
+import blockRegistry from "@/blocks/registry";
+import {
+  type ContextMenuConfig,
+  fromJS,
+  type MenuDefinition,
+} from "@/extensionPoints/contextMenu";
+
+const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
+  define<ExtensionPointConfig<MenuDefinition>>({
+    apiVersion: "v3",
+    kind: "extensionPoint",
+    metadata: (n: number) =>
+      ({
+        id: validateRegistryId(`test/extension-point-${n}`),
+        name: "Test Extension Point",
+      } as Metadata),
+    definition: define<MenuDefinition>({
+      type: "contextMenu",
+      contexts: () => ["page"] as any,
+      targetMode: "document",
+      isAvailable: () => ({
+        matchPatterns: ["*://*/*"],
+      }),
+      reader: () => [rootReader.id],
+      ...definitionOverrides,
+    }),
+  });
+
+const extensionFactory = define<ResolvedExtension<ContextMenuConfig>>({
+  apiVersion: "v3",
+  _resolvedExtensionBrand: undefined,
+  id: uuidSequence,
+  extensionPointId: (n: number) =>
+    validateRegistryId(`test/extension-point-${n}`),
+  _recipe: null,
+  label: "Test Extension",
+  config: define<ContextMenuConfig>({
+    title: "Test Menu Item",
+    action: () => [] as BlockPipeline,
+  }),
+});
+
+const rootReader = new RootReader();
+
+beforeEach(() => {
+  window.document.body.innerHTML = "";
+  document.body.innerHTML = "";
+  blockRegistry.clear();
+  blockRegistry.register([rootReader]);
+  rootReader.readCount = 0;
+  rootReader.ref = undefined;
+});
+
+describe("contextMenuExtension", () => {
+  it("should add extension", async () => {
+    const extensionPoint = fromJS(extensionPointFactory()());
+    const extension = extensionFactory();
+    extensionPoint.addExtension(extension);
+  });
+
+  it("should include context menu props in schema", async () => {
+    const extensionPoint = fromJS(extensionPointFactory()());
+    const reader = await extensionPoint.defaultReader();
+    expect(reader.outputSchema.properties).toHaveProperty("selectionText");
+  });
+
+  it("should include context menu props in preview", async () => {
+    const extensionPoint = fromJS(extensionPointFactory()());
+    const reader = await extensionPoint.previewReader();
+    const value = await reader.read(document);
+    expect(value).toHaveProperty("selectionText");
+  });
+});

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -58,7 +58,10 @@ import { blockList } from "@/blocks/util";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
 import { makeServiceContext } from "@/services/serviceUtils";
 import { guessSelectedElement } from "@/utils/selectionController";
-import { ContextMenuReader } from "@/extensionPoints/contextMenuReader";
+import {
+  ContextMenuReader,
+  contextMenuReaderShim,
+} from "@/extensionPoints/contextMenuReader";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import { BusinessError } from "@/errors/businessErrors";
 
@@ -176,6 +179,13 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
     return new ArrayCompositeReader([
       await this.getBaseReader(),
       new ContextMenuReader(),
+    ]);
+  }
+
+  override async previewReader(): Promise<IReader> {
+    return new ArrayCompositeReader([
+      await this.getBaseReader(),
+      contextMenuReaderShim as unknown as IReader,
     ]);
   }
 

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -24,10 +24,6 @@ import {
 } from "@/core";
 import { $safeFind } from "@/helpers";
 import { EXTENSION_POINT_DATA_ATTR } from "@/common";
-import { type JsonObject } from "type-fest";
-import { ensureJsonObject, isObject } from "@/utils";
-import { BusinessError } from "@/errors/businessErrors";
-import selectionController from "@/utils/selectionController";
 
 function getAncestors(node: Node): Node[] {
   const ancestors = [node];
@@ -223,46 +219,6 @@ export function selectExtensionContext(
     blueprintId: extension._recipe?.id,
     blueprintVersion: extension._recipe?.version,
   };
-}
-
-export function pickEventProperties(nativeEvent: Event): JsonObject {
-  if (nativeEvent instanceof KeyboardEvent) {
-    // Can't use Object.entries because they're on the prototype. Can't use lodash's pick because the type isn't
-    // precise enough (per-picked property) to support the JsonObject return type.
-    const { key, keyCode, metaKey, altKey, shiftKey, ctrlKey } = nativeEvent;
-
-    return {
-      key,
-      keyCode,
-      metaKey,
-      altKey,
-      shiftKey,
-      ctrlKey,
-    };
-  }
-
-  if (nativeEvent instanceof CustomEvent) {
-    const { detail = {} } = nativeEvent;
-
-    if (isObject(detail)) {
-      // Ensure detail is a serialized/a JSON object. The custom trigger can also pick up JS custom event, which could
-      // have real JS data in them (vs. a JsonObject the user has provided via our @pixiebrix/event brick)
-      return ensureJsonObject(detail);
-    }
-
-    throw new BusinessError("Custom event detail is not an object");
-  }
-
-  // https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event
-  if (nativeEvent.type === "selectionchange") {
-    // https://developer.mozilla.org/en-US/docs/Web/API/Selection
-    return {
-      // Match the behavior for contextMenu and quickBar
-      selectionText: selectionController.get(),
-    };
-  }
-
-  return {};
 }
 
 export function makeShouldRunExtensionForStateChange(

--- a/src/extensionPoints/quickBarProviderExtension.tsx
+++ b/src/extensionPoints/quickBarProviderExtension.tsx
@@ -60,7 +60,10 @@ import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { isSpecificError } from "@/errors/errorHelpers";
 import { type ActionGenerator } from "@/components/quickBar/quickbarTypes";
 import ArrayCompositeReader from "@/blocks/readers/ArrayCompositeReader";
-import { QuickbarQueryReader } from "@/extensionPoints/quickbarQueryReader";
+import {
+  QuickbarQueryReader,
+  quickbarQueryReaderShim,
+} from "@/extensionPoints/quickbarQueryReader";
 
 export type QuickBarProviderConfig = {
   /**
@@ -170,6 +173,13 @@ export abstract class QuickBarProviderExtensionPoint extends ExtensionPoint<Quic
     return new ArrayCompositeReader([
       // Include QuickbarQueryReader for the outputSchema. The value gets filled in by the run method
       new QuickbarQueryReader(),
+      await this.getBaseReader(),
+    ]);
+  }
+
+  override async previewReader(): Promise<IReader> {
+    return new ArrayCompositeReader([
+      quickbarQueryReaderShim as unknown as IReader,
       await this.getBaseReader(),
     ]);
   }

--- a/src/extensionPoints/quickBarProviderExtension.tsx
+++ b/src/extensionPoints/quickBarProviderExtension.tsx
@@ -168,6 +168,7 @@ export abstract class QuickBarProviderExtensionPoint extends ExtensionPoint<Quic
 
   override async defaultReader(): Promise<IReader> {
     return new ArrayCompositeReader([
+      // Include QuickbarQueryReader for the outputSchema. The value gets filled in by the run method
       new QuickbarQueryReader(),
       await this.getBaseReader(),
     ]);

--- a/src/extensionPoints/quickBarProviderExtension.tsx
+++ b/src/extensionPoints/quickBarProviderExtension.tsx
@@ -59,6 +59,8 @@ import {
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { isSpecificError } from "@/errors/errorHelpers";
 import { type ActionGenerator } from "@/components/quickBar/quickbarTypes";
+import ArrayCompositeReader from "@/blocks/readers/ArrayCompositeReader";
+import { QuickbarQueryReader } from "@/extensionPoints/quickbarQueryReader";
 
 export type QuickBarProviderConfig = {
   /**
@@ -165,7 +167,10 @@ export abstract class QuickBarProviderExtensionPoint extends ExtensionPoint<Quic
   }
 
   override async defaultReader(): Promise<IReader> {
-    return this.getBaseReader();
+    return new ArrayCompositeReader([
+      new QuickbarQueryReader(),
+      await this.getBaseReader(),
+    ]);
   }
 
   private async syncActionProvidersForUrl(): Promise<void> {
@@ -249,6 +254,7 @@ export abstract class QuickBarProviderExtensionPoint extends ExtensionPoint<Quic
       const targetElement = guessSelectedElement() ?? document;
 
       const input = {
+        // Make sure to match the order in defaultReader so override behavior in the schema is accurate
         query,
         ...(await reader.read(targetElement)),
       };

--- a/src/extensionPoints/quickbarProviderExtension.test.ts
+++ b/src/extensionPoints/quickbarProviderExtension.test.ts
@@ -213,4 +213,11 @@ describe("quickBarProviderExtension", () => {
     const reader = await extensionPoint.defaultReader();
     expect(reader.outputSchema.properties).toHaveProperty("query");
   });
+
+  it("includes query in preview", async () => {
+    const extensionPoint = fromJS(extensionPointFactory());
+    const reader = await extensionPoint.previewReader();
+    const value = await reader.read(document);
+    expect(value).toHaveProperty("query");
+  });
 });

--- a/src/extensionPoints/quickbarProviderExtension.test.ts
+++ b/src/extensionPoints/quickbarProviderExtension.test.ts
@@ -207,4 +207,10 @@ describe("quickBarProviderExtension", () => {
     toggleQuickBar();
     await tick();
   });
+
+  it("includes query in the schema", async () => {
+    const extensionPoint = fromJS(extensionPointFactory());
+    const reader = await extensionPoint.defaultReader();
+    expect(reader.outputSchema.properties).toHaveProperty("query");
+  });
 });

--- a/src/extensionPoints/quickbarQueryReader.ts
+++ b/src/extensionPoints/quickbarQueryReader.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Reader } from "@/types";
+import { type ReaderOutput, type Schema } from "@/core";
+
+/**
+ * A reader "stub" for dynamic Quick Bar query.
+ *
+ * The data for the output scheme is filled by the dynamic Quick Bar.
+ */
+export class QuickbarQueryReader extends Reader {
+  constructor() {
+    super(
+      "@pixiebrix/quickbar/query",
+      "Quick Bar Query",
+      "Data from the current Quick Bar query"
+    );
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async read(): Promise<ReaderOutput> {
+    // The actual field is set by the extension point, not the reader, because it's made available
+    // by the browser API in the menu handler
+    throw new Error("QuickbarQueryReader.read() should not be called directly");
+  }
+
+  override outputSchema: Schema = {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "The current query string in the Quick Bar",
+      },
+    },
+  };
+}

--- a/src/extensionPoints/quickbarQueryReader.ts
+++ b/src/extensionPoints/quickbarQueryReader.ts
@@ -52,3 +52,15 @@ export class QuickbarQueryReader extends Reader {
     },
   };
 }
+
+export const quickbarQueryReaderShim = {
+  isAvailable: async () => true,
+
+  outputSchema: new QuickbarQueryReader().outputSchema,
+
+  async read() {
+    return {
+      query: "Quick Bar query placeholder",
+    };
+  },
+};

--- a/src/extensionPoints/triggerEventReaders.ts
+++ b/src/extensionPoints/triggerEventReaders.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Reader } from "@/types";
+import { type IReader, type ReaderOutput, type Schema } from "@/core";
+import { type JsonObject } from "type-fest";
+import { ensureJsonObject, isObject } from "@/utils";
+import { BusinessError } from "@/errors/businessErrors";
+import selectionController from "@/utils/selectionController";
+import {
+  KEYBOARD_TRIGGERS,
+  type Trigger,
+} from "@/extensionPoints/triggerExtensionTypes";
+
+export function pickEventProperties(nativeEvent: Event): JsonObject {
+  if (nativeEvent instanceof KeyboardEvent) {
+    // Must be kept in sync with KeyboardEventReader
+
+    // Can't use Object.entries because they're on the prototype. Can't use lodash's pick because the type isn't
+    // precise enough (per-picked property) to support the JsonObject return type.
+    const { key, keyCode, metaKey, altKey, shiftKey, ctrlKey } = nativeEvent;
+
+    return {
+      key,
+      keyCode,
+      metaKey,
+      altKey,
+      shiftKey,
+      ctrlKey,
+    };
+  }
+
+  if (nativeEvent instanceof CustomEvent) {
+    const { detail = {} } = nativeEvent;
+
+    if (isObject(detail)) {
+      // Ensure detail is a serialized/a JSON object. The custom trigger can also pick up JS custom event, which could
+      // have real JS data in them (vs. a JsonObject the user has provided via our @pixiebrix/event brick)
+      return ensureJsonObject(detail);
+    }
+
+    throw new BusinessError("Custom event detail is not an object");
+  }
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event
+  if (nativeEvent.type === "selectionchange") {
+    // https://developer.mozilla.org/en-US/docs/Web/API/Selection
+    return {
+      // Match the behavior for contextMenu and quickBar
+      selectionText: selectionController.get(),
+    };
+  }
+
+  return {};
+}
+
+/**
+ * A reader "stub" for KeyboardEvent triggers
+ */
+export class KeyboardEventReader extends Reader {
+  constructor() {
+    super(
+      "@pixiebrix/event/keyboard",
+      "Keyboard Event Reader",
+      "Data from a keyboard event"
+    );
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async read(): Promise<ReaderOutput> {
+    // The actual field is set by the extension point, not the reader
+    throw new Error("KeyboardEventReader.read() should not be called directly");
+  }
+
+  /**
+   * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+   */
+  override outputSchema: Schema = {
+    type: "object",
+    properties: {
+      key: {
+        type: "string",
+        description:
+          "The value of the key pressed by the user, taking into consideration the state of modifier keys such as Shift as well as the keyboard locale and layout",
+      },
+      keyCode: {
+        type: "number",
+        description:
+          "Represents a system and implementation dependent numerical code identifying the unmodified value of the pressed key",
+      },
+      metaKey: {
+        type: "boolean",
+        description:
+          "A boolean value that indicates if the Meta key was pressed (true) or not (false) when the event occurred",
+      },
+      altKey: {
+        type: "boolean",
+        description:
+          "A boolean value that indicates if the Alt key was pressed (true) or not (false) when the event occurred",
+      },
+      shiftKey: {
+        type: "boolean",
+        description:
+          "A boolean value that indicates if the Shift key was pressed (true) or not (false) when the event occurred",
+      },
+      ctrlKey: {
+        type: "boolean",
+        description:
+          "A boolean value that indicates if the Ctrl key was pressed (true) or not (false) when the event occurred",
+      },
+    },
+  };
+}
+
+/**
+ * A reader "stub" for KeyboardEvent triggers
+ */
+export class SelectionChangedReader extends Reader {
+  constructor() {
+    super(
+      "@pixiebrix/event/selection",
+      "Selection Changed Reader",
+      "Data from a selection changed event"
+    );
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async read(): Promise<ReaderOutput> {
+    // The actual field is set by the extension point, not the reader
+    throw new Error(
+      "SelectionChangedReader.read() should not be called directly"
+    );
+  }
+
+  /**
+   * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+   */
+  override outputSchema: Schema = {
+    type: "object",
+    properties: {
+      selectionText: {
+        type: "string",
+        description: "The currently selected text, if any",
+      },
+    },
+  };
+}
+
+/**
+ * A reader "stub" for KeyboardEvent triggers
+ */
+export class CustomEventReader extends Reader {
+  constructor() {
+    super(
+      "@pixiebrix/event/custom",
+      "Custom Event Reader",
+      "Data from a custom event"
+    );
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async read(): Promise<ReaderOutput> {
+    // The actual field is set by the extension point, not the reader
+    throw new Error(
+      "SelectionChangedReader.read() should not be called directly"
+    );
+  }
+
+  /**
+   * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+   */
+  override outputSchema: Schema = {
+    type: "object",
+    properties: {},
+    additionalProperties: true,
+  };
+}
+
+export function getEventReader(trigger: Trigger): IReader | null {
+  if (KEYBOARD_TRIGGERS.includes(trigger)) {
+    return new KeyboardEventReader();
+  }
+
+  if (trigger === "selectionchange") {
+    return new SelectionChangedReader();
+  }
+
+  if (trigger === "custom") {
+    return new CustomEventReader();
+  }
+
+  return null;
+}

--- a/src/extensionPoints/triggerEventReaders.ts
+++ b/src/extensionPoints/triggerEventReaders.ts
@@ -216,6 +216,24 @@ export class CustomEventReader extends Reader {
   };
 }
 
+export function getShimEventReader(trigger: Trigger): unknown {
+  const reader = getEventReader(trigger);
+
+  if (reader) {
+    return {
+      isAvailable: async () => true,
+
+      outputSchema: reader.outputSchema,
+
+      async read() {
+        return "Event data not available in preview";
+      },
+    };
+  }
+
+  return null;
+}
+
 export function getEventReader(trigger: Trigger): IReader | null {
   if (KEYBOARD_TRIGGERS.includes(trigger)) {
     return new KeyboardEventReader();

--- a/src/extensionPoints/triggerExtension.test.ts
+++ b/src/extensionPoints/triggerExtension.test.ts
@@ -334,4 +334,18 @@ describe("triggerExtension", () => {
     const reader = await extensionPoint.defaultReader();
     expect((reader.outputSchema.properties as any).event).toBeUndefined();
   });
+
+  it.each([["selectionchange"], ["click"], ["keypress"], ["custom"]])(
+    "smoke test for preview %s",
+    async (trigger) => {
+      const extensionPoint = fromJS(
+        extensionPointFactory({
+          trigger,
+        })()
+      );
+
+      const reader = await extensionPoint.previewReader();
+      await reader.read(document);
+    }
+  );
 });

--- a/src/extensionPoints/triggerExtension.test.ts
+++ b/src/extensionPoints/triggerExtension.test.ts
@@ -282,4 +282,56 @@ describe("triggerExtension", () => {
 
     extensionPoint.uninstall();
   });
+
+  it("includes selection change reader schema", async () => {
+    const extensionPoint = fromJS(
+      extensionPointFactory({
+        trigger: "selectionchange",
+      })()
+    );
+
+    const reader = await extensionPoint.defaultReader();
+
+    expect(
+      (reader.outputSchema.properties as any).event.properties.selectionText
+        .type
+    ).toBe("string");
+  });
+
+  it("includes custom event schema", async () => {
+    const extensionPoint = fromJS(
+      extensionPointFactory({
+        trigger: "custom",
+      })()
+    );
+
+    const reader = await extensionPoint.defaultReader();
+    expect(
+      (reader.outputSchema.properties as any).event.additionalProperties
+    ).toBe(true);
+  });
+
+  it("includes keyboard event schema", async () => {
+    const extensionPoint = fromJS(
+      extensionPointFactory({
+        trigger: "keypress",
+      })()
+    );
+
+    const reader = await extensionPoint.defaultReader();
+    expect(
+      (reader.outputSchema.properties as any).event.properties.key.type
+    ).toBe("string");
+  });
+
+  it("excludes event for mouse click", async () => {
+    const extensionPoint = fromJS(
+      extensionPointFactory({
+        trigger: "click",
+      })()
+    );
+
+    const reader = await extensionPoint.defaultReader();
+    expect((reader.outputSchema.properties as any).event).toBeUndefined();
+  });
 });

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -73,6 +73,7 @@ import {
 } from "@/extensionPoints/triggerExtensionTypes";
 import {
   getEventReader,
+  getShimEventReader,
   pickEventProperties,
 } from "@/extensionPoints/triggerEventReaders";
 import CompositeReader from "@/blocks/readers/CompositeReader";
@@ -288,6 +289,17 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     return new ArrayCompositeReader(
       compact([
         eventReader ? new CompositeReader({ event: eventReader }) : null,
+        await this.getBaseReader(),
+      ])
+    );
+  }
+
+  override async previewReader(): Promise<IReader> {
+    const shim = getShimEventReader(this.trigger) as IReader;
+
+    return new ArrayCompositeReader(
+      compact([
+        shim ? new CompositeReader({ event: shim }) : null,
         await this.getBaseReader(),
       ])
     );

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -22,6 +22,7 @@ import {
 import {
   type IBlock,
   type IExtensionPoint,
+  type IReader,
   type ReaderOutput,
   type ReaderRoot,
   type ResolvedExtension,
@@ -43,7 +44,6 @@ import reportError from "@/telemetry/reportError";
 import { reportEvent } from "@/telemetry/events";
 import {
   awaitElementOnce,
-  pickEventProperties,
   selectExtensionContext,
 } from "@/extensionPoints/helpers";
 import notify from "@/utils/notify";
@@ -62,95 +62,23 @@ import { PromiseCancelled } from "@/errors/genericErrors";
 import { BusinessError } from "@/errors/businessErrors";
 import { guessSelectedElement } from "@/utils/selectionController";
 import "@/vendors/hoverintent/hoverintent";
+import ArrayCompositeReader from "@/blocks/readers/ArrayCompositeReader";
+import {
+  type AttachMode,
+  type IntervalArgs,
+  type ReportMode,
+  type TargetMode,
+  type Trigger,
+  USER_ACTION_TRIGGERS,
+} from "@/extensionPoints/triggerExtensionTypes";
+import {
+  getEventReader,
+  pickEventProperties,
+} from "@/extensionPoints/triggerEventReaders";
+import CompositeReader from "@/blocks/readers/CompositeReader";
 
 export type TriggerConfig = {
   action: BlockPipeline | BlockConfig;
-};
-
-export type AttachMode =
-  // Attach handlers once (for any elements available at the time of attaching handlers) (default)
-  | "once"
-  // Watch for new elements and attach triggers to any new elements that matches the selector. Only supports native
-  // CSS selectors (because it uses MutationObserver under the hood)
-  | "watch";
-
-export type TargetMode =
-  // The element that triggered the event
-  // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget
-  | "eventTarget"
-  // The element the trigger is attached to
-  | "root";
-
-export type ReportMode =
-  // Events (trigger/error) reported only once per extension per page
-  | "once"
-  // Report all events
-  | "all";
-
-export type Trigger =
-  // `load` is page load
-  | "load"
-  // `interval` is a fixed interval
-  | "interval"
-  // `appear` is triggered when an element enters the user's viewport
-  | "appear"
-  // `initialize` is triggered when an element is added to the DOM
-  | "initialize"
-  | "blur"
-  | "click"
-  | "dblclick"
-  | "mouseover"
-  // https://ux.stackexchange.com/questions/109288/how-long-in-milliseconds-is-long-enough-to-decide-a-user-is-actually-hovering
-  | "hover"
-  | "keydown"
-  | "keyup"
-  | "keypress"
-  | "change"
-  // https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event
-  | "selectionchange"
-  // The PixieBrix page state changed
-  | "statechange"
-  // A custom event configured by the user. Can also be an external event from the page
-  | "custom";
-
-/**
- * Triggers considered user actions for the purpose of defaulting the reportMode if not provided.
- *
- * Currently, includes mouse events and input blur. Keyboard events, e.g., "keydown", are not included because single
- * key events do not convey user intent.
- *
- * @see ReportMode
- * @see getDefaultReportModeForTrigger
- */
-const USER_ACTION_TRIGGERS: Trigger[] = [
-  "click",
-  "dblclick",
-  "blur",
-  "mouseover",
-  "hover",
-];
-
-type IntervalArgs = {
-  /**
-   * Interval in milliseconds.
-   */
-  intervalMillis: number;
-
-  /**
-   * Effect to run on each interval.
-   */
-  effectGenerator: () => Promise<void>;
-
-  /**
-   * AbortSignal to cancel the interval
-   */
-  signal: AbortSignal;
-
-  /**
-   * Request an animation frame so that animation effects (e.g., confetti) don't pile up while the user is not
-   * using the tab/frame running the interval.
-   */
-  requestAnimationFrame: boolean;
 };
 
 export function getDefaultReportModeForTrigger(trigger: Trigger): ReportMode {
@@ -212,6 +140,8 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
   abstract get customTriggerOptions(): CustomEventOptions;
 
   abstract get triggerSelector(): string | null;
+
+  abstract getBaseReader(): Promise<IReader>;
 
   /**
    * Map from extension ID to elements a trigger is currently running on.
@@ -352,6 +282,17 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     return blockList(extension.config.action);
   }
 
+  override async defaultReader(): Promise<IReader> {
+    const eventReader = getEventReader(this.trigger);
+
+    return new ArrayCompositeReader(
+      compact([
+        eventReader ? new CompositeReader({ event: eventReader }) : null,
+        await this.getBaseReader(),
+      ])
+    );
+  }
+
   private async runExtension(
     ctxt: ReaderOutput,
     extension: ResolvedExtension<TriggerConfig>,
@@ -462,7 +403,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
     const reader = await this.defaultReader();
 
     const readerContext = {
-      // The default reader overrides the event property
+      // The default reader overrides the event property. Should match the override precedence in defaultReader()
       event: nativeEvent ? pickEventProperties(nativeEvent) : null,
       ...(await reader.read(root)),
     };
@@ -964,7 +905,7 @@ class RemoteTriggerExtensionPoint extends TriggerExtensionPoint {
     return this._definition.background ?? false;
   }
 
-  override async defaultReader() {
+  override async getBaseReader(): Promise<IReader> {
     return mergeReaders(this._definition.reader);
   }
 

--- a/src/extensionPoints/triggerExtensionTypes.ts
+++ b/src/extensionPoints/triggerExtensionTypes.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type AttachMode =
+  // Attach handlers once (for any elements available at the time of attaching handlers) (default)
+  | "once"
+  // Watch for new elements and attach triggers to any new elements that matches the selector. Only supports native
+  // CSS selectors (because it uses MutationObserver under the hood)
+  | "watch";
+
+export type TargetMode =
+  // The element that triggered the event
+  // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget
+  | "eventTarget"
+  // The element the trigger is attached to
+  | "root";
+
+export type ReportMode =
+  // Events (trigger/error) reported only once per extension per page
+  | "once"
+  // Report all events
+  | "all";
+
+export type Trigger =
+  // `load` is page load
+  | "load"
+  // `interval` is a fixed interval
+  | "interval"
+  // `appear` is triggered when an element enters the user's viewport
+  | "appear"
+  // `initialize` is triggered when an element is added to the DOM
+  | "initialize"
+  | "blur"
+  | "click"
+  | "dblclick"
+  | "mouseover"
+  // https://ux.stackexchange.com/questions/109288/how-long-in-milliseconds-is-long-enough-to-decide-a-user-is-actually-hovering
+  | "hover"
+  | "keydown"
+  | "keyup"
+  | "keypress"
+  | "change"
+  // https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event
+  | "selectionchange"
+  // The PixieBrix page state changed
+  | "statechange"
+  // A custom event configured by the user. Can also be an external event from the page
+  | "custom";
+
+export const KEYBOARD_TRIGGERS: Trigger[] = ["keydown", "keyup", "keypress"];
+
+/**
+ * Triggers considered user actions for the purpose of defaulting the reportMode if not provided.
+ *
+ * Currently, includes mouse events and input blur. Keyboard events, e.g., "keydown", are not included because single
+ * key events do not convey user intent.
+ *
+ * @see ReportMode
+ * @see getDefaultReportModeForTrigger
+ */
+export const USER_ACTION_TRIGGERS: Trigger[] = [
+  "click",
+  "dblclick",
+  "blur",
+  "mouseover",
+  "hover",
+];
+
+export type IntervalArgs = {
+  /**
+   * Interval in milliseconds.
+   */
+  intervalMillis: number;
+
+  /**
+   * Effect to run on each interval.
+   */
+  effectGenerator: () => Promise<void>;
+
+  /**
+   * AbortSignal to cancel the interval
+   */
+  signal: AbortSignal;
+
+  /**
+   * Request an animation frame so that animation effects (e.g., confetti) don't pile up while the user is not
+   * using the tab/frame running the interval.
+   */
+  requestAnimationFrame: boolean;
+};

--- a/src/extensionPoints/types.ts
+++ b/src/extensionPoints/types.ts
@@ -215,6 +215,10 @@ export abstract class ExtensionPoint<TConfig extends EmptyConfig>
 
   abstract defaultReader(): Promise<IReader>;
 
+  async previewReader(): Promise<IReader> {
+    return this.defaultReader();
+  }
+
   abstract getBlocks(extension: ResolvedExtension<TConfig>): Promise<IBlock[]>;
 
   abstract isAvailable(): Promise<boolean>;

--- a/src/options/pages/settings/ExperimentalSettings.tsx
+++ b/src/options/pages/settings/ExperimentalSettings.tsx
@@ -60,7 +60,6 @@ const ExperimentalSettings: React.FunctionComponent = () => {
     suggestElements,
     excludeRandomClasses,
     selectionTools,
-    varAnalysis,
     varAutosuggest,
   } = useSelector(selectSettings);
 
@@ -116,22 +115,8 @@ const ExperimentalSettings: React.FunctionComponent = () => {
             }}
           />
           <ExperimentalFeature
-            id="varAnalysis"
-            label="Perform Analysis of Variables in Page Editor:"
-            description="Toggle on to enable validation of variables in Page Editor. Shows a warning if use of an undefined variable is detected"
-            isEnabled={varAnalysis}
-            onChange={(value) => {
-              dispatch(
-                settingsSlice.actions.setFlag({
-                  flag: "varAnalysis",
-                  value,
-                })
-              );
-            }}
-          />
-          <ExperimentalFeature
             id="varAutosuggest"
-            label="Autosuggest Variables in Page Editor. You must also enable Analysis of Variables to use this feature:"
+            label="Autosuggest Variables in Page Editor."
             description="Toggle on to enable variable autosuggest for variable and text template entry modes"
             isEnabled={varAutosuggest}
             onChange={(value) => {

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -24,7 +24,7 @@ import TraceAnalysis from "@/analysis/analysisVisitors/traceAnalysis";
 import ReduxAnalysisManager from "@/analysis/ReduxAnalysisManager";
 import { type UUID } from "@/core";
 import { type TraceRecord } from "@/telemetry/trace";
-import { type PayloadAction, isAnyOf } from "@reduxjs/toolkit";
+import { isAnyOf, type PayloadAction } from "@reduxjs/toolkit";
 import { type RootState } from "./pageEditorTypes";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 import runtimeSlice from "./slices/runtimeSlice";
@@ -33,7 +33,6 @@ import FormBrickAnalysis from "@/analysis/analysisVisitors/formBrickAnalysis";
 import { selectActiveElementTraces } from "./slices/runtimeSelectors";
 import VarAnalysis from "@/analysis/analysisVisitors/varAnalysis/varAnalysis";
 import analysisSlice from "@/analysis/analysisSlice";
-import { selectSettings } from "@/store/settingsSelectors";
 import RegexAnalysis from "@/analysis/analysisVisitors/regexAnalysis";
 
 const runtimeActions = runtimeSlice.actions;
@@ -119,13 +118,7 @@ const varAnalysisFactory = (
   action: PayloadAction<{ extensionId: UUID; records: TraceRecord[] }>,
   state: RootState
 ) => {
-  const { varAnalysis } = selectSettings(state);
-  if (!varAnalysis) {
-    return null;
-  }
-
   const records = selectActiveElementTraces(state);
-
   return new VarAnalysis(records);
 };
 

--- a/src/pageEditor/extensionPoints/formStateTypes.ts
+++ b/src/pageEditor/extensionPoints/formStateTypes.ts
@@ -41,7 +41,7 @@ import {
   type ReportMode,
   type TargetMode,
   type Trigger as TriggerTrigger,
-} from "@/extensionPoints/triggerExtension";
+} from "@/extensionPoints/triggerExtensionTypes";
 import {
   type CustomEventOptions,
   type DebounceOptions,

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -35,7 +35,7 @@ import {
   getBlockAnnotations,
   getDocumentPipelinePaths,
   getFoundationNodeAnnotations,
-  getInputKeyForSubPipeline,
+  getVariableKeyForSubPipeline,
   getPipelinePropNames,
 } from "@/pageEditor/utils";
 import { isNullOrBlank, joinName, joinPathParts } from "@/utils";
@@ -132,7 +132,10 @@ function getSubPipelinesForBlock(blockConfig: BlockConfig): SubPipeline[] {
         flavor: PipelineFlavor.NoRenderer,
       };
 
-      const inputKey = getInputKeyForSubPipeline(blockConfig, pipelinePropName);
+      const inputKey = getVariableKeyForSubPipeline(
+        blockConfig,
+        pipelinePropName
+      );
 
       if (inputKey) {
         subPipeline.inputKey = inputKey;

--- a/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
+++ b/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
@@ -55,7 +55,8 @@ const renderUseReportTraceError = (traces: TraceRecord[] = []) => {
         },
       },
     },
-  });
+    // Was getting "Type instantiation is excessively deep and possibly infinite" during compilation
+  } as any);
 
   return renderHook(
     () => {

--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
@@ -23,10 +23,7 @@ import FieldSection from "@/pageEditor/fields/FieldSection";
 import LocationWidget from "@/pageEditor/fields/LocationWidget";
 import { useField, useFormikContext } from "formik";
 import { type TriggerFormState } from "@/pageEditor/extensionPoints/formStateTypes";
-import {
-  getDefaultReportModeForTrigger,
-  type Trigger,
-} from "@/extensionPoints/triggerExtension";
+import { getDefaultReportModeForTrigger } from "@/extensionPoints/triggerExtension";
 import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldProps";
 import BooleanWidget from "@/components/fields/schemaFields/widgets/BooleanWidget";
 import { partial } from "lodash";
@@ -35,6 +32,7 @@ import MatchRulesSection from "@/pageEditor/tabs/MatchRulesSection";
 import DebounceFieldSet from "@/pageEditor/tabs/trigger/DebounceFieldSet";
 import { type DebounceOptions } from "@/extensionPoints/types";
 import ExtraPermissionsSection from "@/pageEditor/tabs/ExtraPermissionsSection";
+import { type Trigger } from "@/extensionPoints/triggerExtensionTypes";
 
 function supportsSelector(trigger: Trigger) {
   return !["load", "interval", "selectionchange", "statechange"].includes(

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -142,13 +142,16 @@ export function getPipelinePropNames(block: BlockConfig): string[] {
   }
 }
 
-export function getInputKeyForSubPipeline(
+export function getVariableKeyForSubPipeline(
   blockConfig: BlockConfig,
   pipelinePropName: string
 ): string | null {
   let keyPropName: string = null;
 
-  if (blockConfig.id === ForEach.BLOCK_ID && pipelinePropName === "body") {
+  if (
+    [ForEach.BLOCK_ID, ForEachElement.BLOCK_ID].includes(blockConfig.id) &&
+    pipelinePropName === "body"
+  ) {
     keyPropName = "elementKey";
   }
 

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -33,7 +33,6 @@ export const initialSettingsState: SettingsState = {
   nextUpdate: null as number,
   suggestElements: false,
   browserWarningDismissed: false,
-  varAnalysis: false,
   varAutosuggest: false,
   partnerId: null,
   authMethod: null,

--- a/src/store/settingsTypes.ts
+++ b/src/store/settingsTypes.ts
@@ -110,11 +110,6 @@ export type SkunkworksSettings = {
   selectionTools?: boolean;
 
   /**
-   * Experimental setting to support analysis of variables in the Page Editor
-   */
-  varAnalysis?: boolean;
-
-  /**
    * Experimental setting to support autosuggest for variables in the Page Editor
    */
   varAutosuggest?: boolean;


### PR DESCRIPTION
## What does this PR do?

- Closes #5255 
- Adds handling for Document Builder List Element to varAnalysis
- Adds reader metadata for Trigger and Dynamic Quick Bar starter bricks
- Modified `setInputVars` to use the defaultReader method from ExtensionPoint instance object
- Adds a `previewReader` method to IExtensionPoint for returning the reader to be user when generating Page Editor previews

## Included in PR

- [x] Remove skunkworks flag for var analysis
- [x] Add test for Try-Except brick
- [x] Add test for For-Each Element brick
- [x] Fix handling of Document Builder List Element
- [x] Fix Dynamic Quick Bar `@input.query`
- [x] Fix Trigger `@input.event`
- [x] ~~Fix Trigger `@input.element`~~ already working

## Remaining Work

- [x] Fix preview of Dynamic Quick Bar Inputs
- [x] Ensure preview of Trigger works

## Demo

- https://www.loom.com/share/0b1ae728b0c448d8a0ced2467b01e6eb

## Future Work

- In List Element, pass through the shape of the list/array element. Right now it just allows anything on the element
- In the For Each brick, pass through the shape of the array items if known. Right now it just allows any prop on the element

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
