### PR TITLE
Insert Button bug - run page script even if no extension points are installed

### DIFF
--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -493,12 +493,12 @@ export async function handleNavigate({
 
   const extensionPoints = await loadPersistedExtensionsOnce();
 
+  const abortSignal = createNavigationAbortSignal();
+
+  // Page script is needed for inserting elements into the page
+  await Promise.all([injectPageScriptOnce(), waitDocumentLoad(abortSignal)]);
+
   if (extensionPoints.length > 0) {
-    const abortSignal = createNavigationAbortSignal();
-
-    // Extension Points may need the pageScript to be injected to run
-    await Promise.all([injectPageScriptOnce(), waitDocumentLoad(abortSignal)]);
-
     // Safe to use Promise.all because the inner method can't throw
     await Promise.all(
       extensionPoints.map(async (extensionPoint) => {


### PR DESCRIPTION
## What does this PR do?

- Fixes the 1.7.24 release blocker where button insertion doesn't work with no extensions installed

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
