### PR TITLE
#5536 - Auto-creation of personal mod DBs - Slice 2

### DIFF
--- a/src/activation/useActivateRecipe.test.ts
+++ b/src/activation/useActivateRecipe.test.ts
@@ -34,25 +34,11 @@ import { type RecipeDefinition } from "@/types/recipeTypes";
 import extensionsSlice from "@/store/extensionsSlice";
 import { type InnerDefinitions } from "@/types/registryTypes";
 import { checkRecipePermissions } from "@/recipes/recipePermissionsHelpers";
-import {
-  emptyPermissionsFactory,
-  ensurePermissionsFromUserGesture,
-} from "@/permissions/permissionsUtils";
+import { emptyPermissionsFactory } from "@/permissions/permissionsUtils";
 import databaseSchema from "@schemas/database.json";
 import { set } from "lodash";
 
 const checkPermissionsMock = jest.mocked(checkRecipePermissions);
-
-jest.mock("@/permissions/permissionsUtils", () => {
-  const actual = jest.requireActual("@/permissions/permissionsUtils");
-  return {
-    ...actual,
-    ensurePermissionsFromUserGesture: jest.fn(),
-  };
-});
-
-const ensurePermissionsMock = jest.mocked(ensurePermissionsFromUserGesture);
-
 const uninstallRecipeMock = jest.mocked(uninstallRecipe);
 const reactivateEveryTabMock = jest.mocked(reactivateEveryTab);
 
