### PR TITLE
#6163: don't require mod configuration in sidebar if all inputs optional

### DIFF
--- a/src/sidebar/activateRecipe/RequireMods.test.ts
+++ b/src/sidebar/activateRecipe/RequireMods.test.ts
@@ -1,0 +1,89 @@
+import { modDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { requiresUserConfiguration } from "@/sidebar/activateRecipe/RequireMods";
+
+describe("requiresUserConfiguration", () => {
+  it("treats no options as required if required is missing", () => {
+    const definition = modDefinitionFactory({
+      options: {
+        schema: {
+          properties: {
+            foo: {
+              type: "string",
+            },
+          },
+        },
+      },
+    });
+
+    expect(requiresUserConfiguration(definition, [])).toBe(false);
+  });
+
+  it("handles empty required prop", () => {
+    const definition = modDefinitionFactory({
+      options: {
+        schema: {
+          properties: {
+            foo: {
+              type: "string",
+            },
+          },
+          required: [],
+        },
+      },
+    });
+
+    expect(requiresUserConfiguration(definition, [])).toBe(false);
+  });
+
+  it("considers required field", () => {
+    const definition = modDefinitionFactory({
+      options: {
+        schema: {
+          properties: {
+            foo: {
+              type: "string",
+            },
+          },
+          required: ["foo"],
+        },
+      },
+    });
+
+    expect(requiresUserConfiguration(definition, [])).toBe(true);
+  });
+
+  it("databases don't require configuration when required", () => {
+    const definition = modDefinitionFactory({
+      options: {
+        schema: {
+          properties: {
+            foo: {
+              $ref: "https://app.pixiebrix.com/schemas/database#",
+              format: "preview",
+            },
+          },
+          required: ["foo"],
+        },
+      },
+    });
+
+    expect(requiresUserConfiguration(definition, [])).toBe(false);
+  });
+
+  it("non-preview databases require configuration", () => {
+    const definition = modDefinitionFactory({
+      options: {
+        schema: {
+          properties: {
+            foo: {
+              $ref: "https://app.pixiebrix.com/schemas/database#",
+            },
+          },
+          required: ["foo"],
+        },
+      },
+    });
+
+    expect(requiresUserConfiguration(definition, [])).toBe(true);
+  });
+});

--- a/src/sidebar/activateRecipe/RequireMods.tsx
+++ b/src/sidebar/activateRecipe/RequireMods.tsx
@@ -76,8 +76,8 @@ export function requiresUserConfiguration(
     authOptions
   );
 
-  const recipeOptions = recipe.options?.schema?.properties;
-  const requiredOptions = recipe.options?.schema?.required ?? [];
+  const { properties: recipeOptions, required: requiredOptions = [] } =
+    recipe.options?.schema ?? {};
 
   const needsOptionsInputs =
     !isEmpty(recipeOptions) &&

--- a/src/sidebar/activateRecipe/RequireMods.tsx
+++ b/src/sidebar/activateRecipe/RequireMods.tsx
@@ -67,7 +67,7 @@ type Props = {
  * @param authOptions the integration configurations available to the user
  * @see checkRecipePermissions
  */
-function requiresUserConfiguration(
+export function requiresUserConfiguration(
   recipe: ModDefinition,
   authOptions: AuthOption[]
 ): boolean {
@@ -77,27 +77,28 @@ function requiresUserConfiguration(
   );
 
   const recipeOptions = recipe.options?.schema?.properties;
+  const requiredOptions = recipe.options?.schema?.required ?? [];
 
   const needsOptionsInputs =
     !isEmpty(recipeOptions) &&
-    Object.values(recipeOptions).some((optionSchema) => {
+    Object.entries(recipeOptions).some(([name, optionSchema]) => {
       // This should not occur in practice, but it's here for type narrowing
       if (typeof optionSchema === "boolean") {
         return false;
       }
 
-      // We return false here for any option that does not need user input
-      // and can be auto-activated in the marketplace activation flow.
+      // We return false here for any option that does not need user input and can be auto-activated in the marketplace
+      // activation flow.
       // Options that allow auto-activation:
       // - Database fields with format "preview"
-      // TODO: add more safe-default option types here
+      // - Options not marked as required
 
       if (isDatabaseField(optionSchema) && optionSchema.format === "preview") {
         return false;
       }
 
       // We require user input for any option that isn't explicitly excluded, so we return true here
-      return true;
+      return requiredOptions.includes(name);
     });
 
   const recipeServiceIds = uniq(


### PR DESCRIPTION
## What does this PR do?

- Closes #6163 
- Makes it so mod doesn't show configuration if no options are required

## Discussion

- @BLoe do you foresee any problems with this change?
- This is sufficient for what we want to do with 1.7.35
- We'll have a problem when we introduce the Google integration to the mod, as we have no way to mark integration configurations as optional in the mod definition. But we can defer that for now

## Checklist

- [x] Add tests: @BLoe 
- [x] Designate a primary reviewer: @BLoe 
