### PR TITLE
Update sidebar tab design

### DIFF
--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -23,8 +23,6 @@
 }
 
 .tabContainer {
-  display: flex;
-  justify-content: space-evenly;
   flex-wrap: nowrap;
 }
 

--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -60,19 +60,30 @@
     content: "";
     background: transparent;
     height: 10px;
-    width: 20px;
+    width: 30px;
     bottom: 0;
-    z-index: 1;
   }
 
   &::after {
-    right: -20px;
+    right: -30px;
     border-bottom-left-radius: 10px;
   }
   &::before {
     // 2px left extra to account for the border that hides the left divider
-    left: -22px;
+    left: -32px;
     border-bottom-right-radius: 10px;
+  }
+
+  &:hover {
+    &::before {
+      box-shadow: 20px 0px 0px 0px $S3;
+      z-index: 1;
+    }
+
+    &::after {
+      box-shadow: -20px 0px 0px 0px $S3;
+      z-index: 1;
+    }
   }
 
   &.active {
@@ -89,11 +100,13 @@
     }
 
     &::before {
-      box-shadow: 10px 0px 0px 0px $S0;
+      box-shadow: 20px 0px 0px 0px $S0;
+      z-index: 2;
     }
 
     &::after {
-      box-shadow: -10px 0px 0px 0px $S0;
+      box-shadow: -20px 0px 0px 0px $S0;
+      z-index: 2;
     }
   }
 

--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -15,23 +15,60 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@import "@/themes/colors.scss";
+
 // Overrides for Bootstraps opinionated styling of tab content
 .paneOverrides {
   text-align: initial;
 }
 
-.tabHeader {
+.tabContainer {
   display: flex;
-  padding: 0 !important; // Reset Bootstrap padding to align and widen the close button
+  flex-wrap: nowrap;
+}
+
+.tabHeader {
+  border-radius: 0.5rem 0.5rem 0 0 !important;
+  border: none !important;
+  // Only show first 8 items
+  display: none;
+  &:nth-child(-n + 8) {
+    display: flex;
+  }
+
+  background: $S2 !important;
+  &:hover {
+    background: $S3 !important;
+  }
   &.active {
     // Disable cursor:pointer because there's no action
     // This also makes it easier to see when you're hovering the close button
     cursor: default;
+
+    background: $S0 !important;
+    &:hover {
+      background: $S0 !important;
+    }
   }
 
+  padding: 0.5rem 0.75rem !important;
+  // Add padding between each item without adding to the overall width
+  & > * {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  & > *:first-child {
+    padding-left: 0;
+  }
+  & > *:last-child {
+    padding-right: 0;
+  }
+
+  overflow: hidden;
+
   :global .close {
-    // Visually center the icon
-    padding: 0 0.6rem 0.2rem 0.7rem;
+    // The close icon is the actual letter "X" so this thins the icon
+    font-weight: 400;
     &:hover {
       background: rgba(0, 0, 0, 10%);
     }
@@ -43,6 +80,5 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  padding: 0.75rem 1rem;
   min-width: 0; // Avoid stretching the flex parent
 }

--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -46,6 +46,13 @@
     background: $S3;
   }
 
+  // We had to remove overflow:hidden to show the outer corner
+  // decorations but that broke the clamping. By setting the width
+  // to 0 we can rely on the flex justify-content property to size
+  // the tabs equally
+  width: 0;
+
+  // Position relative so the outside decorations can be positioned
   position: relative;
   &::before,
   &::after {

--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -46,6 +46,28 @@
     background: $S3;
   }
 
+  position: relative;
+  &::before,
+  &::after {
+    position: absolute;
+    content: "";
+    background: transparent;
+    height: 10px;
+    width: 20px;
+    bottom: 0;
+    z-index: 1;
+  }
+
+  &::after {
+    right: -20px;
+    border-bottom-left-radius: 10px;
+  }
+  &::before {
+    // 2px left extra to account for the border that hides the left divider
+    left: -22px;
+    border-bottom-right-radius: 10px;
+  }
+
   &.active {
     // Trickery to hide the divider on the left. Move the item over the divider,
     // then add a border to maintain the position
@@ -58,6 +80,14 @@
     &:hover {
       background: $S0;
     }
+
+    &::before {
+      box-shadow: 10px 0px 0px 0px $S0;
+    }
+
+    &::after {
+      box-shadow: -10px 0px 0px 0px $S0;
+    }
   }
 
   .tabDivider {
@@ -65,10 +95,6 @@
     width: 1px;
     margin: 10px 0;
     background: $S4;
-    &::after {
-      // Unicode for nbsp
-      content: "\a0";
-    }
   }
 
   // We don't want a divider on the far right
@@ -88,8 +114,6 @@
       display: none;
     }
   }
