### PR TITLE
Bugfix: click through tab decoration

### DIFF
--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -67,11 +67,13 @@
   &::after {
     right: -30px;
     border-bottom-left-radius: 10px;
+    pointer-events: none;
   }
   &::before {
     // 2px left extra to account for the border that hides the left divider
     left: -32px;
     border-bottom-right-radius: 10px;
+    pointer-events: none;
   }
 
   &:hover {

--- a/src/sidebar/Tabs.module.scss
+++ b/src/sidebar/Tabs.module.scss
@@ -93,6 +93,7 @@
     // then add a border to maintain the position
     margin-left: -2px;
     border-left: 2px solid $S0;
+    z-index: 2;
     // Disable cursor:pointer because there's no action
     // This also makes it easier to see when you're hovering the close button
     cursor: default;
@@ -124,6 +125,7 @@
   &:nth-child(-n + 7) {
     .tabDivider {
       display: block;
+      z-index: 1;
     }
   }
 
@@ -134,6 +136,7 @@
   &.active {
     .tabDivider {
       display: none;
+      z-index: 1;
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

FIx issue where you can't click through the invisible element that makes the rounded corner on the tabs

context: https://pixiebrix.slack.com/archives/C03CA2M4RCM/p1691607788518789

## Demo

-[Loom](https://www.loom.com/share/ca022e9923414cd69f1f8355a8eb5753?sid=03ef1d9b-17e7-409e-b4cd-281dbc3dd10e)

-divider fix: 
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/24994029-15b2-4f6d-852d-9418a1fa265f)


## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @BLoe  
