### PR TITLE
#6193: initial support for mod variable static analysis

### DIFF
--- a/src/analysis/analysisVisitors/pageStateAnalysis/modVariableNamesVisitor.test.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/modVariableNamesVisitor.test.ts
@@ -68,4 +68,31 @@ describe("CollectNamesVisitor", () => {
       knownNames: ["foo", "bar"],
     });
   });
+
+  it("does not duplicate names", async () => {
+    const formState = formStateFactory();
+    formState.extension.blockPipeline[0] = {
+      id: AssignModVariable.BRICK_ID,
+      config: {
+        variableName: "foo",
+      },
+    };
+
+    const otherFormState = formStateFactory();
+    otherFormState.extension.blockPipeline[0] = {
+      id: AssignModVariable.BRICK_ID,
+      config: {
+        variableName: "foo",
+      },
+    };
+
+    const result = CollectNamesVisitor.collectNames([
+      formState,
+      otherFormState,
+    ]);
+
+    await expect(result).resolves.toEqual({
+      knownNames: ["foo"],
+    });
+  });
 });

--- a/src/analysis/analysisVisitors/pageStateAnalysis/modVariableNamesVisitor.test.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/modVariableNamesVisitor.test.ts
@@ -25,7 +25,7 @@ beforeAll(() => {
   registerBuiltinBlocks();
 });
 
