### PR TITLE
defaults getSettingsState to the settingsSlice initialState

### DIFF
--- a/src/store/settingsStorage.ts
+++ b/src/store/settingsStorage.ts
@@ -17,13 +17,14 @@
 
 import { localStorage } from "redux-persist-webextension-storage";
 import { type SettingsState } from "@/store/settingsTypes";
-import { mapValues } from "lodash";
+import { isEmpty, mapValues } from "lodash";
 import { expectContext } from "@/utils/expectContext";
 import {
   readReduxStorage,
   type ReduxStorageKey,
   setReduxStorage,
 } from "@/utils/storageUtils";
+import { initialSettingsState } from "@/store/settingsSlice";
 
 const SETTINGS_STORAGE_KEY = "persist:settings" as ReduxStorageKey;
 
@@ -34,6 +35,10 @@ export async function getSettingsState(): Promise<SettingsState> {
   expectContext("extension");
 
   const rawSettings = await readReduxStorage(SETTINGS_STORAGE_KEY, {});
+  if (isEmpty(rawSettings)) {
+    return initialSettingsState;
+  }
+
   const parsedSettings = mapValues(rawSettings, (setting) =>
     JSON.parse(setting)
   ) as SettingsState;


### PR DESCRIPTION
## What does this PR do?

- Fixes issue where the FAB wasn't showing up after initially installing and linking
- Context: https://pixiebrix.slack.com/archives/C023KL47XV4/p1691584311179569

## Demo

https://app.rainforestqa.com/runs/1478212/tests/396036/browsers/windows10_chrome?job=51052613

## Checklist

- [x] Designate a primary reviewer @twschiller 
