### PR TITLE
add overflow:hidden to panels

### DIFF
--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -56,7 +56,10 @@ const BodyContainer: React.FC<
   BodyProps & { onAction: (action: SubmitPanelAction) => void }
 > = ({ blockId, body, onAction, meta }) => (
   // Use a shadow dom to prevent the webpage styles from affecting the sidebar
-  <EmotionShadowRoot.div className="full-height" data-block-id={blockId}>
+  <EmotionShadowRoot.div
+    className="full-height overflow-hidden"
+    data-block-id={blockId}
+  >
     <RendererComponent
       blockId={blockId}
       body={body}


### PR DESCRIPTION
## What does this PR do?

- Fixes scrollbars on overflowed items in sidebar
- This happened because bootstrap likes using negative margins to compensate for over-padding.

## Demo

- [Loom](https://www.loom.com/share/7c2756346da047a8acab5460397259b3?sid=7e55422e-f913-4a23-bb87-473b62a759c1)

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
