### PR TITLE
#5989: add field to conditionally hide Document Builder elements

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -9974,35 +9974,6 @@ exports[`Storyshots Widgets/CssClassWidget Blank Expression 1`] = `
             </button>
           </div>
         </div>
-        <div
-          className="mx-2 btn-group"
-          role="group"
-        >
-          <button
-            className="flagButton btn btn-light btn-sm"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-eye-slash fa-w-20 "
-              data-icon="eye-slash"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={{}}
-              viewBox="0 0 640 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
-                fill="currentColor"
-                style={{}}
-              />
-            </svg>
-          </button>
-        </div>
       </div>
       <div
         className="d-flex my-2"
@@ -10433,35 +10404,6 @@ exports[`Storyshots Widgets/CssClassWidget Blank Literal 1`] = `
               </svg>
             </button>
           </div>
-        </div>
-        <div
-          className="mx-2 btn-group"
-          role="group"
-        >
-          <button
-            className="flagButton btn btn-light btn-sm"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-eye-slash fa-w-20 "
-              data-icon="eye-slash"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={{}}
-              viewBox="0 0 640 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
-                fill="currentColor"
-                style={{}}
-              />
-            </svg>
-          </button>
         </div>
       </div>
       <div
@@ -10894,35 +10836,6 @@ exports[`Storyshots Widgets/CssClassWidget Omitted 1`] = `
             </button>
           </div>
         </div>
-        <div
-          className="mx-2 btn-group"
-          role="group"
-        >
-          <button
-            className="flagButton btn btn-light btn-sm"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-eye-slash fa-w-20 "
-              data-icon="eye-slash"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={{}}
-              viewBox="0 0 640 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
-                fill="currentColor"
-                style={{}}
-              />
-            </svg>
-          </button>
-        </div>
       </div>
       <div
         className="d-flex my-2"
@@ -11351,35 +11264,6 @@ exports[`Storyshots Widgets/CssClassWidget Variable Expression 1`] = `
               </svg>
             </button>
           </div>
-        </div>
-        <div
-          className="mx-2 btn-group"
-          role="group"
-        >
-          <button
-            className="flagButton btn btn-light btn-sm"
-            disabled={true}
-            onClick={[Function]}
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              className="svg-inline--fa fa-eye-slash fa-w-20 "
-              data-icon="eye-slash"
-              data-prefix="fas"
-              focusable="false"
-              role="img"
-              style={{}}
-              viewBox="0 0 640 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
-                fill="currentColor"
-                style={{}}
-              />
-            </svg>
-          </button>
         </div>
       </div>
       <div

