### PR TITLE
#5854 Fix NPE in Home Panel for mods with no inner definition found

### DIFF
--- a/src/sidebar/homePanel/ActiveModListItem.tsx
+++ b/src/sidebar/homePanel/ActiveModListItem.tsx
@@ -33,7 +33,6 @@ import EllipsisMenu from "@/components/ellipsisMenu/EllipsisMenu";
 import useMarketplaceUrl from "@/installables/hooks/useMarketplaceUrl";
 import useRequestPermissionsAction from "@/installables/hooks/useRequestPermissionsAction";
 import cx from "classnames";
-import { fallbackValue } from "@/utils/asyncStateUtils";
 import useReportError from "@/hooks/useReportError";
 
 // eslint-disable-next-line unicorn/prevent-abbreviations -- Mod is not short for anything
@@ -44,15 +43,13 @@ export const ActiveModListItem: React.FunctionComponent<{
   const marketplaceListingUrl = useMarketplaceUrl(installableItem);
   const requestPermissions = useRequestPermissionsAction(installableItem);
 
-  const state = useAsyncState(
+  const { data: starterBricksContained = [], error } = useAsyncState(
     async () => getContainedStarterBrickNames(installableItem),
     [],
     { initialValue: [] }
   );
 
-  const { data: starterBricksContained } = fallbackValue(state, []);
-
-  useReportError(state.error);
+  useReportError(error);
 
   return (
     <ListGroup.Item className={styles.root}>

--- a/src/sidebar/homePanel/ActiveModListItem.tsx
+++ b/src/sidebar/homePanel/ActiveModListItem.tsx
@@ -33,6 +33,8 @@ import EllipsisMenu from "@/components/ellipsisMenu/EllipsisMenu";
 import useMarketplaceUrl from "@/installables/hooks/useMarketplaceUrl";
 import useRequestPermissionsAction from "@/installables/hooks/useRequestPermissionsAction";
 import cx from "classnames";
+import { fallbackValue } from "@/utils/asyncStateUtils";
+import useReportError from "@/hooks/useReportError";
 
 // eslint-disable-next-line unicorn/prevent-abbreviations -- Mod is not short for anything
 export const ActiveModListItem: React.FunctionComponent<{
@@ -42,17 +44,15 @@ export const ActiveModListItem: React.FunctionComponent<{
   const marketplaceListingUrl = useMarketplaceUrl(installableItem);
   const requestPermissions = useRequestPermissionsAction(installableItem);
 
-  const { data: starterBricksContained, error } = useAsyncState(
+  const state = useAsyncState(
     async () => getContainedStarterBrickNames(installableItem),
     [],
     { initialValue: [] }
   );
 
-  if (error) {
-    // Don't swallow logic errors, but don't crash the UI either
-    // Starter brick information is nice-to-have, but not a must-have
-    console.error(error);
-  }
+  const { data: starterBricksContained, error } = fallbackValue(state, []);
+
+  useReportError(error);
 
   return (
     <ListGroup.Item className={styles.root}>
@@ -71,7 +71,7 @@ export const ActiveModListItem: React.FunctionComponent<{
                   : styles.lineClampTwoLines
               )}
             >
-              {(starterBricksContained ?? []).join(" • ")}
+              {starterBricksContained.join(" • ")}
             </span>
           </div>
           {requestPermissions && (

--- a/src/sidebar/homePanel/ActiveModListItem.tsx
+++ b/src/sidebar/homePanel/ActiveModListItem.tsx
@@ -50,7 +50,7 @@ export const ActiveModListItem: React.FunctionComponent<{
 
   if (error) {
     // Don't swallow logic errors, but don't crash the UI either
-    // Start brick information is nice-to-have, but not a must-have
+    // Starter brick information is nice-to-have, but not a must-have
     console.error(error);
   }
 

--- a/src/sidebar/homePanel/ActiveModListItem.tsx
+++ b/src/sidebar/homePanel/ActiveModListItem.tsx
@@ -50,9 +50,9 @@ export const ActiveModListItem: React.FunctionComponent<{
     { initialValue: [] }
   );
 
-  const { data: starterBricksContained, error } = fallbackValue(state, []);
+  const { data: starterBricksContained } = fallbackValue(state, []);
 
-  useReportError(error);
+  useReportError(state.error);
 
   return (
     <ListGroup.Item className={styles.root}>

--- a/src/sidebar/homePanel/ActiveModListItem.tsx
+++ b/src/sidebar/homePanel/ActiveModListItem.tsx
@@ -42,11 +42,17 @@ export const ActiveModListItem: React.FunctionComponent<{
   const marketplaceListingUrl = useMarketplaceUrl(installableItem);
   const requestPermissions = useRequestPermissionsAction(installableItem);
 
-  const { data: starterBricksContained } = useAsyncState(
+  const { data: starterBricksContained, error } = useAsyncState(
     async () => getContainedStarterBrickNames(installableItem),
     [],
     { initialValue: [] }
   );
+
+  if (error) {
+    // Don't swallow logic errors, but don't crash the UI either
+    // Start brick information is nice-to-have, but not a must-have
+    console.error(error);
+  }
 
   return (
     <ListGroup.Item className={styles.root}>
@@ -65,7 +71,7 @@ export const ActiveModListItem: React.FunctionComponent<{
                   : styles.lineClampTwoLines
               )}
             >
-              {starterBricksContained.join(" • ")}
+              {(starterBricksContained ?? []).join(" • ")}
             </span>
           </div>
           {requestPermissions && (

--- a/src/utils/recipeUtils.test.ts
+++ b/src/utils/recipeUtils.test.ts
@@ -96,4 +96,17 @@ describe("getContainedExtensionPointTypes", () => {
 
     expect(result).toStrictEqual([]);
   });
+
+  test("inner definition not found", async () => {
+    (extensionPointRegistry.lookup as jest.Mock).mockImplementation(() => null);
+
+    const result = await getContainedExtensionPointTypes(
+      recipeFactory({
+        extensionPoints: [extensionPointConfigFactory()],
+        definitions: {},
+      })
+    );
+
+    expect(result).toStrictEqual([]);
+  });
 });

--- a/src/utils/recipeUtils.ts
+++ b/src/utils/recipeUtils.ts
@@ -66,10 +66,10 @@ const getExtensionPointType = async (
   recipe: RecipeDefinition
 ): Promise<ExtensionPointType | null> => {
   // Look up the extension point in recipe inner definitions first
-  if (recipe.definitions) {
+  if (recipe.definitions?.[extensionPoint.id]) {
     const definition: ExtensionPointDefinition = recipe.definitions[
       extensionPoint.id
-    ]?.definition as ExtensionPointDefinition;
+    ].definition as ExtensionPointDefinition;
     const extensionPointType = definition?.type;
 
     if (extensionPointType) {

--- a/src/utils/recipeUtils.ts
+++ b/src/utils/recipeUtils.ts
@@ -63,13 +63,13 @@ export const getRequiredServiceIds = (recipe: RecipeDefinition): RegistryId[] =>
 
 const getExtensionPointType = async (
   extensionPoint: ExtensionDefinition,
-  recipe?: RecipeDefinition
+  recipe: RecipeDefinition
 ): Promise<ExtensionPointType | null> => {
   // Look up the extension point in recipe inner definitions first
   if (recipe.definitions) {
     const definition: ExtensionPointDefinition = recipe.definitions[
       extensionPoint.id
-    ].definition as ExtensionPointDefinition;
+    ]?.definition as ExtensionPointDefinition;
     const extensionPointType = definition?.type;
 
     if (extensionPointType) {


### PR DESCRIPTION
## What does this PR do?

- Fixes #5854
- Fixes NPE for mods that have no inner definition defined for the extension point (i.e. if `definitions = {}`, as opposed to `definitions = undefined`)
- Prevents the UI from crashing if `getContainedStaterBrickNames` (called in the `useAsyncState` hook) throws an error (the starter brick feature is not critical to the UI)

## Reviewer Tips

- Note the test that I added to demonstrate the fix - it will fail if the changes to `getExtensionPointType` are reverted

## Discussion

- See question here in the engineering channel about the proper way to handle logic errors in `useAsyncState` hooks: https://pixiebrix.slack.com/archives/C023KL47XV4/p1685988221732089

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @BLoe 
