### PR TITLE
#5403: fix factory reset to reset all persisted state

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.1.0).
+ * Mock Service Worker (1.2.0).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/src/auth/authSlice.ts
+++ b/src/auth/authSlice.ts
@@ -21,14 +21,12 @@ import { type AuthState } from "./authTypes";
 import { localStorage } from "redux-persist-webextension-storage";
 import { isEmpty } from "lodash";
 import { type StorageInterface } from "@/store/StorageInterface";
+import { revertAll } from "@/store/commonActions";
 
 export const authSlice = createSlice({
   name: "auth",
   initialState: anonAuth,
   reducers: {
-    resetAuth() {
-      return anonAuth;
-    },
     setAuth(state, { payload }: PayloadAction<AuthState>) {
       console.debug("authSlice:setAuth", payload);
 
@@ -42,6 +40,9 @@ export const authSlice = createSlice({
         groups: Array.isArray(payload.groups) ? payload.groups : [],
       };
     },
+  },
+  extraReducers(builder) {
+    builder.addCase(revertAll, () => anonAuth);
   },
 });
 

--- a/src/auth/authSlice.ts
+++ b/src/auth/authSlice.ts
@@ -26,6 +26,9 @@ export const authSlice = createSlice({
   name: "auth",
   initialState: anonAuth,
   reducers: {
+    resetAuth() {
+      return anonAuth;
+    },
     setAuth(state, { payload }: PayloadAction<AuthState>) {
       console.debug("authSlice:setAuth", payload);
 

--- a/src/options/pages/blueprints/blueprintsSlice.ts
+++ b/src/options/pages/blueprints/blueprintsSlice.ts
@@ -20,6 +20,7 @@ import { type Filters, type SortingRule } from "react-table";
 import { localStorage } from "redux-persist-webextension-storage";
 import { type InstallableViewItem } from "./blueprintsTypes";
 import { type StorageInterface } from "@/store/StorageInterface";
+import { revertAll } from "@/store/commonActions";
 
 type View = "list" | "grid";
 
@@ -54,9 +55,6 @@ const blueprintsSlice = createSlice({
   name: "blueprints",
   initialState,
   reducers: {
-    resetScreen() {
-      return initialState;
-    },
     setView(state, { payload: view }: PayloadAction<View>) {
       state.view = view;
     },
@@ -77,6 +75,9 @@ const blueprintsSlice = createSlice({
     setSearchQuery(state, { payload: searchQuery }: PayloadAction<string>) {
       state.searchQuery = searchQuery;
     },
+  },
+  extraReducers(builder) {
+    builder.addCase(revertAll, () => initialState);
   },
 });
 

--- a/src/options/pages/blueprints/blueprintsSlice.ts
+++ b/src/options/pages/blueprints/blueprintsSlice.ts
@@ -54,6 +54,9 @@ const blueprintsSlice = createSlice({
   name: "blueprints",
   initialState,
   reducers: {
+    resetScreen() {
+      return initialState;
+    },
     setView(state, { payload: view }: PayloadAction<View>) {
       state.view = view;
     },

--- a/src/options/pages/settings/FactoryResetSettings.tsx
+++ b/src/options/pages/settings/FactoryResetSettings.tsx
@@ -19,15 +19,8 @@ import { Card } from "react-bootstrap";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import notify from "@/utils/notify";
-import extensionsSlice from "@/store/extensionsSlice";
-import servicesSlice from "@/store/servicesSlice";
 import { clearPackages } from "@/baseRegistry";
-import { recipesSlice } from "@/recipes/recipesSlice";
-import { authSlice } from "@/auth/authSlice";
 import { clearLogs, reactivateEveryTab } from "@/background/messenger/api";
-import blueprintsSlice from "@/options/pages/blueprints/blueprintsSlice";
-import settingsSlice from "@/store/settingsSlice";
-import workshopSlice from "@/store/workshopSlice";
 import { sessionChangesActions } from "@/store/sessionChanges/sessionChangesSlice";
 import AsyncButton from "@/components/AsyncButton";
 import { reportEvent } from "@/telemetry/events";
@@ -36,14 +29,7 @@ import { type Permissions } from "webextension-polyfill";
 import { selectAdditionalPermissionsSync } from "webext-additional-permissions";
 import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 import { persistor } from "@/store/optionsStore";
-
-const { resetOptions } = extensionsSlice.actions;
-const { resetServices } = servicesSlice.actions;
-const { resetRecipes } = recipesSlice.actions;
-const { resetAuth } = authSlice.actions;
-const { resetScreen: resetBlueprintsScreen } = blueprintsSlice.actions;
-const { resetSettings } = settingsSlice.actions;
-const { resetWorkshop } = workshopSlice.actions;
+import { revertAll } from "@/store/commonActions";
 
 async function revokeAllAdditionalPermissions() {
   const permissions: Permissions.AnyPermissions =
@@ -88,13 +74,8 @@ const FactoryResetSettings: React.FunctionComponent = () => {
 
             try {
               // Reset all persisted state -- see optionsStore.ts
-              dispatch(resetBlueprintsScreen());
-              dispatch(resetOptions());
-              dispatch(resetServices());
-              dispatch(resetRecipes());
-              dispatch(resetAuth());
-              dispatch(resetSettings());
-              dispatch(resetWorkshop());
+              dispatch(revertAll());
+
               dispatch(sessionChangesActions.resetSessionChanges());
               // Force all open page editors to be reloaded
               dispatch(sessionChangesActions.setSessionChanges({ sessionId }));

--- a/src/options/pages/settings/FactoryResetSettings.tsx
+++ b/src/options/pages/settings/FactoryResetSettings.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Button, Card } from "react-bootstrap";
+import { Card } from "react-bootstrap";
 import React from "react";
 import { useDispatch } from "react-redux";
 import notify from "@/utils/notify";
@@ -25,11 +25,12 @@ import { clearPackages } from "@/baseRegistry";
 import { editorSlice } from "@/pageEditor/slices/editorSlice";
 import { recipesSlice } from "@/recipes/recipesSlice";
 import { authSlice } from "@/auth/authSlice";
-import { clearLogs } from "@/background/messenger/api";
+import { clearLogs, reactivateEveryTab } from "@/background/messenger/api";
 import blueprintsSlice from "@/options/pages/blueprints/blueprintsSlice";
 import settingsSlice from "@/store/settingsSlice";
 import workshopSlice from "@/store/workshopSlice";
 import { sessionChangesSlice } from "@/store/sessionChanges/sessionChangesSlice";
+import AsyncButton from "@/components/AsyncButton";
 
 const { resetOptions } = extensionsSlice.actions;
 const { resetServices } = servicesSlice.actions;
@@ -52,7 +53,7 @@ const FactoryResetSettings: React.FunctionComponent = () => {
           Click here to reset your local PixieBrix data.{" "}
           <b>This will deactivate any mods you&apos;ve installed.</b>
         </p>
-        <Button
+        <AsyncButton
           variant="danger"
           onClick={async () => {
             try {
@@ -74,6 +75,8 @@ const FactoryResetSettings: React.FunctionComponent = () => {
                 clearPackages(),
               ]);
 
+              reactivateEveryTab();
+
               notify.success("Reset all mods and integration configurations");
             } catch (error) {
               notify.error({
@@ -84,7 +87,7 @@ const FactoryResetSettings: React.FunctionComponent = () => {
           }}
         >
           Factory Reset
-        </Button>
+        </AsyncButton>
       </Card.Body>
     </Card>
   );

--- a/src/options/pages/settings/FactoryResetSettings.tsx
+++ b/src/options/pages/settings/FactoryResetSettings.tsx
@@ -96,6 +96,7 @@ const FactoryResetSettings: React.FunctionComponent = () => {
               dispatch(resetSettings());
               dispatch(resetWorkshop());
               dispatch(sessionChangesActions.resetSessionChanges());
+              // Force all open page editors to be reloaded
               dispatch(sessionChangesActions.setSessionChanges({ sessionId }));
 
               await Promise.allSettled([

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -322,6 +322,9 @@ export const editorSlice = createSlice({
   name: "editor",
   initialState,
   reducers: {
+    resetEditor() {
+      return initialState;
+    },
     toggleInsert(state, action: PayloadAction<ExtensionPointType>) {
       state.inserting = action.payload;
       state.beta = false;

--- a/src/recipes/recipesSlice.ts
+++ b/src/recipes/recipesSlice.ts
@@ -77,6 +77,9 @@ export const recipesSlice = createSlice({
   name: "recipes",
   initialState,
   reducers: {
+    resetRecipes() {
+      return initialState;
+    },
     startLoadingFromCache(state) {
       state.isFetchingFromCache = true;
     },

--- a/src/recipes/recipesSlice.ts
+++ b/src/recipes/recipesSlice.ts
@@ -20,6 +20,7 @@ import { serializeError } from "serialize-error";
 import { type RecipesRootState, type RecipesState } from "./recipesTypes";
 import recipeRegistry from "./registry";
 import { fetchNewPackages } from "@/baseRegistry";
+import { revertAll } from "@/store/commonActions";
 
 export const initialState: RecipesState = Object.freeze({
   recipes: [],
@@ -77,9 +78,6 @@ export const recipesSlice = createSlice({
   name: "recipes",
   initialState,
   reducers: {
-    resetRecipes() {
-      return initialState;
-    },
     startLoadingFromCache(state) {
       state.isFetchingFromCache = true;
     },
@@ -106,6 +104,9 @@ export const recipesSlice = createSlice({
       state.isFetching = false;
       state.isLoading = false;
     },
+  },
+  extraReducers(builder) {
+    builder.addCase(revertAll, () => initialState);
   },
 });
 

--- a/src/store/commonActions.ts
+++ b/src/store/commonActions.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { createAction } from "@reduxjs/toolkit";
+
+/**
+ * Redux action to revert slices to their initial state.
+ */
+export const revertAll = createAction("REVERT_ALL");

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -45,6 +45,7 @@ import {
 } from "@/store/extensionsTypes";
 import { type Except } from "type-fest";
 import { assertExtensionNotResolved } from "@/runtime/runtimeUtils";
+import { revertAll } from "@/store/commonActions";
 
 const initialExtensionsState: ExtensionOptionsState = {
   extensions: [],
@@ -66,10 +67,6 @@ const extensionsSlice = createSlice({
   name: "extensions",
   initialState: initialExtensionsState,
   reducers: {
-    resetOptions(state) {
-      state.extensions = [];
-    },
-
     installCloudExtension(
       state,
       { payload }: PayloadAction<{ extension: CloudExtension }>
@@ -347,6 +344,9 @@ const extensionsSlice = createSlice({
       // NOTE: We aren't deleting the extension on the server. The user must do that separately from the dashboard
       state.extensions = state.extensions.filter((x) => x.id !== extensionId);
     },
+  },
+  extraReducers(builder) {
+    builder.addCase(revertAll, () => initialExtensionsState);
   },
 });
 

--- a/src/store/servicesSlice.ts
+++ b/src/store/servicesSlice.ts
@@ -19,6 +19,7 @@ import { type RawServiceConfiguration, type UUID } from "@/core";
 import { localStorage } from "redux-persist-webextension-storage";
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { type StorageInterface } from "@/store/StorageInterface";
+import { revertAll } from "@/store/commonActions";
 
 export interface ServicesState {
   configured: Record<string, RawServiceConfiguration>;
@@ -58,11 +59,10 @@ const servicesSlice = createSlice({
         config,
       } as RawServiceConfiguration;
     },
-    resetServices(state) {
-      state.configured = {};
-    },
   },
-
+  extraReducers(builder) {
+    builder.addCase(revertAll, () => initialServicesState);
+  },
   /* eslint-enable security/detect-object-injection */
 });
 

--- a/src/store/sessionChanges/sessionChangesSlice.ts
+++ b/src/store/sessionChanges/sessionChangesSlice.ts
@@ -20,7 +20,6 @@ import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { localStorage } from "redux-persist-webextension-storage";
 import { type StorageInterface } from "@/store/StorageInterface";
 import { type SessionChangesState } from "@/store/sessionChanges/sessionChangesTypes";
-import { uuidv4 } from "@/types/helpers";
 
 export const initialState: SessionChangesState = {
   latestChanges: {},
@@ -33,10 +32,7 @@ export const sessionChangesSlice = createSlice({
   initialState,
   reducers: {
     resetSessionChanges() {
-      const state = { ...initialState };
-      // Add an entry to force open Page Editors to show session expired warning
-      state.latestChanges[uuidv4()] = Date.now();
-      return state;
+      return initialState;
     },
     setSessionChanges(
       state,

--- a/src/store/sessionChanges/sessionChangesSlice.ts
+++ b/src/store/sessionChanges/sessionChangesSlice.ts
@@ -20,6 +20,7 @@ import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { localStorage } from "redux-persist-webextension-storage";
 import { type StorageInterface } from "@/store/StorageInterface";
 import { type SessionChangesState } from "@/store/sessionChanges/sessionChangesTypes";
+import { uuidv4 } from "@/types/helpers";
 
 export const initialState: SessionChangesState = {
   latestChanges: {},
@@ -31,6 +32,12 @@ export const sessionChangesSlice = createSlice({
   name: key,
   initialState,
   reducers: {
+    resetSessionChanges() {
+      const state = { ...initialState };
+      // Add an entry to force open Page Editors to show session expired warning
+      state.latestChanges[uuidv4()] = Date.now();
+      return state;
+    },
     setSessionChanges(
       state,
       action: PayloadAction<{

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -27,6 +27,7 @@ import { DEFAULT_THEME } from "@/options/types";
 import { isValidTheme } from "@/utils/themeUtils";
 import { type RegistryId } from "@/core";
 import { isRegistryId } from "@/types/helpers";
+import { revertAll } from "@/store/commonActions";
 
 export const initialSettingsState: SettingsState = {
   mode: "remote",
@@ -45,9 +46,6 @@ const settingsSlice = createSlice({
   name: "settings",
   initialState: initialSettingsState,
   reducers: {
-    resetSettings() {
-      return initialSettingsState;
-    },
     setMode(state, { payload: { mode } }) {
       state.mode = mode;
     },
@@ -115,6 +113,9 @@ const settingsSlice = createSlice({
         reportError(new Error(`Selected theme "${theme}" doesn't exist.`));
       });
     },
+  },
+  extraReducers(builder) {
+    builder.addCase(revertAll, () => initialSettingsState);
   },
 });
 

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -45,6 +45,9 @@ const settingsSlice = createSlice({
   name: "settings",
   initialState: initialSettingsState,
   reducers: {
+    resetSettings() {
+      return initialSettingsState;
+    },
     setMode(state, { payload: { mode } }) {
       state.mode = mode;
     },

--- a/src/store/workshopSlice.ts
+++ b/src/store/workshopSlice.ts
@@ -19,6 +19,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import { orderBy } from "lodash";
 import { localStorage } from "redux-persist-webextension-storage";
 import { type StorageInterface } from "@/store/StorageInterface";
+import { revertAll } from "@/store/commonActions";
 
 type RecentBrick = {
   id: string;
@@ -56,9 +57,6 @@ const workshopSlice = createSlice({
   name: "workshop",
   initialState: initialWorkshopState,
   reducers: {
-    resetWorkshop() {
-      return initialWorkshopState;
-    },
     setScopes(state, { payload: scopes }) {
       state.filters.scopes = scopes;
     },
@@ -89,6 +87,9 @@ const workshopSlice = createSlice({
         ).slice(0, state.maxRecent);
       }
     },
+  },
+  extraReducers(builder) {
+    builder.addCase(revertAll, () => initialWorkshopState);
   },
 });
 

--- a/src/store/workshopSlice.ts
+++ b/src/store/workshopSlice.ts
@@ -56,6 +56,9 @@ const workshopSlice = createSlice({
   name: "workshop",
   initialState: initialWorkshopState,
   reducers: {
+    resetWorkshop() {
+      return initialWorkshopState;
+    },
     setScopes(state, { payload: scopes }) {
       state.filters.scopes = scopes;
     },


### PR DESCRIPTION
## What does this PR do?

- Fixes #5403 
- Fixes Factory Reset to reset all persisted state, and reactivate PixieBrix on all tabs

## Discussion

- Calls dispatch on the reducers vs. clearing localStorage for persisted state directly

## Demo

- https://www.loom.com/share/60646e763a084abdbda8b63bc9eba5b0

## Checklist

- [ ] Add tests: N/A - not worth it at this time given code to number of mocks required
- [x] Designate a primary reviewer: @BLoe 
