### PR TITLE
#3914: google sheets file picker widget error handling and telemetry

### DIFF
--- a/src/contrib/google/initGoogle.ts
+++ b/src/contrib/google/initGoogle.ts
@@ -158,7 +158,14 @@ export function subscribe(listener: Listener): () => void {
   };
 }
 
-// `pMemoize` will avoid multiple injections, while also allow retrying if the first injection fails
+/**
+ * Initialize the Google API.
+ *
+ * Memoized to avoid multiple injections, while also allow retrying if the initial injection fails or the context
+ * is later invalidated.
+ *
+ * @see markGoogleInvalidated
+ */
 const initGoogle = pMemoize(_initGoogle);
 
 export default initGoogle;

--- a/src/contrib/google/sheets/RequireGoogleApi.tsx
+++ b/src/contrib/google/sheets/RequireGoogleApi.tsx
@@ -51,7 +51,7 @@ export const RequireGoogleApi: React.FC = ({ children }) => {
         $browser: detectBrowser(navigator.userAgent, navigator.vendor),
       });
     } else if (!isInitialized) {
-      reportEvent("UninitializedGAPIBrowserGateView", {
+      reportEvent("UninitializedGAPIGateView", {
         $browser: detectBrowser(navigator.userAgent, navigator.vendor),
       });
     }

--- a/src/contrib/google/sheets/RequireGoogleApi.tsx
+++ b/src/contrib/google/sheets/RequireGoogleApi.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { useEffect } from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim";
 import initGoogle, {
   subscribe,
@@ -24,6 +24,8 @@ import initGoogle, {
 } from "@/contrib/google/initGoogle";
 import AsyncButton from "@/components/AsyncButton";
 import useUserAction from "@/hooks/useUserAction";
+import { reportEvent } from "@/telemetry/events";
+import { detectBrowser } from "@/vendors/mixpanel";
 
 /**
  * Wrapper component to require that the Google API is initialized before rendering its children.
@@ -32,6 +34,7 @@ import useUserAction from "@/hooks/useUserAction";
  */
 export const RequireGoogleApi: React.FC = ({ children }) => {
   const isInitialized = useSyncExternalStore(subscribe, isGoogleInitialized);
+  const isSupported = isGAPISupported();
 
   const initGoogleAction = useUserAction(
     initGoogle,
@@ -41,7 +44,20 @@ export const RequireGoogleApi: React.FC = ({ children }) => {
     []
   );
 
-  if (!isGAPISupported()) {
+  // Report to help provide customer support
+  useEffect(() => {
+    if (!isSupported) {
+      reportEvent("UnsupportedBrowserGateView", {
+        $browser: detectBrowser(navigator.userAgent, navigator.vendor),
+      });
+    } else if (!isInitialized) {
+      reportEvent("UninitializedGAPIBrowserGateView", {
+        $browser: detectBrowser(navigator.userAgent, navigator.vendor),
+      });
+    }
+  }, [isSupported, isInitialized]);
+
+  if (!isSupported) {
     return (
       <div>
         The Google API is not supported in this browser. Please use Google

--- a/src/contrib/google/sheets/SheetsFileWidget.test.tsx
+++ b/src/contrib/google/sheets/SheetsFileWidget.test.tsx
@@ -27,7 +27,10 @@ import { type OutputKey } from "@/types/runtimeTypes";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { blockConfigFactory } from "@/testUtils/factories/blockFactories";
-import { isGoogleInitialized } from "@/contrib/google/initGoogle";
+import {
+  isGAPISupported,
+  isGoogleInitialized,
+} from "@/contrib/google/initGoogle";
 import userEvent from "@testing-library/user-event";
 import useGoogleSpreadsheetPicker from "@/contrib/google/sheets/useGoogleSpreadsheetPicker";
 import { act, screen } from "@testing-library/react";
@@ -59,11 +62,13 @@ jest.mock("@/background/messenger/api", () => ({
 const useGoogleSpreadsheetPickerMock = jest.mocked(useGoogleSpreadsheetPicker);
 const getSheetPropertiesMock = jest.mocked(sheets.getSheetProperties);
 const isGoogleInitializedMock = jest.mocked(isGoogleInitialized);
+const isGAPISupportedMock = jest.mocked(isGAPISupported);
 
 describe("SheetsFileWidget", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     isGoogleInitializedMock.mockReturnValue(true);
+    isGAPISupportedMock.mockReturnValue(true);
   });
 
   it("smoke test", async () => {
@@ -79,7 +84,7 @@ describe("SheetsFileWidget", () => {
     expect(rendered.asFragment()).toMatchSnapshot();
   });
 
-  it("required gapi", async () => {
+  it("requires gapi", async () => {
     isGoogleInitializedMock.mockReturnValue(false);
 
     render(
@@ -98,10 +103,34 @@ describe("SheetsFileWidget", () => {
     ).toBeVisible();
   });
 
+  it("requires gapi support", async () => {
+    isGAPISupportedMock.mockReturnValue(false);
+
+    render(
+      <SheetsFileWidget name="spreadsheetId" schema={BASE_SHEET_SCHEMA} />,
+      {
+        initialValues: { spreadsheetId: null },
+      }
+    );
+
+    await waitForEffect();
+
+    // Text provided by the requireGoogleHOC
+    expect(
+      screen.getByText(
+        "The Google API is not supported in this browser. Please use Google Chrome."
+      )
+    ).toBeVisible();
+  });
+
   it("selects from file picker", async () => {
     const showPickerMock = jest.fn().mockResolvedValue({
       id: "abc123",
       name: "Test Sheet",
+    });
+
+    getSheetPropertiesMock.mockResolvedValue({
+      title: "Test Sheet",
     });
 
     useGoogleSpreadsheetPickerMock.mockReturnValue({
@@ -122,6 +151,9 @@ describe("SheetsFileWidget", () => {
     await act(async () => {
       await userEvent.click(screen.getByText("Select"));
     });
+
+    // Verify the widget fetches the information for the selected sheet to re-verify access to the sheet via the API
+    expect(getSheetPropertiesMock).toHaveBeenCalledOnce();
 
     expect(rendered.asFragment()).toMatchSnapshot();
   });
@@ -177,6 +209,10 @@ describe("SheetsFileWidget", () => {
   });
 
   it("removes unused service on mount", async () => {
+    getSheetPropertiesMock.mockResolvedValue({
+      title: "Test Sheet",
+    });
+
     const initialValues = formStateFactory(
       {
         services: [

--- a/src/contrib/google/sheets/__snapshots__/SheetsFileWidget.test.tsx.snap
+++ b/src/contrib/google/sheets/__snapshots__/SheetsFileWidget.test.tsx.snap
@@ -12,9 +12,8 @@ exports[`SheetsFileWidget selects from file picker 1`] = `
         class="form-control"
         disabled=""
         id="spreadsheetId"
-        name="spreadsheetId"
         type="text"
-        value="abc123"
+        value="Test Sheet"
       />
       <div
         class="input-group-append"

--- a/src/contrib/google/sheets/useGoogleSpreadsheetPicker.ts
+++ b/src/contrib/google/sheets/useGoogleSpreadsheetPicker.ts
@@ -96,10 +96,10 @@ function useGoogleSpreadsheetPicker(): {
       throw new Error("Internal error: Google API key is not configured");
     }
 
-    reportEvent("SelectGoogleSpreadsheetEnsureToken");
+    reportEvent("SelectGoogleSpreadsheetEnsureTokenStart");
     const token = await ensureSheetsToken();
 
-    reportEvent("SelectGoogleSpreadsheetLoadLibary");
+    reportEvent("SelectGoogleSpreadsheetLoadLibraryStart");
     await new Promise((resolve, reject) => {
       // https://github.com/google/google-api-javascript-client/blob/master/docs/reference.md#----gapiloadlibraries-callbackorconfig------
       gapi.load("picker", {
@@ -119,7 +119,7 @@ function useGoogleSpreadsheetPicker(): {
 
     const deferredPromise = pDefer<Doc>();
 
-    reportEvent("SelectGoogleSpreadsheetShowPicker");
+    reportEvent("SelectGoogleSpreadsheetShowPickerStart");
     const picker = new google.picker.PickerBuilder()
       .enableFeature(google.picker.Feature.NAV_HIDDEN)
       .setTitle("Select Spreadsheet")

--- a/src/contrib/google/sheets/useGoogleSpreadsheetPicker.ts
+++ b/src/contrib/google/sheets/useGoogleSpreadsheetPicker.ts
@@ -50,6 +50,7 @@ function useGoogleSpreadsheetPicker(): {
   hasRejectedPermissions: boolean;
 } {
   const pickerOrigin = useCurrentOrigin();
+
   const [hasRejectedPermissions, setHasRejectedPermissions] =
     useState<boolean>(false);
 
@@ -95,8 +96,10 @@ function useGoogleSpreadsheetPicker(): {
       throw new Error("Internal error: Google API key is not configured");
     }
 
+    reportEvent("SelectGoogleSpreadsheetEnsureToken");
     const token = await ensureSheetsToken();
 
+    reportEvent("SelectGoogleSpreadsheetLoadLibary");
     await new Promise((resolve, reject) => {
       // https://github.com/google/google-api-javascript-client/blob/master/docs/reference.md#----gapiloadlibraries-callbackorconfig------
       gapi.load("picker", {
@@ -116,6 +119,7 @@ function useGoogleSpreadsheetPicker(): {
 
     const deferredPromise = pDefer<Doc>();
 
+    reportEvent("SelectGoogleSpreadsheetShowPicker");
     const picker = new google.picker.PickerBuilder()
       .enableFeature(google.picker.Feature.NAV_HIDDEN)
       .setTitle("Select Spreadsheet")
@@ -146,6 +150,7 @@ function useGoogleSpreadsheetPicker(): {
           reportEvent("SelectGoogleSpreadsheetPicked");
           deferredPromise.resolve(doc);
         } else if (data.action === google.picker.Action.CANCEL) {
+          reportEvent("SelectGoogleSpreadsheetCancelled");
           deferredPromise.reject(new CancelError("No spreadsheet selected"));
         }
       })


### PR DESCRIPTION
## What does this PR do?

- Part of #3914 
- `SheetsFileWidget`:  (main functional changes)
  - Add picker failure error state with retry
  - On selection, fetch the sheet metadata via API to verify access
  - Refactor to use useAsyncState
- `RequireGoogleApi`: adds telemetry events
  - `UnsupportedBrowserGateView`
  - `UninitializedGAPIGateView`
- `useGoogleSpreadsheetPicker` add event to help with remote customer support
  - Add `SelectGoogleSpreadsheetEnsureTokenStart`
  - Add `SelectGoogleSpreadsheetLoadLibraryStart`
  - Add `SelectGoogleSpreadsheetShowPickerStart`
  - Add `SelectGoogleSpreadsheetCancelled`

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
