### PR TITLE
#5377: sync revoked packages and show unavailable on mod screen

### DIFF
--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -70,7 +70,6 @@ export const ensureContextMenu = getMethod("ENSURE_CONTEXT_MENU", bg);
 export const openTab = getMethod("OPEN_TAB", bg);
 
 export const registry = {
-  fetch: getMethod("REGISTRY_FETCH", bg),
   syncRemote: getMethod("REGISTRY_SYNC", bg),
   getByKinds: getMethod("REGISTRY_GET_BY_KINDS", bg),
   find: getMethod("REGISTRY_FIND", bg),

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -106,7 +106,6 @@ declare global {
     REMOVE_EXTENSION_EVERY_TAB: typeof removeExtensionForEveryTab;
     CLOSE_TAB: typeof closeTab;
     OPEN_TAB: typeof openTab;
-    REGISTRY_FETCH: typeof registry.fetchNewPackages;
     REGISTRY_SYNC: typeof registry.syncPackages;
     REGISTRY_CLEAR: typeof registry.clear;
     REGISTRY_GET_BY_KINDS: typeof registry.getByKinds;
@@ -181,7 +180,6 @@ export default function registerMessenger(): void {
     REMOVE_EXTENSION_EVERY_TAB: removeExtensionForEveryTab,
     CLOSE_TAB: closeTab,
     OPEN_TAB: openTab,
-    REGISTRY_FETCH: registry.fetchNewPackages,
     REGISTRY_SYNC: registry.syncPackages,
     REGISTRY_CLEAR: registry.clear,
     REGISTRY_GET_BY_KINDS: registry.getByKinds,

--- a/src/background/partnerIntegrations.test.ts
+++ b/src/background/partnerIntegrations.test.ts
@@ -34,7 +34,7 @@ import { readPartnerAuthData, setPartnerAuth } from "@/auth/token";
 import { setCachedAuthData } from "@/background/auth";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
-import { fetchNewPackages } from "@/baseRegistry";
+import { syncRemotePackages } from "@/baseRegistry";
 
 const serviceMap = new Map([
   [(controlRoomTokenService as any).metadata.id, controlRoomTokenService],
@@ -72,7 +72,7 @@ jest.mock("@/background/messenger/api", () => {
           config,
         };
       },
-      fetch: jest.fn().mockResolvedValue(undefined),
+      syncRemote: jest.fn().mockResolvedValue(undefined),
     },
   };
 });
@@ -110,7 +110,7 @@ describe("getPartnerPrincipals", () => {
       controlRoomOAuthService,
     ]);
 
-    await fetchNewPackages();
+    await syncRemotePackages();
 
     // No remote services configured
     fetchMock.mockResolvedValue([]);
@@ -127,7 +127,7 @@ describe("getPartnerPrincipals", () => {
       controlRoomOAuthService,
     ]);
 
-    await fetchNewPackages();
+    await syncRemotePackages();
 
     // No remote services configured
     fetchMock.mockResolvedValue([]);

--- a/src/background/refreshRegistries.ts
+++ b/src/background/refreshRegistries.ts
@@ -16,12 +16,20 @@
  */
 
 import { refreshServices } from "./locator";
-import { fetchNewPackages } from "@/baseRegistry";
+import { syncRemotePackages } from "@/baseRegistry";
+import { expectContext } from "@/utils/expectContext";
 
+/**
+ * Method to refresh packages and services in the background context.
+ *
+ * @see useRefreshRegistries
+ */
 export async function refreshRegistries(): Promise<void> {
+  expectContext("background");
+
   await Promise.all([
     // Call the @/baseRegistry copy of fetchNewPackages so it invalidates in-memory registries
-    fetchNewPackages(),
+    syncRemotePackages(),
     refreshServices(),
   ]);
 }

--- a/src/baseRegistry.ts
+++ b/src/baseRegistry.ts
@@ -58,19 +58,6 @@ function notifyDatabaseListeners() {
 }
 
 /**
- * Fetch new remote packages and notify listeners.
- */
-export const fetchNewPackages = memoizeUntilSettled(async () => {
-  expectContext("extension");
-
-  const changed = await backgroundRegistry.fetch();
-
-  if (changed) {
-    notifyDatabaseListeners();
-  }
-});
-
-/**
  * Replace IDB with remote packages and notify listeners.
  */
 export const syncRemotePackages = memoizeUntilSettled(async () => {

--- a/src/hooks/useRefreshRegistries.ts
+++ b/src/hooks/useRefreshRegistries.ts
@@ -23,7 +23,7 @@ import {
   clearServiceCache,
   services as serviceAuthRegistry,
 } from "@/background/messenger/api";
-import { fetchNewPackages } from "@/baseRegistry";
+import { syncRemotePackages } from "@/baseRegistry";
 
 const refreshServices = async () => {
   await serviceAuthRegistry.refresh();
@@ -38,8 +38,9 @@ const refreshServices = async () => {
  * Additionally, refreshes background states necessary for making network calls.
  */
 export async function refreshRegistries(): Promise<void> {
+  // Sync remote packages in order to be able to remove packages that have been deleted/the user no longer has access to
   console.debug("Refreshing bricks from the server");
-  await Promise.all([fetchNewPackages(), refreshServices()]);
+  await Promise.all([syncRemotePackages(), refreshServices()]);
 }
 
 const throttledRefreshRegistries = throttle(

--- a/src/options/pages/blueprints/InstallableIcon.tsx
+++ b/src/options/pages/blueprints/InstallableIcon.tsx
@@ -17,15 +17,26 @@
 
 import React, { useMemo } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCube, faCubes } from "@fortawesome/free-solid-svg-icons";
+import {
+  faCube,
+  faCubes,
+  faExclamationCircle,
+} from "@fortawesome/free-solid-svg-icons";
 import { useAsyncIcon } from "@/components/asyncIcon";
 import { type MarketplaceListing } from "@/types/contract";
 import { type Installable } from "@/options/pages/blueprints/blueprintsTypes";
-import { isBlueprint } from "@/options/pages/blueprints/utils/installableUtils";
+import {
+  isBlueprint,
+  isUnavailableRecipe,
+} from "@/options/pages/blueprints/utils/installableUtils";
 import cx from "classnames";
 import styles from "./InstallableIcon.module.scss";
 
 function getDefaultInstallableIcon(installable: Installable) {
+  if (isUnavailableRecipe(installable)) {
+    return faExclamationCircle;
+  }
+
   if (isBlueprint(installable) && installable.extensionPoints.length > 1) {
     return faCubes;
   }
@@ -33,7 +44,7 @@ function getDefaultInstallableIcon(installable: Installable) {
   return faCube;
 }
 
-const DEFAULT_TEXT_ICON_COLOR = "#241C32";
+export const DEFAULT_TEXT_ICON_COLOR = "#241C32";
 
 const InstallableIcon: React.FunctionComponent<{
   listing: MarketplaceListing;

--- a/src/options/pages/blueprints/Status.test.tsx
+++ b/src/options/pages/blueprints/Status.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import Status from "@/options/pages/blueprints/Status";
+
+import useInstallableViewItemActions from "./useInstallableViewItemActions";
+
+jest.mock("./useInstallableViewItemActions", () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue({}),
+}));
+
+const useInstallableViewItemActionsMock =
+  useInstallableViewItemActions as jest.MockedFunction<
+    typeof useInstallableViewItemActions
+  >;
+
+describe("Status", () => {
+  beforeEach(() => {
+    useInstallableViewItemActionsMock.mockReturnValue({} as any);
+  });
+
+  it("shows active", async () => {
+    const wrapper = render(
+      <Status
+        installableViewItem={
+          {
+            active: true,
+          } as any
+        }
+      />
+    );
+
+    expect(wrapper.getByText("Active")).toBeVisible();
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+
+  it("shows activate", async () => {
+    useInstallableViewItemActionsMock.mockReturnValue({
+      activate: jest.fn(),
+    } as any);
+
+    const wrapper = render(
+      <Status
+        installableViewItem={
+          {
+            active: true,
+          } as any
+        }
+      />
+    );
+
+    expect(wrapper.getByText("Activate")).toBeVisible();
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+
+  it("shows warning for unavailable", async () => {
+    const wrapper = render(
+      <Status
+        installableViewItem={
+          {
+            unavailable: true,
+          } as any
+        }
+      />
+    );
+
+    expect(wrapper.getByText("No longer available")).toBeVisible();
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+
+  it("paused", async () => {
+    const wrapper = render(
+      <Status
+        installableViewItem={
+          {
+            status: "Paused",
+          } as any
+        }
+      />
+    );
+
+    expect(wrapper.getByText("Paused")).toBeVisible();
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/options/pages/blueprints/Status.tsx
+++ b/src/options/pages/blueprints/Status.tsx
@@ -33,10 +33,18 @@ import AsyncButton from "@/components/AsyncButton";
 const Status: React.VoidFunctionComponent<{
   installableViewItem: InstallableViewItem;
 }> = ({ installableViewItem }) => {
-  const { activate, reinstall, requestPermissions } =
+  const { activate, reinstall, requestPermissions, uninstall } =
     useInstallableViewItemActions(installableViewItem);
 
   const { hasUpdate, status, installedVersionNumber } = installableViewItem;
+
+  if (status === "Unavailable") {
+    return (
+      <Button size="sm" variant="outline-primary" onClick={uninstall}>
+        Deactivate
+      </Button>
+    );
+  }
 
   if (activate) {
     return (

--- a/src/options/pages/blueprints/Status.tsx
+++ b/src/options/pages/blueprints/Status.tsx
@@ -24,6 +24,7 @@ import useInstallableViewItemActions from "./useInstallableViewItemActions";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faCheck,
+  faExclamationTriangle,
   faPause,
   faShieldAlt,
   faSync,
@@ -33,16 +34,23 @@ import AsyncButton from "@/components/AsyncButton";
 const Status: React.VoidFunctionComponent<{
   installableViewItem: InstallableViewItem;
 }> = ({ installableViewItem }) => {
-  const { activate, reinstall, requestPermissions, uninstall } =
+  const { activate, reinstall, requestPermissions } =
     useInstallableViewItemActions(installableViewItem);
 
-  const { hasUpdate, status, installedVersionNumber } = installableViewItem;
+  const { hasUpdate, status, installedVersionNumber, unavailable } =
+    installableViewItem;
 
-  if (status === "Unavailable") {
+  if (unavailable) {
     return (
-      <Button size="sm" variant="outline-primary" onClick={uninstall}>
-        Deactivate
-      </Button>
+      <div className="text-warning">
+        <div className={styles.root}>
+          <FontAwesomeIcon icon={faExclamationTriangle} />
+          <span className={styles.textStatus}>
+            Active
+            <span className={styles.versionNumber}>No longer available</span>
+          </span>
+        </div>
+      </div>
     );
   }
 

--- a/src/options/pages/blueprints/__snapshots__/Status.test.tsx.snap
+++ b/src/options/pages/blueprints/__snapshots__/Status.test.tsx.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Status paused 1`] = `
+<DocumentFragment>
+  <div
+    class="text-muted"
+  >
+    <div
+      class="root"
+    >
+      <svg
+        aria-hidden="true"
+        class="svg-inline--fa fa-pause fa-w-14 "
+        data-icon="pause"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        viewBox="0 0 448 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M144 479H48c-26.5 0-48-21.5-48-48V79c0-26.5 21.5-48 48-48h96c26.5 0 48 21.5 48 48v352c0 26.5-21.5 48-48 48zm304-48V79c0-26.5-21.5-48-48-48h-96c-26.5 0-48 21.5-48 48v352c0 26.5 21.5 48 48 48h96c26.5 0 48-21.5 48-48z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="textStatus"
+      >
+        Paused
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Status shows activate 1`] = `
+<DocumentFragment>
+  <button
+    class="btn btn-outline-primary btn-sm"
+    type="button"
+  >
+    Activate
+  </button>
+</DocumentFragment>
+`;
+
+exports[`Status shows active 1`] = `
+<DocumentFragment>
+  <div
+    class="text-success"
+  >
+    <div
+      class="root"
+    >
+      <svg
+        aria-hidden="true"
+        class="svg-inline--fa fa-check fa-w-16 "
+        data-icon="check"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        viewBox="0 0 512 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="textStatus"
+      >
+        Active
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Status shows warning for unavailable 1`] = `
+<DocumentFragment>
+  <div
+    class="text-warning"
+  >
+    <div
+      class="root"
+    >
+      <svg
+        aria-hidden="true"
+        class="svg-inline--fa fa-exclamation-triangle fa-w-18 "
+        data-icon="exclamation-triangle"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        viewBox="0 0 576 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="textStatus"
+      >
+        Active
+        <span
+          class="versionNumber"
+        >
+          No longer available
+        </span>
+      </span>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/options/pages/blueprints/blueprintsTypes.ts
+++ b/src/options/pages/blueprints/blueprintsTypes.ts
@@ -49,9 +49,7 @@ export type InstallableStatus =
   | "Active"
   | "Inactive"
   // The installable is a deployment that has been paused
-  | "Paused"
-  // The IExtension(s) for a mod are installed, but the user no longer has access to the source mod
-  | "Unavailable";
+  | "Paused";
 
 // Reshaped Installable to easily filter, sort, and group Installables
 export type InstallableViewItem = {
@@ -69,6 +67,10 @@ export type InstallableViewItem = {
   icon: ReactNode;
   // Used to get Installable actions from useInstallableActions
   installable: Installable;
+  /**
+   * True if the source package is no longer available
+   */
+  unavailable: boolean;
 };
 
 export type BlueprintsPageContentProps = {

--- a/src/options/pages/blueprints/blueprintsTypes.ts
+++ b/src/options/pages/blueprints/blueprintsTypes.ts
@@ -21,8 +21,22 @@ import { type RecipeDefinition } from "@/types/definitions";
 import { type ReactNode } from "react";
 import { type Organization } from "@/types/contract";
 
+/**
+ * A recipe that has been deleted (or user no longer has access) from the registry, but is still installed locally.
+ * @since 1.7.22
+ */
+export type UnavailableRecipe = Pick<
+  RecipeDefinition,
+  "kind" | "metadata" | "updated_at" | "sharing"
+> & {
+  isStub: true;
+};
+
 // XXX: should this be UnresolvedExtension instead of ResolvedExtension? The old screens used ResolvedExtension
-export type Installable = RecipeDefinition | ResolvedExtension;
+export type Installable =
+  | RecipeDefinition
+  | ResolvedExtension
+  | UnavailableRecipe;
 
 export type SharingType = "Personal" | "Team" | "Public" | "Deployment";
 export type SharingSource = {
@@ -31,7 +45,13 @@ export type SharingSource = {
   organization: Organization;
 };
 
-export type InstallableStatus = "Active" | "Inactive" | "Paused";
+export type InstallableStatus =
+  | "Active"
+  | "Inactive"
+  // The installable is a deployment that has been paused
+  | "Paused"
+  // The IExtension(s) for a mod are installed, but the user no longer has access to the source mod
+  | "Unavailable";
 
 // Reshaped Installable to easily filter, sort, and group Installables
 export type InstallableViewItem = {

--- a/src/options/pages/blueprints/gridView/GridCardErrorBoundary.tsx
+++ b/src/options/pages/blueprints/gridView/GridCardErrorBoundary.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { Component } from "react";
+import { Card } from "react-bootstrap";
+import { getErrorMessage } from "@/errors/errorHelpers";
+import { type InstallableViewItem } from "@/options/pages/blueprints/blueprintsTypes";
+
+import styles from "./GridCard.module.scss";
+import cx from "classnames";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
+import { DEFAULT_TEXT_ICON_COLOR } from "@/options/pages/blueprints/InstallableIcon";
+
+type Props = {
+  /**
+   * Where the error happened, a hint in a free form
+   */
+  errorContext?: string;
+
+  installableItem: InstallableViewItem;
+};
+
+type State = {
+  hasError: boolean;
+  errorMessage: string;
+  stack: string;
+};
+
+class GridCardErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, errorMessage: undefined, stack: undefined };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    // Update state so the next render will show the fallback UI.
+    return {
+      hasError: true,
+      errorMessage: getErrorMessage(error),
+      stack: error.stack,
+    };
+  }
+
+  override render(): React.ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className={styles.root}>
+          <Card className={styles.card}>
+            <Card.Body className={styles.cardBody}>
+              <div className={styles.primaryInfo}>
+                <div className="d-flex justify-content-between">
+                  <div>
+                    <h5 className={styles.name}>
+                      {this.props.installableItem.name}
+                    </h5>
+                    <span className={cx(styles.description, "text-muted")}>
+                      An error occurred retrieving mod
+                    </span>
+                    <div className={styles.packageId}>
+                      {this.props.installableItem.sharing.packageId}
+                    </div>
+                  </div>
+                  <span className="mb-2">
+                    <FontAwesomeIcon
+                      icon={faExclamationCircle}
+                      color={DEFAULT_TEXT_ICON_COLOR}
+                      size="2x"
+                      fixedWidth
+                    />
+                  </span>
+                </div>
+              </div>
+              <div>
+                <div className={styles.actions}></div>
+              </div>
+            </Card.Body>
+            <Card.Footer className={styles.cardFooter}></Card.Footer>
+          </Card>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default GridCardErrorBoundary;

--- a/src/options/pages/blueprints/gridView/GridView.tsx
+++ b/src/options/pages/blueprints/gridView/GridView.tsx
@@ -28,6 +28,7 @@ import { type Row } from "react-table";
 import ListGroupHeader from "@/options/pages/blueprints/listView/ListGroupHeader";
 import { uuidv4 } from "@/types/helpers";
 import { getUniqueId } from "@/options/pages/blueprints/utils/installableUtils";
+import GridCardErrorBoundary from "@/options/pages/blueprints/gridView/GridCardErrorBoundary";
 
 /**
  *  Expands `react-table` rows recursively in chunks of
@@ -125,10 +126,15 @@ const GridView: React.VoidFunctionComponent<BlueprintsPageContentProps> = ({
           {gridRow.map((row: Row<InstallableViewItem>) => {
             tableInstance.prepareRow(row);
             return (
-              <GridCard
-                key={getUniqueId(row.original.installable)}
+              <GridCardErrorBoundary
                 installableItem={row.original}
-              />
+                key={getUniqueId(row.original.installable)}
+              >
+                <GridCard
+                  key={getUniqueId(row.original.installable)}
+                  installableItem={row.original}
+                />
+              </GridCardErrorBoundary>
             );
           })}
         </div>

--- a/src/options/pages/blueprints/labels/LastUpdatedLabel.tsx
+++ b/src/options/pages/blueprints/labels/LastUpdatedLabel.tsx
@@ -25,9 +25,13 @@ import React from "react";
 import cx from "classnames";
 
 const LastUpdatedLabel: React.VoidFunctionComponent<{
-  timestamp: string;
+  timestamp: string | null;
   className?: string;
 }> = ({ timestamp, className }) => {
+  if (timestamp == null) {
+    return null;
+  }
+
   const timestampFormatted = new Date(timestamp).toLocaleString();
 
   // Omitted attributes aren't required

--- a/src/options/pages/blueprints/listView/ListItemErrorBoundary.tsx
+++ b/src/options/pages/blueprints/listView/ListItemErrorBoundary.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { Component } from "react";
+import { ListGroup } from "react-bootstrap";
+import { getErrorMessage } from "@/errors/errorHelpers";
+import { type InstallableViewItem } from "@/options/pages/blueprints/blueprintsTypes";
+
+import styles from "./ListItem.module.scss";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
+import { DEFAULT_TEXT_ICON_COLOR } from "@/options/pages/blueprints/InstallableIcon";
+import cx from "classnames";
+
+type Props = {
+  /**
+   * Where the error happened, a hint in a free form
+   */
+  errorContext?: string;
+
+  installableItem: InstallableViewItem;
+
+  style: React.CSSProperties;
+};
+
+type State = {
+  hasError: boolean;
+  errorMessage: string;
+  stack: string;
+};
+
+class ListItemErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, errorMessage: undefined, stack: undefined };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    // Update state so the next render will show the fallback UI.
+    return {
+      hasError: true,
+      errorMessage: getErrorMessage(error),
+      stack: error.stack,
+    };
+  }
+
+  override render(): React.ReactNode {
+    if (this.state.hasError) {
+      return (
+        <ListGroup.Item className={styles.root} style={this.props.style}>
+          <div className={styles.icon}>
+            <FontAwesomeIcon
+              icon={faExclamationCircle}
+              color={DEFAULT_TEXT_ICON_COLOR}
+              size="2x"
+              fixedWidth
+            />
+          </div>
+          <div className={styles.primaryInfo}>
+            <h5 className={styles.name}>{this.props.installableItem.name}</h5>
+            <p className={cx(styles.description, "text-muted")}>
+              An error occurred retrieving mod
+            </p>
+            <div className={styles.packageId}>
+              {this.props.installableItem.sharing.packageId}
+            </div>
+          </div>
+          <div className="flex-shrink-0"></div>
+          <div className={styles.status}></div>
+          <div className="flex-shrink-0"></div>
+        </ListGroup.Item>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ListItemErrorBoundary;

--- a/src/options/pages/blueprints/listView/ListView.tsx
+++ b/src/options/pages/blueprints/listView/ListView.tsx
@@ -22,6 +22,7 @@ import { VariableSizeList as List } from "react-window";
 import ListGroupHeader from "@/options/pages/blueprints/listView/ListGroupHeader";
 import { uuidv4 } from "@/types/helpers";
 import { type BlueprintsPageContentProps } from "@/options/pages/blueprints/blueprintsTypes";
+import ListItemErrorBoundary from "@/options/pages/blueprints/listView/ListItemErrorBoundary";
 
 const ROW_HEIGHT_PX = 90;
 const HEADER_ROW_HEIGHT_PX = 43;
@@ -70,7 +71,9 @@ const ListView: React.VoidFunctionComponent<BlueprintsPageContentProps> = ({
           return row.isGrouped ? (
             <ListGroupHeader groupName={row.groupByVal} style={style} />
           ) : (
-            <ListItem installableItem={row.original} style={style} />
+            <ListItemErrorBoundary installableItem={row.original} style={style}>
+              <ListItem installableItem={row.original} style={style} />
+            </ListItemErrorBoundary>
           );
         }}
       </List>

--- a/src/options/pages/blueprints/useInstallableViewItemActions.test.tsx
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.test.tsx
@@ -90,10 +90,12 @@ const installableItemFactory = ({
   isExtension,
   sharingType,
   status,
+  unavailable = false,
 }: {
   isExtension: boolean;
   sharingType: SharingType;
   status: InstallableStatus;
+  unavailable?: boolean;
 }) =>
   ({
     installable: isExtension ? extensionFactory() : recipeFactory(),
@@ -103,6 +105,7 @@ const installableItemFactory = ({
       },
     },
     status,
+    unavailable,
   } as InstallableViewItem);
 
 afterEach(() => {
@@ -280,7 +283,8 @@ describe("useInstallableViewItemActions", () => {
     const blueprintItem = installableItemFactory({
       isExtension: false,
       sharingType: "Team",
-      status: "Unavailable",
+      status: "Active",
+      unavailable: true,
     });
 
     const {

--- a/src/options/pages/blueprints/useInstallableViewItemActions.test.tsx
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.test.tsx
@@ -275,6 +275,20 @@ describe("useInstallableViewItemActions", () => {
     );
   });
 
+  test("blueprint with access revoked", () => {
+    mockHooks();
+    const blueprintItem = installableItemFactory({
+      isExtension: false,
+      sharingType: "Team",
+      status: "Unavailable",
+    });
+
+    const {
+      result: { current: actions },
+    } = renderHook(() => useInstallableViewItemActions(blueprintItem));
+    expectActions(["uninstall", "viewLogs"], actions);
+  });
+
   test("paused deployment with unrestricted user", () => {
     mockHooks({ restricted: false });
     const deploymentItem = installableItemFactory({

--- a/src/options/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.ts
@@ -68,7 +68,8 @@ function useInstallableViewItemActions(
   const { restrict } = useFlags();
 
   // NOTE: paused deployments are installed, but they are not executed. See deployments.ts:isDeploymentActive
-  const isInstalled = status === "Active" || status === "Paused";
+  const isInstalled =
+    status === "Active" || status === "Paused" || status === "Unavailable";
   const isInstallableExtension = isExtension(installable);
   const isInstallableBlueprint = !isInstallableExtension;
 
@@ -82,6 +83,7 @@ function useInstallableViewItemActions(
   const hasBlueprint =
     isExtensionFromRecipe(installable) || isInstallableBlueprint;
 
+  const isUnavailable = status === "Unavailable";
   const isDeployment = sharing.source.type === "Deployment";
 
   // Restricted users aren't allowed to uninstall/reinstall deployments. They are controlled by the admin from the
@@ -245,6 +247,7 @@ function useInstallableViewItemActions(
   };
 
   const showPublishAction =
+    !isUnavailable &&
     // Deployment sharing is controlled via the Admin Console
     !isDeployment &&
     // Extensions can be published
@@ -253,7 +256,7 @@ function useInstallableViewItemActions(
       sharing.listingId == null);
 
   const viewInMarketplaceHref =
-    isDeployment || showPublishAction
+    isDeployment || showPublishAction || isUnavailable
       ? null
       : // If showPublishAction is false, then the listing for the recipe is defined
         `${MARKETPLACE_URL}${sharing.listingId}/`;
@@ -262,12 +265,15 @@ function useInstallableViewItemActions(
     viewPublish: showPublishAction ? viewPublish : null,
     viewInMarketplaceHref,
     // Deployment sharing is controlled via the Admin Console
-    viewShare: isDeployment ? null : viewShare,
+    viewShare: isDeployment || isUnavailable ? null : viewShare,
     deleteExtension: isCloudExtension ? deleteExtension : null,
     uninstall: isInstalled && !isRestricted ? uninstall : null,
     // Only blueprints/deployments can be reinstalled. (Because there's no reason to reinstall an extension... there's
     // no activation-time integrations/options associated with them.)
-    reinstall: hasBlueprint && isInstalled && !isRestricted ? reinstall : null,
+    reinstall:
+      hasBlueprint && isInstalled && !isRestricted && !isUnavailable
+        ? reinstall
+        : null,
     viewLogs: status === "Inactive" ? null : viewLogs,
     activate: status === "Inactive" ? activate : null,
     requestPermissions: hasPermissions ? null : requestPermissions,

--- a/src/options/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/options/pages/blueprints/useInstallableViewItemActions.ts
@@ -61,15 +61,14 @@ export type InstallableViewItemActions = {
 function useInstallableViewItemActions(
   installableViewItem: InstallableViewItem
 ): InstallableViewItemActions {
-  const { installable, status, sharing } = installableViewItem;
+  const { installable, status, sharing, unavailable } = installableViewItem;
   const dispatch = useDispatch();
   const modals = useModals();
   const [deleteCloudExtension] = useDeleteCloudExtensionMutation();
   const { restrict } = useFlags();
 
   // NOTE: paused deployments are installed, but they are not executed. See deployments.ts:isDeploymentActive
-  const isInstalled =
-    status === "Active" || status === "Paused" || status === "Unavailable";
+  const isInstalled = status === "Active" || status === "Paused";
   const isInstallableExtension = isExtension(installable);
   const isInstallableBlueprint = !isInstallableExtension;
 
@@ -83,7 +82,6 @@ function useInstallableViewItemActions(
   const hasBlueprint =
     isExtensionFromRecipe(installable) || isInstallableBlueprint;
 
-  const isUnavailable = status === "Unavailable";
   const isDeployment = sharing.source.type === "Deployment";
 
   // Restricted users aren't allowed to uninstall/reinstall deployments. They are controlled by the admin from the
@@ -247,7 +245,7 @@ function useInstallableViewItemActions(
   };
 
   const showPublishAction =
-    !isUnavailable &&
+    !unavailable &&
     // Deployment sharing is controlled via the Admin Console
     !isDeployment &&
     // Extensions can be published
@@ -256,7 +254,7 @@ function useInstallableViewItemActions(
       sharing.listingId == null);
 
   const viewInMarketplaceHref =
-    isDeployment || showPublishAction || isUnavailable
+    isDeployment || showPublishAction || unavailable
       ? null
       : // If showPublishAction is false, then the listing for the recipe is defined
         `${MARKETPLACE_URL}${sharing.listingId}/`;
@@ -265,13 +263,13 @@ function useInstallableViewItemActions(
     viewPublish: showPublishAction ? viewPublish : null,
     viewInMarketplaceHref,
     // Deployment sharing is controlled via the Admin Console
-    viewShare: isDeployment || isUnavailable ? null : viewShare,
+    viewShare: isDeployment || unavailable ? null : viewShare,
     deleteExtension: isCloudExtension ? deleteExtension : null,
     uninstall: isInstalled && !isRestricted ? uninstall : null,
     // Only blueprints/deployments can be reinstalled. (Because there's no reason to reinstall an extension... there's
     // no activation-time integrations/options associated with them.)
     reinstall:
-      hasBlueprint && isInstalled && !isRestricted && !isUnavailable
+      hasBlueprint && isInstalled && !isRestricted && !unavailable
         ? reinstall
         : null,
     viewLogs: status === "Inactive" ? null : viewLogs,

--- a/src/options/pages/blueprints/useInstallableViewItems.tsx
+++ b/src/options/pages/blueprints/useInstallableViewItems.tsx
@@ -34,6 +34,7 @@ import {
   getUpdatedAt,
   isDeployment,
   isExtension,
+  isUnavailableRecipe,
   updateAvailable,
 } from "@/options/pages/blueprints/utils/installableUtils";
 import { useGetMarketplaceListingsQuery } from "@/services/api";
@@ -79,6 +80,10 @@ function useInstallableViewItems(installables: Installable[]): {
 
   const getStatus = useCallback(
     (installable: Installable): InstallableStatus => {
+      if (isUnavailableRecipe(installable)) {
+        return "Unavailable";
+      }
+
       if (isDeployment(installable, installedExtensions)) {
         if (isExtension(installable)) {
           return isDeploymentActive(installable) ? "Active" : "Paused";

--- a/src/options/pages/blueprints/useInstallableViewItems.tsx
+++ b/src/options/pages/blueprints/useInstallableViewItems.tsx
@@ -80,10 +80,6 @@ function useInstallableViewItems(installables: Installable[]): {
 
   const getStatus = useCallback(
     (installable: Installable): InstallableStatus => {
-      if (isUnavailableRecipe(installable)) {
-        return "Unavailable";
-      }
-
       if (isDeployment(installable, installedExtensions)) {
         if (isExtension(installable)) {
           return isDeploymentActive(installable) ? "Active" : "Paused";
@@ -148,6 +144,7 @@ function useInstallableViewItems(installables: Installable[]): {
             installable
           ),
           icon: installableIcon(installable),
+          unavailable: isUnavailableRecipe(installable),
           installable,
         } satisfies InstallableViewItem;
       }),

--- a/src/options/pages/blueprints/useInstallables.test.ts
+++ b/src/options/pages/blueprints/useInstallables.test.ts
@@ -75,8 +75,8 @@ describe("useInstallables", () => {
   it("handles unavailable", async () => {
     const wrapper = renderHook(() => useInstallables(), {
       setupRedux(dispatch) {
-        // eslint-disable-next-line new-cap -- unsave
         dispatch(
+          // eslint-disable-next-line new-cap -- unsave
           extensionsSlice.actions.UNSAFE_setExtensions([
             persistedExtensionFactory({
               _recipe: {
@@ -116,8 +116,8 @@ describe("useInstallables", () => {
 
     const wrapper = renderHook(() => useInstallables(), {
       setupRedux(dispatch) {
-        // eslint-disable-next-line new-cap -- test setup
         dispatch(
+          // eslint-disable-next-line new-cap -- test setup
           extensionsSlice.actions.UNSAFE_setExtensions([
             persistedExtensionFactory({
               _recipe: {
@@ -186,8 +186,8 @@ describe("useInstallables", () => {
 
     const wrapper = renderHook(() => useInstallables(), {
       setupRedux(dispatch) {
-        // eslint-disable-next-line new-cap -- test setup
         dispatch(
+          // eslint-disable-next-line new-cap -- test setup
           extensionsSlice.actions.UNSAFE_setExtensions([
             // Content doesn't matter, just need to match the ID
             persistedExtensionFactory({ id: cloudExtension.id }),

--- a/src/options/pages/blueprints/useInstallables.test.ts
+++ b/src/options/pages/blueprints/useInstallables.test.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { renderHook } from "@/options/testHelpers";
+import useInstallables from "@/options/pages/blueprints/useInstallables";
+import extensionsSlice from "@/store/extensionsSlice";
+import { useGetCloudExtensionsQuery } from "@/services/api";
+import {
+  cloudExtensionFactory,
+  persistedExtensionFactory,
+  recipeDefinitionFactory,
+  recipeMetadataFactory,
+} from "@/testUtils/factories";
+import { validateTimestamp } from "@/types/helpers";
+import { useAllRecipes } from "@/recipes/recipesHooks";
+
+jest.mock("@/services/api", () => ({
+  useGetCloudExtensionsQuery: jest.fn(),
+}));
+
+jest.mock("@/recipes/recipesHooks", () => ({
+  useAllRecipes: jest.fn(),
+}));
+
+const useGetCloudExtensionsQueryMock =
+  useGetCloudExtensionsQuery as jest.MockedFunction<
+    typeof useGetCloudExtensionsQuery
+  >;
+const useAllRecipesMock = useAllRecipes as jest.MockedFunction<
+  typeof useAllRecipes
+>;
+
+describe("useInstallables", () => {
+  beforeEach(() => {
+    useGetCloudExtensionsQueryMock.mockReset();
+    useGetCloudExtensionsQueryMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: false,
+      refetch: jest.fn(),
+    });
+
+    useAllRecipesMock.mockReset();
+    useAllRecipesMock.mockReturnValue({ data: undefined } as any);
+  });
+
+  it("handles empty state", async () => {
+    const wrapper = renderHook(() => useInstallables());
+
+    await wrapper.act(async () => {
+      // NOP -- wait for async state to resolve
+    });
+
+    expect(wrapper.result.current).toEqual({
+      installables: [],
+      isLoading: false,
+      error: false,
+    });
+  });
+
+  it("handles unavailable", async () => {
+    const wrapper = renderHook(() => useInstallables(), {
+      setupRedux(dispatch) {
+        // eslint-disable-next-line new-cap -- unsave
+        dispatch(
+          extensionsSlice.actions.UNSAFE_setExtensions([
+            persistedExtensionFactory({
+              _recipe: {
+                ...recipeMetadataFactory(),
+                updated_at: validateTimestamp(new Date().toISOString()),
+                sharing: { public: false, organizations: [] },
+              },
+            }),
+          ])
+        );
+      },
+    });
+
+    await wrapper.act(async () => {
+      // NOP -- wait for async state to resolve
+    });
+
+    expect(wrapper.result.current).toEqual({
+      installables: [
+        expect.objectContaining({
+          isStub: true,
+        }),
+      ],
+      isLoading: false,
+      error: false,
+    });
+  });
+
+  it("handles known recipe", async () => {
+    const metadata = recipeMetadataFactory();
+
+    useAllRecipesMock.mockReturnValue({
+      data: [recipeDefinitionFactory({ metadata })],
+      isLoading: false,
+      error: undefined,
+    } as any);
+
+    const wrapper = renderHook(() => useInstallables(), {
+      setupRedux(dispatch) {
+        // eslint-disable-next-line new-cap -- test setup
+        dispatch(
+          extensionsSlice.actions.UNSAFE_setExtensions([
+            persistedExtensionFactory({
+              _recipe: {
+                ...metadata,
+                updated_at: validateTimestamp(new Date().toISOString()),
+                sharing: { public: false, organizations: [] },
+              },
+            }),
+          ])
+        );
+      },
+    });
+
+    await wrapper.act(async () => {
+      // NOP -- wait for async state to resolve
+    });
+
+    expect(wrapper.result.current).toEqual({
+      installables: [
+        expect.objectContaining({
+          kind: "recipe",
+        }),
+      ],
+      isLoading: false,
+      error: false,
+    });
+
+    expect(wrapper.result.current.installables[0]).not.toHaveProperty("isStub");
+  });
+
+  it("handles inactive cloud extension", async () => {
+    useGetCloudExtensionsQueryMock.mockReturnValue({
+      data: [cloudExtensionFactory()],
+      isLoading: false,
+      error: false,
+      refetch: jest.fn(),
+    });
+
+    const wrapper = renderHook(() => useInstallables());
+
+    await wrapper.act(async () => {
+      // NOP -- wait for async state to resolve
+    });
+
+    expect(wrapper.result.current).toEqual({
+      installables: [
+        expect.objectContaining({
+          active: false,
+          extensionPointId: expect.toBeString(),
+        }),
+      ],
+      isLoading: false,
+      error: false,
+    });
+  });
+
+  it("handles active cloud extension", async () => {
+    const cloudExtension = cloudExtensionFactory();
+
+    useGetCloudExtensionsQueryMock.mockReturnValue({
+      data: [cloudExtension],
+      isLoading: false,
+      error: false,
+      refetch: jest.fn(),
+    });
+
+    const wrapper = renderHook(() => useInstallables(), {
+      setupRedux(dispatch) {
+        // eslint-disable-next-line new-cap -- test setup
+        dispatch(
+          extensionsSlice.actions.UNSAFE_setExtensions([
+            // Content doesn't matter, just need to match the ID
+            persistedExtensionFactory({ id: cloudExtension.id }),
+          ])
+        );
+      },
+    });
+
+    await wrapper.act(async () => {
+      // NOP -- wait for async state to resolve
+    });
+
+    expect(wrapper.result.current).toEqual({
+      installables: [
+        expect.objectContaining({
+          active: true,
+          extensionPointId: expect.toBeString(),
+        }),
+      ],
+      isLoading: false,
+      error: false,
+    });
+  });
+});

--- a/src/options/pages/blueprints/useInstallables.ts
+++ b/src/options/pages/blueprints/useInstallables.ts
@@ -21,7 +21,7 @@ import { useSelector } from "react-redux";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import { useAsyncState } from "@/hooks/common";
 import { resolveDefinitions } from "@/registry/internal";
-import { type Installable } from "./blueprintsTypes";
+import { type Installable, UnavailableRecipe } from "./blueprintsTypes";
 import { useGetCloudExtensionsQuery } from "@/services/api";
 import { selectScope } from "@/auth/authSelectors";
 import { useAllRecipes } from "@/recipes/recipesHooks";
@@ -32,11 +32,15 @@ type InstallablesState = {
   error: unknown;
 };
 
+/**
+ * React Hook returning `Installable`s, a common abstraction for recipes and un-packaged IExtensions.
+ * @see Installable
+ */
 function useInstallables(): InstallablesState {
   const scope = useSelector(selectScope);
   const unresolvedExtensions = useSelector(selectExtensions);
 
-  const recipes = useAllRecipes();
+  const { data: knownRecipes, ...recipesState } = useAllRecipes();
   const cloudExtensions = useGetCloudExtensionsQuery();
 
   const { installedExtensionIds, installedRecipeIds } = useMemo(
@@ -51,9 +55,14 @@ function useInstallables(): InstallablesState {
     [unresolvedExtensions]
   );
 
-  const personalOrTeamBlueprints = useMemo(
+  const knownRecipeIds = useMemo(
+    () => new Set((knownRecipes ?? []).map((x) => x.metadata.id)),
+    [knownRecipes]
+  );
+
+  const knownPersonalOrTeamRecipes = useMemo(
     () =>
-      (recipes.data ?? []).filter(
+      (knownRecipes ?? []).filter(
         (recipe) =>
           // Is personal blueprint
           recipe.metadata.id.includes(scope) ||
@@ -62,7 +71,7 @@ function useInstallables(): InstallablesState {
           // Is blueprint active, e.g. installed via marketplace
           installedRecipeIds.has(recipe.metadata.id)
       ),
-    [installedRecipeIds, recipes.data, scope]
+    [installedRecipeIds, knownRecipes, scope]
   );
 
   const allExtensions = useMemo(() => {
@@ -86,7 +95,7 @@ function useInstallables(): InstallablesState {
 
   const extensionsWithoutRecipe = useMemo(
     () =>
-      // Can be undefined if resolveDefinitions errors above
+      // `resolvedExtensions` can be undefined if resolveDefinitions errors above
       (resolvedExtensions ?? []).filter((extension) =>
         extension._recipe?.id
           ? !installedRecipeIds.has(extension._recipe?.id)
@@ -95,13 +104,33 @@ function useInstallables(): InstallablesState {
     [installedRecipeIds, resolvedExtensions]
   );
 
+  const unknownRecipes: UnavailableRecipe[] = useMemo(() => {
+    // `resolvedExtensions` can be undefined if resolveDefinitions errors above
+    const unavailable = (resolvedExtensions ?? []).filter(
+      (extension) =>
+        extension._recipe?.id && !knownRecipeIds.has(extension._recipe?.id)
+    );
+
+    return unavailable.map((x) => ({
+      metadata: x._recipe,
+      kind: "recipe",
+      isStub: true,
+      updated_at: x._recipe.updated_at,
+      sharing: x._recipe.sharing,
+    }));
+  }, [knownRecipeIds, resolvedExtensions]);
+
   return {
-    installables: [...extensionsWithoutRecipe, ...personalOrTeamBlueprints],
+    installables: [
+      ...extensionsWithoutRecipe,
+      ...knownPersonalOrTeamRecipes,
+      ...unknownRecipes,
+    ],
     isLoading:
-      recipes.isFetching ||
+      recipesState.isFetching ||
       cloudExtensions.isLoading ||
       resolvedExtensionsIsLoading,
-    error: cloudExtensions.error ?? recipes.error ?? resolveError,
+    error: cloudExtensions.error ?? recipesState.error ?? resolveError,
   };
 }
 

--- a/src/options/pages/blueprints/useInstallables.ts
+++ b/src/options/pages/blueprints/useInstallables.ts
@@ -21,7 +21,7 @@ import { useSelector } from "react-redux";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import { useAsyncState } from "@/hooks/common";
 import { resolveDefinitions } from "@/registry/internal";
-import { type Installable, UnavailableRecipe } from "./blueprintsTypes";
+import { type Installable, type UnavailableRecipe } from "./blueprintsTypes";
 import { useGetCloudExtensionsQuery } from "@/services/api";
 import { selectScope } from "@/auth/authSelectors";
 import { useAllRecipes } from "@/recipes/recipesHooks";

--- a/src/options/pages/blueprints/utils/exportBlueprint.test.ts
+++ b/src/options/pages/blueprints/utils/exportBlueprint.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { makeBlueprint } from "@/options/pages/blueprints/utils/exportBlueprint";
+import { extensionFactory } from "@/testUtils/factories";
+import { validateRegistryId } from "@/types/helpers";
+import { type UnresolvedExtension } from "@/core";
+
+describe("makeBlueprint", () => {
+  it("smoke test", () => {
+    const result = makeBlueprint(extensionFactory() as UnresolvedExtension, {
+      id: validateRegistryId("test/blueprint"),
+      name: "test",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "recipe",
+      })
+    );
+  });
+
+  it("infers blueprint options", () => {
+    const extension = extensionFactory({
+      optionsArgs: {
+        foo: "hello world!",
+      },
+    }) as UnresolvedExtension;
+
+    const result = makeBlueprint(extension, {
+      id: validateRegistryId("test/blueprint"),
+      name: "test",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "recipe",
+        options: {
+          schema: {
+            $schema: "http://json-schema.org/draft-04/schema#",
+            properties: {
+              foo: {
+                type: "string",
+              },
+            },
+            title: "Mod Options",
+            type: "object",
+          },
+        },
+      })
+    );
+  });
+});

--- a/src/options/pages/blueprints/utils/exportBlueprint.ts
+++ b/src/options/pages/blueprints/utils/exportBlueprint.ts
@@ -53,6 +53,7 @@ export function makeBlueprint(
   const {
     extensionPointId,
     label,
+    // Use v1 for backward compatibility
     apiVersion = "v1",
     templateEngine,
     permissions,

--- a/src/options/pages/blueprints/utils/installableUtils.test.ts
+++ b/src/options/pages/blueprints/utils/installableUtils.test.ts
@@ -27,7 +27,10 @@ import {
 } from "./installableUtils";
 import { uuidv4 } from "@/types/helpers";
 import { UserRole } from "@/types/contract";
-import { type Installable } from "@/options/pages/blueprints/blueprintsTypes";
+import {
+  type Installable,
+  UnavailableRecipe,
+} from "@/options/pages/blueprints/blueprintsTypes";
 import { type ResolvedExtension } from "@/core";
 
 describe("getSharingType", () => {
@@ -158,6 +161,13 @@ describe("isUnavailableRecipe", () => {
   it("returns false for a recipe definition", () => {
     const installable = recipeDefinitionFactory();
     expect(isUnavailableRecipe(installable)).toBe(false);
+  });
+
+  it("returns true for UnavailableRecipe", () => {
+    const installable = {
+      isStub: true,
+    } as UnavailableRecipe;
+    expect(isUnavailableRecipe(installable)).toBe(true);
   });
 
   it("returns false for an extension", () => {

--- a/src/options/pages/blueprints/utils/installableUtils.test.ts
+++ b/src/options/pages/blueprints/utils/installableUtils.test.ts
@@ -29,7 +29,7 @@ import { uuidv4 } from "@/types/helpers";
 import { UserRole } from "@/types/contract";
 import {
   type Installable,
-  UnavailableRecipe,
+  type UnavailableRecipe,
 } from "@/options/pages/blueprints/blueprintsTypes";
 import { type ResolvedExtension } from "@/core";
 

--- a/src/options/pages/blueprints/utils/installableUtils.test.ts
+++ b/src/options/pages/blueprints/utils/installableUtils.test.ts
@@ -20,10 +20,15 @@ import {
   recipeDefinitionFactory,
   sharingDefinitionFactory,
 } from "@/testUtils/factories";
-import { getSharingType } from "./installableUtils";
+import {
+  getSharingType,
+  isExtension,
+  isUnavailableRecipe,
+} from "./installableUtils";
 import { uuidv4 } from "@/types/helpers";
 import { UserRole } from "@/types/contract";
 import { type Installable } from "@/options/pages/blueprints/blueprintsTypes";
+import { type ResolvedExtension } from "@/core";
 
 describe("getSharingType", () => {
   test("personal extension", () => {
@@ -134,5 +139,29 @@ describe("getSharingType", () => {
 
     expect(type).toBe("Public");
     expect(label).toBe("Public");
+  });
+});
+
+describe("isExtension", () => {
+  it("returns true for an extension", () => {
+    const installable = extensionFactory() as ResolvedExtension;
+    expect(isExtension(installable)).toBe(true);
+  });
+
+  it("returns false for a recipe", () => {
+    const installable = recipeDefinitionFactory();
+    expect(isExtension(installable)).toBe(false);
+  });
+});
+
+describe("isUnavailableRecipe", () => {
+  it("returns false for a recipe definition", () => {
+    const installable = recipeDefinitionFactory();
+    expect(isUnavailableRecipe(installable)).toBe(false);
+  });
+
+  it("returns false for an extension", () => {
+    const installable = extensionFactory() as ResolvedExtension;
+    expect(isUnavailableRecipe(installable)).toBe(false);
   });
 });

--- a/src/options/pages/blueprints/utils/installableUtils.ts
+++ b/src/options/pages/blueprints/utils/installableUtils.ts
@@ -73,10 +73,18 @@ export function isBlueprint(
   return !isExtension(installable);
 }
 
+/**
+ * Returns a unique id for the installable. Suitable for use as a React key
+ * @param installable the installable
+ */
 export function getUniqueId(installable: Installable): UUID | RegistryId {
   return isExtension(installable) ? installable.id : installable.metadata.id;
 }
 
+/**
+ * Returns the human-readable label for the installable
+ * @param installable the installable
+ */
 export function getLabel(installable: Installable): string {
   return isExtension(installable)
     ? installable.label
@@ -84,12 +92,12 @@ export function getLabel(installable: Installable): string {
 }
 
 export const getDescription = (installable: Installable): string => {
-  let description = isExtension(installable)
+  const description = isExtension(installable)
     ? installable._recipe?.description
     : installable.metadata.description;
 
   if (!description && isExtension(installable)) {
-    description = "Created in the Page Editor";
+    return "Created in the Page Editor";
   }
 
   return description;
@@ -136,7 +144,12 @@ function hasRecipeScope(
   return Boolean(recipe.metadata?.id.startsWith(scope + "/"));
 }
 
-function isPersonal(installable: Installable, userScope: string) {
+/**
+ * Returns true if the user directly owns the installable
+ * @param installable the installable
+ * @param userScope the user's scope, or null if it's not set
+ */
+function isPersonal(installable: Installable, userScope: string | null) {
   if (isExtension(installable)) {
     return (
       isPersonalExtension(installable) ||
@@ -180,7 +193,7 @@ export function isDeployment(
 }
 
 /**
- * Checks if a Blueprint has been made public but is not yet published to the Marketplace.
+ * Returns true if a Blueprint has been made public but is not yet published to the Marketplace.
  */
 export function isRecipePendingPublish(
   recipe: RecipeDefinition,

--- a/src/options/pages/blueprints/utils/installableUtils.ts
+++ b/src/options/pages/blueprints/utils/installableUtils.ts
@@ -29,26 +29,59 @@ import {
   type Installable,
   type SharingSource,
   type SharingType,
+  type UnavailableRecipe,
 } from "@/options/pages/blueprints/blueprintsTypes";
 import { createSelector } from "reselect";
 import { selectExtensions } from "@/store/extensionsSelectors";
 
-export const isExtension = (
+/**
+ * Returns true if installable is an UnavailableRecipe
+ * @param installable the installable
+ * @see UnavailableRecipe
+ */
+export function isUnavailableRecipe(
   installable: Installable
-): installable is ResolvedExtension => "extensionPointId" in installable;
+): installable is UnavailableRecipe {
+  return "isStub" in installable && installable.isStub;
+}
 
-export const isExtensionFromRecipe = (installable: Installable) =>
-  isExtension(installable) && Boolean(installable._recipe);
-
-export const isBlueprint = (
+/**
+ * Returns true if the installable is a singleton extension, not a recipe.
+ * @param installable the installable
+ */
+export function isExtension(
   installable: Installable
-): installable is RecipeDefinition => !isExtension(installable);
+): installable is ResolvedExtension {
+  return "extensionPointId" in installable;
+}
 
-export const getUniqueId = (installable: Installable): UUID | RegistryId =>
-  isExtension(installable) ? installable.id : installable.metadata.id;
+/**
+ * Return true if the installable is an IExtension that originated from a recipe.
+ * @param installable the installable
+ */
+export function isExtensionFromRecipe(installable: Installable): boolean {
+  return isExtension(installable) && Boolean(installable._recipe);
+}
 
-export const getLabel = (installable: Installable): string =>
-  isExtension(installable) ? installable.label : installable.metadata.name;
+/**
+ * Return true if the installable is a RecipeDefinition or UnavailableRecipe
+ * @param installable the installable
+ */
+export function isBlueprint(
+  installable: Installable
+): installable is RecipeDefinition | UnavailableRecipe {
+  return !isExtension(installable);
+}
+
+export function getUniqueId(installable: Installable): UUID | RegistryId {
+  return isExtension(installable) ? installable.id : installable.metadata.id;
+}
+
+export function getLabel(installable: Installable): string {
+  return isExtension(installable)
+    ? installable.label
+    : installable.metadata.name;
+}
 
 export const getDescription = (installable: Installable): string => {
   let description = isExtension(installable)
@@ -62,30 +95,48 @@ export const getDescription = (installable: Installable): string => {
   return description;
 };
 
-export const getPackageId = (installable: Installable): RegistryId =>
-  isExtension(installable) ? installable._recipe?.id : installable.metadata.id;
+/**
+ * Return the registry id associated with an installable, or null
+ * @param installable the installable
+ */
+export function getPackageId(installable: Installable): RegistryId | null {
+  return isExtension(installable)
+    ? installable._recipe?.id
+    : installable.metadata.id;
+}
 
-export const getUpdatedAt = (installable: Installable): string =>
-  isExtension(installable)
+export function getUpdatedAt(installable: Installable): string | null {
+  return isExtension(installable)
     ? // @ts-expect-error -- TODO: need to figure out why updateTimestamp isn't included on IExtension here
       installable._recipe?.updated_at ?? installable.updateTimestamp
     : installable.updated_at;
+}
 
-const isPublic = (installable: Installable): boolean =>
-  isExtension(installable)
+function isPublic(installable: Installable): boolean {
+  return isExtension(installable)
     ? installable._recipe?.sharing?.public
     : installable.sharing.public;
+}
 
-const isPersonalExtension = (extension: IExtension) =>
-  !extension._recipe && !extension._deployment;
+function isPersonalExtension(extension: IExtension): boolean {
+  return !extension._recipe && !extension._deployment;
+}
 
-const hasSourceRecipeWithScope = (extension: IExtension, scope: string) =>
-  scope && extension._recipe?.id.startsWith(scope + "/");
+function hasSourceRecipeWithScope(
+  extension: IExtension,
+  scope: string
+): boolean {
+  return scope && extension._recipe?.id.startsWith(scope + "/");
+}
 
-const hasRecipeScope = (recipe: RecipeDefinition, scope: string) =>
-  Boolean(recipe.metadata?.id.startsWith(scope + "/"));
+function hasRecipeScope(
+  recipe: RecipeDefinition | UnavailableRecipe,
+  scope: string
+) {
+  return Boolean(recipe.metadata?.id.startsWith(scope + "/"));
+}
 
-const isPersonal = (installable: Installable, userScope: string) => {
+function isPersonal(installable: Installable, userScope: string) {
   if (isExtension(installable)) {
     return (
       isPersonalExtension(installable) ||
@@ -94,12 +145,12 @@ const isPersonal = (installable: Installable, userScope: string) => {
   }
 
   return hasRecipeScope(installable, userScope);
-};
+}
 
-export const getInstalledVersionNumber = (
+export function getInstalledVersionNumber(
   installedExtensions: UnresolvedExtension[],
   installable: Installable
-): string | null => {
+): string | null {
   if (isExtension(installable)) {
     return installable._recipe?.version;
   }
@@ -110,12 +161,12 @@ export const getInstalledVersionNumber = (
   );
 
   return installedExtension?._recipe?.version;
-};
+}
 
-export const isDeployment = (
+export function isDeployment(
   installable: Installable,
   installedExtensions: UnresolvedExtension[]
-) => {
+): boolean {
   if (isExtension(installable)) {
     return Boolean(installable._deployment);
   }
@@ -126,17 +177,19 @@ export const isDeployment = (
       installedExtension._recipe?.id === recipeId &&
       installedExtension?._deployment
   );
-};
+}
 
 /**
  * Checks if a Blueprint has been made public but is not yet published to the Marketplace.
  */
-export const isRecipePendingPublish = (
+export function isRecipePendingPublish(
   recipe: RecipeDefinition,
   marketplaceListings: Record<RegistryId, MarketplaceListing>
-) => recipe.sharing.public && !marketplaceListings[recipe.metadata.id];
+): boolean {
+  return recipe.sharing.public && !marketplaceListings[recipe.metadata.id];
+}
 
-export const getSharingType = ({
+export function getSharingType({
   installable,
   organizations,
   scope,
@@ -146,7 +199,7 @@ export const getSharingType = ({
   organizations: Organization[];
   scope: string;
   installedExtensions: UnresolvedExtension[];
-}): SharingSource => {
+}): SharingSource {
   let sharingType: SharingType = null;
   const organization = getOrganization(installable, organizations);
 
@@ -177,7 +230,7 @@ export const getSharingType = ({
     label,
     organization,
   };
-};
+}
 
 export function updateAvailable(
   availableRecipes: RecipeDefinition[],
@@ -185,6 +238,11 @@ export function updateAvailable(
   installable: Installable
 ): boolean {
   let installedExtension: ResolvedExtension | UnresolvedExtension = null;
+
+  if (isUnavailableRecipe(installable)) {
+    // Unavailable recipes are never update-able
+    return false;
+  }
 
   if (isBlueprint(installable)) {
     installedExtension = installedExtensions?.find(
@@ -236,10 +294,10 @@ export function updateAvailable(
   return false;
 }
 
-const getOrganization = (
+function getOrganization(
   installable: Installable,
   organizations: Organization[]
-) => {
+): Organization {
   const sharing = isExtension(installable)
     ? installable._recipe?.sharing
     : installable.sharing;
@@ -253,7 +311,7 @@ const getOrganization = (
   return organizations.find((org) =>
     sharing.organizations.includes(org.id as UUID)
   );
-};
+}
 
 /**
  * Select UnresolvedExtensions currently installed from the installable.

--- a/src/options/pages/onboarding/SetupPage.tsx
+++ b/src/options/pages/onboarding/SetupPage.tsx
@@ -29,7 +29,7 @@ import PartnerSetupCard from "@/options/pages/onboarding/partner/PartnerSetupCar
 import { useLocation } from "react-router";
 import { clearServiceCache } from "@/background/messenger/api";
 import notify from "@/utils/notify";
-import { fetchNewPackages } from "@/baseRegistry";
+import { syncRemotePackages } from "@/baseRegistry";
 
 const Layout: React.FunctionComponent = ({ children }) => (
   <Row className="w-100 mx-0">
@@ -61,7 +61,7 @@ const SetupPage: React.FunctionComponent = () => {
   // useAsyncState with ignored output to track loading state
   const [_, serviceDefinitionsLoading] = useAsyncState(async () => {
     try {
-      await fetchNewPackages();
+      await syncRemotePackages();
       // Must happen after the call to fetch service definitions
       await clearServiceCache();
     } catch (error) {

--- a/src/recipes/recipes.test.tsx
+++ b/src/recipes/recipes.test.tsx
@@ -91,8 +91,8 @@ test("load recipes and save one", async () => {
     localRegistry.getByKinds
   );
 
-  (messengerRegistry.fetch as jest.Mock).mockImplementation(
-    localRegistry.fetchNewPackages
+  (messengerRegistry.syncRemote as jest.Mock).mockImplementation(
+    localRegistry.syncPackages
   );
 
   const fetchingSavingPromise = pDefer<void>();

--- a/src/recipes/recipesHooks.ts
+++ b/src/recipes/recipesHooks.ts
@@ -38,7 +38,7 @@ export function useRecipe(
 }
 
 /**
- * Pulls all recipes from the registry
+ * Pulls all recipes from the registry, and triggers refresh if they're not available locally.
  */
 export function useAllRecipes(): UseCachedQueryResult<RecipeDefinition[]> {
   const dispatch = useDispatch();

--- a/src/recipes/recipesSlice.test.ts
+++ b/src/recipes/recipesSlice.test.ts
@@ -20,7 +20,7 @@ import { serializeError } from "serialize-error";
 import { initialState, recipesActions, recipesSlice } from "./recipesSlice";
 import { type RecipesRootState } from "./recipesTypes";
 import recipesRegistry from "./registry";
-import { fetchNewPackages } from "@/baseRegistry";
+import { syncRemotePackages } from "@/baseRegistry";
 
 jest.mock("./registry", () => ({
   __esModule: true,
@@ -32,16 +32,16 @@ jest.mock("./registry", () => ({
 jest.mock("@/baseRegistry", () => ({
   __esModule: true,
   ...jest.requireActual("@/baseRegistry"),
-  fetchNewPackages: jest.fn(),
+  syncRemotePackages: jest.fn(),
 }));
-
-const fetchNewPackagesMock = fetchNewPackages as jest.MockedFn<
-  typeof fetchNewPackages
->;
 
 afterEach(() => {
   jest.resetAllMocks();
 });
+
+const syncRemotePackagesMock = syncRemotePackages as jest.MockedFn<
+  typeof syncRemotePackages
+>;
 
 describe("loadRecipesFromCache", () => {
   test("calls registry and dispatches setRecipesFromCache action", async () => {
@@ -75,7 +75,7 @@ describe("refreshRecipes", () => {
       undefined
     );
 
-    expect(fetchNewPackagesMock).not.toHaveBeenCalled();
+    expect(syncRemotePackagesMock).not.toHaveBeenCalled();
   });
 
   test("fetches recipes and updates the state", async () => {
@@ -92,7 +92,7 @@ describe("refreshRecipes", () => {
     );
 
     expect(dispatch).toHaveBeenCalledWith(recipesActions.startLoading());
-    expect(fetchNewPackagesMock).toHaveBeenCalledTimes(1);
+    expect(syncRemotePackagesMock).toHaveBeenCalledTimes(1);
     expect(recipesRegistry.all).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledWith(
       recipesActions.setRecipes(cachedRecipes)
@@ -103,7 +103,7 @@ describe("refreshRecipes", () => {
     const dispatch = jest.fn();
 
     const error = new Error("test");
-    fetchNewPackagesMock.mockRejectedValueOnce(error);
+    syncRemotePackagesMock.mockRejectedValueOnce(error);
 
     const thunkFunction = recipesActions.refreshRecipes();
     await thunkFunction(

--- a/src/recipes/recipesSlice.ts
+++ b/src/recipes/recipesSlice.ts
@@ -19,7 +19,7 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { serializeError } from "serialize-error";
 import { type RecipesRootState, type RecipesState } from "./recipesTypes";
 import recipeRegistry from "./registry";
-import { fetchNewPackages } from "@/baseRegistry";
+import { syncRemotePackages } from "@/baseRegistry";
 
 export const initialState: RecipesState = Object.freeze({
   recipes: [],
@@ -62,7 +62,7 @@ export const refreshRecipes = createAsyncThunk<
   dispatch(recipesSlice.actions.startLoading());
 
   try {
-    await fetchNewPackages();
+    await syncRemotePackages();
   } catch (error) {
     const serializedError = serializeError(error, { useToJSON: false });
     dispatch(recipesSlice.actions.setError(serializedError));

--- a/src/registry/localRegistry.test.ts
+++ b/src/registry/localRegistry.test.ts
@@ -16,7 +16,6 @@
  */
 
 import {
-  fetchNewPackages,
   clear,
   getByKinds,
   syncPackages,
@@ -39,23 +38,9 @@ describe("localRegistry", () => {
     getApiClientMock.mockResolvedValue({
       get: jest.fn().mockResolvedValue({ data: [recipeDefinitionFactory()] }),
     });
-    await fetchNewPackages();
+    await syncPackages();
     const recipes = await getByKinds(["recipe"]);
     expect(recipes).toHaveLength(1);
-  });
-
-  it("should fetch new packages", async () => {
-    getApiClientMock.mockResolvedValue({
-      get: jest.fn().mockResolvedValue({ data: [recipeDefinitionFactory()] }),
-    });
-    await fetchNewPackages();
-    await fetchNewPackages();
-
-    const client = await getApiClientMock();
-    expect((client.get as jest.Mock).mock.calls).toEqual([
-      ["/api/registry/bricks/?"],
-      [expect.stringMatching(/\/api\/registry\/bricks\/\?updated_at__gt=\S+/)],
-    ]);
   });
 
   it("should sync packages for empty db", async () => {

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -35,7 +35,7 @@ import {
   type RecipeDefinition,
 } from "@/types/definitions";
 import { uuidv4 } from "@/types/helpers";
-import { partition, pick } from "lodash";
+import { cloneDeep, partition, pick } from "lodash";
 import { saveUserExtension } from "@/services/apiClient";
 import reportError from "@/telemetry/reportError";
 import {
@@ -68,6 +68,14 @@ const extensionsSlice = createSlice({
   reducers: {
     resetOptions(state) {
       state.extensions = [];
+    },
+
+    // Helper reducers method to directly update extensions in tests
+    UNSAFE_setExtensions(
+      state,
+      { payload }: PayloadAction<PersistedExtension[]>
+    ) {
+      state.extensions = cloneDeep(payload);
     },
 
     installCloudExtension(

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -70,7 +70,8 @@ const extensionsSlice = createSlice({
       state.extensions = [];
     },
 
-    // Helper reducers method to directly update extensions in tests
+    // Helper for tests reducers method to directly update extensions in tests. Can't use installCloudExtension because
+    // CloudExtension doesn't have the _recipe field
     UNSAFE_setExtensions(
       state,
       { payload }: PayloadAction<PersistedExtension[]>

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -70,8 +70,8 @@ const extensionsSlice = createSlice({
       state.extensions = [];
     },
 
-    // Helper for tests reducers method to directly update extensions in tests. Can't use installCloudExtension because
-    // CloudExtension doesn't have the _recipe field
+    // Helper method to directly update extensions in tests. Can't use installCloudExtension because CloudExtension
+    // doesn't have the _recipe field
     UNSAFE_setExtensions(
       state,
       { payload }: PayloadAction<PersistedExtension[]>

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -20,6 +20,7 @@ import {
   type Config,
   define,
   derive,
+  extend,
   type FactoryConfig,
 } from "cooky-cutter";
 import { type BlockConfig, type BlockPipeline } from "@/blocks/types";
@@ -31,6 +32,7 @@ import {
   type InnerDefinitions,
   type Metadata,
   type OutputKey,
+  type PersistedExtension,
   type RecipeMetadata,
   type RegistryId,
   type RenderedArgs,
@@ -243,6 +245,16 @@ export const extensionFactory = define<IExtension>({
   }),
   active: true,
 });
+
+export const persistedExtensionFactory = extend<IExtension, PersistedExtension>(
+  extensionFactory,
+  {
+    createTimestamp: timestampFactory,
+    updateTimestamp: timestampFactory,
+    _unresolvedExtensionBrand: undefined,
+    active: true,
+  }
+);
 
 export const cloudExtensionFactory = (
   override?: Partial<Config<CloudExtension>>


### PR DESCRIPTION
## What does this PR do?

- Closes #5377 
- Removes `fetchNewPackages` from the extension. Extension always uses syncPackages now to ensure deleted/revoked packages are removed locally
- Adds an `UnavailableRecipe` type to represent mods the user no longer has access to on the mods screen
- Adds ErrorBoundaries around the Grid and List items to add resilience on per-card/item rendering

## Review Tips

- Review the switch from `fetchNewPackages` to `syncPackages`
- Review the changes to `useInstallables.ts`
- Review changes to `installableUtils.ts`
- Review changes to other files

## Demo

- https://www.loom.com/share/48e54db087b54d168b085b63345f1b1c

## Future Work

- Handle the stuck "Loading..." state in the Page Editor for unavailable mods

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
