### PR TITLE
#5476: add all_urls as optional permission

### DIFF
--- a/src/analysis/analysisVisitors/extensionUrlPatternAnalysis.ts
+++ b/src/analysis/analysisVisitors/extensionUrlPatternAnalysis.ts
@@ -28,6 +28,8 @@ import { AnnotationType } from "@/types";
 const urlRegexp = /^(?<scheme>.*):\/\/(?<host>[^/]*)?(?<path>.*)?$/;
 const schemeRegexp = /^\*|https?$/;
 const hostRegexp = /^(\*|(^(\*\.)?[^*/]+))$/;
+// All URLs is required for certain interactions, e.g., taking screenshots without activeTab
+const allUrls = "<all_urls>";
 
 const urlPatternFields = ["extensionPoint.definition.isAvailable.urlPatterns"];
 
@@ -122,6 +124,10 @@ class ExtensionUrlPatternAnalysis implements Analysis {
     fieldName: string
   ): Promise<void> {
     for (const [index, url] of Object.entries(urls)) {
+      if (url === allUrls) {
+        continue;
+      }
+
       if (isEmpty(url)) {
         this.pushErrorAnnotation({
           path: joinPathParts(fieldName, index),

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -30,7 +30,7 @@
   "sandbox": {
     "pages": ["sandbox.html"]
   },
-  "optional_permissions": ["clipboardWrite", "*://*/*"],
+  "optional_permissions": ["clipboardWrite", "*://*/*", "<all_urls>"],
   "permissions": [
     "activeTab",
     "storage",


### PR DESCRIPTION
## What does this PR do?

- Closes #5476 

## Remaining Work

- [x] Allow `<all_urls>` in Page Editor (currently barfs on field validation)

## Discussion

- Should not CWS impact review time because it's an optional permission

## Demo

- https://www.loom.com/share/6178a49ff5d743859e057d3c769c9a2f

## Future Work

- Add analysis rule to show warning if `<all_urls>` not specified and Take Screenshot is in starter brick that doesn't support it

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
