### PR TITLE
#5998 - verifies blueprintId is not null in fixActiveTabOnRemove

### DIFF
--- a/src/sidebar/sidebarSlice.test.ts
+++ b/src/sidebar/sidebarSlice.test.ts
@@ -297,7 +297,7 @@ describe("sidebarSlice.fixActiveTabOnRemove", () => {
     });
   });
 
-  it("does not set the activeKey to the active key of a panel when both modIds are null", () => {
+  it("does not set the activeKey to the active key of a panel with matching modId when both modIds are null", () => {
     const extensionId = uuidv4();
 
     const originalPanel = sidebarEntryFactory("panel", {
@@ -307,7 +307,7 @@ describe("sidebarSlice.fixActiveTabOnRemove", () => {
       extensionId,
     });
     const nullModId = sidebarEntryFactory("form", {
-      extensionId,
+      extensionId: uuidv4(),
       blueprintId: null,
     });
     const newPanel = sidebarEntryFactory("temporaryPanel", {

--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -177,7 +177,8 @@ export function fixActiveTabOnRemove(
         ({ blueprintId }) =>
           "blueprintId" in removedEntry &&
           // Need to check for removedEntry.blueprintId to avoid switching between IExtensions that don't have blueprint ids
-          blueprintId === removedEntry.blueprintId
+          blueprintId === removedEntry.blueprintId &&
+          blueprintId
       );
 
       if (matchingMod) {


### PR DESCRIPTION
## What does this PR do?

- Fixes #5998 
- Relates to https://github.com/pixiebrix/pixiebrix-extension/pull/6018

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @twschiller 
