### PR TITLE
#5963: centralizes the `InstallBlueprint`/`ActivateMod` telemetry event

### DIFF
--- a/src/activation/useActivateRecipe.test.ts
+++ b/src/activation/useActivateRecipe.test.ts
@@ -178,6 +178,8 @@ describe("useActivateRecipe", () => {
         extensionPoints: recipe.extensionPoints,
         services: {},
         optionsArgs: {},
+        screen: "extensionConsole",
+        isReinstall: false,
       })
     );
 
@@ -248,6 +250,8 @@ describe("useActivateRecipe", () => {
         optionsArgs: {
           myDatabase: createdDatabase.id,
         },
+        screen: "marketplace",
+        isReinstall: false,
       })
     );
   });

--- a/src/activation/useActivateRecipe.ts
+++ b/src/activation/useActivateRecipe.ts
@@ -169,14 +169,10 @@ function useActivateRecipe(
               services.map(({ id, config }) => [id, config])
             ),
             optionsArgs,
+            screen: source,
+            isReinstall: recipeExtensions.length > 0,
           })
         );
-
-        reportEvent("InstallBlueprint", {
-          blueprintId: recipe.metadata.id,
-          screen: source,
-          reinstall: recipeExtensions.length > 0,
-        });
 
         reactivateEveryTab();
       } catch (error) {

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -216,6 +216,10 @@ async function installDeployment(
   let options = optionsState;
   let editor = editorState;
 
+  const isReinstall = optionsState.extensions.some(
+    (x) => x._deployment?.id === deployment.id
+  );
+
   // Uninstall existing versions of the extensions
   const result = await uninstallRecipe(
     options,
@@ -239,6 +243,8 @@ async function installDeployment(
       ),
       // Assume backend properly validates the options
       optionsArgs: deployment.options_config as OptionsArgs,
+      screen: "background",
+      isReinstall,
     })
   );
 

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -98,6 +98,8 @@ function installBlueprint(
       recipe: blueprint,
       extensionPoints: blueprint.extensionPoints,
       services,
+      screen: "starterMod",
+      isReinstall: false,
     })
   );
 }

--- a/src/extensionConsole/pages/blueprints/BotGamesView.tsx
+++ b/src/extensionConsole/pages/blueprints/BotGamesView.tsx
@@ -72,6 +72,8 @@ export const useInstallBotGamesBlueprint = () => {
       installRecipe({
         recipe: botGamesRecipe,
         extensionPoints: botGamesRecipe.extensionPoints,
+        screen: "extensionConsole",
+        isReinstall: false,
       })
     );
 

--- a/src/extensionConsole/pages/blueprints/utils/useReinstall.ts
+++ b/src/extensionConsole/pages/blueprints/utils/useReinstall.ts
@@ -54,6 +54,8 @@ function useReinstall(): Reinstall {
           extensionPoints: recipe.extensionPoints,
           services: currentAuths,
           optionsArgs: currentOptions,
+          screen: "extensionConsole",
+          isReinstall: true,
         })
       );
     },

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
@@ -76,6 +76,8 @@ async function activateDeployment(
   deployment: Deployment,
   installed: IExtension[]
 ): Promise<void> {
+  let isReinstall = false;
+
   // Clear existing installations of the blueprint
   for (const extension of installed) {
     // Extension won't have recipe if it was locally created by a developer
@@ -85,6 +87,8 @@ async function activateDeployment(
           extensionId: extension.id,
         })
       );
+
+      isReinstall = true;
     }
   }
 
@@ -100,6 +104,8 @@ async function activateDeployment(
       ),
       // Assume validation on the backend for options
       optionsArgs: deployment.options_config,
+      screen: "extensionConsole",
+      isReinstall,
     })
   );
 

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -100,6 +100,8 @@ describe("replaceRecipeExtension round trip", () => {
         recipe,
         services: {},
         extensionPoints: recipe.extensionPoints,
+        screen: "pageEditor",
+        isReinstall: false,
       })
     );
 
@@ -144,6 +146,8 @@ describe("replaceRecipeExtension round trip", () => {
         recipe,
         services: {},
         extensionPoints: recipe.extensionPoints,
+        screen: "pageEditor",
+        isReinstall: false,
       })
     );
 
@@ -179,6 +183,8 @@ describe("replaceRecipeExtension round trip", () => {
         recipe,
         services: {},
         extensionPoints: recipe.extensionPoints,
+        screen: "pageEditor",
+        isReinstall: false,
       })
     );
 
@@ -229,6 +235,8 @@ describe("replaceRecipeExtension round trip", () => {
         recipe,
         services: {},
         extensionPoints: recipe.extensionPoints,
+        screen: "pageEditor",
+        isReinstall: false,
       })
     );
 
@@ -289,6 +297,8 @@ describe("replaceRecipeExtension round trip", () => {
         recipe,
         services: {},
         extensionPoints: recipe.extensionPoints,
+        screen: "pageEditor",
+        isReinstall: false,
       })
     );
 
@@ -346,6 +356,8 @@ describe("replaceRecipeExtension round trip", () => {
         recipe,
         services: {},
         extensionPoints: recipe.extensionPoints,
+        screen: "pageEditor",
+        isReinstall: false,
       })
     );
 
