### PR TITLE
Add performance diagnostics brick

### DIFF
--- a/src/__mocks__/@/background/messenger/api.ts
+++ b/src/__mocks__/@/background/messenger/api.ts
@@ -42,6 +42,11 @@ export const getAvailableVersion = getMethod("GET_AVAILABLE_VERSION", bg);
 export const ensureContentScript = getMethod("INJECT_SCRIPT", bg);
 export const openPopupPrompt = getMethod("OPEN_POPUP_PROMPT", bg);
 export const getUID = jest.fn().mockResolvedValue(uuidv4());
+
+export const pong = jest.fn(() => ({
+  timestamp: Date.now(),
+}));
+
 export const waitForTargetByUrl = getMethod("WAIT_FOR_TARGET_BY_URL", bg);
 
 export const activatePartnerTheme = getMethod("ACTIVATE_PARTNER_THEME", bg);

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -140,3 +140,8 @@ export const installStarterBlueprints = getMethod(
 );
 
 export const ping = getMethod("PING", bg);
+
+export const collectPerformanceDiagnostics = getMethod(
+  "COLLECT_PERFORMANCE_DIAGNOSTICS",
+  bg
+);

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -138,3 +138,5 @@ export const installStarterBlueprints = getMethod(
   "INSTALL_STARTER_BLUEPRINTS",
   bg
 );
