### PR TITLE
#5566: don't show both loader and content while panel content is re-fetching

### DIFF
--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -50,25 +50,19 @@ export type PanelContext = MessageContext & {
 };
 
 const BodyContainer: React.FC<
-  BodyProps & {
-    isFetching: boolean;
-    onAction: (action: SubmitPanelAction) => void;
-  }
-> = ({ blockId, body, isFetching, onAction, meta }) => (
-  <>
-    {isFetching && <Loader />}
-
-    <div className="full-height" data-block-id={blockId}>
-      <ReactShadowRoot>
-        <RendererComponent
-          blockId={blockId}
-          body={body}
-          meta={meta}
-          onAction={onAction}
-        />
-      </ReactShadowRoot>
-    </div>
-  </>
+  // In the future, may want to support providing isFetching to show a loading indicator/badge over the previous content
+  BodyProps & { onAction: (action: SubmitPanelAction) => void }
+> = ({ blockId, body, onAction, meta }) => (
+  <div className="full-height" data-block-id={blockId}>
+    <ReactShadowRoot>
+      <RendererComponent
+        blockId={blockId}
+        body={body}
+        meta={meta}
+        onAction={onAction}
+      />
+    </ReactShadowRoot>
+  </div>
 );
 
 type State = {
@@ -236,13 +230,7 @@ const PanelBody: React.FunctionComponent<{
     );
   }
 
-  return (
-    <BodyContainer
-      {...state.component}
-      isFetching={state.isFetching}
-      onAction={onAction}
-    />
-  );
+  return <BodyContainer {...state.component} onAction={onAction} />;
 };
 
 export default PanelBody;


### PR DESCRIPTION
## What does this PR do?

- Closes: #5566 
- Removes loading indicator when PanelBody content is re-fetching

## Demo

- https://www.loom.com/share/12dbeb4d9dae442e8fd8af2971b1cbf5

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer
