### PR TITLE
#5962: drop unused `/starter-blueprints/install/` mocks

### DIFF
--- a/src/background/starterBlueprints.test.ts
+++ b/src/background/starterBlueprints.test.ts
@@ -81,7 +81,6 @@ describe("installStarterBlueprints", () => {
     axiosMock
       .onGet("/api/onboarding/starter-blueprints/")
       .reply(200, [recipeFactory()]);
-    axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
 
     await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
@@ -165,11 +164,7 @@ describe("installStarterBlueprints", () => {
   test("starter blueprints request fails", async () => {
     isLinkedMock.mockResolvedValue(true);
 
-    axiosMock
-      .onGet("/api/onboarding/starter-blueprints/install/")
-      .reply(200, { install_starter_blueprints: true });
     axiosMock.onGet("/api/onboarding/starter-blueprints/").reply(500);
-    axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
 
     await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
@@ -183,7 +178,6 @@ describe("installStarterBlueprints", () => {
     axiosMock
       .onGet("/api/onboarding/starter-blueprints/")
       .reply(200, [recipeFactory()]);
-    axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(500);
 
     await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
@@ -201,8 +195,6 @@ describe("installStarterBlueprints", () => {
       .reply(200, builtInServiceAuths);
 
     axiosMock.onGet("/api/onboarding/starter-blueprints/").reply(200, [recipe]);
-
-    axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
 
     await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
@@ -238,18 +230,12 @@ describe("installStarterBlueprints", () => {
       extensions: [extension],
     });
 
-    axiosMock
-      .onGet("/api/onboarding/starter-blueprints/install/")
-      .reply(200, { install_starter_blueprints: true });
-
     axiosMock.onGet("/api/onboarding/starter-blueprints/").reply(200, [
       {
         extensionPoints: [extension],
         ...recipe,
       },
     ]);
-
-    axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
 
     await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
@@ -268,13 +254,8 @@ describe("installStarterBlueprints", () => {
     });
 
     axiosMock
-      .onGet("/api/onboarding/starter-blueprints/install/")
-      .reply(200, { install_starter_blueprints: true });
-
-    axiosMock
       .onGet("/api/onboarding/starter-blueprints/")
       .reply(200, [recipeFactory()]);
-    axiosMock.onPost("/api/onboarding/starter-blueprints/install/").reply(204);
 
     await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();


### PR DESCRIPTION
## What does this PR do?

- Part of #5962 
- Drops unused `/starter-blueprints/install/` mocks from Jest tests. The code no longer calls that endpoint
- The code was dropped in this PR: https://github.com/pixiebrix/pixiebrix-extension/pull/5500

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @mnholtz 
