### PR TITLE
#5600: revert singleton IDB connection PR; use fresh IDB connection for each operation

### DIFF
--- a/src/extensionConsole/pages/settings/StorageSettings.tsx
+++ b/src/extensionConsole/pages/settings/StorageSettings.tsx
@@ -71,8 +71,8 @@ const StorageSettings: React.FunctionComponent = () => {
       await recalculate();
     },
     {
-      successMessage: "Cleaned up unnecessary local data",
-      errorMessage: "Error cleaning unnecessary local data",
+      successMessage: "Reclaimed local space",
+      errorMessage: "Error reclaiming local space",
     },
     [recalculate]
   );
@@ -156,7 +156,7 @@ const StorageSettings: React.FunctionComponent = () => {
       </Card.Body>
       <Card.Footer className={styles.cardFooter}>
         <AsyncButton variant="info" onClick={clearLogsAction}>
-          <FontAwesomeIcon icon={faBroom} /> Cleanup Unnecessary Data
+          <FontAwesomeIcon icon={faBroom} /> Reclaim Local Space
         </AsyncButton>
 
         <AsyncButton variant="warning" onClick={recoverStorageAction}>


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-extension/issues/5530
- Follow up to https://github.com/pixiebrix/pixiebrix-extension/pull/5558

## Remaining Work

- [ ] Test performance on release build

## Discussion

- Switching to a singleton IDB instance per context seemed to be slowing down initialization time: https://www.notion.so/pixiebrix/Release-1-7-24-3fa746bb6a5748f6b1f257163d0f00e8?pvs=4
- There is very little guidance floating around on how many connections you can/should use: https://stackoverflow.com/questions/21418954/is-it-bad-to-open-several-database-connections-in-indexeddb. They seem to be very light-weight
- The main thing is the logic we had added previously to close connections when required (i.e., when a page is trying to upgrade/delete the DB)
- It's unlikely the multiple IDB connections are a cause of the rollbar errors we're seeing. We should be seeing them more consistently if that was the case
 
## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @BLoe 
