### PR TITLE
Remove playground link from page editor starter panel

### DIFF
--- a/src/pageEditor/NonScriptablePage.tsx
+++ b/src/pageEditor/NonScriptablePage.tsx
@@ -33,17 +33,6 @@ const GetStarted: React.FunctionComponent = () => (
       To start, navigate to a web page that you&apos;d like to modify and then
       click the &quot;Add&quot; button.
     </p>
-    <p>
-      Try the{" "}
-      <a
-        href="https://www.pixiebrix.com/playground/playground"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        PixieBrix Playground
-      </a>
-      .
-    </p>
   </>
 );
 

--- a/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
@@ -25,17 +25,6 @@ exports[`NonScriptablePage it renders 1`] = `
           <p>
             To start, navigate to a web page that you'd like to modify and then click the "Add" button.
           </p>
-          <p>
-            Try the 
-            <a
-              href="https://www.pixiebrix.com/playground/playground"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              PixieBrix Playground
-            </a>
-            .
-          </p>
         </div>
         <div
           class="d-flex align-items-center justify-content-center col-lg-3"


### PR DESCRIPTION
## What does this PR do?

- Removes the playground link from the starter page in the page editor
- Requested by @BrandonPxBx 

## Checklist

- [x] Add tests - updated snapshots
- [x] Designate a primary reviewer - @mnholtz 
