### PR TITLE
#5951: drop `webext-dynamic-content-scripts` dependency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,6 @@ module.exports = {
           "@/telemetry/reportUncaughtErrors",
           "@testing-library/jest-dom",
           "jest-location-mock",
-          "webext-dynamic-content-scripts/including-active-tab", // Automatic registration
           "regenerator-runtime/runtime", // Automatic registration
           "@/vendors/hoverintent/hoverintent", // JQuery plugin
           "iframe-resizer/js/iframeResizer.contentWindow", // vendor library imported for side-effect

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,6 @@
         "webext-base-css": "^1.4.3",
         "webext-content-scripts": "^2.5.3",
         "webext-detect-page": "^4.1.0",
-        "webext-dynamic-content-scripts": "10.0.0-3",
         "webext-messenger": "^0.22.0",
         "webext-patterns": "^1.3.0",
         "webext-polyfill-kinda": "^1.0.2",
@@ -16748,19 +16747,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/content-scripts-register-polyfill": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/content-scripts-register-polyfill/-/content-scripts-register-polyfill-4.0.2.tgz",
-      "integrity": "sha512-8hDm+tu3BkxHZP7EUIIIo/495F6QNXF7cI9Lwr4PQaiohw2wWmi9k2SE4W4kNrAaLnFw6RZ2ev8EmrQb+sCoGQ==",
-      "dependencies": {
-        "webext-content-scripts": "^2.5.2",
-        "webext-patterns": "^1.3.0",
-        "webext-polyfill-kinda": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fregante"
-      }
     },
     "node_modules/content-type": {
       "version": "1.0.4",
@@ -36731,27 +36717,6 @@
       "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-4.1.0.tgz",
       "integrity": "sha512-GFL+0XLO18/1d7425E2Yt3o1RfggjIrwrKskfdBbQBx8jmH9WBKOTAfI3XCROyECIvYoG1T53I0qPMN87bzHuw=="
     },
-    "node_modules/webext-dynamic-content-scripts": {
-      "version": "10.0.0-3",
-      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-10.0.0-3.tgz",
-      "integrity": "sha512-d6GBuQIbasRONDmguSkIKFVSOMKm3RWzdf/LormIVOaK9VsopAkdPSYG1PZVfSLDFh5zokB8Ond7n6zBjEVbWA==",
-      "dependencies": {
-        "content-scripts-register-polyfill": "^4.0.1",
-        "webext-additional-permissions": "^2.3.0",
-        "webext-content-scripts": "^2.5.3",
-        "webext-detect-page": "^4.0.1",
-        "webext-patterns": "^1.2.0",
-        "webext-polyfill-kinda": "^0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fregante"
-      }
-    },
-    "node_modules/webext-dynamic-content-scripts/node_modules/webext-polyfill-kinda": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-0.10.0.tgz",
-      "integrity": "sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA=="
-    },
     "node_modules/webext-messenger": {
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.22.0.tgz",
@@ -49989,16 +49954,6 @@
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
           "dev": true
         }
