### PR TITLE
Update webpack for react image crop update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "react-focus-lock": "^2.9.4",
         "react-hot-toast": "^2.4.1",
         "react-hotkeys": "^2.0.0",
-        "react-image-crop": "^10.0.11",
+        "react-image-crop": "^10.1.4",
         "react-json-tree": "^0.18.0",
         "react-outside-click-handler": "^1.3.0",
         "react-redux": "^7.2.4",
@@ -31791,9 +31791,9 @@
       }
     },
     "node_modules/react-image-crop": {
-      "version": "10.0.11",
-      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-10.0.11.tgz",
-      "integrity": "sha512-uwhlDYZttn5jKTWfvV5WZrhSMxfdCklW5mHF5DZw9tlea/3bwpws07EZczo6pSbjh9/dHfdrHPSzaOAeLgB6sw==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-10.1.4.tgz",
+      "integrity": "sha512-bEc/SfJRPU06ApivtzuNmofEH3rqf1WsKgWNwloiZ4ttCB37DEETwR4KsQb+KkW87srvRtWpCbOhPs0a4TVAKw==",
       "dependencies": {
         "clsx": "^1.2.1"
       },
@@ -61371,9 +61371,9 @@
       }
     },
     "react-image-crop": {
-      "version": "10.0.11",
-      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-10.0.11.tgz",
-      "integrity": "sha512-uwhlDYZttn5jKTWfvV5WZrhSMxfdCklW5mHF5DZw9tlea/3bwpws07EZczo6pSbjh9/dHfdrHPSzaOAeLgB6sw==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-10.1.4.tgz",
+      "integrity": "sha512-bEc/SfJRPU06ApivtzuNmofEH3rqf1WsKgWNwloiZ4ttCB37DEETwR4KsQb+KkW87srvRtWpCbOhPs0a4TVAKw==",
       "requires": {
         "clsx": "^1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react-focus-lock": "^2.9.4",
     "react-hot-toast": "^2.4.1",
     "react-hotkeys": "^2.0.0",
-    "react-image-crop": "^10.0.11",
+    "react-image-crop": "^10.1.4",
     "react-json-tree": "^0.18.0",
     "react-outside-click-handler": "^1.3.0",
     "react-redux": "^7.2.4",

--- a/scripts/webpack.scripts.js
+++ b/scripts/webpack.scripts.js
@@ -17,6 +17,7 @@
 
 const path = require("node:path");
 const webpack = require("webpack");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const mergeWithShared = require("../webpack.sharedConfig.js");
 
 module.exports = mergeWithShared({
@@ -75,5 +76,31 @@ module.exports = mergeWithShared({
       /\.module\.(css|scss)$/,
       "identity-obj-proxy"
     ),
+    new MiniCssExtractPlugin({
+      chunkFilename: "css/[id].css",
+    }),
   ],
+  module: {
+    rules: [
+      {
+        test: /\.s?css$/,
+        resourceQuery: { not: [/loadAsUrl/] },
+        use: [MiniCssExtractPlugin.loader, "css-loader"],
+      },
+      {
+        test: /\.scss$/,
+        use: [
+          {
+            loader: "sass-loader",
+            options: {
+              sassOptions: {
+                // Due to warnings in dart-sass https://github.com/pixiebrix/pixiebrix-extension/pull/1070
+                quietDeps: true,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
 });

--- a/scripts/webpack.scripts.js
+++ b/scripts/webpack.scripts.js
@@ -17,7 +17,6 @@
 
 const path = require("node:path");
 const webpack = require("webpack");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const mergeWithShared = require("../webpack.sharedConfig.js");
 
 module.exports = mergeWithShared({
@@ -73,34 +72,8 @@ module.exports = mergeWithShared({
     // Don't fail on import of styles.
     // Using an identity object instead of actual style sheet because styles are not needed for headers generations
     new webpack.NormalModuleReplacementPlugin(
-      /\.module\.(css|scss)$/,
+      /.(css|scss)$/,
       "identity-obj-proxy"
     ),
-    new MiniCssExtractPlugin({
-      chunkFilename: "css/[id].css",
-    }),
   ],
-  module: {
-    rules: [
-      {
-        test: /\.s?css$/,
-        resourceQuery: { not: [/loadAsUrl/] },
-        use: [MiniCssExtractPlugin.loader, "css-loader"],
-      },
-      {
-        test: /\.scss$/,
-        use: [
-          {
-            loader: "sass-loader",
-            options: {
-              sassOptions: {
-                // Due to warnings in dart-sass https://github.com/pixiebrix/pixiebrix-extension/pull/1070
-                quietDeps: true,
-              },
-            },
-          },
-        ],
-      },
-    ],
-  },
 });

--- a/src/components/formBuilder/ImageCropWidget.tsx
+++ b/src/components/formBuilder/ImageCropWidget.tsx
@@ -19,8 +19,7 @@ import React, { useRef, useState } from "react";
 import ReactCrop, { type Crop } from "react-image-crop";
 import { FormGroup, FormLabel } from "react-bootstrap";
 import { type WidgetProps } from "@rjsf/core";
-import styles from "react-image-crop/dist/ReactCrop.css?loadAsUrl";
-import { Stylesheets } from "@/components/Stylesheets";
+import "react-image-crop/src/ReactCrop.scss";
 
 const ImageCropWidget: React.VFC<WidgetProps> = ({
   schema,
@@ -93,7 +92,7 @@ const ImageCropWidget: React.VFC<WidgetProps> = ({
     <FormGroup>
       <FormLabel>{schema.title}</FormLabel>
       {source && (
-        <Stylesheets href={styles}>
+        <>
           <ReactCrop
             crop={crop}
             onComplete={onCropComplete}
@@ -106,7 +105,7 @@ const ImageCropWidget: React.VFC<WidgetProps> = ({
               onLoad={onImageLoaded}
             />
           </ReactCrop>
-        </Stylesheets>
+        </>
       )}
       {croppedImageUrl && (
         <>


### PR DESCRIPTION
## What does this PR do?

- Bump react-image-crop from 10.0.11 to 10.1.4 (replaces dependabot #5818)
- updates import in ImageCropWidget to use new scss export
- updates webpack.script.js with sass-loader (resolves generate-headers error)

## Checklist
- [x] Designate a primary reviewer
