### PR TITLE
#6176: add troubleshooting message after delay in getting Google token

### DIFF
--- a/src/contrib/google/sheets/core/sheetsApi.ts
+++ b/src/contrib/google/sheets/core/sheetsApi.ts
@@ -84,7 +84,7 @@ async function _ensureSheetsReadyOnce({
 /**
  * Ensure the Google Sheets API is ready to be called, and return the user's token.
  * @param maxRetries the maximum number of retries
- * @param interactive true to show the Google authentication UI if needed
+ * @param interactive true to show the Google authentication UI, if authentication is required
  * @param timeoutMillis a timeout for ensuring the token if the Google API is not ready
  * @return token the user's Google token
  */

--- a/src/contrib/google/sheets/ui/SheetsFileWidget.test.tsx
+++ b/src/contrib/google/sheets/ui/SheetsFileWidget.test.tsx
@@ -137,6 +137,7 @@ describe("SheetsFileWidget", () => {
       showPicker: showPickerMock,
       hasRejectedPermissions: false,
       ensureSheetsTokenAction: jest.fn(),
+      startTimestamp: null,
     });
 
     const rendered = render(
@@ -286,6 +287,7 @@ describe("SheetsFileWidget", () => {
       showPicker: jest.fn(),
       hasRejectedPermissions: true,
       ensureSheetsTokenAction: jest.fn(),
+      startTimestamp: null,
     });
 
     render(
@@ -302,5 +304,35 @@ describe("SheetsFileWidget", () => {
         exact: false,
       })
     ).toBeVisible();
+  });
+
+  it("displays isEnsureSheetsHanging message", async () => {
+    jest.useFakeTimers();
+
+    useGoogleSpreadsheetPickerMock.mockReturnValue({
+      showPicker: jest.fn(),
+      hasRejectedPermissions: false,
+      ensureSheetsTokenAction: jest.fn(),
+      startTimestamp: Date.now(),
+    });
+
+    render(
+      <SheetsFileWidget name="spreadsheetId" schema={BASE_SHEET_SCHEMA} />,
+      {
+        initialValues: { spreadsheetId: null },
+      }
+    );
+
+    jest.advanceTimersByTime(5000);
+
+    await waitForEffect();
+
+    expect(
+      screen.getByText("If Chrome is not displaying an authentication popup", {
+        exact: false,
+      })
+    ).toBeVisible();
+
+    jest.useRealTimers();
   });
 });

--- a/src/contrib/google/sheets/ui/SheetsFileWidget.test.tsx
+++ b/src/contrib/google/sheets/ui/SheetsFileWidget.test.tsx
@@ -300,9 +300,12 @@ describe("SheetsFileWidget", () => {
     await waitForEffect();
 
     expect(
-      screen.getByText("PixieBrix cannot access your Google Account.", {
-        exact: false,
-      })
+      screen.getByText(
+        "You did not approve access, or your company policy prevents access to Google Sheets.",
+        {
+          exact: false,
+        }
+      )
     ).toBeVisible();
   });
 

--- a/src/contrib/google/sheets/ui/useGoogleSpreadsheetPicker.ts
+++ b/src/contrib/google/sheets/ui/useGoogleSpreadsheetPicker.ts
@@ -51,7 +51,7 @@ function useGoogleSpreadsheetPicker(): {
   hasRejectedPermissions: boolean;
 
   /**
-   * The timestamp when ensureSheetsReady was called, or nu,ll if not waiting for a token. Used to determine if the
+   * The timestamp when ensureSheetsReady was called, or null if not waiting for a token. Used to determine if the
    * Chrome APIs for retrieving the token are hanging.
    */
   startTimestamp: number | null;

--- a/src/contrib/google/sheets/ui/useGoogleSpreadsheetPicker.ts
+++ b/src/contrib/google/sheets/ui/useGoogleSpreadsheetPicker.ts
@@ -58,7 +58,7 @@ function useGoogleSpreadsheetPicker(): {
 } {
   const pickerOrigin = useCurrentOrigin();
 
-  // The timestamp when ensureSheetsReady was called. Used to determine if token is hanging.
+  // The timestamp when ensureSheetsReady was called. Used to determine if the Chrome identity APIs might be hanging.
   const [startTimestamp, setStartTimestamp] = useState<number | null>(null);
 
   // `true` if the user has explicitly rejected permissions when shown the authentication prompt

--- a/src/hooks/useTimeoutState.test.ts
+++ b/src/hooks/useTimeoutState.test.ts
@@ -29,3 +29,17 @@ test("useTimeoutState", () => {
   jest.advanceTimersByTime(300);
   expect(result.current).toEqual(true);
 });
+
+test("clear timeout state", () => {
+  const { result, rerender } = renderHook((props) => useTimeoutState(props), {
+    initialProps: 300,
+  });
+
+  expect(result.current).toEqual(false);
+  jest.advanceTimersByTime(30);
+  expect(result.current).toEqual(false);
+  jest.advanceTimersByTime(300);
+  expect(result.current).toEqual(true);
+  rerender(null);
+  expect(result.current).toEqual(false);
+});

--- a/src/hooks/useTimeoutState.ts
+++ b/src/hooks/useTimeoutState.ts
@@ -17,10 +17,19 @@
 
 import { useEffect, useState } from "react";
 
-export default function useTimeoutState(millis: number): boolean {
+/**
+ * Hook that returns `true` after `millis` milliseconds.
+ * @param millis milliseconds to wait after mount, or null to clear the timeout
+ */
+export default function useTimeoutState(millis: number | null): boolean {
   const [state, setState] = useState(false);
 
   useEffect(() => {
+    if (millis == null) {
+      setState(false);
+      return;
+    }
+
     const timer = setTimeout(setState, millis, true);
     return () => {
       clearTimeout(timer);

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -94,6 +94,7 @@ export const Events = {
   SELECT_GOOGLE_SPREADSHEET_SHOW_PICKER_START:
     "SelectGoogleSpreadsheetShowPickerStart",
   SELECT_GOOGLE_SPREADSHEET_START: "SelectGoogleSpreadsheetStart",
+  SELECT_GOOGLE_SPREADSHEET_VIEW_WARNING: "SelectGoogleSpreadsheetViewWarning",
 
   SIDE_PANEL_HIDE: "SidePanelHide",
   SIDE_BAR_SHOW: "SidePanelShow",


### PR DESCRIPTION
## What does this PR do?

- Closes #6176
- Closes #6172
- Shows an error message if there's a delay in getting to Google token
- Reports to Mixpanel when Google auth warning/error is shown to the user
- Calls `clearAllCachedAuthTokens` on retry to try to clear out any bad auth cache state

## New Telemetry Events

- `SelectGoogleSpreadsheetViewWarning`

## Post-Merge Actions

- Add event `SelectGoogleSpreadsheetViewWarning` to the lexicon

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
