### PR TITLE
#5530: IDB ErrorBoundary in Extension Console to recover from IDB errors

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3808,40 +3808,10 @@ exports[`Storyshots ExtensionConsole/IDBErrorDisplay Normal Error 1`] = `
   <pre
     className="mt-2 small text-secondary"
   >
-    Error: This is a normal error
-    at Object.&lt;anonymous&gt; (/Users/tschiller/projects/pixiebrix-extension/src/extensionConsole/components/IDBErrorDisplay.stories.tsx:52:21)
-    at Runtime._execModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:1429:24)
-    at Runtime._loadModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:1013:12)
-    at Runtime.requireModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:873:12)
-    at Runtime.requireModuleOrMock (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:1039:21)
-    at requireContext (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/babel-plugin-require-context-hook/register.js:29:12)
-    at /Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/executeLoadable.js:79:29
-    at Array.forEach (&lt;anonymous&gt;)
-    at /Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/executeLoadable.js:77:18
-    at Array.forEach (&lt;anonymous&gt;)
-    at executeLoadable (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/executeLoadable.js:76:10)
-    at executeLoadableForChanges (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/executeLoadable.js:127:20)
-    at Object.getProjectAnnotations [as nextFn] (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/start.js:161:84)
-    at /Users/tschiller/projects/pixiebrix-extension/node_modules/synchronous-promise/index.js:217:29
-    at Array.forEach (&lt;anonymous&gt;)
-    at SynchronousPromise._runResolutions (/Users/tschiller/projects/pixiebrix-extension/node_modules/synchronous-promise/index.js:214:19)
-    at SynchronousPromise.then (/Users/tschiller/projects/pixiebrix-extension/node_modules/synchronous-promise/index.js:67:10)
-    at PreviewWeb.getProjectAnnotationsOrRenderError (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/preview-web/dist/cjs/Preview.js:159:63)
-    at PreviewWeb.initialize (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/preview-web/dist/cjs/Preview.js:138:19)
-    at Object.configure (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/start.js:187:17)
-    at Object.configure (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/react/dist/cjs/client/preview/index.js:35:24)
-    at Object.configure [as default] (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/addon-storyshots/dist/ts3.9/frameworks/configure.js:83:19)
-    at Object.load (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/addon-storyshots/dist/ts3.9/frameworks/react/loader.js:13:24)
-    at Object.loadFramework [as default] (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/addon-storyshots/dist/ts3.9/frameworks/frameworkLoader.js:26:19)
-    at testStorySnapshots (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/addon-storyshots/dist/ts3.9/api/index.js:28:94)
-    at Object.&lt;anonymous&gt; (/Users/tschiller/projects/pixiebrix-extension/src/Storyshots.test.js:29:15)
-    at Runtime._execModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:1429:24)
-    at Runtime._loadModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:1013:12)
-    at Runtime.requireModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:873:12)
-    at jestAdapter (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:77:13)
-    at runTestInternal (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runner/build/runTest.js:367:16)
-    at runTest (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runner/build/runTest.js:444:34)
-    at Object.worker (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runner/build/testWorker.js:106:12)
+    ContextError: Encountered full disk while opening backing store for indexedDB.open.
+at k (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/bundles/85282.bundle.js:2:35318)
+ at $ (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/bundles/85282.bundle.js:2:36577)
+ at async L.runExtension (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/bundles/contentScriptCore.bundle.js:1:220194)
   </pre>
 </div>
 `;

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3724,6 +3724,171 @@ exports[`Storyshots Editor/LogToolbar Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots ExtensionConsole/IDBErrorDisplay Connection Error 1`] = `
+<div
+  className="p-3"
+>
+  <h1>
+    Something went wrong.
+  </h1>
+  <div>
+    <p>
+      Error connecting to local database.
+    </p>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-redo fa-w-16 "
+        data-icon="redo"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={{}}
+        viewBox="0 0 512 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M500.33 0h-47.41a12 12 0 0 0-12 12.57l4 82.76A247.42 247.42 0 0 0 256 8C119.34 8 7.9 119.53 8 256.19 8.1 393.07 119.1 504 256 504a247.1 247.1 0 0 0 166.18-63.91 12 12 0 0 0 .48-17.43l-34-34a12 12 0 0 0-16.38-.55A176 176 0 1 1 402.1 157.8l-101.53-4.87a12 12 0 0 0-12.57 12v47.41a12 12 0 0 0 12 12h200.33a12 12 0 0 0 12-12V12a12 12 0 0 0-12-12z"
+          fill="currentColor"
+          style={{}}
+        />
+      </svg>
+       Retry
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Storyshots ExtensionConsole/IDBErrorDisplay Normal Error 1`] = `
+<div
+  className="p-3"
+>
+  <h1>
+    Something went wrong.
+  </h1>
+  <div>
+    <p>
+      This is a normal error
+    </p>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-redo fa-w-16 "
+        data-icon="redo"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={{}}
+        viewBox="0 0 512 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M500.33 0h-47.41a12 12 0 0 0-12 12.57l4 82.76A247.42 247.42 0 0 0 256 8C119.34 8 7.9 119.53 8 256.19 8.1 393.07 119.1 504 256 504a247.1 247.1 0 0 0 166.18-63.91 12 12 0 0 0 .48-17.43l-34-34a12 12 0 0 0-16.38-.55A176 176 0 1 1 402.1 157.8l-101.53-4.87a12 12 0 0 0-12.57 12v47.41a12 12 0 0 0 12 12h200.33a12 12 0 0 0 12-12V12a12 12 0 0 0-12-12z"
+          fill="currentColor"
+          style={{}}
+        />
+      </svg>
+       Reload the Page
+    </button>
+  </div>
+  <pre
+    className="mt-2 small text-secondary"
+  >
+    Error: This is a normal error
+    at Object.&lt;anonymous&gt; (/Users/tschiller/projects/pixiebrix-extension/src/extensionConsole/components/IDBErrorDisplay.stories.tsx:52:21)
+    at Runtime._execModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:1429:24)
+    at Runtime._loadModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:1013:12)
+    at Runtime.requireModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:873:12)
+    at Runtime.requireModuleOrMock (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:1039:21)
+    at requireContext (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/babel-plugin-require-context-hook/register.js:29:12)
+    at /Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/executeLoadable.js:79:29
+    at Array.forEach (&lt;anonymous&gt;)
+    at /Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/executeLoadable.js:77:18
+    at Array.forEach (&lt;anonymous&gt;)
+    at executeLoadable (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/executeLoadable.js:76:10)
+    at executeLoadableForChanges (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/executeLoadable.js:127:20)
+    at Object.getProjectAnnotations [as nextFn] (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/start.js:161:84)
+    at /Users/tschiller/projects/pixiebrix-extension/node_modules/synchronous-promise/index.js:217:29
+    at Array.forEach (&lt;anonymous&gt;)
+    at SynchronousPromise._runResolutions (/Users/tschiller/projects/pixiebrix-extension/node_modules/synchronous-promise/index.js:214:19)
+    at SynchronousPromise.then (/Users/tschiller/projects/pixiebrix-extension/node_modules/synchronous-promise/index.js:67:10)
+    at PreviewWeb.getProjectAnnotationsOrRenderError (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/preview-web/dist/cjs/Preview.js:159:63)
+    at PreviewWeb.initialize (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/preview-web/dist/cjs/Preview.js:138:19)
+    at Object.configure (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/core-client/dist/cjs/preview/start.js:187:17)
+    at Object.configure (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/react/dist/cjs/client/preview/index.js:35:24)
+    at Object.configure [as default] (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/addon-storyshots/dist/ts3.9/frameworks/configure.js:83:19)
+    at Object.load (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/addon-storyshots/dist/ts3.9/frameworks/react/loader.js:13:24)
+    at Object.loadFramework [as default] (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/addon-storyshots/dist/ts3.9/frameworks/frameworkLoader.js:26:19)
+    at testStorySnapshots (/Users/tschiller/projects/pixiebrix-extension/node_modules/@storybook/addon-storyshots/dist/ts3.9/api/index.js:28:94)
+    at Object.&lt;anonymous&gt; (/Users/tschiller/projects/pixiebrix-extension/src/Storyshots.test.js:29:15)
+    at Runtime._execModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:1429:24)
+    at Runtime._loadModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:1013:12)
+    at Runtime.requireModule (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runtime/build/index.js:873:12)
+    at jestAdapter (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:77:13)
+    at runTestInternal (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runner/build/runTest.js:367:16)
+    at runTest (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runner/build/runTest.js:444:34)
+    at Object.worker (/Users/tschiller/projects/pixiebrix-extension/node_modules/jest-runner/build/testWorker.js:106:12)
+  </pre>
+</div>
+`;
+
+exports[`Storyshots ExtensionConsole/IDBErrorDisplay Quota Error 1`] = `
+<div
+  className="p-3"
+>
+  <h1>
+    Something went wrong.
+  </h1>
+  <div>
+    <p>
+      Insufficient storage space available to PixieBrix.
+    </p>
+    <p />
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="svg-inline--fa fa-redo fa-w-16 "
+        data-icon="redo"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={{}}
+        viewBox="0 0 512 512"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M500.33 0h-47.41a12 12 0 0 0-12 12.57l4 82.76A247.42 247.42 0 0 0 256 8C119.34 8 7.9 119.53 8 256.19 8.1 393.07 119.1 504 256 504a247.1 247.1 0 0 0 166.18-63.91 12 12 0 0 0 .48-17.43l-34-34a12 12 0 0 0-16.38-.55A176 176 0 1 1 402.1 157.8l-101.53-4.87a12 12 0 0 0-12.57 12v47.41a12 12 0 0 0 12 12h200.33a12 12 0 0 0 12-12V12a12 12 0 0 0-12-12z"
+          fill="currentColor"
+          style={{}}
+        />
+      </svg>
+       Reclaim Space
+    </button>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Fields/ChildObjectField Primitive Value 1`] = `
 <form
   action="#"

--- a/src/extensionConsole/App.tsx
+++ b/src/extensionConsole/App.tsx
@@ -53,6 +53,7 @@ import { logActions } from "@/components/logViewer/logSlice";
 import ReduxPersistenceContext, {
   type ReduxPersistenceContextType,
 } from "@/store/ReduxPersistenceContext";
+import IDBErrorDisplay from "@/extensionConsole/components/IDBErrorDisplay";
 
 // Register the built-in bricks
 registerEditors();
@@ -83,7 +84,7 @@ const Layout = () => {
       <Navbar logo={logo} />
       <Container fluid className="page-body-wrapper">
         {/* It is guaranteed that under RequireAuth the user has a valid API token (either PixieBrix token or partner JWT). */}
-        <ErrorBoundary>
+        <ErrorBoundary ErrorComponent={IDBErrorDisplay}>
           <RequireAuth LoginPage={SetupPage}>
             <RefreshBricks />
             <Sidebar />
@@ -94,7 +95,7 @@ const Layout = () => {
               <DeploymentBanner />
               <InvitationBanner />
               <div className="content-wrapper">
-                <ErrorBoundary>
+                <ErrorBoundary ErrorComponent={IDBErrorDisplay}>
                   <Switch>
                     <Route
                       exact

--- a/src/extensionConsole/components/IDBErrorDisplay.stories.tsx
+++ b/src/extensionConsole/components/IDBErrorDisplay.stories.tsx
@@ -52,12 +52,15 @@ const quotaError = new Error(
   "Encountered full disk while opening backing store for indexedDB.open."
 );
 const connectionError = new Error("Error Opening IndexedDB");
+// Hard-code a stack because the stack includes the file path on local/CI builds, so Storyshots will fail
+const stack =
+  "ContextError: Encountered full disk while opening backing store for indexedDB.open.\nat k (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/bundles/85282.bundle.js:2:35318)\n at $ (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/bundles/85282.bundle.js:2:36577)\n at async L.runExtension (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/bundles/contentScriptCore.bundle.js:1:220194)";
 
 export const NormalError = Template.bind({});
 NormalError.args = {
   error: normalError,
   errorMessage: getErrorMessage(normalError),
-  stack: normalError.stack,
+  stack,
   hasError: true,
 };
 
@@ -65,7 +68,7 @@ export const QuotaError = Template.bind({});
 QuotaError.args = {
   error: quotaError,
   errorMessage: getErrorMessage(quotaError),
-  stack: quotaError.stack,
+  stack,
   hasError: true,
 };
 
@@ -73,6 +76,6 @@ export const ConnectionError = Template.bind({});
 ConnectionError.args = {
   error: connectionError,
   errorMessage: getErrorMessage(connectionError),
-  stack: connectionError.stack,
+  stack,
   hasError: true,
 };

--- a/src/extensionConsole/components/IDBErrorDisplay.stories.tsx
+++ b/src/extensionConsole/components/IDBErrorDisplay.stories.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { type ComponentStory, type ComponentMeta } from "@storybook/react";
+
+import IDBErrorDisplay from "@/extensionConsole/components/IDBErrorDisplay";
+import { getErrorMessage } from "@/errors/errorHelpers";
+
+export default {
+  title: "ExtensionConsole/IDBErrorDisplay",
+  component: IDBErrorDisplay,
+} as ComponentMeta<typeof IDBErrorDisplay>;
+
+const Template: ComponentStory<typeof IDBErrorDisplay> = (args) => (
+  <IDBErrorDisplay {...args} />
+);
+
+const normalError = new Error("This is a normal error");
+const quotaError = new Error(
+  "Encountered full disk while opening backing store for indexedDB.open."
+);
+const connectionError = new Error("Error Opening IndexedDB");
+
+export const NormalError = Template.bind({});
+NormalError.args = {
+  error: normalError,
+  errorMessage: getErrorMessage(normalError),
+  stack: normalError.stack,
+  hasError: true,
+};
+
+export const QuotaError = Template.bind({});
+QuotaError.args = {
+  error: quotaError,
+  errorMessage: getErrorMessage(quotaError),
+  stack: quotaError.stack,
+  hasError: true,
+};
+
+export const ConnectionError = Template.bind({});
+ConnectionError.args = {
+  error: connectionError,
+  errorMessage: getErrorMessage(connectionError),
+  stack: connectionError.stack,
+  hasError: true,
+};

--- a/src/extensionConsole/components/IDBErrorDisplay.tsx
+++ b/src/extensionConsole/components/IDBErrorDisplay.tsx
@@ -113,7 +113,13 @@ const QuotaErrorDisplay: React.FC<ErrorDisplayProps> = ({
       <h1>Something went wrong.</h1>
       <div>
         <p>Insufficient storage space available to PixieBrix.</p>
-        <AsyncStateGate state={state} renderLoader={() => <p></p>}>
+        <AsyncStateGate
+          state={state}
+          renderLoader={() => <p></p>}
+          renderError={() => (
+            <p className="text-small">Unable to retrieve usage and quota.</p>
+          )}
+        >
           {({ data: { storageEstimate } }) => (
             <p className="text-small">
               Using {round(storageEstimate.usage / 1e6, 1).toLocaleString()} MB

--- a/src/extensionConsole/components/IDBErrorDisplay.tsx
+++ b/src/extensionConsole/components/IDBErrorDisplay.tsx
@@ -1,0 +1,157 @@
+/* eslint-disable unicorn/filename-case -- IDB is an abbreviation */
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import {
+  DefaultErrorComponent,
+  type ErrorDisplayProps,
+} from "@/components/ErrorBoundary";
+import { isIDBConnectionError, isIDBQuotaError } from "@/utils/idbUtils";
+import useUserAction from "@/hooks/useUserAction";
+import { clearLogs, recreateDB as recreateLogDB } from "@/telemetry/logging";
+import { clearTraces, recreateDB as recreateTraceDB } from "@/telemetry/trace";
+import { recreateDB as recreateBrickDB } from "@/registry/localRegistry";
+// eslint-disable-next-line import/no-restricted-paths -- safe import because IDB is shared resource
+import {
+  recreateDB as recreateEventDB,
+  clear as clearEvents,
+} from "@/background/telemetry";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faRedo } from "@fortawesome/free-solid-svg-icons";
+import AsyncButton from "@/components/AsyncButton";
+import { sleep } from "@/utils";
+import { useAsyncState } from "@/hooks/common";
+import { type StorageEstimate } from "@/types/browserTypes";
+import { expectContext } from "@/utils/expectContext";
+import AsyncStateGate from "@/components/AsyncStateGate";
+import { round } from "lodash";
+
+const ConnectionErrorDisplay: React.FC = () => {
+  const recoverAction = useUserAction(
+    async () => {
+      await Promise.all([
+        recreateLogDB(),
+        recreateTraceDB(),
+        recreateBrickDB(),
+        recreateEventDB(),
+      ]);
+    },
+    {
+      successMessage: "Recreated local databases. Reloading page.",
+      errorMessage: "Error recreating local databases",
+    },
+    []
+  );
+
+  return (
+    <div className="p-3">
+      <h1>Something went wrong.</h1>
+      <div>
+        <p>Error connecting to local database.</p>
+      </div>
+      <div>
+        <AsyncButton
+          onClick={async () => {
+            await recoverAction();
+            // Put outside the action so user can see the success message before the page reloads.
+            await sleep(250);
+            location.reload();
+          }}
+        >
+          <FontAwesomeIcon icon={faRedo} /> Retry
+        </AsyncButton>
+      </div>
+    </div>
+  );
+};
+
+const QuotaErrorDisplay: React.FC = () => {
+  const state = useAsyncState(
+    async () => ({
+      storageEstimate: (await navigator.storage.estimate()) as StorageEstimate,
+    }),
+    []
+  );
+
+  const recoverAction = useUserAction(
+    async () => {
+      await Promise.all([clearLogs(), clearTraces(), clearEvents()]);
+    },
+    {
+      successMessage: "Reclaimed local space. Reloading page.",
+      errorMessage: "Error reclaiming local space",
+    },
+    []
+  );
+
+  return (
+    <div className="p-3">
+      <h1>Something went wrong.</h1>
+      <div>
+        <p>Insufficient storage space available to PixieBrix.</p>
+        <AsyncStateGate state={state} renderLoader={() => <p></p>}>
+          {({ data: { storageEstimate } }) => (
+            <p className="text-small">
+              Using
+              {round(storageEstimate.usage / 1e6, 1).toLocaleString()} MB of
+              {round(storageEstimate.quota / 1e6, 0).toLocaleString()} MB
+              available
+            </p>
+          )}
+        </AsyncStateGate>
+      </div>
+      <div>
+        <AsyncButton
+          onClick={async () => {
+            await recoverAction();
+            // Put outside the action so user can see the success message before the page reloads.
+            await sleep(250);
+            location.reload();
+          }}
+        >
+          <FontAwesomeIcon icon={faRedo} /> Reclaim Space
+        </AsyncButton>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * A component that displays custom error messages for IDB errors.
+ *
+ * Use with ErrorBoundary.ErrorComponent
+ *
+ * @see ErrorBoundary
+ */
+const IDBErrorDisplay: React.FC<ErrorDisplayProps> = (props) => {
+  expectContext("extension");
+
+  const { error } = props;
+
+  if (isIDBConnectionError(error)) {
+    return <ConnectionErrorDisplay {...props} />;
+  }
+
+  if (isIDBQuotaError(error)) {
+    return <QuotaErrorDisplay {...props} />;
+  }
+
+  return <DefaultErrorComponent {...props} />;
+};
+
+export default IDBErrorDisplay;

--- a/src/extensionConsole/components/IDBErrorDisplay.tsx
+++ b/src/extensionConsole/components/IDBErrorDisplay.tsx
@@ -116,9 +116,8 @@ const QuotaErrorDisplay: React.FC<ErrorDisplayProps> = ({
         <AsyncStateGate state={state} renderLoader={() => <p></p>}>
           {({ data: { storageEstimate } }) => (
             <p className="text-small">
-              Using
-              {round(storageEstimate.usage / 1e6, 1).toLocaleString()} MB of
-              {round(storageEstimate.quota / 1e6, 0).toLocaleString()} MB
+              Using {round(storageEstimate.usage / 1e6, 1).toLocaleString()} MB
+              of {round(storageEstimate.quota / 1e6, 0).toLocaleString()} MB
               available
             </p>
           )}

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -143,7 +143,7 @@ async function getDB() {
       databaseRef = null;
     },
     terminated() {
-      console.debug("Brick database connection was unexpectedly terminated");
+      console.debug("Log database connection was unexpectedly terminated");
       databaseRef = null;
     },
   });

--- a/src/types/browserTypes.ts
+++ b/src/types/browserTypes.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// XXX: the default types are not complete, so we need to augment them
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/estimate
+ * @see navigator.storage.estimate
+ */
+export type StorageEstimate = {
+  /**
+   * A numeric value in bytes approximating the amount of storage space currently being used by the site or Web app,
+   * out of the available space as indicated by quota. Unit is byte.
+   */
+  usage: number;
+  /**
+   * A numeric value in bytes which provides a conservative approximation of the total storage the user's device or
+   * computer has available for the site origin or Web app. It's possible that there's more than this amount of space
+   * available though you can't rely on that being the case.
+   */
+  quota: number;
+
+  /**
+   * An object containing a breakdown of usage by storage system. All included properties will have a usage greater
+   * than 0 and any storage system with 0 usage will be excluded from the object.
+   */
+  usageDetails: {
+    // https://github.com/whatwg/storage/issues/63#issuecomment-437990804
+    indexedDB?: number;
+    caches?: number;
+    serviceWorkerRegistrations?: number;
+    other: number;
+  };
+};

--- a/src/utils/idbUtils.ts
+++ b/src/utils/idbUtils.ts
@@ -1,5 +1,18 @@
 import pDefer from "p-defer";
 import { deleteDB } from "idb/with-async-ittr";
+import { getErrorMessage } from "@/errors/errorHelpers";
+
+// IDB Connection Error message strings:
+// https://app.rollbar.com/a/pixiebrix/fix/item/pixiebrix/6675
+const connectionErrors = ["Error Opening IndexedDB"];
+
+// IDB Quota Error message strings:
+// https://app.rollbar.com/a/pixiebrix/fix/item/pixiebrix/7979
+// https://app.rollbar.com/a/pixiebrix/fix/item/pixiebrix/6681
+const quotaErrors = [
+  "Encountered full disk while opening backing store for indexedDB.open",
+  "IndexedDB Full",
+];
 
 /**
  * Delete an IndexedDB database.
@@ -16,4 +29,27 @@ export async function deleteDatabase(databaseName: string): Promise<void> {
     },
   });
   await Promise.race([deletePromise, deferred.promise]);
+}
+
+/**
+ * Returns true if the error corresponds to not being able to connect to IndexedDB, e.g., due to a corrupt database.
+ * Does not include quota errors.
+ * @param error the error object
+ * @see isIDBQuotaError
+ */
+export function isIDBConnectionError(error: unknown): boolean {
+  const message = getErrorMessage(error);
+  return connectionErrors.some((connectionError) =>
+    message.includes(connectionError)
+  );
+}
+
+/**
+ * Returns true if the error corresponds to IndexedDB not having enough available quota.
+ * @param error the error object
+ * @see isIDBConnectionError
+ */
+export function isIDBQuotaError(error: unknown): boolean {
+  const message = getErrorMessage(error);
+  return quotaErrors.some((quotaError) => message.includes(quotaError));
 }


### PR DESCRIPTION
## What does this PR do?

- Follow up to https://github.com/pixiebrix/pixiebrix-extension/pull/5558
- Closes #5530 
- Adds support for custom error display to ErrorBoundary
- Defines custom error display for IDB errors
- Includes the event buffer DB in clearing/recreating databases

## Demo

- See Storybook

## Checklist

- [x] Add tests: add via Storybook Storyshots
- [x] Designate a primary reviewer: @BLoe 
