### PR TITLE
#5843: handle cancelling Google File Picker

### DIFF
--- a/src/contrib/google/sheets/SheetsFileWidget.tsx
+++ b/src/contrib/google/sheets/SheetsFileWidget.tsx
@@ -36,7 +36,8 @@ import { produce } from "immer";
 import { produceExcludeUnusedDependencies } from "@/components/fields/schemaFields/serviceFieldUtils";
 import useGoogleSpreadsheetPicker from "@/contrib/google/sheets/useGoogleSpreadsheetPicker";
 import { requireGoogleHOC } from "@/contrib/google/sheets/RequireGoogleApi";
-import { getErrorMessage } from "@/errors/errorHelpers";
+import { getErrorMessage, isSpecificError } from "@/errors/errorHelpers";
+import { CancelError } from "@/errors/businessErrors";
 
 const SheetsFileWidget: React.FC<SchemaFieldProps> = (props) => {
   const [spreadsheetIdField, , spreadsheetIdFieldHelpers] = useField<
@@ -175,12 +176,14 @@ const SheetsFileWidget: React.FC<SchemaFieldProps> = (props) => {
               spreadsheetIdFieldHelpers.setValue(doc.id);
               setSheetMetadata(doc);
             } catch (error) {
-              // Ensure we're notifying Rollbar
-              notify.error({
-                message: "Error loading file picker",
-                error,
-                includeErrorDetails: true,
-              });
+              if (!isSpecificError(error, CancelError)) {
+                // Ensure we're notifying Rollbar
+                notify.error({
+                  message: "Error loading file picker",
+                  error,
+                  includeErrorDetails: true,
+                });
+              }
             }
           }}
         >

--- a/src/contrib/google/sheets/useGoogleSpreadsheetPicker.ts
+++ b/src/contrib/google/sheets/useGoogleSpreadsheetPicker.ts
@@ -114,6 +114,14 @@ function useGoogleSpreadsheetPicker(): {
       .setDeveloperKey(API_KEY)
       .setAppId(APP_ID)
       .setCallback((data: Data) => {
+        // The File Picker also does a callback for "loaded", but that action doesn't appear in the types and doesn't
+        // appear in the documentation: https://developers.google.com/drive/picker/reference#callback-types
+        // For now, report the event to help diagnose issues users are facing with the picker. In the future,
+        // could consider making this a NOP.
+        reportEvent("GoogleFilePickerEvent", {
+          action: data.action,
+        });
+
         if (data.action === google.picker.Action.PICKED) {
           const doc = data.docs[0];
           if (doc.mimeType !== "application/vnd.google-apps.spreadsheet") {
@@ -126,10 +134,6 @@ function useGoogleSpreadsheetPicker(): {
           deferredPromise.resolve(doc);
         } else if (data.action === google.picker.Action.CANCEL) {
           deferredPromise.reject(new CancelError("No spreadsheet selected"));
-        } else {
-          deferredPromise.reject(
-            new Error(`Unexpected File Picker action: ${data.action}`)
-          );
         }
       })
       .setOrigin(pickerOrigin)

--- a/src/contrib/google/sheets/useGoogleSpreadsheetPicker.ts
+++ b/src/contrib/google/sheets/useGoogleSpreadsheetPicker.ts
@@ -23,6 +23,7 @@ import { type Data, type Doc } from "@/contrib/google/sheets/types";
 import pDefer from "p-defer";
 import { reportEvent } from "@/telemetry/events";
 import useUserAction from "@/hooks/useUserAction";
+import { CancelError } from "@/errors/businessErrors";
 
 const API_KEY = process.env.GOOGLE_API_KEY;
 const APP_ID = process.env.GOOGLE_APP_ID;
@@ -123,6 +124,12 @@ function useGoogleSpreadsheetPicker(): {
 
           reportEvent("SelectGoogleSpreadsheetPicked");
           deferredPromise.resolve(doc);
+        } else if (data.action === google.picker.Action.CANCEL) {
+          deferredPromise.reject(new CancelError("No spreadsheet selected"));
+        } else {
+          deferredPromise.reject(
+            new Error(`Unexpected File Picker action: ${data.action}`)
+          );
         }
       })
       .setOrigin(pickerOrigin)


### PR DESCRIPTION
## What does this PR do?

- Fixes #5843 
- Adds case for `Action.CANCEL`

## Discussion / Future Work

- If you cancel out of the Google Auth flow (if you're not already logged into a Google Account) you can also get stuck in a pending state. I'm not aware of any way to detect that though -- it seems the chromeP.identity.getAuthToken doesn't throw it the user closes the new tab that's open with the Google Login

## Checklist

- Add tests: we haven't figured out a good way to write File Picker test mocks/tests yet. I manually QA'd locally
- [x] Designate a primary reviewer: @BLoe 
