### PR TITLE
Fix false positive warning in service locator

### DIFF
--- a/src/services/locator.ts
+++ b/src/services/locator.ts
@@ -284,7 +284,10 @@ class LazyLocatorFactory {
       );
     }
 
-    if (isEmpty(match.config)) {
+    const proxy = service.hasAuth && !match.local;
+
+    // Proxy configurations have their secrets removed, so can be empty on the client-side
+    if (isEmpty(match.config) && !proxy) {
       console.warn(`Config ${authId} for service ${serviceId} is empty`);
     }
 
@@ -293,14 +296,14 @@ class LazyLocatorFactory {
       updateTimestamp: this.updateTimestamp,
       id: authId,
       config: match.config,
-      proxy: service.hasAuth && !match.local,
+      proxy,
     });
 
     return {
       _sanitizedServiceConfigurationBrand: undefined,
       id: authId,
       serviceId,
-      proxy: service.hasAuth && !match.local,
+      proxy,
       config: excludeSecrets(service, match.config),
     };
   }


### PR DESCRIPTION
## What does this PR do?

- Fixes an incorrect warning in the service locator:

Original Warning
![image](https://user-images.githubusercontent.com/1879821/226483191-9e2e164e-b7bc-414b-bac8-640c9763d100.png)

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @BLoe 
