### PR TITLE
Set emoji size in quickbar

### DIFF
--- a/src/components/quickBar/QuickBarResults.tsx
+++ b/src/components/quickBar/QuickBarResults.tsx
@@ -73,7 +73,9 @@ const ResultItem = forwardRef(
             fontWeight: 400,
           }}
         >
-          <div style={{ alignSelf: "flex-start" }}>{icon ?? null}</div>
+          <div style={{ alignSelf: "flex-start", fontSize: 14, width: 16 }}>
+            {icon ?? null}
+          </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
             <div>
               {ancestors.length > 0 &&

--- a/src/components/quickBar/QuickBarResults.tsx
+++ b/src/components/quickBar/QuickBarResults.tsx
@@ -71,9 +71,17 @@ const ResultItem = forwardRef(
             alignItems: "center",
             fontSize: 16,
             fontWeight: 400,
+            lineHeight: "16px",
           }}
         >
-          <div style={{ alignSelf: "flex-start", fontSize: 14, width: 16 }}>
+          <div
+            style={{
+              alignSelf: "flex-start",
+              width: 18,
+              display: "flex",
+              justifyContent: "center",
+            }}
+          >
             {icon ?? null}
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>

--- a/src/components/quickBar/quickBarTheme.tsx
+++ b/src/components/quickBar/quickBarTheme.tsx
@@ -46,7 +46,6 @@ export const animatorStyle: React.CSSProperties = {
   color: theme.foreground,
   borderRadius: "8px",
   overflow: "hidden",
-  boxShadow: theme.shadow,
 };
 
 export const groupNameStyle = {

--- a/src/components/quickBar/quickBarTheme.tsx
+++ b/src/components/quickBar/quickBarTheme.tsx
@@ -46,6 +46,7 @@ export const animatorStyle: React.CSSProperties = {
   color: theme.foreground,
   borderRadius: "8px",
   overflow: "hidden",
+  boxShadow: theme.shadow,
 };
 
 export const groupNameStyle = {


### PR DESCRIPTION
## What does this PR do?

Fixes emoji size issue in quickbar.

[context](https://www.notion.so/pixiebrix/Release-1-7-24-3fa746bb6a5748f6b1f257163d0f00e8?pvs=4#8f2e97066c7845fba0b41fbaac5278ea)

This sets the font-size for emoji to 14px.


## Demo

before:
![image](https://user-images.githubusercontent.com/10778363/234083503-94637ea6-4146-4517-b112-9bd7a08f756d.png)

after (updated): 
![image](https://user-images.githubusercontent.com/10778363/234092973-c59a052f-bbe1-4004-a72d-f8eaddfa3fde.png)

after (with subtitle):
![image](https://user-images.githubusercontent.com/10778363/234093275-176f93da-80c3-45e4-9605-6ebef11b3970.png)


- [ ] Designate a primary reviewer
