### PR TITLE
Only swap-out Activate buttons with data-activate-button attribute

### DIFF
--- a/src/contentScript/marketplace.test.ts
+++ b/src/contentScript/marketplace.test.ts
@@ -76,10 +76,10 @@ const recipeId2 = validateRegistryId("@pixies/github/github-notifications");
 
 const activateButtonsHtml = `
 <div>
-    <a class="btn btn-primary" href="https://app.pixiebrix.com/activate?id=${encodeURIComponent(
+    <a class="btn btn-primary" data-activate-button href="https://app.pixiebrix.com/activate?id=${encodeURIComponent(
       recipeId1
     )}&utm_source=marketplace&utm_campaign=activate_blueprint" target="_blank" rel="noreferrer noopener"><i class="fas fa-plus-circle"></i> Activate</a>
-    <a class="btn btn-primary" href="https://app.pixiebrix.com/activate?id=${encodeURIComponent(
+    <a class="btn btn-primary" data-activate-button href="https://app.pixiebrix.com/activate?id=${encodeURIComponent(
       recipeId2
     )}&utm_source=marketplace&utm_campaign=activate_blueprint" target="_blank" rel="noreferrer noopener"><i class="fas fa-plus-circle"></i> Activate</a>
 </div>

--- a/src/contentScript/marketplace.ts
+++ b/src/contentScript/marketplace.ts
@@ -76,7 +76,10 @@ async function getInProgressRecipeActivation(): Promise<RegistryId | null> {
 }
 
 function changeActivateButtonToActiveLabel(button: HTMLAnchorElement) {
-  if (button.innerHTML.includes("Reactivate")) {
+  // Check if the button is already changed to an active label or if it isn't a special activate button that
+  // should be swapped to an active label
+  const isActivateButton = $(button).attr("data-activate-button");
+  if (button.innerHTML.includes("Reactivate") || !isActivateButton) {
     return;
   }
 

--- a/src/contentScript/marketplace.ts
+++ b/src/contentScript/marketplace.ts
@@ -78,7 +78,7 @@ async function getInProgressRecipeActivation(): Promise<RegistryId | null> {
 function changeActivateButtonToActiveLabel(button: HTMLAnchorElement) {
   // Check if the button is already changed to an active label or if it isn't a special activate button that
   // should be swapped to an active label
-  const isActivateButton = $(button).attr("data-activate-button");
+  const isActivateButton = Object.hasOwn(button.dataset, "activateButton");
   if (button.innerHTML.includes("Reactivate") || !isActivateButton) {
     return;
   }


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-extension/pull/5584
- Marketplace-side PR: https://github.com/pixiebrix/pixiebrix-www/pull/734
- Only targets Activate buttons with data-activate-button boolean data attribute for "Active/Reactivate" label swapout
- Still continues to add onclick handler to all activate links on the page (so that all links can still trigger a reactivation)

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer @BLoe 
