### PR TITLE
#5933: fix access before initialization in sidebarSlice.addForms

### DIFF
--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -197,13 +197,13 @@ const sidebarSlice = createSlice({
       state.pendingActivePanel = null;
     },
     addForm(state, action: PayloadAction<{ form: FormPanelEntry }>) {
+      const { form } = action.payload;
+
       if (state.forms.some((x) => x.nonce === form.nonce)) {
         // Panel is already in the sidebar, do nothing as form definitions can't be updated. (There's no placeholder
         // loading state for forms.)
         return;
       }
-
-      const { form } = action.payload;
 
       const [thisExtensionForms, otherForms] = partition(
         state.forms,


### PR DESCRIPTION
## What does this PR do?

- Closes #5933 
- Fix access before initialization in sidebarSlice

## Discussion

- Not sure why Typescript or Eslint wouldn't have caught this
- Sidebar forms still work without this. I didn't dig much into how they were working

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
