### PR TITLE
#5258: fix partner useInstallUrl hook to handle slash

### DIFF
--- a/src/options/pages/onboarding/partner/PartnerSetupCard.test.tsx
+++ b/src/options/pages/onboarding/partner/PartnerSetupCard.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useInstallUrl } from "@/options/pages/onboarding/partner/PartnerSetupCard";
+import { waitForEffect } from "@/testUtils/testHelpers";
+import React from "react";
+import { Provider } from "react-redux";
+import { HashRouter } from "react-router-dom";
+import { getBaseURL } from "@/services/baseService";
+import { renderHook } from "@/options/testHelpers";
+
+jest.mock("@/services/baseService", () => ({
+  getBaseURL: jest.fn().mockResolvedValue("https://app.pixiebrix.com"),
+}));
+
+const getBaseURLMock = getBaseURL as jest.MockedFunction<typeof getBaseURL>;
+
+describe("useInstallUrl", () => {
+  it.each(["https://app.pixiebrix.com", "https://app.pixiebrix.com/"])(
+    "should return the app install url: %s",
+    async (baseURL) => {
+      getBaseURLMock.mockResolvedValue(baseURL);
+
+      const result = renderHook(
+        () => {
+          return useInstallUrl();
+        },
+        {
+          renderWrapper:
+            (store) =>
+            ({ children }) =>
+              (
+                <Provider store={store}>
+                  <HashRouter>{children}</HashRouter>
+                </Provider>
+              ),
+        }
+      );
+
+      await waitForEffect();
+
+      expect(result.result.current).toEqual({
+        installURL:
+          "https://app.pixiebrix.com/start?partner=automation-anywhere",
+        isPending: false,
+      });
+    }
+  );
+});

--- a/src/options/pages/onboarding/partner/PartnerSetupCard.tsx
+++ b/src/options/pages/onboarding/partner/PartnerSetupCard.tsx
@@ -38,14 +38,20 @@ import {
   isCommunityControlRoom,
 } from "@/contrib/automationanywhere/aaUtils";
 
-function useInstallUrl() {
+/**
+ * Get the PixieBrix app URL for completing the partner browser extension installation.
+ */
+export function useInstallUrl(): {
+  installURL: string | null;
+  isPending: boolean;
+} {
   const { data: me } = appApi.endpoints.getMe.useQueryState();
 
   const controlRoomUrl = me?.organization?.control_room?.url;
 
   const [installURL, isPending] = useAsyncState(async () => {
     const baseUrl = await getBaseURL();
-    const startUrl = new URL(`${baseUrl}start`);
+    const startUrl = new URL("/start", baseUrl);
 
     if (controlRoomUrl) {
       const parsedControlRoomUrl = new URL(controlRoomUrl);

--- a/src/testUtils/testHelpers.tsx
+++ b/src/testUtils/testHelpers.tsx
@@ -226,6 +226,7 @@ export function createRenderWithWrappers(configureStore: ConfigureStore) {
 
 type HookWrapperOptions<TProps> = Omit<RenderHookOptions<TProps>, "wrapper"> & {
   setupRedux?: SetupRedux;
+  renderWrapper?: (store: any) => React.FC;
 };
 
 type HookWrapperResult<
@@ -248,7 +249,11 @@ type HookWrapperResult<
 export function createRenderHookWithWrappers(configureStore: ConfigureStore) {
   return <TProps, TResult>(
     hook: (props: TProps) => TResult,
-    { setupRedux = noop, ...renderOptions }: HookWrapperOptions<TProps> = {}
+    {
+      setupRedux = noop,
+      renderWrapper,
+      ...renderOptions
+    }: HookWrapperOptions<TProps> = {}
   ): HookWrapperResult<TProps, TResult> => {
     const store = configureStore();
 
@@ -256,12 +261,12 @@ export function createRenderHookWithWrappers(configureStore: ConfigureStore) {
       store,
     });
 
-    const Wrapper: React.FC = ({ children }) => (
+    const DefaultWrapper: React.FC = ({ children }) => (
       <Provider store={store}>{children}</Provider>
     );
 
     const renderResult = renderHook(hook, {
-      wrapper: Wrapper,
+      wrapper: renderWrapper ? renderWrapper(store) : DefaultWrapper,
       ...renderOptions,
     });
 


### PR DESCRIPTION
## What does this PR do?

- Part of #5258 
- Fixes useInstallUrl to handle base URL with/without slash

## Remaining Work

Test is failing with an error related to imports
```
TypeError: (0 , _connectedReactRouter.connectRouter) is not a function
```

## Checklist

- [x] Add tests
- [ ] Designate a primary reviewer
