### PR TITLE
#5835: capture closure for pipeline args to ExternalBlock

### DIFF
--- a/src/blocks/effects/AddQuickBarAction.tsx
+++ b/src/blocks/effects/AddQuickBarAction.tsx
@@ -158,7 +158,7 @@ class AddQuickBarAction extends Effect {
       ),
       async perform() {
         const pipelinePromise = runPipeline(
-          actionPipeline.__value__ ?? [],
+          actionPipeline,
           {
             key: "action",
             counter,

--- a/src/blocks/transformers/controlFlow/ForEach.ts
+++ b/src/blocks/transformers/controlFlow/ForEach.ts
@@ -86,7 +86,7 @@ class ForEach extends Transformer {
     for (const [index, element] of elements.entries()) {
       // eslint-disable-next-line no-await-in-loop -- synchronous for-loop brick
       last = await options.runPipeline(
-        bodyPipeline.__value__,
+        bodyPipeline,
         { key: "body", counter: index },
         {
           [`@${elementKey}`]: element,

--- a/src/blocks/transformers/controlFlow/ForEachElement.ts
+++ b/src/blocks/transformers/controlFlow/ForEachElement.ts
@@ -108,7 +108,7 @@ class ForEachElement extends Transformer {
 
       // eslint-disable-next-line no-await-in-loop -- synchronous for-loop brick
       last = await options.runPipeline(
-        bodyPipeline.__value__,
+        bodyPipeline,
         { key: "body", counter: index },
         extraContext,
         element

--- a/src/blocks/transformers/controlFlow/IfElse.ts
+++ b/src/blocks/transformers/controlFlow/IfElse.ts
@@ -78,13 +78,13 @@ class IfElse extends Transformer {
     const condition = boolean(rawCondition);
 
     if (condition) {
-      return options.runPipeline(ifPipeline.__value__ ?? [], {
+      return options.runPipeline(ifPipeline, {
         key: "if",
         counter: 0,
       });
     }
 
-    return options.runPipeline(elsePipeline?.__value__ ?? [], {
+    return options.runPipeline(elsePipeline, {
       key: "else",
       counter: 0,
     });

--- a/src/blocks/transformers/controlFlow/Retry.ts
+++ b/src/blocks/transformers/controlFlow/Retry.ts
@@ -85,7 +85,7 @@ class Retry extends Transformer {
 
       try {
         // eslint-disable-next-line no-await-in-loop -- retry loop
-        return await options.runPipeline(bodyPipeline.__value__, {
+        return await options.runPipeline(bodyPipeline, {
           key: "branch",
           counter: retryCount,
         });

--- a/src/blocks/transformers/controlFlow/Run.ts
+++ b/src/blocks/transformers/controlFlow/Run.ts
@@ -78,7 +78,7 @@ class Run extends Transformer {
     }>,
     options: BlockOptions
   ): Promise<unknown> {
-    const promise = options.runPipeline(bodyPipeline.__value__, {
+    const promise = options.runPipeline(bodyPipeline, {
       key: "body",
       counter: 0,
     });

--- a/src/blocks/transformers/controlFlow/TryExcept.ts
+++ b/src/blocks/transformers/controlFlow/TryExcept.ts
@@ -81,7 +81,7 @@ class TryExcept extends Transformer {
     options: BlockOptions
   ): Promise<unknown> {
     try {
-      return await options.runPipeline(tryPipeline.__value__, {
+      return await options.runPipeline(tryPipeline, {
         key: "try",
         counter: 0,
       });
@@ -89,7 +89,7 @@ class TryExcept extends Transformer {
       options.logger.debug("Caught error", { error });
 
       return options.runPipeline(
-        exceptPipeline?.__value__ ?? [],
+        exceptPipeline,
         { key: "catch", counter: 0 },
         {
           [`@${errorKey}`]: serializeError(error, { useToJSON: false }),

--- a/src/blocks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
+++ b/src/blocks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
@@ -385,7 +385,7 @@ class DisplayTemporaryInfo extends Transformer {
 
     const getPayload = async () => {
       const result = await runRendererPipeline(
-        bodyPipeline?.__value__ ?? [],
+        bodyPipeline,
         {
           key: "body",
           counter,

--- a/src/blocks/transformers/tourStep/tourStep.ts
+++ b/src/blocks/transformers/tourStep/tourStep.ts
@@ -348,7 +348,7 @@ export class TourStepTransformer extends Transformer {
 
     const getPayload = async () => {
       const result = await runRendererPipeline(
-        (body as PipelineExpression)?.__value__ ?? [],
+        body as PipelineExpression,
         {
           key: "body",
           counter,
@@ -518,7 +518,7 @@ export class TourStepTransformer extends Transformer {
     try {
       if (!isEmpty(onBeforeShow?.__value__)) {
         await options.runPipeline(
-          onBeforeShow.__value__ ?? [],
+          onBeforeShow,
           {
             key: "onBeforeShow",
             counter: 0,
@@ -543,7 +543,7 @@ export class TourStepTransformer extends Transformer {
 
       if (!isEmpty(onAfterShow?.__value__)) {
         await options.runPipeline(
-          onAfterShow.__value__ ?? [],
+          onAfterShow,
           {
             key: "onAfterShow",
             counter: 0,

--- a/src/runtime/mapArgs.ts
+++ b/src/runtime/mapArgs.ts
@@ -66,10 +66,24 @@ export function isExpression(value: unknown): value is Expression<unknown> {
 
 export type PipelineExpression = Expression<BlockPipeline, "pipeline">;
 
+/**
+ * A PipelineExpression with an attached lexical environment. Internal type used by the runtime
+ * @since 1.7.29
+ */
+export type PipelineClosureExpression = PipelineExpression & {
+  __env__: UnknownObject;
+};
+
 export function isPipelineExpression(
   value: unknown
 ): value is PipelineExpression {
   return isExpression(value) && value.__type__ === "pipeline";
+}
+
+export function isPipelineClosureExpression(
+  value: unknown
+): value is PipelineClosureExpression {
+  return isPipelineExpression(value) && "__env__" in value;
 }
 
 export type DeferExpression<TValue = UnknownObject> = Expression<

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -21,14 +21,21 @@ import { type Schema } from "@/types/schemaTypes";
 
 const logger = new ConsoleLogger();
 
-class ContextBlock extends Block {
+export class ContextBlock extends Block {
+  static contexts: UnknownObject[] = [];
+
   constructor() {
     super("test/context", "Return Context");
+  }
+
+  static clearContexts() {
+    ContextBlock.contexts = [];
   }
 
   inputSchema = propertiesToSchema({});
 
   async run(arg: BlockArgs, { ctxt }: BlockOptions) {
+    ContextBlock.contexts.push(ctxt);
     return ctxt;
   }
 }
@@ -147,6 +154,9 @@ const pipelineSchema: Schema = {
   },
 };
 
+/**
+ * A block for testing pipeline functionality. Returns the length of the provided pipeline block input.
+ */
 class PipelineBlock extends Block {
   constructor() {
     super("test/pipeline", "Pipeline Block");

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -30,7 +30,11 @@ import { engineRenderer } from "@/runtime/renderers";
 import { type TraceExitData, type TraceRecordMeta } from "@/telemetry/trace";
 import { type JsonObject } from "type-fest";
 import { uuidv4, validateSemVerString } from "@/types/helpers";
-import { mapArgs } from "@/runtime/mapArgs";
+import {
+  isPipelineClosureExpression,
+  mapArgs,
+  type PipelineExpression,
+} from "@/runtime/mapArgs";
 import {
   type ApiVersionOptions,
   DEFAULT_IMPLICIT_TEMPLATE_ENGINE,
@@ -261,6 +265,34 @@ type RunBlockOptions = CommonOptions & {
 };
 
 /**
+ * Get the lexical environment for running a pipeline. Currently, we're just tracking on the pipeline arg itself.
+ * https://en.wikipedia.org/wiki/Closure_(computer_programming)
+ *
+ * @see ExternalBlock.initPipelineClosures
+ */
+function getPipelineLexicalEnvironment({
+  pipeline,
+  ctxt,
+  extraContext,
+}: {
+  pipeline: PipelineExpression;
+  ctxt: UnknownObject;
+  extraContext: UnknownObject | null;
+}): UnknownObject {
+  if (isPipelineClosureExpression(pipeline)) {
+    return {
+      ...pipeline.__env__,
+      ...extraContext,
+    };
+  }
+
+  return {
+    ...ctxt,
+    ...extraContext,
+  };
+}
+
+/**
  * Execute/run the resolved block in the target (self, etc.) with the validated args.
  */
 async function executeBlockWithValidatedProps(
@@ -314,11 +346,12 @@ async function executeBlockWithValidatedProps(
 
           const { runId, extensionId, branches } = options.trace;
           return reducePipelineExpression(
-            pipeline,
-            {
-              ...commonOptions.ctxt,
-              ...extraContext,
-            },
+            pipeline?.__value__ ?? [],
+            getPipelineLexicalEnvironment({
+              pipeline,
+              ctxt: commonOptions.ctxt,
+              extraContext,
+            }),
             rootOverride ?? root,
             {
               ...options,
@@ -350,11 +383,12 @@ async function executeBlockWithValidatedProps(
           let payload: PanelPayload;
           try {
             await reducePipelineExpression(
-              pipeline,
-              {
-                ...commonOptions.ctxt,
-                ...extraContext,
-              },
+              pipeline?.__value__ ?? [],
+              getPipelineLexicalEnvironment({
+                pipeline,
+                ctxt: commonOptions.ctxt,
+                extraContext,
+              }),
               rootOverride ?? root,
               {
                 ...options,
@@ -418,7 +452,7 @@ async function renderBlockArg(
     autoescape,
   } = options;
 
-  // Support YAML short-hand of leaving of `config:` directive for blocks that don't have parameters
+  // Support YAML shorthand of leaving of `config:` directive for blocks that don't have parameters
   const stageTemplate = config.config ?? {};
 
   if (type === "reader") {

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -21,6 +21,7 @@ import { type SafeHTML, type UUID } from "@/types/stringTypes";
 import { type SanitizedServiceConfiguration } from "@/types/serviceTypes";
 import { type Primitive } from "type-fest";
 import { type Logger } from "@/types/loggerTypes";
+import { type PipelineExpression } from "@/runtime/mapArgs";
 
 /**
  * The PixieBrix brick definition API. Controls how the PixieBrix runtime interprets brick definitions.
@@ -263,17 +264,13 @@ export type BlockOptions<
    * @since 1.6.4
    */
   runPipeline: (
-    // This should be BlockPipeline, but our dependencies are too tangled to use
-    // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/3477
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- brick is responsible for providing shape
-    pipeline: any,
+    pipeline: PipelineExpression,
     // The branch for tracing. Used to determine order of pipeline runs
     branch: {
       key: string;
       counter: number;
     },
-    // Should be UnknownObject, but can't use to introduce a circular dependency
-    extraContext?: Record<string, unknown>,
+    extraContext?: UnknownObject,
     root?: SelectorRoot
   ) => Promise<unknown>;
 
@@ -282,10 +279,7 @@ export type BlockOptions<
    * @since 1.7.13
    */
   runRendererPipeline: (
-    // This should be BlockPipeline, but our dependencies are too tangled to use
-    // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/3477
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- brick is responsible for providing shape
-    pipeline: any,
+    pipeline: PipelineExpression,
     // The branch for tracing. Used to determine order of pipeline runs
     branch: {
       key: string;


### PR DESCRIPTION
## What does this PR do?

- Follow up to https://github.com/pixiebrix/pixiebrix-extension/pull/5836
- Captures closure for pipeline args to ExternalBlock. Currently only at the top-level
- Modifies executeBlockWithValidatedProps to use the closure if available when running a pipeline

## Discussion

- Took the simple/naive approach of just dropping the lexical environment onto the pipeline expression that's passed along
- That's less efficient for tracing, because it duplicates part of the tree in traces
- As noted in the PR, technically, mapArgs:renderExplicit would be a better place to capture the closure
- However, it'd be wasteful because ExternalBlock is currently the only brick when tracking the complete requirement is necessary
- The try-catch, for-each bricks technically use a closure. But we didn't need to introduce any mechanics for them aside to `extraContext` to pass in the additional variables

## Reviewer Tips

- Review changes in reducePipeline.ts
- Review changes in blockFactory and blockFactory.test.ts
- Other files are just adjustments for reducePipeline.ts file function signatures changing

## Demo

- Demo of a custom brick taking a pipeline and the pipeline argument using the outside context
- https://www.loom.com/share/f39a14fb48304cf291cc0c723e6282e1

## Future Work

- Record the closure somewhere else to avoid unnecessary data on trace objects

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
