### PR TITLE
#5955: load main content script in all_frames

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,6 +24,7 @@
       "matches": ["https://*/*"],
       "js": ["contentScript.js"],
       "css": ["contentScript.css"],
+      "all_frames": true,
       "run_at": "document_idle"
     },
     {


### PR DESCRIPTION
## What does this PR do?

- Closes #5955
- Changes contentScript declaration to load main content script in all frames

## Discussion

- The marketplace enhancement contentScript is still only applied to the top-level frame

## Future Work

- With the permissions change in 1.7.30, we may need to take a look at the bundle size/memory usage of the content script when it's not being used. Injecting in all frames (even ad iframes) could cause memory utilization issues if user has a lot of tabs open

## Checklist

- [x] Add tests: https://app.rainforestqa.com/tests/390679
- [x] Designate a primary reviewer: @grahamlangford 
