### PR TITLE
#6069: add match_about_blank to manifest to run on iframes without src set

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,6 +25,7 @@
       "js": ["contentScript.js"],
       "css": ["contentScript.css"],
       "all_frames": true,
+      "match_about_blank": true,
       "run_at": "document_idle"
     },
     {


### PR DESCRIPTION
## What does this PR do?

- Closes #6069 
- Adds `match_about_blank` to the main content script in the manifest so the contentScript is loaded in those context

## Remaining Work

- [x] Double-check it doesn't result in extension being disabled out of permissions. (It shouldn't but do out of abundance of caution)

## Reviewer Tips

- If testing locally, reload your extension to ensure you have the latest manifest

## Demo

- https://www.tiny.cloud/docs/demo/full-featured/
- https://www.loom.com/share/d421fba2b409457b9427cee0b2bc78de?sid=ea645e10-a3f0-41d4-a655-8751cfeb1386

## Checklist

- [x] Add tests: will add a RainforestQA test once the PR is in a build
- [x] Designate a primary reviewer
