### PR TITLE
#6119: improve HTTP Brick labelling/lint rules/network error message

### DIFF
--- a/src/analysis/analysisVisitors/httpRequestAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/httpRequestAnalysis.test.ts
@@ -26,7 +26,7 @@ const position: BrickPosition = {
   path: "test.path",
 };
 
-describe("RegexAnalysis", () => {
+describe("httpRequestAnalysis", () => {
   test("flags URL parameters as info", () => {
     const analysis = new HttpRequestAnalysis();
     analysis.visitBrick(
@@ -44,6 +44,11 @@ describe("RegexAnalysis", () => {
     expect(analysis.getAnnotations()).toStrictEqual([
       expect.objectContaining({
         type: AnnotationType.Info,
+        message:
+          "Pro-tip: you can pass URL parameters to the Search Parameters field. When using the Search Parameters field, PixieBrix automatically encodes parameter values.",
+        position: {
+          path: "test.path.config.url",
+        },
       }),
     ]);
   });
@@ -88,6 +93,11 @@ describe("RegexAnalysis", () => {
     expect(analysis.getAnnotations()).toStrictEqual([
       expect.objectContaining({
         type: AnnotationType.Warning,
+        message:
+          "Watch Out: APIs typically expect GET request input via URL Search Parameters instead of JSON data.",
+        position: {
+          path: "test.path.config.data",
+        },
       }),
     ]);
   });
@@ -115,6 +125,11 @@ describe("RegexAnalysis", () => {
     expect(analysis.getAnnotations()).toStrictEqual([
       expect.objectContaining({
         type: AnnotationType.Warning,
+        message:
+          "Watch Out! You are passing the data as text instead of as an object",
+        position: {
+          path: "test.path.config.data",
+        },
       }),
     ]);
   });
@@ -162,6 +177,11 @@ describe("RegexAnalysis", () => {
     expect(analysis.getAnnotations()).toStrictEqual([
       expect.objectContaining({
         type: AnnotationType.Warning,
+        message:
+          "Watch Out: APIs typically expect GET request input via URL Search Parameters instead of JSON data.",
+        position: {
+          path: "test.path.config.data",
+        },
       }),
     ]);
   });

--- a/src/analysis/analysisVisitors/httpRequestAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/httpRequestAnalysis.test.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type BrickPosition } from "@/bricks/types";
+import { type VisitBlockExtra } from "@/bricks/PipelineVisitor";
+import HttpRequestAnalysis from "@/analysis/analysisVisitors/httpRequestAnalysis";
+import { RemoteMethod } from "@/bricks/transformers/remoteMethod";
+import { AnnotationType } from "@/types/annotationTypes";
+import { makeTemplateExpression } from "@/runtime/expressionCreators";
+
+const position: BrickPosition = {
+  path: "test.path",
+};
+
+describe("RegexAnalysis", () => {
+  test("flags URL parameters as info", () => {
+    const analysis = new HttpRequestAnalysis();
+    analysis.visitBrick(
+      position,
+      {
+        id: RemoteMethod.BLOCK_ID,
+        config: {
+          method: "get",
+          url: "https://example.com/?foo=42",
+        },
+      },
+      {} as VisitBlockExtra
+    );
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      expect.objectContaining({
+        type: AnnotationType.Info,
+      }),
+    ]);
+  });
+
+  test("flags passing params as data", () => {
+    const analysis = new HttpRequestAnalysis();
+    analysis.visitBrick(
+      position,
+      {
+        id: RemoteMethod.BLOCK_ID,
+        config: {
+          method: "get",
+          url: "https://example.com",
+          data: {
+            foo: 42,
+          },
+        },
+      },
+      {} as VisitBlockExtra
+    );
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      expect.objectContaining({
+        type: AnnotationType.Warning,
+      }),
+    ]);
+  });
+
+  test("passing string data", () => {
+    const analysis = new HttpRequestAnalysis();
+    analysis.visitBrick(
+      position,
+      {
+        id: RemoteMethod.BLOCK_ID,
+        config: {
+          method: "post",
+          url: "https://example.com",
+          data: makeTemplateExpression(
+            "nunjucks",
+            JSON.stringify({
+              foo: 42,
+            })
+          ),
+        },
+      },
+      {} as VisitBlockExtra
+    );
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      expect.objectContaining({
+        type: AnnotationType.Warning,
+      }),
+    ]);
+  });
+
+  test("passing data for get", () => {
+    const analysis = new HttpRequestAnalysis();
+    analysis.visitBrick(
+      position,
+      {
+        id: RemoteMethod.BLOCK_ID,
+        config: {
+          method: "get",
+          url: "https://example.com",
+          data: {
+            foo: 42,
+          },
+        },
+      },
+      {} as VisitBlockExtra
+    );
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      expect.objectContaining({
+        type: AnnotationType.Warning,
+      }),
+    ]);
+  });
+
+  test("valid get request", () => {
+    const analysis = new HttpRequestAnalysis();
+    analysis.visitBrick(
+      position,
+      {
+        id: RemoteMethod.BLOCK_ID,
+        config: {
+          method: "get",
+          url: "https://example.com",
+          params: {
+            foo: 42,
+          },
+        },
+      },
+      {} as VisitBlockExtra
+    );
+
+    expect(analysis.getAnnotations()).toStrictEqual([]);
+  });
+
+  test("valid post request", () => {
+    const analysis = new HttpRequestAnalysis();
+    analysis.visitBrick(
+      position,
+      {
+        id: RemoteMethod.BLOCK_ID,
+        config: {
+          method: "post",
+          url: "https://example.com",
+          data: {
+            foo: 42,
+          },
+        },
+      },
+      {} as VisitBlockExtra
+    );
+
+    expect(analysis.getAnnotations()).toStrictEqual([]);
+  });
+});

