### PR TITLE
#5753: add support for watching for new menus

### DIFF
--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -36,6 +36,13 @@ function getAncestors(node: Node): Node[] {
   return ancestors;
 }
 
+/**
+ * Attach a callback to be called when a node is removed from the DOM
+ * @param node the DOM node to observe
+ * @param callback callback to call when the node is removed
+ * @return method to disconnect stop observing for node removal
+ */
+// TODO: replace callback with having caller pass AbortSignal
 export function onNodeRemoved(node: Node, callback: () => void): () => void {
   const ancestors = getAncestors(node);
 
@@ -179,23 +186,23 @@ export function awaitElementOnce(
 }
 
 /**
- * Marks extensionPointId as owning a DOM element.
+ * Marks extensionPointId as owning a DOM element and returns a callback that notifies if the element is removed
+ * from the DOM
  * @param element the element to acquire
  * @param extensionPointId the owner extension ID
- * @param onRemove callback to call when the element is removed from the DOM
+ * @return true if the element was successfully acquired, false if it was already acquired by another extension point
  */
 export function acquireElement(
   element: HTMLElement,
-  extensionPointId: string,
-  onRemove: () => void
-): () => void | null {
+  extensionPointId: string
+): boolean {
   const existing = element.getAttribute(EXTENSION_POINT_DATA_ATTR);
   if (existing) {
     if (extensionPointId !== existing) {
       console.warn(
         `acquireElement: cannot acquire for ${extensionPointId} because it has extension point ${existing} attached to it`
       );
-      return null;
+      return false;
     }
 
     console.debug(
@@ -204,7 +211,7 @@ export function acquireElement(
   }
 
   element.setAttribute(EXTENSION_POINT_DATA_ATTR, extensionPointId);
-  return onNodeRemoved(element, onRemove);
+  return true;
 }
 
 /**

--- a/src/pageEditor/extensionPoints/formStateTypes.ts
+++ b/src/pageEditor/extensionPoints/formStateTypes.ts
@@ -74,6 +74,10 @@ type ActionExtensionPointState = BaseExtensionPointState & {
      * @since 1.7.16
      */
     targetMode?: "document" | "eventTarget";
+    /**
+     * @since 1.7.28
+     */
+    attachMode?: "once" | "watch";
     reader: SingleLayerReaderConfig;
     isAvailable: NormalizedAvailability;
   };

--- a/src/pageEditor/extensionPoints/menuItem.ts
+++ b/src/pageEditor/extensionPoints/menuItem.ts
@@ -67,6 +67,7 @@ function fromNativeElement(
         reader: getImplicitReader("menuItem"),
         isAvailable: makeIsAvailable(url),
         targetMode: "document",
+        attachMode: "once",
       },
       traits: {
         style: {
@@ -96,6 +97,7 @@ function selectExtensionPointConfig(
       reader,
       containerSelector,
       targetMode,
+      attachMode,
     },
   } = extensionPoint;
   return removeEmptyValues({
@@ -106,6 +108,7 @@ function selectExtensionPointConfig(
       isAvailable: pickBy(isAvailable, identity),
       containerSelector,
       targetMode,
+      attachMode,
       position,
       template,
     },

--- a/src/pageEditor/tabs/menuItem/MenuItemConfiguration.tsx
+++ b/src/pageEditor/tabs/menuItem/MenuItemConfiguration.tsx
@@ -67,6 +67,7 @@ const MenuItemConfiguration: React.FC<{
         name="extensionPoint.definition.isAvailable.matchPatterns"
         {...makeLockableFieldProps("Sites", isLocked)}
       />
+
       <ConnectedCollapsibleFieldSection title="Advanced: Item Options">
         <ConnectedFieldTemplate
           name="extension.icon"
@@ -91,6 +92,23 @@ const MenuItemConfiguration: React.FC<{
           snippets={menuSnippets}
           {...makeLockableFieldProps("Template", isLocked)}
         />
+
+        <ConnectedFieldTemplate
+          name="extensionPoint.definition.attachMode"
+          as="select"
+          title="Attach Mode"
+          description={
+            <p>
+              Use&nbsp;<code>once</code> to add the buttons once the menu
+              becomes available. Use&nbsp;
+              <code>watch</code> to continue to watch the page for new menus.
+            </p>
+          }
+          {...makeLockableFieldProps("Attach Mode", isLocked)}
+        >
+          <option value="once">once</option>
+          <option value="watch">watch</option>
+        </ConnectedFieldTemplate>
 
         <ConnectedFieldTemplate
           name="extensionPoint.definition.targetMode"


### PR DESCRIPTION
## What does this PR do?

- Closes #5753 
- Adds a `watch` mode for the button extension point to watch for new menus on the page
- Cleans up a confusing helper method

## Reviewer Tips

- Main changes are in menuItemExtension.ts
- Also look at MenuItemConfiguration

## Discussion

- I closed out issue: https://github.com/pixiebrix/pixiebrix-extension/issues/1811. It might be related, but appeared to be old/stale

## Demo

- https://www.loom.com/share/d9af09ce4a9b41e184a91759db52de84

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
