### PR TITLE
#5268: infer dynamic output schema for a few bricks

### DIFF
--- a/src/blocks/transformers/ephemeralForm/formTransformer.test.ts
+++ b/src/blocks/transformers/ephemeralForm/formTransformer.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { FormTransformer } from "@/blocks/transformers/ephemeralForm/formTransformer";
+import { makeVariableExpression } from "@/runtime/expressionCreators";
+
+const brick = new FormTransformer();
+
+describe("FormTransformer", () => {
+  it("returns form schema for output schema", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    };
+
+    const outputSchema = brick.getOutputSchema({
+      id: brick.id,
+      config: {
+        schema,
+      },
+    });
+
+    expect(outputSchema).toEqual(schema);
+  });
+
+  it("return default schema for top-level variable", () => {
+    const outputSchema = brick.getOutputSchema({
+      id: brick.id,
+      config: {
+        schema: makeVariableExpression("@test"),
+      },
+    });
+
+    expect(outputSchema).toEqual(brick.outputSchema);
+  });
+});

--- a/src/blocks/transformers/ephemeralForm/formTransformer.ts
+++ b/src/blocks/transformers/ephemeralForm/formTransformer.ts
@@ -31,6 +31,8 @@ import {
 } from "@/contentScript/sidebarController";
 import { showModal } from "@/blocks/transformers/ephemeralForm/modalUtils";
 import { getThisFrame } from "webext-messenger";
+import { type BlockConfig } from "@/blocks/types";
+import { isExpression } from "@/runtime/mapArgs";
 
 // The modes for createFrameSrc are different than the location argument for FormTransformer. The mode for the frame
 // just determines the layout container of the form
@@ -95,6 +97,21 @@ export class FormTransformer extends Transformer {
     },
     required: ["schema"],
   };
+
+  override outputSchema: Schema = {
+    type: "object",
+    additionalProperties: true,
+  };
+
+  override getOutputSchema(config: BlockConfig): Schema | undefined {
+    const formSchema = config.config?.schema as Schema;
+
+    if (isExpression(formSchema)) {
+      return this.outputSchema;
+    }
+
+    return formSchema ?? this.outputSchema;
+  }
 
   async transform(
     {

--- a/src/blocks/transformers/jquery/JQueryReader.test.ts
+++ b/src/blocks/transformers/jquery/JQueryReader.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { JQueryReader } from "@/blocks/transformers/jquery/JQueryReader";
+import { makeVariableExpression } from "@/runtime/expressionCreators";
+
+const brick = new JQueryReader();
+
+describe("JQueryReader", () => {
+  it("generates output schema for expression", () => {
+    const schema = brick.getOutputSchema({
+      id: brick.id,
+      config: {
+        selectors: makeVariableExpression("@test"),
+      },
+    });
+
+    expect(schema).toEqual(brick.outputSchema);
+  });
+
+  it("generates simple output schema", () => {
+    const schema = brick.getOutputSchema({
+      id: brick.id,
+      config: {
+        selectors: {
+          name: "#name",
+        },
+      },
+    });
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    });
+  });
+
+  it("handles complex", () => {
+    const schema = brick.getOutputSchema({
+      id: brick.id,
+      config: {
+        selectors: {
+          name: {
+            selector: "#name",
+          },
+        },
+      },
+    });
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        // For now we're punting on complex/nested types since they can't be produced in the Page Editor
+        name: {},
+      },
+    });
+  });
+
+  it("handles multi", () => {
+    const schema = brick.getOutputSchema({
+      id: brick.id,
+      config: {
+        selectors: {
+          names: {
+            selector: "#name",
+            multi: true,
+          },
+        },
+      },
+    });
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        names: { type: "array", items: {} },
+      },
+    });
+  });
+});

