### PR TITLE
#5646 - Fix page state form rerenders

### DIFF
--- a/src/auth/useRequiredPartnerAuth.ts
+++ b/src/auth/useRequiredPartnerAuth.ts
@@ -116,6 +116,7 @@ function decidePartnerServiceIds({
  * - Integration required, using partner JWT for authentication
  */
 function useRequiredPartnerAuth(): RequiredPartnerState {
+  // Prefer the most recent /api/me/ data from the server
   const { isLoading, data: me, error } = appApi.endpoints.getMe.useQueryState();
   const localAuth = useSelector(selectAuth);
   const {

--- a/src/auth/useRequiredPartnerAuth.ts
+++ b/src/auth/useRequiredPartnerAuth.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { appApi } from "@/services/api";
+import { useGetMeQuery } from "@/services/api";
 import { useSelector } from "react-redux";
 import { selectAuth } from "@/auth/authSelectors";
 import { selectConfiguredServices } from "@/store/servicesSelectors";
@@ -116,8 +116,14 @@ function decidePartnerServiceIds({
  * - Integration required, using partner JWT for authentication
  */
 function useRequiredPartnerAuth(): RequiredPartnerState {
-  // Prefer the most recent /api/me/ data from the server
-  const { isLoading, data: me, error } = appApi.endpoints.getMe.useQueryState();
+  const {
+    data: me,
+    isLoading,
+    error,
+  } = useGetMeQuery(undefined, {
+    // Prefer the most recent /api/me/ data from the server
+    refetchOnMountOrArgChange: true,
+  });
   const localAuth = useSelector(selectAuth);
   const {
     authServiceId: authServiceIdOverride,

--- a/src/auth/useRequiredPartnerAuth.ts
+++ b/src/auth/useRequiredPartnerAuth.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useGetMeQuery } from "@/services/api";
+import { appApi } from "@/services/api";
 import { useSelector } from "react-redux";
 import { selectAuth } from "@/auth/authSelectors";
 import { selectConfiguredServices } from "@/store/servicesSelectors";
@@ -116,14 +116,7 @@ function decidePartnerServiceIds({
  * - Integration required, using partner JWT for authentication
  */
 function useRequiredPartnerAuth(): RequiredPartnerState {
-  const {
-    data: me,
-    isLoading,
-    error,
-  } = useGetMeQuery(undefined, {
-    // Prefer the most recent /api/me/ data from the server
-    refetchOnMountOrArgChange: true,
-  });
+  const { isLoading, data: me, error } = appApi.endpoints.getMe.useQueryState();
   const localAuth = useSelector(selectAuth);
   const {
     authServiceId: authServiceIdOverride,

--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
@@ -116,8 +116,8 @@ const TemplateToggleWidget: React.VFC<TemplateToggleWidgetProps> = ({
         "select",
         "string",
         "number",
-        "var",
         "boolean",
+        "var",
         "array",
         "object",
       ];

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from "react";
-import { type PanelEntry } from "@/types/sidebarTypes";
+import React, { useCallback, useEffect } from "react";
+import { type PanelEntry, TemporaryPanelEntry } from "@/types/sidebarTypes";
 import { eventKeyForEntry, getBodyForStaticPanel } from "@/sidebar/utils";
 import { type UUID } from "@/types/stringTypes";
 import { reportEvent } from "@/telemetry/events";
@@ -34,7 +34,11 @@ import ActivateRecipePanel from "@/sidebar/activateRecipe/ActivateRecipePanel";
 import { useDispatch, useSelector } from "react-redux";
 import {
   selectSidebarActiveTabKey,
-  selectSidebarTabsContent,
+  selectSidebarForms,
+  selectSidebarPanels,
+  selectSidebarRecipeToActivate,
+  selectSidebarStaticPanels,
+  selectSidebarTemporaryPanels,
 } from "@/sidebar/sidebarSelectors";
 import sidebarSlice from "@/sidebar/sidebarSlice";
 
@@ -42,11 +46,53 @@ const permanentSidebarPanelAction = () => {
   throw new BusinessError("Action not supported for permanent sidebar panels");
 };
 
+// Need to memoize this to make sure it doesn't rerender unless its entry actually changes
+// This was part of the fix for issue: https://github.com/pixiebrix/pixiebrix-extension/issues/5646
+const TemporaryPanelTabPane: React.FC<{
+  panel: TemporaryPanelEntry;
+}> = React.memo(({ panel }) => {
+  const dispatch = useDispatch();
+  const onAction = useCallback(
+    (action: SubmitPanelAction) => {
+      dispatch(
+        sidebarSlice.actions.resolveTemporaryPanel({
+          nonce: panel.nonce,
+          action,
+        })
+      );
+    },
+    [dispatch, panel.nonce]
+  );
+
+  return (
+    <Tab.Pane
+      className={cx("full-height flex-grow", styles.paneOverrides)}
+      eventKey={eventKeyForEntry(panel)}
+    >
+      <ErrorBoundary>
+        <PanelBody
+          isRootPanel={false}
+          payload={panel.payload}
+          context={{
+            extensionId: panel.extensionId,
+            blueprintId: panel.blueprintId,
+          }}
+          onAction={onAction}
+        />
+      </ErrorBoundary>
+    </Tab.Pane>
+  );
+});
+TemporaryPanelTabPane.displayName = "TemporaryPanelTabPane";
+
 const Tabs: React.FC = () => {
   const dispatch = useDispatch();
   const activeKey = useSelector(selectSidebarActiveTabKey);
-  const { panels, forms, temporaryPanels, recipeToActivate, staticPanels } =
-    useSelector(selectSidebarTabsContent);
+  const panels = useSelector(selectSidebarPanels);
+  const forms = useSelector(selectSidebarForms);
+  const temporaryPanels = useSelector(selectSidebarTemporaryPanels);
+  const recipeToActivate = useSelector(selectSidebarRecipeToActivate);
+  const staticPanels = useSelector(selectSidebarStaticPanels);
 
   const onSelect = (eventKey: string) => {
     reportEvent("ViewSidePanelPanel", {
@@ -59,10 +105,6 @@ const Tabs: React.FC = () => {
 
   const onCloseTemporaryTab = (nonce: UUID) => {
     dispatch(sidebarSlice.actions.removeTemporaryPanel(nonce));
-  };
-
-  const onResolveTemporaryPanel = (nonce: UUID, action: SubmitPanelAction) => {
-    dispatch(sidebarSlice.actions.resolveTemporaryPanel({ nonce, action }));
   };
 
   useEffect(
@@ -186,25 +228,7 @@ const Tabs: React.FC = () => {
             </Tab.Pane>
           ))}
           {temporaryPanels.map((panel) => (
-            <Tab.Pane
-              className={cx("full-height flex-grow", styles.paneOverrides)}
-              key={panel.nonce}
-              eventKey={eventKeyForEntry(panel)}
-            >
-              <ErrorBoundary>
-                <PanelBody
-                  isRootPanel={false}
-                  payload={panel.payload}
-                  context={{
-                    extensionId: panel.extensionId,
-                    blueprintId: panel.blueprintId,
-                  }}
-                  onAction={(action: SubmitPanelAction) => {
-                    onResolveTemporaryPanel(panel.nonce, action);
-                  }}
-                />
-              </ErrorBoundary>
-            </Tab.Pane>
+            <TemporaryPanelTabPane panel={panel} key={panel.nonce} />
           ))}
           {recipeToActivate && (
             <Tab.Pane

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -16,7 +16,10 @@
  */
 
 import React, { useCallback, useEffect } from "react";
-import { type PanelEntry, TemporaryPanelEntry } from "@/types/sidebarTypes";
+import {
+  type PanelEntry,
+  type TemporaryPanelEntry,
+} from "@/types/sidebarTypes";
 import { eventKeyForEntry, getBodyForStaticPanel } from "@/sidebar/utils";
 import { type UUID } from "@/types/stringTypes";
 import { reportEvent } from "@/telemetry/events";

--- a/src/sidebar/sidebar.html
+++ b/src/sidebar/sidebar.html
@@ -18,6 +18,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!--Uncomment this script tag to enable the React Dev Tools app-->
+    <!--See https://github.com/pixiebrix/pixiebrix-extension/wiki/Development-commands#react-dev-tools -->
+    <!--<script src="http://localhost:8097"></script>-->
     <meta charset="utf-8" />
     <!-- Open all links in new tab, never in the sidebar #851 -->
     <base target="_blank" />

--- a/src/sidebar/sidebarSelectors.ts
+++ b/src/sidebar/sidebarSelectors.ts
@@ -28,10 +28,17 @@ export const selectIsSidebarEmpty = ({ sidebar }: SidebarRootState) =>
 export const selectSidebarActiveTabKey = ({ sidebar }: SidebarRootState) =>
   sidebar.activeKey;
 
-export const selectSidebarTabsContent = ({ sidebar }: SidebarRootState) => ({
-  panels: sidebar.panels,
-  forms: sidebar.forms,
-  temporaryPanels: sidebar.temporaryPanels,
-  staticPanels: sidebar.staticPanels,
-  recipeToActivate: sidebar.recipeToActivate,
-});
+export const selectSidebarPanels = ({ sidebar }: SidebarRootState) =>
+  sidebar.panels;
+
+export const selectSidebarForms = ({ sidebar }: SidebarRootState) =>
+  sidebar.forms;
+
+export const selectSidebarTemporaryPanels = ({ sidebar }: SidebarRootState) =>
+  sidebar.temporaryPanels;
+
+export const selectSidebarStaticPanels = ({ sidebar }: SidebarRootState) =>
+  sidebar.staticPanels;
+
+export const selectSidebarRecipeToActivate = ({ sidebar }: SidebarRootState) =>
+  sidebar.recipeToActivate;

--- a/src/store/servicesSelectors.ts
+++ b/src/store/servicesSelectors.ts
@@ -16,10 +16,9 @@
  */
 
 import { type ServicesState } from "@/store/servicesSlice";
-import { type RawServiceConfiguration } from "@/types/serviceTypes";
+import { createSelector } from "reselect";
 
-export const selectConfiguredServices = ({
-  services,
-}: {
-  services: ServicesState;
-}): RawServiceConfiguration[] => Object.values(services.configured);
+export const selectConfiguredServices = createSelector(
+  ({ services }: { services: ServicesState }) => services.configured,
+  (configured) => Object.values(configured)
+);


### PR DESCRIPTION
## What does this PR do?

- Fixes #5646
- Added the React DevTools script tag to the sidebar app

## Reviewer Tips

- The main changes that fixed the bug were memoizing the services selector to prevent `RequireAuth` (+children) from re-rendering unnecessarily, and memoizing the temporary panel Tab.Pane components to make sure they don't re-render unless the panel entry actually changes, not just when `Tabs` re-renders in general

## Discussion

- We need to make sure and do a lot of QA on sidebars to make sure I didn't break anything with these changes...

## Demo

https://www.loom.com/share/bb5ad62bf6ff47dfb23a17ad8ab897dd

## Future Work

- I split up the selector for the `Tabs` content, I anticipate in the future breaking up these components even more granularly to further reduce unneeded panel re-rendering, I think there's still more progress that can be made here in the future, with more granular, memoized selectors, and more-specific, defined React components for each panel, etc.

## Checklist

- [ ] Add tests - 😢 I need to spend some time and think a little more holistically about how to test the sidebar app behavior here with forms, page state, etc.
- [x] Designate a primary reviewer - @twschiller 
