### PR TITLE
#5556: fix nested brick permissions calculation and use native clipboard API 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "chrono-node": "^2.6.3",
         "classnames": "^2.3.1",
         "connected-react-router": "^6.9.1",
-        "copy-text-to-clipboard": "^3.1.0",
         "csharp-helpers": "^0.9.3",
         "css-selector-generator": "^3.6.0",
         "date-fns": "^2.28.0",
@@ -16865,17 +16864,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/copy-text-to-clipboard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
-      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/copy-webpack-plugin": {
@@ -49995,11 +49983,6 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true
-    },
-    "copy-text-to-clipboard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
-      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng=="
     },
     "copy-webpack-plugin": {
       "version": "10.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "chrono-node": "^2.6.3",
         "classnames": "^2.3.1",
         "connected-react-router": "^6.9.1",
+        "copy-text-to-clipboard": "^3.1.0",
         "csharp-helpers": "^0.9.3",
         "css-selector-generator": "^3.6.0",
         "date-fns": "^2.28.0",
@@ -16864,6 +16865,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/copy-text-to-clipboard": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
+      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/copy-webpack-plugin": {
@@ -49983,6 +49995,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true
+    },
+    "copy-text-to-clipboard": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
+      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng=="
     },
     "copy-webpack-plugin": {
       "version": "10.2.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "chrono-node": "^2.6.3",
     "classnames": "^2.3.1",
     "connected-react-router": "^6.9.1",
+    "copy-text-to-clipboard": "^3.1.0",
     "csharp-helpers": "^0.9.3",
     "css-selector-generator": "^3.6.0",
     "date-fns": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "chrono-node": "^2.6.3",
     "classnames": "^2.3.1",
     "connected-react-router": "^6.9.1",
-    "copy-text-to-clipboard": "^3.1.0",
     "csharp-helpers": "^0.9.3",
     "css-selector-generator": "^3.6.0",
     "date-fns": "^2.28.0",

--- a/src/analysis/analysisVisitors/blockIdVisitor.ts
+++ b/src/analysis/analysisVisitors/blockIdVisitor.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import PipelineVisitor, {
+  type VisitBlockExtra,
+} from "@/blocks/PipelineVisitor";
+import { type RegistryId } from "@/types/registryTypes";
+import { type BlockConfig, type BlockPosition } from "@/blocks/types";
+import { castArray } from "lodash";
+
+/**
+ * A visitor that recursively collects all block IDs used in a pipeline.
+ *
+ * Typically should be called as BlockIdVisitor.collectBlockIds
+ *
+ * @see BlockIdVisitor.collectBlockIds
+ */
+class BlockIdVisitor extends PipelineVisitor {
+  readonly _blockIds = new Set<RegistryId>();
+
+  get blockIds(): Set<RegistryId> {
+    return new Set(this._blockIds);
+  }
+
+  override visitBlock(
+    position: BlockPosition,
+    blockConfig: BlockConfig,
+    extra: VisitBlockExtra
+  ): void {
+    super.visitBlock(position, blockConfig, extra);
+    this._blockIds.add(blockConfig.id);
+  }
+
+  public static collectBlockIds(
+    pipeline: BlockConfig | BlockConfig[]
+  ): Set<RegistryId> {
+    const visitor = new BlockIdVisitor();
+    visitor.visitRootPipeline(castArray(pipeline));
+    return visitor.blockIds;
+  }
+}
+
+export default BlockIdVisitor;

--- a/src/components/AsyncButton.tsx
+++ b/src/components/AsyncButton.tsx
@@ -19,7 +19,9 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Button, type ButtonProps } from "react-bootstrap";
 
 export type AsyncButtonProps = ButtonProps & {
-  onClick: (() => Promise<void>) | (() => void);
+  onClick:
+    | ((event: React.MouseEvent) => Promise<void>)
+    | ((event: React.MouseEvent) => void);
   autoFocus?: boolean;
 };
 
@@ -40,16 +42,19 @@ const AsyncButton: React.FunctionComponent<AsyncButtonProps> = ({
     };
   }, []);
 
