### PR TITLE
#5994 - Refactor/rename TypeScript types Slice 4

### DIFF
--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -33,7 +33,7 @@ import { allSettledValues, memoizeUntilSettled } from "@/utils";
 import { type UUID } from "@/types/stringTypes";
 import {
   type ModComponentBase,
-  type ResolvedExtension,
+  type ResolvedModComponent,
 } from "@/types/extensionTypes";
 
 const MENU_PREFIX = "pixiebrix-";
@@ -175,7 +175,7 @@ export async function preloadContextMenus(
       );
       if (extensionPoint instanceof ContextMenuExtensionPoint) {
         await extensionPoint.ensureMenu(
-          definition as unknown as ResolvedExtension<ContextMenuConfig>
+          definition as unknown as ResolvedModComponent<ContextMenuConfig>
         );
       }
     })

--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -25,7 +25,7 @@ import { expectContext } from "@/utils/expectContext";
 import extensionPointRegistry from "@/extensionPoints/registry";
 import {
   type ContextMenuConfig,
-  ContextMenuExtensionPoint,
+  ContextMenuStarterBrickABC,
 } from "@/extensionPoints/contextMenu";
 import { loadOptions } from "@/store/extensionsStorage";
 import { resolveExtensionInnerDefinitions } from "@/registry/internal";
