### PR TITLE
#6245 Handle error in content script navigation init

### DIFF
--- a/src/contentScript/contentScript.ts
+++ b/src/contentScript/contentScript.ts
@@ -92,6 +92,8 @@ async function initContentScript() {
 }
 
 // Support running in secure pages and about: pages, which are used by srcdoc frames
+// Note: Due to our permissive settings for content script running in frames, there
+// are cases where this can execute in a frame within an invalid parent context/protocol.
 if (ALLOWED_PROTOCOLS.includes(location.protocol) || DEBUG) {
   // eslint-disable-next-line promise/prefer-await-to-then -- top-level await isn't available
   void initContentScript().catch((error) => {

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -49,7 +49,7 @@ onUncaughtError((error) => {
 });
 
 export async function init(): Promise<void> {
-  console.debug("contentScriptCore: init");
+  console.debug(`contentScriptCore: init, location: ${location.href}`);
 
   registerMessenger();
   registerExternalMessenger();

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -28,7 +28,7 @@ import { traces } from "@/background/messenger/api";
 import { isDeploymentActive } from "@/utils/deploymentUtils";
 import { PromiseCancelled } from "@/errors/genericErrors";
 import injectScriptTag from "@/utils/injectScriptTag";
-import { getThisFrame } from "webext-messenger";
+import { type FrameTarget, getThisFrame } from "webext-messenger";
 import { type StarterBrick } from "@/types/starterBrickTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
@@ -566,11 +566,11 @@ export async function handleNavigate({
 }: { force?: boolean } = {}): Promise<void> {
   const runReason = decideRunReason({ force });
 
-  const thisTarget = await getThisFrame();
-  if (thisTarget.frameId == null) {
-    console.debug(
-      "Ignoring handleNavigate because thisTarget.frameId is not set yet"
-    );
+  let thisTarget: FrameTarget;
+  try {
+    thisTarget = await getThisFrame();
+  } catch (error: unknown) {
+    console.debug("Ignoring handleNavigate because getThisFrame failed", error);
     return;
   }
 

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -570,7 +570,9 @@ export async function handleNavigate({
   try {
     // Note: We used to check for invalid (undefined) frameId after calling
     // this, but now getThisFrame will throw an error itself internally if
-    // the frameId is not a valid number.
+    // the frameId is not a valid number. An example situation where this
+    // happens is when the dynamic gsheets code loads a frame within the
+    // extension background page.
     thisTarget = await getThisFrame();
   } catch (error: unknown) {
     console.debug("Ignoring handleNavigate because getThisFrame failed", error);

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -568,6 +568,9 @@ export async function handleNavigate({
 
   let thisTarget: FrameTarget;
   try {
+    // Note: We used to check for invalid (undefined) frameId after calling
+    // this, but now getThisFrame will throw an error itself internally if
+    // the frameId is not a valid number.
     thisTarget = await getThisFrame();
   } catch (error: unknown) {
     console.debug("Ignoring handleNavigate because getThisFrame failed", error);


### PR DESCRIPTION
## What does this PR do?

- Part of #6245 

## Discussion

- I'm also attempting to figure out how to improve our logic to know when a frame is a child-frame of the background page, but getting blocked by a cross-origin request error:
<img width="925" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/2801308/791ac85e-134a-4c64-b674-9cb16be5f644">

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer - @twschiller 
