### PR TITLE
Narrow threshold of brick search results in the Page Editor add brick modal

### DIFF
--- a/src/components/addBlockModal/useBlockSearch.ts
+++ b/src/components/addBlockModal/useBlockSearch.ts
@@ -68,6 +68,8 @@ function useBlockSearch(
     );
     const fuse = new Fuse<BlockOption>(blockOptions, {
       keys: ["label", "blockResult.description", "value"],
+      threshold: 0.2,
+      ignoreLocation: true,
     });
 
     return { blockOptions, fuse };

--- a/src/components/addBlockModal/useBlockSearch.ts
+++ b/src/components/addBlockModal/useBlockSearch.ts
@@ -68,7 +68,12 @@ function useBlockSearch(
     );
     const fuse = new Fuse<BlockOption>(blockOptions, {
       keys: ["label", "blockResult.description", "value"],
+      // Arbitrary threshold that seems strict enough to avoid search results that are unrelated to the query.
       threshold: 0.2,
+      // If ignoreLocation is false (which it is, by default), Fuse will only consider the first threshold * distance
+      // number of characters while scoring (assuming location is 0).
+      // We want to match on any part of the string, so we set ignoreLocation to true.
+      // See https://fusejs.io/concepts/scoring-theory.html#scoring-theory for more information.
       ignoreLocation: true,
     });
 


### PR DESCRIPTION
## What does this PR do?

- Closes #5656 

## Discussion

- See fuse's documentation for scoring theory here: https://fusejs.io/concepts/scoring-theory.html#scoring-theory
- If `ignoreLocation` is `false` (which it is, by default) it will only consider the first `threshold * distance` number of characters as a match (assuming `location` is `0`)
- I added the `ignoreLocation: true` option because I speculated we might not want to match only the first `n` characters of a given string (maybe google is mentioned in a brick description after the first 20 characters?)
- Aside from this, I erred on the side of a more strict `threshold` value of `0.2` (as opposed to the default of `0.6` that we were using before)

## Demo

- https://www.loom.com/share/30438de7010548989ec30e87311a6bdd

## Future Work/Out of Scope

- Adding the ability to `clear` a search query in the search bar as suggested by @BLoe 
- Adding these options to other instances of fuse in the extension (e.g. the workshop or service selector modal) 

## Checklist

- [x] Designate a primary reviewer @BLoe 