@@ -173,7 +173,7 @@ export async function preloadContextMenus(
       const extensionPoint = await extensionPointRegistry.lookup(
         resolved.extensionPointId
       );
-      if (extensionPoint instanceof ContextMenuExtensionPoint) {
+      if (extensionPoint instanceof ContextMenuStarterBrickABC) {
         await extensionPoint.ensureMenu(
           definition as unknown as ResolvedModComponent<ContextMenuConfig>
         );

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -56,7 +56,7 @@ import registerContribBlocks from "@/contrib/registerContribBlocks";
 import { launchSsoFlow } from "@/store/enterprise/singleSignOn";
 import { readManagedStorage } from "@/store/enterprise/managedStorage";
 import { type UUID } from "@/types/stringTypes";
-import { type UnresolvedExtension } from "@/types/extensionTypes";
+import { type UnresolvedModComponent } from "@/types/extensionTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type OptionsArgs } from "@/types/runtimeTypes";
 import { checkDeploymentPermissions } from "@/permissions/deploymentPermissionsHelpers";
@@ -91,7 +91,7 @@ function uninstallExtensionFromStates(
 }
 
 async function uninstallExtensionsAndSaveState(
-  toUninstall: UnresolvedExtension[],
+  toUninstall: UnresolvedModComponent[],
   {
     editorState,
     optionsState,

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -31,7 +31,7 @@ import { maybeGetLinkedApiClient } from "@/services/apiClient";
 import { queueReactivateTab } from "@/contentScript/messenger/api";
 import { forEachTab } from "@/background/activeTab";
 import { parse as parseSemVer, satisfies, type SemVer } from "semver";
-import { type ExtensionOptionsState } from "@/store/extensionsTypes";
+import { type ModComponentOptionsState } from "@/store/extensionsTypes";
 import extensionsSlice from "@/store/extensionsSlice";
 import { loadOptions, saveOptions } from "@/store/extensionsStorage";
 import { expectContext } from "@/utils/expectContext";
@@ -67,17 +67,19 @@ const locateAllForService = locator.locateAllForService.bind(locator);
 
 const UPDATE_INTERVAL_MS = 5 * 60 * 1000;
 
-async function setExtensionsState(state: ExtensionOptionsState): Promise<void> {
+async function setExtensionsState(
+  state: ModComponentOptionsState
+): Promise<void> {
   await saveOptions(state);
   await forEachTab(queueReactivateTab);
 }
 
 function uninstallExtensionFromStates(
-  optionsState: ExtensionOptionsState,
+  optionsState: ModComponentOptionsState,
   editorState: EditorState | undefined,
   extensionId: UUID
 ): {
-  options: ExtensionOptionsState;
+  options: ModComponentOptionsState;
   editor: EditorState;
 } {
   const options = optionsReducer(
@@ -95,7 +97,7 @@ async function uninstallExtensionsAndSaveState(
   {
     editorState,
     optionsState,
-  }: { editorState: EditorState; optionsState: ExtensionOptionsState }
+  }: { editorState: EditorState; optionsState: ModComponentOptionsState }
 ): Promise<void> {
   // Uninstall existing versions of the extensions
   for (const extension of toUninstall) {
@@ -182,11 +184,11 @@ async function uninstallUnmatchedDeployments(
 }
 
 async function uninstallRecipe(
-  optionsState: ExtensionOptionsState,
+  optionsState: ModComponentOptionsState,
   editorState: EditorState | undefined,
   recipeId: RegistryId
 ): Promise<{
-  options: ExtensionOptionsState;
+  options: ModComponentOptionsState;
   editor: EditorState | undefined;
 }> {
   let options = optionsState;
@@ -206,11 +208,11 @@ async function uninstallRecipe(
 }
 
 async function installDeployment(
-  optionsState: ExtensionOptionsState,
+  optionsState: ModComponentOptionsState,
   editorState: EditorState | undefined,
   deployment: Deployment
 ): Promise<{
-  options: ExtensionOptionsState;
+  options: ModComponentOptionsState;
   editor: EditorState | undefined;
 }> {
   let options = optionsState;

--- a/src/background/starterBlueprints.ts
+++ b/src/background/starterBlueprints.ts
@@ -21,7 +21,7 @@ import { loadOptions, saveOptions } from "@/store/extensionsStorage";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { forEachTab } from "@/background/activeTab";
 import { queueReactivateTab } from "@/contentScript/messenger/api";
-import { type ExtensionOptionsState } from "@/store/extensionsTypes";
+import { type ModComponentOptionsState } from "@/store/extensionsTypes";
 import reportError from "@/telemetry/reportError";
 import { debounce, uniq } from "lodash";
 import { refreshRegistries } from "./refreshRegistries";
@@ -88,10 +88,10 @@ export async function getBuiltInAuthsByRequiredServiceIds(
 }
 
 function installBlueprint(
-  state: ExtensionOptionsState,
+  state: ModComponentOptionsState,
   blueprint: ModDefinition,
   services: Record<RegistryId, UUID>
-): ExtensionOptionsState {
+): ModComponentOptionsState {
   return reducer(
     state,
     actions.installRecipe({

--- a/src/blocks/effects/runSubTour.test.ts
+++ b/src/blocks/effects/runSubTour.test.ts
@@ -27,7 +27,7 @@ import ConsoleLogger from "@/utils/ConsoleLogger";
 import { tick } from "@/extensionPoints/extensionPointTestUtils";
 import {
   type ModComponentBase,
-  type ResolvedExtension,
+  type ResolvedModComponent,
 } from "@/types/extensionTypes";
 import { type BrickOptions } from "@/types/runtimeTypes";
 
@@ -44,7 +44,7 @@ describe("runSubTour", () => {
         id: uuidv4(),
         label: "Test Extension",
         _recipe: { id: blueprintId } as ModComponentBase["_recipe"],
-      } as ResolvedExtension,
+      } as ResolvedModComponent,
       allowUserRun: false,
       run: () => ({
         promise: deferredTour.promise,

--- a/src/components/BrickIcon.tsx
+++ b/src/components/BrickIcon.tsx
@@ -31,7 +31,7 @@ import {
   faWindowMaximize,
 } from "@fortawesome/free-solid-svg-icons";
 import { TriggerExtensionPoint } from "@/extensionPoints/triggerExtension";
-import { MenuItemExtensionPoint } from "@/extensionPoints/menuItemExtension";
+import { MenuItemStarterBrickABC } from "@/extensionPoints/menuItemExtension";
 import { ContextMenuExtensionPoint } from "@/extensionPoints/contextMenu";
 import { PanelExtensionPoint } from "@/extensionPoints/panelExtension";
 import { SidebarExtensionPoint } from "@/extensionPoints/sidebarExtension";
@@ -74,7 +74,7 @@ function getDefaultBrickIcon(brick: IBrick, blockType: BrickType): IconProp {
     return faBolt;
   }
 
-  if (brick instanceof MenuItemExtensionPoint) {
+  if (brick instanceof MenuItemStarterBrickABC) {
     return faMousePointer;
   }
 

--- a/src/components/BrickIcon.tsx
+++ b/src/components/BrickIcon.tsx
@@ -30,11 +30,11 @@ import {
   faRandom,
   faWindowMaximize,
 } from "@fortawesome/free-solid-svg-icons";
-import { TriggerExtensionPoint } from "@/extensionPoints/triggerExtension";
+import { TriggerStarterBrickABC } from "@/extensionPoints/triggerExtension";
 import { MenuItemStarterBrickABC } from "@/extensionPoints/menuItemExtension";
-import { ContextMenuExtensionPoint } from "@/extensionPoints/contextMenu";
-import { PanelExtensionPoint } from "@/extensionPoints/panelExtension";
-import { SidebarExtensionPoint } from "@/extensionPoints/sidebarExtension";
+import { ContextMenuStarterBrickABC } from "@/extensionPoints/contextMenu";
+import { PanelStarterBrickABC } from "@/extensionPoints/panelExtension";
+import { SidebarStarterBrickABC } from "@/extensionPoints/sidebarExtension";
 import { appApi } from "@/services/api";
 import { useAsyncState } from "@/hooks/common";
 import { useAsyncIcon } from "@/components/asyncIcon";
@@ -70,7 +70,7 @@ function getDefaultBrickIcon(brick: IBrick, blockType: BrickType): IconProp {
     }
   }
 
-  if (brick instanceof TriggerExtensionPoint) {
+  if (brick instanceof TriggerStarterBrickABC) {
     return faBolt;
   }
 
@@ -78,15 +78,15 @@ function getDefaultBrickIcon(brick: IBrick, blockType: BrickType): IconProp {
     return faMousePointer;
   }
 
-  if (brick instanceof ContextMenuExtensionPoint) {
+  if (brick instanceof ContextMenuStarterBrickABC) {
     return faBars;
   }
 
-  if (brick instanceof PanelExtensionPoint) {
+  if (brick instanceof PanelStarterBrickABC) {
     return faWindowMaximize;
   }
 
-  if (brick instanceof SidebarExtensionPoint) {
+  if (brick instanceof SidebarStarterBrickABC) {
     return faColumns;
   }
 

--- a/src/contentScript/lifecycle.test.ts
+++ b/src/contentScript/lifecycle.test.ts
@@ -70,7 +70,7 @@ const extensionFactory = define<ActivatedModComponent<TriggerConfig>>({
   config: define<TriggerConfig>({
     action: () => [] as BrickPipeline,
   }),
-  _unresolvedExtensionBrand: null,
+  _unresolvedModComponentBrand: null,
   createTimestamp: new Date().toISOString(),
   updateTimestamp: new Date().toISOString(),
   active: true,

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -35,7 +35,7 @@ import { type StarterBrick } from "@/types/extensionPointTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { RunReason } from "@/types/runtimeTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type SidebarExtensionPoint } from "@/extensionPoints/sidebarExtension";
 
 /**
@@ -380,7 +380,7 @@ export async function runEditorExtension(
  * used to do that clean up at a more appropriate time, e.g. upon navigation.
  */
 function cleanUpDeactivatedExtensionPoints(
-  activeExtensionMap: Record<RegistryId, ResolvedExtension[]>
+  activeExtensionMap: Record<RegistryId, ResolvedModComponent[]>
 ): void {
   for (const extensionPoint of _activeExtensionPoints) {
     const hasActiveExtensions = Object.hasOwn(
@@ -442,7 +442,7 @@ async function loadPersistedExtensions(): Promise<StarterBrick[]> {
       Object.entries(activeExtensionMap).map(
         async ([extensionPointId, extensions]: [
           RegistryId,
-          ResolvedExtension[]
+          ResolvedModComponent[]
         ]) => {
           try {
             const extensionPoint = await extensionPointRegistry.lookup(

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -36,7 +36,7 @@ import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { RunReason } from "@/types/runtimeTypes";
 import { type ResolvedModComponent } from "@/types/extensionTypes";
-import { type SidebarExtensionPoint } from "@/extensionPoints/sidebarExtension";
+import { type SidebarStarterBrickABC } from "@/extensionPoints/sidebarExtension";
 
 /**
  * True if handling the initial page load.
@@ -281,7 +281,7 @@ export function clearEditorExtension(
       const extensionPoint = _editorExtensions.get(extensionId);
 
       if (extensionPoint.kind === "actionPanel" && preserveSidebar) {
-        const sidebar = extensionPoint as SidebarExtensionPoint;
+        const sidebar = extensionPoint as SidebarStarterBrickABC;
         // eslint-disable-next-line new-cap -- hack for action panels
         sidebar.HACK_uninstallExceptExtension(extensionId);
       } else {

--- a/src/contentScript/pageEditor/types.ts
+++ b/src/contentScript/pageEditor/types.ts
@@ -27,7 +27,7 @@ import {
 } from "@/extensionPoints/panelExtension";
 import {
   type MenuDefinition,
-  type MenuItemExtensionConfig,
+  type MenuItemStarterBrickConfig,
 } from "@/extensionPoints/menuItemExtension";
 import { type ElementInfo } from "@/pageScript/frameworks";
 import { type ModComponentBase } from "@/types/extensionTypes";
@@ -55,12 +55,12 @@ export type PanelSelectionResult = {
 };
 export type ButtonDefinition = DynamicDefinition<
   MenuDefinition,
-  MenuItemExtensionConfig
+  MenuItemStarterBrickConfig
 >;
 export type ButtonSelectionResult = {
   uuid: UUID;
   menu: Except<MenuDefinition, "defaultOptions" | "isAvailable" | "reader">;
-  item: Pick<MenuItemExtensionConfig, "caption">;
+  item: Pick<MenuItemStarterBrickConfig, "caption">;
   containerInfo: ElementInfo;
 };
 

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -31,7 +31,7 @@ import { type Except } from "type-fest";
 import { type RunArgs, RunReason } from "@/types/runtimeTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
-import { type ExtensionRef } from "@/types/extensionTypes";
+import { type ModComponentRef } from "@/types/extensionTypes";
 import type {
   ActivatePanelOptions,
   ActivateModPanelEntry,
@@ -350,7 +350,7 @@ export function removeExtensionPoint(
 /**
  * Create placeholder panels showing loading indicators
  */
-export function reservePanels(refs: ExtensionRef[]): void {
+export function reservePanels(refs: ModComponentRef[]): void {
   if (refs.length === 0) {
     return;
   }
@@ -408,7 +408,7 @@ export function updateHeading(extensionId: UUID, heading: string): void {
 }
 
 export function upsertPanel(
-  { extensionId, extensionPointId, blueprintId }: ExtensionRef,
+  { extensionId, extensionPointId, blueprintId }: ModComponentRef,
   heading: string,
   payload: PanelPayload
 ): void {

--- a/src/contrib/google/sheets/SheetsFileWidget.tsx
+++ b/src/contrib/google/sheets/SheetsFileWidget.tsx
@@ -29,7 +29,7 @@ import AsyncButton from "@/components/AsyncButton";
 import { type Expression } from "@/types/runtimeTypes";
 import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
-import { isFormState } from "@/pageEditor/extensionPoints/formStateTypes";
+import { isModComponentFormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { produce } from "immer";
 import { produceExcludeUnusedDependencies } from "@/components/fields/schemaFields/serviceFieldUtils";
 import useGoogleSpreadsheetPicker from "@/contrib/google/sheets/useGoogleSpreadsheetPicker";
@@ -58,7 +58,7 @@ const SheetsFileWidget: React.FC<SchemaFieldProps> = (props) => {
       // This widget is also used outside the Edit tab of the Page Editor,
       // so this won't always be FormState. We only need to clean up services
       // when it is FormState.
-      if (!isFormState(formState)) {
+      if (!isModComponentFormState(formState)) {
         return;
       }
 

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
@@ -31,7 +31,7 @@ import {
   maybeGetLinkedApiClient,
 } from "@/services/apiClient";
 import { getErrorMessage } from "@/errors/errorHelpers";
-import { type ExtensionOptionsState } from "@/store/extensionsTypes";
+import { type ModComponentOptionsState } from "@/store/extensionsTypes";
 
 import { deploymentFactory } from "@/testUtils/factories/deploymentFactories";
 
@@ -109,6 +109,6 @@ describe("DeploymentsContext", () => {
     expect(axiosMock.history.get).toHaveLength(0);
 
     const { options } = wrapper.getReduxStore().getState();
-    expect((options as ExtensionOptionsState).extensions).toHaveLength(1);
+    expect((options as ModComponentOptionsState).extensions).toHaveLength(1);
   });
 });

--- a/src/extensionConsole/pages/mods/hooks/useReactivateAction.ts
+++ b/src/extensionConsole/pages/mods/hooks/useReactivateAction.ts
@@ -18,7 +18,7 @@
 import { type ModViewItem } from "@/types/modTypes";
 import { useDispatch } from "react-redux";
 import useFlags from "@/hooks/useFlags";
-import { isExtensionFromRecipe, isModDefinition } from "@/utils/modUtils";
+import { isModComponentFromRecipe, isModDefinition } from "@/utils/modUtils";
 import { reportEvent } from "@/telemetry/events";
 import { push } from "connected-react-router";
 import notify from "@/utils/notify";
@@ -27,7 +27,8 @@ const useReactivateAction = (modViewItem: ModViewItem): (() => void | null) => {
   const dispatch = useDispatch();
   const { restrict } = useFlags();
   const { mod, unavailable, status, sharing } = modViewItem;
-  const hasModDefinition = isExtensionFromRecipe(mod) || isModDefinition(mod);
+  const hasModDefinition =
+    isModComponentFromRecipe(mod) || isModDefinition(mod);
   const isActive = status === "Active" || status === "Paused";
   const isDeployment = sharing.source.type === "Deployment";
   const isRestricted = isDeployment && restrict("uninstall");

--- a/src/extensionConsole/pages/mods/hooks/useViewPublishAction.ts
+++ b/src/extensionConsole/pages/mods/hooks/useViewPublishAction.ts
@@ -19,7 +19,7 @@ import { type ModViewItem } from "@/types/modTypes";
 import { useDispatch } from "react-redux";
 import {
   getPackageId,
-  isResolvedExtension,
+  isResolvedModComponent,
   isModDefinition,
 } from "@/utils/modUtils";
 import {
@@ -49,7 +49,7 @@ function useViewPublishAction(modViewItem: ModViewItem): () => void | null {
     // Deployment sharing is controlled via the Admin Console
     !isDeployment &&
     // Extensions can be published
-    (isResolvedExtension(mod) ||
+    (isResolvedModComponent(mod) ||
       // In case of blueprint, skip if it is already published
       sharing.listingId == null);
 

--- a/src/extensionConsole/pages/mods/hooks/useViewPublishAction.ts
+++ b/src/extensionConsole/pages/mods/hooks/useViewPublishAction.ts
@@ -17,7 +17,11 @@
 
 import { type ModViewItem } from "@/types/modTypes";
 import { useDispatch } from "react-redux";
-import { getPackageId, isExtension, isModDefinition } from "@/utils/modUtils";
+import {
+  getPackageId,
+  isResolvedExtension,
+  isModDefinition,
+} from "@/utils/modUtils";
 import {
   modModalsSlice,
   type PublishContext,
@@ -45,7 +49,7 @@ function useViewPublishAction(modViewItem: ModViewItem): () => void | null {
     // Deployment sharing is controlled via the Admin Console
     !isDeployment &&
     // Extensions can be published
-    (isExtension(mod) ||
+    (isResolvedExtension(mod) ||
       // In case of blueprint, skip if it is already published
       sharing.listingId == null);
 

--- a/src/extensionConsole/pages/mods/utils/exportBlueprint.test.ts
+++ b/src/extensionConsole/pages/mods/utils/exportBlueprint.test.ts
@@ -17,12 +17,12 @@
 
 import { makeBlueprint } from "@/extensionConsole/pages/mods/utils/exportBlueprint";
 import { validateRegistryId } from "@/types/helpers";
-import { type UnresolvedExtension } from "@/types/extensionTypes";
+import { type UnresolvedModComponent } from "@/types/extensionTypes";
 import { extensionFactory } from "@/testUtils/factories/extensionFactories";
 
 describe("makeBlueprint", () => {
   it("smoke test", () => {
-    const result = makeBlueprint(extensionFactory() as UnresolvedExtension, {
+    const result = makeBlueprint(extensionFactory() as UnresolvedModComponent, {
       id: validateRegistryId("test/blueprint"),
       name: "test",
     });
@@ -39,7 +39,7 @@ describe("makeBlueprint", () => {
       optionsArgs: {
         foo: "hello world!",
       },
-    }) as UnresolvedExtension;
+    }) as UnresolvedModComponent;
 
     const result = makeBlueprint(extension, {
       id: validateRegistryId("test/blueprint"),

--- a/src/extensionConsole/pages/mods/utils/exportBlueprint.ts
+++ b/src/extensionConsole/pages/mods/utils/exportBlueprint.ts
@@ -25,7 +25,7 @@ import {
   type UnsavedModDefinition,
 } from "@/types/modDefinitionTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type UnresolvedExtension } from "@/types/extensionTypes";
+import { type UnresolvedModComponent } from "@/types/extensionTypes";
 import { isInnerDefinitionRegistryId } from "@/types/helpers";
 
 /**
@@ -45,7 +45,7 @@ function inferOptionsSchema(optionsArgs: OptionsArgs): ModOptionsDefinition {
 }
 
 export function makeBlueprint(
-  extension: UnresolvedExtension,
+  extension: UnresolvedModComponent,
   metadata: Metadata
 ): UnsavedModDefinition {
   const {

--- a/src/extensionConsole/pages/mods/utils/useReinstall.test.ts
+++ b/src/extensionConsole/pages/mods/utils/useReinstall.test.ts
@@ -20,8 +20,8 @@ import useReinstall from "./useReinstall";
 import { actions as extensionActions } from "@/store/extensionsSlice";
 import { uninstallRecipe } from "@/store/uninstallUtils";
 import {
-  type ExtensionOptionsState,
-  type ExtensionsRootState,
+  type ModComponentOptionsState,
+  type ModComponentsRootState,
 } from "@/store/extensionsTypes";
 import { recipeDefinitionFactory } from "@/testUtils/factories/recipeFactories";
 import { cloudExtensionFactory } from "@/testUtils/factories/extensionFactories";
@@ -56,8 +56,8 @@ test("uninstalls recipe extensions", async () => {
   });
 
   const expectedExtension = (
-    (getReduxStore().getState() as ExtensionsRootState)
-      .options as ExtensionOptionsState
+    (getReduxStore().getState() as ModComponentsRootState)
+      .options as ModComponentOptionsState
   ).extensions[0];
 
   await act(async () => reinstall(recipe));

--- a/src/extensionConsole/pages/settings/useDiagnostics.ts
+++ b/src/extensionConsole/pages/settings/useDiagnostics.ts
@@ -20,7 +20,7 @@ import { selectExtensions } from "@/store/extensionsSelectors";
 import useExtensionPermissions, {
   type DetailedPermissions,
 } from "@/permissions/useExtensionPermissions";
-import { type UnresolvedExtension } from "@/types/extensionTypes";
+import { type UnresolvedModComponent } from "@/types/extensionTypes";
 import { compact, pick, uniqBy } from "lodash";
 import { type StorageEstimate } from "@/types/browserTypes";
 import { count as registrySize } from "@/registry/localRegistry";
@@ -35,7 +35,7 @@ async function collectDiagnostics({
   extensions,
   permissions,
 }: {
-  extensions: UnresolvedExtension[];
+  extensions: UnresolvedModComponent[];
   permissions: DetailedPermissions;
 }) {
   const manifest = browser.runtime.getManifest();

--- a/src/extensionPoints/contextMenu.test.ts
+++ b/src/extensionPoints/contextMenu.test.ts
@@ -28,7 +28,7 @@ import {
   fromJS,
   type MenuDefinition,
 } from "@/extensionPoints/contextMenu";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 
@@ -55,7 +55,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const extensionFactory = define<ResolvedExtension<ContextMenuConfig>>({
+const extensionFactory = define<ResolvedModComponent<ContextMenuConfig>>({
   apiVersion: "v3",
   _resolvedExtensionBrand: undefined,
   id: uuidSequence,

--- a/src/extensionPoints/contextMenu.test.ts
+++ b/src/extensionPoints/contextMenu.test.ts
@@ -57,7 +57,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
 
 const extensionFactory = define<ResolvedModComponent<ContextMenuConfig>>({
   apiVersion: "v3",
-  _resolvedExtensionBrand: undefined,
+  _resolvedModComponentBrand: undefined,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/extension-point-${n}`),

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -63,7 +63,7 @@ import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import { BusinessError, CancelError } from "@/errors/businessErrors";
 import { type Reader } from "@/types/bricks/readerTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type StarterBrick } from "@/types/extensionPointTypes";
 
@@ -163,7 +163,7 @@ export abstract class ContextMenuExtensionPoint extends StarterBrickABC<ContextM
   );
 
   async getBlocks(
-    extension: ResolvedExtension<ContextMenuConfig>
+    extension: ResolvedModComponent<ContextMenuConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.action);
   }
@@ -206,7 +206,7 @@ export abstract class ContextMenuExtensionPoint extends StarterBrickABC<ContextM
 
   async ensureMenu(
     extension: Pick<
-      ResolvedExtension<ContextMenuConfig>,
+      ResolvedModComponent<ContextMenuConfig>,
       "id" | "config" | "_deployment"
     >
   ): Promise<void> {
@@ -299,7 +299,7 @@ export abstract class ContextMenuExtensionPoint extends StarterBrickABC<ContextM
   }
 
   private async registerExtension(
-    extension: ResolvedExtension<ContextMenuConfig>
+    extension: ResolvedModComponent<ContextMenuConfig>
   ): Promise<void> {
     const { action: actionConfig, onSuccess = {} } = extension.config;
 

--- a/src/extensionPoints/contextMenu.ts
+++ b/src/extensionPoints/contextMenu.ts
@@ -125,7 +125,7 @@ function installMouseHandlerOnce(): void {
 /**
  * See also: https://developer.chrome.com/extensions/contextMenus
  */
-export abstract class ContextMenuExtensionPoint extends StarterBrickABC<ContextMenuConfig> {
+export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<ContextMenuConfig> {
   public override get syncInstall() {
     return true;
   }
@@ -234,7 +234,7 @@ export abstract class ContextMenuExtensionPoint extends StarterBrickABC<ContextM
     console.debug(
       "Registering",
       this.extensions.length,
-      "contextMenu extension points"
+      "contextMenu starter bricks"
     );
 
     const results = await Promise.allSettled(
@@ -386,7 +386,7 @@ export interface MenuDefinition extends StarterBrickDefinition {
   defaultOptions?: MenuDefaultOptions;
 }
 
-class RemoteContextMenuExtensionPoint extends ContextMenuExtensionPoint {
+class RemoteContextMenuExtensionPoint extends ContextMenuStarterBrickABC {
   private readonly _definition: MenuDefinition;
 
   public readonly permissions: Permissions.Permissions;

--- a/src/extensionPoints/helpers.ts
+++ b/src/extensionPoints/helpers.ts
@@ -21,7 +21,7 @@ import { $safeFind } from "@/helpers";
 import { EXTENSION_POINT_DATA_ATTR } from "@/common";
 import {
   type ModComponentBase,
-  type ResolvedExtension,
+  type ResolvedModComponent,
 } from "@/types/extensionTypes";
 import { type MessageContext } from "@/types/loggerTypes";
 
@@ -218,7 +218,7 @@ export function acquireElement(
  * Returns the MessageContext associated with `extension`.
  */
 export function selectExtensionContext(
-  extension: ResolvedExtension
+  extension: ResolvedModComponent
 ): MessageContext {
   return {
     // The step label will be re-assigned later in reducePipeline

--- a/src/extensionPoints/menuItemExtension.test.ts
+++ b/src/extensionPoints/menuItemExtension.test.ts
@@ -34,7 +34,7 @@ import {
 } from "@/extensionPoints/extensionPointTestUtils";
 import { type BrickPipeline } from "@/blocks/types";
 import { reduceExtensionPipeline } from "@/runtime/reducePipeline";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { RunReason } from "@/types/runtimeTypes";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -78,7 +78,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const extensionFactory = define<ResolvedExtension>({
+const extensionFactory = define<ResolvedModComponent>({
   apiVersion: "v3",
   _resolvedExtensionBrand: undefined,
   id: uuidSequence,

--- a/src/extensionPoints/menuItemExtension.test.ts
+++ b/src/extensionPoints/menuItemExtension.test.ts
@@ -18,7 +18,7 @@
 import {
   fromJS,
   type MenuDefinition,
-  type MenuItemExtensionConfig,
+  type MenuItemStarterBrickConfig,
 } from "@/extensionPoints/menuItemExtension";
 import { validateRegistryId } from "@/types/helpers";
 import { type Metadata } from "@/types/registryTypes";
@@ -80,13 +80,13 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
 
 const extensionFactory = define<ResolvedModComponent>({
   apiVersion: "v3",
-  _resolvedExtensionBrand: undefined,
+  _resolvedModComponentBrand: undefined,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/extension-point-${n}`),
   _recipe: null,
   label: "Test Extension",
-  config: define<MenuItemExtensionConfig>({
+  config: define<MenuItemStarterBrickConfig>({
     caption: "Hello World",
     action: () => [] as BrickPipeline,
     synchronous: false,

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -73,7 +73,7 @@ import { PromiseCancelled } from "@/errors/genericErrors";
 import { rejectOnCancelled } from "@/errors/rejectOnCancelled";
 import { type IconConfig } from "@/types/iconTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type JsonObject } from "type-fest";
 import {
@@ -402,7 +402,7 @@ export abstract class MenuItemExtensionPoint extends StarterBrickABC<MenuItemExt
   }
 
   async getBlocks(
-    extension: ResolvedExtension<MenuItemExtensionConfig>
+    extension: ResolvedModComponent<MenuItemExtensionConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.action);
   }
@@ -566,13 +566,13 @@ export abstract class MenuItemExtensionPoint extends StarterBrickABC<MenuItemExt
 
   protected abstract makeItem(
     html: string,
-    extension: ResolvedExtension<MenuItemExtensionConfig>
+    extension: ResolvedModComponent<MenuItemExtensionConfig>
   ): JQuery;
 
   private async runExtension(
     menu: HTMLElement,
     ctxtPromise: Promise<JsonObject>,
-    extension: ResolvedExtension<MenuItemExtensionConfig>
+    extension: ResolvedModComponent<MenuItemExtensionConfig>
   ) {
     if (!extension.id) {
       this.logger.error(`Refusing to run mod without id for ${this.id}`);
@@ -775,7 +775,7 @@ export abstract class MenuItemExtensionPoint extends StarterBrickABC<MenuItemExt
   }
 
   watchDependencies(
-    extension: ResolvedExtension<MenuItemExtensionConfig>
+    extension: ResolvedModComponent<MenuItemExtensionConfig>
   ): void {
     const { dependencies = [] } = extension.config;
 
@@ -1141,7 +1141,7 @@ export class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
 
   protected makeItem(
     unsanitizedHTML: string,
-    extension: ResolvedExtension<MenuItemExtensionConfig>
+    extension: ResolvedModComponent<MenuItemExtensionConfig>
   ): JQuery {
     const sanitizedHTML = sanitize(unsanitizedHTML);
 

--- a/src/extensionPoints/menuItemExtension.ts
+++ b/src/extensionPoints/menuItemExtension.ts
@@ -104,7 +104,7 @@ const DATA_ATTR = "data-pb-uuid";
 
 const MENU_INSTALL_ERROR_DEBOUNCE_MS = 1000;
 
-export type MenuItemExtensionConfig = {
+export type MenuItemStarterBrickConfig = {
   /**
    * The button caption to supply to the `caption` in the extension point template.
    * If `dynamicCaption` is true, can include template expressions.
@@ -177,7 +177,7 @@ async function cancelOnNavigation<T>(promise: Promise<T>): Promise<T> {
 
 type MenuTargetMode = "document" | "eventTarget";
 
-export abstract class MenuItemExtensionPoint extends StarterBrickABC<MenuItemExtensionConfig> {
+export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemStarterBrickConfig> {
   /**
    * Mapping of menu container nonce UUID to the DOM element for the menu container
    * @protected
@@ -200,7 +200,7 @@ export abstract class MenuItemExtensionPoint extends StarterBrickABC<MenuItemExt
   /**
    * Map from extension id to callback to cancel observers for its dependencies.
    *
-   * @see MenuItemExtensionConfig.dependencies
+   * @see MenuItemStarterBrickConfig.dependencies
    * @private
    */
   private readonly cancelDependencyObservers: Map<UUID, () => void>;
@@ -213,7 +213,7 @@ export abstract class MenuItemExtensionPoint extends StarterBrickABC<MenuItemExt
 
   /**
    * Mapping from extension id to the set of menu items that have been clicked and still running.
-   * @see MenuItemExtensionConfig.synchronous
+   * @see MenuItemStarterBrickConfig.synchronous
    * @private
    */
   private readonly runningExtensionElements = new Map<
@@ -402,7 +402,7 @@ export abstract class MenuItemExtensionPoint extends StarterBrickABC<MenuItemExt
   }
 
   async getBlocks(
-    extension: ResolvedModComponent<MenuItemExtensionConfig>
+    extension: ResolvedModComponent<MenuItemStarterBrickConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.action);
   }
@@ -566,13 +566,13 @@ export abstract class MenuItemExtensionPoint extends StarterBrickABC<MenuItemExt
 
   protected abstract makeItem(
     html: string,
-    extension: ResolvedModComponent<MenuItemExtensionConfig>
+    extension: ResolvedModComponent<MenuItemStarterBrickConfig>
   ): JQuery;
 
   private async runExtension(
     menu: HTMLElement,
     ctxtPromise: Promise<JsonObject>,
-    extension: ResolvedModComponent<MenuItemExtensionConfig>
+    extension: ResolvedModComponent<MenuItemStarterBrickConfig>
   ) {
     if (!extension.id) {
       this.logger.error(`Refusing to run mod without id for ${this.id}`);
@@ -775,7 +775,7 @@ export abstract class MenuItemExtensionPoint extends StarterBrickABC<MenuItemExt
   }
 
   watchDependencies(
-    extension: ResolvedModComponent<MenuItemExtensionConfig>
+    extension: ResolvedModComponent<MenuItemStarterBrickConfig>
   ): void {
     const { dependencies = [] } = extension.config;
 
@@ -991,7 +991,7 @@ export interface MenuDefinition extends StarterBrickDefinition {
   attachMode?: AttachMode;
 }
 
-export class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
+export class RemoteMenuItemExtensionPoint extends MenuItemStarterBrickABC {
   private readonly _definition: MenuDefinition;
 
   public readonly permissions: Permissions.Permissions;
@@ -1141,7 +1141,7 @@ export class RemoteMenuItemExtensionPoint extends MenuItemExtensionPoint {
 
   protected makeItem(
     unsanitizedHTML: string,
-    extension: ResolvedModComponent<MenuItemExtensionConfig>
+    extension: ResolvedModComponent<MenuItemStarterBrickConfig>
   ): JQuery {
     const sanitizedHTML = sanitize(unsanitizedHTML);
 

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -55,7 +55,7 @@ import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import { type IconConfig } from "@/types/iconTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
 import { type JsonObject } from "type-fest";
@@ -157,7 +157,9 @@ export abstract class PanelExtensionPoint extends StarterBrickABC<PanelConfig> {
     return "panel";
   }
 
-  async getBlocks(extension: ResolvedExtension<PanelConfig>): Promise<Brick[]> {
+  async getBlocks(
+    extension: ResolvedModComponent<PanelConfig>
+  ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.body);
   }
 
@@ -263,7 +265,7 @@ export abstract class PanelExtensionPoint extends StarterBrickABC<PanelConfig> {
 
   private async runExtension(
     readerOutput: JsonObject,
-    extension: ResolvedExtension<PanelConfig>
+    extension: ResolvedModComponent<PanelConfig>
   ) {
     if (this.uninstalled) {
       throw new Error("panelExtension has already been destroyed");

--- a/src/extensionPoints/panelExtension.ts
+++ b/src/extensionPoints/panelExtension.ts
@@ -97,7 +97,7 @@ function detectLoop(timestamps: Date[]): void {
 /**
  * Extension point that adds a panel to a web page.
  */
-export abstract class PanelExtensionPoint extends StarterBrickABC<PanelConfig> {
+export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> {
   protected $container: JQuery;
 
   private readonly collapsedExtensions: Map<UUID, boolean>;
@@ -497,7 +497,7 @@ export interface PanelDefinition extends StarterBrickDefinition {
   defaultOptions?: PanelDefaultOptions;
 }
 
-class RemotePanelExtensionPoint extends PanelExtensionPoint {
+class RemotePanelExtensionPoint extends PanelStarterBrickABC {
   private readonly _definition: PanelDefinition;
 
   public readonly permissions: Permissions.Permissions;

--- a/src/extensionPoints/quickBarExtension.test.ts
+++ b/src/extensionPoints/quickBarExtension.test.ts
@@ -70,7 +70,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
 
 const extensionFactory = define<ResolvedModComponent<QuickBarConfig>>({
   apiVersion: "v3",
-  _resolvedExtensionBrand: undefined,
+  _resolvedModComponentBrand: undefined,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/extension-point-${n}`),

--- a/src/extensionPoints/quickBarExtension.test.ts
+++ b/src/extensionPoints/quickBarExtension.test.ts
@@ -38,7 +38,7 @@ import userEvent from "@testing-library/user-event";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import { toggleQuickBar } from "@/components/quickBar/QuickBarApp";
 import { mockAnimationsApi } from "jsdom-testing-mocks";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { RunReason } from "@/types/runtimeTypes";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -68,7 +68,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const extensionFactory = define<ResolvedExtension<QuickBarConfig>>({
+const extensionFactory = define<ResolvedModComponent<QuickBarConfig>>({
   apiVersion: "v3",
   _resolvedExtensionBrand: undefined,
   id: uuidSequence,

--- a/src/extensionPoints/quickBarExtension.tsx
+++ b/src/extensionPoints/quickBarExtension.tsx
@@ -57,7 +57,7 @@ import { type IconConfig } from "@/types/iconTypes";
 import { type StarterBrick } from "@/types/extensionPointTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type UUID } from "@/types/stringTypes";
 
@@ -116,7 +116,7 @@ export abstract class QuickBarExtensionPoint extends StarterBrickABC<QuickBarCon
   );
 
   async getBlocks(
-    extension: ResolvedExtension<QuickBarConfig>
+    extension: ResolvedModComponent<QuickBarConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.action);
   }
@@ -193,7 +193,7 @@ export abstract class QuickBarExtensionPoint extends StarterBrickABC<QuickBarCon
    * @private
    */
   private async registerExtensionAction(
-    extension: ResolvedExtension<QuickBarConfig>
+    extension: ResolvedModComponent<QuickBarConfig>
   ): Promise<void> {
     const {
       title: name,

--- a/src/extensionPoints/quickBarExtension.tsx
+++ b/src/extensionPoints/quickBarExtension.tsx
@@ -77,10 +77,10 @@ export type QuickBarConfig = {
   action: BrickConfig | BrickPipeline;
 };
 
-export abstract class QuickBarExtensionPoint extends StarterBrickABC<QuickBarConfig> {
+export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarConfig> {
   static isQuickBarExtensionPoint(
     extensionPoint: StarterBrick
-  ): extensionPoint is QuickBarExtensionPoint {
+  ): extensionPoint is QuickBarStarterBrickABC {
     // Need to a access a type specific property (QuickBarExtensionPoint._definition) on a base-typed entity (StarterBrick)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (extensionPoint as any)?._definition?.type === "quickBar";
@@ -289,7 +289,7 @@ export interface QuickBarDefinition extends StarterBrickDefinition {
   defaultOptions?: QuickBarDefaultOptions;
 }
 
-export class RemoteQuickBarExtensionPoint extends QuickBarExtensionPoint {
+export class RemoteQuickBarExtensionPoint extends QuickBarStarterBrickABC {
   private readonly _definition: QuickBarDefinition;
 
   public readonly permissions: Permissions.Permissions;

--- a/src/extensionPoints/quickBarProviderExtension.tsx
+++ b/src/extensionPoints/quickBarProviderExtension.tsx
@@ -60,7 +60,7 @@ import { type Reader } from "@/types/bricks/readerTypes";
 import { type StarterBrick } from "@/types/extensionPointTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type Brick } from "@/types/brickTypes";
 
 export type QuickBarProviderConfig = {
@@ -132,7 +132,7 @@ export abstract class QuickBarProviderExtensionPoint extends StarterBrickABC<Qui
   );
 
   async getBlocks(
-    extension: ResolvedExtension<QuickBarProviderConfig>
+    extension: ResolvedModComponent<QuickBarProviderConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.generator);
   }
@@ -213,7 +213,7 @@ export abstract class QuickBarProviderExtensionPoint extends StarterBrickABC<Qui
    * @private
    */
   private async registerActionProvider(
-    extension: ResolvedExtension<QuickBarProviderConfig>
+    extension: ResolvedModComponent<QuickBarProviderConfig>
   ): Promise<void> {
     const { generator, rootAction } = extension.config;
 

--- a/src/extensionPoints/quickBarProviderExtension.tsx
+++ b/src/extensionPoints/quickBarProviderExtension.tsx
@@ -90,10 +90,10 @@ export type QuickBarProviderConfig = {
   generator: BrickConfig | BrickPipeline;
 };
 
-export abstract class QuickBarProviderExtensionPoint extends StarterBrickABC<QuickBarProviderConfig> {
+export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<QuickBarProviderConfig> {
   static isQuickBarProviderExtensionPoint(
     extensionPoint: StarterBrick
-  ): extensionPoint is QuickBarProviderExtensionPoint {
+  ): extensionPoint is QuickBarProviderStarterBrickABC {
     // Need to a access a type specific property (QuickBarProviderExtensionPoint._definition) on a base-typed entity (StarterBrick)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (extensionPoint as any)?._definition?.type === "quickBarProvider";
@@ -322,7 +322,7 @@ export interface QuickBarProviderDefinition extends StarterBrickDefinition {
   defaultOptions?: QuickBarProviderDefaultOptions;
 }
 
-export class RemoteQuickBarProviderExtensionPoint extends QuickBarProviderExtensionPoint {
+export class RemoteQuickBarProviderExtensionPoint extends QuickBarProviderStarterBrickABC {
   private readonly _definition: QuickBarProviderDefinition;
 
   public readonly permissions: Permissions.Permissions;

--- a/src/extensionPoints/quickbarProviderExtension.test.ts
+++ b/src/extensionPoints/quickbarProviderExtension.test.ts
@@ -36,7 +36,7 @@ import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import { toggleQuickBar } from "@/components/quickBar/QuickBarApp";
 import defaultActions from "@/components/quickBar/defaultActions";
 import { waitForEffect } from "@/testUtils/testHelpers";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { RunReason } from "@/types/runtimeTypes";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -57,7 +57,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const extensionFactory = define<ResolvedExtension<QuickBarProviderConfig>>({
+const extensionFactory = define<ResolvedModComponent<QuickBarProviderConfig>>({
   apiVersion: "v3",
   _resolvedExtensionBrand: undefined,
   id: uuidSequence,

--- a/src/extensionPoints/quickbarProviderExtension.test.ts
+++ b/src/extensionPoints/quickbarProviderExtension.test.ts
@@ -59,7 +59,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
 
 const extensionFactory = define<ResolvedModComponent<QuickBarProviderConfig>>({
   apiVersion: "v3",
-  _resolvedExtensionBrand: undefined,
+  _resolvedModComponentBrand: undefined,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/extension-point-${n}`),

--- a/src/extensionPoints/sidebarExtension.ts
+++ b/src/extensionPoints/sidebarExtension.ts
@@ -57,7 +57,7 @@ import { isSidebarFrameVisible } from "@/contentScript/sidebarDomControllerLite"
 import { type Schema } from "@/types/schemaTypes";
 import {
   type ModComponentBase,
-  type ResolvedExtension,
+  type ResolvedModComponent,
 } from "@/types/extensionTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type JsonObject } from "type-fest";
@@ -126,7 +126,7 @@ export abstract class SidebarExtensionPoint extends StarterBrickABC<SidebarConfi
   }
 
   async getBlocks(
-    extension: ResolvedExtension<SidebarConfig>
+    extension: ResolvedModComponent<SidebarConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.body);
   }
@@ -161,7 +161,7 @@ export abstract class SidebarExtensionPoint extends StarterBrickABC<SidebarConfi
 
   private async runExtension(
     readerContext: JsonObject,
-    extension: ResolvedExtension<SidebarConfig>
+    extension: ResolvedModComponent<SidebarConfig>
   ) {
     // Generate our own run id so that we know it (to pass to upsertPanel)
     const runId = uuidv4();

--- a/src/extensionPoints/sidebarExtension.ts
+++ b/src/extensionPoints/sidebarExtension.ts
@@ -83,7 +83,7 @@ export type Trigger =
   // A custom event configured by the user
   | "custom";
 
-export abstract class SidebarExtensionPoint extends StarterBrickABC<SidebarConfig> {
+export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConfig> {
   abstract get trigger(): Trigger;
 
   abstract get debounceOptions(): DebounceOptions;
@@ -139,7 +139,7 @@ export abstract class SidebarExtensionPoint extends StarterBrickABC<SidebarConfi
     this.clearExtensionInterfaceAndEvents();
     removeExtensionPoint(this.id);
     console.debug(
-      "SidebarExtensionPoint:uninstall: stop listening for sidebarShowEvents"
+      "SidebarStarterBrick:uninstall: stop listening for sidebarShowEvents"
     );
     sidebarShowEvents.remove(this.run);
     this.cancelListeners();
@@ -154,7 +154,7 @@ export abstract class SidebarExtensionPoint extends StarterBrickABC<SidebarConfi
     this.clearExtensionInterfaceAndEvents();
     removeExtensionPoint(this.id, { preserveExtensionIds: [extensionId] });
     console.debug(
-      "SidebarExtensionPoint:HACK_uninstallExceptExtension: stop listening for sidebarShowEvents"
+      "SidebarStarterBrick:HACK_uninstallExceptExtension: stop listening for sidebarShowEvents"
     );
     sidebarShowEvents.remove(this.run);
   }
@@ -280,7 +280,7 @@ export abstract class SidebarExtensionPoint extends StarterBrickABC<SidebarConfi
   };
 
   /**
-   * Refresh all panels for the extension point
+   * Refresh all panels for the StarterBrick
    * @private
    */
   private debouncedRefreshPanels = this.refreshPanels; // Default to un-debounced
@@ -330,7 +330,7 @@ export abstract class SidebarExtensionPoint extends StarterBrickABC<SidebarConfi
   run = async ({ reason }: RunArgs): Promise<void> => {
     if (!(await this.isAvailable())) {
       console.debug(
-        "SidebarExtensionPoint:run calling sidebarController:removeExtensionPoint because extension point is not available for URL",
+        "SidebarStarterBrick:run calling sidebarController:removeExtensionPoint because StarterBrick is not available for URL",
         this.id
       );
 
@@ -341,7 +341,7 @@ export abstract class SidebarExtensionPoint extends StarterBrickABC<SidebarConfi
 
     if (this.extensions.length === 0) {
       console.debug(
-        "SidebarExtensionPoint:run Sidebar extension point %s has no installed extensions",
+        "SidebarStarterBrick:run Sidebar StarterBrick %s has no installed extensions",
         this.id
       );
 
@@ -360,7 +360,7 @@ export abstract class SidebarExtensionPoint extends StarterBrickABC<SidebarConfi
 
     if (!isSidebarFrameVisible()) {
       console.debug(
-        "SidebarExtensionPoint:run Skipping run for %s because sidebar is not visible",
+        "SidebarStarterBrick:run Skipping run for %s because sidebar is not visible",
         this.id
       );
       return;
@@ -413,7 +413,7 @@ export abstract class SidebarExtensionPoint extends StarterBrickABC<SidebarConfi
 
       // Add event listener so content for the panel is calculated/loaded when the sidebar opens
       console.debug(
-        "SidebarExtensionPoint:install: listen for sidebarShowEvents"
+        "SidebarStarterBrick:install: listen for sidebarShowEvents"
       );
       sidebarShowEvents.add(this.run);
     } else {
@@ -456,7 +456,7 @@ export interface PanelDefinition extends StarterBrickDefinition {
   debounce?: DebounceOptions;
 }
 
-class RemotePanelExtensionPoint extends SidebarExtensionPoint {
+class RemotePanelExtensionPoint extends SidebarStarterBrickABC {
   private readonly definition: PanelDefinition;
 
   public readonly rawConfig: StarterBrickConfig;

--- a/src/extensionPoints/tourController.test.ts
+++ b/src/extensionPoints/tourController.test.ts
@@ -26,7 +26,7 @@ import {
 } from "@/extensionPoints/tourController";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import pDefer from "p-defer";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 
 describe("tourController", () => {
   test("ad-hoc tour", () => {
@@ -74,7 +74,7 @@ describe("tourController", () => {
         id: uuidv4(),
         label: "Test Tour",
         _recipe: null,
-      } as ResolvedExtension,
+      } as ResolvedModComponent,
       allowUserRun: false,
       run: () => ({
         promise: tourPromise.promise,

--- a/src/extensionPoints/tourController.tsx
+++ b/src/extensionPoints/tourController.tsx
@@ -28,7 +28,7 @@ import { reportEvent } from "@/telemetry/events";
 import { selectEventData } from "@/telemetry/deployments";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type MessageContext } from "@/types/loggerTypes";
 
 /**
@@ -122,9 +122,9 @@ export function getCurrentTour(): TourRun | null {
 export function markTourStart(
   nonce: UUID,
   extension: {
-    id: ResolvedExtension["id"];
-    label: ResolvedExtension["label"];
-    _recipe?: Pick<ResolvedExtension["_recipe"], "id">;
+    id: ResolvedModComponent["id"];
+    label: ResolvedModComponent["label"];
+    _recipe?: Pick<ResolvedModComponent["_recipe"], "id">;
   },
   {
     promise,
@@ -254,7 +254,7 @@ export function registerTour({
   run,
 }: {
   blueprintId: RegistryId;
-  extension: ResolvedExtension;
+  extension: ResolvedModComponent;
   allowUserRun?: boolean;
   run: () => { promise: Promise<void>; abortController: AbortController };
 }): RegisteredTour {

--- a/src/extensionPoints/tourExtension.test.ts
+++ b/src/extensionPoints/tourExtension.test.ts
@@ -31,7 +31,7 @@ import blockRegistry from "@/blocks/registry";
 import { isTourInProgress } from "@/extensionPoints/tourController";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import defaultActions from "@/components/quickBar/defaultActions";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { RunReason } from "@/types/runtimeTypes";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -57,7 +57,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const extensionFactory = define<ResolvedExtension<TourConfig>>({
+const extensionFactory = define<ResolvedModComponent<TourConfig>>({
   apiVersion: "v3",
   _resolvedExtensionBrand: undefined,
   id: uuidSequence,

--- a/src/extensionPoints/tourExtension.test.ts
+++ b/src/extensionPoints/tourExtension.test.ts
@@ -59,7 +59,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
 
 const extensionFactory = define<ResolvedModComponent<TourConfig>>({
   apiVersion: "v3",
-  _resolvedExtensionBrand: undefined,
+  _resolvedModComponentBrand: undefined,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/extension-point-${n}`),

--- a/src/extensionPoints/tourExtension.ts
+++ b/src/extensionPoints/tourExtension.ts
@@ -54,7 +54,7 @@ import {
 import { getAll } from "@/tours/tourRunDatabase";
 import { initPopoverPool } from "@/blocks/transformers/temporaryInfo/popoverUtils";
 import { type UUID } from "@/types/stringTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type RunArgs, RunReason } from "@/types/runtimeTypes";
@@ -129,12 +129,14 @@ export abstract class TourExtensionPoint extends StarterBrickABC<TourConfig> {
     },
   });
 
-  async getBlocks(extension: ResolvedExtension<TourConfig>): Promise<Brick[]> {
+  async getBlocks(
+    extension: ResolvedModComponent<TourConfig>
+  ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.tour);
   }
 
   private async runExtensionTour(
-    extension: ResolvedExtension<TourConfig>,
+    extension: ResolvedModComponent<TourConfig>,
     abortController: AbortController
   ): Promise<void> {
     const reader = await this.defaultReader();
@@ -164,7 +166,7 @@ export abstract class TourExtensionPoint extends StarterBrickABC<TourConfig> {
    * @param extension the tour extension
    * @private
    */
-  private registerTour(extension: ResolvedExtension<TourConfig>): void {
+  private registerTour(extension: ResolvedModComponent<TourConfig>): void {
     const tour = registerTour({
       blueprintId: extension._recipe?.id,
       extension,
@@ -189,7 +191,7 @@ export abstract class TourExtensionPoint extends StarterBrickABC<TourConfig> {
    *
    * @see autoRunSchedule
    */
-  async decideAutoRunTour(): Promise<ResolvedExtension<TourConfig>> {
+  async decideAutoRunTour(): Promise<ResolvedModComponent<TourConfig>> {
     const extensionIds = new Set(this.extensions.map((x) => x.id));
 
     const runs = await getAll();

--- a/src/extensionPoints/tourExtension.ts
+++ b/src/extensionPoints/tourExtension.ts
@@ -87,7 +87,7 @@ export interface TourDefinition extends StarterBrickDefinition {
   allowUserRun?: boolean;
 }
 
-export abstract class TourExtensionPoint extends StarterBrickABC<TourConfig> {
+export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
   public get kind(): "tour" {
     return "tour";
   }
@@ -270,7 +270,7 @@ export abstract class TourExtensionPoint extends StarterBrickABC<TourConfig> {
   }
 }
 
-class RemoteTourExtensionPoint extends TourExtensionPoint {
+class RemoteTourExtensionPoint extends TourStarterBrickABC {
   private readonly _definition: TourDefinition;
 
   public readonly permissions: Permissions.Permissions;

--- a/src/extensionPoints/triggerExtension.test.ts
+++ b/src/extensionPoints/triggerExtension.test.ts
@@ -73,7 +73,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
 
 const extensionFactory = define<ResolvedModComponent<TriggerConfig>>({
   apiVersion: "v3",
-  _resolvedExtensionBrand: undefined,
+  _resolvedModComponentBrand: undefined,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/extension-point-${n}`),

--- a/src/extensionPoints/triggerExtension.test.ts
+++ b/src/extensionPoints/triggerExtension.test.ts
@@ -36,7 +36,7 @@ import { getReferenceForElement } from "@/contentScript/elementReference";
 import userEvent from "@testing-library/user-event";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { ensureMocksReset, requestIdleCallback } from "@shopify/jest-dom-mocks";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { RunReason } from "@/types/runtimeTypes";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -71,7 +71,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const extensionFactory = define<ResolvedExtension<TriggerConfig>>({
+const extensionFactory = define<ResolvedModComponent<TriggerConfig>>({
   apiVersion: "v3",
   _resolvedExtensionBrand: undefined,
   id: uuidSequence,

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -70,7 +70,7 @@ import {
 import CompositeReader from "@/blocks/readers/CompositeReader";
 import { type Reader } from "@/types/bricks/readerTypes";
 import { type UUID } from "@/types/stringTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type SelectorRoot } from "@/types/runtimeTypes";
@@ -275,7 +275,7 @@ export abstract class TriggerExtensionPoint extends StarterBrickABC<TriggerConfi
   });
 
   async getBlocks(
-    extension: ResolvedExtension<TriggerConfig>
+    extension: ResolvedModComponent<TriggerConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.action);
   }
@@ -306,7 +306,7 @@ export abstract class TriggerExtensionPoint extends StarterBrickABC<TriggerConfi
 
   private async runExtension(
     ctxt: JsonObject,
-    extension: ResolvedExtension<TriggerConfig>,
+    extension: ResolvedModComponent<TriggerConfig>,
     root: SelectorRoot
   ) {
     const extensionLogger = this.logger.childLogger(

--- a/src/extensionPoints/triggerExtension.ts
+++ b/src/extensionPoints/triggerExtension.ts
@@ -122,7 +122,7 @@ async function interval({
   console.debug("interval:completed");
 }
 
-export abstract class TriggerExtensionPoint extends StarterBrickABC<TriggerConfig> {
+export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConfig> {
   abstract get trigger(): Trigger;
 
   abstract get attachMode(): AttachMode;
@@ -467,7 +467,7 @@ export abstract class TriggerExtensionPoint extends StarterBrickABC<TriggerConfi
       x.status === "fulfilled" ? x.value : x.reason
     );
 
-    TriggerExtensionPoint.notifyErrors(errors);
+    TriggerStarterBrickABC.notifyErrors(errors);
   };
 
   /**
@@ -847,7 +847,7 @@ export interface TriggerDefinition extends StarterBrickDefinition {
   debounce?: DebounceOptions;
 }
 
-class RemoteTriggerExtensionPoint extends TriggerExtensionPoint {
+class RemoteTriggerExtensionPoint extends TriggerStarterBrickABC {
   private readonly _definition: TriggerDefinition;
 
   public readonly permissions: Permissions.Permissions;

--- a/src/extensionPoints/types.ts
+++ b/src/extensionPoints/types.ts
@@ -22,7 +22,7 @@ import { type ApiVersion, type RunArgs } from "@/types/runtimeTypes";
 import { type RegistryId, type Metadata } from "@/types/registryTypes";
 import { type StarterBrick } from "@/types/extensionPointTypes";
 import { type BrickIcon } from "@/types/iconTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type Logger } from "@/types/loggerTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
@@ -86,17 +86,17 @@ export interface StarterBrickConfig<
   kind: "extensionPoint";
 }
 
-export function assertExtensionPointConfig(
-  maybeExtensionPointConfig: unknown
-): asserts maybeExtensionPointConfig is StarterBrickConfig {
-  const errorContext = { value: maybeExtensionPointConfig };
+export function assertStarterBrickConfig(
+  maybeStarterBrickConfig: unknown
+): asserts maybeStarterBrickConfig is StarterBrickConfig {
+  const errorContext = { value: maybeStarterBrickConfig };
 
-  if (typeof maybeExtensionPointConfig !== "object") {
+  if (typeof maybeStarterBrickConfig !== "object") {
     console.warn("Expected extension point", errorContext);
     throw new TypeError("Expected object for StarterBrickConfig");
   }
 
-  const config = maybeExtensionPointConfig as Record<string, unknown>;
+  const config = maybeStarterBrickConfig as Record<string, unknown>;
 
   if (config.kind !== "extensionPoint") {
     console.warn("Expected extension point", errorContext);
@@ -134,7 +134,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
 
   public readonly description: string;
 
-  protected readonly extensions: Array<ResolvedExtension<TConfig>> = [];
+  protected readonly extensions: Array<ResolvedModComponent<TConfig>> = [];
 
   protected readonly template?: string;
 
@@ -180,7 +180,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
     extensionIds: UUID[]
   ): void;
 
-  syncExtensions(extensions: Array<ResolvedExtension<TConfig>>): void {
+  syncExtensions(extensions: Array<ResolvedModComponent<TConfig>>): void {
     const before = this.extensions.map((x) => x.id);
 
     const updatedIds = new Set(extensions.map((x) => x.id));
@@ -204,7 +204,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
     this.syncExtensions(this.extensions.filter((x) => x.id !== extensionId));
   }
 
-  addExtension(extension: ResolvedExtension<TConfig>): void {
+  addExtension(extension: ResolvedModComponent<TConfig>): void {
     const index = this.extensions.findIndex((x) => x.id === extension.id);
     if (index >= 0) {
       console.warn(
@@ -224,7 +224,9 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
     return this.defaultReader();
   }
 
-  abstract getBlocks(extension: ResolvedExtension<TConfig>): Promise<Brick[]>;
+  abstract getBlocks(
+    extension: ResolvedModComponent<TConfig>
+  ): Promise<Brick[]>;
 
   abstract isAvailable(): Promise<boolean>;
 

--- a/src/mods/hooks/useDeleteExtensionAction.ts
+++ b/src/mods/hooks/useDeleteExtensionAction.ts
@@ -20,7 +20,7 @@ import { useModals } from "@/components/ConfirmationModal";
 import { useDeleteCloudExtensionMutation } from "@/services/api";
 import {
   getLabel,
-  isResolvedExtension,
+  isResolvedModComponent,
   isModDefinition,
 } from "@/utils/modUtils";
 import useUserAction from "@/hooks/useUserAction";
@@ -33,7 +33,7 @@ function useDeleteExtensionAction(modViewItem: ModViewItem): () => void | null {
   const isActive = status === "Active" || status === "Paused";
 
   const isCloudExtension =
-    isResolvedExtension(mod) &&
+    isResolvedModComponent(mod) &&
     sharing.source.type === "Personal" &&
     // If the status is active, there is still likely a copy of the extension saved on our server. But the point
     // this check is for extensions that aren't also installed locally

--- a/src/mods/hooks/useDeleteExtensionAction.ts
+++ b/src/mods/hooks/useDeleteExtensionAction.ts
@@ -18,7 +18,11 @@
 import { type ModViewItem } from "@/types/modTypes";
 import { useModals } from "@/components/ConfirmationModal";
 import { useDeleteCloudExtensionMutation } from "@/services/api";
-import { getLabel, isExtension, isModDefinition } from "@/utils/modUtils";
+import {
+  getLabel,
+  isResolvedExtension,
+  isModDefinition,
+} from "@/utils/modUtils";
 import useUserAction from "@/hooks/useUserAction";
 import { CancelError } from "@/errors/businessErrors";
 
@@ -29,7 +33,7 @@ function useDeleteExtensionAction(modViewItem: ModViewItem): () => void | null {
   const isActive = status === "Active" || status === "Paused";
 
   const isCloudExtension =
-    isExtension(mod) &&
+    isResolvedExtension(mod) &&
     sharing.source.type === "Personal" &&
     // If the status is active, there is still likely a copy of the extension saved on our server. But the point
     // this check is for extensions that aren't also installed locally

--- a/src/mods/useModViewItems.test.tsx
+++ b/src/mods/useModViewItems.test.tsx
@@ -19,7 +19,7 @@
 import useModViewItems from "@/mods/useModViewItems";
 import {
   type ActivatedModComponent,
-  type ResolvedExtension,
+  type ResolvedModComponent,
   selectSourceRecipeMetadata,
 } from "@/types/extensionTypes";
 import extensionsSlice from "@/store/extensionsSlice";
@@ -42,7 +42,7 @@ describe("useModViewItems", () => {
   });
 
   it("creates entry for ModComponentBase", async () => {
-    const extension = extensionFactory() as ResolvedExtension;
+    const extension = extensionFactory() as ResolvedModComponent;
 
     const wrapper = renderHook(() => useModViewItems([extension]), {
       setupRedux(dispatch) {

--- a/src/mods/useModViewItems.tsx
+++ b/src/mods/useModViewItems.tsx
@@ -29,7 +29,7 @@ import {
   getSharingType,
   getUpdatedAt,
   isDeployment,
-  isResolvedExtension,
+  isResolvedModComponent,
   isUnavailableMod,
   updateAvailable,
 } from "@/utils/modUtils";
@@ -64,7 +64,7 @@ function useModViewItems(mods: Mod[]): {
 
   const isActive = useCallback(
     (mod: Mod) => {
-      if (isResolvedExtension(mod)) {
+      if (isResolvedModComponent(mod)) {
         return installedExtensionIds.has(mod.id);
       }
 
@@ -76,7 +76,7 @@ function useModViewItems(mods: Mod[]): {
   const getStatus = useCallback(
     (mod: Mod): ModStatus => {
       if (isDeployment(mod, installedExtensions)) {
-        if (isResolvedExtension(mod)) {
+        if (isResolvedModComponent(mod)) {
           return isDeploymentActive(mod) ? "Active" : "Paused";
         }
 

--- a/src/mods/useModViewItems.tsx
+++ b/src/mods/useModViewItems.tsx
@@ -29,7 +29,7 @@ import {
   getSharingType,
   getUpdatedAt,
   isDeployment,
-  isExtension,
+  isResolvedExtension,
   isUnavailableMod,
   updateAvailable,
 } from "@/utils/modUtils";
@@ -64,7 +64,7 @@ function useModViewItems(mods: Mod[]): {
 
   const isActive = useCallback(
     (mod: Mod) => {
-      if (isExtension(mod)) {
+      if (isResolvedExtension(mod)) {
         return installedExtensionIds.has(mod.id);
       }
 
@@ -76,7 +76,7 @@ function useModViewItems(mods: Mod[]): {
   const getStatus = useCallback(
     (mod: Mod): ModStatus => {
       if (isDeployment(mod, installedExtensions)) {
-        if (isExtension(mod)) {
+        if (isResolvedExtension(mod)) {
           return isDeploymentActive(mod) ? "Active" : "Paused";
         }
 

--- a/src/pageEditor/extensionPoints/base.ts
+++ b/src/pageEditor/extensionPoints/base.ts
@@ -22,7 +22,7 @@ import {
 } from "@/types/registryTypes";
 import { castArray, cloneDeep, isEmpty } from "lodash";
 import {
-  assertExtensionPointConfig,
+  assertStarterBrickConfig,
   type StarterBrickConfig,
   type StarterBrickDefinition,
   type StarterBrickType,
@@ -214,7 +214,7 @@ export function internalExtensionPointMetaFactory(): Metadata {
 export function selectIsAvailable(
   extensionPoint: StarterBrickConfig
 ): NormalizedAvailability {
-  assertExtensionPointConfig(extensionPoint);
+  assertStarterBrickConfig(extensionPoint);
 
   const availability: NormalizedAvailability = {};
 
@@ -285,7 +285,7 @@ export async function lookupExtensionPoint<
       definition: { type: TType };
     };
 
-    assertExtensionPointConfig(innerExtensionPoint);
+    assertStarterBrickConfig(innerExtensionPoint);
     return innerExtensionPoint;
   }
 

--- a/src/pageEditor/extensionPoints/contextMenu.ts
+++ b/src/pageEditor/extensionPoints/contextMenu.ts
@@ -33,7 +33,7 @@ import {
 import { type StarterBrickConfig } from "@/extensionPoints/types";
 import {
   type ContextMenuConfig,
-  ContextMenuExtensionPoint,
+  ContextMenuStarterBrickABC,
   type MenuDefinition,
 } from "@/extensionPoints/contextMenu";
 import { faBars } from "@fortawesome/free-solid-svg-icons";
@@ -175,7 +175,7 @@ const config: ElementConfig<undefined, ContextMenuFormState> = {
   displayOrder: 1,
   elementType: "contextMenu",
   label: "Context Menu",
-  baseClass: ContextMenuExtensionPoint,
+  baseClass: ContextMenuStarterBrickABC,
   EditorNode: ContextMenuConfiguration,
   selectNativeElement: undefined,
   icon: faBars,

--- a/src/pageEditor/extensionPoints/formStateTypes.ts
+++ b/src/pageEditor/extensionPoints/formStateTypes.ts
@@ -23,7 +23,7 @@ import {
   type MenuDefaultOptions as ContextMenuDefaultOptions,
 } from "@/extensionPoints/contextMenu";
 import {
-  type MenuItemExtensionConfig,
+  type MenuItemStarterBrickConfig,
   type MenuPosition,
 } from "@/extensionPoints/menuItemExtension";
 import { type PanelConfig } from "@/extensionPoints/panelExtension";
@@ -63,7 +63,7 @@ import { type TourDefinition } from "@/extensionPoints/tourExtension";
 
 // ActionFormState
 type ActionExtensionState = BaseExtensionState &
-  Except<MenuItemExtensionConfig, "action">;
+  Except<MenuItemStarterBrickConfig, "action">;
 type ActionExtensionPointState = BaseExtensionPointState & {
   definition: {
     type: StarterBrickType;

--- a/src/pageEditor/extensionPoints/formStateTypes.ts
+++ b/src/pageEditor/extensionPoints/formStateTypes.ts
@@ -290,7 +290,7 @@ export type ModComponentFormState =
   | QuickBarProviderFormState
   | TourFormState;
 
-export function isFormState(
+export function isModComponentFormState(
   formState: unknown
 ): formState is ModComponentFormState {
   if (

--- a/src/pageEditor/extensionPoints/menuItem.ts
+++ b/src/pageEditor/extensionPoints/menuItem.ts
@@ -33,8 +33,8 @@ import {
 import { omitEditorMetadata } from "./pipelineMapping";
 import {
   type MenuDefinition,
-  type MenuItemExtensionConfig,
-  MenuItemExtensionPoint,
+  type MenuItemStarterBrickConfig,
+  MenuItemStarterBrickABC,
 } from "@/extensionPoints/menuItemExtension";
 import { type StarterBrickConfig } from "@/extensionPoints/types";
 import { identity, pickBy } from "lodash";
@@ -118,9 +118,9 @@ function selectExtensionPointConfig(
 function selectExtension(
   state: ActionFormState,
   options: { includeInstanceIds?: boolean } = {}
-): ModComponentBase<MenuItemExtensionConfig> {
+): ModComponentBase<MenuItemStarterBrickConfig> {
   const { extension } = state;
-  const config: MenuItemExtensionConfig = {
+  const config: MenuItemStarterBrickConfig = {
     caption: extension.caption,
     icon: extension.icon,
     action: options.includeInstanceIds
@@ -137,11 +137,11 @@ function selectExtension(
 }
 
 async function fromExtension(
-  config: ModComponentBase<MenuItemExtensionConfig>
+  config: ModComponentBase<MenuItemStarterBrickConfig>
 ): Promise<ActionFormState> {
   const extensionPoint = await lookupExtensionPoint<
     MenuDefinition,
-    MenuItemExtensionConfig,
+    MenuItemStarterBrickConfig,
     "menuItem"
   >(config, "menuItem");
 
@@ -183,7 +183,7 @@ const config: ElementConfig<ButtonSelectionResult, ActionFormState> = {
   elementType: "menuItem",
   label: "Button",
   icon: faMousePointer,
-  baseClass: MenuItemExtensionPoint,
+  baseClass: MenuItemStarterBrickABC,
   EditorNode: MenuItemConfiguration,
   selectNativeElement: insertButton,
   fromNativeElement,

--- a/src/pageEditor/extensionPoints/panel.ts
+++ b/src/pageEditor/extensionPoints/panel.ts
@@ -35,7 +35,7 @@ import { type StarterBrickConfig } from "@/extensionPoints/types";
 import {
   type PanelConfig,
   type PanelDefinition,
-  PanelExtensionPoint,
+  PanelStarterBrickABC,
 } from "@/extensionPoints/panelExtension";
 import { getDomain } from "@/permissions/patterns";
 import { faWindowMaximize } from "@fortawesome/free-solid-svg-icons";
@@ -175,7 +175,7 @@ const config: ElementConfig<PanelSelectionResult, PanelFormState> = {
   elementType: "panel",
   label: "Panel",
   icon: faWindowMaximize,
-  baseClass: PanelExtensionPoint,
+  baseClass: PanelStarterBrickABC,
   selectNativeElement: insertPanel,
   flag: "page-editor-extension-panel",
   EditorNode: PanelConfiguration,

--- a/src/pageEditor/extensionPoints/quickBar.ts
+++ b/src/pageEditor/extensionPoints/quickBar.ts
@@ -40,7 +40,7 @@ import {
 import {
   type QuickBarConfig,
   type QuickBarDefinition,
-  QuickBarExtensionPoint,
+  QuickBarStarterBrickABC,
 } from "@/extensionPoints/quickBarExtension";
 import QuickBarConfiguration from "@/pageEditor/tabs/quickBar/QuickBarConfiguration";
 import type { DynamicDefinition } from "@/contentScript/pageEditor/types";
@@ -172,7 +172,7 @@ const config: ElementConfig<undefined, QuickBarFormState> = {
   displayOrder: 1,
   elementType: "quickBar",
   label: "Quick Bar Action",
-  baseClass: QuickBarExtensionPoint,
+  baseClass: QuickBarStarterBrickABC,
   EditorNode: QuickBarConfiguration,
   selectNativeElement: undefined,
   icon: faThLarge,

--- a/src/pageEditor/extensionPoints/quickBarProvider.ts
+++ b/src/pageEditor/extensionPoints/quickBarProvider.ts
@@ -42,7 +42,7 @@ import { type QuickBarProviderFormState } from "./formStateTypes";
 import {
   type QuickBarProviderConfig,
   type QuickBarProviderDefinition,
-  QuickBarProviderExtensionPoint,
+  QuickBarProviderStarterBrickABC,
 } from "@/extensionPoints/quickBarProviderExtension";
 import QuickBarProviderConfiguration from "@/pageEditor/tabs/quickBarProvider/QuickBarProviderConfiguration";
 
@@ -164,7 +164,7 @@ const config: ElementConfig<undefined, QuickBarProviderFormState> = {
   displayOrder: 1,
   elementType: "quickBarProvider",
   label: "Dynamic Quick Bar",
-  baseClass: QuickBarProviderExtensionPoint,
+  baseClass: QuickBarProviderStarterBrickABC,
   EditorNode: QuickBarProviderConfiguration,
   selectNativeElement: undefined,
   icon: faPlusSquare,

--- a/src/pageEditor/extensionPoints/sidebar.ts
+++ b/src/pageEditor/extensionPoints/sidebar.ts
@@ -35,7 +35,7 @@ import { type StarterBrickConfig } from "@/extensionPoints/types";
 import {
   type PanelDefinition,
   type SidebarConfig,
-  SidebarExtensionPoint,
+  SidebarStarterBrickABC,
 } from "@/extensionPoints/sidebarExtension";
 import { getDomain } from "@/permissions/patterns";
 import { faColumns } from "@fortawesome/free-solid-svg-icons";
@@ -169,7 +169,7 @@ const config: ElementConfig<never, SidebarFormState> = {
   displayOrder: 3,
   elementType: "actionPanel",
   label: "Sidebar Panel",
-  baseClass: SidebarExtensionPoint,
+  baseClass: SidebarStarterBrickABC,
   selectNativeElement: undefined,
   icon: faColumns,
   fromNativeElement,

--- a/src/pageEditor/extensionPoints/tour.ts
+++ b/src/pageEditor/extensionPoints/tour.ts
@@ -40,7 +40,7 @@ import { type TourFormState } from "./formStateTypes";
 import {
   type TourConfig,
   type TourDefinition,
-  TourExtensionPoint,
+  TourStarterBrickABC,
 } from "@/extensionPoints/tourExtension";
 import TourConfiguration from "@/pageEditor/tabs/tour/TourConfiguration";
 import { type ModComponentBase } from "@/types/extensionTypes";
@@ -148,7 +148,7 @@ const config: ElementConfig<undefined, TourFormState> = {
   displayOrder: 8,
   elementType: "tour",
   label: "Tour",
-  baseClass: TourExtensionPoint,
+  baseClass: TourStarterBrickABC,
   flag: "pageeditor-tour",
   EditorNode: TourConfiguration,
   selectNativeElement: undefined,

--- a/src/pageEditor/extensionPoints/trigger.ts
+++ b/src/pageEditor/extensionPoints/trigger.ts
@@ -34,7 +34,7 @@ import {
   getDefaultReportModeForTrigger,
   type TriggerConfig,
   type TriggerDefinition,
-  TriggerExtensionPoint,
+  TriggerStarterBrickABC,
 } from "@/extensionPoints/triggerExtension";
 import { type StarterBrickConfig } from "@/extensionPoints/types";
 import { identity, pickBy } from "lodash";
@@ -198,7 +198,7 @@ const config: ElementConfig<undefined, TriggerFormState> = {
   displayOrder: 4,
   elementType: "trigger",
   label: "Trigger",
-  baseClass: TriggerExtensionPoint,
+  baseClass: TriggerStarterBrickABC,
   EditorNode: TriggerConfiguration,
   selectNativeElement: undefined,
   icon: faBolt,

--- a/src/pageEditor/pageEditorTypes.ts
+++ b/src/pageEditor/pageEditorTypes.ts
@@ -17,7 +17,7 @@
 
 import { type AuthRootState } from "@/auth/authTypes";
 import { type LogRootState } from "@/components/logViewer/logViewerTypes";
-import { type ExtensionsRootState } from "@/store/extensionsTypes";
+import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import { type SavingExtensionState } from "@/pageEditor/panes/save/savingExtensionSlice";
 import { type SettingsRootState } from "@/store/settingsTypes";
 import { type RuntimeRootState } from "@/pageEditor/slices/runtimeSliceTypes";
@@ -237,7 +237,7 @@ export type EditorRootState = {
 
 export type RootState = AuthRootState &
   LogRootState &
-  ExtensionsRootState &
+  ModComponentsRootState &
   AnalysisRootState &
   EditorRootState &
   RecipesRootState &

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -50,7 +50,7 @@ import {
   type ModOptionsDefinition,
   type UnsavedModDefinition,
 } from "@/types/modDefinitionTypes";
-import { type UnresolvedExtension } from "@/types/extensionTypes";
+import { type UnresolvedModComponent } from "@/types/extensionTypes";
 import { type EditablePackageMetadata } from "@/types/contract";
 import { extensionFactory } from "@/testUtils/factories/extensionFactories";
 import {
@@ -624,7 +624,7 @@ describe("buildRecipe", () => {
   test("Clean extension referencing extensionPoint registry package", async () => {
     const extension = extensionFactory({
       apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
-    }) as UnresolvedExtension;
+    }) as UnresolvedModComponent;
 
     // Call the function under test
     const newRecipe = buildRecipe({
@@ -648,7 +648,7 @@ describe("buildRecipe", () => {
       apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
       services: [{ id: serviceId, outputKey, config: null }],
       extensionPointId: extensionPoint.metadata.id,
-    }) as UnresolvedExtension;
+    }) as UnresolvedModComponent;
 
     const adapter = ADAPTERS.get(extensionPoint.definition.type);
 
@@ -684,7 +684,7 @@ describe("buildRecipe", () => {
     const extensions = extensionPoints.map((extensionPoint) => {
       const extension = extensionFactory({
         apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
-      }) as UnresolvedExtension;
+      }) as UnresolvedModComponent;
 
       extension.definitions = {
         extensionPoint: {
@@ -721,7 +721,7 @@ describe("buildRecipe", () => {
     const extensions = range(0, 2).map(() => {
       const extension = extensionFactory({
         apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
-      }) as UnresolvedExtension;
+      }) as UnresolvedModComponent;
 
       extension.definitions = {
         extensionPoint: {

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -44,7 +44,7 @@ import {
 } from "@/types/modDefinitionTypes";
 import {
   type ModComponentBase,
-  type UnresolvedExtension,
+  type UnresolvedModComponent,
 } from "@/types/extensionTypes";
 import { type SafeString } from "@/types/stringTypes";
 import { type ModMetadataFormState } from "@/pageEditor/pageEditorTypes";
@@ -289,7 +289,7 @@ function selectExtensionPointConfig(
 
 type RecipeParts = {
   sourceRecipe?: ModDefinition;
-  cleanRecipeExtensions: UnresolvedExtension[];
+  cleanRecipeExtensions: UnresolvedModComponent[];
   dirtyRecipeElements: ModComponentFormState[];
   options?: ModOptionsDefinition;
   metadata?: ModMetadataFormState;

--- a/src/pageEditor/sidebar/ExtensionEntry.tsx
+++ b/src/pageEditor/sidebar/ExtensionEntry.tsx
@@ -18,7 +18,7 @@
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import React from "react";
 import { type ModComponentFormState } from "@/pageEditor/extensionPoints/formStateTypes";
-import { isExtension } from "./common";
+import { isModComponentBase } from "./common";
 import DynamicEntry from "./DynamicEntry";
 import InstalledEntry from "./InstalledEntry";
 import { type ModComponentBase } from "@/types/extensionTypes";
@@ -39,7 +39,7 @@ const ExtensionEntry: React.FunctionComponent<ExtensionEntryProps> = ({
   availableDynamicIds,
   isNested = false,
 }) =>
-  isExtension(extension) ? (
+  isModComponentBase(extension) ? (
     <InstalledEntry
       key={`installed-${extension.id}`}
       extension={extension}

--- a/src/pageEditor/sidebar/RecipeEntry.test.tsx
+++ b/src/pageEditor/sidebar/RecipeEntry.test.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/pageEditor/slices/editorSlice";
 import RecipeEntry, { type RecipeEntryProps } from "./RecipeEntry";
 import { type EditorState } from "@/pageEditor/pageEditorTypes";
-import { type ExtensionOptionsState } from "@/store/extensionsTypes";
+import { type ModComponentOptionsState } from "@/store/extensionsTypes";
 import { validateSemVerString } from "@/types/helpers";
 import {
   recipeFactory,
@@ -37,7 +37,7 @@ import {
 let renderRecipeEntry: RenderFunctionWithRedux<
   {
     editor: EditorState;
-    options: ExtensionOptionsState;
+    options: ModComponentOptionsState;
   },
   RecipeEntryProps
 >;

--- a/src/pageEditor/sidebar/SidebarExpanded.tsx
+++ b/src/pageEditor/sidebar/SidebarExpanded.tsx
@@ -28,7 +28,7 @@ import {
 } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import hash from "object-hash";
-import { isExtension } from "@/pageEditor/sidebar/common";
+import { isModComponentBase } from "@/pageEditor/sidebar/common";
 import { faAngleDoubleLeft } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
 import RecipeEntry from "@/pageEditor/sidebar/RecipeEntry";
@@ -151,7 +151,7 @@ const SidebarExpanded: React.FunctionComponent<{
         firstElement == null
           ? // If there's no extensions in the Blueprint (empty Blueprint?), use the Blueprint's version
             recipe?.metadata?.version
-          : isExtension(firstElement)
+          : isModComponentBase(firstElement)
           ? firstElement._recipe.version
           : firstElement.recipe.version;
 

--- a/src/pageEditor/sidebar/arrangeElements.ts
+++ b/src/pageEditor/sidebar/arrangeElements.ts
@@ -19,10 +19,10 @@ import { groupBy, lowerCase, sortBy } from "lodash";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import {
   type ModComponentFormState,
-  isFormState,
+  isModComponentFormState,
 } from "@/pageEditor/extensionPoints/formStateTypes";
 import { getRecipeById } from "@/pageEditor/utils";
-import { isExtension } from "@/pageEditor/sidebar/common";
+import { isModComponentBase } from "@/pageEditor/sidebar/common";
 import { type UUID } from "@/types/stringTypes";
 import { type ModComponentBase } from "@/types/extensionTypes";
 import { type RegistryId } from "@/types/registryTypes";
@@ -49,13 +49,13 @@ function arrangeElements({
   const elementIds = new Set(elements.map((formState) => formState.uuid));
 
   const queryFilter = (item: ModComponentBase | ModComponentFormState) => {
-    const recipe = isFormState(item) ? item.recipe : item._recipe;
+    const recipe = isModComponentFormState(item) ? item.recipe : item._recipe;
     const queryName = recipe?.name ?? item.label;
 
     return (
       activeRecipeId === recipe?.id ||
       query.length === 0 ||
-      (isFormState(item) && activeElementId === item.uuid) ||
+      (isModComponentFormState(item) && activeElementId === item.uuid) ||
       (query.length > 0 && lowerCase(queryName).includes(lowerCase(query)))
     );
   };
@@ -73,7 +73,9 @@ function arrangeElements({
   const grouped = groupBy(
     [...filteredExtensions, ...filteredDynamicElements],
     (extension) =>
-      isExtension(extension) ? extension._recipe?.id : extension.recipe?.id
+      isModComponentBase(extension)
+        ? extension._recipe?.id
+        : extension.recipe?.id
   );
 
   const _elementsByRecipeId = new Map<string, Element[]>(
@@ -105,7 +107,7 @@ function arrangeElements({
 
     // Look for a recipe name in the elements/extensions in case recipes are still loading
     for (const element of elements) {
-      const name = isExtension(element)
+      const name = isModComponentBase(element)
         ? element._recipe?.name
         : element.recipe?.name;
       if (name) {

--- a/src/pageEditor/sidebar/common.ts
+++ b/src/pageEditor/sidebar/common.ts
@@ -24,6 +24,8 @@ export function getLabel(extension: ModComponentFormState): string {
   return extension.label ?? extension.extensionPoint.metadata.name;
 }
 
-export function isExtension(value: SidebarItem): value is ModComponentBase {
+export function isModComponentBase(
+  value: SidebarItem
+): value is ModComponentBase {
   return "extensionPointId" in value;
 }

--- a/src/pageEditor/slices/editorSelectors.ts
+++ b/src/pageEditor/slices/editorSelectors.ts
@@ -28,7 +28,7 @@ import {
   type ElementUIState,
   type TabUIState,
 } from "@/pageEditor/uiState/uiStateTypes";
-import { type ExtensionsRootState } from "@/store/extensionsTypes";
+import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import { type ModComponentFormState } from "@/pageEditor/extensionPoints/formStateTypes";
 import { deserializeError } from "serialize-error";
 import { type ModComponentBase } from "@/types/extensionTypes";
@@ -95,7 +95,7 @@ export const selectNotDeletedElements: ({
 
 export const selectNotDeletedExtensions: ({
   options,
-}: ExtensionsRootState) => ModComponentBase[] = createSelector(
+}: ModComponentsRootState) => ModComponentBase[] = createSelector(
   selectExtensions,
   selectAllDeletedElementIds,
   (extensions, deletedElementIds) =>

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -77,7 +77,7 @@ import {
 } from "@/contentScript/messenger/api";
 import { getCurrentURL, thisTab } from "@/pageEditor/utils";
 import { resolveExtensionInnerDefinitions } from "@/registry/internal";
-import { QuickBarExtensionPoint } from "@/extensionPoints/quickBarExtension";
+import { QuickBarStarterBrickABC } from "@/extensionPoints/quickBarExtension";
 import { testMatchPatterns } from "@/blocks/available";
 import { type BaseExtensionPointState } from "@/pageEditor/extensionPoints/elementConfig";
 import { BusinessError } from "@/errors/businessErrors";
@@ -185,7 +185,7 @@ const checkAvailableInstalledExtensions = createAsyncThunk<
       }
 
       // QuickBar is installed on every page, need to filter by the documentUrlPatterns
-      if (QuickBarExtensionPoint.isQuickBarExtensionPoint(extensionPoint)) {
+      if (QuickBarStarterBrickABC.isQuickBarExtensionPoint(extensionPoint)) {
         return testMatchPatterns(extensionPoint.documentUrlPatterns, tabUrl);
       }
 

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -82,7 +82,7 @@ import { testMatchPatterns } from "@/blocks/available";
 import { type BaseExtensionPointState } from "@/pageEditor/extensionPoints/elementConfig";
 import { BusinessError } from "@/errors/businessErrors";
 import { serializeError } from "serialize-error";
-import { isExtension } from "@/pageEditor/sidebar/common";
+import { isModComponentBase } from "@/pageEditor/sidebar/common";
 import { type StorageInterface } from "@/store/StorageInterface";
 import { localStorage } from "redux-persist-webextension-storage";
 import {
@@ -303,7 +303,7 @@ const checkActiveElementAvailability = createAsyncThunk<
     installedExtensions,
     dynamicElements,
     (extensionOrElement) => {
-      if (isExtension(extensionOrElement)) {
+      if (isModComponentBase(extensionOrElement)) {
         return extensionOrElement.id;
       }
 

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -70,7 +70,7 @@ import {
 } from "@/pageEditor/slices/editorSliceHelpers";
 import { produce } from "immer";
 import { normalizePipelineForEditor } from "@/pageEditor/extensionPoints/pipelineMapping";
-import { type ExtensionsRootState } from "@/store/extensionsTypes";
+import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import {
   checkAvailable,
   getInstalledExtensionPoints,
@@ -162,7 +162,7 @@ type AvailableInstalled = {
 const checkAvailableInstalledExtensions = createAsyncThunk<
   AvailableInstalled,
   void,
-  { state: EditorRootState & ExtensionsRootState }
+  { state: EditorRootState & ModComponentsRootState }
 >("editor/checkAvailableInstalledExtensions", async (arg, thunkAPI) => {
   const elements = selectNotDeletedElements(thunkAPI.getState());
   const extensions = selectNotDeletedExtensions(thunkAPI.getState());
@@ -263,7 +263,7 @@ const checkActiveElementAvailability = createAsyncThunk<
     unavailableDynamicCount: number;
   },
   void,
-  { state: EditorRootState & ExtensionsRootState }
+  { state: EditorRootState & ModComponentsRootState }
 >("editor/checkDynamicElementAvailability", async (arg, thunkAPI) => {
   const tabUrl = await getCurrentURL();
   const state = thunkAPI.getState();

--- a/src/pageEditor/tabState/tabStateSlice.ts
+++ b/src/pageEditor/tabState/tabStateSlice.ts
@@ -29,7 +29,7 @@ import {
   type TabStateRootState,
 } from "@/pageEditor/tabState/tabStateTypes";
 import { type EditorRootState } from "@/pageEditor/pageEditorTypes";
-import { type ExtensionsRootState } from "@/store/extensionsTypes";
+import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import { actions } from "@/pageEditor/slices/editorSlice";
 import { canAccessTab } from "@/permissions/permissionsUtils";
 import { serializeError } from "serialize-error";
@@ -64,7 +64,7 @@ const connectToContentScript = createAsyncThunk<
   FrameConnectionState,
   void,
   // We need to include these states to enable dispatching the availability async thunk actions
-  { state: TabStateRootState & EditorRootState & ExtensionsRootState }
+  { state: TabStateRootState & EditorRootState & ModComponentsRootState }
 >("tabState/connectToContentScript", async (_, thunkAPI) => {
   const uuid = uuidv4();
   const common = { ...defaultFrameState, navSequence: uuid };

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -16,7 +16,7 @@
  */
 
 import { type ModComponentFormState } from "@/pageEditor/extensionPoints/formStateTypes";
-import { isExtension } from "@/pageEditor/sidebar/common";
+import { isModComponentBase } from "@/pageEditor/sidebar/common";
 import { type BrickConfig } from "@/blocks/types";
 import ForEach from "@/blocks/transformers/controlFlow/ForEach";
 import TryExcept from "@/blocks/transformers/controlFlow/TryExcept";
@@ -65,13 +65,13 @@ export const thisTab: Target = {
 export function getIdForElement(
   element: ModComponentBase | ModComponentFormState
 ): UUID {
-  return isExtension(element) ? element.id : element.uuid;
+  return isModComponentBase(element) ? element.id : element.uuid;
 }
 
 export function getRecipeIdForElement(
   element: ModComponentBase | ModComponentFormState
 ): RegistryId {
-  return isExtension(element) ? element._recipe?.id : element.recipe?.id;
+  return isModComponentBase(element) ? element._recipe?.id : element.recipe?.id;
 }
 
 export function getRecipeById(

--- a/src/permissions/cloudExtensionPermissionsHelpers.ts
+++ b/src/permissions/cloudExtensionPermissionsHelpers.ts
@@ -19,7 +19,7 @@ import { type StandaloneModDefinition } from "@/types/contract";
 import { type IntegrationDependency } from "@/types/serviceTypes";
 import { type PermissionsStatus } from "@/permissions/permissionsTypes";
 import { resolveExtensionInnerDefinitions } from "@/registry/internal";
-import { type ResolvedExtensionDefinition } from "@/types/modDefinitionTypes";
+import { type ResolvedModComponentDefinition } from "@/types/modDefinitionTypes";
 import { checkRecipePermissions } from "@/recipes/recipePermissionsHelpers";
 
 // Separate from extensionPermissionsHelpers.ts to avoid a circular dependency with recipePermissionsHelpers.ts
@@ -49,7 +49,7 @@ export async function checkCloudExtensionPermissions(
         services: Object.fromEntries(
           services.map((service) => [service.outputKey, service.id])
         ),
-      } as ResolvedExtensionDefinition,
+      } as ResolvedModComponentDefinition,
     ],
   };
 

--- a/src/recipes/recipePermissionsHelpers.ts
+++ b/src/recipes/recipePermissionsHelpers.ts
@@ -17,7 +17,7 @@
 
 import {
   type ModDefinition,
-  type ResolvedExtensionDefinition,
+  type ResolvedModComponentDefinition,
 } from "@/types/modDefinitionTypes";
 import { type IntegrationConfigPair } from "@/types/serviceTypes";
 import { resolveRecipeInnerDefinitions } from "@/registry/internal";
@@ -35,7 +35,7 @@ import { collectExtensionPermissions } from "@/permissions/extensionPermissionsH
 import { type PermissionsStatus } from "@/permissions/permissionsTypes";
 
 async function collectExtensionDefinitionPermissions(
-  extensionPoints: ResolvedExtensionDefinition[],
+  extensionPoints: ResolvedModComponentDefinition[],
   serviceAuths: IntegrationConfigPair[]
 ): Promise<Permissions.Permissions> {
   const servicePromises = serviceAuths.map(async (serviceAuth) =>
@@ -43,7 +43,11 @@ async function collectExtensionDefinitionPermissions(
   );
 
   const extensionPointPromises = extensionPoints.map(
-    async ({ id, permissions = {}, config }: ResolvedExtensionDefinition) => {
+    async ({
+      id,
+      permissions = {},
+      config,
+    }: ResolvedModComponentDefinition) => {
       const extensionPoint = await extensionPointRegistry.lookup(id);
 
       let inner: Permissions.Permissions = {};

--- a/src/registry/internal.ts
+++ b/src/registry/internal.ts
@@ -32,7 +32,7 @@ import { fromJS as blockFactory } from "@/blocks/transformers/brickFactory";
 import { resolveObj } from "@/utils";
 import {
   type ModDefinition,
-  type ResolvedExtensionDefinition,
+  type ResolvedModComponentDefinition,
 } from "@/types/modDefinitionTypes";
 import { type StarterBrickConfig } from "@/extensionPoints/types";
 import { type ReaderConfig } from "@/blocks/types";
@@ -254,11 +254,11 @@ export async function resolveExtensionInnerDefinitions<
  */
 export async function resolveRecipeInnerDefinitions(
   recipe: Pick<ModDefinition, "extensionPoints" | "definitions">
-): Promise<ResolvedExtensionDefinition[]> {
+): Promise<ResolvedModComponentDefinition[]> {
   const extensionDefinitions = recipe.extensionPoints;
 
   if (isEmpty(recipe.definitions)) {
-    return extensionDefinitions as ResolvedExtensionDefinition[];
+    return extensionDefinitions as ResolvedModComponentDefinition[];
   }
 
   const extensionPointReferences = new Set<string>(
@@ -283,7 +283,7 @@ export async function resolveRecipeInnerDefinitions(
     (definition) =>
       (definition.id in resolvedDefinitions
         ? { ...definition, id: resolvedDefinitions[definition.id].id }
-        : definition) as ResolvedExtensionDefinition
+        : definition) as ResolvedModComponentDefinition
   );
 }
 

--- a/src/registry/internal.ts
+++ b/src/registry/internal.ts
@@ -44,7 +44,7 @@ import {
 } from "@/types/registryTypes";
 import {
   type ModComponentBase,
-  type ResolvedExtension,
+  type ResolvedModComponent,
 } from "@/types/extensionTypes";
 import { type StarterBrick } from "@/types/extensionPointTypes";
 import { type Brick } from "@/types/brickTypes";
@@ -222,9 +222,9 @@ async function resolveInnerDefinition(
  */
 export async function resolveExtensionInnerDefinitions<
   T extends UnknownObject = UnknownObject
->(extension: ModComponentBase<T>): Promise<ResolvedExtension<T>> {
+>(extension: ModComponentBase<T>): Promise<ResolvedModComponent<T>> {
   if (isEmpty(extension.definitions)) {
-    return extension as ResolvedExtension<T>;
+    return extension as ResolvedModComponent<T>;
   }
 
   return produce(extension, async (draft) => {
@@ -245,7 +245,7 @@ export async function resolveExtensionInnerDefinitions<
     if (resolvedDefinitions[draft.extensionPointId] != null) {
       draft.extensionPointId = resolvedDefinitions[draft.extensionPointId].id;
     }
-  }) as Promise<ResolvedExtension<T>>;
+  }) as Promise<ResolvedModComponent<T>>;
 }
 
 /**
@@ -291,7 +291,7 @@ export async function resolveRecipeInnerDefinitions(
  * Returns true if the extension is using an InnerDefinitionRef. _Will always return false for ResolvedExtensions._
  * @see InnerDefinitionRef
  * @see UnresolvedExtension
- * @see ResolvedExtension
+ * @see ResolvedModComponent
  */
 export function hasInnerExtensionPointRef(
   extension: ModComponentBase

--- a/src/runtime/runtimeUtils.ts
+++ b/src/runtime/runtimeUtils.ts
@@ -236,12 +236,12 @@ export async function selectBlockRootElement(
   return $root.get(0);
 }
 
-export function assertExtensionNotResolved<T extends ModComponentBase>(
+export function assertModComponentNotResolved<T extends ModComponentBase>(
   extension: ModComponentBase
 ): asserts extension is T & {
-  _unresolvedExtensionBrand: never;
+  _unresolvedModComponentBrand: never;
 } {
   if (isInnerDefinitionRegistryId(extension.extensionPointId)) {
-    throw new Error("Expected UnresolvedExtension");
+    throw new Error("Expected UnresolvedModComponent");
   }
 }

--- a/src/sidebar/sidebarSelectors.ts
+++ b/src/sidebar/sidebarSelectors.ts
@@ -16,7 +16,7 @@
  */
 
 import {
-  isBaseExtensionPanelEntry,
+  isBaseModComponentPanelEntry,
   type SidebarRootState,
 } from "@/types/sidebarTypes";
 import { isEmpty } from "lodash";
@@ -68,7 +68,7 @@ export const selectExtensionFromEventKey =
       (entry) => eventKeyForEntry(entry) === eventKey
     );
 
-    if (!isBaseExtensionPanelEntry(sidebarEntry)) {
+    if (!isBaseModComponentPanelEntry(sidebarEntry)) {
       return;
     }
 

--- a/src/store/checkActiveElementAvailability.test.ts
+++ b/src/store/checkActiveElementAvailability.test.ts
@@ -18,7 +18,7 @@
 import { getCurrentURL } from "@/pageEditor/utils";
 import { configureStore } from "@reduxjs/toolkit";
 import { type EditorRootState } from "@/pageEditor/pageEditorTypes";
-import { type ExtensionsRootState } from "@/store/extensionsTypes";
+import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import { actions, editorSlice } from "@/pageEditor/slices/editorSlice";
 import extensionsSlice from "@/store/extensionsSlice";
 import { validateRegistryId } from "@/types/helpers";
@@ -47,7 +47,7 @@ describe("checkActiveElementAvailability", () => {
     const testUrl = "https://www.myUrl.com/*";
     (getCurrentURL as jest.Mock).mockResolvedValue(testUrl);
 
-    const store = configureStore<EditorRootState & ExtensionsRootState>({
+    const store = configureStore<EditorRootState & ModComponentsRootState>({
       reducer: {
         editor: editorSlice.reducer,
         options: extensionsReducer,

--- a/src/store/checkAvailableDynamicElements.test.ts
+++ b/src/store/checkAvailableDynamicElements.test.ts
@@ -27,7 +27,7 @@ import { checkAvailable as backgroundCheckAvailable } from "@/blocks/available";
 import { type Target } from "@/types/messengerTypes";
 import { type PageTarget } from "webext-messenger";
 import { type Availability } from "@/blocks/types";
-import { type ExtensionsRootState } from "@/store/extensionsTypes";
+import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import extensionsSlice from "@/store/extensionsSlice";
 import { menuItemFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
 
@@ -46,7 +46,7 @@ describe("checkAvailableDynamicElements", () => {
     const testUrl = "https://www.myUrl.com/*";
     (getCurrentURL as jest.Mock).mockResolvedValue(testUrl);
 
-    const store = configureStore<EditorRootState & ExtensionsRootState>({
+    const store = configureStore<EditorRootState & ModComponentsRootState>({
       reducer: {
         editor: editorSlice.reducer,
         options: extensionsReducer,

--- a/src/store/checkAvailableInstalledExtensions.test.ts
+++ b/src/store/checkAvailableInstalledExtensions.test.ts
@@ -19,7 +19,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import { actions, editorSlice } from "@/pageEditor/slices/editorSlice";
 import extensionsSlice from "@/store/extensionsSlice";
 import { type EditorRootState } from "@/pageEditor/pageEditorTypes";
-import { type ExtensionsRootState } from "@/store/extensionsTypes";
+import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import { selectExtensionAvailability } from "@/pageEditor/slices/editorSelectors";
 import { getInstalledExtensionPoints } from "@/contentScript/messenger/api";
 import { getCurrentURL } from "@/pageEditor/utils";
@@ -124,7 +124,7 @@ describe("checkAvailableInstalledExtensions", () => {
       availableQuickbarExtensionPoint,
     ]);
 
-    const store = configureStore<EditorRootState & ExtensionsRootState>({
+    const store = configureStore<EditorRootState & ModComponentsRootState>({
       reducer: {
         editor: editorSlice.reducer,
         options: extensionsReducer,

--- a/src/store/extensionsMigrations.ts
+++ b/src/store/extensionsMigrations.ts
@@ -21,9 +21,9 @@ import {
 } from "redux-persist/es/types";
 import { type ActivatedModComponent } from "@/types/extensionTypes";
 import {
-  type ExtensionOptionsState,
-  type LegacyExtensionObjectShapeState,
-  type LegacyExtensionObjectState,
+  type ModComponentOptionsState,
+  type LegacyModComponentObjectShapeState,
+  type LegacyModComponentObjectState,
   type OptionsState,
 } from "@/store/extensionsTypes";
 
@@ -31,21 +31,22 @@ export const migrations: MigrationManifest = {
   1: (state: PersistedState & OptionsState) => migrateExtensionsShape(state),
   2: (state: PersistedState & OptionsState) =>
     migrateActiveExtensions(
-      state as PersistedState & LegacyExtensionObjectState
+      state as PersistedState & LegacyModComponentObjectState
     ),
 };
 
 // Putting here because it was causing circular dependencies
 export function migrateExtensionsShape<T>(
-  state: T & (LegacyExtensionObjectShapeState | LegacyExtensionObjectState)
-): T & LegacyExtensionObjectState {
+  state: T &
+    (LegacyModComponentObjectShapeState | LegacyModComponentObjectState)
+): T & LegacyModComponentObjectState {
   if (state.extensions == null) {
     return { ...state, extensions: [] };
   }
 
   if (Array.isArray(state.extensions)) {
     // Already migrated
-    return state as T & LegacyExtensionObjectState;
+    return state as T & LegacyModComponentObjectState;
   }
 
   return {
@@ -57,8 +58,8 @@ export function migrateExtensionsShape<T>(
 }
 
 export function migrateActiveExtensions<T>(
-  state: T & (LegacyExtensionObjectState | ExtensionOptionsState)
-): T & ExtensionOptionsState {
+  state: T & (LegacyModComponentObjectState | ModComponentOptionsState)
+): T & ModComponentOptionsState {
   const timestamp = new Date().toISOString();
 
   return {

--- a/src/store/extensionsSelectors.ts
+++ b/src/store/extensionsSelectors.ts
@@ -17,13 +17,13 @@
 
 import { type ExtensionsRootState } from "@/store/extensionsTypes";
 import { createSelector } from "reselect";
-import { type UnresolvedExtension } from "@/types/extensionTypes";
+import { type UnresolvedModComponent } from "@/types/extensionTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { isEmpty } from "lodash";
 
 export function selectExtensions({
   options,
-}: ExtensionsRootState): UnresolvedExtension[] {
+}: ExtensionsRootState): UnresolvedModComponent[] {
   if (!Array.isArray(options.extensions)) {
     console.warn("state migration has not been applied yet", {
       options,

--- a/src/store/extensionsSelectors.ts
+++ b/src/store/extensionsSelectors.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type ExtensionsRootState } from "@/store/extensionsTypes";
+import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import { createSelector } from "reselect";
 import { type UnresolvedModComponent } from "@/types/extensionTypes";
 import { type RegistryId } from "@/types/registryTypes";
@@ -23,7 +23,7 @@ import { isEmpty } from "lodash";
 
 export function selectExtensions({
   options,
-}: ExtensionsRootState): UnresolvedModComponent[] {
+}: ModComponentsRootState): UnresolvedModComponent[] {
   if (!Array.isArray(options.extensions)) {
     console.warn("state migration has not been applied yet", {
       options,
@@ -36,15 +36,15 @@ export function selectExtensions({
 
 const extensionsForRecipeSelector = createSelector(
   selectExtensions,
-  (state: ExtensionsRootState, recipeId: RegistryId) => recipeId,
+  (state: ModComponentsRootState, recipeId: RegistryId) => recipeId,
   (extensions, recipeId) =>
     extensions.filter((extension) => extension._recipe?.id === recipeId)
 );
 
 export const selectExtensionsForRecipe =
-  (recipeId: RegistryId) => (state: ExtensionsRootState) =>
+  (recipeId: RegistryId) => (state: ModComponentsRootState) =>
     extensionsForRecipeSelector(state, recipeId);
 
 export const selectRecipeHasAnyExtensionsInstalled =
-  (recipeId: RegistryId) => (state: ExtensionsRootState) =>
+  (recipeId: RegistryId) => (state: ModComponentsRootState) =>
     !isEmpty(extensionsForRecipeSelector(state, recipeId));

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -28,8 +28,8 @@ import { cloneDeep, partition } from "lodash";
 import { saveUserExtension } from "@/services/apiClient";
 import reportError from "@/telemetry/reportError";
 import {
-  type ExtensionOptionsState,
-  type LegacyExtensionObjectState,
+  type ModComponentOptionsState,
+  type LegacyModComponentObjectState,
   type OptionsState,
 } from "@/store/extensionsTypes";
 import { type Except } from "type-fest";
@@ -48,7 +48,7 @@ import {
 import { type RegistryId } from "@/types/registryTypes";
 import { type OutputKey, type OptionsArgs } from "@/types/runtimeTypes";
 
-const initialExtensionsState: ExtensionOptionsState = {
+const initialExtensionsState: ModComponentOptionsState = {
   extensions: [],
 };
 
@@ -393,7 +393,7 @@ const extensionsSlice = createSlice({
  */
 function requireLatestState(
   state: OptionsState
-): asserts state is LegacyExtensionObjectState | ExtensionOptionsState {
+): asserts state is LegacyModComponentObjectState | ModComponentOptionsState {
   if (!Array.isArray(state.extensions)) {
     throw new TypeError("redux state has not been migrated");
   }

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -33,7 +33,7 @@ import {
   type OptionsState,
 } from "@/store/extensionsTypes";
 import { type Except } from "type-fest";
-import { assertExtensionNotResolved } from "@/runtime/runtimeUtils";
+import { assertModComponentNotResolved } from "@/runtime/runtimeUtils";
 import { revertAll } from "@/store/commonActions";
 import {
   type ModComponentBase,
@@ -176,7 +176,7 @@ const extensionsSlice = createSlice({
 
         const extension: Except<
           ActivatedModComponent,
-          "_unresolvedExtensionBrand"
+          "_unresolvedModComponentBrand"
         > = {
           id: extensionId,
           // Default to `v1` for backward compatability
@@ -215,7 +215,7 @@ const extensionsSlice = createSlice({
           extension.templateEngine = templateEngine;
         }
 
-        assertExtensionNotResolved(extension);
+        assertModComponentNotResolved(extension);
 
         // Display name is 'StarterBrickActivate' in telemetry
         reportEvent("ExtensionActivate", selectEventData(extension));
@@ -281,7 +281,7 @@ const extensionsSlice = createSlice({
 
       const extension: Except<
         ActivatedModComponent,
-        "_unresolvedExtensionBrand"
+        "_unresolvedModComponentBrand"
       > = {
         id,
         apiVersion,
@@ -298,7 +298,7 @@ const extensionsSlice = createSlice({
         active: true,
       };
 
-      assertExtensionNotResolved(extension);
+      assertModComponentNotResolved(extension);
 
       if (pushToCloud && !_deployment) {
         // In the future, we'll want to make the Redux action async. For now, just fail silently in the interface

--- a/src/store/extensionsStorage.ts
+++ b/src/store/extensionsStorage.ts
@@ -28,7 +28,7 @@ import {
   migrateExtensionsShape,
   migrations,
 } from "@/store/extensionsMigrations";
-import { type ExtensionOptionsState } from "./extensionsTypes";
+import { type ModComponentOptionsState } from "./extensionsTypes";
 import { type StorageInterface } from "@/store/StorageInterface";
 
 const STORAGE_KEY = "persist:extensionOptions" as ReduxStorageKey;
@@ -44,7 +44,7 @@ async function getOptionsState(): Promise<PersistedOptionsState> {
 /**
  * Read extension options from local storage (without going through redux-persistor).
  */
-export async function loadOptions(): Promise<ExtensionOptionsState> {
+export async function loadOptions(): Promise<ModComponentOptionsState> {
   const base = await getOptionsState();
   // The redux persist layer persists the extensions value as JSON-string.
   // Also apply the upgradeExtensionsState migration here because the migration in store might not have run yet.
@@ -58,7 +58,9 @@ export async function loadOptions(): Promise<ExtensionOptionsState> {
 /**
  * Save extension options to local storage (without going through redux-persistor).
  */
-export async function saveOptions(state: ExtensionOptionsState): Promise<void> {
+export async function saveOptions(
+  state: ModComponentOptionsState
+): Promise<void> {
   const base = await getOptionsState();
   await setReduxStorage(STORAGE_KEY, {
     ...base,

--- a/src/store/extensionsTypes.ts
+++ b/src/store/extensionsTypes.ts
@@ -17,7 +17,7 @@
 
 import {
   type ActivatedModComponent,
-  type UnresolvedExtension,
+  type UnresolvedModComponent,
 } from "@/types/extensionTypes";
 
 /**
@@ -28,7 +28,7 @@ export type LegacyExtensionObjectShapeState = {
   extensions: {
     // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- Record doesn't allow labelled keys
     [extensionPointId: string]: {
-      [extensionId: string]: UnresolvedExtension;
+      [extensionId: string]: UnresolvedModComponent;
     };
   };
 };
@@ -41,7 +41,7 @@ export type ExtensionOptionsState = {
  * @deprecated use ExtensionOptionsState - this is only used in a migration
  */
 export type LegacyExtensionObjectState = {
-  extensions: UnresolvedExtension[];
+  extensions: UnresolvedModComponent[];
 };
 
 export type OptionsState =

--- a/src/store/extensionsTypes.ts
+++ b/src/store/extensionsTypes.ts
@@ -23,7 +23,7 @@ import {
 /**
  * @deprecated use PersistedOptionsState - this is only used in the migration
  */
-export type LegacyExtensionObjectShapeState = {
+export type LegacyModComponentObjectShapeState = {
   // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- Record doesn't allow labelled keys
   extensions: {
     // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- Record doesn't allow labelled keys
@@ -33,22 +33,22 @@ export type LegacyExtensionObjectShapeState = {
   };
 };
 
-export type ExtensionOptionsState = {
+export type ModComponentOptionsState = {
   extensions: ActivatedModComponent[];
 };
 
 /**
- * @deprecated use ExtensionOptionsState - this is only used in a migration
+ * @deprecated use ModComponentOptionsState - this is only used in a migration
  */
-export type LegacyExtensionObjectState = {
+export type LegacyModComponentObjectState = {
   extensions: UnresolvedModComponent[];
 };
 
 export type OptionsState =
-  | LegacyExtensionObjectShapeState
-  | LegacyExtensionObjectState
-  | ExtensionOptionsState;
+  | LegacyModComponentObjectShapeState
+  | LegacyModComponentObjectState
+  | ModComponentOptionsState;
 
-export type ExtensionsRootState = {
+export type ModComponentsRootState = {
   options: OptionsState;
 };

--- a/src/store/optionsStore.ts
+++ b/src/store/optionsStore.ts
@@ -21,7 +21,7 @@ import { createLogger } from "redux-logger";
 import { connectRouter, routerMiddleware } from "connected-react-router";
 import { createHashHistory } from "history";
 import { boolean } from "@/utils";
-import { type ExtensionsRootState } from "@/store/extensionsTypes";
+import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import servicesSlice, {
   persistServicesConfig,
   type ServicesRootState,
@@ -69,7 +69,7 @@ export const hashHistory = createHashHistory({ hashType: "slash" });
 export type RootState = AuthRootState &
   LogRootState &
   ModsPageRootState &
-  ExtensionsRootState &
+  ModComponentsRootState &
   ServicesRootState &
   SettingsRootState &
   WorkshopRootState &

--- a/src/store/uninstallUtils.ts
+++ b/src/store/uninstallUtils.ts
@@ -23,7 +23,7 @@ import {
 import { actions as extensionActions } from "@/store/extensionsSlice";
 import { removeExtensionForEveryTab } from "@/background/messenger/api";
 import { uniq } from "lodash";
-import { type UnresolvedExtension } from "@/types/extensionTypes";
+import { type UnresolvedModComponent } from "@/types/extensionTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type UUID } from "@/types/stringTypes";
 
@@ -37,7 +37,7 @@ import { type UUID } from "@/types/stringTypes";
  */
 export async function uninstallRecipe(
   recipeId: RegistryId,
-  recipeExtensions: UnresolvedExtension[],
+  recipeExtensions: UnresolvedModComponent[],
   dispatch: Dispatch<unknown>
 ): Promise<void> {
   const dynamicElementsToUninstall = await removeDynamicElementsForRecipe(

--- a/src/testUtils/factories/extensionFactories.ts
+++ b/src/testUtils/factories/extensionFactories.ts
@@ -91,7 +91,7 @@ export const persistedExtensionFactory = extend<
 >(extensionFactory, {
   createTimestamp: timestampFactory,
   updateTimestamp: timestampFactory,
-  _unresolvedExtensionBrand: undefined,
+  _unresolvedModComponentBrand: undefined,
   active: true,
 });
 

--- a/src/types/extensionPointTypes.ts
+++ b/src/types/extensionPointTypes.ts
@@ -34,12 +34,12 @@ export type Location =
 
 export type StarterBrick = Metadata & {
   /**
-   * The kind of extension point.
+   * The kind of StarterBrick.
    */
   kind: string;
 
   /**
-   * The input schema for extension point-specific configuration.
+   * The input schema for StarterBrick-specific configuration.
    */
   inputSchema: Schema;
 
@@ -49,12 +49,12 @@ export type StarterBrick = Metadata & {
   defaultOptions: UnknownObject;
 
   /**
-   * Permissions required to use the extension point.
+   * Permissions required to use the StarterBrick.
    */
   permissions: Permissions.Permissions;
 
   /**
-   * Return the Reader used by the extension point. This method should only be called for calculating availability
+   * Return the Reader used by the StarterBrick. This method should only be called for calculating availability
    * and the schema, as it may include stub readers.
    *
    * @see StarterBrick.previewReader
@@ -69,7 +69,7 @@ export type StarterBrick = Metadata & {
   previewReader: () => Promise<Reader>;
 
   /**
-   * Return true if the extension point is available on the current page. Based on:
+   * Return true if the StarterBrick is available on the current page. Based on:
    *
    * - URL match patterns
    * - URL pattern rules
@@ -78,38 +78,38 @@ export type StarterBrick = Metadata & {
   isAvailable: () => Promise<boolean>;
 
   /**
-   * True iff the extension point must be installed before the page can be considered ready
+   * True if the StarterBrick must be installed before the page can be considered ready
    */
   syncInstall: boolean;
 
   /**
-   * Install/add the extension point to the page.
+   * Install/add the StarterBrick to the page.
    */
   install(): Promise<boolean>;
 
   /**
-   * Remove the extension point and installed extensions from the page.
+   * Remove the StarterBrick and installed ModComponents from the page.
    */
   uninstall(options?: { global?: boolean }): void;
 
   /**
-   * Remove the extension from the extension point.
+   * Remove the ModComponent from the StarterBrick.
    */
-  removeExtension(extensionId: UUID): void;
+  removeExtension(modComponentId: UUID): void;
 
   /**
-   * Register an extension with the extension point. Does not actually install/run the extension.
+   * Register an ModComponent with the StarterBrick. Does not actually install/run the ModComponent.
    */
-  addExtension(extension: ResolvedModComponent): void;
+  addExtension(modComponent: ResolvedModComponent): void;
 
   /**
-   * Sync registered extensions, removing any extensions that aren't provided here. Does not actually install/run
-   * the extensions.
+   * Sync registered ModComponents, removing any ModComponents that aren't provided here. Does not actually install/run
+   * the ModComponents.
    */
-  syncExtensions(extensions: ResolvedModComponent[]): void;
+  syncExtensions(modComponents: ResolvedModComponent[]): void;
 
   /**
-   * Run the installed extensions for extension point.
+   * Run the installed ModComponents for StarterBrick.
    */
   run(args: RunArgs): Promise<void>;
 
@@ -118,5 +118,5 @@ export type StarterBrick = Metadata & {
    *
    * @see PipelineExpression
    */
-  getBlocks: (extension: ResolvedModComponent) => Promise<Brick[]>;
+  getBlocks: (modComponent: ResolvedModComponent) => Promise<Brick[]>;
 };

--- a/src/types/extensionPointTypes.ts
+++ b/src/types/extensionPointTypes.ts
@@ -18,7 +18,7 @@
 import { type Permissions } from "webextension-polyfill";
 import { type Schema } from "@/types/schemaTypes";
 import { type UUID } from "@/types/stringTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type RunArgs } from "@/types/runtimeTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
@@ -100,13 +100,13 @@ export type StarterBrick = Metadata & {
   /**
    * Register an extension with the extension point. Does not actually install/run the extension.
    */
-  addExtension(extension: ResolvedExtension): void;
+  addExtension(extension: ResolvedModComponent): void;
 
   /**
    * Sync registered extensions, removing any extensions that aren't provided here. Does not actually install/run
    * the extensions.
    */
-  syncExtensions(extensions: ResolvedExtension[]): void;
+  syncExtensions(extensions: ResolvedModComponent[]): void;
 
   /**
    * Run the installed extensions for extension point.
@@ -118,5 +118,5 @@ export type StarterBrick = Metadata & {
    *
    * @see PipelineExpression
    */
-  getBlocks: (extension: ResolvedExtension) => Promise<Brick[]>;
+  getBlocks: (extension: ResolvedModComponent) => Promise<Brick[]>;
 };

--- a/src/types/extensionTypes.ts
+++ b/src/types/extensionTypes.ts
@@ -38,7 +38,7 @@ import { type ModDefinition } from "@/types/modDefinitionTypes";
 /**
  * ModMetadata that includes sharing information.
  *
- * We created this type as an alternative to Metadata in order to include information about the origin of an extension,
+ * We created this type as an alternative to Metadata in order to include information about the origin of a ModComponent,
  * e.g. on the ActiveBricks page.
  *
  * @see optionsSlice
@@ -87,7 +87,7 @@ type DeploymentMetadata = {
 // XXX: technically Config could be JsonObject, but that's annoying to work with at callsites.
 export type ModComponentBase<Config extends UnknownObject = UnknownObject> = {
   /**
-   * UUID of the extension.
+   * UUID of the ModComponent.
    */
   id: UUID;
 
@@ -98,29 +98,29 @@ export type ModComponentBase<Config extends UnknownObject = UnknownObject> = {
   apiVersion: ApiVersion;
 
   /**
-   * Registry id of the extension point, or a reference to the definitions section.
+   * Registry id of the StarterBrick, or a reference to the definitions section.
    */
   extensionPointId: RegistryId | InnerDefinitionRef;
 
   /**
-   * Metadata about the deployment used to install the extension, or `undefined` if the extension was not installed
+   * Metadata about the deployment used to install the ModComponent, or `undefined` if the ModComponent was not installed
    * via a deployment.
    */
   _deployment?: DeploymentMetadata;
 
   /**
-   * Metadata about the recipe used to install the extension, or `undefined` if the user created this extension
+   * Metadata about the recipe used to install the ModComponent, or `undefined` if the user created this ModComponent
    * directly
    */
   _recipe: ModMetadata | undefined;
 
   /**
-   * A human-readable label for the extension.
+   * A human-readable label for the ModComponent.
    */
   label: string | null;
 
   /**
-   * Default template engine when running the extension.
+   * Default template engine when running the ModComponent.
    * @deprecated not used in v3 of the runtime
    */
   templateEngine?: TemplateEngine;
@@ -131,19 +131,19 @@ export type ModComponentBase<Config extends UnknownObject = UnknownObject> = {
   permissions?: Permissions.Permissions;
 
   /**
-   * Inner/anonymous definitions used by the extension.
+   * Inner/anonymous definitions used by the ModComponent.
    *
    * Supported definitions:
-   * - extension points
+   * - StarterBricks
    * - components
    * - readers
    *
-   * @see ResolvedExtension
+   * @see ResolvedModComponent
    */
   definitions?: InnerDefinitions;
 
   /**
-   * Configured services/integrations for the extension.
+   * Configured services/integrations for the ModComponent.
    */
   services?: IntegrationDependency[];
 
@@ -153,14 +153,14 @@ export type ModComponentBase<Config extends UnknownObject = UnknownObject> = {
   optionsArgs?: OptionsArgs;
 
   /**
-   * The extension configuration for the extension point.
+   * The ModComponent configuration for the StarterBrick.
    */
   config: Config;
 
   /**
-   * True iff the extension is activated in the client
+   * True if the ModComponent is activated in the client
    *
-   * For extensions on the server, but not activated on the client, this will be false.
+   * For ModComponents on the server, but not activated on the client, this will be false.
    */
   active?: boolean;
 };
@@ -168,27 +168,28 @@ export type ModComponentBase<Config extends UnknownObject = UnknownObject> = {
 /**
  * An ModComponentBase that is known not to have had its definitions resolved.
  *
- * NOTE: it might be the case that the extension does not have a definitions section/inner definitions. This nominal
+ * NOTE: it might be the case that the ModComponent does not have a definitions section/inner definitions. This nominal
  * type is just tracking whether we've passed the instance through resolution yet.
  *
  * @see ModComponentBase
- * @see ResolvedExtension
+ * @see ResolvedModComponent
  */
-export type UnresolvedExtension<Config extends UnknownObject = UnknownObject> =
-  ModComponentBase<Config> & {
-    _unresolvedExtensionBrand: never;
-  };
+export type UnresolvedModComponent<
+  Config extends UnknownObject = UnknownObject
+> = ModComponentBase<Config> & {
+  _unresolvedExtensionBrand: never;
+};
 
 /**
- * An extension that has been saved locally
+ * A ModComponent that has been saved locally
  * @see ModComponentBase
  * @see UserExtension
  */
 export type ActivatedModComponent<
   Config extends UnknownObject = UnknownObject
-> = UnresolvedExtension<Config> & {
+> = UnresolvedModComponent<Config> & {
   /**
-   * True to indicate this extension has been activated on the client.
+   * True to indicate this ModComponent has been activated on the client.
    */
   active: true;
 
@@ -211,14 +212,14 @@ export type ActivatedModComponent<
  * An `ModComponentBase` with all inner definitions resolved.
  * @see resolveDefinitions
  */
-export type ResolvedExtension<Config extends UnknownObject = UnknownObject> =
+export type ResolvedModComponent<Config extends UnknownObject = UnknownObject> =
   Except<
     ModComponentBase<Config>,
     // There's no definition section after resolution
     "definitions"
   > & {
     /**
-     * The registry id of the extension point (will be an `@internal` scope, if the extension point was originally defined
+     * The registry id of the StarterBrick (will be an `@internal` scope, if the StarterBrick was originally defined
      * internally.
      */
     extensionPointId: RegistryId;
@@ -232,19 +233,19 @@ export type ResolvedExtension<Config extends UnknownObject = UnknownObject> =
 /**
  * A reference to an ModComponentBase.
  */
-export type ExtensionRef = {
+export type ModComponentRef = {
   /**
-   * UUID of the extension.
+   * UUID of the ModComponent.
    */
   extensionId: UUID;
 
   /**
-   * Registry id of the extension point.
+   * Registry id of the StarterBrick.
    */
   extensionPointId: RegistryId;
 
   /**
-   * Blueprint the extension is from.
+   * Mod the ModComponent is from.
    */
   blueprintId: RegistryId | null;
 };
@@ -252,7 +253,7 @@ export type ExtensionRef = {
 /**
  * Select information about the ModDefinition used to install an ModComponentBase
  *
- * TODO: move to extensionHelpers file once we have it
+ * TODO: move to modComponentHelpers file once we have it
  *
  * @see ModComponentBase._recipe
  */

--- a/src/types/extensionTypes.ts
+++ b/src/types/extensionTypes.ts
@@ -177,7 +177,7 @@ export type ModComponentBase<Config extends UnknownObject = UnknownObject> = {
 export type UnresolvedModComponent<
   Config extends UnknownObject = UnknownObject
 > = ModComponentBase<Config> & {
-  _unresolvedExtensionBrand: never;
+  _unresolvedModComponentBrand: never;
 };
 
 /**
@@ -227,7 +227,7 @@ export type ResolvedModComponent<Config extends UnknownObject = UnknownObject> =
     /**
      * Brand for nominal typing.
      */
-    _resolvedExtensionBrand: never;
+    _resolvedModComponentBrand: never;
   };
 
 /**

--- a/src/types/modDefinitionTypes.ts
+++ b/src/types/modDefinitionTypes.ts
@@ -38,40 +38,40 @@ export type ModOptionsDefinition = {
 };
 
 /**
- * An extension defined in a mod.
+ * An ModComponent defined in a mod.
  * @see ModDefinition.extensionPoints
  */
 export type ModComponentDefinition = {
   /**
-   * The id of the ExtensionPoint.
+   * The id of the StarterBrick.
    */
   id: RegistryId | InnerDefinitionRef;
 
   /**
-   * Human-readable name for the extension to display in the UI.
+   * Human-readable name for the ModComponent to display in the UI.
    */
   label: string;
 
   /**
-   * Additional permissions required by the configured extension. This section will generally be missing/blank unless
-   * the permissions need to be declared to account for dynamic URLs accessed by the extension.
+   * Additional permissions required by the configured ModComponent. This section will generally be missing/blank unless
+   * the permissions need to be declared to account for dynamic URLs accessed by the ModComponent.
    */
   permissions?: Permissions.Permissions;
 
   /**
-   * Services to make available to the extension. During activation, the user will be prompted to select a credential
+   * Services to make available to the ModComponent. During activation, the user will be prompted to select a credential
    * for each service entry.
    */
   services?: Record<OutputKey, RegistryId>;
 
   /**
-   * The default template engine for the extension.
+   * The default template engine for the ModComponent.
    * @deprecated in apiVersion v3 the expression engine is controlled explicitly
    */
   templateEngine?: TemplateEngine;
 
   /**
-   * The extension configuration.
+   * The ModComponent configuration.
    */
   config: UnknownObject;
 };
@@ -80,11 +80,11 @@ export type ModComponentDefinition = {
  * An ModComponentDefinition with all inner definition references resolved.
  * @see resolveDefinitions
  */
-export type ResolvedExtensionDefinition = ModComponentDefinition & {
+export type ResolvedModComponentDefinition = ModComponentDefinition & {
   // Known to be a registry id instead of an InnerDefinitionRef
   id: RegistryId;
 
-  _resolvedExtensionDefinitionBrand: never;
+  _resolvedModComponentDefinitionBrand: never;
 };
 
 /**
@@ -120,7 +120,7 @@ type SharingDefinition = {
 };
 
 /**
- * Config of a Package returned from the PixieBrix API. Used to install extensions.
+ * Config of a Package returned from the PixieBrix API. Used to install ModComponents.
  *
  * If you are creating a mod definition locally, you probably want UnsavedModDefinition, which doesn't include
  * the `sharing` and `updated_at` fields which aren't stored on the YAML/JSON, but are added by the server on responses.

--- a/src/types/modTypes.ts
+++ b/src/types/modTypes.ts
@@ -17,7 +17,7 @@
 
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { type Organization } from "@/types/contract";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { type RegistryId } from "@/types/registryTypes";
 
 /**
@@ -33,7 +33,7 @@ export type UnavailableMod = Pick<
 };
 
 // XXX: should this be UnresolvedExtension instead of ResolvedExtension? The old screens used ResolvedExtension
-export type Mod = ModDefinition | ResolvedExtension | UnavailableMod;
+export type Mod = ModDefinition | ResolvedModComponent | UnavailableMod;
 
 export type SharingType = "Personal" | "Team" | "Public" | "Deployment";
 export type SharingSource = {

--- a/src/types/modTypes.ts
+++ b/src/types/modTypes.ts
@@ -32,7 +32,7 @@ export type UnavailableMod = Pick<
   isStub: true;
 };
 
-// XXX: should this be UnresolvedExtension instead of ResolvedExtension? The old screens used ResolvedExtension
+// XXX: should this be UnresolvedModComponent instead of ResolvedModComponent? The old screens used ResolvedModComponent
 export type Mod = ModDefinition | ResolvedModComponent | UnavailableMod;
 
 export type SharingType = "Personal" | "Team" | "Public" | "Deployment";

--- a/src/types/registryTypes.ts
+++ b/src/types/registryTypes.ts
@@ -51,7 +51,7 @@ export type SemVerString = string & {
 };
 
 /**
- * Metadata about a block, extension point, service, or recipe.
+ * Metadata about a Brick, StarterBrick, Integration, or recipe.
  */
 export interface Metadata {
   /**
@@ -66,7 +66,7 @@ export interface Metadata {
 
   readonly description?: string;
 
-  // Currently optional because it defaults to the browser extension version for blocks defined in JS
+  // Currently optional because it defaults to the browser extension version for bricks defined in JS
   readonly version?: SemVerString;
 
   /**
@@ -75,7 +75,7 @@ export interface Metadata {
   readonly icon?: BrickIcon;
 
   /**
-   * PixieBrix extension version required to install the brick/run the extension
+   * PixieBrix extension version required to install the brick/run the ModComponent
    * @since 1.4.0
    */
   // FIXME: this type is wrong. In practice, the value should be a semantic version range, e.g., >=1.4.0

--- a/src/types/rendererTypes.ts
+++ b/src/types/rendererTypes.ts
@@ -25,11 +25,11 @@ type BaseRendererPayload = {
    */
   key: string;
   /**
-   * The extension the produced the payload.
+   * The ModComponent that produced the payload.
    */
   extensionId: UUID;
   /**
-   * The extension run that produced the payload
+   * The ModComponent run that produced the payload
    * @since 1.7.0
    */
   runId: UUID;

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -136,7 +136,7 @@ export type DeferExpression<TValue = UnknownObject> = Expression<
 >;
 
 /**
- * The extension run reason.
+ * The ModComponent run reason.
  * @since 1.6.5
  */
 export enum RunReason {
@@ -152,15 +152,15 @@ export enum RunReason {
   NAVIGATE = 2,
   /**
    * A manual run request. One of:
-   * - The user toggled the sidebar (sidebar extensions only)
+   * - The user toggled the sidebar (sidebar ModComponents only)
    * - A brick issued a reactivation event
    * - PixieBrix issues a re-activate (e.g., on extension install/uninstall)
    */
   MANUAL = 3,
   /**
-   * Experimental: a declared dependency of the extension point changed.
+   * Experimental: a declared dependency of the StarterBrick changed.
    *
-   * See MenuItemExtensionPoint
+   * See MenuItemStarterBrickABC
    */
   DEPENDENCY_CHANGED = 4,
   /**
@@ -168,7 +168,7 @@ export enum RunReason {
    */
   MUTATION = 5,
   /**
-   * Page Editor updated the extension
+   * Page Editor updated the ModComponent
    * @since 1.7.19
    */
   PAGE_EDITOR = 6,
@@ -180,11 +180,11 @@ export enum RunReason {
  */
 export type RunArgs = {
   /**
-   * The reason for running the extension point.
+   * The reason for running the StarterBrick.
    */
   reason: RunReason;
   /**
-   * If provided, only run the specified extensions.
+   * If provided, only run the specified ModComponents.
    */
   extensionIds?: UUID[];
 };

--- a/src/types/sidebarTypes.ts
+++ b/src/types/sidebarTypes.ts
@@ -24,7 +24,7 @@ import {
   type RendererRunPayload,
 } from "@/types/rendererTypes";
 import { type MessageContext } from "@/types/loggerTypes";
-import { type ExtensionOptionsState } from "@/store/extensionsTypes";
+import { type ModComponentOptionsState } from "@/store/extensionsTypes";
 
 /**
  * Entry types supported by the sidebar.
@@ -327,6 +327,6 @@ export type SidebarState = SidebarEntries & {
 };
 
 export interface SidebarRootState {
-  options: ExtensionOptionsState;
+  options: ModComponentOptionsState;
   sidebar: SidebarState;
 }

--- a/src/types/sidebarTypes.ts
+++ b/src/types/sidebarTypes.ts
@@ -120,15 +120,15 @@ type BasePanelEntry = {
  * A panel added to the page by an ModComponentBase.
  *
  * @see DisplayTemporaryInfo
- * @see SidebarExtensionPoint
+ * @see SidebarStarterBrickABC
  */
-export type BaseExtensionPanelEntry = BasePanelEntry & {
+export type BaseModComponentPanelEntry = BasePanelEntry & {
   /**
-   * The id of the extension that added the panel
+   * The id of the ModComponent that added the panel
    */
   extensionId: UUID;
   /**
-   * The blueprint associated with the extension that added the panel.
+   * The blueprint associated with the ModComponent that added the panel.
    *
    * Used to:
    * - Give preference to blueprint side panels when using the "Show Sidebar" brick.
@@ -152,21 +152,21 @@ export type BaseExtensionPanelEntry = BasePanelEntry & {
   actions?: PanelButton[];
 };
 
-export function isBaseExtensionPanelEntry(
+export function isBaseModComponentPanelEntry(
   panel: unknown
-): panel is BaseExtensionPanelEntry {
-  return (panel as BaseExtensionPanelEntry)?.extensionId != null;
+): panel is BaseModComponentPanelEntry {
+  return (panel as BaseModComponentPanelEntry)?.extensionId != null;
 }
 
 /**
- * A panel added by an extension attached to an SidebarExtensionPoint
- * @see SidebarExtensionPoint
+ * A panel added by an ModComponent attached to an SidebarStarterBrickABC
+ * @see SidebarStarterBrickABC
  */
-export type PanelEntry = BaseExtensionPanelEntry & {
+export type PanelEntry = BaseModComponentPanelEntry & {
   type: "panel";
   /**
    * The sidebar extension point
-   * @see SidebarExtensionPoint
+   * @see SidebarStarterBrickABC
    */
   extensionPointId: RegistryId;
 };
@@ -178,7 +178,7 @@ export function isPanelEntry(panel: unknown): panel is PanelEntry {
 /**
  * An ephemeral panel to show in the sidebar. Only one temporary panel can be shown from an extension at a time.
  */
-export type TemporaryPanelEntry = BaseExtensionPanelEntry & {
+export type TemporaryPanelEntry = BaseModComponentPanelEntry & {
   type: "temporaryPanel";
   /**
    * Unique identifier for the temporary panel instance. Used to correlate panel-close action.

--- a/src/utils/includesQuickBarExtensionPoint.ts
+++ b/src/utils/includesQuickBarExtensionPoint.ts
@@ -16,8 +16,8 @@
  */
 
 import extensionPointRegistry from "@/extensionPoints/registry";
-import { QuickBarExtensionPoint } from "@/extensionPoints/quickBarExtension";
-import { QuickBarProviderExtensionPoint } from "@/extensionPoints/quickBarProviderExtension";
+import { QuickBarStarterBrickABC } from "@/extensionPoints/quickBarExtension";
+import { QuickBarProviderStarterBrickABC } from "@/extensionPoints/quickBarProviderExtension";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { resolveRecipeInnerDefinitions } from "@/registry/internal";
 
@@ -36,8 +36,8 @@ export default async function includesQuickBarExtensionPoint(
     // eslint-disable-next-line no-await-in-loop -- can break when we find one
     const extensionPoint = await extensionPointRegistry.lookup(id);
     if (
-      QuickBarExtensionPoint.isQuickBarExtensionPoint(extensionPoint) ||
-      QuickBarProviderExtensionPoint.isQuickBarProviderExtensionPoint(
+      QuickBarStarterBrickABC.isQuickBarExtensionPoint(extensionPoint) ||
+      QuickBarProviderStarterBrickABC.isQuickBarProviderExtensionPoint(
         extensionPoint
       )
     ) {

--- a/src/utils/modUtils.test.ts
+++ b/src/utils/modUtils.test.ts
@@ -15,11 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getSharingType, isExtension, isUnavailableMod } from "./modUtils";
+import {
+  getSharingType,
+  isResolvedExtension,
+  isUnavailableMod,
+} from "./modUtils";
 import { uuidv4 } from "@/types/helpers";
 import { UserRole } from "@/types/contract";
 import { type Mod, type UnavailableMod } from "@/types/modTypes";
-import { type ResolvedExtension } from "@/types/extensionTypes";
+import { type ResolvedModComponent } from "@/types/extensionTypes";
 import { extensionFactory } from "@/testUtils/factories/extensionFactories";
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { recipeDefinitionFactory } from "@/testUtils/factories/recipeFactories";
@@ -138,13 +142,13 @@ describe("getSharingType", () => {
 
 describe("isExtension", () => {
   it("returns true for an extension", () => {
-    const mod = extensionFactory() as ResolvedExtension;
-    expect(isExtension(mod)).toBe(true);
+    const mod = extensionFactory() as ResolvedModComponent;
+    expect(isResolvedExtension(mod)).toBe(true);
   });
 
   it("returns false for a recipe", () => {
     const mod = recipeDefinitionFactory();
-    expect(isExtension(mod)).toBe(false);
+    expect(isResolvedExtension(mod)).toBe(false);
   });
 });
 
@@ -162,7 +166,7 @@ describe("isUnavailableMod", () => {
   });
 
   it("returns false for an extension", () => {
-    const mod = extensionFactory() as ResolvedExtension;
+    const mod = extensionFactory() as ResolvedModComponent;
     expect(isUnavailableMod(mod)).toBe(false);
   });
 });

--- a/src/utils/modUtils.test.ts
+++ b/src/utils/modUtils.test.ts
@@ -17,7 +17,7 @@
 
 import {
   getSharingType,
-  isResolvedExtension,
+  isResolvedModComponent,
   isUnavailableMod,
 } from "./modUtils";
 import { uuidv4 } from "@/types/helpers";
@@ -143,12 +143,12 @@ describe("getSharingType", () => {
 describe("isExtension", () => {
   it("returns true for an extension", () => {
     const mod = extensionFactory() as ResolvedModComponent;
-    expect(isResolvedExtension(mod)).toBe(true);
+    expect(isResolvedModComponent(mod)).toBe(true);
   });
 
   it("returns false for a recipe", () => {
     const mod = recipeDefinitionFactory();
-    expect(isResolvedExtension(mod)).toBe(false);
+    expect(isResolvedModComponent(mod)).toBe(false);
   });
 });
 

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -51,7 +51,7 @@ export function isUnavailableMod(mod: Mod): mod is UnavailableMod {
  * Returns true if the mod is a ResolvedExtension, instead of a mod definition.
  * @param mod the mod
  */
-export function isResolvedExtension(mod: Mod): mod is ResolvedModComponent {
+export function isResolvedModComponent(mod: Mod): mod is ResolvedModComponent {
   return "extensionPointId" in mod;
 }
 
@@ -59,8 +59,8 @@ export function isResolvedExtension(mod: Mod): mod is ResolvedModComponent {
  * Return true if the mod is an ModComponentBase that originated from a recipe.
  * @param mod the mod
  */
-export function isExtensionFromRecipe(mod: Mod): boolean {
-  return isResolvedExtension(mod) && Boolean(mod._recipe);
+export function isModComponentFromRecipe(mod: Mod): boolean {
+  return isResolvedModComponent(mod) && Boolean(mod._recipe);
 }
 
 /**
@@ -70,7 +70,7 @@ export function isExtensionFromRecipe(mod: Mod): boolean {
 export function isModDefinition(
   mod: Mod
 ): mod is ModDefinition | UnavailableMod {
-  return !isResolvedExtension(mod);
+  return !isResolvedModComponent(mod);
 }
 
 /**
@@ -78,7 +78,7 @@ export function isModDefinition(
  * @param mod the mod
  */
 export function getUniqueId(mod: Mod): UUID | RegistryId {
-  return isResolvedExtension(mod) ? mod.id : mod.metadata.id;
+  return isResolvedModComponent(mod) ? mod.id : mod.metadata.id;
 }
 
 /**
@@ -86,7 +86,7 @@ export function getUniqueId(mod: Mod): UUID | RegistryId {
  * @param mod the mod
  */
 export function getLabel(mod: Mod): string {
-  return isResolvedExtension(mod) ? mod.label : mod.metadata.name;
+  return isResolvedModComponent(mod) ? mod.label : mod.metadata.name;
 }
 
 /**
@@ -94,11 +94,11 @@ export function getLabel(mod: Mod): string {
  * @param mod the mod
  */
 export const getDescription = (mod: Mod): string => {
-  const description = isResolvedExtension(mod)
+  const description = isResolvedModComponent(mod)
     ? mod._recipe?.description
     : mod.metadata.description;
 
-  if (!description && isResolvedExtension(mod)) {
+  if (!description && isResolvedModComponent(mod)) {
     return "Created in the Page Editor";
   }
 
@@ -110,7 +110,7 @@ export const getDescription = (mod: Mod): string => {
  * @param mod the mod
  */
 export function getPackageId(mod: Mod): RegistryId | null {
-  return isResolvedExtension(mod) ? mod._recipe?.id : mod.metadata.id;
+  return isResolvedModComponent(mod) ? mod._recipe?.id : mod.metadata.id;
 }
 
 /**
@@ -118,19 +118,19 @@ export function getPackageId(mod: Mod): RegistryId | null {
  * @param mod the mod
  */
 export function getUpdatedAt(mod: Mod): string | null {
-  return isResolvedExtension(mod)
+  return isResolvedModComponent(mod)
     ? // @ts-expect-error -- TODO: need to figure out why updateTimestamp isn't included on ModComponentBase here
       mod._recipe?.updated_at ?? mod.updateTimestamp
     : mod.updated_at;
 }
 
 function isPublic(mod: Mod): boolean {
-  return isResolvedExtension(mod)
+  return isResolvedModComponent(mod)
     ? mod._recipe?.sharing?.public
     : mod.sharing.public;
 }
 
-function isPersonalExtension(extension: ModComponentBase): boolean {
+function isPersonalModComponent(extension: ModComponentBase): boolean {
   return !extension._recipe && !extension._deployment;
 }
 
@@ -151,8 +151,10 @@ function hasRecipeScope(recipe: ModDefinition | UnavailableMod, scope: string) {
  * @param userScope the user's scope, or null if it's not set
  */
 function isPersonal(mod: Mod, userScope: string | null) {
-  if (isResolvedExtension(mod)) {
-    return isPersonalExtension(mod) || hasSourceRecipeWithScope(mod, userScope);
+  if (isResolvedModComponent(mod)) {
+    return (
+      isPersonalModComponent(mod) || hasSourceRecipeWithScope(mod, userScope)
+    );
   }
 
   return hasRecipeScope(mod, userScope);
@@ -162,7 +164,7 @@ export function getInstalledVersionNumber(
   installedExtensions: UnresolvedModComponent[],
   mod: Mod
 ): string | null {
-  if (isResolvedExtension(mod)) {
+  if (isResolvedModComponent(mod)) {
     return mod._recipe?.version;
   }
 
@@ -178,7 +180,7 @@ export function isDeployment(
   mod: Mod,
   installedExtensions: UnresolvedModComponent[]
 ): boolean {
-  if (isResolvedExtension(mod)) {
+  if (isResolvedModComponent(mod)) {
     return Boolean(mod._deployment);
   }
 
@@ -300,7 +302,9 @@ function getOrganization(
   mod: Mod,
   organizations: Organization[]
 ): Organization {
-  const sharing = isResolvedExtension(mod) ? mod._recipe?.sharing : mod.sharing;
+  const sharing = isResolvedModComponent(mod)
+    ? mod._recipe?.sharing
+    : mod.sharing;
 
   if (!sharing || sharing.organizations.length === 0) {
     return null;


### PR DESCRIPTION
## What does this PR do?

- Part of #5994

## Reviewer Tips
- see `src/types/extensionTypes.ts` for type name changes that weren't in the spec

## Discussion
- covers some final name changes
- includes typeguard name changes

## Future Work
- Rename types files to better fit new types
- Rename factory functions

## Checklist

- [ ] Designate a primary reviewer
