### PR TITLE
#5305: fix AsyncRemoteSelectWidget and AA bot fetching on empty state

### DIFF
--- a/src/components/form/widgets/AsyncRemoteSelectWidget.test.tsx
+++ b/src/components/form/widgets/AsyncRemoteSelectWidget.test.tsx
@@ -103,7 +103,7 @@ describe("AsyncRemoteSelectWidget", () => {
       await userEvent.type(container.querySelector('[role="combobox"]'), "foo");
 
       // Wait for the debounce. :shrug: would be cleaner to advance timers here, but this will do for now
-      await sleep(100);
+      await sleep(1000);
       await waitForEffect();
     });
 
@@ -137,7 +137,7 @@ describe("AsyncRemoteSelectWidget", () => {
       await userEvent.type(container.querySelector('[role="combobox"]'), "foo");
 
       // Wait for the debounce. :shrug: would be cleaner to advance timers here, but this will do for now
-      await sleep(100);
+      await sleep(1000);
       await waitForEffect();
     });
 
@@ -161,7 +161,8 @@ describe("AsyncRemoteSelectWidget", () => {
     );
 
     await act(async () => {
-      await sleep(100);
+      // Wait for the debounce. :shrug: would be cleaner to advance timers here, but this will do for now
+      await sleep(1000);
       await waitForEffect();
     });
 

--- a/src/components/form/widgets/AsyncRemoteSelectWidget.test.tsx
+++ b/src/components/form/widgets/AsyncRemoteSelectWidget.test.tsx
@@ -179,7 +179,7 @@ describe("AsyncRemoteSelectWidget", () => {
 
     const deferred: Array<DeferredPromise<Option[]>> = [];
 
-    const optionsFactoryMock = jest.fn().mockImplementation(() => {
+    const optionsFactoryMock = jest.fn().mockImplementation(async () => {
       const deferredOptions = pDefer<Option[]>();
       deferred.push(deferredOptions);
       return deferredOptions.promise;

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -175,7 +175,8 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
               description="The Automation Anywhere bot to run. Type a query to search available bots by name"
               as={AsyncRemoteSelectWidget}
               defaultOptions
-              cacheOptions
+              // Was running into issue with it showing stale results
+              cacheOptions={false}
               optionsFactory={cachedSearchBots}
               loadingMessage={BotLoadingMessage}
               noOptonsMessage={BotNoOptionsMessage}

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -130,7 +130,9 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
   // Additional args passed to the remote options factories
   const factoryArgs = useMemo(
     () => ({
-      workspaceType: workspaceType as WorkspaceType,
+      // Default to "private" because that's compatible with both CE and EE
+      // The workspaceType can be temporarily null when switching between CR configurations
+      workspaceType: (workspaceType as WorkspaceType) ?? "private",
     }),
     [workspaceType]
   );

--- a/src/contrib/automationanywhere/BotOptions.tsx
+++ b/src/contrib/automationanywhere/BotOptions.tsx
@@ -175,7 +175,7 @@ const BotOptions: React.FunctionComponent<BlockOptionProps> = ({
               description="The Automation Anywhere bot to run. Type a query to search available bots by name"
               as={AsyncRemoteSelectWidget}
               defaultOptions
-              // Was running into issue with it showing stale results
+              // Ensure we get current results, because there's not refresh button
               cacheOptions={false}
               optionsFactory={cachedSearchBots}
               loadingMessage={BotLoadingMessage}

--- a/src/contrib/automationanywhere/aaApi.ts
+++ b/src/contrib/automationanywhere/aaApi.ts
@@ -167,7 +167,7 @@ async function searchBots(
         {
           operator: "substring",
           field: "name",
-          value: options.query,
+          value: options.query ?? "",
         },
         {
           operator: "eq",

--- a/src/contrib/automationanywhere/aaApi.ts
+++ b/src/contrib/automationanywhere/aaApi.ts
@@ -91,6 +91,12 @@ async function fetchPages<TData>(
     config,
     paginatedRequestConfig
   );
+
+  if (initialResponse.data.list == null) {
+    // Use TypeError instead of BusinessError to ensure we get the telemetry in Rollbar if we're calling API incorrectly
+    throw new TypeError("Expected list response from Control Room");
+  }
+
   const results: TData[] = [...initialResponse.data.list];
   const total = initialResponse.data.page.totalFilter;
 

--- a/src/contrib/automationanywhere/aaApi.ts
+++ b/src/contrib/automationanywhere/aaApi.ts
@@ -159,6 +159,10 @@ async function searchBots(
   config: SanitizedServiceConfiguration,
   options: { workspaceType: WorkspaceType; query: string; value: string | null }
 ): Promise<Option[]> {
+  if (isNullOrBlank(options.workspaceType)) {
+    throw new TypeError("workspaceType is required");
+  }
+
   let searchPayload = {
     ...SORT_BY_NAME,
     filter: {

--- a/src/utils/cachePromise.test.ts
+++ b/src/utils/cachePromise.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { cachePromiseMethod } from "@/utils/cachePromise";
+import pDefer, { type DeferredPromise } from "p-defer";
+
+describe("cachePromise", () => {
+  it("should handle rejection", async () => {
+    const deferred: Array<DeferredPromise<unknown>> = [];
+
+    const factory = jest.fn().mockImplementation(async () => {
+      const d = pDefer();
+      deferred.push(d);
+      return d.promise;
+    });
+
+    // The method is cached at module-level. So need to use different key per test
+    const cachedMethod = cachePromiseMethod(["a"], factory);
+
+    const cached1 = cachedMethod();
+    const cached2 = cachedMethod();
+
+    // The promises are cached
+    expect(deferred).toHaveLength(1);
+
+    deferred[0].reject(new Error("error"));
+
+    await expect(cached1).rejects.toThrow("error");
+    await expect(cached2).rejects.toThrow("error");
+  });
+
+  it("should not cache failed result", async () => {
+    const deferred: Array<DeferredPromise<unknown>> = [];
+
+    const factory = jest.fn().mockImplementation(async () => {
+      const d = pDefer();
+      deferred.push(d);
+      return d.promise;
+    });
+
+    // The method is cached at module-level. So need to use different key per test
+    const cachedMethod = cachePromiseMethod(["b"], factory);
+
+    const cached1 = cachedMethod();
+
+    expect(deferred).toHaveLength(1);
+    deferred[0].reject(new Error("error"));
+    await expect(cached1).rejects.toThrow("error");
+
+    const cached2 = cachedMethod();
+    expect(deferred).toHaveLength(2);
+
+    deferred[1].reject(new Error("other error"));
+    await expect(cached2).rejects.toThrow("other error");
+  });
+
+  it("should handle resolution", async () => {
+    const deferred: Array<DeferredPromise<unknown>> = [];
+
+    const factory = jest.fn().mockImplementation(async () => {
+      const d = pDefer();
+      deferred.push(d);
+      return d.promise;
+    });
+
+    // The method is cached at module-level. So need to use different key per test
+    const cachedMethod = cachePromiseMethod(["a"], factory);
+
+    const cached1 = cachedMethod();
+    const cached2 = cachedMethod();
+
+    // The promises are cached
+    expect(deferred).toHaveLength(1);
+
+    deferred[0].resolve(42);
+
+    await expect(cached1).resolves.toEqual(42);
+    await expect(cached2).resolves.toEqual(42);
+  });
+});

--- a/src/utils/cachePromise.ts
+++ b/src/utils/cachePromise.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isEqual } from "lodash";
+import { isEqual, remove } from "lodash";
 
 type SharedPromise<T = unknown> = {
   dependencies: unknown[];
@@ -34,6 +34,7 @@ async function cachePromise<T = unknown>(
   const match = promises.find((x) => isEqual(x.dependencies, dependencies));
 
   if (match) {
+    // Return existing promise
     return match.promise as Promise<T>;
   }
 
@@ -43,13 +44,9 @@ async function cachePromise<T = unknown>(
   try {
     return await promise;
   } catch {
-    // Remove failed promises so they can be retried
-    const index = promises.findIndex(
-      (x) => !isEqual(x.dependencies, dependencies)
-    );
-    if (index >= 0) {
-      promises.splice(index, 1);
-    }
+    remove(promises, (x) => isEqual(x.dependencies, dependencies));
+    // Return promise so caller can handle the rejection
+    return promise;
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #5305
- Fix loadOptions for AsyncRemoteSelectWidget to only use `callback(...)` to ensure debouncing works properly
- Fix bug in `cachePromise` where rejections came back as undefined
- Fix corner-case in loadOptions where component could error by trying to spread non-iterable value when using with cachePromise (see bug above)
- Be defensive about `null` query in searchBots
- Fall back to searching "private" workspace during options initialization

## Discussion

- Wow, issues on so many levels... definitely need to improve test coverage of some of this older options code now that we're relying on it more

## Remaining Work

- [x] Test against Enterprise Edition (EE) Control Room with expired license
- [x] Add Jest tests to ensure widget handles response sequencing correctly

## Demo

Screenshot of message if CR license is expired (which results in a 402 error) 
<img width="829" alt="image" src="https://user-images.githubusercontent.com/1879821/223619343-d4583c72-4e6e-419d-9a28-765354c7bab8.png">

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
