### PR TITLE
#6174: [WIP] improve content script bundle size/baseline memory utilization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -206,6 +206,7 @@
         "@types/webpack-env": "^1.18.1",
         "@types/whatwg-mimetype": "^3.0.0",
         "axios-mock-adapter": "^1.21.5",
+        "browserslist": "^4.21.10",
         "compass-mixins": "^0.12.10",
         "concurrently": "^8.2.0",
         "cooky-cutter": "^1.5.4",
@@ -15536,9 +15537,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "dev": true,
       "funding": [
         {
@@ -15548,13 +15549,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.11"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -15837,9 +15842,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001427",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001427.tgz",
-      "integrity": "sha512-lfXQ73oB9c8DP5Suxaszm+Ta2sr/4tf8+381GkIm1MLj/YdLf+rEDyDSRCzeltuyTVGm+/s18gdZ0q+Wmp8VsQ==",
+      "version": "1.0.30001519",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
+      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
       "dev": true,
       "funding": [
         {
@@ -15849,6 +15854,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -18989,9 +18998,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.284",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+      "version": "1.4.482",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.482.tgz",
+      "integrity": "sha512-h+UqpfmEr1Qkk0zp7ej/jid7CXoq4m4QzW6wNTb0ELJ/BZCpA4wgUylBIMGCe621tnr4l5VmoHjdoSx2lbnNJA==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -29632,8 +29641,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.6",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "node_modules/nopt": {
@@ -35946,9 +35956,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
       "dev": true,
       "funding": [
         {
@@ -35958,6 +35968,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
@@ -35965,7 +35979,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -49091,15 +49105,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.11"
       }
     },
     "bser": {
@@ -49312,9 +49326,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001427",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001427.tgz",
-      "integrity": "sha512-lfXQ73oB9c8DP5Suxaszm+Ta2sr/4tf8+381GkIm1MLj/YdLf+rEDyDSRCzeltuyTVGm+/s18gdZ0q+Wmp8VsQ==",
+      "version": "1.0.30001519",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
+      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
       "dev": true
     },
     "canvas-confetti": {
@@ -51637,9 +51651,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.284",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+      "version": "1.4.482",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.482.tgz",
+      "integrity": "sha512-h+UqpfmEr1Qkk0zp7ej/jid7CXoq4m4QzW6wNTb0ELJ/BZCpA4wgUylBIMGCe621tnr4l5VmoHjdoSx2lbnNJA==",
       "dev": true
     },
     "elliptic": {
@@ -59737,8 +59751,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.6",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "nopt": {
@@ -64532,9 +64547,9 @@
       "optional": true
     },
     "update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -225,6 +225,7 @@
     "@types/webpack-env": "^1.18.1",
     "@types/whatwg-mimetype": "^3.0.0",
     "axios-mock-adapter": "^1.21.5",
+    "browserslist": "^4.21.10",
     "compass-mixins": "^0.12.10",
     "concurrently": "^8.2.0",
     "cooky-cutter": "^1.5.4",
@@ -284,5 +285,9 @@
   },
   "msw": {
     "workerDirectory": "public"
-  }
+  },
+  "browserslist": [
+    "chrome >= 95",
+    "edge >= 95"
+  ]
 }

--- a/src/bricks/registry.ts
+++ b/src/bricks/registry.ts
@@ -18,12 +18,8 @@
 // eslint-disable-next-line no-restricted-imports
 import BaseRegistry from "../registry/memoryRegistry";
 import { fromJS } from "@/bricks/transformers/brickFactory";
-import {
-  type BrickType,
-  type ResolvedBrickConfig,
-} from "@/runtime/runtimeTypes";
+import { type BrickType } from "@/runtime/runtimeTypes";
 import getType from "@/runtime/getType";
-import { type BrickConfig } from "@/bricks/types";
 import { type RegistryId } from "@/types/registryTypes";
 import { type Brick } from "@/types/brickTypes";
 
@@ -103,17 +99,7 @@ class BrickRegistry extends BaseRegistry<RegistryId, Brick> {
   }
 }
 
+/** Singleton brick registry */
 const registry = new BrickRegistry();
 
 export default registry;
-
-export async function resolveBlockConfig(
-  config: BrickConfig
-): Promise<ResolvedBrickConfig> {
-  const block = await registry.lookup(config.id);
-  return {
-    config,
-    block,
-    type: await getType(block),
-  };
-}

--- a/src/bricks/registry.ts
+++ b/src/bricks/registry.ts
@@ -37,7 +37,10 @@ export type TypedBrickPair = {
 
 export type TypedBlockMap = Map<RegistryId, TypedBrickPair>;
 
-class BricksRegistry extends BaseRegistry<RegistryId, Brick> {
+/**
+ * In-memory brick registry.
+ */
+class BrickRegistry extends BaseRegistry<RegistryId, Brick> {
   constructor() {
     super(["block", "component", "effect", "reader"], fromJS);
 
@@ -100,7 +103,7 @@ class BricksRegistry extends BaseRegistry<RegistryId, Brick> {
   }
 }
 
-const registry = new BricksRegistry();
+const registry = new BrickRegistry();
 
 export default registry;
 

--- a/src/components/floatingActions/initFloatingActions.ts
+++ b/src/components/floatingActions/initFloatingActions.ts
@@ -54,6 +54,7 @@ export default async function initFloatingActions(): Promise<void> {
     !isEnterpriseOrPartnerUser
   ) {
     const { renderFloatingActions } = await import(
+      /* webpackMode: "lazy" */
       /* webpackChunkName: "fab" */ "@/components/floatingActions/FloatingActions"
     );
     await renderFloatingActions();

--- a/src/components/floatingActions/initFloatingActions.ts
+++ b/src/components/floatingActions/initFloatingActions.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { isLoadedInIframe } from "@/utils/iframeUtils";
+import { getSettingsState } from "@/store/settingsStorage";
+import { getUserData } from "@/background/messenger/api";
+import { DEFAULT_THEME } from "@/themes/themeTypes";
+import { syncFlagOn } from "@/store/syncFlags";
+
+/**
+ * Add the floating action button to the page if the user is not an enterprise/partner user.
+ *
+ * Split from FloatingActions.tsx to avoid importing React in frames that don't need it.
+ */
+export default async function initFloatingActions(): Promise<void> {
+  if (isLoadedInIframe()) {
+    // Skip expensive checks
+    return;
+  }
+
+  const [settings, { telemetryOrganizationId }] = await Promise.all([
+    getSettingsState(),
+    getUserData(),
+  ]);
+
+  // `telemetryOrganizationId` indicates user is part of an enterprise organization
+  // See https://github.com/pixiebrix/pixiebrix-app/blob/39fac4874402a541f62e80ab74aaefd446cc3743/api/models/user.py#L68-L68
+  // Just get the theme from the store instead of using getActive theme to avoid extra Chrome storage reads
+  // In practice, the Chrome policy should not change between useGetTheme and a call to initFloatingActions on a page
+  const isEnterpriseOrPartnerUser =
+    Boolean(telemetryOrganizationId) || settings.theme !== DEFAULT_THEME;
+
+  // Add floating action button if the feature flag and settings are enabled
+  // XXX: consider moving checks into React component, so we can use the Redux context
+  if (
+    settings.isFloatingActionButtonEnabled &&
+    // XXX: there's likely a race here with when syncFlagOn gets the flag from localStorage. But in practice, this
+    // seems to work fine. (Likely because the flags will be loaded by the time the Promise.all above resolves)
+    syncFlagOn("floating-quickbar-button-freemium") &&
+    !isEnterpriseOrPartnerUser
+  ) {
+    const { renderFloatingActions } = await import(
+      /* webpackChunkName: "fab" */ "@/components/floatingActions/FloatingActions"
+    );
+    await renderFloatingActions();
+  }
+}

--- a/src/contentScript/contentScript.ts
+++ b/src/contentScript/contentScript.ts
@@ -33,7 +33,7 @@ import { logPromiseDuration } from "@/utils/promiseUtils";
 // eslint-disable-next-line prefer-destructuring -- process.env substitution
 const DEBUG = process.env.DEBUG;
 
-// Track module load so we hear something from content script in the console if Chrome attempted to import the module.
+// Track module load, so we hear something from content script in the console if Chrome attempted to import the module.
 console.debug("contentScript: module load");
 
 // See note in `@/contentScript/ready.ts` for further details about the lifecycle of content scripts

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -34,9 +34,9 @@ import {
   notifyContextInvalidated,
 } from "@/errors/contextInvalidated";
 import { onUncaughtError } from "@/errors/errorHelpers";
-import { initFloatingActions } from "@/components/floatingActions/FloatingActions";
 import { initSidebarActivation } from "@/contentScript/sidebarActivation";
 import { initPerformanceMonitoring } from "@/contentScript/performanceMonitoring";
+import initFloatingActions from "@/components/floatingActions/initFloatingActions";
 
 // Must come before the default handler for ignoring errors. Otherwise, this handler might not be run
 onUncaughtError((error) => {
@@ -53,6 +53,9 @@ export async function init(): Promise<void> {
 
   registerMessenger();
   registerExternalMessenger();
+
+  // Need to register even if there are no mods on the page because mods may run bricks in this frame.
+  // For performance, would be nice to find a way to lazy-load
   registerBuiltinBlocks();
   registerContribBlocks();
 

--- a/src/errors/contextInvalidated.ts
+++ b/src/errors/contextInvalidated.ts
@@ -30,10 +30,11 @@ const id = "connection-lost";
  * all communication becomes impossible.
  */
 export async function notifyContextInvalidated(): Promise<void> {
-  // `import()` is only needed to avoid execution of its dependencies, not to lazy-load it
+  // `import()` is needed to avoid execution of its dependencies (telemetry)
+  // Also, lazily importing avoid importing React unnecessarily
   // https://github.com/pixiebrix/pixiebrix-extension/issues/4058#issuecomment-1217391772
-  // eslint-disable-next-line import/dynamic-import-chunkname
-  const { notify } = await import(/* webpackMode: "eager" */ "@/utils/notify");
+  // eslint-disable-next-line import/dynamic-import-chunkname -- avoid importing react
+  const { notify } = await import(/* webpackMode: "lazy" */ "@/utils/notify");
   notify.error({
     id,
     message: "PixieBrix was updated or restarted. Reload the page to continue",
@@ -51,6 +52,9 @@ export function isContextInvalidatedError(possibleError: unknown): boolean {
   );
 }
 
+/**
+ * Return true if the browser extension context has been invalidated, e.g., due to a restart/update/crash.
+ */
 export const wasContextInvalidated = () => !chrome.runtime?.id;
 
 /**

--- a/src/runtime/runtimeTypes.ts
+++ b/src/runtime/runtimeTypes.ts
@@ -20,6 +20,7 @@ import { type Brick } from "@/types/brickTypes";
 import { type BrickArgs, type OutputKey } from "@/types/runtimeTypes";
 
 export type BrickType = "reader" | "effect" | "transform" | "renderer";
+
 /**
  * A block configuration with the corresponding resolved Brick and BrickType.
  * @see BrickConfig

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -15,7 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { valid as semVerValid } from "semver";
+// Don't import from "semver" b/c tree-shaking doesn't work and this file is included in the contentScript
+import semVerValid from "semver/functions/valid";
 import { startsWith } from "lodash";
 import validUuidRegex from "@/vendors/validateUuid";
 import { type Timestamp, type UUID } from "@/types/stringTypes";

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -20,7 +20,6 @@ import * as semver from "semver";
 import { type MarketplaceListing, type Organization } from "@/types/contract";
 import {
   type Mod,
-  type ModViewItem,
   type SharingSource,
   type SharingType,
   type UnavailableMod,
@@ -34,9 +33,6 @@ import {
 } from "@/types/modComponentTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type UUID } from "@/types/stringTypes";
-import { type StarterBrickType } from "@/starterBricks/types";
-import extensionPointRegistry from "@/starterBricks/registry";
-import { getContainedStarterBrickTypes } from "@/utils/modDefinitionUtils";
 
 /**
  * Returns true if the mod is an UnavailableMod
@@ -332,54 +328,3 @@ export const selectExtensionsFromMod = createSelector(
         )
       : installedExtensions.filter((x) => x.id === mod.id)
 );
-
-export const StarterBrickMap: Record<StarterBrickType, string> = {
-  panel: "Sidebar Panel",
-  menuItem: "Button",
-  trigger: "Trigger",
-  contextMenu: "Context Menu",
-  actionPanel: "Sidebar",
-  quickBar: "Quick Bar Action",
-  quickBarProvider: "Dynamic Quick Bar",
-  tour: "Tour",
-};
-
-const getStarterBrickType = async (
-  modComponent: ResolvedModComponent
-): Promise<StarterBrickType> => {
-  const extensionPoint = await extensionPointRegistry.lookup(
-    modComponent.extensionPointId
-  );
-
-  return extensionPoint.kind as StarterBrickType;
-};
-
-const getExtensionPointTypesContained = async (
-  modViewItem: ModViewItem
-): Promise<StarterBrickType[]> => {
-  if (isUnavailableMod(modViewItem.mod)) {
-    return [];
-  }
-
-  return isModDefinition(modViewItem.mod)
-    ? getContainedStarterBrickTypes(modViewItem.mod)
-    : [await getStarterBrickType(modViewItem.mod)];
-};
-
-export const getContainedStarterBrickNames = async (
-  modViewItem: ModViewItem
-): Promise<string[]> => {
-  const extensionPointTypes = await getExtensionPointTypesContained(
-    modViewItem
-  );
-  const starterBricksContained = [];
-  for (const extensionPointType of extensionPointTypes) {
-    // eslint-disable-next-line security/detect-object-injection -- extensionPointType is type ExtensionPointType
-    const starterBrick = StarterBrickMap[extensionPointType];
-    if (starterBrick) {
-      starterBricksContained.push(starterBrick);
-    }
-  }
-
-  return starterBricksContained;
-};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -308,6 +308,10 @@ module.exports = (env, options) =>
       alias: {
         ...mockHeavyDependencies(),
 
+        // Transparently swap with tree-shakable lodash-es
+        // See corresponding entry in tsconfig.json
+        lodash: "lodash-es",
+
         ...(isProd(options) || process.env.DEV_REDUX_LOGGER === "false"
           ? { "redux-logger": false }
           : {}),


### PR DESCRIPTION
## What does this PR do?

- Part of #6174 

## Remaining Work

- [x] Conditionally import React - currently imported by notification system. Need to verify behavior if the browser extension context is invalidated, though
- [x] Conditionally imports FAB
- [ ] Conditionally import JS bricks
- [ ] Tries to fix lodash module shaking -- still all being included in the bundle 😞 

## Discussion

- Previously we had already split contentScript entry point from contentScriptCore. contentScript is a small entry point to bootstrap contentScriptCore if it hasn't already been initialized

## Demo

### Before
contentScript (635KB stat)
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/b612eb97-a099-4275-ae1e-8f881cc2d8ab)

contentScript core (1.1MB stat)
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/12ce28f4-82e2-436b-ad75-bd263a6b0d30)

### After

- _Paste a screenshot or demo video here_

## Future Work

- _Work for the issue/ticket that will be in a follow-up PR_

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
