### PR TITLE
#5471: add current title to document context brick

### DIFF
--- a/src/blocks/readers/DocumentReader.test.ts
+++ b/src/blocks/readers/DocumentReader.test.ts
@@ -15,14 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import "jest-location-mock";
 import DocumentReader from "@/blocks/readers/DocumentReader";
 
 const brick = new DocumentReader();
 
 describe("DocumentReader", () => {
   it("reads current title", async () => {
-    document.head.innerHTML = `<title>Original</title><link rel="canonical" href="https://example.com" />`;
+    document.head.innerHTML =
+      '<title>Original</title><link rel="canonical" href="https://example.com" />';
     window.location.assign("https://example.com");
 
     await expect(brick.read()).resolves.toStrictEqual({

--- a/src/blocks/readers/DocumentReader.test.ts
+++ b/src/blocks/readers/DocumentReader.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import "jest-location-mock";
+import DocumentReader from "@/blocks/readers/DocumentReader";
+
+const brick = new DocumentReader();
+
+describe("DocumentReader", () => {
+  it("reads current title", async () => {
+    document.head.innerHTML = `<title>Original</title><link rel="canonical" href="https://example.com" />`;
+    window.location.assign("https://example.com");
+
+    await expect(brick.read()).resolves.toStrictEqual({
+      timestamp: expect.toBeDateString(),
+      url: expect.toBeString(),
+      title: "Original",
+    });
+
+    document.title = "New Title";
+
+    await expect(brick.read()).resolves.toStrictEqual({
+      timestamp: expect.toBeDateString(),
+      url: expect.toBeString(),
+      title: "New Title",
+    });
+  });
+});

--- a/src/blocks/readers/DocumentReader.ts
+++ b/src/blocks/readers/DocumentReader.ts
@@ -32,6 +32,7 @@ class DocumentReader extends Reader {
   async read() {
     return {
       url: document.location.href,
+      title: document.title,
       timestamp: new Date().toISOString(),
     };
   }
@@ -53,13 +54,17 @@ class DocumentReader extends Reader {
         format: "uri",
         description: "The current URL",
       },
+      title: {
+        type: "string",
+        description: "The current title",
+      },
       timestamp: {
         type: "string",
         format: "date-time",
         description: "The current time in ISO format",
       },
     },
-    required: ["url", "timestamp"],
+    required: ["url", "title", "timestamp"],
   };
 
   async isAvailable() {


### PR DESCRIPTION
## What does this PR do?

- Closes #5471 
- Modified `@pixiebrix/document-context` to return the current title of the page

## Discussion

- This change is backward-compatible because it's adding a new prop to the brick
- The mod behavior is slightly backward incompatible, because the title will override the title coming from the `@pixiebrix/document-metadata`. I think that's OK though, because likely no one cares about the original title for SPAs

## Demo

- _Paste a screenshot or demo video here_

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
