### PR TITLE
#5357: support images in the copy to clipboard brick

### DIFF
--- a/src/blocks/effects/clipboard.test.ts
+++ b/src/blocks/effects/clipboard.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { CopyToClipboard } from "@/blocks/effects/clipboard";
+import copy from "copy-text-to-clipboard";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { PropError } from "@/errors/businessErrors";
+
+const brick = new CopyToClipboard();
+
+jest.mock("copy-text-to-clipboard", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const copyMock = copy as jest.MockedFunction<typeof copy>;
+
+// From https://en.wikipedia.org/wiki/Data_URI_scheme
+const SMALL_RED_DOT_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==";
+
+// Clipboard API not available in JSDOM: https://github.com/jsdom/jsdom/issues/1568
+(navigator as any).clipboard = {
+  ...navigator.clipboard,
+  write: jest.fn(),
+};
+
+globalThis.ClipboardItem = jest.fn();
+
+const writeMock = navigator.clipboard.write as jest.MockedFunction<
+  typeof navigator.clipboard.write
+>;
+
+describe("CopyToClipboard", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("copies to clipboard", async () => {
+    const text = "Hello, world!";
+    await brick.run(unsafeAssumeValidArg({ text }), {} as any);
+    expect(copyMock).toHaveBeenCalledWith(text);
+  });
+
+  it("copies null to clipboard", async () => {
+    await brick.run(
+      unsafeAssumeValidArg({ text: null, contentType: "infer" }),
+      {} as any
+    );
+    expect(copyMock).toHaveBeenCalledWith("null");
+  });
+
+  it("copies boolean clipboard", async () => {
+    await brick.run(
+      unsafeAssumeValidArg({ text: false, contentType: "infer" }),
+      {} as any
+    );
+    expect(copyMock).toHaveBeenCalledWith("false");
+  });
+
+  it("copies image to clipboard", async () => {
+    await brick.run(
+      unsafeAssumeValidArg({ text: SMALL_RED_DOT_URI, contentType: "infer" }),
+      {} as any
+    );
+    expect(copyMock).not.toHaveBeenCalled();
+    expect(writeMock).toHaveBeenCalled();
+    expect(ClipboardItem).toHaveBeenCalledWith({
+      "image/png": expect.any(Blob),
+    });
+  });
+
+  it("throws prop error on invalid image content", async () => {
+    await expect(async () =>
+      brick.run(
+        unsafeAssumeValidArg({ text: false, contentType: "image" }),
+        {} as any
+      )
+    ).rejects.toThrow(PropError);
+  });
+});

--- a/src/blocks/effects/clipboard.ts
+++ b/src/blocks/effects/clipboard.ts
@@ -19,13 +19,50 @@ import { Effect } from "@/types";
 import copy from "copy-text-to-clipboard";
 import { type BlockArg, type Schema } from "@/core";
 import { type Permissions } from "webextension-polyfill";
+import { BusinessError, PropError } from "@/errors/businessErrors";
+
+type ContentType = "infer" | "text" | "image";
+
+function detectContentType(content: unknown): "text" | "image" {
+  if (typeof content === "string" && content.startsWith("data:image/")) {
+    return "image";
+  }
+
+  return "text";
+}
+
+// Parse instead of using fetch to avoid potential CSP issues with data: URIs
+// https://stackoverflow.com/a/12300351
+function dataURItoBlob(dataURI: string): Blob {
+  // Convert base64 to raw binary data held in a string doesn't handle URLEncoded DataURIs - see SO answer #6850276 for
+  // code that does this
+  const byteString = atob(dataURI.split(",")[1]);
+
+  // Separate out the mime component
+  const mimeString = dataURI.split(",")[0].split(":")[1].split(";")[0];
+
+  // Write the bytes of the string to an ArrayBuffer
+  const ab = new ArrayBuffer(byteString.length);
+
+  // Create a view into the buffer
+  const ia = new Uint8Array(ab);
+
+  // Set the bytes of the buffer to the correct values
+  for (let i = 0; i < byteString.length; i++) {
+    // eslint-disable-next-line unicorn/prefer-code-point,security/detect-object-injection -- is a number; copied SO
+    ia[i] = byteString.charCodeAt(i);
+  }
+
+  // Write the ArrayBuffer to a blob, and you're done
+  return new Blob([ab], { type: mimeString });
+}
 
 export class CopyToClipboard extends Effect {
   constructor() {
     super(
       "@pixiebrix/clipboard/copy",
       "Copy to clipboard",
-      "Copy content to your clipboard"
+      "Copy text or images to your clipboard"
     );
   }
 
@@ -38,12 +75,69 @@ export class CopyToClipboard extends Effect {
     type: "object",
     properties: {
       text: {
+        title: "Content",
+        description: "The text or image content to copy to the clipboard",
         type: ["string", "boolean", "number"],
+      },
+      contentType: {
+        title: "Content Type",
+        type: "string",
+        description:
+          "The type of content to copy to the clipboard, of 'infer' to detect automatically",
+        default: "infer",
+        enum: ["infer", "text", "image"],
       },
     },
   };
 
-  async effect({ text }: BlockArg): Promise<void> {
-    copy(String(text));
+  async effect({
+    text,
+    // Fallback to "text" for backward compatability
+    contentType: contentTypeInput = "text",
+  }: BlockArg<{
+    text: string | boolean | number;
+    contentType: ContentType;
+  }>): Promise<void> {
+    const contentType =
+      contentTypeInput === "infer" ? detectContentType(text) : contentTypeInput;
+
+    switch (contentType) {
+      case "image": {
+        let blob: Blob;
+
+        if (typeof text !== "string") {
+          throw new PropError(
+            "Invalid image content, expected data URI",
+            this.id,
+            "text",
+            text
+          );
+        }
+
+        try {
+          blob = dataURItoBlob(text);
+        } catch (error) {
+          throw new BusinessError("Invalid image content", { cause: error });
+        }
+
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            [blob.type]: blob,
+          }),
+        ]);
+
+        break;
+      }
+
+      case "text": {
+        copy(String(text));
+        break;
+      }
+
+      default: {
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
+        throw new BusinessError(`Invalid content type: ${contentType}`);
+      }
+    }
   }
 }

--- a/src/blocks/effects/clipboard.ts
+++ b/src/blocks/effects/clipboard.ts
@@ -120,6 +120,12 @@ export class CopyToClipboard extends Effect {
           throw new BusinessError("Invalid image content", { cause: error });
         }
 
+        if (!("write" in navigator.clipboard)) {
+          throw new BusinessError(
+            "Your browser does not support writing images to the clipboard"
+          );
+        }
+
         await navigator.clipboard.write([
           new ClipboardItem({
             [blob.type]: blob,

--- a/src/blocks/transformers/screenshotTab.ts
+++ b/src/blocks/transformers/screenshotTab.ts
@@ -61,7 +61,7 @@ export class ScreenshotTab extends Transformer {
         // - Executing a context menu item
         // - Executing a keyboard shortcut from the commands API
         throw new BusinessError(
-          "The Screenshot Tab brick can only be run from the context menu or sidebar of the active tab"
+          "The Screenshot Tab brick can only be run from the context menu, quick bar, or sidebar of the active tab"
         );
       }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #5357 
- Adds support for copying image data URI to the clipboard as an image, e.g. for use with our Screenshot Tab brick

## Discussion

- The `copy-text-to-clipboard` library can likely be removed now that the browser clipboard API is stable

## Demo

- https://www.loom.com/share/8796835cde91401fb435ba3ba215c41a

## Future Work

- See if there's other content types (e.g., rich text, etc.) we should be supporting on the clipboard brick

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
