### PR TITLE
#6079: warn in Page Editor if using reserved name as output variable name

### DIFF
--- a/src/analysis/analysisVisitors/outputKeyAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/outputKeyAnalysis.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { triggerFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
+
+import OutputKeyAnalysis from "@/analysis/analysisVisitors/outputKeyAnalysis";
+import { ContextBrick } from "@/runtime/pipelineTests/pipelineTestHelpers";
+import { validateOutputKey } from "@/runtime/runtimeTypes";
+import { AnnotationType } from "@/types/annotationTypes";
+
+describe("outputKeyAnalysis", () => {
+  it("no warning", async () => {
+    const formState = triggerFormStateFactory({}, [
+      {
+        id: ContextBrick.BLOCK_ID,
+        config: {},
+        outputKey: validateOutputKey("foo"),
+      },
+    ]);
+
+    const analysis = new OutputKeyAnalysis();
+    await analysis.run(formState);
+
+    expect(analysis.getAnnotations()).toEqual([]);
+  });
+
+  it.each(["input", "options", "mod"])("reserved name: %s", async (name) => {
+    const formState = triggerFormStateFactory({}, [
+      // Syntactically it's a valid output key
+      {
+        id: ContextBrick.BLOCK_ID,
+        config: {},
+        outputKey: validateOutputKey(name),
+      },
+    ]);
+
+    const analysis = new OutputKeyAnalysis();
+    await analysis.run(formState);
+
+    expect(analysis.getAnnotations()).toEqual([
+      expect.objectContaining({
+        type: AnnotationType.Warning,
+      }),
+    ]);
+  });
+});

--- a/src/analysis/analysisVisitors/outputKeyAnalysis.ts
+++ b/src/analysis/analysisVisitors/outputKeyAnalysis.ts
@@ -39,6 +39,45 @@ class OutputKeyAnalysis extends AnalysisVisitorWithResolvedBricksABC {
 
     let errorMessage: string;
     const { id, outputKey } = blockConfig;
+
+    switch (outputKey) {
+      case "mod": {
+        this.annotations.push({
+          position: nestedPosition(position, "outputKey"),
+          message: "Variable name 'mod' is reserved for mod variables.",
+          analysisId: this.id,
+          type: AnnotationType.Warning,
+        });
+
+        break;
+      }
+
+      case "input": {
+        this.annotations.push({
+          position: nestedPosition(position, "outputKey"),
+          message: "Variable name 'input' is reserved for the starter brick.",
+          analysisId: this.id,
+          type: AnnotationType.Warning,
+        });
+
+        break;
+      }
+
+      case "options": {
+        this.annotations.push({
+          position: nestedPosition(position, "outputKey"),
+          message: "Variable name 'options' is reserved for mod options.",
+          analysisId: this.id,
+          type: AnnotationType.Warning,
+        });
+
+        break;
+      }
+
+      // Output key is not a reserved name
+      default:
+    }
+
     const typedBlock = this.allBlocks.get(id);
     if (typedBlock == null) {
       return;
@@ -50,7 +89,7 @@ class OutputKeyAnalysis extends AnalysisVisitorWithResolvedBricksABC {
         return;
       }
 
-      errorMessage = `OutputKey must be empty for "${blockType}" block.`;
+      errorMessage = `Output variable name must be empty for "${blockType}" block.`;
     } else if (!outputKey) {
       errorMessage = "This field is required.";
     } else if (outputKeyRegex.test(outputKey)) {

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -56,7 +56,7 @@ const EditorNodeConfigPanel: React.FC = () => {
   );
   const outputDescription = isOutputDisabled
     ? "Effect and renderer bricks do not produce outputs"
-    : "Provide an output key to refer to the outputs of this block later.";
+    : "Provide an output variable name to refer to the outputs of this brick later.";
 
   const PopoverOutputLabel = (
     <PopoverInfoLabel


### PR DESCRIPTION
## What does this PR do?

- Closes #6079 
- Adds a warning in Page Editor if you're using a reserved name: mod, options, input

## Demo

- https://www.loom.com/share/d96e87e33861418cb4c7c23c4c7d97c1?sid=47307dc2-cb08-47ed-ae77-9684faab476f

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
