### PR TITLE
Darken card headers and fix body background color

### DIFF
--- a/src/themes/colors.scss
+++ b/src/themes/colors.scss
@@ -41,6 +41,10 @@ $P300: #9065e6;
 $P500: #5a19da;
 $P900: #260b5c;
 
+// Surface
+$S0: #ffffff;
+$S30: #f0eff2;
+
 /*
 * Misc Tokens
 *

--- a/src/vendors/theme/assets/styles/_themes.scss
+++ b/src/vendors/theme/assets/styles/_themes.scss
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@import "@/themes/colors";
 
 /*
 * Used for dynamic theming of components with css variables,
@@ -69,7 +70,7 @@ $variable-theme-colors: (
   --theme-dark-l: 30%;
   --theme-dark: hsl(213, 19%, 30%);
 
-  --theme-bg-light: $neutral-surface-color;
+  --theme-bg-light: #{$neutral-surface-color};
 
   --logo-height: 28px;
 }

--- a/src/vendors/theme/assets/styles/_variables.scss
+++ b/src/vendors/theme/assets/styles/_variables.scss
@@ -45,6 +45,7 @@ $body-color: #343a40;
 $card-description-color: #76838f;
 $card-title-color: $body-color;
 $card-bg-varient: #fff;
+$card-cap-bg: $S30;
 ///////// CARD ////////
 
 ////////// SIDEBAR ////////


### PR DESCRIPTION
## What does this PR do?

- Part of #5573 
- Darkens card headers to `$S30` from the Design System colors on Figma
- Fixes the `body` background color (css variable imports weren't working before, so the base body color was white instead of the proper new surface color)

## Demo

- https://www.loom.com/share/d16ad12c91db43ad997f9929c5ec74e2

## Discussion

- Proper way to override bootstrap components is to override the scss variable, `$card-cap-bg` in this case

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @BLoe 
