### PR TITLE
#5792: fix sidebar initialization race by buffering messages during ConnectedSidebar initialization

### DIFF
--- a/src/sidebar/protocol.tsx
+++ b/src/sidebar/protocol.tsx
@@ -26,6 +26,7 @@ import {
 import { type FormDefinition } from "@/blocks/transformers/ephemeralForm/formTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
+import { sortBy } from "lodash";
 
 let lastMessageSeen = -1;
 // Track activate messages separately. The Sidebar App Redux state has special handling for these messages to account
@@ -52,6 +53,14 @@ export type SidebarListener = {
   onHideActivateRecipe: (recipeId: RegistryId) => void;
 };
 
+// Because protocol.tsx accepts webext-messenger messages before the React App and listener initializes, we have to
+// keep track messages sent in the interim. This buffer is flushed once the listener is initialized.
+const messageBuffer: Array<{
+  method: keyof SidebarListener;
+  sequence: number;
+  data: unknown;
+}> = [];
+
 const listeners: SidebarListener[] = [];
 
 export function addListener(fn: SidebarListener): void {
@@ -60,10 +69,37 @@ export function addListener(fn: SidebarListener): void {
   } else {
     listeners.push(fn);
   }
+
+  if (listeners.length === 1) {
+    // First listener was added
+    flushMessageBuffer();
+  }
 }
 
 export function removeListener(fn: SidebarListener): void {
   listeners.splice(0, listeners.length, ...listeners.filter((x) => x !== fn));
+}
+
+/**
+ * Flush the message buffer to the listener and clear the buffer.
+ */
+function flushMessageBuffer(): void {
+  if (listeners.length === 0) {
+    throw new Error("Expected one or more listeners");
+  }
+
+  // `sortBy` to handle case where messages were received out of order
+  const orderedMessageBuffer = sortBy(messageBuffer, "sequence");
+  messageBuffer.splice(0, messageBuffer.length);
+
+  for (const { method, sequence, data } of orderedMessageBuffer) {
+    console.debug("flushMessageBuffer: %s", method, {
+      sequence,
+      data,
+    });
+
+    runListeners(method, sequence, data);
+  }
 }
 
 function runListeners<Method extends keyof SidebarListener>(
@@ -72,6 +108,12 @@ function runListeners<Method extends keyof SidebarListener>(
   data: Parameters<SidebarListener[Method]>[0],
   { force = false }: { force?: boolean } = {}
 ): void {
+  // Buffer messages until the listener is initialized
+  if (listeners.length === 0) {
+    messageBuffer.push({ method, sequence, data });
+    return;
+  }
+
   if (sequence < lastMessageSeen && !force) {
     console.debug(
       "Skipping stale message (seq: %d, current: %d)",
@@ -82,7 +124,7 @@ function runListeners<Method extends keyof SidebarListener>(
     return;
   }
 
-  // Use Match.max to account for unordered messages with force
+  // Use Math.max to account for unordered messages with force
   lastMessageSeen = Math.max(sequence, lastMessageSeen);
 
   console.debug(`Running ${listeners.length} listener(s) for %s`, method, {

--- a/src/sidebar/protocol.tsx
+++ b/src/sidebar/protocol.tsx
@@ -63,12 +63,21 @@ const messageBuffer: Array<{
 
 const listeners: SidebarListener[] = [];
 
-export function addListener(fn: SidebarListener): void {
-  if (listeners.includes(fn)) {
+/**
+ * Add a listener.
+ *
+ * If this is only listener, any buffered messages from webext-messenger will be flushed to the listener. This is to
+ * account for races between webext-messenger and React App initialization.
+ *
+ * @param listener the listener to add
+ */
+export function addListener(listener: SidebarListener): void {
+  if (listeners.includes(listener)) {
     console.warn("Listener already registered for sidebar");
-  } else {
-    listeners.push(fn);
+    return;
   }
+
+  listeners.push(listener);
 
   if (listeners.length === 1) {
     // First listener was added
@@ -76,8 +85,12 @@ export function addListener(fn: SidebarListener): void {
   }
 }
 
-export function removeListener(fn: SidebarListener): void {
-  listeners.splice(0, listeners.length, ...listeners.filter((x) => x !== fn));
+export function removeListener(listener: SidebarListener): void {
+  listeners.splice(
+    0,
+    listeners.length,
+    ...listeners.filter((x) => x !== listener)
+  );
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Part of #5792 
- Follow up to https://github.com/pixiebrix/pixiebrix-extension/pull/5847
- Adds a buffer to protocol.tsx to ensure no messages are dropped during ConnectedSidebar initialization

## Discussion

- Manually QA'd by adding a 4-second sleep in ConnectedSidebar before registering the listener
- This might make https://github.com/pixiebrix/pixiebrix-extension/pull/5863/files unnecessary, because showSidebarActivationForRecipe calls ensureSidebar before calling showActivateRecipeInSidebar (to ensure webext-messenger is listening), so the message will be in the message buffer that's flushed to the react app
  - It's probably still a good idea to merge https://github.com/pixiebrix/pixiebrix-extension/pull/5863/files so the panel is reserved though

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @BLoe 
