### PR TITLE
upload cws version of extension to s3 in rainforestqa workflow

### DIFF
--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -45,6 +45,13 @@ jobs:
           echo "BUILD_PATH=builds/pixiebrix-extension-release.zip" >> $GITHUB_ENV
           echo "RUN_GROUP=14130" >> $GITHUB_ENV
         if: github.ref_name != 'main'
+      - name: Determine if CWS release branch
+        # shell script used because GitHub actions doesn't support regex in if statements
+        run: |
+          if [[ $github.ref_name =~ ^release\/[0-9]+.[0-9]+.[0-9]+$ ]]; then
+            echo "BUILD_PATH=builds/pixiebrix-extension-cws.zip" >> $GITHUB_ENV
+            echo "RUN_GROUP=14131" >> $GITHUB_ENV
+          fi
 
       - name: Upload Extension
         run: bash scripts/upload-extension.sh ${{ env.BUILD_PATH }}

--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -15,7 +15,10 @@ on:
 jobs:
   rainforestqa:
     runs-on: ubuntu-latest
-
+    env:
+      RAINFOREST_RUN_GROUP_MAIN: 14129
+      RAINFOREST_RUN_GROUP_RELEASE: 14130
+      RAINFOREST_RUN_GROUP_CWS: 14131
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -34,16 +37,16 @@ jobs:
           CHROME_MANIFEST_KEY: ${{ secrets.CHROME_MANIFEST_PROD_PUBLIC_KEY }}
 
       # https://stackoverflow.com/a/58142637
-      # github doesn't support if-else, only if, so we need two separate steps
+      # GitHub doesn't support if-else, only if, so we need two separate steps
       - name: Determine if main branch
         run: |
           echo "BUILD_PATH=builds/pixiebrix-extension-main.zip" >> $GITHUB_ENV
-          echo "RUN_GROUP=14129" >> $GITHUB_ENV
+          echo "RUN_GROUP=$RAINFOREST_RUN_GROUP_MAIN" >> $GITHUB_ENV
         if: github.ref_name == 'main'
       - name: Determine if release branch
         run: |
           echo "BUILD_PATH=builds/pixiebrix-extension-release.zip" >> $GITHUB_ENV
-          echo "RUN_GROUP=14130" >> $GITHUB_ENV
+          echo "RUN_GROUP=$RAINFOREST_RUN_GROUP_RELEASE" >> $GITHUB_ENV
         if: startsWith(github.ref_name, 'release/')
       - name: Determine if CWS release branch
         # shell script used because GitHub actions doesn't support regex in if statements
@@ -51,7 +54,7 @@ jobs:
         run: |
           if [[ $github.ref_name =~ ^release\/[0-9]+.[0-9]+.[0-9]+$ ]]; then
             echo "BUILD_PATH=builds/pixiebrix-extension-cws.zip" >> $GITHUB_ENV
-            echo "RUN_GROUP=14131" >> $GITHUB_ENV
+            echo "RUN_GROUP=$RAINFOREST_RUN_GROUP_CWS" >> $GITHUB_ENV
           fi
 
       - name: Upload Extension

--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -44,9 +44,10 @@ jobs:
         run: |
           echo "BUILD_PATH=builds/pixiebrix-extension-release.zip" >> $GITHUB_ENV
           echo "RUN_GROUP=14130" >> $GITHUB_ENV
-        if: github.ref_name != 'main'
+        if: startsWith(github.ref_name, 'release/')
       - name: Determine if CWS release branch
         # shell script used because GitHub actions doesn't support regex in if statements
+        # will overwrite the previous step correctly if it's a CWS-release branch
         run: |
           if [[ $github.ref_name =~ ^release\/[0-9]+.[0-9]+.[0-9]+$ ]]; then
             echo "BUILD_PATH=builds/pixiebrix-extension-cws.zip" >> $GITHUB_ENV


### PR DESCRIPTION
## What does this PR do?

- Closes #5527 

## Discussion

- See concern described in ticket for issue above, currently implemented to upload extension to S3 before version is public / approved by CWS

## Checklist

- [ ] ~Add tests~ N/A
- [x] Designate a primary reviewer: @mnholtz 
