### PR TITLE
Bundle icons in Extension webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -459,6 +459,29 @@ module.exports = (env, options) =>
             },
           ],
         },
+        // Pull bootstrap-icons and simple-icons from CDN to reduce bundle size.
+        {
+          test: /bootstrap-icons\/.*\.svg$/,
+          type: "asset/resource",
+          generator: {
+            emit: false,
+            publicPath: `https://cdn.jsdelivr.net/npm/bootstrap-icons@${
+              require("bootstrap-icons/package.json").version
+            }/`,
+            filename: "icons/[name][ext]",
+          },
+        },
+        {
+          test: /simple-icons\/.*\.svg$/,
+          type: "asset/resource",
+          generator: {
+            emit: false,
+            publicPath: `https://cdn.jsdelivr.net/npm/simple-icons@${
+              require("simple-icons/package.json").version
+            }/`,
+            filename: "icons/[name][ext]",
+          },
+        },
       ],
     },
   });

--- a/webpack.sharedConfig.js
+++ b/webpack.sharedConfig.js
@@ -86,29 +86,6 @@ const shared = {
           filename: "img/[name][ext]",
         },
       },
-      // Pull bootstrap-icons and simple-icons from CDN to reduce bundle size.
-      {
-        test: /bootstrap-icons\/.*\.svg$/,
-        type: "asset/resource",
-        generator: {
-          emit: false,
-          publicPath: `https://cdn.jsdelivr.net/npm/bootstrap-icons@${
-            require("bootstrap-icons/package.json").version
-          }/`,
-          filename: "icons/[name][ext]",
-        },
-      },
-      {
-        test: /simple-icons\/.*\.svg$/,
-        type: "asset/resource",
-        generator: {
-          emit: false,
-          publicPath: `https://cdn.jsdelivr.net/npm/simple-icons@${
-            require("simple-icons/package.json").version
-          }/`,
-          filename: "icons/[name][ext]",
-        },
-      },
       {
         test: /custom-icons\/.*\.svg$/,
         type: "asset/resource",


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-app/issues/3475
- Move webpack rules to pull simple-icons and bootstrap-icons from shared webpack config to the Extension-only webpack config. This prevents a build error from happening the App project

## Discussion

- Another option is to exclude these two rules from the App webpack config but I couldn't figure out how to do that and this is simpler/better

## Checklist

- [x] Designate a primary reviewer: @BLoe 
