### PR TITLE
#5408: add Datadog for performance monitoring/tracing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@apidevtools/json-schema-ref-parser": "^10.1.0",
         "@atlaskit/tree": "^8.7.0",
         "@cfworker/json-schema": "^1.8.1",
+        "@datadog/browser-rum": "^4.36.0",
         "@floating-ui/dom": "^1.2.5",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.15.4",
@@ -2207,6 +2208,36 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@datadog/browser-core": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.36.0.tgz",
+      "integrity": "sha512-eJIygwTOfkeWN/+V7DcQzSQCZM0Bu7zXXbTkWrgYyWU9a4u/6op1LJtF7ZP/nD7yXg18Tvxx9INPN9ikzjoiiQ=="
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.36.0.tgz",
+      "integrity": "sha512-bS+4qlDouYgFjuMdYKH2xrqwClQm+kiwSEuaaRPlj2eYLffsVWlOuOrMupp7MqfSvFy9RhOCudiHtk+bdYQ83A==",
+      "dependencies": {
+        "@datadog/browser-core": "4.36.0",
+        "@datadog/browser-rum-core": "4.36.0"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "4.36.0"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-rum-core": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.36.0.tgz",
+      "integrity": "sha512-8Sq5NJ6FpHJ4OsuBx2FSCY5N6C6774EG4QLK48hK4D9Dcb7zEgwBS2KZ7g9DC+yYdnTLxhUo4JV2/XIdZ4SP0g==",
+      "dependencies": {
+        "@datadog/browser-core": "4.36.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -38316,6 +38347,28 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
       "optional": true
+    },
+    "@datadog/browser-core": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.36.0.tgz",
+      "integrity": "sha512-eJIygwTOfkeWN/+V7DcQzSQCZM0Bu7zXXbTkWrgYyWU9a4u/6op1LJtF7ZP/nD7yXg18Tvxx9INPN9ikzjoiiQ=="
+    },
+    "@datadog/browser-rum": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.36.0.tgz",
+      "integrity": "sha512-bS+4qlDouYgFjuMdYKH2xrqwClQm+kiwSEuaaRPlj2eYLffsVWlOuOrMupp7MqfSvFy9RhOCudiHtk+bdYQ83A==",
+      "requires": {
+        "@datadog/browser-core": "4.36.0",
+        "@datadog/browser-rum-core": "4.36.0"
+      }
+    },
+    "@datadog/browser-rum-core": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.36.0.tgz",
+      "integrity": "sha512-8Sq5NJ6FpHJ4OsuBx2FSCY5N6C6774EG4QLK48hK4D9Dcb7zEgwBS2KZ7g9DC+yYdnTLxhUo4JV2/XIdZ4SP0g==",
+      "requires": {
+        "@datadog/browser-core": "4.36.0"
+      }
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
     "@atlaskit/tree": "^8.7.0",
     "@cfworker/json-schema": "^1.8.1",
+    "@datadog/browser-rum": "^4.36.0",
     "@floating-ui/dom": "^1.2.5",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-brands-svg-icons": "^5.15.4",

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -56,6 +56,10 @@ export async function readAuthData(): Promise<
   return readStorage(STORAGE_EXTENSION_KEY, {});
 }
 
