### PR TITLE
#6006: allow regex without named capture group in the Regex Extractor brick

### DIFF
--- a/src/analysis/analysisVisitors/regexAnalysis.ts
+++ b/src/analysis/analysisVisitors/regexAnalysis.ts
@@ -82,9 +82,6 @@ class RegexAnalysis extends AnalysisVisitor {
       compileError = error;
     }
 
-    // Create new regex on each analysis call to avoid state issues with test
-    const namedCapturedGroupRegex = /\(\?<\S+>.*?\)/g;
-
     if (compileError) {
       this.annotations.push({
         position: {
@@ -93,16 +90,6 @@ class RegexAnalysis extends AnalysisVisitor {
         message: getErrorMessage(compileError),
         analysisId: this.id,
         type: AnnotationType.Error,
-      });
-    } else if (!namedCapturedGroupRegex.test(pattern)) {
-      this.annotations.push({
-        position: {
-          path: joinPathParts(position.path, "config", "regex"),
-        },
-        message:
-          "Expected regular expression to contain at least one named capture group: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Backreferences",
-        analysisId: this.id,
-        type: AnnotationType.Warning,
       });
     }
   }

--- a/src/analysis/analysisVisitors/regexAnalysisTest.test.ts
+++ b/src/analysis/analysisVisitors/regexAnalysisTest.test.ts
@@ -82,25 +82,6 @@ describe("RegexAnalysis", () => {
     );
   });
 
-  test("warns on missing regex named capture group", () => {
-    const analysis = new RegexAnalysis();
-    analysis.visitBlock(
-      position,
-      {
-        id: validateRegistryId("@pixiebrix/regex"),
-        config: {
-          regex: {
-            __type__: "nunjucks",
-            __value__: "^bar$",
-          },
-        },
-      },
-      {} as VisitBlockExtra
-    );
-
-    expect(analysis.getAnnotations()).toHaveLength(1);
-  });
-
   test.each([
     ["^(?<foo>bar)$"],
     ["^(?<foo>bar)(?<bar>baz)$"],

--- a/src/blocks/transformers/regex.ts
+++ b/src/blocks/transformers/regex.ts
@@ -25,6 +25,13 @@ import { type BrickConfig } from "@/blocks/types";
 import { extractRegexLiteral } from "@/analysis/analysisVisitors/regexAnalysis";
 import { isNunjucksExpression } from "@/runtime/mapArgs";
 
+export function extractNamedCaptureGroups(pattern: string): string[] {
+  // Create new regex on each analysis call to avoid state issues with test
+  const namedCapturedGroupRegex = /\(\?<(\S+)>.*?\)/g;
+
+  return [...pattern.matchAll(namedCapturedGroupRegex)].map((x) => x[1]);
+}
+
 export class RegexTransformer extends Transformer {
   override async isPure(): Promise<boolean> {
     return true;
@@ -45,6 +52,8 @@ export class RegexTransformer extends Transformer {
     {
       regex: {
         type: "string",
+        description:
+          "A regular expression pattern. Supports [named capture groups](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) to extract multiple properties.",
       },
       input: {
         oneOf: [
@@ -54,6 +63,8 @@ export class RegexTransformer extends Transformer {
       },
       ignoreCase: {
         type: "boolean",
+        description: "True to ignore case when matching. Defaults to false.",
+        default: false,
       },
     },
     ["regex", "input"]
@@ -103,19 +114,22 @@ export class RegexTransformer extends Transformer {
       return this.outputSchema;
     }
 
-    // Create new regex on each analysis call to avoid state issues with test
-    const namedCapturedGroupRegex = /\(\?<(\S+)>.*?\)/g;
+    const namedGroups = extractNamedCaptureGroups(pattern);
 
-    const namedGroups: string[] = [
-      ...pattern.matchAll(namedCapturedGroupRegex),
-    ].map((x) => x[1]);
-
-    const itemSchema: Schema = {
-      type: "object",
-      properties: Object.fromEntries(
-        namedGroups.map((name) => [name, { type: "string" }])
-      ),
-    };
+    const itemSchema: Schema =
+      namedGroups.length > 0
+        ? {
+            type: "object",
+            properties: Object.fromEntries(
+              namedGroups.map((name) => [name, { type: "string" }])
+            ),
+          }
+        : {
+            type: "object",
+            properties: {
+              match: { type: "string" },
+            },
+          };
 
     if (isArray(input)) {
       return {
@@ -130,15 +144,17 @@ export class RegexTransformer extends Transformer {
   async transform({
     regex,
     input,
+    ignoreCase = false,
   }: BrickArgs<{
     regex: string | RegExp;
     input: string | null | Array<string | null>;
+    ignoreCase?: boolean;
   }>): Promise<Record<string, string> | Array<Record<string, string>>> {
     let compiled: RegExp;
 
     try {
       // eslint-disable-next-line security/detect-non-literal-regexp -- It's what the brick is about
-      compiled = new RegExp(regex);
+      compiled = new RegExp(regex, ignoreCase ? "i" : undefined);
     } catch (error) {
       if (error instanceof SyntaxError) {
         throw new PropError(error.message, this.id, "regex", regex);
@@ -147,13 +163,18 @@ export class RegexTransformer extends Transformer {
       throw error;
     }
 
-    const extract = (x: string | null) => {
-      if (x == null) {
+    const extract = (string: string | null) => {
+      if (string == null) {
         return null;
       }
 
-      const match = compiled.exec(x);
-      // Console.debug(`Search for ${regex} in ${x}`, match);
+      const match = compiled.exec(string);
+
+      if (match && match.groups == null) {
+        // No named groups, return the global match
+        return { match: match[0] };
+      }
+
       return match?.groups ?? {};
     };
 


### PR DESCRIPTION
## What does this PR do?

- Closes #6006 
- Eliminates the requirement to have a named capture group in the Regex Extractor brick
- If no named capture group exists, provides the global match

## Discussion

- Only the global match is returned. No unnamed capture groups are returned

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
