### PR TITLE
#5906: await sidebarDomControllerLite.ts load

### DIFF
--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -194,7 +194,6 @@ export async function reloadSidebar(): Promise<void> {
  * - `browserAction` calls toggleSidebarFrame to immediately adds the sidebar iframe
  * - It injects the content script
  * - It calls this method via messenger to complete the sidebar initialization
- * but the content
  */
 export function rehydrateSidebar(): void {
   // To assist with debugging race conditions in sidebar initialization

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -20,7 +20,7 @@ import { reportEvent } from "@/telemetry/events";
 import { expectContext } from "@/utils/expectContext";
 import sidebarInThisTab from "@/sidebar/messenger/api";
 import { isEmpty } from "lodash";
-import { logPromiseDuration } from "@/utils";
+import { logPromiseDuration, waitAnimationFrame } from "@/utils";
 import { SimpleEventTarget } from "@/utils/SimpleEventTarget";
 import {
   insertSidebarFrame,
@@ -195,7 +195,12 @@ export async function reloadSidebar(): Promise<void> {
  * - It injects the content script
  * - It calls this method via messenger to complete the sidebar initialization
  */
-export function rehydrateSidebar(): void {
+export async function rehydrateSidebar(): Promise<void> {
+  // Ensure DOM state is ready for accurate call to isSidebarFrameVisible. Shouldn't strictly be necessary, but
+  // giving it a try and shouldn't impact performance. The background page has limited ability to determine when it's
+  // OK to call rehydrateSidebar via messenger. See background/browserAction.ts.
+  await waitAnimationFrame();
+
   // To assist with debugging race conditions in sidebar initialization
   console.debug("sidebarController:rehydrateSidebar", {
     isSidebarFrameVisible: isSidebarFrameVisible(),

--- a/src/contentScript/sidebarDomControllerLite.ts
+++ b/src/contentScript/sidebarDomControllerLite.ts
@@ -73,7 +73,7 @@ export function isSidebarFrameVisible(): boolean {
 export function removeSidebarFrame(): boolean {
   const sidebar = getSidebar();
 
-  console.debug("sidebarDomControllerLite:removeSidebarFrame: sidebar exists", {
+  console.debug("sidebarDomControllerLite:removeSidebarFrame", {
     isSidebarFrameVisible: Boolean(sidebar),
   });
 

--- a/src/contentScript/sidebarDomControllerLite.ts
+++ b/src/contentScript/sidebarDomControllerLite.ts
@@ -73,7 +73,9 @@ export function isSidebarFrameVisible(): boolean {
 export function removeSidebarFrame(): boolean {
   const sidebar = getSidebar();
 
-  console.debug("removeSidebarFrame: sidebar exists", Boolean(sidebar));
+  console.debug("sidebarDomControllerLite:removeSidebarFrame: sidebar exists", {
+    isSidebarFrameVisible: Boolean(sidebar),
+  });
 
   if (sidebar) {
     sidebar.remove();
@@ -85,6 +87,10 @@ export function removeSidebarFrame(): boolean {
 
 /** Inserts the element; Returns false if it already existed */
 export function insertSidebarFrame(): boolean {
+  console.debug("sidebarDomControllerLite:insertSidebarFrame", {
+    isSidebarFrameVisible: isSidebarFrameVisible(),
+  });
+
   if (isSidebarFrameVisible()) {
     console.debug("insertSidebarFrame: sidebar frame already exists");
     return false;
@@ -138,6 +144,10 @@ export function insertSidebarFrame(): boolean {
  * Toggle the sidebar frame. Returns true if the sidebar is now visible, false otherwise.
  */
 export function toggleSidebarFrame(): boolean {
+  console.debug("sidebarDomControllerLite:toggleSidebarFrame", {
+    isSidebarFrameVisible: isSidebarFrameVisible(),
+  });
+
   if (isSidebarFrameVisible()) {
     removeSidebarFrame();
     return false;


### PR DESCRIPTION
## What does this PR do?

- Fixed #5906 🤞 
- Switches to `browser.tabs.executeScript` to eliminate race with the frame being added to the DOM
- Adds a waitAnimationFrame to rehydrateSidebar to ensure we're seeing the latest DOM state

## Discussion

- I opened a ticket in webext-content-scripts: https://github.com/fregante/webext-content-scripts/issues/22

## Checklist

- Add tests: there's not really much of a test to add here. If we write one, it would just be double-checking we're awaiting the tabs.executeScript promise in _toggleSidebar
- [x] Designate a primary reviewer: @BLoe 
