### PR TITLE
#6160 - slice 3 make persistent tabs closable

### DIFF
--- a/src/sidebar/Tabs.test.tsx
+++ b/src/sidebar/Tabs.test.tsx
@@ -18,7 +18,7 @@
 import React from "react";
 import Tabs from "@/sidebar/Tabs";
 import { render } from "@/sidebar/testHelpers";
-import { type PanelEntry } from "@/types/sidebarTypes";
+import { type SidebarEntries } from "@/types/sidebarTypes";
 import sidebarSlice from "@/sidebar/sidebarSlice";
 import { sidebarEntryFactory } from "@/testUtils/factories/sidebarEntryFactories";
 import { screen, within } from "@testing-library/react";
@@ -31,23 +31,21 @@ jest.mock("@/hooks/useFlags", () =>
   jest.fn().mockReturnValue({ flagOn: jest.fn() })
 );
 
-async function setupPanelsAndRender(
-  panels: PanelEntry[] = [],
-  hasModLauncher = false
-) {
+async function setupPanelsAndRender(sidebarEntries: Partial<SidebarEntries>) {
   (useFlags as jest.Mock).mockReturnValue({
-    flagOn: jest.fn().mockReturnValue(hasModLauncher),
+    flagOn: jest.fn().mockReturnValue(sidebarEntries.staticPanels?.length > 0),
   });
 
   const renderResult = render(<Tabs />, {
     setupRedux(dispatch) {
       dispatch(
         sidebarSlice.actions.setInitialPanels({
-          panels,
-          staticPanels: hasModLauncher ? [MOD_LAUNCHER] : [],
+          panels: [],
+          staticPanels: [],
           temporaryPanels: [],
           forms: [],
           modActivationPanel: undefined,
+          ...sidebarEntries,
         })
       );
     },
@@ -67,20 +65,22 @@ describe("Tabs", () => {
   });
 
   test("renders with panels", async () => {
-    await setupPanelsAndRender([panel]);
+    await setupPanelsAndRender({ panels: [panel] });
 
     expect(screen.getByText("Panel Test 1")).toBeInTheDocument();
   });
 
   describe("Mod Launcher", () => {
     test("renders with mod launcher when flag is enabled", async () => {
-      const { asFragment } = await setupPanelsAndRender([], true);
+      const { asFragment } = await setupPanelsAndRender({
+        staticPanels: [MOD_LAUNCHER],
+      });
 
       expect(asFragment()).toMatchSnapshot();
     });
 
     test("displays no active sidebar panels view when no panels are active", async () => {
-      await setupPanelsAndRender([], true);
+      await setupPanelsAndRender({ staticPanels: [MOD_LAUNCHER] });
 
       expect(
         screen.getByText("We didn't find any mods to run")
@@ -91,7 +91,10 @@ describe("Tabs", () => {
     });
 
     test("can close the mod launcher", async () => {
-      await setupPanelsAndRender([panel], true);
+      await setupPanelsAndRender({
+        panels: [panel],
+        staticPanels: [MOD_LAUNCHER],
+      });
 
       expect(screen.getByText("Mods")).toBeInTheDocument();
 
@@ -100,12 +103,15 @@ describe("Tabs", () => {
         .click();
 
       expect(
-        screen.queryByRole("tabs", { name: /mods/i })
+        screen.queryByRole("tab", { name: /mods/i })
       ).not.toBeInTheDocument();
     });
 
     test("can open the mod launcher", async () => {
-      await setupPanelsAndRender([panel], true);
+      await setupPanelsAndRender({
+        panels: [panel],
+        staticPanels: [MOD_LAUNCHER],
+      });
 
       expect(screen.getByText("Mods")).toBeInTheDocument();
 
@@ -121,7 +127,7 @@ describe("Tabs", () => {
     });
 
     test("clicking open the mod launcher multiple times does not open multiple mod launchers", async () => {
-      await setupPanelsAndRender([], true);
+      await setupPanelsAndRender({ staticPanels: [MOD_LAUNCHER] });
 
       expect(screen.getByText("Mods")).toBeInTheDocument();
 
@@ -135,19 +141,22 @@ describe("Tabs", () => {
 
   describe("Persistent Panels", () => {
     test("can close a panel when mod launcher is available", async () => {
-      await setupPanelsAndRender([panel], true);
+      await setupPanelsAndRender({
+        panels: [panel],
+        staticPanels: [MOD_LAUNCHER],
+      });
 
       within(screen.getByRole("tab", { name: /panel test 1/i }))
         .getByRole("button", { name: "Close" })
         .click();
 
       expect(
-        screen.queryByRole("tabs", { name: /panel test 1/i })
+        screen.queryByRole("tab", { name: /panel test 1/i })
       ).not.toBeInTheDocument();
     });
 
     test("cannot close panel when mod launcher is unavailable", async () => {
-      await setupPanelsAndRender([panel], false);
+      await setupPanelsAndRender({ panels: [panel] });
 
       expect(
         within(screen.getByRole("tab", { name: /panel test 1/i })).queryByRole(
@@ -158,7 +167,10 @@ describe("Tabs", () => {
     });
 
     test("can open a closed panel when mod launcher is available", async () => {
-      await setupPanelsAndRender([panel], true);
+      await setupPanelsAndRender({
+        panels: [panel],
+        staticPanels: [MOD_LAUNCHER],
+      });
 
       within(screen.getByRole("tab", { name: /panel test 1/i }))
         .getByRole("button", { name: "Close" })
@@ -173,6 +185,56 @@ describe("Tabs", () => {
       expect(
         screen.getByRole("tab", { name: /panel test 1/i })
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("Temporary Panels", () => {
+    const temporaryPanel = sidebarEntryFactory("temporaryPanel");
+
+    test("can close a temporary panel when mod launcher is available", async () => {
+      await setupPanelsAndRender({
+        temporaryPanels: [temporaryPanel],
+        staticPanels: [MOD_LAUNCHER],
+      });
+
+      within(screen.getByRole("tab", { name: /temporary panel test 1/i }))
+        .getByRole("button", { name: "Close" })
+        .click();
+
+      expect(
+        screen.queryByRole("tab", { name: /temporary panel test 1/i })
+      ).not.toBeInTheDocument();
+    });
+
+    test("can close a tempoarary panel when mod launcher is unavailable", async () => {
+      await setupPanelsAndRender({ temporaryPanels: [temporaryPanel] });
+
+      within(screen.getByRole("tab", { name: /temporary panel test 1/i }))
+        .getByRole("button", { name: "Close" })
+        .click();
+
+      expect(
+        screen.queryByRole("tab", { name: /temporary panel test 1/i })
+      ).not.toBeInTheDocument();
+    });
+
+    test("cannot re-open a closed temporary panel with the mod launcher", async () => {
+      await setupPanelsAndRender({
+        temporaryPanels: [temporaryPanel],
+        staticPanels: [MOD_LAUNCHER],
+      });
+
+      within(screen.getByRole("tab", { name: /temporary panel test 1/i }))
+        .getByRole("button", { name: "Close" })
+        .click();
+
+      expect(
+        screen.queryByRole("tab", { name: /temporary panel test 1/i })
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByRole("heading", { name: /temporary panel test 1/i })
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -61,7 +61,6 @@ import { TemporaryPanelTabPane } from "./TemporaryPanelTabPane";
 import { MOD_LAUNCHER } from "@/sidebar/modLauncher/ModLauncher";
 import { getTopLevelFrame } from "webext-messenger";
 import { hideSidebar } from "@/contentScript/messenger/api";
-import { type Dispatch } from "redux";
 import useAsyncEffect from "use-async-effect";
 
 const permanentSidebarPanelAction = () => {

--- a/src/sidebar/eventKeyUtils.test.ts
+++ b/src/sidebar/eventKeyUtils.test.ts
@@ -93,16 +93,38 @@ describe("defaultEventKey", () => {
     });
   });
 
-  it("returns static panel as last resort before returning null", () => {
-    const args = {
-      forms: [],
-      temporaryPanels: [],
-      panels: [],
-      staticPanels: [MOD_LAUNCHER],
-    } as unknown as SidebarEntries;
+  describe("staticPanels", () => {
+    it("returns static panel as last resort before returning null", () => {
+      const args = {
+        forms: [],
+        temporaryPanels: [],
+        panels: [],
+        staticPanels: [MOD_LAUNCHER],
+      } as unknown as SidebarEntries;
 
-    expect(defaultEventKey(args)).toBe(eventKeyForEntry(MOD_LAUNCHER));
-    expect(defaultEventKey(args)).not.toBe("panel-undefined");
+      expect(defaultEventKey(args)).toBe(eventKeyForEntry(MOD_LAUNCHER));
+      expect(defaultEventKey(args)).not.toBe("panel-undefined");
+    });
+
+    it("ignores closed static panels", () => {
+      const firstPanel = sidebarEntryFactory("staticPanel");
+      const secondPanel = sidebarEntryFactory("staticPanel");
+      const args = {
+        forms: [],
+        temporaryPanels: [],
+        panels: [],
+        staticPanels: [firstPanel, secondPanel],
+      } as unknown as SidebarEntries;
+
+      const closedTabs: SidebarState["closedTabs"] = {
+        [eventKeyForEntry(firstPanel)]: true,
+      };
+
+      expect(defaultEventKey(args, closedTabs)).toBe(
+        eventKeyForEntry(args.staticPanels[1])
+      );
+      expect(defaultEventKey(args, closedTabs)).not.toBe("panel-undefined");
+    });
   });
 });
 

--- a/src/sidebar/eventKeyUtils.test.ts
+++ b/src/sidebar/eventKeyUtils.test.ts
@@ -17,7 +17,7 @@
 
 import { defaultEventKey, eventKeyForEntry } from "@/sidebar/eventKeyUtils";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
-import { type SidebarEntries } from "@/types/sidebarTypes";
+import { type SidebarState, type SidebarEntries } from "@/types/sidebarTypes";
 
 import { sidebarEntryFactory } from "@/testUtils/factories/sidebarEntryFactories";
 import { MOD_LAUNCHER } from "@/sidebar/modLauncher/ModLauncher";
@@ -59,15 +59,38 @@ describe("defaultEventKey", () => {
     expect(defaultEventKey(args)).not.toBe("temporaryPanel-undefined");
   });
 
-  it("prefers first panel", () => {
-    const args = {
-      forms: [],
-      temporaryPanels: [],
-      panels: [{ extensionId: uuidv4() }, { extensionId: uuidv4() }],
-    } as SidebarEntries;
+  describe("panels", () => {
+    it("prefers first panel", () => {
+      const entries = {
+        forms: [],
+        temporaryPanels: [],
+        panels: [{ extensionId: uuidv4() }, { extensionId: uuidv4() }],
+      } as SidebarEntries;
 
-    expect(defaultEventKey(args)).toBe(eventKeyForEntry(args.panels[0]));
-    expect(defaultEventKey(args)).not.toBe("panel-undefined");
+      expect(defaultEventKey(entries)).toBe(
+        eventKeyForEntry(entries.panels[0])
+      );
+      expect(defaultEventKey(entries)).not.toBe("panel-undefined");
+    });
+
+    it("ignores closed panels", () => {
+      const firstPanel = sidebarEntryFactory("panel");
+      const secondPanel = sidebarEntryFactory("panel");
+      const entries = {
+        forms: [],
+        temporaryPanels: [],
+        panels: [firstPanel, secondPanel],
+      } as SidebarEntries;
+
+      const closedTabs: SidebarState["closedTabs"] = {
+        [eventKeyForEntry(firstPanel)]: true,
+      };
+
+      expect(defaultEventKey(entries, closedTabs)).toBe(
+        eventKeyForEntry(entries.panels[1])
+      );
+      expect(defaultEventKey(entries, closedTabs)).not.toBe("panel-undefined");
+    });
   });
 
   it("returns static panel as last resort before returning null", () => {

--- a/src/sidebar/eventKeyUtils.tsx
+++ b/src/sidebar/eventKeyUtils.tsx
@@ -15,7 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import type { SidebarEntries, SidebarEntry } from "@/types/sidebarTypes";
+import type {
+  SidebarEntries,
+  SidebarEntry,
+  SidebarState,
+} from "@/types/sidebarTypes";
 import {
   isModActivationPanelEntry,
   isPanelEntry,
@@ -53,13 +57,16 @@ export function eventKeyForEntry(entry: SidebarEntry | null): string | null {
  * - Most recent temporary panel
  * - First panel
  */
-export function defaultEventKey({
-  forms = [],
-  panels = [],
-  temporaryPanels = [],
-  staticPanels = [],
-  modActivationPanel = null,
-}: SidebarEntries): string | null {
+export function defaultEventKey(
+  {
+    forms = [],
+    panels = [],
+    temporaryPanels = [],
+    staticPanels = [],
+    modActivationPanel = null,
+  }: SidebarEntries,
+  closedTabs: SidebarState["closedTabs"] = {}
+): string | null {
   if (forms.length > 0) {
     return eventKeyForEntry(forms.at(-1));
   }
@@ -68,8 +75,11 @@ export function defaultEventKey({
     return eventKeyForEntry(temporaryPanels.at(-1));
   }
 
-  if (panels.length > 0) {
-    return eventKeyForEntry(panels.at(0));
+  const openPanels = panels.filter(
+    (panel) => !closedTabs[eventKeyForEntry(panel)]
+  );
+  if (openPanels.length > 0) {
+    return eventKeyForEntry(openPanels.at(0));
   }
 
   if (modActivationPanel) {

--- a/src/sidebar/eventKeyUtils.tsx
+++ b/src/sidebar/eventKeyUtils.tsx
@@ -75,9 +75,7 @@ export function defaultEventKey(
     return eventKeyForEntry(temporaryPanels.at(-1));
   }
 
-  const openPanels = panels.filter(
-    (panel) => !closedTabs[eventKeyForEntry(panel)]
-  );
+  const openPanels = getOpenPanelEntries(panels, closedTabs);
   if (openPanels.length > 0) {
     return eventKeyForEntry(openPanels.at(0));
   }
@@ -86,9 +84,17 @@ export function defaultEventKey(
     return eventKeyForEntry(modActivationPanel);
   }
 
-  if (staticPanels.length > 0) {
-    return eventKeyForEntry(staticPanels.at(0));
+  const openStaticPanels = getOpenPanelEntries(staticPanels, closedTabs);
+  if (openStaticPanels.length > 0) {
+    return eventKeyForEntry(openStaticPanels.at(0));
   }
 
   return null;
+}
+
+function getOpenPanelEntries(
+  entries: SidebarEntry[],
+  closedTabs: SidebarState["closedTabs"]
+): SidebarEntry[] {
+  return entries.filter((entry) => !closedTabs[eventKeyForEntry(entry)]);
 }

--- a/src/sidebar/sidebarSelectors.ts
+++ b/src/sidebar/sidebarSelectors.ts
@@ -91,6 +91,7 @@ export const selectVisiblePanelCount = ({ sidebar }: SidebarRootState) => {
     closedTabs,
   } = sidebar;
 
+  // Temporary Panels are removed from the sidebar state when they are closed, so we don't need to filter them out
   const closablePanels = [...panels, ...staticPanels];
   const openPanels = closablePanels.filter(
     (panel) => !closedTabs[eventKeyForEntry(panel)]

--- a/src/sidebar/sidebarSelectors.ts
+++ b/src/sidebar/sidebarSelectors.ts
@@ -80,3 +80,26 @@ export const selectExtensionFromEventKey =
 
 export const selectClosedTabs = ({ sidebar }: SidebarRootState) =>
   sidebar.closedTabs;
+
+export const selectVisiblePanelCount = ({ sidebar }: SidebarRootState) => {
+  const {
+    panels,
+    forms,
+    temporaryPanels,
+    staticPanels,
+    modActivationPanel,
+    closedTabs,
+  } = sidebar;
+
+  const closablePanels = [...panels, ...staticPanels];
+  const openPanels = closablePanels.filter(
+    (panel) => !closedTabs[eventKeyForEntry(panel)]
+  );
+
+  return (
+    openPanels.length +
+    forms.length +
+    temporaryPanels.length +
+    (modActivationPanel ? 1 : 0)
+  );
+};

--- a/src/sidebar/sidebarSlice.ts
+++ b/src/sidebar/sidebarSlice.ts
@@ -215,9 +215,10 @@ const sidebarSlice = createSlice({
     selectTab(state, action: PayloadAction<string>) {
       // We were seeing some automatic calls to selectTab with a stale event key...
       // Calling selectTab with a stale event key shouldn't change the current tab
-      state.activeKey = eventKeyExists(state, action.payload)
-        ? action.payload
-        : state.activeKey;
+      if (eventKeyExists(state, action.payload)) {
+        state.activeKey = action.payload;
+        state.closedTabs[action.payload] = false;
+      }
 
       // User manually selected a panel, so cancel any pending automatic panel activation
       state.pendingActivePanel = null;
@@ -377,7 +378,7 @@ const sidebarSlice = createSlice({
       state.closedTabs[action.payload] = true;
 
       if (state.activeKey === action.payload) {
-        state.activeKey = defaultEventKey(state);
+        state.activeKey = defaultEventKey(state, state.closedTabs);
       }
     },
     openTab(state, action: PayloadAction<string>) {

--- a/src/types/sidebarTypes.ts
+++ b/src/types/sidebarTypes.ts
@@ -191,6 +191,12 @@ export type TemporaryPanelEntry = BaseModComponentPanelEntry & {
   showCloseButton?: boolean;
 };
 
+export function isTemporaryPanelEntry(
+  panel: unknown
+): panel is TemporaryPanelEntry {
+  return (panel as TemporaryPanelEntry)?.type === "temporaryPanel";
+}
+
 /**
  * An ephemeral form to show in the sidebar. Only one form can be shown from an extension at a time.
  * @see ModalTransformer


### PR DESCRIPTION
## What does this PR do?

- Closes #6160

## Discussion

- Considered using an async thunk to close the sidebar
- Went with the panel count in an asyncUseEffect instead to keep UI concerns out of redux
- updated close sidebar logic to close the sidebar when any kind of panel is the last panel closed
- updated `defaultEventKey` to account for `closedTabs` when getting the next active key

## Demo
https://www.loom.com/share/efbbb85e1073446b90a757802e072f29

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @mnholtz 
