### PR TITLE
removes font-size override from brick name in page editor

### DIFF
--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
@@ -25,6 +25,5 @@
 }
 
 .brickInfo {
-  font-size: 80%;
   font-weight: 500;
 }


### PR DESCRIPTION
## What does this PR do?

* Per feedback from @BrandonPxBx, removes font-size override from brick name in page editor
* Brick name and docs link should be same size as `Advanced: ` header


## Demo
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/f369683d-30a1-47e6-8e29-dc391a2b6d5c)

## Checklist

- [x] Designate a primary reviewer @BLoe 
