### PR TITLE
#5532 Trigger Activate button 'refresh' after successful in-marketplace activation

### DIFF
--- a/src/contentScript/marketplace.test.ts
+++ b/src/contentScript/marketplace.test.ts
@@ -62,6 +62,12 @@ jest.mock("@/background/messenger/external/_implementation", () => ({
   getActivatingBlueprint: jest.fn(),
 }));
 
+jest.mock("@/sidebar/store", () => ({
+  persistor: {
+    flush: jest.fn(),
+  },
+}));
+
 const getActivatingBlueprintMock =
   getActivatingBlueprint as jest.MockedFunction<typeof getActivatingBlueprint>;
 
@@ -175,7 +181,7 @@ describe("marketplace enhancements", () => {
     await initMarketplaceEnhancements();
 
     const activateButtons = document.querySelectorAll("a");
-    expect(activateButtons[0].textContent).toBe(" Reactivate");
+    expect(activateButtons[0].textContent).toBe("Reactivate");
     expect(activateButtons[1].textContent).toBe(" Activate");
   });
 

--- a/src/contentScript/marketplace.ts
+++ b/src/contentScript/marketplace.ts
@@ -83,18 +83,11 @@ function changeActivateButtonToActiveLabel(button: HTMLAnchorElement) {
   button.className = "";
   button.innerHTML = "Reactivate";
 
-  const parent = button.parentElement;
-
-  const activeLabelContainer = document.createElement("div");
-  activeLabelContainer.classList.add("d-flex", "flex-column");
-
-  const activeLabel = document.createElement("span");
-  activeLabel.classList.add("text-success");
-  activeLabel.innerHTML = '<i class="fas fa-check"></i> Active';
-
-  activeLabelContainer.append(activeLabel);
-  parent?.replaceChild(activeLabelContainer, button);
-  activeLabelContainer.append(button);
+  const activeLabel = $(
+    '<div class="d-flex flex-column"><span class="text-success"><i class="fas fa-check"></i> Active</span></div>'
+  );
+  $(button).replaceWith(activeLabel);
+  activeLabel.append(button);
 }
 
 async function showSidebarActivationForRecipe(recipeId: RegistryId) {

--- a/src/contentScript/marketplace.ts
+++ b/src/contentScript/marketplace.ts
@@ -75,7 +75,7 @@ async function getInProgressRecipeActivation(): Promise<RegistryId | null> {
   }
 }
 
