### PR TITLE
#5371: initialize registries on heartbeat initiation

### DIFF
--- a/src/background/deployment.ts
+++ b/src/background/deployment.ts
@@ -57,6 +57,8 @@ import { getEditorState, saveEditorState } from "@/store/dynamicElementStorage";
 import { type EditorState } from "@/pageEditor/pageEditorTypes";
 import { editorSlice } from "@/pageEditor/slices/editorSlice";
 import { removeExtensionForEveryTab } from "@/background/removeExtensionForEveryTab";
+import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
+import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 const { reducer: optionsReducer, actions: optionsActions } = extensionsSlice;
 const { reducer: editorReducer, actions: editorActions } = editorSlice;
@@ -521,7 +523,7 @@ export async function updateDeployments(): Promise<void> {
   } catch (error) {
     reportError(error);
     void browser.runtime.openOptionsPage();
-    // Bail and open the main options page, which 1) fetches the latest bricks, and 2) will prompt the user the to
+    // Bail and open the main options page, which 1) fetches the latest bricks, and 2) will prompt the user to
     // manually install the deployments via the banner
     return;
   }
@@ -587,6 +589,10 @@ async function resetUpdatePromptTimestamp() {
 }
 
 function initDeploymentUpdater(): void {
+  // Need to load the built-in bricks for permissions checks to work on initial startup
+  registerBuiltinBlocks();
+  registerContribBlocks();
+
   setInterval(updateDeployments, UPDATE_INTERVAL_MS);
   void resetUpdatePromptTimestamp();
   void updateDeployments();

--- a/src/blocks/registerBuiltinBlocks.ts
+++ b/src/blocks/registerBuiltinBlocks.ts
@@ -23,7 +23,15 @@ import getAllReaders, {
 } from "@/blocks/readers/getAllReaders";
 import blockRegistry from "@/blocks/registry";
 
+let registered = false;
+
 function registerBuiltinBlocks() {
+  if (registered) {
+    console.warn(
+      "registerBuiltinBlocks already called; multiple calls are unnecessary and may impact startup performance"
+    );
+  }
+
   blockRegistry.register([
     ...getAllTransformers(),
     ...getAllEffects(),
@@ -32,6 +40,8 @@ function registerBuiltinBlocks() {
   ]);
 
   registerReaderFactories();
+
+  registered = true;
 }
 
 export default registerBuiltinBlocks;

--- a/src/contrib/registerContribBlocks.ts
+++ b/src/contrib/registerContribBlocks.ts
@@ -38,7 +38,15 @@ import { PushZap } from "./zapier/push";
 import { RunBot } from "./automationanywhere/RunBot";
 import { GoogleSheetsLookup } from "@/contrib/google/sheets/lookup";
 
+let registered = false;
+
 function registerContribBlocks(): void {
+  if (registered) {
+    console.warn(
+      "registerBuiltinBlocks already called; multiple calls are unnecessary and may impact startup performance"
+    );
+  }
+
   blockRegistry.register([
     // Google
     new GoogleSheetsAppend(),
@@ -75,6 +83,8 @@ function registerContribBlocks(): void {
     // Automation Anywhere
     new RunBot(),
   ]);
+
+  registered = true;
 }
 
 export default registerContribBlocks;

--- a/src/hooks/useRefreshRegistries.ts
+++ b/src/hooks/useRefreshRegistries.ts
@@ -25,6 +25,13 @@ import {
 } from "@/background/messenger/api";
 import { fetchNewPackages } from "@/baseRegistry";
 
+const refreshServices = async () => {
+  await serviceAuthRegistry.refresh();
+  // Ensure the background page is using the latest service definitions for fulfilling requests. This must come after
+  // the call to serviceRegistry, because that populates the local IDB definitions.
+  await clearServiceCache();
+};
+
 /**
  * Refresh registries for the current context.
  *
@@ -32,11 +39,7 @@ import { fetchNewPackages } from "@/baseRegistry";
  */
 export async function refreshRegistries(): Promise<void> {
   console.debug("Refreshing bricks from the server");
-  await Promise.allSettled([fetchNewPackages(), serviceAuthRegistry.refresh()]);
-
-  // Ensure the background page is using the latest service definitions for fulfilling requests. This must come after
-  // the call to serviceRegistry, because that populates the local IDB definitions.
-  await clearServiceCache();
+  await Promise.all([fetchNewPackages(), refreshServices()]);
 }
 
 const throttledRefreshRegistries = throttle(


### PR DESCRIPTION
## What does this PR do?

- Fixes #5371 
- Registers bricks in background worker before initializing heartbeat
- Modifies refreshRegistries to throw if updating bricks fails

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