+/**
+ * Returns true if the specified flag is on for the current user.
+ * @param flag the feature flag to check
+ */
 export async function flagOn(flag: string): Promise<boolean> {
   const authData = await readAuthData();
   return authData.flags?.includes(flag);

--- a/src/options/options.tsx
+++ b/src/options/options.tsx
@@ -30,6 +30,7 @@ import initGoogle from "@/contrib/google/initGoogle";
 import { initToaster } from "@/utils/notify";
 import { initTelemetry } from "@/background/messenger/api";
 import registerMessenger from "@/options/messenger/registration";
+import { initPerformanceMonitoring } from "@/telemetry/performance";
 
 function init(): void {
   render(<App />, document.querySelector("#container"));
@@ -39,4 +40,5 @@ registerMessenger();
 void initGoogle();
 initToaster();
 initTelemetry();
+void initPerformanceMonitoring();
 init();

--- a/src/options/pages/activateExtension/ActivatePage.tsx
+++ b/src/options/pages/activateExtension/ActivatePage.tsx
@@ -36,7 +36,7 @@ const ActivatePage: React.FunctionComponent = () => {
     data: extension,
     isLoading,
     error,
-  } = useFetch<CloudExtension>(`/api/extensions/${extensionId}`);
+  } = useFetch<CloudExtension>(`/api/extensions/${extensionId}/`);
 
   const [authOptions, refreshAuthOptions] = useAuthOptions();
 

--- a/src/pageEditor/pageEditor.tsx
+++ b/src/pageEditor/pageEditor.tsx
@@ -31,11 +31,13 @@ import { watchNavigation } from "@/pageEditor/protocol";
 import initGoogle from "@/contrib/google/initGoogle";
 import { initToaster } from "@/utils/notify";
 import { markAppStart } from "@/utils/performance";
+import { initPerformanceMonitoring } from "@/telemetry/performance";
 
 markAppStart();
 
 registerMessenger();
 void initGoogle();
+void initPerformanceMonitoring();
 watchNavigation();
 initToaster();
 

--- a/src/sidebar/sidebar.tsx
+++ b/src/sidebar/sidebar.tsx
@@ -31,6 +31,7 @@ import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 import { initToaster } from "@/utils/notify";
 import initGoogle from "@/contrib/google/initGoogle";
+import { initPerformanceMonitoring } from "@/telemetry/performance";
 
 function init(): void {
   ReactDOM.render(<App />, document.querySelector("#container"));
@@ -38,6 +39,7 @@ function init(): void {
 
 registerMessenger();
 void initGoogle();
+void initPerformanceMonitoring();
 registerContribBlocks();
 registerBuiltinBlocks();
 initToaster();

--- a/src/telemetry/performance.ts
+++ b/src/telemetry/performance.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { datadogRum } from "@datadog/browser-rum";
+import { getDNT } from "@/telemetry/dnt";
+import { getBaseURL } from "@/services/baseService";
+
+const environment = process.env.ENVIRONMENT;
+const applicationId = process.env.DATADOG_APPLICATION_ID;
+const clientToken = process.env.DATADOG_CLIENT_TOKEN;
+
+/**
+ * Initialize Datadog Real User Monitoring (RUM) for performance monitoring.
+ */
+export async function initPerformanceMonitoring(): Promise<void> {
+  const dnt = await getDNT();
+  const baseUrl = await getBaseURL();
+
+  if (dnt) {
+    return;
+  }
+
+  if (!applicationId || !clientToken) {
+    console.warn("Missing Datadog application ID or client token");
+    return;
+  }
+
+  const { version_name } = browser.runtime.getManifest();
+
+  datadogRum.init({
+    applicationId,
+    clientToken,
+    site: "datadoghq.com",
+    service: "pixiebrix-browser-extension",
+    env: environment,
+    version: version_name,
+    sessionSampleRate: 100,
+    sessionReplaySampleRate: 20,
+    trackUserInteractions: true,
+    trackResources: true,
+    trackLongTasks: true,
+    defaultPrivacyLevel: "mask",
+    // https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum#usage
+    allowedTracingUrls: [baseUrl],
+  });
+
+  datadogRum.startSessionReplayRecording();
+}

--- a/src/telemetry/performance.ts
+++ b/src/telemetry/performance.ts
@@ -19,7 +19,7 @@ import { datadogRum } from "@datadog/browser-rum";
 import { getDNT } from "@/telemetry/dnt";
 import { getBaseURL } from "@/services/baseService";
 import { expectContext, forbidContext } from "@/utils/expectContext";
-import { flagOn } from "@/auth/token";
+import { flagOn, getUserData } from "@/auth/token";
 
 const environment = process.env.ENVIRONMENT;
 const applicationId = process.env.DATADOG_APPLICATION_ID;
@@ -50,6 +50,7 @@ export async function initPerformanceMonitoring(): Promise<void> {
   }
 
   const { version_name } = browser.runtime.getManifest();
+  const { user: userId } = await getUserData();
 
   datadogRum.init({
     applicationId,
@@ -67,6 +68,11 @@ export async function initPerformanceMonitoring(): Promise<void> {
     // List the URLs/origins for sending trace headers
     // https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum#usage
     allowedTracingUrls: [baseUrl],
+  });
+
+  // https://docs.datadoghq.com/real_user_monitoring/browser/modifying_data_and_context/?tab=npm#user-session
+  datadogRum.setUser({
+    id: userId,
   });
 
   datadogRum.startSessionReplayRecording();

--- a/src/telemetry/performance.ts
+++ b/src/telemetry/performance.ts
@@ -64,16 +64,17 @@ export async function initPerformanceMonitoring(): Promise<void> {
     trackUserInteractions: true,
     trackResources: true,
     trackLongTasks: true,
+    trackFrustrations: true,
     defaultPrivacyLevel: "mask",
     // List the URLs/origins for sending trace headers
     // https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum#usage
     allowedTracingUrls: [baseUrl],
   });
 
+  datadogRum.startSessionReplayRecording();
+
   // https://docs.datadoghq.com/real_user_monitoring/browser/modifying_data_and_context/?tab=npm#user-session
   datadogRum.setUser({
     id: userId,
   });
-
-  datadogRum.startSessionReplayRecording();
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -409,6 +409,10 @@ module.exports = (env, options) =>
         ROLLBAR_BROWSER_ACCESS_TOKEN: null,
         GOOGLE_API_KEY: null,
         GOOGLE_APP_ID: null,
+
+        // DataDog RUM
+        DATADOG_APPLICATION_ID: null,
+        DATADOG_CLIENT_TOKEN: null,
       }),
 
       new MiniCssExtractPlugin({


### PR DESCRIPTION
## What does this PR do?

- Closes #5408 
- Is behind the `telemetry-performance` feature flag
- Monitors the following:
   - Extension Console
   - Page Editor
   - Sidebar  

## Discussion

- I left the default `sessionSampleRate` and `sessionReplaySampleRate`. We'll need to determine what the rates for these need to be

## Release QA

- [ ] Ensure the tracing headers are being processed by the server (CORS might be blocking them)

## Demo

Data in Datadog
![image](https://user-images.githubusercontent.com/1879821/227823517-f8ffb133-41aa-447b-972a-3cfb5f956574.png)

Tracing headers included with requests:
![image](https://user-images.githubusercontent.com/1879821/227824353-10b4e513-7bcc-46c6-b58c-41d9415b503e.png)

## Future Work

- Modify the Page Editor to either: 1) use hash routing, 2) mark page switches to better support navigation timings
- Add action tracking by hooking into report event: https://docs.datadoghq.com/real_user_monitoring/browser/tracking_user_actions/
- Consider adding RUM for contentPage startup and tiny pages (modal, etc.)
- Upload source maps to Datadog to improve stack trace analysis

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @johnnymetz 
