### PR TITLE
#6102: fix duplicate menus/panels

### DIFF
--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -49,12 +49,18 @@ type SelectionMenuOptions = {
   documentUrlPatterns: string[];
 };
 
+/**
+ * Return a unique context menu item id for the given extension id.
+ * @param extensionId
+ */
 function makeMenuId(extensionId: UUID): string {
   return `${MENU_PREFIX}${extensionId}`;
 }
 
 /**
+ * Dispatch a Chrome context menu event to the corresponding content script.
  * FIXME: this method doesn't handle frames
+ * @see handleMenuAction
  */
 async function dispatchMenu(
   info: Menus.OnClickData,
@@ -124,9 +130,13 @@ export async function uninstallContextMenu({
   }
 }
 
+/**
+ * Register a context menu item.
+ */
 export const ensureContextMenu = memoizeUntilSettled(_ensureContextMenu, {
   cacheKey: ([{ extensionId }]) => extensionId,
 });
+
 async function _ensureContextMenu({
   extensionId,
   contexts,
@@ -162,6 +172,11 @@ async function _ensureContextMenu({
   }
 }
 
+/**
+ * Add context menu items to the Chrome context menu, in anticipation that on Page Load, the content script will
+ * register a handler for the item.
+ * @param extensions the ModComponent to preload.
+ */
 export async function preloadContextMenus(
   extensions: ModComponentBase[]
 ): Promise<void> {

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -36,7 +36,7 @@ import {
   hideSidebar,
   showSidebar,
   rehydrateSidebar,
-  removeExtension as removeSidebar,
+  removeExtensions as removeSidebars,
   reloadSidebar,
   getReservedPanelEntries,
 } from "@/contentScript/sidebarController";
@@ -103,7 +103,7 @@ declare global {
     HIDE_SIDEBAR: typeof hideSidebar;
     GET_RESERVED_SIDEBAR_ENTRIES: typeof getReservedPanelEntries;
     RELOAD_SIDEBAR: typeof reloadSidebar;
-    REMOVE_SIDEBAR: typeof removeSidebar;
+    REMOVE_SIDEBARS: typeof removeSidebars;
 
     INSERT_PANEL: typeof insertPanel;
     INSERT_BUTTON: typeof insertButton;
@@ -167,7 +167,7 @@ export default function registerMessenger(): void {
     SHOW_SIDEBAR: showSidebar,
     HIDE_SIDEBAR: hideSidebar,
     RELOAD_SIDEBAR: reloadSidebar,
-    REMOVE_SIDEBAR: removeSidebar,
+    REMOVE_SIDEBARS: removeSidebars,
 
     INSERT_PANEL: insertPanel,
     INSERT_BUTTON: insertButton,

--- a/src/contentScript/ready.ts
+++ b/src/contentScript/ready.ts
@@ -116,3 +116,19 @@ export async function getTargetState(target: Target): Promise<TargetState> {
     };
   });
 }
+
+let reloadOnNextNavigate = false;
+
+/**
+ * Return true if the mods should be reloaded on the next navigation.
+ */
+export function getReloadOnNextNavigate(): boolean {
+  return reloadOnNextNavigate;
+}
+
+/**
+ * Set if the mods should be reloaded on the next navigation.
+ */
+export function setReloadOnNextNavigate(value: boolean): void {
+  reloadOnNextNavigate = value;
+}

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -304,16 +304,18 @@ export function hideTemporarySidebarPanel(nonce: UUID): void {
   void sidebarInThisTab.hideTemporaryPanel(sequence, nonce);
 }
 
-export function removeExtension(extensionId: UUID): void {
+/**
+ * Remove all panels associated with given extensionIds.
+ * @param extensionIds the extension UUIDs to remove
+ */
+export function removeExtensions(extensionIds: UUID[]): void {
   expectContext("contentScript");
 
-  console.debug("sidebarController:removeExtension %s", extensionId, {
-    panel: panels.find((x) => x.extensionId === extensionId),
-  });
+  console.debug("sidebarController:removeExtensions", { extensionIds });
 
   // `panels` is const, so replace the contents
   const current = panels.splice(0, panels.length);
-  panels.push(...current.filter((x) => x.extensionId !== extensionId));
+  panels.push(...current.filter((x) => !extensionIds.includes(x.extensionId)));
   renderPanelsIfVisible();
 }
 

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -66,6 +66,7 @@ import { type Schema } from "@/types/schemaTypes";
 import { type ResolvedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type StarterBrick } from "@/types/starterBrickTypes";
+import { type UUID } from "@/types/stringTypes";
 
 export type ContextMenuTargetMode =
   // In `legacy` mode, the target was passed to the readers but the document is passed to reducePipeline
@@ -178,8 +179,21 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
     }
   }
 
-  clearExtensionInterfaceAndEvents(): void {
-    // Don't need to do any cleanup since context menu registration is handled globally
+  /**
+   * Remove the context menu items for the given extensions from all tabs/contexts.
+   * @see uninstallContextMenu
+   * @see preloadContextMenus
+   */
+  clearExtensionInterfaceAndEvents(extensionIds: UUID[]): void {
+    // Context menus are registered with Chrome by document pattern via the background page. Therefore, it's impossible
+    // to clear the UI menu item from a single tab. Calling `uninstallContextMenu` removes the tab from all menus.
+
+    // Uninstalling context menus is the least-bad approach because it prevents duplicate menu item titles due to
+    // re-activating a context menu (during re-activation, mod components get new extensionIds.)
+
+    for (const extensionId of extensionIds) {
+      void uninstallContextMenu({ extensionId });
+    }
   }
 
   async install(): Promise<boolean> {

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -32,6 +32,7 @@ import { checkAvailable } from "@/bricks/available";
 import notify from "@/utils/notify";
 import {
   removeExtensionPoint,
+  removeExtensions,
   reservePanels,
   sidebarShowEvents,
   updateHeading,
@@ -44,7 +45,7 @@ import {
   makeShouldRunExtensionForStateChange,
   selectExtensionContext,
 } from "@/starterBricks/helpers";
-import { cloneDeep, debounce, stubTrue } from "lodash";
+import { cloneDeep, debounce, remove, stubTrue } from "lodash";
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { selectAllBlocks } from "@/bricks/util";
@@ -131,12 +132,13 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     return selectAllBlocks(extension.config.body);
   }
 
-  clearExtensionInterfaceAndEvents(): void {
-    this.extensions.splice(0, this.extensions.length);
+  clearExtensionInterfaceAndEvents(extensionIds: UUID[]): void {
+    removeExtensions(extensionIds);
   }
 
   public override uninstall(): void {
-    this.clearExtensionInterfaceAndEvents();
+    const extensions = this.extensions.splice(0, this.extensions.length);
+    this.clearExtensionInterfaceAndEvents(extensions.map((x) => x.id));
     removeExtensionPoint(this.id);
     console.debug(
       "SidebarStarterBrick:uninstall: stop listening for sidebarShowEvents"
@@ -151,7 +153,8 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
    * @see uninstall
    */
   public HACK_uninstallExceptExtension(extensionId: UUID): void {
-    this.clearExtensionInterfaceAndEvents();
+    // Don't call this.clearExtensionInterfaceAndEvents to keep the panel. Instead, mutate this.extensions to exclude id
+    remove(this.extensions, (x) => x.id === extensionId);
     removeExtensionPoint(this.id, { preserveExtensionIds: [extensionId] });
     console.debug(
       "SidebarStarterBrick:HACK_uninstallExceptExtension: stop listening for sidebarShowEvents"


### PR DESCRIPTION
## What does this PR do?

- Closes #6102
- Fixes `clearExtensionInterfaceAndEvents` to properly clear the UI for context menus and sidebars when lifecycle calls syncExtensions on queued reloads after mod updates

## Discussion

- During a mod update, when the first tab calls syncExtensions on queued navigation, it will remove the menu item and swap in a menu item with a new extensionId and the same name
- The handle on existing tabs will now be invalid

## Demo

- _Paste a screenshot or demo video here_

## Future Work

- Indicate when a context menu failed because it's a new menu item in the Page Editor, and is not available on the tab yet
- Could try being fancy to do menu item name matching to link updated menu items to the old item with the same name/different id

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @mnholtz 
