### PR TITLE
#6174: mark quickbar/sidebar starter bricks as unavailable in iframes

### DIFF
--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -173,7 +173,9 @@ export const QuickBarApp: React.FC = () => (
 export const initQuickBarApp = once(() => {
   expectContext("contentScript");
 
+  // The QuickBarApp only lives in the top-level frame
   if (isLoadedInIframe()) {
+    console.warn("initQuickBarApp called in iframe");
     return;
   }
 

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -448,6 +448,11 @@ async function loadPersistedExtensions(): Promise<StarterBrick[]> {
               extensionPointId
             );
 
+            if (!(await extensionPoint.isAvailable())) {
+              // For efficiency, just skip synchronization/adding because it won't be available
+              return;
+            }
+
             extensionPoint.synchronizeModComponents(extensions);
 
             // Mark the extensions as installed

--- a/src/starterBricks/quickBarExtension.tsx
+++ b/src/starterBricks/quickBarExtension.tsx
@@ -61,6 +61,7 @@ import { type Schema } from "@/types/schemaTypes";
 import { type ResolvedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type UUID } from "@/types/stringTypes";
+import { isLoadedInIframe } from "@/utils/iframeUtils";
 
 export type QuickBarTargetMode = "document" | "eventTarget";
 
@@ -323,6 +324,11 @@ export class RemoteQuickBarExtensionPoint extends QuickBarStarterBrickABC {
   }
 
   async isAvailable(): Promise<boolean> {
+    // The quick bar lives on the top-level frame. So any actions contributed will never be visible
+    if (isLoadedInIframe()) {
+      return false;
+    }
+
     if (
       !isEmpty(this._definition.isAvailable) &&
       (await checkAvailable(this._definition.isAvailable))

--- a/src/starterBricks/quickBarProviderExtension.tsx
+++ b/src/starterBricks/quickBarProviderExtension.tsx
@@ -62,6 +62,7 @@ import { type UUID } from "@/types/stringTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type ResolvedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
+import { isLoadedInIframe } from "@/utils/iframeUtils";
 
 export type QuickBarProviderConfig = {
   /**
@@ -355,6 +356,11 @@ export class RemoteQuickBarProviderExtensionPoint extends QuickBarProviderStarte
   }
 
   async isAvailable(): Promise<boolean> {
+    // The quick bar lives on the top-level frame. So any actions contributed will never be visible
+    if (isLoadedInIframe()) {
+      return false;
+    }
+
     if (
       !isEmpty(this._definition.isAvailable) &&
       (await checkAvailable(this._definition.isAvailable))

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -66,6 +66,7 @@ import { type UUID } from "@/types/stringTypes";
 import { type RunArgs, RunReason } from "@/types/runtimeTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
 import { type StarterBrick } from "@/types/starterBrickTypes";
+import { isLoadedInIframe } from "@/utils/iframeUtils";
 
 export type SidebarConfig = {
   heading: string;
@@ -502,7 +503,8 @@ class RemotePanelExtensionPoint extends SidebarStarterBrickABC {
   }
 
   async isAvailable(): Promise<boolean> {
-    return checkAvailable(this.definition.isAvailable);
+    // Persistent sidebar panels are not available in iframes. They should be installed on the top frame.
+    return !isLoadedInIframe() && checkAvailable(this.definition.isAvailable);
   }
 }
 

--- a/src/types/starterBrickTypes.ts
+++ b/src/types/starterBrickTypes.ts
@@ -93,7 +93,10 @@ export interface StarterBrick extends Metadata {
    *
    * Safe to call multiple times.
    *
+   * Does not install if `isAvailable` returns false.
+   *
    * @see runModComponents
+   * @see isAvailable
    */
   install(): Promise<boolean>;
 

--- a/src/types/starterBrickTypes.ts
+++ b/src/types/starterBrickTypes.ts
@@ -93,8 +93,6 @@ export interface StarterBrick extends Metadata {
    *
    * Safe to call multiple times.
    *
-   * Does not install if `isAvailable` returns false.
-   *
    * @see runModComponents
    * @see isAvailable
    */


### PR DESCRIPTION
## What does this PR do?

- Part of #6174
- Modifies `isAvailable` check for Quickbar/Sidebar to report not-available in frame
- Modifies lifecycle.ts to check isAvailable prior to registering/synchronizing components

## Discussion

- Reducing the number of irrelevant starter bricks in sub-frames should speed up frame initialization time

## Future Work

- For mod components using inner starter brick definitions, could avoid the hydration step for sidebar/quickbar/etc. starter brick types. That'd avoid the unnecessary work of registering the starter brick definition in the in-memory registry

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
