### PR TITLE
#5965: Create google PKCE integration definition

### DIFF
--- a/contrib/services/google-oauth2-pkce.yaml
+++ b/contrib/services/google-oauth2-pkce.yaml
@@ -5,18 +5,6 @@ metadata:
   version: 1.0.0
   name: Google (Client Integration)
   description: OAuth2 PKCE Authentication for Google
-inputSchema:
-  $schema: https://json-schema.org/draft/2019-09/schema#
-  type: object
-  properties:
-    clientId:
-      type: string
-      description: The OAuth 2.0 client ID
-      default: 676864882630-n33qt0a585mcaf2vithipddia0l8blmc.apps.googleusercontent.com
-    clientSecret:
-      type: string
-      description: The OAuth 2.0 client secret. Note that this "secret" can be shared publicly.
-      default: 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
 authentication:
   # No baseURL because we're hitting multiple different Google API base URLs
   oauth2:
@@ -25,7 +13,7 @@ authentication:
     tokenUrl: https://oauth2.googleapis.com/token
     code_challenge_method: S256
     scope: https://www.googleapis.com/auth/drive
-    client_id: "{{#clientId}}{{{.}}}{{/clientId}}{{^clientId}}g2qrB2fvyLYbotkb3zi9wwO5qjmje3eM{{/clientId}}"
-    client_secret: "{{#clientSecret}}{{{.}}}{{/clientSecret}}{{^clientSecret}}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{{/clientSecret}}"
+    client_id: 676864882630-n33qt0a585mcaf2vithipddia0l8blmc.apps.googleusercontent.com
+    client_secret: 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
   headers:
     Authorization: "Bearer {{{ access_token }}}"

--- a/contrib/services/google-oauth2-pkce.yaml
+++ b/contrib/services/google-oauth2-pkce.yaml
@@ -18,7 +18,7 @@ inputSchema:
       description: The OAuth 2.0 client secret. Note that this "secret" can be shared publicly.
       default: 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
 authentication:
-  # No baseURL is okay here, right?
+  # No baseURL because we're hitting multiple different Google API base URLs
   oauth2:
     # access_type=offline and prompt=consent will force a refresh token to be returned
     authorizeUrl: https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent

--- a/contrib/services/google-oauth2-pkce.yaml
+++ b/contrib/services/google-oauth2-pkce.yaml
@@ -8,6 +8,7 @@ metadata:
 inputSchema:
   $schema: "https://json-schema.org/draft/2019-09/schema#"
   type: object
+  properties: {}
 authentication:
   # No baseURL because we're hitting multiple different Google API base URLs
   oauth2:

--- a/contrib/services/google-oauth2-pkce.yaml
+++ b/contrib/services/google-oauth2-pkce.yaml
@@ -5,6 +5,9 @@ metadata:
   version: 1.0.0
   name: Google (Client Integration)
   description: OAuth2 PKCE Authentication for Google
+inputSchema:
+  $schema: "https://json-schema.org/draft/2019-09/schema#"
+  type: object
 authentication:
   # No baseURL because we're hitting multiple different Google API base URLs
   oauth2:

--- a/contrib/services/google-oauth2-pkce.yaml
+++ b/contrib/services/google-oauth2-pkce.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: service
+metadata:
+  id: google/oauth2-pkce
+  version: 1.0.0
+  name: Google (Client Integration)
+  description: OAuth2 PKCE Authentication for Google
+inputSchema:
+  $schema: https://json-schema.org/draft/2019-09/schema#
+  type: object
+  properties:
+    clientId:
+      type: string
+      description: The OAuth 2.0 client ID
+      default: 676864882630-n33qt0a585mcaf2vithipddia0l8blmc.apps.googleusercontent.com
+    clientSecret:
+      type: string
+      description: The OAuth 2.0 client secret. Note that this "secret" can be shared publicly.
+      default: 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
+authentication:
+  # No baseURL is okay here, right?
+  oauth2:
+    # access_type=offline and prompt=consent will force a refresh token to be returned
+    authorizeUrl: https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent
+    tokenUrl: https://oauth2.googleapis.com/token
+    code_challenge_method: S256
+    scope: https://www.googleapis.com/auth/drive
+    client_id: "{{#clientId}}{{{.}}}{{/clientId}}{{^clientId}}g2qrB2fvyLYbotkb3zi9wwO5qjmje3eM{{/clientId}}"
+    client_secret: "{{#clientSecret}}{{{.}}}{{/clientSecret}}{{^clientSecret}}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{{/clientSecret}}"
+  headers:
+    Authorization: "Bearer {{{ access_token }}}"


### PR DESCRIPTION
## What does this PR do?

- Closes #5965 

## Reviewer Tips

- I created two new OAuth2 client in the Google Cloud Console. The prod credentials are currently listed as the default in the YAML definition.

<img width="297" alt="Screenshot 2023-06-26 at 5 08 22 PM" src="https://github.com/pixiebrix/pixiebrix-extension/assets/20693145/9df54397-4360-4a39-bc85-e979e6b56bf4">

## Demo

https://www.loom.com/share/3385c712589343f8b12e179c44cb6398

## Team Coordination

- [x] After PR is merged, paste definition into Workshop and ensure it gets added as a `Package` obj in the database

## Checklist

- [x] Designate a primary reviewer: @mnholtz 
