### PR TITLE
#5703 Add `searchQuery` to Mod Page table dependencies

### DIFF
--- a/src/extensionConsole/pages/blueprints/BlueprintsPageLayout.test.tsx
+++ b/src/extensionConsole/pages/blueprints/BlueprintsPageLayout.test.tsx
@@ -242,17 +242,12 @@ describe("BlueprintsPageLayout", () => {
 
   test("search query heading renders", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const rendered = render(
-      <BlueprintsPageLayout installables={installables} />
-    );
+    render(<BlueprintsPageLayout installables={installables} />);
 
     await waitForEffect();
 
     await user.type(
       screen.getByTestId("blueprints-search-input"),
-      "hello world"
-    );
-    expect(rendered.getByTestId("blueprints-search-input").value).toBe(
       "hello world"
     );
     jest.runAllTimers();

--- a/src/extensionConsole/pages/blueprints/BlueprintsPageLayout.test.tsx
+++ b/src/extensionConsole/pages/blueprints/BlueprintsPageLayout.test.tsx
@@ -33,6 +33,7 @@ import blueprintsSlice, {
   persistBlueprintsConfig,
 } from "@/extensionConsole/pages/blueprints/blueprintsSlice";
 import { type Me } from "@/types/contract";
+import userEvent from "@testing-library/user-event";
 
 const EMPTY_RESPONSE = Object.freeze({
   data: Object.freeze([]),
@@ -96,10 +97,13 @@ describe("BlueprintsPageLayout", () => {
     jest.resetModules();
     process.env = { ...env };
     jest.clearAllMocks();
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
     process.env = env;
+    jest.runAllTimers();
+    jest.useRealTimers();
   });
 
   test("renders", async () => {
@@ -234,6 +238,26 @@ describe("BlueprintsPageLayout", () => {
     await waitForEffect();
     expect(screen.queryByText("Bot Games")).not.toBeNull();
     expect(screen.getByTestId("bot-games-blueprint-tab")).toHaveClass("active");
+  });
+
+  test("search query heading renders", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const rendered = render(
+      <BlueprintsPageLayout installables={installables} />
+    );
+
+    await waitForEffect();
+
+    await user.type(
+      screen.getByTestId("blueprints-search-input"),
+      "hello world"
+    );
+    screen.debug();
+    expect(rendered.getByTestId("blueprints-search-input").value).toBe(
+      "hello world"
+    );
+    jest.runAllTimers();
+    expect(screen.queryByText('0 results for "hello world"')).not.toBeNull();
   });
 });
 

--- a/src/extensionConsole/pages/blueprints/BlueprintsPageLayout.test.tsx
+++ b/src/extensionConsole/pages/blueprints/BlueprintsPageLayout.test.tsx
@@ -252,7 +252,6 @@ describe("BlueprintsPageLayout", () => {
       screen.getByTestId("blueprints-search-input"),
       "hello world"
     );
-    screen.debug();
     expect(rendered.getByTestId("blueprints-search-input").value).toBe(
       "hello world"
     );

--- a/src/extensionConsole/pages/blueprints/BlueprintsPageLayout.test.tsx
+++ b/src/extensionConsole/pages/blueprints/BlueprintsPageLayout.test.tsx
@@ -21,7 +21,7 @@ import BlueprintsPageLayout from "@/extensionConsole/pages/blueprints/Blueprints
 import { type Installable } from "@/extensionConsole/pages/blueprints/blueprintsTypes";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { appApi, useGetStarterBlueprintsQuery } from "@/services/api";
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import { organizationFactory } from "@/testUtils/factories";
 import { configureStore } from "@reduxjs/toolkit";
 import { persistReducer } from "redux-persist";
@@ -250,8 +250,21 @@ describe("BlueprintsPageLayout", () => {
       screen.getByTestId("blueprints-search-input"),
       "hello world"
     );
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(screen.queryByText('0 results for "hello world"')).not.toBeNull();
+
+    await user.type(
+      screen.getByTestId("blueprints-search-input"),
+      " hello world again!"
+    );
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(
+      screen.queryByText('0 results for "hello world hello world again!"')
+    ).not.toBeNull();
   });
 });
 

--- a/src/extensionConsole/pages/blueprints/BlueprintsPageLayout.tsx
+++ b/src/extensionConsole/pages/blueprints/BlueprintsPageLayout.tsx
@@ -146,7 +146,7 @@ const BlueprintsPageLayout: React.FunctionComponent<{
             globalFilter: searchQuery,
           }),
           // eslint-disable-next-line react-hooks/exhaustive-deps -- table props are required dependencies
-          [state, groupBy, sortBy, activeTab.filters]
+          [searchQuery, state, groupBy, sortBy, activeTab.filters]
         ),
     },
     useFilters,

--- a/src/extensionConsole/pages/blueprints/BlueprintsPageSidebar.tsx
+++ b/src/extensionConsole/pages/blueprints/BlueprintsPageSidebar.tsx
@@ -257,6 +257,7 @@ const BlueprintsPageSidebar: React.FunctionComponent<
           placeholder="Search all mods"
           size="sm"
           value={searchInput}
+          data-testid="blueprints-search-input"
           onChange={({ target }) => {
             setSearchInput(target.value);
           }}

--- a/src/extensionConsole/pages/blueprints/__snapshots__/BlueprintsPageLayout.test.tsx.snap
+++ b/src/extensionConsole/pages/blueprints/__snapshots__/BlueprintsPageLayout.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`BlueprintsPageLayout renders 1`] = `
       >
         <input
           class="form-control form-control-sm"
+          data-testid="blueprints-search-input"
           id="query"
           placeholder="Search all mods"
           value=""


### PR DESCRIPTION
## What does this PR do?

- Fixes #5703 
- @twschiller and I aren't 100% sure why this was working before without the dependency added
- Adds a unit test to confirm searchQuery responsiveness

## Discussion

- I attempted to add a test with installables populated with test data, but ran into some snags that I think are still out of scope

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @twschiller 
