### PR TITLE
#4558: show proxied response error details in Page Editor and Logs

### DIFF
--- a/src/background/proxyUtils.test.ts
+++ b/src/background/proxyUtils.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  proxyResponseToAxiosResponse,
+  selectRemoteResponseErrorMessage,
+} from "@/background/proxyUtils";
+
+describe("selectRemoteResponseErrorMessage", () => {
+  it("prefers top-level message", () => {
+    const result = selectRemoteResponseErrorMessage({
+      message: "top-level message",
+      status_code: 400,
+      json: { error: { message: "json message" } },
+    });
+    expect(result).toBe("top-level message");
+  });
+
+  it("handles message in payload", () => {
+    const result = selectRemoteResponseErrorMessage({
+      message: undefined,
+      status_code: 400,
+      json: { message: "json message" },
+    });
+    expect(result).toBe("json message");
+  });
+
+  it("punts on non-string payload", () => {
+    const result = selectRemoteResponseErrorMessage({
+      message: undefined,
+      status_code: 400,
+      json: { message: ["json message"] },
+    });
+    expect(result).toBe("Bad Request");
+  });
+
+  it("handles error.message in payload", () => {
+    const result = selectRemoteResponseErrorMessage({
+      message: undefined,
+      status_code: 400,
+      json: { error: { message: "json message" } },
+    });
+    expect(result).toBe("json message");
+  });
+
+  it("falls back to reason", () => {
+    const result = selectRemoteResponseErrorMessage({
+      message: undefined,
+      status_code: 400,
+      reason: "Custom Reason",
+      json: {},
+    });
+    expect(result).toBe("Custom Reason");
+  });
+
+  it("falls back to status", () => {
+    const result = selectRemoteResponseErrorMessage({
+      message: undefined,
+      status_code: 400,
+      json: {},
+    });
+    expect(result).toBe("Bad Request");
+  });
+});
+
+describe("proxyResponseToAxiosResponse", () => {
+  it("converts a 404 bad request", () => {
+    const result = proxyResponseToAxiosResponse({
+      json: {
+        error: {
+          code: 404,
+          message: "ID not found",
+        },
+      },
+      status_code: 404,
+    });
+
+    expect(result).toStrictEqual({
+      data: {
+        error: {
+          code: 404,
+          message: "ID not found",
+        },
+      },
+      status: 404,
+      statusText: undefined,
+    });
+  });
+});

--- a/src/background/proxyUtils.ts
+++ b/src/background/proxyUtils.ts
@@ -22,6 +22,33 @@ import {
 } from "@/types/contract";
 import { safeGuessStatusText } from "@/errors/networkErrorHelpers";
 
+/**
+ * Return the error message from a 3rd party API proxied through the PixieBrix API proxy
+ * @param errorData an error response from the PixieBrix API proxy.
+ */
+export function selectRemoteResponseErrorMessage(
+  errorData: ProxyResponseErrorData
+): string {
+  if (errorData.message) {
+    return errorData.message;
+  }
+
+  if (typeof errorData.json === "object") {
+    const errorPayload = errorData.json as any;
+    // OpenAI uses error.message payload
+    const customMessage = errorPayload?.error?.message ?? errorPayload?.message;
+    if (typeof customMessage === "string") {
+      return customMessage;
+    }
+  }
+
+  return errorData.reason ?? safeGuessStatusText(errorData.status_code);
+}
+
+/**
+ * Convert a proxied response from the PixieBrix API proxy /api/proxy/ to an Axios-like response
+ * @param data the response from the PixieBrix proxy
+ */
 export function proxyResponseToAxiosResponse(
   data: ProxyResponseData
 ): Pick<AxiosResponse, "data" | "status" | "statusText"> {
@@ -41,6 +68,11 @@ export function proxyResponseToAxiosResponse(
   };
 }
 