-
-  overflow: hidden;
 }
 
 .tabHeader {

--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -24,35 +24,88 @@
 
 .tabContainer {
   display: flex;
+  justify-content: space-evenly;
   flex-wrap: nowrap;
+
+  & > * {
+    flex: 1;
+  }
 }
 
-.tabHeader {
-  border-radius: 0.5rem 0.5rem 0 0 !important;
-  border: none !important;
+.tabWrapper {
+  display: flex;
+  align-items: stretch;
+  // Copying bootstraps alignment rule for Nav.Link
+  margin-bottom: -1px;
+
   // Only show first 8 items
   display: none;
   &:nth-child(-n + 8) {
     display: flex;
   }
+  border-radius: 0.5rem 0.5rem 0 0;
 
-  background: $S2 !important;
+  background: $S2;
   &:hover {
-    background: $S3 !important;
+    background: $S3;
   }
+
   &.active {
+    // Trickery to hide the divider on the left. Move the item over the divider,
+    // then add a border to maintain the position
+    margin-left: -2px;
+    border-left: 2px solid $S0;
     // Disable cursor:pointer because there's no action
     // This also makes it easier to see when you're hovering the close button
     cursor: default;
-
-    background: $S0 !important;
+    background: $S0;
     &:hover {
-      background: $S0 !important;
+      background: $S0;
     }
   }
 
+  .tabDivider {
+    display: none;
+    width: 1px;
+    margin: 10px 0;
+    background: $S4;
+    &::after {
+      // Unicode for nbsp
+      content: "\a0";
+    }
+  }
+
+  // We don't want a divider on the far right
+  // If we have 8+ items; only show the first 7
+  &:nth-child(-n + 7) {
+    .tabDivider {
+      display: block;
+    }
+  }
+
+  // If we have < 8 items; don't show on the last item
+  // Don't show on active tab. This only hides the right-side divider. We use a border trick to hide
+  // the one on the left
+  &:last-child,
+  &.active {
+    .tabDivider {
+      display: none;
+    }
+  }
+
+  overflow: hidden;
+}
+
+.tabHeader {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-grow: 1;
+
+  border: none !important;
+  background: transparent !important;
   padding: 0.5rem 0.75rem !important;
-  // Add padding between each item without adding to the overall width
+
+  // Add padding between each item without padding the outside
   & > * {
     padding-left: 0.5rem;
     padding-right: 0.5rem;

--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -36,7 +36,7 @@
 
   // Only show first 8 items
   display: none;
-  &:nth-child(-n + 8) {
+  &:nth-child(-n + 1) {
     display: flex;
   }
   border-radius: 0.5rem 0.5rem 0 0;
@@ -143,7 +143,7 @@
 
   border: none !important;
   background: transparent !important;
-  padding: 0.5rem 0.75rem !important;
+  padding: 0.5rem 0.5rem 0.7rem !important;
 
   // Add padding between each item without padding the outside
   & > * {
@@ -162,8 +162,13 @@
   :global .close {
     // The close icon is the actual letter "X" so this thins the icon
     font-weight: 400;
+    font-size: 20px;
+    border-radius: 4px;
+    padding: 0 2px 2px;
+    text-align: center;
+    line-height: 11px;
     &:hover {
-      background: rgba(0, 0, 0, 10%);
+      background: $S4;
     }
   }
 }

--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -26,10 +26,6 @@
   display: flex;
   justify-content: space-evenly;
   flex-wrap: nowrap;
-
-  & > * {
-    flex: 1;
-  }
 }
 
 .tabWrapper {
@@ -37,6 +33,8 @@
   align-items: stretch;
   // Copying bootstraps alignment rule for Nav.Link
   margin-bottom: -1px;
+
+  flex: 1;
 
   // Only show first 8 items
   display: none;

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -101,11 +101,8 @@ const TemporaryPanelTabPane: React.FC<{
 TemporaryPanelTabPane.displayName = "TemporaryPanelTabPane";
 
 const TabWithDivider = ({ children, active, ...props }: NavLinkProps) => (
-  <Nav.Item className={cx(styles.tabWrapper, active && styles.active)}>
-    <Nav.Link
-      {...props}
-      className={cx(styles.tabHeader, { [styles.active]: active })}
-    >
+  <Nav.Item className={cx(styles.tabWrapper, { [styles.active]: active })}>
+    <Nav.Link {...props} className={styles.tabHeader}>
       {children}
     </Nav.Link>
     <div className={styles.tabDivider} />

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -15,9 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   type PanelEntry,
+  type SidebarEntry,
   type TemporaryPanelEntry,
 } from "@/types/sidebarTypes";
 import { eventKeyForEntry, getBodyForStaticPanel } from "@/sidebar/utils";
@@ -121,6 +122,8 @@ const Tabs: React.FC = () => {
     dispatch(sidebarSlice.actions.removeTemporaryPanel(nonce));
   };
 
+  const [testPanel, setTestPanel] = useState([1, 2, 3, 4, 5, 6, 7, 8]);
+
   useEffect(
     () => {
       reportEvent("ViewSidePanelPanel", {
@@ -132,18 +135,29 @@ const Tabs: React.FC = () => {
     []
   );
 
+  const isPanelActive = (key: SidebarEntry) =>
+    eventKeyForEntry(key) === activeKey;
+
   return (
     <Tab.Container
       id="panel-container"
       defaultActiveKey={activeKey}
       activeKey={activeKey}
     >
-      <div className="full-height bg-white">
-        <Nav fill variant="tabs" onSelect={onSelect}>
+      <div className="full-height">
+        <Nav
+          fill
+          variant="tabs"
+          className={styles.tabContainer}
+          onSelect={onSelect}
+        >
           {staticPanels.map((staticPanel) => (
             <Nav.Link
               key={staticPanel.key}
-              className={styles.tabHeader}
+              className={cx(
+                styles.tabHeader,
+                isPanelActive(staticPanel) && styles.active
+              )}
               eventKey={eventKeyForEntry(staticPanel)}
             >
               <span className={styles.tabTitle}>{staticPanel.heading}</span>
@@ -153,7 +167,10 @@ const Tabs: React.FC = () => {
             <Nav.Link
               key={panel.extensionId}
               eventKey={eventKeyForEntry(panel)}
-              className={styles.tabHeader}
+              className={cx(
+                styles.tabHeader,
+                isPanelActive(panel) && styles.active
+              )}
             >
               <span className={styles.tabTitle}>
                 {panel.heading ?? <FontAwesomeIcon icon={faSpinner} />}
@@ -164,18 +181,25 @@ const Tabs: React.FC = () => {
             <Nav.Link
               key={form.extensionId}
               eventKey={eventKeyForEntry(form)}
-              className={styles.tabHeader}
+              className={cx(
+                styles.tabHeader,
+                isPanelActive(form) && styles.active
+              )}
             >
               <span className={styles.tabTitle}>
                 {form.form.schema.title ?? "Form"}
               </span>
             </Nav.Link>
           ))}
+
           {temporaryPanels.map((panel) => (
             <Nav.Link
               key={panel.nonce}
               eventKey={eventKeyForEntry(panel)}
-              className={styles.tabHeader}
+              className={cx(
+                styles.tabHeader,
+                isPanelActive(panel) && styles.active
+              )}
             >
               <span className={styles.tabTitle}>{panel.heading}</span>
               <CloseButton
@@ -189,15 +213,29 @@ const Tabs: React.FC = () => {
             <Nav.Link
               key={recipeToActivate.recipeId}
               eventKey={eventKeyForEntry(recipeToActivate)}
-              className={styles.tabHeader}
+              className={cx(
+                styles.tabHeader,
+                isPanelActive(recipeToActivate) && styles.active
+              )}
             >
               <span className={styles.tabTitle}>
                 {recipeToActivate.heading}
               </span>
             </Nav.Link>
           )}
+
+          {testPanel.map((i) => (
+            <Nav.Link key={i} className={cx(styles.tabHeader)} eventKey={i}>
+              <span className={styles.tabTitle}>Test item {i}</span>
+              <CloseButton
+                onClick={() => {
+                  setTestPanel(testPanel.filter((item) => item !== i));
+                }}
+              />
+            </Nav.Link>
+          ))}
         </Nav>
-        <Tab.Content className="p-0 border-0 full-height">
+        <Tab.Content className="p-0 border-0 full-height bg-white">
           {staticPanels.map((staticPanel) => (
             <Tab.Pane
               className={cx("h-100", styles.paneOverrides)}

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect } from "react";
 import {
   type PanelEntry,
   type SidebarEntry,
@@ -122,8 +122,6 @@ const Tabs: React.FC = () => {
     dispatch(sidebarSlice.actions.removeTemporaryPanel(nonce));
   };
 
-  const [testPanel, setTestPanel] = useState([1, 2, 3, 4, 5, 6, 7, 8]);
-
   useEffect(
     () => {
       reportEvent("ViewSidePanelPanel", {
@@ -223,17 +221,6 @@ const Tabs: React.FC = () => {
               </span>
             </Nav.Link>
           )}
-
-          {testPanel.map((i) => (
-            <Nav.Link key={i} className={cx(styles.tabHeader)} eventKey={i}>
-              <span className={styles.tabTitle}>Test item {i}</span>
-              <CloseButton
-                onClick={() => {
-                  setTestPanel(testPanel.filter((item) => item !== i));
-                }}
-              />
-            </Nav.Link>
-          ))}
         </Nav>
         <Tab.Content className="p-0 border-0 full-height bg-white">
           {staticPanels.map((staticPanel) => (

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -104,7 +104,7 @@ const TabWithDivider = ({ children, active, ...props }: NavLinkProps) => (
   <Nav.Item className={cx(styles.tabWrapper, active && styles.active)}>
     <Nav.Link
       {...props}
-      className={cx(styles.tabHeader, active && styles.active)}
+      className={cx(styles.tabHeader, { [styles.active]: active })}
     >
       {children}
     </Nav.Link>
@@ -156,7 +156,7 @@ const Tabs: React.FC = () => {
     >
       <div className="full-height">
         <Nav
-          fill
+          justify
           variant="tabs"
           className={styles.tabContainer}
           onSelect={onSelect}

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -24,7 +24,7 @@ import {
 import { eventKeyForEntry, getBodyForStaticPanel } from "@/sidebar/utils";
 import { type UUID } from "@/types/stringTypes";
 import { reportEvent } from "@/telemetry/events";
-import { CloseButton, Nav, Tab } from "react-bootstrap";
+import { CloseButton, Nav, type NavLinkProps, Tab } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import PanelBody from "@/sidebar/PanelBody";
@@ -100,6 +100,18 @@ const TemporaryPanelTabPane: React.FC<{
 });
 TemporaryPanelTabPane.displayName = "TemporaryPanelTabPane";
 
+const TabWithDivider = ({ children, active, ...props }: NavLinkProps) => (
+  <Nav.Item className={cx(styles.tabWrapper, active && styles.active)}>
+    <Nav.Link
+      {...props}
+      className={cx(styles.tabHeader, active && styles.active)}
+    >
+      {children}
+    </Nav.Link>
+    <div className={styles.tabDivider} />
+  </Nav.Item>
+);
+
 const Tabs: React.FC = () => {
   const dispatch = useDispatch();
   const activeKey = useSelector(selectSidebarActiveTabKey);
@@ -150,54 +162,42 @@ const Tabs: React.FC = () => {
           onSelect={onSelect}
         >
           {staticPanels.map((staticPanel) => (
-            <Nav.Link
+            <TabWithDivider
               key={staticPanel.key}
-              className={cx(
-                styles.tabHeader,
-                isPanelActive(staticPanel) && styles.active
-              )}
+              active={isPanelActive(staticPanel)}
               eventKey={eventKeyForEntry(staticPanel)}
             >
               <span className={styles.tabTitle}>{staticPanel.heading}</span>
-            </Nav.Link>
+            </TabWithDivider>
           ))}
           {panels.map((panel) => (
-            <Nav.Link
+            <TabWithDivider
               key={panel.extensionId}
+              active={isPanelActive(panel)}
               eventKey={eventKeyForEntry(panel)}
-              className={cx(
-                styles.tabHeader,
-                isPanelActive(panel) && styles.active
-              )}
             >
               <span className={styles.tabTitle}>
                 {panel.heading ?? <FontAwesomeIcon icon={faSpinner} />}
               </span>
-            </Nav.Link>
+            </TabWithDivider>
           ))}
           {forms.map((form) => (
-            <Nav.Link
+            <TabWithDivider
               key={form.extensionId}
+              active={isPanelActive(form)}
               eventKey={eventKeyForEntry(form)}
-              className={cx(
-                styles.tabHeader,
-                isPanelActive(form) && styles.active
-              )}
             >
               <span className={styles.tabTitle}>
                 {form.form.schema.title ?? "Form"}
               </span>
-            </Nav.Link>
+            </TabWithDivider>
           ))}
 
           {temporaryPanels.map((panel) => (
-            <Nav.Link
+            <TabWithDivider
               key={panel.nonce}
+              active={isPanelActive(panel)}
               eventKey={eventKeyForEntry(panel)}
-              className={cx(
-                styles.tabHeader,
-                isPanelActive(panel) && styles.active
-              )}
             >
               <span className={styles.tabTitle}>{panel.heading}</span>
               <CloseButton
@@ -205,21 +205,18 @@ const Tabs: React.FC = () => {
                   onCloseTemporaryTab(panel.nonce);
                 }}
               />
-            </Nav.Link>
+            </TabWithDivider>
           ))}
           {recipeToActivate && (
-            <Nav.Link
+            <TabWithDivider
               key={recipeToActivate.recipeId}
+              active={isPanelActive(recipeToActivate)}
               eventKey={eventKeyForEntry(recipeToActivate)}
-              className={cx(
-                styles.tabHeader,
-                isPanelActive(recipeToActivate) && styles.active
-              )}
             >
               <span className={styles.tabTitle}>
                 {recipeToActivate.heading}
               </span>
-            </Nav.Link>
+            </TabWithDivider>
           )}
         </Nav>
         <Tab.Content className="p-0 border-0 full-height bg-white">

--- a/src/sidebar/sidebar.scss
+++ b/src/sidebar/sidebar.scss
@@ -15,6 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@import "@/themes/colors.scss";
+
 .tab-content > .active.full-height {
   display: flex; /* Overrides Tab.Content’ "block" when active */
+}
+
+body {
+  background: $S2;
 }

--- a/src/themes/colors.scss
+++ b/src/themes/colors.scss
@@ -45,6 +45,9 @@ $P900: #260b5c;
 // Surface
 $S0: #ffffff;
 $S1: #f0eff2;
+$S2: #efeef1;
+$S3: #dedbe3;
+$S4: #cbc7d1;
 
 // Warning
 $W30: #ffc754;


### PR DESCRIPTION
## What does this PR do?

- Closes #6056 
- Add missing design system colors to `colors.scss`
- Fix active state class
- Update tab design
  - [x] Ensure tabs remain in a single row
  - [x] Tabs evenly fill all available width (replace `fill` with `justify`)
  - [x] Handle Tab title overflow
  - [x] Replace the icon used for close buttons
  - [x] Hover state for close button (background color and border radius)
  - [x] Hover state for close button of inactive tab sets hover state for tab
  - [x] Border rounding on active tabs
  - [x] Border rounding and backgroundColor on tabs when in `hover` state
    - [ ] Sibling on left should have border-bottom-right rounding if not in active state
    - [ ] Sibling on right should always have border-bottom-left rounding if not in active state
    - [ ] Background color outside the border-radius should be hover color
  - [x] Border rounding on siblings of active tabs
    - [ ] Sibling on left should always have border-bottom-right rounding
    - [ ] Sibling on right should always have border-bottom-left rounding
    - [ ] Background color outside the border-radius should be active color
  - [x] Hide tabs after 8 have been added
  - [x] Divider between inactive & unhovered tabs (potentially use an :after)
 
~~Because the `Nav.Link` component now has a border radius, `border-right` looks like a shadow.`::after` shows the divider inside the tab rather than next to it. But because bootstrap does a lot of positioning on `Nav.Link` I can't simply give it a container div.~~

By I got around the bootstrap issues by wrapping all the Nav.Links in a `Nav.Item`.

## Demo

- [loom](https://www.loom.com/share/f43b7fab21324e668b9c70e951344510?sid=e81f8414-1628-4875-b1ac-b065dee1ba53)

Max tabs while hovering on the 3rd:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/7c99e9b2-94f3-45ee-b37c-a2cf9a3acde0)

3 tabs:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/beaf8e3f-4c03-4218-923d-b08517e97864)

Single tab:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/c9408ae3-6462-4dd6-b168-46b85e6d65ec)

## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
