### PR TITLE
Dependency Management - Update Immer & Redux Toolkit to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "http-status-codes": "^2.1.4",
         "idb": "^7.1.1",
         "iframe-resizer": "^4.3.4",
-        "immer": "9.0.18",
+        "immer": "^9.0.18",
         "intro.js": "^7.0.1",
         "is-promise": "^4.0.0",
         "jq-web": "^0.5.1",
@@ -4794,14 +4794,14 @@
       "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.3.tgz",
-      "integrity": "sha512-GU2TNBQVofL09VGmuSioNPQIu6Ml0YLf4EJhgj0AvBadRlCGzUWet8372LjvO4fqKZF2vH1xU0htAa7BrK9pZg==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
+      "integrity": "sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==",
       "dependencies": {
-        "immer": "^9.0.16",
-        "redux": "^4.2.0",
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
         "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.7"
+        "reselect": "^4.1.8"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18",
@@ -22636,9 +22636,9 @@
       "dev": true
     },
     "node_modules/immer": {
-      "version": "9.0.18",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.18.tgz",
-      "integrity": "sha512-eAPNpsj7Ax1q6Y/3lm2PmlwRcFzpON7HSNQ3ru5WQH1/PSpnyed/HpNOELl2CxLKoj4r+bAHgdyKqW5gc2Se1A==",
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -32264,8 +32264,9 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.0",
-      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -40744,14 +40745,14 @@
       "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
     },
     "@reduxjs/toolkit": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.3.tgz",
-      "integrity": "sha512-GU2TNBQVofL09VGmuSioNPQIu6Ml0YLf4EJhgj0AvBadRlCGzUWet8372LjvO4fqKZF2vH1xU0htAa7BrK9pZg==",
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
+      "integrity": "sha512-Rt97jHmfTeaxL4swLRNPD/zV4OxTes4la07Xc4hetpUW/vc75t5m1ANyxG6ymnEQ2FsLQsoMlYB2vV1sO3m8tQ==",
       "requires": {
-        "immer": "^9.0.16",
-        "redux": "^4.2.0",
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
         "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.7"
+        "reselect": "^4.1.8"
       }
     },
     "@restart/context": {
@@ -54231,9 +54232,9 @@
       "dev": true
     },
     "immer": {
-      "version": "9.0.18",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.18.tgz",
-      "integrity": "sha512-eAPNpsj7Ax1q6Y/3lm2PmlwRcFzpON7HSNQ3ru5WQH1/PSpnyed/HpNOELl2CxLKoj4r+bAHgdyKqW5gc2Se1A=="
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA=="
     },
     "immutable": {
       "version": "4.0.0",
@@ -61547,8 +61548,9 @@
       }
     },
     "redux": {
-      "version": "4.2.0",
-      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "http-status-codes": "^2.1.4",
     "idb": "^7.1.1",
     "iframe-resizer": "^4.3.4",
-    "immer": "9.0.18",
+    "immer": "^9.0.18",
     "intro.js": "^7.0.1",
     "is-promise": "^4.0.0",
     "jq-web": "^0.5.1",

--- a/src/utils/asyncStateUtils.ts
+++ b/src/utils/asyncStateUtils.ts
@@ -25,7 +25,7 @@ import {
 import { noop } from "lodash";
 import { type WritableDraft } from "immer/dist/types/types-external";
 import { serializeError } from "serialize-error";
-import { type Draft } from "immer";
+import { castDraft } from "immer";
 
 /**
  * Merge multiple async states into a single async state using a synchronous merge function.
@@ -293,10 +293,8 @@ export function setValueOnState<T>(
   state: WritableDraft<AsyncState<T>>,
   value: T
 ): WritableDraft<AsyncState<T>> {
-  // eslint-disable-next-line @typescript-eslint/ban-types -- match types from immer
-  state.data = value as T extends object ? Draft<T> : T;
-  // eslint-disable-next-line @typescript-eslint/ban-types -- match types from immer
-  state.currentData = value as T extends object ? Draft<T> : T;
+  state.data = castDraft(value);
+  state.currentData = castDraft(value);
   state.isUninitialized = false;
   state.isLoading = false;
   state.isFetching = false;


### PR DESCRIPTION
## What does this PR do?

- Un-pins Immer
  - See: https://github.com/pixiebrix/pixiebrix-extension/pull/5124
  - New major version of Immer has been released, the broken patch we avoided with pinning was superseded a while ago
- Updates Immer and Redux-Toolkit to latest npm versions
  - Was having trouble dealing with this on the dependabot PRs, so decided to just do it manually for this one

## Checklist

- [ ] Add tests - N/A, dependency update only
- [x] Designate a primary reviewer - @twschiller 
