### PR TITLE
Add mod variables to popover; improve filtering

### DIFF
--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -101,7 +101,7 @@ describe("Collecting available vars", () => {
 
   describe("general", () => {
     beforeEach(() => {
-      analysis = new VarAnalysis([], {});
+      analysis = new VarAnalysis({ trace: [], modState: {} });
     });
 
     test("collects the context vars", async () => {
@@ -205,7 +205,7 @@ describe("Collecting available vars", () => {
 
   describe("mod variables", () => {
     it("collects actual mod variables", async () => {
-      const analysis = new VarAnalysis([], { foo: 42 });
+      const analysis = new VarAnalysis({ trace: [], modState: { foo: 42 } });
 
       const extension = formStateFactory({}, [brickConfigFactory()]);
 
@@ -223,7 +223,7 @@ describe("Collecting available vars", () => {
 
   describe("blueprint @options", () => {
     beforeEach(() => {
-      analysis = new VarAnalysis([], {});
+      analysis = new VarAnalysis({ trace: [], modState: {} });
     });
 
     test.each([{}, null, undefined])("no options", async (optionsSchema) => {
@@ -700,7 +700,7 @@ describe("Collecting available vars", () => {
 
       const extension = formStateFactory(undefined, [documentRendererBrick]);
 
-      analysis = new VarAnalysis([], {});
+      analysis = new VarAnalysis({ trace: [], modState: {} });
       await analysis.run(extension);
     });
 
@@ -762,7 +762,7 @@ describe("Collecting available vars", () => {
 
       const extension = formStateFactory(undefined, [documentRendererBrick]);
 
-      analysis = new VarAnalysis([], {});
+      analysis = new VarAnalysis({ trace: [], modState: {} });
       await analysis.run(extension);
     });
 
@@ -812,7 +812,7 @@ describe("Collecting available vars", () => {
         brickConfigFactory(),
       ]);
 
-      analysis = new VarAnalysis([], {});
+      analysis = new VarAnalysis({ trace: [], modState: {} });
       await analysis.run(extension);
     });
 
@@ -852,7 +852,7 @@ describe("Collecting available vars", () => {
         brickConfigFactory(),
       ]);
 
-      analysis = new VarAnalysis([], {});
+      analysis = new VarAnalysis({ trace: [], modState: {} });
       await analysis.run(extension);
     });
 
@@ -888,7 +888,7 @@ describe("Collecting available vars", () => {
         brickConfigFactory(),
       ]);
 
-      analysis = new VarAnalysis([], {});
+      analysis = new VarAnalysis({ trace: [], modState: {} });
       await analysis.run(extension);
     });
 
@@ -984,7 +984,7 @@ describe("Invalid template", () => {
 
     extension = formStateFactory(undefined, [invalidEchoBlock, validEchoBlock]);
 
-    analysis = new VarAnalysis([], {});
+    analysis = new VarAnalysis({ trace: [], modState: {} });
   });
 
   test("analysis doesn't throw", async () => {
@@ -1017,7 +1017,7 @@ describe("var expression annotations", () => {
       },
     ]);
 
-    const analysis = new VarAnalysis([], {});
+    const analysis = new VarAnalysis({ trace: [], modState: {} });
     await analysis.run(extension);
 
     expect(analysis.getAnnotations()).toHaveLength(0);
@@ -1033,7 +1033,7 @@ describe("var expression annotations", () => {
       },
     ]);
 
-    const analysis = new VarAnalysis([], {});
+    const analysis = new VarAnalysis({ trace: [], modState: {} });
     await analysis.run(extension);
 
     expect(analysis.getAnnotations()).toHaveLength(0);
@@ -1049,7 +1049,7 @@ describe("var expression annotations", () => {
       },
     ]);
 
-    const analysis = new VarAnalysis([], {});
+    const analysis = new VarAnalysis({ trace: [], modState: {} });
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();
@@ -1069,7 +1069,7 @@ describe("var expression annotations", () => {
       },
     ]);
 
-    const analysis = new VarAnalysis([], {});
+    const analysis = new VarAnalysis({ trace: [], modState: {} });
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();
@@ -1087,7 +1087,7 @@ describe("var expression annotations", () => {
       },
     ]);
 
-    const analysis = new VarAnalysis([], {});
+    const analysis = new VarAnalysis({ trace: [], modState: {} });
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();
@@ -1112,7 +1112,7 @@ describe("var analysis integration tests", () => {
 
     extension.extensionPoint.definition.trigger = "keypress";
 
-    const analysis = new VarAnalysis([], {});
+    const analysis = new VarAnalysis({ trace: [], modState: {} });
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();
@@ -1134,7 +1134,7 @@ describe("var analysis integration tests", () => {
 
     extension.extensionPoint.definition.trigger = "custom";
 
-    const analysis = new VarAnalysis([], {});
+    const analysis = new VarAnalysis({ trace: [], modState: {} });
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();
@@ -1157,7 +1157,7 @@ describe("var analysis integration tests", () => {
 
     extension.extensionPoint.definition.trigger = "selectionchange";
 
-    const analysis = new VarAnalysis([], {});
+    const analysis = new VarAnalysis({ trace: [], modState: {} });
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -341,6 +341,17 @@ async function setModVariables(
 
 class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
   /**
+   * The current trace, or empty if there is no trace.
+   * @private
+   */
+  private readonly trace: TraceRecord[];
+
+  /**
+   * The current mod page state
+   */
+  private readonly modState: UnknownObject;
+
+  /**
    * Accumulator for known variables at each block visited. Mapping from block path to VarMap.
    * @see VarMap
    * @private
@@ -415,11 +426,16 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
    * @param trace the trace for the latest run of the extension
    * @param modState the current mod page state
    */
-  constructor(
-    private readonly trace: TraceRecord[],
-    private readonly modState: UnknownObject
-  ) {
+  constructor({
+    trace,
+    modState,
+  }: {
+    trace: TraceRecord[];
+    modState: UnknownObject;
+  }) {
     super();
+    this.trace = trace;
+    this.modState = modState;
   }
 
   /**
@@ -449,7 +465,7 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
         x.templateContext != null
     );
 
-    if (traceRecord != null) {
+    if (traceRecord?.templateContext != null) {
       blockKnownVars.setExistenceFromValues({
         source: KnownSources.TRACE,
         values: traceRecord.templateContext,

--- a/src/analysis/analysisVisitors/varAnalysis/varMap.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varMap.ts
@@ -217,6 +217,11 @@ class VarMap {
     values,
     parentPath = "",
   }: SetExistenceFromValuesArgs): void {
+    if (values == null) {
+      console.warn(`setExistenceFromValues: values null for source: ${source}`);
+      return;
+    }
+
     for (const [key, value] of Object.entries(values)) {
       if (typeof value === "object") {
         this.setExistenceFromValues({

--- a/src/components/fields/schemaFields/widgets/TextWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TextWidget.tsx
@@ -89,10 +89,9 @@ export function isVarLike(value: string): boolean {
     isVarValue(value) ||
     // User-just started typing a variable
     value === "@" ||
-    // User is accessing a sub property.
+    // User is starting to access a sub property.
     isVarValue(trimEndOnce(value, ".")) ||
-    // User is accessing an array index, or property with whitespace.
-    // Technically, this should only trim at most one bracket
+    // User is starting to access an array index, or property with whitespace.
     isVarValue(trimEndOnce(value, "["))
   ) {
     return true;

--- a/src/components/fields/schemaFields/widgets/varPopup/SourceLabel.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/SourceLabel.tsx
@@ -20,9 +20,12 @@ const SourceLabel: React.FunctionComponent<SourceLabelProps> = ({
   const [kind] = source.split(":");
   let label: string;
   if (
-    [KnownSources.INPUT, KnownSources.OPTIONS, KnownSources.SERVICE].includes(
-      kind as KnownSources
-    )
+    [
+      KnownSources.INPUT,
+      KnownSources.OPTIONS,
+      KnownSources.SERVICE,
+      KnownSources.MOD,
+    ].includes(kind as KnownSources)
   ) {
     switch (kind) {
       case KnownSources.INPUT: {
@@ -32,6 +35,11 @@ const SourceLabel: React.FunctionComponent<SourceLabelProps> = ({
 
       case KnownSources.OPTIONS: {
         label = "Mod Options";
+        break;
+      }
+
+      case KnownSources.MOD: {
+        label = "Mod Variables";
         break;
       }
 

--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.module.scss
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.module.scss
@@ -17,29 +17,34 @@
 
 @import "@/themes/colors";
 
+// Color when selected via the keyboard vs. mouse hover
+$color-active: #c7e0ff;
+$color-hover: #a9d2ff;
+
+$popover-height: 300px;
+$footer-height: 20px;
+$menu-padding-y: 4px;
+
 // Aligned with the style of react-select's menu
 .menu {
   width: 100%;
   min-width: 200px;
-  height: 300px;
-  max-height: 300px;
+  height: $popover-height;
+  max-height: $popover-height;
   z-index: 1;
   background-color: rgb(255, 255, 255);
   border-radius: 4px;
   box-shadow: #0000001a 0 0 0 1px;
 
-  padding-top: 4px;
-  padding-bottom: 4px;
-
-  max-height: 300px;
-  overflow-y: auto;
+  padding-top: $menu-padding-y;
+  padding-bottom: $menu-padding-y;
 
   position: absolute;
   top: 0;
   bottom: 0;
 
   :global(.active:not(.hover)) {
-    background-color: #c7e0ff;
+    background-color: $color-active;
 
     ul {
       background-color: white;
@@ -47,7 +52,7 @@
   }
 
   :global(.hover) {
-    background-color: #a9d2ff !important;
+    background-color: $color-hover !important;
     cursor: pointer;
 
     ul {
@@ -55,6 +60,20 @@
       cursor: none;
     }
   }
+}
+
+.body {
+  height: calc(100% - #{$footer-height} - #{$menu-padding-y} * 2);
+  overflow-y: auto;
+}
+
+.footer {
+  padding: 5px 10px;
+
+  height: $footer-height;
+  max-height: $footer-height;
+  font-size: 0.875em;
+  color: #9c9fa6;
 }
 
 .sourceItem {

--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.test.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.test.tsx
@@ -98,7 +98,7 @@ describe("VarMenu", () => {
           );
 
           // Run analysis directly
-          const analysis = new VarAnalysis([], {});
+          const analysis = new VarAnalysis({ trace: [], modState: {} });
           await analysis.run(formState);
 
           dispatch(
@@ -142,7 +142,7 @@ describe("VarMenu", () => {
           );
 
           // Run analysis directly
-          const analysis = new VarAnalysis([], {});
+          const analysis = new VarAnalysis({ trace: [], modState: {} });
           await analysis.run(formState);
 
           dispatch(

--- a/src/components/fields/schemaFields/widgets/varPopup/__snapshots__/VarMenu.test.tsx.snap
+++ b/src/components/fields/schemaFields/widgets/varPopup/__snapshots__/VarMenu.test.tsx.snap
@@ -8,64 +8,73 @@ exports[`VarMenu shows view for match 1`] = `
     style="max-height: -16px; transform: translate3d(0, 8px, 0);"
   >
     <div
-      class="sourceItem"
+      class="body"
     >
       <div
-        class="label"
+        class="sourceItem"
       >
-        Starter Brick: Panel
-      </div>
-      <ul
-        style="border: 0px; padding: 0px; margin: 0.5em 0px 0.5em 0.125em; list-style: none; background-color: rgb(253, 255, 255);"
-      >
-        <li
-          style="padding: 0px; margin: 0px;"
+        <div
+          class="label"
         >
-          <ul
-            style="padding: 0px; margin: 0px; list-style: none;"
+          Starter Brick: Panel
+        </div>
+        <ul
+          style="border: 0px; padding: 0px; margin: 0.5em 0px 0.5em 0.125em; list-style: none; background-color: rgb(253, 255, 255);"
+        >
+          <li
+            style="padding: 0px; margin: 0px;"
           >
-            <li
-              class="active"
-              style="position: relative; padding-top: 0.25em; margin-left: 0px; padding-left: 0px; display: flex; align-items: center; flex-wrap: wrap;"
+            <ul
+              style="padding: 0px; margin: 0px; list-style: none;"
             >
-              <div
-                style="display: inline-block; cursor: pointer; padding: 4px; margin-right: 10px; background-color: rgb(240, 239, 242); border-radius: 2px;"
+              <li
+                class="active"
+                style="position: relative; padding-top: 0.25em; margin-left: 0px; padding-left: 0px; display: flex; align-items: center; flex-wrap: wrap;"
               >
                 <div
-                  style="margin-left: 0px; transition: 150ms; transform: rotateZ(0deg); transform-origin: 45% 50%; position: relative; line-height: 1.1em; font-size: 0.75em; height: 12px; width: 12px; display: flex; justify-content: center; align-items: center; color: rgb(46, 36, 65);"
+                  style="display: inline-block; cursor: pointer; padding: 4px; margin-right: 10px; background-color: rgb(240, 239, 242); border-radius: 2px;"
                 >
-                  ▶
-                </div>
-              </div>
-              <label
-                style="display: inline-block; color: rgb(46, 36, 65); word-break: initial; text-indent: -0.5em; margin: 0px; padding: 0px; cursor: pointer;"
-              >
-                <button
-                  class="btn"
-                  type="button"
-                >
-                  @input
-                </button>
-              </label>
-              <span
-                style="padding-left: 0.5em; cursor: default; color: rgb(64, 175, 108);"
-              >
-                <span>
-                  <span
-                    style="margin-left: 0.3em; margin-right: 0.3em;"
+                  <div
+                    style="margin-left: 0px; transition: 150ms; transform: rotateZ(0deg); transform-origin: 45% 50%; position: relative; line-height: 1.1em; font-size: 0.75em; height: 12px; width: 12px; display: flex; justify-content: center; align-items: center; color: rgb(46, 36, 65);"
                   >
-                    {}
+                    ▶
+                  </div>
+                </div>
+                <label
+                  style="display: inline-block; color: rgb(46, 36, 65); word-break: initial; text-indent: -0.5em; margin: 0px; padding: 0px; cursor: pointer;"
+                >
+                  <button
+                    class="btn"
+                    type="button"
+                  >
+                    @input
+                  </button>
+                </label>
+                <span
+                  style="padding-left: 0.5em; cursor: default; color: rgb(64, 175, 108);"
+                >
+                  <span>
+                    <span
+                      style="margin-left: 0.3em; margin-right: 0.3em;"
+                    >
+                      {}
+                    </span>
+                     3 keys
                   </span>
-                   3 keys
                 </span>
-              </span>
-              <ul
-                style="padding: 0px; margin: 0px; list-style: none; display: block; width: 100%;"
-              />
-            </li>
-          </ul>
-        </li>
-      </ul>
+                <ul
+                  style="padding: 0px; margin: 0px; list-style: none; display: block; width: 100%;"
+                />
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div
+      class="footer"
+    >
+      Use up/down keys to navigate, tab to select
     </div>
   </div>
 </DocumentFragment>

--- a/src/components/fields/schemaFields/widgets/varPopup/getMenuOptions.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/getMenuOptions.test.ts
@@ -15,7 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { KnownSources } from "@/analysis/analysisVisitors/varAnalysis/varAnalysis";
+import VarAnalysis, {
+  KnownSources,
+} from "@/analysis/analysisVisitors/varAnalysis/varAnalysis";
 import VarMap, {
   ALLOW_ANY_CHILD,
   IS_ARRAY,
@@ -24,6 +26,13 @@ import VarMap, {
 } from "@/analysis/analysisVisitors/varAnalysis/varMap";
 import getMenuOptions from "./getMenuOptions";
 import { type JsonObject } from "type-fest";
+import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import { brickConfigFactory } from "@/testUtils/factories/brickFactories";
+import registerBuiltinBlocks from "@/blocks/registerBuiltinBlocks";
+
+beforeAll(() => {
+  registerBuiltinBlocks();
+});
 
 describe("setting values", () => {
   let knownVars: VarMap;
@@ -163,6 +172,22 @@ describe("arrays", () => {
           },
         },
       ],
+    ]);
+  });
+});
+
+describe("mod variables", () => {
+  test("it includes mod variables entry", async () => {
+    const analysis = new VarAnalysis({ trace: [], modState: { foo: 42 } });
+    const extension = formStateFactory({}, [brickConfigFactory()]);
+    await analysis.run(extension);
+
+    const knownVars = analysis.getKnownVars().get("extension.blockPipeline.0");
+
+    const actual = getMenuOptions(knownVars, null);
+    expect(actual).toEqual([
+      ["mod", expect.toBeObject()],
+      ["input", expect.toBeObject()],
     ]);
   });
 });

--- a/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.test.ts
@@ -77,6 +77,51 @@ describe("detects the variable and returns its name", () => {
     const actual = getLikelyVariableAtPosition(template, 4).name;
     expect(actual).toEqual("@");
   });
+
+  test("clamp position on full match", () => {
+    const template = "@abc";
+    const actual = getLikelyVariableAtPosition(template, 2, {
+      clampPosition: true,
+      clampPosition: true,
+    }).name;
+    expect(actual).toEqual("@a");
+  });
+
+  test("clamp position on partial match", () => {
+    const template = "{{ @abc";
+    const actual = getLikelyVariableAtPosition(template, 5, {
+      clampPosition: true,
+      includeBoundary: true,
+    }).name;
+    expect(actual).toEqual("@a");
+  });
+
+  test("test match end boundary", () => {
+    const template = "@abc";
+    const actual = getLikelyVariableAtPosition(template, 4, {
+      includeBoundary: true,
+      clampPosition: true,
+    }).name;
+    expect(actual).toEqual("@abc");
+  });
+
+  test("test match end boundary on partial match", () => {
+    const template = "{{ @abc";
+    const actual = getLikelyVariableAtPosition(template, 7, {
+      includeBoundary: true,
+      clampPosition: true,
+    }).name;
+    expect(actual).toEqual("@abc");
+  });
+
+  test("test match start boundary", () => {
+    const template = "{{ @abc }}";
+    const actual = getLikelyVariableAtPosition(template, 3, {
+      includeBoundary: true,
+      clampPosition: true,
+    }).name;
+    expect(actual).toEqual("@");
+  });
 });
 
 describe("returns the start and end index of the variable", () => {

--- a/src/hooks/useKeyboardShortcut.ts
+++ b/src/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect } from "react";
+
+/**
+ * Basic keyboard shortcut hook. If we introduce more shortcuts, we should consider using a library.
+ * @param code the key code, e.g., "F5"
+ * @param callback the callback to call when the key is pressed.
+ */
+function useKeyboardShortcut(code: string, callback: () => void): void {
+  useEffect(() => {
+    const handleShortcut = (event: KeyboardEvent) => {
+      if (event.code === code) {
+        callback();
+      }
+    };
+
+    document.addEventListener("keydown", handleShortcut);
+
+    return () => {
+      document.removeEventListener("keydown", handleShortcut);
+    };
+  });
+}
+
+export default useKeyboardShortcut;

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -167,7 +167,7 @@ async function varAnalysisFactory(
   action: PayloadAction<{ extensionId: UUID; records: TraceRecord[] }>,
   state: RootState
 ) {
-  const records = selectActiveElementTraces(state);
+  const trace = selectActiveElementTraces(state);
   const extension = selectActiveElement(state);
 
   const modState = await getPageState(thisTab, {
@@ -176,7 +176,7 @@ async function varAnalysisFactory(
     blueprintId: extension.recipe?.id,
   });
 
-  return new VarAnalysis(records, modState);
+  return new VarAnalysis({ trace, modState });
 }
 
 // OutputKeyAnalysis seems to be the slowest one, so we register it in the end

--- a/src/pageEditor/toolbar/ReloadToolbar.tsx
+++ b/src/pageEditor/toolbar/ReloadToolbar.tsx
@@ -26,6 +26,7 @@ import { type FormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { reportEvent } from "@/telemetry/events";
 import { useSelector } from "react-redux";
 import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
+import useKeyboardShortcut from "@/hooks/useKeyboardShortcut";
 
 const DEFAULT_RELOAD_MILLIS = 350;
 
@@ -107,6 +108,8 @@ const ReloadToolbar: React.FunctionComponent<{
 
     await run();
   };
+
+  useKeyboardShortcut("F5", manualRun);
 
   const debouncedRun = useDebouncedCallback(run, refreshMillis, {
     // If we could distinguish between types of edits, it might be reasonable to set leading: true. But in


### PR DESCRIPTION
## What does this PR do?

- Follow up to https://github.com/pixiebrix/pixiebrix-extension/pull/5645
- Add mod variables and values to the variable popover
- Show popover of variable boundary
- Add usage tip to the bottom of the variable popover
- Clean up method signature for varAnalysis
- Bonus: add F5 as a keyboard shortcut to manually run mods in the Page Editor

## Remaining Work

- [ ] Adjust onSelect behavior for Nujucks templates. If you select an object/array, don't move the cursor to the end of the newly inserted `}}`.

## Demo

- _Paste a screenshot or demo video here_

## Future Work

- _Work for the issue/ticket that will be in a follow-up PR_

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
