### PR TITLE
#6208: lazily load react in content script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15838,9 +15838,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001427",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001427.tgz",
-      "integrity": "sha512-lfXQ73oB9c8DP5Suxaszm+Ta2sr/4tf8+381GkIm1MLj/YdLf+rEDyDSRCzeltuyTVGm+/s18gdZ0q+Wmp8VsQ==",
+      "version": "1.0.30001519",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
+      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
       "dev": true,
       "funding": [
         {
@@ -15850,6 +15850,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -49316,9 +49320,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001427",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001427.tgz",
-      "integrity": "sha512-lfXQ73oB9c8DP5Suxaszm+Ta2sr/4tf8+381GkIm1MLj/YdLf+rEDyDSRCzeltuyTVGm+/s18gdZ0q+Wmp8VsQ==",
+      "version": "1.0.30001519",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
+      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
       "dev": true
     },
     "canvas-confetti": {

--- a/src/components/floatingActions/initFloatingActions.ts
+++ b/src/components/floatingActions/initFloatingActions.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { isLoadedInIframe } from "@/utils/iframeUtils";
+import { getSettingsState } from "@/store/settingsStorage";
+import { getUserData } from "@/background/messenger/api";
+import { DEFAULT_THEME } from "@/themes/themeTypes";
+import { syncFlagOn } from "@/store/syncFlags";
+
+/**
+ * Add the floating action button to the page if the user is not an enterprise/partner user.
+ *
+ * Split from FloatingActions.tsx to avoid importing React in frames that don't need it.
+ */
+export default async function initFloatingActions(): Promise<void> {
+  if (isLoadedInIframe()) {
+    // Skip expensive checks
+    return;
+  }
+
+  const [settings, { telemetryOrganizationId }] = await Promise.all([
+    getSettingsState(),
+    getUserData(),
+  ]);
+
+  // `telemetryOrganizationId` indicates user is part of an enterprise organization
+  // See https://github.com/pixiebrix/pixiebrix-app/blob/39fac4874402a541f62e80ab74aaefd446cc3743/api/models/user.py#L68-L68
+  // Just get the theme from the store instead of using getActive theme to avoid extra Chrome storage reads
+  // In practice, the Chrome policy should not change between useGetTheme and a call to initFloatingActions on a page
+  const isEnterpriseOrPartnerUser =
+    Boolean(telemetryOrganizationId) || settings.theme !== DEFAULT_THEME;
+
+  // Add floating action button if the feature flag and settings are enabled
+  // XXX: consider moving checks into React component, so we can use the Redux context
+  if (
+    settings.isFloatingActionButtonEnabled &&
+    // XXX: there's likely a race here with when syncFlagOn gets the flag from localStorage. But in practice, this
+    // seems to work fine. (Likely because the flags will be loaded by the time the Promise.all above resolves)
+    syncFlagOn("floating-quickbar-button-freemium") &&
+    !isEnterpriseOrPartnerUser
+  ) {
+    const { renderFloatingActions } = await import(
+      /* webpackMode: "lazy" */
+      /* webpackChunkName: "fab" */ "@/components/floatingActions/FloatingActions"
+    );
+    await renderFloatingActions();
+  }
+}

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -34,7 +34,7 @@ import {
   notifyContextInvalidated,
 } from "@/errors/contextInvalidated";
 import { onUncaughtError } from "@/errors/errorHelpers";
-import { initFloatingActions } from "@/components/floatingActions/FloatingActions";
+import initFloatingActions from "@/components/floatingActions/initFloatingActions";
 import { initSidebarActivation } from "@/contentScript/sidebarActivation";
 import { initPerformanceMonitoring } from "@/contentScript/performanceMonitoring";
 

--- a/src/errors/contextInvalidated.ts
+++ b/src/errors/contextInvalidated.ts
@@ -23,19 +23,23 @@ import {
   getRootCause,
 } from "./errorHelpers";
 
-const id = "connection-lost";
+/**
+ * Notification id to avoid displaying the same notification multiple times.
+ */
+const CONNECT_LOST_NOTIFICATION_ID = "connection-lost";
 
 /**
  * Display a notification when the background page unloads/reloads because at this point
  * all communication becomes impossible.
  */
 export async function notifyContextInvalidated(): Promise<void> {
-  // `import()` is only needed to avoid execution of its dependencies, not to lazy-load it
+  // `import()` is needed to avoid execution of its dependencies (telemetry)
+  // Also, lazily import to avoid importing React unnecessarily
   // https://github.com/pixiebrix/pixiebrix-extension/issues/4058#issuecomment-1217391772
   // eslint-disable-next-line import/dynamic-import-chunkname
-  const { notify } = await import(/* webpackMode: "eager" */ "@/utils/notify");
+  const { notify } = await import(/* webpackMode: "lazy" */ "@/utils/notify");
   notify.error({
-    id,
+    id: CONNECT_LOST_NOTIFICATION_ID,
     message: "PixieBrix was updated or restarted. Reload the page to continue",
     reportError: false, // It cannot report it because its background page no longer exists
     duration: Number.POSITIVE_INFINITY,
@@ -51,6 +55,9 @@ export function isContextInvalidatedError(possibleError: unknown): boolean {
   );
 }
 
+/**
+ * Return true if the browser extension context has been invalidated, e.g., due to a restart/update/crash.
+ */
 export const wasContextInvalidated = () => !chrome.runtime?.id;
 
 /**

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -20,7 +20,6 @@ import * as semver from "semver";
 import { type MarketplaceListing, type Organization } from "@/types/contract";
 import {
   type Mod,
-  type ModViewItem,
   type SharingSource,
   type SharingType,
   type UnavailableMod,
@@ -34,9 +33,6 @@ import {
 } from "@/types/modComponentTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type UUID } from "@/types/stringTypes";
-import { type StarterBrickType } from "@/starterBricks/types";
-import extensionPointRegistry from "@/starterBricks/registry";
-import { getContainedStarterBrickTypes } from "@/utils/modDefinitionUtils";
 
 /**
  * Returns true if the mod is an UnavailableMod
@@ -332,54 +328,3 @@ export const selectExtensionsFromMod = createSelector(
         )
       : installedExtensions.filter((x) => x.id === mod.id)
 );
-
-export const StarterBrickMap: Record<StarterBrickType, string> = {
-  panel: "Sidebar Panel",
-  menuItem: "Button",
-  trigger: "Trigger",
-  contextMenu: "Context Menu",
-  actionPanel: "Sidebar",
-  quickBar: "Quick Bar Action",
-  quickBarProvider: "Dynamic Quick Bar",
-  tour: "Tour",
-};
-
-const getStarterBrickType = async (
-  modComponent: ResolvedModComponent
-): Promise<StarterBrickType> => {
-  const extensionPoint = await extensionPointRegistry.lookup(
-    modComponent.extensionPointId
-  );
-
-  return extensionPoint.kind as StarterBrickType;
-};
-
-const getExtensionPointTypesContained = async (
-  modViewItem: ModViewItem
-): Promise<StarterBrickType[]> => {
-  if (isUnavailableMod(modViewItem.mod)) {
-    return [];
-  }
-
-  return isModDefinition(modViewItem.mod)
-    ? getContainedStarterBrickTypes(modViewItem.mod)
-    : [await getStarterBrickType(modViewItem.mod)];
-};
-
-export const getContainedStarterBrickNames = async (
-  modViewItem: ModViewItem
-): Promise<string[]> => {
-  const extensionPointTypes = await getExtensionPointTypesContained(
-    modViewItem
-  );
-  const starterBricksContained = [];
-  for (const extensionPointType of extensionPointTypes) {
-    // eslint-disable-next-line security/detect-object-injection -- extensionPointType is type ExtensionPointType
-    const starterBrick = StarterBrickMap[extensionPointType];
-    if (starterBrick) {
-      starterBricksContained.push(starterBrick);
-    }
-  }
-
-  return starterBricksContained;
-};


### PR DESCRIPTION
## What does this PR do?

- Part of #6208 
- Lazily load React in the content script
  - Lazily load the FAB
  - Lazily load the notification toaster
- Drops some dead code from modUtils

## Discussion

- The main thing I was concerned about is the "Context Invalidated" message not showing if the extension context was necessary for dynamic imports. I tested that locally
- There's a decent chance React will still get loaded eagerly (but dynamically) due to brick instances being eagerly loaded in contentScriptCore. React ends up in the same bundle as nunjucks

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/59af6c53-406f-45dc-96e5-ed6adc099404)

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/c95c1b3d-d219-484b-b5c8-8cd48a65450d)

## Future Work

- The remaining unnecessary code in the contentScript appears to be from broken tree-shaking for lodash-es and semVer
- I'm also not sure what the buffer polyfill is used for (probably being added due to NodePolyfillPlugin usage)
- Lazy load brick entities into memory to lower memory usage where no mods are active

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @grahamlangford 
