### PR TITLE
Fix vertical alignment of field type toggle icons in the page editor

### DIFF
--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.module.scss
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.module.scss
@@ -25,9 +25,6 @@
   flex-grow: 0;
   flex-shrink: 0;
 
-  display: flex;
-  align-items: center;
-
   > button {
     // React-bootstrap Button defaults to 0.75rem horizontal
     // and 0.375rem vertical padding; we don't need that much


### PR DESCRIPTION
## What does this PR do?

- Fixes [the papercut UI issue described here](https://www.notion.so/pixiebrix/Release-1-7-20-19105237a54e41ecb33ab4e4144c86df?pvs=4#93f17bc3942040d983fe3d54ef57e899)

## Discussion

- Alignment still looks off on the console pages, but we'll need to figure out a console-specific CSS change to make for that, so it doesn't mess up the page editor as well. The inputs are taller in the console styles, that's why the alignment looks off compared to the page editor.
![image](https://user-images.githubusercontent.com/2801308/223882590-87fa093a-cd06-437a-851d-1d2217dd5d82.png)
<img width="482" alt="image" src="https://user-images.githubusercontent.com/2801308/223882708-8a6cc784-1094-4e9f-93c0-bf137d16925c.png">

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
