### PR TITLE
#4863: add performance timers to lifecycle

### DIFF
--- a/src/registry/internal.ts
+++ b/src/registry/internal.ts
@@ -205,11 +205,6 @@ export async function resolveDefinitions<
     return extension as ResolvedExtension<T>;
   }
 
-  // Too noisy since all IExtensions created with Page Editor have definitions
-  // console.debug("Resolving definitions for extension: %s", extension.id, {
-  //   extension,
-  // });
-
   return produce(extension, async (draft) => {
     const ensured = await resolveObj(
       mapValues(draft.definitions, async (definition) =>

--- a/src/store/extensionsMigrations.ts
+++ b/src/store/extensionsMigrations.ts
@@ -40,17 +40,13 @@ export function migrateExtensionsShape<T>(
   state: T & (LegacyExtensionObjectShapeState | LegacyExtensionObjectState)
 ): T & LegacyExtensionObjectState {
   if (state.extensions == null) {
-    console.info("Repairing redux state");
     return { ...state, extensions: [] };
   }
 
   if (Array.isArray(state.extensions)) {
     // Already migrated
-    console.debug("Redux extensions state already migrated");
     return state as T & LegacyExtensionObjectState;
   }
-
-  console.info("Migrating Redux state");
 
   return {
     ...state,

--- a/src/store/extensionsStorage.ts
+++ b/src/store/extensionsStorage.ts
@@ -45,8 +45,6 @@ async function getOptionsState(): Promise<PersistedOptionsState> {
  * Read extension options from local storage (without going through redux-persistor).
  */
 export async function loadOptions(): Promise<ExtensionOptionsState> {
-  console.debug("Loading raw options from storage");
-
   const base = await getOptionsState();
   // The redux persist layer persists the extensions value as JSON-string.
   // Also apply the upgradeExtensionsState migration here because the migration in store might not have run yet.


### PR DESCRIPTION
## What does this PR do?

- Part of #4863 
- Add performance timers for page lifecycle to try to diagnose contentScript startup issues

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @BLoe 
