### PR TITLE
#5527: Fix faulty regex

### DIFF
--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -37,25 +37,25 @@ jobs:
           CHROME_MANIFEST_KEY: ${{ secrets.CHROME_MANIFEST_PROD_PUBLIC_KEY }}
 
       # https://stackoverflow.com/a/58142637
-      # GitHub doesn't support if-else, only if, so we need two separate steps
+      # GitHub doesn't support if-else, so we need separate steps
       - name: Determine if main branch
         run: |
           echo "BUILD_PATH=builds/pixiebrix-extension-main.zip" >> $GITHUB_ENV
           echo "RUN_GROUP=$RAINFOREST_RUN_GROUP_MAIN" >> $GITHUB_ENV
         if: github.ref_name == 'main'
+      - name: Determine if CWS release branch
+        run: |
+          echo "BUILD_PATH=builds/pixiebrix-extension-cws.zip" >> $GITHUB_ENV
+          echo "RUN_GROUP=$RAINFOREST_RUN_GROUP_CWS" >> $GITHUB_ENV
+        if: startsWith(github.ref_name, 'release/')
       - name: Determine if release branch
+        # should overwrite the previous step correctly if not a CWS-release branch
         run: |
           echo "BUILD_PATH=builds/pixiebrix-extension-release.zip" >> $GITHUB_ENV
           echo "RUN_GROUP=$RAINFOREST_RUN_GROUP_RELEASE" >> $GITHUB_ENV
-        if: startsWith(github.ref_name, 'release/')
-      - name: Determine if CWS release branch
-        # shell script used because GitHub actions doesn't support regex in if statements
-        # will overwrite the previous step correctly if it's a CWS-release branch
-        run: |
-          if [[ $github.ref_name =~ ^release\/[0-9]+.[0-9]+.[0-9]+$ ]]; then
-            echo "BUILD_PATH=builds/pixiebrix-extension-cws.zip" >> $GITHUB_ENV
-            echo "RUN_GROUP=$RAINFOREST_RUN_GROUP_CWS" >> $GITHUB_ENV
-          fi
+        if: |
+          startsWith(github.ref_name, 'release/') &&
+          (contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta'))
 
       - name: Upload Extension
         run: bash scripts/upload-extension.sh ${{ env.BUILD_PATH }}

--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -43,19 +43,21 @@ jobs:
           echo "BUILD_PATH=builds/pixiebrix-extension-main.zip" >> $GITHUB_ENV
           echo "RUN_GROUP=$RAINFOREST_RUN_GROUP_MAIN" >> $GITHUB_ENV
         if: github.ref_name == 'main'
-      - name: Determine if CWS release branch
-        run: |
-          echo "BUILD_PATH=builds/pixiebrix-extension-cws.zip" >> $GITHUB_ENV
-          echo "RUN_GROUP=$RAINFOREST_RUN_GROUP_CWS" >> $GITHUB_ENV
-        if: startsWith(github.ref_name, 'release/')
       - name: Determine if release branch
-        # should overwrite the previous step correctly if not a CWS-release branch
         run: |
           echo "BUILD_PATH=builds/pixiebrix-extension-release.zip" >> $GITHUB_ENV
           echo "RUN_GROUP=$RAINFOREST_RUN_GROUP_RELEASE" >> $GITHUB_ENV
-        if: |
-          startsWith(github.ref_name, 'release/') &&
-          (contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta'))
+        if: startsWith(github.ref_name, 'release/')
+      - name: Determine if CWS release branch
+        # shell script used because GitHub actions doesn't support regex in if statements
+        # will overwrite the previous step correctly if it's a CWS-release branch
+        run: |
+          if [[ $ref_name =~ ^release\/[0-9]+.[0-9]+.[0-9]+$ ]]; then
+            echo "BUILD_PATH=builds/pixiebrix-extension-cws.zip" >> $GITHUB_ENV
+            echo "RUN_GROUP=$RAINFOREST_RUN_GROUP_CWS" >> $GITHUB_ENV
+          fi
+        env:
+          ref_name: ${{ github.ref_name }}
 
       - name: Upload Extension
         run: bash scripts/upload-extension.sh ${{ env.BUILD_PATH }}


### PR DESCRIPTION
## What does this PR do?

- Fixes #5542 
- When I manually tested that the CWS version is uploaded / ran on rainforest, I noticed it wasn't. 
- Fixes the faulty env var use in the bash script for upload CWS step

## Discussion

- Ignore the first commit, I undo those changes in the second as they're not needed.
- [Verification that the CWS Upload works now](https://github.com/pixiebrix/pixiebrix-extension/actions/runs/4735939581/jobs/8406822330?pr=5561) (click Upload Extension step and see what path is used)

## Checklist

- [ ] ~Add tests~ N/A
- [x] Designate a primary reviewer: @mnholtz 
