### PR TITLE
#6004: add full width toggle to button element in Document Builder

### DIFF
--- a/src/components/documentBuilder/createNewElement.test.ts
+++ b/src/components/documentBuilder/createNewElement.test.ts
@@ -90,6 +90,11 @@ test("sets default config for button", () => {
   const expectedConfig = {
     label: "Button",
     title: "Action",
+    size: "md",
+    hidden: false,
+    fullWidth: false,
+    variant: "primary",
+    disabled: false,
     onClick: {
       __type__: "pipeline",
       __value__: [] as BrickPipeline,

--- a/src/components/documentBuilder/createNewElement.ts
+++ b/src/components/documentBuilder/createNewElement.ts
@@ -126,6 +126,11 @@ export function createNewElement(
     case "button": {
       element.config.label = "Button";
       element.config.title = "Action";
+      element.config.size = "md";
+      element.config.variant = "primary";
+      element.config.fullWidth = false;
+      element.config.disabled = false;
+      element.config.hidden = false;
 
       element.config.onClick = {
         __type__: "pipeline",

--- a/src/components/documentBuilder/documentBuilderTypes.ts
+++ b/src/components/documentBuilder/documentBuilderTypes.ts
@@ -85,9 +85,10 @@ export type ButtonDocumentConfig = {
   title: string | Expression;
   variant?: string | Expression;
   /**
-   * Default size type coming from Bootstrap Button
+   * Default size type coming from React Bootstrap Button
    */
   size?: "sm" | "lg" | Expression<"sm" | "lg">;
+  fullWidth?: boolean | Expression;
   disabled?: boolean | Expression;
   className?: string | Expression;
   onClick: PipelineExpression;

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -274,6 +274,24 @@ describe("When rendered in panel", () => {
       expect(element).not.toBeDisabled();
     });
 
+    test("renders full width button", () => {
+      const config: DocumentElement = {
+        type: "button",
+        config: {
+          title: "Button under test",
+          fullWidth: true,
+          onClick: {
+            __type__: "pipeline",
+            __value__: jest.fn(),
+          },
+        },
+      };
+      const { container } = renderDocument(config);
+      const element = container.querySelector("button");
+
+      expect(element).toHaveClass("btn-block");
+    });
+
     test.each`
       variant        | className
       ${"primary"}   | ${"btn-primary"}

--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -185,7 +185,7 @@ export function getComponentDefinition(
     }
 
     case "button": {
-      const { title, onClick, variant, size, className, disabled } =
+      const { title, onClick, variant, size, fullWidth, className, disabled } =
         config as ButtonDocumentConfig;
       if (onClick !== undefined && !isPipelineExpression(onClick)) {
         console.debug("Expected pipeline expression for onClick", {
@@ -200,6 +200,7 @@ export function getComponentDefinition(
         props: {
           children: title,
           onClick: onClick.__value__,
+          fullWidth,
           tracePath,
           variant,
           disabled,

--- a/src/components/documentBuilder/edit/getElementEditSchemas.tsx
+++ b/src/components/documentBuilder/edit/getElementEditSchemas.tsx
@@ -158,7 +158,7 @@ function getElementEditSchemas(
         name: joinName(elementName, "config", "title"),
         schema: { type: "string" },
         label: "Title",
-        description: "The text to display on the button.",
+        description: "The text to display on the button",
       };
       const variantEdit: SchemaFieldProps = {
         name: joinName(elementName, "config", "variant"),
@@ -185,23 +185,41 @@ function getElementEditSchemas(
             "outline-link",
           ],
         },
-        label: "Variant",
+        label: "Button Style",
+        description: "The style/variant of the button",
       };
       const sizeEdit: SchemaFieldProps = {
         name: joinName(elementName, "config", "size"),
         schema: { type: "string", enum: ["lg", "md", "sm"] },
-        label: "Size",
+        label: "Button Size",
+        description: "The size of the button: Small, Medium, or Large",
+      };
+      const fullWidthEdit: SchemaFieldProps = {
+        name: joinName(elementName, "config", "fullWidth"),
+        schema: { type: "boolean" },
+        label: "Full Width",
+        description:
+          "Toggle on to expand the button to fit the width of the column",
       };
       const disabledEdit: SchemaFieldProps = {
         name: joinName(elementName, "config", "disabled"),
         // Allow any to permit truthy values like for other conditional fields
         schema: { type: ["string", "boolean", "null", "number"] },
         label: "Disabled",
+        description: (
+          <div>
+            Condition determining whether to disable the button. Truthy string
+            values are&nbsp;
+            <code>true</code>, <code>t</code>, <code>yes</code>, <code>y</code>,{" "}
+            <code>on</code>, and <code>1</code> (case-insensitive)
+          </div>
+        ),
       };
       return [
         titleEdit,
         variantEdit,
         sizeEdit,
+        fullWidthEdit,
         disabledEdit,
         getHiddenEdit(elementName),
         getClassNameEdit(elementName),

--- a/src/components/documentBuilder/preview/DocumentPreview.tsx
+++ b/src/components/documentBuilder/preview/DocumentPreview.tsx
@@ -132,11 +132,11 @@ const DocumentPreview = ({
         onMouseOver={onMouseOver}
         onMouseLeave={onMouseLeave}
       >
-        {bodyPreview.map((childElement, i) => (
+        {bodyPreview.map((childElement, childIndex) => (
           <ElementPreview
-            key={`${documentBodyName}.${i}`}
+            key={`${documentBodyName}.${childIndex}`}
             documentBodyName={documentBodyName}
-            elementName={String(i)}
+            elementName={String(childIndex)}
             previewElement={childElement}
             activeElement={activeElement}
             setActiveElement={setActiveElement}

--- a/src/components/documentBuilder/preview/ElementPreview.tsx
+++ b/src/components/documentBuilder/preview/ElementPreview.tsx
@@ -20,6 +20,7 @@ import styles from "./ElementPreview.module.scss";
 import cx from "classnames";
 import {
   type DocumentElement,
+  isButtonElement,
   isListElement,
 } from "@/components/documentBuilder/documentBuilderTypes";
 import AddElementAction from "./AddElementAction";
@@ -89,6 +90,12 @@ const ElementPreview: React.FC<ElementPreviewProps> = ({
   // Render the item template and the Item Type Selector for the list element
   const isList = isListElement(previewElement);
 
+  // Have to apply to the wrapper PreviewComponent, because otherwise the button itself will expand to just the
+  // size of the wrapper which would not be full width.
+  // In the future, we could consider also inspecting className for `w-` and `btn-block` utility classes
+  const isFullWidth =
+    isButtonElement(previewElement) && previewElement.config.fullWidth;
+
   const { Component: PreviewComponent, props } = useMemo(
     () => getPreviewComponentDefinition(previewElement),
     [previewElement]
@@ -101,6 +108,7 @@ const ElementPreview: React.FC<ElementPreviewProps> = ({
       className={cx(styles.root, {
         [styles.active]: isActive,
         [styles.hovered]: isHovered,
+        "btn-block": isFullWidth,
       })}
       onMouseOver={onMouseOver}
       onMouseLeave={onMouseLeave}

--- a/src/components/documentBuilder/preview/__snapshots__/ElementPreview.test.tsx.snap
+++ b/src/components/documentBuilder/preview/__snapshots__/ElementPreview.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`can preview default button 1`] = `
         class="root inlineWrapper"
       >
         <button
-          class="btn btn-primary"
+          class="btn btn-primary btn-md"
           type="button"
         >
           Action

--- a/src/components/documentBuilder/preview/elementsPreview/Button.tsx
+++ b/src/components/documentBuilder/preview/elementsPreview/Button.tsx
@@ -45,7 +45,13 @@ const Button: React.FunctionComponent<ButtonProps> = ({
 }) => {
   // NOTE: not passing through "disabled" prop because that prevents the user from clicking the button in the preview
   // to select the element in the Document Builder.
-  const { title, variant, size, className: buttonClassName } = buttonProps;
+  const {
+    title,
+    variant,
+    size,
+    fullWidth,
+    className: buttonClassName,
+  } = buttonProps;
 
   return (
     <div>
@@ -64,9 +70,10 @@ const Button: React.FunctionComponent<ButtonProps> = ({
         <BsButton
           onClick={() => {}}
           // Not resolving expressions in Preview
-          className={
-            isExpression(buttonClassName) ? undefined : buttonClassName
-          }
+          className={cx(
+            isExpression(buttonClassName) ? undefined : buttonClassName,
+            { "btn-block": fullWidth }
+          )}
           variant={isExpression(variant) ? undefined : variant}
           size={isExpression(size) ? undefined : size}
         >

--- a/src/components/documentBuilder/render/ButtonElement.tsx
+++ b/src/components/documentBuilder/render/ButtonElement.tsx
@@ -28,17 +28,24 @@ import { getTopLevelFrame } from "webext-messenger";
 import { getRootCause, hasSpecificErrorCause } from "@/errors/errorHelpers";
 import { SubmitPanelAction } from "@/blocks/errors";
 import { boolean } from "@/utils";
+import cx from "classnames";
 
 type ButtonElementProps = Except<AsyncButtonProps, "onClick"> & {
   onClick: BrickPipeline;
   elementName: string;
   tracePath: DynamicPath;
+  /**
+   * True to expand the button to the full width of the container.
+   */
+  fullWidth?: boolean;
 };
 
 const ButtonElement: React.FC<ButtonElementProps> = ({
   onClick,
   tracePath,
   disabled: rawDisabled,
+  fullWidth = false,
+  className,
   ...restProps
 }) => {
   const {
@@ -94,6 +101,9 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
     <AsyncButton
       onClick={handler}
       disabled={boolean(rawDisabled)}
+      // `btn-block` is the classname in Bootstrap 4
+      // Discussion: https://stackoverflow.com/questions/23183343/bootstrap-btn-block-not-working
+      className={cx(className, { "btn-block": fullWidth })}
       {...restProps}
     />
   );


### PR DESCRIPTION
## What does this PR do?

- Closes #6004 
- Adds Full Width field to the button element in the Document Builder

## Demo

- _Paste a screenshot or demo video here_

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