+/**
+ * Returns true if the response is an error response
+ * @param data response from the PixieBrix proxy
+ * @see ProxyResponseErrorData
+ */
 export function isProxiedErrorResponse(
   data: ProxyResponseData
 ): data is ProxyResponseErrorData {

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -44,6 +44,7 @@ import { absoluteApiUrl } from "@/services/apiClient";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import { type ProxyResponseData, type RemoteResponse } from "@/types/contract";
 import {
+  selectRemoteResponseErrorMessage,
   isProxiedErrorResponse,
   proxyResponseToAxiosResponse,
 } from "@/background/proxyUtils";
@@ -218,7 +219,7 @@ async function proxyRequest<T>(
 
   if (isProxiedErrorResponse(remoteResponse)) {
     throw new ProxiedRemoteServiceError(
-      remoteResponse.message ?? remoteResponse.reason,
+      selectRemoteResponseErrorMessage(remoteResponse),
       proxyResponseToAxiosResponse(remoteResponse)
     );
   }

--- a/src/components/errors/ErrorDetail.module.scss
+++ b/src/components/errors/ErrorDetail.module.scss
@@ -16,6 +16,7 @@
  */
 
 .root {
+  margin-top: 1em;
   display: flex;
   flex-wrap: wrap;
 }

--- a/src/components/errors/RemoteApiErrorDetail.tsx
+++ b/src/components/errors/RemoteApiErrorDetail.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { type ProxiedResponse } from "@/errors/businessErrors";
+import styles from "@/components/errors/ErrorDetail.module.scss";
+import { safeGuessStatusText } from "@/errors/networkErrorHelpers";
+import JsonTree from "@/components/jsonTree/JsonTree";
+
+/**
+ * Component for showing error details for a remote API proxied via PixieBrix.
+ * @param response the proxied response from the remote API
+ * @see ProxiedRemoteServiceError
+ */
+const RemoteApiErrorDetail: React.FunctionComponent<{
+  response: ProxiedResponse;
+}> = ({ response }) => {
+  const { status } = response;
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.column}>
+        <h5>Response from Remote API</h5>
+
+        {status && (
+          <div>
+            Status: {status} &mdash; {safeGuessStatusText(status)}
+          </div>
+        )}
+        <JsonTree data={response} />
+      </div>
+    </div>
+  );
+};
+
+export default RemoteApiErrorDetail;

--- a/src/components/errors/__snapshots__/getErrorDetails.test.tsx.snap
+++ b/src/components/errors/__snapshots__/getErrorDetails.test.tsx.snap
@@ -567,6 +567,108 @@ exports[`Network error 1`] = `
 </DocumentFragment>
 `;
 
