### PR TITLE
#5242 Fix invitation banner url & copy

### DIFF
--- a/src/options/pages/InvitationBanner.tsx
+++ b/src/options/pages/InvitationBanner.tsx
@@ -41,11 +41,11 @@ const InvitationBanner: React.FunctionComponent = () => {
       <span role="img" aria-label="envelope">
         ✉️
       </span>
-      &nbsp; You can view them on the{" "}
-      <a href={`${SERVICE_URL}/team`} target="_blank" rel="noopener noreferrer">
-        &quot;My Team&quot; Page <FontAwesomeIcon icon={faExternalLinkAlt} />
+      &nbsp; Visit the{" "}
+      <a href={`${SERVICE_URL}`} target="_blank" rel="noopener noreferrer">
+        Admin Console <FontAwesomeIcon icon={faExternalLinkAlt} />
       </a>{" "}
-      of the Admin Console.
+      to view them.
     </Banner>
   );
 };


### PR DESCRIPTION
## What does this PR do?

- Closes #5242

## Reviewer Tips

- At some point, we removed the `/teams` route in the Admin console. Team invitations are now displayed on the root url.

## Discussion

- It would be nice to add a Rainforest test for this feature; this would require some tweaking to test accounts on the app project, however

## Demo

<img width="1472" alt="Screen Shot 2023-02-28 at 1 58 36 PM" src="https://user-images.githubusercontent.com/36575242/221990828-99ede01a-3801-4164-8b85-4a157f9bcb26.png">

https://www.loom.com/share/36e01e1a176242a7b9c9e6a65a444446

## Checklist

- [x] Add tests - created a Rainforest test here https://app.rainforestqa.com/tests/368971 that I'm adding to CI and will tweak once this feature is released
- [x] Designate a primary reviewer
