### PR TITLE
Fix regex to capture apple emoji variation characters in quickbar

### DIFF
--- a/src/utils/stringUtils.test.ts
+++ b/src/utils/stringUtils.test.ts
@@ -39,6 +39,19 @@ describe("string utilities", () => {
     });
     expect(
       splitStartingEmoji(
+        "🏜️ using apples troublesome emoji with .trim()"
+      ).rest.trim()
+    ).toStrictEqual("using apples troublesome emoji with .trim()");
+
+    expect(
+      splitStartingEmoji("🏜️ using apples troublesome emoji with .trim()")
+    ).toStrictEqual({
+      startingEmoji: "🏜️",
+      rest: " using apples troublesome emoji with .trim()",
+    });
+
+    expect(
+      splitStartingEmoji(
         "😊😊 some test string with multiple emojis at the start"
       )
     ).toStrictEqual({

--- a/src/utils/stringUtils.test.ts
+++ b/src/utils/stringUtils.test.ts
@@ -31,11 +31,19 @@ describe("string utilities", () => {
     });
     expect(
       splitStartingEmoji(
-        "😊 😊 some test string with multiple emojis at the start"
+        "😊 😊 some test string with multiple emojis at the start separated by space"
       )
     ).toStrictEqual({
       startingEmoji: "😊",
-      rest: " 😊 some test string with multiple emojis at the start",
+      rest: " 😊 some test string with multiple emojis at the start separated by space",
+    });
+    expect(
+      splitStartingEmoji(
+        "😊😊 some test string with multiple emojis at the start"
+      )
+    ).toStrictEqual({
+      startingEmoji: "😊",
+      rest: "😊 some test string with multiple emojis at the start",
     });
     expect(
       splitStartingEmoji("👋🏿 some test string with colors emoji at the start")

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -23,7 +23,6 @@ export function splitStartingEmoji(value: string) {
   const emojiRegex =
     /^((?:\p{Extended_Pictographic}\p{Emoji_Modifier_Base}?\p{Emoji_Modifier}?\uFE0F?))?(.*)/u;
   const match = emojiRegex.exec(value);
-  console.log({ rest: match[2]?.charCodeAt(0) });
   return {
     startingEmoji: match[1],
     rest: match[2],

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -21,8 +21,9 @@
  */
 export function splitStartingEmoji(value: string) {
   const emojiRegex =
-    /^((?:\p{Extended_Pictographic}\p{Emoji_Modifier_Base}?\p{Emoji_Modifier}?)+)?(.*)/u;
+    /^((?:\p{Extended_Pictographic}\p{Emoji_Modifier_Base}?\p{Emoji_Modifier}?\uFE0F?))?(.*)/u;
   const match = emojiRegex.exec(value);
+  console.log({ rest: match[2]?.charCodeAt(0) });
   return {
     startingEmoji: match[1],
     rest: match[2],


### PR DESCRIPTION
## What does this PR do?

`.trim()` wasn't working on the quickbar name when using certain emojis because apple's version of certain emojis contain an extra `\uFE0F` character which wasn't being captured by the emoji regex. This fixes that.

## Demo
![image](https://user-images.githubusercontent.com/10778363/234140593-93a3ca39-69cb-4cd8-a269-ab4dc129422b.png)
## Checklist

- [x] Add tests
- [x] Designate a primary reviewer