@@ -121,7 +107,7 @@ function setRecipeHasPermissions(hasPermissions: boolean) {
 }
 
 function setUserAcceptedPermissions(accepted: boolean) {
-  ensurePermissionsMock.mockResolvedValue(accepted);
+  jest.mocked(browser.permissions.request).mockResolvedValue(accepted);
 }
 
 describe("useActivateRecipe", () => {

--- a/src/activation/useActivateRecipe.ts
+++ b/src/activation/useActivateRecipe.ts
@@ -28,6 +28,9 @@ import { selectExtensions } from "@/store/extensionsSelectors";
 import { ensurePermissionsFromUserGesture } from "@/permissions/permissionsUtils";
 import { checkRecipePermissions } from "@/recipes/recipePermissionsHelpers";
 import { isEmpty } from "lodash";
+import { useCreateDatabaseMutation } from "@/services/api";
+import { isDatabaseField } from "@/components/fields/schemaFields/fieldTypeCheckers";
+import { isUUID, validateUUID } from "@/types/helpers";
 
 export type ActivateResult = {
   success: boolean;
@@ -71,6 +74,8 @@ function useActivateRecipe(
   const dispatch = useDispatch();
   const extensions = useSelector(selectExtensions);
 
+  const [createDatabase] = useCreateDatabaseMutation();
+
   return useCallback(
     async (formValues: WizardValues, recipe: RecipeDefinition) => {
       const recipeExtensions = extensions.filter(
@@ -95,11 +100,13 @@ function useActivateRecipe(
       );
 
       try {
-        if (
-          !(await ensurePermissionsFromUserGesture(
-            await checkRecipePermissions(recipe, serviceAuths)
-          ))
-        ) {
+        const recipePermissions = await checkRecipePermissions(
+          recipe,
+          serviceAuths
+        );
+        const isPermissionsAcceptedByUser =
+          await ensurePermissionsFromUserGesture(recipePermissions);
+        if (!isPermissionsAcceptedByUser) {
           if (source === "extensionConsole") {
             // Note: The prefix "Marketplace" on the telemetry event name
             // here is legacy terminology from before the public marketplace
@@ -118,6 +125,47 @@ function useActivateRecipe(
           };
         }
 
+        const { optionsArgs, services } = formValues;
+
+        // Create databases for any recipe options database fields where the
+        // schema format is "preview", and the field value is a string to use
+        // as the database name
+        const autoCreateDatabaseFieldNames = Object.entries(
+          recipe.options?.schema?.properties ?? {}
+        )
+          .filter(
+            ([name, fieldSchema]) =>
+              typeof fieldSchema !== "boolean" &&
+              isDatabaseField(fieldSchema) &&
+              fieldSchema.format === "preview" &&
+              optionsArgs[name] &&
+              typeof optionsArgs[name] === "string" &&
+              // If the value is a UUID, then it's a database ID for an existing database
+              !isUUID(optionsArgs[name] as string)
+          )
+          .map(([name]) => name);
+        const createDatabasePromises = autoCreateDatabaseFieldNames.map(
+          async (name) => {
+            // Type-checked in the filter above
+            const databaseName: string = optionsArgs[name] as string;
+            const result = await createDatabase({ name: databaseName });
+
+            if ("error" in result) {
+              return {
+                success: false,
+                error: getErrorMessage(result.error),
+              };
+            }
+
+            optionsArgs[name] = validateUUID(result.data.id);
+          }
+        );
+        await Promise.all(createDatabasePromises);
+
+        const recipeExtensions = extensions.filter(
+          (extension) => extension._recipe?.id === recipe.metadata.id
+        );
+
         await uninstallRecipe(recipe.metadata.id, recipeExtensions, dispatch);
 
         dispatch(
@@ -125,9 +173,9 @@ function useActivateRecipe(
             recipe,
             extensionPoints: recipe.extensionPoints,
             services: Object.fromEntries(
-              formValues.services.map(({ id, config }) => [id, config])
+              services.map(({ id, config }) => [id, config])
             ),
-            optionsArgs: formValues.optionsArgs,
+            optionsArgs,
           })
         );
 

--- a/src/activation/useWizard.ts
+++ b/src/activation/useWizard.ts
@@ -35,7 +35,7 @@ import { type RegistryId } from "@/types/registryTypes";
 import { type AuthOption } from "@/auth/authTypes";
 import { inferRecipeAuths, inferRecipeOptions } from "@/store/extensionsUtils";
 import { isDatabaseField } from "@/components/fields/schemaFields/fieldTypeCheckers";
-import { Primitive } from "type-fest";
+import { type Primitive } from "type-fest";
 
 const STEPS: WizardStep[] = [
   // OptionsBody takes only a slice of the RecipeDefinition, however the types aren't set up in a way for TypeScript

--- a/src/activation/useWizard.ts
+++ b/src/activation/useWizard.ts
@@ -34,6 +34,8 @@ import { type Schema } from "@/types/schemaTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type AuthOption } from "@/auth/authTypes";
 import { inferRecipeAuths, inferRecipeOptions } from "@/store/extensionsUtils";
+import { isDatabaseField } from "@/components/fields/schemaFields/fieldTypeCheckers";
+import { Primitive } from "type-fest";
 
 const STEPS: WizardStep[] = [
   // OptionsBody takes only a slice of the RecipeDefinition, however the types aren't set up in a way for TypeScript
@@ -48,6 +50,10 @@ const STEPS: WizardStep[] = [
   { key: "services", label: "Integrations", Component: ServicesBody },
   { key: "activate", label: "Permissions & URLs", Component: PermissionsBody },
 ];
+
+function forcePrimitive(value: unknown): Primitive | undefined {
+  return isPrimitive(value) ? value : undefined;
+}
 
 function useWizard(
   blueprint: RecipeDefinition,
@@ -106,9 +112,19 @@ function useWizard(
       optionsArgs: mapValues(
         blueprint.options?.schema?.properties ?? {},
         (optionSchema: Schema, name: string) => {
-          // eslint-disable-next-line security/detect-object-injection -- name from the schema
-          const value = installedOptions[name] ?? optionSchema.default;
-          return isPrimitive(value) ? value : undefined;
+          const installed = installedOptions[name];
+          if (installed) {
+            return forcePrimitive(installed);
+          }
+
+          if (
+            isDatabaseField(optionSchema) &&
+            optionSchema.format === "preview"
+          ) {
+            return `${blueprint.metadata.name} - ${optionSchema.title ?? name}`;
+          }
+
+          return forcePrimitive(optionSchema.default);
         }
       ),
     };

--- a/src/components/fields/schemaFields/widgets/DatabaseWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/DatabaseWidget.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 import { useField } from "formik";
 import useDatabaseOptions from "@/hooks/useDatabaseOptions";
 import DatabaseCreateModal from "./DatabaseCreateModal";
@@ -29,38 +29,67 @@ import { makeTemplateExpression } from "@/runtime/expressionCreators";
 import FieldRuntimeContext from "@/components/fields/schemaFields/FieldRuntimeContext";
 import { type UUID } from "@/types/stringTypes";
 import { type Expression } from "@/types/runtimeTypes";
+import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
+import { useIsMounted } from "@/hooks/common";
+import { type SelectStringOption } from "@/components/formBuilder/formBuilderTypes";
+import { isUUID } from "@/types/helpers";
 
-const DatabaseWidget: React.FunctionComponent<{
-  /**
-   * The database Formik field name.
-   */
-  name: string;
-}> = ({ name }) => {
+const DatabaseWidget: React.FunctionComponent<SchemaFieldProps> = ({
+  name,
+  schema,
+  isRequired,
+}) => {
   const [showModal, setShowModal] = useState(false);
-  const [{ value }, , { setValue }] = useField<UUID | Expression>(name);
+  const [{ value: fieldValue }, , { setValue: setFieldValue }] = useField<
+    UUID | Expression | string
+  >(name);
   const { allowExpressions } = useContext(FieldRuntimeContext);
 
   const { databaseOptions, isLoading: isLoadingDatabaseOptions } =
     useDatabaseOptions();
 
-  const isMountedRef = useRef(true);
-  useEffect(
-    () => () => {
-      isMountedRef.current = false;
-    },
-    []
-  );
+  const [fullDatabaseOptions, setFullDatabaseOptions] = useState<
+    SelectStringOption[]
+  >([]);
+
+  const initialFieldValue = useMemo(() => fieldValue, []);
+
+  // If the schema format is 'preview', and the initial field value is a string, use that string
+  // as the auto-created database name, and add it as an option to the database dropdown at the
+  // top of the list.
+  useEffect(() => {
+    const loadedOptions = isLoadingDatabaseOptions ? [] : databaseOptions;
+    if (
+      schema.format === "preview" &&
+      typeof initialFieldValue === "string" &&
+      !isUUID(initialFieldValue)
+    ) {
+      loadedOptions.unshift({
+        label: initialFieldValue,
+        value: initialFieldValue,
+      });
+    }
+
+    setFullDatabaseOptions(loadedOptions);
+  }, [
+    initialFieldValue,
+    databaseOptions,
+    schema.format,
+    isLoadingDatabaseOptions,
+  ]);
+
+  const checkIsMounted = useIsMounted();
 
   const setDatabaseId = (databaseId: UUID) => {
     if (allowExpressions) {
-      setValue(makeTemplateExpression("nunjucks", databaseId));
+      setFieldValue(makeTemplateExpression("nunjucks", databaseId));
     } else {
-      setValue(databaseId);
+      setFieldValue(databaseId);
     }
   };
 
   const onModalClose = () => {
-    if (!isMountedRef.current) {
+    if (!checkIsMounted()) {
       return;
     }
 
@@ -68,7 +97,7 @@ const DatabaseWidget: React.FunctionComponent<{
   };
 
   const onDatabaseCreated = (databaseId: UUID) => {
-    if (!isMountedRef.current) {
+    if (!checkIsMounted()) {
       return;
     }
 
@@ -86,9 +115,10 @@ const DatabaseWidget: React.FunctionComponent<{
 
       <SelectWidget
         name={name}
-        options={databaseOptions}
+        options={fullDatabaseOptions}
         isLoading={isLoadingDatabaseOptions}
-        value={isExpression(value) ? value.__value__ : value}
+        isClearable={!isRequired || isLoadingDatabaseOptions}
+        value={isExpression(fieldValue) ? fieldValue.__value__ : fieldValue}
         onChange={(event: React.ChangeEvent<SelectLike<Option<UUID>>>) => {
           setDatabaseId(event.target.value);
         }}

--- a/src/components/fields/schemaFields/widgets/DatabaseWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/DatabaseWidget.tsx
@@ -62,7 +62,9 @@ const DatabaseWidget: React.FunctionComponent<SchemaFieldProps> = ({
     if (
       schema.format === "preview" &&
       typeof initialFieldValue === "string" &&
-      !isUUID(initialFieldValue)
+      !isUUID(initialFieldValue) &&
+      // Don't add the placeholder if a DB with the name already exists
+      !loadedOptions.some((option) => option.label === initialFieldValue)
     ) {
       loadedOptions.unshift({
         label: initialFieldValue,

--- a/src/components/fields/schemaFields/widgets/DatabaseWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/DatabaseWidget.tsx
@@ -63,10 +63,13 @@ const DatabaseWidget: React.FunctionComponent<SchemaFieldProps> = ({
       // Don't add the placeholder if a DB with the name already exists
       !loadedOptions.some((option) => option.label === initialFieldValue)
     ) {
-      loadedOptions.unshift({
-        label: initialFieldValue,
-        value: initialFieldValue,
-      });
+      return [
+        {
+          label: initialFieldValue,
+          value: initialFieldValue,
+        },
+        ...loadedOptions,
+      ];
     }
 
     return loadedOptions;

--- a/src/components/fields/schemaFields/widgets/DatabaseWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/DatabaseWidget.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useContext, useEffect, useMemo, useState } from "react";
+import React, { useContext, useMemo, useState } from "react";
 import { useField } from "formik";
 import useDatabaseOptions from "@/hooks/useDatabaseOptions";
 import DatabaseCreateModal from "./DatabaseCreateModal";
@@ -31,7 +31,6 @@ import { type UUID } from "@/types/stringTypes";
 import { type Expression } from "@/types/runtimeTypes";
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import { useIsMounted } from "@/hooks/common";
-import { type SelectStringOption } from "@/components/formBuilder/formBuilderTypes";
 import { isUUID } from "@/types/helpers";
 
 const DatabaseWidget: React.FunctionComponent<SchemaFieldProps> = ({
@@ -48,17 +47,15 @@ const DatabaseWidget: React.FunctionComponent<SchemaFieldProps> = ({
   const { databaseOptions, isLoading: isLoadingDatabaseOptions } =
     useDatabaseOptions();
 
-  const [fullDatabaseOptions, setFullDatabaseOptions] = useState<
-    SelectStringOption[]
-  >([]);
-
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount
   const initialFieldValue = useMemo(() => fieldValue, []);
 
-  // If the schema format is 'preview', and the initial field value is a string, use that string
-  // as the auto-created database name, and add it as an option to the database dropdown at the
-  // top of the list.
-  useEffect(() => {
+  const fullDatabaseOptions = useMemo(() => {
     const loadedOptions = isLoadingDatabaseOptions ? [] : databaseOptions;
+
+    // If the schema format is 'preview', and the initial field value is a string, use that string
+    // as the auto-created database name, and add it as an option to the database dropdown at the
+    // top of the list.
     if (
       schema.format === "preview" &&
       typeof initialFieldValue === "string" &&
@@ -72,12 +69,12 @@ const DatabaseWidget: React.FunctionComponent<SchemaFieldProps> = ({
       });
     }
 
-    setFullDatabaseOptions(loadedOptions);
+    return loadedOptions;
   }, [
-    initialFieldValue,
     databaseOptions,
-    schema.format,
+    initialFieldValue,
     isLoadingDatabaseOptions,
+    schema.format,
   ]);
 
   const checkIsMounted = useIsMounted();

--- a/src/components/formBuilder/edit/FieldEditor.tsx
+++ b/src/components/formBuilder/edit/FieldEditor.tsx
@@ -62,6 +62,11 @@ const imageForCroppingSourceSchema: Schema = {
     "The source image data URI: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs",
 };
 
+const UNKNOWN_OPTION: SelectStringOption = {
+  label: "unknown",
+  value: null,
+};
+
 const FieldEditor: React.FC<{
   name: string;
   propertyName: string;
@@ -142,10 +147,12 @@ const FieldEditor: React.FC<{
 
   const getSelectedUiTypeOption = () => {
     const fieldSchema = schema.properties[propertyName];
-    const isDatabaseFieldType =
-      typeof fieldSchema !== "boolean" && isDatabaseField(fieldSchema);
-    const isGoogleSheetFieldType =
-      typeof fieldSchema !== "boolean" && isGoogleSheetIdField(fieldSchema);
+    if (typeof fieldSchema === "boolean") {
+      return UNKNOWN_OPTION;
+    }
+
+    const isDatabaseFieldType = isDatabaseField(fieldSchema);
+    const isGoogleSheetFieldType = isGoogleSheetIdField(fieldSchema);
 
     const propertyType =
       isDatabaseFieldType || isGoogleSheetFieldType
@@ -173,12 +180,7 @@ const FieldEditor: React.FC<{
 
     const selected = fieldTypes.find((option) => option.value === uiType);
 
-    return (
-      selected ?? {
-        label: "unknown",
-        value: null,
-      }
-    );
+    return selected ?? UNKNOWN_OPTION;
   };
 
   const onRequiredChange = ({

--- a/src/components/formBuilder/formBuilderHelpers.ts
+++ b/src/components/formBuilder/formBuilderHelpers.ts
@@ -82,6 +82,11 @@ export const FIELD_TYPES_WITHOUT_DEFAULT = [
   stringifyUiType({ propertyType: "string", uiWidget: "database" }),
   stringifyUiType({
     propertyType: "string",
+    uiWidget: "database",
+    propertyFormat: "preview",
+  }),
+  stringifyUiType({
+    propertyType: "string",
     uiWidget: "googleSheet",
   }),
 ];

--- a/src/components/formBuilder/preview/FormPreview.tsx
+++ b/src/components/formBuilder/preview/FormPreview.tsx
@@ -86,9 +86,16 @@ const FormPreview: React.FC<FormPreviewProps> = ({
           for (const property of databaseProperties) {
             property.type = "string";
 
-            // Intentionally setting a string value, not an array. @see FormPreviewSchemaField for details
-            // @ts-expect-error -- intentionally assigning to a string
-            property.enum = "Select...";
+            if (property.format === "preview") {
+              // Intentionally setting a string value, not an array. @see FormPreviewSchemaField for details
+              // @ts-expect-error -- intentionally assigning to a string
+              property.enum = `[Mod Name] - ${activeField} database`;
+            } else {
+              // Intentionally setting a string value, not an array. @see FormPreviewSchemaField for details
+              // @ts-expect-error -- intentionally assigning to a string
+              property.enum = "Select...";
+            }
+
             delete property.$ref;
           }
 

--- a/src/pageEditor/tabs/recipeOptionsDefinitions/RecipeOptionsDefinition.tsx
+++ b/src/pageEditor/tabs/recipeOptionsDefinitions/RecipeOptionsDefinition.tsx
@@ -59,7 +59,11 @@ const fieldTypes = [
   },
   {
     label: "Database automatically created at activation",
-    value: stringifyUiType({ propertyType: "string", uiWidget: "database" }),
+    value: stringifyUiType({
+      propertyType: "string",
+      uiWidget: "database",
+      propertyFormat: "preview",
+    }),
   },
   {
     label: "Google Sheet",

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -149,7 +149,7 @@ export const appApi = createApi({
     }),
     createDatabase: builder.mutation<
       Database,
-      { name: string; organizationId: string }
+      { name: string; organizationId?: string | undefined }
     >({
       query: ({ name, organizationId }) => ({
         url: organizationId

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -50,6 +50,7 @@ import {
 } from "@/extensionPoints/types";
 import {
   type CloudExtension,
+  Database,
   type Deployment,
   type MarketplaceListing,
   type MarketplaceTag,
@@ -962,3 +963,10 @@ export const getRecipeWithBuiltInServiceAuths = () => {
 
   return { recipe, builtInServiceAuths };
 };
+
+export const databaseFactory = define<Database>({
+  id: uuidSequence,
+  name: (n: number) => `Test Database ${n}`,
+  created_at: () => new Date().toISOString(),
+  last_write_at: () => new Date().toISOString(),
+});

--- a/src/testUtils/factories.ts
+++ b/src/testUtils/factories.ts
@@ -50,7 +50,7 @@ import {
 } from "@/extensionPoints/types";
 import {
   type CloudExtension,
-  Database,
+  type Database,
   type Deployment,
   type MarketplaceListing,
   type MarketplaceTag,


### PR DESCRIPTION
## What does this PR do?

- Closes #5536 

## Reviewer Tips

- Look at changes to `useWizard.ts` to set up the initial value for an auto-created personal DB
- Look at how the values are handled and presented in `DatabaseWidget.tsx`
- Look at how the DB is created in `useActivateRecipe.ts`

## Demo

https://www.loom.com/share/68713c897f1a4b3dabab5d47188eaa38

## Future Work

- Hide the database field during marketplace activation and allow personal DB fields to be auto-activated
- Build a feature to add see data to the personal DB that's created

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer - @twschiller 
