### PR TITLE
Add mod activation telemetry details

### DIFF
--- a/src/contentScript/marketplace.ts
+++ b/src/contentScript/marketplace.ts
@@ -32,6 +32,7 @@ import {
   setActivatingBlueprint,
 } from "@/background/messenger/external/_implementation";
 import reportError from "@/telemetry/reportError";
+import { reportEvent } from "@/telemetry/events";
 
 function getActivateButtonLinks(): NodeListOf<HTMLAnchorElement> {
   return document.querySelectorAll<HTMLAnchorElement>(
@@ -134,6 +135,12 @@ async function loadPageEnhancements(): Promise<void> {
         window.location.assign(button.href);
         return;
       }
+
+      reportEvent("StartInstallBlueprint", {
+        blueprintId: recipeId,
+        screen: "marketplace",
+        reinstall: installedRecipeIds.has(recipeId),
+      });
 
       await showSidebarActivationForRecipe(recipeId);
     });

--- a/src/hooks/activateRecipe/useMarketplaceActivateRecipe.test.ts
+++ b/src/hooks/activateRecipe/useMarketplaceActivateRecipe.test.ts
@@ -23,7 +23,7 @@ import {
 } from "@/testUtils/factories";
 import { type WizardValues } from "@/options/pages/marketplace/wizardTypes";
 import { renderHook } from "@/pageEditor/testHelpers";
-import useActivateRecipe from "@/hooks/activateRecipe/useActivateRecipe";
+import useMarketplaceActivateRecipe from "@/hooks/activateRecipe/useMarketplaceActivateRecipe";
 import { validateRegistryId } from "@/types/helpers";
 import { type ExtensionPointConfig } from "@/extensionPoints/types";
 import { type MenuDefinition } from "@/extensionPoints/contextMenu";