--- a/src/blocks/renderers/documentView/DocumentView.tsx
+++ b/src/blocks/renderers/documentView/DocumentView.tsx
@@ -46,10 +46,16 @@ const DocumentView: React.FC<DocumentViewProps> = ({
       <EmotionShadowRoot.div className="h-100">
         <Stylesheets href={bootstrap}>
           {body.map((documentElement, index) => {
-            const { Component, props } = buildDocumentBranch(documentElement, {
+            const documentBranch = buildDocumentBranch(documentElement, {
               staticId: joinPathParts("body", "children"),
               branches: [],
             });
+
+            if (documentBranch == null) {
+              return null;
+            }
+
+            const { Component, props } = documentBranch;
             return <Component key={index} {...props} />;
           })}
         </Stylesheets>

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -47,10 +47,14 @@ describe("When rendered in panel", () => {
   });
 
   const renderDocument = (config: DocumentElement) => {
-    const { Component, props } = buildDocumentBranch(config, {
+    const branch = buildDocumentBranch(config, {
       staticId: "body",
       branches: [],
     });
+
+    const { Component, props } = branch ?? {};
+    const component = branch == null ? null : <Component {...props} />;
+
     return render(
       <DocumentContext.Provider
         value={{
@@ -61,7 +65,7 @@ describe("When rendered in panel", () => {
           },
         }}
       >
-        <Component {...props} />
+        {component}
       </DocumentContext.Provider>
     );
   };
@@ -106,6 +110,20 @@ describe("When rendered in panel", () => {
     expect(element).not.toBeNull();
     expect(element).toHaveClass("test-class");
     expect(element).toHaveTextContent("Test Paragraph");
+  });
+
+  test("does not render hidden element at root", () => {
+    const config: DocumentElement = {
+      type: "text",
+      config: {
+        text: "Test Paragraph",
+        className: "test-class",
+        hidden: true,
+      },
+    };
+    const { container } = renderDocument(config);
+    const element = container.querySelector("p");
+    expect(element).toBeNull();
   });
 
   test("renders markdown", () => {

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -53,7 +53,7 @@ describe("When rendered in panel", () => {
     });
 
     const { Component, props } = branch ?? {};
-    const component = branch == null ? null : <Component {...props} />;
+    const children = Component ? <Component {...props} /> : null;
 
     return render(
       <DocumentContext.Provider
@@ -65,7 +65,7 @@ describe("When rendered in panel", () => {
           },
         }}
       >
-        {component}
+        {children}
       </DocumentContext.Provider>
     );
   };

--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -58,18 +58,31 @@ const UnknownType: React.FC<{ componentType: string }> = ({
 
 export const buildDocumentBranch: BuildDocumentBranch = (root, tracePath) => {
   const { staticId, branches } = tracePath;
-  const componentDefinition = getComponentDefinition(root, tracePath);
 
-  if (componentDefinition == null) {
-    return;
+  const { hidden: rawHidden } = root.config ?? {};
+  const hidden = boolean(rawHidden);
+
+  // We're excluding hidden elements from the DOM completely. HTML does have an attribute 'hidden' and Boostrap has
+  // a `d-none` class, but those still include the element in the DOM. By excluding the element completely, we can
+  // avoid brick and list computations.
+  if (hidden) {
+    return null;
   }
+
+  const componentDefinition = getComponentDefinition(root, tracePath);
 
   if (root.children?.length > 0) {
     componentDefinition.props.children = root.children.map((child, index) => {
-      const { Component, props } = buildDocumentBranch(child, {
+      const branch = buildDocumentBranch(child, {
         staticId: joinPathParts(staticId, root.type, "children"),
         branches: [...branches, { staticId, index }],
       });
+
+      if (branch == null) {
+        return null;
+      }
+
+      const { Component, props } = branch;
       return <Component key={index} {...props} />;
     });
   }
@@ -83,17 +96,8 @@ export function getComponentDefinition(
   tracePath: DynamicPath
 ): DocumentComponent | null {
   const componentType = element.type;
-  const config = get(element, "config", {} as UnknownObject);
-
-  const { hidden: rawHidden } = config;
-  const hidden = boolean(rawHidden);
-
-  // We're excluding hidden elements from the DOM completely. HTML does have an attribute 'hidden' and Boostrap has
-  // a `d-none` class, but those still include the element in the DOM. By excluding the element completely, we can
-  // avoid brick and list computations.
-  if (hidden) {
-    return null;
-  }
+  // Destructure hidden from config, so we don't spread it onto components
+  const { hidden, ...config } = get(element, "config", {} as UnknownObject);
 
   switch (componentType) {
     // Provide backwards compatibility for old elements

--- a/src/components/documentBuilder/edit/getElementEditSchemas.tsx
+++ b/src/components/documentBuilder/edit/getElementEditSchemas.tsx
@@ -18,12 +18,30 @@
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import { joinName } from "@/utils";
 import { type DocumentElementType } from "@/components/documentBuilder/documentBuilderTypes";
+import React from "react";
 
 function getClassNameEdit(elementName: string): SchemaFieldProps {
   return {
     name: joinName(elementName, "config", "className"),
     schema: { type: "string", format: "bootstrap-class" },
     label: "Layout/Style",
+  };
+}
+
+function getHiddenEdit(elementName: string): SchemaFieldProps {
+  return {
+    name: joinName(elementName, "config", "hidden"),
+    // Allow any to permit truthy values like for other conditional fields
+    schema: { type: ["string", "boolean", "null", "number"] },
+    label: "Hidden",
+    description: (
+      <p>
+        Condition determining whether to hide the element. Truthy string values
+        are&nbsp;
+        <code>true</code>, <code>t</code>, <code>yes</code>, <code>y</code>,{" "}
+        <code>on</code>, and <code>1</code> (case-insensitive)
+      </p>
+    ),
   };
 }
 
@@ -41,7 +59,11 @@ function getElementEditSchemas(
         schema: { type: "string" },
         label: "Title",
       };
-      return [titleEdit, getClassNameEdit(elementName)];
+      return [
+        titleEdit,
+        getHiddenEdit(elementName),
+        getClassNameEdit(elementName),
+      ];
     }
 
     case "header": {
@@ -60,7 +82,12 @@ function getElementEditSchemas(
         label: "Heading",
         isRequired: true,
       };
-      return [titleEdit, heading, getClassNameEdit(elementName)];
+      return [
+        titleEdit,
+        heading,
+        getHiddenEdit(elementName),
+        getClassNameEdit(elementName),
+      ];
     }
 
     case "text": {
@@ -75,7 +102,12 @@ function getElementEditSchemas(
         label: "Enable markdown",
         isRequired: true,
       };
-      return [textEdit, enableMarkdown, getClassNameEdit(elementName)];
+      return [
+        textEdit,
+        enableMarkdown,
+        getHiddenEdit(elementName),
+        getClassNameEdit(elementName),
+      ];
     }
 
     case "image": {
@@ -94,7 +126,13 @@ function getElementEditSchemas(
         schema: { type: ["string", "number"] },
         label: "Width",
       };
-      return [imageUrl, height, width, getClassNameEdit(elementName)];
+      return [
+        imageUrl,
+        height,
+        width,
+        getHiddenEdit(elementName),
+        getClassNameEdit(elementName),
+      ];
     }
 
     case "card": {
@@ -103,7 +141,11 @@ function getElementEditSchemas(
         schema: { type: "string" },
         label: "Heading",
       };
-      return [headingEdit, getClassNameEdit(elementName)];
+      return [
+        headingEdit,
+        getHiddenEdit(elementName),
+        getClassNameEdit(elementName),
+      ];
     }
 
     case "pipeline": {
@@ -160,6 +202,7 @@ function getElementEditSchemas(
         variantEdit,
         sizeEdit,
         disabledEdit,
+        getHiddenEdit(elementName),
         getClassNameEdit(elementName),
       ];
     }
@@ -169,7 +212,7 @@ function getElementEditSchemas(
     }
 
     default: {
-      return [getClassNameEdit(elementName)];
+      return [getHiddenEdit(elementName), getClassNameEdit(elementName)];
     }
   }
 }

--- a/src/components/documentBuilder/preview/getPreviewComponentDefinition.tsx
+++ b/src/components/documentBuilder/preview/getPreviewComponentDefinition.tsx
@@ -41,6 +41,9 @@ const DUMMY_TRACE_PATH: DynamicPath = { staticId: "preview", branches: [] };
 
 const allowedBootstrapPrefixes = ["text", "bg"];
 function filterCssClassesForPreview(props: UnknownObject | undefined) {
+  // Never hide elements in the preview
+  delete props.hidden;
+
   if (typeof props?.className === "string") {
     props.className = props.className
       .split(" ")
@@ -54,6 +57,8 @@ function filterCssClassesForPreview(props: UnknownObject | undefined) {
 function getPreviewComponentDefinition(
   element: DocumentElement
 ): DocumentComponent {
+  // FIXME: need to handle the 'hidden' prop
+
   const componentType = String(element.type);
   const config = get(element, "config", {} as UnknownObject);
 
@@ -67,6 +72,7 @@ function getPreviewComponentDefinition(
         element,
         DUMMY_TRACE_PATH
       );
+
       filterCssClassesForPreview(documentComponent.props);
 
       return {

--- a/src/components/documentBuilder/preview/getPreviewComponentDefinition.tsx
+++ b/src/components/documentBuilder/preview/getPreviewComponentDefinition.tsx
@@ -40,7 +40,7 @@ import List from "./elementsPreview/List";
 const DUMMY_TRACE_PATH: DynamicPath = { staticId: "preview", branches: [] };
 
 const allowedBootstrapPrefixes = ["text", "bg"];
-function filterCssClassesForPreview(props: UnknownObject | undefined) {
+function filterCssClassesForPreview(props: UnknownObject | undefined): void {
   // Never hide elements in the preview
   delete props.hidden;
 
@@ -57,10 +57,13 @@ function filterCssClassesForPreview(props: UnknownObject | undefined) {
 function getPreviewComponentDefinition(
   element: DocumentElement
 ): DocumentComponent {
-  // FIXME: need to handle the 'hidden' prop
+  const previewElement = produce(element, (draft) => {
+    // Don't hide elements in the preview
+    delete draft.config.hidden;
+  });
 
-  const componentType = String(element.type);
-  const config = get(element, "config", {} as UnknownObject);
+  const componentType = String(previewElement.type);
+  const config = get(previewElement, "config", {} as UnknownObject);
 
   switch (componentType) {
     case "header_1":
@@ -69,7 +72,7 @@ function getPreviewComponentDefinition(
     case "header":
     case "text": {
       const documentComponent = getComponentDefinition(
-        element,
+        previewElement,
         DUMMY_TRACE_PATH
       );
 
@@ -78,7 +81,7 @@ function getPreviewComponentDefinition(
       return {
         Component: Basic,
         props: {
-          elementType: element.type,
+          elementType: previewElement.type,
           documentComponent,
         },
       };
@@ -86,7 +89,7 @@ function getPreviewComponentDefinition(
 
     case "image": {
       const documentComponent = getComponentDefinition(
-        element,
+        previewElement,
         DUMMY_TRACE_PATH
       );
       filterCssClassesForPreview(documentComponent.props);
@@ -94,7 +97,7 @@ function getPreviewComponentDefinition(
       return {
         Component: Image,
         props: {
-          elementType: element.type,
+          elementType: previewElement.type,
           documentComponent,
         },
       };
@@ -104,7 +107,7 @@ function getPreviewComponentDefinition(
     case "row":
     case "column": {
       const documentComponent = getComponentDefinition(
-        element,
+        previewElement,
         DUMMY_TRACE_PATH
       );
       filterCssClassesForPreview(documentComponent.props);
@@ -112,19 +115,19 @@ function getPreviewComponentDefinition(
       return {
         Component: Container,
         props: {
-          element,
+          element: previewElement,
           documentComponent,
         },
       };
     }
 
     case "card": {
-      const previewElement = produce(element, (draft) => {
+      const cardPreviewElement = produce(previewElement, (draft) => {
         draft.config.bodyClassName = documentTreeStyles.container;
       });
 
       const documentComponent = getComponentDefinition(
-        previewElement,
+        cardPreviewElement,
         DUMMY_TRACE_PATH
       );
       filterCssClassesForPreview(documentComponent.props);
@@ -132,7 +135,7 @@ function getPreviewComponentDefinition(
       return {
         Component: Card,
         props: {
-          element,
+          element: previewElement,
           documentComponent,
         },
       };
@@ -142,7 +145,7 @@ function getPreviewComponentDefinition(
       return {
         Component: Pipeline,
         props: {
-          element,
+          element: previewElement,
         },
       };
     }
@@ -154,14 +157,14 @@ function getPreviewComponentDefinition(
       return {
         Component: Button,
         props: {
-          element,
+          element: previewElement,
           buttonProps,
         },
       };
     }
 
     case "list": {
-      return { Component: List, props: { element } };
+      return { Component: List, props: { element: previewElement } };
     }
 
     default: {

--- a/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/CssClassWidget.tsx
@@ -36,7 +36,6 @@ import {
   faCaretDown,
   faCaretRight,
   faCheck,
-  faEyeSlash,
   faFill,
   faFont,
   faItalic,
@@ -83,10 +82,6 @@ const flags = {
   italic: {
     className: "font-italic",
     title: <FontAwesomeIcon icon={faItalic} />,
-  },
-  hide: {
-    className: "d-none",
-    title: <FontAwesomeIcon icon={faEyeSlash} />,
   },
 };
 
@@ -644,18 +639,6 @@ const CssClassWidget: React.VFC<
               />
             ))}
           </DropdownButton>
-        </ButtonGroup>
-
-        <ButtonGroup className="mx-2">
-          {[flags.hide].map((flag) => (
-            <FlagButton
-              key={flag.className}
-              {...flag}
-              disabled={disableControls}
-              classes={classes}
-              toggleClass={toggleClass}
-            />
-          ))}
         </ButtonGroup>
       </div>
 

--- a/src/components/fields/schemaFields/widgets/__snapshots__/ClassClassWidget.test.tsx.snap
+++ b/src/components/fields/schemaFields/widgets/__snapshots__/ClassClassWidget.test.tsx.snap
@@ -233,31 +233,6 @@ exports[`CssClassWidget should render blank literal 1`] = `
           </button>
         </div>
       </div>
-      <div
-        class="mx-2 btn-group"
-        role="group"
-      >
-        <button
-          class="flagButton btn btn-light btn-sm"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="svg-inline--fa fa-eye-slash fa-w-20 "
-            data-icon="eye-slash"
-            data-prefix="fas"
-            focusable="false"
-            role="img"
-            viewBox="0 0 640 512"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
-              fill="currentColor"
-            />
-          </svg>
-        </button>
-      </div>
     </div>
     <div
       class="d-flex my-2"


### PR DESCRIPTION
## What does this PR do?

- Closes #5989 
- Adds a 'hidden' field to Document Builder elements to conditional hide fields without using Nunjucks conditionals with `d-none` 
- Drops the 'visible` toggle from Style/Layout that has no practical purpose

## Remaining Work

- [x] Figure out how to exclude hiding from the preview
- [x] Add tests

## Discussion

- We can't put in "Advanced Options" because the advanced options refer to the containing Render Document brick, not the element that's currently being edited
- We could consider starting the field as a toggle in the "off" state instead of excluded

## Demo

- https://www.loom.com/share/c578c7abb19d4634838c3839e295093b

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