--- a/src/analysis/analysisVisitors/httpRequestAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/httpRequestAnalysis.test.ts
@@ -48,6 +48,26 @@ describe("RegexAnalysis", () => {
     ]);
   });
 
+  test("ignores URL with template", () => {
+    const analysis = new HttpRequestAnalysis();
+    analysis.visitBrick(
+      position,
+      {
+        id: RemoteMethod.BLOCK_ID,
+        config: {
+          method: "get",
+          url: makeTemplateExpression(
+            "nunjucks",
+            "https://example.com/?foo={{ @foo }}"
+          ),
+        },
+      },
+      {} as VisitBlockExtra
+    );
+
+    expect(analysis.getAnnotations()).toStrictEqual([]);
+  });
+
   test("flags passing params as data", () => {
     const analysis = new HttpRequestAnalysis();
     analysis.visitBrick(
@@ -97,6 +117,29 @@ describe("RegexAnalysis", () => {
         type: AnnotationType.Warning,
       }),
     ]);
+  });
+
+  test("ignores data with template", () => {
+    const analysis = new HttpRequestAnalysis();
+    analysis.visitBrick(
+      position,
+      {
+        id: RemoteMethod.BLOCK_ID,
+        config: {
+          method: "post",
+          url: "https://example.com",
+          data: makeTemplateExpression(
+            "nunjucks",
+            JSON.stringify({
+              foo: "{{ @foo }}",
+            })
+          ),
+        },
+      },
+      {} as VisitBlockExtra
+    );
+
+    expect(analysis.getAnnotations()).toStrictEqual([]);
   });
 
   test("passing data for get", () => {

--- a/src/analysis/analysisVisitors/httpRequestAnalysis.ts
+++ b/src/analysis/analysisVisitors/httpRequestAnalysis.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AnalysisVisitorABC } from "./baseAnalysisVisitors";
+import { type BrickConfig, type BrickPosition } from "@/bricks/types";
+import { type VisitBlockExtra } from "@/bricks/PipelineVisitor";
+import { joinPathParts } from "@/utils";
+import { AnnotationType } from "@/types/annotationTypes";
+import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
+import { RemoteMethod } from "@/bricks/transformers/remoteMethod";
+import { isEmpty } from "lodash";
+import { type JsonObject } from "type-fest";
+
+function tryParse(value: unknown): JsonObject | null {
+  if (typeof value === "string") {
+    try {
+      // If payload is JSON, parse it for easier reading
+      return JSON.parse(value);
+    } catch {
+      // NOP
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Visitor to detect common mistakes when using the HTTP Request brick.
+ */
+class HttpRequestAnalysis extends AnalysisVisitorABC {
+  get id() {
+    return "http";
+  }
+
+  override visitBrick(
+    position: BrickPosition,
+    blockConfig: BrickConfig,
+    extra: VisitBlockExtra
+  ) {
+    super.visitBrick(position, blockConfig, extra);
+
+    if (blockConfig.id !== RemoteMethod.BLOCK_ID) {
+      return;
+    }
+
+    const { method, data, params, url } = blockConfig.config;
+
+    let urlLiteral;
+    let dataLiteral;
+    let methodLiteral;
+
+    try {
+      urlLiteral = new URL(castTextLiteralOrThrow(url));
+    } catch {
+      // NOP
+    }
+
+    try {
+      methodLiteral = castTextLiteralOrThrow(method);
+    } catch {
+      // NOP
+    }
+
+    try {
+      dataLiteral = tryParse(castTextLiteralOrThrow(data));
+    } catch {
+      // NOP
+    }
+
+    if (methodLiteral === "get" && !isEmpty(data) && isEmpty(params)) {
+      this.annotations.push({
+        position: {
+          path: joinPathParts(position.path, "config", "data"),
+        },
+        message:
+          "Watch Out: APIs typically expect GET request input via URL Search Parameters instead of JSON data.",
+        analysisId: this.id,
+        type: AnnotationType.Warning,
+      });
+    }
+
+    // URLSearchParams returns a symbol in the iterator
+    if (
+      methodLiteral === "get" &&
+      isEmpty(params) &&
+      urlLiteral &&
+      [...urlLiteral.searchParams.keys()].length > 0
+    ) {
+      this.annotations.push({
+        position: {
+          path: joinPathParts(position.path, "config", "url"),
+        },
+        message:
+          "Pro-tip: you can pass URL parameters to the Search Parameters field. When using the Search Parameters field, PixieBrix automatically encodes parameter values.",
+        analysisId: this.id,
+        type: AnnotationType.Info,
+      });
+    }
+
+    if (dataLiteral) {
+      this.annotations.push({
+        position: {
+          path: joinPathParts(position.path, "config", "data"),
+        },
+        message:
+          "Watch Out! You are passing the data as text instead of as an object",
+        analysisId: this.id,
+        type: AnnotationType.Warning,
+      });
+    }
+
+    if (
+      !["get", "delete", "options"].includes(methodLiteral) &&
+      isEmpty(data) &&
+      !isEmpty(params)
+    ) {
+      this.annotations.push({
+        position: {
+          path: joinPathParts(position.path, "config", "params"),
+        },
+        message: `Watch Out! APIs typically expect input to be passed via data payload instead of URL query parameters for ${methodLiteral} requests`,
+        analysisId: this.id,
+        type: AnnotationType.Warning,
+      });
+    }
+  }
+}
+
+export default HttpRequestAnalysis;

--- a/src/bricks/transformers/remoteMethod.ts
+++ b/src/bricks/transformers/remoteMethod.ts
@@ -27,32 +27,38 @@ import { type SanitizedIntegrationConfig } from "@/types/integrationTypes";
 
 export const inputProperties: Record<string, Schema> = {
   url: {
+    title: "URL",
     type: "string",
-    description: "The API URL",
+    description: "The API endpoint URL",
   },
   service: {
+    title: "Integration Configuration",
     $ref: "https://app.pixiebrix.com/schemas/service#/definitions/configuredService",
     description:
-      "Optional. The service to authenticate the request, if authorization is required",
+      "Optional. The integration configuration to authenticate the request, if authorization is required",
   },
   method: {
+    title: "Method",
     type: "string",
     default: "post",
     description: "The HTTP method",
     enum: ["post", "put", "patch", "delete", "get"],
   },
   params: {
+    title: "Search Parameters",
     type: "object",
     description: "Search/query params",
     additionalProperties: { type: ["string", "number", "boolean"] },
   },
   headers: {
+    title: "Headers",
     type: "object",
     description: "Additional request headers",
     additionalProperties: { type: "string" },
   },
   // Match anything, as valid values are determined by the API being called
   data: {
+    title: "JSON Data",
     description:
       "Supports a JSON payload provided by either a variable or an object",
   },

--- a/src/components/errors/NetworkErrorDetail.tsx
+++ b/src/components/errors/NetworkErrorDetail.tsx
@@ -66,7 +66,7 @@ const NetworkErrorDetail: React.FunctionComponent<{
   const cleanResponse = useMemo(() => {
     if (error.response) {
       const { request, config, data, ...rest } = error.response;
-      // Don't include request or config, since we're showing it the other column
+      // Don't include request or config, because we're showing it the other column
       return {
         ...rest,
         data: tryParse(data),
@@ -94,9 +94,10 @@ const NetworkErrorDetail: React.FunctionComponent<{
             ) : (
               <div className="text-warning">
                 <FontAwesomeIcon icon={faExclamationTriangle} /> PixieBrix does
-                not have permission to access {absoluteUrl}. Specify an
-                Integration to access the API, or add an Extra Permissions rule
-                to the mod.
+                not have permission to access {absoluteUrl}. Contact your IT
+                Administrator for the
+                <code>runtime_blocked_hosts</code> Chrome Browser Extension
+                policy.
               </div>
             )
           }
@@ -108,17 +109,16 @@ const NetworkErrorDetail: React.FunctionComponent<{
         )}
         {cleanResponse == null ? (
           <div>
-            <div>PixieBrix did not receive a response. Possible causes:</div>
-            <ul>
-              <li>
-                Your browser or another extension blocked the request. Check
-                that PixieBrix has permission to the access the host. If
-                PixieBrix is not showing a Grant Permissions button, ensure that
-                the integration has an{" "}
-                <code className="px-0 mx-0">isAvailable</code> section defined
-              </li>
-              <li>The remote server did not respond. Try the request again</li>
-            </ul>
+            <div>
+              PixieBrix did not receive a response. See{" "}
+              <a
+                href="https://docs.pixiebrix.com/network-errors"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Troubleshooting Network Errors
+              </a>
+            </div>
           </div>
         ) : (
           <JsonTree data={cleanResponse} />

--- a/src/components/errors/__snapshots__/getErrorDetails.test.tsx.snap
+++ b/src/components/errors/__snapshots__/getErrorDetails.test.tsx.snap
@@ -268,26 +268,23 @@ exports[`Network error 1`] = `
             fill="currentColor"
           />
         </svg>
-         PixieBrix does not have permission to access https://fail.com. Specify an Integration to access the API, or add an Extra Permissions rule to the mod.
+         PixieBrix does not have permission to access https://fail.com. Contact your IT Administrator for the
+        <code>
+          runtime_blocked_hosts
+        </code>
+         Chrome Browser Extension policy.
       </div>
       <div>
         <div>
-          PixieBrix did not receive a response. Possible causes:
+          PixieBrix did not receive a response. See 
+          <a
+            href="https://docs.pixiebrix.com/network-errors"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Troubleshooting Network Errors
+          </a>
         </div>
-        <ul>
-          <li>
-            Your browser or another extension blocked the request. Check that PixieBrix has permission to the access the host. If PixieBrix is not showing a Grant Permissions button, ensure that the integration has an 
-            <code
-              class="px-0 mx-0"
-            >
-              isAvailable
-            </code>
-             section defined
-          </li>
-          <li>
-            The remote server did not respond. Try the request again
-          </li>
-        </ul>
       </div>
     </div>
     <div

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -42,6 +42,7 @@ import { selectExtensions } from "@/store/extensionsSelectors";
 import { extensionToFormState } from "@/pageEditor/starterBricks/adapter";
 import { getPageState } from "@/contentScript/messenger/api";
 import { thisTab } from "@/pageEditor/utils";
+import HttpRequestAnalysis from "@/analysis/analysisVisitors/httpRequestAnalysis";
 
 const runtimeActions = runtimeSlice.actions;
 
@@ -162,6 +163,13 @@ pageEditorAnalysisManager.registerAnalysisEffect(
 pageEditorAnalysisManager.registerAnalysisEffect(() => new RegexAnalysis(), {
   matcher: isAnyOf(editorActions.editElement, ...nodeListMutationActions),
 });
+
+pageEditorAnalysisManager.registerAnalysisEffect(
+  () => new HttpRequestAnalysis(),
+  {
+    matcher: isAnyOf(editorActions.editElement, ...nodeListMutationActions),
+  }
+);
 
 async function varAnalysisFactory(
   action: PayloadAction<{ extensionId: UUID; records: TraceRecord[] }>,


### PR DESCRIPTION
## What does this PR do?

- Closes #6119 
- Fixes the network error error view
- Implements lint rules, but without quick fixes: https://www.notion.so/pixiebrix/Simplifying-Calling-APIs-with-the-HTTP-Request-brick-6e401bd8524b412ebb14423c85fbc850?pvs=4#8a2aa984c58244a694dcc8aa11a755b3

## Future Work

- Implement quick fixes for the lint rules

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
