### PR TITLE
#5538 use starting emoji as action icon

### DIFF
--- a/src/components/fields/IconWidget.tsx
+++ b/src/components/fields/IconWidget.tsx
@@ -55,7 +55,11 @@ const IconWidget: CustomFieldWidget = (props) => {
 
   return (
     <Suspense fallback={<div>Loading icons...</div>}>
-      <IconSelector value={meta.value} onChange={handleSelect} />
+      <IconSelector
+        value={meta.value}
+        onChange={handleSelect}
+        disabled={props.disabled}
+      />
     </Suspense>
   );
 };

--- a/src/components/quickBar/QuickBarResults.tsx
+++ b/src/components/quickBar/QuickBarResults.tsx
@@ -15,9 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { forwardRef } from "react";
+import React, { forwardRef, useMemo } from "react";
 import { type ActionId, type ActionImpl, KBarResults, useMatches } from "kbar";
 import { theme, groupNameStyle } from "./quickBarTheme";
+import { useGetActionNameAndIcon } from "@/components/quickBar/utils";
 
 const ResultItem = forwardRef(
   (
@@ -32,7 +33,7 @@ const ResultItem = forwardRef(
     },
     ref: React.Ref<HTMLDivElement>
   ) => {
-    const ancestors = React.useMemo(() => {
+    const ancestors = useMemo(() => {
       if (!currentRootActionId) return action.ancestors;
       const index = action.ancestors.findIndex(
         (ancestor) => ancestor.id === currentRootActionId
@@ -43,6 +44,8 @@ const ResultItem = forwardRef(
       // but rather just "Dark"
       return action.ancestors.slice(index + 1);
     }, [action.ancestors, currentRootActionId]);
+
+    const { name, icon } = useGetActionNameAndIcon(action);
 
     return (
       <div
@@ -70,9 +73,7 @@ const ResultItem = forwardRef(
             fontWeight: 400,
           }}
         >
-          <div style={{ alignSelf: "flex-start" }}>
-            {action.icon && action.icon}
-          </div>
+          <div style={{ alignSelf: "flex-start" }}>{icon ?? null}</div>
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
             <div>
               {ancestors.length > 0 &&
@@ -95,7 +96,7 @@ const ResultItem = forwardRef(
                     </span>
                   </React.Fragment>
                 ))}
-              <span>{action.name}</span>
+              <span>{name}</span>
             </div>
             {action.subtitle && (
               <span

--- a/src/components/quickBar/utils.ts
+++ b/src/components/quickBar/utils.ts
@@ -23,7 +23,7 @@ export function useGetActionNameAndIcon({ name, icon }: ActionImpl) {
   return useMemo(() => {
     const { startingEmoji, rest } = splitStartingEmoji(name);
     return {
-      name: rest,
+      name: rest.trim(), // Trim whitespace if there is any from the emoji split
       icon: startingEmoji ?? icon,
     };
   }, [name, icon]);

--- a/src/components/quickBar/utils.ts
+++ b/src/components/quickBar/utils.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type ActionImpl } from "kbar";
+import { useMemo } from "react";
+import { splitStartingEmoji } from "@/utils/stringUtils";
+
+export function useGetActionNameAndIcon({ name, icon }: ActionImpl) {
+  return useMemo(() => {
+    const { startingEmoji, rest } = splitStartingEmoji(name);
+    return {
+      name: rest,
+      icon: startingEmoji ?? icon,
+    };
+  }, [name, icon]);
+}

--- a/src/components/quickBar/utils.ts
+++ b/src/components/quickBar/utils.ts
@@ -15,11 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type ActionImpl } from "kbar";
+import { type Action } from "kbar";
 import { useMemo } from "react";
 import { splitStartingEmoji } from "@/utils/stringUtils";
 
-export function useGetActionNameAndIcon({ name, icon }: ActionImpl) {
+export function useGetActionNameAndIcon({ name, icon }: Action) {
   return useMemo(() => {
     const { startingEmoji, rest } = splitStartingEmoji(name);
     return {

--- a/src/icons/IconSelector.tsx
+++ b/src/icons/IconSelector.tsx
@@ -56,12 +56,14 @@ interface OwnProps {
   value: { id: string; library: IconLibrary };
   isClearable?: boolean;
   onChange: (option: IconOption | null) => void;
+  disabled?: boolean;
 }
 
 const IconSelector: React.FunctionComponent<OwnProps> = ({
   value,
   isClearable = true,
   onChange,
+  disabled = false,
 }) => {
   const selectedOption = useMemo(() => {
     if (value) {
@@ -75,6 +77,7 @@ const IconSelector: React.FunctionComponent<OwnProps> = ({
 
   return (
     <Select
+      isDisabled={disabled}
       isClearable={isClearable}
       value={selectedOption}
       options={iconOptions}

--- a/src/pageEditor/fields/makeLockableFieldProps.tsx
+++ b/src/pageEditor/fields/makeLockableFieldProps.tsx
@@ -18,9 +18,17 @@
 import React from "react";
 import LockedExtensionPointLabel from "@/components/form/lockedLabel/LockedExtensionPointLabel";
 
-export function makeLockableFieldProps(label: string, isLocked: boolean) {
+export function makeLockableFieldProps(
+  label: string,
+  isLocked: boolean,
+  message?: string
+) {
   return {
     disabled: isLocked,
-    label: isLocked ? <LockedExtensionPointLabel label={label} /> : label,
+    label: isLocked ? (
+      <LockedExtensionPointLabel label={label} message={message} />
+    ) : (
+      label
+    ),
   };
 }

--- a/src/pageEditor/tabs/quickBar/QuickBarConfiguration.tsx
+++ b/src/pageEditor/tabs/quickBar/QuickBarConfiguration.tsx
@@ -25,93 +25,103 @@ import { makeLockableFieldProps } from "@/pageEditor/fields/makeLockableFieldPro
 import { contextOptions } from "@/pageEditor/tabs/contextMenu/ContextMenuConfiguration";
 import IconWidget from "@/components/fields/IconWidget";
 import ExtraPermissionsSection from "@/pageEditor/tabs/ExtraPermissionsSection";
+import { useField } from "formik";
+import { splitStartingEmoji } from "@/utils/stringUtils";
 
 const QuickBarConfiguration: React.FC<{
   isLocked: boolean;
-}> = ({ isLocked = false }) => (
-  <Card>
-    <FieldSection title="Configuration">
-      <ConnectedFieldTemplate
-        name="extension.title"
-        label="Action Title"
-        description="Quick Bar action title"
-      />
+}> = ({ isLocked = false }) => {
+  const [{ value: actionTitle }] = useField("extension.title");
+  const emojiFirstCharacter =
+    splitStartingEmoji(actionTitle).startingEmoji !== undefined;
 
-      <ConnectedFieldTemplate
-        name="extensionPoint.definition.contexts"
-        as={MultiSelectWidget}
-        options={contextOptions}
-        description={
-          <span>
-            One or more contexts to include the quick bar item. For example, use
-            the <code>selection</code> context to show the action item when text
-            is selected.
-          </span>
-        }
-        {...makeLockableFieldProps("Contexts", isLocked)}
-      />
+  return (
+    <Card>
+      <FieldSection title="Configuration">
+        <ConnectedFieldTemplate
+          name="extension.title"
+          label="Action Title"
+          description="Quick Bar action title"
+        />
 
-      <UrlMatchPatternField
-        name="extensionPoint.definition.documentUrlPatterns"
-        {...makeLockableFieldProps("Sites", isLocked)}
-        description={
-          <span>
-            URL match patterns to show the menu item on. See{" "}
-            <a
-              href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <code>match_patterns</code> Documentation
-            </a>{" "}
-            for examples.
-          </span>
-        }
-      />
-    </FieldSection>
+        <ConnectedFieldTemplate
+          name="extensionPoint.definition.contexts"
+          as={MultiSelectWidget}
+          options={contextOptions}
+          description={
+            <span>
+              One or more contexts to include the quick bar item. For example,
+              use the <code>selection</code> context to show the action item
+              when text is selected.
+            </span>
+          }
+          {...makeLockableFieldProps("Contexts", isLocked)}
+        />
 
-    <FieldSection title="Advanced">
-      <ConnectedFieldTemplate
-        name="extension.icon"
-        label="Icon"
-        as={IconWidget}
-        description="Icon to show in the menu"
-      />
+        <UrlMatchPatternField
+          name="extensionPoint.definition.documentUrlPatterns"
+          {...makeLockableFieldProps("Sites", isLocked)}
+          description={
+            <span>
+              URL match patterns to show the menu item on. See{" "}
+              <a
+                href="https://developer.chrome.com/docs/extensions/mv2/match_patterns/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <code>match_patterns</code> Documentation
+              </a>{" "}
+              for examples.
+            </span>
+          }
+        />
+      </FieldSection>
 
-      <ConnectedFieldTemplate
-        name="extensionPoint.definition.targetMode"
-        as="select"
-        title="Target Mode"
-        blankValue="eventTarget"
-        description={
-          <p>
-            Use&nbsp;<code>eventTarget</code> to pass the focused element as the
-            action root. Use&nbsp;
-            <code>document</code> to pass the document as the action root.
-          </p>
-        }
-        {...makeLockableFieldProps("Target Mode", isLocked)}
-      >
-        <option value="eventTarget">eventTarget</option>
-        <option value="document">document</option>
-      </ConnectedFieldTemplate>
+      <FieldSection title="Advanced">
+        <ConnectedFieldTemplate
+          name="extension.icon"
+          label="Icon"
+          as={IconWidget}
+          description="Icon to show in the menu"
+          // Disable icon select if an emoji is the first character since we use the emoji in its place
+          disabled={emojiFirstCharacter}
+        />
 
-      <UrlMatchPatternField
-        name="extensionPoint.definition.isAvailable.matchPatterns"
-        description={
-          <span>
-            URL match patterns give PixieBrix access to a page without you first
-            clicking the context menu. Including URLs here helps PixieBrix run
-            you action quicker, and accurately detect which page element you
-            clicked to invoke the context menu.
-          </span>
-        }
-        {...makeLockableFieldProps("Automatic Permissions", isLocked)}
-      />
-    </FieldSection>
+        <ConnectedFieldTemplate
+          name="extensionPoint.definition.targetMode"
+          as="select"
+          title="Target Mode"
+          blankValue="eventTarget"
+          description={
+            <p>
+              Use&nbsp;<code>eventTarget</code> to pass the focused element as
+              the action root. Use&nbsp;
+              <code>document</code> to pass the document as the action root.
+            </p>
+          }
+          {...makeLockableFieldProps("Target Mode", isLocked)}
+        >
+          <option value="eventTarget">eventTarget</option>
+          <option value="document">document</option>
+        </ConnectedFieldTemplate>
 
-    <ExtraPermissionsSection />
-  </Card>
-);
+        <UrlMatchPatternField
+          name="extensionPoint.definition.isAvailable.matchPatterns"
+          description={
+            <span>
+              URL match patterns give PixieBrix access to a page without you
+              first clicking the context menu. Including URLs here helps
+              PixieBrix run you action quicker, and accurately detect which page
+              element you clicked to invoke the context menu.
+            </span>
+          }
+          {...makeLockableFieldProps("Automatic Permissions", isLocked)}
+        />
+      </FieldSection>
+
+      <ExtraPermissionsSection />
+    </Card>
+  );
+};
 
 export default QuickBarConfiguration;

--- a/src/pageEditor/tabs/quickBar/QuickBarConfiguration.tsx
+++ b/src/pageEditor/tabs/quickBar/QuickBarConfiguration.tsx
@@ -80,11 +80,13 @@ const QuickBarConfiguration: React.FC<{
       <FieldSection title="Advanced">
         <ConnectedFieldTemplate
           name="extension.icon"
-          label="Icon"
           as={IconWidget}
           description="Icon to show in the menu"
-          // Disable icon select if an emoji is the first character since we use the emoji in its place
-          disabled={emojiFirstCharacter}
+          {...makeLockableFieldProps(
+            "Icon",
+            emojiFirstCharacter,
+            "If the first character in the action title is an emoji we will use that in the place of an icon."
+          )}
         />
 
         <ConnectedFieldTemplate

--- a/src/utils/stringUtils.test.ts
+++ b/src/utils/stringUtils.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { splitStartingEmoji } from "@/utils/stringUtils";
+
+describe("string utilities", () => {
+  test("splitStartingEmoji", () => {
+    expect(splitStartingEmoji("some test string")).toStrictEqual({
+      startingEmoji: undefined,
+      rest: "some test string",
+    });
+    expect(
+      splitStartingEmoji("😊 some test string with an emoji at the start")
+    ).toStrictEqual({
+      startingEmoji: "😊",
+      rest: " some test string with an emoji at the start",
+    });
+    expect(
+      splitStartingEmoji(
+        "😊 😊 some test string with multiple emojis at the start"
+      )
+    ).toStrictEqual({
+      startingEmoji: "😊",
+      rest: " 😊 some test string with multiple emojis at the start",
+    });
+    expect(
+      splitStartingEmoji("some test string with an emoji at the end 😊")
+    ).toStrictEqual({
+      startingEmoji: undefined,
+      rest: "some test string with an emoji at the end 😊",
+    });
+    expect(splitStartingEmoji("")).toStrictEqual({
+      startingEmoji: undefined,
+      rest: "",
+    });
+    expect(splitStartingEmoji("😊")).toStrictEqual({
+      startingEmoji: "😊",
+      rest: "",
+    });
+  });
+});

--- a/src/utils/stringUtils.test.ts
+++ b/src/utils/stringUtils.test.ts
@@ -38,6 +38,12 @@ describe("string utilities", () => {
       rest: " 😊 some test string with multiple emojis at the start",
     });
     expect(
+      splitStartingEmoji("👋🏿 some test string with colors emoji at the start")
+    ).toStrictEqual({
+      startingEmoji: "👋🏿",
+      rest: " some test string with colors emoji at the start",
+    });
+    expect(
       splitStartingEmoji("some test string with an emoji at the end 😊")
     ).toStrictEqual({
       startingEmoji: undefined,

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * If a string contains an emoji, returns an object that contains the separated emoji and the remaining string.
+ * @param string
+ */
+export function splitStartingEmoji(string: string) {
+  const emojiRegex = /^(\p{Emoji})?(.*)/u;
+  const match = emojiRegex.exec(string);
+  return {
+    startingEmoji: match[1],
+    rest: match[2],
+  };
+}

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -17,11 +17,12 @@
 
 /**
  * If a string contains an emoji, returns an object that contains the separated emoji and the remaining string.
- * @param string
+ * @param value
  */
-export function splitStartingEmoji(string: string) {
-  const emojiRegex = /^(\p{Emoji})?(.*)/u;
-  const match = emojiRegex.exec(string);
+export function splitStartingEmoji(value: string) {
+  const emojiRegex =
+    /^((?:\p{Extended_Pictographic}\p{Emoji_Modifier_Base}?\p{Emoji_Modifier}?)+)?(.*)/u;
+  const match = emojiRegex.exec(value);
   return {
     startingEmoji: match[1],
     rest: match[2],


### PR DESCRIPTION
## What does this PR do?

- closes #5538

## Reviewer Tips

- _What order should the reviewer review the files in?_
`QuickBarResults.tsx` and `src/components/quickBar/utils.ts` are related to showing the emoji in the quickbar.

The rest is either tests or what I needed to disable the icon selector.

## Discussion

- _Were there multiple approaches you were deciding between?_

I considered setting the emoji itself as the icon but the UX seemed nicer when there was a regular icon as a fallback.

## Demo

[Loom](https://www.loom.com/share/53cd2cbe7d784b6db2522673b8bfd20b)

![image](https://user-images.githubusercontent.com/10778363/233509492-c400618e-ca19-4ef0-bc3b-67f12d90d438.png)

![image](https://user-images.githubusercontent.com/10778363/233709669-fb7683e8-eecf-4577-917e-750d980de9cb.png)


## Checklist

- [x] Add tests
- [x] Designate a primary reviewer
