### PR TITLE
Assign dependabot PRs to Ben by default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       timezone: Etc/UTC
     versioning-strategy: increase # Update package.json too https://stackoverflow.com/a/66819358/288906
     open-pull-requests-limit: 30
+    assignees:
+      - BLoe
     ignore:
       # Update it manually instead https://github.com/pixiebrix/pixiebrix-extension/issues/4436
       - dependency-name: "@storybook/*"
@@ -26,3 +28,5 @@ updates:
       time: "08:42"
       timezone: Etc/UTC
     open-pull-requests-limit: 30
+    assignees:
+      - BLoe


### PR DESCRIPTION
## What does this PR do?

- Sets the `assignees` field on our dependabot config to make me the default assignee for these PRs

