### PR TITLE
#5430: fix DataDog RUM in extension console

### DIFF
--- a/src/pageEditor/pageEditor.tsx
+++ b/src/pageEditor/pageEditor.tsx
@@ -31,13 +31,11 @@ import { watchNavigation } from "@/pageEditor/protocol";
 import initGoogle from "@/contrib/google/initGoogle";
 import { initToaster } from "@/utils/notify";
 import { markAppStart } from "@/utils/performance";
-import { initPerformanceMonitoring } from "@/telemetry/performance";
 
 markAppStart();
 
 registerMessenger();
 void initGoogle();
-void initPerformanceMonitoring();
 watchNavigation();
 initToaster();
 

--- a/src/sidebar/sidebar.tsx
+++ b/src/sidebar/sidebar.tsx
@@ -31,7 +31,6 @@ import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 import { initToaster } from "@/utils/notify";
 import initGoogle from "@/contrib/google/initGoogle";
-import { initPerformanceMonitoring } from "@/telemetry/performance";
 
 function init(): void {
   ReactDOM.render(<App />, document.querySelector("#container"));
@@ -39,7 +38,6 @@ function init(): void {
 
 registerMessenger();
 void initGoogle();
-void initPerformanceMonitoring();
 registerContribBlocks();
 registerBuiltinBlocks();
 initToaster();

--- a/src/telemetry/performance.ts
+++ b/src/telemetry/performance.ts
@@ -29,10 +29,18 @@ const RUM_FLAG = "telemetry-performance";
 
 /**
  * Initialize Datadog Real User Monitoring (RUM) for performance monitoring.
+ * WARNING: can only be used in the Extension Console, due to cookie limitations in frames.
  */
 export async function initPerformanceMonitoring(): Promise<void> {
+  // Require the extension context because we don't want to track performance of the host sites
   expectContext("extension");
   forbidContext("contentScript");
+  // DataDog issue that RUM doesn't work in browser extension contexts, e.g., DevTools
+  // https://github.com/DataDog/browser-sdk/issues/798
+  forbidContext("devTools");
+  forbidContext("sidebar");
+  // There's no user interactions to track in the background page
+  forbidContext("background");
 
   const baseUrl = await getBaseURL();
 
@@ -67,8 +75,10 @@ export async function initPerformanceMonitoring(): Promise<void> {
     trackLongTasks: true,
     trackFrustrations: true,
     defaultPrivacyLevel: "mask",
+    // From the docs, it would appear that useCrossSiteSessionCookie would enable support for iframes like the
+    // sidebar and page editor. But in reality, it breaks the Extension Console tracking too.
     // To support in Page Editor and Sidebar because they're iframes
-    useCrossSiteSessionCookie: true,
+    // useCrossSiteSessionCookie: true,
     // List the URLs/origins for sending trace headers
     // https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum#usage
     allowedTracingUrls: [baseUrl],


### PR DESCRIPTION
## What does this PR do?

- Closes #5430

## Discussion

- 😞  RUM can't work in the Page Editor or Sidebar (see GH issue linked in the code)
- Has to be tested in a production build, as I've seen that the behavior is different locally vs. production
- It's still behind the feature flag `telemetry-performance` that's currently enabled for PixieBrix team members

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @mnholtz 
