### PR TITLE
#5919 - Only close sidebar after activation if no remaining panels

### DIFF
--- a/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.test.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { useRequiredRecipe } from "@/recipes/recipesHooks";
-import { render } from "@/sidebar/testHelpers";
+import { render, screen } from "@/sidebar/testHelpers";
 import ActivateRecipePanel from "@/sidebar/activateRecipe/ActivateRecipePanel";
 import sidebarSlice from "@/sidebar/sidebarSlice";
 import { waitForEffect } from "@/testUtils/testHelpers";
@@ -39,13 +39,22 @@ import {
   marketplaceListingFactory,
   recipeToMarketplacePackage,
 } from "@/testUtils/factories/marketplaceFactories";
+import * as messengerApi from "@/contentScript/messenger/api";
+import { selectSidebarHasModPanels } from "@/sidebar/sidebarSelectors";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("@/recipes/recipesHooks", () => ({
   useRequiredRecipe: jest.fn(),
 }));
 
+jest.mock("@/sidebar/sidebarSelectors", () => ({
+  selectSidebarHasModPanels: jest.fn(),
+}));
+
 const useRequiredRecipeMock = jest.mocked(useRequiredRecipe);
 const checkRecipePermissionsMock = jest.mocked(checkRecipePermissions);
+const selectSidebarHasModPanelsMock = jest.mocked(selectSidebarHasModPanels);
+const hideSidebarSpy = jest.spyOn(messengerApi, "hideSidebar");
 
 jest.mock("@/utils/includesQuickBarExtensionPoint", () => ({
   __esModule: true,
@@ -107,6 +116,8 @@ function setupMocksAndRender(recipeOverride?: Partial<RecipeDefinition>) {
 
 beforeEach(() => {
   appApiMock.reset();
+  selectSidebarHasModPanelsMock.mockReset();
+  hideSidebarSpy.mockReset();
 
   includesQuickBarMock.mockResolvedValue(false);
 
@@ -265,5 +276,27 @@ describe("ActivateRecipePanel", () => {
     await waitForEffect();
 
     expect(rendered.getByTestId("loader")).not.toBeNull();
+  });
+
+  it("activating a mod closes the sidebar when there are no other mod panels to show", async () => {
+    selectSidebarHasModPanelsMock.mockImplementation(() => false);
+
+    setupMocksAndRender();
+    await waitForEffect();
+
+    await userEvent.click(screen.getByRole("button", { name: /ok/i }));
+
+    expect(hideSidebarSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("activating a mod leaves the sidebar open when there are other mod panels to show", async () => {
+    selectSidebarHasModPanelsMock.mockImplementation(() => true);
+
+    setupMocksAndRender();
+    await waitForEffect();
+
+    await userEvent.click(screen.getByRole("button", { name: /ok/i }));
+
+    expect(hideSidebarSpy).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
@@ -46,7 +46,7 @@ import RequireRecipe, {
 import { persistor } from "@/sidebar/store";
 import { checkRecipePermissions } from "@/recipes/recipePermissionsHelpers";
 import AsyncStateGate from "@/components/AsyncStateGate";
-import { selectShouldCloseSidebarAfterActivate } from "@/sidebar/sidebarSelectors";
+import { selectSidebarHasModPanels } from "@/sidebar/sidebarSelectors";
 
 const { actions } = sidebarSlice;
 
@@ -189,7 +189,7 @@ const ActivateRecipePanelContent: React.FC<
 }) => {
   const reduxDispatch = useDispatch();
   const marketplaceActivateRecipe = useActivateRecipe("marketplace");
-  const shouldCloseSidebar = useSelector(selectShouldCloseSidebarAfterActivate);
+  const sidebarHasModPanels = useSelector(selectSidebarHasModPanels);
 
   const [state, stateDispatch] = useReducer(
     activationSlice.reducer,
@@ -199,7 +199,7 @@ const ActivateRecipePanelContent: React.FC<
   async function handleActivationDecision() {
     reduxDispatch(actions.hideActivateRecipe());
 
-    if (shouldCloseSidebar) {
+    if (!sidebarHasModPanels) {
       const topFrame = await getTopLevelFrame();
       void hideSidebar(topFrame);
     }

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
@@ -46,7 +46,7 @@ import RequireRecipe, {
 import { persistor } from "@/sidebar/store";
 import { checkRecipePermissions } from "@/recipes/recipePermissionsHelpers";
 import AsyncStateGate from "@/components/AsyncStateGate";
-import { selectPanelCount } from "@/sidebar/sidebarSelectors";
+import { selectShouldCloseSidebarAfterActivate } from "@/sidebar/sidebarSelectors";
 
 const { actions } = sidebarSlice;
 
@@ -189,7 +189,7 @@ const ActivateRecipePanelContent: React.FC<
 }) => {
   const reduxDispatch = useDispatch();
   const marketplaceActivateRecipe = useActivateRecipe("marketplace");
-  const panelCount = useSelector(selectPanelCount);
+  const shouldCloseSidebar = useSelector(selectShouldCloseSidebarAfterActivate);
 
   const [state, stateDispatch] = useReducer(
     activationSlice.reducer,
@@ -199,7 +199,7 @@ const ActivateRecipePanelContent: React.FC<
   async function handleActivationDecision() {
     reduxDispatch(actions.hideActivateRecipe());
 
-    if (panelCount === 0) {
+    if (shouldCloseSidebar) {
       const topFrame = await getTopLevelFrame();
       void hideSidebar(topFrame);
     }

--- a/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateRecipePanel.tsx
@@ -21,7 +21,7 @@ import Loader from "@/components/Loader";
 import activationCompleteImage from "@img/blueprint-activation-complete.png";
 import styles from "./ActivateRecipePanel.module.scss";
 import AsyncButton from "@/components/AsyncButton";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import sidebarSlice from "@/sidebar/sidebarSlice";
 import {
   hideSidebar,
@@ -46,6 +46,7 @@ import RequireRecipe, {
 import { persistor } from "@/sidebar/store";
 import { checkRecipePermissions } from "@/recipes/recipePermissionsHelpers";
 import AsyncStateGate from "@/components/AsyncStateGate";
+import { selectPanelCount } from "@/sidebar/sidebarSelectors";
 
 const { actions } = sidebarSlice;
 
@@ -188,16 +189,20 @@ const ActivateRecipePanelContent: React.FC<
 }) => {
   const reduxDispatch = useDispatch();
   const marketplaceActivateRecipe = useActivateRecipe("marketplace");
+  const panelCount = useSelector(selectPanelCount);
 
   const [state, stateDispatch] = useReducer(
     activationSlice.reducer,
     initialState
   );
 
-  async function closeSidebar() {
+  async function handleActivationDecision() {
     reduxDispatch(actions.hideActivateRecipe());
-    const topFrame = await getTopLevelFrame();
-    void hideSidebar(topFrame);
+
+    if (panelCount === 0) {
+      const topFrame = await getTopLevelFrame();
+      void hideSidebar(topFrame);
+    }
   }
 
   const formValuesRef = useRef<WizardValues>(initialValues);
@@ -292,7 +297,7 @@ const ActivateRecipePanelContent: React.FC<
           </div>
         </div>
         <div className={styles.footer}>
-          <AsyncButton onClick={closeSidebar}>Ok</AsyncButton>
+          <AsyncButton onClick={handleActivationDecision}>Ok</AsyncButton>
         </div>
       </div>
     );
@@ -306,7 +311,7 @@ const ActivateRecipePanelContent: React.FC<
         initialValues={initialValues}
         onChange={onChange}
         validationSchema={validationSchema}
-        onClickCancel={closeSidebar}
+        onClickCancel={handleActivationDecision}
         needsPermissions={state.needsPermissions}
         header={
           <>

--- a/src/sidebar/sidebarSelectors.test.ts
+++ b/src/sidebar/sidebarSelectors.test.ts
@@ -1,0 +1,59 @@
+import { selectSidebarHasModPanels } from "@/sidebar/sidebarSelectors";
+import { sidebarEntryFactory } from "@/testUtils/factories/sidebarEntryFactories";
+import { type SidebarRootState } from "@/types/sidebarTypes";
+
+describe("sidebarSelectors", () => {
+  describe("selectSidebarHasModPanels", () => {
+    const sidebarRootState: SidebarRootState = {
+      sidebar: {
+        activeKey: "",
+        panels: [],
+        forms: [],
+        temporaryPanels: [],
+        staticPanels: [],
+        recipeToActivate: null,
+        pendingActivePanel: null,
+      },
+    };
+
+    it("returns false if there are no sidebar panels, forms, or temporaryPanels", () => {
+      expect(selectSidebarHasModPanels(sidebarRootState)).toBeFalse();
+    });
+
+    it("returns true if there are panels", () => {
+      expect(
+        selectSidebarHasModPanels({
+          ...sidebarRootState,
+          sidebar: {
+            ...sidebarRootState.sidebar,
+            panels: [sidebarEntryFactory("panel")],
+          },
+        })
+      ).toBeTrue();
+    });
+
+    it("returns true if there are forms", () => {
+      expect(
+        selectSidebarHasModPanels({
+          ...sidebarRootState,
+          sidebar: {
+            ...sidebarRootState.sidebar,
+            forms: [sidebarEntryFactory("form")],
+          },
+        })
+      ).toBeTrue();
+    });
+
+    it("returns true if there are temp", () => {
+      expect(
+        selectSidebarHasModPanels({
+          ...sidebarRootState,
+          sidebar: {
+            ...sidebarRootState.sidebar,
+            temporaryPanels: [sidebarEntryFactory("temporaryPanel")],
+          },
+        })
+      ).toBeTrue();
+    });
+  });
+});

--- a/src/sidebar/sidebarSelectors.ts
+++ b/src/sidebar/sidebarSelectors.ts
@@ -25,11 +25,13 @@ export const selectIsSidebarEmpty = ({ sidebar }: SidebarRootState) =>
   isEmpty(sidebar.staticPanels) &&
   sidebar.recipeToActivate == null;
 
-export const selectPanelCount = ({ sidebar }: SidebarRootState) =>
-  sidebar.panels.length +
-  sidebar.forms.length +
-  sidebar.temporaryPanels.length +
-  sidebar.staticPanels.length;
+export const selectShouldCloseSidebarAfterActivate = ({
+  sidebar,
+}: SidebarRootState) =>
+  isEmpty(sidebar.panels) &&
+  isEmpty(sidebar.forms) &&
+  isEmpty(sidebar.temporaryPanels) &&
+  isEmpty(sidebar.staticPanels);
 
 export const selectSidebarActiveTabKey = ({ sidebar }: SidebarRootState) =>
   sidebar.activeKey;

--- a/src/sidebar/sidebarSelectors.ts
+++ b/src/sidebar/sidebarSelectors.ts
@@ -25,13 +25,10 @@ export const selectIsSidebarEmpty = ({ sidebar }: SidebarRootState) =>
   isEmpty(sidebar.staticPanels) &&
   sidebar.recipeToActivate == null;
 
-export const selectShouldCloseSidebarAfterActivate = ({
-  sidebar,
-}: SidebarRootState) =>
-  isEmpty(sidebar.panels) &&
-  isEmpty(sidebar.forms) &&
-  isEmpty(sidebar.temporaryPanels) &&
-  isEmpty(sidebar.staticPanels);
+export const selectSidebarHasModPanels = ({ sidebar }: SidebarRootState) =>
+  !isEmpty(sidebar.panels) ||
+  !isEmpty(sidebar.forms) ||
+  !isEmpty(sidebar.temporaryPanels);
 
 export const selectSidebarActiveTabKey = ({ sidebar }: SidebarRootState) =>
   sidebar.activeKey;

--- a/src/sidebar/sidebarSelectors.ts
+++ b/src/sidebar/sidebarSelectors.ts
@@ -25,6 +25,12 @@ export const selectIsSidebarEmpty = ({ sidebar }: SidebarRootState) =>
   isEmpty(sidebar.staticPanels) &&
   sidebar.recipeToActivate == null;
 
+export const selectPanelCount = ({ sidebar }: SidebarRootState) =>
+  sidebar.panels.length +
+  sidebar.forms.length +
+  sidebar.temporaryPanels.length +
+  sidebar.staticPanels.length;
+
 export const selectSidebarActiveTabKey = ({ sidebar }: SidebarRootState) =>
   sidebar.activeKey;
 

--- a/src/testUtils/factories/sidebarEntryFactories.ts
+++ b/src/testUtils/factories/sidebarEntryFactories.ts
@@ -69,7 +69,7 @@ const panelEntryFactory = define<PanelEntry>({
   heading: (n: number) => `Panel Test ${n}`,
   payload: null,
   extensionPointId: (n: number) =>
-    validateRegistryId(`@test/panel-extensionPoint-test-${n}`),
+    validateRegistryId(`@test/panel-extension-point-test-${n}`),
 });
 
 export function sidebarEntryFactory(


### PR DESCRIPTION
## What does this PR do?

- Closes #5919

## Discussion

- I went with a rather specific redux selector, but I had other ideas:

1) create a `selectPanelCount` selector and close the sidebar if the count === 0
2) use the existing `selectIsSidebarEmpty` with a `useAsyncEffect` and close the sidebar if the sidebar is empty after `sidebar.recipeToActivate` is set to null
3) make `selectIsSidebarEmpty` a higher order function and pass in whether to include `sidebar.recipeToActivate` in determining if the sidebar is empty
4) change `ActivateRecipePanel.closeSidebar()` to be an async thunk and check for other panels, dispatch `hideActivateRecipe`, and handle closing the sidebar there


## Demo

https://www.loom.com/share/3166cb6aa5af4c109a4cb47b69743846?sid=b3c6bcd4-f068-43b3-bf77-a9f1069805da

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer @BLoe 
