### PR TITLE
UI paper-cut fix - center-align text on the finish screen of sidebar activate panel

### DIFF
--- a/src/sidebar/activateRecipe/ActivateRecipePanel.module.scss
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.module.scss
@@ -35,6 +35,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  text-align: center;
 }
 
 .footer {

--- a/src/utils/includesQuickBarExtensionPoint.ts
+++ b/src/utils/includesQuickBarExtensionPoint.ts
@@ -24,7 +24,7 @@ export default async function includesQuickBarExtensionPoint(
   extensionPointConfigs?: ResolvedExtensionDefinition[]
 ): Promise<boolean> {
   if (!extensionPointConfigs) {
-    return;
+    return false;
   }
 
   for (const { id } of extensionPointConfigs) {


### PR DESCRIPTION
## What does this PR do?

- Quick fix to the text alignment on the final sidebar activate panel view

- [ ] Add tests
- [x] Designate a primary reviewer - @twschiller 
