### PR TITLE
Stop Toggling Data Panel When Pressing Enter.

### DIFF
--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -1243,6 +1243,7 @@ exports[`renders an extension with sub pipeline 1`] = `
           >
             <button
               class="toggle active"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -2116,6 +2117,7 @@ exports[`renders the first selected node 1`] = `
           >
             <button
               class="toggle active"
+              type="button"
             >
               <svg
                 aria-hidden="true"

--- a/src/pageEditor/tabs/editTab/EditTab.tsx
+++ b/src/pageEditor/tabs/editTab/EditTab.tsx
@@ -135,6 +135,7 @@ const EditTab: React.FC<{
             className={cx(styles.toggle, {
               [styles.active]: isDataPanelExpanded,
             })}
+            type="button"
             onClick={() => {
               dispatch(
                 actions.setDataSectionExpanded({


### PR DESCRIPTION
## What does this PR do?

- Fixes #6274
- The button type for the collapse button wasn't set. Because it existed in a form, pressing enter will treat the first button without a type as the "submit" button, thus toggling the data-panel.

## Demo

- [Loom](https://www.loom.com/share/0aff56c97a674bae8ac2ba997ff81e2e?sid=7d0d5fd6-4b05-48a6-8f4e-fae56cfacbaf)

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @mnholtz 