-      }
-    },
-    "content-scripts-register-polyfill": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/content-scripts-register-polyfill/-/content-scripts-register-polyfill-4.0.2.tgz",
-      "integrity": "sha512-8hDm+tu3BkxHZP7EUIIIo/495F6QNXF7cI9Lwr4PQaiohw2wWmi9k2SE4W4kNrAaLnFw6RZ2ev8EmrQb+sCoGQ==",
-      "requires": {
-        "webext-content-scripts": "^2.5.2",
-        "webext-patterns": "^1.3.0",
-        "webext-polyfill-kinda": "^1.0.0"
       }
     },
     "content-type": {
@@ -65143,26 +65098,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-4.1.0.tgz",
       "integrity": "sha512-GFL+0XLO18/1d7425E2Yt3o1RfggjIrwrKskfdBbQBx8jmH9WBKOTAfI3XCROyECIvYoG1T53I0qPMN87bzHuw=="
-    },
-    "webext-dynamic-content-scripts": {
-      "version": "10.0.0-3",
-      "resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-10.0.0-3.tgz",
-      "integrity": "sha512-d6GBuQIbasRONDmguSkIKFVSOMKm3RWzdf/LormIVOaK9VsopAkdPSYG1PZVfSLDFh5zokB8Ond7n6zBjEVbWA==",
-      "requires": {
-        "content-scripts-register-polyfill": "^4.0.1",
-        "webext-additional-permissions": "^2.3.0",
-        "webext-content-scripts": "^2.5.3",
-        "webext-detect-page": "^4.0.1",
-        "webext-patterns": "^1.2.0",
-        "webext-polyfill-kinda": "^0.10.0"
-      },
-      "dependencies": {
-        "webext-polyfill-kinda": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-0.10.0.tgz",
-          "integrity": "sha512-Yz5WTwig5byFfMXgagtfaJkVU+RrnVqtL1hmvA+GIbpRaGKU1DIrFYHMUUFkeyFqxRSuhbOdLKzteXxCd6VNzA=="
-        }
-      }
     },
     "webext-messenger": {
       "version": "0.22.0",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "webext-base-css": "^1.4.3",
     "webext-content-scripts": "^2.5.3",
     "webext-detect-page": "^4.1.0",
-    "webext-dynamic-content-scripts": "10.0.0-3",
     "webext-messenger": "^0.22.0",
     "webext-patterns": "^1.3.0",
     "webext-polyfill-kinda": "^1.0.2",

--- a/src/background/activeTab.ts
+++ b/src/background/activeTab.ts
@@ -1,29 +1,13 @@
 /** @file It's possible that some of these tabs might lose the permission in the meantime, we can't track that exactly */
 
-import { updatePageEditor } from "@/pageEditor/messenger/api";
 import { uniq } from "lodash";
-import {
-  type ActiveTab,
-  addActiveTabListener,
-  possiblyActiveTabs,
-} from "webext-dynamic-content-scripts/distribution/active-tab";
 
 type TabId = number;
-
-function updateUI(tab: ActiveTab): void {
-  // Inform pageEditor that it now has the ActiveTab permission, if it's open
-  updatePageEditor({ page: `/pageEditor.html?tabId=${tab.id}` });
-}
-
-export default function initActiveTabTracking() {
-  addActiveTabListener(updateUI);
-}
 
 export async function getTabsWithAccess(): Promise<TabId[]> {
   const { origins } = await browser.permissions.getAll();
   const tabs = await browser.tabs.query({ url: origins });
-  // The union of browser.tabs.query and possiblyActiveTabs can contain duplicates, hence applying uniq
-  return uniq([...tabs.map((x) => x.id), ...possiblyActiveTabs.keys()]);
+  return uniq(tabs.map((x) => x.id));
 }
 
 /**

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -24,8 +24,6 @@ import "@/development/errorsBadge";
 // Required for MV3; Service Workers don't have XMLHttpRequest
 import "@/background/axiosFetch";
 
-import "webext-dynamic-content-scripts/including-active-tab";
-
 import registerMessenger from "@/background/messenger/registration";
 import registerExternalMessenger from "@/background/messenger/external/registration";
 import initLocator from "@/background/locator";
@@ -39,7 +37,6 @@ import initBrowserCommands from "@/background/initBrowserCommands";
 import initDeploymentUpdater from "@/background/deployment";
 import initFirefoxCompat from "@/background/firefoxCompat";
 import activateBrowserActionIcon from "@/background/activateBrowserActionIcon";
-import initActiveTabTracking from "@/background/activeTab";
 import initPartnerTheme from "@/background/partnerTheme";
 import initStarterBlueprints from "@/background/starterBlueprints";
 import { initPartnerTokenRefresh } from "@/background/partnerIntegrations";
@@ -58,7 +55,6 @@ initBrowserCommands();
 initDeploymentUpdater();
 initFirefoxCompat();
 activateBrowserActionIcon();
-initActiveTabTracking();
 initPartnerTheme();
 initStarterBlueprints();
 initPartnerTokenRefresh();

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -58,8 +58,7 @@ async function _toggleSidebar(tabId: number, tabUrl: string): Promise<void> {
     runAt: "document_end",
   });
 
-  // Clicking the browser action grants active tab. So PixieBrix might just now be getting access to run on the tab.
-  // It should automatically get added by webext-dynamic-content-scripts which tries to watch for new active tabs.
+  // Chrome adds automatically at document_idle, so it might not be ready yet when the user click the browser action
   const contentScriptPromise = ensureContentScript({
     tabId,
     frameId: TOP_LEVEL_FRAME_ID,

--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -70,8 +70,7 @@ async function dispatchMenu(
 
   console.time("ensureContentScript");
 
-  // Using the context menu gives temporary access to the page. The content script should already be injected via
-  // webext-dynamic-content-scripts, but double check just in case.
+  // Browser will add at document_idle. But ensure it's ready before continuing
   await pTimeout(ensureContentScript(target), {
     milliseconds: CONTEXT_SCRIPT_INSTALL_MS,
     message: `contentScript for context menu handler not ready in ${CONTEXT_SCRIPT_INSTALL_MS}ms`,

--- a/src/background/navigation.ts
+++ b/src/background/navigation.ts
@@ -22,7 +22,6 @@ import { canAccessTab, isScriptableUrl } from "@/permissions/permissionsUtils";
 import { debounce } from "lodash";
 import { syncFlagOn } from "@/store/syncFlags";
 import { canAccessTab as canInjectTab, getTabUrl } from "webext-tools";
-import { isContentScriptRegistered } from "webext-dynamic-content-scripts/utils";
 import { getTargetState } from "@/contentScript/ready";
 
 export function reactivateEveryTab(): void {
@@ -41,7 +40,6 @@ async function traceNavigation(target: Target): Promise<void> {
     tabUrl,
     isScriptableUrl: isScriptableUrl(tabUrl),
     contentScriptState: await getTargetState(target),
-    isContentScriptRegistered: await isContentScriptRegistered(tabUrl),
     canInject: await canInjectTab(target),
     // PixieBrix has some additional constraints on which tabs can be accessed (i.e., only https:)
     canAccessTab: await canAccessTab(target),
@@ -54,8 +52,7 @@ async function onNavigation({ tabId, frameId }: Target): Promise<void> {
   }
 
   if (await canAccessTab({ tabId, frameId })) {
-    // The content script will already be injected on webNavigation.onCommitted via webext-dynamic-content-scripts and
-    // content-scripts-register-polyfill, so we don't have to call ensureContentScript before messaging the
+    // The content script will already be injected, so we don't have to call ensureContentScript before messaging the
     // content script with handleNavigate.
     handleNavigate({ tabId, frameId });
   }

--- a/src/contentScript/contentScript.ts
+++ b/src/contentScript/contentScript.ts
@@ -39,10 +39,10 @@ async function initContentScript() {
   const uuid = uuidv4();
 
   if (isInstalledInThisSession()) {
-    // `webext-dynamic-content-scripts` to 10.0.0-1 can inject the same content script multiple times
-    // https://github.com/pixiebrix/pixiebrix-extension/pull/5743
     // Must prevent multiple injection because repeat messenger registration causes message handling errors:
     // https://github.com/pixiebrix/webext-messenger/issues/88
+    // Prior to 1.7.31 we had been using `webext-dynamic-content-scripts` which can inject the same content script
+    // multiple times: https://github.com/pixiebrix/pixiebrix-extension/pull/5743
     console.warn(
       `contentScript: was requested twice in the same context, skipping content script initialization ${context}`
     );

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,7 @@
   "content_security_policy": "script-src 'self' https://apis.google.com 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https:; object-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-src 'self' https: https://*.googleapis.com https://docs.google.com",
   "content_scripts": [
     {
-      "matches": ["https://*.pixiebrix.com/*"],
+      "matches": ["*://*/*"],
       "js": ["contentScript.js"],
       "css": ["contentScript.css"],
       "run_at": "document_idle"

--- a/src/testUtils/testAfterEnv.js
+++ b/src/testUtils/testAfterEnv.js
@@ -45,7 +45,5 @@ globalThis.crypto = {
   getRandomValues: (array) => crypto.randomBytes(array.length),
 };
 
-jest.setMock("webext-dynamic-content-scripts/distribution/active-tab", {});
-
 jest.setMock("webext-detect-page", detectPageMock);
 jest.setMock("@/services/apiClient", apiClientMock);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -306,10 +306,6 @@ module.exports = (env, options) =>
 
     resolve: {
       alias: {
-        // Enforce a single version
-        // TODO: Undo after https://github.com/fregante/webext-dynamic-content-scripts/issues/54
-        "webext-content-scripts": require.resolve("webext-content-scripts"),
-
         ...mockHeavyDependencies(),
 
         ...(isProd(options) || process.env.DEV_REDUX_LOGGER === "false"


### PR DESCRIPTION
## What does this PR do?

- #5951 
- Updates manifest to load content script on `"*://*/*"` which matches all http and https pages
- Drops the `webext-dynamic-content-scripts` and related dynamic permissions code

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
