### PR TITLE
Remove GSheets mod inputs feature flag

### DIFF
--- a/src/components/fields/schemaFields/getToggleOptions.tsx
+++ b/src/components/fields/schemaFields/getToggleOptions.tsx
@@ -24,7 +24,6 @@ import { faCloud } from "@fortawesome/free-solid-svg-icons";
 import { faFileAlt } from "@fortawesome/free-regular-svg-icons";
 import { ServiceFieldDescription } from "@/components/fields/schemaFields/ServiceField";
 import { isCustomizableObjectSchema } from "@/components/fields/schemaFields/widgets/widgetUtils";
-import { syncFlagOn } from "@/store/syncFlags";
 import { type Schema } from "@/types/schemaTypes";
 import { type ExpressionType } from "@/types/runtimeTypes";
 
@@ -217,11 +216,7 @@ export function getToggleOptions({
       Widget: widgetsRegistry.SheetsFileWidget,
       interpretValue: () => "",
     });
-
-    if (syncFlagOn("gsheets-mod-inputs")) {
-      handleVarOption();
-    }
-
+    handleVarOption();
     handleOptionalValue();
     return options;
   }

--- a/src/components/form/widgets/AsyncRemoteSelectWidget.test.tsx
+++ b/src/components/form/widgets/AsyncRemoteSelectWidget.test.tsx
@@ -29,6 +29,14 @@ import { type Option } from "@/components/form/widgets/SelectWidget";
 const id = "widget";
 const name = "widget";
 
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe("AsyncRemoteSelectWidget", () => {
   test("does not fetch by default without defaultOptions", async () => {
     const onChangeMock = jest.fn();

--- a/src/components/form/widgets/AsyncRemoteSelectWidget.test.tsx
+++ b/src/components/form/widgets/AsyncRemoteSelectWidget.test.tsx
@@ -29,14 +29,6 @@ import { type Option } from "@/components/form/widgets/SelectWidget";
 const id = "widget";
 const name = "widget";
 
-beforeEach(() => {
-  jest.useFakeTimers();
-});
-
-afterEach(() => {
-  jest.useRealTimers();
-});
-
 describe("AsyncRemoteSelectWidget", () => {
   test("does not fetch by default without defaultOptions", async () => {
     const onChangeMock = jest.fn();

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.test.tsx
@@ -27,10 +27,7 @@ import {
 } from "@/runtime/expressionCreators";
 import { getToggleOptions } from "@/components/fields/schemaFields/getToggleOptions";
 import { dereference } from "@/validators/generic";
-import {
-  BASE_SHEET_SCHEMA,
-  SHEET_SERVICE_SCHEMA,
-} from "@/contrib/google/sheets/schemas";
+import { BASE_SHEET_SCHEMA } from "@/contrib/google/sheets/schemas";
 import SheetsFileWidget from "@/contrib/google/sheets/SheetsFileWidget";
 import { render } from "@/pageEditor/testHelpers";
 import {
@@ -39,8 +36,6 @@ import {
 } from "@/testUtils/factories";
 import { validateRegistryId } from "@/types/helpers";
 import { services, sheets } from "@/background/messenger/api";
-import { syncFlagOn } from "@/store/syncFlags";
-import useFlags from "@/hooks/useFlags";
 import { selectSchemaFieldType } from "@/testUtils/formHelpers";
 
 const TEST_SPREADSHEET_ID = uuidSequence(1);

--- a/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/AppendSpreadsheetOptions.tsx
@@ -20,7 +20,6 @@ import { type BlockOptionProps } from "@/components/fields/schemaFields/genericO
 import { sheets } from "@/background/messenger/api";
 import { useField } from "formik";
 import { type Expression } from "@/types/runtimeTypes";
-
 import { useAsyncState } from "@/hooks/common";
 import { APPEND_SCHEMA } from "@/contrib/google/sheets/append";
 import { isNullOrBlank, joinName } from "@/utils";
@@ -32,14 +31,10 @@ import { dereference } from "@/validators/generic";
 import Loader from "@/components/Loader";
 import { FormErrorContext } from "@/components/form/FormErrorContext";
 import useSpreadsheetId from "@/contrib/google/sheets/useSpreadsheetId";
-import {
-  BASE_SHEET_SCHEMA,
-  SHEET_SERVICE_SCHEMA,
-} from "@/contrib/google/sheets/schemas";
+import { BASE_SHEET_SCHEMA } from "@/contrib/google/sheets/schemas";
 import { isEmpty, isEqual } from "lodash";
 import { useOnChangeEffect } from "@/contrib/google/sheets/useOnChangeEffect";
 import { requireGoogleHOC } from "@/contrib/google/sheets/RequireGoogleApi";
-import useFlags from "@/hooks/useFlags";
 import { type Schema } from "@/types/schemaTypes";
 
 const DEFAULT_FIELDS_SCHEMA: Schema = {
@@ -105,7 +100,6 @@ const AppendSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
 }) => {
   const basePath = joinName(name, configKey);
   const spreadsheetId = useSpreadsheetId(basePath);
-  const { flagOn } = useFlags();
 
   const [{ value: tabNameValue }] = useField<string | Expression>(
     joinName(basePath, "tabName")
@@ -134,15 +128,6 @@ const AppendSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
     BASE_SHEET_SCHEMA
   );
 
-  const oldSheetSchema: Schema = {
-    title: "Spreadsheet",
-    oneOf: [SHEET_SERVICE_SCHEMA, sheetSchema ?? BASE_SHEET_SCHEMA],
-  };
-
-  const sheetFieldSchema = flagOn("gsheets-mod-inputs")
-    ? sheetSchema
-    : oldSheetSchema;
-
   return (
     <div className="my-2">
       {isLoadingSheetSchema ? (
@@ -157,7 +142,7 @@ const AppendSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
         >
           <SchemaField
             name={joinName(basePath, "spreadsheetId")}
-            schema={sheetFieldSchema}
+            schema={sheetSchema}
             isRequired
           />
           {

--- a/src/contrib/google/sheets/LookupSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/LookupSpreadsheetOptions.test.tsx
@@ -24,7 +24,6 @@ import {
   makeTemplateExpression,
   makeVariableExpression,
 } from "@/runtime/expressionCreators";
-import { useAuthOptions } from "@/hooks/auth";
 import { validateRegistryId } from "@/types/helpers";
 import selectEvent from "react-select-event";
 import { render } from "@/pageEditor/testHelpers";

--- a/src/contrib/google/sheets/LookupSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/LookupSpreadsheetOptions.test.tsx
@@ -25,20 +25,17 @@ import {
   makeVariableExpression,
 } from "@/runtime/expressionCreators";
 import { useAuthOptions } from "@/hooks/auth";
-import { uuidv4, validateRegistryId } from "@/types/helpers";
+import { validateRegistryId } from "@/types/helpers";
 import selectEvent from "react-select-event";
-import { noop } from "lodash";
 import { render } from "@/pageEditor/testHelpers";
 import {
   sanitizedServiceConfigurationFactory,
   uuidSequence,
 } from "@/testUtils/factories";
 import { services, sheets } from "@/background/messenger/api";
-import { syncFlagOn } from "@/store/syncFlags";
-import useFlags from "@/hooks/useFlags";
 import {
-  isGoogleSupported,
   isGoogleInitialized,
+  isGoogleSupported,
 } from "@/contrib/google/initGoogle";
 
 const TEST_SPREADSHEET_ID = uuidSequence(1);
@@ -84,35 +81,7 @@ const getHeadersMock = sheets.getHeaders as jest.MockedFunction<
   typeof sheets.getHeaders
 >;
 
-const useAuthOptionsMock = useAuthOptions as jest.MockedFunction<
-  typeof useAuthOptions
->;
-
-jest.mock("@/store/syncFlags", () => ({
-  syncFlagOn: jest.fn(),
-}));
-
-const syncFlagOnMock = syncFlagOn as jest.MockedFunction<typeof syncFlagOn>;
-
-jest.mock("@/hooks/useFlags", () => ({
-  __esModule: true,
-  default: jest.fn(),
-}));
-
-const useFlagsMock = useFlags as jest.MockedFunction<typeof useFlags>;
-
-function mockFlagOn(on = true) {
-  syncFlagOnMock.mockReturnValue(on);
-  useFlagsMock.mockReturnValue({
-    permit: jest.fn(),
-    restrict: jest.fn(),
-    flagOn: jest.fn(() => on),
-    flagOff: jest.fn(),
-  });
-}
-
 beforeEach(() => {
-  mockFlagOn(false);
   isGoogleInitializedMock.mockReturnValue(true);
   isGoogleSupportedMock.mockReturnValue(true);
 });
@@ -203,66 +172,6 @@ describe("LookupSpreadsheetOptions", () => {
     expect(rendered.asFragment()).toMatchSnapshot();
   });
 
-  it("should show tab names automatically when config is selected, with null spreadsheetId value and empty nunjucks tabName", async () => {
-    useAuthOptionsMock.mockReturnValue([
-      [
-        // Provide 2 so ServiceSelectWidget won't select one by default
-        {
-          label: "Test 1",
-          value: uuidv4(),
-          local: true,
-          serviceId: validateRegistryId("google/sheet"),
-        },
-        {
-          label: "Test 2",
-          value: uuidv4(),
-          local: true,
-          serviceId: validateRegistryId("google/sheet"),
-        },
-      ],
-      noop,
-    ]);
-
-    render(<LookupSpreadsheetOptions name="" configKey="config" />, {
-      initialValues: {
-        // This state happens when a user first adds a Google Sheets brick to a new mod
-        config: {
-          // Causes integration configuration checker to be shown
-          spreadsheetId: null,
-          tabName: makeTemplateExpression("nunjucks", ""),
-          header: makeTemplateExpression("nunjucks", ""),
-          query: makeTemplateExpression("nunjucks", ""),
-          multi: false,
-        },
-        services: [],
-      },
-    });
-
-    await waitForEffect();
-
-    // Simulate user selecting a sheet integration configuration
-    const spreadsheetSelect = await screen.findByLabelText("Spreadsheet");
-    await act(async () => {
-      await selectEvent.select(spreadsheetSelect, "Test 1");
-    });
-
-    // Tab1 will be picked automatically since it's first in the list
-    expect(screen.getByText("Tab1")).toBeVisible();
-
-    // Ensure headers loaded in for Tab1
-    const headerSelect = await screen.findByLabelText("Column Header");
-    selectEvent.openMenu(headerSelect);
-    // Input value and select option in the dropdown, 2 instances
-    const column1Options = screen.getAllByText("Column1");
-    expect(column1Options).toHaveLength(2);
-    expect(column1Options[0]).toBeVisible();
-    expect(column1Options[1]).toBeVisible();
-
-    expect(screen.getByText("Column2")).toBeVisible();
-    expect(screen.queryByText("Foo")).not.toBeInTheDocument();
-    expect(screen.queryByText("Bar")).not.toBeInTheDocument();
-  });
-
   it("loads in tab names and header values with string spreadsheetId value and empty nunjucks tabName", async () => {
     render(<LookupSpreadsheetOptions name="" configKey="config" />, {
       initialValues: {
@@ -318,8 +227,6 @@ describe("LookupSpreadsheetOptions", () => {
   });
 
   it("loads in tab names and header values with mod input variable spreadsheetId value and empty nunjucks tabName", async () => {
-    mockFlagOn();
-
     render(<LookupSpreadsheetOptions name="" configKey="config" />, {
       initialValues: {
         config: {
@@ -376,33 +283,7 @@ describe("LookupSpreadsheetOptions", () => {
     expect(screen.queryByText("Column2")).not.toBeInTheDocument();
   });
 
-  it("does not clear initial tabName and header values with string spreadsheetId value and flag off", async () => {
-    render(<LookupSpreadsheetOptions name="" configKey="config" />, {
-      initialValues: {
-        config: {
-          spreadsheetId: TEST_SPREADSHEET_ID,
-          tabName: "Tab2",
-          header: "Bar",
-          query: makeTemplateExpression("nunjucks", "testQuery"),
-          multi: true,
-        },
-      },
-    });
-
-    await waitForEffect();
-
-    // Ensure title loaded
-    expect(screen.getByDisplayValue("Test Sheet")).toBeVisible();
-    // Ensure tab name has not changed -- use getByText for react-select value
-    expect(screen.getByText("Tab2")).toBeVisible();
-    // Ensure header has not changed -- use getByText for react-select value
-    expect(screen.getByText("Bar")).toBeVisible();
-    expect(screen.getByDisplayValue("testQuery")).toBeVisible();
-  });
-
-  it("does not clear initial tabName and header values with string spreadsheetId value and flag on", async () => {
-    mockFlagOn();
-
+  it("does not clear initial tabName and header values with string spreadsheetId value", async () => {
     render(<LookupSpreadsheetOptions name="" configKey="config" />, {
       initialValues: {
         config: {
@@ -427,8 +308,6 @@ describe("LookupSpreadsheetOptions", () => {
   });
 
   it("does not clear initial variable values", async () => {
-    mockFlagOn();
-
     render(<LookupSpreadsheetOptions name="" configKey="config" />, {
       initialValues: {
         config: {

--- a/src/contrib/google/sheets/LookupSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/LookupSpreadsheetOptions.tsx
@@ -31,15 +31,11 @@ import { isEmpty, isEqual } from "lodash";
 import { isExpression, isTemplateExpression } from "@/runtime/mapArgs";
 import useSpreadsheetId from "@/contrib/google/sheets/useSpreadsheetId";
 import { dereference } from "@/validators/generic";
-import {
-  BASE_SHEET_SCHEMA,
-  SHEET_SERVICE_SCHEMA,
-} from "@/contrib/google/sheets/schemas";
+import { BASE_SHEET_SCHEMA } from "@/contrib/google/sheets/schemas";
 import Loader from "@/components/Loader";
 import { FormErrorContext } from "@/components/form/FormErrorContext";
 import { useOnChangeEffect } from "@/contrib/google/sheets/useOnChangeEffect";
 import { requireGoogleHOC } from "@/contrib/google/sheets/RequireGoogleApi";
-import useFlags from "@/hooks/useFlags";
 import { makeTemplateExpression } from "@/runtime/expressionCreators";
 
 const HeaderField: React.FunctionComponent<{
@@ -129,7 +125,6 @@ const LookupSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
 }) => {
   const basePath = joinName(name, configKey);
   const spreadsheetId = useSpreadsheetId(basePath);
-  const { flagOn } = useFlags();
 
   const [{ value: tabNameValue }] = useField<string | Expression>(
     joinName(basePath, "tabName")
@@ -156,15 +151,6 @@ const LookupSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
     BASE_SHEET_SCHEMA
   );
 
-  const oldSheetSchema: Schema = {
-    title: "Spreadsheet",
-    oneOf: [SHEET_SERVICE_SCHEMA, sheetSchema ?? BASE_SHEET_SCHEMA],
-  };
-
-  const sheetFieldSchema = flagOn("gsheets-mod-inputs")
-    ? sheetSchema
-    : oldSheetSchema;
-
   return (
     <div className="my-2">
       {isLoadingSheetSchema ? (
@@ -179,7 +165,7 @@ const LookupSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
         >
           <SchemaField
             name={joinName(basePath, "spreadsheetId")}
-            schema={sheetFieldSchema}
+            schema={sheetSchema}
             isRequired
           />
           {

--- a/src/contrib/google/sheets/__snapshots__/AppendSpreadsheetOptions.test.tsx.snap
+++ b/src/contrib/google/sheets/__snapshots__/AppendSpreadsheetOptions.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`AppendSpreadsheetOptions should render successfully with string spreads
           class="label form-label col-form-label col-xl-2 col-lg-3"
           for="config.spreadsheetId"
         >
-          Spreadsheet
+          Google Sheet
         </label>
         <div
           class="col-xl-10 col-lg-9"
@@ -412,7 +412,7 @@ exports[`AppendSpreadsheetOptions should render successfully with string spreads
           class="label form-label col-form-label col-xl-2 col-lg-3"
           for="config.spreadsheetId"
         >
-          Spreadsheet
+          Google Sheet
         </label>
         <div
           class="col-xl-10 col-lg-9"
@@ -809,7 +809,7 @@ exports[`AppendSpreadsheetOptions should render successfully with string spreads
           class="label form-label col-form-label col-xl-2 col-lg-3"
           for="config.spreadsheetId"
         >
-          Spreadsheet
+          Google Sheet
         </label>
         <div
           class="col-xl-10 col-lg-9"

--- a/src/contrib/google/sheets/__snapshots__/LookupSpreadsheetOptions.test.tsx.snap
+++ b/src/contrib/google/sheets/__snapshots__/LookupSpreadsheetOptions.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`LookupSpreadsheetOptions should render successfully with string spreads
           class="label form-label col-form-label col-xl-2 col-lg-3"
           for="config.spreadsheetId"
         >
-          Spreadsheet
+          Google Sheet
         </label>
         <div
           class="col-xl-10 col-lg-9"
@@ -482,7 +482,7 @@ exports[`LookupSpreadsheetOptions should render successfully with string spreads
           class="label form-label col-form-label col-xl-2 col-lg-3"
           for="config.spreadsheetId"
         >
-          Spreadsheet
+          Google Sheet
         </label>
         <div
           class="col-xl-10 col-lg-9"
@@ -949,7 +949,7 @@ exports[`LookupSpreadsheetOptions should render successfully with string spreads
           class="label form-label col-form-label col-xl-2 col-lg-3"
           for="config.spreadsheetId"
         >
-          Spreadsheet
+          Google Sheet
         </label>
         <div
           class="col-xl-10 col-lg-9"

--- a/src/pageEditor/tabs/recipeOptionsDefinitions/RecipeOptionsDefinition.tsx
+++ b/src/pageEditor/tabs/recipeOptionsDefinitions/RecipeOptionsDefinition.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useState } from "react";
 import FieldRuntimeContext, {
   type RuntimeContext,
 } from "@/components/fields/schemaFields/FieldRuntimeContext";
@@ -48,15 +48,21 @@ import { actions } from "@/pageEditor/slices/editorSlice";
 import Effect from "@/components/Effect";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { useRecipe } from "@/recipes/recipesHooks";
-import useFlags from "@/hooks/useFlags";
 
-const baseFieldTypes = [
+const fieldTypes = [
   ...FORM_FIELD_TYPE_OPTIONS.filter(
     (type) => !["File", "Image crop"].includes(type.label)
   ),
   {
     label: "Database selector",
     value: stringifyUiType({ propertyType: "string", uiWidget: "database" }),
+  },
+  {
+    label: "Google Sheet",
+    value: stringifyUiType({
+      propertyType: "string",
+      uiWidget: "googleSheet",
+    }),
   },
 ];
 
@@ -74,24 +80,6 @@ const RecipeOptionsDefinition: React.VFC = () => {
   const [activeField, setActiveField] = useState<string>();
   const recipeId = useSelector(selectActiveRecipeId);
   const { data: recipe, isFetching, error } = useRecipe(recipeId);
-
-  const { flagOn } = useFlags();
-  const fieldTypes = useMemo(() => {
-    if (!flagOn("gsheets-mod-inputs")) {
-      return baseFieldTypes;
-    }
-
-    return [
-      ...baseFieldTypes,
-      {
-        label: "Google Sheet",
-        value: stringifyUiType({
-          propertyType: "string",
-          uiWidget: "googleSheet",
-        }),
-      },
-    ];
-  }, [flagOn]);
 
   const savedOptions = recipe?.options;
   const dirtyOptions = useSelector(


### PR DESCRIPTION
## What does this PR do?

- Closes the loop on the recent GSheets work by removing the feature flag code from the extension
- This will "launch" the gsheets mod inputs change to all users upon the next CWS update (cc @corinnemayans, @BrandonPxBx  )

## Future Work

- We can remove the `gsheets-mod-inputs` feature flag on the back end at some point, although it doesn't really hurt anything to leave it there for now

## Checklist

- [x] Add tests - Updated/fixed tests to remove the extra cases for the pre-feature-flag code/logic
- [x] Designate a primary reviewer - @twschiller 
