### PR TITLE
Add dropdown with known events to "Emit Custom Event" brick

### DIFF
--- a/src/bricks/effects/customEvent.ts
+++ b/src/bricks/effects/customEvent.ts
@@ -17,7 +17,7 @@
 
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type JsonObject } from "type-fest";
-import { type Schema } from "@/types/schemaTypes";
+import { type UiSchema, type Schema } from "@/types/schemaTypes";
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { validateRegistryId } from "@/types/helpers";
 
@@ -46,6 +46,12 @@ class CustomEventEffect extends EffectABC {
       },
     },
     required: ["eventName"],
+  };
+
+  uiSchema: UiSchema = {
+    eventName: {
+      "ui:widget": "SchemaCustomEventWidget",
+    },
   };
 
   override async isRootAware(): Promise<boolean> {

--- a/src/bricks/effects/customEvent.ts
+++ b/src/bricks/effects/customEvent.ts
@@ -50,7 +50,7 @@ class CustomEventEffect extends EffectABC {
 
   uiSchema: UiSchema = {
     eventName: {
-      "ui:widget": "SchemaCustomEventWidget",
+      "ui:widget": "CustomEventField",
     },
   };
 

--- a/src/bricks/effects/customEvent.ts
+++ b/src/bricks/effects/customEvent.ts
@@ -50,7 +50,7 @@ class CustomEventEffect extends EffectABC {
 
   uiSchema: UiSchema = {
     eventName: {
-      "ui:widget": "CustomEventField",
+      "ui:widget": "SchemaCustomEventWidget",
     },
   };
 

--- a/src/components/documentBuilder/edit/getElementEditSchemas.tsx
+++ b/src/components/documentBuilder/edit/getElementEditSchemas.tsx
@@ -194,7 +194,7 @@ function getElementEditSchemas(
           ],
         },
         uiSchema: {
-          "ui:widget": "ButtonVariantSchemaField",
+          "ui:widget": "SchemaButtonVariantWidget",
         },
         label: "Button Style",
         description: "The style/variant of the button",

--- a/src/components/documentBuilder/edit/getElementEditSchemas.tsx
+++ b/src/components/documentBuilder/edit/getElementEditSchemas.tsx
@@ -194,7 +194,7 @@ function getElementEditSchemas(
           ],
         },
         uiSchema: {
-          "ui:widget": "SchemaButtonVariantWidget",
+          "ui:widget": "ButtonVariantSchemaField",
         },
         label: "Button Style",
         description: "The style/variant of the button",

--- a/src/components/fields/schemaFields/ButtonVariantSchemaField.tsx
+++ b/src/components/fields/schemaFields/ButtonVariantSchemaField.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { defaultFieldFactory } from "./defaultFieldFactory";
+import defaultFieldFactory from "@/components/fields/schemaFields/defaultFieldFactory";
 import SchemaButtonVariantWidget from "@/components/fields/schemaFields/widgets/SchemaButtonVariantWidget";
 
 const ButtonVariantSchemaField = defaultFieldFactory(SchemaButtonVariantWidget);

--- a/src/components/fields/schemaFields/ButtonVariantSchemaField.tsx
+++ b/src/components/fields/schemaFields/ButtonVariantSchemaField.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFieldContext";
+import { defaultFieldFactory } from "./defaultFieldFactory";
 import SchemaButtonVariantWidget from "@/components/fields/schemaFields/widgets/SchemaButtonVariantWidget";
 
 const ButtonVariantSchemaField = defaultFieldFactory(SchemaButtonVariantWidget);

--- a/src/components/fields/schemaFields/CssClassField.tsx
+++ b/src/components/fields/schemaFields/CssClassField.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useMemo } from "react";
-import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFieldContext";
+import { defaultFieldFactory } from "./defaultFieldFactory";
 import CssClassWidget from "@/components/fields/schemaFields/widgets/cssClassWidgets/CssClassWidget";
 import { getToggleOptions } from "@/components/fields/schemaFields/getToggleOptions";
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";

