### PR TITLE
5888 Add hide option for the FAB, update FAB styles

### DIFF
--- a/src/components/floatingActions/FloatingActions.scss
+++ b/src/components/floatingActions/FloatingActions.scss
@@ -33,6 +33,8 @@
   }
 
   .hide-button {
+    // Explicit font size since bootstrap uses REM sizes that get overriden by parent page
+    font-size: 16px;
     padding: 2px 6px;
     border-radius: 8px;
     background-color: $N0;

--- a/src/components/floatingActions/FloatingActions.scss
+++ b/src/components/floatingActions/FloatingActions.scss
@@ -23,23 +23,49 @@
   left: 40px;
 }
 
-.button {
-  padding: 0;
-  border: none;
-  overflow: hidden;
-  box-shadow: 0px 4px 4px rgba(56, 51, 66, 0.12);
-  background-color: $P500;
-  &:hover,
-  &:focus {
-    background-color: $P600 !important;
+.quickbar-button-container {
+  display: flex;
+  flex-direction: column;
+  .hide-button-container {
+    max-height: 0;
+    transition: max-height 0.5s ease-in-out;
+    overflow: hidden;
   }
 
-  &:active {
-    background-color: $P900 !important;
+  .hide-button {
+    padding: 2px 6px;
+    border-radius: 8px;
+    background-color: $N0;
+    margin: 10px 0;
+    border: 1px solid $N50;
+    box-shadow: 0px 4px 8px -4px rgba(56, 51, 66, 0.16);
+    font-weight: 700;
+    color: $N400;
   }
 
-  &:focus {
-    box-shadow: none !important;
+  &:hover > .hide-button-container {
+    max-height: 200px;
+  }
+
+  .quickbar-button {
+    padding: 7px;
+    border: none;
+    overflow: hidden;
+    box-shadow: 0px 4px 4px rgba(56, 51, 66, 0.12);
+    background-color: $P500;
+    border-radius: 12px;
+    &:hover,
+    &:focus {
+      background-color: $P600 !important;
+    }
+
+    &:active {
+      background-color: $P900 !important;
+    }
+
+    &:focus {
+      box-shadow: none !important;
+    }
   }
 }
 

--- a/src/components/floatingActions/QuickbarButton.tsx
+++ b/src/components/floatingActions/QuickbarButton.tsx
@@ -15,29 +15,62 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { useState } from "react";
 import logoUrl from "@/icons/custom-icons/logo.svg";
 import { Button } from "react-bootstrap";
 import { toggleQuickBar } from "@/components/quickBar/QuickBarApp";
 import { reportEvent } from "@/telemetry/events";
+import AsyncButton from "@/components/AsyncButton";
+import { getSettingsState, saveSettingsState } from "@/store/settingsStorage";
 
 /**
  * Opens the quickbar menu
  */
 export function QuickbarButton() {
-  return (
+  // Using this boolean to hide the FAB since the setting state doesn't refresh immediately
+  const [hidden, setHidden] = useState<boolean>(false);
+
+  return hidden ? null : (
     // Using standard css here because the shadow dom in `FloatingActions.tsx`
     // prevents us from using regular css modules.
-    <Button
-      className="button"
-      onClick={() => {
-        reportEvent("FloatingQuickBarButtonClick");
-        toggleQuickBar();
-      }}
-    >
-      {/* <img> tag since we're using a different svg than the <Logo> component and it overrides all the styles
+    <div className="quickbar-button-container">
+      <div className="hide-button-container">
+        <AsyncButton
+          className="hide-button"
+          onClick={async () => {
+            try {
+              setHidden(true);
+              const settings = await getSettingsState();
+              await saveSettingsState({
+                ...settings,
+                isFloatingActionButtonEnabled: false,
+              });
+            } catch {
+              setHidden(false);
+            }
+          }}
+          variant="outline"
+        >
+          Hide Button
+        </AsyncButton>
+      </div>
+      <div>
+        <Button
+          className="quickbar-button"
+          onClick={() => {
+            reportEvent("FloatingQuickBarButtonClick");
+            toggleQuickBar();
+          }}
+        >
+          {/* <img> tag since we're using a different svg than the <Logo> component and it overrides all the styles
               anyway */}
-      <img src={logoUrl} className="logo" alt="open the PixieBrix quick bar" />
-    </Button>
+          <img
+            src={logoUrl}
+            className="logo"
+            alt="open the PixieBrix quick bar"
+          />
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/src/components/floatingActions/QuickbarButton.tsx
+++ b/src/components/floatingActions/QuickbarButton.tsx
@@ -22,7 +22,6 @@ import { toggleQuickBar } from "@/components/quickBar/QuickBarApp";
 import { reportEvent } from "@/telemetry/events";
 import AsyncButton from "@/components/AsyncButton";
 import { getSettingsState, saveSettingsState } from "@/store/settingsStorage";
-import reportError from "@/telemetry/reportError";
 import notify from "@/utils/notify";
 
 /**
@@ -49,8 +48,7 @@ export function QuickbarButton() {
               });
               reportEvent("FloatingQuickBarButtonOnScreenHide");
             } catch (error) {
-              notify.error("Error saving settings");
-              reportError(error);
+              notify.error({ message: "Error saving settings", error });
               setHidden(false);
             }
           }}

--- a/src/components/floatingActions/QuickbarButton.tsx
+++ b/src/components/floatingActions/QuickbarButton.tsx
@@ -22,6 +22,8 @@ import { toggleQuickBar } from "@/components/quickBar/QuickBarApp";
 import { reportEvent } from "@/telemetry/events";
 import AsyncButton from "@/components/AsyncButton";
 import { getSettingsState, saveSettingsState } from "@/store/settingsStorage";
+import reportError from "@/telemetry/reportError";
+import notify from "@/utils/notify";
 
 /**
  * Opens the quickbar menu
@@ -46,7 +48,9 @@ export function QuickbarButton() {
                 isFloatingActionButtonEnabled: false,
               });
               reportEvent("OnScreenHideFloatingQuickBarButton");
-            } catch {
+            } catch (error) {
+              notify.error("Error saving settings");
+              reportError(error);
               setHidden(false);
             }
           }}

--- a/src/components/floatingActions/QuickbarButton.tsx
+++ b/src/components/floatingActions/QuickbarButton.tsx
@@ -45,6 +45,7 @@ export function QuickbarButton() {
                 ...settings,
                 isFloatingActionButtonEnabled: false,
               });
+              reportEvent("OnScreenHideFloatingQuickBarButton");
             } catch {
               setHidden(false);
             }

--- a/src/components/floatingActions/QuickbarButton.tsx
+++ b/src/components/floatingActions/QuickbarButton.tsx
@@ -47,7 +47,7 @@ export function QuickbarButton() {
                 ...settings,
                 isFloatingActionButtonEnabled: false,
               });
-              reportEvent("OnScreenHideFloatingQuickBarButton");
+              reportEvent("FloatingQuickBarButtonOnScreenHide");
             } catch (error) {
               notify.error("Error saving settings");
               reportError(error);


### PR DESCRIPTION
## What does this PR do?

- Part of #5888
- Adds hide button to disable the floating action button
- Updates CSS for the FAB to reflect @BrandonPxBx s feedback
- Does not include the modal with information. That will come after the repositioning slice
- Telemetry for the FAB hide button use

## Demo

Before:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/b8dfb1a0-80b6-416b-8420-6dfa428403f6)

After:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/b9a78a16-fff1-4eec-bd68-d1babaf4ab11)

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/eeccccde-6090-4583-8d4a-95512849f46d)

[Loom](https://www.loom.com/share/22288438d9084b67a52f997947d9d5ca?sid=aed8b263-96fb-4c93-ba42-6d54aab21df9) 

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer: @grahamlangford 
