### PR TITLE
#6065: fix rendering of user-defined bricks in the sidebar

### DIFF
--- a/src/blocks/errors.ts
+++ b/src/blocks/errors.ts
@@ -23,6 +23,7 @@ import { BusinessError, CancelError } from "@/errors/businessErrors";
 import { type MessageContext } from "@/types/loggerTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type Schema } from "@/types/schemaTypes";
+import { type BrickArgs, type BrickArgsContext } from "@/types/runtimeTypes";
 
 export class PipelineConfigurationError extends BusinessError {
   override name = "PipelineConfigurationError";
@@ -45,16 +46,16 @@ export class HeadlessModeError extends Error {
 
   public readonly blockId: RegistryId;
 
-  public readonly args: unknown;
+  public readonly args: BrickArgs;
 
-  public readonly ctxt: unknown;
+  public readonly ctxt: BrickArgsContext;
 
   public readonly loggerContext: MessageContext;
 
   constructor(
     blockId: RegistryId,
-    args: unknown, // BlockArg
-    ctxt: unknown, // BrickArgsContext
+    args: BrickArgs,
+    ctxt: BrickArgsContext,
     loggerContext: MessageContext
   ) {
     super(`${blockId} is a renderer`);

--- a/src/blocks/transformers/brickFactory.test.ts
+++ b/src/blocks/transformers/brickFactory.test.ts
@@ -33,6 +33,9 @@ import Run from "@/blocks/transformers/controlFlow/Run";
 import { GetPageState } from "@/blocks/effects/pageState";
 import { cloneDeep } from "lodash";
 import { extraEmptyModStateContext } from "@/runtime/extendModVariableContext";
+import { setContext } from "@/testUtils/detectPageMock";
+
+setContext("contentScript");
 
 beforeEach(() => {
   blockRegistry.clear();

--- a/src/components/documentBuilder/render/ButtonElement.tsx
+++ b/src/components/documentBuilder/render/ButtonElement.tsx
@@ -18,7 +18,7 @@
 import React, { useContext, useState } from "react";
 import { type BrickPipeline } from "@/blocks/types";
 import AsyncButton, { type AsyncButtonProps } from "@/components/AsyncButton";
-import { runEffectPipeline } from "@/contentScript/messenger/api";
+import { runHeadlessPipeline } from "@/contentScript/messenger/api";
 import { uuidv4 } from "@/types/helpers";
 import DocumentContext from "@/components/documentBuilder/render/DocumentContext";
 import { type Except } from "type-fest";
@@ -68,7 +68,7 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
     const topLevelFrame = await getTopLevelFrame();
 
     try {
-      await runEffectPipeline(topLevelFrame, {
+      await runHeadlessPipeline(topLevelFrame, {
         nonce: uuidv4(),
         context: ctxt,
         pipeline: onClick,

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -73,7 +73,7 @@ export const cancelSelect = getMethod("CANCEL_SELECT_ELEMENT");
 export const selectElement = getMethod("SELECT_ELEMENT");
 
 export const runRendererPipeline = getMethod("RUN_RENDERER_PIPELINE");
-export const runEffectPipeline = getMethod("RUN_EFFECT_PIPELINE");
+export const runHeadlessPipeline = getMethod("RUN_HEADLESS_PIPELINE");
 export const runMapArgs = getMethod("RUN_MAP_ARGS");
 
 export const getPageState = getMethod("GET_PAGE_STATE");

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -64,7 +64,7 @@ import {
   selectElement,
 } from "@/contentScript/pageEditor/elementPicker";
 import {
-  runEffectPipeline,
+  runHeadlessPipeline,
   runMapArgs,
   runRendererPipeline,
 } from "@/contentScript/pipelineProtocol";
@@ -130,7 +130,7 @@ declare global {
     SELECT_ELEMENT: typeof selectElement;
 
     RUN_RENDERER_PIPELINE: typeof runRendererPipeline;
-    RUN_EFFECT_PIPELINE: typeof runEffectPipeline;
+    RUN_HEADLESS_PIPELINE: typeof runHeadlessPipeline;
     RUN_MAP_ARGS: typeof runMapArgs;
 
     NOTIFY_INFO: typeof notify.info;
@@ -195,7 +195,7 @@ export default function registerMessenger(): void {
     SELECT_ELEMENT: selectElement,
 
     RUN_RENDERER_PIPELINE: runRendererPipeline,
-    RUN_EFFECT_PIPELINE: runEffectPipeline,
+    RUN_HEADLESS_PIPELINE: runHeadlessPipeline,
     RUN_MAP_ARGS: runMapArgs,
 
     NOTIFY_INFO: notify.info,

--- a/src/contentScript/pipelineProtocol.ts
+++ b/src/contentScript/pipelineProtocol.ts
@@ -102,20 +102,23 @@ export async function runRendererPipeline({
   throw new BusinessError("Pipeline does not include a renderer");
 }
 
-export async function runEffectPipeline({
+/**
+ * Run a pipeline in headless mode.
+ */
+export async function runHeadlessPipeline({
   pipeline,
   context,
   options,
   meta,
   messageContext,
-}: RunPipelineParams): Promise<void> {
+}: RunPipelineParams): Promise<unknown> {
   expectContext("contentScript");
 
   if (meta.extensionId == null) {
-    throw new Error("runEffectPipeline requires meta.extensionId");
+    throw new Error("runHeadlessPipeline requires meta.extensionId");
   }
 
-  await reducePipeline(
+  return reducePipeline(
     pipeline,
     {
       input: context["@input"] ?? {},

--- a/src/runtime/pipelineTests/component.test.ts
+++ b/src/runtime/pipelineTests/component.test.ts
@@ -27,6 +27,9 @@ import {
 
 import { fromJS } from "@/blocks/transformers/brickFactory";
 import { validateSemVerString } from "@/types/helpers";
+import { setContext } from "@/testUtils/detectPageMock";
+
+setContext("contentScript");
 
 beforeEach(() => {
   blockRegistry.clear();

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -44,7 +44,10 @@ import {
   throwIfInvalidInput,
 } from "@/runtime/runtimeUtils";
 import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type ResolvedBrickConfig } from "@/runtime/runtimeTypes";
+import {
+  type ResolvedBrickConfig,
+  unsafeAssumeValidArg,
+} from "@/runtime/runtimeTypes";
 import { type RunBlock } from "@/contentScript/runBlockTypes";
 import { resolveBlockConfig } from "@/blocks/registry";
 import { isObject } from "@/utils";
@@ -570,7 +573,8 @@ export async function runBlock(
 
     throw new HeadlessModeError(
       block.id,
-      props.args,
+      // Call to throwIfInvalidInput above ensures args are valid for the brick
+      unsafeAssumeValidArg(props.args),
       props.context,
       logger.context
     );

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -160,8 +160,7 @@ const PanelBody: React.FunctionComponent<{
         console.debug("Running panel body for panel payload", payload);
 
         const block = await blockRegistry.lookup(blockId);
-        // In the future, the renderer brick should run in the contentScript, not the panel frame
-        // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/1939
+
         const body = await block.run(unsafeAssumeValidArg(args), {
           ctxt,
           root: null,

--- a/src/sidebar/RendererComponent.test.tsx
+++ b/src/sidebar/RendererComponent.test.tsx
@@ -25,19 +25,21 @@ import { screen } from "shadow-dom-testing-library";
 import { act } from "@testing-library/react";
 import { SubmitPanelAction } from "@/blocks/errors";
 import ConsoleLogger from "@/utils/ConsoleLogger";
-import { runEffectPipeline } from "@/contentScript/messenger/api";
+import { runHeadlessPipeline } from "@/contentScript/messenger/api";
 
 jest.mock("@/contentScript/messenger/api", () => ({
-  runEffectPipeline: jest.fn().mockRejectedValue(new Error("not implemented")),
+  runHeadlessPipeline: jest
+    .fn()
+    .mockRejectedValue(new Error("not implemented")),
 }));
 
-const runEffectPipelineMock = runEffectPipeline as jest.MockedFunction<
-  typeof runEffectPipeline
+const runHeadlessPipelineMock = runHeadlessPipeline as jest.MockedFunction<
+  typeof runHeadlessPipeline
 >;
 
 describe("RendererComponent", () => {
   beforeEach(() => {
-    runEffectPipelineMock.mockReset();
+    runHeadlessPipelineMock.mockReset();
   });
 
   test("provide onAction to document renderer", async () => {
@@ -45,7 +47,7 @@ describe("RendererComponent", () => {
     const extensionId = uuidv4();
     const onAction = jest.fn();
 
-    runEffectPipelineMock.mockRejectedValue(
+    runHeadlessPipelineMock.mockRejectedValue(
       new SubmitPanelAction("submit", { foo: "bar" })
     );
 

--- a/src/testUtils/detectPageMock.ts
+++ b/src/testUtils/detectPageMock.ts
@@ -53,6 +53,10 @@ export function isWeb() {
   return _context === "web";
 }
 
+export function isContentScript() {
+  return _context === "contentScript";
+}
+
 export function getContextName(): ContextName {
   return _context;
 }

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -208,7 +208,18 @@ export type BrickArgsContext = UnknownObject & {
 };
 
 /**
- * The JSON Schema validated arguments to pass into the `run` method of an Brick.
+ * Returns an object as a BrickArgsContext, or throw a TypeError if it's not a valid context.
+ */
+export function validateBrickArgsContext(obj: UnknownObject): BrickArgsContext {
+  if (!("@input" in obj)) {
+    throw new TypeError("BrickArgsContext must have @input property");
+  }
+
+  return obj as BrickArgsContext;
+}
+
+/**
+ * The JSON Schema validated arguments to pass into the `run` method of a Brick.
  *
  * Uses `any` for values so that bricks don't have to assert/cast all their argument types. The input values
  * are validated using JSON Schema in `reducePipeline`.
@@ -225,7 +236,7 @@ export type BrickArgs<
 };
 
 /**
- * The non-validated arguments to pass into the `run` method of an Brick.
+ * The non-validated arguments to pass into the `run` method of a Brick.
  * @see BrickArgs
  */
 export type RenderedArgs = UnknownObject & {


### PR DESCRIPTION
## What does this PR do?

- Closes #6065 
- Closes #1939
- Fixes the `run` method of `ExternalBrick` (now called UserDefinedBrick) to run the pipeline in the contentScript

## Reviewer Tips

- Review changes in `brickFactory.ts`
- Modifies `runEffectPipeline` to `runHeadlessPipeline` and has it return it's value

## Discussion

- The root cause of the bug was an interaction between #1939 and #6052
- Instead of catching the HeadlessModeError, could call inferType and then conditionally call runEffectPipeline or runRendererPipeline based on the result. But would still need the logic to actually run the renderer brick after runRendererPipeline. So as-is, the implementation is the PR is a bit simpler

## Demos

Added directly to sidebar:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/baa3f594-22d0-476a-957b-93e13f764328)

Embedded in Document Builder:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/a5353ab9-9d14-4075-be9a-93c7d0eabf3f)

Referencing a `@mod` variable inside of the user-defined brick:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/91c8da01-13af-4090-be40-fa655f52d4ce)

## Future Work

- Update to call the `contentScript` directly once https://github.com/pixiebrix/webext-messenger/issues/72 is implemented

## Post-Merge Actions

- [ ] Update the Rainforest test to double-check the user-defined social links brick in the AI Copilot mod are rendered properly

## Checklist

- [x] Add tests: updated, but see above on Rainforest
- [x] Designate a primary reviewer: @grahamlangford 
