### PR TITLE
#5459: show partner oauth2 screen on managed partner id

### DIFF
--- a/src/background/partnerTheme.ts
+++ b/src/background/partnerTheme.ts
@@ -20,19 +20,26 @@ import { getThemeLogo } from "@/utils/themeUtils";
 import activateBrowserActionIcon from "@/background/activateBrowserActionIcon";
 import { DEFAULT_THEME } from "@/options/types";
 import { browserAction } from "@/mv3/api";
+import { expectContext } from "@/utils/expectContext";
+import { readManagedStorage } from "@/store/enterprise/managedStorage";
 
 async function setToolbarIcon(): Promise<void> {
   const { theme } = await getSettingsState();
+  const { partnerId: managedPartnerId } = await readManagedStorage();
 
-  if (theme === DEFAULT_THEME) {
+  const activeTheme = managedPartnerId ?? theme;
+
+  if (activeTheme === DEFAULT_THEME) {
     activateBrowserActionIcon();
     return;
   }
 
-  const themeLogo = getThemeLogo(theme);
+  const themeLogo = getThemeLogo(activeTheme);
   browserAction.setIcon({ path: themeLogo.small });
 }
 
 export default function initPartnerTheme() {
+  expectContext("background");
+
   void setToolbarIcon();
 }

--- a/src/testUtils/testHelpers.tsx
+++ b/src/testUtils/testHelpers.tsx
@@ -68,6 +68,12 @@ export const getChromeEventMocks = () => ({
   hasListeners: jest.fn(),
 });
 
+/**
+ * Wait for async handlers, e.g., useAsyncEffect and useAsyncState.
+ *
+ * NOTE: this assumes you're using "react-dom/test-utils". For hooks you have to use act from
+ * "@testing-library/react-hooks"
+ */
 export const waitForEffect = async () =>
   act(async () => {
     // Awaiting the async state update


### PR DESCRIPTION
## What does this PR do?

- Closes #5459 
- Show AA OAuth2 screen if partnerId is set in managed storage
- Sets extension theme to the key in managed storage on startup

## Remaining Work

- [x] Fix test interference

## Demo

- https://www.loom.com/share/d0972947ff284abb9053f0035e4b033f

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @mnholtz 
