### PR TITLE
Add branch name & job id to Rainforest run name

### DIFF
--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -82,7 +82,7 @@ jobs:
         #   they're all using the same server
         # Use --fail-fast so that we're not using GitHub build minutes if not necessary
         run: |
-          ./rainforest run --fail-fast --run-group $RUN_GROUP --release "${{ github.sha }}" --conflict cancel-all
+          ./rainforest run --fail-fast --description "pixiebrix-extension - ${{ github.ref_name }} ${{ github.job }}" --run-group $RUN_GROUP --release "${{ github.sha }}" --conflict cancel-all
         env:
           RAINFOREST_API_TOKEN: ${{ secrets.RAINFORESTQA_TOKEN }}
           # The run group for tests to run during CI, now has start URL built-in

--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -82,7 +82,7 @@ jobs:
         #   they're all using the same server
         # Use --fail-fast so that we're not using GitHub build minutes if not necessary
         run: |
-          ./rainforest run --fail-fast --description "CI automatic run" --run-group $RUN_GROUP --release "${{ github.sha }}" --conflict cancel-all
+          ./rainforest run --fail-fast --run-group $RUN_GROUP --release "${{ github.sha }}" --conflict cancel-all
         env:
           RAINFOREST_API_TOKEN: ${{ secrets.RAINFORESTQA_TOKEN }}
           # The run group for tests to run during CI, now has start URL built-in


### PR DESCRIPTION
## What does this PR do?

We currently call all Rainforest runs triggered by our workflow "CI automatic run". This makes it a little hard to see at a glance what caused test failures:

<img width="432" alt="Screen Shot 2023-04-19 at 4 59 20 PM" src="https://user-images.githubusercontent.com/36575242/233224243-1cb11249-2839-44d2-a74c-0a3891b90c72.png">

This changes the run name to be `pixiebrix-extension - <branch_name> <job_id>`, e.g. `pixiebrix-extension - release/1.0.0 42`, which includes the branch name & the workflow job id respectively. The commit hash is already uploaded to Rainforest under the `--release` flag.

## Checklist

- [x] Add tests - n/a
- [x] Designate a primary reviewer @BLoe 
