### PR TITLE
Make getFormState() more intuitive

### DIFF
--- a/src/components/documentBuilder/edit/DocumentEditor.test.tsx
+++ b/src/components/documentBuilder/edit/DocumentEditor.test.tsx
@@ -219,7 +219,6 @@ describe("remove element", () => {
 
     await userEvent.click(rendered.getByText("Remove element"));
 
-    const actualFormState = await rendered.getFormState();
-    expect(actualFormState.services).toStrictEqual([]);
+    expect(rendered.getFormState().services).toStrictEqual([]);
   });
 });

--- a/src/components/fields/schemaFields/widgets/ArrayWidget.test.tsx
+++ b/src/components/fields/schemaFields/widgets/ArrayWidget.test.tsx
@@ -112,9 +112,7 @@ describe("ArrayWidget", () => {
     // Change the item value
     await userEvent.type(itemInput, "myValue");
 
-    const formState = await getFormState();
-
-    expect(formState).toStrictEqual({
+    expect(getFormState()).toStrictEqual({
       [fieldName]: [stringToExpression("myValue", "nunjucks")],
     });
   });
@@ -150,10 +148,8 @@ describe("ArrayWidget", () => {
     // Select "Remove" since we're in an array
     await userEvent.click(screen.getByText("Remove"));
 
-    const formState = await getFormState();
-
     // Expect excluded property to be removed from the state
-    expect(formState).toStrictEqual({
+    expect(getFormState()).toStrictEqual({
       [fieldName]: ["abc"],
     });
   });

--- a/src/components/fields/schemaFields/widgets/ObjectWidget.test.tsx
+++ b/src/components/fields/schemaFields/widgets/ObjectWidget.test.tsx
@@ -117,9 +117,7 @@ describe("ObjectWidget", () => {
     // Blur the value input to set the value
     await userEvent.click(nameInput);
 
-    const formState = await getFormState();
-
-    expect(formState).toStrictEqual({
+    expect(getFormState()).toStrictEqual({
       [fieldName]: {
         myProp: stringToExpression("myValue", "nunjucks"),
       },
@@ -159,10 +157,8 @@ describe("ObjectWidget", () => {
     // Select "Exclude"
     await userEvent.click(screen.getByText("Exclude"));
 
-    const formState = await getFormState();
-
     // Expect excluded property to be removed from the state
-    expect(formState).toStrictEqual({
+    expect(getFormState()).toStrictEqual({
       [fieldName]: {
         foo: "bar",
       },
@@ -207,10 +203,8 @@ describe("ObjectWidget", () => {
     // Select "Exclude"
     await userEvent.click(screen.getByText("Exclude"));
 
-    const formState = await getFormState();
-
     // Expect excluded property to be removed from the state
-    expect(formState).toStrictEqual({
+    expect(getFormState()).toStrictEqual({
       [fieldName]: {
         foo: "fooValue",
       },

--- a/src/components/fields/schemaFields/widgets/TextWidget.test.tsx
+++ b/src/components/fields/schemaFields/widgets/TextWidget.test.tsx
@@ -66,9 +66,7 @@ describe("TextWidget", () => {
 
     await userEvent.type(screen.getByRole("textbox"), "abc");
 
-    const formState = await getFormState();
-
-    expect(formState).toStrictEqual({
+    expect(getFormState()).toStrictEqual({
       [fieldName]: stringToExpression("abc", "nunjucks"),
     });
   });

--- a/src/components/form/widgets/RegistryIdWidget.test.tsx
+++ b/src/components/form/widgets/RegistryIdWidget.test.tsx
@@ -125,8 +125,7 @@ describe("RegistryIdWidget", () => {
     await userEvent.clear(idInput);
     await userEvent.type(idInput, newTestId);
 
-    const formState = await getFormState();
-    expect(formState).toStrictEqual({
+    expect(getFormState()).toStrictEqual({
       testField: `${anotherOrganization.scope}/${newTestId}`,
     });
   });

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.test.tsx
@@ -622,21 +622,24 @@ describe("AppendSpreadsheetOptions", () => {
   it("does not automatically toggle the field to select and choose the first item, if the input is focused by the user", async () => {
     mockFlagOn();
 
-    render(<AppendSpreadsheetOptions name="" configKey="config" />, {
-      initialValues: {
-        config: {
-          spreadsheetId: makeVariableExpression("@options.sheetId"),
-          tabName: makeTemplateExpression("nunjucks", "Tab2"),
-          rowValues: {
-            Foo: makeTemplateExpression("nunjucks", "valueA"),
-            Bar: makeTemplateExpression("nunjucks", "valueB"),
+    const { getFormState } = render(
+      <AppendSpreadsheetOptions name="" configKey="config" />,
+      {
+        initialValues: {
+          config: {
+            spreadsheetId: makeVariableExpression("@options.sheetId"),
+            tabName: makeTemplateExpression("nunjucks", "Tab2"),
+            rowValues: {
+              Foo: makeTemplateExpression("nunjucks", "valueA"),
+              Bar: makeTemplateExpression("nunjucks", "valueB"),
+            },
+          },
+          optionsArgs: {
+            sheetId: TEST_SPREADSHEET_ID,
           },
         },
-        optionsArgs: {
-          sheetId: TEST_SPREADSHEET_ID,
-        },
-      },
-    });
+      }
+    );
 
     await waitForEffect();
 
@@ -655,11 +658,9 @@ describe("AppendSpreadsheetOptions", () => {
     // Ensure tab name has not been reset to the first item, use queryByText to match react-select value
     expect(screen.queryByText("Tab1")).not.toBeInTheDocument();
 
-    // Due to the way getFormState() is implemented, we cannot currently use it here to
-    // pull the form state and check the field value, because it actually clicks the submit
-    // button to submit the form and get the state values, and clicking the button changes
-    // the focused field in the document, which causes the tab-names-loading/default logic
-    // to run, and the field gets toggled back to 'select' inputMode.
+    expect(getFormState().config.tabName).toEqual(
+      makeTemplateExpression("nunjucks", "")
+    );
   });
 
   it("does not clear selected tabName and rowValues fieldValues until a different spreadsheetId is loaded", async () => {

--- a/src/contrib/google/sheets/SheetsFileWidget.test.tsx
+++ b/src/contrib/google/sheets/SheetsFileWidget.test.tsx
@@ -137,9 +137,7 @@ describe("SheetsFileWidget", () => {
 
     await waitForEffect();
 
-    const formState = await getFormState();
-
-    expect(formState.services).toHaveLength(0);
+    expect(getFormState().services).toHaveLength(0);
   });
 
   it("does not remove used service on mount", async () => {
@@ -172,7 +170,7 @@ describe("SheetsFileWidget", () => {
 
     await waitForEffect();
 
-    const formState = await getFormState();
+    const formState = getFormState();
 
     expect(formState.services).toHaveLength(1);
     expect(formState.services[0]).toEqual(service);


### PR DESCRIPTION
## What does this PR do?

- Makes this function synchronous and doesn't submit the form anymore. If we need form submission behavior we can add it separately but it's not really used for anything

## Checklist

- [ ] Add tests - n/a
- [x] Designate a primary reviewer - @twschiller 
