### PR TITLE
#6229 Add active styling to active pipeline header nodes

### DIFF
--- a/src/pageEditor/tabs/editTab/editTabTypes.ts
+++ b/src/pageEditor/tabs/editTab/editTabTypes.ts
@@ -59,7 +59,7 @@ export type BrickNodeProps = BrickNodeContentProps &
   MoveBrickControlProps & {
     onClick?: () => void;
     active?: boolean;
-    parentIsActive?: boolean;
+    parentActive?: boolean;
     onHoverChange: (hovered: boolean) => void;
     nestingLevel: number;
     hasSubPipelines?: boolean;

--- a/src/pageEditor/tabs/editTab/editTabTypes.ts
+++ b/src/pageEditor/tabs/editTab/editTabTypes.ts
@@ -59,7 +59,7 @@ export type BrickNodeProps = BrickNodeContentProps &
   MoveBrickControlProps & {
     onClick?: () => void;
     active?: boolean;
-    parentActive?: boolean;
+    isParentActive?: boolean;
     onHoverChange: (hovered: boolean) => void;
     nestingLevel: number;
     hasSubPipelines?: boolean;

--- a/src/pageEditor/tabs/editTab/editTabTypes.ts
+++ b/src/pageEditor/tabs/editTab/editTabTypes.ts
@@ -67,5 +67,5 @@ export type BrickNodeProps = BrickNodeContentProps &
     nodeActions: NodeAction[];
     showBiggerActions?: boolean;
     trailingMessage?: string;
-    activeSubPipelineHeader: boolean;
+    activeSubPipelineHeader?: boolean;
   };

--- a/src/pageEditor/tabs/editTab/editTabTypes.ts
+++ b/src/pageEditor/tabs/editTab/editTabTypes.ts
@@ -67,5 +67,5 @@ export type BrickNodeProps = BrickNodeContentProps &
     nodeActions: NodeAction[];
     showBiggerActions?: boolean;
     trailingMessage?: string;
-    subPipelineHeaderActive?: boolean;
+    isSubPipelineHeaderActive?: boolean;
   };

--- a/src/pageEditor/tabs/editTab/editTabTypes.ts
+++ b/src/pageEditor/tabs/editTab/editTabTypes.ts
@@ -67,4 +67,5 @@ export type BrickNodeProps = BrickNodeContentProps &
     nodeActions: NodeAction[];
     showBiggerActions?: boolean;
     trailingMessage?: string;
+    activeSubPipelineHeader: boolean;
   };

--- a/src/pageEditor/tabs/editTab/editTabTypes.ts
+++ b/src/pageEditor/tabs/editTab/editTabTypes.ts
@@ -67,5 +67,5 @@ export type BrickNodeProps = BrickNodeContentProps &
     nodeActions: NodeAction[];
     showBiggerActions?: boolean;
     trailingMessage?: string;