-  const handleClick = useCallback(async () => {
-    setPending(true);
-    try {
-      await onClick();
-    } finally {
-      if (mounted.current) {
-        setPending(false);
+  const handleClick = useCallback(
+    async (event: React.MouseEvent) => {
+      setPending(true);
+      try {
+        await onClick(event);
+      } finally {
+        if (mounted.current) {
+          setPending(false);
+        }
       }
-    }
-  }, [onClick]);
+    },
+    [onClick]
+  );
 
   return (
     <Button
@@ -57,7 +62,7 @@ const AsyncButton: React.FunctionComponent<AsyncButtonProps> = ({
       {...buttonProps}
       onClick={(event) => {
         event.stopPropagation();
-        void handleClick();
+        void handleClick(event);
       }}
     >
       {children}

--- a/src/components/AsyncButton.tsx
+++ b/src/components/AsyncButton.tsx
@@ -19,8 +19,10 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Button, type ButtonProps } from "react-bootstrap";
 
 export type AsyncButtonProps = ButtonProps & {
-  onClick:
-    | ((event: React.MouseEvent) => Promise<void>)
+  onClick: // Don't simplify to (event: React.MouseEvent) => Promise<void> | void. Union necessary to allow
+  // callsites to pass in a function that returns a Promise<T>. (Because Typescript does not consider Promise<T>
+  // compatible with void return type.
+  | ((event: React.MouseEvent) => Promise<void>)
     | ((event: React.MouseEvent) => void);
   autoFocus?: boolean;
 };

--- a/src/components/jsonTree/JsonTree.tsx
+++ b/src/components/jsonTree/JsonTree.tsx
@@ -44,11 +44,10 @@ import { type Styling, type Theme } from "react-base16-styling";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCode } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
-import copy from "copy-text-to-clipboard";
 import notify from "@/utils/notify";
 import safeJsonStringify from "json-stringify-safe";
-import { Button } from "react-bootstrap";
 import styles from "./JsonTree.module.scss";
+import AsyncButton from "@/components/AsyncButton";
 
 const SEARCH_DEBOUNCE_MS = 100;
 
@@ -153,20 +152,20 @@ const jsonTreeTheme: Theme = {
 const CopyDataButton: React.FunctionComponent<{ data: unknown }> = ({
   data,
 }) => (
-  <Button
+  <AsyncButton
     variant="text"
     className={cx(styles.copyPath, "p-0")}
     aria-label="copy data"
     href="#"
-    onClick={(event) => {
-      copy(safeJsonStringify(data, null, 2));
+    onClick={async (event) => {
+      await navigator.clipboard.writeText(safeJsonStringify(data, null, 2));
       event.preventDefault();
       event.stopPropagation();
       notify.info("Copied data to the clipboard");
     }}
   >
     <FontAwesomeIcon icon={faCode} aria-hidden />
-  </Button>
+  </AsyncButton>
 );
 
 /**

--- a/src/components/jsonTree/JsonTree.tsx
+++ b/src/components/jsonTree/JsonTree.tsx
@@ -48,6 +48,7 @@ import notify from "@/utils/notify";
 import safeJsonStringify from "json-stringify-safe";
 import styles from "./JsonTree.module.scss";
 import AsyncButton from "@/components/AsyncButton";
+import { writeTextToClipboard } from "@/utils/clipboardUtils";
 
 const SEARCH_DEBOUNCE_MS = 100;
 
@@ -158,7 +159,7 @@ const CopyDataButton: React.FunctionComponent<{ data: unknown }> = ({
     aria-label="copy data"
     href="#"
     onClick={async (event) => {
-      await navigator.clipboard.writeText(safeJsonStringify(data, null, 2));
+      await writeTextToClipboard(safeJsonStringify(data, null, 2));
       event.preventDefault();
       event.stopPropagation();
       notify.info("Copied data to the clipboard");

--- a/src/components/jsonTree/treeHooks.tsx
+++ b/src/components/jsonTree/treeHooks.tsx
@@ -16,14 +16,13 @@
  */
 
 import React, { useCallback } from "react";
-import copy from "copy-text-to-clipboard";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCopy } from "@fortawesome/free-solid-svg-icons";
 import notify from "@/utils/notify";
 import styles from "./JsonTree.module.scss";
-import { Button } from "react-bootstrap";
 import cx from "classnames";
 import { getPathFromArray } from "@/runtime/pathHelpers";
+import AsyncButton from "@/components/AsyncButton";
 
 export function useLabelRenderer() {
   // https://github.com/reduxjs/redux-devtools/blob/85b4b0fb04b1d6d95054d5073fa17fa61efc0df3/packages/redux-devtools-inspector-monitor/src/ActionPreview.tsx
@@ -39,20 +38,22 @@ export function useLabelRenderer() {
         {/* The button must not be a form element,
         otherwise the wrapping label from JSONTree is associated with the element's contents (the button).
         See https://www.w3.org/TR/html401/interact/forms.html#h-17.9.1 */}
-        <Button
+        <AsyncButton
           variant="text"
           className={cx(styles.copyPath, "p-0")}
           aria-label="Copy path"
           href="#"
-          onClick={(event) => {
-            copy(getPathFromArray([key, ...rest].reverse()));
+          onClick={async (event) => {
+            await navigator.clipboard.writeText(
+              getPathFromArray([key, ...rest].reverse())
+            );
             event.preventDefault();
             event.stopPropagation();
             notify.info("Copied property path to the clipboard");
           }}
         >
           <FontAwesomeIcon icon={faCopy} aria-hidden />
-        </Button>
+        </AsyncButton>
       </div>
     ),
     []

--- a/src/components/jsonTree/treeHooks.tsx
+++ b/src/components/jsonTree/treeHooks.tsx
@@ -23,6 +23,7 @@ import styles from "./JsonTree.module.scss";
 import cx from "classnames";
 import { getPathFromArray } from "@/runtime/pathHelpers";
 import AsyncButton from "@/components/AsyncButton";
+import { writeTextToClipboard } from "@/utils/clipboardUtils";
 
 export function useLabelRenderer() {
   // https://github.com/reduxjs/redux-devtools/blob/85b4b0fb04b1d6d95054d5073fa17fa61efc0df3/packages/redux-devtools-inspector-monitor/src/ActionPreview.tsx
@@ -44,7 +45,7 @@ export function useLabelRenderer() {
           aria-label="Copy path"
           href="#"
           onClick={async (event) => {
-            await navigator.clipboard.writeText(
+            await writeTextToClipboard(
               getPathFromArray([key, ...rest].reverse())
             );
             event.preventDefault();

--- a/src/extensionConsole/pages/blueprints/modals/shareModals/ActivationLink.tsx
+++ b/src/extensionConsole/pages/blueprints/modals/shareModals/ActivationLink.tsx
@@ -17,12 +17,12 @@
 
 import { type RegistryId } from "@/types/registryTypes";
 import React from "react";
-import copy from "copy-text-to-clipboard";
 import notify from "@/utils/notify";
 // eslint-disable-next-line no-restricted-imports -- TODO: Fix over time
-import { Button, Form, InputGroup } from "react-bootstrap";
+import { Form, InputGroup } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCopy } from "@fortawesome/free-solid-svg-icons";
+import AsyncButton from "@/components/AsyncButton";
 
 type ActivationLinkProps = {
   blueprintId: RegistryId;
@@ -37,16 +37,16 @@ const ActivationLink: React.FunctionComponent<ActivationLinkProps> = ({
     <InputGroup>
       <Form.Control type="text" readOnly defaultValue={installationLink} />
       <InputGroup.Append>
-        <Button
+        <AsyncButton
           variant="info"
-          onClick={() => {
-            copy(installationLink);
+          onClick={async () => {
+            await navigator.clipboard.writeText(installationLink);
             // Don't close the modal - that allows the user to re-copy the link and verify the link works
             notify.success("Copied activation link to clipboard");
           }}
         >
           <FontAwesomeIcon icon={faCopy} />
-        </Button>
+        </AsyncButton>
       </InputGroup.Append>
     </InputGroup>
   );

--- a/src/extensionConsole/pages/blueprints/modals/shareModals/ActivationLink.tsx
+++ b/src/extensionConsole/pages/blueprints/modals/shareModals/ActivationLink.tsx
@@ -23,6 +23,7 @@ import { Form, InputGroup } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCopy } from "@fortawesome/free-solid-svg-icons";
 import AsyncButton from "@/components/AsyncButton";
+import { writeTextToClipboard } from "@/utils/clipboardUtils";
 
 type ActivationLinkProps = {
   blueprintId: RegistryId;
@@ -40,7 +41,7 @@ const ActivationLink: React.FunctionComponent<ActivationLinkProps> = ({
         <AsyncButton
           variant="info"
           onClick={async () => {
-            await navigator.clipboard.writeText(installationLink);
+            await writeTextToClipboard(installationLink);
             // Don't close the modal - that allows the user to re-copy the link and verify the link works
             notify.success("Copied activation link to clipboard");
           }}

--- a/src/extensionConsole/pages/brickEditor/referenceTab/BrickDetail.tsx
+++ b/src/extensionConsole/pages/brickEditor/referenceTab/BrickDetail.tsx
@@ -34,6 +34,7 @@ import { type Schema } from "@/types/schemaTypes";
 import { useGetMarketplaceListingsQuery } from "@/services/api";
 import BrickIcon from "@/components/BrickIcon";
 import { MARKETPLACE_URL } from "@/utils/strings";
+import { writeTextToClipboard } from "@/utils/clipboardUtils";
 
 function makeArgumentYaml(schema: Schema): string {
   let result = "";
@@ -82,7 +83,7 @@ const BrickDetail: React.FunctionComponent<{
 
   const copyHandler = useUserAction(
     async () => {
-      await navigator.clipboard.writeText(makeArgumentYaml(schema));
+      await writeTextToClipboard(makeArgumentYaml(schema));
     },
     {
       successMessage: "Copied input argument YAML to clipboard",

--- a/src/extensionConsole/pages/brickEditor/referenceTab/BrickDetail.tsx
+++ b/src/extensionConsole/pages/brickEditor/referenceTab/BrickDetail.tsx
@@ -20,7 +20,6 @@ import styles from "./BrickDetail.module.scss";
 import React, { Suspense } from "react";
 import { Button } from "react-bootstrap";
 import { isEmpty } from "lodash";
-import copy from "copy-text-to-clipboard";
 import AceEditor from "@/vendors/AceEditor";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -83,7 +82,7 @@ const BrickDetail: React.FunctionComponent<{
 
   const copyHandler = useUserAction(
     async () => {
-      copy(makeArgumentYaml(schema));
+      await navigator.clipboard.writeText(makeArgumentYaml(schema));
     },
     {
       successMessage: "Copied input argument YAML to clipboard",

--- a/src/extensionConsole/pages/services/ZapierModal.tsx
+++ b/src/extensionConsole/pages/services/ZapierModal.tsx
@@ -23,6 +23,7 @@ import { faCopy } from "@fortawesome/free-solid-svg-icons";
 import useFetch from "@/hooks/useFetch";
 import notify from "@/utils/notify";
 import { reportEvent } from "@/telemetry/events";
+import { writeTextToClipboard } from "@/utils/clipboardUtils";
 
 interface OwnProps {
   onClose: () => void;
@@ -32,7 +33,7 @@ const ZapierModal: React.FunctionComponent<OwnProps> = ({ onClose }) => {
   const { data } = useFetch<{ api_key: string }>("/api/webhooks/key/");
 
   const handleCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(data?.api_key);
+    await writeTextToClipboard(String(data?.api_key));
     notify.success("Copied API Key to clipboard");
     reportEvent("ZapierKeyCopy");
   }, [data?.api_key]);

--- a/src/extensionConsole/pages/services/ZapierModal.tsx
+++ b/src/extensionConsole/pages/services/ZapierModal.tsx
@@ -20,7 +20,6 @@ import { Button, Modal, Form, InputGroup } from "react-bootstrap";
 import React, { useCallback } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCopy } from "@fortawesome/free-solid-svg-icons";
-import copy from "copy-text-to-clipboard";
 import useFetch from "@/hooks/useFetch";
 import notify from "@/utils/notify";
 import { reportEvent } from "@/telemetry/events";
@@ -32,8 +31,8 @@ interface OwnProps {
 const ZapierModal: React.FunctionComponent<OwnProps> = ({ onClose }) => {
   const { data } = useFetch<{ api_key: string }>("/api/webhooks/key/");
 
-  const handleCopy = useCallback(() => {
-    copy(data?.api_key);
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(data?.api_key);
     notify.success("Copied API Key to clipboard");
     reportEvent("ZapierKeyCopy");
   }, [data?.api_key]);

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -47,7 +47,7 @@ import { selectExtensionContext } from "@/extensionPoints/helpers";
 import { type BlockConfig, type BlockPipeline } from "@/blocks/types";
 import { isDeploymentActive } from "@/utils/deploymentUtils";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
-import { blockList } from "@/blocks/util";
+import { selectAllBlocks } from "@/blocks/util";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
 import { makeServiceContext } from "@/services/serviceUtils";
 import { guessSelectedElement } from "@/utils/selectionController";
@@ -148,7 +148,7 @@ export abstract class ContextMenuExtensionPoint extends ExtensionPoint<ContextMe
   async getBlocks(
     extension: ResolvedExtension<ContextMenuConfig>
   ): Promise<IBlock[]> {
-    return blockList(extension.config.action);
+    return selectAllBlocks(extension.config.action);
   }
 
   override uninstall({ global = false }: { global?: boolean }): void {

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -54,7 +54,7 @@ import apiVersionOptions, {
 } from "@/runtime/apiVersionOptions";
 import { engineRenderer } from "@/runtime/renderers";
 import { mapArgs } from "@/runtime/mapArgs";
-import { blockList } from "@/blocks/util";
+import { selectAllBlocks } from "@/blocks/util";
 import { makeServiceContext } from "@/services/serviceUtils";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
 import { $safeFind } from "@/helpers";
@@ -373,7 +373,7 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
   async getBlocks(
     extension: ResolvedExtension<MenuItemExtensionConfig>
   ): Promise<IBlock[]> {
-    return blockList(extension.config.action);
+    return selectAllBlocks(extension.config.action);
   }
 
   private async reacquire(uuid: string): Promise<void> {

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -46,7 +46,7 @@ import getSvgIcon from "@/icons/getSvgIcon";
 import { type BlockConfig, type BlockPipeline } from "@/blocks/types";
 import { selectEventData } from "@/telemetry/deployments";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
-import { blockList } from "@/blocks/util";
+import { selectAllBlocks } from "@/blocks/util";
 import { makeServiceContext } from "@/services/serviceUtils";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
 import { PIXIEBRIX_DATA_ATTR } from "@/common";
@@ -159,7 +159,7 @@ export abstract class PanelExtensionPoint extends ExtensionPoint<PanelConfig> {
   async getBlocks(
     extension: ResolvedExtension<PanelConfig>
   ): Promise<IBlock[]> {
-    return blockList(extension.config.body);
+    return selectAllBlocks(extension.config.body);
   }
 
   clearExtensionInterfaceAndEvents(): void {

--- a/src/extensionPoints/quickBarExtension.tsx
+++ b/src/extensionPoints/quickBarExtension.tsx
@@ -44,7 +44,7 @@ import { selectEventData } from "@/telemetry/deployments";
 import { selectExtensionContext } from "@/extensionPoints/helpers";
 import { type BlockConfig, type BlockPipeline } from "@/blocks/types";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
-import { blockList } from "@/blocks/util";
+import { selectAllBlocks } from "@/blocks/util";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
 import { makeServiceContext } from "@/services/serviceUtils";
 import { initQuickBarApp } from "@/components/quickBar/QuickBarApp";
@@ -118,7 +118,7 @@ export abstract class QuickBarExtensionPoint extends ExtensionPoint<QuickBarConf
   async getBlocks(
     extension: ResolvedExtension<QuickBarConfig>
   ): Promise<IBlock[]> {
-    return blockList(extension.config.action);
+    return selectAllBlocks(extension.config.action);
   }
 
   public get kind(): "quickBar" {

--- a/src/extensionPoints/quickBarProviderExtension.tsx
+++ b/src/extensionPoints/quickBarProviderExtension.tsx
@@ -34,7 +34,7 @@ import notify from "@/utils/notify";
 import { selectEventData } from "@/telemetry/deployments";
 import { selectExtensionContext } from "@/extensionPoints/helpers";
 import { type BlockConfig, type BlockPipeline } from "@/blocks/types";
-import { blockList } from "@/blocks/util";
+import { selectAllBlocks } from "@/blocks/util";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
 import { initQuickBarApp } from "@/components/quickBar/QuickBarApp";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
@@ -134,7 +134,7 @@ export abstract class QuickBarProviderExtensionPoint extends ExtensionPoint<Quic
   async getBlocks(
     extension: ResolvedExtension<QuickBarProviderConfig>
   ): Promise<IBlock[]> {
-    return blockList(extension.config.generator);
+    return selectAllBlocks(extension.config.generator);
   }
 
   public get kind(): "quickBarProvider" {

--- a/src/extensionPoints/sidebarExtension.ts
+++ b/src/extensionPoints/sidebarExtension.ts
@@ -47,7 +47,7 @@ import {
 import { cloneDeep, debounce, stubTrue } from "lodash";
 import { type BlockConfig, type BlockPipeline } from "@/blocks/types";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
-import { blockList } from "@/blocks/util";
+import { selectAllBlocks } from "@/blocks/util";
 import { makeServiceContext } from "@/services/serviceUtils";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
@@ -128,7 +128,7 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
   async getBlocks(
     extension: ResolvedExtension<SidebarConfig>
   ): Promise<IBlock[]> {
-    return blockList(extension.config.body);
+    return selectAllBlocks(extension.config.body);
   }
 
   clearExtensionInterfaceAndEvents(): void {

--- a/src/extensionPoints/tourExtension.ts
+++ b/src/extensionPoints/tourExtension.ts
@@ -33,7 +33,7 @@ import {
 } from "lodash";
 import { checkAvailable } from "@/blocks/available";
 import { type BlockConfig, type BlockPipeline } from "@/blocks/types";
-import { blockList } from "@/blocks/util";
+import { selectAllBlocks } from "@/blocks/util";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import "@/vendors/hoverintent/hoverintent";
@@ -111,7 +111,7 @@ export abstract class TourExtensionPoint extends ExtensionPoint<TourConfig> {
   });
 
   async getBlocks(extension: ResolvedExtension<TourConfig>): Promise<IBlock[]> {
-    return blockList(extension.config.tour);
+    return selectAllBlocks(extension.config.tour);
   }
 
   private async runExtensionTour(

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -41,7 +41,7 @@ import notify from "@/utils/notify";
 import { type BlockConfig, type BlockPipeline } from "@/blocks/types";
 import { selectEventData } from "@/telemetry/deployments";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
-import { blockList } from "@/blocks/util";
+import { selectAllBlocks } from "@/blocks/util";
 import { makeServiceContext } from "@/services/serviceUtils";
 import { mergeReaders } from "@/blocks/readers/readerUtils";
 import { sleep, waitAnimationFrame } from "@/utils";
@@ -277,7 +277,7 @@ export abstract class TriggerExtensionPoint extends ExtensionPoint<TriggerConfig
   async getBlocks(
     extension: ResolvedExtension<TriggerConfig>
   ): Promise<IBlock[]> {
-    return blockList(extension.config.action);
+    return selectAllBlocks(extension.config.action);
   }
 
   override async defaultReader(): Promise<IReader> {

--- a/src/permissions/index.ts
+++ b/src/permissions/index.ts
@@ -161,7 +161,7 @@ type PermissionOptions = {
 };
 
 /**
- * Returns browser permissions required to run the extension
+ * Returns browser permissions required to run the IExtension
  * - Extension
  * - Blocks
  * - Services (optional, default=true)

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -329,7 +329,6 @@ export const blockFactory = define<IBlock>({
   id: (i: number) => validateRegistryId(`${TEST_BLOCK_ID}_${i}`),
   name: (i: number) => `${TEST_BLOCK_ID} ${i}`,
   inputSchema: null as Schema,
-  defaultOptions: null,
   permissions: makeEmptyPermissions(),
   run: jest.fn(),
 });

--- a/src/types/blockTypes.ts
+++ b/src/types/blockTypes.ts
@@ -54,11 +54,12 @@ export interface IBlock extends Metadata {
    */
   getOutputSchema?: (config: BlockConfig) => Schema | undefined;
 
-  defaultOptions: Record<string, unknown>;
-
   /**
-   * Returns the optional permissions required to run this block
-   * https://developer.chrome.com/extensions/permission_warnings
+   * Returns the optional permissions required to run this block.
+   *
+   * Only includes this block's permissions, not the permissions of any blocks passed as inputs to the block.
+   *
+   * See https://developer.chrome.com/extensions/permission_warnings
    */
   permissions: Permissions.Permissions;
 
@@ -102,6 +103,11 @@ export interface IBlock extends Metadata {
    */
   defaultOutputKey?: string;
 
+  /**
+   * Run the block.
+   * @param value the rendered input values
+   * @param options the runtime options for the block.
+   */
   run: (value: BlockArgs, options: BlockOptions) => Promise<unknown>;
 }
 
@@ -122,8 +128,6 @@ export abstract class Block implements IBlock {
   outputSchema?: Schema = undefined;
 
   readonly permissions = {};
-
-  readonly defaultOptions = {};
 
   async isPure(): Promise<boolean> {
     // Safe default

--- a/src/types/extensionPointTypes.ts
+++ b/src/types/extensionPointTypes.ts
@@ -23,15 +23,28 @@ import { type RunArgs } from "@/types/runtimeTypes";
 import { type IBlock } from "@/types/blockTypes";
 import { type IReader } from "@/types/blocks/readerTypes";
 import { type Metadata } from "@/types/registryTypes";
+import { type UnknownObject } from "@/types/objectTypes";
 
 export type IExtensionPoint = Metadata & {
+  /**
+   * The kind of extension point.
+   */
   kind: string;
 
+  /**
+   * The input schema for extension point-specific configuration.
+   */
   inputSchema: Schema;
 
-  permissions: Permissions.Permissions;
+  /**
+   * Default options to provide to the inputSchema.
+   */
+  defaultOptions: UnknownObject;
 
-  defaultOptions: Record<string, unknown>;
+  /**
+   * Permissions required to use the extension point.
+   */
+  permissions: Permissions.Permissions;
 
   /**
    * Return the IReader used by the extension point. This method should only be called for calculating availability
@@ -48,6 +61,13 @@ export type IExtensionPoint = Metadata & {
    */
   previewReader: () => Promise<IReader>;
 
+  /**
+   * Return true if the extension point is available on the current page. Based on:
+   *
+   * - URL match patterns
+   * - URL pattern rules
+   * - Element selector rules
+   */
   isAvailable: () => Promise<boolean>;
 
   /**
@@ -55,6 +75,9 @@ export type IExtensionPoint = Metadata & {
    */
   syncInstall: boolean;
 
+  /**
+   * Install/add the extension point to the page.
+   */
   install(): Promise<boolean>;
 
   /**
@@ -84,7 +107,9 @@ export type IExtensionPoint = Metadata & {
   run(args: RunArgs): Promise<void>;
 
   /**
-   * Returns any blocks configured in extension.
+   * Returns all blocks configured in the IExtension, including sub pipelines.
+   *
+   * @see PipelineExpression
    */
   getBlocks: (extension: ResolvedExtension) => Promise<IBlock[]>;
 };

--- a/src/utils/clipboardUtils.ts
+++ b/src/utils/clipboardUtils.ts
@@ -129,6 +129,8 @@ async function interactiveWriteToClipboard(
 export async function writeTextToClipboard(text: string): Promise<void> {
   try {
     await interactiveWriteToClipboard(
+      // Fails in frame contexts if the frame CSP doesn't include clipboard-write. Unfortunately, that includes the
+      // Chrome DevTools. In this case, will fall back to legacy method
       async () => navigator.clipboard.writeText(text),
       {
         type: "text",

--- a/src/utils/clipboardUtils.ts
+++ b/src/utils/clipboardUtils.ts
@@ -137,7 +137,7 @@ export async function writeTextToClipboard(text: string): Promise<void> {
   } catch (error) {
     if (isPermissionError(error)) {
       // Legacy method of copying text to clipboard doesn't require clipboard-write in frame CSP. However, it can
-      // sometimes return `true` even if the text wasn't actually copied.
+      // sometimes return `true` even if the text wasn't actually copied so try to use navigator.clipboard first
       const copied = legacyCopyText(text);
       if (!copied) {
         throw new BusinessError("Unable to write text to clipboard");

--- a/src/utils/clipboardUtils.ts
+++ b/src/utils/clipboardUtils.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import pDefer from "p-defer";
+import notify, { hideNotification } from "@/utils/notify";
+import { BusinessError } from "@/errors/businessErrors";
+import legacyCopyText from "copy-text-to-clipboard";
+import { getErrorMessage } from "@/errors/errorHelpers";
+
+export type ContentType = "infer" | "text" | "image";
+
+export function detectContentType(content: unknown): "text" | "image" {
+  if (typeof content === "string" && content.startsWith("data:image/")) {
+    return "image";
+  }
+
+  return "text";
+}
+
+function isDocumentFocusError(error: unknown): boolean {
+  // Chrome throws a DOMException with the message "Document is not focused" when it can't establish a user action
+  // for the clipboard write request
+  // https://stackoverflow.com/questions/56306153/domexception-on-calling-navigator-clipboard-readtext/70386674#70386674
+  return getErrorMessage(error)
+    .toLowerCase()
+    .includes("document is not focused");
+}
+
+function isPermissionError(error: unknown): boolean {
+  return getErrorMessage(error).toLowerCase().includes("has been blocked");
+}
+
+// Parse instead of using fetch to avoid potential CSP issues with data: URIs
+// https://stackoverflow.com/a/12300351
+export function dataURItoBlob(dataURI: string): Blob {
+  // Convert base64 to raw binary data held in a string doesn't handle URLEncoded DataURIs - see SO answer #6850276 for
+  // code that does this
+  const byteString = atob(dataURI.split(",")[1]);
+
+  // Separate out the mime component
+  const mimeString = dataURI.split(",")[0].split(":")[1].split(";")[0];
+
+  // Write the bytes of the string to an ArrayBuffer
+  const ab = new ArrayBuffer(byteString.length);
+
+  // Create a view into the buffer
+  const ia = new Uint8Array(ab);
+
+  // Set the bytes of the buffer to the correct values
+  for (let i = 0; i < byteString.length; i++) {
+    // eslint-disable-next-line unicorn/prefer-code-point,security/detect-object-injection -- is a number; copied SO
+    ia[i] = byteString.charCodeAt(i);
+  }
+
+  // Write the ArrayBuffer to a blob, and you're done
+  return new Blob([ab], { type: mimeString });
+}
+
+/**
+ * Copy to clipboard, and prompt user to interact with page if the browser blocks the clipboard write due to focus
+ * @param clipboardFn function to copy to the clipboard
+ * @param type the data type, to show in the message to the user.
+ */
+async function interactiveWriteToClipboard(
+  clipboardFn: () => Promise<void>,
+  { type }: { type: "text" | "image" }
+): Promise<void> {
+  try {
+    await clipboardFn();
+  } catch (error) {
+    if (isDocumentFocusError(error)) {
+      const copyPromise = pDefer<void>();
+
+      const notificationId = notify.info({
+        message: `Click anywhere to copy ${type} to clipboard`,
+        duration: Number.POSITIVE_INFINITY,
+        dismissable: false,
+      });
+
+      const handler = async () => {
+        try {
+          hideNotification(notificationId);
+          await clipboardFn();
+          copyPromise.resolve();
+        } catch (error) {
+          if (isDocumentFocusError(error)) {
+            copyPromise.reject(
+              new BusinessError(
+                "Your Browser was unable to determine the user action that initiated the clipboard write."
+              )
+            );
+            return;
+          }
+
+          copyPromise.reject(error);
+        }
+      };
+
+      document.body.addEventListener("click", handler);
+
+      try {
+        await copyPromise.promise;
+      } finally {
+        document.body.removeEventListener("click", handler);
+      }
+
+      // Remember to return to avoid falling through to the original error
+      return;
+    }
+
+    throw error;
+  }
+}
+
+export async function writeTextToClipboard(text: string): Promise<void> {
+  try {
+    await interactiveWriteToClipboard(
+      async () => navigator.clipboard.writeText(text),
+      {
+        type: "text",
+      }
+    );
+  } catch (error) {
+    if (isPermissionError(error)) {
+      // Legacy method of copying text to clipboard doesn't require clipboard-write in frame CSP. However, it can
+      // sometimes return `true` even if the text wasn't actually copied.
+      const copied = legacyCopyText(text);
+      if (!copied) {
+        throw new BusinessError("Unable to write text to clipboard");
+      }
+
+      return;
+    }
+
+    throw error;
+  }
+}
+
+export async function writeToClipboard(items: ClipboardItems): Promise<void> {
+  await interactiveWriteToClipboard(
+    async () => navigator.clipboard.write(items),
+    {
+      type: "image",
+    }
+  );
+}


### PR DESCRIPTION
## What does this PR do?

- Closes #5556
- Fixes permissions calculation to recurse all bricks (using visitor)
- Tries to use native API where possible
- Renames `blockList` to `selectAllBlocks`

## Remaining Work

- [x] The clipboard API might not be available in the Page Editor. Might need to fallback to the NPM package

## Reviewer Notes

- See `BlockIdVisitor`
- See definition of selectAllBlocks
- See `clipboard.ts`
- See `clipboardUtils.ts`

## Future Work

- Introduce lint rule to prevent use of navigator.clipboard.writeText directly

## Checklist

- [x] Add tests: updated existing mocks
- [x] Designate a primary reviewer: @BLoe 
