### PR TITLE
#6251: add disableBrowserWarning managed storage option

### DIFF
--- a/src/extensionConsole/pages/BrowserBanner.test.tsx
+++ b/src/extensionConsole/pages/BrowserBanner.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render } from "@/extensionConsole/testHelpers";
+import BrowserBanner from "@/extensionConsole/pages/BrowserBanner";
+import { waitForEffect } from "@/testUtils/testHelpers";
+import { screen } from "@testing-library/react";
+import { INTERNAL_reset } from "@/store/enterprise/managedStorage";
+
+beforeEach(async () => {
+  // eslint-disable-next-line new-cap -- test helper method
+  INTERNAL_reset();
+  await browser.storage.managed.clear();
+});
+
+describe("BrowserBanner", () => {
+  it("renders warning for jest environment", async () => {
+    await browser.storage.managed.set({ disableBrowserWarning: false });
+
+    const wrapper = render(
+      <div>
+        <BrowserBanner />
+      </div>
+    );
+
+    await waitForEffect();
+
+    expect(
+      screen.queryByText("PixieBrix officially supports Google Chrome", {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+
+  it("suppress with managed storage", async () => {
+    await browser.storage.managed.set({ disableBrowserWarning: true });
+
+    const wrapper = render(
+      <div>
+        <BrowserBanner />
+      </div>
+    );
+
+    await waitForEffect();
+
+    expect(
+      screen.queryByText("PixieBrix officially supports Google Chrome.", {
+        exact: false,
+      })
+    ).not.toBeInTheDocument();
+
+    expect(wrapper.asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/extensionConsole/pages/BrowserBanner.tsx
+++ b/src/extensionConsole/pages/BrowserBanner.tsx
@@ -24,14 +24,23 @@ import { Button } from "react-bootstrap";
 import settingsSlice from "@/store/settingsSlice";
 
 import { isGoogleChrome } from "@/utils/browserUtils";
+import useManagedStorageState from "@/store/enterprise/useManagedStorageState";
 
 const BrowserBanner: React.VoidFunctionComponent = () => {
   const dispatch = useDispatch();
+
   const browserWarningDismissed = useSelector<RootState, boolean>(
     selectBrowserWarningDismissed
   );
 
-  if (browserWarningDismissed || isGoogleChrome()) {
+  const enterpriseState = useManagedStorageState();
+
+  if (
+    browserWarningDismissed ||
+    isGoogleChrome() ||
+    enterpriseState.isLoading ||
+    enterpriseState.data?.disableBrowserWarning
+  ) {
     return null;
   }
 

--- a/src/extensionConsole/pages/__snapshots__/BrowserBanner.test.tsx.snap
+++ b/src/extensionConsole/pages/__snapshots__/BrowserBanner.test.tsx.snap
@@ -1,49 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BrowserBanner defaults to warning 1`] = `
-<DocumentFragment>
-  <div />
-</DocumentFragment>
-`;
-
-exports[`BrowserBanner disableBrowserWarning defaults to tru 1`] = `
-<DocumentFragment>
-  <div />
-</DocumentFragment>
-`;
-
-exports[`BrowserBanner disableBrowserWarning defaults to true 1`] = `
-<DocumentFragment>
-  <div>
-    <div
-      class="root warning"
-    >
-      <div
-        class="mx-auto d-flex"
-      >
-        <div
-          class="flex-grow-1"
-        />
-        <div
-          class="align-self-center"
-        >
-          PixieBrix officially supports Google Chrome. Some functionality may not be available on your browser.
-          <button
-            class="info ml-3 btn btn-primary btn-sm"
-            type="button"
-          >
-            OK
-          </button>
-        </div>
-        <div
-          class="flex-grow-1"
-        />
-      </div>
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`BrowserBanner renders warning for jest environment 1`] = `
 <DocumentFragment>
   <div>
@@ -75,8 +31,6 @@ exports[`BrowserBanner renders warning for jest environment 1`] = `
   </div>
 </DocumentFragment>
 `;
-
-exports[`BrowserBanner renders warning for node 1`] = `<DocumentFragment />`;
 
 exports[`BrowserBanner suppress with managed storage 1`] = `
 <DocumentFragment>

--- a/src/extensionConsole/pages/__snapshots__/BrowserBanner.test.tsx.snap
+++ b/src/extensionConsole/pages/__snapshots__/BrowserBanner.test.tsx.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BrowserBanner defaults to warning 1`] = `
+<DocumentFragment>
+  <div />
+</DocumentFragment>
+`;
+
+exports[`BrowserBanner disableBrowserWarning defaults to tru 1`] = `
+<DocumentFragment>
+  <div />
+</DocumentFragment>
+`;
+
+exports[`BrowserBanner disableBrowserWarning defaults to true 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="root warning"
+    >
+      <div
+        class="mx-auto d-flex"
+      >
+        <div
+          class="flex-grow-1"
+        />
+        <div
+          class="align-self-center"
+        >
+          PixieBrix officially supports Google Chrome. Some functionality may not be available on your browser.
+          <button
+            class="info ml-3 btn btn-primary btn-sm"
+            type="button"
+          >
+            OK
+          </button>
+        </div>
+        <div
+          class="flex-grow-1"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`BrowserBanner renders warning for jest environment 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="root warning"
+    >
+      <div
+        class="mx-auto d-flex"
+      >
+        <div
+          class="flex-grow-1"
+        />
+        <div
+          class="align-self-center"
+        >
+          PixieBrix officially supports Google Chrome. Some functionality may not be available on your browser.
+          <button
+            class="info ml-3 btn btn-primary btn-sm"
+            type="button"
+          >
+            OK
+          </button>
+        </div>
+        <div
+          class="flex-grow-1"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`BrowserBanner renders warning for node 1`] = `<DocumentFragment />`;
+
+exports[`BrowserBanner suppress with managed storage 1`] = `
+<DocumentFragment>
+  <div />
+</DocumentFragment>
+`;

--- a/src/store/enterprise/managedStorageTypes.ts
+++ b/src/store/enterprise/managedStorageTypes.ts
@@ -47,4 +47,9 @@ export type ManagedStorageState = {
    * PixieBrix service URL
    */
   serviceUrl?: string;
+  /**
+   * Disable the browser warning for non-Chrome browsers, e.g., Microsoft Edge
+   * @since 1.7.36
+   */
+  disableBrowserWarning?: boolean;
 };

--- a/static/managedStorageSchema.json
+++ b/static/managedStorageSchema.json
@@ -30,6 +30,11 @@
       "type": "string",
       "description": "PixieBrix service URL",
       "default": "https://app.pixiebrix.com"
+    },
+    "disableBrowserWarning": {
+      "type": "boolean",
+      "description": "Disable the browser warning for non-Chrome browsers, e.g., Microsoft Edge",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #6251 
- Adds a `disableBrowserWarning` flag to enterprise-managed storage

## Checklist

- [x] Add tests
- [ ] Rainforest test for banner/warning: https://app.rainforestqa.com/tests/397874 (WIP)
- [x] Designate a primary reviewer: @turbochef 
