### PR TITLE
#5830 Fix get extension point types for RecipeDefinitions

### DIFF
--- a/src/utils/installableUtils.ts
+++ b/src/utils/installableUtils.ts
@@ -347,7 +347,7 @@ export const StarterBrickMap: Record<ExtensionPointType, string> = {
   tour: "Tour",
 };
 
-export const getExtensionPointType = async (
+const getExtensionPointType = async (
   extension: ResolvedExtension
 ): Promise<ExtensionPointType> => {
   const extensionPoint = await extensionPointRegistry.lookup(

--- a/src/utils/installableUtils.ts
+++ b/src/utils/installableUtils.ts
@@ -347,7 +347,7 @@ export const StarterBrickMap: Record<ExtensionPointType, string> = {
   tour: "Tour",
 };
 
-const getExtensionPointType = async (
+export const getExtensionPointType = async (
   extension: ResolvedExtension
 ): Promise<ExtensionPointType> => {
   const extensionPoint = await extensionPointRegistry.lookup(

--- a/src/utils/recipeUtils.test.ts
+++ b/src/utils/recipeUtils.test.ts
@@ -15,7 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { generateRecipeId } from "./recipeUtils";
+import {
+  generateRecipeId,
+  getContainedExtensionPointTypes,
+} from "./recipeUtils";
+import { recipeFactory } from "@/testUtils/factories/recipeFactories";
 
 describe("generateRecipeId", () => {
   test("no special chars", () => {
@@ -38,5 +42,12 @@ describe("generateRecipeId", () => {
 
   test("return empty on invalid", () => {
     expect(generateRecipeId("", "This   Is a Test")).toBe("");
+  });
+
+  test("getContainedExtensionPointTypes", () => {
+    console.log(recipeFactory());
+    expect(getContainedExtensionPointTypes(recipeFactory())).toStrictEqual([
+      "menuItem",
+    ]);
   });
 });

--- a/src/utils/recipeUtils.ts
+++ b/src/utils/recipeUtils.ts
@@ -88,13 +88,11 @@ const getExtensionPointType = async (
 export const getContainedExtensionPointTypes = async (
   recipe: RecipeDefinition
 ): Promise<ExtensionPointType[]> => {
-  const extensionPointTypes = new Set<ExtensionPointType>();
+  const extensionPointTypes = await Promise.all(
+    recipe.extensionPoints.map(async (extensionPoint) => {
+      return getExtensionPointType(extensionPoint, recipe);
+    })
+  );
 
-  for (const extensionPoint of recipe.extensionPoints) {
-    extensionPointTypes.add(
-      await getExtensionPointType(extensionPoint, recipe)
-    );
-  }
-
-  return [...extensionPointTypes];
+  return uniq(extensionPointTypes);
 };

--- a/src/utils/recipeUtils.ts
+++ b/src/utils/recipeUtils.ts
@@ -19,7 +19,7 @@ import { type RegistryId } from "@/types/registryTypes";
 import { validateRegistryId } from "@/types/helpers";
 import slugify from "slugify";
 import {
-  ExtensionDefinition,
+  type ExtensionDefinition,
   type RecipeDefinition,
 } from "@/types/recipeTypes";
 import { uniq } from "lodash";
@@ -89,9 +89,9 @@ export const getContainedExtensionPointTypes = async (
   recipe: RecipeDefinition
 ): Promise<ExtensionPointType[]> => {
   const extensionPointTypes = await Promise.all(
-    recipe.extensionPoints.map(async (extensionPoint) => {
-      return getExtensionPointType(extensionPoint, recipe);
-    })
+    recipe.extensionPoints.map(async (extensionPoint) =>
+      getExtensionPointType(extensionPoint, recipe)
+    )
   );
 
   return uniq(extensionPointTypes);

--- a/src/utils/recipeUtils.ts
+++ b/src/utils/recipeUtils.ts
@@ -25,6 +25,7 @@ import type {
   ExtensionPointDefinition,
   ExtensionPointType,
 } from "@/extensionPoints/types";
+import extensionPointRegistry from "@/extensionPoints/registry";
 
 /**
  * Return a valid recipe id, or empty string in case of error.
@@ -57,10 +58,31 @@ export const getRequiredServiceIds = (recipe: RecipeDefinition): RegistryId[] =>
       .filter((serviceId) => serviceId !== PIXIEBRIX_SERVICE_ID)
   );
 
+// export const getContainedExtensionPointTypes = async (
+//   recipe: RecipeDefinition
+// ): Promise<ExtensionPointType[]> => {
+//   const extensionPointTypes = new Set<ExtensionPointType>();
+//
+//   for (const extensionPoint of Object.values(recipe.extensionPoints)) {
+//     // ExtensionDefinition.id can be either a RegistryId or an InnerDefinitionRef
+//     const extensionPointFromRegistry = await extensionPointRegistry.lookup(
+//       extensionPoint.id
+//     );
+//
+//     if (extensionPointFromRegistry) {
+//       extensionPointTypes.add(extensionPointFromRegistry.kind as ExtensionPointType);
+//     }
+//   }
+//
+//   return [...extensionPointTypes];
+// };
+
 export const getContainedExtensionPointTypes = (
   recipe: RecipeDefinition
 ): ExtensionPointType[] => {
   const extensionPointTypes = new Set<ExtensionPointType>();
+
+  console.log("*** recipe", recipe);
 
   for (const definition of Object.values(recipe.definitions ?? [])) {
     if (definition.kind !== "extensionPoint") {

--- a/src/utils/recipeUtils.ts
+++ b/src/utils/recipeUtils.ts
@@ -22,7 +22,7 @@ import {
   type ExtensionDefinition,
   type RecipeDefinition,
 } from "@/types/recipeTypes";
-import { uniq } from "lodash";
+import { compact, uniq } from "lodash";
 import { PIXIEBRIX_SERVICE_ID } from "@/services/constants";
 import type {
   ExtensionPointDefinition,
@@ -94,5 +94,5 @@ export const getContainedExtensionPointTypes = async (
     )
   );
 
-  return uniq(extensionPointTypes.filter((type) => type !== null));
+  return uniq(compact(extensionPointTypes));
 };

--- a/src/utils/recipeUtils.ts
+++ b/src/utils/recipeUtils.ts
@@ -62,7 +62,7 @@ export const getContainedExtensionPointTypes = (
 ): ExtensionPointType[] => {
   const extensionPointTypes = new Set<ExtensionPointType>();
 
-  for (const definition of Object.values(recipe.definitions)) {
+  for (const definition of Object.values(recipe.definitions ?? [])) {
     if (definition.kind !== "extensionPoint") {
       continue;
     }

--- a/src/utils/recipeUtils.ts
+++ b/src/utils/recipeUtils.ts
@@ -64,8 +64,8 @@ export const getRequiredServiceIds = (recipe: RecipeDefinition): RegistryId[] =>
 const getExtensionPointType = async (
   extensionPoint: ExtensionDefinition,
   recipe?: RecipeDefinition
-) => {
-  // Look up the extension point in recipe definitions first
+): Promise<ExtensionPointType | null> => {
+  // Look up the extension point in recipe inner definitions first
   if (recipe.definitions) {
     const definition: ExtensionPointDefinition = recipe.definitions[
       extensionPoint.id
@@ -77,7 +77,7 @@ const getExtensionPointType = async (
     }
   }
 
-  // If no internal definitions, look up the extension point in the registry
+  // If no inner definitions, look up the extension point in the registry
   const extensionPointFromRegistry = await extensionPointRegistry.lookup(
     extensionPoint.id as RegistryId
   );
@@ -94,5 +94,5 @@ export const getContainedExtensionPointTypes = async (
     )
   );
 
-  return uniq(extensionPointTypes);
+  return uniq(extensionPointTypes.filter((type) => type !== null));
 };

--- a/src/utils/recipeUtils.ts
+++ b/src/utils/recipeUtils.ts
@@ -91,14 +91,9 @@ export const getContainedExtensionPointTypes = async (
   const extensionPointTypes = new Set<ExtensionPointType>();
 
   for (const extensionPoint of recipe.extensionPoints) {
-    const extensionPointType = await getExtensionPointType(
-      extensionPoint,
-      recipe
+    extensionPointTypes.add(
+      await getExtensionPointType(extensionPoint, recipe)
     );
-
-    if (extensionPointType) {
-      extensionPointTypes.add(extensionPointType);
-    }
   }
 
   return [...extensionPointTypes];


### PR DESCRIPTION
## What does this PR do?

- Fixes #5830
- Handles getting extension point types for the two different states extension points in a `RecipeDefinition` (extension points that reference inner definitions, or entries in the extension point registry)

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @twschiller 
