### PR TITLE
#5533 Enable in-marketplace one-click activation for mods with built-in service configs

### DIFF
--- a/src/activation/useWizard.test.tsx
+++ b/src/activation/useWizard.test.tsx
@@ -24,6 +24,11 @@ import { propertiesToSchema } from "@/validators/generic";
 jest.mock("@/components/auth/AuthWidget", () => {});
 jest.mock("react-redux");
 jest.mock("connected-react-router");
+jest.mock("@/services/api", () => ({
+  useGetServiceAuthsQuery: jest.fn().mockReturnValue({
+    data: [],
+  }),
+}));
 
 describe("useWizard", () => {
   test("show personalized tab", () => {

--- a/src/activation/useWizard.ts
+++ b/src/activation/useWizard.ts
@@ -35,7 +35,7 @@ import * as Yup from "yup";
 import useAsyncRecipeOptionsValidationSchema from "@/hooks/useAsyncRecipeOptionsValidationSchema";
 import { type RecipeDefinition } from "@/types/recipeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { useDefaultAuthsByRequiredServiceIds } from "@/hooks/auth";
+import { useAuthsByRequiredServiceIds } from "@/hooks/auth";
 
 const STEPS: WizardStep[] = [
   // OptionsBody takes only a slice of the RecipeDefinition, however the types aren't set up in a way for TypeScript
@@ -58,8 +58,8 @@ function useWizard(
   const [optionsValidationSchema] = useAsyncRecipeOptionsValidationSchema(
     blueprint.options?.schema
   );
-  const { builtInServiceAuths } =
-    useDefaultAuthsByRequiredServiceIds(blueprint);
+  const { builtInServiceAuths, personalOrSharedServiceAuths } =
+    useAuthsByRequiredServiceIds(blueprint);
 
   return useMemo(() => {
     const extensionPoints = blueprint.extensionPoints ?? [];
@@ -103,7 +103,10 @@ function useWizard(
       services: serviceIds.map((id) => ({
         id,
         // eslint-disable-next-line security/detect-object-injection -- is a registry id
-        config: installedServices[id] ?? builtInServiceAuths[id],
+        config:
+          installedServices[id] ??
+          personalOrSharedServiceAuths[id] ??
+          builtInServiceAuths[id],
       })),
       optionsArgs: mapValues(
         blueprint.options?.schema?.properties ?? {},

--- a/src/activation/useWizard.ts
+++ b/src/activation/useWizard.ts
@@ -35,7 +35,7 @@ import * as Yup from "yup";
 import useAsyncRecipeOptionsValidationSchema from "@/hooks/useAsyncRecipeOptionsValidationSchema";
 import { type RecipeDefinition } from "@/types/recipeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { useAuthsByRequiredServiceIds } from "@/hooks/auth";
+import { useDefaultAuthOptions } from "@/hooks/auth";
 
 const STEPS: WizardStep[] = [
   // OptionsBody takes only a slice of the RecipeDefinition, however the types aren't set up in a way for TypeScript
@@ -58,7 +58,7 @@ function useWizard(
   const [optionsValidationSchema] = useAsyncRecipeOptionsValidationSchema(
     blueprint.options?.schema
   );
-  const { builtInServiceAuths } = useAuthsByRequiredServiceIds(blueprint);
+  const { defaultAuthOptions } = useDefaultAuthOptions(blueprint);
 
   return useMemo(() => {
     const extensionPoints = blueprint.extensionPoints ?? [];
@@ -101,8 +101,9 @@ function useWizard(
       ),
       services: serviceIds.map((id) => ({
         id,
+        // Prefer the installed config for reinstall cases, otherwise use the default
         // eslint-disable-next-line security/detect-object-injection -- is a registry id
-        config: installedServices[id] ?? builtInServiceAuths[id],
+        config: installedServices[id] ?? defaultAuthOptions[id]?.value,
       })),
       optionsArgs: mapValues(
         blueprint.options?.schema?.properties ?? {},
@@ -136,9 +137,9 @@ function useWizard(
     blueprint.extensionPoints,
     blueprint.metadata.id,
     blueprint.options?.schema,
-    builtInServiceAuths,
     installedExtensions,
     optionsValidationSchema,
+    defaultAuthOptions,
   ]);
 }
 

--- a/src/activation/useWizard.ts
+++ b/src/activation/useWizard.ts
@@ -35,7 +35,7 @@ import * as Yup from "yup";
 import useAsyncRecipeOptionsValidationSchema from "@/hooks/useAsyncRecipeOptionsValidationSchema";
 import { type RecipeDefinition } from "@/types/recipeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { useBuiltInServiceAuths } from "@/hooks/auth";
+import { useBuiltInAuthsByRequiredServiceId } from "@/hooks/auth";
 
 const STEPS: WizardStep[] = [
   // OptionsBody takes only a slice of the RecipeDefinition, however the types aren't set up in a way for TypeScript
@@ -58,7 +58,7 @@ function useWizard(
   const [optionsValidationSchema] = useAsyncRecipeOptionsValidationSchema(
     blueprint.options?.schema
   );
-  const builtInServices = useBuiltInServiceAuths(blueprint);
+  const { builtInServiceAuths } = useBuiltInAuthsByRequiredServiceId(blueprint);
 
   return useMemo(() => {
     const extensionPoints = blueprint.extensionPoints ?? [];
@@ -102,7 +102,7 @@ function useWizard(
       services: serviceIds.map((id) => ({
         id,
         // eslint-disable-next-line security/detect-object-injection -- is a registry id
-        config: installedServices[id] ?? builtInServices[id],
+        config: installedServices[id] ?? builtInServiceAuths[id],
       })),
       optionsArgs: mapValues(
         blueprint.options?.schema?.properties ?? {},
@@ -132,7 +132,14 @@ function useWizard(
     });
 
     return [steps, initialValues, validationSchema];
-  }, [blueprint, installedExtensions, optionsValidationSchema]);
+  }, [
+    blueprint.extensionPoints,
+    blueprint.metadata.id,
+    blueprint.options?.schema,
+    builtInServiceAuths,
+    installedExtensions,
+    optionsValidationSchema,
+  ]);
 }
 
 export default useWizard;

--- a/src/activation/useWizard.ts
+++ b/src/activation/useWizard.ts
@@ -58,8 +58,7 @@ function useWizard(
   const [optionsValidationSchema] = useAsyncRecipeOptionsValidationSchema(
     blueprint.options?.schema
   );
-  const { builtInServiceAuths, personalOrSharedServiceAuths } =
-    useAuthsByRequiredServiceIds(blueprint);
+  const { builtInServiceAuths } = useAuthsByRequiredServiceIds(blueprint);
 
   return useMemo(() => {
     const extensionPoints = blueprint.extensionPoints ?? [];
@@ -103,10 +102,7 @@ function useWizard(
       services: serviceIds.map((id) => ({
         id,
         // eslint-disable-next-line security/detect-object-injection -- is a registry id
-        config:
-          installedServices[id] ??
-          personalOrSharedServiceAuths[id] ??
-          builtInServiceAuths[id],
+        config: installedServices[id] ?? builtInServiceAuths[id],
       })),
       optionsArgs: mapValues(
         blueprint.options?.schema?.properties ?? {},

--- a/src/activation/useWizard.ts
+++ b/src/activation/useWizard.ts
@@ -35,7 +35,7 @@ import * as Yup from "yup";
 import useAsyncRecipeOptionsValidationSchema from "@/hooks/useAsyncRecipeOptionsValidationSchema";
 import { type RecipeDefinition } from "@/types/recipeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { useBuiltInAuthsByRequiredServiceId } from "@/hooks/auth";
+import { useBuiltInAuthsByRequiredServiceIds } from "@/hooks/auth";
 
 const STEPS: WizardStep[] = [
   // OptionsBody takes only a slice of the RecipeDefinition, however the types aren't set up in a way for TypeScript
@@ -58,7 +58,8 @@ function useWizard(
   const [optionsValidationSchema] = useAsyncRecipeOptionsValidationSchema(
     blueprint.options?.schema
   );
-  const { builtInServiceAuths } = useBuiltInAuthsByRequiredServiceId(blueprint);
+  const { builtInServiceAuths } =
+    useBuiltInAuthsByRequiredServiceIds(blueprint);
 
   return useMemo(() => {
     const extensionPoints = blueprint.extensionPoints ?? [];

--- a/src/activation/useWizard.ts
+++ b/src/activation/useWizard.ts
@@ -74,6 +74,8 @@ function useWizard(
       extensionPoints.flatMap((x) => Object.values(x.services ?? {}))
     );
 
+    const builtInServices = [];
+
     const steps = STEPS.filter((step) => {
       switch (step.key) {
         case "services": {
@@ -101,6 +103,7 @@ function useWizard(
         id,
         // eslint-disable-next-line security/detect-object-injection -- is a registry id
         config: installedServices[id],
+        // config: installedServices[id] ?? builtInServices[id]
       })),
       optionsArgs: mapValues(
         blueprint.options?.schema?.properties ?? {},

--- a/src/activation/useWizard.ts
+++ b/src/activation/useWizard.ts
@@ -35,7 +35,7 @@ import * as Yup from "yup";
 import useAsyncRecipeOptionsValidationSchema from "@/hooks/useAsyncRecipeOptionsValidationSchema";
 import { type RecipeDefinition } from "@/types/recipeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { useBuiltInAuthsByRequiredServiceIds } from "@/hooks/auth";
+import { useDefaultAuthsByRequiredServiceIds } from "@/hooks/auth";
 
 const STEPS: WizardStep[] = [
   // OptionsBody takes only a slice of the RecipeDefinition, however the types aren't set up in a way for TypeScript
@@ -59,7 +59,7 @@ function useWizard(
     blueprint.options?.schema
   );
   const { builtInServiceAuths } =
-    useBuiltInAuthsByRequiredServiceIds(blueprint);
+    useDefaultAuthsByRequiredServiceIds(blueprint);
 
   return useMemo(() => {
     const extensionPoints = blueprint.extensionPoints ?? [];

--- a/src/activation/useWizard.ts
+++ b/src/activation/useWizard.ts
@@ -35,6 +35,7 @@ import * as Yup from "yup";
 import useAsyncRecipeOptionsValidationSchema from "@/hooks/useAsyncRecipeOptionsValidationSchema";
 import { type RecipeDefinition } from "@/types/recipeTypes";
 import { type Schema } from "@/types/schemaTypes";
+import { useBuiltInServiceAuths } from "@/hooks/auth";
 
 const STEPS: WizardStep[] = [
   // OptionsBody takes only a slice of the RecipeDefinition, however the types aren't set up in a way for TypeScript
@@ -57,6 +58,7 @@ function useWizard(
   const [optionsValidationSchema] = useAsyncRecipeOptionsValidationSchema(
     blueprint.options?.schema
   );
+  const builtInServices = useBuiltInServiceAuths(blueprint);
 
   return useMemo(() => {
     const extensionPoints = blueprint.extensionPoints ?? [];
@@ -73,8 +75,6 @@ function useWizard(
     const serviceIds = uniq(
       extensionPoints.flatMap((x) => Object.values(x.services ?? {}))
     );
-
-    const builtInServices = [];
 
     const steps = STEPS.filter((step) => {
       switch (step.key) {
@@ -102,8 +102,7 @@ function useWizard(
       services: serviceIds.map((id) => ({
         id,
         // eslint-disable-next-line security/detect-object-injection -- is a registry id
-        config: installedServices[id],
-        // config: installedServices[id] ?? builtInServices[id]
+        config: installedServices[id] ?? builtInServices[id],
       })),
       optionsArgs: mapValues(
         blueprint.options?.schema?.properties ?? {},

--- a/src/auth/authTypes.ts
+++ b/src/auth/authTypes.ts
@@ -24,12 +24,14 @@ import { type Except } from "type-fest";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
 
+export type AuthSharing = "private" | "shared" | "built-in";
 export interface AuthOption {
   label: string;
   /** The UUID of the auth credential **/
   value: UUID;
   serviceId: RegistryId;
   local: boolean;
+  sharingType: AuthSharing;
 }
 
 export type UserData = Partial<{

--- a/src/background/starterBlueprints.test.ts
+++ b/src/background/starterBlueprints.test.ts
@@ -28,17 +28,17 @@ import { isLinked } from "@/auth/token";
 import {
   extensionFactory,
   extensionPointConfigFactory,
+  getRecipeWithBuiltInServiceAuths,
   organizationFactory,
   recipeFactory,
   sanitizedAuthFactory,
-  sanitizedAuthServiceFactory,
 } from "@/testUtils/factories";
 import { refreshRegistries } from "./refreshRegistries";
 import {
   type IExtension,
   type PersistedExtension,
 } from "@/types/extensionTypes";
-import { uuidv4, validateRegistryId } from "@/types/helpers";
+import { uuidv4 } from "@/types/helpers";
 import { type RegistryId } from "@/types/registryTypes";
 import { type OutputKey } from "@/types/runtimeTypes";
 
@@ -73,46 +73,6 @@ beforeEach(async () => {
 
   jest.clearAllMocks();
 });
-
-const getRecipeWithBuiltInServiceAuths = () => {
-  const extensionServices = {
-    service1: "@pixiebrix/service1",
-    service2: "@pixiebrix/service2",
-  } as Record<OutputKey, RegistryId>;
-
-  const extensionPointDefinition = extensionPointConfigFactory({
-    services: extensionServices,
-  });
-
-  const recipe = recipeFactory({
-    extensionPoints: [extensionPointDefinition],
-  });
-
-  const builtInServiceAuths = [
-    sanitizedAuthFactory({
-      service: sanitizedAuthServiceFactory({
-        config: {
-          metadata: {
-            id: validateRegistryId("@pixiebrix/service1"),
-            name: "Service 1",
-          },
-        },
-      }),
-    }),
-    sanitizedAuthFactory({
-      service: sanitizedAuthServiceFactory({
-        config: {
-          metadata: {
-            id: validateRegistryId("@pixiebrix/service2"),
-            name: "Service 2",
-          },
-        },
-      }),
-    }),
-  ];
-
-  return { recipe, builtInServiceAuths };
-};
 
 describe("installStarterBlueprints", () => {
   test("user has starter blueprints available to install", async () => {

--- a/src/components/fields/schemaFields/widgets/ServiceSelectWidget.stories.tsx
+++ b/src/components/fields/schemaFields/widgets/ServiceSelectWidget.stories.tsx
@@ -51,12 +51,14 @@ SelectedOption.args = {
       local: true,
       value: uuidv4(),
       serviceId: validateRegistryId("@story/service"),
+      sharingType: "private",
     },
     {
       label: "Team Config",
       local: false,
       value: uuidv4(),
       serviceId: validateRegistryId("@story/service"),
+      sharingType: "shared",
     },
   ],
 };

--- a/src/components/fields/schemaFields/widgets/ServiceWidget.test.tsx
+++ b/src/components/fields/schemaFields/widgets/ServiceWidget.test.tsx
@@ -84,13 +84,26 @@ describe("ServiceWidget", () => {
   it("should not default if there are multiple auth options", async () => {
     const serviceId = validateRegistryId("jest/api");
 
-    useAuthOptionsMock.mockReturnValue([
-      [
-        { serviceId, label: "Test 1", value: uuidv4(), local: true },
-        { serviceId, label: "Test 2", value: uuidv4(), local: true },
+    useAuthOptionsMock.mockReturnValue({
+      authOptions: [
+        {
+          serviceId,
+          label: "Test 1",
+          value: uuidv4(),
+          local: true,
+          sharingType: "built-in",
+        },
+        {
+          serviceId,
+          label: "Test 2",
+          value: uuidv4(),
+          local: true,
+          sharingType: "built-in",
+        },
       ],
-      noop,
-    ]);
+      refresh: noop,
+      isLoading: false,
+    });
 
     const schema = {
       $ref: `https://app.pixiebrix.com/schemas/services/${serviceId}`,
@@ -108,10 +121,19 @@ describe("ServiceWidget", () => {
   it("should default to only configuration", async () => {
     const serviceId = validateRegistryId("jest/api");
 
-    useAuthOptionsMock.mockReturnValue([
-      [{ serviceId, label: "Test 1", value: uuidv4(), local: true }],
-      noop,
-    ]);
+    useAuthOptionsMock.mockReturnValue({
+      authOptions: [
+        {
+          serviceId,
+          label: "Test 1",
+          value: uuidv4(),
+          local: true,
+          sharingType: "built-in",
+        },
+      ],
+      refresh: noop,
+      isLoading: false,
+    });
 
     const schema = {
       $ref: `https://app.pixiebrix.com/schemas/services/${serviceId}`,

--- a/src/components/fields/schemaFields/widgets/ServiceWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/ServiceWidget.tsx
@@ -173,7 +173,7 @@ const ServiceWidget: React.FC<ServiceWidgetProps> = ({
   ...props
 }) => {
   const { schema } = props;
-  const [authOptions, refreshOptions] = useAuthOptions();
+  const { authOptions, refresh: refreshOptions } = useAuthOptions();
   const { values: root, setValues: setRootValues } =
     useFormikContext<ServiceSlice>();
   const [{ value, ...field }, , helpers] =

--- a/src/contrib/automationanywhere/BotOptions.test.tsx
+++ b/src/contrib/automationanywhere/BotOptions.test.tsx
@@ -48,7 +48,11 @@ jest.mock("@/services/useDependency", () =>
   })
 );
 jest.mock("@/hooks/auth", () => ({
-  useAuthOptions: jest.fn().mockReturnValue([[], jest.fn()]),
+  useAuthOptions: jest.fn().mockReturnValue({
+    authOptions: [],
+    refresh: jest.fn(),
+    isLoading: false,
+  }),
 }));
 jest.mock("@/hooks/auth");
 jest.mock("@/contentScript/messenger/api");

--- a/src/contrib/uipath/LocalProcessOptions.test.tsx
+++ b/src/contrib/uipath/LocalProcessOptions.test.tsx
@@ -135,7 +135,11 @@ describe("UiPath LocalProcess Options", () => {
   test("Can render consent code and service selector", async () => {
     (
       auth.useAuthOptions as jest.MockedFunction<typeof auth.useAuthOptions>
-    ).mockReturnValue([[], jest.fn()]);
+    ).mockReturnValue({
+      authOptions: [],
+      refresh: jest.fn(),
+      isLoading: false,
+    });
     (
       contentScriptApi.getProcesses as jest.MockedFunction<
         typeof contentScriptApi.getProcesses
@@ -180,10 +184,19 @@ describe("UiPath LocalProcess Options", () => {
     });
     (
       auth.useAuthOptions as jest.MockedFunction<typeof auth.useAuthOptions>
-    ).mockReturnValue([
-      [{ label: "Test Auth", value: config, serviceId, local: true }],
-      jest.fn(),
-    ]);
+    ).mockReturnValue({
+      authOptions: [
+        {
+          label: "Test Auth",
+          value: config,
+          serviceId,
+          local: true,
+          sharingType: "private",
+        },
+      ],
+      refresh: jest.fn(),
+      isLoading: false,
+    });
     (
       contentScriptApi.getProcesses as jest.MockedFunction<
         typeof contentScriptApi.getProcesses

--- a/src/contrib/uipath/ProcessOptions.test.tsx
+++ b/src/contrib/uipath/ProcessOptions.test.tsx
@@ -47,7 +47,9 @@ jest.mock("@/services/useDependency", () =>
   })
 );
 jest.mock("@/hooks/auth", () => ({
-  useAuthOptions: jest.fn().mockReturnValue([[], jest.fn()]),
+  useAuthOptions: jest
+    .fn()
+    .mockReturnValue({ authOptions: [], refresh: jest.fn(), isLoading: false }),
 }));
 jest.mock("@/contrib/uipath/uipathHooks");
 jest.mock("@/hooks/auth");

--- a/src/extensionConsole/pages/activateExtension/ActivatePage.tsx
+++ b/src/extensionConsole/pages/activateExtension/ActivatePage.tsx
@@ -38,7 +38,7 @@ const ActivatePage: React.FunctionComponent = () => {
     error,
   } = useFetch<CloudExtension>(`/api/extensions/${extensionId}/`);
 
-  const [authOptions, refreshAuthOptions] = useAuthOptions();
+  const { authOptions, refresh: refreshAuthOptions } = useAuthOptions();
 
   return (
     <Page

--- a/src/extensionConsole/pages/activateRecipe/ActivateWizard.test.tsx
+++ b/src/extensionConsole/pages/activateRecipe/ActivateWizard.test.tsx
@@ -72,6 +72,9 @@ jest.mock("@/services/api", () => ({
   useCreateDatabaseMutation: jest.fn(() => [jest.fn()]),
   useAddDatabaseToGroupMutation: jest.fn(() => [jest.fn()]),
   useCreateMilestoneMutation: jest.fn(() => [jest.fn()]),
+  useGetServiceAuthsQuery: jest
+    .fn()
+    .mockReturnValue({ data: [], isLoading: false }),
   appApi: {
     useLazyGetMeQuery: jest.fn(() => [
       jest.fn(),

--- a/src/extensionConsole/pages/activateRecipe/ServicesBody.tsx
+++ b/src/extensionConsole/pages/activateRecipe/ServicesBody.tsx
@@ -37,7 +37,7 @@ interface OwnProps {
 }
 
 const ServicesBody: React.FunctionComponent<OwnProps> = ({ blueprint }) => {
-  const [authOptions, refreshAuthOptions] = useAuthOptions();
+  const { authOptions, refresh: refreshAuthOptions } = useAuthOptions();
 
   const [field, { error }] = useField<ServiceAuthPair[]>("services");
 

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -23,9 +23,9 @@ import { useGetServiceAuthsQuery } from "@/services/api";
 import { sortBy } from "lodash";
 import { type SanitizedAuth } from "@/types/contract";
 import { type RawServiceConfiguration } from "@/types/serviceTypes";
-import { RecipeDefinition } from "@/types/recipeTypes";
-import { RegistryId } from "@/types/registryTypes";
-import { UUID } from "@/types/stringTypes";
+import { type RecipeDefinition } from "@/types/recipeTypes";
+import { type RegistryId } from "@/types/registryTypes";
+import { type UUID } from "@/types/stringTypes";
 import { getRequiredServiceIds } from "@/utils/recipeUtils";
 
 function defaultLabel(label: string): string {
@@ -68,7 +68,7 @@ function getRemoteLabel(auth: SanitizedAuth): string {
   return `${defaultLabel(auth.label)} — ${getVisibilityLabel(auth)}`;
 }
 
-function useBuiltInServiceAuths(
+export function useBuiltInServiceAuths(
   recipe: RecipeDefinition
 ): Record<RegistryId, UUID | null> {
   const { data: serviceAuths, isLoading } = useGetServiceAuthsQuery();
@@ -82,7 +82,7 @@ function useBuiltInServiceAuths(
   );
   const requiredServiceIds = getRequiredServiceIds(recipe);
 
-  return Object.entries(
+  return Object.fromEntries(
     requiredServiceIds.map((serviceId) => {
       const builtInAuth = builtInAuths.find(
         (auth) => auth.service.config.metadata.id === serviceId

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -65,7 +65,11 @@ function getRemoteLabel(auth: SanitizedAuth): string {
   return `${defaultLabel(auth.label)} — ${getVisibilityLabel(auth)}`;
 }
 
-export function useAuthOptions(): [AuthOption[], () => void, boolean] {
+export function useAuthOptions(): {
+  authOptions: AuthOption[];
+  refresh: () => void;
+  isLoading: boolean;
+} {
   // Using readRawConfigurations instead of the store for now so that we can refresh the list independent of the
   // redux store. (The option may have been added in a different tab). At some point, we'll need parts of the redux
   // store to reload if it's changed on another tab
@@ -115,19 +119,18 @@ export function useAuthOptions(): [AuthOption[], () => void, boolean] {
 
   const isLoading = isLocalLoading || isRemoteLoading;
 
-  if (isLoading === undefined) {
-    console.warn("IS LOADING UNDEFINED", isLocalLoading, isRemoteLoading);
-  }
-
-  // TODO: make return type an object instead, since we're adding isLoading
-  return [isLoading ? [] : authOptions, refresh, isLoading];
+  return {
+    authOptions: isLoading ? [] : authOptions,
+    refresh,
+    isLoading,
+  };
 }
 
 export function useDefaultAuthOptions(recipe: RecipeDefinition): {
   defaultAuthOptions: Record<RegistryId, AuthOption | null>;
   isLoading: boolean;
 } {
-  const [authOptions, , isLoading] = useAuthOptions();
+  const { authOptions, isLoading } = useAuthOptions();
 
   const requiredServiceIds = getRequiredServiceIds(recipe);
 

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -68,7 +68,7 @@ function getRemoteLabel(auth: SanitizedAuth): string {
   return `${defaultLabel(auth.label)} — ${getVisibilityLabel(auth)}`;
 }
 
-export function useBuiltInAuthsByRequiredServiceId(
+export function useBuiltInAuthsByRequiredServiceIds(
   recipe: RecipeDefinition | null
 ): {
   builtInServiceAuths: Record<RegistryId, UUID | undefined>;

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -126,6 +126,14 @@ export function useAuthOptions(): {
   };
 }
 
+/*
+ * Get a list of required service ids for a recipe mapped to a default auth option.
+ *
+ * If there is no default auth option, the value will be null.
+ * Prefer an arbitrary personal or shared auth option over built-in.
+ *
+ * Assumes that the recipe is not yet installed.
+ */
 export function useDefaultAuthOptions(recipe: RecipeDefinition): {
   defaultAuthOptions: Record<RegistryId, AuthOption | null>;
   isLoading: boolean;

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -129,7 +129,7 @@ export function useAuthOptions(): {
 /*
  * Get a list of required service ids for a recipe mapped to a default auth option.
  *
- * If there is no default auth option, the value will be null.
+ * If there are no options available for the service, the value will be null.
  * Prefer an arbitrary personal or shared auth option over built-in.
  *
  * Assumes that the recipe is not yet installed.

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
@@ -19,17 +19,13 @@ import React from "react";
 import { useRecipe } from "@/recipes/recipesHooks";
 import { useGetMarketplaceListingsQuery } from "@/services/api";
 import {
-  extensionPointConfigFactory,
   getRecipeWithBuiltInServiceAuths,
   marketplaceListingFactory,
   recipeDefinitionFactory,
-  recipeFactory,
-  sanitizedAuthFactory,
-  sanitizedAuthServiceFactory,
   sidebarEntryFactory,
 } from "@/testUtils/factories";
 import { type UseCachedQueryResult } from "@/types/sliceTypes";
-import { uuidv4, validateRegistryId } from "@/types/helpers";
+import { uuidv4 } from "@/types/helpers";
 import { render } from "@/sidebar/testHelpers";
 import ActivateRecipePanel from "@/sidebar/activateRecipe/ActivateRecipePanel";
 import sidebarSlice from "@/sidebar/sidebarSlice";
@@ -39,8 +35,6 @@ import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/reg
 import includesQuickBarExtensionPoint from "@/utils/includesQuickBarExtensionPoint";
 import useQuickbarShortcut from "@/hooks/useQuickbarShortcut";
 import { type RecipeDefinition } from "@/types/recipeTypes";
-import { OutputKey } from "@/types/runtimeTypes";
-import { RegistryId } from "@/types/registryTypes";
 import * as api from "@/services/api";
 
 jest.mock("@/recipes/recipesHooks", () => ({

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
@@ -58,6 +58,7 @@ jest.mock("@/services/api", () => ({
   useGetServiceAuthsQuery: jest.fn().mockReturnValue({
     data: [],
     isLoading: false,
+    isFetching: false,
   }),
   useGetServicesQuery: jest.fn().mockReturnValue({
     data: [],
@@ -194,6 +195,12 @@ beforeEach(() => {
     shortcut: null,
     isConfigured: false,
   });
+
+  (api.useGetServiceAuthsQuery as jest.Mock).mockReturnValue({
+    data: [],
+    isLoading: false,
+    isFetching: false,
+  });
 });
 
 describe("ActivateRecipePanel", () => {
@@ -286,8 +293,9 @@ describe("ActivateRecipePanel", () => {
     const { recipe } = getRecipeWithBuiltInServiceAuths();
 
     (api.useGetServiceAuthsQuery as jest.Mock).mockReturnValue({
-      data: undefined,
+      data: [],
       isLoading: true,
+      isFetching: true,
     });
 
     const rendered = setupMocksAndRender(recipe);

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
@@ -260,12 +260,13 @@ describe("ActivateRecipePanel", () => {
 
   test("it renders with service configuration if no built-in service configs available", async () => {
     const { recipe } = getRecipeWithBuiltInServiceAuths();
-    const rendered = setupMocksAndRender(recipe);
 
     (api.useGetServicesQuery as jest.Mock).mockReturnValue({
       data: [],
       isLoading: false,
     });
+
+    const rendered = setupMocksAndRender(recipe);
 
     await waitForEffect();
 
@@ -274,12 +275,13 @@ describe("ActivateRecipePanel", () => {
 
   test("it activates recipe with built-in services automatically and renders well-done page", async () => {
     const { recipe, builtInServiceAuths } = getRecipeWithBuiltInServiceAuths();
-    const rendered = setupMocksAndRender(recipe);
 
     (api.useGetServiceAuthsQuery as jest.Mock).mockReturnValue({
       data: builtInServiceAuths,
       isLoading: false,
     });
+
+    const rendered = setupMocksAndRender(recipe);
 
     await waitForEffect();
 
@@ -288,15 +290,16 @@ describe("ActivateRecipePanel", () => {
 
   test("it doesn't flicker while built-in auths are loading", async () => {
     const { recipe } = getRecipeWithBuiltInServiceAuths();
-    const rendered = setupMocksAndRender(recipe);
 
     (api.useGetServiceAuthsQuery as jest.Mock).mockReturnValue({
       data: undefined,
       isLoading: true,
     });
 
+    const rendered = setupMocksAndRender(recipe);
+
     await waitForEffect();
 
-    expect(rendered.asFragment()).toMatchSnapshot();
+    expect(rendered.getByTestId("loader")).not.toBeNull();
   });
 });

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
@@ -285,4 +285,18 @@ describe("ActivateRecipePanel", () => {
 
     expect(rendered.asFragment()).toMatchSnapshot();
   });
+
+  test("it doesn't flicker while built-in auths are loading", async () => {
+    const { recipe } = getRecipeWithBuiltInServiceAuths();
+    const rendered = setupMocksAndRender(recipe);
+
+    (api.useGetServiceAuthsQuery as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+
+    await waitForEffect();
+
+    expect(rendered.asFragment()).toMatchSnapshot();
+  });
 });

--- a/src/sidebar/activateRecipe/RequireRecipe.tsx
+++ b/src/sidebar/activateRecipe/RequireRecipe.tsx
@@ -25,60 +25,17 @@ import styles from "./RequireRecipe.module.scss";
 import { useAsyncState } from "@/hooks/common";
 import { resolveRecipe } from "@/registry/internal";
 import includesQuickBarExtensionPoint from "@/utils/includesQuickBarExtensionPoint";
-import { useAuthsByRequiredServiceIds } from "@/hooks/auth";
-import { isEmpty, uniq } from "lodash";
-import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 
 export type RecipeState = {
   recipe: RecipeDefinition;
   recipeNameNode: React.ReactNode | null;
   includesQuickBar: boolean;
-  canAutoActivate: boolean;
 };
 
 type RequireRecipeProps = {
   recipeId: RegistryId;
   children: (props: RecipeState) => React.ReactElement;
 };
-
-function useCanAutoActivate(recipe: RecipeDefinition | null): {
-  canAutoActivate: boolean;
-  isLoading: boolean;
-} {
-  const { builtInServiceAuths, personalOrSharedServiceAuths, isLoading } =
-    useAuthsByRequiredServiceIds(recipe);
-
-  if (!recipe) {
-    return { canAutoActivate: false, isLoading };
-  }
-
-  const hasRecipeOptions = !isEmpty(recipe.options?.schema?.properties);
-  const recipeServiceIds = uniq(
-    recipe.extensionPoints.flatMap(({ services }) =>
-      services ? Object.values(services) : []
-    )
-  );
-
-  const needsServiceInputs = recipeServiceIds.some((serviceId) => {
-    if (serviceId === PIXIEBRIX_SERVICE_ID) {
-      return false;
-    }
-
-    // eslint-disable-next-line security/detect-object-injection -- serviceId is a registry ID
-    if (personalOrSharedServiceAuths[serviceId]) {
-      return true;
-    }
-
-    // eslint-disable-next-line security/detect-object-injection -- serviceId is a registry ID
-    return !builtInServiceAuths[serviceId];
-  });
-
-  // Can auto-activate if no configuration required, or all services have only built-in configurations
-  return {
-    canAutoActivate: !hasRecipeOptions && !needsServiceInputs,
-    isLoading,
-  };
-}
 
 const RequireRecipe: React.FC<RequireRecipeProps> = ({
   recipeId,
@@ -100,10 +57,6 @@ const RequireRecipe: React.FC<RequireRecipeProps> = ({
   } = useGetMarketplaceListingsQuery({ package__name: recipeId });
   // eslint-disable-next-line security/detect-object-injection -- RegistryId
   const listing = useMemo(() => listings?.[recipeId], [listings, recipeId]);
-
-  // Can auto-activate
-  const { canAutoActivate, isLoading: isAutoActivateLoading } =
-    useCanAutoActivate(recipe);
 
   // Name component
   const recipeName =
@@ -134,11 +87,7 @@ const RequireRecipe: React.FC<RequireRecipeProps> = ({
 
   // Loading state
   const isLoading =
-    isUninitialized ||
-    isLoadingRecipe ||
-    isLoadingListing ||
-    isLoadingQuickbar ||
-    isAutoActivateLoading;
+    isUninitialized || isLoadingRecipe || isLoadingListing || isLoadingQuickbar;
 
   if (isLoading) {
     return <Loader />;
@@ -148,7 +97,6 @@ const RequireRecipe: React.FC<RequireRecipeProps> = ({
     recipe,
     recipeNameNode: <div className={styles.recipeName}>{recipeName}</div>,
     includesQuickBar: includesQuickbar,
-    canAutoActivate,
   };
 
   return children(recipeState);

--- a/src/sidebar/activateRecipe/RequireRecipe.tsx
+++ b/src/sidebar/activateRecipe/RequireRecipe.tsx
@@ -25,7 +25,7 @@ import styles from "./RequireRecipe.module.scss";
 import { useAsyncState } from "@/hooks/common";
 import { resolveRecipe } from "@/registry/internal";
 import includesQuickBarExtensionPoint from "@/utils/includesQuickBarExtensionPoint";
-import { useBuiltInAuthsByRequiredServiceIds } from "@/hooks/auth";
+import { useDefaultAuthsByRequiredServiceIds } from "@/hooks/auth";
 import { isEmpty, uniq } from "lodash";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 
@@ -46,7 +46,7 @@ function useCanAutoActivate(recipe: RecipeDefinition | null): {
   isLoading: boolean;
 } {
   const { builtInServiceAuths, isLoading } =
-    useBuiltInAuthsByRequiredServiceIds(recipe);
+    useDefaultAuthsByRequiredServiceIds(recipe);
 
   if (!recipe) {
     return { canAutoActivate: false, isLoading };

--- a/src/sidebar/activateRecipe/RequireRecipe.tsx
+++ b/src/sidebar/activateRecipe/RequireRecipe.tsx
@@ -25,7 +25,7 @@ import styles from "./RequireRecipe.module.scss";
 import { useAsyncState } from "@/hooks/common";
 import { resolveRecipe } from "@/registry/internal";
 import includesQuickBarExtensionPoint from "@/utils/includesQuickBarExtensionPoint";
-import { useDefaultAuthsByRequiredServiceIds } from "@/hooks/auth";
+import { useAuthsByRequiredServiceIds } from "@/hooks/auth";
 import { isEmpty, uniq } from "lodash";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 
@@ -45,8 +45,8 @@ function useCanAutoActivate(recipe: RecipeDefinition | null): {
   canAutoActivate: boolean;
   isLoading: boolean;
 } {
-  const { builtInServiceAuths, isLoading } =
-    useDefaultAuthsByRequiredServiceIds(recipe);
+  const { builtInServiceAuths, personalOrSharedServiceAuths, isLoading } =
+    useAuthsByRequiredServiceIds(recipe);
 
   if (!recipe) {
     return { canAutoActivate: false, isLoading };
@@ -65,10 +65,15 @@ function useCanAutoActivate(recipe: RecipeDefinition | null): {
     }
 
     // eslint-disable-next-line security/detect-object-injection -- serviceId is a registry ID
+    if (personalOrSharedServiceAuths[serviceId]) {
+      return true;
+    }
+
+    // eslint-disable-next-line security/detect-object-injection -- serviceId is a registry ID
     return !builtInServiceAuths[serviceId];
   });
 
-  // Can auto-activate if no configuration required, or all services have built-in configurations
+  // Can auto-activate if no configuration required, or all services have only built-in configurations
   return {
     canAutoActivate: !hasRecipeOptions && !needsServiceInputs,
     isLoading,

--- a/src/sidebar/activateRecipe/RequireRecipe.tsx
+++ b/src/sidebar/activateRecipe/RequireRecipe.tsx
@@ -25,7 +25,7 @@ import styles from "./RequireRecipe.module.scss";
 import { useAsyncState } from "@/hooks/common";
 import { resolveRecipe } from "@/registry/internal";
 import includesQuickBarExtensionPoint from "@/utils/includesQuickBarExtensionPoint";
-import { useBuiltInAuthsByRequiredServiceId } from "@/hooks/auth";
+import { useBuiltInAuthsByRequiredServiceIds } from "@/hooks/auth";
 import { isEmpty, uniq } from "lodash";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 
@@ -46,7 +46,7 @@ function useCanAutoActivate(recipe: RecipeDefinition | null): {
   isLoading: boolean;
 } {
   const { builtInServiceAuths, isLoading } =
-    useBuiltInAuthsByRequiredServiceId(recipe);
+    useBuiltInAuthsByRequiredServiceIds(recipe);
 
   if (!recipe) {
     return { canAutoActivate: false, isLoading };

--- a/src/sidebar/activateRecipe/RequireRecipe.tsx
+++ b/src/sidebar/activateRecipe/RequireRecipe.tsx
@@ -48,7 +48,7 @@ function useCanAutoActivate(recipe: RecipeDefinition | null): {
   const { builtInServiceAuths, isLoading } =
     useBuiltInAuthsByRequiredServiceId(recipe);
 
-  if (isLoading || !recipe) {
+  if (!recipe) {
     return { canAutoActivate: false, isLoading };
   }
 

--- a/src/sidebar/activateRecipe/__snapshots__/ActivateRecipePanel.test.tsx.snap
+++ b/src/sidebar/activateRecipe/__snapshots__/ActivateRecipePanel.test.tsx.snap
@@ -47,6 +47,53 @@ exports[`ActivateRecipePanel it activates basic recipe automatically and renders
 </DocumentFragment>
 `;
 
+exports[`ActivateRecipePanel it activates recipe with built-in services automatically and renders well-done page 1`] = `
+<DocumentFragment>
+  <div
+    class="root"
+  >
+    <div
+      class="scrollable-area content"
+    >
+      <h1>
+        Well done!
+      </h1>
+      <img
+        alt=""
+        src="test-file-stub"
+        width="300"
+      />
+      <div
+        class="textContainer"
+      >
+        <div
+          class="recipeName"
+        >
+          My Test Listing
+        </div>
+        <div>
+          is ready to use!
+        </div>
+        <br />
+        <div>
+          Go try it out now, or activate another mod.
+        </div>
+      </div>
+    </div>
+    <div
+      class="footer"
+    >
+      <button
+        class="btn btn-primary"
+        type="button"
+      >
+        Ok
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`ActivateRecipePanel it renders well-done page for quick bar mod shortcut is configured 1`] = `
 <DocumentFragment>
   <div
@@ -457,6 +504,198 @@ exports[`ActivateRecipePanel it renders with options, permissions info 1`] = `
           </div>
           <div>
             Without permissions, PixieBrix won't work. We'll ask for these in just a second.
+          </div>
+        </div>
+      </div>
+      <div
+        class="footer"
+      >
+        <button
+          class="btn btn-outline-danger"
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          class="btn btn-primary"
+          type="submit"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-magic fa-w-16 "
+            data-icon="magic"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M224 96l16-32 32-16-32-16-16-32-16 32-32 16 32 16 16 32zM80 160l26.66-53.33L160 80l-53.34-26.67L80 0 53.34 53.33 0 80l53.34 26.67L80 160zm352 128l-26.66 53.33L352 368l53.34 26.67L432 448l26.66-53.33L512 368l-53.34-26.67L432 288zm70.62-193.77L417.77 9.38C411.53 3.12 403.34 0 395.15 0c-8.19 0-16.38 3.12-22.63 9.38L9.38 372.52c-12.5 12.5-12.5 32.76 0 45.25l84.85 84.85c6.25 6.25 14.44 9.37 22.62 9.37 8.19 0 16.38-3.12 22.63-9.37l363.14-363.15c12.5-12.48 12.5-32.75 0-45.24zM359.45 203.46l-50.91-50.91 86.6-86.6 50.91 50.91-86.6 86.6z"
+              fill="currentColor"
+            />
+          </svg>
+           Finish Activating
+        </button>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ActivateRecipePanel it renders with service configuration if no built-in service configs available 1`] = `
+<DocumentFragment>
+  <div
+    class="root"
+  >
+    <form
+      class="form"
+      novalidate=""
+    >
+      <div
+        class="scrollable-area formBody"
+      >
+        <div
+          class="recipeName"
+        >
+          My Test Listing
+        </div>
+        <p>
+          We're almost there. This mod has a few settings to configure before using. You can always change these later.
+        </p>
+        <div
+          class="mt-1"
+        >
+          <div>
+            <h4>
+              Integrations
+            </h4>
+          </div>
+          <div>
+            <div
+              class="serviceCard card"
+            >
+              <div
+                class="serviceCardHeader"
+              >
+                <code
+                  class="serviceId"
+                >
+                  @pixiebrix/service1
+                </code>
+              </div>
+              <div
+                class="d-inline-flex justify-content-end"
+              >
+                <button
+                  class="actionButton btn btn-info btn-sm"
+                  disabled=""
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-plus fa-w-14 "
+                    data-icon="plus"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                   Configure
+                </button>
+                <button
+                  class="actionButton btn btn-info btn-sm"
+                  title="Refresh integration configurations"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-sync fa-w-16 "
+                    data-icon="sync"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M440.65 12.57l4 82.77A247.16 247.16 0 0 0 255.83 8C134.73 8 33.91 94.92 12.29 209.82A12 12 0 0 0 24.09 224h49.05a12 12 0 0 0 11.67-9.26 175.91 175.91 0 0 1 317-56.94l-101.46-4.86a12 12 0 0 0-12.57 12v47.41a12 12 0 0 0 12 12H500a12 12 0 0 0 12-12V12a12 12 0 0 0-12-12h-47.37a12 12 0 0 0-11.98 12.57zM255.83 432a175.61 175.61 0 0 1-146-77.8l101.8 4.87a12 12 0 0 0 12.57-12v-47.4a12 12 0 0 0-12-12H12a12 12 0 0 0-12 12V500a12 12 0 0 0 12 12h47.35a12 12 0 0 0 12-12.6l-4.15-82.57A247.17 247.17 0 0 0 255.83 504c121.11 0 221.93-86.92 243.55-201.82a12 12 0 0 0-11.8-14.18h-49.05a12 12 0 0 0-11.67 9.26A175.86 175.86 0 0 1 255.83 432z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                   Refresh
+                </button>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div
+              class="serviceCard card"
+            >
+              <div
+                class="serviceCardHeader"
+              >
+                <code
+                  class="serviceId"
+                >
+                  @pixiebrix/service2
+                </code>
+              </div>
+              <div
+                class="d-inline-flex justify-content-end"
+              >
+                <button
+                  class="actionButton btn btn-info btn-sm"
+                  disabled=""
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-plus fa-w-14 "
+                    data-icon="plus"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                   Configure
+                </button>
+                <button
+                  class="actionButton btn btn-info btn-sm"
+                  title="Refresh integration configurations"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-sync fa-w-16 "
+                    data-icon="sync"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M440.65 12.57l4 82.77A247.16 247.16 0 0 0 255.83 8C134.73 8 33.91 94.92 12.29 209.82A12 12 0 0 0 24.09 224h49.05a12 12 0 0 0 11.67-9.26 175.91 175.91 0 0 1 317-56.94l-101.46-4.86a12 12 0 0 0-12.57 12v47.41a12 12 0 0 0 12 12H500a12 12 0 0 0 12-12V12a12 12 0 0 0-12-12h-47.37a12 12 0 0 0-11.98 12.57zM255.83 432a175.61 175.61 0 0 1-146-77.8l101.8 4.87a12 12 0 0 0 12.57-12v-47.4a12 12 0 0 0-12-12H12a12 12 0 0 0-12 12V500a12 12 0 0 0 12 12h47.35a12 12 0 0 0 12-12.6l-4.15-82.57A247.17 247.17 0 0 0 255.83 504c121.11 0 221.93-86.92 243.55-201.82a12 12 0 0 0-11.8-14.18h-49.05a12 12 0 0 0-11.67 9.26A175.86 175.86 0 0 1 255.83 432z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                   Refresh
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/sidebar/activateRecipe/__snapshots__/ActivateRecipePanel.test.tsx.snap
+++ b/src/sidebar/activateRecipe/__snapshots__/ActivateRecipePanel.test.tsx.snap
@@ -94,47 +94,6 @@ exports[`ActivateRecipePanel it activates recipe with built-in services automati
 </DocumentFragment>
 `;
 
-exports[`ActivateRecipePanel it doesn't flicker while built-in auths are loading 1`] = `
-<DocumentFragment>
-  <div
-    class="root"
-    data-testid="loader"
-  >
-    <span
-      style="width: 57px; font-size: 0px; display: inline-block;"
-    >
-      <span
-        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 1.17406554392515s 0.37406554392515007s infinite ease;"
-      />
-      <span
-        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 1.0900577890303067s 0.2900577890303066s infinite ease;"
-      />
-      <span
-        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 0.9518337856806428s 0.15183378568064282s infinite ease;"
-      />
-      <span
-        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 0.8290649552628108s 0.02906495526281075s infinite ease;"
-      />
-      <span
-        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 1.158779232076296s 0.3587792320762961s infinite ease;"
-      />
-      <span
-        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 1.1285008190615589s 0.32850081906155876s infinite ease;"
-      />
-      <span
-        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 0.9409744943745423s 0.1409744943745423s infinite ease;"
-      />
-      <span
-        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 1.5961787681171797s 0.7961787681171797s infinite ease;"
-      />
-      <span
-        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 0.8384916046905077s 0.038491604690507636s infinite ease;"
-      />
-    </span>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`ActivateRecipePanel it renders well-done page for quick bar mod shortcut is configured 1`] = `
 <DocumentFragment>
   <div

--- a/src/sidebar/activateRecipe/__snapshots__/ActivateRecipePanel.test.tsx.snap
+++ b/src/sidebar/activateRecipe/__snapshots__/ActivateRecipePanel.test.tsx.snap
@@ -94,6 +94,47 @@ exports[`ActivateRecipePanel it activates recipe with built-in services automati
 </DocumentFragment>
 `;
 
+exports[`ActivateRecipePanel it doesn't flicker while built-in auths are loading 1`] = `
+<DocumentFragment>
+  <div
+    class="root"
+    data-testid="loader"
+  >
+    <span
+      style="width: 57px; font-size: 0px; display: inline-block;"
+    >
+      <span
+        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 1.17406554392515s 0.37406554392515007s infinite ease;"
+      />
+      <span
+        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 1.0900577890303067s 0.2900577890303066s infinite ease;"
+      />
+      <span
+        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 0.9518337856806428s 0.15183378568064282s infinite ease;"
+      />
+      <span
+        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 0.8290649552628108s 0.02906495526281075s infinite ease;"
+      />
+      <span
+        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 1.158779232076296s 0.3587792320762961s infinite ease;"
+      />
+      <span
+        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 1.1285008190615589s 0.32850081906155876s infinite ease;"
+      />
+      <span
+        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 0.9409744943745423s 0.1409744943745423s infinite ease;"
+      />
+      <span
+        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 1.5961787681171797s 0.7961787681171797s infinite ease;"
+      />
+      <span
+        style="display: inline-block; background-color: rgb(0, 0, 0); width: 15px; height: 15px; margin: 2px; border-radius: 100%; animation-fill-mode: both; animation: react-spinners-GridLoader-grid 0.8384916046905077s 0.038491604690507636s infinite ease;"
+      />
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`ActivateRecipePanel it renders well-done page for quick bar mod shortcut is configured 1`] = `
 <DocumentFragment>
   <div

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -906,3 +906,43 @@ export function sidebarEntryFactory(
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- allow never, future-proof for new types
   throw new Error(`Unknown entry type: ${type}`);
 }
+
+export const getRecipeWithBuiltInServiceAuths = () => {
+  const extensionServices = {
+    service1: "@pixiebrix/service1",
+    service2: "@pixiebrix/service2",
+  } as Record<OutputKey, RegistryId>;
+
+  const extensionPointDefinition = extensionPointConfigFactory({
+    services: extensionServices,
+  });
+
+  const recipe = recipeFactory({
+    extensionPoints: [extensionPointDefinition],
+  });
+
+  const builtInServiceAuths = [
+    sanitizedAuthFactory({
+      service: sanitizedAuthServiceFactory({
+        config: {
+          metadata: {
+            id: validateRegistryId("@pixiebrix/service1"),
+            name: "Service 1",
+          },
+        },
+      }),
+    }),
+    sanitizedAuthFactory({
+      service: sanitizedAuthServiceFactory({
+        config: {
+          metadata: {
+            id: validateRegistryId("@pixiebrix/service2"),
+            name: "Service 2",
+          },
+        },
+      }),
+    }),
+  ];
+
+  return { recipe, builtInServiceAuths };
+};


### PR DESCRIPTION
## What does this PR do?

- Closes #5533
- Refactors `canAutoActivate` into a `useCanAutoActivate` hook
- Introduces a `useBuiltInServiceAuthsByRequiredServiceIds` hook
- Adds tests for auto-activating mods with and without built-in service configurations

## Reviewer Tips

- Pre-fills services with built-in configurations in `useWizard` (prefers configurations that are already installed)
- Modifies `canAutoActivate` to be truthy if all services have built-in configurations
- Moves `canAutoActivate` to `RequireRecipe` component to reduce complexity around component flickering while fetching built-in auths

## Demo

- https://www.loom.com/share/4df37c03df1846309738f9f452f7cc1c

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @BLoe 
