### PR TITLE
#6021: ensure Match All field doesn't get stuck in loading state in Extract from Page brick

### DIFF
--- a/src/analysis/analysisVisitors/regexAnalysis.ts
+++ b/src/analysis/analysisVisitors/regexAnalysis.ts
@@ -23,10 +23,7 @@ import { isTemplateExpression } from "@/runtime/mapArgs";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { joinPathParts } from "@/utils";
 import { AnnotationType } from "@/types/annotationTypes";
-
-function containsTemplateExpression(literalOrTemplate: string): boolean {
-  return literalOrTemplate.includes("{{") || literalOrTemplate.includes("{%");
-}
+import { containsTemplateExpression } from "@/utils/templateUtils";
 
 /**
  * Returns the regex literal pattern, or null if the regex is a variable or template expression

--- a/src/blocks/readers/jquery.ts
+++ b/src/blocks/readers/jquery.ts
@@ -62,7 +62,7 @@ export interface ChildrenSelector {
    * The sub-selectors to apply.
    */
   // eslint-disable-next-line @typescript-eslint/no-use-before-define -- this is a recursive type
-  find?: SelectorMap;
+  find?: SelectorConfigMap;
 }
 
 export type CommonSelector = ChildrenSelector | SingleSelector;
@@ -73,14 +73,17 @@ export function isChildrenSelector(
   return "find" in selector;
 }
 
