### PR TITLE
Only initialize the quick bar container in top-level frames

### DIFF
--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -30,7 +30,7 @@ import EmotionShadowRoot from "react-shadow/emotion";
 import faStyleSheet from "@fortawesome/fontawesome-svg-core/styles.css?loadAsUrl";
 import { expectContext } from "@/utils/expectContext";
 import { once } from "lodash";
-import { MAX_Z_INDEX } from "@/domConstants";
+import { MAX_Z_INDEX, PIXIEBRIX_QUICK_BAR_CONTAINER_ID } from "@/domConstants";
 import { useEventListener } from "@/hooks/useEventListener";
 import { Stylesheets } from "@/components/Stylesheets";
 import selection from "@/utils/selectionController";
@@ -39,6 +39,7 @@ import QuickBarResults from "./QuickBarResults";
 import useActionGenerators from "@/components/quickBar/useActionGenerators";
 import useActions from "@/components/quickBar/useActions";
 import FocusLock from "react-focus-lock";
+import { isLoadedInIframe } from "@/utils/iframeUtils";
 
 /**
  * Set to true if the KBar should be displayed on initial mount (i.e., because it was triggered by the
@@ -172,8 +173,12 @@ export const QuickBarApp: React.FC = () => (
 export const initQuickBarApp = once(() => {
   expectContext("contentScript");
 
+  if (isLoadedInIframe()) {
+    return;
+  }
+
   const container = document.createElement("div");
-  container.id = "pixiebrix-quickbar-container";
+  container.id = PIXIEBRIX_QUICK_BAR_CONTAINER_ID;
   document.body.prepend(container);
   ReactDOM.render(<QuickBarApp />, container);
 

--- a/src/domConstants.ts
+++ b/src/domConstants.ts
@@ -25,6 +25,8 @@ export const PANEL_FRAME_ID = "pixiebrix-extension";
 
 export const PIXIEBRIX_DATA_ATTR = "data-pb-uuid";
 
+export const PIXIEBRIX_QUICK_BAR_CONTAINER_ID = "pixiebrix-quickbar-container";
+
 export const EXTENSION_POINT_DATA_ATTR = "data-pb-extension-point";
 
 /**
@@ -35,6 +37,7 @@ export const EXTENSION_POINT_DATA_ATTR = "data-pb-extension-point";
 // When adding additional properties, be sure to make sure they're compatible with :not
 export const PRIVATE_ATTRIBUTES_SELECTOR = `
   #${PANEL_FRAME_ID},
+  #${PIXIEBRIX_QUICK_BAR_CONTAINER_ID},
   [${PIXIEBRIX_DATA_ATTR}],
   [${CONTENT_SCRIPT_READY_ATTRIBUTE}],
   [${EXTENSION_POINT_DATA_ATTR}]


### PR DESCRIPTION
## What does this PR do?

- Fixes a bug where the quick bar container is loaded in iframes
- This causes an extra div to be added in the TinyMCE editor frame

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @turbochef 
