### PR TITLE
#5577 Save collapse states for data-panel, mod list

### DIFF
--- a/src/pageEditor/fields/ConnectedCollapsibleFieldSection.tsx
+++ b/src/pageEditor/fields/ConnectedCollapsibleFieldSection.tsx
@@ -15,7 +15,7 @@ const ConnectedCollapsibleFieldSection = ({
   const dispatch = useDispatch();
   const UIState = useSelector(selectActiveNodeUIState);
   // Allow to fail gracefully using nullish coalescing operator
-  const isExpanded = UIState?.expandedFieldSections?.[title] ?? true;
+  const isExpanded = UIState?.expandedFieldSections?.[title] ?? false;
 
   return (
     <CollapsibleFieldSection

--- a/src/pageEditor/pageEditorTypes.ts
+++ b/src/pageEditor/pageEditorTypes.ts
@@ -208,6 +208,16 @@ export interface EditorState {
    * How many dynamic elements are not available on the current tab?
    */
   unavailableDynamicCount: number;
+
+  /**
+   * Is data panel expanded or collapsed
+   */
+  expandedDataPanel: boolean;
+
+  /**
+   * Is mod list expanded or collapsed
+   */
+  isModListExpanded: boolean;
 }
 
 export type EditorRootState = {

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -841,7 +841,7 @@ exports[`renders an extension with sub pipeline 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
                   data-icon="chevron-right"
                   data-prefix="fas"
                   focusable="false"
@@ -857,7 +857,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                 Advanced
               </button>
               <div
-                class="body collapse show"
+                class="body collapse"
               >
                 <div
                   class="formGroup form-group row"
@@ -1008,7 +1008,7 @@ exports[`renders an extension with sub pipeline 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
                   data-icon="chevron-right"
                   data-prefix="fas"
                   focusable="false"
@@ -1024,7 +1024,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                 Advanced: Match Rules
               </button>
               <div
-                class="body collapse show"
+                class="body collapse"
               >
                 <div
                   class="formGroup form-group row"
@@ -1142,7 +1142,7 @@ exports[`renders an extension with sub pipeline 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
                   data-icon="chevron-right"
                   data-prefix="fas"
                   focusable="false"
@@ -1158,7 +1158,7 @@ exports[`renders an extension with sub pipeline 1`] = `
                 Advanced: Extra Permissions
               </button>
               <div
-                class="body collapse show"
+                class="body collapse"
               >
                 <div
                   class="formGroup form-group row"
@@ -2058,7 +2058,7 @@ exports[`renders the first selected node 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+                  class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
                   data-icon="chevron-right"
                   data-prefix="fas"
                   focusable="false"
@@ -2074,7 +2074,7 @@ exports[`renders the first selected node 1`] = `
                 Advanced Options
               </button>
               <div
-                class="body collapse show"
+                class="body collapse"
               >
                 <small
                   class="text-muted font-italic"

--- a/src/pageEditor/sidebar/Sidebar.tsx
+++ b/src/pageEditor/sidebar/Sidebar.tsx
@@ -17,11 +17,14 @@
 
 import styles from "./Sidebar.module.scss";
 
-import React, { useState } from "react";
+import React from "react";
 import { CSSTransition } from "react-transition-group";
 import { type CSSTransitionProps } from "react-transition-group/CSSTransition";
 import SidebarCollapsed from "./SidebarCollapsed";
 import SidebarExpanded from "./SidebarExpanded";
+import { useDispatch, useSelector } from "react-redux";
+import { selectActiveNodeUIState } from "@/pageEditor/slices/editorSelectors";
+import { actions } from "@/pageEditor/slices/editorSlice";
 
 const transitionProps: CSSTransitionProps = {
   classNames: {
@@ -36,20 +39,32 @@ const transitionProps: CSSTransitionProps = {
 };
 
 const Sidebar: React.VFC = () => {
-  const [collapsed, setCollapsed] = useState<boolean>(false);
+  const dispatch = useDispatch();
+
+  const UIState = useSelector(selectActiveNodeUIState);
+  const expanded = UIState?.expandedModList ?? true;
+
   return (
     <>
-      <CSSTransition {...transitionProps} in={collapsed}>
+      <CSSTransition {...transitionProps} in={!expanded}>
         <SidebarCollapsed
           expandSidebar={() => {
-            setCollapsed(false);
+            dispatch(
+              actions.setExpandedModList({
+                isExpanded: true,
+              })
+            );
           }}
         />
       </CSSTransition>
-      <CSSTransition {...transitionProps} in={!collapsed}>
+      <CSSTransition {...transitionProps} in={expanded}>
         <SidebarExpanded
           collapseSidebar={() => {
-            setCollapsed(true);
+            dispatch(
+              actions.setExpandedModList({
+                isExpanded: false,
+              })
+            );
           }}
         />
       </CSSTransition>

--- a/src/pageEditor/sidebar/Sidebar.tsx
+++ b/src/pageEditor/sidebar/Sidebar.tsx
@@ -23,7 +23,7 @@ import { type CSSTransitionProps } from "react-transition-group/CSSTransition";
 import SidebarCollapsed from "./SidebarCollapsed";
 import SidebarExpanded from "./SidebarExpanded";
 import { useDispatch, useSelector } from "react-redux";
-import { selectActiveNodeUIState } from "@/pageEditor/slices/editorSelectors";
+import { selectModuleListExpanded } from "@/pageEditor/slices/editorSelectors";
 import { actions } from "@/pageEditor/slices/editorSlice";
 
 const transitionProps: CSSTransitionProps = {
@@ -41,8 +41,7 @@ const transitionProps: CSSTransitionProps = {
 const Sidebar: React.VFC = () => {
   const dispatch = useDispatch();
 
-  const UIState = useSelector(selectActiveNodeUIState);
-  const expanded = UIState?.expandedModList ?? true;
+  const expanded = useSelector(selectModuleListExpanded);
 
   return (
     <>
@@ -50,7 +49,7 @@ const Sidebar: React.VFC = () => {
         <SidebarCollapsed
           expandSidebar={() => {
             dispatch(
-              actions.setExpandedModList({
+              actions.setModListExpanded({
                 isExpanded: true,
               })
             );
@@ -61,7 +60,7 @@ const Sidebar: React.VFC = () => {
         <SidebarExpanded
           collapseSidebar={() => {
             dispatch(
-              actions.setExpandedModList({
+              actions.setModListExpanded({
                 isExpanded: false,
               })
             );

--- a/src/pageEditor/slices/editorSelectors.ts
+++ b/src/pageEditor/slices/editorSelectors.ts
@@ -223,6 +223,12 @@ export const selectSelectionSeq = ({ editor }: EditorRootState) =>
 export const selectNewRecipeIds = ({ editor }: EditorRootState) =>
   editor.newRecipeIds;
 
+export const selectModuleListExpanded = ({ editor }: EditorRootState) =>
+  editor.isModListExpanded;
+
+export const selectDataPanelExpanded = ({ editor }: EditorRootState) =>
+  editor.expandedDataPanel;
+
 export const selectKeepLocalCopyOnCreateRecipe = ({
   editor,
 }: EditorRootState) => editor.keepLocalCopyOnCreateRecipe;

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -862,6 +862,26 @@ export const editorSlice = createSlice({
       const { id, isExpanded } = payload;
       uiState.expandedFieldSections[id] = isExpanded;
     },
+    setExpandedDataSection(
+      state,
+      { payload }: PayloadAction<{ isExpanded: boolean }>
+    ) {
+      const uiState = selectActiveNodeUIState({
+        editor: state,
+      });
+
+      uiState.expandedDataPanel = payload.isExpanded;
+    },
+    setExpandedModList(
+      state,
+      { payload }: PayloadAction<{ isExpanded: boolean }>
+    ) {
+      const uiState = selectActiveNodeUIState({
+        editor: state,
+      });
+
+      uiState.expandedModList = payload.isExpanded;
+    },
   },
   extraReducers(builder) {
     builder

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -121,6 +121,8 @@ export const initialState: EditorState = {
   availableDynamicIds: [],
   unavailableDynamicCount: 0,
   isPendingDynamicExtensions: false,
+  isModListExpanded: true,
+  expandedDataPanel: true,
 };
 
 /* eslint-disable security/detect-object-injection -- lots of immer-style code here dealing with Records */
@@ -862,25 +864,17 @@ export const editorSlice = createSlice({
       const { id, isExpanded } = payload;
       uiState.expandedFieldSections[id] = isExpanded;
     },
-    setExpandedDataSection(
+    setDataSectionExpanded(
       state,
       { payload }: PayloadAction<{ isExpanded: boolean }>
     ) {
-      const uiState = selectActiveNodeUIState({
-        editor: state,
-      });
-
-      uiState.expandedDataPanel = payload.isExpanded;
+      state.expandedDataPanel = payload.isExpanded;
     },
-    setExpandedModList(
+    setModListExpanded(
       state,
       { payload }: PayloadAction<{ isExpanded: boolean }>
     ) {
-      const uiState = selectActiveNodeUIState({
-        editor: state,
-      });
-
-      uiState.expandedModList = payload.isExpanded;
+      state.isModListExpanded = payload.isExpanded;
     },
   },
   extraReducers(builder) {

--- a/src/pageEditor/tabs/__snapshots__/ExtraPermissionsSection.test.tsx.snap
+++ b/src/pageEditor/tabs/__snapshots__/ExtraPermissionsSection.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`ExtraPermissionsSection render empty section 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
           data-icon="chevron-right"
           data-prefix="fas"
           focusable="false"
@@ -29,7 +29,7 @@ exports[`ExtraPermissionsSection render empty section 1`] = `
         Advanced: Extra Permissions
       </button>
       <div
-        class="body collapse show"
+        class="body collapse"
       >
         <div
           class="formGroup form-group row"
@@ -116,7 +116,7 @@ exports[`ExtraPermissionsSection render populated section 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
           data-icon="chevron-right"
           data-prefix="fas"
           focusable="false"
@@ -132,7 +132,7 @@ exports[`ExtraPermissionsSection render populated section 1`] = `
         Advanced: Extra Permissions
       </button>
       <div
-        class="body collapse show"
+        class="body collapse"
       >
         <div
           class="formGroup form-group row"

--- a/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
+++ b/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`MatchRulesSection render empty section 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
           data-icon="chevron-right"
           data-prefix="fas"
           focusable="false"
@@ -29,7 +29,7 @@ exports[`MatchRulesSection render empty section 1`] = `
         Advanced: Match Rules
       </button>
       <div
-        class="body collapse show"
+        class="body collapse"
       >
         <div
           class="formGroup form-group row"
@@ -127,7 +127,7 @@ exports[`MatchRulesSection render populated section 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
           data-icon="chevron-right"
           data-prefix="fas"
           focusable="false"
@@ -143,7 +143,7 @@ exports[`MatchRulesSection render populated section 1`] = `
         Advanced: Match Rules
       </button>
       <div
-        class="body collapse show"
+        class="body collapse"
       >
         <div
           class="formGroup form-group row"

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -28,7 +28,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { FOUNDATION_NODE_ID } from "@/pageEditor/uiState/uiState";
 import {
   selectActiveNodeId,
-  selectActiveNodeUIState,
+  selectDataPanelExpanded,
   selectPipelineMap,
 } from "@/pageEditor/slices/editorSelectors";
 import useApiVersionAtLeast from "@/pageEditor/hooks/useApiVersionAtLeast";
@@ -59,8 +59,7 @@ const EditTab: React.FC<{
 
   const pipelineMap = useSelector(selectPipelineMap);
 
-  const UIState = useSelector(selectActiveNodeUIState);
-  const dataPanelIsExpanded = UIState?.expandedDataPanel ?? true;
+  const isDataPanelExpanded = useSelector(selectDataPanelExpanded);
 
   function copyBlock(instanceId: UUID) {
     // eslint-disable-next-line security/detect-object-injection -- UUID
@@ -134,12 +133,12 @@ const EditTab: React.FC<{
         <div className={styles.collapseWrapper}>
           <button
             className={cx(styles.toggle, {
-              [styles.active]: dataPanelIsExpanded,
+              [styles.active]: isDataPanelExpanded,
             })}
             onClick={() => {
               dispatch(
-                actions.setExpandedDataSection({
-                  isExpanded: !dataPanelIsExpanded,
+                actions.setDataSectionExpanded({
+                  isExpanded: !isDataPanelExpanded,
                 })
               );
             }}
@@ -148,7 +147,7 @@ const EditTab: React.FC<{
           </button>
           <Collapse
             dimension="width"
-            in={dataPanelIsExpanded}
+            in={isDataPanelExpanded}
             unmountOnExit={true}
             mountOnEnter={true}
           >

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from "react";
+import React from "react";
 import { Collapse, Tab } from "react-bootstrap";
 import EditorNodeLayout from "@/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout";
 import EditorNodeConfigPanel from "@/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel";
@@ -28,6 +28,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { FOUNDATION_NODE_ID } from "@/pageEditor/uiState/uiState";
 import {
   selectActiveNodeId,
+  selectActiveNodeUIState,
   selectPipelineMap,
 } from "@/pageEditor/slices/editorSelectors";
 import useApiVersionAtLeast from "@/pageEditor/hooks/useApiVersionAtLeast";
@@ -58,6 +59,9 @@ const EditTab: React.FC<{
 
   const pipelineMap = useSelector(selectPipelineMap);
 
+  const UIState = useSelector(selectActiveNodeUIState);
+  const dataPanelIsExpanded = UIState?.expandedDataPanel ?? true;
+
   function copyBlock(instanceId: UUID) {
     // eslint-disable-next-line security/detect-object-injection -- UUID
     const blockToCopy = pipelineMap[instanceId]?.blockConfig;
@@ -69,8 +73,6 @@ const EditTab: React.FC<{
   function removeBlock(nodeIdToRemove: UUID) {
     dispatch(actions.removeNode(nodeIdToRemove));
   }
-
-  const [isExpanded, setIsExpanded] = useState(true);
 
   return (
     <Tab.Pane eventKey={eventKey} className={styles.tabPane}>
@@ -131,16 +133,22 @@ const EditTab: React.FC<{
         </div>
         <div className={styles.collapseWrapper}>
           <button
-            className={cx(styles.toggle, { [styles.active]: isExpanded })}
+            className={cx(styles.toggle, {
+              [styles.active]: dataPanelIsExpanded,
+            })}
             onClick={() => {
-              setIsExpanded(!isExpanded);
+              dispatch(
+                actions.setExpandedDataSection({
+                  isExpanded: !dataPanelIsExpanded,
+                })
+              );
             }}
           >
             <FontAwesomeIcon icon={faAngleDoubleLeft} />
           </button>
           <Collapse
             dimension="width"
-            in={isExpanded}
+            in={dataPanelIsExpanded}
             unmountOnExit={true}
             mountOnEnter={true}
           >

--- a/src/pageEditor/tabs/effect/__snapshots__/BlockConfiguration.test.tsx.snap
+++ b/src/pageEditor/tabs/effect/__snapshots__/BlockConfiguration.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`renders 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator active"
+          class="svg-inline--fa fa-chevron-right fa-w-10 activeIndicator"
           data-icon="chevron-right"
           data-prefix="fas"
           focusable="false"
@@ -77,7 +77,7 @@ exports[`renders 1`] = `
         Advanced Options
       </button>
       <div
-        class="body collapse show"
+        class="body collapse"
       >
         <small
           class="text-muted font-italic"

--- a/src/pageEditor/uiState/uiStateTypes.ts
+++ b/src/pageEditor/uiState/uiStateTypes.ts
@@ -90,7 +90,20 @@ export type NodeUIState = {
     activeTabKey: DataPanelTabKey | null;
   };
 
+  /**
+   * Which fields are expanded or collapsed
+   */
   expandedFieldSections: Record<string, boolean>;
+
+  /**
+   * Is data panel expanded or collapsed
+   */
+  expandedDataPanel: boolean;
+
+  /**
+   * Is mod list expanded or collapsed
+   */
+  expandedModList: boolean;
 };
 
 export type ElementUIState = {

--- a/src/pageEditor/uiState/uiStateTypes.ts
+++ b/src/pageEditor/uiState/uiStateTypes.ts
@@ -94,16 +94,6 @@ export type NodeUIState = {
    * Which fields are expanded or collapsed
    */
   expandedFieldSections: Record<string, boolean>;
-
-  /**
-   * Is data panel expanded or collapsed
-   */
-  expandedDataPanel: boolean;
-
-  /**
-   * Is mod list expanded or collapsed
-   */
-  expandedModList: boolean;
 };
 
 export type ElementUIState = {


### PR DESCRIPTION
## What does this PR do?

- Closes #5577 
- Mod list and data panel collapse are preserved at the editor level. Switching between mods does not affect the collapsed state for either of these.

## Demo

- [Loom](https://www.loom.com/share/b4994d7d22884b388140f431817e0510)

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
