### PR TITLE
#5526: fix duplicate entries in workshop type filter

### DIFF
--- a/src/extensionConsole/pages/brickEditor/Editor.tsx
+++ b/src/extensionConsole/pages/brickEditor/Editor.tsx
@@ -36,7 +36,7 @@ import serviceRegistry from "@/services/registry";
 import blockRegistry from "@/blocks/registry";
 import extensionPointRegistry from "@/extensionPoints/registry";
 import { fetch } from "@/hooks/fetch";
-import { type EditablePackage } from "@/types/contract";
+import { type EditablePackageMetadata } from "@/types/contract";
 import ConfirmNavigationModal from "@/components/ConfirmNavigationModal";
 import notify from "@/utils/notify";
 import { type ReferenceEntry } from "./brickEditorTypes";
@@ -75,7 +75,7 @@ interface OwnProps {
 function useOpenEditorTab() {
   return useCallback(async (id: string) => {
     // Call to translate the brick registry id into the editable package id
-    const available = await fetch<EditablePackage[]>("/api/bricks/");
+    const available = await fetch<EditablePackageMetadata[]>("/api/bricks/");
     const brick = available.find((x) => x.name === id);
     if (brick) {
       console.debug("Open editor for brick: %s", id, { brick });

--- a/src/extensionConsole/pages/workshop/CustomBricksCard.tsx
+++ b/src/extensionConsole/pages/workshop/CustomBricksCard.tsx
@@ -19,7 +19,6 @@ import React, { useMemo } from "react";
 import {
   faBars,
   faBolt,
-  faBookOpen,
   faCloud,
   faColumns,
   faCube,
@@ -27,7 +26,6 @@ import {
   faStoreAlt,
   faWindowMaximize,
 } from "@fortawesome/free-solid-svg-icons";
-import { type Kind } from "@/registry/localRegistry";
 import styles from "./CustomBricksCard.module.scss";
 import { type IconProp } from "@fortawesome/fontawesome-svg-core";
 import { type Column } from "react-table";
@@ -35,24 +33,23 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { type EnrichedBrick, type NavigateProps } from "./workshopTypes";
 import PaginatedTable from "@/components/paginatedTable/PaginatedTable";
 import AsyncCard from "@/components/asyncCard/AsyncCard";
-import { getKindDisplayName } from "@/extensionConsole/pages/workshop/workshopUtils";
+import {
+  type KindFilterValue,
+  mapKindToKindUiValue,
+} from "@/extensionConsole/pages/workshop/workshopUtils";
 
 type TableColumn = Column<EnrichedBrick>;
-function inferIcon(kind: Kind, verboseName: string): IconProp {
-  switch (kind.toLocaleLowerCase()) {
-    case "service": {
+function inferIcon(kind: KindFilterValue, verboseName: string): IconProp {
+  switch (kind) {
+    case "Integration": {
       return faCloud;
     }
 
-    case "reader": {
-      return faBookOpen;
-    }
-
-    case "blueprint": {
+    case "Mod": {
       return faStoreAlt;
     }
 
-    case "foundation": {
+    case "Starter": {
       // HACK: inferring from the brick naming convention instead of the type since the API doesn't return it yet
       const normalized = verboseName.toLowerCase();
       if (normalized.includes("trigger")) {
@@ -90,7 +87,12 @@ function inferIcon(kind: Kind, verboseName: string): IconProp {
 
 const KindIcon: React.FunctionComponent<{ brick: EnrichedBrick }> = ({
   brick: { kind, verbose_name },
-}) => <FontAwesomeIcon icon={inferIcon(kind, verbose_name)} fixedWidth />;
+}) => (
+  <FontAwesomeIcon
+    icon={inferIcon(mapKindToKindUiValue(kind), verbose_name)}
+    fixedWidth
+  />
+);
 
 const columnFactory = (): TableColumn[] => [
   {
@@ -119,7 +121,7 @@ const columnFactory = (): TableColumn[] => [
   },
   {
     Header: "Type",
-    accessor: ({ kind }) => getKindDisplayName(kind),
+    accessor: ({ kind }) => mapKindToKindUiValue(kind),
   },
   {
     Header: "Version",

--- a/src/extensionConsole/pages/workshop/WorkshopPage.test.tsx
+++ b/src/extensionConsole/pages/workshop/WorkshopPage.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import WorkshopPage, {
+  useEnrichBricks,
+  useSearchOptions,
+} from "@/extensionConsole/pages/workshop/WorkshopPage";
+import { render, renderHook } from "@/extensionConsole/testHelpers";
+import { editablePackageFactory } from "@/testUtils/factories/registryFactories";
+import React from "react";
+import { screen } from "@testing-library/react";
+import { authStateFactory } from "@/testUtils/factories/authFactories";
+import { waitForEffect } from "@/testUtils/testHelpers";
+import { authSlice } from "@/auth/authSlice";
+import { appApiMock } from "@/testUtils/appApiMock";
+import { MemoryRouter } from "react-router";
+
+describe("useSearchOptions", () => {
+  it("consolidates reader and block options", () => {
+    const packages = [
+      editablePackageFactory({ kind: "Reader" }),
+      editablePackageFactory({ kind: "Block" }),
+    ];
+
+    const wrapper = renderHook(() => {
+      const bricks = useEnrichBricks(packages);
+      return useSearchOptions(bricks);
+    });
+    expect(wrapper.result.current).toEqual({
+      collectionOptions: [{ label: "test", value: "test" }],
+      kindOptions: [{ label: "Brick", value: "Brick" }],
+      scopeOptions: [{ label: "[No Scope]", value: undefined }],
+    });
+  });
+});
+
+describe("WorkshopPage", () => {
+  it("require account alias", () => {
+    const { asFragment } = render(<WorkshopPage />);
+
+    expect(
+      screen.queryByText(
+        "To use the Workshop, you must first set an account alias for your PixieBrix account"
+      )
+    ).toBeInTheDocument();
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders empty workshop", async () => {
+    appApiMock.reset();
+    appApiMock.onGet("/api/bricks/").reply(200, []);
+
+    const { asFragment } = render(
+      <MemoryRouter>
+        <WorkshopPage />
+      </MemoryRouter>,
+      {
+        setupRedux(dispatch) {
+          dispatch(
+            authSlice.actions.setAuth(
+              authStateFactory({
+                scope: "workshopuser",
+              })
+            )
+          );
+        },
+      }
+    );
+
+    await waitForEffect();
+
+    expect(
+      screen.queryByText(
+        "To use the Workshop, you must first set an account alias for your PixieBrix account"
+      )
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByTestId("loader")).not.toBeInTheDocument();
+    expect(screen.queryByText("No records found.")).toBeInTheDocument();
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/extensionConsole/pages/workshop/WorkshopPage.test.tsx
+++ b/src/extensionConsole/pages/workshop/WorkshopPage.test.tsx
@@ -20,7 +20,7 @@ import WorkshopPage, {
   useSearchOptions,
 } from "@/extensionConsole/pages/workshop/WorkshopPage";
 import { render, renderHook } from "@/extensionConsole/testHelpers";
-import { editablePackageFactory } from "@/testUtils/factories/registryFactories";
+import { editablePackageMetadataFactory } from "@/testUtils/factories/registryFactories";
 import React from "react";
 import { screen } from "@testing-library/react";
 import { authStateFactory } from "@/testUtils/factories/authFactories";
@@ -32,8 +32,8 @@ import { MemoryRouter } from "react-router";
 describe("useSearchOptions", () => {
   it("consolidates reader and block options", () => {
     const packages = [
-      editablePackageFactory({ kind: "Reader" }),
-      editablePackageFactory({ kind: "Block" }),
+      editablePackageMetadataFactory({ kind: "Reader" }),
+      editablePackageMetadataFactory({ kind: "Block" }),
     ];
 
     const wrapper = renderHook(() => {

--- a/src/extensionConsole/pages/workshop/WorkshopPage.tsx
+++ b/src/extensionConsole/pages/workshop/WorkshopPage.tsx
@@ -33,7 +33,7 @@ import { RequireScope } from "@/auth/RequireScope";
 import { mapKindToKindUiValue } from "@/extensionConsole/pages/workshop/workshopUtils";
 import { PACKAGE_REGEX } from "@/types/helpers";
 import { useGetEditablePackagesQuery } from "@/services/api";
-import { type EditablePackage } from "@/types/contract";
+import { type EditablePackageMetadata } from "@/types/contract";
 
 const { actions } = workshopSlice;
 
@@ -45,7 +45,9 @@ function selectFilters(state: { workshop: WorkshopState }) {
   return state.workshop.filters;
 }
 
-export function useEnrichBricks(bricks: EditablePackage[]): EnrichedBrick[] {
+export function useEnrichBricks(
+  bricks: EditablePackageMetadata[]
+): EnrichedBrick[] {
   const recent = useSelector(selectRecent);
 
   return useMemo(() => {

--- a/src/extensionConsole/pages/workshop/WorkshopPage.tsx
+++ b/src/extensionConsole/pages/workshop/WorkshopPage.tsx
@@ -21,7 +21,7 @@ import { faHammer, faPlus, faTimes } from "@fortawesome/free-solid-svg-icons";
 // eslint-disable-next-line no-restricted-imports -- TODO: Fix over time
 import { Button, Form, InputGroup } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { compact, isEmpty, orderBy, sortBy, uniq } from "lodash";
+import { isEmpty, orderBy, sortBy, uniq } from "lodash";
 import Select from "react-select";
 import workshopSlice, { type WorkshopState } from "@/store/workshopSlice";
 import { connect, useDispatch, useSelector } from "react-redux";
@@ -91,12 +91,12 @@ export function useSearchOptions(bricks: EnrichedBrick[]) {
 
   const kindOptions = useMemo(
     () =>
-      sortBy(
-        compact(uniq((bricks ?? []).map((x) => mapKindToKindUiValue(x.kind))))
-      ).map((value) => ({
-        value,
-        label: value,
-      })),
+      sortBy(uniq((bricks ?? []).map((x) => mapKindToKindUiValue(x.kind)))).map(
+        (value) => ({
+          value,
+          label: value,
+        })
+      ),
     [bricks]
   );
 

--- a/src/extensionConsole/pages/workshop/WorkshopPage.tsx
+++ b/src/extensionConsole/pages/workshop/WorkshopPage.tsx
@@ -30,7 +30,7 @@ import { push } from "connected-react-router";
 import CustomBricksCard from "./CustomBricksCard";
 import { type EnrichedBrick, type NavigateProps } from "./workshopTypes";
 import { RequireScope } from "@/auth/RequireScope";
-import { getKindDisplayName } from "@/extensionConsole/pages/workshop/workshopUtils";
+import { mapKindToKindUiValue } from "@/extensionConsole/pages/workshop/workshopUtils";
 import { PACKAGE_REGEX } from "@/types/helpers";
 import { useGetEditablePackagesQuery } from "@/services/api";
 import { type EditablePackage } from "@/types/contract";
@@ -45,7 +45,7 @@ function selectFilters(state: { workshop: WorkshopState }) {
   return state.workshop.filters;
 }
 
-function useEnrichBricks(bricks: EditablePackage[]): EnrichedBrick[] {
+export function useEnrichBricks(bricks: EditablePackage[]): EnrichedBrick[] {
   const recent = useSelector(selectRecent);
 
   return useMemo(() => {
@@ -68,7 +68,7 @@ function useEnrichBricks(bricks: EditablePackage[]): EnrichedBrick[] {
   }, [recent, bricks]);
 }
 
-function useSearchOptions(bricks: EnrichedBrick[]) {
+export function useSearchOptions(bricks: EnrichedBrick[]) {
   const scopeOptions = useMemo(
     () =>
       sortBy(uniq((bricks ?? []).map((x) => x.scope))).map((value) => ({
@@ -89,9 +89,11 @@ function useSearchOptions(bricks: EnrichedBrick[]) {
 
   const kindOptions = useMemo(
     () =>
-      sortBy(compact(uniq((bricks ?? []).map((x) => x.kind)))).map((value) => ({
+      sortBy(
+        compact(uniq((bricks ?? []).map((x) => mapKindToKindUiValue(x.kind))))
+      ).map((value) => ({
         value,
-        label: getKindDisplayName(value),
+        label: value,
       })),
     [bricks]
   );
@@ -113,7 +115,7 @@ const CustomBricksSection: React.FunctionComponent<NavigateProps> = ({
     isLoading,
     error,
   } = useGetEditablePackagesQuery(undefined, {
-    // Make sure user always see the latest bricks available
+    // Make sure user always see the latest bricks available (e.g., because they just saved a mod in the page editor)
     refetchOnMountOrArgChange: true,
   });
   const {
@@ -142,7 +144,7 @@ const CustomBricksSection: React.FunctionComponent<NavigateProps> = ({
       (x) =>
         (scopes.length === 0 || scopes.includes(x.scope)) &&
         (collections.length === 0 || collections.includes(x.collection)) &&
-        (kinds.length === 0 || kinds.includes(x.kind))
+        (kinds.length === 0 || kinds.includes(mapKindToKindUiValue(x.kind)))
     );
   }, [fuse, query, scopes, collections, kinds, bricks]);
 

--- a/src/extensionConsole/pages/workshop/__snapshots__/WorkshopPage.test.tsx.snap
+++ b/src/extensionConsole/pages/workshop/__snapshots__/WorkshopPage.test.tsx.snap
@@ -1,0 +1,770 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WorkshopPage renders empty workshop 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="d-flex"
+    >
+      <div
+        class="flex-grow-1"
+      >
+        <div
+          class="page-header"
+        >
+          <h3
+            class="page-title"
+          >
+            <span
+              class="page-title-icon bg-gradient-primary text-white mr-2"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-hammer fa-w-18 "
+                data-icon="hammer"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 576 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M571.31 193.94l-22.63-22.63c-6.25-6.25-16.38-6.25-22.63 0l-11.31 11.31-28.9-28.9c5.63-21.31.36-44.9-16.35-61.61l-45.25-45.25c-62.48-62.48-163.79-62.48-226.28 0l90.51 45.25v18.75c0 16.97 6.74 33.25 18.75 45.25l49.14 49.14c16.71 16.71 40.3 21.98 61.61 16.35l28.9 28.9-11.31 11.31c-6.25 6.25-6.25 16.38 0 22.63l22.63 22.63c6.25 6.25 16.38 6.25 22.63 0l90.51-90.51c6.23-6.24 6.23-16.37-.02-22.62zm-286.72-15.2c-3.7-3.7-6.84-7.79-9.85-11.95L19.64 404.96c-25.57 23.88-26.26 64.19-1.53 88.93s65.05 24.05 88.93-1.53l238.13-255.07c-3.96-2.91-7.9-5.87-11.44-9.41l-49.14-49.14z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            Workshop
+          </h3>
+        </div>
+      </div>
+      <div>
+        <button
+          class="btn btn-info"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-plus fa-w-14 "
+            data-icon="plus"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            viewBox="0 0 448 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+              fill="currentColor"
+            />
+          </svg>
+           Create New Brick
+        </button>
+      </div>
+    </div>
+    <div
+      class="pb-4"
+    >
+      <p>
+        Text-based editor for advanced users to create and edit bricks. Mods created in the Page Editor can also be edited here.
+      </p>
+    </div>
+    <div
+      class="max-950"
+    >
+      <form
+        class=""
+      >
+        <div
+          class="mb-2 mr-sm-2 input-group"
+        >
+          <div
+            class="input-group-prepend"
+          >
+            <span
+              class="input-group-text"
+            >
+              Search
+            </span>
+          </div>
+          <input
+            class="form-control"
+            id="query"
+            placeholder="Start typing to find results"
+            value=""
+          />
+        </div>
+      </form>
+      <div
+        class="d-flex"
+      >
+        <div
+          style="width: 200px;"
+        >
+          <div
+            class=" css-b62m3t-container"
+          >
+            <span
+              class="css-1f43avz-a11yText-A11yText"
+              id="react-select-2-live-region"
+            />
+            <span
+              aria-atomic="false"
+              aria-live="polite"
+              aria-relevant="additions text"
+              class="css-1f43avz-a11yText-A11yText"
+            />
+            <div
+              class=" css-13cymwt-control"
+            >
+              <div
+                class=" css-1fdsijx-ValueContainer"
+              >
+                <div
+                  class=" css-1jqq78o-placeholder"
+                  id="react-select-2-placeholder"
+                >
+                  Filter @scope
+                </div>
+                <div
+                  class=" css-qbdosj-Input"
+                  data-value=""
+                >
+                  <input
+                    aria-autocomplete="list"
+                    aria-describedby="react-select-2-placeholder"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class=""
+                    id="react-select-2-input"
+                    role="combobox"
+                    spellcheck="false"
+                    style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                    tabindex="0"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <div
+                class=" css-1hb7zxy-IndicatorsContainer"
+              >
+                <span
+                  class=" css-1u9des2-indicatorSeparator"
+                />
+                <div
+                  aria-hidden="true"
+                  class=" css-1xc3v61-indicatorContainer"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="css-tj5bde-Svg"
+                    focusable="false"
+                    height="20"
+                    viewBox="0 0 20 20"
+                    width="20"
+                  >
+                    <path
+                      d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ml-3"
+          style="width: 200px;"
+        >
+          <div
+            class=" css-b62m3t-container"
+          >
+            <span
+              class="css-1f43avz-a11yText-A11yText"
+              id="react-select-3-live-region"
+            />
+            <span
+              aria-atomic="false"
+              aria-live="polite"
+              aria-relevant="additions text"
+              class="css-1f43avz-a11yText-A11yText"
+            />
+            <div
+              class=" css-13cymwt-control"
+            >
+              <div
+                class=" css-1fdsijx-ValueContainer"
+              >
+                <div
+                  class=" css-1jqq78o-placeholder"
+                  id="react-select-3-placeholder"
+                >
+                  Filter collection
+                </div>
+                <div
+                  class=" css-qbdosj-Input"
+                  data-value=""
+                >
+                  <input
+                    aria-autocomplete="list"
+                    aria-describedby="react-select-3-placeholder"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class=""
+                    id="react-select-3-input"
+                    role="combobox"
+                    spellcheck="false"
+                    style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                    tabindex="0"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <div
+                class=" css-1hb7zxy-IndicatorsContainer"
+              >
+                <span
+                  class=" css-1u9des2-indicatorSeparator"
+                />
+                <div
+                  aria-hidden="true"
+                  class=" css-1xc3v61-indicatorContainer"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="css-tj5bde-Svg"
+                    focusable="false"
+                    height="20"
+                    viewBox="0 0 20 20"
+                    width="20"
+                  >
+                    <path
+                      d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ml-3"
+          style="width: 200px;"
+        >
+          <div
+            class=" css-b62m3t-container"
+          >
+            <span
+              class="css-1f43avz-a11yText-A11yText"
+              id="react-select-4-live-region"
+            />
+            <span
+              aria-atomic="false"
+              aria-live="polite"
+              aria-relevant="additions text"
+              class="css-1f43avz-a11yText-A11yText"
+            />
+            <div
+              class=" css-13cymwt-control"
+            >
+              <div
+                class=" css-1fdsijx-ValueContainer"
+              >
+                <div
+                  class=" css-1jqq78o-placeholder"
+                  id="react-select-4-placeholder"
+                >
+                  Filter type
+                </div>
+                <div
+                  class=" css-qbdosj-Input"
+                  data-value=""
+                >
+                  <input
+                    aria-autocomplete="list"
+                    aria-describedby="react-select-4-placeholder"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    autocorrect="off"
+                    class=""
+                    id="react-select-4-input"
+                    role="combobox"
+                    spellcheck="false"
+                    style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                    tabindex="0"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <div
+                class=" css-1hb7zxy-IndicatorsContainer"
+              >
+                <span
+                  class=" css-1u9des2-indicatorSeparator"
+                />
+                <div
+                  aria-hidden="true"
+                  class=" css-1xc3v61-indicatorContainer"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="css-tj5bde-Svg"
+                    focusable="false"
+                    height="20"
+                    viewBox="0 0 20 20"
+                    width="20"
+                  >
+                    <path
+                      d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ml-3"
+        />
+      </div>
+      <div
+        class="mt-4"
+      >
+        <div
+          class="card"
+        >
+          <div
+            class="d-flex align-items-center card-header"
+          >
+            <div
+              class="flex-grow-1"
+            >
+              Custom Bricks
+            </div>
+          </div>
+          <div
+            class="p-0 card-body"
+          >
+            <div
+              class="table-responsive"
+            >
+              <table
+                class="paginatedTable table"
+                role="table"
+                style="min-width: 0px;"
+              >
+                <thead
+                  class="d-block w-100"
+                >
+                  <tr
+                    role="row"
+                    style="display: flex; flex: 1 0 auto; min-width: 0px;"
+                  >
+                    <th
+                      class="th"
+                      colspan="1"
+                      role="columnheader"
+                      style="position: relative; box-sizing: border-box; flex: 250 0 auto; min-width: 0px; width: 250px; cursor: pointer;"
+                      title="Toggle SortBy"
+                    >
+                      <div
+                        class="header-content d-flex"
+                      >
+                        Name
+                        <span
+                          class="text-muted ml-2"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="svg-inline--fa fa-sort fa-w-10 sortIcon"
+                            data-icon="sort"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </span>
+                      </div>
+                      <div
+                        class="resize"
+                        draggable="false"
+                        role="separator"
+                        style="cursor: col-resize;"
+                      />
+                    </th>
+                    <th
+                      class="th"
+                      colspan="1"
+                      role="columnheader"
+                      style="position: relative; box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                      title="Toggle SortBy"
+                    >
+                      <div
+                        class="header-content d-flex"
+                      >
+                        Collection
+                        <span
+                          class="text-muted ml-2"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="svg-inline--fa fa-sort fa-w-10 sortIcon"
+                            data-icon="sort"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </span>
+                      </div>
+                      <div
+                        class="resize"
+                        draggable="false"
+                        role="separator"
+                        style="cursor: col-resize;"
+                      />
+                    </th>
+                    <th
+                      class="th"
+                      colspan="1"
+                      role="columnheader"
+                      style="position: relative; box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                      title="Toggle SortBy"
+                    >
+                      <div
+                        class="header-content d-flex"
+                      >
+                        Type
+                        <span
+                          class="text-muted ml-2"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="svg-inline--fa fa-sort fa-w-10 sortIcon"
+                            data-icon="sort"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </span>
+                      </div>
+                      <div
+                        class="resize"
+                        draggable="false"
+                        role="separator"
+                        style="cursor: col-resize;"
+                      />
+                    </th>
+                    <th
+                      class="th"
+                      colspan="1"
+                      role="columnheader"
+                      style="position: relative; box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                      title="Toggle SortBy"
+                    >
+                      <div
+                        class="header-content d-flex"
+                      >
+                        Version
+                        <span
+                          class="text-muted ml-2"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="svg-inline--fa fa-sort fa-w-10 sortIcon"
+                            data-icon="sort"
+                            data-prefix="fas"
+                            focusable="false"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                              fill="currentColor"
+                            />
+                          </svg>
+                        </span>
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="d-block w-100"
+                  role="rowgroup"
+                >
+                  <tr>
+                    <td
+                      class="text-muted"
+                      colspan="5"
+                    >
+                      No records found.
+                    </td>
+                  </tr>
+                </tbody>
+                <tfoot
+                  class="tfoot"
+                >
+                  <tr
+                    class="d-block w-100"
+                  >
+                    <td
+                      class="d-block w-100"
+                    >
+                      <div
+                        class="d-flex align-items-center"
+                      >
+                        <div
+                          class="text-muted"
+                        >
+                          Showing 0 to 0 of 0
+                        </div>
+                        <div
+                          class="flex-grow-1"
+                        >
+                          <ul
+                            class="m-0 float-right pagination"
+                          >
+                            <li
+                              class="page-item disabled"
+                            >
+                              <span
+                                class="page-link"
+                                disabled=""
+                              >
+                                <span
+                                  aria-hidden="true"
+                                >
+                                  «
+                                </span>
+                                <span
+                                  class="sr-only"
+                                >
+                                  First
+                                </span>
+                              </span>
+                            </li>
+                            <li
+                              class="page-item disabled"
+                            >
+                              <span
+                                class="page-link"
+                                disabled=""
+                              >
+                                <span
+                                  aria-hidden="true"
+                                >
+                                  ‹
+                                </span>
+                                <span
+                                  class="sr-only"
+                                >
+                                  Previous
+                                </span>
+                              </span>
+                            </li>
+                            <li
+                              class="page-item disabled"
+                            >
+                              <span
+                                class="page-link"
+                                disabled=""
+                              >
+                                Page 1 of 1
+                              </span>
+                            </li>
+                            <li
+                              class="page-item disabled"
+                            >
+                              <span
+                                class="page-link"
+                                disabled=""
+                              >
+                                <span
+                                  aria-hidden="true"
+                                >
+                                  ›
+                                </span>
+                                <span
+                                  class="sr-only"
+                                >
+                                  Next
+                                </span>
+                              </span>
+                            </li>
+                            <li
+                              class="page-item disabled"
+                            >
+                              <span
+                                class="page-link"
+                                disabled=""
+                              >
+                                <span
+                                  aria-hidden="true"
+                                >
+                                  »
+                                </span>
+                                <span
+                                  class="sr-only"
+                                >
+                                  Last
+                                </span>
+                              </span>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`WorkshopPage require account alias 1`] = `
+<DocumentFragment>
+  <div
+    class="root"
+  >
+    <div
+      class="title"
+    >
+      Welcome to the PixieBrix Workshop!
+    </div>
+    <div
+      class="font-weight-bold"
+    >
+      To use the Workshop, you must first set an account alias for your PixieBrix account
+    </div>
+    <div
+      class="fade mt-2 alert alert-info show"
+      role="alert"
+    >
+      <p>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-info fa-w-6 "
+          data-icon="info"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 192 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20 424.229h20V279.771H20c-11.046 0-20-8.954-20-20V212c0-11.046 8.954-20 20-20h112c11.046 0 20 8.954 20 20v212.229h20c11.046 0 20 8.954 20 20V492c0 11.046-8.954 20-20 20H20c-11.046 0-20-8.954-20-20v-47.771c0-11.046 8.954-20 20-20zM96 0C56.235 0 24 32.235 24 72s32.235 72 72 72 72-32.235 72-72S135.764 0 96 0z"
+            fill="currentColor"
+          />
+        </svg>
+         Your account alias is a unique name used to prevent duplicate identifiers between the bricks you create and public/team bricks.
+      </p>
+    </div>
+    <div
+      class="fade mt-2 alert alert-info show"
+      role="alert"
+    >
+      <p>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-eye-slash fa-w-20 "
+          data-icon="eye-slash"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 640 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1l-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142l-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"
+            fill="currentColor"
+          />
+        </svg>
+         You account alias will not be visible to anyone unless you choose to share a brick or mod.
+      </p>
+    </div>
+    <div
+      class="container"
+    >
+      <form
+        class=""
+        novalidate=""
+      >
+        <div
+          class="formGroup form-group row"
+        >
+          <label
+            class="label form-label col-form-label col-lg-auto"
+            for="scope"
+          >
+            Account Alias
+          </label>
+          <div
+            class="col-lg"
+          >
+            <input
+              class="form-control"
+              id="scope"
+              name="scope"
+              placeholder="@peter-parker"
+              value=""
+            />
+            <small
+              class="text-muted form-text"
+            >
+              <span>
+                Your @alias for publishing bricks, e.g. @peter-parker
+              </span>
+            </small>
+          </div>
+        </div>
+        <div
+          class="submitDiv"
+        >
+          <button
+            class="submit btn btn-primary"
+            type="submit"
+          >
+            Set My Account Alias
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/extensionConsole/pages/workshop/workshopTypes.ts
+++ b/src/extensionConsole/pages/workshop/workshopTypes.ts
@@ -15,9 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type EditablePackage } from "@/types/contract";
+import { type EditablePackageMetadata } from "@/types/contract";
 
-export type EnrichedBrick = EditablePackage & {
+export type EnrichedBrick = EditablePackageMetadata & {
   scope: string;
   collection: string;
   timestamp: number | null;

--- a/src/extensionConsole/pages/workshop/workshopUtils.test.ts
+++ b/src/extensionConsole/pages/workshop/workshopUtils.test.ts
@@ -15,21 +15,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getKindDisplayName } from "@/extensionConsole/pages/workshop/workshopUtils";
+import { mapKindToKindUiValue } from "@/extensionConsole/pages/workshop/workshopUtils";
 import { type EditablePackage } from "@/types/contract";
 
 describe("getKindDisplayName", () => {
   it.each(["block", "Block", "reader"])(
     "maps %s to Brick",
     (kind: EditablePackage["kind"]) => {
-      expect(getKindDisplayName(kind)).toEqual("Brick");
+      expect(mapKindToKindUiValue(kind)).toEqual("Brick");
     }
   );
 
   it.each(["recipe", "Recipe", "blueprint"])(
     "maps %s to Mod",
     (kind: EditablePackage["kind"]) => {
-      expect(getKindDisplayName(kind)).toEqual("Mod");
+      expect(mapKindToKindUiValue(kind)).toEqual("Mod");
     }
   );
 });

--- a/src/extensionConsole/pages/workshop/workshopUtils.test.ts
+++ b/src/extensionConsole/pages/workshop/workshopUtils.test.ts
@@ -16,19 +16,19 @@
  */
 
 import { mapKindToKindUiValue } from "@/extensionConsole/pages/workshop/workshopUtils";
-import { type EditablePackage } from "@/types/contract";
+import { type EditablePackageMetadata } from "@/types/contract";
 
 describe("getKindDisplayName", () => {
   it.each(["block", "Block", "reader"])(
     "maps %s to Brick",
-    (kind: EditablePackage["kind"]) => {
+    (kind: EditablePackageMetadata["kind"]) => {
       expect(mapKindToKindUiValue(kind)).toEqual("Brick");
     }
   );
 
-  it.each(["recipe", "Recipe", "blueprint"])(
+  it.each(["blueprint", "Blueprint"])(
     "maps %s to Mod",
-    (kind: EditablePackage["kind"]) => {
+    (kind: EditablePackageMetadata["kind"]) => {
       expect(mapKindToKindUiValue(kind)).toEqual("Mod");
     }
   );

--- a/src/extensionConsole/pages/workshop/workshopUtils.ts
+++ b/src/extensionConsole/pages/workshop/workshopUtils.ts
@@ -16,26 +16,44 @@
  */
 
 import { type EditablePackage } from "@/types/contract";
-import { startCase } from "lodash";
-
-const kindDisplayNameMap = new Map<EditablePackage["kind"], string>([
-  ["block", "Brick"],
-  ["reader", "Brick"],
-  ["blueprint", "Mod"],
-  ["recipe", "Mod"],
-  ["service", "Integration"],
-  // Full name is "starter brick", but user shorter name
-  ["foundation", "Starter"],
-]);
 
 /**
- * Returns the display name for a brick kind.
+ * A valid kind value.
+ *
+ * Excludes "reader" because it has the same display name as "block".
+ *
+ * @since 1.7.34
+ */
+export type KindFilterValue = "Brick" | "Mod" | "Integration" | "Starter";
+
+/**
+ * Returns the kind for the Workshop table/filter.
  * @since 1.7.20
  */
-export function getKindDisplayName(kind: EditablePackage["kind"]): string {
-  // Be defensive and lowercase for the match, some callers may not have the correct casing
-  return (
-    kindDisplayNameMap.get(kind.toLowerCase() as EditablePackage["kind"]) ??
-    startCase(kind)
-  );
+export function mapKindToKindUiValue(
+  kind: EditablePackage["kind"]
+): KindFilterValue {
+  switch (kind.toLowerCase()) {
+    case "brick":
+    case "reader": {
+      return "Brick";
+    }
+
+    case "recipe":
+    case "blueprint": {
+      return "Mod";
+    }
+
+    case "service": {
+      return "Integration";
+    }
+
+    case "foundation": {
+      return "Starter";
+    }
+
+    default: {
+      return "Brick";
+    }
+  }
 }

--- a/src/extensionConsole/pages/workshop/workshopUtils.ts
+++ b/src/extensionConsole/pages/workshop/workshopUtils.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type EditablePackage } from "@/types/contract";
+import { type EditablePackageMetadata } from "@/types/contract";
 
 /**
  * A valid kind value.
@@ -31,7 +31,7 @@ export type KindFilterValue = "Brick" | "Mod" | "Integration" | "Starter";
  * @since 1.7.20
  */
 export function mapKindToKindUiValue(
-  kind: EditablePackage["kind"]
+  kind: EditablePackageMetadata["kind"]
 ): KindFilterValue {
   switch (kind.toLowerCase()) {
     case "brick":
@@ -39,7 +39,6 @@ export function mapKindToKindUiValue(
       return "Brick";
     }
 
-    case "recipe":
     case "blueprint": {
       return "Mod";
     }

--- a/src/extensionConsole/pages/workshop/workshopUtils.ts
+++ b/src/extensionConsole/pages/workshop/workshopUtils.ts
@@ -18,9 +18,9 @@
 import { type EditablePackageMetadata } from "@/types/contract";
 
 /**
- * A valid kind value.
+ * Valid values for the Workshop table/filters.
  *
- * Excludes "reader" because it has the same display name as "block".
+ * Excludes and entry for readers because they're deprecated.
  *
  * @since 1.7.34
  */

--- a/src/extensionConsole/testHelpers.tsx
+++ b/src/extensionConsole/testHelpers.tsx
@@ -29,6 +29,7 @@ import { recipesSlice } from "@/recipes/recipesSlice";
 import { appApi } from "@/services/api";
 import { recipesMiddleware } from "@/recipes/recipesListenerMiddleware";
 import servicesSlice from "@/store/servicesSlice";
+import workshopSlice from "@/store/workshopSlice";
 
 const configureStoreForTests = () =>
   configureStore({
@@ -40,6 +41,7 @@ const configureStoreForTests = () =>
       modsPage: modsPageSlice.reducer,
       recipes: recipesSlice.reducer,
       services: servicesSlice.reducer,
+      workshop: workshopSlice.reducer,
       [appApi.reducerPath]: appApi.reducer,
     },
     middleware(getDefaultMiddleware) {

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -49,7 +49,7 @@ import {
 } from "@/runtime/expressionCreators";
 import { type PipelineExpression } from "@/runtime/mapArgs";
 import AddBlockModal from "@/components/addBlockModal/AddBlockModal";
-import { type EditablePackage } from "@/types/contract";
+import { type EditablePackageMetadata } from "@/types/contract";
 import { fireTextInput } from "@/testUtils/formHelpers";
 import { MarkdownRenderer } from "@/blocks/renderers/markdown";
 import { PIPELINE_BLOCKS_FIELD_NAME } from "@/pageEditor/consts";
@@ -128,7 +128,7 @@ beforeAll(async () => {
       ({
         id: uuidSequence(index),
         name: listing.id,
-      } as EditablePackage)
+      } as EditablePackageMetadata)
   );
 
   appApiMock.onGet("/api/marketplace/tags/").reply(200, tags);

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -51,7 +51,7 @@ import {
   type UnsavedModDefinition,
 } from "@/types/modDefinitionTypes";
 import { type UnresolvedExtension } from "@/types/extensionTypes";
-import { type EditablePackage } from "@/types/contract";
+import { type EditablePackageMetadata } from "@/types/contract";
 import { extensionFactory } from "@/testUtils/factories/extensionFactories";
 import {
   extensionPointConfigFactory,
@@ -567,7 +567,7 @@ describe("blueprint options", () => {
 describe("isRecipeEditable", () => {
   test("returns true if recipe is in editable packages", () => {
     const recipe = recipeFactory();
-    const editablePackages: EditablePackage[] = [
+    const editablePackages: EditablePackageMetadata[] = [
       {
         id: null,
         name: validateRegistryId("test/recipe"),
@@ -576,30 +576,30 @@ describe("isRecipeEditable", () => {
         id: null,
         name: recipe.metadata.id,
       },
-    ] as EditablePackage[];
+    ] as EditablePackageMetadata[];
 
     expect(isRecipeEditable(editablePackages, recipe)).toBe(true);
   });
 
   test("returns false if recipe is not in editable packages", () => {
     const recipe = recipeFactory();
-    const editablePackages: EditablePackage[] = [
+    const editablePackages: EditablePackageMetadata[] = [
       {
         id: null,
         name: validateRegistryId("test/recipe"),
       },
-    ] as EditablePackage[];
+    ] as EditablePackageMetadata[];
 
     expect(isRecipeEditable(editablePackages, recipe)).toBe(false);
   });
 
   test("returns false if recipe is null", () => {
-    const editablePackages: EditablePackage[] = [
+    const editablePackages: EditablePackageMetadata[] = [
       {
         id: null,
         name: validateRegistryId("test/recipe"),
       },
-    ] as EditablePackage[];
+    ] as EditablePackageMetadata[];
 
     expect(isRecipeEditable(editablePackages, null)).toBe(false);
   });

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -48,7 +48,7 @@ import {
 } from "@/types/extensionTypes";
 import { type SafeString } from "@/types/stringTypes";
 import { type RecipeMetadataFormState } from "@/pageEditor/pageEditorTypes";
-import { type EditablePackage } from "@/types/contract";
+import { type EditablePackageMetadata } from "@/types/contract";
 
 /**
  * Generate a new registry id from an existing registry id by adding/replacing the scope.
@@ -66,7 +66,7 @@ export function generateScopeBrickId(
 }
 
 export function isRecipeEditable(
-  editablePackages: EditablePackage[],
+  editablePackages: EditablePackageMetadata[],
   recipe: ModDefinition
 ): boolean {
   // The user might lose access to the recipe while they were editing it (the recipe or an extension)

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -21,7 +21,7 @@ import { type BaseQueryFn, createApi } from "@reduxjs/toolkit/query/react";
 import { type AxiosRequestConfig } from "axios";
 import { getApiClient, getLinkedApiClient } from "@/services/apiClient";
 import {
-  type EditablePackage,
+  type EditablePackageMetadata,
   type CloudExtension,
   type Database,
   type Group,
@@ -262,7 +262,7 @@ export const appApi = createApi({
       query: () => ({ url: "/api/marketplace/tags/", method: "get" }),
       providesTags: ["MarketplaceTags"],
     }),
-    getEditablePackages: builder.query<EditablePackage[], void>({
+    getEditablePackages: builder.query<EditablePackageMetadata[], void>({
       query: () => ({ url: "/api/bricks/", method: "get" }),
       providesTags: ["EditablePackages"],
     }),

--- a/src/store/workshopSlice.ts
+++ b/src/store/workshopSlice.ts
@@ -20,6 +20,7 @@ import { orderBy } from "lodash";
 import { localStorage } from "redux-persist-webextension-storage";
 import { type StorageInterface } from "@/store/StorageInterface";
 import { revertAll } from "@/store/commonActions";
+import { type KindFilterValue } from "@/extensionConsole/pages/workshop/workshopUtils";
 
 type RecentBrick = {
   id: string;
@@ -33,7 +34,7 @@ export type WorkshopState = {
   filters: {
     scopes: string[];
     collections: string[];
-    kinds: string[];
+    kinds: KindFilterValue[];
   };
 };
 

--- a/src/testUtils/factories/registryFactories.ts
+++ b/src/testUtils/factories/registryFactories.ts
@@ -37,6 +37,6 @@ export const editablePackageFactory = define<EditablePackage>({
   version: "1.0.0",
   kind: "Blueprint",
   updated_at: timestampFactory(),
-  sharing: sharingDefinitionFactory(),
+  sharing: sharingDefinitionFactory,
   _editableBrickBrand: undefined,
 });

--- a/src/testUtils/factories/registryFactories.ts
+++ b/src/testUtils/factories/registryFactories.ts
@@ -18,7 +18,7 @@
 import { define } from "cooky-cutter";
 import { type Sharing } from "@/types/registryTypes";
 import { type UUID } from "@/types/stringTypes";
-import { type EditablePackage } from "@/types/contract";
+import { type EditablePackageMetadata } from "@/types/contract";
 import {
   autoUUIDSequence,
   registryIdFactory,
@@ -30,7 +30,7 @@ export const sharingDefinitionFactory = define<Sharing>({
   organizations: () => [] as UUID[],
 });
 
-export const editablePackageFactory = define<EditablePackage>({
+export const editablePackageFactory = define<EditablePackageMetadata>({
   id: autoUUIDSequence(),
   name: registryIdFactory(),
   verbose_name: (n: number) => `Editable Package ${n}`,

--- a/src/testUtils/factories/registryFactories.ts
+++ b/src/testUtils/factories/registryFactories.ts
@@ -18,8 +18,25 @@
 import { define } from "cooky-cutter";
 import { type Sharing } from "@/types/registryTypes";
 import { type UUID } from "@/types/stringTypes";
+import { EditablePackage } from "@/types/contract";
+import {
+  autoUUIDSequence,
+  registryIdFactory,
+  timestampFactory,
+} from "@/testUtils/factories/stringFactories";
 
 export const sharingDefinitionFactory = define<Sharing>({
   public: false,
   organizations: () => [] as UUID[],
+});
+
+export const editablePackageFactory = define<EditablePackage>({
+  id: autoUUIDSequence(),
+  name: registryIdFactory(),
+  verbose_name: "Not Really: Ask AI to Suggest a Tweet",
+  version: "1.0.0",
+  kind: "Blueprint",
+  updated_at: timestampFactory(),
+  sharing: sharingDefinitionFactory(),
+  _editableBrickBrand: undefined,
 });

--- a/src/testUtils/factories/registryFactories.ts
+++ b/src/testUtils/factories/registryFactories.ts
@@ -30,7 +30,7 @@ export const sharingDefinitionFactory = define<Sharing>({
   organizations: () => [] as UUID[],
 });
 
-export const editablePackageFactory = define<EditablePackageMetadata>({
+export const editablePackageMetadataFactory = define<EditablePackageMetadata>({
   id: autoUUIDSequence(),
   name: registryIdFactory(),
   verbose_name: (n: number) => `Editable Package ${n}`,

--- a/src/testUtils/factories/registryFactories.ts
+++ b/src/testUtils/factories/registryFactories.ts
@@ -18,7 +18,7 @@
 import { define } from "cooky-cutter";
 import { type Sharing } from "@/types/registryTypes";
 import { type UUID } from "@/types/stringTypes";
-import { EditablePackage } from "@/types/contract";
+import { type EditablePackage } from "@/types/contract";
 import {
   autoUUIDSequence,
   registryIdFactory,
@@ -33,7 +33,7 @@ export const sharingDefinitionFactory = define<Sharing>({
 export const editablePackageFactory = define<EditablePackage>({
   id: autoUUIDSequence(),
   name: registryIdFactory(),
-  verbose_name: "Not Really: Ask AI to Suggest a Tweet",
+  verbose_name: (n: number) => `Editable Package ${n}`,
   version: "1.0.0",
   kind: "Blueprint",
   updated_at: timestampFactory(),

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -168,14 +168,16 @@ export type Deployment = Except<
 };
 
 /**
- * An editable package in the registry.
+ * Metadata for an editable package in the registry. See PackageMetaSerializer.
  */
-export type EditablePackage = components["schemas"]["PackageMeta"] & {
+export type EditablePackageMetadata = components["schemas"]["PackageMeta"] & {
   id: UUID;
 
   name: RegistryId;
 
-  kind: "Blueprint" | "Recipe" | "Service" | "Block" | "Reader" | "Foundation";
+  // Display names from Package.kind.
+  // https://github.com/pixiebrix/pixiebrix-app/blob/be1c486eba393e3c8e2f99401f78af5958b4060b/api/models/registry.py#L210-L210
+  kind: "Blueprint" | "Service" | "Block" | "Reader" | "Foundation";
 
   // Nominal typing to help distinguish from registry Metadata
   _editableBrickBrand: never;

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -175,7 +175,7 @@ export type EditablePackage = components["schemas"]["PackageMeta"] & {
 
   name: RegistryId;
 
-  kind: Kind;
+  kind: "Blueprint" | "Recipe" | "Service" | "Block" | "Reader" | "Foundation";
 
   // Nominal typing to help distinguish from registry Metadata
   _editableBrickBrand: never;

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -167,8 +167,10 @@ export type EditablePackageMetadata = components["schemas"]["PackageMeta"] & {
 
   name: RegistryId;
 
-  // Display names from Package.kind.
-  // https://github.com/pixiebrix/pixiebrix-app/blob/be1c486eba393e3c8e2f99401f78af5958b4060b/api/models/registry.py#L210-L210
+  /**
+   * Backend display name for the Package.kind.
+   * @see https://github.com/pixiebrix/pixiebrix-app/blob/be1c486eba393e3c8e2f99401f78af5958b4060b/api/models/registry.py#L210-L210
+   */
   kind: "Blueprint" | "Service" | "Block" | "Reader" | "Foundation";
 
   // Nominal typing to help distinguish from registry Metadata
@@ -182,9 +184,11 @@ export type RegistryPackage = Pick<
   // XXX: update serializer to include proper child serializer
   metadata: Metadata;
 
-  // A valid `kind:` in the YAML definition
-  // Validated here: https://github.com/pixiebrix/pixiebrix-app/blob/43f0a4b81d8b7aaaf11adbe7fd8e4530ca4b8bf0/api/serializers/brick.py#L204-L204
-  // Note that EditablePackageMetadata uses the backend's display name for this field
+  /**
+   * Valid `kind` value in the YAML definition.
+   * Note that EditablePackageMetadata uses the backend's display name for this field
+   * @see https://github.com/pixiebrix/pixiebrix-app/blob/43f0a4b81d8b7aaaf11adbe7fd8e4530ca4b8bf0/api/serializers/brick.py#L204-L204
+   */
   kind: "component" | "extensionPoint" | "recipe" | "service" | "reader";
 };
 

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -40,14 +40,6 @@ import { type PersistedExtension } from "@/types/extensionTypes";
 import { type UnknownObject } from "@/types/objectTypes";
 import { type OptionsArgs } from "@/types/runtimeTypes";
 
-type Kind =
-  | "block"
-  | "foundation"
-  | "service"
-  | "blueprint"
-  | "reader"
-  | "recipe";
-
 type MeGroup = components["schemas"]["Me"]["group_memberships"][number] & {
   id: UUID;
 };
@@ -189,7 +181,11 @@ export type RegistryPackage = Pick<
 > & {
   // XXX: update serializer to include proper child serializer
   metadata: Metadata;
-  kind: Kind;
+
+  // A valid `kind:` in the YAML definition
+  // Validated here: https://github.com/pixiebrix/pixiebrix-app/blob/43f0a4b81d8b7aaaf11adbe7fd8e4530ca4b8bf0/api/serializers/brick.py#L204-L204
+  // Note that EditablePackageMetadata uses the backend's display name for this field
+  kind: "component" | "extensionPoint" | "recipe" | "service" | "reader";
 };
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Closes #5526 
- Fixes the type of `EditablePackage.kind` (see contract.ts). The values are the display values here: 
  - https://github.com/pixiebrix/pixiebrix-app/blob/be1c486eba393e3c8e2f99401f78af5958b4060b/api/models/registry.py#L210-L210
  - https://github.com/pixiebrix/pixiebrix-app/blob/be1c486eba393e3c8e2f99401f78af5958b4060b/api/serializers/brick.py#L65-L65 
- Fixes the workshop filter by mapping the values to not distinguish bricks vs. readers

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @mnholtz 
