### PR TITLE
#5549: track blueprint id for temporary panels

### DIFF
--- a/src/blocks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
+++ b/src/blocks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
@@ -337,7 +337,7 @@ class DisplayTemporaryInfo extends Transformer {
     }>,
     {
       logger: {
-        context: { extensionId },
+        context: { extensionId, blueprintId },
       },
       root,
       ctxt,
@@ -370,6 +370,7 @@ class DisplayTemporaryInfo extends Transformer {
         heading: title,
         payload,
         extensionId,
+        blueprintId,
       };
     };
 

--- a/src/blocks/transformers/temporaryInfo/EphemeralPanel.tsx
+++ b/src/blocks/transformers/temporaryInfo/EphemeralPanel.tsx
@@ -225,7 +225,10 @@ const EphemeralPanel: React.FC = () => {
           <PanelBody
             isRootPanel={false}
             payload={entry.payload}
-            context={{ extensionId: entry.extensionId }}
+            context={{
+              extensionId: entry.extensionId,
+              blueprintId: entry.blueprintId,
+            }}
             onAction={(action) => {
               resolveTemporaryPanel(target, panelNonce, action);
             }}

--- a/src/blocks/transformers/temporaryInfo/EphemeralPanel.tsx
+++ b/src/blocks/transformers/temporaryInfo/EphemeralPanel.tsx
@@ -180,7 +180,10 @@ const EphemeralPanel: React.FC = () => {
             <PanelBody
               isRootPanel={false}
               payload={entry.payload}
-              context={{ extensionId: entry.extensionId }}
+              context={{
+                extensionId: entry.extensionId,
+                blueprintId: entry.blueprintId,
+              }}
               onAction={(action) => {
                 resolveTemporaryPanel(target, panelNonce, action);
               }}

--- a/src/blocks/transformers/tourStep/tourStep.ts
+++ b/src/blocks/transformers/tourStep/tourStep.ts
@@ -314,7 +314,7 @@ export class TourStepTransformer extends Transformer {
     {
       abortSignal,
       logger: {
-        context: { extensionId, extensionPointId, blueprintId },
+        context: { extensionId, blueprintId },
       },
       runRendererPipeline,
     }: BlockOptions
@@ -353,6 +353,7 @@ export class TourStepTransformer extends Transformer {
 
       return {
         extensionId,
+        blueprintId,
         heading: title,
         payload,
         actions,

--- a/src/components/documentBuilder/render/BlockElement.tsx
+++ b/src/components/documentBuilder/render/BlockElement.tsx
@@ -22,7 +22,7 @@ import { getErrorMessage } from "@/errors/errorHelpers";
 import DocumentContext from "@/components/documentBuilder/render/DocumentContext";
 import { runRendererPipeline } from "@/contentScript/messenger/api";
 import { uuidv4 } from "@/types/helpers";
-import PanelBody from "@/sidebar/PanelBody";
+import PanelBody, { type PanelContext } from "@/sidebar/PanelBody";
 import { type RendererPayload } from "@/runtime/runtimeTypes";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { serializeError } from "serialize-error";
@@ -44,6 +44,9 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline, tracePath }) => {
     options: { ctxt, logger },
     onAction,
   } = useContext(DocumentContext);
+
+  // Logger context will have both extensionId and blueprintId because they're passed from the containing PanelBody
+  const panelContext = logger.context as PanelContext;
 
   const [payload, isLoading, error] =
     useAsyncState<RendererPayload>(async () => {
@@ -67,14 +70,14 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline, tracePath }) => {
 
   if (isLoading) {
     return (
-      <PanelBody payload={null} context={logger.context} onAction={onAction} />
+      <PanelBody payload={null} context={panelContext} onAction={onAction} />
     );
   }
 
   if (error) {
     return (
       <PanelBody
-        context={logger.context}
+        context={panelContext}
         onAction={onAction}
         payload={{
           key: `error-${getErrorMessage(error)}`,
@@ -86,7 +89,7 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline, tracePath }) => {
   }
 
   return (
-    <PanelBody context={logger.context} payload={payload} onAction={onAction} />
+    <PanelBody context={panelContext} payload={payload} onAction={onAction} />
   );
 };
 

--- a/src/contentScript/pageEditor.ts
+++ b/src/contentScript/pageEditor.ts
@@ -44,9 +44,16 @@ import { createFrameSource } from "@/blocks/transformers/temporaryInfo/DisplayTe
 import { waitForTemporaryPanel } from "@/blocks/transformers/temporaryInfo/temporaryPanelProtocol";
 import { type ApiVersion, type BlockArgsContext } from "@/types/runtimeTypes";
 import { type UUID } from "@/types/stringTypes";
+import { type RegistryId } from "@/types/registryTypes";
 
 export type RunBlockArgs = {
+  /**
+   * The runtime API version to use
+   */
   apiVersion: ApiVersion;
+  /**
+   * The IBlock configuration.
+   */
   blockConfig: BlockConfig;
   /**
    * Context to render the BlockArg, should include @input, @options, and service context
@@ -141,13 +148,21 @@ type Location = "modal" | "panel";
  * Note: Currently only implemented for the temporary sidebar panels
  * @see useDocumentPreviewRunBlock
  */
-export async function runRendererBlock(
-  extensionId: UUID,
-  runId: UUID,
-  title: string,
-  args: RunBlockArgs,
-  location: Location
-): Promise<void> {
+export async function runRendererBlock({
+  extensionId,
+  blueprintId,
+  runId,
+  title,
+  args,
+  location,
+}: {
+  extensionId: UUID;
+  blueprintId: RegistryId | null;
+  runId: UUID;
+  title: string;
+  args: RunBlockArgs;
+  location: Location;
+}): Promise<void> {
   const nonce = uuidv4();
 
   let payload: PanelPayload;
@@ -179,6 +194,7 @@ export async function runRendererBlock(
       showTemporarySidebarPanel({
         // Pass extension id so previous run is cancelled
         extensionId,
+        blueprintId,
         nonce,
         heading: title,
         payload,
@@ -192,6 +208,7 @@ export async function runRendererBlock(
       try {
         await waitForTemporaryPanel(nonce, {
           extensionId,
+          blueprintId,
           nonce,
           heading: title,
           payload,

--- a/src/pageEditor/tabs/effect/ConfigurationTitle.tsx
+++ b/src/pageEditor/tabs/effect/ConfigurationTitle.tsx
@@ -39,11 +39,13 @@ import { MARKETPLACE_URL } from "@/utils/strings";
 const DOCUMENT_BODY_PATH = "config.body";
 
 const PlainTitle: React.FC = () => <span className={styles.title}>Input</span>;
+
 const TextTitle: React.FC<{ title: string }> = ({ title }) => (
   <span className={styles.title}>
     Input: <span className={styles.blockName}>{title}</span>
   </span>
 );
+
 const BreadcrumbTitle: React.FC<{
   crumbTitle: string;
   crumbAction: () => void;
@@ -72,11 +74,13 @@ const ConfigurationTitle: React.FunctionComponent = () => {
     selectActiveNodeId,
     pageEditorActions.setElementActiveNodeId
   );
+  // eslint-disable-next-line security/detect-object-injection -- is a UUID
   const activeNodeInfo = nodesPipelineMap[activeNodeId];
   const { blockConfig: activeNode, parentNodeId } = activeNodeInfo;
   const blockId = activeNode.id;
   const block = allBlocks.get(blockId)?.block;
   const { data: listings = {} } = useGetMarketplaceListingsQuery();
+  // eslint-disable-next-line security/detect-object-injection -- is a registry id
   const listing = listings[blockId];
 
   const [activeNodePreviewElementName, setActiveNodePreviewElementName] =
@@ -98,20 +102,28 @@ const ConfigurationTitle: React.FunctionComponent = () => {
       activeNode,
       joinPathParts(DOCUMENT_BODY_PATH, activeNodePreviewElementName)
     );
-    const activeDocumentElementName =
-      getProperty<string>(elementTypeLabels, activeDocumentElement.type) ??
-      "Unknown element";
-    title = (
-      <BreadcrumbTitle
-        crumbTitle={block?.name}
-        crumbAction={() => {
-          setActiveNodePreviewElementName(null);
-        }}
-        title={activeDocumentElementName}
-      />
-    );
+
+    if (activeDocumentElement == null) {
+      // There's a race condition when adding a new element to the document where activeNodePreviewElementName might
+      // not be available in the activeNode yet.
+      title = <PlainTitle />;
+    } else {
+      const activeDocumentElementName =
+        getProperty<string>(elementTypeLabels, activeDocumentElement.type) ??
+        "Unknown element";
+      title = (
+        <BreadcrumbTitle
+          crumbTitle={block?.name}
+          crumbAction={() => {
+            setActiveNodePreviewElementName(null);
+          }}
+          title={activeDocumentElementName}
+        />
+      );
+    }
   } else if (
     parentNodeId != null &&
+    // eslint-disable-next-line security/detect-object-injection -- is a UUID
     nodesPipelineMap[parentNodeId].blockId === DocumentRenderer.BLOCK_ID
   ) {
     // Editing a direct descendant of a document node

--- a/src/pageEditor/tabs/effect/useDocumentPreviewRunBlock.ts
+++ b/src/pageEditor/tabs/effect/useDocumentPreviewRunBlock.ts
@@ -105,6 +105,7 @@ export default function useDocumentPreviewRunBlock(
 
   const {
     uuid: extensionId,
+    recipe,
     apiVersion,
     services,
     extensionPoint,
@@ -186,12 +187,12 @@ export default function useDocumentPreviewRunBlock(
         (parentBlockInfo?.blockConfig.config.location as Location) ?? "panel";
 
       try {
-        await runRendererBlock(
-          thisTab,
+        await runRendererBlock(thisTab, {
           extensionId,
-          traceRecord.runId,
+          blueprintId: recipe?.id,
+          runId: traceRecord.runId,
           title,
-          {
+          args: {
             apiVersion,
             blockConfig: {
               ...removeEmptyValues(blockConfig),
@@ -200,8 +201,8 @@ export default function useDocumentPreviewRunBlock(
             context,
             rootSelector,
           },
-          location
-        );
+          location,
+        });
         dispatch(previewSlice.actions.setSuccess({ output: {} }));
       } catch (error) {
         dispatch(previewSlice.actions.setError({ error }));

--- a/src/sidebar/PanelBody.test.tsx
+++ b/src/sidebar/PanelBody.test.tsx
@@ -26,6 +26,7 @@ import { type RendererPayload } from "@/runtime/runtimeTypes";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import blocksRegistry from "@/blocks/registry";
 import { HtmlRenderer } from "@/blocks/renderers/html";
+import { registryIdFactory } from "@/testUtils/factories";
 
 jest.mock("@/blocks/registry", () => ({
   __esModule: true,
@@ -35,6 +36,9 @@ jest.mock("@/blocks/registry", () => ({
 }));
 
 const lookupMock = blocksRegistry.lookup as jest.Mock;
+
+const extensionId = uuidv4();
+const blueprintId = registryIdFactory();
 
 describe("PanelBody", () => {
   beforeEach(() => {
@@ -46,14 +50,14 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new Error("test error")),
       runId: uuidv4(),
-      extensionId: uuidv4(),
+      extensionId,
     };
 
     const result = render(
       <PanelBody
         isRootPanel
         onAction={jest.fn()}
-        context={{}}
+        context={{ extensionId, blueprintId }}
         payload={payload}
       />
     );
@@ -66,14 +70,14 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new BusinessError("test error")),
       runId: uuidv4(),
-      extensionId: uuidv4(),
+      extensionId,
     };
 
     const result = render(
       <PanelBody
         isRootPanel
         onAction={jest.fn()}
-        context={{}}
+        context={{ extensionId, blueprintId }}
         payload={payload}
       />
     );
@@ -86,14 +90,14 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new CancelError("test error")),
       runId: uuidv4(),
-      extensionId: uuidv4(),
+      extensionId,
     };
 
     const result = render(
       <PanelBody
         isRootPanel
         onAction={jest.fn()}
-        context={{}}
+        context={{ extensionId, blueprintId }}
         payload={payload}
       />
     );
@@ -105,7 +109,7 @@ describe("PanelBody", () => {
     const payload: RendererPayload = {
       key: uuidv4(),
       runId: uuidv4(),
-      extensionId: uuidv4(),
+      extensionId,
       blockId: validateRegistryId("@pixiebrix/html"),
       args: {
         html: "<h1>Test</h1>",
@@ -119,7 +123,7 @@ describe("PanelBody", () => {
       <PanelBody
         isRootPanel
         onAction={jest.fn()}
-        context={{}}
+        context={{ extensionId, blueprintId }}
         payload={payload}
       />
     );

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -33,11 +33,20 @@ import { type RegistryId } from "@/types/registryTypes";
 import { type RendererOutput } from "@/types/runtimeTypes";
 import { type MessageContext } from "@/types/loggerTypes";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { type UUID } from "@/types/stringTypes";
 
 type BodyProps = {
   blockId: RegistryId;
   body: RendererOutput;
   meta: PanelRunMeta;
+};
+
+/**
+ * Context for panel, with fields required for functionality marked as required.
+ */
+export type PanelContext = MessageContext & {
+  extensionId: UUID;
+  blueprintId: RegistryId | null;
 };
 
 const BodyContainer: React.FC<
@@ -115,7 +124,7 @@ const slice = createSlice({
 const PanelBody: React.FunctionComponent<{
   isRootPanel?: boolean;
   payload: PanelPayload;
-  context: MessageContext;
+  context: PanelContext;
   onAction: (action: SubmitPanelAction) => void;
 }> = ({ payload, context, isRootPanel = false, onAction }) => {
   const [state, dispatch] = useReducer(slice.reducer, initialPanelState);

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -30,8 +30,9 @@ import RootErrorPanel from "@/sidebar/components/RootErrorPanel";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import { type SubmitPanelAction } from "@/blocks/errors";
 import { type RegistryId } from "@/types/registryTypes";
-import { type BlockArgs, type RendererOutput } from "@/types/runtimeTypes";
+import { type RendererOutput } from "@/types/runtimeTypes";
 import { type MessageContext } from "@/types/loggerTypes";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 
 type BodyProps = {
   blockId: RegistryId;
@@ -142,7 +143,7 @@ const PanelBody: React.FunctionComponent<{
         const block = await blockRegistry.lookup(blockId);
         // In the future, the renderer brick should run in the contentScript, not the panel frame
         // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/1939
-        const body = await block.run(args as BlockArgs, {
+        const body = await block.run(unsafeAssumeValidArg(args), {
           ctxt,
           root: null,
           logger: new BackgroundLogger({

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -175,7 +175,10 @@ const Tabs: React.FunctionComponent<SidebarTabsProps> = ({
                 <PanelBody
                   isRootPanel={false}
                   payload={panel.payload}
-                  context={{ extensionId: panel.extensionId }}
+                  context={{
+                    extensionId: panel.extensionId,
+                    blueprintId: panel.blueprintId,
+                  }}
                   onAction={(action: SubmitPanelAction) => {
                     onResolveTemporaryPanel(panel.nonce, action);
                   }}

--- a/src/sidebar/types.ts
+++ b/src/sidebar/types.ts
@@ -92,14 +92,33 @@ export type PanelButton = PanelAction & {
 };
 
 type BasePanelEntry = {
+  /**
+   * The panel type.
+   */
   type: EntryType;
 };
 
+/**
+ * A panel added to the page by an IExtension.
+ *
+ * @see DisplayTemporaryInfo
+ * @see SidebarExtensionPoint
+ */
 export type BaseExtensionPanelEntry = BasePanelEntry & {
   /**
    * The id of the extension that added the panel
    */
   extensionId: UUID;
+  /**
+   * The blueprint associated with the extension that added the panel.
+   *
+   * Used to:
+   * - Give preference to blueprint side panels when using the "Show Sidebar" brick.
+   * - Pass to the panel for actions that require the blueprint id, e.g., Get Page State, Set Page State, etc.
+   *
+   * @since 1.6.5
+   */
+  blueprintId: RegistryId | null;
   /**
    * Heading for tab name in the sidebar
    */
@@ -108,7 +127,6 @@ export type BaseExtensionPanelEntry = BasePanelEntry & {
    * The information required to run the renderer of a pipeline, or error information if the pipeline run errored.
    */
   payload: PanelPayload;
-
   /**
    * Actions to show for the panel
    * @since 1.7.19
@@ -122,14 +140,6 @@ export type BaseExtensionPanelEntry = BasePanelEntry & {
  */
 export type PanelEntry = BaseExtensionPanelEntry & {
   type: "panel";
-  /**
-   * The blueprint associated with the extension that added the panel.
-   *
-   * Used to give preference to blueprint side panels when using the "Show Sidebar" brick.
-   *
-   * @since 1.6.5
-   */
-  blueprintId: RegistryId | null;
   /**
    * The sidebar extension point
    * @see SidebarExtensionPoint
@@ -146,7 +156,6 @@ export type TemporaryPanelEntry = BaseExtensionPanelEntry & {
    * Unique identifier for the temporary panel instance. Used to correlate panel-close action.
    */
   nonce: UUID;
-
   /**
    * True if the panel has an "x" to be closed by the user (default=true)
    * @since 1.7.19
@@ -176,7 +185,13 @@ export type FormEntry = BasePanelEntry & {
 
 export type ActivateRecipeEntry = BasePanelEntry & {
   type: "activateRecipe";
+  /**
+   * The blueprint id of the recipe to activate
+   */
   recipeId: RegistryId;
+  /**
+   * Heading for tab name in the sidebar
+   */
   heading: string;
 };
 

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -26,6 +26,7 @@ import {
 import { type BlockConfig, type BlockPipeline } from "@/blocks/types";
 import { type TraceError, type TraceRecord } from "@/telemetry/trace";
 import {
+  uuidv4,
   validateRegistryId,
   validateSemVerString,
   validateTimestamp,
@@ -113,10 +114,16 @@ import {
   type RecipeDefinition,
 } from "@/types/recipeTypes";
 
-// UUID sequence generator that's predictable across runs. A couple characters can't be 0
-// https://stackoverflow.com/a/19989922/402560
+/**
+ * UUID sequence generator that's predictable across runs.
+ *
+ * A couple characters can't be 0 https://stackoverflow.com/a/19989922/402560
+ * @param n
+ */
 export const uuidSequence = (n: number) =>
   validateUUID(`${padStart(String(n), 8, "0")}-0000-4000-A000-000000000000`);
+
+export const registryIdFactory = () => validateRegistryId(`test/${uuidv4()}`);
 
 const timestampFactory = () => new Date().toISOString();
 

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -821,6 +821,7 @@ const formEntryFactory = define<FormEntry>({
 const temporaryPanelEntryFactory = define<TemporaryPanelEntry>({
   type: "temporaryPanel",
   extensionId: uuidSequence,
+  blueprintId: null,
   heading: (n: number) => `Temporary Panel Test ${n}`,
   payload: null,
   nonce: uuidSequence,
@@ -829,10 +830,10 @@ const temporaryPanelEntryFactory = define<TemporaryPanelEntry>({
 const panelEntryFactory = define<PanelEntry>({
   type: "panel",
   extensionId: uuidSequence,
-  heading: (n: number) => `Panel Test ${n}`,
-  payload: null,
   blueprintId: (n: number) =>
     validateRegistryId(`@test/panel-recipe-test-${n}`),
+  heading: (n: number) => `Panel Test ${n}`,
+  payload: null,
   extensionPointId: (n: number) =>
     validateRegistryId(`@test/panel-extensionPoint-test-${n}`),
 });


### PR DESCRIPTION
## What does this PR do?

- Closes #5549 
- Passes `blueprintId` along to temporary panels
- Strengthens the type of prop `PanelBody.context` to ensure callers pass through blueprintId if available

## Demo

- https://www.loom.com/share/9f54370791c140fdbeaf8c1ab40ae377

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
