### PR TITLE
#5508: add postmessage brick

### DIFF
--- a/src/blocks/effects/getAllEffects.ts
+++ b/src/blocks/effects/getAllEffects.ts
@@ -19,7 +19,7 @@ import { LogEffect } from "./logger";
 import { NavigateURLEffect, OpenURLEffect } from "./redirectPage";
 import { CopyToClipboard } from "./clipboard";
 import { FormFill, SetInputValue } from "./forms";
-import { CloseTabEffect, ActivateTabEffect } from "./tabs";
+import { ActivateTabEffect, CloseTabEffect } from "./tabs";
 import { HighlightEffect } from "./highlight";
 import { SetVueValues } from "./vue";
 import { ElementEvent } from "./event";
@@ -50,6 +50,7 @@ import ToggleQuickbarEffect from "@/blocks/effects/ToggleQuickbarEffect";
 import SubmitPanelEffect from "@/blocks/effects/submitPanel";
 import { RunSubTourEffect } from "@/blocks/effects/runSubTour";
 import { type IBlock } from "@/types/blockTypes";
+import PostMessageEffect from "@/blocks/effects/postMessage";
 
 function getAllEffects(): IBlock[] {
   return [
@@ -86,6 +87,7 @@ function getAllEffects(): IBlock[] {
     new DisableEffect(),
     new InsertHtml(),
     new CustomEventEffect(),
+    new PostMessageEffect(),
     new ReplaceTextEffect(),
     new HighlightText(),
     new ScrollIntoViewEffect(),

--- a/src/blocks/effects/postMessage.test.ts
+++ b/src/blocks/effects/postMessage.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import PostMessageEffect from "@/blocks/effects/postMessage";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { type BlockOptions } from "@/types/runtimeTypes";
+
+const brick = new PostMessageEffect();
+
+describe("postMessage", () => {
+  it("is root aware", async () => {
+    await expect(brick.isRootAware()).resolves.toBe(true);
+  });
+
+  it("messages frame", async () => {
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+
+    frame.contentWindow.postMessage = jest.fn();
+
+    await brick.run(
+      unsafeAssumeValidArg({
+        selector: "iframe",
+        message: { text: "Hello, frame!" },
+      }),
+      { root: document } as BlockOptions
+    );
+
+    expect(frame.contentWindow.postMessage).toHaveBeenCalledWith(
+      { text: "Hello, frame!" },
+      "*"
+    );
+  });
+});

--- a/src/blocks/effects/postMessage.ts
+++ b/src/blocks/effects/postMessage.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Effect } from "@/types/blocks/effectTypes";
+import { type BlockArgs, type BlockOptions } from "@/types/runtimeTypes";
+import { type Schema } from "@/types/schemaTypes";
+import { $safeFindElementsWithRootMode } from "@/blocks/rootModeHelpers";
+import { type UnknownObject } from "@/types/objectTypes";
+import { PropError } from "@/errors/businessErrors";
+
+class PostMessageEffect extends Effect {
+  // https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
+
+  constructor() {
+    super(
+      "@pixiebrix/dom/post-message",
+      "Post message to a frame",
+      "Post a message to an iframe on the page"
+    );
+  }
+
+  inputSchema: Schema = {
+    type: "object",
+    properties: {
+      selector: {
+        type: "string",
+        format: "selector",
+        description: "The selector of the iframe to post the message to",
+      },
+      message: {
+        type: "object",
+        description: "Data to be sent to the other window.",
+        additionalProperties: true,
+      },
+      targetOrigin: {
+        type: "string",
+        description:
+          'Specifies what the origin of this window must be for the event to be dispatched, either as the literal string "*" (indicating no preference) or as a URI',
+      },
+    },
+    required: ["message"],
+  };
+
+  override async isRootAware(): Promise<boolean> {
+    return true;
+  }
+
+  async effect(
+    {
+      selector,
+      message,
+      targetOrigin = "*",
+    }: BlockArgs<{
+      selector?: string;
+      message: UnknownObject;
+      targetOrigin?: string;
+    }>,
+    { logger, root }: BlockOptions
+  ): Promise<void> {
+    const $elements = $safeFindElementsWithRootMode({
+      selector,
+      isRootAware: true,
+      root,
+      blockId: this.id,
+    });
+
+    for (const element of $elements) {
+      if (!(element instanceof HTMLIFrameElement)) {
+        throw new PropError(
+          "Element is not an iframe",
+          this.id,
+          "selector",
+          selector
+        );
+      }
+
+      element.contentWindow.postMessage(message, targetOrigin);
+    }
+  }
+}
+
+export default PostMessageEffect;

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -27,7 +27,7 @@ import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 114;
+const EXPECTED_HEADER_COUNT = 115;
 
 registerBuiltinBlocks();
 registerContribBlocks();


### PR DESCRIPTION
## What does this PR do?

- Closes #5508 
- Adds a Post Message brick for sending messages to other frames
- Introduced to support running CKEditor commands on Salesforce

## Demo

- https://www.loom.com/share/47f2321f24ea4b48b745d9d5a163ac33

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
