### PR TITLE
#5473: add installStarterBlueprints to external messenger api

### DIFF
--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -132,4 +132,7 @@ export const captureTab = getMethod("CAPTURE_TAB", bg);
 
 export const getUserData = getMethod("GET_USER_DATA", bg);
 
-export const installStarterBlueprints = getMethod("ACTIVATE_STARTER_BLUEPRINTS", bg);
+export const installStarterBlueprints = getMethod(
+  "ACTIVATE_STARTER_BLUEPRINTS",
+  bg
+);

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -132,4 +132,4 @@ export const captureTab = getMethod("CAPTURE_TAB", bg);
 
 export const getUserData = getMethod("GET_USER_DATA", bg);
 
-export const installStarterBlueprints = getMethod("INSTALL_STARTER_BLUEPRINTS", bg);
+export const installStarterBlueprints = getMethod("ACTIVATE_STARTER_BLUEPRINTS", bg);

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -131,3 +131,5 @@ export const sendDeploymentAlert = getNotifier("SEND_DEPLOYMENT_ALERT", bg);
 export const captureTab = getMethod("CAPTURE_TAB", bg);
 
 export const getUserData = getMethod("GET_USER_DATA", bg);
+
+export const activateStarterBlueprints = getMethod("ACTIVATE_STARTER_BLUEPRINTS", bg);

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -132,4 +132,4 @@ export const captureTab = getMethod("CAPTURE_TAB", bg);
 
 export const getUserData = getMethod("GET_USER_DATA", bg);
 
-export const activateStarterBlueprints = getMethod("ACTIVATE_STARTER_BLUEPRINTS", bg);
+export const installStarterBlueprints = getMethod("INSTALL_STARTER_BLUEPRINTS", bg);

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -133,6 +133,6 @@ export const captureTab = getMethod("CAPTURE_TAB", bg);
 export const getUserData = getMethod("GET_USER_DATA", bg);
 
 export const installStarterBlueprints = getMethod(
-  "ACTIVATE_STARTER_BLUEPRINTS",
+  "INSTALL_STARTER_BLUEPRINTS",
   bg
 );

--- a/src/background/messenger/external/_implementation.ts
+++ b/src/background/messenger/external/_implementation.ts
@@ -23,6 +23,7 @@ import { linkExtension } from "@/auth/token";
 import { type TokenAuthData } from "@/auth/authTypes";
 import { reportEvent } from "@/telemetry/events";
 import { type ManualStorageKey, readStorage, setStorage } from "@/chrome";
+import { activateStarterBlueprints } from "@/background/messenger/api";
 
 const HACK_EXTENSION_LINK_RELOAD_DELAY_MS = 100;
 
@@ -133,6 +134,7 @@ export async function openExtensionOptions() {
 }
 
 export async function installStarterBlueprints() {
-  console.log("Implement me!");
+  console.log("installing starter blueprints!")
+  activateStarterBlueprints();
   return true;
 }

--- a/src/background/messenger/external/_implementation.ts
+++ b/src/background/messenger/external/_implementation.ts
@@ -131,3 +131,8 @@ export async function openExtensionOptions() {
   await browser.runtime.openOptionsPage();
   return true;
 }
+
+export async function installStarterBlueprints() {
+  console.log("Implement me!");
+  return true;
+}

--- a/src/background/messenger/external/_implementation.ts
+++ b/src/background/messenger/external/_implementation.ts
@@ -23,7 +23,7 @@ import { linkExtension } from "@/auth/token";
 import { type TokenAuthData } from "@/auth/authTypes";
 import { reportEvent } from "@/telemetry/events";
 import { type ManualStorageKey, readStorage, setStorage } from "@/chrome";
-import { activateStarterBlueprints } from "@/background/messenger/api";
+import { installStarterBlueprints } from "@/background/messenger/api";
 
 const HACK_EXTENSION_LINK_RELOAD_DELAY_MS = 100;
 
@@ -133,8 +133,8 @@ export async function openExtensionOptions() {
   return true;
 }
 
