### PR TITLE
Show full version string in extension console footer

### DIFF
--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -21,7 +21,7 @@ import { isExtensionContext } from "webext-detect-page";
 const Footer: React.FunctionComponent = () => {
   const extensionVersion = useMemo(() => {
     if (isExtensionContext()) {
-      return browser.runtime.getManifest().version;
+      return browser.runtime.getManifest().version_name;
     }
 
     return null;
@@ -31,7 +31,7 @@ const Footer: React.FunctionComponent = () => {
     <footer className="footer">
       <div className="d-sm-flex justify-content-center justify-content-sm-between">
         <span className="text-muted text-center text-sm-left d-block d-sm-inline-block">
-          Copyright © 2022{" "}
+          Copyright © 2023{" "}
           <a href="https://www.pixiebrix.com">PixieBrix, Inc.</a> All rights
           reserved.
         </span>


### PR DESCRIPTION
## What does this PR do?

- Shows the full version string in the footer to help diagnose user-reported bugs who are using pre-releases
- Bumps the copyright year in the footer

## Demo

![image](https://user-images.githubusercontent.com/1879821/221443045-4c22eb73-b5d9-4658-addc-510b5e283698.png)

## Checklist

- Add tests: YOLO
- [x] Designate a primary reviewer: @mnholtz 
