### PR TITLE
Use browser.tabs, not chrome.tabs; fix vertical toggle icon alignment; catch useOrigin errors

### DIFF
--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.module.scss
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.module.scss
@@ -25,6 +25,9 @@
   flex-grow: 0;
   flex-shrink: 0;
 
+  display: flex;
+  align-items: center;
+
   > button {
     // React-bootstrap Button defaults to 0.75rem horizontal
     // and 0.375rem vertical padding; we don't need that much

--- a/src/contrib/google/sheets/SheetsFileWidget.tsx
+++ b/src/contrib/google/sheets/SheetsFileWidget.tsx
@@ -143,7 +143,7 @@ const SheetsFileWidget: React.FC<SchemaFieldProps> = (props) => {
         error,
       });
     }
-  }, [helpers]);
+  }, [helpers, pickerOrigin]);
 
   return isExpression(field.value) ? (
     <WorkshopMessageWidget />


### PR DESCRIPTION
## What does this PR do?

- Fixes coming out of developer (me) release testing/QA for the 1.7.20 extension release

## Checklist

- [ ] Add tests
  - Already had test coverage but the API was being mocked in the test so the syntax bug didn't show up in tests
- [ ] Designate a primary reviewer - @twschiller 