-    activeSubPipelineHeader?: boolean;
+    subPipelineHeaderActive?: boolean;
   };

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -442,6 +442,11 @@ const usePipelineNodes = (): {
       nodeActions: expanded ? [] : brickNodeActions,
       showBiggerActions,
       trailingMessage,
+      activeSubPipelineHeader: subPipelines.some(
+        ({ path }) =>
+          activeNodePreviewElementId ===
+          getNodePreviewElementId(blockConfig, path)
+      ),
     };
 
     nodes.push({

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -466,14 +466,6 @@ const usePipelineNodes = (): {
       activeSubPipelineHeader,
     };
 
-    if (isNodeActive) {
-      console.log(
-        "*** brick",
-        contentProps.brickLabel,
-        activeSubPipelineHeader
-      );
-    }
-
     nodes.push({
       type: "brick",
       key: blockConfig.instanceId,
@@ -495,6 +487,8 @@ const usePipelineNodes = (): {
         const isHeaderNodeActive = activeNodePreviewElementId
           ? nodePreviewElementId === activeNodePreviewElementId
           : false;
+
+        const activeSiblingHeader = activeSubPipelineHeader;
 
         const headerActions: NodeAction[] = [
           {
@@ -530,8 +524,8 @@ const usePipelineNodes = (): {
           nodeActions: headerActions,
           pipelineInputKey: inputKey,
           active: isHeaderNodeActive,
-          parentActive: activeSubPipelineHeader ? false : isNodeActive,
-          ancestorActive: activeSubPipelineHeader ? false : parentActive,
+          parentActive: activeSiblingHeader ? false : isNodeActive,
+          ancestorActive: activeSiblingHeader ? false : parentActive,
           nodePreviewElement: nodePreviewElementId
             ? {
                 name: nodePreviewElementId,
@@ -562,10 +556,10 @@ const usePipelineNodes = (): {
           flavor,
           pipelinePath: fullSubPath,
           nestingLevel: nestingLevel + 1,
-          parentActive: activeSubPipelineHeader
+          parentActive: activeSiblingHeader
             ? isHeaderNodeActive
             : isNodeActive || parentActive,
-          ancestorActive: activeSubPipelineHeader
+          ancestorActive: activeSiblingHeader
             ? isHeaderNodeActive
             : parentActive || ancestorActive,
         });

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -328,23 +328,23 @@ const usePipelineNodes = (): {
     const expanded = hasSubPipelines && !collapsed;
 
     const onClick = () => {
-      if (isNodeActive) {
-        if (activeNodePreviewElementId) {
-          dispatch(actions.setNodePreviewActiveElement(null));
+      if (activeNodePreviewElementId) {
+        dispatch(actions.setNodePreviewActiveElement(null));
+
+        if (isNodeActive) {
           return;
         }
+      }
 
-        if (hasSubPipelines) {
-          dispatch(
-            actions.toggleCollapseBrickPipelineNode(blockConfig.instanceId)
-          );
-        }
-      } else {
-        if (activeNodePreviewElementId) {
-          dispatch(actions.setNodePreviewActiveElement(null));
-        }
-
+      if (!isNodeActive) {
         setActiveNodeId(blockConfig.instanceId);
+        return;
+      }
+
+      if (hasSubPipelines) {
+        dispatch(
+          actions.toggleCollapseBrickPipelineNode(blockConfig.instanceId)
+        );
       }
     };
 
@@ -453,7 +453,7 @@ const usePipelineNodes = (): {
       onClickMoveUp,
       onClickMoveDown,
       onClick,
-      active: subPipelineHeaderActive ? false : isNodeActive,
+      active: !subPipelineHeaderActive && isNodeActive,
       onHoverChange,
       parentActive,
       nestingLevel,
@@ -483,10 +483,9 @@ const usePipelineNodes = (): {
         const headerName = `${nodeId}-header`;
         const fullSubPath = joinPathParts(pipelinePath, index, path);
         const nodePreviewElementId = getNodePreviewElementId(blockConfig, path);
-        const isHeaderNodeActive = activeNodePreviewElementId
-          ? nodePreviewElementId === activeNodePreviewElementId
-          : false;
-
+        const isHeaderNodeActive =
+          activeNodePreviewElementId &&
+          nodePreviewElementId === activeNodePreviewElementId;
         const activeSiblingHeader = subPipelineHeaderActive;
 
         const headerActions: NodeAction[] = [
@@ -523,8 +522,8 @@ const usePipelineNodes = (): {
           nodeActions: headerActions,
           pipelineInputKey: inputKey,
           active: isHeaderNodeActive,
-          parentActive: activeSiblingHeader ? false : isNodeActive,
-          ancestorActive: activeSiblingHeader ? false : parentActive,
+          parentActive: !activeSiblingHeader && isNodeActive,
+          ancestorActive: !activeSiblingHeader && parentActive,
           nodePreviewElement: nodePreviewElementId
             ? {
                 name: nodePreviewElementId,
@@ -581,7 +580,7 @@ const usePipelineNodes = (): {
         showBiggerActions,
         trailingMessage,
         nestingLevel,
-        active: subPipelineHeaderActive ? false : isNodeActive,
+        active: !subPipelineHeaderActive && isNodeActive,
         nestedActive: parentActive,
         hovered,
         onHoverChange,

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -327,10 +327,7 @@ const usePipelineNodes = (): {
 
     const onClick = () => {
       if (nodeIsActive) {
-        if (
-          blockConfig.id === DocumentRenderer.BLOCK_ID &&
-          activeNodePreviewElementId
-        ) {
+        if (activeNodePreviewElementId) {
           dispatch(actions.setNodePreviewActiveElement(null));
           return;
         }
@@ -434,6 +431,12 @@ const usePipelineNodes = (): {
       };
     }
 
+    const activeSubPipelineHeader = subPipelines.some(
+      ({ path }) =>
+        activeNodePreviewElementId ===
+        getNodePreviewElementId(blockConfig, path)
+    );
+
     const restBrickNodeProps: Except<
       BrickNodeProps,
       keyof BrickNodeContentProps
@@ -441,7 +444,7 @@ const usePipelineNodes = (): {
       onClickMoveUp,
       onClickMoveDown,
       onClick,
-      active: nodeIsActive,
+      active: activeSubPipelineHeader ? false : nodeIsActive,
       onHoverChange,
       parentIsActive,
       nestingLevel,
@@ -450,11 +453,7 @@ const usePipelineNodes = (): {
       nodeActions: expanded ? [] : brickNodeActions,
       showBiggerActions,
       trailingMessage,
-      activeSubPipelineHeader: subPipelines.some(
-        ({ path }) =>
-          activeNodePreviewElementId ===
-          getNodePreviewElementId(blockConfig, path)
-      ),
+      activeSubPipelineHeader,
     };
 
     nodes.push({
@@ -509,7 +508,9 @@ const usePipelineNodes = (): {
           nestingLevel,
           nodeActions: headerActions,
           pipelineInputKey: inputKey,
-          active: nodeIsActive,
+          active: restBrickNodeProps.activeSubPipelineHeader
+            ? nodePreviewElementId === activeNodePreviewElementId
+            : nodeIsActive,
           nestedActive: parentIsActive,
           nodePreviewElement: nodePreviewElementId
             ? {
@@ -541,7 +542,9 @@ const usePipelineNodes = (): {
           flavor,
           pipelinePath: fullSubPath,
           nestingLevel: nestingLevel + 1,
-          parentIsActive: nodeIsActive || parentIsActive,
+          parentIsActive: restBrickNodeProps.activeSubPipelineHeader
+            ? headerNodeProps.nodePreviewElement?.active
+            : nodeIsActive || parentIsActive,
         });
 
         nodes.push(
@@ -562,7 +565,7 @@ const usePipelineNodes = (): {
         showBiggerActions,
         trailingMessage,
         nestingLevel,
-        active: nodeIsActive,
+        active: activeSubPipelineHeader ? false : nodeIsActive,
         nestedActive: parentIsActive,
         hovered,
         onHoverChange,

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -327,6 +327,14 @@ const usePipelineNodes = (): {
 
     const onClick = () => {
       if (nodeIsActive) {
+        if (
+          blockConfig.id === DocumentRenderer.BLOCK_ID &&
+          activeNodePreviewElementId
+        ) {
+          dispatch(actions.setNodePreviewActiveElement(null));
+          return;
+        }
+
         if (hasSubPipelines) {
           dispatch(
             actions.toggleCollapseBrickPipelineNode(blockConfig.instanceId)

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -437,7 +437,7 @@ const usePipelineNodes = (): {
       };
     }
 
-    const activeSubPipelineHeader =
+    const subPipelineHeaderActive =
       activeNodePreviewElementId === null
         ? false
         : subPipelines.some(
@@ -453,7 +453,7 @@ const usePipelineNodes = (): {
       onClickMoveUp,
       onClickMoveDown,
       onClick,
-      active: activeSubPipelineHeader ? false : isNodeActive,
+      active: subPipelineHeaderActive ? false : isNodeActive,
       onHoverChange,
       parentActive,
       nestingLevel,
@@ -462,8 +462,7 @@ const usePipelineNodes = (): {
       nodeActions: expanded ? [] : brickNodeActions,
       showBiggerActions,
       trailingMessage,
-      // TODO: rename me subPipelineHeaderActive
-      activeSubPipelineHeader,
+      subPipelineHeaderActive,
     };
 
     nodes.push({
@@ -488,7 +487,7 @@ const usePipelineNodes = (): {
           ? nodePreviewElementId === activeNodePreviewElementId
           : false;
 
-        const activeSiblingHeader = activeSubPipelineHeader;
+        const activeSiblingHeader = subPipelineHeaderActive;
 
         const headerActions: NodeAction[] = [
           {
@@ -582,7 +581,7 @@ const usePipelineNodes = (): {
         showBiggerActions,
         trailingMessage,
         nestingLevel,
-        active: activeSubPipelineHeader ? false : isNodeActive,
+        active: subPipelineHeaderActive ? false : isNodeActive,
         nestedActive: parentActive,
         hovered,
         onHoverChange,

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -274,8 +274,8 @@ const usePipelineNodes = (): {
     lastIndex,
     isRootPipeline,
     showAppend,
-    parentActive,
-    ancestorActive,
+    isParentActive,
+    isAncestorActive,
     nestingLevel,
     extensionHasTraces: extensionHasTracesInput,
   }: {
@@ -287,8 +287,8 @@ const usePipelineNodes = (): {
     lastIndex: number;
     isRootPipeline: boolean;
     showAppend: boolean;
-    parentActive: boolean;
-    ancestorActive: boolean;
+    isParentActive: boolean;
+    isAncestorActive: boolean;
     nestingLevel: number;
     extensionHasTraces?: boolean;
   }): MapOutput {
@@ -455,7 +455,7 @@ const usePipelineNodes = (): {
       onClick,
       active: !subPipelineHeaderActive && isNodeActive,
       onHoverChange,
-      parentActive,
+      isParentActive,
       nestingLevel,
       hasSubPipelines,
       collapsed,
@@ -522,8 +522,8 @@ const usePipelineNodes = (): {
           nodeActions: headerActions,
           pipelineInputKey: inputKey,
           active: isHeaderNodeActive,
-          parentActive: !activeSiblingHeader && isNodeActive,
-          ancestorActive: !activeSiblingHeader && parentActive,
+          isParentActive: !activeSiblingHeader && isNodeActive,
+          isAncestorActive: !activeSiblingHeader && isParentActive,
           nodePreviewElement: nodePreviewElementId
             ? {
                 name: nodePreviewElementId,
@@ -554,12 +554,12 @@ const usePipelineNodes = (): {
           flavor,
           pipelinePath: fullSubPath,
           nestingLevel: nestingLevel + 1,
-          parentActive: activeSiblingHeader
+          isParentActive: activeSiblingHeader
             ? isHeaderNodeActive
-            : isNodeActive || parentActive,
-          ancestorActive: activeSiblingHeader
+            : isNodeActive || isParentActive,
+          isAncestorActive: activeSiblingHeader
             ? isHeaderNodeActive
-            : parentActive || ancestorActive,
+            : isParentActive || isAncestorActive,
         });
 
         nodes.push(
@@ -581,7 +581,7 @@ const usePipelineNodes = (): {
         trailingMessage,
         nestingLevel,
         active: !subPipelineHeaderActive && isNodeActive,
-        nestedActive: parentActive,
+        nestedActive: isParentActive,
         hovered,
         onHoverChange,
         onClick,
@@ -604,15 +604,15 @@ const usePipelineNodes = (): {
     flavor,
     pipelinePath = PIPELINE_BLOCKS_FIELD_NAME,
     nestingLevel = 0,
-    parentActive = false,
-    ancestorActive = false,
+    isParentActive = false,
+    isAncestorActive = false,
   }: {
     pipeline: BrickPipeline;
     flavor: PipelineFlavor;
     pipelinePath?: string;
     nestingLevel?: number;
-    parentActive?: boolean;
-    ancestorActive?: boolean;
+    isParentActive?: boolean;
+    isAncestorActive?: boolean;
   }): MapOutput {
     const isRootPipeline = pipelinePath === PIPELINE_BLOCKS_FIELD_NAME;
     const lastIndex = pipeline.length - 1;
@@ -647,8 +647,8 @@ const usePipelineNodes = (): {
           lastIndex,
           isRootPipeline,
           showAppend,
-          parentActive,
-          ancestorActive,
+          isParentActive,
+          isAncestorActive,
           nestingLevel,
           extensionHasTraces,
         });

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -437,7 +437,7 @@ const usePipelineNodes = (): {
       };
     }
 
-    const subPipelineHeaderActive =
+    const isSubPipelineHeaderActive =
       activeNodePreviewElementId === null
         ? false
         : subPipelines.some(
@@ -453,7 +453,7 @@ const usePipelineNodes = (): {
       onClickMoveUp,
       onClickMoveDown,
       onClick,
-      active: !subPipelineHeaderActive && isNodeActive,
+      active: !isSubPipelineHeaderActive && isNodeActive,
       onHoverChange,
       isParentActive,
       nestingLevel,
@@ -462,7 +462,7 @@ const usePipelineNodes = (): {
       nodeActions: expanded ? [] : brickNodeActions,
       showBiggerActions,
       trailingMessage,
-      subPipelineHeaderActive,
+      isSubPipelineHeaderActive,
     };
 
     nodes.push({
@@ -486,7 +486,7 @@ const usePipelineNodes = (): {
         const isHeaderNodeActive =
           activeNodePreviewElementId &&
           nodePreviewElementId === activeNodePreviewElementId;
-        const activeSiblingHeader = subPipelineHeaderActive;
+        const isSiblingHeaderActive = isSubPipelineHeaderActive;
 
         const headerActions: NodeAction[] = [
           {
@@ -522,8 +522,8 @@ const usePipelineNodes = (): {
           nodeActions: headerActions,
           pipelineInputKey: inputKey,
           active: isHeaderNodeActive,
-          isParentActive: !activeSiblingHeader && isNodeActive,
-          isAncestorActive: !activeSiblingHeader && isParentActive,
+          isParentActive: !isSiblingHeaderActive && isNodeActive,
+          isAncestorActive: !isSiblingHeaderActive && isParentActive,
           nodePreviewElement: nodePreviewElementId
             ? {
                 name: nodePreviewElementId,
@@ -554,10 +554,10 @@ const usePipelineNodes = (): {
           flavor,
           pipelinePath: fullSubPath,
           nestingLevel: nestingLevel + 1,
-          isParentActive: activeSiblingHeader
+          isParentActive: isSiblingHeaderActive
             ? isHeaderNodeActive
             : isNodeActive || isParentActive,
-          isAncestorActive: activeSiblingHeader
+          isAncestorActive: isSiblingHeaderActive
             ? isHeaderNodeActive
             : isParentActive || isAncestorActive,
         });
@@ -580,7 +580,7 @@ const usePipelineNodes = (): {
         showBiggerActions,
         trailingMessage,
         nestingLevel,
-        active: !subPipelineHeaderActive && isNodeActive,
+        active: !isSubPipelineHeaderActive && isNodeActive,
         nestedActive: isParentActive,
         hovered,
         onHoverChange,

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
@@ -28,8 +28,12 @@ $headerPipeLineHeight: 4px;
   padding: 0;
   display: flex;
 
+  &.parentNodeActive {
+    background: $activeHeaderColor;
+  }
+
   &.nestedActive {
-    background-color: $activeHeaderColor;
+    background-color: $nestedActiveColor;
   }
 }
 
@@ -38,13 +42,13 @@ $headerPipeLineHeight: 4px;
   position: relative; // Allow children to position relative to this element
   padding: $headerOffsetY 0 0 $headerOffsetX;
 
-  &.active {
-    background-color: $activeHeaderColor;
-  }
-
-  &.nestedActive {
-    background-color: $nestedActiveColor;
-  }
+  //&.active {
+  //  background-color: $activeHeaderColor;
+  //}
+  //
+  //&.nestedActive {
+  //  background-color: $nestedActiveColor;
+  //}
 }
 
 .headerContent {

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
@@ -41,14 +41,6 @@ $headerPipeLineHeight: 4px;
   flex-grow: 1;
   position: relative; // Allow children to position relative to this element
   padding: $headerOffsetY 0 0 $headerOffsetX;
-
-  //&.active {
-  //  background-color: $activeHeaderColor;
-  //}
-  //
-  //&.nestedActive {
-  //  background-color: $nestedActiveColor;
-  //}
 }
 
 .headerContent {
@@ -88,6 +80,10 @@ $headerPipeLineHeight: 4px;
   width: $pipeLineOffset;
   height: $headerPipeLineHeight;
   border-right: $pipeLineBorderWidth solid black;
+
+  &.active {
+    border-color: white;
+  }
 }
 
 .headerPipeLineBottom {
@@ -97,4 +93,8 @@ $headerPipeLineHeight: 4px;
   width: $pipeLineOffset;
   height: $headerPipeLineHeight;
   border-right: $pipeLineBorderWidth solid black;
+
+  &.active {
+    border-color: white;
+  }
 }

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
@@ -32,8 +32,8 @@ $headerPipeLineHeight: 4px;
     background: $activeHeaderColor;
   }
 
-  &.nestedActive {
-    background-color: $nestedActiveColor;
+  &.ancestorActive {
+    background: $nestedActiveColor;
   }
 }
 
@@ -63,7 +63,6 @@ $headerPipeLineHeight: 4px;
 .documentPreviewIcon {
   margin-top: 2px;
   margin-right: 4px;
-  color: $bs-dark-grey;
 }
 
 .subPipelineLabel {

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.module.scss
@@ -24,15 +24,18 @@ $headerOffsetY: 0.5rem;
 $headerPipeLineHeight: 4px;
 
 .root {
-  display: flex;
-  border-bottom: 1px solid lightgrey;
+  background: $defaultHeaderColor;
   padding: 0;
+  display: flex;
+
+  &.nestedActive {
+    background-color: $activeHeaderColor;
+  }
 }
 
 .header {
   flex-grow: 1;
   position: relative; // Allow children to position relative to this element
-  background: $defaultHeaderColor;
   padding: $headerOffsetY 0 0 $headerOffsetX;
 
   &.active {

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
@@ -39,7 +39,8 @@ export type PipelineHeaderNodeProps = {
   } | null;
   pipelineInputKey?: string;
   active?: boolean;
-  nestedActive?: boolean;
+  parentActive?: boolean;
+  ancestorActive?: boolean;
   isPipelineLoading: boolean;
 };
 
@@ -49,7 +50,8 @@ const PipelineHeaderNode: React.VFC<PipelineHeaderNodeProps> = ({
   nodeActions,
   pipelineInputKey,
   active,
-  nestedActive,
+  parentActive,
+  ancestorActive,
   nodePreviewElement,
   isPipelineLoading,
 }) => {
@@ -88,21 +90,18 @@ const PipelineHeaderNode: React.VFC<PipelineHeaderNodeProps> = ({
   return (
     <>
       <ListGroup.Item
-        active={nodePreviewElement?.active}
+        active={active}
         className={cx(styles.root, {
           [styles.clickable]: Boolean(nodePreviewElement),
-          [styles.parentNodeActive]: nodePreviewElement?.active
-            ? false
-            : active,
-          [styles.nestedActive]: nestedActive,
+          [styles.parentNodeActive]: parentActive,
+          [styles.ancestorActive]: ancestorActive,
         })}
         onClick={nodePreviewElement?.focus}
         ref={nodeRef}
       >
         <PipelineOffsetView
           nestingLevel={nestingLevel}
-          nestedActive={active || nestedActive} // Color for this offset-view is chosen using the header flag
-          isHeader={!nestedActive} // Don't color deeply-nested pipeline headers as active headers
+          nestedActive={parentActive || ancestorActive} // Color for this offset-view is chosen using the header flag
         />
         <div className={styles.header}>
           <div className={styles.headerPipeLineTop} />

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
@@ -99,13 +99,18 @@ const PipelineHeaderNode: React.VFC<PipelineHeaderNodeProps> = ({
         onClick={nodePreviewElement?.focus}
         ref={nodeRef}
       >
-        <PipelineOffsetView
-          nestingLevel={nestingLevel}
-          nestedActive={parentActive || ancestorActive} // Color for this offset-view is chosen using the header flag
-        />
+        <PipelineOffsetView nestingLevel={nestingLevel} active={active} />
         <div className={styles.header}>
-          <div className={styles.headerPipeLineTop} />
-          <div className={styles.headerPipeLineBottom} />
+          <div
+            className={cx(styles.headerPipeLineTop, {
+              [styles.active]: active,
+            })}
+          />
+          <div
+            className={cx(styles.headerPipeLineBottom, {
+              [styles.active]: active,
+            })}
+          />
           <div className={styles.headerContent}>
             <div className={styles.labelAndInputKey}>
               <div className={styles.subPipelineLabel}>{headerLabel}</div>

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
@@ -88,8 +88,10 @@ const PipelineHeaderNode: React.VFC<PipelineHeaderNodeProps> = ({
   return (
     <>
       <ListGroup.Item
+        active={nodePreviewElement?.active}
         className={cx(styles.root, {
           [styles.clickable]: Boolean(nodePreviewElement),
+          [styles.nestedActive]: nestedActive,
         })}
         onClick={nodePreviewElement?.focus}
         ref={nodeRef}
@@ -99,12 +101,7 @@ const PipelineHeaderNode: React.VFC<PipelineHeaderNodeProps> = ({
           nestedActive={active || nestedActive} // Color for this offset-view is chosen using the header flag
           isHeader={!nestedActive} // Don't color deeply-nested pipeline headers as active headers
         />
-        <div
-          className={cx(styles.header, {
-            [styles.active]: active,
-            [styles.nestedActive]: nestedActive,
-          })}
-        >
+        <div className={styles.header}>
           <div className={styles.headerPipeLineTop} />
           <div className={styles.headerPipeLineBottom} />
           <div className={styles.headerContent}>

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
@@ -39,8 +39,8 @@ export type PipelineHeaderNodeProps = {
   } | null;
   pipelineInputKey?: string;
   active?: boolean;
-  parentActive?: boolean;
-  ancestorActive?: boolean;
+  isParentActive?: boolean;
+  isAncestorActive?: boolean;
   isPipelineLoading: boolean;
 };
 
@@ -50,8 +50,8 @@ const PipelineHeaderNode: React.VFC<PipelineHeaderNodeProps> = ({
   nodeActions,
   pipelineInputKey,
   active,
-  parentActive,
-  ancestorActive,
+  isParentActive,
+  isAncestorActive,
   nodePreviewElement,
   isPipelineLoading,
 }) => {
@@ -93,8 +93,8 @@ const PipelineHeaderNode: React.VFC<PipelineHeaderNodeProps> = ({
         active={active}
         className={cx(styles.root, {
           [styles.clickable]: Boolean(nodePreviewElement),
-          [styles.parentNodeActive]: parentActive,
-          [styles.ancestorActive]: ancestorActive,
+          [styles.parentNodeActive]: isParentActive,
+          [styles.ancestorActive]: isAncestorActive,
         })}
         onClick={nodePreviewElement?.focus}
         ref={nodeRef}

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineHeaderNode.tsx
@@ -91,6 +91,9 @@ const PipelineHeaderNode: React.VFC<PipelineHeaderNodeProps> = ({
         active={nodePreviewElement?.active}
         className={cx(styles.root, {
           [styles.clickable]: Boolean(nodePreviewElement),
+          [styles.parentNodeActive]: nodePreviewElement?.active
+            ? false
+            : active,
           [styles.nestedActive]: nestedActive,
         })}
         onClick={nodePreviewElement?.focus}

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.module.scss
@@ -31,11 +31,11 @@
     background-color: $nestedActiveColor;
   }
 
-  &.isHeader {
-    background-color: $defaultHeaderColor;
-
-    &.nestedActive {
-      background-color: $activeHeaderColor;
-    }
-  }
+  //&.isHeader {
+  //  background-color: $defaultHeaderColor;
+  //
+  //  &.nestedActive {
+  //    background-color: $activeHeaderColor;
+  //  }
+  //}
 }

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.module.scss
@@ -22,20 +22,9 @@
   border-right: $pipeLineBorderWidth solid black;
   flex-shrink: 0;
   flex-grow: 0;
+  background-color: transparent;
 
   &.active {
     border-color: white;
   }
-
-  &.nestedActive {
-    background-color: $nestedActiveColor;
-  }
-
-  //&.isHeader {
-  //  background-color: $defaultHeaderColor;
-  //
-  //  &.nestedActive {
-  //    background-color: $activeHeaderColor;
-  //  }
-  //}
 }

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.tsx
@@ -23,13 +23,11 @@ import styles from "./PipelineOffsetView.module.scss";
 type PipelineOffsetViewProps = {
   nestingLevel: number;
   active?: boolean;
-  nestedActive?: boolean;
 };
 
 const PipelineOffsetView: React.VFC<PipelineOffsetViewProps> = ({
   nestingLevel,
   active,
-  nestedActive,
 }) => (
   <>
     {nestingLevel > 0 &&
@@ -38,7 +36,6 @@ const PipelineOffsetView: React.VFC<PipelineOffsetViewProps> = ({
           key={n}
           className={cx(styles.pipeLine, {
             [styles.active]: active,
-            [styles.nestedActive]: nestedActive,
           })}
         />
       ))}

--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineOffsetView.tsx
@@ -24,14 +24,12 @@ type PipelineOffsetViewProps = {
   nestingLevel: number;
   active?: boolean;
   nestedActive?: boolean;
-  isHeader?: boolean;
 };
 
 const PipelineOffsetView: React.VFC<PipelineOffsetViewProps> = ({
   nestingLevel,
   active,
   nestedActive,
-  isHeader,
 }) => (
   <>
     {nestingLevel > 0 &&
@@ -41,7 +39,6 @@ const PipelineOffsetView: React.VFC<PipelineOffsetViewProps> = ({
           className={cx(styles.pipeLine, {
             [styles.active]: active,
             [styles.nestedActive]: nestedActive,
-            [styles.isHeader]: isHeader,
           })}
         />
       ))}

--- a/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.tsx
@@ -47,7 +47,6 @@ const BrickNode: React.VFC<BrickNodeProps> = ({
   nodeActions,
   showBiggerActions,
   trailingMessage,
-  activeSubPipelineHeader,
 }) => {
   const nodeRef = useRef<HTMLDivElement>(null);
 
@@ -59,7 +58,7 @@ const BrickNode: React.VFC<BrickNodeProps> = ({
         ref={nodeRef}
         as="div"
         onClick={onClick}
-        active={activeSubPipelineHeader ? false : active}
+        active={active}
         className={cx(styles.root, "list-group-item-action", {
           [styles.expanded]: hasSubPipelines && !collapsed,
           [styles.parentIsActive]: parentIsActive,
@@ -77,15 +76,12 @@ const BrickNode: React.VFC<BrickNodeProps> = ({
           onHoverChange(false);
         }}
       >
-        <PipelineOffsetView
-          nestingLevel={nestingLevel}
-          active={activeSubPipelineHeader ? false : active}
-        />
+        <PipelineOffsetView nestingLevel={nestingLevel} active={active} />
         {hasSubPipelines && (
           <div className={styles.handleContainer}>
             <div
               className={cx({
-                [styles.active]: activeSubPipelineHeader ? false : active,
+                [styles.active]: active,
                 [styles.closedHandle]: collapsed,
                 [styles.openHandle]: !collapsed,
                 [styles.noOutputKey]: !outputKey,

--- a/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.tsx
@@ -33,7 +33,7 @@ import {
 const BrickNode: React.VFC<BrickNodeProps> = ({
   onClick,
   active,
-  parentActive,
+  isParentActive,
   onHoverChange,
   icon,
   runStatus,
@@ -61,7 +61,7 @@ const BrickNode: React.VFC<BrickNodeProps> = ({
         active={active}
         className={cx(styles.root, "list-group-item-action", {
           [styles.expanded]: hasSubPipelines && !collapsed,
-          [styles.parentIsActive]: parentActive,
+          [styles.parentIsActive]: isParentActive,
         })}
         title={
           runStatus === RunStatus.SKIPPED

--- a/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.tsx
@@ -47,6 +47,7 @@ const BrickNode: React.VFC<BrickNodeProps> = ({
   nodeActions,
   showBiggerActions,
   trailingMessage,
+  activeSubPipelineHeader,
 }) => {
   const nodeRef = useRef<HTMLDivElement>(null);
 
@@ -58,7 +59,7 @@ const BrickNode: React.VFC<BrickNodeProps> = ({
         ref={nodeRef}
         as="div"
         onClick={onClick}
-        active={active}
+        active={activeSubPipelineHeader ? false : active}
         className={cx(styles.root, "list-group-item-action", {
           [styles.expanded]: hasSubPipelines && !collapsed,
           [styles.parentIsActive]: parentIsActive,
@@ -76,12 +77,15 @@ const BrickNode: React.VFC<BrickNodeProps> = ({
           onHoverChange(false);
         }}
       >
-        <PipelineOffsetView nestingLevel={nestingLevel} active={active} />
+        <PipelineOffsetView
+          nestingLevel={nestingLevel}
+          active={activeSubPipelineHeader ? false : active}
+        />
         {hasSubPipelines && (
           <div className={styles.handleContainer}>
             <div
               className={cx({
-                [styles.active]: active,
+                [styles.active]: activeSubPipelineHeader ? false : active,
                 [styles.closedHandle]: collapsed,
                 [styles.openHandle]: !collapsed,
                 [styles.noOutputKey]: !outputKey,

--- a/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNode.tsx
@@ -33,7 +33,7 @@ import {
 const BrickNode: React.VFC<BrickNodeProps> = ({
   onClick,
   active,
-  parentIsActive,
+  parentActive,
   onHoverChange,
   icon,
   runStatus,
@@ -61,7 +61,7 @@ const BrickNode: React.VFC<BrickNodeProps> = ({
         active={active}
         className={cx(styles.root, "list-group-item-action", {
           [styles.expanded]: hasSubPipelines && !collapsed,
-          [styles.parentIsActive]: parentIsActive,
+          [styles.parentIsActive]: parentActive,
         })}
         title={
           runStatus === RunStatus.SKIPPED


### PR DESCRIPTION
## What does this PR do?

- Closes #6229

## Reviewer Tips

- This feature might be a little tricky to review because it involves recursion, and modifying the already-complex `usePipelineNodes` file. Happy to conduct and in-person review if this is helpful.

## Discussion

I clarified/renamed the terms `active`, `nestedActive`, `parentIsActive`, since I found these terms to be confusing. Here is a list of the new terminology and definitions that I am using:

- For `PipelineHeaderNodeProps` and `BrickNodeProps` (UI representations of nodes)
**active**: This is the node that should be appear to the user as "selected" in the UI; the node should be displayed in "cobalt blue"
**parentActive**: The node is a direct child of a node that is active, and should be light baby-blue (if it is a brick node) and dark baby-blue (if it is a header node)
**ancestorActive**: The node is a descendent of a node that is active, but not a direct child of the active node. Always will be light baby-blue color.

- For just `BrickNodeProps`
**activeSubPipelineHeader**: This node has child header that is "active"

## Demo

- https://www.loom.com/share/75efcb4bb2dd43f6a1c1a02cb768fa68

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer @BLoe 
