### PR TITLE
#6139: fix multiple activation permissions check; always show options during reactivation

### DIFF
--- a/src/activation/useActivateRecipe.test.ts
+++ b/src/activation/useActivateRecipe.test.ts
@@ -138,6 +138,28 @@ describe("useActivateRecipe", () => {
     expect(reactivateEveryTabMock).not.toHaveBeenCalled();
   });
 
+  it("ignores permissions if flag set", async () => {
+    const { formValues, recipe } = setupInputs();
+    setRecipeHasPermissions(false);
+    setUserAcceptedPermissions(false);
+
+    const {
+      result: { current: activateRecipe },
+    } = renderHook(
+      () => useActivateRecipe("marketplace", { checkPermissions: false }),
+      {
+        setupRedux(dispatch, { store }) {
+          jest.spyOn(store, "dispatch");
+        },
+      }
+    );
+
+    const { success, error } = await activateRecipe(formValues, recipe);
+
+    expect(success).toBe(true);
+    expect(error).toBeUndefined();
+  });
+
   it("calls uninstallRecipe, installs to extensionsSlice, and calls reactivateEveryTab, if permissions are granted", async () => {
     const { formValues, recipe } = setupInputs();
     setRecipeHasPermissions(false);

--- a/src/activation/useActivateRecipe.test.ts
+++ b/src/activation/useActivateRecipe.test.ts
@@ -112,6 +112,10 @@ function setUserAcceptedPermissions(accepted: boolean) {
 }
 
 describe("useActivateRecipe", () => {
+  beforeEach(() => {
+    reactivateEveryTabMock.mockClear();
+  });
+
   it("returns error if permissions are not granted", async () => {
     const { formValues, recipe } = setupInputs();
     setRecipeHasPermissions(false);

--- a/src/activation/useActivateRecipe.ts
+++ b/src/activation/useActivateRecipe.ts
@@ -69,7 +69,7 @@ function selectActivateEventData(recipe: ModDefinition) {
  */
 function useActivateRecipe(
   source: ActivationSource,
-  { checkPermissions = false }: { checkPermissions?: boolean } = {}
+  { checkPermissions = true }: { checkPermissions?: boolean } = {}
 ): ActivateRecipeFormCallback {
   const dispatch = useDispatch();
   const extensions = useSelector(selectExtensions);

--- a/src/sidebar/activateRecipe/ActivateModPanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateModPanel.tsx
@@ -221,6 +221,7 @@ const ActivateRecipePanelContent: React.FC<
   wizardSteps,
   initialValues,
   validationSchema,
+  isActive,
 }) => {
   const reduxDispatch = useDispatch();
   const marketplaceActivateRecipe = useActivateRecipe("marketplace");
@@ -293,14 +294,16 @@ const ActivateRecipePanelContent: React.FC<
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount
   }, []);
 
-  // Trigger auto-activation if the recipe does not require permissions or user
-  // configuration, and there's no error
+  // Trigger auto-activation if the recipe does not require permissions or user configuration, and there's no error.
+  // Additionally, always show the options if this is a reactivation.  (Reactivation, in practice, is used to
+  // reconfigure mod options)
   useEffect(() => {
     if (
       state.needsPermissions != null &&
       !state.needsPermissions &&
       !requiresConfiguration &&
-      !state.activationError
+      !state.activationError &&
+      !isActive
     ) {
       // State is checked inside activateRecipe to prevent double-activation
       void activateRecipe();
@@ -311,6 +314,7 @@ const ActivateRecipePanelContent: React.FC<
     requiresConfiguration,
     state.needsPermissions,
     state.activationError,
+    isActive,
   ]);
 
   // Show loader if panel is determining if it can auto-activate, or if it's activating.

--- a/src/sidebar/activateRecipe/ActivateMultipleModsPanel.tsx
+++ b/src/sidebar/activateRecipe/ActivateMultipleModsPanel.tsx
@@ -74,7 +74,12 @@ const MultipleSuccessPanel: React.FC<{ results: ModResultPair[] }> = ({
 const AutoActivatePanel: React.FC<{ mods: RequiredModDefinition[] }> = ({
   mods,
 }) => {
-  const activate = useActivateRecipe("marketplace");
+  // Assume mods work without all permissions. Currently, the only optional permission is `clipboardWrite`, which isn't
+  // actually enforced by Chrome. (Mods can still copy to the clipboard.). The only way a mod would not have all
+  // permissions is if their Enterprise policy has disabled some permissions.
+  const activate = useActivateRecipe("marketplace", {
+    checkPermissions: false,
+  });
 
   // Only activate new mods that the user does not already have activated. If there are updates available, the
   // user will be prompted to update according to marketplace mod updater rules.
@@ -113,7 +118,8 @@ const AutoActivatePanel: React.FC<{ mods: RequiredModDefinition[] }> = ({
 
           if (result.error) {
             throw new Error(
-              `Error activating ${mod.modDefinition.metadata.name}`
+              `Error activating ${mod.modDefinition.metadata.name}`,
+              { cause: new Error(result.error) }
             );
           }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #6139 
- Ignores permissions during multiple mod activation
- Always shows mod options during reactivation in sidebar. (Because reactivation is used for reconfiguration)
- NOTE: for multiple mod activation, mods that are already active are ignored

## Checklist

- [x] Add tests: the are getting covered in Rainforest QA: https://app.rainforestqa.com/tests/395899
- [x] Designate a primary reviewer: @BLoe 
