### PR TITLE
#5343: fix variable analysis false positives for Document Builder list buttons

### DIFF
--- a/src/analysis/ReduxAnalysisManager.ts
+++ b/src/analysis/ReduxAnalysisManager.ts
@@ -33,6 +33,7 @@ import { type RootState } from "@/pageEditor/pageEditorTypes";
 import { debounce } from "lodash";
 import { type UUID } from "@/core";
 import AsyncAnalysisQueue from "./asyncAnalysisQueue";
+import { serializeError } from "serialize-error";
 
 type AnalysisEffect = ListenerEffect<
   AnyAction,
@@ -116,7 +117,18 @@ class ReduxAnalysisManager {
           })
         );
 
-        await analysis.run(activeElement);
+        try {
+          await analysis.run(activeElement);
+        } catch (error) {
+          listenerApi.dispatch(
+            analysisSlice.actions.failAnalysis({
+              extensionId,
+              analysisId: analysis.id,
+              error: serializeError(error),
+            })
+          );
+          return;
+        }
 
         listenerApi.dispatch(
           analysisSlice.actions.finishAnalysis({

--- a/src/analysis/analysisSlice.ts
+++ b/src/analysis/analysisSlice.ts
@@ -23,6 +23,7 @@ import {
 } from "@/analysis/analysisTypes";
 import { type UUID } from "@/core";
 import type VarMap from "./analysisVisitors/varAnalysis/varMap";
+import { type ErrorObject } from "serialize-error";
 
 const initialState: AnalysisState = {
   extensionAnnotations: {},
@@ -33,12 +34,23 @@ const analysisSlice = createSlice({
   name: "analysis",
   initialState,
   reducers: {
-    // TODO: if you see this action and it's still NOOP, remove it
+    // `startAnalysis` action is to help with debugging via redux-logger
     startAnalysis(
       state,
       action: PayloadAction<{ extensionId: UUID; analysisId: string }>
     ) {
-      // NOOP
+      // NOP
+    },
+    // `failAnalysis` action is to help with debugging via redux-logger
+    failAnalysis(
+      state,
+      action: PayloadAction<{
+        extensionId: UUID;
+        analysisId: string;
+        error: ErrorObject;
+      }>
+    ) {
+      // NOP
     },
     finishAnalysis(
       state,

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -748,7 +748,7 @@ describe("Collecting available vars", () => {
     test("adds the list element key list body", () => {
       const knownVars = analysis.getKnownVars();
       const buttonPipelineVarMap = knownVars.get(
-        "extension.blockPipeline.0.config.body.0.config.element.__value__.children.0.children.0.config.onClick.__value__.0"
+        "extension.blockPipeline.0.config.body.0.config.element.__value__.children.0.children.0.config.onClick.0"
       );
 
       expect(buttonPipelineVarMap.isVariableDefined("@input")).toBeTrue();
@@ -758,23 +758,7 @@ describe("Collecting available vars", () => {
 
     test("adds annotations", () => {
       const annotations = analysis.getAnnotations();
-      expect(annotations).toHaveLength(2);
-
-      // Check warning is generated for @foo but not @element
-      expect(annotations[0].message).toEqual(
-        'Variable "@foo" might not be defined'
-      );
-      expect(annotations[0].position.path).toEqual(
-        "extension.blockPipeline.0.config.body.0.config.element.__value__.config.text"
-      );
-
-      // Not available in to the peer element to the list
-      expect(annotations[1].message).toEqual(
-        'Variable "@element" might not be defined'
-      );
-      expect(annotations[1].position.path).toEqual(
-        "extension.blockPipeline.0.config.body.1.config.text"
-      );
+      expect(annotations).toHaveLength(0);
     });
   });
 

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -729,7 +729,11 @@ describe("Collecting available vars", () => {
       rowElement.children[0].children.push(buttonElement);
 
       buttonElement.config.onClick = makePipelineExpression([
-        blockConfigFactory(),
+        blockConfigFactory({
+          config: {
+            text: makeTemplateExpression("nunjucks", "{{ @foo }}"),
+          },
+        }),
       ]);
 
       const documentRendererBrick = {
@@ -748,7 +752,7 @@ describe("Collecting available vars", () => {
     test("adds the list element key list body", () => {
       const knownVars = analysis.getKnownVars();
       const buttonPipelineVarMap = knownVars.get(
-        "extension.blockPipeline.0.config.body.0.config.element.__value__.children.0.children.0.config.onClick.0"
+        "extension.blockPipeline.0.config.body.0.config.element.__value__.children.0.children.0.config.onClick.__value__.0"
       );
 
       expect(buttonPipelineVarMap.isVariableDefined("@input")).toBeTrue();
@@ -758,7 +762,19 @@ describe("Collecting available vars", () => {
 
     test("adds annotations", () => {
       const annotations = analysis.getAnnotations();
-      expect(annotations).toHaveLength(0);
+      expect(annotations).toHaveLength(1);
+
+      expect(annotations[0]).toStrictEqual({
+        analysisId: "var",
+        message: 'Variable "@foo" might not be defined',
+        type: "warning",
+        position: {
+          path: "extension.blockPipeline.0.config.body.0.config.element.__value__.children.0.children.0.config.onClick.__value__.0.config.text",
+        },
+        detail: {
+          expression: expect.toBeObject(),
+        },
+      });
     });
   });
 

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -593,15 +593,17 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
     element,
     pathInBlock,
   }: VisitDocumentElementArgs) {
+    const listElement = element as ListDocumentElement;
+
     // Variable name without the `@` prefix
-    const variableKey = element.config.elementKey ?? "element";
-    const listBodyExpression = element.config.element;
+    const variableKey = listElement.config.elementKey ?? "element";
+    const listBodyExpression = listElement.config.element;
 
     // `element` of ListElement will always be a deferred expression when using Page Editor. But guard just in case.
     if (isDeferExpression(listBodyExpression)) {
-      let deferredExpressionVars: VarMap;
+      const deferredExpressionVars = new VarMap();
+
       if (typeof variableKey === "string") {
-        deferredExpressionVars = new VarMap();
         deferredExpressionVars.setVariableExistence({
           source: position.path,
           variableName: `@${variableKey}`,

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -179,13 +179,14 @@ type SetVarsFromSchemaArgs = {
  * - Service configuration schema
  */
 function setVarsFromSchema({
-  schema,
+  schema = {},
   contextVars,
   source,
   parentPath,
   existenceOverride,
 }: SetVarsFromSchemaArgs) {
   const { properties, required } = schema;
+
   if (properties == null) {
     contextVars.setExistence({
       source,

--- a/src/analysis/analysisVisitors/varAnalysis/varMap.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varMap.test.ts
@@ -246,15 +246,15 @@ describe("setting output key", () => {
   test("sets the existence", () => {
     const varMap = new VarMap();
 
-    varMap.setOutputKeyExistence({
+    varMap.setVariableExistence({
       source: "brick1",
-      outputKey: "@foo",
+      variableName: "@foo",
       existence: VarExistence.DEFINITELY,
       allowAnyChild: false,
     });
-    varMap.setOutputKeyExistence({
+    varMap.setVariableExistence({
       source: "brick2",
-      outputKey: "@bar",
+      variableName: "@bar",
       existence: VarExistence.DEFINITELY,
       allowAnyChild: false,
     });
@@ -265,16 +265,16 @@ describe("setting output key", () => {
   // No real use case, just a functionality expectations
   test("overwrites any previous for the same source", () => {
     const varMap = new VarMap();
-    varMap.setOutputKeyExistence({
+    varMap.setVariableExistence({
       source: "brick1",
-      outputKey: "@foo",
+      variableName: "@foo",
       existence: VarExistence.DEFINITELY,
       allowAnyChild: false,
     });
 
-    varMap.setOutputKeyExistence({
+    varMap.setVariableExistence({
       source: "brick1",
-      outputKey: "@bar",
+      variableName: "@bar",
       existence: VarExistence.DEFINITELY,
       allowAnyChild: false,
     });
@@ -288,9 +288,9 @@ describe("setting output key", () => {
     [false, false],
   ])("works when allow any child = %s", (allowAnyChild, expectedExistence) => {
     const varMap = new VarMap();
-    varMap.setOutputKeyExistence({
+    varMap.setVariableExistence({
       source: "brick1",
-      outputKey: "@foo",
+      variableName: "@foo",
       existence: VarExistence.DEFINITELY,
       allowAnyChild,
     });
@@ -371,17 +371,17 @@ describe("setExistenceFromValues", () => {
 describe("cloning", () => {
   test("clones a var map", () => {
     const varMap = new VarMap();
-    varMap.setOutputKeyExistence({
+    varMap.setVariableExistence({
       source: "brick1",
-      outputKey: "@foo",
+      variableName: "@foo",
       existence: VarExistence.DEFINITELY,
       allowAnyChild: false,
     });
 
     const clone = varMap.clone();
-    clone.setOutputKeyExistence({
+    clone.setVariableExistence({
       source: "brick2",
-      outputKey: "@bar",
+      variableName: "@bar",
       existence: VarExistence.DEFINITELY,
       allowAnyChild: false,
     });
@@ -398,17 +398,17 @@ describe("addSourceMap", () => {
   // Use case: adding an output of previous brick to the current brick's available vars
   test("adds a source map", () => {
     const varMap1 = new VarMap();
-    varMap1.setOutputKeyExistence({
+    varMap1.setVariableExistence({
       source: "brick1",
-      outputKey: "@foo",
+      variableName: "@foo",
       existence: VarExistence.DEFINITELY,
       allowAnyChild: false,
     });
 
     const varMap2 = new VarMap();
-    varMap2.setOutputKeyExistence({
+    varMap2.setVariableExistence({
       source: "brick2",
-      outputKey: "@bar",
+      variableName: "@bar",
       existence: VarExistence.DEFINITELY,
       allowAnyChild: false,
     });

--- a/src/analysis/analysisVisitors/varAnalysis/varMap.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varMap.ts
@@ -42,16 +42,16 @@ type SetExistenceArgs = {
   isArray?: boolean;
 };
 
-type SetOutputKeyExistenceArgs = {
+type SetVariableExistenceArgs = {
   /**
    * The source for the VarMap (e.g. "input:reader", "trace", or block path in the pipeline)
    */
   source: string;
 
   /**
-   * The output key of the block
+   * The variable name with `@` prefix, e.g., the output key of the block.
    */
-  outputKey: string;
+  variableName: string;
 
   /**
    * Existence of the variable
@@ -225,18 +225,17 @@ class VarMap {
   }
 
   /**
-   * Adds an existence for a block with output key
+   * Directly set that a variable exists for a given variable name.
    */
-  public setOutputKeyExistence({
+  public setVariableExistence({
     source,
-    outputKey,
+    variableName,
     existence,
     allowAnyChild,
-  }: SetOutputKeyExistenceArgs): void {
-    // While any block can provide no more than one output key,
-    // we are safe to create a new object for the 'source'
+  }: SetVariableExistenceArgs): void {
+    // While any block can provide no more than one output key, we are safe to create a new object for the 'source'
     this.map[source] = {
-      [outputKey]: createNode(existence, { allowAnyChild }),
+      [variableName]: createNode(existence, { allowAnyChild }),
     };
   }
 
@@ -244,7 +243,11 @@ class VarMap {
    * Merges in another VarMap. Overwrites any existing source records
    * @param varMap A VarMap to merge in
    */
-  public addSourceMap(varMap: VarMap): void {
+  public addSourceMap(varMap: VarMap | null): void {
+    if (varMap == null) {
+      return;
+    }
+
     for (const [source, existenceMap] of Object.entries(varMap.map)) {
       this.map[source] = existenceMap;
     }

--- a/src/blocks/PipelineExpressionVisitor.ts
+++ b/src/blocks/PipelineExpressionVisitor.ts
@@ -79,7 +79,7 @@ abstract class PipelineExpressionVisitor extends PipelineVisitor {
     }
   }
 
-  private getFlavor(elementType: string): PipelineFlavor {
+  private getPipelineFlavor(elementType: string): PipelineFlavor {
     switch (elementType) {
       case "block": {
         return PipelineFlavor.NoEffect;
@@ -104,9 +104,13 @@ abstract class PipelineExpressionVisitor extends PipelineVisitor {
     for (const [prop, value] of Object.entries(element.config)) {
       if (isPipelineExpression(value)) {
         this.visitPipeline(
-          nestedPosition(position, pathInBlock, "config", prop),
+          // For pipelines, need to include the __value__ when constructing the position
+          nestedPosition(position, pathInBlock, "config", prop, "__value__"),
           value.__value__,
-          { flavor: this.getFlavor(element.type), parentNode: blockConfig }
+          {
+            flavor: this.getPipelineFlavor(element.type),
+            parentNode: blockConfig,
+          }
         );
       } else if (isExpression(value)) {
         this.visitExpression(

--- a/src/components/fields/schemaFields/widgets/varPopup/getMenuOptions.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/getMenuOptions.test.ts
@@ -39,9 +39,9 @@ describe("setting values", () => {
       parentPath: "@input",
     });
 
-    knownVars.setOutputKeyExistence({
+    knownVars.setVariableExistence({
       source: "extension.blockPipeline.0",
-      outputKey: "@jq",
+      variableName: "@jq",
       existence: VarExistence.DEFINITELY,
       allowAnyChild: true,
     });


### PR DESCRIPTION
## What does this PR do?

- Closes #5343 
- Cleans up `VarAnalysis` internal state to have a single `contextStack` for bookkeeping while recursing and iterating over bricks in a pipeline
- Fixes a bug in where `VarAnalysis.visitDocument` was visiting nested pipelines directly instead of while visting their parent elements in the document
- Updates ReduxAnalysisManager to dispatch an analysis failed action to help with debugging via redux-logger

## Reviewer Tips

1. Read the types in `varAnalysis.ts`
2. Look at the internal state of `VarAnalysis`
3. Look at visitPipeline, visitBlock, visitDocument, and visitDocumentElement methods

## Remaining Work

- [x] Add Jest tests for brick inputs inside the pipeline for the button in the list. (Analysis not currently flagging unknown variable during manual QA)

## Demo

- https://www.loom.com/share/f6ddd8e592004d8999d34624f1300a50

## Future Work

- List Element in the Document Builder can determine the shape of the element based on the item type of the array. Currently, the analysis is allowing any prop on the element

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
