### PR TITLE
#5790 Add delayed render to `PanelBody` loading indicator

### DIFF
--- a/src/sidebar/PanelBody.test.tsx
+++ b/src/sidebar/PanelBody.test.tsx
@@ -28,6 +28,7 @@ import {
   type RendererErrorPayload,
   type RendererRunPayload,
 } from "@/types/rendererTypes";
+import { screen } from "shadow-dom-testing-library";
 
 const extensionId = uuidv4();
 const blueprintId = registryIdFactory();
@@ -122,5 +123,33 @@ describe("PanelBody", () => {
 
     // There's a shadow root in BodyContainer, so the snapshot cuts off at the div
     expect(result.asFragment()).toMatchSnapshot();
+  });
+
+  it("delays loading indicator render", async () => {
+    const payload: RendererRunPayload = {
+      key: uuidv4(),
+      runId: uuidv4(),
+      extensionId,
+      blockId: validateRegistryId("@pixiebrix/html"),
+      args: {
+        html: "<h1>Test</h1>",
+      },
+      ctxt: {},
+    };
+
+    render(
+      <PanelBody
+        isRootPanel
+        onAction={jest.fn()}
+        context={{ extensionId, blueprintId }}
+        payload={payload}
+      />
+    );
+
+    expect(screen.queryByShadowText("Test")).not.toBeInTheDocument();
+
+    await waitForEffect();
+
+    expect(screen.getByShadowText("Test")).toBeVisible();
   });
 });

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -39,6 +39,7 @@ import { type RegistryId } from "@/types/registryTypes";
 import { type RendererOutput } from "@/types/runtimeTypes";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { isEmpty } from "lodash";
+import DelayedRender from "@/components/DelayedRender";
 
 // Used for the loading message
 // import cx from "classnames";
@@ -219,7 +220,11 @@ const PanelBody: React.FunctionComponent<{
     //   );
     // }
 
-    return <Loader />;
+    return (
+      <DelayedRender millis={600}>
+        <Loader />
+      </DelayedRender>
+    );
   }
 
   if (state.error) {


### PR DESCRIPTION
## What does this PR do?

- Closes #5790 

- [x] This PR requires a node/npm version update: let the team know on #engineering
  - `shadow-dom-testing-library`

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer - @twschiller 
