### PR TITLE
#5405: fix variable analysis to input.event

### DIFF
--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -1101,4 +1101,49 @@ describe("var analysis integration tests", () => {
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(0);
   });
+
+  it("should handle trigger custom event", async () => {
+    const extension = triggerFormStateFactory(undefined, [
+      {
+        id: EchoBlock.BLOCK_ID,
+        config: {
+          message: makeTemplateExpression(
+            "nunjucks",
+            "{{ @input.event.thiscouldbeanything }} was pressed"
+          ),
+        },
+      },
+    ]);
+
+    extension.extensionPoint.definition.trigger = "custom";
+
+    const analysis = new VarAnalysis([]);
+    await analysis.run(extension);
+
+    const annotations = analysis.getAnnotations();
+    expect(annotations).toHaveLength(0);
+  });
+
+  it("should handle trigger selectionchange event", async () => {
+    const extension = triggerFormStateFactory(undefined, [
+      {
+        id: EchoBlock.BLOCK_ID,
+        config: {
+          message: makeTemplateExpression(
+            "nunjucks",
+            // Only @input.event.selectedText is available for selectionchange
+            "{{ @input.event.key }} was pressed"
+          ),
+        },
+      },
+    ]);
+
+    extension.extensionPoint.definition.trigger = "selectionchange";
+
+    const analysis = new VarAnalysis([]);
+    await analysis.run(extension);
+
+    const annotations = analysis.getAnnotations();
+    expect(annotations).toHaveLength(1);
+  });
 });

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -203,6 +203,27 @@ function setVarsFromSchema({
     }
 
     if (propertySchema.type === "object") {
+      const nodePath = [...parentPath, key];
+
+      const existence =
+        existenceOverride ?? required?.includes(key)
+          ? VarExistence.DEFINITELY
+          : VarExistence.MAYBE;
+
+      // If the items is an array, then we allow any child to simplify the validation logic
+      const allowAnyChild =
+        propertySchema.additionalProperties != null ||
+        !isEmpty(propertySchema.additionalProperties);
+
+      // Set existence for the current node
+      contextVars.setExistence({
+        source,
+        path: nodePath,
+        existence,
+        isArray: false,
+        allowAnyChild,
+      });
+
       setVarsFromSchema({
         schema: propertySchema,
         contextVars,

--- a/src/extensionPoints/triggerEventReaders.ts
+++ b/src/extensionPoints/triggerEventReaders.ts
@@ -216,6 +216,11 @@ export class CustomEventReader extends Reader {
   };
 }
 
+/**
+ * An event reader to show a helpful message the output preview for the trigger
+ * @param trigger the trigger type.
+ * @see getEventReader
+ */
 export function getShimEventReader(trigger: Trigger): unknown {
   const reader = getEventReader(trigger);
 
@@ -234,6 +239,10 @@ export function getShimEventReader(trigger: Trigger): unknown {
   return null;
 }
 
+/**
+ * Return the reader for the `event` property of the trigger's input, or null if no event data is available.
+ * @param trigger the trigger type
+ */
 export function getEventReader(trigger: Trigger): IReader | null {
   if (KEYBOARD_TRIGGERS.includes(trigger)) {
     return new KeyboardEventReader();


### PR DESCRIPTION
## What does this PR do?

- Fixes #5405 
- VarAnalysis wasn't creating an existence entry for `input.event` for the custom event trigger because it has no named sub-properties

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