+exports[`RemoteApiErrorDetail 1`] = `
+<DocumentFragment>
+  <div
+    class="root"
+  >
+    <div
+      class="column"
+    >
+      <h5>
+        Response from Remote API
+      </h5>
+      <div>
+        Status: 400 — Bad Request
+      </div>
+      <div
+        class="root"
+      >
+        <ul
+          style="border: 0px; padding: 0px; margin: 0.5em 0px 0.5em 0.125em; list-style: none; background-color: rgb(253, 255, 255);"
+        >
+          <li
+            style="padding: 0px; margin: 0px;"
+          >
+            <ul
+              style="padding: 0px; margin: 0px; list-style: none;"
+            >
+              <li
+                style="position: relative; padding-top: 0.25em; margin-left: 0px; padding-left: 0px;"
+              >
+                <div
+                  style="display: inline-block; padding-right: 0.5em; padding-left: 0px; cursor: pointer;"
+                >
+                  <div
+                    style="margin-left: 0px; transition: 150ms; transform: rotateZ(0deg); transform-origin: 45% 50%; position: relative; line-height: 1.1em; font-size: 0.75em; color: rgb(66, 122, 245);"
+                  >
+                    ▶
+                  </div>
+                </div>
+                <label
+                  style="display: inline-block; color: rgb(66, 122, 245); margin: 0px; padding: 0px; cursor: pointer;"
+                >
+                  <span>
+                    data:
+                  </span>
+                </label>
+                <span
+                  style="padding-left: 0.5em; cursor: default; color: rgb(64, 175, 108);"
+                >
+                  <span>
+                    <span
+                      style="margin-left: 0.3em; margin-right: 0.3em;"
+                    >
+                      {}
+                    </span>
+                     1 key
+                  </span>
+                </span>
+                <ul
+                  style="padding: 0px; margin: 0px; list-style: none; display: block;"
+                />
+              </li>
+              <li
+                style="padding-top: 0.25em; padding-right: 0px; margin-left: 0.875em; word-wrap: break-word; padding-left: 1.25em; text-indent: -0.5em; word-break: break-all; white-space: pre-wrap;"
+              >
+                <label
+                  style="display: inline-block; color: rgb(66, 122, 245); margin: 0px 0.5em 0px 0px;"
+                >
+                  <span>
+                    status:
+                  </span>
+                </label>
+                <span
+                  style="color: rgb(243, 100, 51);"
+                >
+                  400
+                </span>
+              </li>
+              <li
+                style="padding-top: 0.25em; padding-right: 0px; margin-left: 0.875em; word-wrap: break-word; padding-left: 1.25em; text-indent: -0.5em; word-break: break-all; white-space: pre-wrap;"
+              >
+                <label
+                  style="display: inline-block; color: rgb(66, 122, 245); margin: 0px 0.5em 0px 0px;"
+                >
+                  <span>
+                    statusText:
+                  </span>
+                </label>
+                <span
+                  style="color: rgb(64, 175, 108);"
+                >
+                  "Bad Request"
+                </span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Template render error 1`] = `
 <DocumentFragment>
   <div>

--- a/src/components/errors/getErrorDetails.test.tsx
+++ b/src/components/errors/getErrorDetails.test.tsx
@@ -145,3 +145,22 @@ test("Network error", async () => {
   await waitForEffect();
   expect(rendered.asFragment()).toMatchSnapshot();
 });
+
+test("RemoteApiErrorDetail", async () => {
+  const error: ErrorObject = {
+    response: {
+      data: { error: { message: "Invalid data" } },
+      status: 400,
+      statusText: "Bad Request",
+    },
+    name: "ProxiedRemoteServiceError",
+    message: "Invalid data message.",
+    stack: "ProxiedRemoteServiceError: Invalid data message",
+  };
+
+  const { title, detailsElement } = getErrorDetails(error);
+  expect(title).toBe("Invalid data message.");
+  const rendered = render(detailsElement);
+  await waitForEffect();
+  expect(rendered.asFragment()).toMatchSnapshot();
+});

--- a/src/components/errors/getErrorDetails.tsx
+++ b/src/components/errors/getErrorDetails.tsx
@@ -67,7 +67,7 @@ export default function getErrorDetails(error: ErrorObject): ErrorDetails {
   }
 
   const remoteApiError = selectSpecificError(error, ProxiedRemoteServiceError);
-  if (remoteApiError.response) {
+  if (remoteApiError?.response) {
     return {
       title: remoteApiError.message,
       detailsElement: (

--- a/src/components/errors/getErrorDetails.tsx
+++ b/src/components/errors/getErrorDetails.tsx
@@ -26,6 +26,8 @@ import InputValidationErrorDetail from "./InputValidationErrorDetail";
 import NetworkErrorDetail from "./NetworkErrorDetail";
 import OutputValidationErrorDetail from "./OutputValidationErrorDetail";
 import { ClientRequestError } from "@/errors/clientRequestErrors";
+import { ProxiedRemoteServiceError } from "@/errors/businessErrors";
+import RemoteApiErrorDetail from "@/components/errors/RemoteApiErrorDetail";
 
 type ErrorDetails = {
   title: string;
@@ -61,6 +63,16 @@ export default function getErrorDetails(error: ErrorObject): ErrorDetails {
     return {
       title: networkError.message,
       detailsElement: <NetworkErrorDetail error={networkError.cause} />,
+    };
+  }
+
+  const remoteApiError = selectSpecificError(error, ProxiedRemoteServiceError);
+  if (remoteApiError.response) {
+    return {
+      title: remoteApiError.message,
+      detailsElement: (
+        <RemoteApiErrorDetail response={remoteApiError.response} />
+      ),
     };
   }
 

--- a/src/errors/businessErrors.ts
+++ b/src/errors/businessErrors.ts
@@ -178,7 +178,10 @@ export class NotConfiguredError extends BusinessError {
   }
 }
 
-type ProxiedResponse = Pick<AxiosResponse, "data" | "status" | "statusText">;
+export type ProxiedResponse = Pick<
+  AxiosResponse,
+  "data" | "status" | "statusText"
+>;
 
 /**
  * An error response from a 3rd party API via the PixieBrix proxy
@@ -189,7 +192,7 @@ export class ProxiedRemoteServiceError extends BusinessError {
   readonly response: ProxiedResponse;
 
   constructor(message: string, response: ProxiedResponse) {
-    super(message);
+    super(`Remote API Error: ${message}`);
 
     this.response = response;
   }

--- a/src/errors/errorHelpers.test.tsx
+++ b/src/errors/errorHelpers.test.tsx
@@ -331,6 +331,14 @@ describe("getErrorMessageWithCauses", () => {
         420."
       `);
   });
+
+  test("ignores duplicate error messages", () => {
+    expect(
+      getErrorMessageWithCauses(
+        new Error(FIRST_ERROR, { cause: new Error(FIRST_ERROR) })
+      )
+    ).toBe(`${FIRST_ERROR}.`);
+  });
 });
 
 describe("isErrorObject", () => {


### PR DESCRIPTION
## What does this PR do?

- Closes #4558 
- Adds an error view for `ProxiedRemoteServiceError` that shows the payload of the error, shown in Output Panel and in Logs
- Adds `selectRemoteResponseErrorMessage` method to select error message from proxied 3rd party API responses
- Eliminates duplicate error messages in `getErrorMessageWithCauses`

## Demo

- https://www.loom.com/share/d9a045803e2c42f384bd6f0dc55a1d6b

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
