### PR TITLE
#4704: fix `disabled` field on Button element in Document Builder

### DIFF
--- a/src/components/documentBuilder/documentBuilderTypes.ts
+++ b/src/components/documentBuilder/documentBuilderTypes.ts
@@ -84,8 +84,11 @@ export type ButtonDocumentConfig = {
   label: string;
   title: string | Expression;
   variant?: string | Expression;
-  // Default size type coming from Bootstrap Button
+  /**
+   * Default size type coming from Bootstrap Button
+   */
   size?: "sm" | "lg" | Expression<"sm" | "lg">;
+  disabled?: boolean | Expression;
   className?: string | Expression;
   onClick: PipelineExpression;
 };

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -238,6 +238,7 @@ describe("When rendered in panel", () => {
       expect(element).not.toBeNull();
       expect(element).toHaveClass("test-class");
       expect(element).toHaveTextContent("Button under test");
+      expect(element).not.toBeDisabled();
     });
 
     test.each`
@@ -265,6 +266,28 @@ describe("When rendered in panel", () => {
         expect(element).toHaveClass(className);
       }
     );
+
+    test("renders disabled button", () => {
+      const config: DocumentElement = {
+        type: "button",
+        config: {
+          title: "Button under test",
+          variant: "primary",
+          className: "test-class",
+          disabled: true,
+          onClick: {
+            __type__: "pipeline",
+            __value__: jest.fn(),
+          },
+        },
+      };
+      const { container } = renderDocument(config);
+      const element = container.querySelector("button");
+
+      expect(element).not.toBeNull();
+      expect(element).toHaveClass("test-class");
+      expect(element).toBeDisabled();
+    });
   });
 
   describe("card", () => {

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -267,14 +267,13 @@ describe("When rendered in panel", () => {
       }
     );
 
-    test("renders disabled button", () => {
+    test.each([true, "y"])("renders disabled button for %s", (disabled) => {
       const config: DocumentElement = {
         type: "button",
         config: {
           title: "Button under test",
-          variant: "primary",
           className: "test-class",
-          disabled: true,
+          disabled,
           onClick: {
             __type__: "pipeline",
             __value__: jest.fn(),

--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -166,7 +166,7 @@ export function getComponentDefinition(
     }
 
     case "button": {
-      const { title, onClick, variant, size, className } =
+      const { title, onClick, variant, size, className, disabled } =
         config as ButtonDocumentConfig;
       if (onClick !== undefined && !isPipelineExpression(onClick)) {
         console.debug("Expected pipeline expression for onClick", {
@@ -183,6 +183,7 @@ export function getComponentDefinition(
           onClick: onClick.__value__,
           tracePath,
           variant,
+          disabled,
           size,
           className,
         },

--- a/src/components/documentBuilder/edit/getElementEditSchemas.ts
+++ b/src/components/documentBuilder/edit/getElementEditSchemas.ts
@@ -151,7 +151,8 @@ function getElementEditSchemas(
       };
       const disabledEdit: SchemaFieldProps = {
         name: joinName(elementName, "config", "disabled"),
-        schema: { type: "boolean" },
+        // Allow any to permit truthy values like for other conditional fields
+        schema: { type: ["string", "boolean", "null", "number"] },
         label: "Disabled",
       };
       return [

--- a/src/components/documentBuilder/preview/elementsPreview/Button.tsx
+++ b/src/components/documentBuilder/preview/elementsPreview/Button.tsx
@@ -43,13 +43,9 @@ const Button: React.FunctionComponent<ButtonProps> = ({
   buttonProps,
   ...restPreviewProps
 }) => {
-  const {
-    title,
-    variant,
-    size,
-    className: buttonClassName,
-    disabled,
-  } = buttonProps;
+  // NOTE: not passing through "disabled" prop because that prevents the user from clicking the button in the preview
+  // to select the element in the Document Builder.
+  const { title, variant, size, className: buttonClassName } = buttonProps;
 
   return (
     <div>
@@ -67,10 +63,6 @@ const Button: React.FunctionComponent<ButtonProps> = ({
         />
         <BsButton
           onClick={() => {}}
-          disabled={
-            // Exact match for literal boolean value
-            disabled === true
-          }
           // Not resolving expressions in Preview
           className={
             isExpression(buttonClassName) ? undefined : buttonClassName

--- a/src/components/documentBuilder/preview/elementsPreview/Button.tsx
+++ b/src/components/documentBuilder/preview/elementsPreview/Button.tsx
@@ -43,7 +43,14 @@ const Button: React.FunctionComponent<ButtonProps> = ({
   buttonProps,
   ...restPreviewProps
 }) => {
-  const { title, variant, size, className: buttonClassName } = buttonProps;
+  const {
+    title,
+    variant,
+    size,
+    className: buttonClassName,
+    disabled,
+  } = buttonProps;
+
   return (
     <div>
       <div
@@ -60,6 +67,10 @@ const Button: React.FunctionComponent<ButtonProps> = ({
         />
         <BsButton
           onClick={() => {}}
+          disabled={
+            // Exact match for literal boolean value
+            disabled === true
+          }
           // Not resolving expressions in Preview
           className={
             isExpression(buttonClassName) ? undefined : buttonClassName

--- a/src/components/documentBuilder/render/ButtonElement.tsx
+++ b/src/components/documentBuilder/render/ButtonElement.tsx
@@ -27,6 +27,7 @@ import { type DynamicPath } from "@/components/documentBuilder/documentBuilderTy
 import { getTopLevelFrame } from "webext-messenger";
 import { getRootCause, hasSpecificErrorCause } from "@/errors/errorHelpers";
 import { SubmitPanelAction } from "@/blocks/errors";
+import { boolean } from "@/utils";
 
 type ButtonElementProps = Except<AsyncButtonProps, "onClick"> & {
   onClick: BlockPipeline;
@@ -37,6 +38,7 @@ type ButtonElementProps = Except<AsyncButtonProps, "onClick"> & {
 const ButtonElement: React.FC<ButtonElementProps> = ({
   onClick,
   tracePath,
+  disabled: rawDisabled,
   ...restProps
 }) => {
   const {
@@ -44,11 +46,14 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
     meta,
     options: { ctxt, logger },
   } = useContext(DocumentContext);
+
   const [counter, setCounter] = useState(0);
 
   if (!meta.extensionId) {
     throw new Error("ButtonElement requires meta.extensionId");
   }
+
+  const disabled = boolean(rawDisabled);
 
   const handler = async () => {
     const currentCounter = counter;
@@ -87,7 +92,7 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
     }
   };
 
-  return <AsyncButton onClick={handler} {...restProps} />;
+  return <AsyncButton onClick={handler} disabled={disabled} {...restProps} />;
 };
 
 export default ButtonElement;

--- a/src/components/documentBuilder/render/ButtonElement.tsx
+++ b/src/components/documentBuilder/render/ButtonElement.tsx
@@ -53,8 +53,6 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
     throw new Error("ButtonElement requires meta.extensionId");
   }
 
-  const disabled = boolean(rawDisabled);
-
   const handler = async () => {
     const currentCounter = counter;
     setCounter((previous) => previous + 1);
@@ -92,7 +90,13 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
     }
   };
 
-  return <AsyncButton onClick={handler} disabled={disabled} {...restProps} />;
+  return (
+    <AsyncButton
+      onClick={handler}
+      disabled={boolean(rawDisabled)}
+      {...restProps}
+    />
+  );
 };
 
 export default ButtonElement;


### PR DESCRIPTION
## What does this PR do?

- Closes #4704 
- Pass disabled field value to the element
- Adds support for passing text, so you can use nunjucks to provide a truthy string

## Discussion

- Can't disable the button in the preview because that prevents it from being selected in the preview

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
