### PR TITLE
#5210: update display names in the workshop to mod and starter brick

### DIFF
--- a/src/options/pages/workshop/CustomBricksCard.tsx
+++ b/src/options/pages/workshop/CustomBricksCard.tsx
@@ -35,6 +35,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { type EnrichedBrick, type NavigateProps } from "./workshopTypes";
 import PaginatedTable from "@/components/paginatedTable/PaginatedTable";
 import AsyncCard from "@/components/asyncCard/AsyncCard";
+import { getKindDisplayName } from "@/options/pages/workshop/workshopUtils";
 
 type TableColumn = Column<EnrichedBrick>;
 function inferIcon(kind: Kind, verboseName: string): IconProp {
@@ -118,7 +119,7 @@ const columnFactory = (): TableColumn[] => [
   },
   {
     Header: "Type",
-    accessor: "kind",
+    accessor: ({ kind }) => getKindDisplayName(kind),
   },
   {
     Header: "Version",

--- a/src/options/pages/workshop/WorkshopPage.tsx
+++ b/src/options/pages/workshop/WorkshopPage.tsx
@@ -33,6 +33,7 @@ import { push } from "connected-react-router";
 import CustomBricksCard from "./CustomBricksCard";
 import { type EnrichedBrick, type NavigateProps } from "./workshopTypes";
 import { RequireScope } from "@/auth/RequireScope";
+import { getKindDisplayName } from "@/options/pages/workshop/workshopUtils";
 
 const { actions } = workshopSlice;
 
@@ -90,7 +91,7 @@ function useSearchOptions(bricks: EnrichedBrick[]) {
     () =>
       sortBy(compact(uniq((bricks ?? []).map((x) => x.kind)))).map((value) => ({
         value,
-        label: value,
+        label: getKindDisplayName(value),
       })),
     [bricks]
   );
@@ -190,7 +191,7 @@ const CustomBricksSection: React.FunctionComponent<NavigateProps> = ({
         <div style={{ width: 200 }} className="ml-3">
           <Select
             isMulti
-            placeholder="Filter kind"
+            placeholder="Filter type"
             options={kindOptions}
             value={kindOptions.filter((x) => kinds.includes(x.value))}
             onChange={(values) => {

--- a/src/options/pages/workshop/workshopUtils.test.ts
+++ b/src/options/pages/workshop/workshopUtils.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getKindDisplayName } from "@/options/pages/workshop/workshopUtils";
+
+describe("getKindDisplayName", () => {
+  it.each(["block", "Block", "reader"])("maps %s to Brick", (kind) => {
+    expect(getKindDisplayName(kind as any)).toEqual("Brick");
+  });
+
+  it.each(["recipe", "Recipe", "blueprint"])("maps %s to Mod", (kind) => {
+    expect(getKindDisplayName(kind as any)).toEqual("Mod");
+  });
+});

--- a/src/options/pages/workshop/workshopUtils.ts
+++ b/src/options/pages/workshop/workshopUtils.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Brick } from "@/types/contract";
+import { startCase } from "lodash";
+
+const kindDisplayNameMap = new Map<Brick["kind"], string>([
+  ["block", "Brick"],
+  ["reader", "Brick"],
+  ["blueprint", "Mod"],
+  ["recipe", "Mod"],
+  ["service", "Integration"],
+  // Full name is "starter brick", but user shorter name
+  ["foundation", "Starter"],
+]);
+
+/**
+ * Returns the display name for a brick kind.
+ * @since 1.7.20
+ */
+export function getKindDisplayName(kind: Brick["kind"]): string {
+  // Be defensive and lowercase for the match, some callers may not have the correct casing
+  return (
+    kindDisplayNameMap.get(kind.toLowerCase() as Brick["kind"]) ??
+    startCase(kind)
+  );
+}

--- a/src/options/pages/workshop/workshopUtils.ts
+++ b/src/options/pages/workshop/workshopUtils.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Brick } from "@/types/contract";
+import { type Brick } from "@/types/contract";
 import { startCase } from "lodash";
 
 const kindDisplayNameMap = new Map<Brick["kind"], string>([


### PR DESCRIPTION
## What does this PR do?

- Part of #5210 
- Updates display names in the workshop

## Discussion

- Uses "Starter" instead of Starter Brick for space

## Demo

![image](https://user-images.githubusercontent.com/1879821/221878735-98548408-5942-4aa3-8146-b0d3e316b368.png)

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @mnholtz 