+
+export const ping = getMethod("PING", bg);

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -64,6 +64,7 @@ import {
 } from "@/telemetry/trace";
 import {
   initTelemetry,
+  pong,
   recordBrickRun,
   recordEvent,
   sendDeploymentAlert,
@@ -106,6 +107,7 @@ declare global {
     GET_UID: typeof uid;
     WAIT_FOR_TARGET_BY_URL: typeof waitForTargetByUrl;
 
+    PING: typeof pong;
     ACTIVATE_TAB: typeof activateTab;
     REACTIVATE_EVERY_TAB: typeof reactivateEveryTab;
     REMOVE_EXTENSION_EVERY_TAB: typeof removeExtensionForEveryTab;
@@ -184,6 +186,7 @@ export default function registerMessenger(): void {
     GET_UID: uid,
     WAIT_FOR_TARGET_BY_URL: waitForTargetByUrl,
 
+    PING: pong,
     ACTIVATE_TAB: activateTab,
     REACTIVATE_EVERY_TAB: reactivateEveryTab,
     REMOVE_EXTENSION_EVERY_TAB: removeExtensionForEveryTab,

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -63,6 +63,7 @@ import {
   clearTraces,
 } from "@/telemetry/trace";
 import {
+  collectPerformanceDiagnostics,
   initTelemetry,
   pong,
   recordBrickRun,
@@ -108,6 +109,8 @@ declare global {
     WAIT_FOR_TARGET_BY_URL: typeof waitForTargetByUrl;
 
     PING: typeof pong;
+    COLLECT_PERFORMANCE_DIAGNOSTICS: typeof collectPerformanceDiagnostics;
+
     ACTIVATE_TAB: typeof activateTab;
     REACTIVATE_EVERY_TAB: typeof reactivateEveryTab;
     REMOVE_EXTENSION_EVERY_TAB: typeof removeExtensionForEveryTab;
@@ -187,6 +190,8 @@ export default function registerMessenger(): void {
     WAIT_FOR_TARGET_BY_URL: waitForTargetByUrl,
 
     PING: pong,
+    COLLECT_PERFORMANCE_DIAGNOSTICS: collectPerformanceDiagnostics,
+
     ACTIVATE_TAB: activateTab,
     REACTIVATE_EVERY_TAB: reactivateEveryTab,
     REMOVE_EXTENSION_EVERY_TAB: removeExtensionForEveryTab,

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -109,7 +109,7 @@ interface UserSummary {
 /**
  * Diagnostic data to report for performance debugging.
  */
-interface Diagnostics extends UserSummary {
+export interface Diagnostics extends UserSummary {
   /**
    * The timestamp the diagnostic data was collected.
    */

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -33,6 +33,9 @@ import { deleteDatabase } from "@/utils/idbUtils";
 import { detectBrowser } from "@/vendors/mixpanel";
 import { type RegistryId } from "@/types/registryTypes";
 import { syncFlagOn } from "@/store/syncFlags";
+import { count as registrySize } from "@/registry/packageRegistry";
+import { count as logSize } from "@/telemetry/logging";
+import { count as traceSize } from "@/telemetry/trace";
 
 const UID_STORAGE_KEY = "USER_UUID" as ManualStorageKey;
 const EVENT_BUFFER_DEBOUNCE_MS = 2000;
@@ -41,11 +44,106 @@ const TELEMETRY_DB_NAME = "telemetrydb";
 const TELEMETRY_DB_VERSION_NUMBER = 1;
 const TELEMETRY_EVENT_OBJECT_STORE = "events";
 
+/**
+ * Timestamp when the background page was initialized.
+ */
+const initTimestamp = Date.now();
+
 interface UserTelemetryEvent {
+  /**
+   * A unique identifier for the event.
+   */
   uid: string;
+  /**
+   * The name of the event.
+   * @see Events
+   */
   event: string;
+  /**
+   * Timestamp when the event occurred.
+   */
   timestamp: number;
+  /**
+   * Event data/payload.
+   */
   data: JsonObject;
+}
+
+interface UserSummary {
+  /**
+   * The version from the manifest.
+   */
+  version: string;
+
+  /**
+   * The version_name from the manifest.
+   */
+  versionName: string;
+
+  /**
+   * The number of active mod components.
+   */
+  numActiveExtensions: number;
+
+  /**
+   * The number of active mods.
+   */
+  numActiveBlueprints: number;
+
+  /**
+   * The number of active starer bricks.
+   */
+  numActiveExtensionPoints: number;
+
+  /**
+   * The detected operating system.
+   */
+  $os: string;
+
+  /**
+   * The detected browser.
+   */
+  $browser: string;
+}
+
+/**
+ * Diagnostic data to report for performance debugging.
+ */
+interface Diagnostics extends UserSummary {
+  /**
+   * The timestamp the diagnostic data was collected.
+   */
+  timestamp: number;
+
+  /**
+   * Time since the background page was initialized.
+   */
+  timeAliveMS: number;
+
+  /**
+   * The number of tabs currently open.
+   */
+  tabCount: number;
+
+  /**
+   * The number of packages in the user's local IDB registry.
+   */
+  packageCount: number;
+
+  /**
+   * The number of logs in the user's local IDB log store.
+   */
+  logCount: number;
+
+  /**
+   * The number of traces in the user's local IDB trace store.
+   */
+  traceCount: number;
+
+  /**
+   * The number of buffered telemetry events in the user's local IDB telemetry store.
+   */
+  eventCount: number;
 }
 
 interface TelemetryDB extends DBSchema {
@@ -205,7 +303,7 @@ export async function TEST_flushAll(): Promise<void> {
   return debouncedFlush.flush();
 }
 
-async function userSummary() {
+async function collectUserSummary(): Promise<UserSummary> {
   const { os } = await browser.runtime.getPlatformInfo();
   const { version, version_name: versionName } = browser.runtime.getManifest();
   // Not supported on Chromium, and may require additional permissions
@@ -245,7 +343,7 @@ async function init(): Promise<void> {
     const client = await getLinkedApiClient();
     await client.post("/api/identify/", {
       uid: await uid(),
-      data: await userSummary(),
+      data: await collectUserSummary(),
     });
   }
 }
@@ -318,4 +416,32 @@ export async function sendDeploymentAlert({
 }) {
   const client = await getLinkedApiClient();
   await client.post(`/api/deployments/${deploymentId}/alerts/`, data);
+}
+
+/**
+ * Return a ping response with the current timestamp.
+ */
+export async function pong(): Promise<{ timestamp: number }> {
+  return {
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Collect performance diagnostics for the current browser session.
+ */
+export async function collectPerformanceDiagnostics(): Promise<Diagnostics> {
+  const timestamp = Date.now();
+  const allTabs = await browser.tabs.query({});
+
+  return {
+    timestamp,
+    ...(await collectUserSummary()),
+    timeAliveMS: timestamp - initTimestamp,
+    tabCount: allTabs.length,
+    packageCount: await registrySize(),
+    logCount: await logSize(),
+    traceCount: await traceSize(),
+    eventCount: await count(),
+  };
 }

--- a/src/bricks/effects/sidebar.ts
+++ b/src/bricks/effects/sidebar.ts
@@ -20,6 +20,7 @@ import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { hideSidebar, showSidebar } from "@/contentScript/sidebarController";
 import { propertiesToSchema } from "@/validators/generic";
+import { logPromiseDuration } from "@/utils";
 
 const NO_PARAMS: Schema = {
   $schema: "https://json-schema.org/draft/2019-09/schema#",
@@ -65,11 +66,14 @@ export class ShowSidebar extends EffectABC {
   ): Promise<void> {
     // Don't pass extensionId here because the extensionId in showOptions refers to the extensionId of the panel,
     // not the extensionId of the extension toggling the sidebar
-    void showSidebar({
-      force: forcePanel,
-      panelHeading,
-      blueprintId: logger.context.blueprintId,
-    });
+    void logPromiseDuration(
+      "ShowSidebar:showSidebar",
+      showSidebar({
+        force: forcePanel,
+        panelHeading,
+        blueprintId: logger.context.blueprintId,
+      })
+    );
   }
 }
 

--- a/src/bricks/transformers/extensionDiagnostics.ts
+++ b/src/bricks/transformers/extensionDiagnostics.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TransformerABC } from "@/types/bricks/transformerTypes";
+import { type Schema } from "@/types/schemaTypes";
+import { propertiesToSchema } from "@/validators/generic";
+import { type UnknownObject } from "@/types/objectTypes";
+import { getDiagnostics as collectFrameDiagnostics } from "@/contentScript/performanceMonitoring";
+import { collectPerformanceDiagnostics as collectExtensionDiagnostics } from "@/background/messenger/api";
+
+export class ExtensionDiagnostics extends TransformerABC {
+  defaultOutputKey = "diagnostics";
+
+  constructor() {
+    super(
+      "@pixiebrix/diagnostics",
+      "Extension Diagnostics",
+      "Collect PixieBrix performance and error diagnostics"
+    );
+  }
+
+  inputSchema: Schema = propertiesToSchema({}, []);
+
+  override outputSchema: Schema = {
+    $schema: "https://json-schema.org/draft/2019-09/schema#",
+    type: "object",
+    properties: {},
+    additionalProperties: true,
+  };
+
+  override async isRootAware(): Promise<boolean> {
+    return false;
+  }
+
+  async transform(): Promise<UnknownObject> {
+    return {
+      ...(await collectFrameDiagnostics()),
+      ...(await collectExtensionDiagnostics()),
+    };
+  }
+}
+
+export default ExtensionDiagnostics;

--- a/src/bricks/transformers/getAllTransformers.ts
+++ b/src/bricks/transformers/getAllTransformers.ts
@@ -50,6 +50,7 @@ import TourStepTransformer from "@/bricks/transformers/tourStep/tourStep";
 import { type Brick } from "@/types/brickTypes";
 import { SelectElement } from "@/bricks/transformers/selectElement";
 import Run from "@/bricks/transformers/controlFlow/Run";
+import ExtensionDiagnostics from "@/bricks/transformers/extensionDiagnostics";
 
 function getAllTransformers(): Brick[] {
   return [
@@ -81,6 +82,7 @@ function getAllTransformers(): Brick[] {
     new RandomNumber(),
     new TraverseElements(),
     new SelectElement(),
+    new ExtensionDiagnostics(),
 
     // Control Flow Bricks
     new ForEach(),

--- a/src/components/floatingActions/FloatingActions.tsx
+++ b/src/components/floatingActions/FloatingActions.tsx
@@ -109,6 +109,8 @@ export async function initFloatingActions(): Promise<void> {
   // XXX: consider moving checks into React component, so we can use the Redux context
   if (
     settings.isFloatingActionButtonEnabled &&
+    // XXX: there's likely a race here with when syncFlagOn gets the flag from localStorage. But in practice, this
+    // seems to work fine. (Likely because the flags will be loaded by the time the Promise.all above resolves)
     syncFlagOn("floating-quickbar-button-freemium") &&
     !isEnterpriseOrPartnerUser
   ) {

--- a/src/components/quickBar/quickBarRegistry.ts
+++ b/src/components/quickBar/quickBarRegistry.ts
@@ -148,7 +148,7 @@ class QuickBarRegistry {
   }
 
   /**
-   * Add a action change handler.
+   * Add an action change handler.
    * @param handler the action change handler
    */
   addListener(handler: ActionsChangeHandler): void {

--- a/src/components/quickBar/quickBarRegistry.ts
+++ b/src/components/quickBar/quickBarRegistry.ts
@@ -204,7 +204,7 @@ class QuickBarRegistry {
 }
 
 /**
- * Singleton registry for the content script
+ * Singleton registry for the content script.
  */
 const quickBarRegistry = new QuickBarRegistry();
 

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -36,6 +36,7 @@ import {
 import { onUncaughtError } from "@/errors/errorHelpers";
 import { initFloatingActions } from "@/components/floatingActions/FloatingActions";
 import { initSidebarActivation } from "@/contentScript/sidebarActivation";
+import { initPerformanceMonitoring } from "@/contentScript/performanceMonitoring";
 
 // Must come before the default handler for ignoring errors. Otherwise, this handler might not be run
 onUncaughtError((error) => {
@@ -71,4 +72,6 @@ export async function init(): Promise<void> {
   // Let the partner page know
   initPartnerIntegrations();
   void initFloatingActions();
+
+  initPerformanceMonitoring();
 }

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -73,5 +73,5 @@ export async function init(): Promise<void> {
   initPartnerIntegrations();
   void initFloatingActions();
 
-  initPerformanceMonitoring();
+  void initPerformanceMonitoring();
 }

--- a/src/contentScript/performanceMonitoring.test.ts
+++ b/src/contentScript/performanceMonitoring.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getDiagnostics } from "@/contentScript/performanceMonitoring";
+
+describe("getDiagnostics", () => {
+  it("gets disabled diagnostics", async () => {
+    await expect(getDiagnostics()).resolves.toStrictEqual({
+      isMonitoringEnabled: false,
+      pingWarnings: [],
+    });
+  });
+});

--- a/src/contentScript/performanceMonitoring.ts
+++ b/src/contentScript/performanceMonitoring.ts
@@ -129,7 +129,7 @@ export async function getDiagnostics(): Promise<Diagnostics> {
 }
 
 /**
- * Initialize performance monitoring for the top level frame, if performance monitoring is turned on.
+ * Initialize performance monitoring for the top-level frame, if performance tracing setting is enabled.
  */
 export async function initPerformanceMonitoring(): Promise<void> {
   if (isLoadedInIframe()) {

--- a/src/contentScript/performanceMonitoring.ts
+++ b/src/contentScript/performanceMonitoring.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ping } from "@/background/messenger/api";
+import { isContextInvalidatedError } from "@/errors/contextInvalidated";
+import { isLoadedInIframe } from "@/iframeUtils";
+
+const PING_INTERVAL_MS = 5 * 1000;
+const PING_WARNING_THRESHOLD_MS = 150;
+
+/**
+ * Ping the background page to measure the latency of the runtime messaging.
+ */
+async function pingBackgroundPage() {
+  const startTimestamp = Date.now();
+
+  let response;
+
+  try {
+    response = await ping();
+  } catch (error) {
+    if (isContextInvalidatedError(error)) {
+      console.debug("ping: context invalidated");
+      return;
+    }
+
+    console.warn("ping: error", error);
+    return;
+  }
+
+  const { timestamp: receiveTimestamp } = response;
+
+  const endTimestamp = Date.now();
+
+  const duration = endTimestamp - startTimestamp;
+
+  const log =
+    duration > PING_WARNING_THRESHOLD_MS ? console.warn : console.debug;
+
+  log(`ping (ms): ${endTimestamp - startTimestamp}`, {
+    // Time for the background page to receive/start handling the message
+    sendMs: receiveTimestamp - startTimestamp,
+    // Time for the content script to receive the response after handling the message
+    responseMs: endTimestamp - receiveTimestamp,
+    // Total time
+    totalMs: endTimestamp - startTimestamp,
+  });
+}
+
+/**
+ * Initialize performance monitoring for the top level frame, if performance monitoring is turned on.
+ */
+export function initPerformanceMonitoring(): void {
+  if (isLoadedInIframe()) {
+    return;
+  }
+
+  void pingBackgroundPage();
+
+  setInterval(pingBackgroundPage, PING_INTERVAL_MS);
+}

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -160,6 +160,10 @@ export async function ensureSidebar(): Promise<void> {
   }
 }
 
+/**
+ * Hide the sidebar. Dispatches HIDE_SIDEBAR_EVENT_NAME event even if the sidebar is not currently visible.
+ * @see HIDE_SIDEBAR_EVENT_NAME
+ */
 export function hideSidebar(): void {
   console.debug("sidebarController:hideSidebar", {
     isSidebarFrameVisible: isSidebarFrameVisible(),

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -27,7 +27,7 @@ import registerBuiltinBlocks from "@/bricks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 117;
+const EXPECTED_HEADER_COUNT = 118;
 
 registerBuiltinBlocks();
 registerContribBlocks();

--- a/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
+++ b/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
@@ -61,6 +61,7 @@ const ExperimentalSettings: React.FunctionComponent = () => {
     excludeRandomClasses,
     selectionTools,
     varAutosuggest,
+    performanceTracing,
   } = useSelector(selectSettings);
 
   return (
@@ -116,13 +117,27 @@ const ExperimentalSettings: React.FunctionComponent = () => {
           />
           <ExperimentalFeature
             id="varAutosuggest"
-            label="Autosuggest Variables in Page Editor."
+            label="Autosuggest Variables in Page Editor:"
             description="Toggle on to enable variable autosuggest for variable and text template entry modes"
             isEnabled={varAutosuggest}
             onChange={(value) => {
               dispatch(
                 settingsSlice.actions.setFlag({
                   flag: "varAutosuggest",
+                  value,
+                })
+              );
+            }}
+          />
+          <ExperimentalFeature
+            id="performanceTracing"
+            label="Performance Tracing:"
+            description="Toggle on to trace runtime performance"
+            isEnabled={performanceTracing}
+            onChange={(value) => {
+              dispatch(
+                settingsSlice.actions.setFlag({
+                  flag: "performanceTracing",
                   value,
                 })
               );

--- a/src/store/settingsTypes.ts
+++ b/src/store/settingsTypes.ts
@@ -47,6 +47,11 @@ export type SkunkworksSettings = {
    * Experimental setting to support autosuggest for variables in the Page Editor
    */
   varAutosuggest?: boolean;
+
+  /**
+   * Experimental setting to track runtime performance
+   */
+  performanceTracing?: boolean;
 };
 
 export type SettingsState = SkunkworksSettings & {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -534,18 +534,6 @@ export async function logPromiseDuration<P>(
   }
 }
 
-export async function logFunctionDuration<
-  Fn extends (...args: unknown[]) => Promise<unknown>
->(title: string, fn: Fn): Promise<ReturnType<Fn>> {
-  const start = Date.now();
-  try {
-    return (await fn()) as Awaited<ReturnType<Fn>>;
-  } finally {
-    // Prefer `debug` level; `console.time` has `log` level
-    console.debug(title, `${Math.round(Date.now() - start)}ms`);
-  }
-}
-
 export function isMac(): boolean {
   // https://stackoverflow.com/a/27862868/402560
   return globalThis.navigator?.platform.includes("Mac");


### PR DESCRIPTION
## What does this PR do?

- Adds skunkworks setting to measure ping between content script and background page
- Adds an `Extension Diagnostics` brick that collects relevant performance information. We can use it to build performance reporting mods for internal use

## Discussion

- I was considering hard-coding a quick bar action that'd report an event with the information
- Exposing the information via a brick will allow us to create a mod that collects information and more easily plugs into slack/bug-triage

## Future Work

- Create the performance reporting mod for team use

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
