### PR TITLE
#5676: disable sandbox iframe injection

### DIFF
--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -34,7 +34,6 @@ import {
   notifyContextInvalidated,
 } from "@/errors/contextInvalidated";
 import { onUncaughtError } from "@/errors/errorHelpers";
-import initSandbox from "@/sandbox/messenger/api";
 import { initMarketplaceEnhancements } from "@/contentScript/marketplace";
 
 // Must come before the default handler for ignoring errors. Otherwise, this handler might not be run
@@ -55,7 +54,9 @@ export async function init(): Promise<void> {
 
   initTelemetry();
   initToaster();
-  void initSandbox();
+
+  // #5676 -- enable sandbox when ready to be used
+  // void initSandbox();
 
   await handleNavigate();
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -286,7 +286,8 @@ module.exports = (env, options) =>
         "pageEditor/pageEditor",
         "extensionConsole/options",
         "sidebar/sidebar",
-        "sandbox/sandbox",
+        // #5676 -- enable sandbox when ready to be used
+        // "sandbox/sandbox",
 
         "tinyPages/ephemeralForm",
         "tinyPages/ephemeralPanel",


### PR DESCRIPTION
## What does this PR do?

- Part of #5676 
- We had introduced a sandbox and then turned it off because it caused crashes on certain bricks
- This PR is disabling sandbox iframe injection. I suspect the iframe injection might be causing problems with contentScript injection

## Future Work

- Reintroduce behind a feature flag

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @turbochef 