-const changeActivateButtonToActiveLabel = (button: HTMLAnchorElement) => {
+function changeActivateButtonToActiveLabel(button: HTMLAnchorElement) {
   if (button.innerHTML.includes("Reactivate")) {
     return;
   }
@@ -95,7 +95,7 @@ const changeActivateButtonToActiveLabel = (button: HTMLAnchorElement) => {
   activeLabelContainer.append(activeLabel);
   parent?.replaceChild(activeLabelContainer, button);
   activeLabelContainer.append(button);
-};
+}
 
 async function showSidebarActivationForRecipe(recipeId: RegistryId) {
   const controller = new AbortController();
@@ -121,7 +121,7 @@ async function showSidebarActivationForRecipe(recipeId: RegistryId) {
 
 let enhancementsLoaded = false;
 
-export async function loadPageEnhancements(): Promise<void> {
+async function loadPageEnhancements(): Promise<void> {
   if (enhancementsLoaded) {
     return;
   }

--- a/src/contentScript/marketplace.ts
+++ b/src/contentScript/marketplace.ts
@@ -122,7 +122,7 @@ export async function loadPageEnhancements(): Promise<void> {
       continue;
     }
 
-    // Check if recipe is already activated, and change button to teate
+    // Check if recipe is already activated, and change button content to indicate active status
     if (installedRecipeIds.has(recipeId)) {
       button.classList.remove("btn", "btn-primary");
       button.classList.add("d-flex", "flex-column");

--- a/src/contentScript/marketplace.ts
+++ b/src/contentScript/marketplace.ts
@@ -75,6 +75,24 @@ async function getInProgressRecipeActivation(): Promise<RegistryId | null> {
   }
 }
 
+const changeActivateButtonToActiveLabel = (button: HTMLAnchorElement) => {
+  button.className = "";
+  button.innerHTML = "Reactivate";
+
+  const parent = button.parentElement;
+
+  const activeLabelContainer = document.createElement("div");
+  activeLabelContainer.classList.add("d-flex", "flex-column");
+
+  const activeLabel = document.createElement("span");
+  activeLabel.classList.add("text-success");
+  activeLabel.innerHTML = '<i class="fas fa-check"></i> Active';
+
+  activeLabelContainer.append(activeLabel);
+  parent?.replaceChild(activeLabelContainer, button);
+  activeLabelContainer.append(button);
+};
+
 async function showSidebarActivationForRecipe(recipeId: RegistryId) {
   const controller = new AbortController();
 
@@ -124,10 +142,7 @@ export async function loadPageEnhancements(): Promise<void> {
 
     // Check if recipe is already activated, and change button content to indicate active status
     if (installedRecipeIds.has(recipeId)) {
-      button.classList.remove("btn", "btn-primary");
-      button.classList.add("d-flex", "flex-column");
-      button.innerHTML =
-        '<span class="text-success"><i class="fas fa-check"></i> Active</span><span>Reactivate</span>';
+      changeActivateButtonToActiveLabel(button);
     }
 
     button.addEventListener("click", async (event) => {

--- a/src/contentScript/marketplace.ts
+++ b/src/contentScript/marketplace.ts
@@ -76,6 +76,10 @@ async function getInProgressRecipeActivation(): Promise<RegistryId | null> {
 }
 
 const changeActivateButtonToActiveLabel = (button: HTMLAnchorElement) => {
+  if (button.innerHTML.includes("Reactivate")) {
+    return;
+  }
+
   button.className = "";
   button.innerHTML = "Reactivate";
 

--- a/src/contentScript/marketplace.ts
+++ b/src/contentScript/marketplace.ts
@@ -99,7 +99,7 @@ async function showSidebarActivationForRecipe(recipeId: RegistryId) {
 
 let enhancementsLoaded = false;
 
-async function loadPageEnhancements(): Promise<void> {
+export async function loadPageEnhancements(): Promise<void> {
   if (enhancementsLoaded) {
     return;
   }
@@ -122,9 +122,12 @@ async function loadPageEnhancements(): Promise<void> {
       continue;
     }
 
-    // Check if recipe is already activated, and change button to Reactivate
+    // Check if recipe is already activated, and change button to teate
     if (installedRecipeIds.has(recipeId)) {
-      button.innerHTML = '<i class="fas fa-sync-alt"></i> Reactivate';
+      button.classList.remove("btn", "btn-primary");
+      button.classList.add("d-flex", "flex-column");
+      button.innerHTML =
+        '<span class="text-success"><i class="fas fa-check"></i> Active</span><span>Reactivate</span>';
     }
 
     button.addEventListener("click", async (event) => {
@@ -145,6 +148,11 @@ async function loadPageEnhancements(): Promise<void> {
       await showSidebarActivationForRecipe(recipeId);
     });
   }
+}
+
+export async function reloadMarketplaceEnhancements() {
+  enhancementsLoaded = false;
+  await loadPageEnhancements();
 }
 
 export async function initMarketplaceEnhancements() {

--- a/src/contentScript/marketplace.ts
+++ b/src/contentScript/marketplace.ts
@@ -87,6 +87,9 @@ function changeActivateButtonToActiveLabel(button: HTMLAnchorElement) {
     '<div class="d-flex flex-column"><span class="text-success"><i class="fas fa-check"></i> Active</span></div>'
   );
   $(button).replaceWith(activeLabel);
+
+  // Keeping the original button element in the dom so that the event listeners can be added in
+  // the loadPageEnhancements function
   activeLabel.append(button);
 }
 

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -71,6 +71,10 @@ export const runMapArgs = getMethod("RUN_MAP_ARGS");
 export const getPageState = getMethod("GET_PAGE_STATE");
 export const setPageState = getMethod("SET_PAGE_STATE");
 
+export const reloadMarketplaceEnhancements = getMethod(
+  "RELOAD_MARKETPLACE_ENHANCEMENTS"
+);
+
 export const notify = {
   info: getNotifier("NOTIFY_INFO"),
   // TODO: Automatically report from api.ts because of https://github.com/pixiebrix/pixiebrix-extension/blob/dce0d5cbb54d5fc1a61d720e43d17383a152df2e/src/background/contextMenus.ts#L92-L95

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -74,6 +74,7 @@ import {
   resolveTemporaryPanel,
   stopWaitingForTemporaryPanels,
 } from "@/blocks/transformers/temporaryInfo/temporaryPanelProtocol";
+import { reloadMarketplaceEnhancements } from "@/contentScript/marketplace";
 
 expectContext("contentScript");
 
@@ -131,6 +132,8 @@ declare global {
 
     GET_PAGE_STATE: typeof getPageState;
     SET_PAGE_STATE: typeof setPageState;
+
+    RELOAD_MARKETPLACE_ENHANCEMENTS: typeof reloadMarketplaceEnhancements;
   }
 }
 
@@ -191,5 +194,7 @@ export default function registerMessenger(): void {
 
     GET_PAGE_STATE: getPageState,
     SET_PAGE_STATE: setPageState,
+
+    RELOAD_MARKETPLACE_ENHANCEMENTS: reloadMarketplaceEnhancements,
   });
 }

--- a/src/sidebar/ConnectedSidebar.test.tsx
+++ b/src/sidebar/ConnectedSidebar.test.tsx
@@ -42,6 +42,13 @@ jest.mock("@/services/api", () => ({
     },
   },
 }));
+
+jest.mock("@/sidebar/store", () => ({
+  persistor: {
+    flush: jest.fn(),
+  },
+}));
+
 jest.mock("@/auth/token", () => {
   const originalModule = jest.requireActual("@/auth/token");
   return {

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
@@ -85,6 +85,12 @@ jest.mock("@/store/optionsStore", () => ({
   },
 }));
 
+jest.mock("@/sidebar/store", () => ({
+  persistor: {
+    flush: jest.fn(),
+  },
+}));
+
 jest.mock("@/permissions/index", () => ({
   collectPermissions: jest.fn().mockReturnValue({
     permissions: [],

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
@@ -134,6 +134,8 @@ function canAutoActivate(
 
 async function reloadMarketplaceEnhancements() {
   const topFrame = await getTopLevelFrame();
+  // Make sure the content script has the most recent state of the store before reloading.
+  // Prevents race condition where the content script reloads before the store is persisted.
   await persistor.flush();
   void reloadMarketplaceEnhancementsInContentScript(topFrame);
 }

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
@@ -25,7 +25,7 @@ import { useDispatch } from "react-redux";
 import sidebarSlice from "@/sidebar/sidebarSlice";
 import {
   hideSidebar,
-  reloadMarketplaceEnhancements,
+  reloadMarketplaceEnhancements as reloadMarketplaceEnhancementsInContentScript,
 } from "@/contentScript/messenger/api";
 import { getTopLevelFrame } from "webext-messenger";
 import cx from "classnames";
@@ -46,6 +46,7 @@ import { type RecipeDefinition } from "@/types/recipeTypes";
 import { useDefaultAuthOptions } from "@/hooks/auth";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import { persistor } from "@/sidebar/store";
+import { type AuthOption } from "@/auth/authTypes";
 
 const { actions } = sidebarSlice;
 
@@ -131,10 +132,10 @@ function canAutoActivate(
   return !hasRecipeOptions && !needsServiceInputs;
 }
 
-async function refreshMarketplaceEnhancements() {
+async function reloadMarketplaceEnhancements() {
   const topFrame = await getTopLevelFrame();
   await persistor.flush();
-  void reloadMarketplaceEnhancements(topFrame);
+  void reloadMarketplaceEnhancementsInContentScript(topFrame);
 }
 
 const ActivateRecipePanelContent: React.FC<RecipeState> = ({
@@ -176,7 +177,7 @@ const ActivateRecipePanelContent: React.FC<RecipeState> = ({
 
     if (success) {
       stateDispatch(activateSuccess());
-      void refreshMarketplaceEnhancements();
+      void reloadMarketplaceEnhancements();
     } else {
       stateDispatch(activateError(error));
     }

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
@@ -23,7 +23,10 @@ import styles from "./ActivateRecipePanel.module.scss";
 import AsyncButton from "@/components/AsyncButton";
 import { useDispatch } from "react-redux";
 import sidebarSlice from "@/sidebar/sidebarSlice";
-import { hideSidebar } from "@/contentScript/messenger/api";
+import {
+  hideSidebar,
+  reloadMarketplaceEnhancements,
+} from "@/contentScript/messenger/api";
 import { getTopLevelFrame } from "webext-messenger";
 import cx from "classnames";
 import { isEmpty, uniq } from "lodash";
@@ -43,6 +46,7 @@ import { type RecipeDefinition } from "@/types/recipeTypes";
 import { useDefaultAuthOptions } from "@/hooks/auth";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import { type AuthOption } from "@/auth/authTypes";
+import { sleep } from "@/utils";
 
 const { actions } = sidebarSlice;
 
@@ -128,6 +132,12 @@ function canAutoActivate(
   return !hasRecipeOptions && !needsServiceInputs;
 }
 
+async function refreshMarketplaceEnhancements() {
+  const topFrame = await getTopLevelFrame();
+  await sleep(100);
+  void reloadMarketplaceEnhancements(topFrame);
+}
+
 const ActivateRecipePanelContent: React.FC<RecipeState> = ({
   recipe,
   recipeNameNode,
@@ -167,6 +177,7 @@ const ActivateRecipePanelContent: React.FC<RecipeState> = ({
 
     if (success) {
       stateDispatch(activateSuccess());
+      void refreshMarketplaceEnhancements();
     } else {
       stateDispatch(activateError(error));
     }

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
@@ -45,8 +45,7 @@ import { useAsyncEffect } from "use-async-effect";
 import { type RecipeDefinition } from "@/types/recipeTypes";
 import { useDefaultAuthOptions } from "@/hooks/auth";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
-import { type AuthOption } from "@/auth/authTypes";
-import { sleep } from "@/utils";
+import { persistor } from "@/sidebar/store";
 
 const { actions } = sidebarSlice;
 
@@ -134,7 +133,7 @@ function canAutoActivate(
 
 async function refreshMarketplaceEnhancements() {
   const topFrame = await getTopLevelFrame();
-  await sleep(100);
+  await persistor.flush();
   void reloadMarketplaceEnhancements(topFrame);
 }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #5532
- Depends on some tweaks to the Marketplace layout: https://github.com/pixiebrix/pixiebrix-www/pull/730 (which can be deployed without waiting for an extension release)
- Adds a method to the content script messenger to reload the marketplace after successful activation (in order to refresh the Activate button)
- Changes the content of the activate button to an "Active" label & reactivate link instead

## Demo

- https://www.loom.com/share/51f07552a4a14c5cb62f35dbb1c8ea60

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @BLoe 
