### PR TITLE
#5444 - Fix SheetsFileWidget and icon spacing

### DIFF
--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.module.scss
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.module.scss
@@ -43,4 +43,8 @@
 .symbol {
   display: inline-block;
   width: 30px;
+
+  > svg {
+    width: 100% !important;
+  }
 }

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.test.tsx
@@ -78,12 +78,6 @@ jest.mock("@/store/syncFlags", () => ({
 
 const syncFlagOnMock = syncFlagOn as jest.MockedFunction<typeof syncFlagOn>;
 
-jest.mock("@/components/fields/schemaFields/serviceFieldUtils", () => ({
-  ...jest.requireActual("@/components/fields/schemaFields/serviceFieldUtils"),
-  // Mock so we don't have to have full Page Editor state in tests
-  produceExcludeUnusedDependencies: jest.fn().mockImplementation((x: any) => x),
-}));
-
 jest.mock("@/hooks/useFlags", () => ({
   __esModule: true,
   default: jest.fn(),

--- a/src/contrib/google/sheets/SheetsFileWidget.test.tsx
+++ b/src/contrib/google/sheets/SheetsFileWidget.test.tsx
@@ -42,29 +42,8 @@ const getSheetPropertiesMock = sheets.getSheetProperties as jest.MockedFunction<
   typeof sheets.getSheetProperties
 >;
 
-let mockServiceExcludeEnabled = false;
-
-jest.mock("@/components/fields/schemaFields/serviceFieldUtils", () => {
-  const actual = jest.requireActual(
-    "@/components/fields/schemaFields/serviceFieldUtils"
-  );
-
-  return {
-    ...actual,
-    produceExcludeUnusedDependencies: jest.fn((x: any) =>
-      mockServiceExcludeEnabled ? x : actual.produceExcludeUnusedDependencies(x)
-    ),
-  };
-});
-
 describe("SheetsFileWidget", () => {
-  beforeEach(() => {
-    mockServiceExcludeEnabled = false;
-  });
-
   it("smoke test", async () => {
-    mockServiceExcludeEnabled = true;
-
     const wrapper = render(
       <SheetsFileWidget name="spreadsheetId" schema={BASE_SHEET_SCHEMA} />,
       {
@@ -78,8 +57,6 @@ describe("SheetsFileWidget", () => {
   });
 
   it("renders valid sheet on load", async () => {
-    mockServiceExcludeEnabled = true;
-
     getSheetPropertiesMock.mockResolvedValue({
       title: "Test Sheet",
     });
@@ -98,8 +75,6 @@ describe("SheetsFileWidget", () => {
   });
 
   it("falls back to spreadsheet id if fetching properties fails", async () => {
-    mockServiceExcludeEnabled = true;
-
     getSheetPropertiesMock.mockRejectedValue(
       new Error("Error fetching sheet properties")
     );
@@ -118,8 +93,6 @@ describe("SheetsFileWidget", () => {
   });
 
   it("shows workshop fallback on expression", async () => {
-    mockServiceExcludeEnabled = true;
-
     const wrapper = render(
       <SheetsFileWidget name="spreadsheetId" schema={BASE_SHEET_SCHEMA} />,
       {

--- a/src/contrib/google/sheets/SheetsFileWidget.tsx
+++ b/src/contrib/google/sheets/SheetsFileWidget.tsx
@@ -34,7 +34,7 @@ import { isExpression } from "@/runtime/mapArgs";
 import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import useCurrentOrigin from "@/contrib/google/sheets/useCurrentOrigin";
-import { type FormState } from "@/pageEditor/extensionPoints/formStateTypes";
+import { isFormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { produce } from "immer";
 import { produceExcludeUnusedDependencies } from "@/components/fields/schemaFields/serviceFieldUtils";
 
@@ -46,12 +46,16 @@ const SheetsFileWidget: React.FC<SchemaFieldProps> = (props) => {
   const [sheetError, setSheetError] = useState(null);
   const [doc, setDoc] = useState<SheetMeta | null>(null);
 
-  const { values: formState, setValues: setFormState } =
-    useFormikContext<FormState>();
+  const { values: formState, setValues: setFormState } = useFormikContext();
 
   // Remove unused services from the element - cleanup from deprecated integration support for gsheets
   useEffect(
     () => {
+      // This widget is also used outside the page editor, so this won't always be FormState
+      if (!isFormState(formState)) {
+        return;
+      }
+
       const newState = produce(formState, (draft) =>
         produceExcludeUnusedDependencies(draft)
       );

--- a/src/contrib/google/sheets/SheetsFileWidget.tsx
+++ b/src/contrib/google/sheets/SheetsFileWidget.tsx
@@ -51,7 +51,9 @@ const SheetsFileWidget: React.FC<SchemaFieldProps> = (props) => {
   // Remove unused services from the element - cleanup from deprecated integration support for gsheets
   useEffect(
     () => {
-      // This widget is also used outside the page editor, so this won't always be FormState
+      // This widget is also used outside the Edit tab of the page editor,
+      // so this won't always be FormState. We only need to clean up services
+      // when it is FormState.
       if (!isFormState(formState)) {
         return;
       }

--- a/src/pageEditor/extensionPoints/formStateTypes.ts
+++ b/src/pageEditor/extensionPoints/formStateTypes.ts
@@ -281,3 +281,20 @@ export type FormState =
   | QuickBarFormState
   | QuickBarProviderFormState
   | TourFormState;
+
+export function isFormState(formState: unknown): formState is FormState {
+  if (
+    typeof formState !== "object" ||
+    formState === null ||
+    Array.isArray(formState)
+  ) {
+    return false;
+  }
+
+  return (
+    "uuid" in formState &&
+    "type" in formState &&
+    "extensionPoint" in formState &&
+    "extension" in formState
+  );
+}

--- a/src/pageEditor/tabs/recipeOptionsValues/RecipeOptionsValues.test.tsx
+++ b/src/pageEditor/tabs/recipeOptionsValues/RecipeOptionsValues.test.tsx
@@ -57,12 +57,6 @@ function mockRecipe(recipe: RecipeDefinition) {
   });
 }
 
-jest.mock("@/components/fields/schemaFields/serviceFieldUtils", () => ({
-  ...jest.requireActual("@/components/fields/schemaFields/serviceFieldUtils"),
-  // Mock so we don't have to have full Page Editor state in tests
-  produceExcludeUnusedDependencies: jest.fn().mockImplementation((x: any) => x),
-}));
-
 beforeEach(() => {
   registerDefaultWidgets();
 });


### PR DESCRIPTION
## What does this PR do?

- Fixes #5444 
- Fix icon spacing/width on the gsheet file icon

## Checklist

- [x] Add tests - now covered by `RecipeOptionsValues.test`, mocking was hiding the error in this test previously, this now tests a case where the state isn't `FormState`, and SheetsFileWidget doesn't fail anymore
- [x] Designate a primary reviewer
