### PR TITLE
Add basic telemetry for experimental options and popover

### DIFF
--- a/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
@@ -15,13 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { useEffect } from "react";
 import { type FieldInputMode } from "@/components/fields/schemaFields/fieldInputMode";
 import { replaceLikelyVariable } from "./likelyVariableUtils";
 import VarMenu from "./VarMenu";
 import fitTextarea from "fit-textarea";
 import { getPathFromArray } from "@/runtime/pathHelpers";
 import useAttachPopup from "@/components/fields/schemaFields/widgets/varPopup/useAttachPopup";
+import reportEvent from "@/telemetry/reportEvent";
+import { Events } from "@/telemetry/events";
 
 type VarPopupProps = {
   /**
@@ -54,11 +56,21 @@ const VarPopup: React.FunctionComponent<VarPopupProps> = ({
     value,
   });
 
+  useEffect(() => {
+    if (isMenuShowing) {
+      reportEvent(Events.VAR_POPOVER_SHOW, {
+        inputMode,
+      });
+    }
+  }, [isMenuShowing, inputMode]);
+
   if (!isMenuShowing) {
     return null;
   }
 
   const onVarSelect = (selectedPath: string[]) => {
+    reportEvent(Events.VAR_POPOVER_SELECT);
+
     const fullVariableName = getPathFromArray(selectedPath);
 
     switch (inputMode) {

--- a/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
+++ b/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
@@ -25,6 +25,8 @@ import { faFlask } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { selectSettings } from "@/store/settingsSelectors";
 import { type SkunkworksSettings } from "@/store/settingsTypes";
+import reportEvent from "@/telemetry/reportEvent";
+import { Events } from "@/telemetry/events";
 
 const ExperimentalFeature: React.FunctionComponent<{
   id: keyof SkunkworksSettings;
@@ -64,6 +66,21 @@ const ExperimentalSettings: React.FunctionComponent = () => {
     performanceTracing,
   } = useSelector(selectSettings);
 
+  const flagChangeHandlerFactory =
+    (flag: keyof SkunkworksSettings) => (value: boolean) => {
+      reportEvent(Events.SKUNKWORKS_CONFIGURE, {
+        name: flag,
+        value,
+      });
+
+      dispatch(
+        settingsSlice.actions.setFlag({
+          flag,
+          value,
+        })
+      );
+    };
+
   return (
     <Card>
       <Card.Header>
@@ -77,14 +94,7 @@ const ExperimentalSettings: React.FunctionComponent = () => {
             description="Toggle on to enable element suggestions/filtering in Page Editor
             selection mode"
             isEnabled={suggestElements}
-            onChange={(value) => {
-              dispatch(
-                settingsSlice.actions.setFlag({
-                  flag: "suggestElements",
-                  value,
-                })
-              );
-            }}
+            onChange={flagChangeHandlerFactory("suggestElements")}
           />
           <ExperimentalFeature
             id="excludeRandomClasses"
@@ -92,56 +102,28 @@ const ExperimentalSettings: React.FunctionComponent = () => {
             description="Toggle on to avoid using randomly-generated classes when picking
             elements from a website"
             isEnabled={excludeRandomClasses}
-            onChange={(value) => {
-              dispatch(
-                settingsSlice.actions.setFlag({
-                  flag: "excludeRandomClasses",
-                  value,
-                })
-              );
-            }}
+            onChange={flagChangeHandlerFactory("excludeRandomClasses")}
           />
           <ExperimentalFeature
             id="selectionTools"
             label="Detect and Support Multi-Element Selection Tools:"
             description="Toggle on to support multi-element selection tools"
             isEnabled={selectionTools}
-            onChange={(value) => {
-              dispatch(
-                settingsSlice.actions.setFlag({
-                  flag: "selectionTools",
-                  value,
-                })
-              );
-            }}
+            onChange={flagChangeHandlerFactory("selectionTools")}
           />
           <ExperimentalFeature
             id="varAutosuggest"
             label="Autosuggest Variables in Page Editor:"
             description="Toggle on to enable variable autosuggest for variable and text template entry modes"
             isEnabled={varAutosuggest}
-            onChange={(value) => {
-              dispatch(
-                settingsSlice.actions.setFlag({
-                  flag: "varAutosuggest",
-                  value,
-                })
-              );
-            }}
+            onChange={flagChangeHandlerFactory("varAutosuggest")}
           />
           <ExperimentalFeature
             id="performanceTracing"
             label="Performance Tracing:"
             description="Toggle on to trace runtime performance"
             isEnabled={performanceTracing}
-            onChange={(value) => {
-              dispatch(
-                settingsSlice.actions.setFlag({
-                  flag: "performanceTracing",
-                  value,
-                })
-              );
-            }}
+            onChange={flagChangeHandlerFactory("performanceTracing")}
           />
         </Form>
       </Card.Body>

--- a/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
+++ b/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
@@ -68,7 +68,7 @@ const ExperimentalSettings: React.FunctionComponent = () => {
 
   const flagChangeHandlerFactory =
     (flag: keyof SkunkworksSettings) => (value: boolean) => {
-      reportEvent(Events.SKUNKWORKS_CONFIGURE, {
+      reportEvent(Events.SETTINGS_EXPERIMENTAL_CONFIGURE, {
         name: flag,
         value,
       });

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -79,6 +79,9 @@ export const Events = {
   PAGE_EDITOR_SESSION_START: "PageEditorSessionStart",
   PAGE_EDITOR_SESSION_END: "PageEditorSessionEnd",
 
+  VAR_POPOVER_SHOW: "VarPopoverShow",
+  VAR_POPOVER_SELECT: "VarPopoverSelect",
+
   PANEL_ADD: "PanelAdd",
 
   PIXIEBRIX_INSTALL: "PixieBrixInstall",
@@ -100,6 +103,7 @@ export const Events = {
   SIDE_BAR_SHOW: "SidePanelShow",
 
   SNOOZE_UPDATES: "SnoozeUpdates",
+  SKUNKWORKS_CONFIGURE: "SkunkworksConfigure",
 
   START_MOD_ACTIVATE: "StartInstallBlueprint",
 

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -103,7 +103,7 @@ export const Events = {
   SIDE_BAR_SHOW: "SidePanelShow",
 
   SNOOZE_UPDATES: "SnoozeUpdates",
-  SKUNKWORKS_CONFIGURE: "SkunkworksConfigure",
+  SETTINGS_EXPERIMENTAL_CONFIGURE: "SettingsExperimentalConfigure",
 
   START_MOD_ACTIVATE: "StartInstallBlueprint",
 


### PR DESCRIPTION
## What does this PR do?

- Adds the following events:
  - VarPopoverShow
  - VarPopoverSelect
  - SettingsExperimentalConfigure

## Future Work

- Indicate in VarPopoverSelect if the mouse or keyboard was used to select it

## Checklist

- [x] Add tests: N/A
- [x] Designate a primary reviewer: @mnholtz 
