### PR TITLE
#5657 Move indexeddb clear operation in `syncPackages` into a single transaction

### DIFF
--- a/src/registry/localRegistry.ts
+++ b/src/registry/localRegistry.ts
@@ -174,9 +174,8 @@ async function putAll(packages: Package[]): Promise<void> {
   const db = await getBrickDB();
   const tx = db.transaction(BRICK_STORE, "readwrite");
 
-  for (const obj of packages) {
-    void tx.store.put(obj);
-  }
+  await tx.store.clear();
+  await Promise.all(packages.map(async (obj) => tx.store.put(obj)));
 
   await tx.done;
 }
@@ -220,11 +219,7 @@ export const syncPackages = memoizeUntilSettled(async () => {
     timestamp,
   }));
 
-  const db = await getBrickDB();
-  const tx = db.transaction(BRICK_STORE, "readwrite");
-  await clear();
   await putAll(packages);
-  await tx.done;
 });
 
 /**

--- a/src/registry/localRegistry.ts
+++ b/src/registry/localRegistry.ts
@@ -167,10 +167,10 @@ export async function count(): Promise<number> {
 }
 
 /**
- * Put all the packages in the local database.
+ * Replace all packages in the local database.
  * @param packages the packages to put in the database
  */
-async function putAll(packages: Package[]): Promise<void> {
+async function replaceAll(packages: Package[]): Promise<void> {
   const db = await getBrickDB();
   const tx = db.transaction(BRICK_STORE, "readwrite");
 
@@ -219,7 +219,7 @@ export const syncPackages = memoizeUntilSettled(async () => {
     timestamp,
   }));
 
-  await putAll(packages);
+  await replaceAll(packages);
 });
 
 /**

--- a/src/registry/localRegistry.ts
+++ b/src/registry/localRegistry.ts
@@ -175,7 +175,7 @@ async function replaceAll(packages: Package[]): Promise<void> {
   const tx = db.transaction(BRICK_STORE, "readwrite");
 
   await tx.store.clear();
-  await Promise.all(packages.map(async (obj) => tx.store.put(obj)));
+  await Promise.all(packages.map(async (obj) => tx.store.add(obj)));
 
   await tx.done;
 }


### PR DESCRIPTION
## What does this PR do?

- Fixes #5657
- See this loom for discussion, PR walkthrough, and demo: https://www.loom.com/share/b1d811fd7a4148cd9d8bf410dd2fcb84

## Future Work

- @BLoe and I would like to start considering shifting from the indexeddb brick registry pattern -> RTK Query

## Checklist

- [x] Add tests - passing Rainforest test here: https://app.rainforestqa.com/runs/1324653
- [x] Designate a primary reviewer @BLoe 
