### PR TITLE
#5574: remove ContextMenuClick telemetry event

### DIFF
--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -71,8 +71,6 @@ async function dispatchMenu(
     throw new TypeError(`Not a PixieBrix menu item: ${info.menuItemId}`);
   }
 
-  reportEvent("ContextMenuClick", { extensionId: info.menuItemId });
-
   console.time("ensureContentScript");
 
   // Using the context menu gives temporary access to the page

--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -22,7 +22,6 @@ import { hasSpecificErrorCause } from "@/errors/errorHelpers";
 import reportError from "@/telemetry/reportError";
 import { handleMenuAction, notify } from "@/contentScript/messenger/api";
 import { ensureContentScript } from "@/background/contentScript";
-import { reportEvent } from "@/telemetry/events";
 import { expectContext } from "@/utils/expectContext";
 import extensionPointRegistry from "@/extensionPoints/registry";
 import {


### PR DESCRIPTION
## What does this PR do?

- Closes #5574 

- The product/marketing team was attempting to use the `ContextMenuClick` event to gain insight into starter brick activity by mod id ([slack context here](https://pixiebrix.slack.com/archives/C0543SZD83F/p1682003479329819)). However, this event is run on the chrome browser event listener we added to context menu item clicks, and we don't have access to the mod information in this context.

- I'm removing this event in favor of directing the team to use `HandleContextMenu` instead, which _does_ have mod information reported along with it. See the updated Lexicon entry for this event here: https://pixiebrix.slack.com/archives/C0543SZD83F/p1682003479329819

- Mixpanel lexicon for deprecated `ContextMenuClick` event: https://mixpanel.com/project/2202701/view/143273/app/lexicon#transformations/events/ContextMenuClick

## Discussion

- @twschiller suggested that we also rename `HandleContextMenu` -> `ContextMenuClick` in addition to removing it from the click handler. I'm going to keep the name the same, so that we still have historical information about context menu activity. 
- We can always change the display name of HandleContextMenu via the Lexicon, which would have the same effect in terms of usage by the product/marketing team.

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @BLoe 
