### PR TITLE
#6167 Make sidepanel forms closable

### DIFF
--- a/src/bricks/transformers/ephemeralForm/EphemeralForm.tsx
+++ b/src/bricks/transformers/ephemeralForm/EphemeralForm.tsx
@@ -34,6 +34,7 @@ import FieldTemplate from "@/components/formBuilder/FieldTemplate";
 import reportError from "@/telemetry/reportError";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import RjsfSelectWidget from "@/components/formBuilder/RjsfSelectWidget";
+import { TOP_LEVEL_FRAME_ID } from "@/domConstants";
 
 const fields = {
   DescriptionField,
@@ -77,7 +78,9 @@ const EphemeralForm: React.FC = () => {
 
   // The opener for a sidebar panel will be the sidebar frame, not the host panel frame. The sidebar only opens in the
   // top-level frame, so hard-code the top-level frameId
-  const target = isModal ? opener : { tabId: opener.tabId, frameId: 0 };
+  const target = isModal
+    ? opener
+    : { tabId: opener.tabId, frameId: TOP_LEVEL_FRAME_ID };
   const FormContainer = isModal ? ModalLayout : PanelLayout;
 
   const [definition, isLoading, error] = useAsyncState(
@@ -140,7 +143,7 @@ const EphemeralForm: React.FC = () => {
             <button className="btn btn-primary" type="submit">
               {definition.submitCaption}
             </button>
-            {definition.cancelable && (
+            {definition.cancelable && isModal && (
               <button
                 className="btn btn-link"
                 type="button"

--- a/src/sidebar/Tabs.test.tsx
+++ b/src/sidebar/Tabs.test.tsx
@@ -20,16 +20,27 @@ import Tabs from "@/sidebar/Tabs";
 import { render } from "@/sidebar/testHelpers";
 import { type SidebarEntries } from "@/types/sidebarTypes";
 import sidebarSlice from "@/sidebar/sidebarSlice";
-import { sidebarEntryFactory } from "@/testUtils/factories/sidebarEntryFactories";
+import {
+  formDefinitionFactory,
+  sidebarEntryFactory,
+} from "@/testUtils/factories/sidebarEntryFactories";
 import { screen, within } from "@testing-library/react";
 import { MOD_LAUNCHER } from "@/sidebar/modLauncher/ModLauncher";
 import useFlags from "@/hooks/useFlags";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import userEvent from "@testing-library/user-event";
+import { cancelForm } from "@/contentScript/messenger/api";
 
 jest.mock("@/hooks/useFlags", () =>
   jest.fn().mockReturnValue({ flagOn: jest.fn() })
 );
+
+jest.mock("@/contentScript/messenger/api", () => ({
+  ...jest.requireActual("@/contentScript/messenger/api"),
+  cancelForm: jest.fn(),
+}));
+
+const cancelFormMock = cancelForm as jest.MockedFunction<typeof cancelForm>;
 
 async function setupPanelsAndRender(sidebarEntries: Partial<SidebarEntries>) {
   (useFlags as jest.Mock).mockReturnValue({
@@ -235,6 +246,29 @@ describe("Tabs", () => {
       expect(
         screen.queryByRole("heading", { name: /temporary panel test 1/i })
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Form Panels", () => {
+    const formPanel = sidebarEntryFactory("form", {
+      form: formDefinitionFactory({ schema: { title: "Form Panel Test" } }),
+    });
+
+    test("closing the form tab calls cancelForm", async () => {
+      await setupPanelsAndRender({
+        forms: [formPanel],
+        staticPanels: [MOD_LAUNCHER],
+      });
+
+      expect(cancelFormMock).not.toHaveBeenCalled();
+
+      within(screen.getByRole("tab", { name: /form panel test/i }))
+        .getByRole("button", { name: "Close" })
+        .click();
+
+      await waitForEffect();
+
+      expect(cancelFormMock).toHaveBeenCalled();
     });
   });
 });

--- a/src/sidebar/Tabs.test.tsx
+++ b/src/sidebar/Tabs.test.tsx
@@ -252,6 +252,12 @@ describe("Tabs", () => {
   describe("Form Panels", () => {
     const formPanel = sidebarEntryFactory("form");
 
+    test("renders with forms", async () => {
+      await setupPanelsAndRender({ forms: [formPanel] });
+
+      expect(screen.getByText("Form Panel Test")).toBeInTheDocument();
+    });
+
     test("closing the form tab calls cancelForm", async () => {
       await setupPanelsAndRender({
         forms: [formPanel],

--- a/src/sidebar/Tabs.test.tsx
+++ b/src/sidebar/Tabs.test.tsx
@@ -20,10 +20,7 @@ import Tabs from "@/sidebar/Tabs";
 import { render } from "@/sidebar/testHelpers";
 import { type SidebarEntries } from "@/types/sidebarTypes";
 import sidebarSlice from "@/sidebar/sidebarSlice";
-import {
-  formDefinitionFactory,
-  sidebarEntryFactory,
-} from "@/testUtils/factories/sidebarEntryFactories";
+import { sidebarEntryFactory } from "@/testUtils/factories/sidebarEntryFactories";
 import { screen, within } from "@testing-library/react";
 import { MOD_LAUNCHER } from "@/sidebar/modLauncher/ModLauncher";
 import useFlags from "@/hooks/useFlags";

--- a/src/sidebar/Tabs.test.tsx
+++ b/src/sidebar/Tabs.test.tsx
@@ -250,9 +250,7 @@ describe("Tabs", () => {
   });
 
   describe("Form Panels", () => {
-    const formPanel = sidebarEntryFactory("form", {
-      form: formDefinitionFactory({ schema: { title: "Form Panel Test" } }),
-    });
+    const formPanel = sidebarEntryFactory("form");
 
     test("closing the form tab calls cancelForm", async () => {
       await setupPanelsAndRender({

--- a/src/sidebar/Tabs.test.tsx
+++ b/src/sidebar/Tabs.test.tsx
@@ -269,7 +269,13 @@ describe("Tabs", () => {
 
       await waitForEffect();
 
-      expect(cancelFormMock).toHaveBeenCalled();
+      expect(cancelFormMock).toHaveBeenCalledWith(
+        {
+          frameId: 0,
+          tabId: 1,
+        },
+        formPanel.nonce
+      );
     });
   });
 });

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -20,6 +20,7 @@ import {
   type PanelEntry,
   type SidebarEntry,
   isTemporaryPanelEntry,
+  isFormPanelEntry,
 } from "@/types/sidebarTypes";
 import { eventKeyForEntry } from "@/sidebar/eventKeyUtils";
 import { getBodyForStaticPanel } from "./staticPanelUtils";
@@ -60,7 +61,7 @@ import useFlags from "@/hooks/useFlags";
 import { TemporaryPanelTabPane } from "./TemporaryPanelTabPane";
 import { MOD_LAUNCHER } from "@/sidebar/modLauncher/ModLauncher";
 import { getTopLevelFrame } from "webext-messenger";
-import { hideSidebar } from "@/contentScript/messenger/api";
+import { cancelForm, hideSidebar } from "@/contentScript/messenger/api";
 import useAsyncEffect from "use-async-effect";
 
 const permanentSidebarPanelAction = () => {
@@ -148,6 +149,9 @@ const Tabs: React.FC = () => {
 
     if (isTemporaryPanelEntry(panel)) {
       dispatch(sidebarSlice.actions.removeTemporaryPanel(panel.nonce));
+    } else if (isFormPanelEntry(panel)) {
+      const frame = await getTopLevelFrame();
+      cancelForm(frame, panel.nonce);
     } else {
       dispatch(sidebarSlice.actions.closeTab(eventKeyForEntry(panel)));
     }
@@ -216,6 +220,9 @@ const Tabs: React.FC = () => {
               <span className={styles.tabTitle}>
                 {form.form.schema.title ?? "Form"}
               </span>
+              <CloseButton
+                onClick={async (event) => onClosePanel(event, form)}
+              />
             </TabWithDivider>
           ))}
 

--- a/src/testUtils/factories/sidebarEntryFactories.ts
+++ b/src/testUtils/factories/sidebarEntryFactories.ts
@@ -39,8 +39,10 @@ const staticPanelEntryFactory = define<StaticPanelEntry>({
   heading: (n: number) => `Static Panel ${n}`,
   key: (n: number) => `static-panel-${n}`,
 });
-export const formDefinitionFactory = define<FormDefinition>({
-  schema: () => ({}),
+const formDefinitionFactory = define<FormDefinition>({
+  schema: () => ({
+    title: "Form Panel Test",
+  }),
   uiSchema: () => ({}),
   cancelable: true,
   submitCaption: "Submit",

--- a/src/testUtils/factories/sidebarEntryFactories.ts
+++ b/src/testUtils/factories/sidebarEntryFactories.ts
@@ -39,7 +39,7 @@ const staticPanelEntryFactory = define<StaticPanelEntry>({
   heading: (n: number) => `Static Panel ${n}`,
   key: (n: number) => `static-panel-${n}`,
 });
-const formDefinitionFactory = define<FormDefinition>({
+export const formDefinitionFactory = define<FormDefinition>({
   schema: () => ({}),
   uiSchema: () => ({}),
   cancelable: true,

--- a/src/types/sidebarTypes.ts
+++ b/src/types/sidebarTypes.ts
@@ -223,6 +223,10 @@ export type FormPanelEntry = BasePanelEntry & {
   form: FormDefinition;
 };
 
+export function isFormPanelEntry(panel: unknown): panel is FormPanelEntry {
+  return (panel as FormPanelEntry)?.type === "form";
+}
+
 /**
  * Panel entry for activating one or more mods.
  *


### PR DESCRIPTION
## What does this PR do?

- Closes #6167 
- Allows using the X on the tab to close forms in the sidepanel
- Removes the `Cancel` button in sidebar form content dialogs still have the old `Cancel`

## Demo

- [Loom](https://www.loom.com/share/fe7507e150fe485e8b4dfb54ee9f3784?sid=a2a6d326-745d-423e-a1ec-53b96b54fa46)

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
