### PR TITLE
Data panel preserve collapse

### DIFF
--- a/src/pageEditor/fields/ConnectedCollapsibleFieldSection.tsx
+++ b/src/pageEditor/fields/ConnectedCollapsibleFieldSection.tsx
@@ -15,7 +15,7 @@ const ConnectedCollapsibleFieldSection = ({
   const dispatch = useDispatch();
   const UIState = useSelector(selectActiveNodeUIState);
   // Allow to fail gracefully using nullish coalescing operator
-  const isExpanded = UIState?.expandedFieldSections?.[title] ?? true;
+  const isExpanded = UIState?._expandedFieldSections?.[title] ?? false;
 
   return (
     <CollapsibleFieldSection

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -841,7 +841,7 @@ exports[`renders an extension with sub pipeline 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
                   data-icon="chevron-right"
                   data-prefix="fas"
                   focusable="false"
@@ -857,7 +857,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                 Advanced
               </button>
               <div
-                class="body collapse show"
+                class="body collapse"
               >
                 <div
                   class="formGroup form-group row"
@@ -1008,7 +1008,7 @@ exports[`renders an extension with sub pipeline 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
                   data-icon="chevron-right"
                   data-prefix="fas"
                   focusable="false"
@@ -1024,7 +1024,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                 Advanced: Match Rules
               </button>
               <div
-                class="body collapse show"
+                class="body collapse"
               >
                 <div
                   class="formGroup form-group row"
@@ -1142,7 +1142,7 @@ exports[`renders an extension with sub pipeline 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
                   data-icon="chevron-right"
                   data-prefix="fas"
                   focusable="false"
@@ -1158,7 +1158,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                 Advanced: Extra Permissions
               </button>
               <div
-                class="body collapse show"
+                class="body collapse"
               >
                 <div
                   class="formGroup form-group row"
@@ -2058,7 +2058,7 @@ exports[`renders the first selected node 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
                   data-icon="chevron-right"
                   data-prefix="fas"
                   focusable="false"
@@ -2074,7 +2074,7 @@ exports[`renders the first selected node 1`] = `
                 Advanced Options
               </button>
               <div
-                class="body collapse show"
+                class="body collapse"
               >
                 <small
                   class="text-muted font-italic"

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -946,9 +946,13 @@ export const actions = {
   checkActiveElementAvailability,
 };
 
+/**
+ * This filter removes any key that starts with _ so that we don't preserve them between sessions.
+ * Docs on transforms: https://github.com/rt2zz/redux-persist#transforms
+ */
 const filterUnderscore = createTransform<EditorState, EditorState>(
-  (inboundState) => removeNamespaced(inboundState, "_", 4),
-  (outbound) => removeNamespaced(outbound, "_", 4),
+  (stateToPersist) => removeNamespaced(stateToPersist, "_", 4),
+  (stateToRehydrate) => removeNamespaced(stateToRehydrate, "_", 4),
   { whitelist: ["elementUIStates"] }
 );
 

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -94,6 +94,8 @@ import { type RegistryId } from "@/types/registryTypes";
 import { type OptionsDefinition } from "@/types/recipeTypes";
 import { type IExtension } from "@/types/extensionTypes";
 import { type OptionsArgs } from "@/types/runtimeTypes";
+import { createTransform } from "redux-persist";
+import { removeNamespaced } from "@/utils/removeNamespaced";
 
 export const initialState: EditorState = {
   selectionSeq: 0,
@@ -855,12 +857,12 @@ export const editorSlice = createSlice({
       const uiState = selectActiveNodeUIState({
         editor: state,
       });
-      if (uiState.expandedFieldSections === undefined) {
-        uiState.expandedFieldSections = {};
+      if (uiState._expandedFieldSections === undefined) {
+        uiState._expandedFieldSections = {};
       }
 
       const { id, isExpanded } = payload;
-      uiState.expandedFieldSections[id] = isExpanded;
+      uiState._expandedFieldSections[id] = isExpanded;
     },
   },
   extraReducers(builder) {
@@ -934,10 +936,22 @@ export const actions = {
   checkActiveElementAvailability,
 };
 
+const filterUnderscore = createTransform<
+  Partial<EditorState>,
+  Partial<EditorState>,
+  EditorState,
+  EditorState
+>(
+  (inboundState) => removeNamespaced(inboundState, "_", 4),
+  (outbound) => removeNamespaced(outbound, "_", 4),
+  { whitelist: ["elementUIStates"] }
+);
+
 export const persistEditorConfig = {
   key: "editor",
   // Change the type of localStorage to our overridden version so that it can be exported
   // See: @/store/StorageInterface.ts
   storage: localStorage as StorageInterface,
   version: 1,
+  transforms: [filterUnderscore],
 };

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -864,6 +864,16 @@ export const editorSlice = createSlice({
       const { id, isExpanded } = payload;
       uiState._expandedFieldSections[id] = isExpanded;
     },
+    setExpandedDataSection(
+      state,
+      { payload }: PayloadAction<{ isExpanded: boolean }>
+    ) {
+      const uiState = selectActiveNodeUIState({
+        editor: state,
+      });
+
+      uiState._expandedDataPanel = payload.isExpanded;
+    },
   },
   extraReducers(builder) {
     builder
@@ -936,12 +946,7 @@ export const actions = {
   checkActiveElementAvailability,
 };
 
-const filterUnderscore = createTransform<
-  Partial<EditorState>,
-  Partial<EditorState>,
-  EditorState,
-  EditorState
->(
+const filterUnderscore = createTransform<EditorState, EditorState>(
   (inboundState) => removeNamespaced(inboundState, "_", 4),
   (outbound) => removeNamespaced(outbound, "_", 4),
   { whitelist: ["elementUIStates"] }

--- a/src/pageEditor/tabs/__snapshots__/ExtraPermissionsSection.test.tsx.snap
+++ b/src/pageEditor/tabs/__snapshots__/ExtraPermissionsSection.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`ExtraPermissionsSection render empty section 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
           data-icon="chevron-right"
           data-prefix="fas"
           focusable="false"
@@ -29,7 +29,7 @@ exports[`ExtraPermissionsSection render empty section 1`] = `
         Advanced: Extra Permissions
       </button>
       <div
-        class="body collapse show"
+        class="body collapse"
       >
         <div
           class="formGroup form-group row"
@@ -116,7 +116,7 @@ exports[`ExtraPermissionsSection render populated section 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
           data-icon="chevron-right"
           data-prefix="fas"
           focusable="false"
@@ -132,7 +132,7 @@ exports[`ExtraPermissionsSection render populated section 1`] = `
         Advanced: Extra Permissions
       </button>
       <div
-        class="body collapse show"
+        class="body collapse"
       >
         <div
           class="formGroup form-group row"

--- a/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
+++ b/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`MatchRulesSection render empty section 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
           data-icon="chevron-right"
           data-prefix="fas"
           focusable="false"
@@ -29,7 +29,7 @@ exports[`MatchRulesSection render empty section 1`] = `
         Advanced: Match Rules
       </button>
       <div
-        class="body collapse show"
+        class="body collapse"
       >
         <div
           class="formGroup form-group row"
@@ -127,7 +127,7 @@ exports[`MatchRulesSection render populated section 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
           data-icon="chevron-right"
           data-prefix="fas"
           focusable="false"
@@ -143,7 +143,7 @@ exports[`MatchRulesSection render populated section 1`] = `
         Advanced: Match Rules
       </button>
       <div
-        class="body collapse show"
+        class="body collapse"
       >
         <div
           class="formGroup form-group row"

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from "react";
+import React from "react";
 import { Collapse, Tab } from "react-bootstrap";
 import EditorNodeLayout from "@/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout";
 import EditorNodeConfigPanel from "@/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel";
@@ -28,6 +28,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { FOUNDATION_NODE_ID } from "@/pageEditor/uiState/uiState";
 import {
   selectActiveNodeId,
+  selectActiveNodeUIState,
   selectPipelineMap,
 } from "@/pageEditor/slices/editorSelectors";
 import useApiVersionAtLeast from "@/pageEditor/hooks/useApiVersionAtLeast";
@@ -57,6 +58,8 @@ const EditTab: React.FC<{
   const activeNodeId = useSelector(selectActiveNodeId);
 
   const pipelineMap = useSelector(selectPipelineMap);
+  const UIState = useSelector(selectActiveNodeUIState);
+  const dataPanelIsExpanded = UIState?._expandedDataPanel ?? true;
 
   function copyBlock(instanceId: UUID) {
     // eslint-disable-next-line security/detect-object-injection -- UUID
@@ -70,7 +73,7 @@ const EditTab: React.FC<{
     dispatch(actions.removeNode(nodeIdToRemove));
   }
 
-  const [isExpanded, setIsExpanded] = useState(true);
+  // Const [isExpanded, setIsExpanded] = useState(true);
 
   return (
     <Tab.Pane eventKey={eventKey} className={styles.tabPane}>
@@ -131,16 +134,22 @@ const EditTab: React.FC<{
         </div>
         <div className={styles.collapseWrapper}>
           <button
-            className={cx(styles.toggle, { [styles.active]: isExpanded })}
+            className={cx(styles.toggle, {
+              [styles.active]: dataPanelIsExpanded,
+            })}
             onClick={() => {
-              setIsExpanded(!isExpanded);
+              dispatch(
+                actions.setExpandedDataSection({
+                  isExpanded: !dataPanelIsExpanded,
+                })
+              );
             }}
           >
             <FontAwesomeIcon icon={faAngleDoubleLeft} />
           </button>
           <Collapse
             dimension="width"
-            in={isExpanded}
+            in={dataPanelIsExpanded}
             unmountOnExit={true}
             mountOnEnter={true}
           >

--- a/src/pageEditor/tabs/effect/__snapshots__/BlockConfiguration.test.tsx.snap
+++ b/src/pageEditor/tabs/effect/__snapshots__/BlockConfiguration.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
           data-icon="chevron-right"
           data-prefix="fas"
           focusable="false"
@@ -77,7 +77,7 @@ exports[`renders 1`] = `
         Advanced Options
       </button>
       <div
-        class="body collapse show"
+        class="body collapse"
       >
         <small
           class="text-muted font-italic"

--- a/src/pageEditor/uiState/uiStateTypes.ts
+++ b/src/pageEditor/uiState/uiStateTypes.ts
@@ -90,7 +90,9 @@ export type NodeUIState = {
     activeTabKey: DataPanelTabKey | null;
   };
 
-  _expandedFieldSections: Record<string, boolean>;
+  _expandedFieldSections?: Record<string, boolean>;
+
+  _expandedDataPanel?: boolean;
 };
 
 export type ElementUIState = {

--- a/src/pageEditor/uiState/uiStateTypes.ts
+++ b/src/pageEditor/uiState/uiStateTypes.ts
@@ -90,7 +90,7 @@ export type NodeUIState = {
     activeTabKey: DataPanelTabKey | null;
   };
 
-  expandedFieldSections: Record<string, boolean>;
+  _expandedFieldSections: Record<string, boolean>;
 };
 
 export type ElementUIState = {

--- a/src/utils/removeNamespaced.test.ts
+++ b/src/utils/removeNamespaced.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { removeNamespaced } from "@/utils/removeNamespaced";
+
+describe("removeNamespaced", () => {
+  test("removes 1 level", () => {
+    expect(removeNamespaced(testObject, "_", 1)).toStrictEqual({
+      foo: 1,
+      fooObject: {
+        favoriteChild: 2,
+        _child: 3,
+        favoriteChildObject: {
+          favoriteGrandChild: 4,
+          _grandChild: 5,
+        },
+        _childObject: {
+          favoriteGrandChild: 6,
+          _grandChild: 7,
+        },
+      },
+    });
+  });
+
+  test("removes 2 levels", () => {
+    expect(removeNamespaced(testObject, "_", 2)).toStrictEqual({
+      foo: 1,
+      fooObject: {
+        favoriteChild: 2,
+        favoriteChildObject: {
+          favoriteGrandChild: 4,
+          _grandChild: 5,
+        },
+      },
+    });
+  });
+});
+
+const testObject = {
+  foo: 1,
+  fooObject: {
+    favoriteChild: 2,
+    _child: 3,
+    favoriteChildObject: {
+      favoriteGrandChild: 4,
+      _grandChild: 5,
+    },
+    _childObject: {
+      favoriteGrandChild: 6,
+      _grandChild: 7,
+    },
+  },
+  _unpopularSibling: {
+    child: 8,
+  },
+};

--- a/src/utils/removeNamespaced.ts
+++ b/src/utils/removeNamespaced.ts
@@ -42,7 +42,7 @@ export function removeNamespaced<T>(
   objToFilter: T,
   namespace: string,
   depth: number
-): Partial<T> {
+): T {
   if (typeof objToFilter !== "object" || depth === 0) {
     return objToFilter;
   }

--- a/src/utils/removeNamespaced.ts
+++ b/src/utils/removeNamespaced.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export function mapObjectValues(obj: any, mapFn: (value: unknown) => unknown) {
+function mapObjectValues(obj: any, mapFn: (value: unknown) => unknown) {
   if (typeof obj !== "object") {
     return obj;
   }
@@ -25,19 +25,22 @@ export function mapObjectValues(obj: any, mapFn: (value: unknown) => unknown) {
   );
 }
 
-export function filterObjectValuesByNamespace(obj: unknown, namespace: string) {
+function filterObjectValuesByNamespace(obj: unknown, namespace: string) {
   if (typeof obj !== "object") {
     return obj;
   }
 
   return Object.fromEntries(
-    Object.entries(obj).filter(([key]) => {
-      console.log(key, !key.startsWith(namespace));
-      return !key.startsWith(namespace);
-    })
+    Object.entries(obj).filter(([key]) => !key.startsWith(namespace))
   );
 }
 
+/**
+ * Removes namespaced values from an object up to a chosen depth
+ * @param objToFilter
+ * @param namespace - string that keys should start with if you want them removed
+ * @param depth - how many nested objects should be scanned. Potential performance hit for large objects
+ */
 export function removeNamespaced<T>(
   objToFilter: T,
   namespace: string,

--- a/src/utils/removeNamespaced.ts
+++ b/src/utils/removeNamespaced.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export function mapObjectValues(obj: any, mapFn: (value: unknown) => unknown) {
+  if (typeof obj !== "object") {
+    return obj;
+  }
+
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key, mapFn(value)])
+  );
+}
+
+export function filterObjectValuesByNamespace(obj: unknown, namespace: string) {
+  if (typeof obj !== "object") {
+    return obj;
+  }
+
+  return Object.fromEntries(
+    Object.entries(obj).filter(([key]) => {
+      console.log(key, !key.startsWith(namespace));
+      return !key.startsWith(namespace);
+    })
+  );
+}
+
+export function removeNamespaced<T>(
+  objToFilter: T,
+  namespace: string,
+  depth: number
+): Partial<T> {
+  if (typeof objToFilter !== "object" || depth === 0) {
+    return objToFilter;
+  }
+
+  const filteredObj = filterObjectValuesByNamespace(objToFilter, namespace);
+
+  return mapObjectValues(filteredObj, (value) =>
+    removeNamespaced(value, namespace, depth - 1)
+  );
+}


### PR DESCRIPTION
## What does this PR do?

- Closes #5577 by preserving the collapse state for the data panel
- Adds a filter to the UI state persistence that removes underscore namespaced values down to the `NodeUIState`

## Discussion

We needed a way to preserve state during the session without overlapping to other browser tabs. With this change we can simply namespace the value with _ to remove it. I've made the namespace value variable so we could change it to something else if this conflicts.

I considered using [redux-persist-filter](https://github.com/edy/redux-persist-transform-filter) but its capabilities are limited to only a single level deep and doesn't account for variable keys.

Another option was to have a totally independent state but this seemed like a better developer QOL. The only downside is a potential performance hit if we start using this for large parts of state but I don't foresee us using this anywhere else.

## Demo

- [Loom](https://www.loom.com/share/40f3d6da9de04abc896a0d41d0e886d8)

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer
