### PR TITLE
#5985: remove excess form padding and add to three dot menu in Document Builder

### DIFF
--- a/src/blocks/renderers/customForm.tsx
+++ b/src/blocks/renderers/customForm.tsx
@@ -89,13 +89,11 @@ const CustomFormComponent: React.FunctionComponent<{
   onSubmit,
 }) => (
   <div
-    className={
-      // Since 1.7.33, support a className prop to allow for adjusting margin/padding
-      cx("CustomForm", {
-        "p-3": className === undefined,
-        [className]: Boolean(className),
-      })
-    }
+    className={cx("CustomForm", className, {
+      // Since 1.7.33, support a className prop to allow for adjusting margin/padding. To maintain the legacy
+      // behavior, apply the default only if the className prop is not provided.
+      "p-3": className === undefined,
+    })}
   >
     <ErrorBoundary>
       <Stylesheets href={[bootstrap, custom]}>

--- a/src/blocks/renderers/customForm.tsx
+++ b/src/blocks/renderers/customForm.tsx
@@ -47,6 +47,7 @@ import {
 import { Renderer } from "@/types/blocks/rendererTypes";
 import RjsfSelectWidget from "@/components/formBuilder/RjsfSelectWidget";
 import { type ISubmitEvent, type IChangeEvent } from "@rjsf/core";
+import cx from "classnames";
 
 const fields = {
   DescriptionField,
@@ -77,8 +78,25 @@ const CustomFormComponent: React.FunctionComponent<{
   formData: JsonObject;
   autoSave: boolean;
   onSubmit: (values: JsonObject) => Promise<void>;
-}> = ({ schema, uiSchema, submitCaption, formData, autoSave, onSubmit }) => (
-  <div className="CustomForm p-3">
+  className?: string;
+}> = ({
+  schema,
+  uiSchema,
+  submitCaption,
+  formData,
+  autoSave,
+  className,
+  onSubmit,
+}) => (
+  <div
+    className={
+      // Since 1.7.33, support a className prop to allow for adjusting margin/padding
+      cx("CustomForm", {
+        "p-3": className === undefined,
+        [className]: Boolean(className),
+      })
+    }
+  >
     <ErrorBoundary>
       <Stylesheets href={[bootstrap, custom]}>
         <JsonSchemaForm
@@ -201,6 +219,11 @@ export const customFormRendererSchema = {
       type: "object",
       additionalProperties: true,
     },
+    // Added in 1.7.33 to allow for adjusting the native margin/padding when used in the document builder
+    className: {
+      schema: { type: "string", format: "bootstrap-class" },
+      label: "Layout/Style",
+    },
   },
   required: ["schema"],
 };
@@ -226,6 +249,7 @@ export class CustomFormRenderer extends Renderer {
       autoSave = false,
       successMessage,
       submitCaption = "Submit",
+      className,
     }: BlockArgs<{
       storage?: Storage;
       successMessage?: string;
@@ -234,6 +258,7 @@ export class CustomFormRenderer extends Renderer {
       submitCaption?: string;
       schema: Schema;
       uiSchema?: UiSchema;
+      className?: string;
     }>,
     { logger }: BlockOptions
   ): Promise<ComponentRef> {
@@ -277,6 +302,7 @@ export class CustomFormRenderer extends Renderer {
         uiSchema,
         autoSave,
         submitCaption,
+        className,
         async onSubmit(values: JsonObject) {
           try {
             const normalizedValues = normalizeOutgoingFormData(schema, values);

--- a/src/components/documentBuilder/createNewElement.test.ts
+++ b/src/components/documentBuilder/createNewElement.test.ts
@@ -106,3 +106,14 @@ test("throws on unknown elements", () => {
     createNewElement("unknown");
   }).toThrow();
 });
+
+test("sets padding to zero for form", () => {
+  const actual = createNewElement("form");
+  expect(actual.type).toBe("pipeline");
+  expect((actual.config as any).pipeline.__value__[0].id).toBe(
+    "@pixiebrix/form"
+  );
+  expect((actual.config as any).pipeline.__value__[0].config.className).toBe(
+    "p-0"
+  );
+});

--- a/src/components/documentBuilder/createNewElement.ts
+++ b/src/components/documentBuilder/createNewElement.ts
@@ -23,10 +23,19 @@ import {
   type DeferExpression,
   type PipelineExpression,
 } from "@/runtime/mapArgs";
+import { validateRegistryId } from "@/types/helpers";
 
-export function createNewElement(elementType: DocumentElementType) {
+const elementExtras: Record<"form", DocumentElementType> = {
+  form: "pipeline",
+};
+
+export function createNewElement(
+  elementType: DocumentElementType | keyof typeof elementExtras
+): DocumentElement {
   const element: DocumentElement = {
-    type: elementType,
+    // Writing as map to make it easier to add similar shortcuts in the future
+    // eslint-disable-next-line security/detect-object-injection -- check for valid element type
+    type: elementType === "form" ? elementExtras[elementType] : elementType,
     config: {},
   };
 
@@ -66,6 +75,42 @@ export function createNewElement(elementType: DocumentElementType) {
     case "card": {
       element.config.heading = "Header";
       element.children = [];
+      break;
+    }
+
+    case "form": {
+      element.config.label = "Form";
+      element.config.pipeline = {
+        __type__: "pipeline",
+        __value__: [
+          {
+            id: validateRegistryId("@pixiebrix/form"),
+            config: {
+              storage: {
+                type: "state",
+                namespace: "blueprint",
+              },
+              submitCaption: "Save",
+              schema: {
+                type: "object",
+                properties: {
+                  notes: {
+                    title: "Example Notes Field",
+                    type: "string",
+                    description: "An example notes field",
+                  },
+                },
+              },
+              uiSchema: {
+                notes: {
+                  "ui:widget": "textarea",
+                },
+              },
+              className: "p-0",
+            },
+          },
+        ],
+      } as PipelineExpression;
       break;
     }
 

--- a/src/components/documentBuilder/edit/PipelineOptions.tsx
+++ b/src/components/documentBuilder/edit/PipelineOptions.tsx
@@ -27,12 +27,12 @@ type PipelineOptionsProps = {
 const PipelineOptions: React.FC<PipelineOptionsProps> = ({ elementName }) => (
   <>
     <Row>
-      <Col>Use the Nodes Tree on the left to edit the nested pipeline.</Col>
+      <Col>Use the Brick Actions Panel on the left to add and edit bricks.</Col>
     </Row>
     <ConnectedFieldTemplate
       name={joinPathParts(elementName, "config", "label")}
       label="Pipeline name"
-      description="The pipeline label displayed in the Nodes Tree"
+      description="The pipeline label displayed in the Brick Actions Panel"
     />
   </>
 );

--- a/src/components/documentBuilder/preview/AddElementAction.tsx
+++ b/src/components/documentBuilder/preview/AddElementAction.tsx
@@ -47,21 +47,36 @@ const AddElementAction: React.FC<AddElementActionProps> = ({
     DocumentElement[]
   >(elementsCollectionName);
 
-  const addElement = (elementType: DocumentElementType) => {
+  const addElement = (elementType: Parameters<typeof createNewElement>[0]) => {
     const element = createNewElement(elementType);
     setValue([...elementsCollection, element]);
   };
+
+  const elementItems = allowedTypes.map((elementType) => ({
+    // eslint-disable-next-line security/detect-object-injection -- type checked
+    title: elementTypeLabels[elementType],
+    action() {
+      addElement(elementType);
+    },
+  }));
+
+  // Extra pipeline items; can be added wherever a pipeline is allowed
+  const pipelineItems = allowedTypes.includes("pipeline")
+    ? [
+        {
+          title: "Form",
+          action() {
+            addElement("form");
+          },
+        },
+      ]
+    : [];
 
   return (
     <EllipsisMenu
       className={className}
       toggleClassName={styles.toggle}
-      items={allowedTypes.map((elementType) => ({
-        title: elementTypeLabels[elementType],
-        action() {
-          addElement(elementType);
-        },
-      }))}
+      items={[...elementItems, ...pipelineItems]}
       menuBoundary={menuBoundary}
     />
   );


### PR DESCRIPTION
## What does this PR do?

- Closes #5985 
- Slices 1.1-1.3 here: https://www.notion.so/pixiebrix/Improve-Embedding-of-Form-Fields-in-the-Document-Builder-377a6f634c1641c6a45b9470e5ce23f5?pvs=4#085f771be17c4e18b6b774c091e50ec6
  - Adds an affordance for custom forms to pass a className to apply to the parent div. But **does not show the affordance in the Page Editor UI**
  - Adds "Form" to the 3-dot menu for elements, which adds the Custom Form brick directly
  - When a form is added that way, the padding is set to zero

## Discussion

- To remove the padding in existing forms/mods, people can use the workshop
- What should the default behavior be for "Auto Save" in the added element? Currently, I have it set to show a submit button but without a success message

The alignment with the header looks like a font quirk with how the letter "E" works as the first letter in headers

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/250d7778-0fc8-4698-b0bf-bbdb6baf27ed)

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/a5136075-b63b-402f-9592-0ea1c5979434)

## Demo

- https://www.loom.com/share/e26450645c424f22a2ce0942a2688e13?sid=a680f9f1-f1cc-497b-b103-b37b7a53c4ae

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
