### PR TITLE
#5510: revert marking `type` as required for alert brick

### DIFF
--- a/src/blocks/effects/alert.test.ts
+++ b/src/blocks/effects/alert.test.ts
@@ -18,11 +18,21 @@
 import { AlertEffect } from "@/blocks/effects/alert";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { type BlockOptions } from "@/types/runtimeTypes";
+import { validateInput } from "@/validators/generic";
 
 const brick = new AlertEffect();
 
 describe("AlertEffect", () => {
-  it("type defaults to window", async () => {
+  it("type is optional", async () => {
+    await expect(
+      validateInput(brick.inputSchema, { message: "Hello, world!" })
+    ).resolves.toStrictEqual({
+      errors: [],
+      valid: true,
+    });
+  });
+
+  it("type defaults to window if excluded", async () => {
     window.alert = jest.fn();
     await brick.run(
       unsafeAssumeValidArg({ message: "Hello, world!" }),

--- a/src/blocks/effects/alert.test.ts
+++ b/src/blocks/effects/alert.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AlertEffect } from "@/blocks/effects/alert";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { type BlockOptions } from "@/types/runtimeTypes";
+
+const brick = new AlertEffect();
+
+describe("AlertEffect", () => {
+  it("type defaults to window", async () => {
+    window.alert = jest.fn();
+    await brick.run(
+      unsafeAssumeValidArg({ message: "Hello, world!" }),
+      {} as BlockOptions
+    );
+    expect(window.alert).toHaveBeenCalledWith("Hello, world!");
+  });
+});

--- a/src/blocks/effects/alert.ts
+++ b/src/blocks/effects/alert.ts
@@ -58,7 +58,7 @@ export class AlertEffect extends Effect {
         default: 2500,
       },
     },
-    ["message", "type"]
+    ["message"]
   );
 
   async effect({


### PR DESCRIPTION
## What does this PR do?

- Closes #5510 
- Reverts marking `type` as required on the Window Alert brick

## Discussion

- The regression was introduced in: https://github.com/pixiebrix/pixiebrix-extension/pull/5483

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer:  @BLoe 
