### PR TITLE
#5700: fix blueprints screen infinite messages bug

### DIFF
--- a/src/background/locator.ts
+++ b/src/background/locator.ts
@@ -17,6 +17,7 @@
 
 import LazyLocatorFactory from "@/services/locator";
 import { expectContext } from "@/utils/expectContext";
+import pMemoize from "p-memoize";
 
 export const locator = new LazyLocatorFactory();
 
@@ -32,7 +33,7 @@ export default async function initLocator() {
   await locator.refresh();
 }
 
-export async function refreshServices({
+async function _refreshServices({
   local = true,
   remote = true,
 } = {}): Promise<void> {
@@ -54,3 +55,11 @@ export async function refreshServices({
     throw new Error("Either local or remote must be set to true");
   }
 }
+
+/**
+ * @see locateWithRetry
+ */
+// Memoize, because multiple elements on the page might be trying to access services
+export const refreshServices = pMemoize(_refreshServices, {
+  cacheKey: JSON.stringify,
+});

--- a/src/background/locator.ts
+++ b/src/background/locator.ts
@@ -17,7 +17,7 @@
 
 import LazyLocatorFactory from "@/services/locator";
 import { expectContext } from "@/utils/expectContext";
-import pMemoize from "p-memoize";
+import { memoizeUntilSettled } from "@/utils";
 
 export const locator = new LazyLocatorFactory();
 
@@ -57,9 +57,11 @@ async function _refreshServices({
 }
 
 /**
+ * Sync local and remote service configurations.
  * @see locateWithRetry
  */
-// Memoize, because multiple elements on the page might be trying to access services
-export const refreshServices = pMemoize(_refreshServices, {
+// Memoize while running, because multiple elements on the page might be trying to refresh services. But can't
+// memoize completely, as that would prevent future refreshes
+export const refreshServices = memoizeUntilSettled(_refreshServices, {
   cacheKey: JSON.stringify,
 });

--- a/src/extensionConsole/pages/blueprints/InstallableIcon.tsx
+++ b/src/extensionConsole/pages/blueprints/InstallableIcon.tsx
@@ -66,6 +66,7 @@ const InstallableIcon: React.FunctionComponent<{
         icon={faCube}
         color={DEFAULT_TEXT_ICON_COLOR}
         size={size}
+        fixedWidth
       />
     );
   }

--- a/src/extensionConsole/pages/blueprints/useInstallablePermissions.ts
+++ b/src/extensionConsole/pages/blueprints/useInstallablePermissions.ts
@@ -32,22 +32,25 @@ const fallback: PermissionsStatus = {
 
 /**
  * WARNING: This hook swallows errors (to simplify the behavior for the blueprints page.
- * Outside of the `BlueprintsPage` you probably want to use useAsyncState with `collectExtensionPermissions`
+ * Outside the `BlueprintsPage` you probably want to use useAsyncState with `collectExtensionPermissions`
  * @see collectExtensionPermissions
  */
 function useInstallablePermissions(extensions: IExtension[]): {
   hasPermissions: boolean;
   requestPermissions: () => Promise<boolean>;
 } {
-  const { data: browserPermissions } = useExtensionPermissions();
+  const { data: browserPermissions, isSuccess } = useExtensionPermissions();
 
   const {
     data: { hasPermissions, permissions },
   } = fallbackValue(
-    useAsyncState(
-      async () => checkExtensionPermissions(extensions),
-      [extensions, browserPermissions]
-    ),
+    useAsyncState(async () => {
+      if (isSuccess) {
+        return checkExtensionPermissions(extensions);
+      }
+
+      return fallback;
+    }, [extensions, browserPermissions, isSuccess]),
     fallback
   );
 

--- a/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.ts
@@ -91,7 +91,7 @@ function useInstallableViewItemActions(
   // https://github.com/pixiebrix/pixiebrix-app/blob/5b30c50d7f9ca7def79fd53ba8f78e0f800a0dcb/api/serializers/account.py#L198-L198
   const isRestricted = isDeployment && restrict("uninstall");
 
-  // Without memoization, the selector the reference changes on every render, which causes useInstallablePermissions
+  // Without memoization, the selector reference changes on every render, which causes useInstallablePermissions
   // to recompute, spamming the background worker with service locator requests
   const memoizedExtensionsSelector = useCallback(
     (state: { options: OptionsState }) =>

--- a/src/extensionConsole/pages/blueprints/useInstallableViewItems.test.tsx
+++ b/src/extensionConsole/pages/blueprints/useInstallableViewItems.test.tsx
@@ -41,6 +41,7 @@ import { appApi } from "@/services/api";
 import pageEditorAnalysisManager from "@/pageEditor/analysisManager";
 import { recipesMiddleware } from "@/recipes/recipesListenerMiddleware";
 import { createRenderHookWithWrappers } from "@/testUtils/testHelpers";
+import { selectUnavailableRecipe } from "@/extensionConsole/pages/blueprints/useInstallables";
 
 const axiosMock = new MockAdapter(axios);
 
@@ -127,16 +128,12 @@ describe("useInstallableViewItems", () => {
     const extension = persistedExtensionFactory({
       _recipe: selectSourceRecipeMetadata(recipe),
     });
-    const stub: UnavailableRecipe = {
-      kind: "recipe" as const,
-      metadata: extension._recipe,
-      isStub: true,
-      updated_at: extension._recipe.updated_at,
-      sharing: extension._recipe.sharing,
-    };
+
+    const unavailableRecipe: UnavailableRecipe =
+      selectUnavailableRecipe(extension);
 
     const wrapper = renderHookWithWrappers(
-      () => useInstallableViewItems([stub]),
+      () => useInstallableViewItems([unavailableRecipe]),
       {
         setupRedux(dispatch) {
           dispatch(extensionsSlice.actions.UNSAFE_setExtensions([extension]));

--- a/src/extensionConsole/pages/blueprints/useInstallableViewItems.test.tsx
+++ b/src/extensionConsole/pages/blueprints/useInstallableViewItems.test.tsx
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { renderHook } from "@/extensionConsole/testHelpers";
 import useInstallableViewItems from "@/extensionConsole/pages/blueprints/useInstallableViewItems";
 import {
   extensionFactory,
@@ -45,7 +44,7 @@ import { createRenderHookWithWrappers } from "@/testUtils/testHelpers";
 
 const axiosMock = new MockAdapter(axios);
 
-// TODO: clean up in https://github.com/pixiebrix/pixiebrix-extension/pull/5674
+// TODO: remove in/after and use testUtils https://github.com/pixiebrix/pixiebrix-extension/pull/5674
 const configureStoreForTests = () =>
   configureStore({
     reducer: {

--- a/src/extensionConsole/pages/blueprints/useInstallableViewItems.test.tsx
+++ b/src/extensionConsole/pages/blueprints/useInstallableViewItems.test.tsx
@@ -1,0 +1,155 @@
+/* eslint-disable new-cap -- test methods */
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { renderHook } from "@/extensionConsole/testHelpers";
+import useInstallableViewItems from "@/extensionConsole/pages/blueprints/useInstallableViewItems";
+import {
+  extensionFactory,
+  persistedExtensionFactory,
+  recipeFactory,
+} from "@/testUtils/factories";
+import {
+  type PersistedExtension,
+  type ResolvedExtension,
+  selectSourceRecipeMetadata,
+} from "@/types/extensionTypes";
+import extensionsSlice from "@/store/extensionsSlice";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import { type UnavailableRecipe } from "@/extensionConsole/pages/blueprints/blueprintsTypes";
+import { configureStore } from "@reduxjs/toolkit";
+import { authSlice } from "@/auth/authSlice";
+import settingsSlice from "@/store/settingsSlice";
+import { blueprintModalsSlice } from "@/extensionConsole/pages/blueprints/modals/blueprintModalsSlice";
+import blueprintsSlice from "@/extensionConsole/pages/blueprints/blueprintsSlice";
+import { recipesSlice } from "@/recipes/recipesSlice";
+import { appApi } from "@/services/api";
+import pageEditorAnalysisManager from "@/pageEditor/analysisManager";
+import { recipesMiddleware } from "@/recipes/recipesListenerMiddleware";
+import { createRenderHookWithWrappers } from "@/testUtils/testHelpers";
+
+const axiosMock = new MockAdapter(axios);
+
+// TODO: clean up in https://github.com/pixiebrix/pixiebrix-extension/pull/5674
+const configureStoreForTests = () =>
+  configureStore({
+    reducer: {
+      auth: authSlice.reducer,
+      settings: settingsSlice.reducer,
+      options: extensionsSlice.reducer,
+      blueprintModals: blueprintModalsSlice.reducer,
+      blueprints: blueprintsSlice.reducer,
+      recipes: recipesSlice.reducer,
+      [appApi.reducerPath]: appApi.reducer,
+    },
+    middleware(getDefaultMiddleware) {
+      /* eslint-disable unicorn/prefer-spread -- It's not Array#concat, can't use spread */
+      return getDefaultMiddleware()
+        .concat(appApi.middleware)
+        .concat(pageEditorAnalysisManager.middleware)
+        .concat(recipesMiddleware);
+      /* eslint-enable unicorn/prefer-spread */
+    },
+  });
+
+const renderHookWithWrappers = createRenderHookWithWrappers(
+  configureStoreForTests
+);
+
+describe("useInstallableViewItems", () => {
+  beforeEach(() => {
+    axiosMock.onGet("/api/marketplace/listings").reply(200, []);
+  });
+
+  it("creates entry for IExtension", async () => {
+    const extension = extensionFactory() as ResolvedExtension;
+
+    const wrapper = renderHookWithWrappers(
+      () => useInstallableViewItems([extension]),
+      {
+        setupRedux(dispatch) {
+          dispatch(
+            extensionsSlice.actions.UNSAFE_setExtensions([
+              extension as unknown as PersistedExtension,
+            ])
+          );
+        },
+      }
+    );
+
+    await wrapper.waitForEffect();
+
+    expect(wrapper.result.current).toEqual({
+      isLoading: false,
+      installableViewItems: [expect.toBeObject()],
+    });
+  });
+
+  it("creates entry for recipe", async () => {
+    const recipe = recipeFactory();
+    const extension = persistedExtensionFactory({
+      _recipe: selectSourceRecipeMetadata(recipe),
+    });
+
+    const wrapper = renderHookWithWrappers(
+      () => useInstallableViewItems([recipe]),
+      {
+        setupRedux(dispatch) {
+          dispatch(extensionsSlice.actions.UNSAFE_setExtensions([extension]));
+        },
+      }
+    );
+
+    await wrapper.waitForEffect();
+
+    expect(wrapper.result.current).toEqual({
+      isLoading: false,
+      installableViewItems: [expect.toBeObject()],
+    });
+  });
+
+  it("creates for unavailable recipe", async () => {
+    const recipe = recipeFactory();
+    const extension = persistedExtensionFactory({
+      _recipe: selectSourceRecipeMetadata(recipe),
+    });
+    const stub: UnavailableRecipe = {
+      kind: "recipe" as const,
+      metadata: extension._recipe,
+      isStub: true,
+      updated_at: extension._recipe.updated_at,
+      sharing: extension._recipe.sharing,
+    };
+
+    const wrapper = renderHookWithWrappers(
+      () => useInstallableViewItems([stub]),
+      {
+        setupRedux(dispatch) {
+          dispatch(extensionsSlice.actions.UNSAFE_setExtensions([extension]));
+        },
+      }
+    );
+
+    await wrapper.waitForEffect();
+
+    expect(wrapper.result.current).toEqual({
+      isLoading: false,
+      installableViewItems: [expect.toBeObject()],
+    });
+  });
+});

--- a/src/extensionConsole/pages/blueprints/useInstallableViewItems.tsx
+++ b/src/extensionConsole/pages/blueprints/useInstallableViewItems.tsx
@@ -174,8 +174,8 @@ function useInstallableViewItems(installables: Installable[]): {
   return {
     installableViewItems,
     // Don't wait for the marketplace listings to load. They're only used to determine the icon and sharing options.
-    // FIXME: when the marketplace data loads, it seems to cause a re-render. So if the user had a 3-dot menu open
-    //  for one of the installables, it will close. This is a bit jarring.
+    // FIXME: when the marketplace data loads, it causes a re-render because the data is passed to React Table. So if
+    //  the user had a 3-dot menu open for one of the installables, it will close. This is a bit jarring.
     isLoading: isRecipesLoading,
   };
 }

--- a/src/extensionConsole/pages/blueprints/useInstallables.test.ts
+++ b/src/extensionConsole/pages/blueprints/useInstallables.test.ts
@@ -66,7 +66,6 @@ describe("useInstallables", () => {
 
     expect(wrapper.result.current).toEqual({
       installables: [],
-      isLoading: false,
       error: false,
     });
   });
@@ -97,7 +96,6 @@ describe("useInstallables", () => {
           isStub: true,
         }),
       ],
-      isLoading: false,
       error: false,
     });
   });
@@ -132,7 +130,6 @@ describe("useInstallables", () => {
           isStub: true,
         }),
       ],
-      isLoading: false,
       error: false,
     });
   });
@@ -142,7 +139,6 @@ describe("useInstallables", () => {
 
     useAllRecipesMock.mockReturnValue({
       data: [recipeDefinitionFactory({ metadata })],
-      isLoading: false,
       error: undefined,
     } as any);
 
@@ -171,7 +167,6 @@ describe("useInstallables", () => {
           kind: "recipe",
         }),
       ],
-      isLoading: false,
       error: false,
     });
 
@@ -197,7 +192,6 @@ describe("useInstallables", () => {
           extensionPointId: expect.toBeString(),
         }),
       ],
-      isLoading: false,
       error: false,
     });
   });
@@ -207,7 +201,6 @@ describe("useInstallables", () => {
 
     useGetAllCloudExtensionsQueryMock.mockReturnValue({
       data: [cloudExtension],
-      isLoading: false,
       error: false,
       refetch: jest.fn(),
     });
@@ -233,7 +226,6 @@ describe("useInstallables", () => {
           extensionPointId: expect.toBeString(),
         }),
       ],
-      isLoading: false,
       error: false,
     });
   });

