### PR TITLE
Feature/5778 sidebar mod actions

### DIFF
--- a/src/extensionConsole/pages/blueprints/BlueprintsPage.tsx
+++ b/src/extensionConsole/pages/blueprints/BlueprintsPage.tsx
@@ -22,10 +22,18 @@ import { useTitle } from "@/hooks/title";
 import { ErrorDisplay } from "@/layout/ErrorDisplay";
 import { reportEvent } from "@/telemetry/events";
 import Modals from "./modals/Modals";
+import { useLocation } from "react-router";
+
+const useShowPublishUrlEffect = () => {
+  const location = useLocation();
+
+  console.log("*** location", location);
+};
 
 const BlueprintsPage: React.FunctionComponent = () => {
   useTitle("Mods");
   const { installables, error } = useInstallables();
+  useShowPublishUrlEffect();
 
   useEffect(() => {
     reportEvent("BlueprintsPageView");

--- a/src/extensionConsole/pages/blueprints/BlueprintsPage.tsx
+++ b/src/extensionConsole/pages/blueprints/BlueprintsPage.tsx
@@ -29,22 +29,24 @@ import {
 } from "@/extensionConsole/pages/blueprints/modals/blueprintModalsSlice";
 import { useDispatch } from "react-redux";
 
+// Supports showing the publish modal via URL, e.g. to be used by the sidebar
 const useShowPublishUrlEffect = () => {
   const location = useLocation();
   const dispatch = useDispatch();
   const history = useHistory();
   const params = new URLSearchParams(location.search);
+
   const showPublish = params.get("publish") === "1";
   const blueprintId = params.get("blueprintId");
   const extensionId = params.get("extensionId");
 
   useEffect(() => {
-    if (blueprintId && extensionId) {
-      // Should never happen
-      return;
-    }
+    // Both blueprintId & extensionId being set should never happen in practice, but
+    // at least one of them needs to be present
+    const validShareContext =
+      (blueprintId || extensionId) && !(blueprintId && extensionId);
 
-    if (showPublish && (blueprintId || extensionId)) {
+    if (showPublish && validShareContext) {
       dispatch(
         blueprintModalsSlice.actions.setShareContext({
           ...(blueprintId ? { blueprintId } : {}),

--- a/src/extensionConsole/pages/blueprints/BlueprintsPage.tsx
+++ b/src/extensionConsole/pages/blueprints/BlueprintsPage.tsx
@@ -23,11 +23,35 @@ import { ErrorDisplay } from "@/layout/ErrorDisplay";
 import { reportEvent } from "@/telemetry/events";
 import Modals from "./modals/Modals";
 import { useLocation } from "react-router";
+import {
+  blueprintModalsSlice,
+  type PublishContext,
+} from "@/extensionConsole/pages/blueprints/modals/blueprintModalsSlice";
+import { useDispatch } from "react-redux";
 
 const useShowPublishUrlEffect = () => {
   const location = useLocation();
+  const dispatch = useDispatch();
+  const params = new URLSearchParams(location.search);
+  const showPublish = params.get("publish") === "1";
+  const blueprintId = params.get("blueprintId");
+  const extensionId = params.get("extensionId");
 
-  console.log("*** location", location);
+  useEffect(() => {
+    if (blueprintId && extensionId) {
+      // Should never happen
+      return;
+    }
+
+    if (showPublish && (blueprintId || extensionId)) {
+      dispatch(
+        blueprintModalsSlice.actions.setShareContext({
+          ...(blueprintId ? { blueprintId } : {}),
+          ...(extensionId ? { extensionId } : {}),
+        } as PublishContext)
+      );
+    }
+  }, []);
 };
 
 const BlueprintsPage: React.FunctionComponent = () => {

--- a/src/extensionConsole/pages/blueprints/BlueprintsPage.tsx
+++ b/src/extensionConsole/pages/blueprints/BlueprintsPage.tsx
@@ -22,7 +22,7 @@ import { useTitle } from "@/hooks/title";
 import { ErrorDisplay } from "@/layout/ErrorDisplay";
 import { reportEvent } from "@/telemetry/events";
 import Modals from "./modals/Modals";
-import { useLocation } from "react-router";
+import { useHistory, useLocation } from "react-router";
 import {
   blueprintModalsSlice,
   type PublishContext,
@@ -32,6 +32,7 @@ import { useDispatch } from "react-redux";
 const useShowPublishUrlEffect = () => {
   const location = useLocation();
   const dispatch = useDispatch();
+  const history = useHistory();
   const params = new URLSearchParams(location.search);
   const showPublish = params.get("publish") === "1";
   const blueprintId = params.get("blueprintId");
@@ -50,6 +51,9 @@ const useShowPublishUrlEffect = () => {
           ...(extensionId ? { extensionId } : {}),
         } as PublishContext)
       );
+
+      // Remove the search params after showing the modal
+      history.push("/");
     }
   }, []);
 };

--- a/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.test.tsx
+++ b/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.test.tsx
@@ -147,7 +147,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: sidebarActions },
     } = renderHook(() => useInstallableViewItemActions(personalExtensionItem));
 
-    expectActions(["deactivate"], sidebarActions);
+    expectActions(["deactivate", "viewPublish"], sidebarActions);
   });
 
   test("active personal blueprint", () => {
@@ -171,7 +171,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: sidebarActions },
     } = renderHook(() => useInstallableViewItemActions(personalBlueprintItem));
 
-    expectActions(["deactivate"], sidebarActions);
+    expectActions(["deactivate", "viewPublish"], sidebarActions);
   });
 
   test("inactive personal blueprint", () => {
@@ -209,7 +209,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: sidebarActions },
     } = renderHook(() => useInstallableViewItemActions(teamBlueprintItem));
 
-    expectActions(["deactivate"], sidebarActions);
+    expectActions(["deactivate", "viewPublish"], sidebarActions);
   });
 
   test("inactive team blueprint", () => {
@@ -247,7 +247,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: sidebarActions },
     } = renderHook(() => useInstallableViewItemActions(publicBlueprintItem));
 
