### PR TITLE
#5906: side panel lifecycle logging and pre/post-condition checks

### DIFF
--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -85,6 +85,12 @@ export async function showSidebar(
 
     // Currently, this runs the listening SidebarExtensionPoint.run callbacks in not particular order. Also note that
     // we're not awaiting their resolution (because they may contain long-running bricks).
+    if (!isSidebarFrameVisible()) {
+      console.warn(
+        "Pre-condition failed: sidebar is not attached in the page for call to sidebarShowEvents.emit"
+      );
+    }
+
     sidebarShowEvents.emit({ reason: RunReason.MANUAL });
   }
 

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -86,7 +86,7 @@ export async function showSidebar(
     // Currently, this runs the listening SidebarExtensionPoint.run callbacks in not particular order. Also note that
     // we're not awaiting their resolution (because they may contain long-running bricks).
     if (!isSidebarFrameVisible()) {
-      console.warn(
+      console.error(
         "Pre-condition failed: sidebar is not attached in the page for call to sidebarShowEvents.emit"
       );
     }

--- a/src/contentScript/sidebarDomControllerLite.ts
+++ b/src/contentScript/sidebarDomControllerLite.ts
@@ -22,11 +22,13 @@
 
 import { MAX_Z_INDEX, PANEL_FRAME_ID } from "@/common";
 import shadowWrap from "@/utils/shadowWrap";
+import { expectContext } from "@/utils/expectContext";
 
 export const SIDEBAR_WIDTH_CSS_PROPERTY = "--pb-sidebar-width";
 const ORIGINAL_MARGIN_CSS_PROPERTY = "--pb-original-margin-right";
 
-const html: HTMLElement = globalThis.document.documentElement;
+// Use ? because it's not defined during header generation. But otherwise it will always be defined.
+const html: HTMLElement = globalThis.document?.documentElement;
 const SIDEBAR_WIDTH_PX = 400;
 
 function storeOriginalCSSOnce() {
@@ -55,6 +57,8 @@ function setSidebarWidth(pixels: number): void {
  * Returns the sidebar frame if it's in the DOM, or null otherwise. The sidebar might not be initialized yet.
  */
 function getSidebar(): Element | null {
+  expectContext("contentScript");
+
   return html.querySelector(`#${PANEL_FRAME_ID}`);
 }
 

--- a/src/contentScript/sidebarDomControllerLite.ts
+++ b/src/contentScript/sidebarDomControllerLite.ts
@@ -26,7 +26,7 @@ import shadowWrap from "@/utils/shadowWrap";
 export const SIDEBAR_WIDTH_CSS_PROPERTY = "--pb-sidebar-width";
 const ORIGINAL_MARGIN_CSS_PROPERTY = "--pb-original-margin-right";
 
-const html = globalThis.document?.documentElement;
+const html: HTMLElement = globalThis.document.documentElement;
 const SIDEBAR_WIDTH_PX = 400;
 
 function storeOriginalCSSOnce() {
@@ -51,16 +51,26 @@ function setSidebarWidth(pixels: number): void {
   html.style.setProperty(SIDEBAR_WIDTH_CSS_PROPERTY, CSS.px(pixels));
 }
 
-const getSidebar = (): Element => document.querySelector(`#${PANEL_FRAME_ID}`);
+/**
+ * Returns the sidebar frame if it's in the DOM, or null otherwise. The sidebar might not be initialized yet.
+ */
+function getSidebar(): Element | null {
+  return html.querySelector(`#${PANEL_FRAME_ID}`);
+}
 
 /**
  * Return true if the sidebar frame is in the DOM. The sidebar might not be initialized yet.
  */
-export const isSidebarFrameVisible = (): boolean => Boolean(getSidebar());
+export function isSidebarFrameVisible(): boolean {
+  return Boolean(getSidebar());
+}
 
 /** Removes the element; Returns false if no element was found */
 export function removeSidebarFrame(): boolean {
   const sidebar = getSidebar();
+
+  console.debug("removeSidebarFrame: sidebar exists", Boolean(sidebar));
+
   if (sidebar) {
     sidebar.remove();
     setSidebarWidth(0);
@@ -72,6 +82,7 @@ export function removeSidebarFrame(): boolean {
 /** Inserts the element; Returns false if it already existed */
 export function insertSidebarFrame(): boolean {
   if (isSidebarFrameVisible()) {
+    console.debug("insertSidebarFrame: sidebar frame already exists");
     return false;
   }
 
@@ -110,9 +121,18 @@ export function insertSidebarFrame(): boolean {
     easing: "cubic-bezier(0.23, 1, 0.32, 1)",
   });
 
+  if (!isSidebarFrameVisible()) {
+    console.error(
+      "Post-condition failed: isSidebarFrameVisible is false after insertSidebarFrame"
+    );
+  }
+
   return true;
 }
 
+/**
+ * Toggle the sidebar frame. Returns true if the sidebar is now visible, false otherwise.
+ */
 export function toggleSidebarFrame(): boolean {
   if (isSidebarFrameVisible()) {
     removeSidebarFrame();

--- a/src/extensionPoints/sidebarExtension.ts
+++ b/src/extensionPoints/sidebarExtension.ts
@@ -320,7 +320,7 @@ export abstract class SidebarExtensionPoint extends ExtensionPoint<SidebarConfig
     });
   }
 
-  // Use arrow syntax to avoid having to bind when passing as listener
+  // Use arrow syntax to avoid having to bind when passing as listener to `sidebarShowEvents.add`
   run = async ({ reason }: RunArgs): Promise<void> => {
     if (!(await this.isAvailable())) {
       // Keep sidebar entries up-to-date regardless of trigger policy


### PR DESCRIPTION
## What does this PR do?

- Part of #5906 
- Try some shot-in-the-dark changes to getSidebar and isSidebarFrameVisible:
   - Use `globalThis.document.documentElement` for the querySelect
   - Use function form for isSidebarFrameVisible
- Adds logging and pre-condition checks to try to identify what's causing the condition where `isSidebarFrameVisible` is somehow false when the sidebar is run after the ConnectedSidebarApp initializes

## Discussion

- Will cut an alpha/beta build with this PR to try to reproduce and then see the sequence/where the invariant became violated. I haven't been able to reproduce the problem on dev as frequently

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @BLoe 