--- a/src/extensionConsole/pages/blueprints/useInstallables.ts
+++ b/src/extensionConsole/pages/blueprints/useInstallables.ts
@@ -26,6 +26,7 @@ import { selectScope } from "@/auth/authSelectors";
 import { useAllRecipes } from "@/recipes/recipesHooks";
 import { uniqBy } from "lodash";
 import useAsyncState from "@/hooks/useAsyncState";
+import { IExtension } from "@/types/extensionTypes";
 
 type InstallablesState = {
   /**
@@ -38,6 +39,18 @@ type InstallablesState = {
    */
   error: unknown;
 };
+
+export function selectUnavailableRecipe(
+  extension: IExtension
+): UnavailableRecipe {
+  return {
+    metadata: extension._recipe,
+    kind: "recipe",
+    isStub: true,
+    updated_at: extension._recipe.updated_at,
+    sharing: extension._recipe.sharing,
+  };
+}
 
 /**
  * React Hook returning `Installable`s, a common abstraction for recipes and un-packaged IExtensions.
@@ -107,7 +120,9 @@ function useInstallables(): InstallablesState {
     [installedRecipeIds, resolvedExtensions]
   );
 
-  const unknownRecipes: UnavailableRecipe[] = useMemo(() => {
+  // Find extensions that were installed by a recipe that's no longer available to the user, e.g., because it was
+  // deleted, or because the user no longer has access to it.
+  const unavailableRecipes: UnavailableRecipe[] = useMemo(() => {
     const knownRecipeIds = new Set(
       (knownRecipes ?? []).map((x) => x.metadata.id)
     );
@@ -120,13 +135,7 @@ function useInstallables(): InstallablesState {
 
     // Show one entry per missing recipe
     return uniqBy(
-      unavailable.map((x) => ({
-        metadata: x._recipe,
-        kind: "recipe",
-        isStub: true,
-        updated_at: x._recipe.updated_at,
-        sharing: x._recipe.sharing,
-      })),
+      unavailable.map((x) => selectUnavailableRecipe(x)),
       (x) => x.metadata.id
     );
   }, [knownRecipes, resolvedExtensions]);
@@ -135,7 +144,7 @@ function useInstallables(): InstallablesState {
     installables: [
       ...extensionsWithoutRecipe,
       ...knownPersonalOrTeamRecipes,
-      ...unknownRecipes,
+      ...unavailableRecipes,
     ],
     error: cloudExtensions.error ?? recipesState.error ?? resolveError,
   };

--- a/src/extensionConsole/pages/blueprints/useInstallables.ts
+++ b/src/extensionConsole/pages/blueprints/useInstallables.ts
@@ -26,7 +26,7 @@ import { selectScope } from "@/auth/authSelectors";
 import { useAllRecipes } from "@/recipes/recipesHooks";
 import { uniqBy } from "lodash";
 import useAsyncState from "@/hooks/useAsyncState";
-import { IExtension } from "@/types/extensionTypes";
+import { type IExtension } from "@/types/extensionTypes";
 
 type InstallablesState = {
   /**

--- a/src/extensionConsole/pages/blueprints/utils/installableUtils.ts
+++ b/src/extensionConsole/pages/blueprints/utils/installableUtils.ts
@@ -246,7 +246,7 @@ export function getSharingType({
 }
 
 export function updateAvailable(
-  availableRecipes: RecipeDefinition[],
+  availableRecipes: Map<RegistryId, RecipeDefinition>,
   installedExtensions: UnresolvedExtension[],
   installable: Installable
 ): boolean {
@@ -258,6 +258,7 @@ export function updateAvailable(
   }
 
   if (isBlueprint(installable)) {
+    // Pick any IExtension from the blueprint to check for updates. All of their versions should be the same.
     installedExtension = installedExtensions?.find(
       (extension) => extension._recipe?.id === installable.metadata.id
     );
@@ -269,9 +270,7 @@ export function updateAvailable(
     return false;
   }
 
-  const availableRecipe = availableRecipes?.find(
-    (recipe) => recipe.metadata.id === installedExtension._recipe.id
-  );
+  const availableRecipe = availableRecipes.get(installedExtension._recipe.id);
 
   if (!availableRecipe) {
     return false;

--- a/src/extensionConsole/pages/blueprints/utils/installableUtils.ts
+++ b/src/extensionConsole/pages/blueprints/utils/installableUtils.ts
@@ -247,24 +247,18 @@ export function getSharingType({
 
 export function updateAvailable(
   availableRecipes: Map<RegistryId, RecipeDefinition>,
-  installedExtensions: UnresolvedExtension[],
+  installedExtensions: Map<RegistryId, UnresolvedExtension>,
   installable: Installable
 ): boolean {
-  let installedExtension: ResolvedExtension | UnresolvedExtension = null;
-
   if (isUnavailableRecipe(installable)) {
     // Unavailable recipes are never update-able
     return false;
   }
 
-  if (isBlueprint(installable)) {
-    // Pick any IExtension from the blueprint to check for updates. All of their versions should be the same.
-    installedExtension = installedExtensions?.find(
-      (extension) => extension._recipe?.id === installable.metadata.id
-    );
-  } else {
-    installedExtension = installable;
-  }
+  const installedExtension: ResolvedExtension | UnresolvedExtension =
+    isBlueprint(installable)
+      ? installedExtensions.get(installable.metadata.id)
+      : installable;
 
   if (!installedExtension?._recipe) {
     return false;

--- a/src/hooks/common.ts
+++ b/src/hooks/common.ts
@@ -75,6 +75,9 @@ const slice = createSlice({
   },
 });
 
+/**
+ * @deprecated use useAsyncState.ts instead
+ */
 export function useAsyncState<T>(
   promiseOrGenerator: StateFactory<T>,
   dependencies: unknown[] = [],

--- a/src/services/serviceUtils.ts
+++ b/src/services/serviceUtils.ts
@@ -105,8 +105,9 @@ async function _locateWithRetry(
  * Locate a service by id and configuration. If it's not found, fetch the latest configurations from local storage
  * and remote, and then try again.
  */
-// Memoize, because multiple elements on the screen may be trying to locate the same service. Might also consider
-// caching, but would have to be careful about invalidating the cache on service configuration changes
+// Memoize until settled, because multiple elements on the screen may be trying to locate the same service. Might
+// also consider full memoization/caching, but would have to be careful about invalidating the cache on service
+// configuration changes
 export const locateWithRetry = memoizeUntilSettled(_locateWithRetry, {
   cacheKey: JSON.stringify,
 });

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -21,7 +21,7 @@ import { reportEvent } from "@/telemetry/events";
 import { selectEventData } from "@/telemetry/deployments";
 import { contextMenus } from "@/background/messenger/api";
 import { uuidv4 } from "@/types/helpers";
-import { cloneDeep, partition, pick } from "lodash";
+import { cloneDeep, partition } from "lodash";
 import { saveUserExtension } from "@/services/apiClient";
 import reportError from "@/telemetry/reportError";
 import {
@@ -35,6 +35,7 @@ import { revertAll } from "@/store/commonActions";
 import {
   type IExtension,
   type PersistedExtension,
+  selectSourceRecipeMetadata,
 } from "@/types/extensionTypes";
 import { type UUID } from "@/types/stringTypes";
 import {
@@ -161,11 +162,7 @@ const extensionsSlice = createSlice({
           // Default to `v1` for backward compatability
           apiVersion: recipe.apiVersion ?? "v1",
           _deployment: selectDeploymentContext(deployment),
-          _recipe: {
-            ...pick(recipe.metadata, ["id", "version", "name", "description"]),
-            sharing: recipe.sharing,
-            updated_at: recipe.updated_at,
-          },
+          _recipe: selectSourceRecipeMetadata(recipe),
           // Definitions are pushed down into the extensions. That's OK because `resolveDefinitions` determines
           // uniqueness based on the content of the definition. Therefore, bricks will be re-used as necessary
           definitions: recipe.definitions ?? {},

--- a/src/types/extensionTypes.ts
+++ b/src/types/extensionTypes.ts
@@ -263,7 +263,12 @@ export function selectSourceRecipeMetadata(
   }
 
   return {
-    ...recipeDefinition.metadata,
+    ...pick(recipeDefinition.metadata, [
+      "id",
+      "version",
+      "name",
+      "description",
+    ]),
     ...pick(recipeDefinition, ["sharing", "updated_at"]),
   };
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #5700
- Main fix: Memoizes the selector that selects the extensions passed to useInstallablePermissions
- Wraps calls to locateWithRetry and refreshServices in memoizeUntilSettled
- Removes unused state property on useInstallable
- Modifies useInstallableViewItems to not show loading indicator during the server call to `useGetMarketplaceListingsQuery`

## Reviewer Tips

- Review `useInstallables` and `useInstallableViewItems` and `useInstallableActions`

## Discussion

- I'm still not sure which change triggered the bug. My understanding is that the reference should have always been changing from the selector

## Demo

- https://www.loom.com/share/52ac8b0d4e4445ad9c23c7bd483c0cfb

## Future Work

- Clean up "installables" code so useInstallableViewItemActions isn't mounted multiple times per installable
- When the marketplace query loads, the installables re-mount. So if you had a 3-dot menu open, it will close. I think this happens because the data is passed to reactTable, so the whole reactTable re-renders. The code needs to be re-factored so that the fields impacted by the marketplace query (`icon` and `sharing`) are calculated on the  individual items instead of pre-calculated. (Although, that might not be possible for sharing, because it needs to be used in filters)

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @mnholtz 
