### PR TITLE
#5335: Update rainforest workflow and upload_extension.sh

### DIFF
--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -15,9 +15,6 @@ on:
 jobs:
   rainforestqa:
     runs-on: ubuntu-latest
-    env:
-      BUILD_FILENAME: ${{ github.job }}-${{ github.sha }}.zip
-      BUILD_PATH: builds/${{ github.job }}-${{ github.sha }}.zip
 
     steps:
       - uses: actions/checkout@v3
@@ -36,7 +33,18 @@ jobs:
           ROLLBAR_POST_SERVER_ITEM_TOKEN: ${{ secrets.ROLLBAR_POST_SERVER_ITEM_TOKEN }}
           CHROME_MANIFEST_KEY: ${{ secrets.CHROME_MANIFEST_PROD_PUBLIC_KEY }}
 
-      - run: bash scripts/upload-extension.sh
+      # https://stackoverflow.com/a/58142637
+      - name: Get Branch
+      - if: github.ref_name == 'main'
+      - run: echo "##[set-output name=build_path;]$(echo builds/pixiebrix-extension-main.zip)"
+      - run: echo "##[set-output name=run_group;]$(echo 14129)"
+      - if: github.ref_name != 'main'
+      - run: echo "##[set-output name=build_path;]$(echo builds/pixiebrix-extension-release.zip)"
+      - run: echo "##[set-output name=run_group;]$(echo 14130)"
+      - id: extract_branch
+
+      - name: Upload Extension
+      - run: bash scripts/upload-extension.sh steps.extract_branch.outputs.build_path
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SOURCEMAP_USER_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SOURCEMAP_USER_KEY }}
@@ -54,13 +62,12 @@ jobs:
 
       # https://github.com/rainforestapp/rainforest-cli
       - name: Run Rainforest QA Extension Test Suite
-        # Include hash on at end of the URL because Rainforest QA automatically appends a "/" to the end of custom URLs
         # Can't pass cancel for conflict because while we're generating a separate Rainforest QA environment for each run
         #   they're all using the same server
         # Use --fail-fast so that we're not using GitHub build minutes if not necessary
         run: |
-          ./rainforest run --fail-fast --description "CI automatic run" --run-group $RUN_GROUP --release "${{ github.sha }}" --conflict cancel-all --custom-url "https://pixiebrix-extension-builds.s3.us-east-2.amazonaws.com/$BUILD_PATH"
+          ./rainforest run --fail-fast --description "CI automatic run" --run-group $RUN_GROUP --release "${{ github.sha }}" --conflict cancel-all
         env:
           RAINFOREST_API_TOKEN: ${{ secrets.RAINFORESTQA_TOKEN }}
-          # The run group for tests to run during CI
-          RUN_GROUP: 9732
+          # The run group for tests to run during CI, now has start URL built-in
+          RUN_GROUP: steps.extract_branch.outputs.run_group

--- a/scripts/upload-extension.sh
+++ b/scripts/upload-extension.sh
@@ -3,9 +3,15 @@
 # Automatically exit on error
 set -e
 
+if [ "$#" -ne 1 ]; then
+  echo "Usage: ./upload-extension.sh <BUILD_PATH>"
+  echo "example: ./upload-extension.sh pixiebrix-extension-cws"
+fi
+
 # Ensure ENVs are set https://stackoverflow.com/a/307735/288906
-: "${BUILD_PATH?Need to set BUILD_PATH}"
-: "${BUILD_FILENAME?Need to set BUILD_FILENAME}"
+# Extract everything after last slash https://unix.stackexchange.com/a/247636
+BUILD_PATH=$1
+BUILD_FILENAME="${BUILD_PATH##*/}"
 
 : "${AWS_ACCESS_KEY_ID?Need to set AWS_ACCESS_KEY_ID}"
 : "${AWS_SECRET_ACCESS_KEY?Need to set AWS_SECRET_ACCESS_KEY}"


### PR DESCRIPTION
## What does this PR do?

- Closes #5335 
- Corresponds to: Test Independent Rainforest Project Slice: 1
- _Are there other changes (e.g., refactoring) included that aren’t from the ticket?_
    - Created 3 new environments in Rainforest (Main, Release, CWS) and 3 new run groups (same names)
    - Placed the existing CI tests in the new run groups

## Discussion
- [Link to specification](https://www.notion.so/pixiebrix/Test-Independent-Rainforest-Environments-67a031a2298547e2835dbccf5d35a5a8?pvs=4#091a70e60fc94aae8eed123e5a329041)
- Filenames for extension uploads should look like this going forward: pixiebrix-extension-[main|release|cws]
    - This simplifies the s3 link: https://pixiebrix-extension-builds.s3.us-east-2.amazonaws.com/builds/$filename
    - **Question**: how does S3 handle duplicate filenames? For example, will uploading pixiebrix-extension-main a second+ time overwrite the previous file, or does the upload fail?

## Checklist

- [x] Designate a primary reviewer: @twschiller 