-describe("collectEventNamesAnalysis", () => {
+describe("CollectNamesVisitor", () => {
   it("collects event name from a template literal", async () => {
     const formState = formStateFactory();
     formState.extension.blockPipeline[0] = {

--- a/src/analysis/analysisVisitors/pageStateAnalysis/modVariableNamesVisitor.test.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/modVariableNamesVisitor.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import CollectNamesVisitor from "@/analysis/analysisVisitors/pageStateAnalysis/modVariableNamesVisitor";
+import AssignModVariable from "@/bricks/effects/assignModVariable";
+import { makeTemplateExpression } from "@/runtime/expressionCreators";
+import registerBuiltinBlocks from "@/bricks/registerBuiltinBlocks";
+
+beforeAll(() => {
+  registerBuiltinBlocks();
+});
+
+describe("collectEventNamesAnalysis", () => {
+  it("collects event name from a template literal", async () => {
+    const formState = formStateFactory();
+    formState.extension.blockPipeline[0] = {
+      id: AssignModVariable.BRICK_ID,
+      config: {
+        variableName: makeTemplateExpression("nunjucks", "foo"),
+      },
+    };
+
+    const result = CollectNamesVisitor.collectNames([formState]);
+
+    await expect(result).resolves.toEqual({
+      knownNames: ["foo"],
+    });
+  });
+
+  it("unions known names", async () => {
+    const formState = formStateFactory();
+    formState.extension.blockPipeline[0] = {
+      id: AssignModVariable.BRICK_ID,
+      config: {
+        variableName: "foo",
+      },
+    };
+
+    const otherFormState = formStateFactory();
+    otherFormState.extension.blockPipeline[0] = {
+      id: AssignModVariable.BRICK_ID,
+      config: {
+        variableName: "bar",
+      },
+    };
+
+    const result = CollectNamesVisitor.collectNames([
+      formState,
+      otherFormState,
+    ]);
+
+    await expect(result).resolves.toEqual({
+      knownNames: ["foo", "bar"],
+    });
+  });
+});

--- a/src/analysis/analysisVisitors/pageStateAnalysis/modVariableNamesVisitor.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/modVariableNamesVisitor.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type BrickConfig, type BrickPosition } from "@/bricks/types";
+import PipelineVisitor, {
+  type VisitBlockExtra,
+} from "@/bricks/PipelineVisitor";
+import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
+import blockRegistry, { type TypedBlockMap } from "@/bricks/registry";
+import { type Schema } from "@/types/schemaTypes";
+import { compact } from "lodash";
+
+export type ModVariableNameResult = {
+  /**
+   * Statically known mod variable names.
+   */
+  knownNames: string[];
+};
+
+/**
+ * Visitor to collect all events fired by a single FormState.
+ * @since 1.7.34
+ */
+class CollectNamesVisitor extends PipelineVisitor {
+  readonly schemaPromises: Array<Promise<Schema>> = [];
+
+  constructor(readonly allBlocks: TypedBlockMap) {
+    super();
+  }
+
+  override visitBrick(
+    position: BrickPosition,
+    blockConfig: BrickConfig,
+    extra: VisitBlockExtra
+  ): void {
+    super.visitBrick(position, blockConfig, extra);
+
+    const { block } = this.allBlocks.get(blockConfig.id) ?? {};
+
+    if (block?.getModVariableSchema) {
+      this.schemaPromises.push(block.getModVariableSchema?.(blockConfig));
+    }
+  }
+
+  static async collectNames(
+    formStates: ModComponentFormState[]
+  ): Promise<ModVariableNameResult> {
+    const allBlocks = await blockRegistry.allTyped();
+    const visitor = new CollectNamesVisitor(allBlocks);
+
+    for (const formState of formStates) {
+      visitor.visitRootPipeline(formState.extension.blockPipeline);
+    }
+
+    // Schema promises return undefined if not page state
+    const schemas: Array<Schema | undefined> = await Promise.all(
+      visitor.schemaPromises
+    );
+
+    const variableNames = new Set<string>();
+
+    for (const schema of compact(schemas)) {
+      for (const variableName of Object.keys(schema.properties ?? {})) {
+        variableNames.add(variableName);
+      }
+    }
+
+    return {
+      knownNames: [...variableNames],
+    };
+  }
+}
+
+export default CollectNamesVisitor;

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -101,7 +101,7 @@ describe("Collecting available vars", () => {
 
   describe("general", () => {
     beforeEach(() => {
-      analysis = new VarAnalysis({ trace: [], modState: {} });
+      analysis = new VarAnalysis();
     });
 
     test("collects the context vars", async () => {
@@ -205,7 +205,7 @@ describe("Collecting available vars", () => {
 
   describe("mod variables", () => {
     it("collects actual mod variables", async () => {
-      const analysis = new VarAnalysis({ trace: [], modState: { foo: 42 } });
+      const analysis = new VarAnalysis({ modState: { foo: 42 } });
 
       const extension = formStateFactory({}, [brickConfigFactory()]);
 
@@ -223,7 +223,7 @@ describe("Collecting available vars", () => {
 
   describe("blueprint @options", () => {
     beforeEach(() => {
-      analysis = new VarAnalysis({ trace: [], modState: {} });
+      analysis = new VarAnalysis();
     });
 
     test.each([{}, null, undefined])("no options", async (optionsSchema) => {
@@ -700,7 +700,7 @@ describe("Collecting available vars", () => {
 
       const extension = formStateFactory(undefined, [documentRendererBrick]);
 
-      analysis = new VarAnalysis({ trace: [], modState: {} });
+      analysis = new VarAnalysis();
       await analysis.run(extension);
     });
 
@@ -762,7 +762,7 @@ describe("Collecting available vars", () => {
 
       const extension = formStateFactory(undefined, [documentRendererBrick]);
 
-      analysis = new VarAnalysis({ trace: [], modState: {} });
+      analysis = new VarAnalysis();
       await analysis.run(extension);
     });
 
@@ -812,7 +812,7 @@ describe("Collecting available vars", () => {
         brickConfigFactory(),
       ]);
 
-      analysis = new VarAnalysis({ trace: [], modState: {} });
+      analysis = new VarAnalysis();
       await analysis.run(extension);
     });
 
@@ -852,7 +852,7 @@ describe("Collecting available vars", () => {
         brickConfigFactory(),
       ]);
 
-      analysis = new VarAnalysis({ trace: [], modState: {} });
+      analysis = new VarAnalysis();
       await analysis.run(extension);
     });
 
@@ -888,7 +888,7 @@ describe("Collecting available vars", () => {
         brickConfigFactory(),
       ]);
 
-      analysis = new VarAnalysis({ trace: [], modState: {} });
+      analysis = new VarAnalysis();
       await analysis.run(extension);
     });
 
@@ -984,7 +984,7 @@ describe("Invalid template", () => {
 
     extension = formStateFactory(undefined, [invalidEchoBlock, validEchoBlock]);
 
-    analysis = new VarAnalysis({ trace: [], modState: {} });
+    analysis = new VarAnalysis();
   });
 
   test("analysis doesn't throw", async () => {
@@ -1017,7 +1017,7 @@ describe("var expression annotations", () => {
       },
     ]);
 
-    const analysis = new VarAnalysis({ trace: [], modState: {} });
+    const analysis = new VarAnalysis();
     await analysis.run(extension);
 
     expect(analysis.getAnnotations()).toHaveLength(0);
@@ -1033,7 +1033,7 @@ describe("var expression annotations", () => {
       },
     ]);
 
-    const analysis = new VarAnalysis({ trace: [], modState: {} });
+    const analysis = new VarAnalysis();
     await analysis.run(extension);
 
     expect(analysis.getAnnotations()).toHaveLength(0);
@@ -1049,7 +1049,7 @@ describe("var expression annotations", () => {
       },
     ]);
 
-    const analysis = new VarAnalysis({ trace: [], modState: {} });
+    const analysis = new VarAnalysis();
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();
@@ -1069,7 +1069,7 @@ describe("var expression annotations", () => {
       },
     ]);
 
-    const analysis = new VarAnalysis({ trace: [], modState: {} });
+    const analysis = new VarAnalysis();
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();
@@ -1087,7 +1087,7 @@ describe("var expression annotations", () => {
       },
     ]);
 
-    const analysis = new VarAnalysis({ trace: [], modState: {} });
+    const analysis = new VarAnalysis();
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();
@@ -1112,7 +1112,7 @@ describe("var analysis integration tests", () => {
 
     extension.extensionPoint.definition.trigger = "keypress";
 
-    const analysis = new VarAnalysis({ trace: [], modState: {} });
+    const analysis = new VarAnalysis();
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();
@@ -1134,7 +1134,7 @@ describe("var analysis integration tests", () => {
 
     extension.extensionPoint.definition.trigger = "custom";
 
-    const analysis = new VarAnalysis({ trace: [], modState: {} });
+    const analysis = new VarAnalysis();
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();
@@ -1157,7 +1157,7 @@ describe("var analysis integration tests", () => {
 
     extension.extensionPoint.definition.trigger = "selectionchange";
 
-    const analysis = new VarAnalysis({ trace: [], modState: {} });
+    const analysis = new VarAnalysis();
     await analysis.run(extension);
 
     const annotations = analysis.getAnnotations();

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -219,6 +219,22 @@ describe("Collecting available vars", () => {
       expect(foundationKnownVars.isVariableDefined("@mod.foo")).toBeTrue();
       expect(foundationKnownVars.isVariableDefined("@mod.bar")).toBeFalse();
     });
+
+    it("handles inferred mod variables", async () => {
+      const analysis = new VarAnalysis({ modVariables: ["foo"] });
+
+      const extension = formStateFactory({}, [brickConfigFactory()]);
+
+      await analysis.run(extension);
+
+      const foundationKnownVars = analysis
+        .getKnownVars()
+        .get("extension.blockPipeline.0");
+
+      expect(foundationKnownVars.isVariableDefined("@mod")).toBeTrue();
+      expect(foundationKnownVars.isVariableDefined("@mod.foo")).toBeTrue();
+      expect(foundationKnownVars.isVariableDefined("@mod.bar")).toBeFalse();
+    });
   });
 
   describe("blueprint @options", () => {
@@ -430,6 +446,21 @@ describe("Collecting available vars", () => {
       // The output key allows any property
       expect(
         secondBlockKnownVars.isVariableDefined(`@${outputKey}.baz`)
+      ).toBeTrue();
+    });
+
+    test("supports true definition in output schema", async () => {
+      const secondBlockKnownVars = await runAnalysisWithOutputSchema({
+        $schema: "https://json-schema.org/draft/2019-09/schema#",
+        type: "object",
+        properties: {
+          foo: true,
+        },
+      });
+
+      // The output key allows any property
+      expect(
+        secondBlockKnownVars.isVariableDefined(`@${outputKey}.foo`)
       ).toBeTrue();
     });
 

--- a/src/bricks/effects/assignModVariable.test.ts
+++ b/src/bricks/effects/assignModVariable.test.ts
@@ -105,4 +105,20 @@ describe("@pixiebrix/state/assign", () => {
       getPageState({ namespace: "blueprint", blueprintId, extensionId })
     ).toEqual({ foo: 42, bar: 0 });
   });
+
+  test("it returns mod variables", async () => {
+    await expect(
+      brick.getModVariableSchema({
+        id: brick.id,
+        config: { variableName: "foo" },
+      })
+    ).resolves.toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        foo: true,
+      },
+      required: ["foo"],
+    });
+  });
 });

--- a/src/bricks/effects/assignModVariable.ts
+++ b/src/bricks/effects/assignModVariable.ts
@@ -5,6 +5,8 @@ import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type JsonObject } from "type-fest";
 import { setPageState } from "@/contentScript/pageState";
 import { EffectABC } from "@/types/bricks/effectTypes";
+import { type BrickConfig } from "@/bricks/types";
+import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
 
 /**
  * A simple brick to assign a value to a Mod Variable.
@@ -27,6 +29,36 @@ class AssignModVariable extends EffectABC {
 
   override async isPageStateAware(): Promise<boolean> {
     return true;
+  }
+
+  override async getModVariableSchema(
+    _config: BrickConfig
+  ): Promise<Schema | undefined> {
+    const { variableName: variableExpression } = _config.config;
+
+    let name = "";
+    try {
+      name = castTextLiteralOrThrow(variableExpression);
+    } catch {
+      return;
+    }
+
+    if (name) {
+      return {
+        type: "object",
+        properties: {
+          // For now, only provide existence information for the variable
+          [name]: true,
+        },
+        additionalProperties: false,
+        required: [name],
+      };
+    }
+
+    return {
+      type: "object",
+      additionalProperties: true,
+    };
   }
 
   inputSchema: Schema = propertiesToSchema(

--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.test.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.test.tsx
@@ -98,7 +98,7 @@ describe("VarMenu", () => {
           );
 
           // Run analysis directly
-          const analysis = new VarAnalysis({ trace: [], modState: {} });
+          const analysis = new VarAnalysis();
           await analysis.run(formState);
 
           dispatch(
@@ -142,7 +142,7 @@ describe("VarMenu", () => {
           );
 
           // Run analysis directly
-          const analysis = new VarAnalysis({ trace: [], modState: {} });
+          const analysis = new VarAnalysis();
           await analysis.run(formState);
 
           dispatch(

--- a/src/components/fields/schemaFields/widgets/varPopup/getMenuOptions.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/getMenuOptions.test.ts
@@ -178,7 +178,7 @@ describe("arrays", () => {
 
 describe("mod variables", () => {
   test("it includes mod variables entry", async () => {
-    const analysis = new VarAnalysis({ trace: [], modState: { foo: 42 } });
+    const analysis = new VarAnalysis({ modState: { foo: 42 } });
     const extension = formStateFactory({}, [brickConfigFactory()]);
     await analysis.run(extension);
 

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -237,6 +237,8 @@ pageEditorAnalysisManager.registerAnalysisEffect(
   {
     matcher: isAnyOf(
       editorActions.showVariablePopover,
+      // Include selectElement so that variable analysis is ready when user first types
+      editorActions.selectElement,
       editorActions.editElement,
       runtimeActions.setExtensionTrace,
       ...nodeListMutationActions

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -43,6 +43,7 @@ import { extensionToFormState } from "@/pageEditor/starterBricks/adapter";
 import { getPageState } from "@/contentScript/messenger/api";
 import { thisTab } from "@/pageEditor/utils";
 import HttpRequestAnalysis from "@/analysis/analysisVisitors/httpRequestAnalysis";
+import ModVariableNames from "@/analysis/analysisVisitors/pageStateAnalysis/modVariableNamesVisitor";
 
 const runtimeActions = runtimeSlice.actions;
 
@@ -178,13 +179,22 @@ async function varAnalysisFactory(
   const trace = selectActiveElementTraces(state);
   const extension = selectActiveElement(state);
 
+  // The potential mod known mod variables
+  const formStates = await selectActiveModFormStates(state);
+  const variables = await ModVariableNames.collectNames(formStates);
+
+  // The actual mod variables
   const modState = await getPageState(thisTab, {
     namespace: "blueprint",
     extensionId: extension.uuid,
     blueprintId: extension.recipe?.id,
   });
 
-  return new VarAnalysis({ trace, modState });
+  return new VarAnalysis({
+    trace,
+    modState,
+    modVariables: variables.knownNames,
+  });
 }
 
 // OutputKeyAnalysis seems to be the slowest one, so we register it in the end

--- a/src/pageEditor/fields/AssignModVariableOptions.tsx
+++ b/src/pageEditor/fields/AssignModVariableOptions.tsx
@@ -29,7 +29,7 @@ import { KnownSources } from "@/analysis/analysisVisitors/varAnalysis/varAnalysi
 import { MOD_VARIABLE_REFERENCE } from "@/runtime/extendModVariableContext";
 import type VarMap from "@/analysis/analysisVisitors/varAnalysis/varMap";
 
-function schemaWithKnownVariableNames(varMap: VarMap): Schema {
+function schemaWithKnownVariableNames(varMap: VarMap | null): Schema {
   const map = varMap?.getMap() ?? {};
   // eslint-disable-next-line security/detect-object-injection -- compile time constant
   const modVars = map[KnownSources.MOD]?.[MOD_VARIABLE_REFERENCE];

--- a/src/pageEditor/fields/AssignModVariableOptions.tsx
+++ b/src/pageEditor/fields/AssignModVariableOptions.tsx
@@ -18,16 +18,38 @@
 import React, { useMemo } from "react";
 import { type BlockOptionProps } from "@/components/fields/schemaFields/genericOptionsFactory";
 import { partial } from "lodash";
-import { useFormikContext } from "formik";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { type Schema } from "@/types/schemaTypes";
-import useAsyncState from "@/hooks/useAsyncState";
-import { getPageState } from "@/contentScript/messenger/api";
-import { thisTab } from "@/pageEditor/utils";
-import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import AssignModVariable from "@/bricks/effects/assignModVariable";
 import { type UnknownObject } from "@/types/objectTypes";
 import { joinName } from "@/utils/formUtils";
+import { useSelector } from "react-redux";
+import { selectKnownVarsForActiveNode } from "@/components/fields/schemaFields/widgets/varPopup/varSelectors";
+import { KnownSources } from "@/analysis/analysisVisitors/varAnalysis/varAnalysis";
+import { MOD_VARIABLE_REFERENCE } from "@/runtime/extendModVariableContext";
+import type VarMap from "@/analysis/analysisVisitors/varAnalysis/varMap";
+
+function schemaWithKnownVariableNames(varMap: VarMap): Schema {
+  const map = varMap?.getMap() ?? {};
+  // eslint-disable-next-line security/detect-object-injection -- compile time constant
+  const modVars = map[KnownSources.MOD]?.[MOD_VARIABLE_REFERENCE];
+  // Filter out the symbols on the ExistenceNode
+  const knownVariableNames = Object.keys(modVars ?? {}).filter(
+    (x) => typeof x === "string"
+  );
+
+  const schema = new AssignModVariable().inputSchema;
+  return {
+    properties: {
+      ...schema.properties,
+      variableName: {
+        ...(schema.properties.variableName as UnknownObject),
+        // Provide as examples, the creator can still create a new variable
+        examples: knownVariableNames,
+      },
+    },
+  };
+}
 
 const AssignModVariableOptions: React.FC<BlockOptionProps> = ({
   name,
@@ -35,44 +57,24 @@ const AssignModVariableOptions: React.FC<BlockOptionProps> = ({
 }) => {
   const basePath = joinName(name, configKey);
   const configName = partial(joinName, basePath);
+  const varMap = useSelector(selectKnownVarsForActiveNode);
 
-  const {
-    values: { uuid: extensionId, recipe },
-  } = useFormikContext<ModComponentFormState>();
-
-  const { data: modState } = useAsyncState(
-    async () =>
-      getPageState(thisTab, {
-        namespace: "blueprint",
-        extensionId,
-        blueprintId: recipe?.id,
-      }),
-    []
+  // Add examples to the schema
+  const { properties } = useMemo(
+    () => schemaWithKnownVariableNames(varMap),
+    [varMap]
   );
-
-  const inputSchema = useMemo(() => {
-    const schema = new AssignModVariable().inputSchema;
-    return {
-      properties: {
-        value: schema.properties.value,
-        variableName: {
-          ...(schema.properties.variableName as UnknownObject),
-          examples: Object.keys(modState ?? {}),
-        },
-      },
-    };
-  }, [modState]);
 
   return (
     <>
       <SchemaField
         name={configName("variableName")}
-        schema={inputSchema.properties.variableName as Schema}
+        schema={properties.variableName as Schema}
         isRequired
       />
       <SchemaField
         name={configName("value")}
-        schema={inputSchema.properties.value as Schema}
+        schema={properties.value as Schema}
         isRequired
       />
     </>

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -154,7 +154,7 @@ export type InitialValues = {
   serviceContext: ServiceContext;
   /**
    * The document root for root-aware bricks, including readers
-   * @see IBlock.isRootAware
+   * @see Brick.isRootAware
    */
   root: SelectorRoot | null;
 };
@@ -174,7 +174,7 @@ export type IntermediateState = {
   context: BrickArgsContext;
   /**
    * The document root for root-aware bricks
-   * @see IBlock.isRootAware
+   * @see Brick.isRootAware
    */
   root: SelectorRoot | null;
   /**
@@ -213,7 +213,7 @@ type BlockProps<TArgs extends RenderedArgs | BrickArgs = RenderedArgs> = {
 
   /**
    * The root for root-aware bricks
-   * @see IBlock.isRootAware
+   * @see Brick.isRootAware
    */
   root: SelectorRoot | null;
 };

--- a/src/types/brickTypes.ts
+++ b/src/types/brickTypes.ts
@@ -55,6 +55,17 @@ export interface Brick extends Metadata {
   getOutputSchema?: (config: BrickConfig) => Schema | undefined;
 
   /**
+   * An optional method to generate a JSON schema describing the mod variables set by the brick.
+   *
+   * Returns `undefined` if `isPageStateAware` is false.
+   *
+   * @param config the brick configuration
+   * @see isPageStateAware
+   * @since 1.7.36
+   */
+  getModVariableSchema?: (config: BrickConfig) => Promise<Schema | undefined>;
+
+  /**
    * Returns the optional permissions required to run this brick.
    *
    * Only includes this brick's permissions, not the permissions of any bricks passed as inputs to the brick.
@@ -155,6 +166,12 @@ export abstract class BrickABC implements Brick {
 
   getOutputSchema(_config: BrickConfig): Schema | undefined {
     return this.outputSchema;
+  }
+
+  async getModVariableSchema(
+    _config: BrickConfig
+  ): Promise<Schema | undefined> {
+    return undefined;
   }
 
   protected constructor(

--- a/src/utils/schemaUtils.test.ts
+++ b/src/utils/schemaUtils.test.ts
@@ -124,4 +124,14 @@ describe("unionSchemaDefinitionTypes", () => {
       required: [],
     });
   });
+
+  it("handles object and primitive", () => {
+    expect(
+      unionSchemaDefinitionTypes(fooObjectSchema, {
+        type: "number",
+      })
+    ).toEqual({
+      anyOf: [fooObjectSchema, { type: "number" }],
+    });
+  });
 });

--- a/src/utils/schemaUtils.test.ts
+++ b/src/utils/schemaUtils.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { unionSchemaDefinitionTypes } from "@/utils/schemaUtils";
+import { type Schema } from "@/types/schemaTypes";
+
+const fooObjectSchema: Schema = {
+  type: "object",
+  properties: { foo: { type: "string" } },
+};
+const barObjectSchema: Schema = {
+  type: "object",
+  properties: { bar: { type: "string" } },
+};
+
+describe("unionSchemaDefinitionTypes", () => {
+  it("merges object properties", () => {
+    expect(
+      unionSchemaDefinitionTypes(fooObjectSchema, barObjectSchema)
+    ).toEqual({
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+        bar: { type: "string" },
+      },
+      additionalProperties: false,
+      required: [],
+    });
+  });
+
+  it("handles additionalProperties", () => {
+    expect(
+      unionSchemaDefinitionTypes(
+        { ...fooObjectSchema, additionalProperties: true },
+        barObjectSchema
+      )
+    ).toEqual({
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+        bar: { type: "string" },
+      },
+      additionalProperties: true,
+      required: [],
+    });
+  });
+
+  it("intersects required properties", () => {
+    expect(
+      unionSchemaDefinitionTypes(
+        { ...fooObjectSchema, required: ["foo"] },
+        { ...fooObjectSchema, required: ["foo"] }
+      )
+    ).toEqual({
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+      },
+      additionalProperties: false,
+      required: ["foo"],
+    });
+  });
+
+  it("unions types", () => {
+    expect(
+      unionSchemaDefinitionTypes({ type: "string" }, { type: "number" })
+    ).toEqual({
+      type: ["string", "number"],
+    });
+  });
+
+  it("unions type array and string", () => {
+    expect(
+      unionSchemaDefinitionTypes(
+        { type: ["string", "number"] },
+        { type: "number" }
+      )
+    ).toEqual({
+      type: ["string", "number"],
+    });
+  });
+
+  it("handles boolean definition", () => {
+    expect(
+      unionSchemaDefinitionTypes(fooObjectSchema, {
+        type: "object",
+        properties: { foo: true },
+      })
+    ).toEqual({
+      type: "object",
+      properties: { foo: true },
+      additionalProperties: false,
+      required: [],
+    });
+  });
+});

--- a/src/utils/schemaUtils.test.ts
+++ b/src/utils/schemaUtils.test.ts
@@ -75,6 +75,23 @@ describe("unionSchemaDefinitionTypes", () => {
     });
   });
 
+  it("intersects required properties excludes mismatch", () => {
+    expect(
+      unionSchemaDefinitionTypes(
+        { ...barObjectSchema, required: ["bar"] },
+        { ...fooObjectSchema, required: ["foo"] }
+      )
+    ).toEqual({
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+        bar: { type: "string" },
+      },
+      additionalProperties: false,
+      required: [],
+    });
+  });
+
   it("unions types", () => {
     expect(
       unionSchemaDefinitionTypes({ type: "string" }, { type: "number" })


### PR DESCRIPTION
## What does this PR do?

- Closes #6193 
- Adds a `Brick.getModVariableSchema` method to return mod variables the brick might set
- Tracks known mod variables within a mod for use in variable analysis/popover

## Reviewer Notes

- Review implementations of getModVariableSchema
- Review AssignModVariableOptions

## Remaining Work

- [x] Fix assign mod variable dropdown to include variables from Set Page State brick

## Demo

- https://www.loom.com/share/2ff5f35ea8ee445f89be0be3bcbc988f?sid=8c9254c7-2d67-4f2c-a576-085e1f63c28b

## Future Work

- Add support for tracking type for literal values
- Add support for tracking type based on variable usage. (Modify getModVariableSchema to accept the known vars for the brick, to dependently type the effect on mod variables)

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