@@ -106,7 +106,7 @@ describe("useActivateRecipe", () => {
     const {
       result: { current: activateRecipe },
       getReduxStore,
-    } = renderHook(() => useActivateRecipe(), {
+    } = renderHook(() => useMarketplaceActivateRecipe(), {
       setupRedux(dispatch, { store }) {
         jest.spyOn(store, "dispatch");
       },
@@ -133,7 +133,7 @@ describe("useActivateRecipe", () => {
       result: { current: activateRecipe },
       getReduxStore,
       act,
-    } = renderHook(() => useActivateRecipe(), {
+    } = renderHook(() => useMarketplaceActivateRecipe(), {
       setupRedux(dispatch, { store }) {
         jest.spyOn(store, "dispatch");
       },

--- a/src/hooks/activateRecipe/useMarketplaceActivateRecipe.ts
+++ b/src/hooks/activateRecipe/useMarketplaceActivateRecipe.ts
@@ -32,12 +32,19 @@ type ActivateResult = {
   error?: string;
 };
 
-type ActivateRecipe = (
+type ActivateRecipeFormCallback = (
   formValues: WizardValues,
   recipe: RecipeDefinition
 ) => Promise<ActivateResult>;
 
-function useActivateRecipe(): ActivateRecipe {
+/**
+ * React hook to install a recipe, suitable for using as a Formik `onSubmit` handler.
+ *
+ * Prompts the user to grant permissions if PixieBrix does not already have the required permissions.
+ *
+ * @see useExtensionConsoleInstall
+ */
+function useMarketplaceActivateRecipe(): ActivateRecipeFormCallback {
   const dispatch = useDispatch();
   const extensions = useSelector(selectExtensions);
 
@@ -71,7 +78,11 @@ function useActivateRecipe(): ActivateRecipe {
           })
         );
 
-        reportEvent("InstallBlueprint");
+        reportEvent("InstallBlueprint", {
+          blueprintId: recipe.metadata.id,
+          screen: "marketplace",
+          reinstall: recipeExtensions.length > 0,
+        });
 
         reactivateEveryTab();
       } catch (error) {
@@ -92,4 +103,4 @@ function useActivateRecipe(): ActivateRecipe {
   );
 }
 
-export default useActivateRecipe;
+export default useMarketplaceActivateRecipe;

--- a/src/options/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.ts
@@ -100,13 +100,19 @@ function useInstallableViewItemActions(
 
   const reinstall = () => {
     if (hasBlueprint) {
+      const blueprintId = isInstallableBlueprint
+        ? installable.metadata.id
+        : installable._recipe.id;
+
+      reportEvent("StartInstallBlueprint", {
+        blueprintId,
+        screen: "extensionConsole",
+        reinstall: true,
+      });
+
       dispatch(
         push(
-          `marketplace/activate/${encodeURIComponent(
-            isInstallableBlueprint
-              ? installable.metadata.id
-              : installable._recipe.id
-          )}?reinstall=1`
+          `marketplace/activate/${encodeURIComponent(blueprintId)}?reinstall=1`
         )
       );
     } else {
@@ -120,6 +126,12 @@ function useInstallableViewItemActions(
 
   const activate = () => {
     if (isInstallableBlueprint) {
+      reportEvent("StartInstallBlueprint", {
+        blueprintId: installable.metadata.id,
+        screen: "extensionConsole",
+        reinstall: false,
+      });
+
       dispatch(
         push(
           `/marketplace/activate/${encodeURIComponent(installable.metadata.id)}`

--- a/src/options/pages/blueprints/utils/useExtensionConsoleInstall.ts
+++ b/src/options/pages/blueprints/utils/useExtensionConsoleInstall.ts
@@ -39,7 +39,7 @@ import { uninstallRecipe } from "@/store/uninstallUtils";
 import { actions as extensionActions } from "@/store/extensionsSlice";
 import { selectExtensionsForRecipe } from "@/store/extensionsSelectors";
 
-type InstallRecipe = (
+type InstallRecipeFormCallback = (
   values: WizardValues,
   helpers: FormikHelpers<WizardValues>
 ) => Promise<void>;
@@ -58,8 +58,11 @@ type InstallRecipe = (
  *
  * @param recipe the blueprint definition to install
  * @see useEnsurePermissions
+ * @see useMarketplaceActivateRecipe
  */
-function useInstall(recipe: RecipeDefinition): InstallRecipe {
+function useExtensionConsoleInstall(
+  recipe: RecipeDefinition
+): InstallRecipeFormCallback {
   const dispatch = useDispatch();
   const [createMilestone] = useCreateMilestoneMutation();
   const { hasMilestone } = useMilestones();
@@ -128,7 +131,11 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
         );
 
         notify.success(`Installed ${recipe.metadata.name}`);
-        reportEvent("InstallBlueprint");
+
+        reportEvent("InstallBlueprint", {
+          blueprintId: recipeId,
+          screen: "extensionConsole",
+        });
 
         if (!hasMilestone("first_time_public_blueprint_install")) {
           await createMilestone({
@@ -170,4 +177,4 @@ function useInstall(recipe: RecipeDefinition): InstallRecipe {
   );
 }
 
-export default useInstall;
+export default useExtensionConsoleInstall;

--- a/src/options/pages/marketplace/ActivateWizard.test.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.test.tsx
@@ -29,7 +29,7 @@ import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/reg
 import { type RegistryId } from "@/core";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
-import useInstall from "@/options/pages/blueprints/utils/useInstall";
+import useExtensionConsoleInstall from "@/options/pages/blueprints/utils/useExtensionConsoleInstall";
 import { ensureAllPermissions } from "@/permissions";
 
 registerDefaultWidgets();
@@ -51,10 +51,13 @@ jest.mock("@/store/optionsStore", () => ({
 
 const installMock = jest.fn();
 
-jest.mock("@/options/pages/blueprints/utils/useInstall", () => ({
-  __esModule: true,
-  default: jest.fn().mockImplementation(() => installMock),
-}));
+jest.mock(
+  "@/options/pages/blueprints/utils/useExtensionConsoleInstall",
+  () => ({
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => installMock),
+  })
+);
 
 jest.mock("@/services/api", () => ({
   useGetMarketplaceListingsQuery: jest
@@ -161,7 +164,7 @@ describe("ActivateWizard", () => {
     expect(rendered.asFragment()).toMatchSnapshot();
     await userEvent.click(rendered.getByText("Activate"));
     await waitForEffect();
-    expect(useInstall).toHaveBeenCalledWith(blueprint);
+    expect(useExtensionConsoleInstall).toHaveBeenCalledWith(blueprint);
 
     expect(installMock).toHaveBeenCalledWith(
       {
@@ -196,7 +199,7 @@ describe("ActivateWizard", () => {
     await waitForEffect();
     await userEvent.click(rendered.getByText("Activate"));
     await waitForEffect();
-    expect(useInstall).toHaveBeenCalledWith(blueprint);
+    expect(useExtensionConsoleInstall).toHaveBeenCalledWith(blueprint);
     expect(installMock).not.toHaveBeenCalled();
   });
 });

--- a/src/options/pages/marketplace/ActivateWizard.tsx
+++ b/src/options/pages/marketplace/ActivateWizard.tsx
@@ -25,7 +25,7 @@ import { truncate } from "lodash";
 // eslint-disable-next-line no-restricted-imports -- TODO: Fix over time
 import { Formik } from "formik";
 import { useTitle } from "@/hooks/title";
-import useInstall from "@/options/pages/blueprints/utils/useInstall";
+import useExtensionConsoleInstall from "@/options/pages/blueprints/utils/useExtensionConsoleInstall";
 import { useLocation } from "react-router";
 import { useDispatch, useSelector } from "react-redux";
 import { selectExtensions } from "@/store/extensionsSelectors";
@@ -86,7 +86,7 @@ const ActivateWizard: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
     new URLSearchParams(location.search).get("reinstall") === "1";
   const [blueprintSteps, initialValues, validationSchema] =
     useWizard(blueprint);
-  const install = useInstall(blueprint);
+  const install = useExtensionConsoleInstall(blueprint);
 
   const installedExtensions = useSelector(selectExtensions);
 

--- a/src/sidebar/activateRecipe/ActivateRecipeInputs.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipeInputs.tsx
@@ -28,7 +28,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExternalLinkAlt, faMagic } from "@fortawesome/free-solid-svg-icons";
 import { type WizardValues } from "@/options/pages/marketplace/wizardTypes";
 import { Button, Col } from "react-bootstrap";
-import useActivateRecipe from "@/hooks/activateRecipe/useActivateRecipe";
+import useMarketplaceActivateRecipe from "@/hooks/activateRecipe/useMarketplaceActivateRecipe";
 import Alert from "@/components/Alert";
 import cx from "classnames";
 import Effect from "@/components/Effect";
@@ -61,7 +61,7 @@ const ActivateRecipeInputs: React.FC<ActivateRecipeInputsProps> = ({
   const [wizardSteps, initialValues, validationSchema] = useWizard(recipe);
   const optionsStep = wizardSteps.find(({ key }) => key === "options");
   const servicesStep = wizardSteps.find(({ key }) => key === "services");
-  const activateRecipe = useActivateRecipe();
+  const activateRecipe = useMarketplaceActivateRecipe();
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [needsPermissions, setNeedsPermissions] = useState(false);
   const [includesQuickbar, setIncludesQuickbar] = useState(false);


### PR DESCRIPTION
## What does this PR do?

- Clarifies naming of `useInstall` and `useActivateRecipe` hook names to clarify where/how they're used
- Adds a `StartInstallBlueprint` telemetry event when the user clicks the "Activate" button
  - `blueprintId`
  - `screen`: `extensionConsole` or `marketplace`
  - `reinstall`: true or false
- Adds details to `InstallBlueprint` event, which fires when the user successfully activates/re-activates a mod
  - `blueprintId`
  - `reinstall`: true or false 

# Discussion

- The `/marketplace/` subdirectory of the extension project is misleading. It actually refers to the extension console. (The naming was introduced back when we introduced the concept of internal/external marketplaces for activating mods)
- Likely a future opportunity to consolidate useExtensionConsoleInstall and useMarketplaceActivateRecipe because there's significant overlap in functionality and they both assume the same Formik state

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @BLoe 
