### PR TITLE
#5999 - GSheets slice 3.1 - Modify Google Sheets brick schemas

### DIFF
--- a/src/contrib/google/sheets/bricks/append.ts
+++ b/src/contrib/google/sheets/bricks/append.ts
@@ -48,7 +48,11 @@ type Shape = KnownShape | "infer";
 export const APPEND_SCHEMA: Schema = propertiesToSchema(
   {
     googleAccount: {
-      $ref: "https://app.pixiebrix.com/schemas/services/google/ouath2-pkce",
+      oneOf: [
+        {
+          $ref: "https://app.pixiebrix.com/schemas/services/google/ouath2-pkce",
+        },
+      ],
     },
     spreadsheetId: {
       // Spreadsheet ID or service config
@@ -104,6 +108,7 @@ export const APPEND_SCHEMA: Schema = propertiesToSchema(
       ],
     },
   },
+  // For backwards compatibility, googleAccount is not required
   ["spreadsheetId", "tabName", "rowValues"]
 );
 

--- a/src/contrib/google/sheets/bricks/append.ts
+++ b/src/contrib/google/sheets/bricks/append.ts
@@ -47,6 +47,9 @@ type Shape = KnownShape | "infer";
 
 export const APPEND_SCHEMA: Schema = propertiesToSchema(
   {
+    googleAccount: {
+      $ref: "https://app.pixiebrix.com/schemas/services/google/ouath2-pkce",
+    },
     spreadsheetId: {
       // Spreadsheet ID or service config
       oneOf: [

--- a/src/contrib/google/sheets/bricks/lookup.ts
+++ b/src/contrib/google/sheets/bricks/lookup.ts
@@ -36,7 +36,11 @@ export const GOOGLE_SHEETS_LOOKUP_ID = validateRegistryId(
 export const LOOKUP_SCHEMA: Schema = propertiesToSchema(
   {
     googleAccount: {
-      $ref: "https://app.pixiebrix.com/schemas/services/google/ouath2-pkce",
+      oneOf: [
+        {
+          $ref: "https://app.pixiebrix.com/schemas/services/google/ouath2-pkce",
+        },
+      ],
     },
     spreadsheetId: {
       // Spreadsheet ID or service config
@@ -69,6 +73,7 @@ export const LOOKUP_SCHEMA: Schema = propertiesToSchema(
       description: "The value to lookup",
     },
   },
+  // For backwards compatibility, googleAccount is not required
   ["spreadsheetId", "tabName", "header", "query"]
 );
 

--- a/src/contrib/google/sheets/bricks/lookup.ts
+++ b/src/contrib/google/sheets/bricks/lookup.ts
@@ -35,6 +35,9 @@ export const GOOGLE_SHEETS_LOOKUP_ID = validateRegistryId(
 
 export const LOOKUP_SCHEMA: Schema = propertiesToSchema(
   {
+    googleAccount: {
+      $ref: "https://app.pixiebrix.com/schemas/services/google/ouath2-pkce",
+    },
     spreadsheetId: {
       // Spreadsheet ID or service config
       oneOf: [


### PR DESCRIPTION
## What does this PR do?

- Closes #5999 

## Reviewer Tips

- The new schema properties are optional because they haven't been added to the `required` arrays on the schemas

## Discussion

- _Note: Modifying the brick args is part of slice 3.2 in the spec_

## Checklist

- [ ] Add tests - N/A
- [x] Designate a primary reviewer - @grahamlangford 
