### PR TITLE
#5855 bug fix - Add recipeToActivate to the initial-panels logic

### DIFF
--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -57,6 +57,8 @@ export const sidebarShowEvents = new SimpleEventTarget<RunArgs>();
 
 const panels: PanelEntry[] = [];
 
+let recipeToActivate: ActivateRecipePanelEntry = null;
+
 /**
  * Attach the sidebar to the page if it's not already attached. Then re-renders all panels.
  * @param activateOptions options controlling the visible panel in the sidebar
@@ -415,11 +417,13 @@ export function showActivateRecipeInSidebar(
     );
   }
 
-  const sequence = renderSequenceNumber++;
-  void sidebarInThisTab.showActivateRecipe(sequence, {
+  recipeToActivate = {
     type: "activateRecipe",
     ...entry,
-  });
+  };
+
+  const sequence = renderSequenceNumber++;
+  void sidebarInThisTab.showActivateRecipe(sequence, recipeToActivate);
 }
 
 export function hideActivateRecipeInSidebar(recipeId: RegistryId): void {
@@ -439,15 +443,18 @@ export function hideActivateRecipeInSidebar(recipeId: RegistryId): void {
  * - Permanent panels added by sidebarExtension
  * - Temporary panels added by DisplayTemporaryInfo
  * - Temporary form definitions added by ephemeralForm
+ * - Activate Recipe panel added by marketplace.ts activate button click-handlers
  */
 export function getReservedPanelEntries(): {
   panels: PanelEntry[];
   temporaryPanels: TemporaryPanelEntry[];
   forms: FormPanelEntry[];
+  recipeToActivate: ActivateRecipePanelEntry | null;
 } {
   return {
     panels,
     temporaryPanels: getTemporaryPanelSidebarEntries(),
     forms: getFormPanelSidebarEntries(),
+    recipeToActivate,
   };
 }

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -429,6 +429,8 @@ export function showActivateRecipeInSidebar(
 export function hideActivateRecipeInSidebar(recipeId: RegistryId): void {
   expectContext("contentScript");
 
+  recipeToActivate = null;
+
   if (!isSidebarFrameVisible()) {
     return;
   }

--- a/src/sidebar/ConnectedSidebar.tsx
+++ b/src/sidebar/ConnectedSidebar.tsx
@@ -102,9 +102,8 @@ const ConnectedSidebar: React.VFC = () => {
     // Ensure persistent sidebar extension points have been installed to have reserve their panels for the sidebar
     await ensureExtensionPointsInstalled(topFrame);
 
-    const { panels, temporaryPanels, forms } = await getReservedSidebarEntries(
-      topFrame
-    );
+    const { panels, temporaryPanels, forms, recipeToActivate } =
+      await getReservedSidebarEntries(topFrame);
 
     const staticPanels = showHomePanel ? [HOME_PANEL] : [];
 
@@ -114,6 +113,7 @@ const ConnectedSidebar: React.VFC = () => {
       temporaryPanels,
       forms,
       staticPanels,
+      recipeToActivate,
     });
 
     dispatch(
@@ -122,6 +122,7 @@ const ConnectedSidebar: React.VFC = () => {
         temporaryPanels,
         forms,
         staticPanels,
+        recipeToActivate,
       })
     );
 

--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -177,12 +177,14 @@ const sidebarSlice = createSlice({
         panels: PanelEntry[];
         temporaryPanels: TemporaryPanelEntry[];
         forms: FormPanelEntry[];
+        recipeToActivate: ActivateRecipePanelEntry | null;
       }>
     ) {
       state.staticPanels = castDraft(action.payload.staticPanels);
       state.forms = castDraft(action.payload.forms);
       state.panels = castDraft(action.payload.panels);
       state.temporaryPanels = castDraft(action.payload.temporaryPanels);
+      state.recipeToActivate = castDraft(action.payload.recipeToActivate);
       state.activeKey = defaultEventKey(state);
     },
     selectTab(state, action: PayloadAction<string>) {


### PR DESCRIPTION
## What does this PR do?

- Fixes #5855 

## Demo

Note: In order to reproduce the issue, I added a 3 second delay to the initial panel logic in `ConnectedSidebar - useAsyncState`

Before:
https://www.loom.com/share/ce15f1d366a94adeb3c23445e43cdb1c

After:
https://www.loom.com/share/e9511c99b3ca4daaaf5a0b9e8cd7ffba

## Future Work

- The `Entry` types/methods could use a good amount of cleanup work here

## Checklist

- [ ] Add tests - 😢 Still not much coverage for the contentScript <--> sidebar-app stuff, need to think about higher level testing architecture here at some point
- [ ] Designate a primary reviewer
