### PR TITLE
#5762: clean up partner onboarding state management, names, add tests

### DIFF
--- a/src/auth/useRequiredPartnerAuth.ts
+++ b/src/auth/useRequiredPartnerAuth.ts
@@ -30,7 +30,7 @@ import { useEffect } from "react";
 import {
   AUTOMATION_ANYWHERE_PARTNER_KEY,
   CONTROL_ROOM_OAUTH_SERVICE_ID,
-  CONTROL_ROOM_SERVICE_ID,
+  CONTROL_ROOM_TOKEN_SERVICE_ID,
 } from "@/services/constants";
 import { type AuthState } from "@/auth/authTypes";
 import { type SettingsState } from "@/store/settingsTypes";
@@ -43,7 +43,7 @@ import { type RegistryId } from "@/types/registryTypes";
 const PARTNER_MAP = new Map<string, Set<RegistryId>>([
   [
     AUTOMATION_ANYWHERE_PARTNER_KEY,
-    new Set([CONTROL_ROOM_SERVICE_ID, CONTROL_ROOM_OAUTH_SERVICE_ID]),
+    new Set([CONTROL_ROOM_TOKEN_SERVICE_ID, CONTROL_ROOM_OAUTH_SERVICE_ID]),
   ],
 ]);
 
@@ -102,7 +102,7 @@ function decidePartnerServiceIds({
   }
 
   if (authMethodOverride === "partner-token") {
-    return new Set<RegistryId>([CONTROL_ROOM_SERVICE_ID]);
+    return new Set<RegistryId>([CONTROL_ROOM_TOKEN_SERVICE_ID]);
   }
 
   return PARTNER_MAP.get(partnerId) ?? new Set();

--- a/src/background/partnerIntegrations.test.ts
+++ b/src/background/partnerIntegrations.test.ts
@@ -26,7 +26,7 @@ import controlRoomOAuthService from "@contrib/services/automation-anywhere-oauth
 import { locator as serviceLocator } from "@/background/locator";
 import {
   CONTROL_ROOM_OAUTH_SERVICE_ID,
-  CONTROL_ROOM_SERVICE_ID,
+  CONTROL_ROOM_TOKEN_SERVICE_ID,
 } from "@/services/constants";
 import { uuidv4 } from "@/types/helpers";
 import { readPartnerAuthData, setPartnerAuth } from "@/auth/token";
@@ -136,7 +136,7 @@ describe("getPartnerPrincipals", () => {
     readRawConfigurationsMock.mockResolvedValue([
       {
         id: uuidv4(),
-        serviceId: CONTROL_ROOM_SERVICE_ID,
+        serviceId: CONTROL_ROOM_TOKEN_SERVICE_ID,
         config: {
           controlRoomUrl: "https://control-room.example.com",
           username: "bot_creator",

--- a/src/background/partnerIntegrations.ts
+++ b/src/background/partnerIntegrations.ts
@@ -26,7 +26,7 @@ import serviceRegistry from "@/services/registry";
 
 import {
   CONTROL_ROOM_OAUTH_SERVICE_ID,
-  CONTROL_ROOM_SERVICE_ID,
+  CONTROL_ROOM_TOKEN_SERVICE_ID,
 } from "@/services/constants";
 import axios from "axios";
 
@@ -51,7 +51,10 @@ type PartnerPrincipal = {
 export async function getPartnerPrincipals(): Promise<PartnerPrincipal[]> {
   expectContext("background");
 
-  const partnerIds = [CONTROL_ROOM_OAUTH_SERVICE_ID, CONTROL_ROOM_SERVICE_ID];
+  const partnerIds = [
+    CONTROL_ROOM_OAUTH_SERVICE_ID,
+    CONTROL_ROOM_TOKEN_SERVICE_ID,
+  ];
 
   const auths = flatten(
     await Promise.all(

--- a/src/contrib/automationanywhere/BotOptions.test.tsx
+++ b/src/contrib/automationanywhere/BotOptions.test.tsx
@@ -20,7 +20,7 @@ import { type FormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { render } from "@/extensionConsole/testHelpers";
 // eslint-disable-next-line no-restricted-imports -- TODO: Fix over time
 import { Formik } from "formik";
-import { CONTROL_ROOM_SERVICE_ID } from "@/services/constants";
+import { CONTROL_ROOM_TOKEN_SERVICE_ID } from "@/services/constants";
 import { AUTOMATION_ANYWHERE_RUN_BOT_ID } from "@/contrib/automationanywhere/RunBot";
 import BotOptions from "@/contrib/automationanywhere/BotOptions";
 import useDependency from "@/services/useDependency";
@@ -52,7 +52,7 @@ function makeBaseState() {
   const baseFormState = menuItemFormStateFactory();
   baseFormState.services = [
     {
-      id: CONTROL_ROOM_SERVICE_ID,
+      id: CONTROL_ROOM_TOKEN_SERVICE_ID,
       outputKey: "automationAnywhere" as OutputKey,
     },
   ];

--- a/src/contrib/automationanywhere/RunBot.test.ts
+++ b/src/contrib/automationanywhere/RunBot.test.ts
@@ -21,7 +21,7 @@ import ConsoleLogger from "@/utils/ConsoleLogger";
 import { uuidv4 } from "@/types/helpers";
 import {
   CONTROL_ROOM_OAUTH_SERVICE_ID,
-  CONTROL_ROOM_SERVICE_ID,
+  CONTROL_ROOM_TOKEN_SERVICE_ID,
 } from "@/services/constants";
 import {
   proxyService,
@@ -85,7 +85,7 @@ describe("Automation Anywhere - RunBot", () => {
         service: {
           id: tokenAuthId,
           proxy: false,
-          serviceId: CONTROL_ROOM_SERVICE_ID,
+          serviceId: CONTROL_ROOM_TOKEN_SERVICE_ID,
           config: {
             controlRoomUrl: CE_CONTROL_ROOM_URL,
           },
@@ -105,7 +105,7 @@ describe("Automation Anywhere - RunBot", () => {
         },
         id: tokenAuthId,
         proxy: false,
-        serviceId: CONTROL_ROOM_SERVICE_ID,
+        serviceId: CONTROL_ROOM_TOKEN_SERVICE_ID,
       },
       {
         data: {
@@ -143,7 +143,7 @@ describe("Automation Anywhere - RunBot", () => {
         service: {
           id: tokenAuthId,
           proxy: false,
-          serviceId: CONTROL_ROOM_SERVICE_ID,
+          serviceId: CONTROL_ROOM_TOKEN_SERVICE_ID,
           config: {
             controlRoomUrl: EE_CONTROL_ROOM_URL,
           },
@@ -166,7 +166,7 @@ describe("Automation Anywhere - RunBot", () => {
         },
         id: tokenAuthId,
         proxy: false,
-        serviceId: CONTROL_ROOM_SERVICE_ID,
+        serviceId: CONTROL_ROOM_TOKEN_SERVICE_ID,
       },
       {
         data: {
@@ -208,7 +208,7 @@ describe("Automation Anywhere - RunBot", () => {
         service: {
           id: tokenAuthId,
           proxy: false,
-          serviceId: CONTROL_ROOM_SERVICE_ID,
+          serviceId: CONTROL_ROOM_TOKEN_SERVICE_ID,
           config: {
             controlRoomUrl: EE_CONTROL_ROOM_URL,
           },
@@ -230,7 +230,7 @@ describe("Automation Anywhere - RunBot", () => {
         },
         id: tokenAuthId,
         proxy: false,
-        serviceId: CONTROL_ROOM_SERVICE_ID,
+        serviceId: CONTROL_ROOM_TOKEN_SERVICE_ID,
       },
       {
         data: {
@@ -272,7 +272,7 @@ describe("Automation Anywhere - RunBot", () => {
         service: {
           id: tokenAuthId,
           proxy: false,
-          serviceId: CONTROL_ROOM_SERVICE_ID,
+          serviceId: CONTROL_ROOM_TOKEN_SERVICE_ID,
           config: {
             controlRoomUrl: EE_CONTROL_ROOM_URL,
           },
@@ -293,7 +293,7 @@ describe("Automation Anywhere - RunBot", () => {
         },
         id: tokenAuthId,
         proxy: false,
-        serviceId: CONTROL_ROOM_SERVICE_ID,
+        serviceId: CONTROL_ROOM_TOKEN_SERVICE_ID,
       },
       {
         data: {
@@ -443,7 +443,7 @@ describe("Automation Anywhere - RunBot", () => {
         service: {
           id: tokenAuthId,
           proxy: false,
-          serviceId: CONTROL_ROOM_SERVICE_ID,
+          serviceId: CONTROL_ROOM_TOKEN_SERVICE_ID,
           config: {
             controlRoomUrl: EE_CONTROL_ROOM_URL,
           },
@@ -465,7 +465,7 @@ describe("Automation Anywhere - RunBot", () => {
         },
         id: tokenAuthId,
         proxy: false,
-        serviceId: CONTROL_ROOM_SERVICE_ID,
+        serviceId: CONTROL_ROOM_TOKEN_SERVICE_ID,
       },
       {
         data: {

--- a/src/contrib/automationanywhere/RunBot.ts
+++ b/src/contrib/automationanywhere/RunBot.ts
@@ -30,7 +30,7 @@ import {
 import { BusinessError, PropError } from "@/errors/businessErrors";
 import {
   CONTROL_ROOM_OAUTH_SERVICE_ID,
-  CONTROL_ROOM_SERVICE_ID,
+  CONTROL_ROOM_TOKEN_SERVICE_ID,
 } from "@/services/constants";
 import { cloneDeep } from "lodash";
 import { getCachedAuthData, getUserData } from "@/background/messenger/api";
@@ -45,7 +45,7 @@ export const AUTOMATION_ANYWHERE_RUN_BOT_ID = validateRegistryId(
 
 export const COMMON_PROPERTIES: SchemaProperties = {
   service: {
-    anyOf: [CONTROL_ROOM_SERVICE_ID, CONTROL_ROOM_OAUTH_SERVICE_ID].map(
+    anyOf: [CONTROL_ROOM_TOKEN_SERVICE_ID, CONTROL_ROOM_OAUTH_SERVICE_ID].map(
       (id) => ({
         $ref: `https://app.pixiebrix.com/schemas/services/${id}`,
       })
@@ -221,7 +221,7 @@ export class RunBot extends Transformer {
       enterpriseBotArgs.poolIds = [];
     } else if (
       enterpriseBotArgs.isAttended &&
-      service.serviceId === CONTROL_ROOM_SERVICE_ID
+      service.serviceId === CONTROL_ROOM_TOKEN_SERVICE_ID
     ) {
       // Attended mode uses the authenticated user id as a runAsUserId
 

--- a/src/extensionConsole/pages/onboarding/SetupPage.test.tsx
+++ b/src/extensionConsole/pages/onboarding/SetupPage.test.tsx
@@ -17,34 +17,18 @@
 
 import React from "react";
 import SetupPage from "@/extensionConsole/pages/onboarding/SetupPage";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
-import { configureStore } from "@reduxjs/toolkit";
-import { persistReducer } from "redux-persist";
-import { authSlice, persistAuthConfig } from "@/auth/authSlice";
-import servicesSlice, { persistServicesConfig } from "@/store/servicesSlice";
-import { Provider } from "react-redux";
-import { appApi } from "@/services/api";
-import settingsSlice from "@/store/settingsSlice";
 import { CONTROL_ROOM_OAUTH_SERVICE_ID } from "@/services/constants";
-import { uuidv4 } from "@/types/helpers";
 import { HashRouter } from "react-router-dom";
 import { createHashHistory } from "history";
 import userEvent from "@testing-library/user-event";
 import { waitForEffect } from "@/testUtils/testHelpers";
-import { type Me } from "@/types/contract";
 import { INTERNAL_reset as resetManagedStorage } from "@/store/enterprise/managedStorage";
-
-function optionsStore(initialState?: any) {
-  return configureStore({
-    reducer: {
-      auth: persistReducer(persistAuthConfig, authSlice.reducer),
-      services: persistReducer(persistServicesConfig, servicesSlice.reducer),
-      settings: settingsSlice.reducer,
-    },
-    preloadedState: initialState,
-  });
-}
+import { render } from "@/extensionConsole/testHelpers";
+import settingsSlice from "@/store/settingsSlice";
+import { mockAnonymousUser, mockCachedUser } from "@/testUtils/userMock";
+import { partnerUserFactory } from "@/testUtils/factories/authFactories";
 
 jest.mock("lodash", () => {
   const lodash = jest.requireActual("lodash");
@@ -67,28 +51,9 @@ jest.mock("p-memoize", () => {
   };
 });
 
-jest.mock("@/services/api", () => ({
-  util: {
-    resetApiState: jest.fn().mockReturnValue({ type: "notarealreset" }),
-  },
-  appApi: {
-    endpoints: {
-      getMe: {
-        useQueryState: jest.fn(() => ({
-          data: {},
-          isLoading: false,
-        })),
-      },
-    },
-  },
-}));
 jest.mock("@/services/baseService", () => ({
   getInstallURL: jest.fn().mockResolvedValue("https://app.pixiebrix.com"),
 }));
-
-function mockMeQuery(state: { isLoading: boolean; data?: Me; error?: any }) {
-  (appApi.endpoints.getMe.useQueryState as jest.Mock).mockReturnValue(state);
-}
 
 beforeEach(async () => {
   jest.clearAllMocks();
@@ -97,18 +62,13 @@ beforeEach(async () => {
 });
 
 describe("SetupPage", () => {
-  test("typical user", async () => {
-    mockMeQuery({
-      isLoading: false,
-      partner: null,
-    } as any);
+  test("anonymous user with no partner", async () => {
+    mockAnonymousUser();
 
     render(
-      <Provider store={optionsStore()}>
-        <MemoryRouter>
-          <SetupPage />
-        </MemoryRouter>
-      </Provider>
+      <MemoryRouter>
+        <SetupPage />
+      </MemoryRouter>
     );
 
     await waitFor(() => {
@@ -118,45 +78,36 @@ describe("SetupPage", () => {
     expect(screen.queryByText("Connect your AARI account")).toBeNull();
   });
 
-  test("OAuth2 partner user", async () => {
-    mockMeQuery({
-      isLoading: false,
-      data: {
-        partner: {
-          id: uuidv4(),
-          name: "Test Partner",
-          theme: "automation-anywhere",
-        },
-      } as any,
-    });
+  test("OAuth2 partner user with required service id in settings", async () => {
+    mockCachedUser(partnerUserFactory());
 
     render(
-      <Provider
-        store={optionsStore({
-          settings: { authServiceId: CONTROL_ROOM_OAUTH_SERVICE_ID },
-        })}
-      >
-        <MemoryRouter>
-          <SetupPage />
-        </MemoryRouter>
-      </Provider>
+      <MemoryRouter>
+        <SetupPage />
+      </MemoryRouter>,
+      {
+        setupRedux(dispatch) {
+          dispatch(
+            settingsSlice.actions.setAuthServiceId({
+              serviceId: CONTROL_ROOM_OAUTH_SERVICE_ID,
+            })
+          );
+        },
+      }
     );
 
     await waitFor(() => {
       expect(screen.queryByTestId("loader")).toBeNull();
     });
 
+    screen.debug();
+
     expect(screen.getByText("Connect your AARI account")).not.toBeNull();
   });
 
   test("Start URL for OAuth2 flow", async () => {
     const user = userEvent.setup();
-
-    // User will be unauthenticated
-    mockMeQuery({
-      isLoading: false,
-      data: {} as any,
-    });
+    mockAnonymousUser();
 
     location.href =
       "chrome-extension://abc123/options.html#/start?hostname=mycontrolroom.com";
@@ -164,11 +115,9 @@ describe("SetupPage", () => {
     // Needs to use HashRouter instead of MemoryRouter for the useLocation calls in the components to work correctly
     // given the URL structure above
     render(
-      <Provider store={optionsStore({})}>
-        <HashRouter>
-          <SetupPage />
-        </HashRouter>
-      </Provider>
+      <HashRouter>
+        <SetupPage />
+      </HashRouter>
     );
 
     await waitFor(() => {
@@ -178,10 +127,10 @@ describe("SetupPage", () => {
     expect(screen.getByText("Connect your AARI account")).not.toBeNull();
     expect(
       screen.getByLabelText("Control Room URL").getAttribute("value")
-      // Schema should get pre-pended automatically
+      // Schema should get pre-pended automatically from hostname
     ).toStrictEqual("https://mycontrolroom.com");
 
-    // Sanity check we haven't redirected away from the start page yet
+    // Sanity check we haven't redirected away from the start screen yet
     expect(location.href).toStrictEqual(
       "chrome-extension://abc123/options.html#/start?hostname=mycontrolroom.com"
     );
@@ -198,11 +147,7 @@ describe("SetupPage", () => {
   });
 
   test("Start URL with Community Edition hostname if user is unauthenticated", async () => {
-    // User is authenticated
-    mockMeQuery({
-      isLoading: false,
-      data: {} as any,
-    });
+    mockAnonymousUser();
 
     const history = createHashHistory();
     // Hostname comes as hostname, not URL
@@ -213,11 +158,9 @@ describe("SetupPage", () => {
     // Needs to use HashRouter instead of MemoryRouter for the useLocation calls in the components to work correctly
     // given the URL structure above
     render(
-      <Provider store={optionsStore({})}>
-        <HashRouter>
-          <SetupPage />
-        </HashRouter>
-      </Provider>
+      <HashRouter>
+        <SetupPage />
+      </HashRouter>
     );
 
     await waitFor(() => {
@@ -229,19 +172,9 @@ describe("SetupPage", () => {
   });
 
   test("Start URL with Community Edition hostname if authenticated", async () => {
-    // User is authenticated
-    mockMeQuery({
-      isLoading: false,
-      data: {
-        id: uuidv4(),
-        partner: {
-          id: uuidv4(),
-          theme: "automation-anywhere",
-        },
-      } as any,
-    });
-
+    mockCachedUser(partnerUserFactory());
     const history = createHashHistory();
+
     // Hostname comes as hostname, not URL
     history.push(
       "/start?hostname=community2.cloud-2.automationanywhere.digital"
@@ -250,11 +183,9 @@ describe("SetupPage", () => {
     // Needs to use HashRouter instead of MemoryRouter for the useLocation calls in the components to work correctly
     // given the URL structure above
     render(
-      <Provider store={optionsStore({})}>
-        <HashRouter>
-          <SetupPage />
-        </HashRouter>
-      </Provider>
+      <HashRouter>
+        <SetupPage />
+      </HashRouter>
     );
 
     await waitFor(() => {
@@ -276,11 +207,7 @@ describe("SetupPage", () => {
   });
 
   test("Managed Storage OAuth2 partner user", async () => {
-    // User will be unauthenticated
-    mockMeQuery({
-      isLoading: false,
-      data: {} as any,
-    });
+    mockAnonymousUser();
 
     await browser.storage.managed.set({
       partnerId: "automation-anywhere",
@@ -288,11 +215,9 @@ describe("SetupPage", () => {
     });
 
     render(
-      <Provider store={optionsStore({})}>
-        <MemoryRouter>
-          <SetupPage />
-        </MemoryRouter>
-      </Provider>
+      <MemoryRouter>
+        <SetupPage />
+      </MemoryRouter>
     );
 
     await waitFor(() => {

--- a/src/extensionConsole/testHelpers.tsx
+++ b/src/extensionConsole/testHelpers.tsx
@@ -28,6 +28,7 @@ import blueprintsSlice from "@/extensionConsole/pages/blueprints/blueprintsSlice
 import { recipesSlice } from "@/recipes/recipesSlice";
 import { appApi } from "@/services/api";
 import { recipesMiddleware } from "@/recipes/recipesListenerMiddleware";
+import servicesSlice from "@/store/servicesSlice";
 
 const configureStoreForTests = () =>
   configureStore({
@@ -38,6 +39,7 @@ const configureStoreForTests = () =>
       blueprintModals: blueprintModalsSlice.reducer,
       blueprints: blueprintsSlice.reducer,
       recipes: recipesSlice.reducer,
+      services: servicesSlice.reducer,
       [appApi.reducerPath]: appApi.reducer,
     },
     middleware(getDefaultMiddleware) {

--- a/src/services/constants.ts
+++ b/src/services/constants.ts
@@ -27,7 +27,7 @@ export const PIXIEBRIX_SERVICE_ID: RegistryId =
 export const AUTOMATION_ANYWHERE_PARTNER_KEY = "automation-anywhere";
 
 // Automation Anywhere partner service definition constants
-export const CONTROL_ROOM_SERVICE_ID: RegistryId = validateRegistryId(
+export const CONTROL_ROOM_TOKEN_SERVICE_ID: RegistryId = validateRegistryId(
   "automation-anywhere/control-room"
 );
 export const CONTROL_ROOM_OAUTH_SERVICE_ID: RegistryId = validateRegistryId(

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -127,7 +127,7 @@ export async function readManagedStorage(): Promise<ManagedStorageState> {
 
 /**
  * Get a _synchronous_ snapshot of the managed storage state.
- * @see useSyncManagedStorage
+ * @see useManagedStorageState
  * @see readManagedStorage
  */
 export function getSnapshot(): ManagedStorageState | undefined {
@@ -140,7 +140,7 @@ export function getSnapshot(): ManagedStorageState | undefined {
  * Subscribe to changes in the managed storage state. In practice, this should only fire once because managed
  * storage is not mutable.
  * @param callback to receive the updated state.
- * @see useSyncManagedStorage
+ * @see useManagedStorageState
  */
 export function subscribe(
   callback: (state: ManagedStorageState) => void

--- a/src/testUtils/factories/authFactories.ts
+++ b/src/testUtils/factories/authFactories.ts
@@ -125,8 +125,8 @@ export const userFactory = define<Me>({
 });
 
 export const partnerUserFactory = extend<Me, Me>(userFactory, {
-  partner: {
+  partner: () => ({
     name: "Automation Anywhere",
     theme: "automation-anywhere",
-  },
+  }),
 });


### PR DESCRIPTION
## What does this PR do?

- Closes #5762 
- Bug fixes:
  - Fixes bug where hostname from URL wasn't being auto-filled in the form: https://github.com/pixiebrix/pixiebrix-extension/pull/5763/files#r1199244815
- Test Cleanup
  - SetupPage.test.tsx: use mocks and add some additional assertions
- Refactoring
  - Renames `CONTROL_ROOM_SERVICE_ID` to `CONTROL_ROOM_TOKEN_SERVICE_ID`

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @mnholtz 
