### PR TITLE
Drop references to compliance token field

### DIFF
--- a/src/auth/authTypes.ts
+++ b/src/auth/authTypes.ts
@@ -182,10 +182,6 @@ export type AuthUserOrganization = {
    * True if the user is a manager of at least one team deployment.
    */
   isDeploymentManager: boolean;
-  /**
-   * True if the organization's compliance auth token is set
-   */
-  hasComplianceAuthToken: boolean;
 };
 
 export type AuthState = {

--- a/src/auth/authUtils.ts
+++ b/src/auth/authUtils.ts
@@ -35,7 +35,6 @@ export function selectOrganizations(
       role,
       scope,
       is_deployment_manager,
-      has_compliance_auth_token,
     }) => ({
       id: organization,
       name: organization_name,
@@ -43,7 +42,6 @@ export function selectOrganizations(
       role,
       scope,
       isDeploymentManager: is_deployment_manager,
-      hasComplianceAuthToken: has_compliance_auth_token,
     })
   );
 }

--- a/src/testUtils/factories/authFactories.ts
+++ b/src/testUtils/factories/authFactories.ts
@@ -37,7 +37,6 @@ export const organizationStateFactory = define<AuthUserOrganization>({
     return `@organization-${n}`;
   },
   isDeploymentManager: false,
-  hasComplianceAuthToken: false,
 });
 
 /**

--- a/src/types/swagger.ts
+++ b/src/types/swagger.ts
@@ -1267,8 +1267,6 @@ export interface components {
            */
           url: string;
         };
-        /** @description True if the organization's compliance auth token is set */
-        has_compliance_auth_token?: boolean;
       }[];
       group_memberships?: readonly {
         /** Format: uuid */


### PR DESCRIPTION
## What does this PR do?

- Counterpart to https://github.com/pixiebrix/pixiebrix-app/pull/3726
- Pulls in swagger and drops reference to compliance token types

## Discussion

- It looks like the compliance token wasn't used anywhere in the extension project

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @johnnymetz 
