### PR TITLE
#5440 Fix inputRef usage in field widgets

### DIFF
--- a/src/components/fields/schemaFields/widgets/NumberWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/NumberWidget.tsx
@@ -18,7 +18,6 @@
 import React, {
   type FocusEventHandler,
   useCallback,
-  useEffect,
   useRef,
   useState,
 } from "react";
@@ -56,16 +55,10 @@ const NumberWidget: React.VFC<
     useField<number>(name);
   const [value, setValue] = useState<string>(String(formValue));
 
-  const inputRef = useRef<HTMLInputElement>();
+  const defaultInputRef = useRef<HTMLElement>();
+  const inputRef = inputRefProp ?? defaultInputRef;
 
   useAutoFocusConfiguration({ elementRef: inputRef, focus: focusInput });
-
-  useEffect(() => {
-    // Sync the ref values
-    if (inputRefProp) {
-      inputRefProp.current = inputRef.current;
-    }
-  }, [inputRef.current]);
 
   const onChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
     ({ target }) => {

--- a/src/components/fields/schemaFields/widgets/PasswordWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/PasswordWidget.tsx
@@ -16,7 +16,7 @@
  */
 import styles from "./PasswordWidget.module.scss";
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import {
   Button,
   // eslint-disable-next-line no-restricted-imports -- TODO: Fix over time
@@ -45,20 +45,15 @@ const PasswordWidget: React.VFC<SchemaFieldProps & FormControlProps> = ({
   const [{ value }, , { setValue }] = useField<string>(name);
   const [show, setShow] = useState<boolean>(false);
 
-  const inputRef = useRef<HTMLInputElement>();
+  const defaultInputRef = useRef<HTMLElement>();
+  const inputRef = inputRefProp ?? defaultInputRef;
   useAutoFocusConfiguration({ elementRef: inputRef, focus: focusInput });
-
-  useEffect(() => {
-    // Sync the ref values
-    if (inputRefProp) {
-      inputRefProp.current = inputRef.current;
-    }
-  }, [inputRef.current]);
 
   const onChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
     ({ target }) => {
       setValue(target.value);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- don't include formik helpers
     []
   );
 

--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
@@ -48,7 +48,7 @@ const TemplateToggleWidget: React.VFC<TemplateToggleWidgetProps> = ({
   inputModeOptions,
   setFieldDescription,
   defaultType,
-  inputRef: inputRefProp, // Cut out from the rest of the props, not used
+  inputRef: inputRefProp,
   ...schemaFieldProps
 }) => {
   const [{ value }, , { setValue }] = useField(schemaFieldProps.name);
@@ -56,7 +56,8 @@ const TemplateToggleWidget: React.VFC<TemplateToggleWidgetProps> = ({
     schemaFieldProps.name,
     schemaFieldProps.schema
   );
-  const inputRef = useRef<HTMLTextAreaElement>();
+  const defaultInputRef = useRef<HTMLElement>();
+  const inputRef = inputRefProp ?? defaultInputRef;
   const selectedOption = getOptionForInputMode(inputModeOptions, inputMode);
   const Widget = selectedOption?.Widget ?? WidgetLoadingIndicator;
   const [focusInput, setFocusInput] = useState(false);

--- a/src/components/fields/schemaFields/widgets/TextWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TextWidget.tsx
@@ -17,6 +17,7 @@
 
 import React, {
   type KeyboardEventHandler,
+  type MutableRefObject,
   useCallback,
   useContext,
   useEffect,
@@ -96,18 +97,15 @@ const TextWidget: React.VFC<SchemaFieldProps & FormControlProps> = ({
     useContext(FieldRuntimeContext);
   const allowExpressions = allowExpressionsContext && !isKeyStringField(schema);
 
-  const textAreaRef = useRef<HTMLTextAreaElement>();
+  const defaultTextAreaRef = useRef<HTMLTextAreaElement>();
+  const textAreaRef: MutableRefObject<HTMLTextAreaElement> =
+    (inputRef as MutableRefObject<HTMLTextAreaElement>) ?? defaultTextAreaRef;
 
   useEffect(() => {
     if (textAreaRef.current) {
       fitTextarea.watch(textAreaRef.current);
     }
-
-    // Sync the ref values
-    if (inputRef) {
-      inputRef.current = textAreaRef.current;
-    }
-  }, [textAreaRef.current]);
+  }, [textAreaRef]);
 
   useEffect(() => {
     if (focusInput) {


### PR DESCRIPTION
## What does this PR do?

- Fixes #5440 
- Unblocks the first issue in #5451 

## Discussion

- This was written together with the fix for the first issue in #5451 to enable checking the inputRef against document.activeElement to detect focus, but that fix will be committed separately in another PR

## Checklist

- [ ] ~Add tests~ - already have coverage on the auto-focus logic, and it's tricky to get the jest rendering right for `useRef()` to work with a rendered document element in tests, so this doesn't seem worth figuring out right now (I gave it a solid 30 minutes effort). I manually validated that the widgets all seem to work fine in the UI.
- [x] Designate a primary reviewer - @twschiller 