-export type Selector = CommonSelector & {
+export type SelectorConfig = CommonSelector & {
   selector?: string;
 
   // Block until the element is available
   maxWaitMillis?: number;
 };
 
-export type SelectorMap = Record<string, string | Selector>;
+/**
+ * Selector configuration by property name key. Assumes the values are already rendered via mapArgs.
+ */
+export type SelectorConfigMap = Record<string, string | SelectorConfig>;
 
 type Result =
   | string
@@ -93,7 +96,7 @@ type Result =
 
 export interface JQueryConfig {
   type: "jquery";
-  selectors: SelectorMap;
+  selectors: SelectorConfigMap;
 }
 
 function cleanValue(value: string): string {
@@ -174,7 +177,7 @@ function processElement($elements: JQuery, selector: SingleSelector) {
 }
 
 async function select(
-  selector: string | Selector,
+  selector: string | SelectorConfig,
   root?: HTMLElement | Document
 ): Promise<Result> {
   const normalizedSelector =

--- a/src/blocks/transformers/jquery/JQueryReader.ts
+++ b/src/blocks/transformers/jquery/JQueryReader.ts
@@ -18,7 +18,7 @@
 import { Transformer } from "@/types/bricks/transformerTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { readJQuery, type SelectorMap } from "@/blocks/readers/jquery";
+import { readJQuery, type SelectorConfigMap } from "@/blocks/readers/jquery";
 import { type BrickConfig } from "@/blocks/types";
 import { mapValues } from "lodash";
 import { isExpression } from "@/runtime/mapArgs";
@@ -95,7 +95,7 @@ export class JQueryReader extends Transformer {
   };
 
   override getOutputSchema(config: BrickConfig): Schema | undefined {
-    const selectors = config.config.selectors as SelectorMap;
+    const selectors = config.config.selectors as SelectorConfigMap;
 
     if (isExpression(selectors)) {
       return this.outputSchema;
@@ -126,7 +126,7 @@ export class JQueryReader extends Transformer {
   }
 
   async transform(
-    { selectors }: BrickArgs<{ selectors: SelectorMap }>,
+    { selectors }: BrickArgs<{ selectors: SelectorConfigMap }>,
     { root }: BrickOptions
   ): Promise<unknown> {
     return readJQuery({ type: "jquery", selectors }, root);

--- a/src/blocks/transformers/jquery/JQueryReaderOptions.test.tsx
+++ b/src/blocks/transformers/jquery/JQueryReaderOptions.test.tsx
@@ -28,9 +28,14 @@ import { menuItemFormStateFactory } from "@/testUtils/factories/pageEditorFactor
 import { JQueryReader } from "@/blocks/transformers/jquery/JQueryReader";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import { waitForEffect } from "@/testUtils/testHelpers";
-import { makeVariableExpression } from "@/runtime/expressionCreators";
+import {
+  makeTemplateExpression,
+  makeVariableExpression,
+} from "@/runtime/expressionCreators";
 import { getAttributeExamples } from "@/contentScript/messenger/api";
 import { screen } from "@testing-library/react";
+import SchemaFieldContext from "@/components/fields/schemaFields/SchemaFieldContext";
+import devtoolFieldOverrides from "@/pageEditor/fields/devtoolFieldOverrides";
 
 jest.mock("@/contentScript/messenger/api", () => ({
   getAttributeExamples: jest.fn(),
@@ -53,12 +58,14 @@ function baseStateFactory() {
 
 function renderOptions(formState: FormState = baseStateFactory()) {
   return render(
-    <Formik onSubmit={jest.fn()} initialValues={formState}>
-      <JQueryReaderOptions
-        name="extension.blockPipeline.0"
-        configKey="config"
-      />
-    </Formik>
+    <SchemaFieldContext.Provider value={devtoolFieldOverrides}>
+      <Formik onSubmit={jest.fn()} initialValues={formState}>
+        <JQueryReaderOptions
+          name="extension.blockPipeline.0"
+          configKey="config"
+        />
+      </Formik>
+    </SchemaFieldContext.Provider>
   );
 }
 
@@ -116,7 +123,71 @@ describe("JQueryReaderOptions", () => {
       "property"
     );
 
-    expect(screen.getByLabelText("Selector")).toHaveValue("h1");
+    expect(
+      screen.getByTestId(
+        "toggle-extension.blockPipeline.0.config.selectors.property.selector"
+      ).dataset.testSelected
+    ).toEqual("Selector");
+
+    expect(screen.getByPlaceholderText("Select an element")).toHaveValue("h1");
+  });
+
+  it("normalizes nested selectors", async () => {
+    const state = baseStateFactory();
+    state.extension.blockPipeline[0].config.selectors = {
+      outer: {
+        selector: "div",
+        find: {
+          inner: "h1",
+        },
+      },
+    };
+
+    renderOptions(state);
+
+    await waitForEffect();
+
+    expect(
+      screen.getByTestId(
+        "toggle-extension.blockPipeline.0.config.selectors.outer.selector"
+      ).dataset.testSelected
+    ).toEqual("Selector");
+    expect(
+      screen.getByTestId(
+        "toggle-extension.blockPipeline.0.config.selectors.outer.find.inner.selector"
+      ).dataset.testSelected
+    ).toEqual("Selector");
+
+    expect(screen.queryAllByText("Loading...")).toHaveLength(0);
+  });
+
+  it("normalizes nunjucks literal selectors", async () => {
+    const state = baseStateFactory();
+    state.extension.blockPipeline[0].config.selectors = {
+      outer: {
+        selector: makeTemplateExpression("nunjucks", "div"),
+        find: {
+          inner: makeTemplateExpression("nunjucks", "h1"),
+        },
+      },
+    };
+
+    renderOptions(state);
+
+    await waitForEffect();
+
+    expect(
+      screen.getByTestId(
+        "toggle-extension.blockPipeline.0.config.selectors.outer.selector"
+      ).dataset.testSelected
+    ).toEqual("Selector");
+    expect(
+      screen.getByTestId(
+        "toggle-extension.blockPipeline.0.config.selectors.outer.find.inner.selector"
+      ).dataset.testSelected
+    ).toEqual("Selector");
+
+    expect(screen.queryAllByText("Loading...")).toHaveLength(0);
   });
 
   it("generates example attributes for nested selectors", async () => {
@@ -152,6 +223,7 @@ describe("type options", () => {
     expect(
       inferActiveTypeOption({
         selector: "div",
+        multi: false,
         find: {},
       })
     ).toEqual("element");
@@ -161,6 +233,7 @@ describe("type options", () => {
     expect(
       inferActiveTypeOption({
         selector: "div",
+        multi: false,
         attr: "foo",
       })
     ).toEqual("attr:foo");
@@ -171,6 +244,7 @@ describe("type options", () => {
       inferActiveTypeOption({
         selector: "div",
         data: "foo",
+        multi: false,
       })
     ).toEqual("attr:data-foo");
   });

--- a/src/blocks/transformers/jquery/JQueryReaderOptions.test.tsx
+++ b/src/blocks/transformers/jquery/JQueryReaderOptions.test.tsx
@@ -36,6 +36,7 @@ import { getAttributeExamples } from "@/contentScript/messenger/api";
 import { screen } from "@testing-library/react";
 import SchemaFieldContext from "@/components/fields/schemaFields/SchemaFieldContext";
 import devtoolFieldOverrides from "@/pageEditor/fields/devtoolFieldOverrides";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("@/contentScript/messenger/api", () => ({
   getAttributeExamples: jest.fn(),
@@ -188,6 +189,32 @@ describe("JQueryReaderOptions", () => {
     ).toEqual("Selector");
 
     expect(screen.queryAllByText("Loading...")).toHaveLength(0);
+  });
+
+  it("allows rename of property", async () => {
+    const state = baseStateFactory();
+    state.extension.blockPipeline[0].config.selectors = {
+      outer: {
+        selector: makeTemplateExpression("nunjucks", "div"),
+        find: {
+          inner: makeTemplateExpression("nunjucks", "h1"),
+        },
+      },
+    };
+
+    const { container } = renderOptions(state);
+
+    await waitForEffect();
+
+    const field = container.querySelector('[value="outer"]');
+
+    await userEvent.type(field, "property");
+    // Click away to blur the field
+    await userEvent.click(screen.getAllByText("Select All")[0]);
+
+    await waitForEffect();
+
+    expect(field).toHaveValue("outerproperty");
   });
 
   it("generates example attributes for nested selectors", async () => {

--- a/src/pageEditor/fields/SelectorSelectorWidget.tsx
+++ b/src/pageEditor/fields/SelectorSelectorWidget.tsx
@@ -43,6 +43,9 @@ import { type SettingsState } from "@/store/settingsTypes";
 import { sortBySelector } from "@/utils/inference/selectorInference";
 import { isSpecificError } from "@/errors/errorHelpers";
 import { CancelError } from "@/errors/businessErrors";
+import { type Expression } from "@/types/runtimeTypes";
+import { castTextLiteralOrThrow, isTextLiteral } from "@/utils/templateUtils";
+import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 
 interface ElementSuggestion extends SuggestionTypeBase {
   value: string;
@@ -156,7 +159,9 @@ const SelectorSelectorWidget: React.FC<SelectorSelectorProps> = ({
   // the order is based on structure (because selectors for multiple elements are returned).
   sort = selectMode === "element",
 }) => {
-  const [{ value }, , { setValue }] = useField<string>(name);
+  const [{ value: valueOrExpression }, , { setValue }] = useField<
+    string | Expression
+  >(name);
 
   const [element, setElement] = useState(initialElement);
   const [isSelecting, setSelecting] = useState(false);
@@ -259,6 +264,10 @@ const SelectorSelectorWidget: React.FC<SelectorSelectorProps> = ({
     }
   };
 
+  if (!isTextLiteral(valueOrExpression)) {
+    return <WorkshopMessageWidget />;
+  }
+
   return (
     // Do not replace this with `InputGroup` because that requires too many style overrides #2658 #2835
     <div className={styles.root}>
@@ -274,7 +283,7 @@ const SelectorSelectorWidget: React.FC<SelectorSelectorProps> = ({
         isClearable={isClearable}
         isDisabled={isSelecting || disabled}
         suggestions={suggestions}
-        inputValue={value}
+        inputValue={castTextLiteralOrThrow(valueOrExpression)}
         inputPlaceholder={placeholder}
         renderSuggestion={renderSuggestion}
         onSuggestionHighlighted={onHighlighted}

--- a/src/pageEditor/fields/SelectorSelectorWidget.tsx
+++ b/src/pageEditor/fields/SelectorSelectorWidget.tsx
@@ -44,7 +44,10 @@ import { sortBySelector } from "@/utils/inference/selectorInference";
 import { isSpecificError } from "@/errors/errorHelpers";
 import { CancelError } from "@/errors/businessErrors";
 import { type Expression } from "@/types/runtimeTypes";
-import { castTextLiteralOrThrow, isTextLiteral } from "@/utils/templateUtils";
+import {
+  castTextLiteralOrThrow,
+  isTextLiteralOrNull,
+} from "@/utils/templateUtils";
 import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 
 interface ElementSuggestion extends SuggestionTypeBase {
@@ -264,7 +267,7 @@ const SelectorSelectorWidget: React.FC<SelectorSelectorProps> = ({
     }
   };
 
-  if (!isTextLiteral(valueOrExpression)) {
+  if (!isTextLiteralOrNull(valueOrExpression)) {
     return <WorkshopMessageWidget />;
   }
 

--- a/src/runtime/renderers.ts
+++ b/src/runtime/renderers.ts
@@ -25,6 +25,7 @@ import {
   renderNunjucksTemplate,
 } from "@/sandbox/messenger/executor";
 import { type UnknownObject } from "@/types/objectTypes";
+import { containsTemplateExpression } from "@/utils/templateUtils";
 
 export type AsyncTemplateRenderer = (
   template: string,
@@ -35,14 +36,6 @@ export type TemplateRenderer = (template: string, context: unknown) => unknown;
 export type RendererOptions = {
   autoescape?: boolean;
 };
-
-/**
- * Returns true if `literalOrTemplate` includes any template expressions that would be replaced by `context`.
- * @param literalOrTemplate the string literal or Nunjucks/Handlebars template.
- */
-function containsTemplateExpression(literalOrTemplate: string): boolean {
-  return literalOrTemplate.includes("{{") || literalOrTemplate.includes("{%");
-}
 
 export function engineRenderer(
   templateEngine: TemplateEngine,

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -76,16 +76,22 @@ export type ServiceVarRef = string & {
 };
 
 /**
- * The tag of an available template engine for rendering an expression given a context.
- * @see mapArgs
+ * A text template engine.
  */
-export type TemplateEngine =
+export type TextTemplateEngine =
   // https://mustache.github.io/
   | "mustache"
   // https://mozilla.github.io/nunjucks/
   | "nunjucks"
   // https://handlebarsjs.com/
-  | "handlebars"
+  | "handlebars";
+
+/**
+ * The tag of an available template engine for rendering an expression given a context.
+ * @see mapArgs
+ */
+export type TemplateEngine =
+  | TextTemplateEngine
   // Variable, with support for ? operator
   | "var";
 

--- a/src/utils/templateUtils.test.ts
+++ b/src/utils/templateUtils.test.ts
@@ -33,7 +33,7 @@ describe("containsTemplateExpression", () => {
     );
   });
 
-  it("ignores spaces between braces", () => {
+  it("require adjacent braces without spaces", () => {
     expect(containsTemplateExpression("{ {foo }}")).toBe(false);
   });
 });

--- a/src/utils/templateUtils.test.ts
+++ b/src/utils/templateUtils.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  castTextLiteralOrThrow,
+  containsTemplateExpression,
+  isTextLiteral,
+} from "@/utils/templateUtils";
+import { makeTemplateExpression } from "@/runtime/expressionCreators";
+
+describe("containsTemplateExpression", () => {
+  it("finds simple template expressions", () => {
+    expect(containsTemplateExpression("{{foo}}")).toBe(true);
+  });
+
+  it("finds template tag", () => {
+    expect(containsTemplateExpression("{% if @foo %}hello!{% endif %}")).toBe(
+      true
+    );
+  });
+
+  it("ignores spaces between braces", () => {
+    expect(containsTemplateExpression("{ {foo }}")).toBe(false);
+  });
+});
+
+describe("isTextLiteral", () => {
+  it("finds typeof string", () => {
+    expect(isTextLiteral("foo")).toBe(true);
+  });
+
+  it("finds template literal", () => {
+    expect(isTextLiteral(makeTemplateExpression("nunjucks", "foo"))).toBe(true);
+  });
+
+  it("finds simple template expressions", () => {
+    expect(isTextLiteral(makeTemplateExpression("nunjucks", "{{foo}}"))).toBe(
+      false
+    );
+  });
+});
+
+describe("castTextLiteralOrThrow", () => {
+  it("finds literal", () => {
+    expect(castTextLiteralOrThrow("foo")).toBe("foo");
+  });
+
+  it("finds simple template expressions", () => {
+    expect(() =>
+      castTextLiteralOrThrow(makeTemplateExpression("nunjucks", "{{foo}}"))
+    ).toThrow(TypeError);
+  });
+});

--- a/src/utils/templateUtils.test.ts
+++ b/src/utils/templateUtils.test.ts
@@ -18,7 +18,7 @@
 import {
   castTextLiteralOrThrow,
   containsTemplateExpression,
-  isTextLiteral,
+  isTextLiteralOrNull,
 } from "@/utils/templateUtils";
 import { makeTemplateExpression } from "@/runtime/expressionCreators";
 
@@ -38,23 +38,33 @@ describe("containsTemplateExpression", () => {
   });
 });
 
-describe("isTextLiteral", () => {
+describe("isTextLiteralOrNull", () => {
+  it("handles null", () => {
+    expect(isTextLiteralOrNull(null)).toBe(true);
+  });
+
   it("finds typeof string", () => {
-    expect(isTextLiteral("foo")).toBe(true);
+    expect(isTextLiteralOrNull("foo")).toBe(true);
   });
 
   it("finds template literal", () => {
-    expect(isTextLiteral(makeTemplateExpression("nunjucks", "foo"))).toBe(true);
+    expect(isTextLiteralOrNull(makeTemplateExpression("nunjucks", "foo"))).toBe(
+      true
+    );
   });
 
   it("finds simple template expressions", () => {
-    expect(isTextLiteral(makeTemplateExpression("nunjucks", "{{foo}}"))).toBe(
-      false
-    );
+    expect(
+      isTextLiteralOrNull(makeTemplateExpression("nunjucks", "{{foo}}"))
+    ).toBe(false);
   });
 });
 
 describe("castTextLiteralOrThrow", () => {
+  it("handles null", () => {
+    expect(castTextLiteralOrThrow(null)).toBe(null);
+  });
+
   it("finds literal", () => {
     expect(castTextLiteralOrThrow("foo")).toBe("foo");
   });

--- a/src/utils/templateUtils.ts
+++ b/src/utils/templateUtils.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type Expression } from "@/types/runtimeTypes";
+
+/**
+ * Returns true if `literalOrTemplate` includes any template expressions that would be replaced by `context`.
+ * @param literalOrTemplate the string literal or Nunjucks/Handlebars template.
+ */
+export function containsTemplateExpression(literalOrTemplate: string): boolean {
+  return literalOrTemplate.includes("{{") || literalOrTemplate.includes("{%");
+}
+
+/**
+ * Returns true if the value is a string, or a literal string expression.
+ * @see castTextLiteralOrThrow
+ */
+export function isTextLiteral(literalOrTemplate: string | Expression): boolean {
+  if (typeof literalOrTemplate === "string") {
+    return true;
+  }
+
+  if (
+    !["mustache", "handlebars", "nunjucks"].includes(literalOrTemplate.__type__)
+  ) {
+    return false;
+  }
+
+  return !containsTemplateExpression(literalOrTemplate.__value__);
+}
+
+/**
+ * Returns the string value of a literal or expression with only literal text.
+ * @see isTextLiteral
+ */
+export function castTextLiteralOrThrow(
+  literalOrTemplate: string | Expression
+): string {
+  if (typeof literalOrTemplate === "string") {
+    return literalOrTemplate;
+  }
+
+  if (!isTextLiteral(literalOrTemplate)) {
+    throw new TypeError("Expected literal, but found template expression");
+  }
+
+  return literalOrTemplate.__value__;
+}

--- a/src/utils/templateUtils.ts
+++ b/src/utils/templateUtils.ts
@@ -29,7 +29,13 @@ export function containsTemplateExpression(literalOrTemplate: string): boolean {
  * Returns true if the value is a string, or a literal string expression.
  * @see castTextLiteralOrThrow
  */
-export function isTextLiteral(literalOrTemplate: string | Expression): boolean {
+export function isTextLiteralOrNull(
+  literalOrTemplate: string | null | Expression
+): boolean {
+  if (literalOrTemplate == null) {
+    return true;
+  }
+
   if (typeof literalOrTemplate === "string") {
     return true;
   }
@@ -45,16 +51,16 @@ export function isTextLiteral(literalOrTemplate: string | Expression): boolean {
 
 /**
  * Returns the string value of a literal or expression with only literal text.
- * @see isTextLiteral
+ * @see isTextLiteralOrNull
  */
 export function castTextLiteralOrThrow(
-  literalOrTemplate: string | Expression
-): string {
-  if (typeof literalOrTemplate === "string") {
-    return literalOrTemplate;
+  literalOrTemplate: string | null | Expression
+): string | null {
+  if (literalOrTemplate == null || typeof literalOrTemplate === "string") {
+    return literalOrTemplate as string | null;
   }
 
-  if (!isTextLiteral(literalOrTemplate)) {
+  if (!isTextLiteralOrNull(literalOrTemplate)) {
     throw new TypeError("Expected literal, but found template expression");
   }
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #6021 
- Set `multi: false` so Match All field doesn't get stuck in a loading state
- Handle nunjucks expressions for selectors (these exist from mods where a nested selector was specified via Advanced Options)
  - Introduces a SelectorDefinition type that accurately reflects the types that can exist in the JQueryReaderOptions component after normalization
  - Have SelectorSelectorWidget fall back to `WorkshopMessageWidget` if it's a nunjucks expression that contains a template expression 
  
## Discussion

- Using Nunjucks in selectors is an advanced use case. It's OK to point people to the workshop for that

## Remaining Work

- [x] Investigate bug where property can't be renamed

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/150a0931-cec9-4dd5-8691-45f5bf8c41be)

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
