### PR TITLE
#6231: run content script on http pages

### DIFF
--- a/src/contentScript/contentScript.ts
+++ b/src/contentScript/contentScript.ts
@@ -33,6 +33,18 @@ import { logPromiseDuration } from "@/utils/promiseUtils";
 // eslint-disable-next-line prefer-destructuring -- process.env substitution
 const DEBUG = process.env.DEBUG;
 
+/**
+ * Protocol allowlist for running the content script. See manifest.json for content script registration.
+ * @since 1.7.36 allow http protocol to support some enterprise development use cases without https tunnel
+ * @since 1.7.36 allow about: protocol to support srcdoc iframes
+ */
+const ALLOWED_PROTOCOLS = [
+  "https:",
+  "http:",
+  // Does not appear in manifest.json, because it corresponds to iframes using srcdoc
+  "about:",
+];
+
 // Track module load so we hear something from content script in the console if Chrome attempted to import the module.
 console.debug("contentScript: module load");
 
@@ -80,7 +92,7 @@ async function initContentScript() {
 }
 
 // Support running in secure pages and about: pages, which are used by srcdoc frames
-if (["https:", "about:"].includes(location.protocol) || DEBUG) {
+if (ALLOWED_PROTOCOLS.includes(location.protocol) || DEBUG) {
   // eslint-disable-next-line promise/prefer-await-to-then -- top-level await isn't available
   void initContentScript().catch((error) => {
     throw new Error("Error initializing contentScript", { cause: error });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,7 @@
   "content_security_policy": "script-src 'self' https://apis.google.com 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https:; object-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-src 'self' https: https://*.googleapis.com https://docs.google.com",
   "content_scripts": [
     {
-      "matches": ["https://*/*"],
+      "matches": ["https://*/*", "http://*/*"],
       "js": ["contentScript.js"],
       "css": ["contentScript.css"],
       "all_frames": true,

--- a/src/pageEditor/NonScriptablePage.tsx
+++ b/src/pageEditor/NonScriptablePage.tsx
@@ -68,13 +68,7 @@ const NonScriptablePage: React.FunctionComponent<{ url: string }> = ({
     <div className="my-auto">
       <Row className={styles.paneRow}>
         <Col lg={9}>
-          {url?.startsWith("http://") ? (
-            <Alert variant="warning">
-              PixieBrix cannot modify insecure HTTP pages
-            </Alert>
-          ) : (
-            <GetStarted />
-          )}
+          <GetStarted />
         </Col>
 
         <Col

--- a/src/pageEditor/NonScriptablePage.tsx
+++ b/src/pageEditor/NonScriptablePage.tsx
@@ -20,7 +20,6 @@ import styles from "./NonScriptablePage.module.scss";
 import React from "react";
 import { Col, Row, Container } from "react-bootstrap";
 import workshopImage from "@img/workshop.svg";
-import Alert from "@/components/Alert";
 
 const GetStarted: React.FunctionComponent = () => (
   <>

--- a/src/pageEditor/panes/NonScriptablePage.test.tsx
+++ b/src/pageEditor/panes/NonScriptablePage.test.tsx
@@ -17,8 +17,7 @@
 
 import React from "react";
 import NonScriptablePage from "@/pageEditor/NonScriptablePage";
-import { render, screen } from "@/pageEditor/testHelpers";
-import { waitFor } from "@testing-library/react";
+import { render } from "@/pageEditor/testHelpers";
 
 describe("NonScriptablePage", () => {
   test("it renders", () => {
@@ -26,13 +25,9 @@ describe("NonScriptablePage", () => {
     expect(rendered.asFragment()).toMatchSnapshot();
   });
 
-  test("it renders right copy when the URL is HTTP", async () => {
-    render(<NonScriptablePage url="http://example.com" />);
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("PixieBrix cannot modify insecure HTTP pages")
-      ).not.toBeNull();
-    });
+  // Since 1.7.36 http: URLs are permitted
+  test("it renders http snapshot", () => {
+    const rendered = render(<NonScriptablePage url="http://test.url" />);
+    expect(rendered.asFragment()).toMatchSnapshot();
   });
 });

--- a/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
@@ -75,3 +75,79 @@ exports[`NonScriptablePage it renders 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`NonScriptablePage it renders http snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="root container-fluid"
+  >
+    <div
+      class="my-auto"
+    >
+      <div
+        class="paneRow row"
+      >
+        <div
+          class="col-lg-9"
+        >
+          <h4
+            class="callout"
+          >
+            Get started with PixieBrix
+          </h4>
+          <p>
+            This is the PixieBrix Page Editor. Use the Page Editor to create web page modifications, called mods.
+          </p>
+          <p>
+            To start, navigate to a web page that you'd like to modify and then click the "Add" button.
+          </p>
+        </div>
+        <div
+          class="d-flex align-items-center justify-content-center col-lg-3"
+        >
+          <img
+            alt=""
+            class="illustration"
+            src="test-file-stub"
+            width="100%"
+          />
+        </div>
+      </div>
+      <div
+        class="paneRowWithDivider row"
+      >
+        <div
+          class="col-lg-9"
+        >
+          <div>
+            <h4
+              class="tinyCallout"
+            >
+              Need more help?
+            </h4>
+            <p>
+              Visit the 
+              <a
+                href="https://docs.pixiebrix.com/quick-start-guide"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Quick Start Guide
+              </a>
+               or ask questions in the 
+              <a
+                href="https://pixiebrixcommunity.slack.com/join/shared_invite/zt-13gmwdijb-Q5nVsSx5wRLmRwL3~lsDww#/shared-invite/email"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Slack Community
+              </a>
+              . 
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/utils/urlUtils.ts
+++ b/src/utils/urlUtils.ts
@@ -63,6 +63,11 @@ export function safeParseUrl(url: string, baseUrl?: string): URL {
   }
 }
 
+/**
+ * Returns true if `value` is a valid absolute URL with a protocol in `protocols`
+ * @param value the value to check
+ * @param protocols valid protocols including colon, defaults to http: and https:
+ */
 export function isValidUrl(
   value: string,
   { protocols = ["http:", "https:"] }: { protocols?: string[] } = {}


### PR DESCRIPTION
## What does this PR do?

- Closes #6231: allows the content script to run on HTTP pages
- The restriction for only making HTTPS API calls still applies

## Discussion

- We might consider making this end-user and managed enterprise settings

## Remaining Work

- [x] Verify the change doesn't require manual permissions acceptance on upgrade

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
