### PR TITLE
#2933: add support for default output keys in brick yaml

### DIFF
--- a/schemas/component.json
+++ b/schemas/component.json
@@ -35,6 +35,12 @@
     "outputSchema": {
       "$ref": "http://json-schema.org/draft-07/schema#"
     },
+    "defaultOutputKey": {
+      "type": "string",
+      "description": "The default key to use for the output when added to a mod",
+      "examples": ["output"],
+      "pattern": "[A-Z_a-z]\\w{0,30}"
+    },
     "services": {
       "type": "object",
       "description": "Optionally declare services to inject into the component",

--- a/src/blocks/transformers/brickFactory.test.ts
+++ b/src/blocks/transformers/brickFactory.test.ts
@@ -30,6 +30,7 @@ import {
 } from "@/runtime/pipelineTests/pipelineTestHelpers";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import Run from "@/blocks/transformers/controlFlow/Run";
+import { cloneDeep } from "lodash";
 
 beforeEach(() => {
   blockRegistry.clear();
@@ -65,12 +66,27 @@ test("block includes version", async () => {
   expect(block.version).toBe("0.0.1");
 });
 
-test("reject invalid fixture fixture", async () => {
+test("reject invalid fixture", async () => {
   try {
     fromJS({ foo: "bar" });
   } catch (error) {
     expect(error).toBeInstanceOf(InvalidDefinitionError);
   }
+});
+
+describe("defaultOutputKey", () => {
+  test("no output key", () => {
+    const block = fromJS(nytimes);
+    expect(block.defaultOutputKey).toBeNull();
+  });
+
+  test("output key", () => {
+    const config = cloneDeep(nytimes);
+    config.defaultOutputKey = "articles";
+
+    const block = fromJS(config);
+    expect(block.defaultOutputKey).toBe("articles");
+  });
 });
 
 describe("isUserDefinedBrick", () => {

--- a/src/blocks/transformers/brickFactory.ts
+++ b/src/blocks/transformers/brickFactory.ts
@@ -29,7 +29,7 @@ import blockRegistry from "@/blocks/registry";
 import { type BrickConfig, type BrickPipeline } from "@/blocks/types";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import getType from "@/runtime/getType";
-import { type BrickType } from "@/runtime/runtimeTypes";
+import { type BrickType, validateOutputKey } from "@/runtime/runtimeTypes";
 import { InvalidDefinitionError } from "@/errors/businessErrors";
 import {
   type ApiVersion,
@@ -61,7 +61,14 @@ type BrickDefinition = {
    * @since 1.7.16
    */
   uiSchema?: UiSchema;
+
   outputSchema?: Schema;
+
+  /**
+   * The default output key to use for the brick
+   * @since 1.7.34
+   */
+  defaultOutputKey?: string;
 
   // Mapping from `key` -> `serviceId`
   services?: Record<string, RegistryId>;
@@ -109,6 +116,19 @@ class ExternalBlock extends BrickABC {
     this.uiSchema = this.component.uiSchema;
     this.outputSchema = this.component.outputSchema;
     this.version = version;
+  }
+
+  get defaultOutputKey(): string | null {
+    if (!this.component.defaultOutputKey) {
+      return null;
+    }
+
+    try {
+      // Already validated in the JSON Schema, but be defensive
+      return validateOutputKey(this.component.defaultOutputKey);
+    } catch {
+      return null;
+    }
   }
 
   override async isPure(): Promise<boolean> {


### PR DESCRIPTION
## What does this PR do?

- Closes #2933 
- Adds support for providing a `defaultOutputKey` in user-defined bricks
- Helpful so users don't have to rename the default `transformed` name

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/7c74f72f-4d5f-4646-b87d-d8df9c6bcf7a)

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/b7467839-91df-428b-8f05-244f1a44aab3)

## Future Work

- In the future, we will add make assigning a brick's output to a variable optional.
- When we do that, we should add support for setting `defaultOutputKey` to `null` to indicate the brick should not set a variable. (I.e., consider null vs. undefined differently)

## Team Coordination

- The schema needs to be updated in the app too. It's not a blocker, because we don't block on verification failure, but it's good for the files to be consistent

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
