### PR TITLE
Hide default value in field editor for google sheet and database field types

### DIFF
--- a/src/components/formBuilder/formBuilderHelpers.ts
+++ b/src/components/formBuilder/formBuilderHelpers.ts
@@ -79,6 +79,11 @@ export const FIELD_TYPES_WITHOUT_DEFAULT = [
     propertyType: "string",
     uiWidget: "imageCrop",
   }),
+  stringifyUiType({ propertyType: "string", uiWidget: "database" }),
+  stringifyUiType({
+    propertyType: "string",
+    uiWidget: "googleSheet",
+  }),
 ];
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Closes #5448 

## Discussion

- There might be a better way to go about this in the future where we handle all `$ref` schemas in the same way, but for right now this is a quick and easy fix for the issue.

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer - @twschiller 
