### PR TITLE
Change playground url to `/welcome`

### DIFF
--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -34,7 +34,7 @@ import { type UUID } from "@/types/stringTypes";
 
 const { reducer, actions } = extensionsSlice;
 
-const PLAYGROUND_URL = "https://www.pixiebrix.com/playground";
+const PLAYGROUND_URL = "https://www.pixiebrix.com/welcome";
 const BLUEPRINT_INSTALLATION_DEBOUNCE_MS = 10_000;
 const BLUEPRINT_INSTALLATION_MAX_MS = 60_000;
 


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-app/pull/3437 
    - See this PR for deployment checklist
- Simply changes the playground url that starter blueprints are installed on to `/welcome`

## Checklist

- [x] Add tests @BLoe 
- [x] Designate a primary reviewer
