### PR TITLE
Refactor starter brick interface method names

### DIFF
--- a/src/contentScript/lifecycle.test.ts
+++ b/src/contentScript/lifecycle.test.ts
@@ -153,7 +153,7 @@ describe("lifecycle", () => {
       extensionPointId: starterBrick.id,
     });
 
-    starterBrick.addExtension(
+    starterBrick.registerComponent(
       await resolveExtensionInnerDefinitions(modComponent)
     );
 
@@ -189,7 +189,7 @@ describe("lifecycle", () => {
     expect(lifecycleModule.TEST_getPersistedExtensions().size).toBe(1);
     expect(lifecycleModule.getActiveExtensionPoints()).toEqual([starterBrick]);
 
-    starterBrick.addExtension(
+    starterBrick.registerComponent(
       await resolveExtensionInnerDefinitions(modComponent)
     );
 

--- a/src/contentScript/lifecycle.test.ts
+++ b/src/contentScript/lifecycle.test.ts
@@ -153,7 +153,7 @@ describe("lifecycle", () => {
       extensionPointId: starterBrick.id,
     });
 
-    starterBrick.registerComponent(
+    starterBrick.registerModComponent(
       await resolveExtensionInnerDefinitions(modComponent)
     );
 
@@ -189,7 +189,7 @@ describe("lifecycle", () => {
     expect(lifecycleModule.TEST_getPersistedExtensions().size).toBe(1);
     expect(lifecycleModule.getActiveExtensionPoints()).toEqual([starterBrick]);
 
-    starterBrick.registerComponent(
+    starterBrick.registerModComponent(
       await resolveExtensionInnerDefinitions(modComponent)
     );
 

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -187,11 +187,11 @@ async function runExtensionPoint(
  *
  * Used to ensure all sidebar extension points have had a chance to reserve panels before showing the sidebar.
  *
- * @see StarterBrick.syncInstall
+ * @see StarterBrick.isSyncInstall
  */
 export async function ensureInstalled(): Promise<void> {
   const extensionPoints = await loadPersistedExtensionsOnce();
-  const sidebarExtensionPoints = extensionPoints.filter((x) => x.syncInstall);
+  const sidebarExtensionPoints = extensionPoints.filter((x) => x.isSyncInstall);
   // Log to help debug race conditions
   console.debug("lifecycle:ensureInstalled", {
     sidebarExtensionPoints,
@@ -246,7 +246,7 @@ export function TEST_getEditorExtensions(): Map<UUID, StarterBrick> {
 export function removePersistedExtension(extensionId: UUID): void {
   // Leaving the extension point in _activeExtensionPoints. Could consider removing if this was the last extension
   const extensionPoint = _persistedExtensions.get(extensionId);
-  extensionPoint?.removeExtension(extensionId);
+  extensionPoint?.removeComponent(extensionId);
   _persistedExtensions.delete(extensionId);
 }
 
@@ -448,7 +448,7 @@ async function loadPersistedExtensions(): Promise<StarterBrick[]> {
               extensionPointId
             );
 
-            extensionPoint.syncExtensions(extensions);
+            extensionPoint.synchronizeComponents(extensions);
 
             // Mark the extensions as installed
             for (const extension of extensions) {
@@ -614,7 +614,7 @@ export async function handleNavigate({
             });
           });
 
-          if (extensionPoint.syncInstall) {
+          if (extensionPoint.isSyncInstall) {
             await runPromise;
           }
         })

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -169,7 +169,7 @@ async function runExtensionPoint(
     details
   );
 
-  await extensionPoint.runComponents({ reason, extensionIds });
+  await extensionPoint.runModComponents({ reason, extensionIds });
   _activeExtensionPoints.add(extensionPoint);
 
   console.debug(
@@ -246,7 +246,7 @@ export function TEST_getEditorExtensions(): Map<UUID, StarterBrick> {
 export function removePersistedExtension(extensionId: UUID): void {
   // Leaving the extension point in _activeExtensionPoints. Could consider removing if this was the last extension
   const extensionPoint = _persistedExtensions.get(extensionId);
-  extensionPoint?.removeComponent(extensionId);
+  extensionPoint?.removeModComponent(extensionId);
   _persistedExtensions.delete(extensionId);
 }
 
@@ -448,7 +448,7 @@ async function loadPersistedExtensions(): Promise<StarterBrick[]> {
               extensionPointId
             );
 
-            extensionPoint.synchronizeComponents(extensions);
+            extensionPoint.synchronizeModComponents(extensions);
 
             // Mark the extensions as installed
             for (const extension of extensions) {

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -169,7 +169,7 @@ async function runExtensionPoint(
     details
   );
 
-  await extensionPoint.run({ reason, extensionIds });
+  await extensionPoint.runComponents({ reason, extensionIds });
   _activeExtensionPoints.add(extensionPoint);
 
   console.debug(

--- a/src/contentScript/pageEditor/dynamic.ts
+++ b/src/contentScript/pageEditor/dynamic.ts
@@ -128,7 +128,7 @@ export async function updateDynamicElement({
   // In practice, should be a no-op because the Page Editor handles the extensionPoint
   const resolved = await resolveExtensionInnerDefinitions(extensionConfig);
 
-  starterBrick.registerComponent(resolved);
+  starterBrick.registerModComponent(resolved);
   await runEditorExtension(extensionConfig.id, starterBrick);
 
   if (starterBrick.kind === "actionPanel") {

--- a/src/contentScript/pageEditor/dynamic.ts
+++ b/src/contentScript/pageEditor/dynamic.ts
@@ -128,7 +128,7 @@ export async function updateDynamicElement({
   // In practice, should be a no-op because the Page Editor handles the extensionPoint
   const resolved = await resolveExtensionInnerDefinitions(extensionConfig);
 
-  starterBrick.addExtension(resolved);
+  starterBrick.registerComponent(resolved);
   await runEditorExtension(extensionConfig.id, starterBrick);
 
   if (starterBrick.kind === "actionPanel") {

--- a/src/permissions/extensionPermissionsHelpers.ts
+++ b/src/permissions/extensionPermissionsHelpers.ts
@@ -77,7 +77,7 @@ export async function collectExtensionPermissions(
     );
   }
 
-  const blocks = await extensionPoint.getBlocks(resolved);
+  const blocks = await extensionPoint.getBricks(resolved);
   const blockPermissions = blocks.map((x) => x.permissions);
 
   return mergePermissions(

--- a/src/starterBricks/contextMenu.test.ts
+++ b/src/starterBricks/contextMenu.test.ts
@@ -91,10 +91,10 @@ describe("contextMenu", () => {
     const starterBrick = fromJS(extensionPointFactory()());
     const modComponent = extensionFactory();
 
-    starterBrick.registerComponent(modComponent);
-    starterBrick.registerComponent(modComponent);
+    starterBrick.registerModComponent(modComponent);
+    starterBrick.registerModComponent(modComponent);
 
-    expect(starterBrick.registeredComponents).toStrictEqual([modComponent]);
+    expect(starterBrick.registeredModComponents).toStrictEqual([modComponent]);
   });
 
   it("should include context menu props in schema", async () => {
@@ -114,13 +114,13 @@ describe("contextMenu", () => {
     const starterBrick = fromJS(extensionPointFactory()());
     const modComponent = extensionFactory();
 
-    starterBrick.registerComponent(modComponent);
+    starterBrick.registerModComponent(modComponent);
 
     await starterBrick.install();
 
     expect(ensureContextMenuMock).not.toHaveBeenCalled();
 
-    await starterBrick.runComponents({ reason: RunReason.MANUAL });
+    await starterBrick.runModComponents({ reason: RunReason.MANUAL });
 
     expect(ensureContextMenuMock).toHaveBeenCalledOnce();
     expect(ensureContextMenuMock).toHaveBeenCalledExactlyOnceWith(
@@ -133,17 +133,17 @@ describe("contextMenu", () => {
   it("should remove from UI from all tabs on sync", async () => {
     const starterBrick = fromJS(extensionPointFactory()());
     const modComponent = extensionFactory();
-    starterBrick.registerComponent(modComponent);
+    starterBrick.registerModComponent(modComponent);
 
     await starterBrick.install();
-    await starterBrick.runComponents({ reason: RunReason.MANUAL });
+    await starterBrick.runModComponents({ reason: RunReason.MANUAL });
 
     // Not read until the menu is actually run
     expect(rootReader.readCount).toBe(0);
 
-    starterBrick.synchronizeComponents([]);
+    starterBrick.synchronizeModComponents([]);
 
-    expect(starterBrick.registeredComponents).toHaveLength(0);
+    expect(starterBrick.registeredModComponents).toHaveLength(0);
 
     expect(uninstallContextMenuMock).toHaveBeenCalledExactlyOnceWith({
       extensionId: modComponent.id,

--- a/src/starterBricks/contextMenu.test.ts
+++ b/src/starterBricks/contextMenu.test.ts
@@ -110,7 +110,7 @@ describe("contextMenu", () => {
     expect(value).toHaveProperty("selectionText");
   });
 
-  it("should register context menu on install", async () => {
+  it("should register context menu on run", async () => {
     const starterBrick = fromJS(extensionPointFactory()());
     const modComponent = extensionFactory();
 
@@ -118,16 +118,16 @@ describe("contextMenu", () => {
 
     await starterBrick.install();
 
+    expect(ensureContextMenuMock).not.toHaveBeenCalled();
+
+    await starterBrick.runComponents({ reason: RunReason.MANUAL });
+
     expect(ensureContextMenuMock).toHaveBeenCalledOnce();
     expect(ensureContextMenuMock).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
         extensionId: modComponent.id,
       })
     );
-
-    // Should not be called again - run is a NOP
-    await starterBrick.runComponents({ reason: RunReason.MANUAL });
-    expect(ensureContextMenuMock).toHaveBeenCalledOnce();
   });
 
   it("should remove from UI from all tabs on sync", async () => {

--- a/src/starterBricks/contextMenu.test.ts
+++ b/src/starterBricks/contextMenu.test.ts
@@ -91,10 +91,10 @@ describe("contextMenu", () => {
     const starterBrick = fromJS(extensionPointFactory()());
     const modComponent = extensionFactory();
 
-    starterBrick.addExtension(modComponent);
-    starterBrick.addExtension(modComponent);
+    starterBrick.registerComponent(modComponent);
+    starterBrick.registerComponent(modComponent);
 
-    expect(starterBrick.registeredExtensions).toStrictEqual([modComponent]);
+    expect(starterBrick.registeredComponents).toStrictEqual([modComponent]);
   });
 
   it("should include context menu props in schema", async () => {
@@ -114,7 +114,7 @@ describe("contextMenu", () => {
     const starterBrick = fromJS(extensionPointFactory()());
     const modComponent = extensionFactory();
 
-    starterBrick.addExtension(modComponent);
+    starterBrick.registerComponent(modComponent);
 
     await starterBrick.install();
 
@@ -133,7 +133,7 @@ describe("contextMenu", () => {
   it("should remove from UI from all tabs on sync", async () => {
     const starterBrick = fromJS(extensionPointFactory()());
     const modComponent = extensionFactory();
-    starterBrick.addExtension(modComponent);
+    starterBrick.registerComponent(modComponent);
 
     await starterBrick.install();
     await starterBrick.run({ reason: RunReason.MANUAL });
@@ -141,9 +141,9 @@ describe("contextMenu", () => {
     // Not read until the menu is actually run
     expect(rootReader.readCount).toBe(0);
 
-    starterBrick.syncExtensions([]);
+    starterBrick.synchronizeComponents([]);
 
-    expect(starterBrick.registeredExtensions).toHaveLength(0);
+    expect(starterBrick.registeredComponents).toHaveLength(0);
 
     expect(uninstallContextMenuMock).toHaveBeenCalledExactlyOnceWith({
       extensionId: modComponent.id,

--- a/src/starterBricks/contextMenu.test.ts
+++ b/src/starterBricks/contextMenu.test.ts
@@ -126,7 +126,7 @@ describe("contextMenu", () => {
     );
 
     // Should not be called again - run is a NOP
-    await starterBrick.run({ reason: RunReason.MANUAL });
+    await starterBrick.runComponents({ reason: RunReason.MANUAL });
     expect(ensureContextMenuMock).toHaveBeenCalledOnce();
   });
 
@@ -136,7 +136,7 @@ describe("contextMenu", () => {
     starterBrick.registerComponent(modComponent);
 
     await starterBrick.install();
-    await starterBrick.run({ reason: RunReason.MANUAL });
+    await starterBrick.runComponents({ reason: RunReason.MANUAL });
 
     // Not read until the menu is actually run
     expect(rootReader.readCount).toBe(0);

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -200,9 +200,11 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
   async install(): Promise<boolean> {
     // Always install the mouse handler in case a context menu is added later
     installMouseHandlerOnce();
-    const available = await this.isAvailable();
+    return this.isAvailable();
+  }
+
+  async runComponents(): Promise<void> {
     await this.registerExtensions();
-    return available;
   }
 
   override async defaultReader(): Promise<Reader> {
@@ -382,10 +384,6 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
         }
       }
     });
-  }
-
-  async run(): Promise<void> {
-    // Already taken care by the `install` method
   }
 }
 

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -185,7 +185,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
    * @see uninstallContextMenu
    * @see preloadContextMenus
    */
-  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearModComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     // Context menus are registered with Chrome by document pattern via the background page. Therefore, it's impossible
     // to clear the UI menu item from a single tab. Calling `uninstallContextMenu` removes the tab from all menus.
 
@@ -203,7 +203,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
     return this.isAvailable();
   }
 
-  async runComponents(): Promise<void> {
+  async runModComponents(): Promise<void> {
     await this.registerExtensions();
   }
 

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -128,7 +128,7 @@ function installMouseHandlerOnce(): void {
  * See also: https://developer.chrome.com/extensions/contextMenus
  */
 export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<ContextMenuConfig> {
-  public override get syncInstall() {
+  public override get isSyncInstall() {
     return true;
   }
 
@@ -164,7 +164,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
     ["title", "action"]
   );
 
-  async getBlocks(
+  async getBricks(
     extension: ResolvedModComponent<ContextMenuConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.action);
@@ -172,7 +172,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
 
   override uninstall({ global = false }: { global?: boolean }): void {
     // NOTE: don't uninstall the mouse/click handler because other context menus need it
-    const extensions = this.extensions.splice(0, this.extensions.length);
+    const extensions = this.components.splice(0, this.components.length);
     if (global) {
       for (const extension of extensions) {
         void uninstallContextMenu({ extensionId: extension.id });
@@ -185,7 +185,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
    * @see uninstallContextMenu
    * @see preloadContextMenus
    */
-  clearExtensionInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     // Context menus are registered with Chrome by document pattern via the background page. Therefore, it's impossible
     // to clear the UI menu item from a single tab. Calling `uninstallContextMenu` removes the tab from all menus.
 
@@ -248,12 +248,12 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
   private async registerExtensions(): Promise<void> {
     console.debug(
       "Registering",
-      this.extensions.length,
+      this.components.length,
       "contextMenu starter bricks"
     );
 
     const results = await Promise.allSettled(
-      this.extensions.map(async (extension) => {
+      this.components.map(async (extension) => {
         try {
           await this.registerExtension(extension);
         } catch (error) {

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -172,7 +172,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
 
   override uninstall({ global = false }: { global?: boolean }): void {
     // NOTE: don't uninstall the mouse/click handler because other context menus need it
-    const extensions = this.components.splice(0, this.components.length);
+    const extensions = this.modComponents.splice(0, this.modComponents.length);
     if (global) {
       for (const extension of extensions) {
         void uninstallContextMenu({ extensionId: extension.id });
@@ -250,12 +250,12 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
   private async registerExtensions(): Promise<void> {
     console.debug(
       "Registering",
-      this.components.length,
+      this.modComponents.length,
       "contextMenu starter bricks"
     );
 
     const results = await Promise.allSettled(
-      this.components.map(async (extension) => {
+      this.modComponents.map(async (extension) => {
         try {
           await this.registerExtension(extension);
         } catch (error) {

--- a/src/starterBricks/menuItemExtension.test.ts
+++ b/src/starterBricks/menuItemExtension.test.ts
@@ -124,7 +124,7 @@ describe("menuItemExtension", () => {
       extensionPoint.registerComponent(modComponent);
 
       await extensionPoint.install();
-      await extensionPoint.run({ reason: RunReason.MANUAL });
+      await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
       expect(document.querySelectorAll("button")).toHaveLength(1);
       expect(document.body.innerHTML).toEqual(
@@ -150,7 +150,7 @@ describe("menuItemExtension", () => {
     extensionPoint.registerComponent(modComponent);
 
     await extensionPoint.install();
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     expect(document.querySelectorAll("button")).toHaveLength(1);
     expect(document.body.innerHTML).toEqual(
@@ -175,7 +175,7 @@ describe("menuItemExtension", () => {
     );
 
     await extensionPoint.install();
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     expect(document.querySelectorAll("button")).toHaveLength(1);
 
@@ -216,7 +216,7 @@ describe("menuItemExtension", () => {
     );
 
     await extensionPoint.install();
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     expect(document.querySelectorAll("button")).toHaveLength(1);
 
@@ -259,7 +259,7 @@ describe("menuItemExtension", () => {
       );
 
       await extensionPoint.install();
-      await extensionPoint.run({ reason: RunReason.MANUAL });
+      await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
       expect(document.querySelectorAll("button")).toHaveLength(1);
 
@@ -295,7 +295,7 @@ describe("menuItemExtension", () => {
     );
 
     await starterBrick.install();
-    await starterBrick.run({ reason: RunReason.MANUAL });
+    await starterBrick.runComponents({ reason: RunReason.MANUAL });
     expect(document.querySelectorAll("button")).toHaveLength(1);
 
     document.body.innerHTML = "";
@@ -332,7 +332,7 @@ describe("menuItemExtension", () => {
 
     await installPromise;
 
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     await tick();
 
@@ -360,7 +360,7 @@ describe("menuItemExtension", () => {
     );
 
     await extensionPoint.install();
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
     expect(document.querySelectorAll("button")).toHaveLength(1);
 
     $("div:first").append("<div class='menu'></div>");
@@ -397,7 +397,7 @@ describe("menuItemExtension", () => {
     await tick();
     await tick();
     await installPromise;
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
     expect(document.querySelectorAll("button")).toHaveLength(1);
 
     // 2 ticks were necessary in the watch test

--- a/src/starterBricks/menuItemExtension.test.ts
+++ b/src/starterBricks/menuItemExtension.test.ts
@@ -121,10 +121,10 @@ describe("menuItemExtension", () => {
         extensionPointId: extensionPoint.id,
       });
 
-      extensionPoint.registerComponent(modComponent);
+      extensionPoint.registerModComponent(modComponent);
 
       await extensionPoint.install();
-      await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+      await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
       expect(document.querySelectorAll("button")).toHaveLength(1);
       expect(document.body.innerHTML).toEqual(
@@ -147,10 +147,10 @@ describe("menuItemExtension", () => {
       extensionPointId: extensionPoint.id,
     });
 
-    extensionPoint.registerComponent(modComponent);
+    extensionPoint.registerModComponent(modComponent);
 
     await extensionPoint.install();
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     expect(document.querySelectorAll("button")).toHaveLength(1);
     expect(document.body.innerHTML).toEqual(
@@ -168,14 +168,14 @@ describe("menuItemExtension", () => {
       })()
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       modComponentFactory({
         extensionPointId: extensionPoint.id,
       })
     );
 
     await extensionPoint.install();
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     expect(document.querySelectorAll("button")).toHaveLength(1);
 
@@ -209,14 +209,14 @@ describe("menuItemExtension", () => {
       })()
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       modComponentFactory({
         extensionPointId: extensionPoint.id,
       })
     );
 
     await extensionPoint.install();
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     expect(document.querySelectorAll("button")).toHaveLength(1);
 
@@ -252,14 +252,14 @@ describe("menuItemExtension", () => {
         })()
       );
 
-      extensionPoint.registerComponent(
+      extensionPoint.registerModComponent(
         modComponentFactory({
           extensionPointId: extensionPoint.id,
         })
       );
 
       await extensionPoint.install();
-      await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+      await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
       expect(document.querySelectorAll("button")).toHaveLength(1);
 
@@ -288,14 +288,14 @@ describe("menuItemExtension", () => {
     document.body.innerHTML = getDocument("<div></div>").body.innerHTML;
     const starterBrick = fromJS(starterBrickFactory()());
 
-    starterBrick.registerComponent(
+    starterBrick.registerModComponent(
       modComponentFactory({
         extensionPointId: starterBrick.id,
       })
     );
 
     await starterBrick.install();
-    await starterBrick.runComponents({ reason: RunReason.MANUAL });
+    await starterBrick.runModComponents({ reason: RunReason.MANUAL });
     expect(document.querySelectorAll("button")).toHaveLength(1);
 
     document.body.innerHTML = "";
@@ -318,7 +318,7 @@ describe("menuItemExtension", () => {
       })()
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       modComponentFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -332,7 +332,7 @@ describe("menuItemExtension", () => {
 
     await installPromise;
 
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     await tick();
 
@@ -353,14 +353,14 @@ describe("menuItemExtension", () => {
 
     const extensionPoint = fromJS(starterBrick);
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       modComponentFactory({
         extensionPointId: extensionPoint.id,
       })
     );
 
     await extensionPoint.install();
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
     expect(document.querySelectorAll("button")).toHaveLength(1);
 
     $("div:first").append("<div class='menu'></div>");
@@ -383,7 +383,7 @@ describe("menuItemExtension", () => {
 
     const extensionPoint = fromJS(starterBrick);
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       modComponentFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -397,7 +397,7 @@ describe("menuItemExtension", () => {
     await tick();
     await tick();
     await installPromise;
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
     expect(document.querySelectorAll("button")).toHaveLength(1);
 
     // 2 ticks were necessary in the watch test

--- a/src/starterBricks/menuItemExtension.test.ts
+++ b/src/starterBricks/menuItemExtension.test.ts
@@ -121,7 +121,7 @@ describe("menuItemExtension", () => {
         extensionPointId: extensionPoint.id,
       });
 
-      extensionPoint.addExtension(modComponent);
+      extensionPoint.registerComponent(modComponent);
 
       await extensionPoint.install();
       await extensionPoint.run({ reason: RunReason.MANUAL });
@@ -147,7 +147,7 @@ describe("menuItemExtension", () => {
       extensionPointId: extensionPoint.id,
     });
 
-    extensionPoint.addExtension(modComponent);
+    extensionPoint.registerComponent(modComponent);
 
     await extensionPoint.install();
     await extensionPoint.run({ reason: RunReason.MANUAL });
@@ -168,7 +168,7 @@ describe("menuItemExtension", () => {
       })()
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       modComponentFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -209,7 +209,7 @@ describe("menuItemExtension", () => {
       })()
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       modComponentFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -252,7 +252,7 @@ describe("menuItemExtension", () => {
         })()
       );
 
-      extensionPoint.addExtension(
+      extensionPoint.registerComponent(
         modComponentFactory({
           extensionPointId: extensionPoint.id,
         })
@@ -288,7 +288,7 @@ describe("menuItemExtension", () => {
     document.body.innerHTML = getDocument("<div></div>").body.innerHTML;
     const starterBrick = fromJS(starterBrickFactory()());
 
-    starterBrick.addExtension(
+    starterBrick.registerComponent(
       modComponentFactory({
         extensionPointId: starterBrick.id,
       })
@@ -318,7 +318,7 @@ describe("menuItemExtension", () => {
       })()
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       modComponentFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -353,7 +353,7 @@ describe("menuItemExtension", () => {
 
     const extensionPoint = fromJS(starterBrick);
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       modComponentFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -383,7 +383,7 @@ describe("menuItemExtension", () => {
 
     const extensionPoint = fromJS(starterBrick);
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       modComponentFactory({
         extensionPointId: extensionPoint.id,
       })

--- a/src/starterBricks/menuItemExtension.ts
+++ b/src/starterBricks/menuItemExtension.ts
@@ -313,7 +313,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
     this.cancelListeners.clear();
   }
 
-  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearModComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     console.debug(
       "Remove extensionIds for menuItem extension point: %s",
       this.id,
@@ -353,7 +353,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
 
     for (const element of menus) {
       try {
-        this.clearComponentInterfaceAndEvents(extensions.map((x) => x.id));
+        this.clearModComponentInterfaceAndEvents(extensions.map((x) => x.id));
         // Release the menu element
         element.removeAttribute(EXTENSION_POINT_DATA_ATTR);
       } catch (error) {
@@ -441,7 +441,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
       // The behavior for multiple buttons is quirky here for "once" attachMode. There's a corner case where
       // 1) if one button is removed, 2) the menus are re-added immediately, 3) PixieBrix stops watching for new buttons
       await this.waitAttachMenus();
-      await this.runComponents({ reason: RunReason.MUTATION });
+      await this.runModComponents({ reason: RunReason.MUTATION });
     }
   }
 
@@ -496,7 +496,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
       containerSelector,
       (index, element) => {
         this.attachMenus($(element as HTMLElement));
-        void this.runComponents({ reason: RunReason.MUTATION });
+        void this.runModComponents({ reason: RunReason.MUTATION });
       },
       // `target` is a required option. Would it be possible to scope if the selector is nested? Would have to consider
       // commas in the selector. E.g., revert back to document if there's a comma
@@ -789,7 +789,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
     if (dependencies.length > 0) {
       const rerun = once(() => {
         console.debug("Dependency changed, re-running extension");
-        void this.runComponents({
+        void this.runModComponents({
           reason: RunReason.DEPENDENCY_CHANGED,
           extensionIds: [extension.id],
         });
@@ -844,7 +844,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
     }
   }
 
-  async runComponents({ extensionIds = null }: RunArgs): Promise<void> {
+  async runModComponents({ extensionIds = null }: RunArgs): Promise<void> {
     if (this.menus.size === 0 || this.modComponents.length === 0) {
       return;
     }

--- a/src/starterBricks/menuItemExtension.ts
+++ b/src/starterBricks/menuItemExtension.ts
@@ -336,7 +336,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
     const menus = [...this.menus.values()];
 
     // Clear so they don't get re-added by the onNodeRemoved mechanism
-    const extensions = this.components.splice(0, this.components.length);
+    const extensions = this.modComponents.splice(0, this.modComponents.length);
     this.menus.clear();
 
     if (extensions.length === 0) {
@@ -845,7 +845,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
   }
 
   async runComponents({ extensionIds = null }: RunArgs): Promise<void> {
-    if (this.menus.size === 0 || this.components.length === 0) {
+    if (this.menus.size === 0 || this.modComponents.length === 0) {
       return;
     }
 
@@ -871,7 +871,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
 
       let ctxtPromise: Promise<JsonObject>;
 
-      for (const extension of this.components) {
+      for (const extension of this.modComponents) {
         // Run in order so that the order stays the same for where they get rendered. The service
         // context is the only thing that's async as part of the initial configuration right now
 

--- a/src/starterBricks/menuItemExtension.ts
+++ b/src/starterBricks/menuItemExtension.ts
@@ -441,7 +441,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
       // The behavior for multiple buttons is quirky here for "once" attachMode. There's a corner case where
       // 1) if one button is removed, 2) the menus are re-added immediately, 3) PixieBrix stops watching for new buttons
       await this.waitAttachMenus();
-      await this.run({ reason: RunReason.MUTATION });
+      await this.runComponents({ reason: RunReason.MUTATION });
     }
   }
 
@@ -496,7 +496,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
       containerSelector,
       (index, element) => {
         this.attachMenus($(element as HTMLElement));
-        void this.run({ reason: RunReason.MUTATION });
+        void this.runComponents({ reason: RunReason.MUTATION });
       },
       // `target` is a required option. Would it be possible to scope if the selector is nested? Would have to consider
       // commas in the selector. E.g., revert back to document if there's a comma
@@ -789,7 +789,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
     if (dependencies.length > 0) {
       const rerun = once(() => {
         console.debug("Dependency changed, re-running extension");
-        void this.run({
+        void this.runComponents({
           reason: RunReason.DEPENDENCY_CHANGED,
           extensionIds: [extension.id],
         });
@@ -844,7 +844,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
     }
   }
 
-  async run({ extensionIds = null }: RunArgs): Promise<void> {
+  async runComponents({ extensionIds = null }: RunArgs): Promise<void> {
     if (this.menus.size === 0 || this.components.length === 0) {
       return;
     }

--- a/src/starterBricks/menuItemExtension.ts
+++ b/src/starterBricks/menuItemExtension.ts
@@ -313,7 +313,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
     this.cancelListeners.clear();
   }
 
-  clearExtensionInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     console.debug(
       "Remove extensionIds for menuItem extension point: %s",
       this.id,
@@ -336,7 +336,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
     const menus = [...this.menus.values()];
 
     // Clear so they don't get re-added by the onNodeRemoved mechanism
-    const extensions = this.extensions.splice(0, this.extensions.length);
+    const extensions = this.components.splice(0, this.components.length);
     this.menus.clear();
 
     if (extensions.length === 0) {
@@ -353,7 +353,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
 
     for (const element of menus) {
       try {
-        this.clearExtensionInterfaceAndEvents(extensions.map((x) => x.id));
+        this.clearComponentInterfaceAndEvents(extensions.map((x) => x.id));
         // Release the menu element
         element.removeAttribute(EXTENSION_POINT_DATA_ATTR);
       } catch (error) {
@@ -402,7 +402,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
     $menu.append($menuItem);
   }
 
-  async getBlocks(
+  async getBricks(
     extension: ResolvedModComponent<MenuItemStarterBrickConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.action);
@@ -845,7 +845,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
   }
 
   async run({ extensionIds = null }: RunArgs): Promise<void> {
-    if (this.menus.size === 0 || this.extensions.length === 0) {
+    if (this.menus.size === 0 || this.components.length === 0) {
       return;
     }
 
@@ -871,7 +871,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
 
       let ctxtPromise: Promise<JsonObject>;
 
-      for (const extension of this.extensions) {
+      for (const extension of this.components) {
         // Run in order so that the order stays the same for where they get rendered. The service
         // context is the only thing that's async as part of the initial configuration right now
 

--- a/src/starterBricks/panelExtension.ts
+++ b/src/starterBricks/panelExtension.ts
@@ -431,7 +431,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
     }
   }
 
-  async run({ extensionIds = null }: RunArgs): Promise<void> {
+  async runComponents({ extensionIds = null }: RunArgs): Promise<void> {
     if (!this.$container || this.components.length === 0) {
       return;
     }

--- a/src/starterBricks/panelExtension.ts
+++ b/src/starterBricks/panelExtension.ts
@@ -173,18 +173,11 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
     throw new Error("PanelExtensionPoint.defaultReader not implemented");
   }
 
-  getTemplate(): string {
-    if (this.template) return this.template;
-    throw new Error("PanelExtensionPoint.getTemplate not implemented");
-  }
+  abstract getTemplate(): string;
 
-  getContainerSelector(): string | string[] {
-    throw new Error("PanelExtensionPoint.getContainerSelector not implemented");
-  }
+  abstract getContainerSelector(): string | string[];
 
-  async isAvailable(): Promise<boolean> {
-    throw new Error("PanelExtensionPoint.isAvailable not implemented");
-  }
+  abstract override isAvailable(): Promise<boolean>;
 
   override uninstall(): void {
     this.uninstalled = true;

--- a/src/starterBricks/panelExtension.ts
+++ b/src/starterBricks/panelExtension.ts
@@ -164,7 +164,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
     return selectAllBlocks(extension.config.body);
   }
 
-  clearComponentInterfaceAndEvents(): void {
+  clearModComponentInterfaceAndEvents(): void {
     // FIXME: implement this to avoid unnecessary firing
     console.warn("removeExtensions not implemented for panel extensionPoint");
   }
@@ -431,7 +431,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
     }
   }
 
-  async runComponents({ extensionIds = null }: RunArgs): Promise<void> {
+  async runModComponents({ extensionIds = null }: RunArgs): Promise<void> {
     if (!this.$container || this.modComponents.length === 0) {
       return;
     }

--- a/src/starterBricks/panelExtension.ts
+++ b/src/starterBricks/panelExtension.ts
@@ -182,7 +182,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
   override uninstall(): void {
     this.uninstalled = true;
 
-    for (const extension of this.components) {
+    for (const extension of this.modComponents) {
       const $item = this.$container.find(
         `[${PIXIEBRIX_DATA_ATTR}="${extension.id}"]`
       );
@@ -432,7 +432,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
   }
 
   async runComponents({ extensionIds = null }: RunArgs): Promise<void> {
-    if (!this.$container || this.components.length === 0) {
+    if (!this.$container || this.modComponents.length === 0) {
       return;
     }
 
@@ -445,7 +445,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
 
     const errors: unknown[] = [];
 
-    for (const extension of this.components) {
+    for (const extension of this.modComponents) {
       if (extensionIds != null && !extensionIds.includes(extension.id)) {
         continue;
       }

--- a/src/starterBricks/panelExtension.ts
+++ b/src/starterBricks/panelExtension.ts
@@ -158,13 +158,13 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
     return "panel";
   }
 
-  async getBlocks(
+  async getBricks(
     extension: ResolvedModComponent<PanelConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.body);
   }
 
-  clearExtensionInterfaceAndEvents(): void {
+  clearComponentInterfaceAndEvents(): void {
     // FIXME: implement this to avoid unnecessary firing
     console.warn("removeExtensions not implemented for panel extensionPoint");
   }
@@ -189,7 +189,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
   override uninstall(): void {
     this.uninstalled = true;
 
-    for (const extension of this.extensions) {
+    for (const extension of this.components) {
       const $item = this.$container.find(
         `[${PIXIEBRIX_DATA_ATTR}="${extension.id}"]`
       );
@@ -439,7 +439,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
   }
 
   async run({ extensionIds = null }: RunArgs): Promise<void> {
-    if (!this.$container || this.extensions.length === 0) {
+    if (!this.$container || this.components.length === 0) {
       return;
     }
 
@@ -452,7 +452,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
 
     const errors: unknown[] = [];
 
-    for (const extension of this.extensions) {
+    for (const extension of this.components) {
       if (extensionIds != null && !extensionIds.includes(extension.id)) {
         continue;
       }

--- a/src/starterBricks/quickBarExtension.test.ts
+++ b/src/starterBricks/quickBarExtension.test.ts
@@ -103,7 +103,7 @@ describe("quickBarExtension", () => {
 
     const starterBrick = fromJS(starterBrickFactory()());
 
-    starterBrick.registerComponent(
+    starterBrick.registerModComponent(
       extensionFactory({
         extensionPointId: starterBrick.id,
       })
@@ -113,7 +113,7 @@ describe("quickBarExtension", () => {
       NUM_DEFAULT_QUICKBAR_ACTIONS
     );
     await starterBrick.install();
-    await starterBrick.runComponents({ reason: RunReason.MANUAL });
+    await starterBrick.runModComponents({ reason: RunReason.MANUAL });
 
     expect(quickBarRegistry.currentActions).toHaveLength(
       NUM_DEFAULT_QUICKBAR_ACTIONS + 1

--- a/src/starterBricks/quickBarExtension.test.ts
+++ b/src/starterBricks/quickBarExtension.test.ts
@@ -113,7 +113,7 @@ describe("quickBarExtension", () => {
       NUM_DEFAULT_QUICKBAR_ACTIONS
     );
     await starterBrick.install();
-    await starterBrick.run({ reason: RunReason.MANUAL });
+    await starterBrick.runComponents({ reason: RunReason.MANUAL });
 
     expect(quickBarRegistry.currentActions).toHaveLength(
       NUM_DEFAULT_QUICKBAR_ACTIONS + 1

--- a/src/starterBricks/quickBarExtension.test.ts
+++ b/src/starterBricks/quickBarExtension.test.ts
@@ -103,7 +103,7 @@ describe("quickBarExtension", () => {
 
     const starterBrick = fromJS(starterBrickFactory()());
 
-    starterBrick.addExtension(
+    starterBrick.registerComponent(
       extensionFactory({
         extensionPointId: starterBrick.id,
       })

--- a/src/starterBricks/quickBarExtension.tsx
+++ b/src/starterBricks/quickBarExtension.tsx
@@ -116,7 +116,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
     ["title", "action"]
   );
 
-  async getBlocks(
+  async getBricks(
     extension: ResolvedModComponent<QuickBarConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.action);
@@ -130,7 +130,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
     quickBarRegistry.removeExtensionPointActions(this.id);
   }
 
-  clearExtensionInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     for (const extensionId of extensionIds) {
       quickBarRegistry.removeAction(extensionId);
     }
@@ -173,7 +173,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
     }
 
     const results = await Promise.allSettled(
-      this.extensions.map(async (extension) => {
+      this.components.map(async (extension) => {
         try {
           await this.registerExtensionAction(extension);
         } catch (error) {
@@ -265,7 +265,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
   }
 
   async run(): Promise<void> {
-    if (this.extensions.length === 0) {
+    if (this.components.length === 0) {
       console.debug(
         `quickBar extension point ${this.id} has no installed extensions`
       );

--- a/src/starterBricks/quickBarExtension.tsx
+++ b/src/starterBricks/quickBarExtension.tsx
@@ -130,7 +130,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
     quickBarRegistry.removeExtensionPointActions(this.id);
   }
 
-  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearModComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     for (const extensionId of extensionIds) {
       quickBarRegistry.removeAction(extensionId);
     }
@@ -264,7 +264,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
     );
   }
 
-  async runComponents(): Promise<void> {
+  async runModComponents(): Promise<void> {
     if (this.modComponents.length === 0) {
       console.debug(
         `quickBar extension point ${this.id} has no installed extensions`

--- a/src/starterBricks/quickBarExtension.tsx
+++ b/src/starterBricks/quickBarExtension.tsx
@@ -264,7 +264,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
     );
   }
 
-  async run(): Promise<void> {
+  async runComponents(): Promise<void> {
     if (this.components.length === 0) {
       console.debug(
         `quickBar extension point ${this.id} has no installed extensions`

--- a/src/starterBricks/quickBarExtension.tsx
+++ b/src/starterBricks/quickBarExtension.tsx
@@ -173,7 +173,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
     }
 
     const results = await Promise.allSettled(
-      this.components.map(async (extension) => {
+      this.modComponents.map(async (extension) => {
         try {
           await this.registerExtensionAction(extension);
         } catch (error) {
@@ -265,7 +265,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
   }
 
   async runComponents(): Promise<void> {
-    if (this.components.length === 0) {
+    if (this.modComponents.length === 0) {
       console.debug(
         `quickBar extension point ${this.id} has no installed extensions`
       );

--- a/src/starterBricks/quickBarProviderExtension.tsx
+++ b/src/starterBricks/quickBarProviderExtension.tsx
@@ -167,6 +167,20 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
     return true;
   }
 
+  async runComponents(): Promise<void> {
+    if (this.components.length === 0) {
+      console.debug(
+        `quickBar starter brick ${this.id} has no installed components`
+      );
+
+      // Not sure if this is needed or not, but remove any straggler extension actions
+      quickBarRegistry.removeExtensionPointActions(this.id);
+      return;
+    }
+
+    await this.syncActionProvidersForUrl();
+  }
+
   override async defaultReader(): Promise<Reader> {
     return new ArrayCompositeReader([
       // Include QuickbarQueryReader for the outputSchema. The value gets filled in by the run method
@@ -299,19 +313,6 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
     // Register new generator
     this.generators.set(extension.id, actionGenerator);
     quickBarRegistry.addGenerator(actionGenerator, rootActionId);
-  }
-
-  async run(): Promise<void> {
-    if (this.components.length === 0) {
-      console.debug(
-        `quickBar extension point ${this.id} has no installed extensions`
-      );
-      // Not sure if this is needed or not, but remove any straggler extension actions
-      quickBarRegistry.removeExtensionPointActions(this.id);
-      return;
-    }
-
-    await this.syncActionProvidersForUrl();
   }
 }
 

--- a/src/starterBricks/quickBarProviderExtension.tsx
+++ b/src/starterBricks/quickBarProviderExtension.tsx
@@ -143,7 +143,9 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
 
   override uninstall(): void {
     // Remove generators and all existing actions in the Quick Bar
-    this.clearComponentInterfaceAndEvents(this.modComponents.map((x) => x.id));
+    this.clearModComponentInterfaceAndEvents(
+      this.modComponents.map((x) => x.id)
+    );
     quickBarRegistry.removeExtensionPointActions(this.id);
     this.modComponents.splice(0, this.modComponents.length);
   }
@@ -152,7 +154,7 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
    * Unregister quick bar action providers for the given extension IDs.
    * @param extensionIds the extensions IDs to unregister
    */
-  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearModComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     for (const extensionId of extensionIds) {
       quickBarRegistry.removeGenerator(this.generators.get(extensionId));
       this.generators.delete(extensionId);
@@ -167,7 +169,7 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
     return true;
   }
 
-  async runComponents(): Promise<void> {
+  async runModComponents(): Promise<void> {
     if (this.modComponents.length === 0) {
       console.debug(
         `quickBar starter brick ${this.id} has no installed components`
@@ -201,7 +203,7 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
     if (!testMatchPatterns(this.documentUrlPatterns)) {
       // Remove actions and un-attach generators
       quickBarRegistry.removeExtensionPointActions(this.id);
-      this.clearComponentInterfaceAndEvents(
+      this.clearModComponentInterfaceAndEvents(
         this.modComponents.map((x) => x.id)
       );
       return;

--- a/src/starterBricks/quickBarProviderExtension.tsx
+++ b/src/starterBricks/quickBarProviderExtension.tsx
@@ -143,9 +143,9 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
 
   override uninstall(): void {
     // Remove generators and all existing actions in the Quick Bar
-    this.clearComponentInterfaceAndEvents(this.components.map((x) => x.id));
+    this.clearComponentInterfaceAndEvents(this.modComponents.map((x) => x.id));
     quickBarRegistry.removeExtensionPointActions(this.id);
-    this.components.splice(0, this.components.length);
+    this.modComponents.splice(0, this.modComponents.length);
   }
 
   /**
@@ -168,7 +168,7 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
   }
 
   async runComponents(): Promise<void> {
-    if (this.components.length === 0) {
+    if (this.modComponents.length === 0) {
       console.debug(
         `quickBar starter brick ${this.id} has no installed components`
       );
@@ -201,12 +201,14 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
     if (!testMatchPatterns(this.documentUrlPatterns)) {
       // Remove actions and un-attach generators
       quickBarRegistry.removeExtensionPointActions(this.id);
-      this.clearComponentInterfaceAndEvents(this.components.map((x) => x.id));
+      this.clearComponentInterfaceAndEvents(
+        this.modComponents.map((x) => x.id)
+      );
       return;
     }
 
     const results = await Promise.allSettled(
-      this.components.map(async (extension) => {
+      this.modComponents.map(async (extension) => {
         try {
           await this.registerActionProvider(extension);
         } catch (error) {

--- a/src/starterBricks/quickBarProviderExtension.tsx
+++ b/src/starterBricks/quickBarProviderExtension.tsx
@@ -131,7 +131,7 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
     ["generator"]
   );
 
-  async getBlocks(
+  async getBricks(
     extension: ResolvedModComponent<QuickBarProviderConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.generator);
@@ -143,16 +143,16 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
 
   override uninstall(): void {
     // Remove generators and all existing actions in the Quick Bar
-    this.clearExtensionInterfaceAndEvents(this.extensions.map((x) => x.id));
+    this.clearComponentInterfaceAndEvents(this.components.map((x) => x.id));
     quickBarRegistry.removeExtensionPointActions(this.id);
-    this.extensions.splice(0, this.extensions.length);
+    this.components.splice(0, this.components.length);
   }
 
   /**
    * Unregister quick bar action providers for the given extension IDs.
    * @param extensionIds the extensions IDs to unregister
    */
-  clearExtensionInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     for (const extensionId of extensionIds) {
       quickBarRegistry.removeGenerator(this.generators.get(extensionId));
       this.generators.delete(extensionId);
@@ -187,12 +187,12 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
     if (!testMatchPatterns(this.documentUrlPatterns)) {
       // Remove actions and un-attach generators
       quickBarRegistry.removeExtensionPointActions(this.id);
-      this.clearExtensionInterfaceAndEvents(this.extensions.map((x) => x.id));
+      this.clearComponentInterfaceAndEvents(this.components.map((x) => x.id));
       return;
     }
 
     const results = await Promise.allSettled(
-      this.extensions.map(async (extension) => {
+      this.components.map(async (extension) => {
         try {
           await this.registerActionProvider(extension);
         } catch (error) {
@@ -302,7 +302,7 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
   }
 
   async run(): Promise<void> {
-    if (this.extensions.length === 0) {
+    if (this.components.length === 0) {
       console.debug(
         `quickBar extension point ${this.id} has no installed extensions`
       );

--- a/src/starterBricks/quickbarProviderExtension.test.ts
+++ b/src/starterBricks/quickbarProviderExtension.test.ts
@@ -94,7 +94,7 @@ describe("quickBarProviderExtension", () => {
 
     const starterBrick = fromJS(starterBrickFactory());
 
-    starterBrick.registerComponent(
+    starterBrick.registerModComponent(
       extensionFactory({
         extensionPointId: starterBrick.id,
       })
@@ -104,7 +104,7 @@ describe("quickBarProviderExtension", () => {
       NUM_DEFAULT_QUICKBAR_ACTIONS
     );
     await starterBrick.install();
-    await starterBrick.runComponents({ reason: RunReason.MANUAL });
+    await starterBrick.runModComponents({ reason: RunReason.MANUAL });
 
     expect(quickBarRegistry.currentActions).toHaveLength(
       NUM_DEFAULT_QUICKBAR_ACTIONS + 1
@@ -142,7 +142,7 @@ describe("quickBarProviderExtension", () => {
 
     const starterBrick = fromJS(starterBrickFactory());
 
-    starterBrick.registerComponent(
+    starterBrick.registerModComponent(
       extensionFactory({
         extensionPointId: starterBrick.id,
         config: {
@@ -152,7 +152,7 @@ describe("quickBarProviderExtension", () => {
     );
 
     await starterBrick.install();
-    await starterBrick.runComponents({ reason: RunReason.MANUAL });
+    await starterBrick.runModComponents({ reason: RunReason.MANUAL });
 
     await tick();
 

--- a/src/starterBricks/quickbarProviderExtension.test.ts
+++ b/src/starterBricks/quickbarProviderExtension.test.ts
@@ -94,7 +94,7 @@ describe("quickBarProviderExtension", () => {
 
     const starterBrick = fromJS(starterBrickFactory());
 
-    starterBrick.addExtension(
+    starterBrick.registerComponent(
       extensionFactory({
         extensionPointId: starterBrick.id,
       })
@@ -142,7 +142,7 @@ describe("quickBarProviderExtension", () => {
 
     const starterBrick = fromJS(starterBrickFactory());
 
-    starterBrick.addExtension(
+    starterBrick.registerComponent(
       extensionFactory({
         extensionPointId: starterBrick.id,
         config: {

--- a/src/starterBricks/quickbarProviderExtension.test.ts
+++ b/src/starterBricks/quickbarProviderExtension.test.ts
@@ -104,7 +104,7 @@ describe("quickBarProviderExtension", () => {
       NUM_DEFAULT_QUICKBAR_ACTIONS
     );
     await starterBrick.install();
-    await starterBrick.run({ reason: RunReason.MANUAL });
+    await starterBrick.runComponents({ reason: RunReason.MANUAL });
 
     expect(quickBarRegistry.currentActions).toHaveLength(
       NUM_DEFAULT_QUICKBAR_ACTIONS + 1
@@ -152,7 +152,7 @@ describe("quickBarProviderExtension", () => {
     );
 
     await starterBrick.install();
-    await starterBrick.run({ reason: RunReason.MANUAL });
+    await starterBrick.runComponents({ reason: RunReason.MANUAL });
 
     await tick();
 

--- a/src/starterBricks/sidebarExtension.test.ts
+++ b/src/starterBricks/sidebarExtension.test.ts
@@ -70,7 +70,7 @@ describe("sidebarExtension", () => {
   it("reserves panel on load", async () => {
     const extensionPoint = fromJS(starterBrickFactory()());
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -99,7 +99,7 @@ describe("sidebarExtension", () => {
   it("synchronize clears panel", async () => {
     const extensionPoint = fromJS(starterBrickFactory()());
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -109,7 +109,7 @@ describe("sidebarExtension", () => {
 
     expect(getReservedPanelEntries().panels).toHaveLength(1);
 
-    extensionPoint.syncExtensions([]);
+    extensionPoint.synchronizeComponents([]);
 
     // Synchronize removes the panel
     expect(getReservedPanelEntries().panels).toHaveLength(0);
@@ -124,13 +124,13 @@ describe("sidebarExtension", () => {
       extensionPointId: extensionPoint.id,
     });
 
-    extensionPoint.addExtension(extension);
+    extensionPoint.registerComponent(extension);
 
     await extensionPoint.install();
 
     expect(getReservedPanelEntries().panels).toHaveLength(1);
 
-    extensionPoint.removeExtension(extension.id);
+    extensionPoint.removeComponent(extension.id);
 
     // Synchronize removes the panel
     expect(getReservedPanelEntries().panels).toHaveLength(0);

--- a/src/starterBricks/sidebarExtension.test.ts
+++ b/src/starterBricks/sidebarExtension.test.ts
@@ -77,11 +77,8 @@ describe("sidebarExtension", () => {
     );
 
     await extensionPoint.install();
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
-    // Not run until shown
-    expect(rootReader.readCount).toBe(0);
-
+    // To avoid race condition, it reserves panels in the install method in addition to the run method
     expect(getReservedPanelEntries()).toStrictEqual({
       forms: [],
       panels: [
@@ -92,6 +89,11 @@ describe("sidebarExtension", () => {
       temporaryPanels: [],
       recipeToActivate: null,
     });
+
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+
+    // Not run until shown
+    expect(rootReader.readCount).toBe(0);
 
     extensionPoint.uninstall();
   });

--- a/src/starterBricks/sidebarExtension.test.ts
+++ b/src/starterBricks/sidebarExtension.test.ts
@@ -70,7 +70,7 @@ describe("sidebarExtension", () => {
   it("reserves panel on load", async () => {
     const extensionPoint = fromJS(starterBrickFactory()());
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -90,7 +90,7 @@ describe("sidebarExtension", () => {
       recipeToActivate: null,
     });
 
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     // Not run until shown
     expect(rootReader.readCount).toBe(0);
@@ -101,7 +101,7 @@ describe("sidebarExtension", () => {
   it("synchronize clears panel", async () => {
     const extensionPoint = fromJS(starterBrickFactory()());
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -111,7 +111,7 @@ describe("sidebarExtension", () => {
 
     expect(getReservedPanelEntries().panels).toHaveLength(1);
 
-    extensionPoint.synchronizeComponents([]);
+    extensionPoint.synchronizeModComponents([]);
 
     // Synchronize removes the panel
     expect(getReservedPanelEntries().panels).toHaveLength(0);
@@ -126,13 +126,13 @@ describe("sidebarExtension", () => {
       extensionPointId: extensionPoint.id,
     });
 
-    extensionPoint.registerComponent(extension);
+    extensionPoint.registerModComponent(extension);
 
     await extensionPoint.install();
 
     expect(getReservedPanelEntries().panels).toHaveLength(1);
 
-    extensionPoint.removeComponent(extension.id);
+    extensionPoint.removeModComponent(extension.id);
 
     // Synchronize removes the panel
     expect(getReservedPanelEntries().panels).toHaveLength(0);

--- a/src/starterBricks/sidebarExtension.test.ts
+++ b/src/starterBricks/sidebarExtension.test.ts
@@ -77,7 +77,7 @@ describe("sidebarExtension", () => {
     );
 
     await extensionPoint.install();
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     // Not run until shown
     expect(rootReader.readCount).toBe(0);

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -330,7 +330,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   }
 
   // Use arrow syntax to avoid having to bind when passing as listener to `sidebarShowEvents.add`
-  run = async ({ reason }: RunArgs): Promise<void> => {
+  runComponents = async ({ reason }: RunArgs): Promise<void> => {
     if (!(await this.isAvailable())) {
       console.debug(
         "SidebarStarterBrick:run calling sidebarController:removeExtensionPoint because StarterBrick is not available for URL",
@@ -424,7 +424,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
         "SidebarStarterBrick:install: listen for sidebarShowEvents"
       );
 
-      sidebarShowEvents.add(this.run);
+      sidebarShowEvents.add(this.runComponents);
     } else {
       removeExtensionPoint(this.id);
     }

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -132,18 +132,18 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     return selectAllBlocks(extension.config.body);
   }
 
-  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearModComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     removeExtensions(extensionIds);
   }
 
   public override uninstall(): void {
     const extensions = this.modComponents.splice(0, this.modComponents.length);
-    this.clearComponentInterfaceAndEvents(extensions.map((x) => x.id));
+    this.clearModComponentInterfaceAndEvents(extensions.map((x) => x.id));
     removeExtensionPoint(this.id);
     console.debug(
       "SidebarStarterBrick:uninstall: stop listening for sidebarShowEvents"
     );
-    sidebarShowEvents.remove(this.runComponents);
+    sidebarShowEvents.remove(this.runModComponents);
     this.cancelListeners();
   }
 
@@ -159,7 +159,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     console.debug(
       "SidebarStarterBrick:HACK_uninstallExceptExtension: stop listening for sidebarShowEvents"
     );
-    sidebarShowEvents.remove(this.runComponents);
+    sidebarShowEvents.remove(this.runModComponents);
   }
 
   private async runExtension(
@@ -330,7 +330,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   }
 
   // Use arrow syntax to avoid having to bind when passing as listener to `sidebarShowEvents.add`
-  runComponents = async ({ reason }: RunArgs): Promise<void> => {
+  runModComponents = async ({ reason }: RunArgs): Promise<void> => {
     if (!(await this.isAvailable())) {
       console.debug(
         "SidebarStarterBrick:run calling sidebarController:removeExtensionPoint because StarterBrick is not available for URL",
@@ -424,7 +424,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
         "SidebarStarterBrick:install: listen for sidebarShowEvents"
       );
 
-      sidebarShowEvents.add(this.runComponents);
+      sidebarShowEvents.add(this.runModComponents);
     } else {
       removeExtensionPoint(this.id);
     }

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -137,7 +137,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   }
 
   public override uninstall(): void {
-    const extensions = this.components.splice(0, this.components.length);
+    const extensions = this.modComponents.splice(0, this.modComponents.length);
     this.clearComponentInterfaceAndEvents(extensions.map((x) => x.id));
     removeExtensionPoint(this.id);
     console.debug(
@@ -154,7 +154,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
    */
   public HACK_uninstallExceptExtension(extensionId: UUID): void {
     // Don't call this.clearExtensionInterfaceAndEvents to keep the panel. Instead, mutate this.extensions to exclude id
-    remove(this.components, (x) => x.id === extensionId);
+    remove(this.modComponents, (x) => x.id === extensionId);
     removeExtensionPoint(this.id, { preserveExtensionIds: [extensionId] });
     console.debug(
       "SidebarStarterBrick:HACK_uninstallExceptExtension: stop listening for sidebarShowEvents"
@@ -245,7 +245,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   }: {
     shouldRunExtension?: (extension: ModComponentBase) => boolean;
   }): Promise<void> => {
-    const extensionsToRefresh = this.components.filter((extension) =>
+    const extensionsToRefresh = this.modComponents.filter((extension) =>
       shouldRunExtension(extension)
     );
 
@@ -342,7 +342,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       return;
     }
 
-    if (this.components.length === 0) {
+    if (this.modComponents.length === 0) {
       console.debug(
         "SidebarStarterBrick:run Sidebar StarterBrick %s has no installed extensions",
         this.id
@@ -354,7 +354,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     // Reserve placeholders in the sidebar for when it becomes visible. `Run` is called from lifecycle.ts on navigation;
     // the sidebar won't be visible yet on initial page load.
     reservePanels(
-      this.components.map((extension) => ({
+      this.modComponents.map((extension) => ({
         extensionId: extension.id,
         extensionPointId: this.id,
         blueprintId: extension._recipe?.id,
@@ -412,7 +412,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       // In the future, we might instead consider gating sidebar content loading based on mods both having been
       // `install`ed and `runComponents` called completed at least once.
       reservePanels(
-        this.components.map((components) => ({
+        this.modComponents.map((components) => ({
           extensionId: components.id,
           extensionPointId: this.id,
           blueprintId: components._recipe?.id,

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -143,7 +143,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     console.debug(
       "SidebarStarterBrick:uninstall: stop listening for sidebarShowEvents"
     );
-    sidebarShowEvents.remove(this.run);
+    sidebarShowEvents.remove(this.runComponents);
     this.cancelListeners();
   }
 
@@ -159,7 +159,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     console.debug(
       "SidebarStarterBrick:HACK_uninstallExceptExtension: stop listening for sidebarShowEvents"
     );
-    sidebarShowEvents.remove(this.run);
+    sidebarShowEvents.remove(this.runComponents);
   }
 
   private async runExtension(
@@ -402,28 +402,8 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
 
   async install(): Promise<boolean> {
     const available = await this.isAvailable();
-    if (available) {
-      // Reserve the panels, so the sidebarController knows about them prior to the sidebar showing.
-      // Previously we were just relying on the sidebarShowEvents event listeners, but that caused race conditions
-      // with how other content is loaded in the sidebar
-      reservePanels(
-        this.components.map((extension) => ({
-          extensionId: extension.id,
-          extensionPointId: this.id,
-          blueprintId: extension._recipe?.id,
-        }))
-      );
 
-      // Add event listener so content for the panel is calculated/loaded when the sidebar opens
-      console.debug(
-        "SidebarStarterBrick:install: listen for sidebarShowEvents"
-      );
-      sidebarShowEvents.add(this.run);
-    } else {
-      removeExtensionPoint(this.id);
-    }
-
-    if (this.debounceOptions?.waitMillis) {
+    if (available && this.debounceOptions?.waitMillis) {
       const { waitMillis, ...options } = this.debounceOptions;
       this.debouncedRefreshPanels = debounce(
         this.refreshPanels,

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -126,19 +126,19 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     return "actionPanel";
   }
 
-  async getBlocks(
+  async getBricks(
     extension: ResolvedModComponent<SidebarConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.body);
   }
 
-  clearExtensionInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     removeExtensions(extensionIds);
   }
 
   public override uninstall(): void {
-    const extensions = this.extensions.splice(0, this.extensions.length);
-    this.clearExtensionInterfaceAndEvents(extensions.map((x) => x.id));
+    const extensions = this.components.splice(0, this.components.length);
+    this.clearComponentInterfaceAndEvents(extensions.map((x) => x.id));
     removeExtensionPoint(this.id);
     console.debug(
       "SidebarStarterBrick:uninstall: stop listening for sidebarShowEvents"
@@ -154,7 +154,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
    */
   public HACK_uninstallExceptExtension(extensionId: UUID): void {
     // Don't call this.clearExtensionInterfaceAndEvents to keep the panel. Instead, mutate this.extensions to exclude id
-    remove(this.extensions, (x) => x.id === extensionId);
+    remove(this.components, (x) => x.id === extensionId);
     removeExtensionPoint(this.id, { preserveExtensionIds: [extensionId] });
     console.debug(
       "SidebarStarterBrick:HACK_uninstallExceptExtension: stop listening for sidebarShowEvents"
@@ -245,7 +245,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   }: {
     shouldRunExtension?: (extension: ModComponentBase) => boolean;
   }): Promise<void> => {
-    const extensionsToRefresh = this.extensions.filter((extension) =>
+    const extensionsToRefresh = this.components.filter((extension) =>
       shouldRunExtension(extension)
     );
 
@@ -342,7 +342,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       return;
     }
 
-    if (this.extensions.length === 0) {
+    if (this.components.length === 0) {
       console.debug(
         "SidebarStarterBrick:run Sidebar StarterBrick %s has no installed extensions",
         this.id
@@ -354,7 +354,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     // Reserve placeholders in the sidebar for when it becomes visible. `Run` is called from lifecycle.ts on navigation;
     // the sidebar won't be visible yet on initial page load.
     reservePanels(
-      this.extensions.map((extension) => ({
+      this.components.map((extension) => ({
         extensionId: extension.id,
         extensionPointId: this.id,
         blueprintId: extension._recipe?.id,
@@ -407,7 +407,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       // Previously we were just relying on the sidebarShowEvents event listeners, but that caused race conditions
       // with how other content is loaded in the sidebar
       reservePanels(
-        this.extensions.map((extension) => ({
+        this.components.map((extension) => ({
           extensionId: extension.id,
           extensionPointId: this.id,
           blueprintId: extension._recipe?.id,
@@ -472,7 +472,7 @@ class RemotePanelExtensionPoint extends SidebarStarterBrickABC {
     this.definition = cloned.definition;
   }
 
-  public override get syncInstall() {
+  public override get isSyncInstall() {
     // Panels must be reserved for the page to be considered ready. Otherwise, there are race conditions with whether
     // the sidebar panels have been reserved by the time the user clicks the browserAction.
     return true;

--- a/src/starterBricks/tourExtension.test.ts
+++ b/src/starterBricks/tourExtension.test.ts
@@ -90,7 +90,7 @@ describe("tourExtension", () => {
     );
 
     await starterBrick.install();
-    await starterBrick.run({ reason: RunReason.PAGE_EDITOR });
+    await starterBrick.runComponents({ reason: RunReason.PAGE_EDITOR });
 
     await tick();
 
@@ -112,7 +112,7 @@ describe("tourExtension", () => {
     );
 
     await extensionPoint.install();
-    await extensionPoint.run({ reason: RunReason.INITIAL_LOAD });
+    await extensionPoint.runComponents({ reason: RunReason.INITIAL_LOAD });
 
     await tick();
 

--- a/src/starterBricks/tourExtension.test.ts
+++ b/src/starterBricks/tourExtension.test.ts
@@ -83,7 +83,7 @@ describe("tourExtension", () => {
   test("install tour via Page Editor", async () => {
     const starterBrick = fromJS(starterBrickFactory()());
 
-    starterBrick.addExtension(
+    starterBrick.registerComponent(
       extensionFactory({
         extensionPointId: starterBrick.id,
       })
@@ -105,7 +105,7 @@ describe("tourExtension", () => {
       starterBrickFactory({ allowUserRun: true, autoRunSchedule: "never" })()
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })

--- a/src/starterBricks/tourExtension.test.ts
+++ b/src/starterBricks/tourExtension.test.ts
@@ -83,14 +83,14 @@ describe("tourExtension", () => {
   test("install tour via Page Editor", async () => {
     const starterBrick = fromJS(starterBrickFactory()());
 
-    starterBrick.registerComponent(
+    starterBrick.registerModComponent(
       extensionFactory({
         extensionPointId: starterBrick.id,
       })
     );
 
     await starterBrick.install();
-    await starterBrick.runComponents({ reason: RunReason.PAGE_EDITOR });
+    await starterBrick.runModComponents({ reason: RunReason.PAGE_EDITOR });
 
     await tick();
 
@@ -105,14 +105,14 @@ describe("tourExtension", () => {
       starterBrickFactory({ allowUserRun: true, autoRunSchedule: "never" })()
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
     );
 
     await extensionPoint.install();
-    await extensionPoint.runComponents({ reason: RunReason.INITIAL_LOAD });
+    await extensionPoint.runModComponents({ reason: RunReason.INITIAL_LOAD });
 
     await tick();
 

--- a/src/starterBricks/tourExtension.ts
+++ b/src/starterBricks/tourExtension.ts
@@ -113,7 +113,7 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
     return false;
   }
 
-  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearModComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     console.debug("tourExtension:removeExtensions");
     unregisterTours(this.modComponents.map((x) => x.id));
   }
@@ -236,7 +236,7 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
     return minBy(someRun, (x) => latest[x.id]);
   }
 
-  async runComponents({ reason, extensionIds }: RunArgs): Promise<void> {
+  async runModComponents({ reason, extensionIds }: RunArgs): Promise<void> {
     if (this.modComponents.length === 0) {
       // NOP
       return;

--- a/src/starterBricks/tourExtension.ts
+++ b/src/starterBricks/tourExtension.ts
@@ -111,16 +111,16 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
     }
   }
 
-  clearExtensionInterfaceAndEvents(extensionIds: UUID[]): void {
+  clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
     console.debug("tourExtension:removeExtensions");
-    unregisterTours(this.extensions.map((x) => x.id));
+    unregisterTours(this.components.map((x) => x.id));
   }
 
   override uninstall(): void {
     console.debug("tourExtension:uninstall", {
       id: this.id,
     });
-    unregisterTours(this.extensions.map((x) => x.id));
+    unregisterTours(this.components.map((x) => x.id));
   }
 
   inputSchema: Schema = propertiesToSchema({
@@ -129,7 +129,7 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
     },
   });
 
-  async getBlocks(
+  async getBricks(
     extension: ResolvedModComponent<TourConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.tour);
@@ -192,7 +192,7 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
    * @see autoRunSchedule
    */
   async decideAutoRunTour(): Promise<ResolvedModComponent<TourConfig>> {
-    const extensionIds = new Set(this.extensions.map((x) => x.id));
+    const extensionIds = new Set(this.components.map((x) => x.id));
 
     const runs = await getAll();
 
@@ -202,7 +202,7 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
         return tour.extensionId;
       }
 
-      for (const extension of this.extensions) {
+      for (const extension of this.components) {
         if (
           extension._recipe?.id === tour.packageId &&
           extension.label === tour.tourName
@@ -218,7 +218,7 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
       max(xs.map((x) => Date.parse(x.updatedAt)))
     );
 
-    const [someRun, neverRun] = partition(this.extensions, (x) => latest[x.id]);
+    const [someRun, neverRun] = partition(this.components, (x) => latest[x.id]);
 
     if (neverRun.length > 0) {
       return neverRun[0];
@@ -232,13 +232,13 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
   }
 
   async run({ reason, extensionIds }: RunArgs): Promise<void> {
-    if (this.extensions.length === 0) {
+    if (this.components.length === 0) {
       // NOP
       return;
     }
 
     // Always ensure all tours are registered
-    for (const extension of this.extensions) {
+    for (const extension of this.components) {
       this.registerTour(extension);
     }
 
@@ -246,7 +246,7 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
     // tours re-running on Page Editor close/open or "Reactivate All" unless they have a matching autoRunSchedule
     if (reason === RunReason.PAGE_EDITOR) {
       cancelAllTours();
-      const extensionPool = extensionIds ?? this.extensions.map((x) => x.id);
+      const extensionPool = extensionIds ?? this.components.map((x) => x.id);
       this.extensionTours.get(extensionPool[0])?.run();
       return;
     }

--- a/src/starterBricks/tourExtension.ts
+++ b/src/starterBricks/tourExtension.ts
@@ -109,6 +109,8 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
       await initPopoverPool();
       return true;
     }
+
+    return false;
   }
 
   clearComponentInterfaceAndEvents(extensionIds: UUID[]): void {
@@ -231,7 +233,7 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
     return minBy(someRun, (x) => latest[x.id]);
   }
 
-  async run({ reason, extensionIds }: RunArgs): Promise<void> {
+  async runComponents({ reason, extensionIds }: RunArgs): Promise<void> {
     if (this.components.length === 0) {
       // NOP
       return;

--- a/src/starterBricks/triggerExtension.test.ts
+++ b/src/starterBricks/triggerExtension.test.ts
@@ -129,14 +129,14 @@ describe("triggerExtension", () => {
         })()
       );
 
-      extensionPoint.registerComponent(
+      extensionPoint.registerModComponent(
         extensionFactory({
           extensionPointId: extensionPoint.id,
         })
       );
 
       await extensionPoint.install();
-      await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+      await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
       expect(rootReader.readCount).toBe(1);
 
@@ -159,14 +159,14 @@ describe("triggerExtension", () => {
         })()
       );
 
-      extensionPoint.registerComponent(
+      extensionPoint.registerModComponent(
         extensionFactory({
           extensionPointId: extensionPoint.id,
         })
       );
 
       await extensionPoint.install();
-      await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+      await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
       expect(rootReader.readCount).toBe(0);
 
@@ -210,14 +210,14 @@ describe("triggerExtension", () => {
         })()
       );
 
-      extensionPoint.registerComponent(
+      extensionPoint.registerModComponent(
         extensionFactory({
           extensionPointId: extensionPoint.id,
         })
       );
 
       await extensionPoint.install();
-      await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+      await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
       document.querySelector("button").click();
       await tick();
@@ -246,14 +246,14 @@ describe("triggerExtension", () => {
       })()
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
     );
 
     await extensionPoint.install();
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     document.querySelector("button").click();
     await tick();
@@ -278,14 +278,14 @@ describe("triggerExtension", () => {
       })()
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
     );
 
     await extensionPoint.install();
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     const element = document.querySelector("input");
 
@@ -309,14 +309,14 @@ describe("triggerExtension", () => {
       })()
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
     );
 
     await extensionPoint.install();
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     const buttonElement = document.querySelector("button");
 
@@ -411,14 +411,14 @@ describe("triggerExtension", () => {
       })({})
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
     );
 
     await extensionPoint.install();
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     expect(notifyErrorMock).not.toHaveBeenCalled();
   });
@@ -437,14 +437,14 @@ describe("triggerExtension", () => {
       })({})
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
     );
 
     await extensionPoint.install();
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     document.querySelector("button").click();
     await tick();
@@ -468,7 +468,7 @@ describe("triggerExtension", () => {
       })({})
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
         config: {
@@ -480,8 +480,8 @@ describe("triggerExtension", () => {
     await extensionPoint.install();
 
     // Run 2x
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     expect(reportErrorMock).toHaveBeenCalledTimes(1);
 
@@ -501,7 +501,7 @@ describe("triggerExtension", () => {
       })({})
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
         config: {
@@ -513,8 +513,8 @@ describe("triggerExtension", () => {
     await extensionPoint.install();
 
     // Run 2x
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     expect(reportErrorMock).toHaveBeenCalledTimes(2);
     expect(notifyErrorMock).toHaveBeenCalledTimes(2);
@@ -530,7 +530,7 @@ describe("triggerExtension", () => {
       })({})
     );
 
-    extensionPoint.registerComponent(
+    extensionPoint.registerModComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
         config: {
@@ -542,8 +542,8 @@ describe("triggerExtension", () => {
     await extensionPoint.install();
 
     // Run 2x
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
-    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runModComponents({ reason: RunReason.MANUAL });
 
     expect(reportErrorMock).toHaveBeenCalledTimes(2);
     expect(notifyErrorMock).toHaveBeenCalledTimes(0);

--- a/src/starterBricks/triggerExtension.test.ts
+++ b/src/starterBricks/triggerExtension.test.ts
@@ -129,7 +129,7 @@ describe("triggerExtension", () => {
         })()
       );
 
-      extensionPoint.addExtension(
+      extensionPoint.registerComponent(
         extensionFactory({
           extensionPointId: extensionPoint.id,
         })
@@ -159,7 +159,7 @@ describe("triggerExtension", () => {
         })()
       );
 
-      extensionPoint.addExtension(
+      extensionPoint.registerComponent(
         extensionFactory({
           extensionPointId: extensionPoint.id,
         })
@@ -210,7 +210,7 @@ describe("triggerExtension", () => {
         })()
       );
 
-      extensionPoint.addExtension(
+      extensionPoint.registerComponent(
         extensionFactory({
           extensionPointId: extensionPoint.id,
         })
@@ -246,7 +246,7 @@ describe("triggerExtension", () => {
       })()
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -278,7 +278,7 @@ describe("triggerExtension", () => {
       })()
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -309,7 +309,7 @@ describe("triggerExtension", () => {
       })()
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -411,7 +411,7 @@ describe("triggerExtension", () => {
       })({})
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -437,7 +437,7 @@ describe("triggerExtension", () => {
       })({})
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
       })
@@ -468,7 +468,7 @@ describe("triggerExtension", () => {
       })({})
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
         config: {
@@ -501,7 +501,7 @@ describe("triggerExtension", () => {
       })({})
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
         config: {
@@ -530,7 +530,7 @@ describe("triggerExtension", () => {
       })({})
     );
 
-    extensionPoint.addExtension(
+    extensionPoint.registerComponent(
       extensionFactory({
         extensionPointId: extensionPoint.id,
         config: {

--- a/src/starterBricks/triggerExtension.test.ts
+++ b/src/starterBricks/triggerExtension.test.ts
@@ -136,7 +136,7 @@ describe("triggerExtension", () => {
       );
 
       await extensionPoint.install();
-      await extensionPoint.run({ reason: RunReason.MANUAL });
+      await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
       expect(rootReader.readCount).toBe(1);
 
@@ -166,7 +166,7 @@ describe("triggerExtension", () => {
       );
 
       await extensionPoint.install();
-      await extensionPoint.run({ reason: RunReason.MANUAL });
+      await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
       expect(rootReader.readCount).toBe(0);
 
@@ -217,7 +217,7 @@ describe("triggerExtension", () => {
       );
 
       await extensionPoint.install();
-      await extensionPoint.run({ reason: RunReason.MANUAL });
+      await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
       document.querySelector("button").click();
       await tick();
@@ -253,7 +253,7 @@ describe("triggerExtension", () => {
     );
 
     await extensionPoint.install();
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     document.querySelector("button").click();
     await tick();
@@ -285,7 +285,7 @@ describe("triggerExtension", () => {
     );
 
     await extensionPoint.install();
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     const element = document.querySelector("input");
 
@@ -316,7 +316,7 @@ describe("triggerExtension", () => {
     );
 
     await extensionPoint.install();
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     const buttonElement = document.querySelector("button");
 
@@ -418,7 +418,7 @@ describe("triggerExtension", () => {
     );
 
     await extensionPoint.install();
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     expect(notifyErrorMock).not.toHaveBeenCalled();
   });
@@ -444,7 +444,7 @@ describe("triggerExtension", () => {
     );
 
     await extensionPoint.install();
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     document.querySelector("button").click();
     await tick();
@@ -480,8 +480,8 @@ describe("triggerExtension", () => {
     await extensionPoint.install();
 
     // Run 2x
-    await extensionPoint.run({ reason: RunReason.MANUAL });
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     expect(reportErrorMock).toHaveBeenCalledTimes(1);
 
@@ -513,8 +513,8 @@ describe("triggerExtension", () => {
     await extensionPoint.install();
 
     // Run 2x
-    await extensionPoint.run({ reason: RunReason.MANUAL });
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     expect(reportErrorMock).toHaveBeenCalledTimes(2);
     expect(notifyErrorMock).toHaveBeenCalledTimes(2);
@@ -542,8 +542,8 @@ describe("triggerExtension", () => {
     await extensionPoint.install();
 
     // Run 2x
-    await extensionPoint.run({ reason: RunReason.MANUAL });
-    await extensionPoint.run({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
+    await extensionPoint.runComponents({ reason: RunReason.MANUAL });
 
     expect(reportErrorMock).toHaveBeenCalledTimes(2);
     expect(notifyErrorMock).toHaveBeenCalledTimes(0);

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -307,7 +307,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     this.installedEvents.clear();
 
     // Remove all extensions to prevent them from running if there are any straggler event handlers on the page
-    this.components.splice(0, this.components.length);
+    this.modComponents.splice(0, this.modComponents.length);
   }
 
   inputSchema: Schema = propertiesToSchema({
@@ -431,7 +431,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
       nativeEvent: Event | null;
     }
   ): Promise<void> {
-    let extensionsToRun = this.components;
+    let extensionsToRun = this.modComponents;
 
     if (this.trigger === "hover") {
       // Enforce synchronous behavior for `hover` event

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -273,7 +273,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     this.abortController.signal.addEventListener("abort", callback);
   }
 
-  clearComponentInterfaceAndEvents(): void {
+  clearModComponentInterfaceAndEvents(): void {
     // NOP: the unregisterExtensionEvents method doesn't need to unregister anything from the page because the
     // observers/handlers are installed for the extensionPoint instance itself, not the extensions. I.e., there's a
     // single load/click/etc. trigger that's shared by all extensions using this extension point.
@@ -780,7 +780,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     }
   }
 
-  async runComponents(): Promise<void> {
+  async runModComponents(): Promise<void> {
     this.cancelObservers();
 
     const $root = await this.getRoot();

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -780,7 +780,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     }
   }
 
-  async run(): Promise<void> {
+  async runComponents(): Promise<void> {
     this.cancelObservers();
 
     const $root = await this.getRoot();

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -273,7 +273,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     this.abortController.signal.addEventListener("abort", callback);
   }
 
-  clearExtensionInterfaceAndEvents(): void {
+  clearComponentInterfaceAndEvents(): void {
     // NOP: the unregisterExtensionEvents method doesn't need to unregister anything from the page because the
     // observers/handlers are installed for the extensionPoint instance itself, not the extensions. I.e., there's a
     // single load/click/etc. trigger that's shared by all extensions using this extension point.
@@ -307,7 +307,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     this.installedEvents.clear();
 
     // Remove all extensions to prevent them from running if there are any straggler event handlers on the page
-    this.extensions.splice(0, this.extensions.length);
+    this.components.splice(0, this.components.length);
   }
 
   inputSchema: Schema = propertiesToSchema({
@@ -316,7 +316,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     },
   });
 
-  async getBlocks(
+  async getBricks(
     extension: ResolvedModComponent<TriggerConfig>
   ): Promise<Brick[]> {
     return selectAllBlocks(extension.config.action);
@@ -431,7 +431,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
       nativeEvent: Event | null;
     }
   ): Promise<void> {
-    let extensionsToRun = this.extensions;
+    let extensionsToRun = this.components;
 
     if (this.trigger === "hover") {
       // Enforce synchronous behavior for `hover` event

--- a/src/starterBricks/types.ts
+++ b/src/starterBricks/types.ts
@@ -141,7 +141,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
    * The current registered mod components.
    * @protected
    */
-  protected readonly components: Array<ResolvedModComponent<TConfig>> = [];
+  protected readonly modComponents: Array<ResolvedModComponent<TConfig>> = [];
 
   public abstract readonly inputSchema: Schema;
 
@@ -154,7 +154,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
   }
 
   public get registeredComponents(): Array<ResolvedModComponent<TConfig>> {
-    return [...this.components];
+    return [...this.modComponents];
   }
 
   /**
@@ -192,17 +192,17 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
   synchronizeComponents(
     components: Array<ResolvedModComponent<TConfig>>
   ): void {
-    const before = this.components.map((x) => x.id);
+    const before = this.modComponents.map((x) => x.id);
 
     const updatedIds = new Set(components.map((x) => x.id));
-    const removed = this.components.filter(
+    const removed = this.modComponents.filter(
       (currentComponent) => !updatedIds.has(currentComponent.id)
     );
     this.clearComponentInterfaceAndEvents(removed.map((x) => x.id));
 
     // Clear extensions and re-populate with updated components
-    this.components.splice(0, this.components.length);
-    this.components.push(...components);
+    this.modComponents.splice(0, this.modComponents.length);
+    this.modComponents.push(...components);
 
     console.debug("synchronizeComponents for extension point %s", this.id, {
       before,
@@ -213,21 +213,21 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
 
   removeComponent(componentId: UUID): void {
     this.synchronizeComponents(
-      this.components.filter((x) => x.id !== componentId)
+      this.modComponents.filter((x) => x.id !== componentId)
     );
   }
 
   registerComponent(component: ResolvedModComponent<TConfig>): void {
-    const index = this.components.findIndex((x) => x.id === component.id);
+    const index = this.modComponents.findIndex((x) => x.id === component.id);
     if (index >= 0) {
       console.warn(
         `Component ${component.id} already registered for the starter brick ${this.id}`
       );
       // Index is guaranteed to be a number, and this.extensions is an array
       // eslint-disable-next-line security/detect-object-injection
-      this.components[index] = component;
+      this.modComponents[index] = component;
     } else {
-      this.components.push(component);
+      this.modComponents.push(component);
     }
   }
 

--- a/src/starterBricks/types.ts
+++ b/src/starterBricks/types.ts
@@ -118,6 +118,9 @@ export function assertStarterBrickConfig(
   }
 }
 
+/**
+ * Abstract base class for StarterBrick implementations.
+ */
 export abstract class StarterBrickABC<TConfig extends UnknownObject>
   implements StarterBrick
 {
@@ -242,9 +245,9 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
 
   abstract install(): Promise<boolean>;
 
+  abstract runComponents(args: RunArgs): Promise<void>;
+
   uninstall(_options?: { global?: boolean }): void {
     console.warn(`Uninstall not implemented for extension point: ${this.id}`);
   }
-
-  abstract run(args: RunArgs): Promise<void>;
 }

--- a/src/starterBricks/types.ts
+++ b/src/starterBricks/types.ts
@@ -217,17 +217,17 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
     );
   }
 
-  registerComponent(componentId: ResolvedModComponent<TConfig>): void {
-    const index = this.components.findIndex((x) => x.id === componentId.id);
+  registerComponent(component: ResolvedModComponent<TConfig>): void {
+    const index = this.components.findIndex((x) => x.id === component.id);
     if (index >= 0) {
       console.warn(
-        `Extension ${componentId.id} already registered for the extension point ${this.id}`
+        `Component ${component.id} already registered for the starter brick ${this.id}`
       );
       // Index is guaranteed to be a number, and this.extensions is an array
       // eslint-disable-next-line security/detect-object-injection
-      this.components[index] = componentId;
+      this.components[index] = component;
     } else {
-      this.components.push(componentId);
+      this.components.push(component);
     }
   }
 

--- a/src/starterBricks/types.ts
+++ b/src/starterBricks/types.ts
@@ -153,7 +153,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
     return false;
   }
 
-  public get registeredComponents(): Array<ResolvedModComponent<TConfig>> {
+  public get registeredModComponents(): Array<ResolvedModComponent<TConfig>> {
     return [...this.modComponents];
   }
 
@@ -182,14 +182,14 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
    * NOTE: when this method is called, the extensions will still be in this.extensions. The caller is responsible for
    * updating this.extensions as necessary.
    *
-   * @see synchronizeComponents
-   * @see removeComponent
+   * @see synchronizeModComponents
+   * @see removeModComponent
    */
-  protected abstract clearComponentInterfaceAndEvents(
+  protected abstract clearModComponentInterfaceAndEvents(
     componentIds: UUID[]
   ): void;
 
-  synchronizeComponents(
+  synchronizeModComponents(
     components: Array<ResolvedModComponent<TConfig>>
   ): void {
     const before = this.modComponents.map((x) => x.id);
@@ -198,7 +198,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
     const removed = this.modComponents.filter(
       (currentComponent) => !updatedIds.has(currentComponent.id)
     );
-    this.clearComponentInterfaceAndEvents(removed.map((x) => x.id));
+    this.clearModComponentInterfaceAndEvents(removed.map((x) => x.id));
 
     // Clear extensions and re-populate with updated components
     this.modComponents.splice(0, this.modComponents.length);
@@ -211,13 +211,13 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
     });
   }
 
-  removeComponent(componentId: UUID): void {
-    this.synchronizeComponents(
+  removeModComponent(componentId: UUID): void {
+    this.synchronizeModComponents(
       this.modComponents.filter((x) => x.id !== componentId)
     );
   }
 
-  registerComponent(component: ResolvedModComponent<TConfig>): void {
+  registerModComponent(component: ResolvedModComponent<TConfig>): void {
     const index = this.modComponents.findIndex((x) => x.id === component.id);
     if (index >= 0) {
       console.warn(
@@ -245,7 +245,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
 
   abstract install(): Promise<boolean>;
 
-  abstract runComponents(args: RunArgs): Promise<void>;
+  abstract runModComponents(args: RunArgs): Promise<void>;
 
   uninstall(_options?: { global?: boolean }): void {
     console.warn(`Uninstall not implemented for extension point: ${this.id}`);

--- a/src/starterBricks/types.ts
+++ b/src/starterBricks/types.ts
@@ -134,9 +134,11 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
 
   public readonly description: string;
 
+  /**
+   * The current registered mod components.
+   * @protected
+   */
   protected readonly components: Array<ResolvedModComponent<TConfig>> = [];
-
-  protected readonly template?: string;
 
   public abstract readonly inputSchema: Schema;
 
@@ -153,7 +155,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
   }
 
   /**
-   * Permissions required to use the extensions attached to the extension point.
+   * Permissions required to use the mod components attached to the starter brick.
    * https://developer.chrome.com/extensions/permission_warnings
    */
   public abstract readonly permissions: Permissions.Permissions;

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -176,7 +176,7 @@ export enum RunReason {
 
 /**
  * Arguments for running an StarterBrick
- * @see StarterBrick.run
+ * @see StarterBrick.runComponents
  */
 export type RunArgs = {
   /**

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -176,7 +176,7 @@ export enum RunReason {
 
 /**
  * Arguments for running an StarterBrick
- * @see StarterBrick.runComponents
+ * @see StarterBrick.runModComponents
  */
 export type RunArgs = {
   /**

--- a/src/types/starterBrickTypes.ts
+++ b/src/types/starterBrickTypes.ts
@@ -87,33 +87,33 @@ export interface StarterBrick extends Metadata {
   /**
    * Install the StarterBrick on the page if/when its target becomes available.
    * Does not run/add ModComponents to the page.
-   * @see runComponents
+   * @see runModComponents
    */
   install(): Promise<boolean>;
 
   /**
    * Register a ModComponent with the StarterBrick. Does not add/run the ModComponent to the page.
-   * @see runComponents
+   * @see runModComponents
    */
-  registerComponent(component: ResolvedModComponent): void;
+  registerModComponent(component: ResolvedModComponent): void;
 
   /**
    * Run all registered ModComponents for this StarterBrick and/or add their UI to the page.
    * @see install
    */
-  runComponents(args: RunArgs): Promise<void>;
+  runModComponents(args: RunArgs): Promise<void>;
 
   /**
    * Remove the ModComponent from the StarterBrick and clear its UI and events from the page.
    */
-  removeComponent(modComponentId: UUID): void;
+  removeModComponent(modComponentId: UUID): void;
 
   /**
    * Remove the StarterBrick and all ModComponents from the page.
    *
    * @param options.global true to indicate the starter brick is being uninstalled from all tabs. This enabled the
    * starter brick to perform global UI cleanup, e.g., unregistering a context menu with the Browser.
-   * @see removeComponent
+   * @see removeModComponent
    */
   uninstall(options?: { global?: boolean }): void;
 
@@ -122,10 +122,10 @@ export interface StarterBrick extends Metadata {
    *
    * Equivalent to calling `removeComponent` and `registerComponent`.
    *
-   * @see removeComponent
-   * @see registerComponent
+   * @see removeModComponent
+   * @see registerModComponent
    */
-  synchronizeComponents(modComponents: ResolvedModComponent[]): void;
+  synchronizeModComponents(modComponents: ResolvedModComponent[]): void;
 
   /**
    * Returns all bricks configured in provided ModComponentBase, including sub-pipelines.
@@ -139,5 +139,5 @@ export interface StarterBrick extends Metadata {
    * The mod components currently registered with the StarterBrick.
    * @since 1.7.34
    */
-  registeredComponents: readonly ResolvedModComponent[];
+  registeredModComponents: readonly ResolvedModComponent[];
 }

--- a/src/types/starterBrickTypes.ts
+++ b/src/types/starterBrickTypes.ts
@@ -47,7 +47,7 @@ export interface StarterBrick extends Metadata {
   inputSchema: Schema;
 
   /**
-   * Default options to provide to the inputSchema.
+   * Default configuration options.
    */
   defaultOptions: UnknownObject;
 
@@ -72,11 +72,10 @@ export interface StarterBrick extends Metadata {
   previewReader: () => Promise<Reader>;
 
   /**
-   * Return true if the StarterBrick should be available on the current page. Based on:
-   *
+   * Return true if the StarterBrick should be available on the current page, based on:
    * - URL match patterns
    * - URL pattern rules
-   * - Element selector rules
+   * - Element selector rules. Does not attempt to wait for the element to be in the DOM.
    */
   isAvailable: () => Promise<boolean>;
 
@@ -86,19 +85,22 @@ export interface StarterBrick extends Metadata {
   isSyncInstall: boolean;
 
   /**
-   * Install/add the StarterBrick to the page.
+   * Install the StarterBrick on the page if/when its target becomes available.
+   * Does not run/add ModComponents to the page.
+   * @see runComponents
    */
   install(): Promise<boolean>;
 
   /**
-   * Register an ModComponent with the StarterBrick. Does not install/run the ModComponent.
+   * Register a ModComponent with the StarterBrick. Does not add/run the ModComponent to the page.
    */
   registerComponent(modComponent: ResolvedModComponent): void;
 
   /**
-   * Run the installed ModComponents for StarterBrick.
+   * Run all registered ModComponents for this StarterBrick and/or add their UI to the page.
+   * @see install
    */
-  run(args: RunArgs): Promise<void>;
+  runComponents(args: RunArgs): Promise<void>;
 
   /**
    * Remove the ModComponent from the StarterBrick and clear its UI from the page.
@@ -108,6 +110,8 @@ export interface StarterBrick extends Metadata {
   /**
    * Remove the StarterBrick and all ModComponents from the page.
    *
+   * @param options.global true to indicate the starter brick is being uninstalled from all tabs. This enabled the
+   * starter brick to perform global UI cleanup, e.g., unregistering a context menu with the Browser.
    * @see removeComponent
    */
   uninstall(options?: { global?: boolean }): void;

--- a/src/types/starterBrickTypes.ts
+++ b/src/types/starterBrickTypes.ts
@@ -32,6 +32,9 @@ export type Location =
   // Sidebar panel. ephemeralForm uses `sidebar` as the location for the sidebar
   "panel" | "modal" | "popover";
 
+/**
+ * A StarterBrick entity on a page that can ModComponents can be added to.
+ */
 export interface StarterBrick extends Metadata {
   /**
    * The kind of StarterBrick.
@@ -69,7 +72,7 @@ export interface StarterBrick extends Metadata {
   previewReader: () => Promise<Reader>;
 
   /**
-   * Return true if the StarterBrick is available on the current page. Based on:
+   * Return true if the StarterBrick should be available on the current page. Based on:
    *
    * - URL match patterns
    * - URL pattern rules
@@ -78,9 +81,9 @@ export interface StarterBrick extends Metadata {
   isAvailable: () => Promise<boolean>;
 
   /**
-   * True if the StarterBrick must be installed before the page can be considered ready
+   * True if the StarterBrick must be installed before the mods on the page should be considered ready.
    */
-  syncInstall: boolean;
+  isSyncInstall: boolean;
 
   /**
    * Install/add the StarterBrick to the page.
@@ -88,25 +91,9 @@ export interface StarterBrick extends Metadata {
   install(): Promise<boolean>;
 
   /**
-   * Remove the StarterBrick and installed ModComponents from the page.
+   * Register an ModComponent with the StarterBrick. Does not install/run the ModComponent.
    */
-  uninstall(options?: { global?: boolean }): void;
-
-  /**
-   * Remove the ModComponent from the StarterBrick.
-   */
-  removeExtension(modComponentId: UUID): void;
-
-  /**
-   * Register an ModComponent with the StarterBrick. Does not actually install/run the ModComponent.
-   */
-  addExtension(modComponent: ResolvedModComponent): void;
-
-  /**
-   * Sync registered ModComponents, removing any ModComponents that aren't provided here. Does not actually install/run
-   * the ModComponents.
-   */
-  syncExtensions(modComponents: ResolvedModComponent[]): void;
+  registerComponent(modComponent: ResolvedModComponent): void;
 
   /**
    * Run the installed ModComponents for StarterBrick.
@@ -114,14 +101,38 @@ export interface StarterBrick extends Metadata {
   run(args: RunArgs): Promise<void>;
 
   /**
-   * Returns all blocks configured in the ModComponentBase, including sub pipelines.
-   *
-   * @see PipelineExpression
+   * Remove the ModComponent from the StarterBrick and clear its UI from the page.
    */
-  getBlocks: (modComponent: ResolvedModComponent) => Promise<Brick[]>;
+  removeComponent(modComponentId: UUID): void;
 
   /**
-   * The current mod components registered with the StarterBrick.
+   * Remove the StarterBrick and all ModComponents from the page.
+   *
+   * @see removeComponent
    */
-  registeredExtensions: ResolvedModComponent[];
+  uninstall(options?: { global?: boolean }): void;
+
+  /**
+   * Synchronize registered ModComponents, removing any ModComponents that aren't provided. DOES NOT run the components.
+   *
+   * Equivalent to calling `removeComponent` and `registerComponent`.
+   *
+   * @see removeComponent
+   * @see registerComponent
+   */
+  synchronizeComponents(modComponents: ResolvedModComponent[]): void;
+
+  /**
+   * Returns all bricks configured in provided ModComponentBase, including sub-pipelines.
+   *
+   * @param modComponent the ModComponent to get bricks for
+   * @see PipelineExpression
+   */
+  getBricks: (modComponent: ResolvedModComponent) => Promise<Brick[]>;
+
+  /**
+   * The mod components currently registered with the StarterBrick.
+   * @since 1.7.34
+   */
+  registeredComponents: readonly ResolvedModComponent[];
 }

--- a/src/types/starterBrickTypes.ts
+++ b/src/types/starterBrickTypes.ts
@@ -93,6 +93,7 @@ export interface StarterBrick extends Metadata {
 
   /**
    * Register a ModComponent with the StarterBrick. Does not add/run the ModComponent to the page.
+   * @see runComponents
    */
   registerComponent(modComponent: ResolvedModComponent): void;
 
@@ -103,7 +104,7 @@ export interface StarterBrick extends Metadata {
   runComponents(args: RunArgs): Promise<void>;
 
   /**
-   * Remove the ModComponent from the StarterBrick and clear its UI from the page.
+   * Remove the ModComponent from the StarterBrick and clear its UI and events from the page.
    */
   removeComponent(modComponentId: UUID): void;
 

--- a/src/types/starterBrickTypes.ts
+++ b/src/types/starterBrickTypes.ts
@@ -95,7 +95,7 @@ export interface StarterBrick extends Metadata {
    * Register a ModComponent with the StarterBrick. Does not add/run the ModComponent to the page.
    * @see runComponents
    */
-  registerComponent(modComponent: ResolvedModComponent): void;
+  registerComponent(component: ResolvedModComponent): void;
 
   /**
    * Run all registered ModComponents for this StarterBrick and/or add their UI to the page.


### PR DESCRIPTION
## What does this PR do?

- Refactors names used in starter brick implementations to match new naming
- Improves method names and documentation to better reflect what the methods do:
  - addExtension -> registerComponent
  - run -> runComponents
  - syncExtensions -> synchronizeComponents
- Removes an unused `template` field on StarterBrickABC

## Remaining Work

- [x] Improve naming and documentation for `install` and `run` methods
- [x] Determine what to do about `sidebarPanel` install vs. run method. Strictly speaking, the `install` method should not reserve panels for individual components. However, there may be a race on initial page load without that
- [x] Fix broken tests

## Future Work

- Clean up local variables/private methods in individual starter brick implementations

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @mnholtz 
