### PR TITLE
#5795: restores link button in console when unlinked 

### DIFF
--- a/src/store/servicesSelectors.ts
+++ b/src/store/servicesSelectors.ts
@@ -16,9 +16,10 @@
  */
 
 import { type ServicesState } from "@/store/servicesSlice";
-import { createSelector } from "reselect";
+import { type RawServiceConfiguration } from "@/types/serviceTypes";
 
-export const selectConfiguredServices = createSelector(
-  ({ services }: { services: ServicesState }) => services.configured,
-  (configured) => Object.values(configured)
-);
+export const selectConfiguredServices = ({
+  services,
+}: {
+  services: ServicesState;
+}): RawServiceConfiguration[] => Object.values(services.configured);


### PR DESCRIPTION
## What does this PR do?

- Fixes #5795

## Discussion

- memoization of the selectConfiguredServices selector prevented useRequiredPartnerAuth from updating and triggering a RequireAuth rerender
- reverting the memoization fixed the bug
- tested the change with @BLoe's "#5646 - Show sidebar form" mod to verify the sidebar fix still worked

## Checklist
- [x] Designate a primary reviewer
