### PR TITLE
#4863: fix duplicate messenger registration

### DIFF
--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -47,6 +47,8 @@ onUncaughtError((error) => {
 });
 
 export async function init(): Promise<void> {
+  console.debug("contentScriptCore: init");
+
   registerMessenger();
   registerExternalMessenger();
   registerBuiltinBlocks();


### PR DESCRIPTION
## What does this PR do?

- Part of #4863 
- Fix bug introduced in https://github.com/pixiebrix/pixiebrix-extension/pull/5743. Can't import auth state in contentScript because it imports the messenger
- The messenger can't be imported in contentScript because it can only be imported once
- See code comments for deeper explanation 

## Future Work

- Figure out how to add lint/dependency analysis to prevent accidentally importing the messenger in contentScript.ts

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @BLoe 