--- a/src/components/fields/schemaFields/CssClassField.tsx
+++ b/src/components/fields/schemaFields/CssClassField.tsx
@@ -16,10 +16,10 @@
  */
 
 import React, { useMemo } from "react";
-import { defaultFieldFactory } from "./defaultFieldFactory";
 import CssClassWidget from "@/components/fields/schemaFields/widgets/cssClassWidgets/CssClassWidget";
 import { getToggleOptions } from "@/components/fields/schemaFields/getToggleOptions";
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
+import defaultFieldFactory from "@/components/fields/schemaFields/defaultFieldFactory";
 
 const RawCssClassField = defaultFieldFactory(CssClassWidget);
 

--- a/src/components/fields/schemaFields/CssSpacingField.tsx
+++ b/src/components/fields/schemaFields/CssSpacingField.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { defaultFieldFactory } from "./defaultFieldFactory";
+import defaultFieldFactory from "@/components/fields/schemaFields/defaultFieldFactory";
 import CssSpacingWidget from "@/components/fields/schemaFields/widgets/cssClassWidgets/CssSpacingWidget";
 
 const CssSpacingField = defaultFieldFactory(CssSpacingWidget);

--- a/src/components/fields/schemaFields/CssSpacingField.tsx
+++ b/src/components/fields/schemaFields/CssSpacingField.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFieldContext";
+import { defaultFieldFactory } from "./defaultFieldFactory";
 import CssSpacingWidget from "@/components/fields/schemaFields/widgets/cssClassWidgets/CssSpacingWidget";
 
 const CssSpacingField = defaultFieldFactory(CssSpacingWidget);

--- a/src/components/fields/schemaFields/CustomEventField.tsx
+++ b/src/components/fields/schemaFields/CustomEventField.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFieldContext";
+import { SchemaCustomEventWidget } from "@/components/fields/schemaFields/widgets/SchemaCustomEventWidget";
+
+const CustomEventField = defaultFieldFactory(SchemaCustomEventWidget);
+export default CustomEventField;

--- a/src/components/fields/schemaFields/CustomEventField.tsx
+++ b/src/components/fields/schemaFields/CustomEventField.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { defaultFieldFactory } from "./defaultFieldFactory";
+import defaultFieldFactory from "@/components/fields/schemaFields/defaultFieldFactory";
 import { SchemaCustomEventWidget } from "@/components/fields/schemaFields/widgets/SchemaCustomEventWidget";
 
 const CustomEventField = defaultFieldFactory(SchemaCustomEventWidget);

--- a/src/components/fields/schemaFields/CustomEventField.tsx
+++ b/src/components/fields/schemaFields/CustomEventField.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFieldContext";
+import { defaultFieldFactory } from "./defaultFieldFactory";
 import { SchemaCustomEventWidget } from "@/components/fields/schemaFields/widgets/SchemaCustomEventWidget";
 
 const CustomEventField = defaultFieldFactory(SchemaCustomEventWidget);

--- a/src/components/fields/schemaFields/HeadingStyleField.tsx
+++ b/src/components/fields/schemaFields/HeadingStyleField.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { defaultFieldFactory } from "./defaultFieldFactory";
+import defaultFieldFactory from "@/components/fields/schemaFields/defaultFieldFactory";
 import HeadingStyleWidget from "./widgets/HeadingStyleWidget";
 
 const HeadingStyleField = defaultFieldFactory(HeadingStyleWidget);

--- a/src/components/fields/schemaFields/HeadingStyleField.tsx
+++ b/src/components/fields/schemaFields/HeadingStyleField.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFieldContext";
+import { defaultFieldFactory } from "./defaultFieldFactory";
 import HeadingStyleWidget from "./widgets/HeadingStyleWidget";
 
 const HeadingStyleField = defaultFieldFactory(HeadingStyleWidget);

--- a/src/components/fields/schemaFields/SchemaField.tsx
+++ b/src/components/fields/schemaFields/SchemaField.tsx
@@ -48,8 +48,10 @@ const SchemaField: SchemaFieldComponent = (props) => {
   }
 
   if (isUiWidget(uiSchema)) {
-    const Component = get(customWidgets, uiSchema["ui:widget"] as string, null);
-    return Component ? <Component {...props} /> : null;
+    const Component = get(customWidgets, uiSchema["ui:widget"] as string);
+
+    // If the uiWidget is registered, render it. Otherwise, render the default field.
+    if (Component) return <Component {...props} />;
   }
 
   if (props.name.endsWith(".isRootAware")) {

--- a/src/components/fields/schemaFields/SchemaField.tsx
+++ b/src/components/fields/schemaFields/SchemaField.tsx
@@ -48,8 +48,7 @@ const SchemaField: SchemaFieldComponent = (props) => {
   }
 
   if (isUiWidget(uiSchema)) {
-    const widgetName = get(uiSchema, "ui:widget", "") as string;
-    const Component = get(customWidgets, widgetName, null);
+    const Component = get(customWidgets, uiSchema["ui:widget"] as string, null);
     return Component ? <Component {...props} /> : null;
   }
 

--- a/src/components/fields/schemaFields/SchemaField.tsx
+++ b/src/components/fields/schemaFields/SchemaField.tsx
@@ -25,10 +25,12 @@ import {
   isAppServiceField,
   isButtonVariantField,
   isCssClassField,
+  isCustomEventField,
   isHeadingStyleField,
 } from "./fieldTypeCheckers";
 import RootAwareField from "@/components/fields/schemaFields/RootAwareField";
 import ButtonVariantSchemaField from "@/components/fields/schemaFields/ButtonVariantSchemaField";
+import CustomEventField from "@/components/fields/schemaFields/CustomEventField";
 
 const SchemaField: SchemaFieldComponent = (props) => {
   const { schema, uiSchema } = props;
@@ -47,6 +49,10 @@ const SchemaField: SchemaFieldComponent = (props) => {
 
   if (isButtonVariantField(uiSchema)) {
     return <ButtonVariantSchemaField {...props} />;
+  }
+
+  if (isCustomEventField(uiSchema)) {
+    return <CustomEventField {...props} />;
   }
 
   if (props.name.endsWith(".isRootAware")) {

--- a/src/components/fields/schemaFields/SchemaField.tsx
+++ b/src/components/fields/schemaFields/SchemaField.tsx
@@ -16,7 +16,10 @@
  */
 
 import React, { useContext } from "react";
-import { type SchemaFieldComponent } from "@/components/fields/schemaFields/propTypes";
+import {
+  type SchemaFieldProps,
+  type SchemaFieldComponent,
+} from "@/components/fields/schemaFields/propTypes";
 import BasicSchemaField from "@/components/fields/schemaFields/BasicSchemaField";
 import AppServiceField from "@/components/fields/schemaFields/AppServiceField";
 import CssClassField from "./CssClassField";
@@ -25,11 +28,12 @@ import {
   isAppServiceField,
   isCssClassField,
   isHeadingStyleField,
-  isUiWidget,
+  hasCustomWidget,
 } from "./fieldTypeCheckers";
 import RootAwareField from "@/components/fields/schemaFields/RootAwareField";
 import SchemaFieldContext from "@/components/fields/schemaFields/SchemaFieldContext";
 import { get } from "lodash";
+import defaultFieldFactory from "@/components/fields/schemaFields/defaultFieldFactory";
 
 const SchemaField: SchemaFieldComponent = (props) => {
   const { schema, uiSchema } = props;
@@ -47,11 +51,16 @@ const SchemaField: SchemaFieldComponent = (props) => {
     return <HeadingStyleField {...props} />;
   }
 
-  if (isUiWidget(uiSchema)) {
-    const Component = get(customWidgets, uiSchema["ui:widget"] as string);
+  if (hasCustomWidget(uiSchema)) {
+    const widget = get(customWidgets, uiSchema["ui:widget"] as string);
 
     // If the uiWidget is registered, render it. Otherwise, render the default field.
-    if (Component) return <Component {...props} />;
+    if (widget) {
+      const Component = defaultFieldFactory(
+        widget as React.VFC<SchemaFieldProps>
+      );
+      return <Component {...props} />;
+    }
   }
 
   if (props.name.endsWith(".isRootAware")) {

--- a/src/components/fields/schemaFields/SchemaField.tsx
+++ b/src/components/fields/schemaFields/SchemaField.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { useContext } from "react";
 import { type SchemaFieldComponent } from "@/components/fields/schemaFields/propTypes";
 import BasicSchemaField from "@/components/fields/schemaFields/BasicSchemaField";
 import AppServiceField from "@/components/fields/schemaFields/AppServiceField";
@@ -23,17 +23,17 @@ import CssClassField from "./CssClassField";
 import HeadingStyleField from "./HeadingStyleField";
 import {
   isAppServiceField,
-  isButtonVariantField,
   isCssClassField,
-  isCustomEventField,
   isHeadingStyleField,
+  isUiWidget,
 } from "./fieldTypeCheckers";
 import RootAwareField from "@/components/fields/schemaFields/RootAwareField";
-import ButtonVariantSchemaField from "@/components/fields/schemaFields/ButtonVariantSchemaField";
-import CustomEventField from "@/components/fields/schemaFields/CustomEventField";
+import SchemaFieldContext from "@/components/fields/schemaFields/SchemaFieldContext";
+import { get } from "lodash";
 
 const SchemaField: SchemaFieldComponent = (props) => {
   const { schema, uiSchema } = props;
+  const { customWidgets } = useContext(SchemaFieldContext);
 
   if (isAppServiceField(schema)) {
     return <AppServiceField {...props} />;
@@ -47,12 +47,10 @@ const SchemaField: SchemaFieldComponent = (props) => {
     return <HeadingStyleField {...props} />;
   }
 
-  if (isButtonVariantField(uiSchema)) {
-    return <ButtonVariantSchemaField {...props} />;
-  }
-
-  if (isCustomEventField(uiSchema)) {
-    return <CustomEventField {...props} />;
+  if (isUiWidget(uiSchema)) {
+    const widgetName = get(uiSchema, "ui:widget", "") as string;
+    const Component = get(customWidgets, widgetName, null);
+    return Component ? <Component {...props} /> : null;
   }
 
   if (props.name.endsWith(".isRootAware")) {

--- a/src/components/fields/schemaFields/SchemaFieldContext.tsx
+++ b/src/components/fields/schemaFields/SchemaFieldContext.tsx
@@ -20,12 +20,12 @@ import {
   type CustomWidgetRegistry,
   type CustomFieldDefinitions,
 } from "@/components/fields/schemaFields/schemaFieldTypes";
-import ButtonVariantSchemaField from "@/components/fields/schemaFields/ButtonVariantSchemaField";
-import CustomEventField from "@/components/fields/schemaFields/CustomEventField";
+import SchemaButtonVariantWidget from "@/components/fields/schemaFields/widgets/SchemaButtonVariantWidget";
+import { SchemaCustomEventWidget } from "@/components/fields/schemaFields/widgets/SchemaCustomEventWidget";
 
 export const customWidgets: CustomWidgetRegistry = {
-  ButtonVariantSchemaField,
-  CustomEventField,
+  SchemaButtonVariantWidget,
+  SchemaCustomEventWidget,
 } as const;
 
 /**

--- a/src/components/fields/schemaFields/SchemaFieldContext.tsx
+++ b/src/components/fields/schemaFields/SchemaFieldContext.tsx
@@ -15,45 +15,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { createContext } from "react";
+import { createContext } from "react";
 import {
-  type SchemaFieldComponent,
-  type SchemaFieldProps,
-} from "@/components/fields/schemaFields/propTypes";
-import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
-import { makeLabelForSchemaField } from "@/components/fields/schemaFields/schemaFieldUtils";
-import { type CustomFieldDefinitions } from "@/components/fields/schemaFields/schemaFieldTypes";
+  type CustomWidgetRegistry,
+  type CustomFieldDefinitions,
+} from "@/components/fields/schemaFields/schemaFieldTypes";
+import ButtonVariantSchemaField from "@/components/fields/schemaFields/ButtonVariantSchemaField";
+import CustomEventField from "@/components/fields/schemaFields/CustomEventField";
 
-export function defaultFieldFactory(
-  Widget: React.FC<SchemaFieldProps>
-): SchemaFieldComponent {
-  if (Widget == null) {
-    // This would indicate a problem with the imports b/c all the call sites are passing in an imported component?
-    // Circular import
-    throw new Error("Widget is required");
-  }
-
-  const Field: React.FunctionComponent<SchemaFieldProps> = (props) => {
-    const { schema, description } = props;
-    return (
-      <ConnectedFieldTemplate
-        {...props}
-        label={makeLabelForSchemaField(props)}
-        description={description ?? schema.description}
-        as={Widget}
-      />
-    );
-  };
-
-  Field.displayName = `SchemaField(${Widget.displayName})`;
-  return Field;
-}
+export const customWidgets: CustomWidgetRegistry = {
+  ButtonVariantSchemaField,
+  CustomEventField,
+} as const;
 
 /**
  * Context defining custom fields and widgets for schema-based fields.
  */
 const SchemaFieldContext = createContext<CustomFieldDefinitions>({
   customToggleModes: [],
+  customWidgets,
 });
 
 export default SchemaFieldContext;

--- a/src/components/fields/schemaFields/defaultFieldFactory.tsx
+++ b/src/components/fields/schemaFields/defaultFieldFactory.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import {
+  type SchemaFieldComponent,
+  type SchemaFieldProps,
+} from "@/components/fields/schemaFields/propTypes";
+import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
+import { makeLabelForSchemaField } from "@/components/fields/schemaFields/schemaFieldUtils";
+
+export function defaultFieldFactory(
+  Widget: React.FC<SchemaFieldProps>
+): SchemaFieldComponent {
+  if (Widget == null) {
+    // This would indicate a problem with the imports b/c all the call sites are passing in an imported component?
+    // Circular import
+    throw new Error("Widget is required");
+  }
+
+  const Field: React.FunctionComponent<SchemaFieldProps> = (props) => {
+    const { schema, description } = props;
+    return (
+      <ConnectedFieldTemplate
+        {...props}
+        label={makeLabelForSchemaField(props)}
+        description={description ?? schema.description}
+        as={Widget}
+      />
+    );
+  };
+
+  Field.displayName = `SchemaField(${Widget.displayName})`;
+  return Field;
+}

--- a/src/components/fields/schemaFields/defaultFieldFactory.tsx
+++ b/src/components/fields/schemaFields/defaultFieldFactory.tsx
@@ -23,7 +23,7 @@ import {
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import { makeLabelForSchemaField } from "@/components/fields/schemaFields/schemaFieldUtils";
 
-export function defaultFieldFactory(
+export default function defaultFieldFactory(
   Widget: React.FC<SchemaFieldProps>
 ): SchemaFieldComponent {
   if (Widget == null) {

--- a/src/components/fields/schemaFields/fieldTypeCheckers.ts
+++ b/src/components/fields/schemaFields/fieldTypeCheckers.ts
@@ -58,6 +58,10 @@ export const isButtonVariantField = (uiSchema?: UiSchema) =>
   typeof uiSchema === "object" &&
   get(uiSchema, ["ui:widget"]) === "SchemaButtonVariantWidget";
 
+export const isCustomEventField = (uiSchema?: UiSchema) =>
+  typeof uiSchema === "object" &&
+  get(uiSchema, ["ui:widget"]) === "SchemaCustomEventWidget";
+
 /**
  * Returns true if the schema uses oneOf and "const" keyword to label enum options.
  * Read more at: https://github.com/json-schema-org/json-schema-spec/issues/57#issuecomment-247861695

--- a/src/components/fields/schemaFields/fieldTypeCheckers.ts
+++ b/src/components/fields/schemaFields/fieldTypeCheckers.ts
@@ -54,13 +54,8 @@ export const isHeadingStyleField = (fieldDefinition: Schema) =>
   fieldDefinition.type === "string" &&
   fieldDefinition.format === "heading-style";
 
-export const isButtonVariantField = (uiSchema?: UiSchema) =>
-  typeof uiSchema === "object" &&
-  get(uiSchema, ["ui:widget"]) === "SchemaButtonVariantWidget";
-
-export const isCustomEventField = (uiSchema?: UiSchema) =>
-  typeof uiSchema === "object" &&
-  get(uiSchema, ["ui:widget"]) === "SchemaCustomEventWidget";
+export const isUiWidget = (uiSchema?: UiSchema) =>
+  typeof get(uiSchema, ["ui:widget"]) === "string";
 
 /**
  * Returns true if the schema uses oneOf and "const" keyword to label enum options.

--- a/src/components/fields/schemaFields/fieldTypeCheckers.ts
+++ b/src/components/fields/schemaFields/fieldTypeCheckers.ts
@@ -54,7 +54,7 @@ export const isHeadingStyleField = (fieldDefinition: Schema) =>
   fieldDefinition.type === "string" &&
   fieldDefinition.format === "heading-style";
 
-export const isUiWidget = (uiSchema?: UiSchema) =>
+export const hasCustomWidget = (uiSchema?: UiSchema) =>
   typeof get(uiSchema, ["ui:widget"]) === "string";
 
 /**

--- a/src/components/fields/schemaFields/schemaFieldTypes.ts
+++ b/src/components/fields/schemaFields/schemaFieldTypes.ts
@@ -17,7 +17,8 @@
 
 import { type Schema } from "@/types/schemaTypes";
 import { type InputModeOption } from "@/components/fields/schemaFields/widgets/templateToggleWidgetTypes";
-import { type SchemaFieldComponent } from "@/components/fields/schemaFields/propTypes";
+import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
+import type React from "react";
 
 export type CustomFieldToggleMode = {
   match: (fieldSchema: Schema) => boolean;
@@ -25,8 +26,8 @@ export type CustomFieldToggleMode = {
 };
 
 export type CustomWidgetRegistry = {
-  ButtonVariantSchemaField: SchemaFieldComponent;
-  CustomEventField: SchemaFieldComponent;
+  SchemaButtonVariantWidget: React.VFC<SchemaFieldProps>;
+  SchemaCustomEventWidget: React.VFC<SchemaFieldProps>;
 };
 
 export type CustomFieldDefinitions = {

--- a/src/components/fields/schemaFields/schemaFieldTypes.ts
+++ b/src/components/fields/schemaFields/schemaFieldTypes.ts
@@ -17,11 +17,19 @@
 
 import { type Schema } from "@/types/schemaTypes";
 import { type InputModeOption } from "@/components/fields/schemaFields/widgets/templateToggleWidgetTypes";
+import { type SchemaFieldComponent } from "@/components/fields/schemaFields/propTypes";
 
 export type CustomFieldToggleMode = {
   match: (fieldSchema: Schema) => boolean;
   option: InputModeOption;
 };
+
+export type CustomWidgetRegistry = {
+  ButtonVariantSchemaField: SchemaFieldComponent;
+  CustomEventField: SchemaFieldComponent;
+};
+
 export type CustomFieldDefinitions = {
   customToggleModes: CustomFieldToggleMode[];
+  customWidgets: CustomWidgetRegistry;
 };

--- a/src/components/fields/schemaFields/widgets/SchemaCustomEventWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/SchemaCustomEventWidget.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import SchemaSelectWidget from "@/components/fields/schemaFields/widgets/SchemaSelectWidget";
+import { selectExtensionKnownEventNames } from "@/pageEditor/slices/editorSelectors";
+import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
+import React from "react";
+import { useSelector } from "react-redux";
+
+export const SchemaCustomEventWidget: React.FC<SchemaFieldProps> = ({
+  schema,
+  ...props
+}) => {
+  const knownEventNames = useSelector(selectExtensionKnownEventNames);
+
+  return (
+    <SchemaSelectWidget
+      schema={{ ...schema, examples: knownEventNames }}
+      {...props}
+    />
+  );
+};

--- a/src/contrib/zapier/PushOptions.tsx
+++ b/src/contrib/zapier/PushOptions.tsx
@@ -29,7 +29,7 @@ import AsyncButton from "@/components/AsyncButton";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import SelectWidget from "@/components/form/widgets/SelectWidget";
 import ObjectWidget from "@/components/fields/schemaFields/widgets/ObjectWidget";
-import { defaultFieldFactory } from "@/components/fields/schemaFields/SchemaFieldContext";
+import { defaultFieldFactory } from "@/components/fields/schemaFields/defaultFieldFactory";
 import { makeLabelForSchemaField } from "@/components/fields/schemaFields/schemaFieldUtils";
 import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 import FieldTemplate from "@/components/form/FieldTemplate";

--- a/src/contrib/zapier/PushOptions.tsx
+++ b/src/contrib/zapier/PushOptions.tsx
@@ -29,7 +29,6 @@ import AsyncButton from "@/components/AsyncButton";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import SelectWidget from "@/components/form/widgets/SelectWidget";
 import ObjectWidget from "@/components/fields/schemaFields/widgets/ObjectWidget";
-import { defaultFieldFactory } from "@/components/fields/schemaFields/defaultFieldFactory";
 import { makeLabelForSchemaField } from "@/components/fields/schemaFields/schemaFieldUtils";
 import WorkshopMessageWidget from "@/components/fields/schemaFields/widgets/WorkshopMessageWidget";
 import FieldTemplate from "@/components/form/FieldTemplate";
@@ -39,6 +38,7 @@ import useExtensionPermissions from "@/permissions/useExtensionPermissions";
 import useRequestPermissionsCallback from "@/permissions/useRequestPermissionsCallback";
 import { isExpression } from "@/utils/expressionUtils";
 import { joinName } from "@/utils/formUtils";
+import defaultFieldFactory from "@/components/fields/schemaFields/defaultFieldFactory";
 
 function useHooks(): {
   hooks: Webhook[];

--- a/src/pageEditor/fields/devtoolFieldOverrides.tsx
+++ b/src/pageEditor/fields/devtoolFieldOverrides.tsx
@@ -23,6 +23,7 @@ import { type Schema } from "@/types/schemaTypes";
 import OptionIcon from "@/components/fields/schemaFields/optionIcon/OptionIcon";
 import { type CustomFieldDefinitions } from "@/components/fields/schemaFields/schemaFieldTypes";
 import { isTemplateExpression } from "@/utils/expressionUtils";
+import { customWidgets } from "@/components/fields/schemaFields/SchemaFieldContext";
 
 const ClearableSelectorWidget: React.FunctionComponent<
   SelectorSelectorProps
@@ -54,6 +55,7 @@ const devtoolFieldOverrides: CustomFieldDefinitions = {
       },
     },
   ],
+  customWidgets,
 };
 
 export default devtoolFieldOverrides;


### PR DESCRIPTION
## What does this PR do?

- Closes #6286 

## Reviewer Tips

- In `@/components/fields/schemaFields/widgets/SchemaCustomEventWidget.tsx`, I'm importing `import { selectExtensionKnownEventNames } from "@/pageEditor/slices/editorSelectors";`. This is throwing a lint warning for `no-restricted-paths`. Is there a different approach I should be taking?

## Demo

https://www.loom.com/share/f938771e49784ca8a301b7fb46e3ed23?sid=f5238822-6b53-415a-ba9d-608401795077

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer @twschiller 
