### PR TITLE
fix negative value inputs and update test

### DIFF
--- a/src/components/fields/schemaFields/widgets/cssClassWidgets/utils.test.ts
+++ b/src/components/fields/schemaFields/widgets/cssClassWidgets/utils.test.ts
@@ -115,7 +115,6 @@ describe("extractSpacing", () => {
       extractSpacing("p", ["p-1", "z-1", "pq-1", "px-2", "pt-n4"])
     ).toStrictEqual([
       { side: null, size: 1 },
-      { side: "x", size: 2 },
       { side: "t", size: -4 },
     ]);
   });

--- a/src/components/fields/schemaFields/widgets/cssClassWidgets/utils.test.ts
+++ b/src/components/fields/schemaFields/widgets/cssClassWidgets/utils.test.ts
@@ -67,8 +67,14 @@ it("should toggle border group", () => {
 
 describe("calculateNextSpacing", () => {
   it("should update size in place", () => {
-    expect(calculateNextSpacing("p-0", "p", { side: null, size: 1 })).toBe(
+    expect(calculateNextSpacing("p-n5", "p", { side: null, size: 1 })).toBe(
       "p-1"
+    );
+  });
+
+  it("should update negative size in place", () => {
+    expect(calculateNextSpacing("p-4", "p", { side: null, size: -1 })).toBe(
+      "p-n1"
     );
   });
 
@@ -95,13 +101,22 @@ describe("calculateNextSpacing", () => {
       "p-2"
     );
   });
+
+  it("should handle negative values correctly", () => {
+    expect(calculateNextSpacing("pt-0", "p", { side: null, size: -2 })).toBe(
+      "p-n2"
+    );
+  });
 });
 
 describe("extractSpacing", () => {
   it("should extract spacing", () => {
-    expect(extractSpacing("p", ["p-1", "z-1", "pq-1", "px-2"])).toStrictEqual([
+    expect(
+      extractSpacing("p", ["p-1", "z-1", "pq-1", "px-2", "pt-n4"])
+    ).toStrictEqual([
       { side: null, size: 1 },
       { side: "x", size: 2 },
+      { side: "t", size: -4 },
     ]);
   });
 });

--- a/src/components/fields/schemaFields/widgets/cssClassWidgets/utils.ts
+++ b/src/components/fields/schemaFields/widgets/cssClassWidgets/utils.ts
@@ -81,9 +81,7 @@ export function parseValue(value: Value): {
 }
 
 function createSpacingRegex(prefix: string): RegExp {
-  return new RegExp(
-    `^${prefix}(?<side>[trblxy]?)-(?<negative>n?)(?<size>\\d+)$`
-  );
+  return new RegExp(`^${prefix}(?<side>[trbl]?)-(?<negative>n?)(?<size>\\d+)$`);
 }
 
 export function extractSpacing(prefix: string, classes: string[]): Spacing[] {

--- a/src/components/fields/schemaFields/widgets/cssClassWidgets/utils.ts
+++ b/src/components/fields/schemaFields/widgets/cssClassWidgets/utils.ts
@@ -81,16 +81,24 @@ export function parseValue(value: Value): {
 }
 
 function createSpacingRegex(prefix: string): RegExp {
-  return new RegExp(`${prefix}(?<side>[tblrxy])?-?(?<size>-?\\d)`);
+  return new RegExp(
+    `^${prefix}(?<side>[trblxy]?)-(?<negative>n?)(?<size>\\d+)$`
+  );
 }
 
 export function extractSpacing(prefix: string, classes: string[]): Spacing[] {
   const re = createSpacingRegex(prefix);
 
-  return compact(classes.map((x) => re.exec(x))).map((x) => ({
-    side: x.groups.side ?? null,
-    size: Number(x.groups.size),
-  })) as Spacing[];
+  return classes
+    .map((element) => re.exec(element))
+    .filter(Boolean)
+    .map((match) => ({
+      side: match.groups.side || null,
+      size:
+        match.groups.negative === "n"
+          ? -Number(match.groups.size)
+          : Number(match.groups.size),
+    })) as Spacing[];
 }
 
 export function calculateNextSpacing(
@@ -111,7 +119,6 @@ export function calculateNextSpacing(
     regex.test(x)
   );
   const spacingRules = extractSpacing(prefix, spacingClasses);
-
   // Select onClear sets the size as null
   if (spacingUpdate.size == null) {
     // Remove spacingRules with same side as spacingUpdate
@@ -138,7 +145,10 @@ export function calculateNextSpacing(
       .filter((rule) =>
         spacingUpdate.side == null ? rule.side == null : rule.side != null
       )
-      .map((x) => `${prefix}${x.side ?? ""}-${x.size}`),
+      .map(
+        (x) =>
+          `${prefix}${x.side ?? ""}-${x.size < 0 ? "n" : ""}${Math.abs(x.size)}`
+      ),
   ];
 
   const nextValue = compact(uniq(nextClasses)).join(" ");


### PR DESCRIPTION
## What does this PR do?

- fix the spacing input format so that negative values are entered/parsed correctly.
- e.x. -5 margin should be `m-n5` instead of `m--5`

## Demo

- [loom](https://www.loom.com/share/062a51ee470d4c99ac78038a863e51e3?sid=8de6bf0e-fd60-4cfc-948b-a30308d91f86)

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
