### PR TITLE
#5450: automatically launch SSO flow; refactor managed storage usage

### DIFF
--- a/src/auth/useRequiredPartnerAuth.ts
+++ b/src/auth/useRequiredPartnerAuth.ts
@@ -35,7 +35,7 @@ import {
 } from "@/services/constants";
 import { type AuthState } from "@/auth/authTypes";
 import { type SettingsState } from "@/store/settingsTypes";
-import { type ManualStorageKey, readStorage } from "@/chrome";
+import useManagedStorageState from "@/store/enterprise/useManagedStorageState";
 
 /**
  * Map from partner keys to partner service IDs
@@ -108,9 +108,6 @@ function decidePartnerServiceIds({
   return PARTNER_MAP.get(partnerId) ?? new Set();
 }
 
-const CONTROL_ROOM_URL_MANAGED_KEY = "controlRoomUrl" as ManualStorageKey;
-const PARTNER_MANAGED_KEY = "partnerId" as ManualStorageKey;
-
 /**
  * Hook for determining if the extension has required integrations for the partner.
  *
@@ -129,17 +126,10 @@ function useRequiredPartnerAuth(): RequiredPartnerState {
   } = useSelector(selectSettings);
   const configuredServices = useSelector(selectConfiguredServices);
 
-  // Control Room URL specified by IT department during force-install
-  const [managedControlRoomUrl] = useAsyncState(
-    async () => readStorage(CONTROL_ROOM_URL_MANAGED_KEY, undefined, "managed"),
-    []
-  );
-
-  // Partner Id/Key specified by IT department during force-install
-  const [managedPartnerId] = useAsyncState(
-    async () => readStorage(PARTNER_MANAGED_KEY, undefined, "managed"),
-    []
-  );
+  // Read enterprise managed state
+  const { data: managedState = {} } = useManagedStorageState();
+  const { controlRoomUrl: managedControlRoomUrl, partnerId: managedPartnerId } =
+    managedState;
 
   // Prefer the latest remote data, but use local data to avoid blocking page load
   const { partner, organization } = me ?? localAuth;

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -28,7 +28,6 @@ import { isCommunityControlRoom } from "@/contrib/automationanywhere/aaUtils";
 import { isEmpty } from "lodash";
 import { expectContext } from "@/utils/expectContext";
 import { AUTOMATION_ANYWHERE_SERVICE_ID } from "@/contrib/automationanywhere/contract";
-import { launchSsoFlow } from "@/store/enterprise/singleSignOn";
 import { readManagedStorageByKey } from "@/store/enterprise/managedStorage";
 
 const UNINSTALL_URL = "https://www.pixiebrix.com/uninstall/";
@@ -200,9 +199,8 @@ async function install({
     // XXX: under what conditions could onInstalled fire, but the extension is already linked?
     if (!(await isLinked())) {
       const ssoUrl = await readManagedStorageByKey("ssoUrl");
-      if (ssoUrl) {
-        void launchSsoFlow(ssoUrl);
-      } else {
+      // Don't launch the SSO page. The SSO flow will be launched by deployment.ts:updateDeployments
+      if (!ssoUrl) {
         void openInstallPage();
       }
     }

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -196,8 +196,11 @@ async function install({
       version,
     });
 
-    // XXX: under what conditions could onInstalled fire, but the extension is already linked?
+    // XXX: under what conditions could onInstalled fire, but the extension is already linked? Is this the case during
+    // development/loading an update of the extension from the file system?
     if (!(await isLinked())) {
+      // PERFORMANCE: readManagedStorageByKey waits up to 2 seconds for managed storage to be available. Shouldn't be
+      // notice-able for end-user relative to the extension download/install time
       const ssoUrl = await readManagedStorageByKey("ssoUrl");
       // Don't launch the SSO page. The SSO flow will be launched by deployment.ts:updateDeployments
       if (!ssoUrl) {

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -20,7 +20,7 @@ import { type Runtime } from "webextension-polyfill";
 import { reportEvent } from "@/telemetry/events";
 import { initTelemetry } from "@/background/telemetry";
 import { getUID } from "@/background/messenger/api";
-import { DNT_STORAGE_KEY, allowsTrack } from "@/telemetry/dnt";
+import { allowsTrack, DNT_STORAGE_KEY } from "@/telemetry/dnt";
 import { gt } from "semver";
 import { getBaseURL } from "@/services/baseService";
 import { getExtensionToken, getUserData, isLinked } from "@/auth/token";
@@ -28,6 +28,8 @@ import { isCommunityControlRoom } from "@/contrib/automationanywhere/aaUtils";
 import { isEmpty } from "lodash";
 import { expectContext } from "@/utils/expectContext";
 import { AUTOMATION_ANYWHERE_SERVICE_ID } from "@/contrib/automationanywhere/contract";
+import { launchSsoFlow } from "@/store/enterprise/singleSignOn";
+import { readManagedStorageByKey } from "@/store/enterprise/managedStorage";
 
 const UNINSTALL_URL = "https://www.pixiebrix.com/uninstall/";
 
@@ -187,7 +189,6 @@ async function install({
 }: Runtime.OnInstalledDetailsType) {
   // https://developer.chrome.com/docs/extensions/reference/runtime/#event-onInstalled
   // https://developer.chrome.com/docs/extensions/reference/runtime/#type-OnInstalledReason
-
   console.debug("onInstalled", { reason, previousVersion });
   const { version } = browser.runtime.getManifest();
 
@@ -198,7 +199,12 @@ async function install({
 
     // XXX: under what conditions could onInstalled fire, but the extension is already linked?
     if (!(await isLinked())) {
-      void openInstallPage();
+      const ssoUrl = await readManagedStorageByKey("ssoUrl");
+      if (ssoUrl) {
+        void launchSsoFlow(ssoUrl);
+      } else {
+        void openInstallPage();
+      }
     }
   } else if (reason === "update") {
     // `update` is also triggered on browser.runtime.reload() and manually reloading from the extensions page

--- a/src/chrome.ts
+++ b/src/chrome.ts
@@ -70,27 +70,26 @@ export class RuntimeNotFoundError extends Error {
   override name = "RuntimeNotFoundError";
 }
 
+/**
+ * Read a value from Chrome storage.
+ *
+ * Does not support enterprise managed storage. Use `readManagedStorage` for that.
+ *
+ * @param storageKey the storage key
+ * @param defaultValue default value to return if the key is not defined in storage. To distinguish between a missing
+ * key and a value of `undefined`, pass a Symbol as the default value.
+ * @param area the storage area
+ * @see readManagedStorage
+ */
 export async function readStorage<T = unknown>(
   storageKey: ManualStorageKey,
   defaultValue?: T,
-  area: "local" | "managed" | "session" = "local"
+  area: "local" | "session" = "local"
 ): Promise<T | undefined> {
-  let result: UnknownObject;
-
-  try {
-    // `browser.storage.local` is supposed to have a signature that takes an object that includes default values.
-    // On Chrome 93.0.4577.63 that signature appears to return the defaultValue even when the value is set?
-    // eslint-disable-next-line security/detect-object-injection -- type-checked
-    result = await browser.storage[area].get(storageKey);
-  } catch (error) {
-    if (area === "managed") {
-      // Handle Opera: https://github.com/pixiebrix/pixiebrix-extension/issues/4069
-      // We don't officially support Opera, but to keep the error telemetry clean.
-      result = {};
-    } else {
-      throw error;
-    }
-  }
+  // `browser.storage.local` is supposed to have a signature that takes an object that includes default values.
+  // On Chrome 93.0.4577.63 that signature appears to return the defaultValue even when the value is set?
+  // eslint-disable-next-line security/detect-object-injection -- type-checked
+  const result: UnknownObject = await browser.storage[area].get(storageKey);
 
   if (Object.hasOwn(result, storageKey)) {
     // eslint-disable-next-line security/detect-object-injection -- Just checked with hasOwn

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -22,8 +22,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { DEFAULT_THEME, type Theme } from "@/options/types";
 import { activatePartnerTheme } from "@/background/messenger/api";
 import { persistor } from "@/store/optionsStore";
-import { useAsyncState } from "@/hooks/common";
-import { type ManualStorageKey, readStorage } from "@/chrome";
 import {
   addThemeClassToDocumentRoot,
   getThemeLogo,
@@ -33,8 +31,7 @@ import {
 } from "@/utils/themeUtils";
 import { appApi } from "@/services/api";
 import { selectAuth } from "@/auth/authSelectors";
-
-const MANAGED_PARTNER_ID_KEY = "partnerId" as ManualStorageKey;
+import useManagedStorageState from "@/store/enterprise/useManagedStorageState";
 
 async function activateBackgroundTheme(): Promise<void> {
   // Flush the Redux state to localStorage to ensure the background page sees the latest state
@@ -58,13 +55,9 @@ export function useGetTheme(): Theme {
     return isValidTheme(cachedTheme) ? cachedTheme : null;
   }, [me, cachedPartner?.theme]);
 
-  // Read from the browser's managed storage. The IT department can set as part of distributing the browser extension
-  // so the correct theme is applied before authentication.
-  const [managedPartnerId, managedPartnerIdIsLoading] = useAsyncState(
-    readStorage(MANAGED_PARTNER_ID_KEY, undefined, "managed"),
-    [],
-    null
-  );
+  const { data: managedState, isLoading: managedPartnerIdIsLoading } =
+    useManagedStorageState();
+  const managedPartnerId = managedState?.partnerId;
 
   useEffect(() => {
     if (partnerId === null && !managedPartnerIdIsLoading) {

--- a/src/options/pages/onboarding/SetupPage.test.tsx
+++ b/src/options/pages/onboarding/SetupPage.test.tsx
@@ -46,9 +46,14 @@ function optionsStore(initialState?: any) {
   });
 }
 
-jest.mock("@/chrome", () => ({
-  readStorage: jest.fn().mockResolvedValue(undefined),
-}));
+jest.mock("lodash", () => {
+  const lodash = jest.requireActual("lodash");
+  return {
+    ...lodash,
+    // Handle multiple calls to managedStorage:initManagedStorage across tests
+    once: (fn: any) => fn,
+  };
+});
 
 jest.mock("@/services/api", () => ({
   util: {

--- a/src/options/pages/onboarding/SetupPage.test.tsx
+++ b/src/options/pages/onboarding/SetupPage.test.tsx
@@ -28,12 +28,12 @@ import { appApi } from "@/services/api";
 import settingsSlice from "@/store/settingsSlice";
 import { CONTROL_ROOM_OAUTH_SERVICE_ID } from "@/services/constants";
 import { uuidv4 } from "@/types/helpers";
-import { readStorage } from "@/chrome";
 import { HashRouter } from "react-router-dom";
 import { createHashHistory } from "history";
 import userEvent from "@testing-library/user-event";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { type Me } from "@/types/contract";
+import { INTERNAL_reset as resetManagedStorage } from "@/store/enterprise/managedStorage";
 
 function optionsStore(initialState?: any) {
   return configureStore({
@@ -87,8 +87,10 @@ function mockMeQuery(state: { isLoading: boolean; data?: Me; error?: any }) {
   (appApi.endpoints.getMe.useQueryState as jest.Mock).mockReturnValue(state);
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   jest.clearAllMocks();
+  resetManagedStorage();
+  await browser.storage.managed.clear();
 });
 
 describe("SetupPage", () => {
@@ -277,14 +279,10 @@ describe("SetupPage", () => {
       data: {} as any,
     });
 
-    const managedConfiguration: Record<string, string> = {
+    await browser.storage.managed.set({
       partnerId: "automation-anywhere",
       controlRoomUrl: "https://notarealcontrolroom.com",
-    };
-
-    (readStorage as jest.Mock).mockImplementation(
-      (key: string) => managedConfiguration[key]
-    );
+    });
 
     render(
       <Provider store={optionsStore({})}>

--- a/src/options/pages/onboarding/SetupPage.test.tsx
+++ b/src/options/pages/onboarding/SetupPage.test.tsx
@@ -55,6 +55,18 @@ jest.mock("lodash", () => {
   };
 });
 
+// `pMemoize` has problems when used in tests because the promise can leak across tests. pMemoizeClear doesn't work
+// because the promise hasn't resolved yet
+jest.mock("p-memoize", () => {
+  const memoize = jest.requireActual("p-memoize");
+  return {
+    ...memoize,
+    __esModule: true,
+    pMemoizeClear: jest.fn(),
+    default: jest.fn().mockImplementation((fn) => fn),
+  };
+});
+
 jest.mock("@/services/api", () => ({
   util: {
     resetApiState: jest.fn().mockReturnValue({ type: "notarealreset" }),

--- a/src/options/pages/onboarding/partner/PartnerSetupCard.tsx
+++ b/src/options/pages/onboarding/partner/PartnerSetupCard.tsx
@@ -31,12 +31,12 @@ import { faLink } from "@fortawesome/free-solid-svg-icons";
 import { useAsyncState } from "@/hooks/common";
 import { getBaseURL } from "@/services/baseService";
 import settingsSlice from "@/store/settingsSlice";
-import { type ManualStorageKey, readStorage } from "@/chrome";
 import { useLocation } from "react-router";
 import {
   hostnameToUrl,
   isCommunityControlRoom,
 } from "@/contrib/automationanywhere/aaUtils";
+import { readManagedStorageByKey } from "@/store/enterprise/managedStorage";
 
 function useInstallUrl() {
   const { data: me } = appApi.endpoints.getMe.useQueryState();
@@ -105,8 +105,6 @@ function usePartnerLoginMode(): "token" | "oauth2" {
   }
 }
 
-const CONTROL_ROOM_URL_MANAGED_KEY = "controlRoomUrl" as ManualStorageKey;
-
 /**
  * A card to set up a required partner integration.
  *
@@ -130,13 +128,8 @@ const PartnerSetupCard: React.FunctionComponent = () => {
   const [controlRoomUrl] = useAsyncState(
     async () => {
       try {
-        return (
-          (await readStorage(
-            CONTROL_ROOM_URL_MANAGED_KEY,
-            undefined,
-            "managed"
-          )) ?? fallbackControlRoomUrl
-        );
+        // Use readManagedStorageByKey instead of useSyncManagedStorage to fallback to fallbackControlRoomUrl
+        return await readManagedStorageByKey("controlRoomUrl");
       } catch {
         return fallbackControlRoomUrl;
       }

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -20,13 +20,12 @@ import { type ManualStorageKey, readStorage, setStorage } from "@/chrome";
 import { isExtensionContext } from "webext-detect-page";
 import { useAsyncEffect } from "use-async-effect";
 import { useCallback, useState } from "react";
+import { readManagedStorageByKey } from "@/store/enterprise/managedStorage";
 
 export const DEFAULT_SERVICE_URL = process.env.SERVICE_URL;
 const SERVICE_STORAGE_KEY = "service-url" as ManualStorageKey;
 
 type ConfiguredHost = string | null | undefined;
-
-const MANAGED_HOSTNAME_KEY = "serviceUrl" as ManualStorageKey;
 
 export function withoutTrailingSlash(url: string): string {
   return url.replace(/\/$/, "");
@@ -46,11 +45,8 @@ export async function getBaseURL(): Promise<string> {
       return withoutTrailingSlash(configured);
     }
 
-    const managed = await readStorage<string>(
-      MANAGED_HOSTNAME_KEY,
-      undefined,
-      "managed"
-    );
+    const managed = await readManagedStorageByKey("serviceUrl");
+
     if (!isEmpty(managed)) {
       return withoutTrailingSlash(managed);
     }

--- a/src/store/enterprise/managedStorage.test.ts
+++ b/src/store/enterprise/managedStorage.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  INTERNAL_reset,
+  readManagedStorage,
+  readManagedStorageByKey,
+} from "@/store/enterprise/managedStorage";
+
+beforeEach(async () => {
+  // eslint-disable-next-line new-cap -- test helper method
+  INTERNAL_reset();
+  await browser.storage.managed.clear();
+});
+
+describe("readManagedStorage", () => {
+  it("reads uninitialized managed storage", async () => {
+    await expect(readManagedStorage()).resolves.toStrictEqual({});
+  });
+
+  it("reads managed storage", async () => {
+    await browser.storage.managed.set({ partnerId: "taco-bell" });
+    await expect(readManagedStorage()).resolves.toStrictEqual({
+      partnerId: "taco-bell",
+    });
+  });
+});
+
+describe("readManagedStorageByKey", () => {
+  it("reads uninitialized managed storage", async () => {
+    await expect(readManagedStorageByKey("partnerId")).resolves.toBeUndefined();
+  });
+
+  it("reads managed storage", async () => {
+    await browser.storage.managed.set({ partnerId: "taco-bell" });
+    await expect(readManagedStorageByKey("partnerId")).resolves.toBe(
+      "taco-bell"
+    );
+  });
+});

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -83,7 +83,12 @@ const waitForInitialManagedStorage = pMemoize(async () => {
 
 /**
  * Read a single-value from enterprise managed storage.
+ *
+ * If managed storage has not been initialized yet, reads from the managed storage API. Waits up to
+ * MAX_MANAGED_STORAGE_WAIT_MILLIS for the data to be available.
+ *
  * @param key the key to read.
+ * @see MAX_MANAGED_STORAGE_WAIT_MILLIS
  */
 export async function readManagedStorageByKey<
   K extends keyof ManagedStorageState
@@ -103,6 +108,11 @@ export async function readManagedStorageByKey<
 
 /**
  * Read a managed storage state from enterprise managed storage.
+ *
+ * If managed storage has not been initialized yet, reads from the managed storage API. Waits up to
+ * MAX_MANAGED_STORAGE_WAIT_MILLIS for the data to be available.
+ *
+ * @see MAX_MANAGED_STORAGE_WAIT_MILLIS
  */
 export async function readManagedStorage(): Promise<ManagedStorageState> {
   expectContext("extension");
@@ -116,8 +126,9 @@ export async function readManagedStorage(): Promise<ManagedStorageState> {
 }
 
 /**
- * Get a synchronous snapshot of the managed storage state.
+ * Get a _synchronous_ snapshot of the managed storage state.
  * @see useSyncManagedStorage
+ * @see readManagedStorage
  */
 export function getSnapshot(): ManagedStorageState | undefined {
   expectContext("extension");

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { pollUntilTruthy } from "@/utils";
+import { type ManagedStorageState } from "@/store/enterprise/managedStorageTypes";
+import { isEmpty, once, remove } from "lodash";
+import { type UnknownObject } from "@/types";
+import { expectContext } from "@/utils/expectContext";
+import pMemoize, { pMemoizeClear } from "p-memoize";
+
+const MAX_MANAGED_STORAGE_WAIT_MILLIS = 2000;
+
+/**
+ * The managedStorageState, or undefined if it hasn't been initialized yet.
+ */
+let managedStorageState: ManagedStorageState | undefined;
+const listeners: Array<(state: ManagedStorageState) => void> = [];
+
+function notifyAll(): void {
+  for (const listener of listeners) {
+    listener(managedStorageState);
+  }
+}
+
+async function readManagedStorageImmediately<T = unknown>(
+  storageKey: keyof ManagedStorageState
+): Promise<T>;
+async function readManagedStorageImmediately<T = unknown>(
+  storageKey: null
+): Promise<UnknownObject>;
+async function readManagedStorageImmediately<T = unknown>(
+  storageKey: keyof ManagedStorageState | null
+): Promise<T | UnknownObject> {
+  let storageValue;
+
+  try {
+    // `browser.storage.local` is supposed to have a signature that takes an object that includes default values.
+    // On Chrome 93.0.4577.63 that signature appears to return the defaultValue even when the value is set?
+    storageValue = await browser.storage.managed.get(storageKey);
+  } catch {
+    // Handle Opera: https://github.com/pixiebrix/pixiebrix-extension/issues/4069
+    // We don't officially support Opera, but to keep the error telemetry clean.
+    storageValue = {};
+  }
+
+  if (storageKey == null) {
+    return storageValue;
+  }
+
+  // eslint-disable-next-line security/detect-object-injection -- type-checked key
+  return storageValue[storageKey];
+}
+
+// It's possible that managed storage is not available on the initial install event
+// Privacy Badger does a looping check for managed storage
+// - https://github.com/EFForg/privacybadger/blob/aeed0539603356a2825e7ce8472f6478abdc85fb/src/js/storage.js
+// - https://github.com/EFForg/privacybadger/issues/2770#issuecomment-853329201
+// - https://github.com/uBlockOrigin/uBlock-issues/issues/1660#issuecomment-880150676
+// uBlock (still) contains a workaround to automatically reload the extension on initial install
+// - https://github.com/gorhill/uBlock/commit/32bd47f05368557044dd3441dcaa414b7b009b39
+const waitForInitialManagedStorage = pMemoize(async () => {
+  managedStorageState = await pollUntilTruthy<ManagedStorageState>(
+    async () => {
+      const value = await readManagedStorageImmediately(null);
+      if (typeof value === "object" && !isEmpty(value)) {
+        return value;
+      }
+    },
+    {
+      maxWaitMillis: MAX_MANAGED_STORAGE_WAIT_MILLIS,
+    }
+  );
+
+  if (managedStorageState) {
+    console.info("Read managed storage settings", {
+      managedStorageState,
+    });
+  } else {
+    console.info("No manual storage settings found", {
+      managedStorageState,
+    });
+  }
+
+  notifyAll();
+
+  return managedStorageState;
+});
+
+/**
+ * Read a single-value from enterprise managed storage.
+ * @param key the key to read.
+ */
+export async function readManagedStorageByKey<
+  K extends keyof ManagedStorageState
+>(key: K): Promise<ManagedStorageState[K]> {
+  expectContext("extension");
+
+  if (managedStorageState != null) {
+    // eslint-disable-next-line security/detect-object-injection -- type-checked key
+    return managedStorageState[key];
+  }
+
+  initManagedStorage();
+  const storage = (await waitForInitialManagedStorage()) ?? {};
+  // eslint-disable-next-line security/detect-object-injection -- type-checked key
+  return storage[key];
+}
+
+/**
+ * Read a managed storage state from enterprise managed storage.
+ */
+export async function readManagedStorage(): Promise<ManagedStorageState> {
+  expectContext("extension");
+
+  if (managedStorageState != null) {
+    return managedStorageState;
+  }
+
+  initManagedStorage();
+  return (await waitForInitialManagedStorage()) ?? {};
+}
+
+/**
+ * Get a synchronous snapshot of the managed storage state.
+ * @see useSyncManagedStorage
+ */
+export function getSnapshot(): ManagedStorageState | undefined {
+  expectContext("extension");
+
+  return managedStorageState;
+}
+
+/**
+ * Subscribe to changes in the managed storage state. In practice, this should only fire once because managed
+ * storage is not mutable.
+ * @param callback to receive the updated state.
+ * @see useSyncManagedStorage
+ */
+export function subscribe(
+  callback: (state: ManagedStorageState) => void
+): () => void {
+  expectContext("extension");
+
+  listeners.push(callback);
+
+  return () => {
+    remove(listeners, (x) => x === callback);
+  };
+}
+
+/**
+ * Helper method for resetting the module for testing.
+ */
+export function INTERNAL_reset(): void {
+  managedStorageState = undefined;
+  listeners.splice(0, listeners.length);
+  pMemoizeClear(waitForInitialManagedStorage);
+}
+
+/**
+ * Initialize the managed storage state and listen for changes. Safe to call multiple times.
+ */
+export const initManagedStorage = once(() => {
+  expectContext("extension");
+
+  try {
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/onChanged
+    // `browser.storage.managed.onChanged` might also exist, but it's not available in testing
+    // See: https://github.com/clarkbw/jest-webextension-mock/issues/170
+    browser.storage.onChanged.addListener(async (changes, area) => {
+      if (area === "managed") {
+        managedStorageState = await readManagedStorageImmediately(null);
+        notifyAll();
+      }
+    });
+  } catch (error) {
+    // Handle Opera: https://github.com/pixiebrix/pixiebrix-extension/issues/4069
+    console.warn(
+      "Not listening for managed storage changes because managed storage is not supported",
+      { error }
+    );
+  }
+
+  void waitForInitialManagedStorage();
+});

--- a/src/store/enterprise/managedStorageTypes.ts
+++ b/src/store/enterprise/managedStorageTypes.ts
@@ -40,7 +40,7 @@ export type ManagedStorageState = {
    */
   campaignIds?: string[];
   /**
-   * The SSO URL specified by IT department during force-install
+   * The SSO URL for automatically performing SSO/SAML authentication.
    */
   ssoUrl?: string;
   /**

--- a/src/store/enterprise/managedStorageTypes.ts
+++ b/src/store/enterprise/managedStorageTypes.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The managed storage state is stored in the browser's managed storage area. Configured by the Enterprise IT department
+ * as part of force install of the extension.
+ *
+ * See managedStorageSchema.json
+ */
+export type ManagedStorageState = {
+  /**
+   * PixieBrix organization ID the extension should link to
+   */
+  managedOrganizationId?: string;
+  /**
+   * PixieBrix partner ID
+   */
+  partnerId?: string;
+  /**
+   * Automation Anywhere Control Room URL specified by IT department
+   */
+  controlRoomUrl?: string;
+  /**
+   * The campaign IDs the user is a part of (if any). Used for analytics when the user has not authenticated
+   * @deprecated
+   */
+  campaignIds?: string[];
+  /**
+   * The SSO URL specified by IT department during force-install
+   */
+  ssoUrl?: string;
+  /**
+   * PixieBrix service URL
+   */
+  serviceUrl?: string;
+};

--- a/src/store/enterprise/singleSignOn.test.ts
+++ b/src/store/enterprise/singleSignOn.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { launchSsoFlow } from "@/store/enterprise/singleSignOn";
+
+describe("launchSsoFlow", () => {
+  it("doesn't hijack active tab", async () => {
+    const url = "https://app.pixiebrix.com/login/saml/?idp=google,1234";
+    await launchSsoFlow(url);
+
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url,
+      active: false,
+    });
+  });
+});

--- a/src/store/enterprise/singleSignOn.ts
+++ b/src/store/enterprise/singleSignOn.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expectContext } from "@/utils/expectContext";
+
+/**
+ * Launch the SAML/SSO flow for the browser extension.
+ * @param url the SSO URL, should be of the form https://app.pixiebrix.com/login/saml/?idp=<name>,<orgId>
+ */
+export async function launchSsoFlow(url: string): Promise<void> {
+  expectContext("extension");
+
+  await browser.tabs.create({ url, active: false });
+}

--- a/src/store/enterprise/useManagedStorageState.test.ts
+++ b/src/store/enterprise/useManagedStorageState.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { INTERNAL_reset } from "@/store/enterprise/managedStorage";
+import { renderHook } from "@testing-library/react-hooks";
+import useManagedStorageState from "@/store/enterprise/useManagedStorageState";
+
+beforeEach(async () => {
+  // eslint-disable-next-line new-cap -- test helper method
+  INTERNAL_reset();
+  await browser.storage.managed.clear();
+});
+
+describe("useManagedStorageState", () => {
+  it("handles state initialization", async () => {
+    const wrapper = renderHook(() => useManagedStorageState());
+    expect(wrapper.result.current).toStrictEqual({
+      data: undefined,
+      isLoading: true,
+    });
+  });
+
+  it("handles already initialized state", async () => {
+    await browser.storage.managed.set({ partnerId: "taco-bell" });
+    const wrapper = renderHook(() => useManagedStorageState());
+    await wrapper.waitForNextUpdate();
+    expect(wrapper.result.current).toStrictEqual({
+      data: { partnerId: "taco-bell" },
+      isLoading: false,
+    });
+  });
+
+  // Can't test because mock doesn't fire change events: https://github.com/clarkbw/jest-webextension-mock/issues/170
+  it.skip("listens for changes", async () => {
+    const wrapper = renderHook(() => useManagedStorageState());
+    expect(wrapper.result.current.data).toBeUndefined();
+    await browser.storage.managed.set({ partnerId: "taco-bell" });
+    await wrapper.waitForNextUpdate();
+    expect(wrapper.result.current).toStrictEqual({
+      data: { partnerId: "taco-bell" },
+      isLoading: false,
+    });
+  });
+});

--- a/src/store/enterprise/useManagedStorageState.ts
+++ b/src/store/enterprise/useManagedStorageState.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useSyncExternalStore } from "use-sync-external-store/shim";
+import {
+  getSnapshot,
+  initManagedStorage,
+  subscribe,
+} from "@/store/enterprise/managedStorage";
+import { useEffect } from "react";
+import { type ManagedStorageState } from "@/store/enterprise/managedStorageTypes";
+
+type HookState = {
+  data: ManagedStorageState | undefined;
+  isLoading: boolean;
+};
+
+/**
+ * React hook to get the current state of managed storage.
+ */
+function useManagedStorageState(): HookState {
+  useEffect(() => {
+    initManagedStorage();
+  }, []);
+
+  const data = useSyncExternalStore(subscribe, getSnapshot);
+
+  return {
+    data,
+    isLoading: data == null,
+  };
+}
+
+export default useManagedStorageState;

--- a/static/managedStorageSchema.json
+++ b/static/managedStorageSchema.json
@@ -9,6 +9,11 @@
       "type": "string",
       "description": "PixieBrix partner ID"
     },
+    "ssoUrl": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL to perform single sign-on, including scheme"
+    },
     "controlRoomUrl": {
       "type": "string",
       "format": "uri",


### PR DESCRIPTION
## What does this PR do?

- Closes #5450 
- Refactors use of browser IT admin managed storage
   - Adds new `store.enterprise` module
   - Adds type for storage to avoid ad-hoc constant definitions 
   - Introduces a `useManagedStorageState` hook for use in React components/hooks
   - Tries to handle quirks in managed storage state initialization time
- Read the `store.enterprise` files first

## Work Remaining

- [x] Manual testing on browser with managed storage state
- [x] On initial install, it opens 2x windows: one from deployments, and one from the installer
- [x] Fix dependent test "SetupPage › Managed Storage OAuth2 partner user" that passes in isolation
- [x] Record demo

## Future Work

- Have the app include a success query parameter in the URL on successful SAML linking, so the browser extension can automatically close the tab. Could alternatively just look for the `https://app.pixiebrix.com/accounts/profile/` URL. But we might be getting rid of that URL @johnnymetz  @mnholtz 

## Demo

- https://www.loom.com/share/7ae375b8bcd04a94b409e34503073b20

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
