### PR TITLE
#4863: content script and menu diagnostics

### DIFF
--- a/src/background/contentScript.ts
+++ b/src/background/contentScript.ts
@@ -142,6 +142,7 @@ export const ensureContentScript = memoizeUntilSettled(
       await pTimeout(ensureContentScriptWithoutTimeout(target, signal), {
         signal,
         milliseconds: timeoutMillis,
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- known to be a number
         message: `contentScript not ready in ${timeoutMillis}ms`,
       });
 
@@ -150,7 +151,7 @@ export const ensureContentScript = memoizeUntilSettled(
       controller.abort();
     }
   },
-  // Stringify since Target is an object
+  // Stringify because Target is an object
   { cacheKey: JSON.stringify }
 );
 

--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -70,7 +70,8 @@ async function dispatchMenu(
 
   console.time("ensureContentScript");
 
-  // Using the context menu gives temporary access to the page
+  // Using the context menu gives temporary access to the page. The content script should already be injected via
+  // webext-dynamic-content-scripts, but double check just in case.
   await pTimeout(ensureContentScript(target), {
     milliseconds: CONTEXT_SCRIPT_INSTALL_MS,
     message: `contentScript for context menu handler not ready in ${CONTEXT_SCRIPT_INSTALL_MS}ms`,

--- a/src/contentScript/contentScript.ts
+++ b/src/contentScript/contentScript.ts
@@ -16,7 +16,7 @@
  */
 
 import "./contentScript.scss";
-import "@/development/visualInjection";
+import { addContentScriptIndicator } from "@/development/visualInjection";
 import { uuidv4 } from "@/types/helpers";
 import {
   isInstalledInThisSession,
@@ -26,6 +26,7 @@ import {
 } from "@/contentScript/ready";
 import { logPromiseDuration } from "@/utils";
 import { onContextInvalidated } from "@/errors/contextInvalidated";
+import { syncFlagOn } from "@/store/syncFlags";
 
 // Track module load so we hear something from content script
 console.debug("contentScript: module load");
@@ -63,6 +64,13 @@ async function initContentScript() {
     unsetReadyInThisDocument(uuid);
     console.debug("contentScript: invalidated", uuid);
   });
+
+  if (
+    process.env.ENVIRONMENT === "development" ||
+    syncFlagOn("navigation-trace")
+  ) {
+    addContentScriptIndicator();
+  }
 }
 
 if (location.protocol === "https:") {

--- a/src/development/visualInjection.ts
+++ b/src/development/visualInjection.ts
@@ -17,7 +17,10 @@
 
 import { MAX_Z_INDEX } from "@/common";
 
-if (process.env.ENVIRONMENT === "development") {
+/**
+ * Add a visual indicator to the top-left of the DOM.
+ */
+export function addContentScriptIndicator() {
   const indicator = document.createElement("div");
 
   // Hide on hover
@@ -36,5 +39,6 @@ if (process.env.ENVIRONMENT === "development") {
     borderLeft: "solid 5px white",
     borderRight: "solid 5px black",
   });
+
   document.body.prepend(indicator);
 }

--- a/src/extensionPoints/helpers.test.ts
+++ b/src/extensionPoints/helpers.test.ts
@@ -53,4 +53,30 @@ describe("awaitElementOnce", () => {
 
     await expect(promise).resolves.toHaveLength(1);
   });
+
+  it("finds button within modal content", async () => {
+    // Mimics targeting the LinkedIn modal
+
+    document.body.innerHTML = getDocument(
+      '<div id="root"></div>'
+    ).body.innerHTML;
+
+    const [promise] = awaitElementOnce(
+      'div[data-test-modal-id="send-invite-modal"] div:has(>button[aria-label="Cancel adding a note"])'
+    );
+
+    $("#root").append(
+      '<div data-test-modal-id="send-invite-modal"><div></div></div>'
+    );
+    requestIdleCallback.runIdleCallbacks();
+    await tick();
+
+    $("[data-test-modal-id] div").append(
+      '<button aria-label="Cancel adding a note"></button>'
+    );
+    requestIdleCallback.runIdleCallbacks();
+    await tick();
+
+    await expect(promise).resolves.toHaveLength(1);
+  });
 });

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -133,8 +133,6 @@ export function awaitElementOnce(
     return [Promise.resolve($root), noop];
   }
 
-  // Console.debug("Awaiting selectors", selectors);
-
   const [nextSelector, ...rest] = selectors;
 
   // Find immediately, or wait for it to be initialized
@@ -145,7 +143,7 @@ export function awaitElementOnce(
 
   if ($elements.length === 0) {
     console.debug(
-      `Selector not immediately found; awaiting selector: ${nextSelector}`
+      `awaitElementOnce: selector not immediately found; awaiting selector: ${nextSelector}`
     );
 
     const [nextElementPromise, cancel] = mutationSelector(
@@ -158,9 +156,15 @@ export function awaitElementOnce(
       nextElementPromise.then(async ($nextElement) => {
         const [innerPromise, inner] = awaitElementOnce(rest, $nextElement);
         innerCancel = inner;
+
+        console.debug(`awaitElementOnce: found selector: ${nextSelector}`);
+
         return innerPromise;
       }),
       () => {
+        console.debug(
+          `awaitElementOnce: caller cancelled wait for selector: ${nextSelector}`
+        );
         cancel();
         innerCancel();
       },

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -262,9 +262,10 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
     console.debug(
       `Cancelling ${this.cancelPending.size} menuItemExtension observers`
     );
+
     for (const cancelObserver of this.cancelPending) {
       try {
-        // `cancelObserver` should always be defined given it's type. But check just in case since we don't have
+        // `cancelObserver` should always be defined given its type. But check just in case since we don't have
         // strictNullChecks on
         if (cancelObserver) {
           cancelObserver();
@@ -426,7 +427,17 @@ export abstract class MenuItemExtensionPoint extends ExtensionPoint<MenuItemExte
     const [menuPromise, cancelWait] = awaitElementOnce(selector);
     this.cancelPending.add(cancelWait);
 
-    const $menuContainers = (await cancelOnNavigation(menuPromise)) as JQuery;
+    let $menuContainers;
+
+    try {
+      $menuContainers = (await cancelOnNavigation(menuPromise)) as JQuery;
+    } catch (error) {
+      console.debug(
+        `${this.instanceNonce}: stopped awaiting menu container for ${this.id}`,
+        { error }
+      );
+      throw error;
+    }
 
     const menuContainers = [...this.menus.values()];
 


### PR DESCRIPTION
## What does this PR do?

- Part of #4863
- Adds more debug logging to awaitElementOnce
- Adds support for the contentScript visual indicator in production with `navigation-trace` feature flag
- Ensures content script is loaded before handleNavigate call 

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer
