### PR TITLE
#5835: add support for a `Run` brick to enable custom-defined control flow

### DIFF
--- a/src/blocks/transformers/controlFlow/Run.test.ts
+++ b/src/blocks/transformers/controlFlow/Run.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import blockRegistry from "@/blocks/registry";
+import {
+  echoBlock,
+  simpleInput,
+  testOptions,
+  throwBlock,
+} from "@/runtime/pipelineTests/pipelineTestHelpers";
+import { reducePipeline } from "@/runtime/reducePipeline";
+import { makePipelineExpression } from "@/runtime/expressionCreators";
+import Run from "@/blocks/transformers/controlFlow/Run";
+import { Block } from "@/types/blockTypes";
+import { validateRegistryId } from "@/types/helpers";
+import { propertiesToSchema } from "@/validators/generic";
+import { type BlockArgs } from "@/types/runtimeTypes";
+import pDefer from "p-defer";
+
+const runBlock = new Run();
+
+class DeferredEchoBlock extends Block {
+  static BLOCK_ID = validateRegistryId("test/deferred");
+  readonly promise: Promise<unknown>;
+  constructor(promise: Promise<unknown>) {
+    super(DeferredEchoBlock.BLOCK_ID, "Deferred Block");
+    this.promise = promise;
+  }
+
+  inputSchema = propertiesToSchema({
+    message: {
+      type: "string",
+    },
+  });
+
+  async run({ message }: BlockArgs) {
+    await this.promise;
+    return { message };
+  }
+}
+
+beforeEach(() => {
+  blockRegistry.clear();
+  blockRegistry.register([throwBlock, echoBlock, runBlock]);
+});
+
+describe("Run", () => {
+  test("throws error body fails", async () => {
+    const pipeline = {
+      id: runBlock.id,
+      config: {
+        body: makePipelineExpression([
+          {
+            id: throwBlock.id,
+            config: {
+              message: "This is an error message!",
+            },
+          },
+        ]),
+      },
+    };
+
+    return expect(
+      reducePipeline(pipeline, simpleInput({}), testOptions("v3"))
+    ).rejects.toThrow();
+  });
+
+  test("returns result on success", async () => {
+    const pipeline = {
+      id: runBlock.id,
+      config: {
+        body: makePipelineExpression([
+          {
+            id: echoBlock.id,
+            config: {
+              message: "Hello, world!",
+            },
+          },
+        ]),
+      },
+    };
+
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      testOptions("v3")
+    );
+
+    expect(result).toStrictEqual({
+      message: "Hello, world!",
+    });
+  });
+
+  test("async returns immediately", async () => {
+    const deferred = pDefer();
+    const asyncBlock = new DeferredEchoBlock(deferred.promise);
+
+    blockRegistry.register([asyncBlock]);
+    const pipeline = {
+      id: runBlock.id,
+      config: {
+        async: true,
+        body: makePipelineExpression([
+          {
+            id: asyncBlock.id,
+            config: {
+              message: "Hello, world!",
+            },
+          },
+        ]),
+      },
+    };
+
+    const result = await reducePipeline(
+      pipeline,
+      simpleInput({}),
+      testOptions("v3")
+    );
+
+    expect(result).toStrictEqual({});
+  });
+});

--- a/src/blocks/transformers/getAllTransformers.ts
+++ b/src/blocks/transformers/getAllTransformers.ts
@@ -49,6 +49,7 @@ import TraverseElements from "@/blocks/transformers/traverseElements";
 import TourStepTransformer from "@/blocks/transformers/tourStep/tourStep";
 import { type IBlock } from "@/types/blockTypes";
 import { SelectElement } from "@/blocks/transformers/selectElement";
+import Run from "@/blocks/transformers/controlFlow/Run";
 
 function getAllTransformers(): IBlock[] {
   return [
@@ -87,6 +88,7 @@ function getAllTransformers(): IBlock[] {
     new TryExcept(),
     new ForEachElement(),
     new Retry(),
+    new Run(),
 
     // Render Pipelines
     new DisplayTemporaryInfo(),

--- a/src/components/fields/schemaFields/genericOptionsFactory.tsx
+++ b/src/components/fields/schemaFields/genericOptionsFactory.tsx
@@ -26,6 +26,7 @@ import {
   isDatabaseField,
   isServiceField,
 } from "@/components/fields/schemaFields/fieldTypeCheckers";
+import { sortedFields } from "@/components/fields/schemaFields/schemaFieldUtils";
 
 export type BlockOptionProps = {
   /**
@@ -43,79 +44,6 @@ export type BlockOptionProps = {
 const NoOptions: React.FunctionComponent = () => (
   <div>This brick does not require any configuration</div>
 );
-
-type FieldConfig = {
-  prop: string;
-  isRequired: boolean;
-  fieldSchema: Schema;
-  propUiSchema: unknown;
-};
-
-export function sortedFields(
-  schema: Schema,
-  uiSchema: UiSchema | null,
-  { preserveSchemaOrder = false }: { preserveSchemaOrder?: boolean } = {}
-): FieldConfig[] {
-  const optionSchema = inputProperties(schema);
-
-  const order = uiSchema?.["ui:order"] ?? ["*"];
-  const asteriskIndex = order.indexOf("*");
-
-  const uiSchemaOrder = (field: FieldConfig) => {
-    // https://react-jsonschema-form.readthedocs.io/en/docs/usage/objects/#specifying-property-order
-    const propIndex = order.indexOf(field.prop);
-    const index = propIndex === -1 ? asteriskIndex : propIndex;
-    return index === -1 ? order.length : index;
-  };
-
-  const fieldTypeOrder = (field: FieldConfig) => {
-    // Integration configurations
-    if (isServiceField(field.fieldSchema)) {
-      return 0;
-    }
-
-    // Databases
-    if (isDatabaseField(field.fieldSchema)) {
-      return 1;
-    }
-
-    // Required fields, and fields that will have input values pre-filled
-    if (field.isRequired || field.fieldSchema.default != null) {
-      return 2;
-    }
-
-    // Optional fields that are excluded by default
-    return Number.MAX_SAFE_INTEGER;
-  };
-
-  // Order by label
-  const labelOrder = (field: FieldConfig) =>
-    (field.fieldSchema.title ?? field.prop).toLowerCase();
-
-  const fields: FieldConfig[] = Object.entries(optionSchema)
-    .filter(
-      ([, fieldSchema]) =>
-        typeof fieldSchema === "object" &&
-        fieldSchema.$ref !== pipelineSchema.$id
-    )
-    .map(([prop, fieldSchema]) => {
-      // Fine because coming from Object.entries for the schema
-      // eslint-disable-next-line security/detect-object-injection
-      const propUiSchema = uiSchema?.[prop];
-
-      return {
-        prop,
-        isRequired: schema.required?.includes(prop),
-        // The fieldSchema type has been filtered so its safe to assume it is Schema
-        fieldSchema: fieldSchema as Schema,
-        propUiSchema,
-      };
-    });
-
-  return preserveSchemaOrder && isEmpty(uiSchema)
-    ? fields
-    : sortBy(fields, uiSchemaOrder, fieldTypeOrder, labelOrder);
-}
 
 /**
  * Return the Options fields for configuring a block with the given schema.

--- a/src/components/fields/schemaFields/schemaFieldUtils.test.ts
+++ b/src/components/fields/schemaFields/schemaFieldUtils.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { sortedFields } from "@/components/fields/schemaFields/genericOptionsFactory";
+import { sortedFields } from "@/components/fields/schemaFields/schemaFieldUtils";
 import { type Schema } from "@/types/schemaTypes";
 
 describe("sortedFields", () => {

--- a/src/components/fields/schemaFields/schemaFieldUtils.ts
+++ b/src/components/fields/schemaFields/schemaFieldUtils.ts
@@ -18,6 +18,14 @@
 import type React from "react";
 import { fieldLabel } from "@/components/fields/fieldUtils";
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
+import { type Schema, type UiSchema } from "@/types/schemaTypes";
+import { inputProperties } from "@/helpers";
+import {
+  isDatabaseField,
+  isServiceField,
+} from "@/components/fields/schemaFields/fieldTypeCheckers";
+import pipelineSchema from "@schemas/pipeline.json";
+import { isEmpty, sortBy } from "lodash";
 
 export function makeLabelForSchemaField({
   name,
@@ -30,4 +38,77 @@ export function makeLabelForSchemaField({
   }
 
   return label ?? title ?? fieldLabel(name);
+}
+
+type FieldConfig = {
+  prop: string;
+  isRequired: boolean;
+  fieldSchema: Schema;
+  propUiSchema: unknown;
+};
+
+export function sortedFields(
+  schema: Schema,
+  uiSchema: UiSchema | null,
+  { preserveSchemaOrder = false }: { preserveSchemaOrder?: boolean } = {}
+): FieldConfig[] {
+  const optionSchema = inputProperties(schema);
+
+  const order = uiSchema?.["ui:order"] ?? ["*"];
+  const asteriskIndex = order.indexOf("*");
+
+  const uiSchemaOrder = (field: FieldConfig) => {
+    // https://react-jsonschema-form.readthedocs.io/en/docs/usage/objects/#specifying-property-order
+    const propIndex = order.indexOf(field.prop);
+    const index = propIndex === -1 ? asteriskIndex : propIndex;
+    return index === -1 ? order.length : index;
+  };
+
+  const fieldTypeOrder = (field: FieldConfig) => {
+    // Integration configurations
+    if (isServiceField(field.fieldSchema)) {
+      return 0;
+    }
+
+    // Databases
+    if (isDatabaseField(field.fieldSchema)) {
+      return 1;
+    }
+
+    // Required fields, and fields that will have input values pre-filled
+    if (field.isRequired || field.fieldSchema.default != null) {
+      return 2;
+    }
+
+    // Optional fields that are excluded by default
+    return Number.MAX_SAFE_INTEGER;
+  };
+
+  // Order by label
+  const labelOrder = (field: FieldConfig) =>
+    (field.fieldSchema.title ?? field.prop).toLowerCase();
+
+  const fields: FieldConfig[] = Object.entries(optionSchema)
+    .filter(
+      ([, fieldSchema]) =>
+        typeof fieldSchema === "object" &&
+        fieldSchema.$ref !== pipelineSchema.$id
+    )
+    .map(([prop, fieldSchema]) => {
+      // Fine because coming from Object.entries for the schema
+      // eslint-disable-next-line security/detect-object-injection
+      const propUiSchema = uiSchema?.[prop];
+
+      return {
+        prop,
+        isRequired: schema.required?.includes(prop),
+        // The fieldSchema type has been filtered so its safe to assume it is Schema
+        fieldSchema: fieldSchema as Schema,
+        propUiSchema,
+      };
+    });
+
+  return preserveSchemaOrder && isEmpty(uiSchema)
+    ? fields
+    : sortBy(fields, uiSchemaOrder, fieldTypeOrder, labelOrder);
 }

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -27,7 +27,7 @@ import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 115;
+const EXPECTED_HEADER_COUNT = 116;
 
 registerBuiltinBlocks();
 registerContribBlocks();

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -70,6 +70,7 @@ import { selectExtensionAnnotations } from "@/analysis/analysisSelectors";
 import usePasteBlock from "@/pageEditor/tabs/editTab/editorNodeLayout/usePasteBlock";
 import { type IconProp } from "@fortawesome/fontawesome-svg-core";
 import { ADAPTERS } from "@/pageEditor/extensionPoints/adapter";
+import { type IBlock } from "@/types/blockTypes";
 
 const ADD_MESSAGE = "Add more bricks with the plus button";
 
@@ -96,7 +97,15 @@ type SubPipeline = {
   inputKey?: string;
 };
 
-function getSubPipelinesForBlock(blockConfig: BlockConfig): SubPipeline[] {
+/**
+ *
+ * @param block the block, or null if the resolved block is not available yet
+ * @param blockConfig the block config
+ */
+function getSubPipelinesForBlock(
+  block: IBlock | null,
+  blockConfig: BlockConfig
+): SubPipeline[] {
   const subPipelines: SubPipeline[] = [];
   if (blockConfig.id === DocumentRenderer.BLOCK_ID) {
     for (const docPipelinePath of getDocumentPipelinePaths(blockConfig)) {
@@ -122,7 +131,7 @@ function getSubPipelinesForBlock(blockConfig: BlockConfig): SubPipeline[] {
       });
     }
   } else {
-    for (const pipelinePropName of getPipelinePropNames(blockConfig)) {
+    for (const pipelinePropName of getPipelinePropNames(block, blockConfig)) {
       const path = joinName("config", pipelinePropName, "__value__");
       const pipeline: BlockPipeline = get(blockConfig, path) ?? [];
 
@@ -285,7 +294,7 @@ const usePipelineNodes = (): {
       extensionHasTraces = true;
     }
 
-    const subPipelines = getSubPipelinesForBlock(blockConfig);
+    const subPipelines = getSubPipelinesForBlock(block, blockConfig);
     const hasSubPipelines = !isEmpty(subPipelines);
     const collapsed = collapsedState[blockConfig.instanceId];
     const expanded = hasSubPipelines && !collapsed;


### PR DESCRIPTION
## What does this PR do?

- Closes #5835 
- Adds a special brick `Run` which takes a pipeline and whether the brick should be run synchronously or async
- Removes hard-coded assumptions about pipeline prop names

## Remaining Work

- [ ] Fix broken tests
- [ ] Manually QA
- [ ] Create demo video

## Reviewer Tips

- Read `Run.ts`

## Demo

- _Paste a screenshot or demo video here_

## Future Work

- _Work for the issue/ticket that will be in a follow-up PR_


## Checklist

- [x] Add tests
- [ ] Designate a primary reviewer