-    expectActions(["deactivate"], sidebarActions);
+    expectActions(["deactivate", "viewPublish"], sidebarActions);
   });
 
   test("team deployment for unrestricted user", () => {
@@ -313,7 +313,10 @@ describe("useInstallableViewItemActions", () => {
       result: { current: sidebarActions },
     } = renderHook(() => useInstallableViewItemActions(deploymentItem));
 
-    expectActions(["deactivate", "requestPermissions"], sidebarActions);
+    expectActions(
+      ["deactivate", "requestPermissions", "viewPublish"],
+      sidebarActions
+    );
   });
 
   test("blueprint with access revoked", () => {
@@ -402,7 +405,7 @@ describe("useInstallableViewItemActions", () => {
         result: { current: sidebarActions },
       } = renderHook(() => useInstallableViewItemActions(blueprintItem));
 
-      expectActions(["deactivate"], sidebarActions);
+      expectActions(["deactivate", "viewPublish"], sidebarActions);
     });
 
     test("published", () => {

--- a/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.test.tsx
+++ b/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.test.tsx
@@ -171,7 +171,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: sidebarActions },
     } = renderHook(() => useInstallableViewItemActions(personalBlueprintItem));
 
-    expectActions(["deactivate", "viewPublish"], sidebarActions);
+    expectActions(["deactivate", "viewPublish", "reactivate"], sidebarActions);
   });
 
   test("inactive personal blueprint", () => {
@@ -209,7 +209,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: sidebarActions },
     } = renderHook(() => useInstallableViewItemActions(teamBlueprintItem));
 
-    expectActions(["deactivate", "viewPublish"], sidebarActions);
+    expectActions(["deactivate", "viewPublish", "reactivate"], sidebarActions);
   });
 
   test("inactive team blueprint", () => {
@@ -247,7 +247,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: sidebarActions },
     } = renderHook(() => useInstallableViewItemActions(publicBlueprintItem));
 
-    expectActions(["deactivate", "viewPublish"], sidebarActions);
+    expectActions(["deactivate", "viewPublish", "reactivate"], sidebarActions);
   });
 
   test("team deployment for unrestricted user", () => {
@@ -268,7 +268,7 @@ describe("useInstallableViewItemActions", () => {
       result: { current: sidebarActions },
     } = renderHook(() => useInstallableViewItemActions(deploymentItem));
 
-    expectActions(["deactivate"], sidebarActions);
+    expectActions(["deactivate", "reactivate"], sidebarActions);
   });
 
   test("restricted team deployment", () => {
@@ -314,7 +314,7 @@ describe("useInstallableViewItemActions", () => {
     } = renderHook(() => useInstallableViewItemActions(deploymentItem));
 
     expectActions(
-      ["deactivate", "requestPermissions", "viewPublish"],
+      ["deactivate", "requestPermissions", "viewPublish", "reactivate"],
       sidebarActions
     );
   });
@@ -405,7 +405,10 @@ describe("useInstallableViewItemActions", () => {
         result: { current: sidebarActions },
       } = renderHook(() => useInstallableViewItemActions(blueprintItem));
 
-      expectActions(["deactivate", "viewPublish"], sidebarActions);
+      expectActions(
+        ["deactivate", "viewPublish", "reactivate"],
+        sidebarActions
+      );
     });
 
     test("published", () => {
@@ -430,7 +433,10 @@ describe("useInstallableViewItemActions", () => {
         result: { current: sidebarActions },
       } = renderHook(() => useInstallableViewItemActions(blueprintItem));
 
-      expectActions(["viewInMarketplaceHref", "deactivate"], sidebarActions);
+      expectActions(
+        ["viewInMarketplaceHref", "deactivate", "reactivate"],
+        sidebarActions
+      );
     });
   });
 });