-export async function installStarterBlueprints() {
+export async function activateStarterBlueprints() {
   console.log("installing starter blueprints!")
-  activateStarterBlueprints();
+  installStarterBlueprints();
   return true;
 }

--- a/src/background/messenger/external/_implementation.ts
+++ b/src/background/messenger/external/_implementation.ts
@@ -23,7 +23,7 @@ import { linkExtension } from "@/auth/token";
 import { type TokenAuthData } from "@/auth/authTypes";
 import { reportEvent } from "@/telemetry/events";
 import { type ManualStorageKey, readStorage, setStorage } from "@/chrome";
-import { installStarterBlueprints } from "@/background/messenger/api";
+import { installStarterBlueprints as installStarterBlueprintsInBackground } from "@/background/messenger/api";
 
 const HACK_EXTENSION_LINK_RELOAD_DELAY_MS = 100;
 
@@ -133,6 +133,6 @@ export async function openExtensionOptions() {
   return true;
 }
 
-export async function activateStarterBlueprints() {
-  return installStarterBlueprints();
+export async function installStarterBlueprints() {
+  return installStarterBlueprintsInBackground();
 }

--- a/src/background/messenger/external/_implementation.ts
+++ b/src/background/messenger/external/_implementation.ts
@@ -134,6 +134,5 @@ export async function openExtensionOptions() {
 }
 
 export async function activateStarterBlueprints() {
-  console.log("installing starter blueprints!")
-  return await installStarterBlueprints();
+  return installStarterBlueprints();
 }

--- a/src/background/messenger/external/_implementation.ts
+++ b/src/background/messenger/external/_implementation.ts
@@ -135,5 +135,5 @@ export async function openExtensionOptions() {
 
 export async function activateStarterBlueprints() {
   console.log("installing starter blueprints!")
-  return installStarterBlueprints();
+  return await installStarterBlueprints();
 }

--- a/src/background/messenger/external/_implementation.ts
+++ b/src/background/messenger/external/_implementation.ts
@@ -23,7 +23,7 @@ import { linkExtension } from "@/auth/token";
 import { type TokenAuthData } from "@/auth/authTypes";
 import { reportEvent } from "@/telemetry/events";
 import { type ManualStorageKey, readStorage, setStorage } from "@/chrome";
-import { debouncedInstallStarterBlueprints } from "@/background/starterBlueprints";
+import { installStarterBlueprints as installStarterBlueprintsInBackground } from "@/background/messenger/api";
 
 const HACK_EXTENSION_LINK_RELOAD_DELAY_MS = 100;
 
@@ -134,5 +134,5 @@ export async function openExtensionOptions() {
 }
 
 export async function installStarterBlueprints() {
-  return debouncedInstallStarterBlueprints();
+  return installStarterBlueprintsInBackground();
 }

--- a/src/background/messenger/external/_implementation.ts
+++ b/src/background/messenger/external/_implementation.ts
@@ -135,6 +135,5 @@ export async function openExtensionOptions() {
 
 export async function activateStarterBlueprints() {
   console.log("installing starter blueprints!")
-  installStarterBlueprints();
-  return true;
+  return installStarterBlueprints();
 }

--- a/src/background/messenger/external/_implementation.ts
+++ b/src/background/messenger/external/_implementation.ts
@@ -23,7 +23,7 @@ import { linkExtension } from "@/auth/token";
 import { type TokenAuthData } from "@/auth/authTypes";
 import { reportEvent } from "@/telemetry/events";
 import { type ManualStorageKey, readStorage, setStorage } from "@/chrome";
-import { installStarterBlueprints as installStarterBlueprintsInBackground } from "@/background/messenger/api";
+import { debouncedInstallStarterBlueprints } from "@/background/starterBlueprints";
 
 const HACK_EXTENSION_LINK_RELOAD_DELAY_MS = 100;
 
@@ -134,5 +134,5 @@ export async function openExtensionOptions() {
 }
 
 export async function installStarterBlueprints() {
-  return installStarterBlueprintsInBackground();
+  return debouncedInstallStarterBlueprints();
 }

--- a/src/background/messenger/external/api.ts
+++ b/src/background/messenger/external/api.ts
@@ -74,7 +74,7 @@ export const getPartnerToken = liftExternal(
   readPartnerAuthData
 );
 
-export const activateStarterBlueprints = liftExternal(
+export const installStarterBlueprints = liftExternal(
   "INSTALL_STARTER_BLUEPRINTS",
-  local.activateStarterBlueprints
+  local.installStarterBlueprints
 );

--- a/src/background/messenger/external/api.ts
+++ b/src/background/messenger/external/api.ts
@@ -74,7 +74,7 @@ export const getPartnerToken = liftExternal(
   readPartnerAuthData
 );
 
-export const installStarterBlueprints = liftExternal(
+export const activateStarterBlueprints = liftExternal(
   "INSTALL_STARTER_BLUEPRINTS",
-  local.installStarterBlueprints
+  local.activateStarterBlueprints
 );

--- a/src/background/messenger/external/api.ts
+++ b/src/background/messenger/external/api.ts
@@ -73,3 +73,8 @@ export const getPartnerToken = liftExternal(
   "GET_PARTNER_TOKEN",
   readPartnerAuthData
 );
+
+export const installStarterBlueprints = liftExternal(
+  "INSTALL_STARTER_BLUEPRINTS",
+  local.installStarterBlueprints
+);

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -46,7 +46,7 @@ import { locator, refreshServices } from "@/background/locator";
 import { reactivateEveryTab } from "@/background/navigation";
 import { removeExtensionForEveryTab } from "@/background/removeExtensionForEveryTab";
 import initPartnerTheme from "@/background/partnerTheme";
-import { firstTimeInstallStarterBlueprints } from "@/background/starterBlueprints";
+import { debouncedInstallStarterBlueprints } from "@/background/starterBlueprints";
 
 import {
   clearExtensionDebugLogs,
@@ -99,7 +99,7 @@ declare global {
     GET_PARTNER_PRINCIPALS: typeof getPartnerPrincipals;
     LAUNCH_AUTH_INTEGRATION: typeof launchAuthIntegration;
 
-    INSTALL_STARTER_BLUEPRINTS: typeof firstTimeInstallStarterBlueprints;
+    INSTALL_STARTER_BLUEPRINTS: typeof debouncedInstallStarterBlueprints;
 
     GET_UID: typeof uid;
     WAIT_FOR_TARGET_BY_URL: typeof waitForTargetByUrl;
@@ -166,7 +166,7 @@ export default function registerMessenger(): void {
     GET_PARTNER_PRINCIPALS: getPartnerPrincipals,
     LAUNCH_AUTH_INTEGRATION: launchAuthIntegration,
 
-    INSTALL_STARTER_BLUEPRINTS: firstTimeInstallStarterBlueprints,
+    INSTALL_STARTER_BLUEPRINTS: debouncedInstallStarterBlueprints,
 
     GET_AVAILABLE_VERSION: getAvailableVersion,
     INJECT_SCRIPT: ensureContentScript,

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -46,7 +46,7 @@ import { locator, refreshServices } from "@/background/locator";
 import { reactivateEveryTab } from "@/background/navigation";
 import { removeExtensionForEveryTab } from "@/background/removeExtensionForEveryTab";
 import initPartnerTheme from "@/background/partnerTheme";
-import firstTimeInstallStarterBlueprints from "@/background/starterBlueprints";
+import { firstTimeInstallStarterBlueprints }  from "@/background/starterBlueprints";
 
 import {
   clearExtensionDebugLogs,

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -99,7 +99,7 @@ declare global {
     GET_PARTNER_PRINCIPALS: typeof getPartnerPrincipals;
     LAUNCH_AUTH_INTEGRATION: typeof launchAuthIntegration;
 
-    ACTIVATE_STARTER_BLUEPRINTS: typeof firstTimeInstallStarterBlueprints;
+    INSTALL_STARTER_BLUEPRINTS: typeof firstTimeInstallStarterBlueprints;
 
     GET_UID: typeof uid;
     WAIT_FOR_TARGET_BY_URL: typeof waitForTargetByUrl;
@@ -166,7 +166,7 @@ export default function registerMessenger(): void {
     GET_PARTNER_PRINCIPALS: getPartnerPrincipals,
     LAUNCH_AUTH_INTEGRATION: launchAuthIntegration,
 
-    ACTIVATE_STARTER_BLUEPRINTS: firstTimeInstallStarterBlueprints,
+    INSTALL_STARTER_BLUEPRINTS: firstTimeInstallStarterBlueprints,
 
     GET_AVAILABLE_VERSION: getAvailableVersion,
     INJECT_SCRIPT: ensureContentScript,

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -46,7 +46,7 @@ import { locator, refreshServices } from "@/background/locator";
 import { reactivateEveryTab } from "@/background/navigation";
 import { removeExtensionForEveryTab } from "@/background/removeExtensionForEveryTab";
 import initPartnerTheme from "@/background/partnerTheme";
-import { firstTimeInstallStarterBlueprints }  from "@/background/starterBlueprints";
+import { firstTimeInstallStarterBlueprints } from "@/background/starterBlueprints";
 
 import {
   clearExtensionDebugLogs,

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -46,7 +46,7 @@ import { locator, refreshServices } from "@/background/locator";
 import { reactivateEveryTab } from "@/background/navigation";
 import { removeExtensionForEveryTab } from "@/background/removeExtensionForEveryTab";
 import initPartnerTheme from "@/background/partnerTheme";
-import { debouncedInstallStarterBlueprints } from "@/background/starterBlueprints";
+import { debouncedInstallStarterBlueprints as installStarterBlueprints } from "@/background/starterBlueprints";
 
 import {
   clearExtensionDebugLogs,
@@ -99,7 +99,7 @@ declare global {
     GET_PARTNER_PRINCIPALS: typeof getPartnerPrincipals;
     LAUNCH_AUTH_INTEGRATION: typeof launchAuthIntegration;
 
-    INSTALL_STARTER_BLUEPRINTS: typeof debouncedInstallStarterBlueprints;
+    INSTALL_STARTER_BLUEPRINTS: typeof installStarterBlueprints;
 
     GET_UID: typeof uid;
     WAIT_FOR_TARGET_BY_URL: typeof waitForTargetByUrl;
@@ -166,7 +166,7 @@ export default function registerMessenger(): void {
     GET_PARTNER_PRINCIPALS: getPartnerPrincipals,
     LAUNCH_AUTH_INTEGRATION: launchAuthIntegration,
 
-    INSTALL_STARTER_BLUEPRINTS: debouncedInstallStarterBlueprints,
+    INSTALL_STARTER_BLUEPRINTS: installStarterBlueprints,
 
     GET_AVAILABLE_VERSION: getAvailableVersion,
     INJECT_SCRIPT: ensureContentScript,

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -46,7 +46,7 @@ import { locator, refreshServices } from "@/background/locator";
 import { reactivateEveryTab } from "@/background/navigation";
 import { removeExtensionForEveryTab } from "@/background/removeExtensionForEveryTab";
 import initPartnerTheme from "@/background/partnerTheme";
-import initStarterBlueprints from "@/background/starterBlueprints";
+import firstTimeInstallStarterBlueprints from "@/background/starterBlueprints";
 
 import {
   clearExtensionDebugLogs,
@@ -99,7 +99,7 @@ declare global {
     GET_PARTNER_PRINCIPALS: typeof getPartnerPrincipals;
     LAUNCH_AUTH_INTEGRATION: typeof launchAuthIntegration;
 
-    ACTIVATE_STARTER_BLUEPRINTS: typeof initStarterBlueprints;
+    ACTIVATE_STARTER_BLUEPRINTS: typeof firstTimeInstallStarterBlueprints;
 
     GET_UID: typeof uid;
     WAIT_FOR_TARGET_BY_URL: typeof waitForTargetByUrl;
@@ -166,7 +166,7 @@ export default function registerMessenger(): void {
     GET_PARTNER_PRINCIPALS: getPartnerPrincipals,
     LAUNCH_AUTH_INTEGRATION: launchAuthIntegration,
 
-    ACTIVATE_STARTER_BLUEPRINTS: initStarterBlueprints,
+    ACTIVATE_STARTER_BLUEPRINTS: firstTimeInstallStarterBlueprints,
 
     GET_AVAILABLE_VERSION: getAvailableVersion,
     INJECT_SCRIPT: ensureContentScript,

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -46,6 +46,7 @@ import { locator, refreshServices } from "@/background/locator";
 import { reactivateEveryTab } from "@/background/navigation";
 import { removeExtensionForEveryTab } from "@/background/removeExtensionForEveryTab";
 import initPartnerTheme from "@/background/partnerTheme";
+import initStarterBlueprints from "@/background/starterBlueprints";
 
 import {
   clearExtensionDebugLogs,
@@ -97,6 +98,8 @@ declare global {
     ACTIVATE_PARTNER_THEME: typeof initPartnerTheme;
     GET_PARTNER_PRINCIPALS: typeof getPartnerPrincipals;
     LAUNCH_AUTH_INTEGRATION: typeof launchAuthIntegration;
+
+    ACTIVATE_STARTER_BLUEPRINTS: typeof initStarterBlueprints;
 
     GET_UID: typeof uid;
     WAIT_FOR_TARGET_BY_URL: typeof waitForTargetByUrl;
@@ -162,6 +165,8 @@ export default function registerMessenger(): void {
     ACTIVATE_PARTNER_THEME: initPartnerTheme,
     GET_PARTNER_PRINCIPALS: getPartnerPrincipals,
     LAUNCH_AUTH_INTEGRATION: launchAuthIntegration,
+
+    ACTIVATE_STARTER_BLUEPRINTS: initStarterBlueprints,
 
     GET_AVAILABLE_VERSION: getAvailableVersion,
     INJECT_SCRIPT: ensureContentScript,

--- a/src/background/starterBlueprints.test.ts
+++ b/src/background/starterBlueprints.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { firstTimeInstallStarterBlueprints } from "@/background/starterBlueprints";
+import { debouncedInstallStarterBlueprints } from "@/background/starterBlueprints";
 import { loadOptions, saveOptions } from "@/store/extensionsStorage";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
@@ -65,7 +65,7 @@ describe("installStarterBlueprints", () => {
       .reply(200, [recipeFactory()]);
     axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
 
-    await firstTimeInstallStarterBlueprints();
+    await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
 
     expect(extensions.length).toBe(1);
@@ -81,7 +81,7 @@ describe("installStarterBlueprints", () => {
     axiosMock.onGet("/api/onboarding/starter-blueprints/").reply(500);
     axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
 
-    await firstTimeInstallStarterBlueprints();
+    await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
 
     expect(extensions.length).toBe(0);
@@ -95,7 +95,7 @@ describe("installStarterBlueprints", () => {
       .reply(200, [recipeFactory()]);
     axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(500);
 
-    await firstTimeInstallStarterBlueprints();
+    await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
 
     expect(extensions.length).toBe(1);
@@ -126,7 +126,7 @@ describe("installStarterBlueprints", () => {
 
     axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
 
-    await firstTimeInstallStarterBlueprints();
+    await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
 
     expect(extensions.length).toBe(1);
@@ -151,7 +151,7 @@ describe("installStarterBlueprints", () => {
       .reply(200, [recipeFactory()]);
     axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
 
-    await firstTimeInstallStarterBlueprints();
+    await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
 
     expect(extensions.length).toBe(2);

--- a/src/background/starterBlueprints.test.ts
+++ b/src/background/starterBlueprints.test.ts
@@ -42,7 +42,6 @@ jest.mock("./refreshRegistries", () => ({
 }));
 
 const isLinkedMock = isLinked as jest.Mock;
-const openPlaygroundPage = browser.tabs.create as jest.Mock;
 jest.useFakeTimers();
 
 beforeEach(async () => {
@@ -62,9 +61,6 @@ describe("installStarterBlueprints", () => {
     isLinkedMock.mockResolvedValue(true);
 
     axiosMock
-      .onGet("/api/onboarding/starter-blueprints/install/")
-      .reply(200, { install_starter_blueprints: true });
-    axiosMock
       .onGet("/api/onboarding/starter-blueprints/")
       .reply(200, [recipeFactory()]);
     axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
@@ -73,26 +69,7 @@ describe("installStarterBlueprints", () => {
     const { extensions } = await loadOptions();
 
     expect(extensions.length).toBe(1);
-    expect(openPlaygroundPage.mock.calls).toHaveLength(1);
     expect((refreshRegistries as jest.Mock).mock.calls).toHaveLength(1);
-  });
-
-  test("user does not have starter blueprints available to install", async () => {
-    isLinkedMock.mockResolvedValue(true);
-
-    axiosMock
-      .onGet("/api/onboarding/starter-blueprints/install/")
-      .reply(200, { install_starter_blueprints: false });
-    axiosMock
-      .onGet("/api/onboarding/starter-blueprints/")
-      .reply(200, [recipeFactory()]);
-    axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
-
-    await firstTimeInstallStarterBlueprints();
-    const { extensions } = await loadOptions();
-
-    expect(extensions.length).toBe(0);
-    expect(openPlaygroundPage.mock.calls).toHaveLength(0);
   });
 
   test("starter blueprints request fails", async () => {
@@ -108,15 +85,11 @@ describe("installStarterBlueprints", () => {
     const { extensions } = await loadOptions();
 
     expect(extensions.length).toBe(0);
-    expect(openPlaygroundPage.mock.calls).toHaveLength(0);
   });
 
   test("starter blueprints installation request fails", async () => {
     isLinkedMock.mockResolvedValue(true);
 
-    axiosMock
-      .onGet("/api/onboarding/starter-blueprints/install/")
-      .reply(200, { install_starter_blueprints: true });
     axiosMock
       .onGet("/api/onboarding/starter-blueprints/")
       .reply(200, [recipeFactory()]);
@@ -125,8 +98,7 @@ describe("installStarterBlueprints", () => {
     await firstTimeInstallStarterBlueprints();
     const { extensions } = await loadOptions();
 
-    expect(extensions.length).toBe(0);
-    expect(openPlaygroundPage.mock.calls).toHaveLength(0);
+    expect(extensions.length).toBe(1);
   });
 
   test("starter blueprint already installed", async () => {
@@ -158,7 +130,6 @@ describe("installStarterBlueprints", () => {
     const { extensions } = await loadOptions();
 
     expect(extensions.length).toBe(1);
-    expect(openPlaygroundPage.mock.calls).toHaveLength(0);
   });
 
   test("extension with no _recipe doesn't throw undefined error", async () => {

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -126,10 +126,7 @@ const debouncedInstallStarterBlueprints = debounce(
 );
 
 export async function firstTimeInstallStarterBlueprints(): Promise<boolean> {
-  console.log("Inside firsttimeinstallstarterblueprints");
-  const installed = await debouncedInstallStarterBlueprints();
-  console.log("returning installed from first time", installed);
-  return installed;
+  return debouncedInstallStarterBlueprints();
 }
 
 function initStarterBlueprints(): void {

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -124,10 +124,6 @@ export const debouncedInstallStarterBlueprints = debounce(
   }
 );
 
-export async function firstTimeInstallStarterBlueprints(): Promise<boolean> {
-  return debouncedInstallStarterBlueprints();
-}
-
 function initStarterBlueprints(): void {
   browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (tab?.url?.startsWith(PLAYGROUND_URL)) {

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -127,7 +127,9 @@ const debouncedInstallStarterBlueprints = debounce(
 
 export async function firstTimeInstallStarterBlueprints(): Promise<boolean> {
   console.log("Inside firsttimeinstallstarterblueprints");
-  return await debouncedInstallStarterBlueprints();
+  const installed = await debouncedInstallStarterBlueprints();
+  console.log("returning installed from first time", installed);
+  return installed;
 }
 
 function initStarterBlueprints(): void {

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -114,7 +114,7 @@ const _installStarterBlueprints = async (): Promise<boolean> => {
   }
 };
 
-const debouncedInstallStarterBlueprints = debounce(
+export const debouncedInstallStarterBlueprints = debounce(
   memoizeUntilSettled(_installStarterBlueprints),
   BLUEPRINT_INSTALLATION_DEBOUNCE_MS,
   {

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -168,6 +168,7 @@ export async function firstTimeInstallStarterBlueprints(): Promise<void> {
 }
 
 function initStarterBlueprints(): void {
+  console.log("this got run :)")
   browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (tab?.url?.startsWith(PLAYGROUND_URL)) {
       void debouncedInstallStarterBlueprints();

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -107,7 +107,6 @@ const _installStarterBlueprints = async (): Promise<boolean> => {
       refreshRegistries(),
     ]);
 
-    console.log("returning installed: ", installed);
     return installed;
   } catch (error) {
     reportError(error);


### PR DESCRIPTION
## What does this PR do?

- Part of the fix for #5473
- Adds starter blueprint installation to the external messenger api
- Removes the open-playground side effect from starter blueprint installation
- Removes the "should install starter blueprints" check from starter blueprint installation - the app will now decide whether or not to install blueprints & utilize the the messenger framework to do so

## Reviewer Tips

- This PR mainly does the following:
    - Adds `installStarterBlueprints` to external messaging api
    - Removes the "should install" check from the installStarterBlueprints logic
    - Removes logic for opening the playground tab
    - (The latter two items are now done on the app-side of things)

## Demo

- See app-side PR referenced above

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @johnnymetz because main changes for this feature were app-side