@@ -395,6 +407,8 @@ describe("replaceRecipeExtension round trip", () => {
         recipe,
         services: {},
         extensionPoints: recipe.extensionPoints,
+        screen: "pageEditor",
+        isReinstall: false,
       })
     );
 
@@ -433,6 +447,8 @@ describe("blueprint options", () => {
         recipe,
         services: {},
         extensionPoints: recipe.extensionPoints,
+        screen: "pageEditor",
+        isReinstall: false,
       })
     );
 
@@ -766,6 +782,8 @@ describe("buildRecipe", () => {
           recipe,
           services: {},
           extensionPoints: recipe.extensionPoints,
+          screen: "pageEditor",
+          isReinstall: false,
         })
       );
 

--- a/src/pageEditor/sidebar/modals/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/CreateRecipeModal.tsx
@@ -228,6 +228,8 @@ function useSaveCallbacks({ activeElement }: { activeElement: FormState }) {
             ...cleanRecipeExtensions,
           ]),
           extensionPoints: savedRecipe.extensionPoints,
+          screen: "pageEditor",
+          isReinstall: false,
         })
       );
 

--- a/src/pageEditor/tabs/recipeOptionsDefinitions/RecipeOptionsDefinitions.test.tsx
+++ b/src/pageEditor/tabs/recipeOptionsDefinitions/RecipeOptionsDefinitions.test.tsx
@@ -46,6 +46,8 @@ describe("RecipeOptionsDefinitions", () => {
           extensionsSlice.actions.installRecipe({
             recipe,
             extensionPoints: recipe.extensionPoints,
+            screen: "pageEditor",
+            isReinstall: false,
           })
         );
       },

--- a/src/pageEditor/tabs/recipeOptionsValues/RecipeOptionsValues.test.tsx
+++ b/src/pageEditor/tabs/recipeOptionsValues/RecipeOptionsValues.test.tsx
@@ -63,6 +63,8 @@ describe("ActivationOptions", () => {
         extensionsSlice.actions.installRecipe({
           recipe,
           extensionPoints: recipe.extensionPoints,
+          screen: "pageEditor",
+          isReinstall: false,
         });
       },
     });
@@ -120,6 +122,8 @@ describe("ActivationOptions", () => {
         extensionsSlice.actions.installRecipe({
           recipe,
           extensionPoints: recipe.extensionPoints,
+          screen: "pageEditor",
+          isReinstall: false,
         });
       },
     });
@@ -144,6 +148,8 @@ describe("ActivationOptions", () => {
         extensionsSlice.actions.installRecipe({
           recipe,
           extensionPoints: recipe.extensionPoints,
+          screen: "pageEditor",
+          isReinstall: false,
         });
       },
     });
@@ -182,6 +188,8 @@ describe("ActivationOptions", () => {
         extensionsSlice.actions.installRecipe({
           recipe,
           extensionPoints: recipe.extensionPoints,
+          screen: "pageEditor",
+          isReinstall: false,
         });
       },
     });
@@ -216,6 +224,8 @@ describe("ActivationOptions", () => {
         extensionsSlice.actions.installRecipe({
           recipe,
           extensionPoints: recipe.extensionPoints,
+          screen: "pageEditor",
+          isReinstall: false,
         });
       },
     });

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -114,6 +114,21 @@ const extensionsSlice = createSlice({
         extensionPoints: ExtensionDefinition[];
         optionsArgs?: OptionsArgs;
         deployment?: Deployment;
+        /**
+         * The screen or source of the installation. Used for telemetry.
+         * @since 1.7.33
+         */
+        screen:
+          | "marketplace"
+          | "extensionConsole"
+          | "pageEditor"
+          | "background"
+          | "starterMod";
+        /**
+         * True if this is reinstalling an already active mod. Used for telemetry.
+         * @since 1.7.33
+         */
+        isReinstall: boolean;
       }>
     ) {
       requireLatestState(state);
@@ -124,6 +139,8 @@ const extensionsSlice = createSlice({
         optionsArgs,
         extensionPoints,
         deployment,
+        screen,
+        isReinstall,
       } = payload;
 
       for (const {
@@ -197,6 +214,7 @@ const extensionsSlice = createSlice({
 
         assertExtensionNotResolved(extension);
 
+        // Display name is 'StarterBrickActivate' in telemetry
         reportEvent("ExtensionActivate", selectEventData(extension));
 
         // NOTE: do not save the extensions in the cloud (because the user can just install from the marketplace /
@@ -206,6 +224,15 @@ const extensionsSlice = createSlice({
 
         void contextMenus.preload([extension]);
       }
+
+      // Display name is 'ModActivate' in telemetry
+      reportEvent("InstallBlueprint", {
+        blueprintId: recipe.metadata.id,
+        blueprintVersion: recipe.metadata.version,
+        deploymentId: deployment?.id,
+        screen,
+        reinstall: isReinstall,
+      });
     },
     // XXX: why do we expose a `extensionId` in addition IExtension's `id` prop here?
     saveExtension(


### PR DESCRIPTION
## What does this PR do?

- Closes #5963 
- Centralizes the `InstallBlueprint` event (display name in MixPanel is ActivateMod) in installRecipe

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
