### PR TITLE
#5364: add brick to prompt user to select element

### DIFF
--- a/src/blocks/transformers/getAllTransformers.ts
+++ b/src/blocks/transformers/getAllTransformers.ts
@@ -48,6 +48,7 @@ import DisplayTemporaryInfo from "@/blocks/transformers/temporaryInfo/DisplayTem
 import TraverseElements from "@/blocks/transformers/traverseElements";
 import TourStepTransformer from "@/blocks/transformers/tourStep/tourStep";
 import { type IBlock } from "@/core";
+import { SelectElement } from "@/blocks/transformers/selectElement";
 
 function getAllTransformers(): IBlock[] {
   return [
@@ -78,6 +79,7 @@ function getAllTransformers(): IBlock[] {
     new ScreenshotTab(),
     new RandomNumber(),
     new TraverseElements(),
+    new SelectElement(),
 
     // Control Flow Bricks
     new ForEach(),

--- a/src/blocks/transformers/selectElement.test.ts
+++ b/src/blocks/transformers/selectElement.test.ts
@@ -54,6 +54,6 @@ describe("selectElement", () => {
 
     userSelectElementMock.mockRejectedValue(new CancelError());
 
-    await expect(() => brick.transform()).rejects.toThrow(CancelError);
+    await expect(async () => brick.transform()).rejects.toThrow(CancelError);
   });
 });

--- a/src/blocks/transformers/selectElement.test.ts
+++ b/src/blocks/transformers/selectElement.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { SelectElement } from "@/blocks/transformers/selectElement";
+import { userSelectElement } from "@/contentScript/pageEditor/elementPicker";
+import { getReferenceForElement } from "@/contentScript/elementReference";
+import { CancelError } from "@/errors/businessErrors";
+
+jest.mock("@/contentScript/pageEditor/elementPicker", () => ({
+  userSelectElement: jest.fn(),
+}));
+
+const userSelectElementMock = userSelectElement as jest.MockedFunction<
+  typeof userSelectElement
+>;
+
+const brick = new SelectElement();
+
+describe("selectElement", () => {
+  it("should select element", async () => {
+    document.body.innerHTML = "<div><button>Hello</button></div>";
+
+    const elements = [...document.querySelectorAll("button")];
+
+    userSelectElementMock.mockResolvedValue({
+      elements,
+      isMulti: false,
+      shouldSelectSimilar: false,
+    });
+
+    const result = await brick.transform();
+
+    expect(result).toEqual({
+      elements: [getReferenceForElement(elements[0])],
+    });
+  });
+
+  it("handle cancel error", async () => {
+    document.body.innerHTML = "<div><button>Hello</button></div>";
+
+    userSelectElementMock.mockRejectedValue(new CancelError());
+
+    await expect(() => brick.transform()).rejects.toThrow(CancelError);
+  });
+});

--- a/src/blocks/transformers/selectElement.ts
+++ b/src/blocks/transformers/selectElement.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Transformer } from "@/types";
+import { type Schema } from "@/core";
+import { propertiesToSchema } from "@/validators/generic";
+import { userSelectElement } from "@/contentScript/pageEditor/elementPicker";
+import { getReferenceForElement } from "@/contentScript/elementReference";
+
+export class SelectElement extends Transformer {
+  constructor() {
+    super(
+      "@pixiebrix/html/select",
+      "Select Element on Page",
+      "Prompt the user to select an element on the page"
+    );
+  }
+
+  defaultOutputKey = "selected";
+
+  // In the future, can add options for selecting multiple elements, providing instructions to the user, filtering
+  // valid elements, etc.
+  inputSchema: Schema = {
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+  };
+
+  override outputSchema: Schema = propertiesToSchema({
+    elements: {
+      type: "array",
+      description: "The array of element references selected",
+      items: {
+        $ref: "https://app.pixiebrix.com/schemas/element#",
+      },
+    },
+  });
+
+  async transform(): Promise<unknown> {
+    const { elements } = await userSelectElement();
+
+    const elementRefs = elements.map((element) =>
+      getReferenceForElement(element)
+    );
+
+    return {
+      elements: elementRefs,
+    };
+  }
+}

--- a/src/blocks/transformers/selectElement.ts
+++ b/src/blocks/transformers/selectElement.ts
@@ -18,7 +18,6 @@
 import { Transformer } from "@/types";
 import { type Schema } from "@/core";
 import { propertiesToSchema } from "@/validators/generic";
-import { userSelectElement } from "@/contentScript/pageEditor/elementPicker";
 import { getReferenceForElement } from "@/contentScript/elementReference";
 
 export class SelectElement extends Transformer {
@@ -51,6 +50,11 @@ export class SelectElement extends Transformer {
   });
 
   async transform(): Promise<unknown> {
+    // Include here to avoid error during header generation (which runs in node environment)
+    const { userSelectElement } = await import(
+      /* webpackChunkName: "editorContentScript" */ "@/contentScript/pageEditor/elementPicker"
+    );
+
     const { elements } = await userSelectElement();
 
     const elementRefs = elements.map((element) =>

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -27,7 +27,7 @@ import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 113;
+const EXPECTED_HEADER_COUNT = 114;
 
 registerBuiltinBlocks();
 registerContribBlocks();


### PR DESCRIPTION
## What does this PR do?

- Closes #5364 
- Adds a brick to prompt the user to select an element
- Selection returned as array of element references. Will allow for multi-select in the future

## Discussion

- The user can escape out of selection mode with `Esc`, which throws a CancelError

## Demo

- https://www.loom.com/share/19b701da7e994ea5ad998a217346a1b1

## Future Work

- Support multi-select with selection tool
- Allow user to specify which element patterns are valid, e.g., only images
- Allow support for showing instructions while in selection mode

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @BLoe 
