### PR TITLE
#3914: require GAPI for GSheets brick configuration

### DIFF
--- a/src/contrib/google/initGoogle.ts
+++ b/src/contrib/google/initGoogle.ts
@@ -27,7 +27,7 @@ const API_KEY = process.env.GOOGLE_API_KEY;
 let initialized = false;
 
 type Listener = () => void;
-let listeners = new Set<Listener>();
+const listeners = new Set<Listener>();
 
 declare global {
   interface Window {
@@ -44,7 +44,13 @@ async function onGAPILoad(): Promise<void> {
       apiKey: API_KEY,
       discoveryDocs: [...SHEETS_DOCS],
     });
+
+    initialized = true;
     console.info("gapi initialized");
+
+    for (const listener of listeners) {
+      listener();
+    }
   } catch (error) {
     // Catch explicitly instead of letting it reach to top-level rejected promise handler
     // https://github.com/google/google-api-javascript-client/issues/64#issuecomment-336488275
@@ -52,9 +58,16 @@ async function onGAPILoad(): Promise<void> {
   }
 }
 
+/**
+ * Return true if GAPI is supported by the browser.
+ */
+export function isGoogleSupported(): boolean {
+  // TODO: Use feature detection instead of sniffing the user agent
+  return isChrome() && !isMV3();
+}
+
 async function _initGoogle(): Promise<boolean> {
-  if (!isChrome() || isMV3()) {
-    // TODO: Use feature detection instead of sniffing the user agent
+  if (!isGoogleSupported()) {
     console.info(
       "Google API not enabled because it's not supported by this browser"
     );
@@ -71,12 +84,6 @@ async function _initGoogle(): Promise<boolean> {
   await injectScriptTag(
     "https://apis.google.com/js/client.js?onload=onGAPILoad"
   );
-
-  initialized = true;
-
-  for (const listener of listeners) {
-    listener();
-  }
 
   return true;
 }

--- a/src/contrib/google/initGoogle.ts
+++ b/src/contrib/google/initGoogle.ts
@@ -24,6 +24,11 @@ import { isMV3 } from "@/mv3/api";
 
 const API_KEY = process.env.GOOGLE_API_KEY;
 
+let initialized = false;
+
+type Listener = () => void;
+let listeners = new Set<Listener>();
+
 declare global {
   interface Window {
     onGAPILoad?: () => Promise<void>;
@@ -67,7 +72,28 @@ async function _initGoogle(): Promise<boolean> {
     "https://apis.google.com/js/client.js?onload=onGAPILoad"
   );
 
+  initialized = true;
+
+  for (const listener of listeners) {
+    listener();
+  }
+
   return true;
+}
+
+/**
+ * Return true if the Google API has been initialized.
+ */
+export function isGoogleInitialized(): boolean {
+  return initialized;
+}
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
 }
 
 // `pMemoize` will avoid multiple injections, while also allow retrying if the first injection fails

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.test.tsx
@@ -47,6 +47,12 @@ const servicesLocateMock = services.locate as jest.MockedFunction<
   typeof services.locate
 >;
 
+jest.mock("@/contrib/google/initGoogle", () => ({
+  isGoogleInitialized: jest.fn().mockResolvedValue(true),
+  isGoogleSupported: jest.fn().mockResolvedValue(true),
+  subscribe: jest.fn().mockImplementation(() => () => {}),
+}));
+
 jest.mock("@/hooks/auth", () => ({
   __esModule: true,
   useAuthOptions: jest.fn().mockReturnValue([[], () => {}]),

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.test.tsx
@@ -48,8 +48,8 @@ const servicesLocateMock = services.locate as jest.MockedFunction<
 >;
 
 jest.mock("@/contrib/google/initGoogle", () => ({
-  isGoogleInitialized: jest.fn().mockResolvedValue(true),
-  isGoogleSupported: jest.fn().mockResolvedValue(true),
+  isGoogleInitialized: jest.fn().mockReturnValue(true),
+  isGoogleSupported: jest.fn().mockReturnValue(true),
   subscribe: jest.fn().mockImplementation(() => () => {}),
 }));
 

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/contrib/google/sheets/schemas";
 import { isEmpty, isEqual } from "lodash";
 import { useOnChangeEffect } from "@/contrib/google/sheets/useOnChangeEffect";
+import { requireGoogleHOC } from "@/contrib/google/sheets/RequireGoogleApi";
 
 const DEFAULT_FIELDS_SCHEMA: Schema = {
   type: "object",
@@ -185,4 +186,4 @@ const AppendSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
   );
 };
 
-export default AppendSpreadsheetOptions;
+export default requireGoogleHOC(AppendSpreadsheetOptions);

--- a/src/contrib/google/sheets/LookupSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/LookupSpreadsheetOptions.test.tsx
@@ -43,6 +43,12 @@ const servicesLocateMock = services.locate as jest.MockedFunction<
   typeof services.locate
 >;
 
+jest.mock("@/contrib/google/initGoogle", () => ({
+  isGoogleInitialized: jest.fn().mockResolvedValue(true),
+  isGoogleSupported: jest.fn().mockResolvedValue(true),
+  subscribe: jest.fn().mockImplementation(() => () => {}),
+}));
+
 jest.mock("@/components/fields/schemaFields/serviceFieldUtils", () => ({
   ...jest.requireActual("@/components/fields/schemaFields/serviceFieldUtils"),
   // Mock so we don't have to have full Page Editor state in tests

--- a/src/contrib/google/sheets/LookupSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/LookupSpreadsheetOptions.tsx
@@ -37,6 +37,7 @@ import {
 import Loader from "@/components/Loader";
 import { FormErrorContext } from "@/components/form/FormErrorContext";
 import { useOnChangeEffect } from "@/contrib/google/sheets/useOnChangeEffect";
+import { requireGoogleHOC } from "@/contrib/google/sheets/RequireGoogleApi";
 
 const DEFAULT_HEADER_SCHEMA: Schema = {
   type: "string",
@@ -200,4 +201,4 @@ const LookupSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
   );
 };
 
-export default LookupSpreadsheetOptions;
+export default requireGoogleHOC(LookupSpreadsheetOptions);

--- a/src/contrib/google/sheets/LookupSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/LookupSpreadsheetOptions.tsx
@@ -41,10 +41,6 @@ import { requireGoogleHOC } from "@/contrib/google/sheets/RequireGoogleApi";
 import useFlags from "@/hooks/useFlags";
 import { makeTemplateExpression } from "@/runtime/expressionCreators";
 
-const DEFAULT_HEADER_SCHEMA: Schema = {
-  type: "string",
-};
-
 const HeaderField: React.FunctionComponent<{
   name: string;
   spreadsheetId: string | null;

--- a/src/contrib/google/sheets/RequireGoogleApi.tsx
+++ b/src/contrib/google/sheets/RequireGoogleApi.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { useSyncExternalStore } from "use-sync-external-store/shim";
+import initGoogle, {
+  subscribe,
+  isGoogleInitialized,
+} from "@/contrib/google/initGoogle";
+import AsyncButton from "@/components/AsyncButton";
+import useUserAction from "@/hooks/useUserAction";
+
+/**
+ * Wrapper component to require that the Google API is initialized before rendering its children.
+ * @constructor
+ */
+export const RequireGoogleApi: React.FC = ({ children }) => {
+  const isInitialized = useSyncExternalStore(subscribe, isGoogleInitialized);
+
+  const initGoogleAction = useUserAction(
+    initGoogle,
+    {
+      errorMessage: "Error initializing Google API",
+    },
+    []
+  );
+
+  if (isInitialized) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div>
+      <span>
+        The Google API is not initialized. Please click the button below to
+        initialize it.
+      </span>
+      <AsyncButton onClick={initGoogleAction}>Retry</AsyncButton>
+    </div>
+  );
+};
+
+export function requireGoogleHOC<P>(
+  Component: React.ComponentType<P>
+): React.ComponentType<P> {
+  const WrappedComponent = (props: P) => (
+    <RequireGoogleApi>
+      <Component {...props} />
+    </RequireGoogleApi>
+  );
+
+  WrappedComponent.displayName = `RequireGoogleApi(${
+    Component.displayName ?? Component.name
+  })`;
+  return WrappedComponent;
+}
+
+export default RequireGoogleApi;

--- a/src/contrib/google/sheets/RequireGoogleApi.tsx
+++ b/src/contrib/google/sheets/RequireGoogleApi.tsx
@@ -20,6 +20,7 @@ import { useSyncExternalStore } from "use-sync-external-store/shim";
 import initGoogle, {
   subscribe,
   isGoogleInitialized,
+  isGoogleSupported,
 } from "@/contrib/google/initGoogle";
 import AsyncButton from "@/components/AsyncButton";
 import useUserAction from "@/hooks/useUserAction";
@@ -39,24 +40,35 @@ export const RequireGoogleApi: React.FC = ({ children }) => {
     []
   );
 
+  if (!isGoogleSupported()) {
+    return (
+      <div>
+        The Google API is not supported in this browser. Please use Google
+        Chrome.
+      </div>
+    );
+  }
+
   if (isInitialized) {
     return <>{children}</>;
   }
 
   return (
     <div>
-      <span>
-        The Google API is not initialized. Please click the button below to
-        initialize it.
-      </span>
-      <AsyncButton onClick={initGoogleAction}>Retry</AsyncButton>
+      <div>
+        The Google API is not initialized. Please click the button to initialize
+        it.
+      </div>
+      <div className="mt-2">
+        <AsyncButton onClick={initGoogleAction}>Initialize</AsyncButton>
+      </div>
     </div>
   );
 };
 
 export function requireGoogleHOC<P>(
-  Component: React.ComponentType<P>
-): React.ComponentType<P> {
+  Component: React.FunctionComponent<P>
+): React.FunctionComponent<P> {
   const WrappedComponent = (props: P) => (
     <RequireGoogleApi>
       <Component {...props} />

--- a/src/contrib/google/sheets/RequireGoogleApi.tsx
+++ b/src/contrib/google/sheets/RequireGoogleApi.tsx
@@ -49,21 +49,21 @@ export const RequireGoogleApi: React.FC = ({ children }) => {
     );
   }
 
-  if (isInitialized) {
-    return <>{children}</>;
+  if (!isInitialized) {
+    return (
+      <div>
+        <div>
+          The Google API is not initialized. Please click the button to
+          initialize it.
+        </div>
+        <div className="mt-2">
+          <AsyncButton onClick={initGoogleAction}>Connect</AsyncButton>
+        </div>
+      </div>
+    );
   }
 
-  return (
-    <div>
-      <div>
-        The Google API is not initialized. Please click the button to initialize
-        it.
-      </div>
-      <div className="mt-2">
-        <AsyncButton onClick={initGoogleAction}>Initialize</AsyncButton>
-      </div>
-    </div>
-  );
+  return <>{children}</>;
 };
 
 export function requireGoogleHOC<P>(

--- a/src/contrib/google/sheets/__snapshots__/LookupSpreadsheetOptions.test.tsx.snap
+++ b/src/contrib/google/sheets/__snapshots__/LookupSpreadsheetOptions.test.tsx.snap
@@ -827,3 +827,49 @@ exports[`LookupSpreadsheetOptions should render successfully 1`] = `
   </form>
 </DocumentFragment>
 `;
+
+exports[`LookupSpreadsheetOptions should require GAPI loaded 1`] = `
+<DocumentFragment>
+  <form
+    action="#"
+  >
+    <div>
+      <div>
+        The Google API is not initialized. Please click the button to initialize it.
+      </div>
+      <div
+        class="mt-2"
+      >
+        <button
+          class="btn btn-primary"
+          type="button"
+        >
+          Connect
+        </button>
+      </div>
+    </div>
+    <button
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;
+
+exports[`LookupSpreadsheetOptions should require GAPI support 1`] = `
+<DocumentFragment>
+  <form
+    action="#"
+  >
+    <div>
+      The Google API is not supported in this browser. Please use Google Chrome.
+    </div>
+    <button
+      type="submit"
+    >
+      Submit
+    </button>
+  </form>
+</DocumentFragment>
+`;


### PR DESCRIPTION
## What does this PR do?

- Part of #3914 
- Adds a requireGoogleHOC wrapper for brick configuration
- Shows message of GAPI is unavailable or initialized

## Remaining Work

- [x] Fix tests
- [x] Add snapshot tests for the wrapper component

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
