### PR TITLE
#5629: set initial needsPermissions state to null

### DIFF
--- a/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
@@ -61,7 +61,7 @@ const ShortcutKeys: React.FC<{ shortcut: string | null }> = ({ shortcut }) => {
 
 type ActivationState = {
   isInitialized: boolean;
-  needsPermissions: boolean;
+  needsPermissions: boolean | null;
   isActivating: boolean;
   isActivated: boolean;
   activationError: string | null;
@@ -69,7 +69,7 @@ type ActivationState = {
 
 const initialState: ActivationState = {
   isInitialized: false,
-  needsPermissions: false,
+  needsPermissions: null,
   isActivating: false,
   isActivated: false,
   activationError: null,
@@ -185,7 +185,11 @@ const ActivateRecipePanelContent: React.FC<RecipeState> = ({
   ]);
 
   useEffect(() => {
-    if (!state.needsPermissions && canAutoActivate) {
+    if (
+      state.needsPermissions !== null &&
+      !state.needsPermissions &&
+      canAutoActivate
+    ) {
       // State is checked inside this function call to prevent duplicate calls,
       // so we can simply dispatch asynchronously with "void" here.
       void activateRecipe();

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
@@ -195,7 +195,7 @@ const ActivateRecipePanelContent: React.FC<RecipeState> = ({
     );
 
     if (
-      state.needsPermissions !== null &&
+      state.needsPermissions != null &&
       !state.needsPermissions &&
       canAutoActivate &&
       !missingServiceConfigurations

--- a/src/sidebar/activateRecipe/RequireRecipe.tsx
+++ b/src/sidebar/activateRecipe/RequireRecipe.tsx
@@ -99,7 +99,6 @@ const RequireRecipe: React.FC<RequireRecipeProps> = ({
         }
 
         const hasPermissions = await containsPermissions(collectedPermissions);
-
         return !hasPermissions;
       };
 

--- a/src/sidebar/activateRecipe/RequireRecipe.tsx
+++ b/src/sidebar/activateRecipe/RequireRecipe.tsx
@@ -88,6 +88,7 @@ const RequireRecipe: React.FC<RequireRecipeProps> = ({
         const serviceAuths = formValues.services.filter(({ config }) =>
           Boolean(config)
         );
+
         const collectedPermissions = await collectPermissions(
           resolvedRecipeConfigs,
           serviceAuths
@@ -98,6 +99,7 @@ const RequireRecipe: React.FC<RequireRecipeProps> = ({
         }
 
         const hasPermissions = await containsPermissions(collectedPermissions);
+
         return !hasPermissions;
       };
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #5629 

## Discussion

- Because `state.needsPermissions` was being set a default value of `false` (before the `needsPermissions` func was ever being called), mods with truthy `canAutoActivate` were being auto-activated despite needing permission confirmation

## Demo
I still notice some form flashing during this process, but leaving that out of scope for this fix.
- https://www.loom.com/share/78ec0ba5dd144f3b90eb1bd7a7801cbc

## Checklist

- [x] Add tests
    - [x] Modify existing Summarize Selected Text Rainforest test https://app.rainforestqa.com/runs/1314443/tests/377988/browsers/windows10_chrome
- [x] Designate a primary reviewer @BLoe 