--- a/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.ts
@@ -124,6 +124,7 @@ function useInstallableViewItemActions(
 
       if (inSidebarContext) {
         window.open(`/options.html#/${reactivatePath}`, "_blank");
+        return;
       }
 
       dispatch(

--- a/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.ts
@@ -118,6 +118,14 @@ function useInstallableViewItemActions(
         reinstall: true,
       });
 
+      const reactivatePath = `marketplace/activate/${encodeURIComponent(
+        blueprintId
+      )}?reinstall=1`;
+
+      if (inSidebarContext) {
+        window.open(`/options.html#/${reactivatePath}`, "_blank");
+      }
+
       dispatch(
         push(
           `marketplace/activate/${encodeURIComponent(blueprintId)}?reinstall=1`
@@ -289,11 +297,7 @@ function useInstallableViewItemActions(
     // Only blueprints/deployments can be reactivated. (Because there's no reason to reactivate an extension... there's
     // no activation-time integrations/options associated with them.)
     reactivate:
-      hasBlueprint &&
-      isActive &&
-      !isRestricted &&
-      !unavailable &&
-      !inSidebarContext
+      hasBlueprint && isActive && !isRestricted && !unavailable
         ? reactivate
         : null,
     viewLogs: showViewLogsAction ? viewLogs : null,

--- a/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.ts
+++ b/src/extensionConsole/pages/blueprints/useInstallableViewItemActions.ts
@@ -165,6 +165,15 @@ function useInstallableViewItemActions(
           extensionId: installable.id,
         };
 
+    if (inSidebarContext) {
+      const publishParams = new URLSearchParams({
+        publish: "1",
+        ...(publishContext as ShareContext),
+      });
+      window.open(`/options.html#/?${publishParams.toString()}`, "_blank");
+      return;
+    }
+
     dispatch(blueprintModalsSlice.actions.setPublishContext(publishContext));
   };
 
@@ -270,7 +279,7 @@ function useInstallableViewItemActions(
         `${MARKETPLACE_URL}${sharing.listingId}/`;
 
   return {
-    viewPublish: showPublishAction && !inSidebarContext ? viewPublish : null,
+    viewPublish: showPublishAction ? viewPublish : null,
     viewInMarketplaceHref,
     // Deployment sharing is controlled via the Admin Console
     viewShare:

--- a/src/sidebar/HomePanel.tsx
+++ b/src/sidebar/HomePanel.tsx
@@ -16,7 +16,7 @@
  */
 import React from "react";
 import { type StaticPanelEntry } from "@/types/sidebarTypes";
-import { ListGroup, Row, Container } from "react-bootstrap";
+import { ListGroup, Row, Container, Button } from "react-bootstrap";
 import type { Column } from "react-table";
 import type {
   Installable,
@@ -28,6 +28,9 @@ import { useTable } from "react-table";
 import useInstallables from "@/extensionConsole/pages/blueprints/useInstallables";
 import { ErrorDisplay } from "@/layout/ErrorDisplay";
 import BlueprintActions from "@/extensionConsole/pages/blueprints/BlueprintActions";
+import useInstallableViewItemActions from "@/extensionConsole/pages/blueprints/useInstallableViewItemActions";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 
 const columns: Array<Column<InstallableViewItem>> = [
   {
@@ -45,6 +48,7 @@ const ListItem: React.FunctionComponent<{
   installableItem: InstallableViewItem;
 }> = ({ installableItem }) => {
   const { name, icon } = installableItem;
+  const { requestPermissions } = useInstallableViewItemActions(installableItem);
 
   return (
     <ListGroup.Item>
@@ -54,6 +58,18 @@ const ListItem: React.FunctionComponent<{
           <div className="d-flex align-items-center">
             <h5 className="flex-grow-1">{name}</h5>
           </div>
+          {requestPermissions && (
+            <Button
+              variant="link"
+              size="sm"
+              className="p-0"
+              onClick={() => {
+                requestPermissions();
+              }}
+            >
+              <FontAwesomeIcon icon={faExclamationCircle} /> Grant Permissions
+            </Button>
+          )}
         </div>
         <div className="flex-shrink-0">
           <BlueprintActions installableViewItem={installableItem} />


### PR DESCRIPTION
## What does this PR do?

- Closes #5778
- Part of https://github.com/pixiebrix/pixiebrix-extension/issues/5735
- Adds the `reactivate`, `viewPublish`, and `requestPermissions` actions to the active mods list items in the sidebar

## Demo

- https://www.loom.com/share/8e40f3f33a1149caa11aab9ee9d55c6d

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer @BLoe 
