### PR TITLE
Force refresh page after oauth2 authentication to fix perpetual loading screen

### DIFF
--- a/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
+++ b/src/options/pages/onboarding/partner/ControlRoomOAuthForm.tsx
@@ -36,7 +36,6 @@ import { getErrorMessage } from "@/errors/errorHelpers";
 import { serviceOriginPermissions } from "@/permissions";
 import { requestPermissions } from "@/utils/permissions";
 import { isEmpty } from "lodash";
-import { util as apiUtil } from "@/services/api";
 import { normalizeControlRoomUrl } from "@/options/pages/onboarding/partner/partnerOnboardingUtils";
 import { useHistory, useLocation } from "react-router";
 
@@ -138,10 +137,10 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
         // Redirect to blueprints screen. The SetupPage always shows a login screen for the "/start" URL
         history.push("/");
 
-        // Refresh auth state so that 1) the user appears as logged in the UI in the navbar, and 2) the Admin Console
-        // link in the navbar links to the URL required for JWT hand-off.
+        // This is a hack - refresh the page so that 1) the user appears as logged in the UI in the navbar, and 2)
+        // the Admin Console link in the navbar links to the URL required for JWT hand-off.
         // See useRequiredAuth hook for more details
-        dispatch(apiUtil.resetApiState());
+        history.go(0);
       } catch (error) {
         helpers.setStatus(getErrorMessage(error));
       }


### PR DESCRIPTION
## What does this PR do?

- Context here: https://pixiebrix.slack.com/archives/C0436P48QHY/p1677610353984379
- This is a quick & dirty fix in order to solve a bug where RTK query was never resolving

## Discussion

The two leads that I haven't had time to follow re this RTK query issue:
1. `hasToken` flickers from `true` to `false`, which also may be flickering the `skip` option on the `useMeQuery` which could be producing unpredictable results
2. I didn't realize until I actually made this hack that we are calling `dispatch(apiUtil.resetApiState());` right before we expect the `useGetMeQuery` to run. I wonder if this is causing unpredictable behavior

## Demo

https://www.loom.com/share/bcacc59c6ce948c3a0b5499a2b40ffe0

## Future Work

- If we decide to merge this, we should create a follow-up ticket

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @BLoe @twschiller 
