### PR TITLE
#6139: support direct multiple mod activation from single link in sidebar

### DIFF
--- a/src/background/messenger/external/_implementation.ts
+++ b/src/background/messenger/external/_implementation.ts
@@ -35,7 +35,7 @@ const HACK_EXTENSION_LINK_RELOAD_DELAY_MS = 100;
 /**
  * Chrome Storage key for tracking the mod id(s) that PixieBrix should start activation for.
  */
-const STORAGE_BLUEPRINT_ID = "activatingBlueprintId" as ManualStorageKey;
+const STORAGE_MOD_IDS_KEY = "activatingBlueprintId" as ManualStorageKey;
 
 /**
  * Set the user's credentials for the PixieBrix extension. Returns true if the data was updated.
@@ -111,7 +111,7 @@ export async function setActivatingMods({
 }: SetActivatingModsOptions): Promise<void> {
   // Defensive check for syntactically valid registry ids
   const modIds = castArray(modIdOrIds).map((x) => validateRegistryId(x));
-  return setStorage(STORAGE_BLUEPRINT_ID, modIds);
+  return setStorage(STORAGE_MOD_IDS_KEY, modIds);
 }
 
 /**
@@ -121,7 +121,7 @@ export async function setActivatingMods({
  */
 export async function getActivatingModIds(): Promise<RegistryId[] | null> {
   const value: RegistryId | RegistryId[] = await readStorage(
-    STORAGE_BLUEPRINT_ID
+    STORAGE_MOD_IDS_KEY
   );
 
   return value?.length > 0 ? castArray(value) : null;
@@ -164,7 +164,6 @@ type ActivateModsOptions = {
 export async function openActivateModPage({
   blueprintId: modIdOrIds,
   newTab = true,
-  pageSource = "marketplace",
   redirectUrl,
 }: ActivateModsOptions): Promise<boolean> {
   const modIds = castArray(modIdOrIds);

--- a/src/background/messenger/external/api.ts
+++ b/src/background/messenger/external/api.ts
@@ -49,7 +49,8 @@ export const setExtensionAuth = liftExternal(
   local.setExtensionAuth
 );
 
-export const setActivatingBlueprint = liftExternal(
+export const setActivatingMods = liftExternal(
+  // Can't change SET_ACTIVATING_BLUEPRINT constant due to backward compatability.
   "SET_ACTIVATING_BLUEPRINT",
   local.setActivatingMods
 );

--- a/src/contentScript/contentScript.ts
+++ b/src/contentScript/contentScript.ts
@@ -30,6 +30,9 @@ import {
 import { logPromiseDuration } from "@/utils";
 import { onContextInvalidated } from "@/errors/contextInvalidated";
 
+// eslint-disable-next-line prefer-destructuring -- process.env substitution
+const DEBUG = process.env.DEBUG;
+
 // Track module load so we hear something from content script in the console if Chrome attempted to import the module.
 console.debug("contentScript: module load");
 
@@ -76,7 +79,7 @@ async function initContentScript() {
   }
 }
 
-if (location.protocol === "https:") {
+if (location.protocol === "https:" || DEBUG) {
   // eslint-disable-next-line promise/prefer-await-to-then -- Top-level await isn't available
   void initContentScript().catch((error) => {
     throw new Error("Error initializing contentScript", { cause: error });

--- a/src/contentScript/loadActivationEnhancements.test.ts
+++ b/src/contentScript/loadActivationEnhancements.test.ts
@@ -138,11 +138,13 @@ describe("marketplace enhancements", () => {
       _recipe: modComponentRecipeFactory,
     });
 
+    const modIds = components.map((x) => x._recipe?.id);
+
     document.body.innerHTML = `
     <div>
         <a class="btn btn-primary" data-activate-button href="https://app.pixiebrix.com/activate?id=${encodeURIComponent(
-          components[0]._recipe.id
-        )}&id=${encodeURIComponent(components[1]._recipe.id)}">Click Me!</a>
+          modIds[0]
+        )}&id=${modIds[1]}">Click Me!</a>
     </div>`;
 
     getActivatedModIdsMock.mockResolvedValue(new Set());
@@ -154,14 +156,16 @@ describe("marketplace enhancements", () => {
     expect(showSidebarMock).not.toHaveBeenCalledOnce();
 
     // Click an activate button
-    const activateButtons = document.querySelectorAll("a");
-    activateButtons[0].click();
+    const activateButton = document.querySelector("a");
+    activateButton.click();
     await waitForEffect();
 
     expect(window.location.href).toBe("https://www.pixiebrix.com/");
     // The show-sidebar function should be called
-    // FIXME: this passes when run individually. There's some test interference going on.
-    expect(showSidebarMock).toHaveBeenCalledOnce();
+    expect(showSidebarMock).toHaveBeenCalledExactlyOnceWith({
+      heading: "Activating",
+      modIds,
+    });
   });
 
   test("given user is not logged in, when activation button clicked, open admin console", async () => {

--- a/src/contentScript/loadActivationEnhancements.test.ts
+++ b/src/contentScript/loadActivationEnhancements.test.ts
@@ -17,7 +17,7 @@
 
 import { showModActivationInSidebar } from "@/contentScript/sidebarController";
 import { initSidebarActivation } from "@/contentScript/sidebarActivation";
-import { loadOptions } from "@/store/extensionsStorage";
+import { getActivatedModIds } from "@/store/extensionsStorage";
 import { getDocument } from "@/starterBricks/starterBrickTestUtils";
 import { validateRegistryId } from "@/types/helpers";
 import { type ActivatedModComponent } from "@/types/modComponentTypes";
@@ -30,18 +30,17 @@ import {
 } from "@/testUtils/factories/modComponentFactories";
 import {
   loadActivationEnhancements,
-  unloadActivationEnhancements,
+  TEST_unloadActivationEnhancements,
 } from "@/contentScript/loadActivationEnhancements";
 import { isReadyInThisDocument } from "@/contentScript/ready";
 import { isLinked } from "@/auth/token";
+import { array } from "cooky-cutter";
 
 jest.mock("@/contentScript/sidebarController", () => ({
   ensureSidebar: jest.fn(),
   showModActivationInSidebar: jest.fn(),
   hideModActivationInSidebar: jest.fn(),
 }));
-
-const showFunctionMock = jest.mocked(showModActivationInSidebar);
 
 jest.mock("@/auth/token", () => ({
   isLinked: jest.fn().mockResolvedValue(true),
@@ -54,10 +53,8 @@ jest.mock("@/contentScript/ready", () => ({
 }));
 
 jest.mock("@/store/extensionsStorage", () => ({
-  loadOptions: jest.fn(),
+  getActivatedModIds: jest.fn().mockResolvedValue([]),
 }));
-
-const loadOptionsMock = loadOptions as jest.MockedFunction<typeof loadOptions>;
 
 jest.mock("@/background/messenger/external/_implementation", () => ({
   setActivatingMods: jest.fn(),
@@ -70,6 +67,8 @@ jest.mock("@/sidebar/store", () => ({
   },
 }));
 
+const showSidebarMock = jest.mocked(showModActivationInSidebar);
+const getActivatedModIdsMock = jest.mocked(getActivatedModIds);
 const getActivatingModIdsMock = jest.mocked(getActivatingModIds);
 
 const recipeId1 = validateRegistryId("@pixies/misc/comment-and-vote");
@@ -91,11 +90,13 @@ describe("marketplace enhancements", () => {
     document.body.innerHTML = "";
     document.body.innerHTML = getDocument(activateButtonsHtml).body.innerHTML;
     (isReadyInThisDocument as jest.Mock).mockImplementation(() => true);
+    getActivatedModIdsMock.mockResolvedValue(new Set());
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     jest.resetAllMocks();
-    unloadActivationEnhancements();
+    // eslint-disable-next-line new-cap -- test method
+    TEST_unloadActivationEnhancements();
   });
 
   test("given user is logged in, when an activate button is clicked, should open the sidebar", async () => {
@@ -108,9 +109,9 @@ describe("marketplace enhancements", () => {
       }),
     }) as ActivatedModComponent;
     const modComponent2 = modComponentFactory() as ActivatedModComponent;
-    loadOptionsMock.mockResolvedValue({
-      extensions: [modComponent1, modComponent2],
-    });
+    getActivatedModIdsMock.mockResolvedValue(
+      new Set([modComponent1._recipe?.id, modComponent2._recipe?.id])
+    );
 
     await loadActivationEnhancements();
     await initSidebarActivation();
@@ -123,7 +124,44 @@ describe("marketplace enhancements", () => {
     // The current page should not navigate away from the marketplace
     expect(window.location.href).toBe(MARKETPLACE_URL);
     // The show-sidebar function should be called
-    expect(showFunctionMock).toHaveBeenCalledOnce();
+    expect(showSidebarMock).toHaveBeenCalledOnce();
+  });
+
+  test("multiple mod activation on non-detail page", async () => {
+    isLinkedMock.mockResolvedValue(true);
+    window.location.assign("https://www.pixiebrix.com/");
+
+    const components = array(
+      modComponentFactory,
+      2
+    )({
+      _recipe: modComponentRecipeFactory,
+    });
+
+    document.body.innerHTML = `
+    <div>
+        <a class="btn btn-primary" data-activate-button href="https://app.pixiebrix.com/activate?id=${encodeURIComponent(
+          components[0]._recipe.id
+        )}&id=${encodeURIComponent(components[1]._recipe.id)}">Click Me!</a>
+    </div>`;
+
+    getActivatedModIdsMock.mockResolvedValue(new Set());
+
+    await loadActivationEnhancements();
+    await initSidebarActivation();
+
+    // Sanity check for test interference
+    expect(showSidebarMock).not.toHaveBeenCalledOnce();
+
+    // Click an activate button
+    const activateButtons = document.querySelectorAll("a");
+    activateButtons[0].click();
+    await waitForEffect();
+
+    expect(window.location.href).toBe("https://www.pixiebrix.com/");
+    // The show-sidebar function should be called
+    // FIXME: this passes when run individually. There's some test interference going on.
+    expect(showSidebarMock).toHaveBeenCalledOnce();
   });
 
   test("given user is not logged in, when activation button clicked, open admin console", async () => {
@@ -154,7 +192,7 @@ describe("marketplace enhancements", () => {
     expect(isLinkedMock).toHaveBeenCalledTimes(1);
     // The getInstalledRecipeIds function should not call loadOptions
     // when the user is not logged in
-    expect(loadOptionsMock).not.toHaveBeenCalled();
+    expect(getActivatedModIdsMock).not.toHaveBeenCalled();
     // The marketplace script should not resume in-progress blueprint
     // activation when the user is not logged in
     expect(getActivatingModIdsMock).not.toHaveBeenCalled();
@@ -170,9 +208,9 @@ describe("marketplace enhancements", () => {
       }),
     }) as ActivatedModComponent;
     const modComponent2 = modComponentFactory() as ActivatedModComponent;
-    loadOptionsMock.mockResolvedValue({
-      extensions: [modComponent1, modComponent2],
-    });
+    getActivatedModIdsMock.mockResolvedValue(
+      new Set([modComponent1._recipe?.id, modComponent2._recipe?.id])
+    );
 
     await loadActivationEnhancements();
     await initSidebarActivation();
@@ -193,9 +231,9 @@ describe("marketplace enhancements", () => {
       }),
     }) as ActivatedModComponent;
     const modComponent2 = modComponentFactory() as ActivatedModComponent;
-    loadOptionsMock.mockResolvedValue({
-      extensions: [modComponent1, modComponent2],
-    });
+    getActivatedModIdsMock.mockResolvedValue(
+      new Set([modComponent1._recipe?.id, modComponent2._recipe?.id])
+    );
 
     await loadActivationEnhancements();
     await initSidebarActivation();
@@ -217,9 +255,9 @@ describe("marketplace enhancements", () => {
     expect(isLinkedMock).toHaveBeenCalledTimes(1);
     // The getInstalledRecipeIds function should call loadOptions
     // when the user is logged in
-    expect(loadOptionsMock).toHaveBeenCalled();
+    expect(getActivatedModIdsMock).toHaveBeenCalledOnce();
     // The marketplace script should resume in-progress blueprint
     // activation when the user is logged in
-    expect(getActivatingModIdsMock).toHaveBeenCalled();
+    expect(getActivatingModIdsMock).toHaveBeenCalledOnce();
   });
 });

--- a/src/contentScript/loadActivationEnhancements.ts
+++ b/src/contentScript/loadActivationEnhancements.ts
@@ -52,7 +52,7 @@ function getActivateButtonLinks(): NodeListOf<HTMLAnchorElement> {
   );
 }
 
-function changeActivateButtonToActiveLabel(button: HTMLAnchorElement) {
+function changeActivateButtonToActiveLabel(button: HTMLAnchorElement): void {
   // Check if the button is already changed to an active label or if it isn't a special activate button that
   // should be swapped to an active label
   const isActivateButton = Object.hasOwn(button.dataset, "activateButton");
@@ -97,8 +97,8 @@ export async function loadActivationEnhancements(): Promise<void> {
       continue;
     }
 
-    // Check if all mods are already activated, and change button content to indicate active status
-    // Note: This should only run on Marketplace pages
+    // On Marketplace pages, check if the single mod / all mods in the pack already activated, and change button content
+    // to indicate active status
     if (isMarketplacePage() && modIds.every((x) => activatedModIds.has(x))) {
       changeActivateButtonToActiveLabel(button);
     }
@@ -129,7 +129,7 @@ export async function loadActivationEnhancements(): Promise<void> {
   }
 }
 
-export async function reloadActivationEnhancements() {
+export async function reloadActivationEnhancements(): Promise<void> {
   enhancementsLoaded = false;
   await loadActivationEnhancements();
 }
@@ -137,7 +137,7 @@ export async function reloadActivationEnhancements() {
 /**
  * Unset loaded state. For use in test cleanup.
  */
-export function TEST_unloadActivationEnhancements() {
+export function TEST_unloadActivationEnhancements(): void {
   enhancementsLoaded = false;
 }
 

--- a/src/contentScript/loadActivationEnhancements.ts
+++ b/src/contentScript/loadActivationEnhancements.ts
@@ -14,10 +14,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { compact, isEmpty, startsWith } from "lodash";
-import { loadOptions } from "@/store/extensionsStorage";
+import { isEmpty, startsWith } from "lodash";
+import { getActivatedModIds } from "@/store/extensionsStorage";
 import { type RegistryId } from "@/types/registryTypes";
-import { validateRegistryId } from "@/types/helpers";
+import { isRegistryId } from "@/types/helpers";
 import { isReadyInThisDocument } from "@/contentScript/ready";
 import { pollUntilTruthy } from "@/utils";
 import { MARKETPLACE_URL } from "@/utils/strings";
@@ -28,21 +28,17 @@ function isMarketplacePage(): boolean {
   return startsWith(window.location.href, MARKETPLACE_URL);
 }
 
+/**
+ * Read all id search params from the URL. Handles both `id` and `id[]`.
+ */
+export function extractIdsFromUrl(searchParams: URLSearchParams): RegistryId[] {
+  const rawIds = [...searchParams.getAll("id"), ...searchParams.getAll("id[]")];
+  return rawIds.filter((x) => isRegistryId(x)) as RegistryId[];
+}
+
 function getActivateButtonLinks(): NodeListOf<HTMLAnchorElement> {
   return document.querySelectorAll<HTMLAnchorElement>(
     "a[href*='.pixiebrix.com/activate']"
-  );
-}
-
-export async function getInstalledRecipeIds(): Promise<Set<RegistryId>> {
-  const options = await loadOptions();
-
-  if (!options) {
-    return new Set();
-  }
-
-  return new Set(
-    compact(options.extensions.map((extension) => extension._recipe?.id))
   );
 }
 
@@ -79,23 +75,24 @@ export async function loadActivationEnhancements(): Promise<void> {
     return;
   }
 
-  const installedRecipeIds = await getInstalledRecipeIds();
+  const activatedModIds = await getActivatedModIds();
 
   for (const button of activateButtonLinks) {
     const url = new URL(button.href);
-    let recipeId: RegistryId;
-    try {
-      recipeId = validateRegistryId(url.searchParams.get("id"));
-    } catch {
+
+    const modIds = extractIdsFromUrl(url.searchParams);
+
+    if (modIds.length === 0) {
       continue;
     }
 
-    // Check if recipe is already activated, and change button content to indicate active status
-    // Note: This should only run on the Marketplace page
-    if (isMarketplacePage() && installedRecipeIds.has(recipeId)) {
+    // Check if all mods are already activated, and change button content to indicate active status
+    // Note: This should only run on Marketplace pages
+    if (isMarketplacePage() && modIds.every((x) => activatedModIds.has(x))) {
       changeActivateButtonToActiveLabel(button);
     }
 
+    // Replace the default click handler with direct mod activation
     button.addEventListener("click", async (event) => {
       event.preventDefault();
 
@@ -109,12 +106,12 @@ export async function loadActivationEnhancements(): Promise<void> {
 
       if (isContentScriptReady) {
         window.dispatchEvent(
-          new CustomEvent("ActivateRecipe", {
-            detail: { recipeId, activateUrl: button.href },
+          new CustomEvent("ActivateMods", {
+            detail: { modIds, activateUrl: button.href },
           })
         );
       } else {
-        // Something probably went wrong with the content script, so just navigate to the activate url
+        // Something probably went wrong with the content script, so navigate to the `/activate` url
         window.location.assign(button.href);
       }
     });
@@ -127,9 +124,9 @@ export async function reloadActivationEnhancements() {
 }
 
 /**
- * This should only be used for testing purposes
+ * Unset loaded state. For use in test cleanup.
  */
-export function unloadActivationEnhancements() {
+export function TEST_unloadActivationEnhancements() {
   enhancementsLoaded = false;
 }
 

--- a/src/contentScript/sidebarActivation.ts
+++ b/src/contentScript/sidebarActivation.ts
@@ -103,14 +103,14 @@ function addActivateModsListener(): void {
       return;
     }
 
-    const installedRecipeIds = await getActivatedModIds();
+    const activatedModIds = await getActivatedModIds();
 
     reportEvent(Events.START_MOD_ACTIVATE, {
       // For legacy, report the first mod id
       blueprintId: modIds[0],
       modIds,
       screen: "marketplace",
-      reinstall: modIds.some((x) => installedRecipeIds.has(x)),
+      reinstall: modIds.some((x) => activatedModIds.has(x)),
     });
 
     await showSidebarActivationForMods(modIds);

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -22,7 +22,11 @@ import { useAsyncEffect } from "use-async-effect";
 import { useCallback, useState } from "react";
 import { readManagedStorageByKey } from "@/store/enterprise/managedStorage";
 
+/**
+ * The default URL of the app, e.g., https://app.pixiebrix.com
+ */
 export const DEFAULT_SERVICE_URL = process.env.SERVICE_URL;
+
 const SERVICE_STORAGE_KEY = "service-url" as ManualStorageKey;
 
 type ConfiguredHost = string | null | undefined;

--- a/src/store/extensionsStorage.ts
+++ b/src/store/extensionsStorage.ts
@@ -30,6 +30,8 @@ import {
 } from "@/store/extensionsMigrations";
 import { type ModComponentOptionsState } from "./extensionsTypes";
 import { type StorageInterface } from "@/store/StorageInterface";
+import { type RegistryId } from "@/types/registryTypes";
+import { compact } from "lodash";
 
 const STORAGE_KEY = "persist:extensionOptions" as ReduxStorageKey;
 
@@ -52,6 +54,21 @@ export async function loadOptions(): Promise<ModComponentOptionsState> {
     migrateExtensionsShape({
       extensions: JSON.parse(base.extensions ?? "[]"),
     })
+  );
+}
+
+/**
+ * Returns the set of currently activated mod ids. Reads current activated mods from storage.
+ */
+export async function getActivatedModIds(): Promise<Set<RegistryId>> {
+  const options = await loadOptions();
+
+  if (!options) {
+    return new Set();
+  }
+
+  return new Set(
+    compact(options.extensions.map((extension) => extension._recipe?.id))
   );
 }
 

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -16,7 +16,7 @@
  */
 
 /**
- * Link to the marketplace
+ * URL of the marketplace, including `/marketplace/` path, e.g., https://www.pixiebrix.com/marketplace/
  */
 // eslint-disable-next-line prefer-destructuring -- breaks EnvironmentPlugin
 export const MARKETPLACE_URL = process.env.MARKETPLACE_URL;


### PR DESCRIPTION
## What does this PR do?

- Part of #6139 
- Add support for directly activating multiple 1-click wonder mods from a link if the user has the extension installed
- Follow up to: https://github.com/pixiebrix/pixiebrix-extension/pull/6140, which added support when being triggered from the app

## Remaining Work

- [x] Fix test interference

## Reviewer Tips

- Main changes are in loadActivationEnhancements

## Demo

- _Paste a screenshot or demo video here_

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
