### PR TITLE
#1361: add Mozilla readability brick for extracting page content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@fortawesome/free-regular-svg-icons": "^5.15.4",
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "@fortawesome/react-fontawesome": "^0.1.14",
+        "@mozilla/readability": "^0.4.4",
         "@reduxjs/toolkit": "^1.9.3",
         "@rjsf/bootstrap-4": "^4.2.3",
         "@rjsf/core": "^4.2.3",
@@ -4538,6 +4539,14 @@
     "node_modules/@microsoft/dynamicproto-js": {
       "version": "1.1.4",
       "integrity": "sha512-Ot53G927ykMF8cQ3/zq4foZtdk+Tt1YpX7aUTHxBU7UHNdkEiBvBfZSq+rnlUmKCJ19VatwPG4mNzvcGpBj4og=="
+    },
+    "node_modules/@mozilla/readability": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.4.4.tgz",
+      "integrity": "sha512-MCgZyANpJ6msfvVMi6+A0UAsvZj//4OHREYUB9f2087uXHVoU+H+SWhuihvb1beKpM323bReQPRio0WNk2+V6g==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -40720,6 +40729,11 @@
     "@microsoft/dynamicproto-js": {
       "version": "1.1.4",
       "integrity": "sha512-Ot53G927ykMF8cQ3/zq4foZtdk+Tt1YpX7aUTHxBU7UHNdkEiBvBfZSq+rnlUmKCJ19VatwPG4mNzvcGpBj4og=="
+    },
+    "@mozilla/readability": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.4.4.tgz",
+      "integrity": "sha512-MCgZyANpJ6msfvVMi6+A0UAsvZj//4OHREYUB9f2087uXHVoU+H+SWhuihvb1beKpM323bReQPRio0WNk2+V6g=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
+    "@mozilla/readability": "^0.4.4",
     "@reduxjs/toolkit": "^1.9.3",
     "@rjsf/bootstrap-4": "^4.2.3",
     "@rjsf/core": "^4.2.3",

--- a/src/bricks/transformers/getAllTransformers.ts
+++ b/src/bricks/transformers/getAllTransformers.ts
@@ -51,6 +51,7 @@ import { type Brick } from "@/types/brickTypes";
 import { SelectElement } from "@/bricks/transformers/selectElement";
 import Run from "@/bricks/transformers/controlFlow/Run";
 import ExtensionDiagnostics from "@/bricks/transformers/extensionDiagnostics";
+import { Readable } from "@/bricks/transformers/readable";
 
 function getAllTransformers(): Brick[] {
   return [
@@ -72,6 +73,7 @@ function getAllTransformers(): Brick[] {
     new TemplateTransformer(),
     new UrlParams(),
     new JQueryReader(),
+    new Readable(),
     new ComponentReader(),
     new TableReader(),
     new TablesReader(),

--- a/src/bricks/transformers/readable.test.ts
+++ b/src/bricks/transformers/readable.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Readable } from "@/bricks/transformers/readable";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { type BrickOptions } from "@/types/runtimeTypes";
+
+const brick = new Readable();
+
+describe("readable", () => {
+  it("extracts readable content", async () => {
+    document.body.innerHTML = "<div><h1>Title</h1><p>content</p></div>";
+
+    const article = await brick.run(
+      unsafeAssumeValidArg({}),
+      {} as BrickOptions
+    );
+
+    expect(article).toEqual(
+      expect.objectContaining({
+        excerpt: "content",
+        textContent: "Titlecontent",
+      })
+    );
+  });
+
+  it("requires document root", async () => {
+    document.body.innerHTML = "<div><h1>Title</h1><p>content</p></div>";
+
+    const element = document.querySelector("div");
+
+    const article = brick.run(unsafeAssumeValidArg({}), {
+      root: element,
+    } as unknown as BrickOptions);
+
+    await expect(article).rejects.toThrow();
+  });
+});

--- a/src/bricks/transformers/readable.ts
+++ b/src/bricks/transformers/readable.ts
@@ -63,7 +63,10 @@ export class Readable extends TransformerABC {
     },
   });
 
-  async transform(_args: never, { root }: BrickOptions): Promise<unknown> {
+  async transform(
+    _args: never,
+    { root = document }: BrickOptions
+  ): Promise<unknown> {
     if (root !== document) {
       throw new BusinessError("Only document target is supported");
     }
@@ -73,7 +76,7 @@ export class Readable extends TransformerABC {
     );
 
     // https://github.com/mozilla/readability#parse
-    const documentClone = document.cloneNode(true);
+    const documentClone = root.cloneNode(true);
 
     try {
       return new Readability(documentClone as Document).parse();

--- a/src/bricks/transformers/readable.ts
+++ b/src/bricks/transformers/readable.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TransformerABC } from "@/types/bricks/transformerTypes";
+import { type Schema } from "@/types/schemaTypes";
+import { propertiesToSchema } from "@/validators/generic";
+import { BusinessError } from "@/errors/businessErrors";
+import { type BrickOptions } from "@/types/runtimeTypes";
+
+export class Readable extends TransformerABC {
+  constructor() {
+    super(
+      "@pixiebrix/extract/readable",
+      "Extract Readable Content",
+      "Extract the readable content from a web page",
+      "faCode"
+    );
+  }
+
+  override async isPure(): Promise<boolean> {
+    // Technically is not pure, because value depends on document state. But it generally won't change
+    return true;
+  }
+
+  override async isRootAware(): Promise<boolean> {
+    // Is root aware, but only document is supported
+    return true;
+  }
+
+  inputSchema: Schema = propertiesToSchema({});
+
+  override outputSchema: Schema = propertiesToSchema({
+    content: {
+      type: "string",
+      description: "HTML string of processed article content",
+    },
+    textContent: {
+      type: "string",
+      description:
+        "Text content of the article, with all the HTML tags removed",
+    },
+    length: {
+      type: "number",
+      description: "Length of an article, in characters",
+    },
+    lang: {
+      type: "string",
+      description: "Language of the article",
+    },
+  });
+
+  async transform(_args: never, { root }: BrickOptions): Promise<unknown> {
+    if (root !== document) {
+      throw new BusinessError("Only document target is supported");
+    }
+
+    const { Readability } = await import(
+      /* webpackChunkName: "readability" */ "@mozilla/readability"
+    );
+
+    // https://github.com/mozilla/readability#parse
+    const documentClone = document.cloneNode(true);
+
+    try {
+      return new Readability(documentClone as Document).parse();
+    } catch {
+      throw new BusinessError("Document is not readable");
+    }
+  }
+}

--- a/src/bricks/transformers/readable.ts
+++ b/src/bricks/transformers/readable.ts
@@ -25,8 +25,8 @@ export class Readable extends TransformerABC {
   constructor() {
     super(
       "@pixiebrix/extract/readable",
-      "Extract Readable Content",
-      "Extract the readable content from a web page",
+      "Extract Article or Readable Content",
+      "Extract the article or other readable content from a web page",
       "faCode"
     );
   }

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -27,7 +27,7 @@ import registerBuiltinBlocks from "@/bricks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 118;
+const EXPECTED_HEADER_COUNT = 119;
 
 registerBuiltinBlocks();
 registerContribBlocks();


### PR DESCRIPTION
## What does this PR do?

- Closes #1361 
- Adds Mozilla Readability brick as "Extract Article or Readable Content" brick
- Introducing for use in some content moderation use cases

## Team Coordination

- [x] Update brick headers
- [x] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
