### PR TITLE
Change FAB feature flag to `floating-quickbar-button-freemium`

### DIFF
--- a/src/components/floatingActions/FloatingActions.tsx
+++ b/src/components/floatingActions/FloatingActions.tsx
@@ -109,7 +109,7 @@ export async function initFloatingActions(): Promise<void> {
   // XXX: consider moving checks into React component, so we can use the Redux context
   if (
     settings.isFloatingActionButtonEnabled &&
-    syncFlagOn("floating-quickbar-button") &&
+    syncFlagOn("floating-quickbar-button-freemium") &&
     !isEnterpriseOrPartnerUser
   ) {
     const container = document.createElement("div");

--- a/src/extensionConsole/pages/settings/SettingsPage.tsx
+++ b/src/extensionConsole/pages/settings/SettingsPage.tsx
@@ -57,7 +57,7 @@ const SettingsPage: React.FunctionComponent = () => {
         </p>
       }
     >
-      {flagOn("floating-quickbar-button") && (
+      {flagOn("floating-quickbar-button-freemium") && (
         <Section>
           <GeneralSettings />
         </Section>


### PR DESCRIPTION
## What does this PR do?

- Changes the FAB feature flag to `floating-quickbar-button-freemium`
- Original is `floating-quickbar-button`
- We have to change the feature flag because old browser extension versions did not have guards for enterprise/partner users. (So we can't flip the feature flag on for everyone.)

## Additional Actions

- [ ] Delete the old `floating-quickbar-button` feature flag
- [x] Create a new `floating-quickbar-button-freemium` feature flag and enable it for all users. (Feature flag is just there as a kill switch)
- [ ] Add RainforestQA assertion that FAB appears for freemium user
- [ ] Add RainforestQA assertion that FAB does not appear for enterprise user

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
