### PR TITLE
#5332 Fix bug when deactivating mods from the console page before opening page editor

### DIFF
--- a/src/store/dynamicElementStorage.test.ts
+++ b/src/store/dynamicElementStorage.test.ts
@@ -21,14 +21,17 @@ import { initialState } from "@/pageEditor/slices/editorSlice";
 import {
   formStateFactory,
   installedRecipeMetadataFactory,
+  uuidSequence,
 } from "@/testUtils/factories";
 import { type UUID } from "@/core";
 import { type NodeUIState } from "@/pageEditor/uiState/uiStateTypes";
 import { getPipelineMap } from "@/pageEditor/tabs/editTab/editHelpers";
 import {
+  getEditorState,
   removeDynamicElements,
   removeDynamicElementsForRecipe,
 } from "@/store/dynamicElementStorage";
+import { validateRegistryId } from "@/types/helpers";
 
 jest.mock("@/chrome", () => ({
   readReduxStorage: jest.fn(),
@@ -317,5 +320,23 @@ describe("dynamicElementStorage", () => {
       "persist:editor",
       jsonifyObject(baseState)
     );
+  });
+});
+
+describe("dynamicElementStorage when no state is persisted", () => {
+  test("getEditorState returns undefined when readReduxStorage returns undefined", async () => {
+    (readReduxStorage as jest.Mock).mockResolvedValue(undefined);
+    const state = await getEditorState();
+    expect(state).toBeUndefined();
+  });
+
+  test("removeDynamicElementsForRecipe doesn't crash when readReduxStorage returns undefined", async () => {
+    (readReduxStorage as jest.Mock).mockResolvedValue(undefined);
+    await removeDynamicElementsForRecipe(validateRegistryId("@test/recipe"));
+  });
+
+  test("removeDynamicElements doesn't crash when readReduxStorage returns undefined", async () => {
+    (readReduxStorage as jest.Mock).mockResolvedValue(undefined);
+    await removeDynamicElements([uuidSequence(0), uuidSequence(1)]);
   });
 });

--- a/src/store/dynamicElementStorage.ts
+++ b/src/store/dynamicElementStorage.ts
@@ -95,20 +95,22 @@ export async function removeDynamicElementsForRecipe(
 
   // If this is called from a page where the page editor has not been opened yet,
   // then the persisted editor state will be undefined, so we need to check for that
-  if (state != null) {
-    const newState = produce(state, (draft) => {
-      removeRecipeData(draft, recipeId);
-
-      for (const element of state.elements) {
-        if (element.recipe?.id === recipeId) {
-          removedDynamicElements.push(element.uuid);
-          removeElement(draft, element.uuid);
-        }
-      }
-    });
-
-    await saveEditorState(newState);
+  if (state == null) {
+    return [] as UUID[];
   }
+
+  const newState = produce(state, (draft) => {
+    removeRecipeData(draft, recipeId);
+
+    for (const element of state.elements) {
+      if (element.recipe?.id === recipeId) {
+        removedDynamicElements.push(element.uuid);
+        removeElement(draft, element.uuid);
+      }
+    }
+  });
+
+  await saveEditorState(newState);
 
   return removedDynamicElements;
 }

--- a/src/store/dynamicElementStorage.ts
+++ b/src/store/dynamicElementStorage.ts
@@ -36,7 +36,7 @@ const STORAGE_KEY = "persist:editor" as ReduxStorageKey;
  *
  * @returns The editor state, if found in storage, otherwise undefined.
  */
-async function getEditorState(): Promise<EditorState | undefined> {
+export async function getEditorState(): Promise<EditorState | undefined> {
   const storage: Record<string, string> = await readReduxStorage(STORAGE_KEY);
 
   if (storage == null) {

--- a/src/store/dynamicElementStorage.ts
+++ b/src/store/dynamicElementStorage.ts
@@ -33,9 +33,17 @@ const STORAGE_KEY = "persist:editor" as ReduxStorageKey;
 
 /**
  * Read dynamic elements from local storage (without going through redux-persist)
+ *
+ * @returns The editor state, if found in storage, otherwise undefined.
  */
-async function getEditorState(): Promise<EditorState> {
+async function getEditorState(): Promise<EditorState | undefined> {
   const storage: Record<string, string> = await readReduxStorage(STORAGE_KEY);
+
+  if (storage == null) {
+    // Explicitly return undefined here instead of returning an empty object and "failing silently"
+    return undefined;
+  }
+
   // Redux-persist stores the values of each top-level property in the state object as a JSON string
   return mapValues(storage, (value) => JSON.parse(value)) as EditorState;
 }
@@ -56,6 +64,13 @@ async function saveEditorState(state: EditorState): Promise<void> {
  */
 export async function removeDynamicElements(elementIds: UUID[]): Promise<void> {
   const state = await getEditorState();
+
+  // If this is called from a page where the page editor has not been opened yet,
+  // then the persisted editor state will be undefined, so we need to check for that
+  if (state == null) {
+    return;
+  }
+
   const newState = produce(state, (draft) => {
     for (const id of elementIds) {
       removeElement(draft, id);
@@ -77,18 +92,23 @@ export async function removeDynamicElementsForRecipe(
 ): Promise<UUID[]> {
   const removedDynamicElements: UUID[] = [];
   const state = await getEditorState();
-  const newState = produce(state, (draft) => {
-    removeRecipeData(draft, recipeId);
 
-    for (const element of state.elements) {
-      if (element.recipe?.id === recipeId) {
-        removedDynamicElements.push(element.uuid);
-        removeElement(draft, element.uuid);
+  // If this is called from a page where the page editor has not been opened yet,
+  // then the persisted editor state will be undefined, so we need to check for that
+  if (state != null) {
+    const newState = produce(state, (draft) => {
+      removeRecipeData(draft, recipeId);
+
+      for (const element of state.elements) {
+        if (element.recipe?.id === recipeId) {
+          removedDynamicElements.push(element.uuid);
+          removeElement(draft, element.uuid);
+        }
       }
-    }
-  });
+    });
 
-  await saveEditorState(newState);
+    await saveEditorState(newState);
+  }
 
   return removedDynamicElements;
 }


### PR DESCRIPTION
## What does this PR do?

- Fixes a bug where an error occurs if you try to deactivate a mod from the extension console when you have never opened the page editor before
- Fixes #5332 

## Discussion

- This adds more motivation for us to better organize our redux state management across the various contexts where it's used. Dynamically editing the persisted redux state by reading/writing directly to local storage is a sketchy pattern that we should try and refactor at some point.

## Checklist

- [x] Add tests - added coverage for some cases where the persisted editor state could be undefined
- [x] Designate a primary reviewer
