### PR TITLE
Fix No Mods Pane copy in Page Editor

### DIFF
--- a/src/pageEditor/EditorContent.tsx
+++ b/src/pageEditor/EditorContent.tsx
@@ -25,8 +25,8 @@ import NoTabAccessPane from "@/pageEditor/panes/NoTabAccessPane";
 import BetaPane from "@/pageEditor/panes/BetaPane";
 import EditorPane from "@/pageEditor/panes/EditorPane";
 import RecipePane from "@/pageEditor/panes/RecipePane";
-import NoExtensionSelectedPane from "@/pageEditor/panes/NoExtensionSelectedPane";
-import NoExtensionsPane from "@/pageEditor/panes/NoExtensionsPane";
+import NoModSelectedPane from "@/pageEditor/panes/NoModSelectedPane";
+import NoModsPane from "@/pageEditor/panes/NoModsPane";
 import WelcomePane from "@/pageEditor/panes/WelcomePane";
 import {
   selectActiveElementId,
@@ -133,11 +133,11 @@ const EditorContent: React.FC = () => {
   }
 
   if (availableDynamicIds?.length > 0 || installed.length > unavailableCount) {
-    return <NoExtensionSelectedPane />;
+    return <NoModSelectedPane />;
   }
 
   if (installed.length > 0) {
-    return <NoExtensionsPane unavailableCount={unavailableCount} />;
+    return <NoModsPane />;
   }
 
   return <WelcomePane />;

--- a/src/pageEditor/panes/NoModSelectedPane.tsx
+++ b/src/pageEditor/panes/NoModSelectedPane.tsx
@@ -21,21 +21,15 @@ import React from "react";
 import Centered from "@/components/Centered";
 import IntroButtons from "./IntroButtons";
 
-const NoExtensionsPane: React.FunctionComponent<{
-  unavailableCount: number;
-}> = ({ unavailableCount }) => (
-  <Centered isScrollable>
-    <div className={styles.title}>No mods on the page</div>
+const NoModSelectedPane: React.FunctionComponent = () => (
+  <Centered>
+    <div className={styles.title}>No mod selected</div>
 
     <div className="text-left">
+      <p>Select a mod in the sidebar to edit</p>
       <p>
-        Click <span className="text-info">Add</span> in the sidebar to add an
-        element to the page.
-      </p>
-
-      <p>
-        Check the &ldquo;Show {unavailableCount ?? 1} unavailable&rdquo; box to
-        list mods that are activated but aren&apos;t available on this page.
+        Or, click the <span className="text-info">Add</span> button in the Mods
+        Panel to add a mod to the page.
       </p>
 
       <IntroButtons />
@@ -43,4 +37,4 @@ const NoExtensionsPane: React.FunctionComponent<{
   </Centered>
 );
 
-export default NoExtensionsPane;
+export default NoModSelectedPane;

--- a/src/pageEditor/panes/NoModsPane.tsx
+++ b/src/pageEditor/panes/NoModsPane.tsx
@@ -21,15 +21,14 @@ import React from "react";
 import Centered from "@/components/Centered";
 import IntroButtons from "./IntroButtons";
 
-const NoExtensionSelectedPane: React.FunctionComponent = () => (
-  <Centered>
-    <div className={styles.title}>No mod selected</div>
+const NoModsPane: React.FunctionComponent = () => (
+  <Centered isScrollable>
+    <div className={styles.title}>No mods on the page</div>
 
     <div className="text-left">
-      <p>Select a mod in the sidebar to edit</p>
       <p>
-        Or, click the <span className="text-info">Add</span> button in the
-        sidebar to add a mod to the page.
+        Click <span className="text-info">Add</span> in the Mods Panel to add a
+        mod to the page.
       </p>
 
       <IntroButtons />
@@ -37,4 +36,4 @@ const NoExtensionSelectedPane: React.FunctionComponent = () => (
   </Centered>
 );
 
-export default NoExtensionSelectedPane;
+export default NoModsPane;

--- a/src/pageEditor/panes/RecipePane.tsx
+++ b/src/pageEditor/panes/RecipePane.tsx
@@ -77,7 +77,7 @@ const RecipePane: React.VFC = () => {
   if (!activeRecipeId) {
     return (
       <Centered>
-        <Alert variant="danger">Recipe not found</Alert>
+        <Alert variant="danger">Mod not found</Alert>
       </Centered>
     );
   }


### PR DESCRIPTION
## What does this PR do?

- Fixes some incorrect copy given that we've removed the "Unavailable" check box in the Page Editor
- Renames some components to use the correct name

## Checklist

- [ ] Add tests: N/A
- [x] Designate a primary reviewer: @turbochef 
