### PR TITLE
Suggestion: Change size styling for logos in the sidebar

### DIFF
--- a/src/sidebar/ConnectedSidebar.module.scss
+++ b/src/sidebar/ConnectedSidebar.module.scss
@@ -45,7 +45,7 @@
 }
 
 .logo {
-  max-width: 100%;
+  max-width: 210px;
   max-height: 80px;
   padding: 0 1.5rem;
 }

--- a/src/sidebar/ConnectedSidebar.module.scss
+++ b/src/sidebar/ConnectedSidebar.module.scss
@@ -41,10 +41,11 @@
   display: inline-flex;
   align-items: center;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .logo {
-  // see _themes.scss
-  height: var(--logo-height);
+  max-width: 100%;
+  max-height: 80px;
   padding: 0 1.5rem;
 }

--- a/src/sidebar/Header.tsx
+++ b/src/sidebar/Header.tsx
@@ -32,7 +32,7 @@ const Header: React.FunctionComponent = () => {
   const wasContextInvalidated = useContextInvalidated();
 
   return (
-    <div className="d-flex p-2 justify-content-between align-content-center">
+    <div className="d-flex p-2 justify-content-between align-items-start">
       {wasContextInvalidated || ( // /* The button doesn't work after invalidation #2359 */
         <Button
           className={cx(

--- a/src/sidebar/__snapshots__/Header.test.tsx.snap
+++ b/src/sidebar/__snapshots__/Header.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Header renders 1`] = `
 <DocumentFragment>
   <div
-    class="d-flex p-2 justify-content-between align-content-center"
+    class="d-flex p-2 justify-content-between align-items-start"
   >
     <button
       class="button themeColorOverride btn btn-link btn-sm"
@@ -66,7 +66,7 @@ exports[`Header renders 1`] = `
 exports[`Header renders sidebar header logo per organization theme 1`] = `
 <DocumentFragment>
   <div
-    class="d-flex p-2 justify-content-between align-content-center"
+    class="d-flex p-2 justify-content-between align-items-start"
   >
     <button
       class="button themeColorOverride btn btn-link btn-sm"

--- a/src/sidebar/__snapshots__/SidebarApp.test.tsx.snap
+++ b/src/sidebar/__snapshots__/SidebarApp.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SidebarApp it renders 1`] = `
 <DocumentFragment>
   <div
-    class="d-flex p-2 justify-content-between align-content-center"
+    class="d-flex p-2 justify-content-between align-items-start"
   >
     <button
       class="button themeColorOverride btn btn-link btn-sm"
@@ -132,7 +132,7 @@ exports[`SidebarApp it renders error when context is invalidated 1`] = `
     Close and reopen the sidebar to continue.
   </div>
   <div
-    class="d-flex p-2 justify-content-between align-content-center"
+    class="d-flex p-2 justify-content-between align-items-start"
   >
     <div
       class="align-self-center"


### PR DESCRIPTION
## What does this PR do?

Our logo size is currently hardcoded to 28px. This causes taller logos to scale down significantly. This change allows logos to expand up to 80px in height (arbitrary size I chose).

## Demo

PB logo before:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/f181a5c4-c985-44c8-80ae-7553148e4326)

PB logo after:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/cd45cf8e-a7d6-4d94-952d-87bedeabc23e)


Custom logo before:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/7b0fa2f5-337c-456e-8fc0-da2cab1c5836)

Custom logo after:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/766bebae-b500-45a3-a039-5d9c2c189a28)
