### PR TITLE
#5512: use abort signal for cancelling pending quickbar action generators

### DIFF
--- a/src/blocks/effects/AddQuickBarAction.test.ts
+++ b/src/blocks/effects/AddQuickBarAction.test.ts
@@ -52,9 +52,12 @@ describe("AddQuickBarAction", () => {
   });
 
   test("adds root action", async () => {
+    const abortController = new AbortController();
+
     await brick.run(unsafeAssumeValidArg({ title: "test" }), {
       logger,
       root: document,
+      abortSignal: abortController.signal,
     } as any);
     expect(addActionMock).toHaveBeenCalledWith({
       id: expect.toBeString(),

--- a/src/blocks/effects/AddQuickBarAction.tsx
+++ b/src/blocks/effects/AddQuickBarAction.tsx
@@ -28,12 +28,29 @@ import { type BlockArgs, type BlockOptions } from "@/types/runtimeTypes";
 import { Effect } from "@/types/blocks/effectTypes";
 
 type ActionConfig = {
+  /**
+   * The title for the Quick Bar Action
+   */
   title: string;
+  /**
+   * An optional subtitle/description for the action
+   */
   subtitle?: string;
+  /**
+   * An optional section for grouping actions
+   */
   section?: string;
-  icon: IconConfig;
+  /**
+   * An optional icon for the action. If not provided, a box will be used.
+   */
+  icon?: IconConfig;
+  /**
+   * Action to run when the Quick Bar Action is run
+   */
   action: PipelineExpression;
-
+  /**
+   * Priority of the action: https://kbar.vercel.app/docs/concepts/priority
+   */
   priority?: number;
 };
 
@@ -73,11 +90,11 @@ class AddQuickBarAction extends Effect {
       },
       subtitle: {
         type: "string",
-        description: "An optional subtitle for the action",
+        description: "An optional subtitle/description for the action",
       },
       section: {
         type: "string",
-        description: "The Quick Bar section to add the action to",
+        description: "An optional section for grouping actions",
       },
       icon: { $ref: "https://app.pixiebrix.com/schemas/icon#" },
       action: {
@@ -106,9 +123,14 @@ class AddQuickBarAction extends Effect {
       // Be explicit about the default priority if non is provided
       priority = DEFAULT_PRIORITY,
     }: BlockArgs<ActionConfig>,
-    { root, logger, runPipeline }: BlockOptions
+    { root, logger, runPipeline, abortSignal }: BlockOptions
   ): Promise<void> {
-    // Keep track of run number for tracing
+    // The runtime checks the abortSignal for each brick. But check here too to avoid flickering in the Quick Bar
+    if (abortSignal.aborted) {
+      return;
+    }
+
+    // Counter to keep track of the action run number for tracing
     let counter = 0;
 
     // Expected parent id from QuickBarProviderExtensionPoint

--- a/src/components/quickBar/QuickBarApp.test.tsx
+++ b/src/components/quickBar/QuickBarApp.test.tsx
@@ -25,7 +25,7 @@ import { mockAnimationsApi } from "jsdom-testing-mocks";
 import selectionController from "@/utils/selectionController";
 import userEvent from "@testing-library/user-event";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
-import { ActionGenerator } from "@/components/quickBar/quickbarTypes";
+import { type ActionGenerator } from "@/components/quickBar/quickbarTypes";
 
 // Could alternatively mock the internal calls, but this is easier if we trust the component
 jest.mock("@/components/Stylesheets", () => ({

--- a/src/components/quickBar/QuickBarApp.test.tsx
+++ b/src/components/quickBar/QuickBarApp.test.tsx
@@ -24,6 +24,8 @@ import React from "react";
 import { mockAnimationsApi } from "jsdom-testing-mocks";
 import selectionController from "@/utils/selectionController";
 import userEvent from "@testing-library/user-event";
+import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
+import { ActionGenerator } from "@/components/quickBar/quickbarTypes";
 
 // Could alternatively mock the internal calls, but this is easier if we trust the component
 jest.mock("@/components/Stylesheets", () => ({
@@ -133,5 +135,44 @@ describe("QuickBarApp", () => {
     });
 
     expect(saveSelectionMock).toHaveBeenCalledOnce();
+  });
+
+  it("debounces action generation on typing", async () => {
+    const user = userEvent.setup({ delay: null });
+    const generatorMock: ActionGenerator = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    quickBarRegistry.addGenerator(generatorMock, null);
+
+    render(<QuickBarApp />);
+
+    await act(async () => {
+      window.dispatchEvent(new Event(QUICKBAR_EVENT_NAME));
+
+      // Fast-forward until all timers have been executed. Can't use runOnlyPendingTimers because the there must be
+      // a setInterval/etc. to get the quick bar into a fully initialized state
+      jest.advanceTimersByTime(2000);
+    });
+
+    // Runs on mount
+    expect(generatorMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await user.type(screen.getByRole("combobox"), "test");
+
+      // Fast-forward until all timers have been executed
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(generatorMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      // Fast-forward until all timers have been executed
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(generatorMock).toHaveBeenCalledTimes(2);
+
+    quickBarRegistry.removeGenerator(generatorMock);
   });
 });

--- a/src/components/quickBar/QuickBarApp.test.tsx
+++ b/src/components/quickBar/QuickBarApp.test.tsx
@@ -148,10 +148,6 @@ describe("QuickBarApp", () => {
 
     await act(async () => {
       window.dispatchEvent(new Event(QUICKBAR_EVENT_NAME));
-
-      // Fast-forward until all timers have been executed. Can't use runOnlyPendingTimers because the there must be
-      // a setInterval/etc. to get the quick bar into a fully initialized state
-      jest.advanceTimersByTime(2000);
     });
 
     // Runs on mount

--- a/src/components/quickBar/quickbarTypes.ts
+++ b/src/components/quickBar/quickbarTypes.ts
@@ -34,11 +34,34 @@ export type CustomAction = Action & {
   extensionId?: UUID;
 };
 
-export type ChangeHandler = (actions: CustomAction[]) => void;
+/**
+ * Handler for when the set of registered actions changes
+ *
+ * @see QuickBarRegistry.addListener
+ * @see QuickBarRegistry.removeListener
+ */
+export type ActionsChangeHandler = (activeActions: CustomAction[]) => void;
 
-export type GeneratorArgs = { query: string; rootActionId: string | null };
+/**
+ * Shape of arguments passed to action generators for dynamic QuickBar action generator.
+ *
+ * @see QuickBarProviderExtensionPoint
+ */
+export type GeneratorArgs = {
+  /**
+   * Current user query in the QuickBar.
+   */
+  query: string;
+
+  /**
+   * Current selected root action id, or null if no root action is selected.
+   */
+  rootActionId: string | null;
+};
 
 /**
  * An action generator. The generator is expected to make calls QuickBarRegistry.addAction
  */
-export type ActionGenerator = (args: GeneratorArgs) => Promise<void>;
+export type ActionGenerator = (
+  args: GeneratorArgs & { abortSignal: AbortSignal }
+) => Promise<void>;

--- a/src/components/quickBar/useActionGenerators.test.tsx
+++ b/src/components/quickBar/useActionGenerators.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import useActionGenerators from "@/components/quickBar/useActionGenerators";
+import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
+import { waitForEffect } from "@/testUtils/testHelpers";
+import { KBarProvider } from "kbar";
+
+jest.mock("@/components/quickBar/quickBarRegistry", () => ({
+  __esModule: true,
+  default: {
+    generateActions: jest.fn(),
+  },
+}));
+
+describe("useActionGenerators", () => {
+  it("generates once on mount", async () => {
+    renderHook(
+      () => {
+        useActionGenerators();
+      },
+      {
+        wrapper: ({ children }) => <KBarProvider>{children}</KBarProvider>,
+      }
+    );
+
+    await waitForEffect();
+    await waitForEffect();
+
+    expect(quickBarRegistry.generateActions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useDebouncedEffect.ts
+++ b/src/hooks/useDebouncedEffect.ts
@@ -15,34 +15,53 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useDebounce } from "use-debounce";
 import { isEqual } from "lodash";
 
-const useDebouncedEffect = <T>(
-  values: T,
-  onChange: (values: T) => void,
-  delayMillis: number,
-  maxWaitMillis?: number
-) => {
-  const [prev, setPrev] = useState(values);
-
-  const [debounced] = useDebounce(values, delayMillis, {
-    leading: false,
-    trailing: true,
+/**
+ * Hook to run an effect when a value changes, but debounced.
+ * @param value the value to watch
+ * @param onChange the change handler to run
+ * @param delayMillis the delay in milliseconds
+ * @param maxWaitMillis maximum wait time in milliseconds
+ * @param leading whether to trigger on the leading edge (default = false)
+ * @param trailing whether to trigger on the trailing edge (default = true)
+ * @param equalityFn the equality function to use (default = isEqual)
+ *
+ * @see useDebounce
+ */
+function useDebouncedEffect<T>(
+  value: T,
+  onChange: (value: T) => void,
+  {
+    delayMillis,
+    maxWaitMillis,
+    leading = false,
+    trailing = true,
+    equalityFn = isEqual,
+  }: {
+    delayMillis: number;
+    maxWaitMillis?: number;
+    leading?: boolean;
+    trailing?: boolean;
+    equalityFn?: (lhs: T, rhs: T) => boolean;
+  }
+): void {
+  const [debounced] = useDebounce(value, delayMillis, {
+    leading,
+    trailing,
     maxWait: maxWaitMillis,
+    equalityFn,
   });
 
   useEffect(
     () => {
-      if (!isEqual(prev, debounced)) {
-        onChange(debounced);
-        setPrev(debounced);
-      }
+      onChange(debounced);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- leave off prev so it doesn't double-trigger the effect
-    [setPrev, debounced, onChange]
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only watch the debounced value
+    [debounced]
   );
-};
+}
 
 export default useDebouncedEffect;

--- a/src/hooks/useUndo.ts
+++ b/src/hooks/useUndo.ts
@@ -44,8 +44,10 @@ function useUndo<T>(
       history.current = [debouncedValue.current, ...oldHistory];
       debouncedValue.current = value;
     },
-    300,
-    500
+    {
+      delayMillis: 300,
+      maxWaitMillis: 500,
+    }
   );
 
   return useCallback(() => {


### PR DESCRIPTION
## What does this PR do?

- Closes #5512 
- Change dynamic quickbar to use abortSignal to avoid showing stale actions. The original promise chaining approach caused major lag for slow APIs
- Improve parameter signature for `useDebouncedEffect`

## Remaining Work

- [x] Fix broken test for AddQuickBarAction
- [x] Add tests for useActionGenerators/debounce
- [x] Record Loom demo

## Demo

- https://www.loom.com/share/2dab54ab85a744a18e1541523699988f

## Future Work

- Show loading indicator while generators are running to provide visual feedback

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @turbochef 
