### PR TITLE
#5987: add h4-h6 headers in the Document Builder

### DIFF
--- a/src/components/documentBuilder/allowedElementTypes.ts
+++ b/src/components/documentBuilder/allowedElementTypes.ts
@@ -49,6 +49,9 @@ const allowedChildTypes: Record<string, DocumentElementType[]> = {
   list: DOCUMENT_ELEMENT_TYPES as unknown as DocumentElementType[],
 };
 
+// HTML5/Bootstrap supports H1-H6: https://getbootstrap.com/docs/4.0/content/typography/
+export const VALID_HEADER_TAGS = ["h1", "h2", "h3", "h4", "h5", "h6"];
+
 export function getAllowedChildTypes(
   parentElement: DocumentElement
 ): DocumentElementType[] {

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -91,6 +91,21 @@ describe("When rendered in panel", () => {
     }
   );
 
+  test.each([1, 2, 3, 4, 5, 6])("renders tag for h%d", (headerLevel) => {
+    const { container } = renderDocument({
+      type: "header",
+      config: {
+        title: "Test Header",
+        heading: `h${headerLevel}`,
+      },
+    });
+
+    const element = container.querySelector(`h${headerLevel}`);
+
+    expect(element).not.toBeNull();
+    expect(element).toHaveTextContent("Test Header");
+  });
+
   test("renders paragraph text", () => {
     const config: DocumentElement = {
       type: "text",

--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -36,13 +36,15 @@ import { joinPathParts } from "@/utils";
 import Markdown from "@/components/Markdown";
 import CardElement from "./render/CardElement";
 
+// Legacy header components, where each header type was a separate element
 const headerComponents = {
   header_1: "h1",
   header_2: "h2",
   header_3: "h3",
 } as const;
 
-const headingComponents = ["h1", "h2", "h3"];
+// Bootstrap supports H1-H6: https://getbootstrap.com/docs/4.0/content/typography/
+const headingComponents = ["h1", "h2", "h3", "h4", "h5", "h6"];
 
 const gridComponents = {
   container: Container,

--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -35,6 +35,7 @@ import { BusinessError } from "@/errors/businessErrors";
 import { joinPathParts } from "@/utils";
 import Markdown from "@/components/Markdown";
 import CardElement from "./render/CardElement";
+import { VALID_HEADER_TAGS } from "@/components/documentBuilder/allowedElementTypes";
 
 // Legacy header components, where each header type was a separate element
 const headerComponents = {
@@ -42,9 +43,6 @@ const headerComponents = {
   header_2: "h2",
   header_3: "h3",
 } as const;
-
-// Bootstrap supports H1-H6: https://getbootstrap.com/docs/4.0/content/typography/
-const headingComponents = ["h1", "h2", "h3", "h4", "h5", "h6"];
 
 const gridComponents = {
   container: Container,
@@ -102,7 +100,7 @@ export function getComponentDefinition(
       props.children = title;
 
       return {
-        Component: headingComponents.includes(heading as string)
+        Component: VALID_HEADER_TAGS.includes(heading as string)
           ? (heading as ElementType)
           : "h1",
         props,

--- a/src/components/documentBuilder/edit/getElementEditSchemas.ts
+++ b/src/components/documentBuilder/edit/getElementEditSchemas.ts
@@ -18,6 +18,7 @@
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import { joinName } from "@/utils";
 import { type DocumentElementType } from "@/components/documentBuilder/documentBuilderTypes";
+import { VALID_HEADER_TAGS } from "@/components/documentBuilder/allowedElementTypes";
 
 function getClassNameEdit(elementName: string): SchemaFieldProps {
   return {
@@ -54,8 +55,7 @@ function getElementEditSchemas(
         name: joinName(elementName, "config", "heading"),
         schema: {
           type: "string",
-          // Bootstrap supports H1-H6: https://getbootstrap.com/docs/4.0/content/typography/
-          enum: ["h1", "h2", "h3", "h4", "h5", "h6"],
+          enum: VALID_HEADER_TAGS,
           format: "heading-style",
         },
         label: "Heading",

--- a/src/components/documentBuilder/edit/getElementEditSchemas.ts
+++ b/src/components/documentBuilder/edit/getElementEditSchemas.ts
@@ -54,7 +54,8 @@ function getElementEditSchemas(
         name: joinName(elementName, "config", "heading"),
         schema: {
           type: "string",
-          enum: ["h1", "h2", "h3"],
+          // Bootstrap supports H1-H6: https://getbootstrap.com/docs/4.0/content/typography/
+          enum: ["h1", "h2", "h3", "h4", "h5", "h6"],
           format: "heading-style",
         },
         label: "Heading",

--- a/src/components/fields/schemaFields/widgets/HeadingStyleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/HeadingStyleWidget.tsx
@@ -22,6 +22,7 @@ import cx from "classnames";
 import styles from "./HeadingStyleWidget.module.scss";
 import { useField } from "formik";
 
+// Bootstrap supports H1-H6: https://getbootstrap.com/docs/4.0/content/typography/
 const headingTypes = {
   h1: {
     heading: "h1",
@@ -35,6 +36,18 @@ const headingTypes = {
     heading: "h3",
     title: "H3",
   },
+  h4: {
+    heading: "h4",
+    title: "H4",
+  },
+  h5: {
+    heading: "h5",
+    title: "H5",
+  },
+  h6: {
+    heading: "h6",
+    title: "H6",
+  },
 };
 
 const HeadingStyleWidget: React.FunctionComponent<SchemaFieldProps> = (
@@ -45,23 +58,21 @@ const HeadingStyleWidget: React.FunctionComponent<SchemaFieldProps> = (
   return (
     <div className="mt-2">
       <ButtonGroup>
-        {[headingTypes.h1, headingTypes.h2, headingTypes.h3].map(
-          (headingType) => (
-            <Button
-              key={headingType.heading}
-              className={cx(styles.button, {
-                active: value === headingType.heading,
-              })}
-              variant="light"
-              size="sm"
-              onClick={() => {
-                setValue(headingType.heading);
-              }}
-            >
-              {headingType.title}
-            </Button>
-          )
-        )}
+        {Object.values(headingTypes).map((headingType) => (
+          <Button
+            key={headingType.heading}
+            className={cx(styles.button, {
+              active: value === headingType.heading,
+            })}
+            variant="light"
+            size="sm"
+            onClick={() => {
+              setValue(headingType.heading);
+            }}
+          >
+            {headingType.title}
+          </Button>
+        ))}
       </ButtonGroup>
     </div>
   );

--- a/src/components/fields/schemaFields/widgets/HeadingStyleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/HeadingStyleWidget.tsx
@@ -21,34 +21,17 @@ import { type SchemaFieldProps } from "@/components/fields/schemaFields/propType
 import cx from "classnames";
 import styles from "./HeadingStyleWidget.module.scss";
 import { useField } from "formik";
+import { VALID_HEADER_TAGS } from "@/components/documentBuilder/allowedElementTypes";
 
-// Bootstrap supports H1-H6: https://getbootstrap.com/docs/4.0/content/typography/
-const headingTypes = {
-  h1: {
-    heading: "h1",
-    title: "H1",
-  },
-  h2: {
-    heading: "h2",
-    title: "H2",
-  },
-  h3: {
-    heading: "h3",
-    title: "H3",
-  },
-  h4: {
-    heading: "h4",
-    title: "H4",
-  },
-  h5: {
-    heading: "h5",
-    title: "H5",
-  },
-  h6: {
-    heading: "h6",
-    title: "H6",
-  },
-};
+const headingTypes = Object.fromEntries(
+  VALID_HEADER_TAGS.map((heading) => [
+    heading,
+    {
+      heading,
+      title: heading.toUpperCase(),
+    },
+  ])
+);
 
 const HeadingStyleWidget: React.FunctionComponent<SchemaFieldProps> = (
   props

--- a/src/components/fields/schemaFields/widgets/HeadingStyleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/HeadingStyleWidget.tsx
@@ -23,16 +23,6 @@ import styles from "./HeadingStyleWidget.module.scss";
 import { useField } from "formik";
 import { VALID_HEADER_TAGS } from "@/components/documentBuilder/allowedElementTypes";
 
-const headingTypes = Object.fromEntries(
-  VALID_HEADER_TAGS.map((heading) => [
-    heading,
-    {
-      heading,
-      title: heading.toUpperCase(),
-    },
-  ])
-);
-
 const HeadingStyleWidget: React.FunctionComponent<SchemaFieldProps> = (
   props
 ) => {
@@ -41,19 +31,19 @@ const HeadingStyleWidget: React.FunctionComponent<SchemaFieldProps> = (
   return (
     <div className="mt-2">
       <ButtonGroup>
-        {Object.values(headingTypes).map((headingType) => (
+        {VALID_HEADER_TAGS.map((headingTag) => (
           <Button
-            key={headingType.heading}
+            key={headingTag}
             className={cx(styles.button, {
-              active: value === headingType.heading,
+              active: value === headingTag,
             })}
             variant="light"
             size="sm"
             onClick={() => {
-              setValue(headingType.heading);
+              setValue(headingTag);
             }}
           >
-            {headingType.title}
+            {headingTag.toUpperCase()}
           </Button>
         ))}
       </ButtonGroup>


### PR DESCRIPTION
## What does this PR do?

- Closes #5987: adds h4-h6 headers in the Document Builder

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/5f68218f-22e6-4ddf-b443-6ba01977801c)

## Future Work

- Add support for switching from a header element to a text element with markdown support that has the header as markdown

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @turbochef 
