### PR TITLE
#5874: add support for JSON5 and lenient JSON parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "js-cookie": "^3.0.0",
         "js-yaml": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
+        "json5": "^2.2.3",
         "jsonpath-plus": "^7.0.0",
         "kbar": "^0.1.0-beta.40",
         "lodash-es": "^4.17.21",
@@ -27574,7 +27575,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -58175,8 +58175,7 @@
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonc-parser": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "js-cookie": "^3.0.0",
     "js-yaml": "^4.1.0",
     "json-stringify-safe": "^5.0.1",
+    "json5": "^2.2.3",
     "jsonpath-plus": "^7.0.0",
     "kbar": "^0.1.0-beta.40",
     "lodash-es": "^4.17.21",

--- a/src/blocks/transformers/ParseJson.ts
+++ b/src/blocks/transformers/ParseJson.ts
@@ -25,6 +25,7 @@ import { sortBy } from "lodash";
 
 function extractJsonString(content: string): string {
   // https://regex101.com/library/sjOfeq?orderBy=MOST_POINTS&page=3&search=json
+  // https://stackoverflow.com/a/63660736
   const objectRegex = /{(?:[^{}]|())*}/g;
   const arrayRegex = /\[(?:[^[\]]|())*]/g;
 

--- a/src/blocks/transformers/ParseJson.ts
+++ b/src/blocks/transformers/ParseJson.ts
@@ -26,8 +26,8 @@ import { sortBy } from "lodash";
 function extractJsonString(content: string): string {
   // https://regex101.com/library/sjOfeq?orderBy=MOST_POINTS&page=3&search=json
   // https://stackoverflow.com/a/63660736
-  const objectRegex = /{(?:[^{}]|())*}/g;
-  const arrayRegex = /\[(?:[^[\]]|())*]/g;
+  const objectRegex = /{.*}/g;
+  const arrayRegex = /\[.*]/g;
 
   const objectMatches = [...content.matchAll(objectRegex)];
   const arrayMatches = [...content.matchAll(arrayRegex)];

--- a/src/blocks/transformers/ParseJson.ts
+++ b/src/blocks/transformers/ParseJson.ts
@@ -21,13 +21,74 @@ import { type Schema } from "@/types/schemaTypes";
 import { propertiesToSchema } from "@/validators/generic";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { BusinessError } from "@/errors/businessErrors";
+import { sortBy } from "lodash";
+
+function extractJsonString(content: string): string {
+  // https://regex101.com/library/sjOfeq?orderBy=MOST_POINTS&page=3&search=json
+  const objectRegex = /{(?:[^{}]|())*}/g;
+  const arrayRegex = /\[(?:[^[\]]|())*]/g;
+
+  const objectMatches = [...content.matchAll(objectRegex)];
+  const arrayMatches = [...content.matchAll(arrayRegex)];
+
+  const sorted = sortBy(
+    [...objectMatches, ...arrayMatches].flatMap((x) => x[0]),
+    (x) => -x.length
+  );
+
+  if (sorted.length === 0) {
+    throw new Error("No JSON object or array found");
+  }
+
+  return sorted[0];
+}
+
+function lenientParserFactory(rootParse: typeof JSON.parse): typeof JSON.parse {
+  function parse(content: string): unknown {
+    try {
+      return rootParse(content);
+    } catch (error) {
+      const extracted = extractJsonString(content);
+      if (extracted !== content) {
+        return parse(extracted);
+      }
+
+      throw error;
+    }
+  }
+
+  return parse;
+}
+
+async function getParser({
+  allowJson5,
+  lenient,
+}: {
+  allowJson5: boolean;
+  lenient: boolean;
+}) {
+  if (!allowJson5 && !lenient) {
+    return JSON.parse;
+  }
+
+  const { default: JSON5 } = await import(
+    /* webpackChunkName: "json5" */ "json5"
+  );
+
+  if (!lenient) {
+    return JSON5.parse;
+  }
+
+  // Lenient implies allowJson5
+  return lenientParserFactory(JSON5.parse);
+}
 
 class ParseJson extends Transformer {
   constructor() {
     super(
       "@pixiebrix/parse/json",
       "Parse JSON",
-      "Parse a JSON string",
+      "Parse a JSON string, with JSON5 support",
       "faCode"
     );
   }
@@ -36,16 +97,43 @@ class ParseJson extends Transformer {
     return true;
   }
 
-  inputSchema: Schema = propertiesToSchema({
-    content: {
-      type: "string",
-      description: "The JSON content",
+  inputSchema: Schema = propertiesToSchema(
+    {
+      content: {
+        title: "Content",
+        type: "string",
+        description: "The JSON content",
+      },
+      allowJson5: {
+        title: "Allow JSON5",
+        type: "boolean",
+        description: "Allow JSON5 syntax (default=true)",
+        default: true,
+      },
+      lenient: {
+        title: "Lenient",
+        type: "boolean",
+        description:
+          "Attempt to recover from malformed JSON, e.g., leading/trailing text. Implies Allow JSON5 (default=false)",
+        default: false,
+      },
     },
-  });
+    ["content"]
+  );
 
-  async transform({ content }: BlockArgs): Promise<unknown> {
+  async transform({
+    content,
+    allowJson5 = true,
+    lenient = false,
+  }: BlockArgs<{
+    content: string;
+    allowJson5?: boolean;
+    lenient?: boolean;
+  }>): Promise<unknown> {
+    const parse = await getParser({ allowJson5, lenient });
+
     try {
-      return JSON.parse(content);
+      return parse(content);
     } catch (error) {
       throw new BusinessError(`Error parsing JSON: ${getErrorMessage(error)}`);
     }

--- a/src/blocks/transformers/parseJson.test.ts
+++ b/src/blocks/transformers/parseJson.test.ts
@@ -125,25 +125,23 @@ describe("ParseJson block", () => {
     });
   });
 
-  test("Lenient returns longest", async () => {
+  test("Errors on multiple peer objects", async () => {
     const brick = new ParseJson();
-    const result = await brick.run(
-      unsafeAssumeValidArg({
-        lenient: true,
-        content: 'abc {"foo": 42} {"bar": 421}',
-      }),
-      {
-        ctxt: null,
-        logger: null,
-        root: null,
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
-    );
-
-    expect(result).toEqual({
-      bar: 421,
-    });
+    await expect(async () => {
+      await brick.run(
+        unsafeAssumeValidArg({
+          lenient: true,
+          content: 'abc {"foo": 42} {"bar": 421}',
+        }),
+        {
+          ctxt: null,
+          logger: null,
+          root: null,
+          runPipeline: neverPromise,
+          runRendererPipeline: neverPromise,
+        }
+      );
+    }).rejects.toThrow(BusinessError);
   });
 
   test("Lenient returns array", async () => {
@@ -164,6 +162,30 @@ describe("ParseJson block", () => {
 
     expect(result).toEqual([
       { foo: 42 },
+      {
+        bar: 421,
+      },
+    ]);
+  });
+
+  test("Lenient handles nested array", async () => {
+    const brick = new ParseJson();
+    const result = await brick.run(
+      unsafeAssumeValidArg({
+        lenient: true,
+        content: 'abc [[{"foo": 42}], {"bar": 421}] def',
+      }),
+      {
+        ctxt: null,
+        logger: null,
+        root: null,
+        runPipeline: neverPromise,
+        runRendererPipeline: neverPromise,
+      }
+    );
+
+    expect(result).toEqual([
+      [{ foo: 42 }],
       {
         bar: 421,
       },


### PR DESCRIPTION
## What does this PR do?

- Closes #5874 
- Add JSON5 parsing support
- Add support for lenient JSON parsing. Currently handles extra text around the JSON array/object. (Sometimes LLMs return extra characters to explain their JSON output)

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/923ca7c9-107b-4838-a589-468ada2a0bc7)

## Future Work

- Add smarter lenient parsing handling, e.g., try to find the maximal valid JSON object/array

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
