### PR TITLE
Refactor: rename recipe factories

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.2.2).
+ * Mock Service Worker (1.2.3).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/src/activation/useActivateRecipe.test.ts
+++ b/src/activation/useActivateRecipe.test.ts
@@ -33,7 +33,7 @@ import { set } from "lodash";
 import {
   modComponentDefinitionFactory,
   starterBrickConfigFactory,
-  recipeFactory,
+  defaultModDefinitionFactory,
   metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 
@@ -86,7 +86,7 @@ function setupInputs(): {
   starterBrickConfig.definition.contexts = ["all"];
   starterBrickConfig.definition.documentUrlPatterns = ["*://*/*"];
 
-  const modDefinition = recipeFactory({
+  const modDefinition = defaultModDefinitionFactory({
     extensionPoints: [modComponentDefinition],
     definitions: {
       [extensionPointId]: starterBrickConfig,

--- a/src/activation/useActivateRecipe.test.ts
+++ b/src/activation/useActivateRecipe.test.ts
@@ -34,7 +34,7 @@ import {
   modComponentDefinitionFactory,
   starterBrickConfigFactory,
   recipeFactory,
-  recipeMetadataFactory,
+  metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 
 import { databaseFactory } from "@/testUtils/factories/databaseFactories";
@@ -68,7 +68,7 @@ function setupInputs(): {
     id: extensionPointId,
   });
   const starterBrickConfig = starterBrickConfigFactory({
-    metadata: recipeMetadataFactory({
+    metadata: metadataFactory({
       id: extensionPointId,
       name: "Text Starter Brick 1",
     }),

--- a/src/activation/useActivateRecipeWizard.test.tsx
+++ b/src/activation/useActivateRecipeWizard.test.tsx
@@ -25,7 +25,7 @@ import useDatabaseOptions from "@/hooks/useDatabaseOptions";
 import { valueToAsyncState } from "@/utils/asyncStateUtils";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 jest.mock("@/components/auth/AuthWidget", () => {});
 jest.mock("react-redux");
@@ -55,7 +55,7 @@ describe("useActivateRecipeWizard", () => {
 
     const { result } = renderHook(() =>
       useActivateRecipeWizard(
-        recipeFactory({
+        defaultModDefinitionFactory({
           // Page Editor produces normalized form
           options: {
             schema: propertiesToSchema({
@@ -77,7 +77,7 @@ describe("useActivateRecipeWizard", () => {
     spy.mockReturnValue([]);
 
     const { result } = renderHook(() =>
-      useActivateRecipeWizard(recipeFactory())
+      useActivateRecipeWizard(defaultModDefinitionFactory())
     );
 
     const {
@@ -91,7 +91,7 @@ describe("useActivateRecipeWizard", () => {
     spy.mockReturnValue([]);
 
     const { result } = renderHook(() =>
-      useActivateRecipeWizard(recipeFactory())
+      useActivateRecipeWizard(defaultModDefinitionFactory())
     );
 
     const {
@@ -109,7 +109,7 @@ describe("useActivateRecipeWizard", () => {
         format: "preview",
       },
     });
-    const modDefinition = recipeFactory({
+    const modDefinition = defaultModDefinitionFactory({
       options: {
         schema: optionSchema,
       },
@@ -133,7 +133,7 @@ describe("useActivateRecipeWizard", () => {
         format: "preview",
       },
     });
-    const modDefinition = recipeFactory({
+    const modDefinition = defaultModDefinitionFactory({
       options: {
         schema: optionSchema,
       },

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -50,7 +50,7 @@ import {
   formStateFactory,
   triggerFormStateFactory,
 } from "@/testUtils/factories/pageEditorFactories";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { sanitizedIntegrationConfigFactory } from "@/testUtils/factories/integrationFactories";
 import { brickConfigFactory } from "@/testUtils/factories/brickFactories";
 
@@ -86,7 +86,7 @@ jest.mock("@/modDefinitions/registry", () => ({
 describe("Collecting available vars", () => {
   function mockBlueprintWithOptions(optionsSchema: any) {
     (recipeRegistry.lookup as jest.Mock).mockResolvedValue(
-      recipeFactory({
+      defaultModDefinitionFactory({
         options: {
           schema: optionsSchema,
         },

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -45,7 +45,7 @@ import {
 } from "@/components/documentBuilder/documentBuilderTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { services } from "@/background/messenger/api";
-import { modComponentRecipeFactory } from "@/testUtils/factories/modComponentFactories";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import {
   formStateFactory,
   triggerFormStateFactory,
@@ -125,7 +125,7 @@ describe("Collecting available vars", () => {
           optionsArgs: {
             foo: "bar",
           },
-          recipe: modComponentRecipeFactory({
+          recipe: modMetadataFactory({
             id: validateRegistryId("test/recipe"),
           }),
         },
@@ -231,7 +231,7 @@ describe("Collecting available vars", () => {
 
       const extension = formStateFactory(
         {
-          recipe: modComponentRecipeFactory({
+          recipe: modMetadataFactory({
             id: validateRegistryId("test/recipe"),
           }),
         },
@@ -266,7 +266,7 @@ describe("Collecting available vars", () => {
             bar: "qux",
             baz: "quux",
           },
-          recipe: modComponentRecipeFactory({
+          recipe: modMetadataFactory({
             id: validateRegistryId("test/recipe"),
           }),
         },
@@ -302,7 +302,7 @@ describe("Collecting available vars", () => {
 
       const extension = formStateFactory(
         {
-          recipe: modComponentRecipeFactory({
+          recipe: modMetadataFactory({
             id: validateRegistryId("test/recipe"),
           }),
         },
@@ -332,7 +332,7 @@ describe("Collecting available vars", () => {
 
       const extension = formStateFactory(
         {
-          recipe: modComponentRecipeFactory({
+          recipe: modMetadataFactory({
             id: validateRegistryId("test/recipe"),
           }),
           optionsArgs: {

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -42,7 +42,7 @@ import { emptyPermissionsFactory } from "@/permissions/permissionsUtils";
 import { setContext } from "@/testUtils/detectPageMock";
 import {
   modComponentFactory,
-  modComponentRecipeFactory,
+  modMetadataFactory,
 } from "@/testUtils/factories/modComponentFactories";
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { starterBrickConfigFactory } from "@/testUtils/factories/modDefinitionFactories";
@@ -533,7 +533,7 @@ describe("updateDeployments", () => {
     }) as ActivatedModComponent;
 
     const recipeModComponent = modComponentFactory({
-      _recipe: modComponentRecipeFactory(),
+      _recipe: modMetadataFactory(),
     }) as ActivatedModComponent;
 
     const deploymentStarterBrick = starterBrickConfigFactory();
@@ -545,7 +545,7 @@ describe("updateDeployments", () => {
     const deploymentModComponent = modComponentFactory({
       extensionPointId: deploymentStarterBrick.metadata.id,
       _deployment: { id: uuidv4(), timestamp: "2021-10-07T12:52:16.189Z" },
-      _recipe: modComponentRecipeFactory(),
+      _recipe: modMetadataFactory(),
     }) as ActivatedModComponent;
 
     registryFindMock.mockImplementation(async (id) => {

--- a/src/background/modUpdater.test.ts
+++ b/src/background/modUpdater.test.ts
@@ -33,7 +33,7 @@ import {
 import type { RegistryId, SemVerString } from "@/types/registryTypes";
 import {
   starterBrickConfigFactory,
-  versionedStarterBrickRecipeFactory,
+  modDefinitionWithVersionedStarterBrickFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { getEditorState } from "@/store/dynamicElementStorage";
 import extensionsSlice from "@/store/extensionsSlice";
@@ -338,7 +338,7 @@ describe("updateModsIfUpdatesAvailable", () => {
   beforeEach(async () => {
     axiosMock.reset();
 
-    publicMod = versionedStarterBrickRecipeFactory()({
+    publicMod = modDefinitionWithVersionedStarterBrickFactory()({
       sharing: sharingDefinitionFactory({ public: true }),
     });
 

--- a/src/background/modUpdater.test.ts
+++ b/src/background/modUpdater.test.ts
@@ -27,7 +27,7 @@ import {
 import reportError from "@/telemetry/reportError";
 import { loadOptions, saveOptions } from "@/store/extensionsStorage";
 import {
-  modComponentRecipeFactory,
+  modMetadataFactory,
   activatedModComponentFactory,
 } from "@/testUtils/factories/modComponentFactories";
 import type { RegistryId, SemVerString } from "@/types/registryTypes";
@@ -94,26 +94,26 @@ describe("getActivatedMarketplaceModVersions function", () => {
     await saveOptions({ extensions: [] });
 
     publicActivatedMod = activatedModComponentFactory({
-      _recipe: modComponentRecipeFactory({
+      _recipe: modMetadataFactory({
         sharing: sharingDefinitionFactory({ public: true }),
       }),
     });
 
     privateActivatedMod = activatedModComponentFactory({
-      _recipe: modComponentRecipeFactory({
+      _recipe: modMetadataFactory({
         sharing: sharingDefinitionFactory({ public: false }),
       }),
     });
 
     publicActivatedDeployment = activatedModComponentFactory({
-      _recipe: modComponentRecipeFactory({
+      _recipe: modMetadataFactory({
         sharing: sharingDefinitionFactory({ public: true }),
       }),
       _deployment: {} as ActivatedModComponent["_deployment"],
     });
 
     privateActivatedDeployment = activatedModComponentFactory({
-      _recipe: modComponentRecipeFactory({
+      _recipe: modMetadataFactory({
         sharing: sharingDefinitionFactory({ public: false }),
       }),
       _deployment: {} as ActivatedModComponent["_deployment"],
@@ -146,7 +146,7 @@ describe("getActivatedMarketplaceModVersions function", () => {
 
   it("returns expected object with registry id keys and version number values", async () => {
     const anotherPublicActivatedMod = activatedModComponentFactory({
-      _recipe: modComponentRecipeFactory({
+      _recipe: modMetadataFactory({
         sharing: sharingDefinitionFactory({ public: true }),
       }),
     });
@@ -170,7 +170,7 @@ describe("getActivatedMarketplaceModVersions function", () => {
   });
 
   it("reports error if multiple mod component versions activated for same mod", async () => {
-    const sameMod = modComponentRecipeFactory({
+    const sameMod = modMetadataFactory({
       sharing: sharingDefinitionFactory({ public: true }),
     });
 
@@ -178,7 +178,7 @@ describe("getActivatedMarketplaceModVersions function", () => {
       _recipe: sameMod,
     });
 
-    const sameModDifferentVersion = modComponentRecipeFactory({
+    const sameModDifferentVersion = modMetadataFactory({
       ...sameMod,
       version: "2.0.0" as SemVerString,
     });
@@ -209,12 +209,12 @@ describe("fetchModUpdates function", () => {
   beforeEach(async () => {
     activatedMods = [
       activatedModComponentFactory({
-        _recipe: modComponentRecipeFactory({
+        _recipe: modMetadataFactory({
           sharing: sharingDefinitionFactory({ public: true }),
         }),
       }),
       activatedModComponentFactory({
-        _recipe: modComponentRecipeFactory({
+        _recipe: modMetadataFactory({
           sharing: sharingDefinitionFactory({ public: true }),
         }),
       }),
@@ -259,8 +259,8 @@ describe("deactivateMod function", () => {
   let modToDeactivate: ActivatedModComponent["_recipe"];
 
   beforeEach(async () => {
-    modToDeactivate = modComponentRecipeFactory({});
-    const anotherMod = modComponentRecipeFactory({});
+    modToDeactivate = modMetadataFactory({});
+    const anotherMod = modMetadataFactory({});
 
     await saveOptions({
       extensions: [
@@ -308,7 +308,7 @@ describe("deactivateMod function", () => {
     const extensionPoint = starterBrickConfigFactory();
     const extension = activatedModComponentFactory({
       extensionPointId: extensionPoint.metadata.id,
-      _recipe: modComponentRecipeFactory({}),
+      _recipe: modMetadataFactory({}),
     });
 
     await saveOptions({

--- a/src/background/starterBlueprints.test.ts
+++ b/src/background/starterBlueprints.test.ts
@@ -37,7 +37,7 @@ import { modComponentFactory } from "@/testUtils/factories/modComponentFactories
 import {
   modComponentDefinitionFactory,
   getRecipeWithBuiltInServiceAuths,
-  recipeFactory,
+  defaultModDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { userOrganizationFactory } from "@/testUtils/factories/authFactories";
 import { remoteIntegrationConfigurationFactory } from "@/testUtils/factories/integrationFactories";
@@ -80,7 +80,7 @@ describe("installStarterBlueprints", () => {
 
     axiosMock
       .onGet("/api/onboarding/starter-blueprints/")
-      .reply(200, [recipeFactory()]);
+      .reply(200, [defaultModDefinitionFactory()]);
 
     await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
@@ -122,7 +122,7 @@ describe("installStarterBlueprints", () => {
       services: extensionServices,
     });
 
-    const recipe = recipeFactory({
+    const recipe = defaultModDefinitionFactory({
       extensionPoints: [starterBrickDefinition],
     });
 
@@ -139,7 +139,7 @@ describe("installStarterBlueprints", () => {
     expect(serviceIds).toEqual([]);
 
     // It works on an array of recipes with no services
-    serviceIds = getAllRequiredServiceIds([recipeFactory()]);
+    serviceIds = getAllRequiredServiceIds([defaultModDefinitionFactory()]);
     expect(serviceIds).toEqual([]);
   });
 
@@ -177,7 +177,7 @@ describe("installStarterBlueprints", () => {
 
     axiosMock
       .onGet("/api/onboarding/starter-blueprints/")
-      .reply(200, [recipeFactory()]);
+      .reply(200, [defaultModDefinitionFactory()]);
 
     await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();
@@ -221,7 +221,7 @@ describe("installStarterBlueprints", () => {
   test("starter blueprint already installed", async () => {
     isLinkedMock.mockResolvedValue(true);
 
-    const recipe = recipeFactory();
+    const recipe = defaultModDefinitionFactory();
 
     const modComponent = modComponentFactory({
       _recipe: { id: recipe.metadata.id } as ModComponentBase["_recipe"],
@@ -255,7 +255,7 @@ describe("installStarterBlueprints", () => {
 
     axiosMock
       .onGet("/api/onboarding/starter-blueprints/")
-      .reply(200, [recipeFactory()]);
+      .reply(200, [defaultModDefinitionFactory()]);
 
     await debouncedInstallStarterBlueprints();
     const { extensions } = await loadOptions();

--- a/src/contentScript/loadActivationEnhancements.test.ts
+++ b/src/contentScript/loadActivationEnhancements.test.ts
@@ -26,7 +26,7 @@ import { MARKETPLACE_URL } from "@/utils/strings";
 import { getActivatingModIds } from "@/background/messenger/external/_implementation";
 import {
   modComponentFactory,
-  modComponentRecipeFactory,
+  modMetadataFactory,
 } from "@/testUtils/factories/modComponentFactories";
 import {
   loadActivationEnhancements,
@@ -104,7 +104,7 @@ describe("marketplace enhancements", () => {
     window.location.assign(MARKETPLACE_URL);
     // Recipe 1 is installed, recipe 2 is not
     const modComponent1 = modComponentFactory({
-      _recipe: modComponentRecipeFactory({
+      _recipe: modMetadataFactory({
         id: recipeId1,
       }),
     }) as ActivatedModComponent;
@@ -135,7 +135,7 @@ describe("marketplace enhancements", () => {
       modComponentFactory,
       2
     )({
-      _recipe: modComponentRecipeFactory,
+      _recipe: modMetadataFactory,
     });
 
     const modIds = components.map((x) => x._recipe?.id);
@@ -207,7 +207,7 @@ describe("marketplace enhancements", () => {
     window.location.assign(MARKETPLACE_URL);
     // Recipe 1 is installed, recipe 2 is not
     const modComponent1 = modComponentFactory({
-      _recipe: modComponentRecipeFactory({
+      _recipe: modMetadataFactory({
         id: recipeId1,
       }),
     }) as ActivatedModComponent;
@@ -230,7 +230,7 @@ describe("marketplace enhancements", () => {
     window.location.assign(MARKETPLACE_URL);
     // Recipe 1 is installed, recipe 2 is not
     const modComponent1 = modComponentFactory({
-      _recipe: modComponentRecipeFactory({
+      _recipe: modMetadataFactory({
         id: recipeId1,
       }),
     }) as ActivatedModComponent;

--- a/src/extensionConsole/pages/activateRecipe/ActivateRecipeCard.test.tsx
+++ b/src/extensionConsole/pages/activateRecipe/ActivateRecipeCard.test.tsx
@@ -33,7 +33,7 @@ import { type RecipeResponse } from "@/types/contract";
 import {
   modComponentDefinitionFactory,
   recipeFactory,
-  recipeMetadataFactory,
+  metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 
 registerDefaultWidgets();
@@ -102,7 +102,7 @@ describe("ActivateRecipeCard", () => {
 
   test("activate mod definition with missing required mod definition options", async () => {
     const modDefinition = recipeFactory({
-      metadata: recipeMetadataFactory({
+      metadata: metadataFactory({
         id: "test/blueprint-with-required-options" as RegistryId,
         name: "Mod with Required Options",
       }),
@@ -137,7 +137,7 @@ describe("ActivateRecipeCard", () => {
 
   test("activate mod defintiion permissions", async () => {
     const modDefinition = recipeFactory({
-      metadata: recipeMetadataFactory({
+      metadata: metadataFactory({
         id: "test/blueprint-with-required-options" as RegistryId,
         name: "A Mod",
       }),
@@ -171,7 +171,7 @@ describe("ActivateRecipeCard", () => {
     });
 
     const modDefinition = recipeFactory({
-      metadata: recipeMetadataFactory({
+      metadata: metadataFactory({
         id: "test/blueprint-with-required-options" as RegistryId,
         name: "A Mod",
       }),

--- a/src/extensionConsole/pages/activateRecipe/ActivateRecipeCard.test.tsx
+++ b/src/extensionConsole/pages/activateRecipe/ActivateRecipeCard.test.tsx
@@ -32,7 +32,7 @@ import { validateRegistryId } from "@/types/helpers";
 import { type RecipeResponse } from "@/types/contract";
 import {
   modComponentDefinitionFactory,
-  recipeFactory,
+  defaultModDefinitionFactory,
   metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 
@@ -94,14 +94,14 @@ const RecipeCard: React.FC = () => {
 
 describe("ActivateRecipeCard", () => {
   test("renders", async () => {
-    setupRecipe(recipeFactory());
+    setupRecipe(defaultModDefinitionFactory());
     const rendered = render(<RecipeCard />);
     await waitForEffect();
     expect(rendered.asFragment()).toMatchSnapshot();
   });
 
   test("activate mod definition with missing required mod definition options", async () => {
-    const modDefinition = recipeFactory({
+    const modDefinition = defaultModDefinitionFactory({
       metadata: metadataFactory({
         id: "test/blueprint-with-required-options" as RegistryId,
         name: "Mod with Required Options",
@@ -136,7 +136,7 @@ describe("ActivateRecipeCard", () => {
   });
 
   test("activate mod defintiion permissions", async () => {
-    const modDefinition = recipeFactory({
+    const modDefinition = defaultModDefinitionFactory({
       metadata: metadataFactory({
         id: "test/blueprint-with-required-options" as RegistryId,
         name: "A Mod",
@@ -170,7 +170,7 @@ describe("ActivateRecipeCard", () => {
       error: "You must accept browser permissions to activate",
     });
 
-    const modDefinition = recipeFactory({
+    const modDefinition = defaultModDefinitionFactory({
       metadata: metadataFactory({
         id: "test/blueprint-with-required-options" as RegistryId,
         name: "A Mod",

--- a/src/extensionConsole/pages/activateRecipe/ServicesBody.test.tsx
+++ b/src/extensionConsole/pages/activateRecipe/ServicesBody.test.tsx
@@ -24,7 +24,7 @@ import { appApiMock } from "@/testUtils/appApiMock";
 import { validateRegistryId } from "@/types/helpers";
 import { render } from "@/extensionConsole/testHelpers";
 import ServicesBody from "@/extensionConsole/pages/activateRecipe/ServicesBody";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { getRequiredServiceIds } from "@/utils/recipeUtils";
 import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 import { waitForEffect } from "@/testUtils/testHelpers";
@@ -127,7 +127,7 @@ describe("ServicesBody", () => {
   it("renders with one service and no options and does not render title", async () => {
     useAuthOptionsMock.mockReturnValue(valueToAsyncState(emptyAuthOptions));
     getRequiredServiceIdsMock.mockReturnValue([serviceId1]);
-    render(<ServicesBody blueprint={recipeFactory()} />, {
+    render(<ServicesBody blueprint={defaultModDefinitionFactory()} />, {
       initialValues: {
         services: [{ id: serviceId1, config: null }],
       },
@@ -144,11 +144,14 @@ describe("ServicesBody", () => {
   it("renders own title properly", async () => {
     useAuthOptionsMock.mockReturnValue(valueToAsyncState(emptyAuthOptions));
     getRequiredServiceIdsMock.mockReturnValue([serviceId1]);
-    render(<ServicesBody blueprint={recipeFactory()} showOwnTitle />, {
-      initialValues: {
-        services: [{ id: serviceId1, config: null }],
-      },
-    });
+    render(
+      <ServicesBody blueprint={defaultModDefinitionFactory()} showOwnTitle />,
+      {
+        initialValues: {
+          services: [{ id: serviceId1, config: null }],
+        },
+      }
+    );
     await waitForEffect();
     // Ensure Integrations title is shown
     expect(screen.getByRole("heading", { name: "Integrations" })).toBeVisible();
@@ -161,7 +164,7 @@ describe("ServicesBody", () => {
     getRequiredServiceIdsMock.mockReturnValue([serviceId1]);
     render(
       <ServicesBody
-        blueprint={recipeFactory()}
+        blueprint={defaultModDefinitionFactory()}
         hideBuiltInServiceIntegrations
       />,
       {
@@ -182,7 +185,7 @@ describe("ServicesBody", () => {
       valueToAsyncState([sharedOption1a, sharedOption1b])
     );
     getRequiredServiceIdsMock.mockReturnValue([serviceId1]);
-    render(<ServicesBody blueprint={recipeFactory()} />, {
+    render(<ServicesBody blueprint={defaultModDefinitionFactory()} />, {
       initialValues: {
         services: [{ id: serviceId1, config: sharedOption1a.value }],
       },
@@ -199,7 +202,7 @@ describe("ServicesBody", () => {
       valueToAsyncState([sharedOption1a, sharedOption1b])
     );
     getRequiredServiceIdsMock.mockReturnValue([serviceId1]);
-    render(<ServicesBody blueprint={recipeFactory()} />, {
+    render(<ServicesBody blueprint={defaultModDefinitionFactory()} />, {
       initialValues: {
         services: [{ id: serviceId1, config: sharedOption1a.value }],
       },
@@ -228,7 +231,7 @@ describe("ServicesBody", () => {
       ])
     );
     getRequiredServiceIdsMock.mockReturnValue([serviceId1, serviceId2]);
-    render(<ServicesBody blueprint={recipeFactory()} />, {
+    render(<ServicesBody blueprint={defaultModDefinitionFactory()} />, {
       initialValues: {
         services: [
           { id: serviceId1, config: sharedOption1a.value },
@@ -251,7 +254,7 @@ describe("ServicesBody", () => {
     getRequiredServiceIdsMock.mockReturnValue([serviceId1]);
     render(
       <ServicesBody
-        blueprint={recipeFactory()}
+        blueprint={defaultModDefinitionFactory()}
         hideBuiltInServiceIntegrations
       />,
       {
@@ -279,7 +282,7 @@ describe("ServicesBody", () => {
     getRequiredServiceIdsMock.mockReturnValue([serviceId1]);
     render(
       <ServicesBody
-        blueprint={recipeFactory()}
+        blueprint={defaultModDefinitionFactory()}
         hideBuiltInServiceIntegrations
       />,
       {
@@ -307,7 +310,7 @@ describe("ServicesBody", () => {
     getRequiredServiceIdsMock.mockReturnValue([serviceId1]);
     render(
       <ServicesBody
-        blueprint={recipeFactory()}
+        blueprint={defaultModDefinitionFactory()}
         hideBuiltInServiceIntegrations
       />,
       {
@@ -330,7 +333,7 @@ describe("ServicesBody", () => {
     getRequiredServiceIdsMock.mockReturnValue([serviceId1]);
     render(
       <ServicesBody
-        blueprint={recipeFactory()}
+        blueprint={defaultModDefinitionFactory()}
         hideBuiltInServiceIntegrations
       />,
       {
@@ -364,7 +367,7 @@ describe("ServicesBody", () => {
     getRequiredServiceIdsMock.mockReturnValue([serviceId1, serviceId2]);
     render(
       <ServicesBody
-        blueprint={recipeFactory()}
+        blueprint={defaultModDefinitionFactory()}
         hideBuiltInServiceIntegrations
       />,
       {
@@ -397,7 +400,7 @@ describe("ServicesBody", () => {
     getRequiredServiceIdsMock.mockReturnValue([serviceId1, serviceId2]);
     render(
       <ServicesBody
-        blueprint={recipeFactory()}
+        blueprint={defaultModDefinitionFactory()}
         hideBuiltInServiceIntegrations
       />,
       {

--- a/src/extensionConsole/pages/activateRecipe/__snapshots__/ActivateRecipeCard.test.tsx.snap
+++ b/src/extensionConsole/pages/activateRecipe/__snapshots__/ActivateRecipeCard.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`ActivateRecipeCard activate mod definition with missing required mod de
               <div
                 class="wizardDescription"
               >
-                Recipe generated from factory
+                Mod generated from factory
               </div>
             </div>
             <div
@@ -323,7 +323,7 @@ exports[`ActivateRecipeCard activate mod defintiion permissions 1`] = `
               <div
                 class="wizardDescription"
               >
-                Recipe generated from factory
+                Mod generated from factory
               </div>
             </div>
             <div
@@ -438,19 +438,19 @@ exports[`ActivateRecipeCard renders 1`] = `
                   <div
                     class="card-title h5"
                   >
-                    Recipe 1
+                    Mod 1
                   </div>
                   <code
                     class="packageId"
                   >
-                    test/recipe-1
+                    test/mod-1
                   </code>
                 </span>
               </div>
               <div
                 class="wizardDescription"
               >
-                Recipe generated from factory
+                Mod generated from factory
               </div>
             </div>
             <div

--- a/src/extensionConsole/pages/mods/hooks/useModsPageActions.test.tsx
+++ b/src/extensionConsole/pages/mods/hooks/useModsPageActions.test.tsx
@@ -39,7 +39,7 @@ import {
   standaloneModDefinitionFactory,
   modComponentFactory,
 } from "@/testUtils/factories/modComponentFactories";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 jest.mock("@/hooks/useFlags", () => jest.fn());
 jest.mock("@/mods/hooks/useModPermissions", () => jest.fn());
@@ -88,7 +88,7 @@ const modViewItemFactory = ({
   unavailable?: boolean;
 }) =>
   ({
-    mod: isExtension ? modComponentFactory() : recipeFactory(),
+    mod: isExtension ? modComponentFactory() : defaultModDefinitionFactory(),
     sharing: {
       source: {
         type: sharingType,
@@ -321,7 +321,7 @@ describe("useModsPageActions", () => {
       mockHooks();
 
       blueprintItem = {
-        mod: recipeFactory({
+        mod: defaultModDefinitionFactory({
           sharing: { public: true, organizations: [] },
         }),
         sharing: {

--- a/src/extensionConsole/pages/mods/modals/shareModals/PublishRecipeModals.test.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/PublishRecipeModals.test.tsx
@@ -27,7 +27,7 @@ import { useGetMarketplaceListingsQuery } from "@/services/api";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { appApiMock } from "@/testUtils/appApiMock";
 import {
-  recipeFactory,
+  defaultModDefinitionFactory,
   metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { authStateFactory } from "@/testUtils/factories/authFactories";
@@ -52,7 +52,7 @@ const MarketplaceListingsWrapper: React.FC = ({ children }) => {
 
 beforeEach(() => {
   auth = authStateFactory();
-  blueprint = recipeFactory({
+  blueprint = defaultModDefinitionFactory({
     metadata: metadataFactory({
       id: validateRegistryId(`${auth.scope}/test`),
     }),

--- a/src/extensionConsole/pages/mods/modals/shareModals/PublishRecipeModals.test.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/PublishRecipeModals.test.tsx
@@ -28,7 +28,7 @@ import { waitForEffect } from "@/testUtils/testHelpers";
 import { appApiMock } from "@/testUtils/appApiMock";
 import {
   recipeFactory,
-  recipeMetadataFactory,
+  metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { authStateFactory } from "@/testUtils/factories/authFactories";
 
@@ -53,7 +53,7 @@ const MarketplaceListingsWrapper: React.FC = ({ children }) => {
 beforeEach(() => {
   auth = authStateFactory();
   blueprint = recipeFactory({
-    metadata: recipeMetadataFactory({
+    metadata: metadataFactory({
       id: validateRegistryId(`${auth.scope}/test`),
     }),
   });

--- a/src/extensionConsole/pages/mods/utils/useReinstall.test.ts
+++ b/src/extensionConsole/pages/mods/utils/useReinstall.test.ts
@@ -23,7 +23,7 @@ import {
   type ModComponentOptionsState,
   type ModComponentsRootState,
 } from "@/store/extensionsTypes";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { standaloneModDefinitionFactory } from "@/testUtils/factories/modComponentFactories";
 
 beforeEach(() => {
@@ -31,7 +31,7 @@ beforeEach(() => {
 });
 
 test("uninstalls recipe mod components", async () => {
-  const modDefinition = recipeFactory();
+  const modDefinition = defaultModDefinitionFactory();
   const standaloneModDefinition = standaloneModDefinitionFactory({
     _recipe: {
       id: modDefinition.metadata.id,
@@ -76,7 +76,7 @@ test("uninstalls recipe mod components", async () => {
 test("dispatches install recipe action", async () => {
   jest.spyOn(extensionActions, "installRecipe");
 
-  const modDefinition = recipeFactory();
+  const modDefinition = defaultModDefinitionFactory();
   const standaloneModDefinition = standaloneModDefinitionFactory({
     _recipe: {
       id: modDefinition.metadata.id,

--- a/src/modDefinitions/modDefinitions.test.tsx
+++ b/src/modDefinitions/modDefinitions.test.tsx
@@ -26,7 +26,7 @@ import * as localRegistry from "@/registry/packageRegistry";
 import pDefer from "p-defer";
 import { defaultInitialValue } from "@/utils/asyncStateUtils";
 import { appApiMock } from "@/testUtils/appApiMock";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 jest.mock("@/components/ConfirmationModal", () => ({
   ...jest.requireActual("@/components/ConfirmationModal"),
@@ -43,7 +43,7 @@ beforeAll(() => {
 // It verifies the proper API calls and the mod definition schema "sent" to the server
 test("load mod definitions and save one", async () => {
   // This is the shape of a mod definition that we get from the API /api/recipes/ endpoint
-  const sourceModDefinition = recipeFactory();
+  const sourceModDefinition = defaultModDefinitionFactory();
 
   const packageId = uuidv4();
   const modDefinitionId = validateRegistryId(sourceModDefinition.metadata.id);

--- a/src/modDefinitions/modDefinitionsSlice.test.ts
+++ b/src/modDefinitions/modDefinitionsSlice.test.ts
@@ -24,7 +24,7 @@ import {
 import { type ModDefinitionsRootState } from "./modDefinitionsTypes";
 import modDefinitionsRegistry from "./registry";
 import { syncRemotePackages } from "@/baseRegistry";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 jest.mock("./registry", () => ({
   __esModule: true,
@@ -50,7 +50,7 @@ const syncRemotePackagesMock = syncRemotePackages as jest.MockedFn<
 describe("loadModDefinitionsFromCache", () => {
   test("calls registry and dispatches setModDefinitionsFromCache action", async () => {
     const dispatch = jest.fn();
-    const cachedModDefinitions = [recipeFactory()];
+    const cachedModDefinitions = [defaultModDefinitionFactory()];
     (modDefinitionsRegistry.all as jest.Mock).mockResolvedValueOnce(
       cachedModDefinitions
     );
@@ -91,7 +91,7 @@ describe("syncRemoteModDefinitions", () => {
   test("fetches mod definitions and updates the state", async () => {
     const dispatch = jest.fn();
 
-    const cachedModDefinitions = [recipeFactory()];
+    const cachedModDefinitions = [defaultModDefinitionFactory()];
     (modDefinitionsRegistry.all as jest.Mock).mockResolvedValueOnce(
       cachedModDefinitions
     );
@@ -145,7 +145,7 @@ describe("reducers", () => {
   });
 
   test("sets mod definitions", () => {
-    const modDefinitions = [recipeFactory()];
+    const modDefinitions = [defaultModDefinitionFactory()];
     const state = {
       ...initialState,
       isFetching: true,

--- a/src/mods/useModViewItems.test.tsx
+++ b/src/mods/useModViewItems.test.tsx
@@ -32,7 +32,7 @@ import {
   modComponentFactory,
   activatedModComponentFactory,
 } from "@/testUtils/factories/modComponentFactories";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 const axiosMock = new MockAdapter(axios);
 
@@ -63,7 +63,7 @@ describe("useModViewItems", () => {
   });
 
   it("creates entry for recipe", async () => {
-    const recipe = recipeFactory();
+    const recipe = defaultModDefinitionFactory();
     const activatedModComponent = activatedModComponentFactory({
       _recipe: selectSourceRecipeMetadata(recipe),
     });
@@ -85,7 +85,7 @@ describe("useModViewItems", () => {
   });
 
   it("creates for unavailable recipe", async () => {
-    const recipe = recipeFactory();
+    const recipe = defaultModDefinitionFactory();
     const activatedModComponent = activatedModComponentFactory({
       _recipe: selectSourceRecipeMetadata(recipe),
     });

--- a/src/mods/useMods.test.ts
+++ b/src/mods/useMods.test.ts
@@ -28,7 +28,7 @@ import {
 } from "@/testUtils/factories/modComponentFactories";
 import {
   recipeFactory,
-  recipeMetadataFactory,
+  metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { type UseCachedQueryResult } from "@/types/sliceTypes";
@@ -69,7 +69,7 @@ describe("useMods", () => {
           extensionsSlice.actions.UNSAFE_setExtensions([
             activatedModComponentFactory({
               _recipe: {
-                ...recipeMetadataFactory(),
+                ...metadataFactory(),
                 updated_at: validateTimestamp(new Date().toISOString()),
                 sharing: { public: false, organizations: [] },
               },
@@ -92,7 +92,7 @@ describe("useMods", () => {
   });
 
   it("multiple unavailable are single mod", async () => {
-    const metadata = recipeMetadataFactory();
+    const metadata = metadataFactory();
 
     const wrapper = renderHook(() => useMods(), {
       setupRedux(dispatch) {
@@ -126,7 +126,7 @@ describe("useMods", () => {
   });
 
   it("handles known recipe", async () => {
-    const metadata = recipeMetadataFactory();
+    const metadata = metadataFactory();
 
     useAllModDefinitionsMock.mockReturnValue({
       data: [recipeFactory({ metadata })],

--- a/src/mods/useMods.test.ts
+++ b/src/mods/useMods.test.ts
@@ -27,7 +27,7 @@ import {
   activatedModComponentFactory,
 } from "@/testUtils/factories/modComponentFactories";
 import {
-  recipeFactory,
+  defaultModDefinitionFactory,
   metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
@@ -129,7 +129,7 @@ describe("useMods", () => {
     const metadata = metadataFactory();
 
     useAllModDefinitionsMock.mockReturnValue({
-      data: [recipeFactory({ metadata })],
+      data: [defaultModDefinitionFactory({ metadata })],
       error: undefined,
     } as UseCachedQueryResult<ModDefinition[]>);
 

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -56,10 +56,10 @@ import { modComponentFactory } from "@/testUtils/factories/modComponentFactories
 import {
   modComponentDefinitionFactory,
   starterBrickConfigFactory,
-  innerStarterBrickRecipeFactory,
+  innerStarterBrickModDefinitionFactory,
   recipeFactory,
-  versionedStarterBrickRecipeFactory,
-  versionedRecipeWithResolvedExtensions,
+  modDefinitionWithVersionedStarterBrickFactory,
+  versionedModDefinitionWithResolvedModComponents,
 } from "@/testUtils/factories/modDefinitionFactories";
 
 jest.mock("@/background/contextMenus");
@@ -90,7 +90,7 @@ describe("generatePersonalBrickId", () => {
 describe("replaceRecipeExtension round trip", () => {
   test("single extension with versioned extensionPoint", async () => {
     const starterBrick = starterBrickConfigFactory();
-    const recipe = versionedStarterBrickRecipeFactory({
+    const recipe = modDefinitionWithVersionedStarterBrickFactory({
       extensionPointId: starterBrick.metadata.id,
     })();
 
@@ -131,7 +131,7 @@ describe("replaceRecipeExtension round trip", () => {
   test("does not modify other starter brick", async () => {
     const starterBrick = starterBrickConfigFactory();
 
-    const recipe = versionedStarterBrickRecipeFactory({
+    const recipe = modDefinitionWithVersionedStarterBrickFactory({
       extensionPointId: starterBrick.metadata.id,
     })();
 
@@ -175,7 +175,7 @@ describe("replaceRecipeExtension round trip", () => {
   });
 
   test("single starter brick with innerDefinition", async () => {
-    const recipe = innerStarterBrickRecipeFactory()();
+    const recipe = innerStarterBrickModDefinitionFactory()();
 
     const state = extensionsSlice.reducer(
       { extensions: [] },
@@ -222,7 +222,7 @@ describe("replaceRecipeExtension round trip", () => {
   });
 
   test("generate fresh identifier definition changed", async () => {
-    const recipe = innerStarterBrickRecipeFactory()();
+    const recipe = innerStarterBrickModDefinitionFactory()();
 
     recipe.extensionPoints.push({
       ...recipe.extensionPoints[0],
@@ -284,7 +284,7 @@ describe("replaceRecipeExtension round trip", () => {
   });
 
   test("reuse identifier definition for multiple if extensionPoint not modified", async () => {
-    const recipe = innerStarterBrickRecipeFactory()();
+    const recipe = innerStarterBrickModDefinitionFactory()();
 
     recipe.extensionPoints.push({
       ...recipe.extensionPoints[0],
@@ -341,7 +341,7 @@ describe("replaceRecipeExtension round trip", () => {
     });
 
     const extensionPointId = starterBrick.metadata.id;
-    const recipe = innerStarterBrickRecipeFactory({
+    const recipe = innerStarterBrickModDefinitionFactory({
       extensionPointRef: extensionPointId as any,
     })({
       apiVersion: "v2",
@@ -389,7 +389,7 @@ describe("replaceRecipeExtension round trip", () => {
 
   test("throws when API version mismatch and cannot update recipe", async () => {
     const starterBrick = starterBrickConfigFactory();
-    const recipe = versionedStarterBrickRecipeFactory({
+    const recipe = modDefinitionWithVersionedStarterBrickFactory({
       extensionPointId: starterBrick.metadata.id,
     })({
       apiVersion: "v2",
@@ -775,7 +775,8 @@ describe("buildRecipe", () => {
       const extensionCount = cleanExtensionCount + dirtyExtensionCount;
 
       // Create a recipe
-      const recipe = versionedRecipeWithResolvedExtensions(extensionCount)();
+      const recipe =
+        versionedModDefinitionWithResolvedModComponents(extensionCount)();
 
       // Install the recipe
       const state = extensionsSlice.reducer(

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -57,7 +57,7 @@ import {
   modComponentDefinitionFactory,
   starterBrickConfigFactory,
   innerStarterBrickModDefinitionFactory,
-  recipeFactory,
+  defaultModDefinitionFactory,
   modDefinitionWithVersionedStarterBrickFactory,
   versionedModDefinitionWithResolvedModComponents,
 } from "@/testUtils/factories/modDefinitionFactories";
@@ -437,7 +437,7 @@ describe("blueprint options", () => {
     recipeOptions: ModOptionsDefinition,
     elementOptions: ModOptionsDefinition
   ) {
-    const recipe = recipeFactory({
+    const recipe = defaultModDefinitionFactory({
       options: recipeOptions,
     });
 
@@ -566,7 +566,7 @@ describe("blueprint options", () => {
 
 describe("isRecipeEditable", () => {
   test("returns true if recipe is in editable packages", () => {
-    const recipe = recipeFactory();
+    const recipe = defaultModDefinitionFactory();
     const editablePackages: EditablePackageMetadata[] = [
       {
         id: null,
@@ -582,7 +582,7 @@ describe("isRecipeEditable", () => {
   });
 
   test("returns false if recipe is not in editable packages", () => {
-    const recipe = recipeFactory();
+    const recipe = defaultModDefinitionFactory();
     const editablePackages: EditablePackageMetadata[] = [
       {
         id: null,

--- a/src/pageEditor/panes/save/useSavingWizard.test.tsx
+++ b/src/pageEditor/panes/save/useSavingWizard.test.tsx
@@ -47,7 +47,7 @@ import {
 } from "@/testUtils/factories/pageEditorFactories";
 import {
   recipeFactory,
-  recipeMetadataFactory,
+  metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 
 jest.mock("@/pageEditor/hooks/useUpsertFormElement");
@@ -342,7 +342,7 @@ describe("saving a Recipe Extension", () => {
     expect(result.current.isSaving).toBe(false);
 
     // Saving with a new Recipe
-    const newRecipeMeta = recipeMetadataFactory();
+    const newRecipeMeta = metadataFactory();
     const savingElementPromise = act(async () =>
       result.current.saveElementAndCreateNewRecipe(newRecipeMeta)
     );
@@ -394,7 +394,7 @@ describe("saving a Recipe Extension", () => {
     });
 
     // Saving with a new Recipe
-    const newRecipeMeta = recipeMetadataFactory();
+    const newRecipeMeta = metadataFactory();
     let creatingRecipePromise: Promise<void>;
     act(() => {
       creatingRecipePromise =
@@ -436,7 +436,7 @@ describe("saving a Recipe Extension", () => {
     expect(result.current.isSaving).toBe(false);
 
     // Saving with a new Recipe
-    const newRecipeMeta = recipeMetadataFactory({ id: recipe.metadata.id });
+    const newRecipeMeta = metadataFactory({ id: recipe.metadata.id });
     const savingElementPromise = act(async () =>
       result.current.saveElementAndUpdateRecipe(newRecipeMeta)
     );
@@ -486,7 +486,7 @@ describe("saving a Recipe Extension", () => {
     });
 
     // Saving with a new Recipe
-    const newRecipeMeta = recipeMetadataFactory();
+    const newRecipeMeta = metadataFactory();
     let updatingRecipePromise: Promise<void>;
     act(() => {
       updatingRecipePromise =

--- a/src/pageEditor/panes/save/useSavingWizard.test.tsx
+++ b/src/pageEditor/panes/save/useSavingWizard.test.tsx
@@ -40,7 +40,7 @@ import extensionsSlice from "@/store/extensionsSlice";
 import { getMinimalUiSchema } from "@/components/formBuilder/formBuilderHelpers";
 import { type ModOptionsDefinition } from "@/types/modDefinitionTypes";
 import { useAllModDefinitions } from "@/modDefinitions/modDefinitionHooks";
-import { modComponentRecipeFactory } from "@/testUtils/factories/modComponentFactories";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import {
   formStateFactory,
   menuItemFormStateFactory,
@@ -95,7 +95,7 @@ test("maintains wizard open state", () => {
     isLoading: false,
   });
 
-  const recipeMetadata = modComponentRecipeFactory(recipe.metadata);
+  const recipeMetadata = modMetadataFactory(recipe.metadata);
   const element = formStateFactory({
     recipe: recipeMetadata,
   });

--- a/src/pageEditor/panes/save/useSavingWizard.test.tsx
+++ b/src/pageEditor/panes/save/useSavingWizard.test.tsx
@@ -46,7 +46,7 @@ import {
   menuItemFormStateFactory,
 } from "@/testUtils/factories/pageEditorFactories";
 import {
-  recipeFactory,
+  defaultModDefinitionFactory,
   metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 
@@ -89,7 +89,7 @@ const renderUseSavingWizard = (store: Store) =>
   });
 
 test("maintains wizard open state", () => {
-  const recipe = recipeFactory();
+  const recipe = defaultModDefinitionFactory();
   (useAllModDefinitions as jest.Mock).mockReturnValue({
     data: [recipe],
     isLoading: false,
@@ -179,7 +179,7 @@ describe("saving a Recipe Extension", () => {
     uiSchema: getMinimalUiSchema(),
   };
   const setupMocks = () => {
-    const recipe = recipeFactory({
+    const recipe = defaultModDefinitionFactory({
       options: recipeOptions,
     });
     (useAllModDefinitions as jest.Mock).mockReturnValue({

--- a/src/pageEditor/sidebar/RecipeEntry.test.tsx
+++ b/src/pageEditor/sidebar/RecipeEntry.test.tsx
@@ -31,7 +31,7 @@ import { type ModComponentOptionsState } from "@/store/extensionsTypes";
 import { validateSemVerString } from "@/types/helpers";
 import {
   recipeFactory,
-  recipeMetadataFactory,
+  metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 
 let renderRecipeEntry: RenderFunctionWithRedux<
@@ -99,7 +99,7 @@ test("renders with empty metadata", () => {
 
 test("renders the warning icon when has update", () => {
   const recipe = recipeFactory({
-    metadata: recipeMetadataFactory({
+    metadata: metadataFactory({
       version: validateSemVerString("2.0.0"),
     }),
   });

--- a/src/pageEditor/sidebar/RecipeEntry.test.tsx
+++ b/src/pageEditor/sidebar/RecipeEntry.test.tsx
@@ -30,7 +30,7 @@ import { type EditorState } from "@/pageEditor/pageEditorTypes";
 import { type ModComponentOptionsState } from "@/store/extensionsTypes";
 import { validateSemVerString } from "@/types/helpers";
 import {
-  recipeFactory,
+  defaultModDefinitionFactory,
   metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 
@@ -43,7 +43,7 @@ let renderRecipeEntry: RenderFunctionWithRedux<
 >;
 
 beforeEach(() => {
-  const recipe = recipeFactory();
+  const recipe = defaultModDefinitionFactory();
   const recipeId = recipe.metadata.id;
   renderRecipeEntry = createRenderFunctionWithRedux({
     reducer: {
@@ -87,7 +87,7 @@ test("renders with empty recipe", () => {
 });
 
 test("renders with empty metadata", () => {
-  const recipe = recipeFactory({ metadata: null });
+  const recipe = defaultModDefinitionFactory({ metadata: null });
   const rendered = renderRecipeEntry({
     propsOverride: {
       recipe,
@@ -98,7 +98,7 @@ test("renders with empty metadata", () => {
 });
 
 test("renders the warning icon when has update", () => {
-  const recipe = recipeFactory({
+  const recipe = defaultModDefinitionFactory({
     metadata: metadataFactory({
       version: validateSemVerString("2.0.0"),
     }),

--- a/src/pageEditor/sidebar/__snapshots__/RecipeEntry.test.tsx.snap
+++ b/src/pageEditor/sidebar/__snapshots__/RecipeEntry.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`it renders 1`] = `
     <span
       class="name"
     >
-      Recipe 1
+      Mod 1
     </span>
   </div>
   <div

--- a/src/pageEditor/sidebar/arrangeElements.test.ts
+++ b/src/pageEditor/sidebar/arrangeElements.test.ts
@@ -22,7 +22,7 @@ import arrangeElements from "@/pageEditor/sidebar/arrangeElements";
 import { type ActionFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import {
   modComponentFactory,
-  modComponentRecipeFactory,
+  modMetadataFactory,
 } from "@/testUtils/factories/modComponentFactories";
 import {
   defaultModDefinitionFactory,
@@ -52,7 +52,7 @@ const ID_FOO_A = uuidv4();
 const installedFooA: ModComponentBase = modComponentFactory({
   id: ID_FOO_A,
   label: "A",
-  _recipe: modComponentRecipeFactory({
+  _recipe: modMetadataFactory({
     id: ID_FOO,
   }),
 });
@@ -61,7 +61,7 @@ const ID_FOO_B = uuidv4();
 const dynamicFooB: ActionFormState = menuItemFormStateFactory({
   uuid: ID_FOO_B,
   label: "B",
-  recipe: modComponentRecipeFactory({
+  recipe: modMetadataFactory({
     id: ID_FOO,
   }),
 });
@@ -76,7 +76,7 @@ const ID_BAR_D = uuidv4();
 const installedBarD: ModComponentBase = modComponentFactory({
   id: ID_BAR_D,
   label: "D",
-  _recipe: modComponentRecipeFactory({
+  _recipe: modMetadataFactory({
     id: ID_BAR,
   }),
 });
@@ -85,7 +85,7 @@ const ID_BAR_E = uuidv4();
 const dynamicBarE: ActionFormState = menuItemFormStateFactory({
   uuid: ID_BAR_E,
   label: "E",
-  recipe: modComponentRecipeFactory({
+  recipe: modMetadataFactory({
     id: ID_BAR,
   }),
 });
@@ -94,7 +94,7 @@ const ID_BAR_F = uuidv4();
 const installedBarF: ModComponentBase = modComponentFactory({
   id: ID_BAR_F,
   label: "F",
-  _recipe: modComponentRecipeFactory({
+  _recipe: modMetadataFactory({
     id: ID_BAR,
   }),
 });

--- a/src/pageEditor/sidebar/arrangeElements.test.ts
+++ b/src/pageEditor/sidebar/arrangeElements.test.ts
@@ -26,14 +26,14 @@ import {
 } from "@/testUtils/factories/modComponentFactories";
 import {
   recipeFactory,
-  recipeMetadataFactory,
+  metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { menuItemFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
 
 // Recipes
 const ID_FOO = validateRegistryId("test/recipe-foo");
 const recipeFoo: ModDefinition = recipeFactory({
-  metadata: recipeMetadataFactory({
+  metadata: metadataFactory({
     id: ID_FOO,
     name: "Foo Recipe",
   }),
@@ -41,7 +41,7 @@ const recipeFoo: ModDefinition = recipeFactory({
 
 const ID_BAR = validateRegistryId("test/recipe-bar");
 const recipeBar: ModDefinition = recipeFactory({
-  metadata: recipeMetadataFactory({
+  metadata: metadataFactory({
     id: ID_BAR,
     name: "Bar Recipe",
   }),

--- a/src/pageEditor/sidebar/arrangeElements.test.ts
+++ b/src/pageEditor/sidebar/arrangeElements.test.ts
@@ -25,14 +25,14 @@ import {
   modComponentRecipeFactory,
 } from "@/testUtils/factories/modComponentFactories";
 import {
-  recipeFactory,
+  defaultModDefinitionFactory,
   metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { menuItemFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
 
 // Recipes
 const ID_FOO = validateRegistryId("test/recipe-foo");
-const recipeFoo: ModDefinition = recipeFactory({
+const recipeFoo: ModDefinition = defaultModDefinitionFactory({
   metadata: metadataFactory({
     id: ID_FOO,
     name: "Foo Recipe",
@@ -40,7 +40,7 @@ const recipeFoo: ModDefinition = recipeFactory({
 });
 
 const ID_BAR = validateRegistryId("test/recipe-bar");
-const recipeBar: ModDefinition = recipeFactory({
+const recipeBar: ModDefinition = defaultModDefinitionFactory({
   metadata: metadataFactory({
     id: ID_BAR,
     name: "Bar Recipe",

--- a/src/pageEditor/slices/editorSliceHelpers.test.ts
+++ b/src/pageEditor/slices/editorSliceHelpers.test.ts
@@ -48,7 +48,7 @@ import {
   selectElements,
   selectExpandedRecipeId,
 } from "@/pageEditor/slices/editorSelectors";
-import { modComponentRecipeFactory } from "@/testUtils/factories/modComponentFactories";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 
 describe("ensureElementUIState", () => {
@@ -351,7 +351,7 @@ describe("removeElement", () => {
 
 describe("removeRecipeData", () => {
   test("removes expanded active recipe", () => {
-    const recipe = modComponentRecipeFactory();
+    const recipe = modMetadataFactory();
     const element1 = formStateFactory({ recipe });
     const element2 = formStateFactory({ recipe });
     const orphanElement = formStateFactory();
@@ -429,7 +429,7 @@ describe("removeRecipeData", () => {
 
 describe("selectRecipeId", () => {
   test("select unselected recipe", () => {
-    const recipe = modComponentRecipeFactory();
+    const recipe = modMetadataFactory();
     const newState = produce(initialState, (draft) => {
       selectRecipeId(draft, recipe.id);
     });
@@ -438,7 +438,7 @@ describe("selectRecipeId", () => {
   });
 
   test("re-select selected recipe", () => {
-    const recipe = modComponentRecipeFactory();
+    const recipe = modMetadataFactory();
     const state: EditorState = {
       ...initialState,
       activeRecipeId: recipe.id,

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.test.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.test.tsx
@@ -24,7 +24,7 @@ import { getPageState } from "@/contentScript/messenger/api";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import { Tab } from "react-bootstrap";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
-import { modComponentRecipeFactory } from "@/testUtils/factories/modComponentFactories";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 
 describe("PageStateTab", () => {
@@ -61,7 +61,7 @@ describe("PageStateTab", () => {
 
   test("it renders with recipe extension", async () => {
     const formState = formStateFactory({
-      recipe: modComponentRecipeFactory(),
+      recipe: modMetadataFactory(),
     });
     const rendered = await renderPageStateTab(formState);
     expect(rendered.asFragment()).toMatchSnapshot();

--- a/src/pageEditor/tabs/recipeOptionsDefinitions/RecipeOptionsDefinitions.test.tsx
+++ b/src/pageEditor/tabs/recipeOptionsDefinitions/RecipeOptionsDefinitions.test.tsx
@@ -24,7 +24,7 @@ import selectEvent from "react-select-event";
 import { screen } from "@testing-library/react";
 import extensionsSlice from "@/store/extensionsSlice";
 import userEvent from "@testing-library/user-event";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 jest.mock("@/hooks/useFlags", () =>
   jest.fn().mockReturnValue({
@@ -38,7 +38,7 @@ beforeAll(() => {
 
 describe("RecipeOptionsDefinitions", () => {
   it("shows google sheets, and both database field type options", async () => {
-    const modDefinition = recipeFactory();
+    const modDefinition = defaultModDefinitionFactory();
 
     render(<RecipeOptionsDefinition />, {
       setupRedux(dispatch) {

--- a/src/pageEditor/tabs/recipeOptionsValues/RecipeOptionsValues.test.tsx
+++ b/src/pageEditor/tabs/recipeOptionsValues/RecipeOptionsValues.test.tsx
@@ -30,7 +30,7 @@ import { type ModDefinition } from "@/types/modDefinitionTypes";
 import databaseSchema from "@schemas/database.json";
 import googleSheetIdSchema from "@schemas/googleSheetId.json";
 import { valueToAsyncCacheState } from "@/utils/asyncStateUtils";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 jest.mock("@/modDefinitions/modDefinitionHooks", () => ({
   useOptionalModDefinition: jest.fn(),
@@ -59,7 +59,7 @@ beforeEach(() => {
 
 describe("ActivationOptions", () => {
   test("renders empty options", async () => {
-    const recipe = recipeFactory();
+    const recipe = defaultModDefinitionFactory();
     mockRecipe(recipe);
     const rendered = render(<RecipeOptionsValues />, {
       setupRedux(dispatch) {
@@ -76,7 +76,7 @@ describe("ActivationOptions", () => {
   });
 
   test("renders blueprint options", async () => {
-    const recipe = recipeFactory({
+    const recipe = defaultModDefinitionFactory({
       options: {
         schema: {
           type: "object",
@@ -135,7 +135,7 @@ describe("ActivationOptions", () => {
   });
 
   test("renders blueprint options with additional props", async () => {
-    const recipe = recipeFactory({
+    const recipe = defaultModDefinitionFactory({
       options: {
         schema: {
           type: "object",
@@ -161,7 +161,7 @@ describe("ActivationOptions", () => {
   });
 
   test("renders blueprint options with uiSchema sort order", async () => {
-    const recipe = recipeFactory({
+    const recipe = defaultModDefinitionFactory({
       options: {
         schema: {
           type: "object",
@@ -208,7 +208,7 @@ describe("ActivationOptions", () => {
   });
 
   it("renders google sheets field type option if gapi is loaded", async () => {
-    const recipe = recipeFactory({
+    const recipe = defaultModDefinitionFactory({
       options: {
         schema: {
           type: "object",

--- a/src/registry/packageRegistry.test.ts
+++ b/src/registry/packageRegistry.test.ts
@@ -24,7 +24,7 @@ import {
 import { produce } from "immer";
 import { type SemVerString } from "@/types/registryTypes";
 import { appApiMock } from "@/testUtils/appApiMock";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 describe("localRegistry", () => {
   beforeEach(() => {
@@ -36,7 +36,9 @@ describe("localRegistry", () => {
   });
 
   it("should sync packages for empty db", async () => {
-    appApiMock.onGet("/api/registry/bricks/").reply(200, [recipeFactory()]);
+    appApiMock
+      .onGet("/api/registry/bricks/")
+      .reply(200, [defaultModDefinitionFactory()]);
     await syncPackages();
     const recipes = await getByKinds(["recipe"]);
     expect(recipes).toHaveLength(1);
@@ -44,7 +46,9 @@ describe("localRegistry", () => {
   });
 
   it("should sync packages", async () => {
-    appApiMock.onGet("/api/registry/bricks/").replyOnce(200, [recipeFactory()]);
+    appApiMock
+      .onGet("/api/registry/bricks/")
+      .replyOnce(200, [defaultModDefinitionFactory()]);
 
     await syncPackages();
 
@@ -57,7 +61,7 @@ describe("localRegistry", () => {
   });
 
   it("should return latest version", async () => {
-    const definition = recipeFactory();
+    const definition = defaultModDefinitionFactory();
     const updated = produce(definition, (draft) => {
       draft.metadata.version = "9.9.9" as SemVerString;
     });

--- a/src/sidebar/activateRecipe/ActivateModPanel.test.tsx
+++ b/src/sidebar/activateRecipe/ActivateModPanel.test.tsx
@@ -32,7 +32,7 @@ import { checkModDefinitionPermissions } from "@/modDefinitions/modDefinitionPer
 import { appApiMock, onDeferredGet } from "@/testUtils/appApiMock";
 import {
   getRecipeWithBuiltInServiceAuths,
-  recipeFactory,
+  defaultModDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { sidebarEntryFactory } from "@/testUtils/factories/sidebarEntryFactories";
 import {
@@ -92,7 +92,7 @@ function setupMocksAndRender(
   recipeOverride?: Partial<ModDefinition>,
   { componentOverride }: { componentOverride?: React.ReactElement } = {}
 ) {
-  const recipe = recipeFactory({
+  const recipe = defaultModDefinitionFactory({
     ...recipeOverride,
     metadata: {
       id: validateRegistryId("test-recipe"),

--- a/src/sidebar/activateRecipe/ActivateModPanel.test.tsx
+++ b/src/sidebar/activateRecipe/ActivateModPanel.test.tsx
@@ -31,7 +31,7 @@ import { validateRegistryId } from "@/types/helpers";
 import { checkModDefinitionPermissions } from "@/modDefinitions/modDefinitionPermissionsHelpers";
 import { appApiMock, onDeferredGet } from "@/testUtils/appApiMock";
 import {
-  getRecipeWithBuiltInServiceAuths,
+  getModDefinitionWithBuiltInServiceAuths,
   defaultModDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { sidebarEntryFactory } from "@/testUtils/factories/sidebarEntryFactories";
@@ -89,22 +89,22 @@ beforeAll(() => {
 });
 
 function setupMocksAndRender(
-  recipeOverride?: Partial<ModDefinition>,
+  modDefinitionOverride?: Partial<ModDefinition>,
   { componentOverride }: { componentOverride?: React.ReactElement } = {}
 ) {
-  const recipe = defaultModDefinitionFactory({
-    ...recipeOverride,
+  const modDefinition = defaultModDefinitionFactory({
+    ...modDefinitionOverride,
     metadata: {
-      id: validateRegistryId("test-recipe"),
+      id: validateRegistryId("test-mod"),
       name: "Test Mod",
     },
   });
   useRequiredModDefinitionsMock.mockReturnValue(
-    valueToAsyncCacheState([recipe])
+    valueToAsyncCacheState([modDefinition])
   );
   const listing = marketplaceListingFactory({
     // Consistent user-visible name for snapshots
-    package: recipeToMarketplacePackage(recipe),
+    package: recipeToMarketplacePackage(modDefinition),
   });
 
   // Tests can override by calling before setupMocksAndRender
@@ -112,12 +112,12 @@ function setupMocksAndRender(
   appApiMock.onGet().reply(200, []);
 
   const entry = sidebarEntryFactory("activateMods", {
-    modIds: [recipe.metadata.id],
+    modIds: [modDefinition.metadata.id],
     heading: "Activate Mod",
   });
 
   const element = componentOverride ?? (
-    <ActivateModPanel modId={recipe.metadata.id} />
+    <ActivateModPanel modId={modDefinition.metadata.id} />
   );
 
   return render(element, {
@@ -255,9 +255,9 @@ describe("ActivateRecipePanel", () => {
   });
 
   it("renders with service configuration if no built-in service configs available", async () => {
-    const { recipe } = getRecipeWithBuiltInServiceAuths();
+    const { modDefinition } = getModDefinitionWithBuiltInServiceAuths();
 
-    const rendered = setupMocksAndRender(recipe);
+    const rendered = setupMocksAndRender(modDefinition);
 
     await waitForEffect();
 
@@ -268,11 +268,12 @@ describe("ActivateRecipePanel", () => {
   });
 
   it("activates recipe with built-in services automatically and renders well-done page", async () => {
-    const { recipe, builtInServiceAuths } = getRecipeWithBuiltInServiceAuths();
+    const { modDefinition, builtInServiceAuths } =
+      getModDefinitionWithBuiltInServiceAuths();
 
     appApiMock.onGet("/api/services/shared/").reply(200, builtInServiceAuths);
 
-    const rendered = setupMocksAndRender(recipe);
+    const rendered = setupMocksAndRender(modDefinition);
 
     await waitForEffect();
 
@@ -280,11 +281,11 @@ describe("ActivateRecipePanel", () => {
   });
 
   it("doesn't flicker while built-in auths are loading", async () => {
-    const { recipe } = getRecipeWithBuiltInServiceAuths();
+    const { modDefinition } = getModDefinitionWithBuiltInServiceAuths();
 
     onDeferredGet("/api/services/shared/");
 
-    const rendered = setupMocksAndRender(recipe);
+    const rendered = setupMocksAndRender(modDefinition);
 
     await waitForEffect();
 
@@ -316,13 +317,14 @@ describe("ActivateRecipePanel", () => {
 
 describe("ActivateMultipleModsPanel", () => {
   it("automatically activates single mod", async () => {
-    const { recipe, builtInServiceAuths } = getRecipeWithBuiltInServiceAuths();
+    const { modDefinition, builtInServiceAuths } =
+      getModDefinitionWithBuiltInServiceAuths();
 
     appApiMock.onGet("/api/services/shared/").reply(200, builtInServiceAuths);
 
-    const rendered = setupMocksAndRender(recipe, {
+    const rendered = setupMocksAndRender(modDefinition, {
       componentOverride: (
-        <ActivateMultipleModsPanel modIds={[recipe.metadata.id]} />
+        <ActivateMultipleModsPanel modIds={[modDefinition.metadata.id]} />
       ),
     });
 
@@ -332,12 +334,12 @@ describe("ActivateMultipleModsPanel", () => {
   });
 
   it("shows error if any mod requires configuration", async () => {
-    const { recipe } = getRecipeWithBuiltInServiceAuths();
+    const { modDefinition } = getModDefinitionWithBuiltInServiceAuths();
 
-    setupMocksAndRender(recipe, {
+    setupMocksAndRender(modDefinition, {
       componentOverride: (
         <ErrorBoundary>
-          <ActivateMultipleModsPanel modIds={[recipe.metadata.id]} />
+          <ActivateMultipleModsPanel modIds={[modDefinition.metadata.id]} />
         </ErrorBoundary>
       ),
     });

--- a/src/sidebar/activateRecipe/ActivateModPanel.test.tsx
+++ b/src/sidebar/activateRecipe/ActivateModPanel.test.tsx
@@ -37,7 +37,7 @@ import {
 import { sidebarEntryFactory } from "@/testUtils/factories/sidebarEntryFactories";
 import {
   marketplaceListingFactory,
-  recipeToMarketplacePackage,
+  modDefinitionToMarketplacePackage,
 } from "@/testUtils/factories/marketplaceFactories";
 import * as messengerApi from "@/contentScript/messenger/api";
 import { selectSidebarHasModPanels } from "@/sidebar/sidebarSelectors";
@@ -104,7 +104,7 @@ function setupMocksAndRender(
   );
   const listing = marketplaceListingFactory({
     // Consistent user-visible name for snapshots
-    package: recipeToMarketplacePackage(modDefinition),
+    package: modDefinitionToMarketplacePackage(modDefinition),
   });
 
   // Tests can override by calling before setupMocksAndRender

--- a/src/store/checkAvailableInstalledExtensions.test.ts
+++ b/src/store/checkAvailableInstalledExtensions.test.ts
@@ -36,7 +36,7 @@ import {
 } from "@/starterBricks/quickBarExtension";
 import {
   starterBrickConfigFactory,
-  recipeMetadataFactory,
+  metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { standaloneModDefinitionFactory } from "@/testUtils/factories/modComponentFactories";
 
@@ -74,7 +74,7 @@ describe("checkAvailableInstalledExtensions", () => {
 
     const availableButtonStarterBrickConfig = starterBrickConfigFactory({
       metadata(): Metadata {
-        return recipeMetadataFactory({
+        return metadataFactory({
           id: availableButtonId,
         });
       },
@@ -96,7 +96,7 @@ describe("checkAvailableInstalledExtensions", () => {
 
     const availableQuickbarStarterBrickConfig = starterBrickConfigFactory({
       metadata(): Metadata {
-        return recipeMetadataFactory({
+        return metadataFactory({
           id: availableQbId,
         });
       },

--- a/src/store/dynamicElementStorage.test.ts
+++ b/src/store/dynamicElementStorage.test.ts
@@ -30,7 +30,7 @@ import {
 import { validateRegistryId } from "@/types/helpers";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
-import { modComponentRecipeFactory } from "@/testUtils/factories/modComponentFactories";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 
 jest.mock("@/chrome", () => ({
@@ -150,7 +150,7 @@ describe("dynamicElementStorage", () => {
   });
 
   test("removes active recipe", async () => {
-    const recipe = modComponentRecipeFactory();
+    const recipe = modMetadataFactory();
     const element1 = formStateFactory({
       recipe,
     });
@@ -237,7 +237,7 @@ describe("dynamicElementStorage", () => {
   });
 
   test("removes inactive recipe", async () => {
-    const recipe = modComponentRecipeFactory();
+    const recipe = modMetadataFactory();
     const element1 = formStateFactory({
       recipe,
     });

--- a/src/testUtils/factories/deploymentFactories.ts
+++ b/src/testUtils/factories/deploymentFactories.ts
@@ -20,7 +20,7 @@ import { type Deployment } from "@/types/contract";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { validateTimestamp } from "@/types/helpers";
 import { type RegistryId } from "@/types/registryTypes";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 // Deployments are returned from the API, but their shape is determined by the registry and ModDefinition type.
 
@@ -38,7 +38,7 @@ export const deploymentPackageFactory = define<Deployment["package"]>({
     ({ config }) => config.metadata.id,
     "config"
   ),
-  config: recipeFactory,
+  config: defaultModDefinitionFactory,
 });
 export const deploymentFactory = define<Deployment>({
   id: uuidSequence,

--- a/src/testUtils/factories/marketplaceFactories.ts
+++ b/src/testUtils/factories/marketplaceFactories.ts
@@ -31,17 +31,17 @@ export const marketplaceTagFactory = define<MarketplaceTag>({
 
 /**
  * Create a MarketplaceListing.package for a ModDefinition.
- * @param recipe
+ * @param modDefinition
  */
-export function recipeToMarketplacePackage(
-  recipe: ModDefinition
+export function modDefinitionToMarketplacePackage(
+  modDefinition: ModDefinition
 ): MarketplaceListing["package"] {
   return {
-    id: recipe.metadata.id,
-    name: recipe.metadata.name,
-    description: recipe.metadata.description,
-    version: recipe.metadata.version,
-    config: recipe as unknown as UnknownObject,
+    id: modDefinition.metadata.id,
+    name: modDefinition.metadata.name,
+    description: modDefinition.metadata.description,
+    version: modDefinition.metadata.version,
+    config: modDefinition as unknown as UnknownObject,
     kind: "recipe",
     author: {},
     organization: {},

--- a/src/testUtils/factories/modComponentFactories.ts
+++ b/src/testUtils/factories/modComponentFactories.ts
@@ -40,46 +40,50 @@ export const modMetadataFactory = extend<Metadata, ModComponentBase["_recipe"]>(
   }
 );
 
+const modComponentConfigFactory = define<ModComponentBase["config"]>({
+  apiVersion: "v3" as ApiVersion,
+  kind: "component",
+  metadata: (n: number) =>
+    metadataFactory({
+      id: validateRegistryId(`test/component-${n}`),
+      name: "Test config",
+    }),
+  inputSchema: {
+    $schema: "https://json-schema.org/draft/2019-09/schema#",
+    type: "object",
+    properties: {},
+    required: [] as string[],
+  },
+
+  // This is the pipeline prop for the menu item starter brick
+  action: [
+    {
+      id: "@pixiebrix/browser/open-tab",
+      config: {
+        url: "http://www.amazon.com/s",
+        params: {
+          url: "search-alias={{{department}}}{{^department}}all{{/department}}&field-keywords={{{query}}}",
+        },
+      },
+    },
+  ],
+});
+
 export const modComponentFactory = define<ModComponentBase>({
   id: uuidSequence,
   apiVersion: "v3" as ApiVersion,
   extensionPointId: (n: number) =>
-    validateRegistryId(`test/extension-point-${n}`),
+    validateRegistryId(`test/starter-brick-${n}`),
   _recipe: undefined,
   _deployment: undefined,
   label: "Test label",
   services(): IntegrationDependency[] {
     return [];
   },
-  config: (n: number) => ({
-    apiVersion: "v3" as ApiVersion,
-    kind: "component",
-    metadata: metadataFactory({
-      id: validateRegistryId(`test/component-${n}`),
-      name: "Test config",
-    }),
-    inputSchema: {
-      $schema: "https://json-schema.org/draft/2019-09/schema#",
-      type: "object",
-      properties: {},
-      required: [] as string[],
-    },
-
-    // This is the pipeline prop for the MenuItem extension point, which is the default for extensionPointDefinitionFactory
-    action: [
-      {
-        id: "@pixiebrix/browser/open-tab",
-        config: {
-          url: "http://www.amazon.com/s",
-          params: {
-            url: "search-alias={{{department}}}{{^department}}all{{/department}}&field-keywords={{{query}}}",
-          },
-        },
-      },
-    ],
-  }),
+  config: modComponentConfigFactory,
   active: true,
 });
+
 export const activatedModComponentFactory = extend<
   ModComponentBase,
   ActivatedModComponent

--- a/src/testUtils/factories/modComponentFactories.ts
+++ b/src/testUtils/factories/modComponentFactories.ts
@@ -32,7 +32,7 @@ import {
 } from "@/types/helpers";
 import { type IntegrationDependency } from "@/types/integrationTypes";
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
-import { recipeMetadataFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { metadataFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { type StandaloneModDefinition } from "@/types/contract";
 
 export const modComponentRecipeFactory = define<ModComponentBase["_recipe"]>({
@@ -57,7 +57,7 @@ export const modComponentFactory = define<ModComponentBase>({
   config: (n: number) => ({
     apiVersion: "v3" as ApiVersion,
     kind: "component",
-    metadata: recipeMetadataFactory({
+    metadata: metadataFactory({
       id: validateRegistryId(`test/component-${n}`),
       name: "Test config",
     }),

--- a/src/testUtils/factories/modComponentFactories.ts
+++ b/src/testUtils/factories/modComponentFactories.ts
@@ -25,24 +25,21 @@ import {
   uuidSequence,
 } from "@/testUtils/factories/stringFactories";
 import { type ApiVersion } from "@/types/runtimeTypes";
-import {
-  validateRegistryId,
-  validateSemVerString,
-  validateTimestamp,
-} from "@/types/helpers";
+import { validateRegistryId, validateTimestamp } from "@/types/helpers";
 import { type IntegrationDependency } from "@/types/integrationTypes";
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { metadataFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { type StandaloneModDefinition } from "@/types/contract";
+import { type Metadata } from "@/types/registryTypes";
 
-export const modComponentRecipeFactory = define<ModComponentBase["_recipe"]>({
-  id: (n: number) => validateRegistryId(`test/recipe-${n}`),
-  name: (n: number) => `Recipe ${n}`,
-  description: "Recipe generated from factory",
-  version: validateSemVerString("1.0.0"),
-  updated_at: validateTimestamp("2021-10-07T12:52:16.189Z"),
-  sharing: sharingDefinitionFactory,
-});
+export const modMetadataFactory = extend<Metadata, ModComponentBase["_recipe"]>(
+  metadataFactory,
+  {
+    updated_at: validateTimestamp("2021-10-07T12:52:16.189Z"),
+    sharing: sharingDefinitionFactory,
+  }
+);
+
 export const modComponentFactory = define<ModComponentBase>({
   id: uuidSequence,
   apiVersion: "v3" as ApiVersion,

--- a/src/testUtils/factories/modDefinitionFactories.ts
+++ b/src/testUtils/factories/modDefinitionFactories.ts
@@ -111,17 +111,7 @@ type ExternalStarterBrickParams = {
 export const modDefinitionWithVersionedStarterBrickFactory = ({
   extensionPointId,
 }: ExternalStarterBrickParams = {}) =>
-  define<ModDefinition>({
-    kind: "recipe",
-    apiVersion: "v3",
-    metadata: (n: number) => ({
-      id: validateRegistryId(`test/mod-${n}`),
-      name: `Mod ${n}`,
-      description: "Mod generated from factory",
-      version: validateSemVerString("1.0.0"),
-    }),
-    updated_at: validateTimestamp("2021-10-07T12:52:16.189Z"),
-    sharing: sharingDefinitionFactory,
+  extend<ModDefinition, ModDefinition>(modDefinitionFactory, {
     definitions: undefined,
     options: undefined,
     extensionPoints: (n: number) => [
@@ -167,12 +157,7 @@ export const versionedModDefinitionWithResolvedModComponents = (
     };
   }
 
-  return define<ModDefinition>({
-    kind: "recipe",
-    apiVersion: "v3",
-    metadata: metadataFactory,
-    sharing: sharingDefinitionFactory,
-    updated_at: validateTimestamp("2021-10-07T12:52:16.189Z"),
+  return extend<ModDefinition, ModDefinition>(modDefinitionFactory, {
     definitions,
     options: undefined,
     extensionPoints: modComponentDefinitions,
@@ -211,9 +196,10 @@ export const innerStarterBrickModDefinitionFactory = ({
   });
 
 /**
- * A default Recipe factory
+ * A default Mod Definition factory
  */
-export const recipeFactory = innerStarterBrickModDefinitionFactory();
+export const defaultModDefinitionFactory =
+  innerStarterBrickModDefinitionFactory();
 export const getRecipeWithBuiltInServiceAuths = () => {
   const extensionServices = {
     service1: "@pixiebrix/service1",
@@ -224,7 +210,7 @@ export const getRecipeWithBuiltInServiceAuths = () => {
     services: extensionServices,
   });
 
-  const recipe = recipeFactory({
+  const recipe = defaultModDefinitionFactory({
     extensionPoints: [modComponentDefinition],
   });
 

--- a/src/testUtils/factories/modDefinitionFactories.ts
+++ b/src/testUtils/factories/modDefinitionFactories.ts
@@ -59,7 +59,7 @@ export const metadataFactory = define<Metadata>({
 
 export const modComponentDefinitionFactory = define<ModComponentDefinition>({
   id: "extensionPoint" as InnerDefinitionRef,
-  label: (n: number) => `Test Extension ${n}`,
+  label: (n: number) => `Test Mod ${n}`,
   services(): Record<OutputKey, RegistryId> {
     return {};
   },
@@ -132,10 +132,10 @@ export const modDefinitionWithVersionedStarterBrickFactory = ({
  * Factory to create a ModDefinition with a definitions section and resolved mod components
  */
 export const versionedModDefinitionWithResolvedModComponents = (
-  extensionCount = 1
+  modComponentCount = 1
 ) => {
   const modComponentDefinitions: ModComponentDefinition[] = [];
-  for (let i = 0; i < extensionCount; i++) {
+  for (let i = 0; i < modComponentCount; i++) {
     // Don't use array(factory, count) here, because it will keep incrementing
     // the modifier number across multiple test runs and cause non-deterministic
     // test execution behavior.
@@ -169,7 +169,7 @@ type InnerStarterBrickParams = {
 };
 
 /**
- * Factory to create a factory that creates a ModDefinition that contains an inner definition
+ * Factory to create a factory that creates a ModDefinition that contains inner definitions
  */
 export const innerStarterBrickModDefinitionFactory = ({
   extensionPointRef = "extensionPoint" as InnerDefinitionRef,
@@ -200,7 +200,8 @@ export const innerStarterBrickModDefinitionFactory = ({
  */
 export const defaultModDefinitionFactory =
   innerStarterBrickModDefinitionFactory();
-export const getRecipeWithBuiltInServiceAuths = () => {
+
+export const getModDefinitionWithBuiltInServiceAuths = () => {
   const extensionServices = {
     service1: "@pixiebrix/service1",
     service2: "@pixiebrix/service2",
@@ -210,7 +211,7 @@ export const getRecipeWithBuiltInServiceAuths = () => {
     services: extensionServices,
   });
 
-  const recipe = defaultModDefinitionFactory({
+  const modDefinition = defaultModDefinitionFactory({
     extensionPoints: [modComponentDefinition],
   });
 
@@ -237,5 +238,5 @@ export const getRecipeWithBuiltInServiceAuths = () => {
     }),
   ];
 
-  return { recipe, builtInServiceAuths };
+  return { modDefinition, builtInServiceAuths };
 };

--- a/src/testUtils/factories/pageEditorFactories.ts
+++ b/src/testUtils/factories/pageEditorFactories.ts
@@ -37,7 +37,7 @@ import {
 } from "@/starterBricks/types";
 import {
   starterBrickConfigFactory,
-  recipeMetadataFactory,
+  metadataFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { type BrickPipeline } from "@/bricks/types";
 import contextMenu from "@/pageEditor/starterBricks/contextMenu";
@@ -106,7 +106,7 @@ export const triggerFormStateFactory = (
 ) => {
   const defaultTriggerProps = trigger.fromNativeElement(
     "https://test.com",
-    recipeMetadataFactory({
+    metadataFactory({
       id: (n: number) => validateRegistryId(`test/extension-point-${n}`),
       name: (n: number) => `Extension Point ${n}`,
     }),
@@ -128,7 +128,7 @@ export const sidebarPanelFormStateFactory = (
 ) => {
   const defaultTriggerProps = sidebar.fromNativeElement(
     "https://test.com",
-    recipeMetadataFactory({
+    metadataFactory({
       id: (n: number) => validateRegistryId(`test/extension-point-${n}`),
       name: (n: number) => `Extension Point ${n}`,
     }),
@@ -151,7 +151,7 @@ export const contextMenuFormStateFactory = (
 ) => {
   const defaultTriggerProps = contextMenu.fromNativeElement(
     "https://test.com",
-    recipeMetadataFactory({
+    metadataFactory({
       id: (n: number) => validateRegistryId(`test/extension-point-${n}`),
       name: (n: number) => `Extension Point ${n}`,
     }),
@@ -173,7 +173,7 @@ export const quickbarFormStateFactory = (
 ) => {
   const defaultTriggerProps = quickBar.fromNativeElement(
     "https://test.com",
-    recipeMetadataFactory({
+    metadataFactory({
       id: (n: number) => validateRegistryId(`test/extension-point-${n}`),
       name: (n: number) => `Extension Point ${n}`,
     }),
@@ -195,7 +195,7 @@ export const menuItemFormStateFactory = (
 ) => {
   const defaultTriggerProps = menuItem.fromNativeElement(
     "https://test.com",
-    recipeMetadataFactory({
+    metadataFactory({
       id: (n: number) => validateRegistryId(`test/extension-point-${n}`),
       name: (n: number) => `Extension Point ${n}`,
     }),

--- a/src/types/modDefinitionTypes.ts
+++ b/src/types/modDefinitionTypes.ts
@@ -38,7 +38,7 @@ export type ModOptionsDefinition = {
 };
 
 /**
- * An ModComponent defined in a mod.
+ * A ModComponent defined in a mod.
  * @see ModDefinition.extensionPoints
  */
 export type ModComponentDefinition = {

--- a/src/types/registryTypes.ts
+++ b/src/types/registryTypes.ts
@@ -51,7 +51,7 @@ export type SemVerString = string & {
 };
 
 /**
- * Metadata about a Brick, StarterBrick, Integration, or recipe.
+ * Metadata about a Brick, StarterBrick, Integration, or Mod.
  */
 export interface Metadata {
   /**

--- a/src/utils/deploymentUtils.test.ts
+++ b/src/utils/deploymentUtils.test.ts
@@ -38,7 +38,7 @@ import { validateOutputKey } from "@/runtime/runtimeTypes";
 import { modComponentFactory } from "@/testUtils/factories/modComponentFactories";
 import {
   modComponentDefinitionFactory,
-  recipeFactory,
+  defaultModDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { sanitizedIntegrationConfigFactory } from "@/testUtils/factories/integrationFactories";
 import {
@@ -200,7 +200,7 @@ describe("extractRecipeServiceIds", () => {
   test("find unique service ids", async () => {
     const deployment = deploymentFactory({
       package: deploymentPackageFactory({
-        config: recipeFactory({
+        config: defaultModDefinitionFactory({
           extensionPoints: [
             modComponentDefinitionFactory({
               services: {
@@ -223,7 +223,7 @@ describe("findPersonalServiceConfigurations", () => {
   test("missing personal service", async () => {
     const deployment = deploymentFactory({
       package: deploymentPackageFactory({
-        config: recipeFactory({
+        config: defaultModDefinitionFactory({
           extensionPoints: [
             modComponentDefinitionFactory({
               services: {
@@ -246,7 +246,7 @@ describe("findPersonalServiceConfigurations", () => {
   test("found personal service", async () => {
     const deployment = deploymentFactory({
       package: deploymentPackageFactory({
-        config: recipeFactory({
+        config: defaultModDefinitionFactory({
           extensionPoints: [
             modComponentDefinitionFactory({
               services: {
@@ -276,7 +276,7 @@ describe("findPersonalServiceConfigurations", () => {
     const deployment = deploymentFactory({
       bindings: [{ auth: { id: uuidv4(), service_id: registryId } }],
       package: deploymentPackageFactory({
-        config: recipeFactory({
+        config: defaultModDefinitionFactory({
           extensionPoints: [
             modComponentDefinitionFactory({
               services: {
@@ -301,7 +301,7 @@ describe("findPersonalServiceConfigurations", () => {
   test("exclude pixiebrix service", async () => {
     const deployment = deploymentFactory({
       package: deploymentPackageFactory({
-        config: recipeFactory({
+        config: defaultModDefinitionFactory({
           extensionPoints: [
             modComponentDefinitionFactory({
               services: {
@@ -332,7 +332,7 @@ describe("mergeDeploymentServiceConfigurations", () => {
     const deployment = deploymentFactory({
       bindings: [{ auth: { id: boundId, service_id: registryId } }],
       package: deploymentPackageFactory({
-        config: recipeFactory({
+        config: defaultModDefinitionFactory({
           extensionPoints: [
             modComponentDefinitionFactory({
               services: {
@@ -359,7 +359,7 @@ describe("mergeDeploymentServiceConfigurations", () => {
   test("take local service", async () => {
     const deployment = deploymentFactory({
       package: deploymentPackageFactory({
-        config: recipeFactory({
+        config: defaultModDefinitionFactory({
           extensionPoints: [
             modComponentDefinitionFactory({
               services: {
@@ -386,7 +386,7 @@ describe("mergeDeploymentServiceConfigurations", () => {
   test("ignore personal remote service", async () => {
     const deployment = deploymentFactory({
       package: deploymentPackageFactory({
-        config: recipeFactory({
+        config: defaultModDefinitionFactory({
           extensionPoints: [
             modComponentDefinitionFactory({
               services: {
@@ -412,7 +412,7 @@ describe("mergeDeploymentServiceConfigurations", () => {
   test("reject multiple personal configurations", async () => {
     const deployment = deploymentFactory({
       package: deploymentPackageFactory({
-        config: recipeFactory({
+        config: defaultModDefinitionFactory({
           extensionPoints: [
             modComponentDefinitionFactory({
               services: {

--- a/src/utils/modUtils.test.ts
+++ b/src/utils/modUtils.test.ts
@@ -26,7 +26,7 @@ import { type Mod, type UnavailableMod } from "@/types/modTypes";
 import { type ResolvedModComponent } from "@/types/modComponentTypes";
 import { modComponentFactory } from "@/testUtils/factories/modComponentFactories";
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
-import { recipeFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 describe("getSharingType", () => {
   test("personal extension", () => {
@@ -99,7 +99,7 @@ describe("getSharingType", () => {
   });
 
   test("team mod", () => {
-    const mod = recipeFactory();
+    const mod = defaultModDefinitionFactory();
     const orgId = uuidv4();
 
     mod.sharing.organizations = [orgId];
@@ -124,7 +124,7 @@ describe("getSharingType", () => {
   });
 
   test("public mod", () => {
-    const mod: Mod = recipeFactory({
+    const mod: Mod = defaultModDefinitionFactory({
       sharing: sharingDefinitionFactory({ public: true }),
     }) as any;
 
@@ -147,14 +147,14 @@ describe("isExtension", () => {
   });
 
   it("returns false for a recipe", () => {
-    const mod = recipeFactory();
+    const mod = defaultModDefinitionFactory();
     expect(isResolvedModComponent(mod)).toBe(false);
   });
 });
 
 describe("isUnavailableMod", () => {
   it("returns false for a recipe definition", () => {
-    const mod = recipeFactory();
+    const mod = defaultModDefinitionFactory();
     expect(isUnavailableMod(mod)).toBe(false);
   });
 

--- a/src/utils/recipeUtils.test.ts
+++ b/src/utils/recipeUtils.test.ts
@@ -21,7 +21,7 @@ import {
 } from "./recipeUtils";
 import {
   modComponentDefinitionFactory,
-  recipeFactory,
+  defaultModDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import extensionPointRegistry from "@/starterBricks/registry";
 
@@ -53,13 +53,15 @@ describe("generateRecipeId", () => {
 
 describe("getContainedExtensionPointTypes", () => {
   test("gets types with inner definitions", async () => {
-    const result = await getContainedExtensionPointTypes(recipeFactory());
+    const result = await getContainedExtensionPointTypes(
+      defaultModDefinitionFactory()
+    );
     expect(result).toStrictEqual(["menuItem"]);
   });
 
   test("returns only unique types", async () => {
     const result = await getContainedExtensionPointTypes(
-      recipeFactory({
+      defaultModDefinitionFactory({
         extensionPoints: [
           modComponentDefinitionFactory(),
           modComponentDefinitionFactory(),
@@ -75,7 +77,7 @@ describe("getContainedExtensionPointTypes", () => {
     }));
 
     const result = await getContainedExtensionPointTypes(
-      recipeFactory({
+      defaultModDefinitionFactory({
         extensionPoints: [modComponentDefinitionFactory()],
         definitions: undefined,
       })
@@ -88,7 +90,7 @@ describe("getContainedExtensionPointTypes", () => {
     (extensionPointRegistry.lookup as jest.Mock).mockImplementation(() => null);
 
     const result = await getContainedExtensionPointTypes(
-      recipeFactory({
+      defaultModDefinitionFactory({
         extensionPoints: [modComponentDefinitionFactory()],
         definitions: undefined,
       })
@@ -101,7 +103,7 @@ describe("getContainedExtensionPointTypes", () => {
     (extensionPointRegistry.lookup as jest.Mock).mockImplementation(() => null);
 
     const result = await getContainedExtensionPointTypes(
-      recipeFactory({
+      defaultModDefinitionFactory({
         extensionPoints: [modComponentDefinitionFactory()],
         definitions: {},
       })


### PR DESCRIPTION
## What does this PR do?

- Rename remaining factories in `testUtils/factories` that still use legacy terms, in particular, "recipe" and "extension point"

## Reviewer Tips

- Focus on reviewing changes in `testUtils/factories`. The rest of the diff is just resulting import renames
## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @grahamlangford 
