### PR TITLE
#6030: adjust FAB offset and z-index and avoid chat widget conflicts

### DIFF
--- a/src/components/floatingActions/FloatingActions.scss
+++ b/src/components/floatingActions/FloatingActions.scss
@@ -18,10 +18,14 @@
 
 .root {
   position: fixed;
-  z-index: 2147481647;
+  // Don't overlap on-screen messengers:
+  // chatlio messenger: 9999999
+  // intercom: 2147483000
+  z-index: calc(9999999 - 1);
   bottom: 0;
   left: 0;
-  margin: 30px 10px;
+  // Initial vertical/horizontal spacing from the bottom left of the screen
+  margin: 70px 10px;
 }
 
 .drag-container {


### PR DESCRIPTION
## What does this PR do?

- Closes #6030 
- Adjust z-index and initial offset

## Discussion

- When you're dragging, it's drags under the items too. We might consider showing it as above the elements while dragging

## Demo

- https://www.loom.com/share/b68c58fcdf854840ab570c9120af2af6?sid=31e258ad-5d09-4290-bef3-97af14d967b3

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @grahamlangford 