--- a/src/blocks/transformers/jquery/JQueryReader.ts
+++ b/src/blocks/transformers/jquery/JQueryReader.ts
@@ -18,6 +18,9 @@
 import { Transformer } from "@/types";
 import { type BlockArg, type BlockOptions, type Schema } from "@/core";
 import { readJQuery, type SelectorMap } from "@/blocks/readers/jquery";
+import { type BlockConfig } from "@/blocks/types";
+import { mapValues } from "lodash";
+import { isExpression } from "@/runtime/mapArgs";
 
 export class JQueryReader extends Transformer {
   constructor() {
@@ -82,6 +85,34 @@ export class JQueryReader extends Transformer {
       },
     },
   };
+
+  override outputSchema: Schema = {
+    type: "object",
+    additionalProperties: true,
+  };
+
+  override getOutputSchema(config: BlockConfig): Schema | undefined {
+    const selectors = config.config.selectors as SelectorMap;
+
+    if (isExpression(selectors)) {
+      return this.outputSchema;
+    }
+
+    return {
+      type: "object",
+      properties: mapValues(selectors, (value) => {
+        if (typeof value === "string") {
+          return { type: "string" } as Schema;
+        }
+
+        if (value.multi) {
+          return { type: "array", items: {} } as Schema;
+        }
+
+        return {};
+      }),
+    };
+  }
 
   override async isRootAware(): Promise<boolean> {
     return true;

--- a/src/blocks/transformers/regex.test.ts
+++ b/src/blocks/transformers/regex.test.ts
@@ -18,6 +18,7 @@
 import { RegexTransformer } from "./regex";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { BusinessError } from "@/errors/businessErrors";
+import { makeTemplateExpression } from "@/runtime/expressionCreators";
 
 const transformer = new RegexTransformer();
 
@@ -66,4 +67,78 @@ test("invalid regex is business error", async () => {
       "Invalid regular expression: /BOOM\\/: \\ at end of pattern"
     )
   );
+});
+
+describe("getOutputSchema", () => {
+  test("returns named groups in output schema", () => {
+    const schema = transformer.getOutputSchema({
+      id: transformer.id,
+      config: {
+        regex: "(?<name>ABC)",
+        input: "ABC",
+      },
+    });
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    });
+  });
+
+  test("handles nunjucks", () => {
+    const schema = transformer.getOutputSchema({
+      id: transformer.id,
+      config: {
+        regex: "(?<name>ABC)",
+        input: makeTemplateExpression("nunjucks", "{{ @test }}"),
+      },
+    });
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    });
+  });
+
+  test("returns multiple named groups in output schema", () => {
+    const schema = transformer.getOutputSchema({
+      id: transformer.id,
+      config: {
+        regex: "(?<name>ABC) (?<other>DEF)?",
+        input: "ABC",
+      },
+    });
+
+    expect(schema).toEqual({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        other: { type: "string" },
+      },
+    });
+  });
+
+  test("handles input array", () => {
+    const schema = transformer.getOutputSchema({
+      id: transformer.id,
+      config: {
+        regex: "(?<name>ABC)",
+        input: ["ABC", "XYZ"],
+      },
+    });
+
+    expect(schema).toEqual({
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+        },
+      },
+    });
+  });
 });

--- a/src/blocks/transformers/regex.test.ts
+++ b/src/blocks/transformers/regex.test.ts
@@ -18,7 +18,10 @@
 import { RegexTransformer } from "./regex";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { BusinessError } from "@/errors/businessErrors";
-import { makeTemplateExpression } from "@/runtime/expressionCreators";
+import {
+  makeTemplateExpression,
+  makeVariableExpression,
+} from "@/runtime/expressionCreators";
 
 const transformer = new RegexTransformer();
 
@@ -87,11 +90,11 @@ describe("getOutputSchema", () => {
     });
   });
 
