### PR TITLE
#6001 #6002 #6003 - Google Sheets - Phase 3 - Slices 3-5

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.2.2).
+ * Mock Service Worker (1.2.3).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/src/components/fields/schemaFields/getToggleOptions.tsx
+++ b/src/components/fields/schemaFields/getToggleOptions.tsx
@@ -398,6 +398,8 @@ export function getToggleOptions({
       isArrayItem,
       allowExpressions,
     }).map((option) => {
+      option.fieldSchemaOverride = subSchema;
+
       // Only use the schema description if a custom description wasn't already
       // set for the input mode option
       if (!option.description) {

--- a/src/components/fields/schemaFields/widgets/ServiceWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/ServiceWidget.tsx
@@ -186,12 +186,13 @@ const ServiceWidget: React.FC<ServiceWidgetProps> = ({
     useField<Expression<ServiceVarRef>>(props);
 
   const { serviceIds, options } = useMemo(() => {
-    const serviceIds = extractServiceIds(schema);
+    const extractedServiceIds = extractServiceIds(schema);
+    const options = isEmpty(extractedServiceIds)
+      ? authOptions
+      : authOptions.filter((x) => extractedServiceIds.includes(x.serviceId));
     return {
-      serviceIds,
-      options: isEmpty(serviceIds)
-        ? authOptions
-        : authOptions.filter((x) => serviceIds.includes(x.serviceId)),
+      serviceIds: extractedServiceIds,
+      options,
     };
   }, [authOptions, schema]);
 

--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
@@ -70,7 +70,7 @@ const TemplateToggleWidget: React.VFC<TemplateToggleWidgetProps> = ({
     }
 
     // XXX: Figure out a less hacky way to handle this
-    // fix string expression inference
+    // fix string expression inference - main use here is when var field auto-swaps to text when user types a space
     if (inputMode === "var" && inferredInputMode === "string") {
       setInputMode("string");
     }

--- a/src/components/fields/schemaFields/widgets/templateToggleWidgetTypes.tsx
+++ b/src/components/fields/schemaFields/widgets/templateToggleWidgetTypes.tsx
@@ -21,6 +21,7 @@ import { type Expression } from "@/types/runtimeTypes";
 import { type UnknownObject } from "@/types/objectTypes";
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import { type JSONSchema7Array } from "json-schema";
+import { type Schema } from "@/types/schemaTypes";
 
 interface InputModeOptionBase<
   TValue extends FieldInputMode,
@@ -32,6 +33,7 @@ interface InputModeOptionBase<
   Widget: As;
   description?: React.ReactNode;
   interpretValue?: (oldValue: unknown) => unknown;
+  fieldSchemaOverride?: Schema;
 }
 
 export type StringOption = InputModeOptionBase<"string" | "select" | "var"> & {

--- a/src/contrib/google/sheets/bricks/append.ts
+++ b/src/contrib/google/sheets/bricks/append.ts
@@ -48,9 +48,10 @@ type Shape = KnownShape | "infer";
 export const APPEND_SCHEMA: Schema = propertiesToSchema(
   {
     googleAccount: {
+      title: "Google Account",
       oneOf: [
         {
-          $ref: "https://app.pixiebrix.com/schemas/services/google/ouath2-pkce",
+          $ref: "https://app.pixiebrix.com/schemas/services/google/oauth2-pkce",
         },
       ],
     },

--- a/src/contrib/google/sheets/bricks/lookup.ts
+++ b/src/contrib/google/sheets/bricks/lookup.ts
@@ -36,9 +36,10 @@ export const GOOGLE_SHEETS_LOOKUP_ID = validateRegistryId(
 export const LOOKUP_SCHEMA: Schema = propertiesToSchema(
   {
     googleAccount: {
+      title: "Google Account",
       oneOf: [
         {
-          $ref: "https://app.pixiebrix.com/schemas/services/google/ouath2-pkce",
+          $ref: "https://app.pixiebrix.com/schemas/services/google/oauth2-pkce",
         },
       ],
     },
@@ -113,7 +114,7 @@ export class GoogleSheetsLookup extends TransformerABC {
         ? spreadsheetIdArg
         : spreadsheetIdArg.config.spreadsheetId;
     const target: SpreadsheetTarget = {
-      googleAccount: null,
+      googleAccount,
       spreadsheetId,
       tabName,
     };

--- a/src/contrib/google/sheets/core/getHeadersForSpreadsheetTab.ts
+++ b/src/contrib/google/sheets/core/getHeadersForSpreadsheetTab.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type Spreadsheet } from "@/contrib/google/sheets/core/types";
+import { type Expression } from "@/types/runtimeTypes";
+import { isExpression } from "@/utils/expressionUtils";
+
+export default function getHeadersForSpreadsheetTab(
+  spreadsheet: Spreadsheet | null,
+  tabName: string | Expression
+): string[] {
+  if (!spreadsheet) {
+    return [];
+  }
+
+  const rawTabName = isExpression(tabName) ? tabName.__value__ : tabName;
+  const sheet = spreadsheet.sheets?.find(
+    (sheet) => sheet.properties.title === rawTabName
+  );
+  return (
+    sheet?.data?.[0]?.rowData?.[0]?.values?.map(
+      (value) => value.formattedValue
+    ) ?? []
+  );
+}

--- a/src/contrib/google/sheets/core/sheetsApi.ts
+++ b/src/contrib/google/sheets/core/sheetsApi.ts
@@ -214,8 +214,7 @@ async function getRows(
     url += `!${range}`;
   }
 
-  const requestConfig: AxiosRequestConfig<never> = { url, method: "get" };
-  return executeRequest<ValueRange>(requestConfig, googleAccount);
+  return executeRequest<ValueRange>({ url, method: "get" }, googleAccount);
 }
 
 export async function getAllRows(
@@ -230,15 +229,20 @@ export async function getHeaders(target: SpreadsheetTarget): Promise<string[]> {
   return values[0]?.map(String);
 }
 
-export async function getSpreadsheet({
-  googleAccount,
-  spreadsheetId,
-}: SpreadsheetTarget): Promise<Spreadsheet> {
-  const requestConfig: AxiosRequestConfig<never> = {
-    url: `${SHEETS_BASE_URL}/${spreadsheetId}`,
-    method: "get",
-  };
-  return executeRequest<Spreadsheet>(requestConfig, googleAccount);
+type GetSpreadsheetOptions = {
+  includeGridData?: boolean;
+};
+
+export async function getSpreadsheet(
+  { googleAccount, spreadsheetId }: SpreadsheetTarget,
+  { includeGridData }: GetSpreadsheetOptions = {}
+): Promise<Spreadsheet> {
+  let url = `${SHEETS_BASE_URL}/${spreadsheetId}`;
+  if (includeGridData) {
+    url += "?includeGridData=true";
+  }
+
+  return executeRequest<Spreadsheet>({ url, method: "get" }, googleAccount);
 }
 
 /**

--- a/src/contrib/google/sheets/core/useGoogleAccount.ts
+++ b/src/contrib/google/sheets/core/useGoogleAccount.ts
@@ -59,7 +59,7 @@ async function deriveGoogleAccountIntegrationConfig(
  * Hook to get the Google account from an integration configuration or direct input.
  */
 function useGoogleAccount(
-  brickConfigPath: string
+  blockConfigPath: string
 ): FetchableAsyncState<SanitizedIntegrationConfig | null> {
   const {
     values: { services: servicesValue },
@@ -67,7 +67,7 @@ function useGoogleAccount(
 
   const [{ value: fieldValue }, , { setError }] = useField<
     Expression | undefined
-  >(joinName(brickConfigPath, "googleAccount"));
+  >(joinName(blockConfigPath, "googleAccount"));
 
   return useAsyncState(async () => {
     try {

--- a/src/contrib/google/sheets/core/useGoogleAccount.ts
+++ b/src/contrib/google/sheets/core/useGoogleAccount.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  type IntegrationDependency,
+  type SanitizedIntegrationConfig,
+} from "@/types/integrationTypes";
+import { type FetchableAsyncState } from "@/types/sliceTypes";
+import { useField, useFormikContext } from "formik";
+import { type ServiceSlice } from "@/components/fields/schemaFields/serviceFieldUtils";
+import { type Expression } from "@/types/runtimeTypes";
+import { joinName } from "@/utils";
+import useAsyncState from "@/hooks/useAsyncState";
+import hash from "object-hash";
+import { isEmpty } from "lodash";
+import { services } from "@/background/messenger/api";
+import { getErrorMessage } from "@/errors/errorHelpers";
+
+async function deriveGoogleAccountIntegrationConfig(
+  servicesValue: IntegrationDependency[],
+  googleAccountValue: Expression | undefined
+): Promise<SanitizedIntegrationConfig | null> {
+  if (googleAccountValue == null || isEmpty(servicesValue)) {
+    return null;
+  }
+
+  const serviceOutputKey = googleAccountValue.__value__.replace(/^@/, "");
+  const integrationDependency = servicesValue.find(
+    (service) => service.outputKey === serviceOutputKey
+  );
+
+  if (integrationDependency == null) {
+    throw new Error(
+      `Could not find service with output key ${serviceOutputKey}`
+    );
+  }
+
+  return services.locate(
+    integrationDependency.id,
+    integrationDependency.config
+  );
+}
+
+/**
+ * Hook to get the Google account from an integration configuration or direct input.
+ */
+function useGoogleAccount(
+  brickConfigPath: string
+): FetchableAsyncState<SanitizedIntegrationConfig | null> {
+  const {
+    values: { services: servicesValue },
+  } = useFormikContext<ServiceSlice>();
+
+  const [{ value: fieldValue }, , { setError }] = useField<
+    Expression | undefined
+  >(joinName(brickConfigPath, "googleAccount"));
+
+  return useAsyncState(async () => {
+    try {
+      return await deriveGoogleAccountIntegrationConfig(
+        servicesValue,
+        fieldValue
+      );
+    } catch (error: unknown) {
+      setError(getErrorMessage(error));
+      return null;
+    }
+  }, [hash(servicesValue)]);
+}
+
+export default useGoogleAccount;

--- a/src/contrib/google/sheets/core/useSpreadsheetId.ts
+++ b/src/contrib/google/sheets/core/useSpreadsheetId.ts
@@ -17,150 +17,109 @@
 
 import { useField, useFormikContext } from "formik";
 import { joinName } from "@/utils";
-import { useReducer } from "react";
 import { type ServiceSlice } from "@/components/fields/schemaFields/serviceFieldUtils";
 import { isServiceValueFormat } from "@/components/fields/schemaFields/fieldTypeCheckers";
 import { isEmpty } from "lodash";
 import { pickDependency } from "@/services/useDependency";
-import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
-import { useAsyncEffect } from "use-async-effect";
 import { services } from "@/background/messenger/api";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { getOptionsArgForFieldValue } from "@/utils/getOptionsArgForFieldValue";
 import { getSheetServiceOutputKey } from "@/contrib/google/sheets/core/getSheetServiceOutputKey";
 import { type Expression, type OptionsArgs } from "@/types/runtimeTypes";
+import { type IntegrationDependency } from "@/types/integrationTypes";
+import useAsyncState from "@/hooks/useAsyncState";
+import hash from "object-hash";
+import { type FetchableAsyncState } from "@/types/sliceTypes";
 
-type SpreadsheetState = {
-  spreadsheetId: string | null;
+async function deriveSpreadsheetId(
+  servicesValue: IntegrationDependency[],
+  spreadsheetIdValue: string | Expression | null,
+  optionsArgs: OptionsArgs
+): Promise<string | null> {
+  // Unselected sheet-picker and select list will both set the field value to null
+  if (spreadsheetIdValue == null) {
+    return null;
+  }
 
-  error: unknown;
-};
+  // Select list will set the field value to the spreadsheetId directly
+  if (typeof spreadsheetIdValue === "string") {
+    return isEmpty(spreadsheetIdValue) ? null : spreadsheetIdValue;
+  }
 
-const initialState: SpreadsheetState = {
-  spreadsheetId: null,
-  error: null,
-};
+  // Check for spreadsheetId var value in mod options
+  const optionsSpreadsheetIdValue = getOptionsArgForFieldValue(
+    spreadsheetIdValue,
+    optionsArgs
+  );
+  if (
+    typeof optionsSpreadsheetIdValue === "string" &&
+    !isEmpty(optionsSpreadsheetIdValue)
+  ) {
+    return optionsSpreadsheetIdValue;
+  }
 
-const spreadsheetSlice = createSlice({
-  name: "spreadsheet",
-  initialState,
-  reducers: {
-    setSpreadsheetId(state, action: PayloadAction<string>) {
-      state.spreadsheetId = action.payload;
-      state.error = null;
-    },
-    setLoading(state) {
-      state.spreadsheetId = null;
-      state.error = null;
-    },
-    setError(state, action: PayloadAction<unknown>) {
-      state.spreadsheetId = null;
-      state.error = action.payload;
-    },
-  },
-});
+  if (!isServiceValueFormat(spreadsheetIdValue)) {
+    throw new Error("Invalid spreadsheetId value");
+  }
+
+  if (isEmpty(servicesValue)) {
+    throw new Error(
+      "Invalid spreadsheetId variable, please use a Mod Inputs variable instead"
+    );
+  }
+
+  const serviceOutputKey = getSheetServiceOutputKey(spreadsheetIdValue);
+  const sheetsService = servicesValue.find(
+    (service) => service.outputKey === serviceOutputKey
+  );
+
+  if (!sheetsService) {
+    throw new Error(
+      "Unable to locate a matching Google Sheets service integration on this mod, please use a Mod Inputs variable instead"
+    );
+  }
+
+  const dependency = pickDependency(servicesValue, [sheetsService.id]);
+  const sanitizedIntegrationConfig = await services.locate(
+    dependency.id,
+    dependency.config
+  );
+  const configSpreadsheetId = sanitizedIntegrationConfig.config?.spreadsheetId;
+
+  if (!configSpreadsheetId) {
+    throw new Error(
+      "Could not find spreadsheetId in service configuration: " +
+        JSON.stringify(sanitizedIntegrationConfig)
+    );
+  }
+
+  return configSpreadsheetId;
+}
 
 /**
  * Hook to get the Google Sheets spreadsheetId from an integration configuration or direct input.
- * @param basePath brick configuration path
  */
-function useSpreadsheetId(basePath: string): string | null {
+function useSpreadsheetId(
+  brickConfigPath: string
+): FetchableAsyncState<string | null> {
   const {
     values: { services: servicesValue },
   } = useFormikContext<ServiceSlice>();
 
   const [{ value: fieldValue }, , { setError }] = useField<string | Expression>(
-    joinName(basePath, "spreadsheetId")
+    joinName(brickConfigPath, "spreadsheetId")
   );
 
   const [{ value: optionsArgs }] = useField<OptionsArgs>("optionsArgs");
 
-  const [state, dispatch] = useReducer(spreadsheetSlice.reducer, initialState);
-
-  /**
-   * Note about when this effect will fire:
-   *
-   * This async effect has fieldValue as its dependency. This can either be a
-   * string spreadsheetId, or a service config, var-expression object, or null.
-   *
-   * When the user switches between two different GSheets service integrations,
-   * the fieldValue will not change, it will stay as this value:
-   * {
-   *   __type__: "var",
-   *   __value__: "@google",
-   * }
-   *
-   * The service selector actually changes the top-level form state to make @google
-   * point to a different GSheet integration. By using fieldValue as the effect
-   * dependency, we're taking advantage of the fact that object comparison will
-   * fail and the effect will fire on every render when a user switches between
-   * GSheet integrations, even if the fieldValue is not actually changing.
-   */
-  useAsyncEffect(async () => {
-    dispatch(spreadsheetSlice.actions.setLoading());
-
-    const optionsValue = getOptionsArgForFieldValue(fieldValue, optionsArgs);
-    if (typeof optionsValue === "string" && !isEmpty(optionsValue)) {
-      dispatch(spreadsheetSlice.actions.setSpreadsheetId(optionsValue));
-      return;
+  return useAsyncState<string | null>(async () => {
+    try {
+      return await deriveSpreadsheetId(servicesValue, fieldValue, optionsArgs);
+    } catch (error: unknown) {
+      setError(getErrorMessage(error));
+      return null;
     }
-
-    if (isServiceValueFormat(fieldValue)) {
-      if (fieldValue == null) {
-        // A service value can be null, but here we don't want to try and load anything if it is null
-        dispatch(spreadsheetSlice.actions.setSpreadsheetId(null));
-        return;
-      }
-
-      try {
-        if (isEmpty(servicesValue)) {
-          throw new Error(
-            "Invalid spreadsheetId variable, please use a Mod Inputs variable instead"
-          );
-        }
-
-        const serviceOutputKey = getSheetServiceOutputKey(fieldValue);
-        const sheetsService = servicesValue.find(
-          (service) => service.outputKey === serviceOutputKey
-        );
-
-        if (!sheetsService) {
-          throw new Error(
-            "Unable to locate a matching Google Sheets service integration on this mod, please use a Mod Inputs variable instead"
-          );
-        }
-
-        const dependency = pickDependency(servicesValue, [sheetsService.id]);
-        const sanitizedServiceConfig = await services.locate(
-          dependency.id,
-          dependency.config
-        );
-        const configSpreadsheetId =
-          sanitizedServiceConfig.config?.spreadsheetId;
-        if (!configSpreadsheetId) {
-          throw new Error(
-            "Could not find spreadsheetId in service configuration: " +
-              JSON.stringify(sanitizedServiceConfig)
-          );
-        }
-
-        if (configSpreadsheetId) {
-          dispatch(
-            spreadsheetSlice.actions.setSpreadsheetId(configSpreadsheetId)
-          );
-        }
-      } catch (error: unknown) {
-        dispatch(spreadsheetSlice.actions.setError(error));
-        setError(getErrorMessage(error));
-      }
-
-      return;
-    }
-
-    dispatch(spreadsheetSlice.actions.setSpreadsheetId(fieldValue));
-  }, [fieldValue]);
-
-  return state.spreadsheetId;
+  }, [hash({ fieldValue, servicesValue, optionsArgs })]);
 }
 
 export default useSpreadsheetId;

--- a/src/contrib/google/sheets/core/useSpreadsheetId.ts
+++ b/src/contrib/google/sheets/core/useSpreadsheetId.ts
@@ -100,14 +100,14 @@ async function deriveSpreadsheetId(
  * Hook to get the Google Sheets spreadsheetId from an integration configuration or direct input.
  */
 function useSpreadsheetId(
-  brickConfigPath: string
+  blockConfigPath: string
 ): FetchableAsyncState<string | null> {
   const {
     values: { services: servicesValue },
   } = useFormikContext<ServiceSlice>();
 
   const [{ value: fieldValue }, , { setError }] = useField<string | Expression>(
-    joinName(brickConfigPath, "spreadsheetId")
+    joinName(blockConfigPath, "spreadsheetId")
   );
 
   const [{ value: optionsArgs }] = useField<OptionsArgs>("optionsArgs");

--- a/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.tsx
@@ -20,14 +20,11 @@ import { type BlockOptionProps } from "@/components/fields/schemaFields/genericO
 import { sheets } from "@/background/messenger/api";
 import { useField } from "formik";
 import { type Expression } from "@/types/runtimeTypes";
-import { useAsyncState } from "@/hooks/common";
 import { APPEND_SCHEMA } from "@/contrib/google/sheets/bricks/append";
 import { isNullOrBlank, joinName } from "@/utils";
-import { getErrorMessage } from "@/errors/errorHelpers";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import TabField from "@/contrib/google/sheets/ui/TabField";
 import { dereference } from "@/validators/generic";
-import Loader from "@/components/Loader";
 import { FormErrorContext } from "@/components/form/FormErrorContext";
 import useSpreadsheetId from "@/contrib/google/sheets/core/useSpreadsheetId";
 import { BASE_SHEET_SCHEMA } from "@/contrib/google/sheets/core/schemas";
@@ -35,50 +32,48 @@ import { isEmpty, isEqual } from "lodash";
 import { useOnChangeEffect } from "@/contrib/google/sheets/core/useOnChangeEffect";
 import { requireGoogleHOC } from "@/contrib/google/sheets/ui/RequireGoogleApi";
 import { type Schema } from "@/types/schemaTypes";
-import { isExpression, isTemplateExpression } from "@/utils/expressionUtils";
-import { type SpreadsheetTarget } from "@/contrib/google/sheets/core/sheetsApi";
+import { isTemplateExpression } from "@/utils/expressionUtils";
+import useGoogleAccount from "@/contrib/google/sheets/core/useGoogleAccount";
+import useDeriveAsyncState from "@/hooks/useDeriveAsyncState";
+import { type SanitizedIntegrationConfig } from "@/types/integrationTypes";
+import { type Spreadsheet } from "@/contrib/google/sheets/core/types";
+import AsyncStateGate from "@/components/AsyncStateGate";
+import useAsyncState from "@/hooks/useAsyncState";
+import { type UnknownObject } from "@/types/objectTypes";
+import getHeadersForSpreadsheetTab from "@/contrib/google/sheets/core/getHeadersForSpreadsheetTab";
 
-const DEFAULT_FIELDS_SCHEMA: Schema = {
-  type: "object",
-  additionalProperties: true,
-};
-
-const PropertiesField: React.FunctionComponent<{
+const RowValuesField: React.FunctionComponent<{
   name: string;
-  spreadsheetId: string | null;
+  spreadsheet: Spreadsheet | null;
   tabName: string | Expression;
-}> = ({ name, spreadsheetId, tabName }) => {
-  const [sheetSchema, , schemaError] = useAsyncState<Schema>(
-    async () => {
-      if (spreadsheetId && tabName) {
-        if (isExpression(tabName)) {
-          return {
-            type: "object",
-            additionalProperties: true,
-          };
-        }
+}> = ({ name, spreadsheet, tabName }) => {
+  const [{ value: rowValues }, , { setValue: setRowValues }] =
+    useField<UnknownObject>(name);
 
-        const target: SpreadsheetTarget = {
-          googleAccount: null,
-          spreadsheetId,
-          tabName,
-        };
-        const headers = await sheets.getHeaders(target);
-
-        return {
-          type: "object",
-          properties: Object.fromEntries(
-            headers
-              .filter((x) => !isNullOrBlank(x))
-              .map((header) => [header, { type: "string" }])
-          ),
-        };
+  const headers = getHeadersForSpreadsheetTab(spreadsheet, tabName);
+  const fieldSchema: Schema = isEmpty(headers)
+    ? {
+        type: "object",
+        additionalProperties: true,
       }
+    : {
+        type: "object",
+        properties: Object.fromEntries(
+          headers
+            .filter((x) => !isNullOrBlank(x))
+            .map((header) => [header, { type: "string" }])
+        ),
+      };
 
-      return DEFAULT_FIELDS_SCHEMA;
+  // Clear row values when tabName changes, if the value is not an expression, or is empty
+  useOnChangeEffect(
+    tabName,
+    () => {
+      if (!isTemplateExpression(rowValues) || isEmpty(rowValues.__value__)) {
+        setRowValues({});
+      }
     },
-    [spreadsheetId, tabName],
-    DEFAULT_FIELDS_SCHEMA
+    isEqual
   );
 
   return (
@@ -86,14 +81,7 @@ const PropertiesField: React.FunctionComponent<{
       name={name}
       label="Row Values"
       isRequired
-      description={
-        schemaError ? (
-          <span className="text-warning">
-            Error determining columns: {getErrorMessage(schemaError)}
-          </span>
-        ) : null
-      }
-      schema={sheetSchema ?? DEFAULT_FIELDS_SCHEMA}
+      schema={fieldSchema}
     />
   );
 };
@@ -103,69 +91,127 @@ const AppendSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
   configKey,
 }) => {
   const basePath = joinName(name, configKey);
-  const spreadsheetId = useSpreadsheetId(basePath);
+  const googleAccountAsyncState = useGoogleAccount(basePath);
+  const spreadsheetIdAsyncState = useSpreadsheetId(basePath);
 
-  const [{ value: tabNameValue }] = useField<string | Expression>(
+  const [{ value: tabName }] = useField<string | Expression>(
     joinName(basePath, "tabName")
   );
 
-  const [{ value: rowValuesValue }, , { setValue: setRowValuesValue }] =
-    useField(joinName(basePath, "rowValues"));
-
-  // Clear row values when tabName changes, if the value is not an expression, or is empty
-  useOnChangeEffect(
-    tabNameValue,
-    () => {
-      if (
-        !isTemplateExpression(rowValuesValue) ||
-        isEmpty(rowValuesValue.__value__)
-      ) {
-        setRowValuesValue({});
-      }
-    },
-    isEqual
-  );
-
-  const [sheetSchema, isLoadingSheetSchema] = useAsyncState(
+  const baseSchemaAsyncState = useAsyncState(
     dereference(BASE_SHEET_SCHEMA),
     [],
-    BASE_SHEET_SCHEMA
+    {
+      initialValue: BASE_SHEET_SCHEMA,
+    }
+  );
+
+  const spreadsheetSchemaState = useDeriveAsyncState(
+    googleAccountAsyncState,
+    baseSchemaAsyncState,
+    async (
+      googleAccount: SanitizedIntegrationConfig | null,
+      baseSchema: Schema
+    ) => {
+      if (googleAccount == null) {
+        return baseSchema;
+      }
+
+      const spreadsheetFileList = await sheets.getAllSpreadsheets(
+        googleAccount
+      );
+      if (isEmpty(spreadsheetFileList.files)) {
+        return baseSchema;
+      }
+
+      const spreadsheetSchemaEnum = spreadsheetFileList.files.map((file) => ({
+        const: file.id,
+        title: file.name,
+      }));
+      return {
+        title: "Spreadsheet",
+        oneOf: [
+          baseSchema,
+          {
+            type: "string",
+            oneOf: spreadsheetSchemaEnum,
+          },
+        ],
+      } as Schema;
+    }
+  );
+
+  const spreadsheetAsyncState = useDeriveAsyncState(
+    googleAccountAsyncState,
+    spreadsheetIdAsyncState,
+    async (
+      googleAccount: SanitizedIntegrationConfig | null,
+      spreadsheetId: string | null
+    ) => {
+      if (spreadsheetId == null) {
+        return null;
+      }
+
+      // Sheets api handles fallback situation when googleAccount is null
+      return sheets.getSpreadsheet(
+        {
+          googleAccount,
+          spreadsheetId,
+        },
+        { includeGridData: true }
+      );
+    }
+  );
+
+  const spreadsheetFormAsyncState = useDeriveAsyncState(
+    spreadsheetAsyncState,
+    spreadsheetSchemaState,
+    async (spreadsheet: Spreadsheet, schema) => ({
+      spreadsheet,
+      schema,
+    })
   );
 
   return (
     <div className="my-2">
-      {isLoadingSheetSchema ? (
-        <Loader />
-      ) : (
-        <FormErrorContext.Provider
-          value={{
-            shouldUseAnalysis: false,
-            showUntouchedErrors: true,
-            showFieldActions: false,
-          }}
-        >
-          <SchemaField
-            name={joinName(basePath, "spreadsheetId")}
-            schema={sheetSchema}
-            isRequired
-          />
-          {
-            // The problem with including this inside the nested FormErrorContext.Provider is that we
-            // would like analysis to run if this is in text/template mode, but not if it's in select mode.
-            // Select mode is more important, so we're leaving it like this for now.
-            <TabField
-              name={joinName(basePath, "tabName")}
-              schema={APPEND_SCHEMA.properties.tabName as Schema}
-              spreadsheetId={spreadsheetId}
-            />
-          }
-        </FormErrorContext.Provider>
-      )}
-      <PropertiesField
-        name={joinName(basePath, "rowValues")}
-        spreadsheetId={spreadsheetId}
-        tabName={tabNameValue}
+      <SchemaField
+        name={joinName(basePath, "googleAccount")}
+        schema={APPEND_SCHEMA.properties.googleAccount as Schema}
       />
+      <AsyncStateGate state={spreadsheetFormAsyncState}>
+        {({ data: { spreadsheet, schema } }) => (
+          <>
+            <FormErrorContext.Provider
+              value={{
+                shouldUseAnalysis: false,
+                showUntouchedErrors: true,
+                showFieldActions: false,
+              }}
+            >
+              <SchemaField
+                name={joinName(basePath, "spreadsheetId")}
+                schema={schema}
+                isRequired
+              />
+              {
+                // The problem with including this inside the nested FormErrorContext.Provider is that we
+                // would like analysis to run if this is in text/template mode, but not if it's in select mode.
+                // Select mode is more important, so we're leaving it like this for now.
+                <TabField
+                  name={joinName(basePath, "tabName")}
+                  schema={APPEND_SCHEMA.properties.tabName as Schema}
+                  spreadsheet={spreadsheet}
+                />
+              }
+            </FormErrorContext.Provider>
+            <RowValuesField
+              name={joinName(basePath, "rowValues")}
+              spreadsheet={spreadsheet}
+              tabName={tabName}
+            />
+          </>
+        )}
+      </AsyncStateGate>
     </div>
   );
 };

--- a/src/contrib/google/sheets/ui/RequireGoogleSheet.tsx
+++ b/src/contrib/google/sheets/ui/RequireGoogleSheet.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { type ReactElement } from "react";
+import { type Spreadsheet } from "@/contrib/google/sheets/core/types";
+import { type Schema } from "@/types/schemaTypes";
+import useGoogleAccount from "@/contrib/google/sheets/core/useGoogleAccount";
+import useSpreadsheetId from "@/contrib/google/sheets/core/useSpreadsheetId";
+import useAsyncState from "@/hooks/useAsyncState";
+import { dereference } from "@/validators/generic";
+import { BASE_SHEET_SCHEMA } from "@/contrib/google/sheets/core/schemas";
+import useDeriveAsyncState from "@/hooks/useDeriveAsyncState";
+import { type SanitizedIntegrationConfig } from "@/types/integrationTypes";
+import { sheets } from "@/background/messenger/api";
+import { isEmpty } from "lodash";
+import { type AsyncState } from "@/types/sliceTypes";
+import AsyncStateGate from "@/components/AsyncStateGate";
+
+type SpreadsheetAndSchema = {
+  spreadsheet: Spreadsheet;
+  schema: Schema;
+};
+
+const RequireGoogleSheet: React.FC<{
+  blockConfigPath: string;
+  children: (props: SpreadsheetAndSchema) => ReactElement;
+}> = ({ blockConfigPath, children }) => {
+  const googleAccountAsyncState = useGoogleAccount(blockConfigPath);
+  const spreadsheetIdAsyncState = useSpreadsheetId(blockConfigPath);
+
+  const baseSchemaAsyncState = useAsyncState(
+    dereference(BASE_SHEET_SCHEMA),
+    [],
+    {
+      initialValue: BASE_SHEET_SCHEMA,
+    }
+  );
+
+  const spreadsheetSchemaState = useDeriveAsyncState(
+    googleAccountAsyncState,
+    baseSchemaAsyncState,
+    async (
+      googleAccount: SanitizedIntegrationConfig | null,
+      baseSchema: Schema
+    ) => {
+      if (googleAccount == null) {
+        return baseSchema;
+      }
+
+      const spreadsheetFileList = await sheets.getAllSpreadsheets(
+        googleAccount
+      );
+      if (isEmpty(spreadsheetFileList.files)) {
+        return baseSchema;
+      }
+
+      const spreadsheetSchemaEnum = spreadsheetFileList.files.map((file) => ({
+        const: file.id,
+        title: file.name,
+      }));
+      return {
+        title: "Spreadsheet",
+        oneOf: [
+          baseSchema,
+          {
+            type: "string",
+            oneOf: spreadsheetSchemaEnum,
+          },
+        ],
+      } as Schema;
+    }
+  );
+
+  const spreadsheetAsyncState = useDeriveAsyncState(
+    googleAccountAsyncState,
+    spreadsheetIdAsyncState,
+    async (
+      googleAccount: SanitizedIntegrationConfig | null,
+      spreadsheetId: string | null
+    ) => {
+      if (spreadsheetId == null) {
+        return null;
+      }
+
+      // Sheets api handles fallback situation when googleAccount is null
+      return sheets.getSpreadsheet(
+        {
+          googleAccount,
+          spreadsheetId,
+        },
+        { includeGridData: true }
+      );
+    }
+  );
+
+  const spreadsheetAndSchemaAsyncState: AsyncState<SpreadsheetAndSchema> =
+    useDeriveAsyncState(
+      spreadsheetAsyncState,
+      spreadsheetSchemaState,
+      async (spreadsheet: Spreadsheet, schema) => ({
+        spreadsheet,
+        schema,
+      })
+    );
+
+  return (
+    <AsyncStateGate state={spreadsheetAndSchemaAsyncState}>
+      {({ data }) => children(data)}
+    </AsyncStateGate>
+  );
+};
+
+export default RequireGoogleSheet;

--- a/src/contrib/google/sheets/ui/TabField.tsx
+++ b/src/contrib/google/sheets/ui/TabField.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { isEmpty } from "lodash";
@@ -36,20 +36,26 @@ const TabField: React.FC<
   const inputRef = useRef<HTMLTextAreaElement>();
 
   const [
-    { value: tabNameFieldValue },
+    { value: tabName },
     ,
-    { setValue: setTabNameValue, setError: setTabNameError },
+    { setValue: setTabName, setError: setTabNameError },
   ] = useField<string | Expression>(name);
 
   const tabNames =
     spreadsheet?.sheets?.map((sheet) => sheet.properties.title) ??
     emptyTabNames;
+  const fieldSchema: Schema = {
+    type: "string",
+    title: "Tab Name",
+    description: "The spreadsheet tab",
+    enum: tabNames,
+  };
 
   // Clear tab name when spreadsheetId changes, if the current value is not
   // an expression, which means it is a selected tab name from another sheet.
   useOnChangeEffect(spreadsheet?.spreadsheetId, () => {
-    if (!isTemplateExpression(tabNameFieldValue)) {
-      setTabNameValue(makeTemplateExpression("nunjucks", ""));
+    if (!isTemplateExpression(tabName)) {
+      setTabName(makeTemplateExpression("nunjucks", ""));
       setTabNameError(null);
     }
   });
@@ -63,25 +69,12 @@ const TabField: React.FC<
       return;
     }
 
-    if (
-      !tabNameFieldValue ||
-      (isExpression(tabNameFieldValue) && isEmpty(tabNameFieldValue.__value__))
-    ) {
-      setTabNameValue(tabNames[0]);
+    if (!tabName || (isExpression(tabName) && isEmpty(tabName.__value__))) {
+      setTabName(tabNames[0]);
       setTabNameError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- don't include formik helpers
-  }, [tabNameFieldValue, tabNames]);
-
-  const fieldSchema = useMemo<Schema>(
-    () => ({
-      type: "string",
-      title: "Tab Name",
-      description: "The spreadsheet tab",
-      enum: tabNames ?? [],
-    }),
-    [tabNames]
-  );
+  }, [tabName, tabNames]);
 
   // TODO: re-add info message that tab will be created
   // {!tabsPending &&

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,7 +22,6 @@
   "content_scripts": [
     {
       "matches": ["https://*/*"],
-      "exclude_matches": ["https://*.googleapis.com/*"],
       "js": ["contentScript.js"],
       "css": ["contentScript.css"],
       "all_frames": true,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,6 +22,7 @@
   "content_scripts": [
     {
       "matches": ["https://*/*"],
+      "exclude_matches": ["https://*.googleapis.com/*"],
       "js": ["contentScript.js"],
       "css": ["contentScript.css"],
       "all_frames": true,


### PR DESCRIPTION
## What does this PR do?

- Closes #6001 
- Closes #6002 
- Closes #6003 

## Reviewer Tips

### Review order
- New hook `useGoogleAccount`
- Changes to `useSpreadsheetId` to align with async state patterns
- New gate component `RequireGoogleSheet`
- Component changes
  - TabField
  - LookupSpreadsheetOptions
  - AppendSpreadsheetOptions

## Demo

- _Paste a screenshot or demo video here_

## Remaining Work

- Fix tests
- Write some new tests
- Loading all grid data is sketchy for large spreadsheets, need to fix this to use the getHeaders api function
- The Google PKCE integration shows the Google login screen twice on top of itself when you open a sheets brick in the page editor
- When you open a sheets brick in the page editor, the spreadsheetId field toggle always defaults to sheet picker over select field (value is the same, raw spreadsheet id string)
- Spreadsheets are not sorted in the select dropdown when using Google PKCE

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
