### PR TITLE
#4863: inner definition performance improvements

### DIFF
--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -28,7 +28,7 @@ import {
   ContextMenuExtensionPoint,
 } from "@/extensionPoints/contextMenu";
 import { loadOptions } from "@/store/extensionsStorage";
-import { resolveDefinitions } from "@/registry/internal";
+import { resolveExtensionInnerDefinitions } from "@/registry/internal";
 import { allSettledValues, memoizeUntilSettled } from "@/utils";
 import { type UUID } from "@/types/stringTypes";
 import {
@@ -168,7 +168,7 @@ export async function preloadContextMenus(
   expectContext("background");
   await Promise.allSettled(
     extensions.map(async (definition) => {
-      const resolved = await resolveDefinitions(definition);
+      const resolved = await resolveExtensionInnerDefinitions(definition);
 
       const extensionPoint = await extensionPointRegistry.lookup(
         resolved.extensionPointId
@@ -185,7 +185,7 @@ export async function preloadContextMenus(
 async function preloadAllContextMenus(): Promise<void> {
   const { extensions } = await loadOptions();
   const resolved = await allSettledValues(
-    extensions.map(async (x) => resolveDefinitions(x))
+    extensions.map(async (x) => resolveExtensionInnerDefinitions(x))
   );
   await preloadContextMenus(resolved);
 }

--- a/src/baseRegistry.ts
+++ b/src/baseRegistry.ts
@@ -20,9 +20,15 @@ import { registry as backgroundRegistry } from "@/background/messenger/api";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { expectContext } from "@/utils/expectContext";
 import { memoizeUntilSettled } from "@/utils";
-import { type RegistryId } from "@/types/registryTypes";
+import { isInnerDefinitionRef, type RegistryId } from "@/types/registryTypes";
 
-type Source = "remote" | "builtin";
+type Source =
+  // From the remote brick registry
+  | "remote"
+  // From a JS-defined brick
+  | "builtin"
+  // From an internal definition
+  | "internal";
 
 export interface RegistryItem<T extends RegistryId = RegistryId> {
   id: T;
@@ -89,6 +95,13 @@ export class Registry<
    * @private
    */
   private readonly _builtins = new Map<RegistryId, Item>();
+
+  /**
+   * Registered internal definitions. Used to keep track across cache clears. They don't need to be cleared because
+   * they are stored by content hash.
+   * @private
+   */
+  private readonly _internal = new Map<RegistryId, Item>();
 
   /**
    * Cache of items in the registry. Contains both built-ins and remote items.
@@ -167,10 +180,15 @@ export class Registry<
       return cached;
     }
 
-    const builtin = this._builtins.get(id);
+    const localItem = this._builtins.get(id) ?? this._internal.get(id);
 
-    if (builtin) {
-      return builtin;
+    if (localItem) {
+      return localItem;
+    }
+
+    if (isInnerDefinitionRef(id)) {
+      // Avoid the IDB lookup for internal definitions, because we know they are not there
+      throw new DoesNotExistError(id);
     }
 
     // Look up in IDB
@@ -204,7 +222,7 @@ export class Registry<
   }
 
   /**
-   * Return built-in JS bricks registered
+   * Return built-in JS bricks registered. Used for header generation.
    */
   get builtins(): Item[] {
     return [...this._builtins.values()];
@@ -249,6 +267,10 @@ export class Registry<
       source: "builtin",
       notify: false,
     });
+    this.register([...this._internal.values()], {
+      source: "internal",
+      notify: false,
+    });
     this.notifyAll();
 
     this._cacheInitialized = true;
@@ -279,6 +301,8 @@ export class Registry<
 
       if (source === "builtin") {
         this._builtins.set(item.id, item);
+      } else if (source === "internal") {
+        this._internal.set(item.id, item);
       }
 
       this._cache.set(item.id, item);
@@ -321,6 +345,7 @@ export class Registry<
     this._cacheInitialized = false;
     this.clear();
     this._builtins.clear();
+    this._internal.clear();
   }
 }
 

--- a/src/contentScript/lifecycle.test.ts
+++ b/src/contentScript/lifecycle.test.ts
@@ -32,7 +32,7 @@ import { type PersistedExtension } from "@/types/extensionTypes";
 import { type BlockPipeline } from "@/blocks/types";
 import { RootReader, tick } from "@/extensionPoints/extensionPointTestUtils";
 import blockRegistry from "@/blocks/registry";
-import { resolveDefinitions } from "@/registry/internal";
+import { resolveExtensionInnerDefinitions } from "@/registry/internal";
 
 let extensionPointRegistry: any;
 let loadOptionsMock: jest.Mock;
@@ -153,7 +153,9 @@ describe("lifecycle", () => {
       extensionPointId: extensionPoint.id,
     });
 
-    extensionPoint.addExtension(await resolveDefinitions(extension));
+    extensionPoint.addExtension(
+      await resolveExtensionInnerDefinitions(extension)
+    );
 
     await lifecycleModule.runEditorExtension(extension.id, extensionPoint);
 
@@ -191,7 +193,9 @@ describe("lifecycle", () => {
       extensionPoint,
     ]);
 
-    extensionPoint.addExtension(await resolveDefinitions(extension));
+    extensionPoint.addExtension(
+      await resolveExtensionInnerDefinitions(extension)
+    );
 
     await lifecycleModule.runEditorExtension(extension.id, extensionPoint);
 

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -24,7 +24,7 @@ import { NAVIGATION_RULES } from "@/contrib/navigationRules";
 import { testMatchPatterns } from "@/blocks/available";
 import reportError from "@/telemetry/reportError";
 import { compact, groupBy, intersection, once, uniq } from "lodash";
-import { resolveDefinitions } from "@/registry/internal";
+import { resolveExtensionInnerDefinitions } from "@/registry/internal";
 import { traces } from "@/background/messenger/api";
 import { isDeploymentActive } from "@/utils/deploymentUtils";
 import { $safeFind } from "@/helpers";
@@ -364,7 +364,9 @@ async function loadPersistedExtensions(): Promise<IExtensionPoint[]> {
 
   const resolvedExtensions = await logPromiseDuration(
     "loadPersistedExtensions:resolveDefinitions",
-    Promise.all(activeExtensions.map(async (x) => resolveDefinitions(x)))
+    Promise.all(
+      activeExtensions.map(async (x) => resolveExtensionInnerDefinitions(x))
+    )
   );
 
   const extensionMap = groupBy(resolvedExtensions, (x) => x.extensionPointId);

--- a/src/contentScript/pageEditor/dynamic.ts
+++ b/src/contentScript/pageEditor/dynamic.ts
@@ -21,7 +21,7 @@ import {
 } from "@/contentScript/lifecycle";
 import { fromJS as extensionPointFactory } from "@/extensionPoints/factory";
 import Overlay from "@/vendors/Overlay";
-import { resolveDefinitions } from "@/registry/internal";
+import { resolveExtensionInnerDefinitions } from "@/registry/internal";
 import { expectContext } from "@/utils/expectContext";
 import { $safeFind } from "@/helpers";
 import { type TriggerDefinition } from "@/extensionPoints/triggerExtension";
@@ -126,7 +126,7 @@ export async function updateDynamicElement({
   }
 
   // In practice, should be a no-op because the Page Editor handles the extensionPoint
-  const resolved = await resolveDefinitions(extensionConfig);
+  const resolved = await resolveExtensionInnerDefinitions(extensionConfig);
 
   extensionPoint.addExtension(resolved);
   await runEditorExtension(extensionConfig.id, extensionPoint);

--- a/src/extensionConsole/pages/blueprints/useInstallables.ts
+++ b/src/extensionConsole/pages/blueprints/useInstallables.ts
@@ -20,7 +20,7 @@ import { useMemo } from "react";
 import { useSelector } from "react-redux";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import { useAsyncState } from "@/hooks/common";
-import { resolveDefinitions } from "@/registry/internal";
+import { resolveExtensionInnerDefinitions } from "@/registry/internal";
 import { type Installable, type UnavailableRecipe } from "./blueprintsTypes";
 import { useGetCloudExtensionsQuery } from "@/services/api";
 import { selectScope } from "@/auth/authSelectors";
@@ -88,7 +88,9 @@ function useInstallables(): InstallablesState {
     useAsyncState(
       async () =>
         Promise.all(
-          allExtensions.map(async (extension) => resolveDefinitions(extension))
+          allExtensions.map(async (extension) =>
+            resolveExtensionInnerDefinitions(extension)
+          )
         ),
       [allExtensions],
       []

--- a/src/extensionConsole/pages/blueprints/utils/exportBlueprint.ts
+++ b/src/extensionConsole/pages/blueprints/utils/exportBlueprint.ts
@@ -20,7 +20,7 @@ import { type Metadata } from "@/types/registryTypes";
 
 import { isNullOrBlank } from "@/utils";
 import GenerateSchema from "generate-schema";
-import { isInnerExtensionPoint } from "@/registry/internal";
+import { isInnerDefinitionRef } from "@/registry/internal";
 import { type OptionsArgs } from "@/types/runtimeTypes";
 import {
   type OptionsDefinition,
@@ -62,7 +62,7 @@ export function makeBlueprint(
     config,
   } = extension;
 
-  if (isInnerExtensionPoint(extensionPointId)) {
+  if (isInnerDefinitionRef(extensionPointId)) {
     throw new Error("Expected unresolved extension");
   }
 

--- a/src/extensionConsole/pages/blueprints/utils/exportBlueprint.ts
+++ b/src/extensionConsole/pages/blueprints/utils/exportBlueprint.ts
@@ -16,11 +16,9 @@
  */
 
 import { isEmpty } from "lodash";
-import { type Metadata } from "@/types/registryTypes";
-
+import { isInnerDefinitionRef, type Metadata } from "@/types/registryTypes";
 import { isNullOrBlank } from "@/utils";
 import GenerateSchema from "generate-schema";
-import { isInnerDefinitionRef } from "@/registry/internal";
 import { type OptionsArgs } from "@/types/runtimeTypes";
 import {
   type OptionsDefinition,

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -15,7 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type Metadata, type RegistryId } from "@/types/registryTypes";
+import {
+  INNER_SCOPE,
+  isInnerDefinitionRef,
+  type Metadata,
+  type RegistryId,
+} from "@/types/registryTypes";
 import { castArray, cloneDeep, isEmpty } from "lodash";
 import {
   assertExtensionPointConfig,
@@ -50,11 +55,7 @@ import {
   getMinimalSchema,
   getMinimalUiSchema,
 } from "@/components/formBuilder/formBuilderHelpers";
-import {
-  hasInnerExtensionPoint,
-  INNER_SCOPE,
-  isInnerDefinitionRef,
-} from "@/registry/internal";
+import { hasInnerExtensionPoint } from "@/registry/internal";
 import { normalizePipelineForEditor } from "./pipelineMapping";
 import { emptyPermissionsFactory } from "@/permissions/permissionsUtils";
 import { type ApiVersion } from "@/types/runtimeTypes";

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -53,7 +53,7 @@ import {
 import {
   hasInnerExtensionPoint,
   INNER_SCOPE,
-  isInnerExtensionPoint,
+  isInnerDefinitionRef,
 } from "@/registry/internal";
 import { normalizePipelineForEditor } from "./pipelineMapping";
 import { emptyPermissionsFactory } from "@/permissions/permissionsUtils";
@@ -333,7 +333,7 @@ export function extensionWithInnerDefinitions(
   extension: IExtension,
   extensionPointDefinition: ExtensionPointDefinition
 ): IExtension {
-  if (isInnerExtensionPoint(extension.extensionPointId)) {
+  if (isInnerDefinitionRef(extension.extensionPointId)) {
     const extensionPointId = freshIdentifier(
       DEFAULT_EXTENSION_POINT_VAR as SafeString,
       Object.keys(extension.definitions ?? {})

--- a/src/pageEditor/hooks/useUpsertFormElement.ts
+++ b/src/pageEditor/hooks/useUpsertFormElement.ts
@@ -31,7 +31,7 @@ import { type UnknownObject } from "@/types/objectTypes";
 import extensionsSlice from "@/store/extensionsSlice";
 import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 import { type FormState } from "@/pageEditor/extensionPoints/formStateTypes";
-import { isInnerExtensionPoint } from "@/registry/internal";
+import { isInnerDefinitionRef } from "@/registry/internal";
 import { isSingleObjectBadRequestError } from "@/errors/networkErrorHelpers";
 import { ensureElementPermissionsFromUserGesture } from "@/pageEditor/editorPermissionsHelpers";
 import { type UUID } from "@/types/stringTypes";
@@ -134,7 +134,7 @@ function useUpsertFormElement(): SaveCallback {
       const adapter = ADAPTERS.get(element.type);
 
       const extensionPointId = element.extensionPoint.metadata.id;
-      const hasInnerExtensionPoint = isInnerExtensionPoint(extensionPointId);
+      const hasInnerExtensionPoint = isInnerDefinitionRef(extensionPointId);
 
       let isEditable = false;
 

--- a/src/pageEditor/hooks/useUpsertFormElement.ts
+++ b/src/pageEditor/hooks/useUpsertFormElement.ts
@@ -31,10 +31,10 @@ import { type UnknownObject } from "@/types/objectTypes";
 import extensionsSlice from "@/store/extensionsSlice";
 import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 import { type FormState } from "@/pageEditor/extensionPoints/formStateTypes";
-import { isInnerDefinitionRef } from "@/registry/internal";
 import { isSingleObjectBadRequestError } from "@/errors/networkErrorHelpers";
 import { ensureElementPermissionsFromUserGesture } from "@/pageEditor/editorPermissionsHelpers";
 import { type UUID } from "@/types/stringTypes";
+import { isInnerDefinitionRef } from "@/types/registryTypes";
 
 const { saveExtension } = extensionsSlice.actions;
 const { markSaved } = editorSlice.actions;

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -28,7 +28,7 @@ import { produce } from "immer";
 import { ADAPTERS } from "@/pageEditor/extensionPoints/adapter";
 import { freshIdentifier } from "@/utils";
 import { type FormState } from "@/pageEditor/extensionPoints/formStateTypes";
-import { isInnerExtensionPoint } from "@/registry/internal";
+import { isInnerDefinitionRef } from "@/registry/internal";
 import {
   DEFAULT_EXTENSION_POINT_VAR,
   PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
@@ -181,7 +181,7 @@ export function replaceRecipeExtension(
     const adapter = ADAPTERS.get(element.type);
     const rawExtension = adapter.selectExtension(element);
     const extensionPointId = element.extensionPoint.metadata.id;
-    const hasInnerExtensionPoint = isInnerExtensionPoint(extensionPointId);
+    const hasInnerExtensionPoint = isInnerDefinitionRef(extensionPointId);
 
     const commonExtensionConfig: Except<ExtensionDefinition, "id"> = {
       ...pick(rawExtension, [
@@ -364,7 +364,7 @@ export function buildRecipe({
         const adapter = ADAPTERS.get(element.type);
         const extension = adapter.selectExtension(element);
 
-        if (isInnerExtensionPoint(extension.extensionPointId)) {
+        if (isInnerDefinitionRef(extension.extensionPointId)) {
           const extensionPointConfig =
             adapter.selectExtensionPointConfig(element);
           extension.definitions = {
@@ -419,7 +419,7 @@ function buildExtensionPoints(
       let isDefinitionAlreadyAdded = false;
       let needsFreshExtensionPointId = false;
 
-      if (isInnerExtensionPoint(extensionPointId)) {
+      if (isInnerDefinitionRef(extensionPointId)) {
         // Always replace inner ids
         needsFreshExtensionPointId = true;
 

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -21,6 +21,7 @@ import {
   type Metadata,
   type RegistryId,
   type InnerDefinitions,
+  isInnerDefinitionRef,
 } from "@/types/registryTypes";
 import { PACKAGE_REGEX, validateRegistryId } from "@/types/helpers";
 import { compact, isEmpty, isEqual, pick, sortBy } from "lodash";
@@ -28,7 +29,6 @@ import { produce } from "immer";
 import { ADAPTERS } from "@/pageEditor/extensionPoints/adapter";
 import { freshIdentifier } from "@/utils";
 import { type FormState } from "@/pageEditor/extensionPoints/formStateTypes";
-import { isInnerDefinitionRef } from "@/registry/internal";
 import {
   DEFAULT_EXTENSION_POINT_VAR,
   PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -76,7 +76,7 @@ import {
   getInstalledExtensionPoints,
 } from "@/contentScript/messenger/api";
 import { getCurrentURL, thisTab } from "@/pageEditor/utils";
-import { resolveDefinitions } from "@/registry/internal";
+import { resolveExtensionInnerDefinitions } from "@/registry/internal";
 import { QuickBarExtensionPoint } from "@/extensionPoints/quickBarExtension";
 import { testMatchPatterns } from "@/blocks/available";
 import { type BaseExtensionPointState } from "@/pageEditor/extensionPoints/elementConfig";
@@ -167,7 +167,9 @@ const checkAvailableInstalledExtensions = createAsyncThunk<
     extensionPoints.map((extensionPoint) => [extensionPoint.id, extensionPoint])
   );
   const resolved = await Promise.all(
-    extensions.map(async (extension) => resolveDefinitions(extension))
+    extensions.map(async (extension) =>
+      resolveExtensionInnerDefinitions(extension)
+    )
   );
   const tabUrl = await getCurrentURL();
   const availableExtensionPointIds = resolved

--- a/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
@@ -20,7 +20,6 @@ import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import ApiVersionField from "@/pageEditor/fields/ApiVersionField";
 import UpgradedToApiV3 from "@/pageEditor/tabs/editTab/UpgradedToApiV3";
 import useFlags from "@/hooks/useFlags";
-import { isInnerDefinitionRef } from "@/registry/internal";
 import devtoolFieldOverrides from "@/pageEditor/fields/devtoolFieldOverrides";
 import SchemaFieldContext from "@/components/fields/schemaFields/SchemaFieldContext";
 import { ADAPTERS } from "@/pageEditor/extensionPoints/adapter";
@@ -31,6 +30,7 @@ import { Alert } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { openShortcutsTab, SHORTCUTS_URL } from "@/chrome";
+import { isInnerDefinitionRef } from "@/types/registryTypes";
 
 const UnconfiguredQuickBarAlert: React.FunctionComponent = () => {
   const { isConfigured } = useQuickbarShortcut();

--- a/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
@@ -20,7 +20,7 @@ import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import ApiVersionField from "@/pageEditor/fields/ApiVersionField";
 import UpgradedToApiV3 from "@/pageEditor/tabs/editTab/UpgradedToApiV3";
 import useFlags from "@/hooks/useFlags";
-import { isInnerExtensionPoint } from "@/registry/internal";
+import { isInnerDefinitionRef } from "@/registry/internal";
 import devtoolFieldOverrides from "@/pageEditor/fields/devtoolFieldOverrides";
 import SchemaFieldContext from "@/components/fields/schemaFields/SchemaFieldContext";
 import { ADAPTERS } from "@/pageEditor/extensionPoints/adapter";
@@ -63,7 +63,7 @@ const FoundationNodeConfigPanel: React.FC = () => {
 
   // For now, don't allow modifying extensionPoint packages via the Page Editor.
   const isLocked = useMemo(
-    () => !isInnerExtensionPoint(extensionPoint.metadata.id),
+    () => !isInnerDefinitionRef(extensionPoint.metadata.id),
     [extensionPoint.metadata.id]
   );
 

--- a/src/permissions/cloudExtensionPermissionsHelpers.ts
+++ b/src/permissions/cloudExtensionPermissionsHelpers.ts
@@ -18,7 +18,7 @@
 import { type CloudExtension } from "@/types/contract";
 import { type ServiceDependency } from "@/types/serviceTypes";
 import { type PermissionsStatus } from "@/permissions/permissionsTypes";
-import { resolveDefinitions } from "@/registry/internal";
+import { resolveExtensionInnerDefinitions } from "@/registry/internal";
 import { type ResolvedExtensionDefinition } from "@/types/recipeTypes";
 import { checkRecipePermissions } from "@/recipes/recipePermissionsHelpers";
 
@@ -33,7 +33,10 @@ export async function checkCloudExtensionPermissions(
   extension: CloudExtension,
   services: ServiceDependency[]
 ): Promise<PermissionsStatus> {
-  const resolved = await resolveDefinitions({ ...extension, services });
+  const resolved = await resolveExtensionInnerDefinitions({
+    ...extension,
+    services,
+  });
 
   const configured = services.filter((x) => x.config);
 

--- a/src/permissions/extensionPermissionsHelpers.ts
+++ b/src/permissions/extensionPermissionsHelpers.ts
@@ -17,7 +17,7 @@
 
 import { type IExtension } from "@/types/extensionTypes";
 import { type Permissions } from "webextension-polyfill";
-import { resolveDefinitions } from "@/registry/internal";
+import { resolveExtensionInnerDefinitions } from "@/registry/internal";
 import extensionPointRegistry from "@/extensionPoints/registry";
 import { castArray, compact } from "lodash";
 import { mergePermissions } from "@/permissions/permissionsUtils";
@@ -59,7 +59,7 @@ export async function collectExtensionPermissions(
   options: PermissionOptions = {}
 ): Promise<Permissions.Permissions> {
   const { includeExtensionPoint = true, includeServices = true } = options;
-  const resolved = await resolveDefinitions(extension);
+  const resolved = await resolveExtensionInnerDefinitions(extension);
 
   const extensionPoint =
     options.extensionPoint ??

--- a/src/recipes/recipePermissionsHelpers.ts
+++ b/src/recipes/recipePermissionsHelpers.ts
@@ -20,7 +20,7 @@ import {
   type ResolvedExtensionDefinition,
 } from "@/types/recipeTypes";
 import { type ServiceAuthPair } from "@/types/serviceTypes";
-import { resolveRecipe } from "@/registry/internal";
+import { resolveRecipeInnerDefinitions } from "@/registry/internal";
 import {
   ensurePermissionsFromUserGesture,
   mergePermissions,
@@ -87,7 +87,7 @@ export async function checkRecipePermissions(
   recipe: Pick<RecipeDefinition, "definitions" | "extensionPoints">,
   selectedAuths: ServiceAuthPair[]
 ): Promise<PermissionsStatus> {
-  const extensionDefinitions = await resolveRecipe(recipe);
+  const extensionDefinitions = await resolveRecipeInnerDefinitions(recipe);
   const permissions = await collectExtensionDefinitionPermissions(
     extensionDefinitions,
     selectedAuths

--- a/src/registry/internal.ts
+++ b/src/registry/internal.ts
@@ -17,7 +17,14 @@
 
 import { produce } from "immer";
 import objectHash from "object-hash";
-import { cloneDeep, isEmpty, isPlainObject, mapValues, pick } from "lodash";
+import {
+  cloneDeep,
+  isEmpty,
+  isPlainObject,
+  mapValues,
+  pick,
+  pickBy,
+} from "lodash";
 import extensionPointRegistry from "@/extensionPoints/registry";
 import blockRegistry from "@/blocks/registry";
 import { fromJS as extensionPointFactory } from "@/extensionPoints/factory";
@@ -50,16 +57,25 @@ type InnerBlock<K extends "component" | "reader" = "component" | "reader"> =
 
 type InnerDefinition = InnerExtensionPoint | InnerBlock;
 
+/**
+ * Scope for inner definitions
+ */
+export const INNER_SCOPE = "@internal";
+
 export function makeInternalId(obj: UnknownObject): RegistryId {
   const hash = objectHash(obj);
   return `${INNER_SCOPE}/${hash}` as RegistryId;
 }
 
-async function ensureBlock(
+export function isInnerDefinitionRef(id: string): id is InnerDefinitionRef {
+  return id.startsWith(INNER_SCOPE + "/");
+}
+
+async function resolveBlockDefinition(
   definitions: InnerDefinitions,
   innerDefinition: InnerDefinition
 ) {
-  // Don't include outputSchema in because it can't affect functionality. Include it in the item in the future?
+  // Don't include outputSchema in because it can't affect functionality
   const obj = pick(innerDefinition, [
     "inputSchema",
     "kind",
@@ -68,8 +84,10 @@ async function ensureBlock(
   ]);
   const registryId = makeInternalId(obj);
 
-  if (await blockRegistry.exists(registryId)) {
-    return blockRegistry.lookup(registryId);
+  try {
+    return await blockRegistry.lookup(registryId);
+  } catch {
+    // Not in registry yet, so add it
   }
 
   const item = blockFactory({
@@ -85,7 +103,7 @@ async function ensureBlock(
   return item;
 }
 
-async function ensureReaders(
+async function resolveReaderDefinition(
   definitions: InnerDefinitions,
   reader: unknown
 ): Promise<ReaderConfig> {
@@ -103,7 +121,7 @@ async function ensureReaders(
         );
       }
 
-      const block = await ensureBlock(
+      const block = await resolveBlockDefinition(
         definitions,
         definition as InnerBlock<"component">
       );
@@ -115,13 +133,15 @@ async function ensureReaders(
   }
 
   if (Array.isArray(reader)) {
-    return Promise.all(reader.map(async (x) => ensureReaders(definitions, x)));
+    return Promise.all(
+      reader.map(async (x) => resolveReaderDefinition(definitions, x))
+    );
   }
 
   if (isPlainObject(reader)) {
     return resolveObj(
       mapValues(reader as Record<string, unknown>, async (x) =>
-        ensureReaders(definitions, x)
+        resolveReaderDefinition(definitions, x)
       )
     );
   }
@@ -134,30 +154,32 @@ async function ensureReaders(
   throw new TypeError("Unexpected reader definition");
 }
 
-async function ensureExtensionPoint(
+async function resolveExtensionPointDefinition(
   definitions: InnerDefinitions,
   originalInnerDefinition: InnerExtensionPoint
-) {
+): Promise<IExtensionPoint> {
   const innerDefinition = cloneDeep(originalInnerDefinition);
 
   // We have to resolve the readers before computing the registry id, b/c otherwise different extension points could
   // clash if they use the same name for different readers
-  innerDefinition.definition.reader = await ensureReaders(
+  innerDefinition.definition.reader = await resolveReaderDefinition(
     definitions,
     innerDefinition.definition.reader
   );
 
   const obj = pick(innerDefinition, ["kind", "definition"]);
-  const registryId = makeInternalId(obj);
+  const internalRegistryId = makeInternalId(obj);
 
-  if (await extensionPointRegistry.exists(registryId)) {
-    return extensionPointRegistry.lookup(registryId);
+  try {
+    return await extensionPointRegistry.lookup(internalRegistryId);
+  } catch {
+    // NOP - will register
   }
 
   const item = extensionPointFactory({
     ...obj,
     metadata: {
-      id: registryId,
+      id: internalRegistryId,
       name: "Anonymous extensionPoint",
     },
   } as ExtensionPointConfig);
@@ -166,7 +188,12 @@ async function ensureExtensionPoint(
   return item;
 }
 
-async function ensureInner(
+/**
+ * Ensure inner definitions are registered in the in-memory brick registry
+ * @param definitions all of the definitions. Used to resolve references from innerDefinition
+ * @param innerDefinition the inner definition to resolve
+ */
+async function resolveInnerDefinition(
   definitions: InnerDefinitions,
   innerDefinition: InnerDefinitions[string]
 ): Promise<IBlock | IExtensionPoint> {
@@ -176,7 +203,7 @@ async function ensureInner(
 
   switch (innerDefinition.kind) {
     case "extensionPoint": {
-      return ensureExtensionPoint(
+      return resolveExtensionPointDefinition(
         definitions,
         innerDefinition as InnerExtensionPoint
       );
@@ -184,7 +211,7 @@ async function ensureInner(
 
     case "reader":
     case "component": {
-      return ensureBlock(definitions, innerDefinition as InnerBlock);
+      return resolveBlockDefinition(definitions, innerDefinition as InnerBlock);
     }
 
     default: {
@@ -198,7 +225,7 @@ async function ensureInner(
 /**
  * Return a new copy of the IExtension with its inner references re-written.
  */
-export async function resolveDefinitions<
+export async function resolveExtensionInnerDefinitions<
   T extends UnknownObject = UnknownObject
 >(extension: IExtension<T>): Promise<ResolvedExtension<T>> {
   if (isEmpty(extension.definitions)) {
@@ -206,24 +233,33 @@ export async function resolveDefinitions<
   }
 
   return produce(extension, async (draft) => {
+    // The IExtension has definitions for all extensionPoints from the mod, even ones it doesn't use
+    const relevantDefinitions = pickBy(
+      draft.definitions,
+      (definition, name) =>
+        (definition.kind === "extensionPoint" &&
+          draft.extensionPointId === name) ||
+        definition.kind !== "extensionPoint"
+    );
+
     const ensured = await resolveObj(
-      mapValues(draft.definitions, async (definition) =>
-        ensureInner(draft.definitions, definition)
+      mapValues(relevantDefinitions, async (definition) =>
+        resolveInnerDefinition(draft.definitions, definition)
       )
     );
-    const definitions = new Map(Object.entries(ensured));
+
     delete draft.definitions;
-    if (definitions.has(draft.extensionPointId)) {
-      draft.extensionPointId = definitions.get(draft.extensionPointId).id;
+    if (ensured[draft.extensionPointId] != null) {
+      draft.extensionPointId = ensured[draft.extensionPointId].id;
     }
   }) as Promise<ResolvedExtension<T>>;
 }
 
 /**
  * Resolve inline extension point definitions.
- * TODO: resolve other definitions within the extensions
+ * TODO: resolve other definitions (brick, service, etc.) within the extensions
  */
-export async function resolveRecipe(
+export async function resolveRecipeInnerDefinitions(
   recipe: Pick<RecipeDefinition, "extensionPoints" | "definitions">
 ): Promise<ResolvedExtensionDefinition[]> {
   const extensionDefinitions = recipe.extensionPoints;
@@ -232,33 +268,38 @@ export async function resolveRecipe(
     return extensionDefinitions as ResolvedExtensionDefinition[];
   }
 
+  const extensionPointReferences = new Set<string>(
+    recipe.extensionPoints.map((x) => x.id)
+  );
+
+  // Some mods created with the Page Editor end up with irrelevant definitions in the recipe, because they aren't
+  // cleaned up properly on save, etc.
+  const relevantDefinitions = pickBy(
+    recipe.definitions,
+    (definition, name) =>
+      (definition.kind === "extensionPoint" &&
+        extensionPointReferences.has(name)) ||
+      definition.kind !== "extensionPoint"
+  );
+
   const ensured = await resolveObj(
-    mapValues(recipe.definitions, async (config) =>
-      ensureInner(recipe.definitions, config)
+    mapValues(relevantDefinitions, async (config) =>
+      resolveInnerDefinition(relevantDefinitions, config)
     )
   );
-  const definitions = new Map(Object.entries(ensured));
+
   return extensionDefinitions.map(
     (definition) =>
-      (definitions.has(definition.id)
-        ? { ...definition, id: definitions.get(definition.id).id }
+      (definition.id in ensured
+        ? { ...definition, id: ensured[definition.id].id }
         : definition) as ResolvedExtensionDefinition
   );
-}
-
-/**
- * Scope for inner definitions
- */
-export const INNER_SCOPE = "@internal";
-
-export function isInnerExtensionPoint(id: string): id is InnerDefinitionRef {
-  return id.startsWith(INNER_SCOPE + "/");
 }
 
 export function hasInnerExtensionPoint(extension: IExtension): boolean {
   const hasInner = extension.extensionPointId in (extension.definitions ?? {});
 
-  if (!hasInner && isInnerExtensionPoint(extension.extensionPointId)) {
+  if (!hasInner && isInnerDefinitionRef(extension.extensionPointId)) {
     console.warn(
       "Extension is missing inner definition for %s",
       extension.extensionPointId,

--- a/src/runtime/runtimeUtils.ts
+++ b/src/runtime/runtimeUtils.ts
@@ -31,7 +31,7 @@ import {
 import { engineRenderer } from "@/runtime/renderers";
 import { mapArgs } from "@/runtime/mapArgs";
 import { $safeFind } from "@/helpers";
-import { isInnerExtensionPoint } from "@/registry/internal";
+import { isInnerDefinitionRef } from "@/registry/internal";
 import { BusinessError } from "@/errors/businessErrors";
 import { validateUUID } from "@/types/helpers";
 import { getElementForReference } from "@/contentScript/elementReference";
@@ -242,7 +242,7 @@ export function assertExtensionNotResolved<T extends IExtension>(
 ): asserts extension is T & {
   _unresolvedExtensionBrand: never;
 } {
-  if (isInnerExtensionPoint(extension.extensionPointId)) {
+  if (isInnerDefinitionRef(extension.extensionPointId)) {
     throw new Error("Expected UnresolvedExtension");
   }
 }

--- a/src/runtime/runtimeUtils.ts
+++ b/src/runtime/runtimeUtils.ts
@@ -31,7 +31,6 @@ import {
 import { engineRenderer } from "@/runtime/renderers";
 import { mapArgs } from "@/runtime/mapArgs";
 import { $safeFind } from "@/helpers";
-import { isInnerDefinitionRef } from "@/registry/internal";
 import { BusinessError } from "@/errors/businessErrors";
 import { validateUUID } from "@/types/helpers";
 import { getElementForReference } from "@/contentScript/elementReference";
@@ -44,6 +43,7 @@ import {
   type RenderedArgs,
 } from "@/types/runtimeTypes";
 import { type IExtension } from "@/types/extensionTypes";
+import { isInnerDefinitionRef } from "@/types/registryTypes";
 
 /**
  * @throws InputValidationError if blockArgs does not match the input schema for block

--- a/src/types/registryTypes.ts
+++ b/src/types/registryTypes.ts
@@ -29,6 +29,11 @@ export type RegistryId = string & {
 };
 
 /**
+ * Scope for inner definitions
+ */
+export const INNER_SCOPE = "@internal";
+
+/**
  * The kind of definition in the external registry
  */
 export type Kind =
@@ -114,6 +119,13 @@ export type InnerDefinitionRef = string & {
   // Nominal subtyping
   _innerDefinitionRefBrand: never;
 };
+
+/**
+ * Return true if `id` refers to an inner registry definition
+ */
+export function isInnerDefinitionRef(id: string): id is InnerDefinitionRef {
+  return id.startsWith(INNER_SCOPE + "/");
+}
 
 /**
  * A reference to a package in the registry that the user has edit permissions for.

--- a/src/utils/includesQuickBarExtensionPoint.ts
+++ b/src/utils/includesQuickBarExtensionPoint.ts
@@ -19,7 +19,7 @@ import extensionPointRegistry from "@/extensionPoints/registry";
 import { QuickBarExtensionPoint } from "@/extensionPoints/quickBarExtension";
 import { QuickBarProviderExtensionPoint } from "@/extensionPoints/quickBarProviderExtension";
 import { type RecipeDefinition } from "@/types/recipeTypes";
-import { resolveRecipe } from "@/registry/internal";
+import { resolveRecipeInnerDefinitions } from "@/registry/internal";
 
 /**
  * Returns true if the recipe includes a static or dynamic Quick Bar entries.
@@ -28,7 +28,9 @@ import { resolveRecipe } from "@/registry/internal";
 export default async function includesQuickBarExtensionPoint(
   recipe?: RecipeDefinition
 ): Promise<boolean> {
-  const resolvedExtensionDefinitions = await resolveRecipe(recipe);
+  const resolvedExtensionDefinitions = await resolveRecipeInnerDefinitions(
+    recipe
+  );
 
   for (const { id } of resolvedExtensionDefinitions) {
     // eslint-disable-next-line no-await-in-loop -- can break when we find one


### PR DESCRIPTION
## What does this PR do?

- Part of #4863 
- Telemetry from https://github.com/pixiebrix/pixiebrix-extension/pull/5678 indicated that resolving definitions is a bottleneck
- This PR adds some improvements to avoid unnecessary computation and messenger calls

## Reviewer Tips

- The functional changes are in `internal.ts`
- The rest of the changes are from naming improvements

## Checklist

- [x] Add tests: N/A - rewriting existing code to be more performant
- [x] Designate a primary reviewer: @BLoe 
