### PR TITLE
add conditional line clamping to starter bricks list

### DIFF
--- a/src/sidebar/homePanel/ActiveModListItem.module.scss
+++ b/src/sidebar/homePanel/ActiveModListItem.module.scss
@@ -33,11 +33,19 @@
   flex-grow: 1;
 }
 
-.modName {
+.lineClampOneLine {
   margin: 0;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 1;
+  overflow: hidden;
+}
+
+.lineClampTwoLines {
+  margin: 0;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   overflow: hidden;
 }
 

--- a/src/sidebar/homePanel/ActiveModListItem.tsx
+++ b/src/sidebar/homePanel/ActiveModListItem.tsx
@@ -32,6 +32,7 @@ import InstallableIcon from "@/installables/InstallableIcon";
 import EllipsisMenu from "@/components/ellipsisMenu/EllipsisMenu";
 import useMarketplaceUrl from "@/installables/hooks/useMarketplaceUrl";
 import useRequestPermissionsAction from "@/installables/hooks/useRequestPermissionsAction";
+import cx from "classnames";
 
 // eslint-disable-next-line unicorn/prevent-abbreviations -- Mod is not short for anything
 export const ActiveModListItem: React.FunctionComponent<{
@@ -55,8 +56,15 @@ export const ActiveModListItem: React.FunctionComponent<{
         </div>
         <div>
           <div>
-            <h5 className={styles.modName}>{name}</h5>
-            <span className={styles.starterBricksList}>
+            <h5 className={styles.lineClampOneLine}>{name}</h5>
+            <span
+              className={cx(
+                styles.starterBricksList,
+                requestPermissions
+                  ? styles.lineClampOneLine
+                  : styles.lineClampTwoLines
+              )}
+            >
               {starterBricksContained.join(" • ")}
             </span>
           </div>


### PR DESCRIPTION
## What does this PR do?

- Adds conditional line clamping to the starter bricks information on the Active Mod list item in the Home Panel to prevent list item overflow (list items are a fixed height)
- Starter brick info will be clamped to 1 line if the "Grant Permissions" link is present
- Otherwise, starter brick info will be clamped to 2 lines
- Note that the Mod title is clamped to 1 line in all cases
- These UI decisions were discussed with @BrandonPxBx 

## Demo

![Screen Shot 2023-06-01 at 11 39 06 AM](https://github.com/pixiebrix/pixiebrix-extension/assets/36575242/d2ae2750-6fc6-4b7b-8513-83d1d80bb294)

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @BLoe 