-  test("handles nunjucks", () => {
+  test("handles nunjucks in input and regex", () => {
     const schema = transformer.getOutputSchema({
       id: transformer.id,
       config: {
-        regex: "(?<name>ABC)",
+        regex: makeTemplateExpression("nunjucks", "(?<name>ABC)"),
         input: makeTemplateExpression("nunjucks", "{{ @test }}"),
       },
     });
@@ -140,5 +143,17 @@ describe("getOutputSchema", () => {
         },
       },
     });
+  });
+
+  test("returns default schema for variable input", () => {
+    const schema = transformer.getOutputSchema({
+      id: transformer.id,
+      config: {
+        regex: "(?<name>ABC)",
+        input: makeVariableExpression("@test"),
+      },
+    });
+
+    expect(schema).toEqual(transformer.outputSchema);
   });
 });

--- a/src/blocks/transformers/regex.ts
+++ b/src/blocks/transformers/regex.ts
@@ -87,11 +87,9 @@ export class RegexTransformer extends Transformer {
     }
 
     if (
-      !(
-        typeof input === "string" ||
-        isNunjucksExpression(input) ||
-        isArray(input)
-      )
+      typeof input !== "string" &&
+      !isNunjucksExpression(input) &&
+      !isArray(input)
     ) {
       // Don't have enough information to determine if output will be an array or object
       return this.outputSchema;

--- a/src/core.ts
+++ b/src/core.ts
@@ -27,6 +27,7 @@ import type { ErrorObject } from "serialize-error";
 import type { Permissions } from "webextension-polyfill";
 import type React from "react";
 import { type contextNames } from "webext-detect-page";
+import { type BlockConfig } from "@/blocks/types";
 
 // Use our own name in the project so we can re-map/adjust the typing as necessary
 export type Schema = JSONSchema7;
@@ -774,8 +775,19 @@ export interface IBlock extends Metadata {
    */
   uiSchema?: UiSchema;
 
-  /** An optional a JSON schema for the output of the block */
+  /**
+   * An optional a JSON schema for the output of the block.
+   * @see getOutputSchema
+   */
   outputSchema?: Schema;
+
+  /**
+   * An optional method to generate a a JSON output schema given a block configuration.
+   * @param config the block configuration
+   * @see outputSchema
+   * @since 1.7.20
+   */
+  getOutputSchema?: (config: BlockConfig) => Schema | undefined;
 
   defaultOptions: Record<string, unknown>;
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -782,7 +782,7 @@ export interface IBlock extends Metadata {
   outputSchema?: Schema;
 
   /**
-   * An optional method to generate a a JSON output schema given a block configuration.
+   * An optional method to generate a JSON output schema given a block configuration.
    * @param config the block configuration
    * @see outputSchema
    * @since 1.7.20

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ import {
 } from "@/core";
 import { type AxiosRequestConfig } from "axios";
 import { validateRegistryId } from "@/types/helpers";
+import { type BlockConfig } from "@/blocks/types";
 
 type SanitizedBrand = { _sanitizedConfigBrand: null };
 type SecretBrand = { _serviceConfigBrand: null };
@@ -109,6 +110,10 @@ export abstract class Block implements IBlock {
   async isRootAware(): Promise<boolean> {
     // Safe default
     return true;
+  }
+
+  getOutputSchema(_config: BlockConfig): Schema | undefined {
+    return this.outputSchema;
   }
 
   protected constructor(


### PR DESCRIPTION
## What does this PR do?

- Part of #5268
- Dynamically generates output schema shape for the following bricks for variable analysis:
  - Form Builder
  - Extract from Page (JQuery Reader)
  - Regex Extractor

## Discussion

- Variable analysis falls back to the static schema if there's an error computing the dynamic output schema

## Future Work

- Handle composite bricks, e.g., If-Else
- Handle complete JQuery configurations. PR currently just covers what you can configure in the Page Editor
- Pass in VarMap for the brick, so bricks have more information for determining output shape when there are variables

## Demo

- https://www.loom.com/share/ba04679217c148b38938d9220fc091ec

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
