### PR TITLE
Add indicator for creatable select options

### DIFF
--- a/src/components/fields/schemaFields/widgets/SchemaSelectWidget.test.tsx
+++ b/src/components/fields/schemaFields/widgets/SchemaSelectWidget.test.tsx
@@ -93,19 +93,6 @@ describe("mapSchemaToOptions", () => {
     });
   });
 
-  it("returns creatable for examples", () => {
-    expect(
-      mapSchemaToOptions({
-        schema: { type: "string", examples: [] },
-        value: "foo",
-        created: [],
-      })
-    ).toEqual({
-      creatable: true,
-      options: [{ value: "foo", label: "foo" }],
-    });
-  });
-
   it("extracts labelled enum values", () => {
     expect(
       mapSchemaToOptions({

--- a/src/components/fields/schemaFields/widgets/SchemaSelectWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/SchemaSelectWidget.tsx
@@ -24,6 +24,7 @@ import useAutoFocusConfiguration from "@/hooks/useAutoFocusConfiguration";
 import { isExpression } from "@/utils/expressionUtils";
 import { mapSchemaToOptions } from "@/components/fields/schemaFields/selectFieldUtils";
 import Creatable from "react-select/creatable";
+import useAddCreatablePlaceholder from "@/components/form/widgets/useAddCreatablePlaceholder";
 
 export type StringOption = {
   value: string;
@@ -61,19 +62,12 @@ const SchemaSelectWidget: React.VFC<
     [schema, created, value]
   );
 
-  // Disabled placeholder option to indicate that a user can create an option
-  // If you change this, make sure you change the equivalent in SelectWidget.tsx
-  const creatablePlaceholder = {
-    value: "",
-    label: "Start typing to filter or create new entry",
-    isDisabled: true,
-  };
-
   // Show placeholder if users can create new options and the search is empty
-  const optionsWithPlaceholder =
-    creatable && textInputValue.length === 0
-      ? [creatablePlaceholder, ...options]
-      : options;
+  const optionsWithPlaceholder = useAddCreatablePlaceholder({
+    creatable,
+    options,
+    textInputValue,
+  });
 
   const selectedValue = options.find((x) => x.value === value) ?? {
     value: null,

--- a/src/components/fields/schemaFields/widgets/SchemaSelectWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/SchemaSelectWidget.tsx
@@ -20,10 +20,10 @@ import Select, { type Options } from "react-select";
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import { isEmpty, uniq } from "lodash";
 import { useField } from "formik";
-import Creatable from "react-select/creatable";
 import useAutoFocusConfiguration from "@/hooks/useAutoFocusConfiguration";
 import { isExpression } from "@/utils/expressionUtils";
 import { mapSchemaToOptions } from "@/components/fields/schemaFields/selectFieldUtils";
+import Creatable from "react-select/creatable";
 
 export type StringOption = {
   value: string;
@@ -49,6 +49,8 @@ const SchemaSelectWidget: React.VFC<
   // from the new value.
   const value = isExpression(fieldValue) ? fieldValue.__value__ : fieldValue;
 
+  const [textInputValue, setTextInputValue] = useState("");
+
   const { creatable, options } = useMemo(
     () =>
       mapSchemaToOptions({
@@ -58,6 +60,20 @@ const SchemaSelectWidget: React.VFC<
       }),
     [schema, created, value]
   );
+
+  // Disabled placeholder option to indicate that a user can create an option
+  // If you change this, make sure you change the equivalent in SelectWidget.tsx
+  const creatablePlaceholder = {
+    value: "",
+    label: "Start typing to filter or create new entry",
+    isDisabled: true,
+  };
+
+  // Show placeholder if users can create new options and the search is empty
+  const optionsWithPlaceholder =
+    creatable && textInputValue.length === 0
+      ? [creatablePlaceholder, ...options]
+      : options;
 
   const selectedValue = options.find((x) => x.value === value) ?? {
     value: null,
@@ -78,7 +94,7 @@ const SchemaSelectWidget: React.VFC<
     <Creatable
       inputId={name}
       isClearable={!isRequired}
-      options={options}
+      options={optionsWithPlaceholder}
       onCreateOption={(value) => {
         setValue(value);
         setCreated(uniq([...created, value]));
@@ -88,6 +104,7 @@ const SchemaSelectWidget: React.VFC<
       ref={elementRef}
       placeholder={placeholder}
       openMenuOnFocus={true}
+      onInputChange={setTextInputValue}
     />
   ) : (
     <Select

--- a/src/components/form/widgets/SelectWidget.tsx
+++ b/src/components/form/widgets/SelectWidget.tsx
@@ -24,6 +24,7 @@ import Select, {
 } from "react-select";
 import Creatable from "react-select/creatable";
 import { getErrorMessage } from "@/errors/errorHelpers";
+import useAddCreatablePlaceholder from "@/components/form/widgets/useAddCreatablePlaceholder";
 
 // Type of the Select options
 export type Option<TValue = string> = {
@@ -90,6 +91,12 @@ const SelectWidget = <TOption extends Option<TOption["value"]>>({
 }: SelectWidgetProps<TOption>) => {
   const [textInputValue, setTextInputValue] = useState("");
 
+  const optionsWithPlaceholder = useAddCreatablePlaceholder({
+    creatable,
+    options,
+    textInputValue,
+  });
+
   if (loadError) {
     return (
       <div className="text-danger">
@@ -110,20 +117,6 @@ const SelectWidget = <TOption extends Option<TOption["value"]>>({
     options?.find((option: TOption) => value === option.value) ?? null;
 
   const Component = creatable ? Creatable : Select;
-
-  // Disabled placeholder option to indicate that a user can create an option
-  // If you change this, make sure you change the equivalent in SchemaSelectWidget.tsx
-  const creatablePlaceholder = {
-    value: "",
-    label: "Start typing to filter or create new entry",
-    isDisabled: true,
-  };
-
-  // Show placeholder if users can create new options and the search is empty
-  const optionsWithPlaceholder =
-    creatable && textInputValue.length === 0
-      ? [creatablePlaceholder, ...options]
-      : options;
 
   return (
     <Component

--- a/src/components/form/widgets/SelectWidget.tsx
+++ b/src/components/form/widgets/SelectWidget.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { type ChangeEvent } from "react";
+import React, { type ChangeEvent, useState } from "react";
 import { type CustomFieldWidgetProps } from "@/components/form/FieldTemplate";
 import Select, {
   type GroupBase,
@@ -62,7 +62,7 @@ export type SelectWidgetProps<TOption extends Option<TOption["value"]>> =
     /**
      * True if the user can create new options. Default is false.
      */
-    createable?: boolean;
+    creatable?: boolean;
   };
 
 export const makeStringOptions = (...items: string[]): Option[] =>
@@ -85,9 +85,11 @@ const SelectWidget = <TOption extends Option<TOption["value"]>>({
   components,
   className,
   styles,
-  createable = false,
+  creatable = false,
   isSearchable = true,
 }: SelectWidgetProps<TOption>) => {
+  const [textInputValue, setTextInputValue] = useState("");
+
   if (loadError) {
     return (
       <div className="text-danger">
@@ -107,7 +109,21 @@ const SelectWidget = <TOption extends Option<TOption["value"]>>({
   const selectedOption =
     options?.find((option: TOption) => value === option.value) ?? null;
 
-  const Component = createable ? Creatable : Select;
+  const Component = creatable ? Creatable : Select;
+
+  // Disabled placeholder option to indicate that a user can create an option
+  // If you change this, make sure you change the equivalent in SchemaSelectWidget.tsx
+  const creatablePlaceholder = {
+    value: "",
+    label: "Start typing to filter or create new entry",
+    isDisabled: true,
+  };
+
+  // Show placeholder if users can create new options and the search is empty
+  const optionsWithPlaceholder =
+    creatable && textInputValue.length === 0
+      ? [creatablePlaceholder, ...options]
+      : options;
 
   return (
     <Component
@@ -118,7 +134,8 @@ const SelectWidget = <TOption extends Option<TOption["value"]>>({
       isDisabled={disabled}
       isLoading={isLoading}
       isClearable={isClearable}
-      options={options}
+      options={optionsWithPlaceholder}
+      onInputChange={setTextInputValue}
       value={selectedOption}
       onChange={patchedOnChange}
       components={components}

--- a/src/components/form/widgets/useAddCreatablePlaceholder.ts
+++ b/src/components/form/widgets/useAddCreatablePlaceholder.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useMemo } from "react";
+
+// Disabled placeholder option to indicate that a user can create an option
+const creatablePlaceholder = {
+  value: "",
+  label: "Start typing to filter or create new entry",
+  isDisabled: true,
+};
+
+/**
+ * Adds a disabled placeholder options if creatable === true and the text-input is empty
+ * @param creatable
+ * @param options
+ * @param textInputValue
+ */
+export default function useAddCreatablePlaceholder<OptionType>({
+  creatable,
+  options,
+  textInputValue,
+}: {
+  creatable?: boolean;
+  options: readonly OptionType[];
+  textInputValue: string;
+}) {
+  return useMemo(
+    () =>
+      creatable && textInputValue.length === 0
+        ? [creatablePlaceholder, ...options]
+        : options,
+    [creatable, options, textInputValue]
+  );
+}

--- a/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
+++ b/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
@@ -143,7 +143,7 @@ exports[`TriggerConfiguration renders custom event field with known event names 
             <span
               id="aria-context"
             >
-              option otherevent focused, 1 of 1. 1 result available. Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
+              option Start typing to filter or create new entry focused disabled, 1 of 2. 2 results available. Use Up and Down to choose options, press Escape to exit the menu, press Tab to select the option and exit the menu.
             </span>
           </span>
           <div
@@ -229,9 +229,17 @@ exports[`TriggerConfiguration renders custom event field with known event names 
               class=" css-1n6sfyn-MenuList"
             >
               <div
-                aria-disabled="false"
-                class=" css-d7l1ni-option"
+                aria-disabled="true"
+                class=" css-sp6brv-option"
                 id="react-select-2-option-0"
+                tabindex="-1"
+              >
+                Start typing to filter or create new entry
+              </div>
+              <div
+                aria-disabled="false"
+                class=" css-10wo9uf-option"
+                id="react-select-2-option-1"
                 tabindex="-1"
               >
                 otherevent


### PR DESCRIPTION
## What does this PR do?

- Closes #6125 
- Adds a placeholder option to indicate that a user can create new options in both the `SchemaSelectWidget` and the `SelectWidget`. It appears when the search input is empty and creatable === true
- Removed a duplicated test

## Demo

- ![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/c4813a76-658a-405e-a841-4c5e0f341f61)

- [Loom](https://www.loom.com/share/373b82de4cba41099fb4c9420dbb0d4d?sid=d43d414f-93ac-4796-83a0-f6f746abafdf)

## Future Work

- I started wrapping the `Creatable` react-select component and applying this logic there, but the typing ended up being rather painful to work with so I opted for this instead. If we need to make more common changes in the future we can reconsider.

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @BLoe 
