### PR TITLE
Follow up to #5572 - Fix initialize so the config screen doesn't flash

### DIFF
--- a/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
@@ -82,6 +82,8 @@ const activationSlice = createSlice({
   reducers: {
     setNeedsPermissions(state, action: PayloadAction<boolean>) {
       state.needsPermissions = action.payload;
+    },
+    initialize(state) {
       state.isInitialized = true;
     },
     activateStart(state) {
@@ -100,8 +102,13 @@ const activationSlice = createSlice({
   },
 });
 
-const { setNeedsPermissions, activateStart, activateSuccess, activateError } =
-  activationSlice.actions;
+const {
+  setNeedsPermissions,
+  initialize,
+  activateStart,
+  activateSuccess,
+  activateError,
+} = activationSlice.actions;
 
 async function reloadMarketplaceEnhancements() {
   const topFrame = await getTopLevelFrame();
@@ -174,8 +181,10 @@ const ActivateRecipePanelContent: React.FC<RecipeState> = ({
   }
 
   useAsyncEffect(async () => {
-    if (state.isInitialized && !state.needsPermissions && canAutoActivate) {
+    if (!state.needsPermissions && canAutoActivate) {
       await activateRecipe();
+    } else {
+      stateDispatch(initialize());
     }
   }, [canAutoActivate, state.isInitialized, state.needsPermissions]);
 


### PR DESCRIPTION
## What does this PR do?

- Fixes a flash of the empty config screen in the activate sidebar before auto-activation:
 
<img width="456" alt="image" src="https://user-images.githubusercontent.com/2801308/234399446-b03364b4-009c-4915-930e-79365add32e4.png">


## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
