### PR TITLE
#6285 Add Checkboxes (multi-select) field option to custom form builder

### DIFF
--- a/src/components/fields/schemaFields/BasicSchemaField.tsx
+++ b/src/components/fields/schemaFields/BasicSchemaField.tsx
@@ -106,6 +106,8 @@ const BasicSchemaField: SchemaFieldComponent = ({
     ]
   );
 
+  console.log("*** schema", name, schema, inputModeOptions);
+
   const validate = getFieldValidator(validationSchema);
 
   const [{ value, onBlur: formikOnBlur }, { touched }, { setValue }] = useField(

--- a/src/components/formBuilder/edit/FieldEditor.tsx
+++ b/src/components/formBuilder/edit/FieldEditor.tsx
@@ -260,8 +260,6 @@ const FieldEditor: React.FC<{
               : undefined,
         };
 
-  console.log("*** propertySchema.items", propertySchema.items);
-
   return (
     <div className={styles.root}>
       <FieldTemplate
@@ -305,6 +303,22 @@ const FieldEditor: React.FC<{
           <SchemaField
             label="Options"
             name={getFullFieldName("enum")}
+            schema={{
+              type: "array",
+              items: {
+                type: "string",
+              },
+            }}
+            isRequired
+          />
+        </>
+      )}
+
+      {propertySchema.type === "array" && (
+        <>
+          <SchemaField
+            label="Options"
+            name={getFullFieldName("items.enum")}
             schema={{
               type: "array",
               items: {

--- a/src/components/formBuilder/edit/FieldEditor.tsx
+++ b/src/components/formBuilder/edit/FieldEditor.tsx
@@ -260,6 +260,8 @@ const FieldEditor: React.FC<{
               : undefined,
         };
 
+  console.log("*** propertySchema.items", propertySchema.items);
+
   return (
     <div className={styles.root}>
       <FieldTemplate

--- a/src/components/formBuilder/edit/FormEditor.tsx
+++ b/src/components/formBuilder/edit/FormEditor.tsx
@@ -70,8 +70,6 @@ const FormEditor: React.FC<FormEditorProps> = ({
     joinName(name, "uiSchema", UI_ORDER)
   );
 
-  console.log("*** fieldTypes:", fieldTypes);
-
   const { schema, uiSchema } = rjsfSchema;
 
   // Select the active field when FormEditor field changes

--- a/src/components/formBuilder/edit/FormEditor.tsx
+++ b/src/components/formBuilder/edit/FormEditor.tsx
@@ -70,6 +70,8 @@ const FormEditor: React.FC<FormEditorProps> = ({
     joinName(name, "uiSchema", UI_ORDER)
   );
 
+  console.log("*** fieldTypes:", fieldTypes);
+
   const { schema, uiSchema } = rjsfSchema;
 
   // Select the active field when FormEditor field changes

--- a/src/components/formBuilder/formBuilderHelpers.ts
+++ b/src/components/formBuilder/formBuilderHelpers.ts
@@ -218,8 +218,6 @@ export const produceSchemaOnUiTypeChange = (
     parseUiType(nextUiType);
 
   return produce(rjsfSchema, (draft) => {
-    console.log("*** inside produce!!!");
-
     // Relying on Immer to protect against object injections
     /* eslint-disable security/detect-object-injection */
     const draftPropertySchema = draft.schema.properties[propertyName] as Schema;
@@ -288,20 +286,13 @@ export const produceSchemaOnUiTypeChange = (
       delete draftPropertySchema.oneOf;
     }
 
-    if (
-      uiWidget === "checkboxes" && // TODO: move me to the field type definition?
-      propertyType === "array"
-    ) {
-      // draftPropertySchema.items = {
-      //   type: "string",
-      //   enum: Array.isArray(draftPropertySchema.enum) ?
-      //     draftPropertySchema.enum.map((item) => ({ const: item } as SchemaDefinition)) : []
-      // };
-      console.log("*** HERE");
+    if (uiWidget === "checkboxes" && propertyType === "array") {
       draftPropertySchema.items = {
         type: "string",
-        enum: ["cat", "dog", "bird"],
+        // TODO: if enum is defined, map it to items.enum
+        enum: [],
       };
+      draftPropertySchema.uniqueItems = true;
     }
   });
 };

--- a/src/components/formBuilder/formBuilderHelpers.ts
+++ b/src/components/formBuilder/formBuilderHelpers.ts
@@ -46,12 +46,14 @@ export type UiTypeExtra = "selectWithLabels" | undefined;
 
 export type UiType = {
   propertyType: SchemaPropertyType;
+  items?: SchemaDefinition;
   uiWidget: string | undefined;
   propertyFormat: string | undefined;
   /** Holds extra config. For instance, indicates whether a dropdown with labels should be used */
   extra: UiTypeExtra;
 };
 
+// TODO: maybe add items type for arrays here
 export const parseUiType = (value: string): UiType => {
   const [propertyType, uiWidget, propertyFormat, extra] = value.split(":");
   return {
@@ -62,6 +64,7 @@ export const parseUiType = (value: string): UiType => {
   };
 };
 
+// TODO: maybe add items type for arrays here
 export const stringifyUiType = ({
   propertyType,
   uiWidget,
@@ -234,6 +237,12 @@ export const produceSchemaOnUiTypeChange = (
 
       default: {
         draftPropertySchema.type = propertyType;
+
+        // TODO: move me to the field type definition?
+        if (propertyType === "array") {
+          draftPropertySchema.items = { type: "string" };
+        }
+
         delete draftPropertySchema.$ref;
       }
     }

--- a/src/components/formBuilder/formBuilderHelpers.ts
+++ b/src/components/formBuilder/formBuilderHelpers.ts
@@ -265,6 +265,15 @@ export const produceSchemaOnUiTypeChange = (
       delete draft.uiSchema[propertyName][UI_WIDGET];
     }
 
+    if (uiWidget === "checkboxes" && propertyType === "array") {
+      draftPropertySchema.items = {
+        type: "string",
+        enum: draftPropertySchema.enum ?? ["Example option"],
+      };
+      draftPropertySchema.uniqueItems = true;
+      delete draftPropertySchema.enum;
+    }
+
     if (uiWidget === "select") {
       if (extra === "selectWithLabels") {
         // If switching from Dropdown, convert the enum to options with labels
@@ -284,15 +293,6 @@ export const produceSchemaOnUiTypeChange = (
     } else {
       delete draftPropertySchema.enum;
       delete draftPropertySchema.oneOf;
-    }
-
-    if (uiWidget === "checkboxes" && propertyType === "array") {
-      draftPropertySchema.items = {
-        type: "string",
-        // TODO: if enum is defined, map it to items.enum
-        enum: [],
-      };
-      draftPropertySchema.uniqueItems = true;
     }
   });
 };

--- a/src/components/formBuilder/formBuilderHelpers.ts
+++ b/src/components/formBuilder/formBuilderHelpers.ts
@@ -218,6 +218,8 @@ export const produceSchemaOnUiTypeChange = (
     parseUiType(nextUiType);
 
   return produce(rjsfSchema, (draft) => {
+    console.log("*** inside produce!!!");
+
     // Relying on Immer to protect against object injections
     /* eslint-disable security/detect-object-injection */
     const draftPropertySchema = draft.schema.properties[propertyName] as Schema;
@@ -237,12 +239,6 @@ export const produceSchemaOnUiTypeChange = (
 
       default: {
         draftPropertySchema.type = propertyType;
-
-        // TODO: move me to the field type definition?
-        if (propertyType === "array") {
-          draftPropertySchema.items = { type: "string" };
-        }
-
         delete draftPropertySchema.$ref;
       }
     }
@@ -291,7 +287,22 @@ export const produceSchemaOnUiTypeChange = (
       delete draftPropertySchema.enum;
       delete draftPropertySchema.oneOf;
     }
-    /* eslint-enable security/detect-object-injection */
+
+    if (
+      uiWidget === "checkboxes" && // TODO: move me to the field type definition?
+      propertyType === "array"
+    ) {
+      // draftPropertySchema.items = {
+      //   type: "string",
+      //   enum: Array.isArray(draftPropertySchema.enum) ?
+      //     draftPropertySchema.enum.map((item) => ({ const: item } as SchemaDefinition)) : []
+      // };
+      console.log("*** HERE");
+      draftPropertySchema.items = {
+        type: "string",
+        enum: ["cat", "dog", "bird"],
+      };
+    }
   });
 };
 

--- a/src/components/formBuilder/preview/FormPreview.tsx
+++ b/src/components/formBuilder/preview/FormPreview.tsx
@@ -143,6 +143,23 @@ const FormPreview: React.FC<FormPreviewProps> = ({
             propertySchema.oneOf = [{ const: "" }];
           }
         }
+
+        for (const [key, value] of Object.entries(draftUiSchema)) {
+          console.log("*** HERE");
+          if (KEYS_OF_UI_SCHEMA.includes(key)) {
+            continue;
+          }
+
+          const propertySchema = draftSchema.properties[key];
+
+          if (
+            value[UI_WIDGET] === "checkboxes" &&
+            typeof propertySchema === "object" &&
+            !Array.isArray(propertySchema.items.enum)
+          ) {
+            propertySchema.items.enum = [];
+          }
+        }
       }),
     [rjsfSchema, activeField]
   );
@@ -181,6 +198,8 @@ const FormPreview: React.FC<FormPreviewProps> = ({
     SelectWidget: RjsfSelectWidget,
     googleSheet: RjsfSelectWidget,
   };
+
+  console.log("*** rjsf schema", previewSchema, previewUiSchema);
 
   return (
     <JsonSchemaForm

--- a/src/components/formBuilder/preview/FormPreview.tsx
+++ b/src/components/formBuilder/preview/FormPreview.tsx
@@ -118,8 +118,6 @@ const FormPreview: React.FC<FormPreviewProps> = ({
         // We're only interested in select with labels, otherwise we don't need to do anything.
         // Loop through the uiSchema props, because UI Widget must be set for the Select, then take a look at the oneOf property.
         for (const [key, value] of Object.entries(draftUiSchema)) {
-          console.log("*** key value", { key, value });
-
           // We're only looking for sub-property UiSchemas
           if (KEYS_OF_UI_SCHEMA.includes(key)) {
             continue;
@@ -145,31 +143,6 @@ const FormPreview: React.FC<FormPreviewProps> = ({
             propertySchema.oneOf = [{ const: "" }];
           }
         }
-
-        for (const [key, value] of Object.entries(draftUiSchema)) {
-          if (
-            value[UI_WIDGET] === "checkboxes" &&
-            !value["ui:options"]?.enumOptions
-          ) {
-            const propertySchema = draftSchema.properties[key];
-            draftUiSchema[key]["ui:options"] = {
-              enumOptions: (propertySchema.items?.enum ?? []).map((option) => ({
-                label: option,
-                value: option,
-              })),
-            };
-          }
-        }
-
-        // TODO: instead of hard-coding me, loop through the properties like above and make sure we
-        //  generate enumOptions from the previewSchema items.enum property
-        // draftUiSchema["example"]["ui:options"] = {
-        //   enumOptions: [
-        //     { label: "cat", value: "cat" },
-        //     { label: "dog", value: "dog" },
-        //     { label: "fish", value: "fish" },
-        //   ],
-        // };
       }),
     [rjsfSchema, activeField]
   );
@@ -208,14 +181,6 @@ const FormPreview: React.FC<FormPreviewProps> = ({
     SelectWidget: RjsfSelectWidget,
     googleSheet: RjsfSelectWidget,
   };
-
-  console.log("*** jsonschemaform props", {
-    data,
-    fields,
-    widgets,
-    previewSchema,
-    previewUiSchema,
-  });
 
   return (
     <JsonSchemaForm

--- a/src/components/formBuilder/preview/FormPreview.tsx
+++ b/src/components/formBuilder/preview/FormPreview.tsx
@@ -182,6 +182,9 @@ const FormPreview: React.FC<FormPreviewProps> = ({
     googleSheet: RjsfSelectWidget,
   };
 
+  console.log("*** activeField", activeField);
+  console.log("*** rjsfSchema", rjsfSchema);
+  console.log("*** previewSchema", previewSchema);
   return (
     <JsonSchemaForm
       tagName="div"

--- a/src/components/formBuilder/preview/FormPreview.tsx
+++ b/src/components/formBuilder/preview/FormPreview.tsx
@@ -143,6 +143,16 @@ const FormPreview: React.FC<FormPreviewProps> = ({
             propertySchema.oneOf = [{ const: "" }];
           }
         }
+
+        // TODO: instead of hard-coding me, loop through the properties like above and make sure we
+        //  generate enumOptions from the previewSchema items.enum property
+        draftUiSchema["example"]["ui:options"] = {
+          enumOptions: [
+            { label: "cat", value: "cat" },
+            { label: "dog", value: "dog" },
+            { label: "fish", value: "fish" },
+          ],
+        };
       }),
     [rjsfSchema, activeField]
   );
@@ -182,9 +192,14 @@ const FormPreview: React.FC<FormPreviewProps> = ({
     googleSheet: RjsfSelectWidget,
   };
 
-  console.log("*** activeField", activeField);
-  console.log("*** rjsfSchema", rjsfSchema);
-  console.log("*** previewSchema", previewSchema);
+  console.log("*** jsonschemaform props", {
+    data,
+    fields,
+    widgets,
+    previewSchema,
+    previewUiSchema,
+  });
+
   return (
     <JsonSchemaForm
       tagName="div"

--- a/src/components/formBuilder/preview/FormPreview.tsx
+++ b/src/components/formBuilder/preview/FormPreview.tsx
@@ -118,6 +118,8 @@ const FormPreview: React.FC<FormPreviewProps> = ({
         // We're only interested in select with labels, otherwise we don't need to do anything.
         // Loop through the uiSchema props, because UI Widget must be set for the Select, then take a look at the oneOf property.
         for (const [key, value] of Object.entries(draftUiSchema)) {
+          console.log("*** key value", { key, value });
+
           // We're only looking for sub-property UiSchemas
           if (KEYS_OF_UI_SCHEMA.includes(key)) {
             continue;
@@ -144,15 +146,30 @@ const FormPreview: React.FC<FormPreviewProps> = ({
           }
         }
 
+        for (const [key, value] of Object.entries(draftUiSchema)) {
+          if (
+            value[UI_WIDGET] === "checkboxes" &&
+            !value["ui:options"]?.enumOptions
+          ) {
+            const propertySchema = draftSchema.properties[key];
+            draftUiSchema[key]["ui:options"] = {
+              enumOptions: (propertySchema.items?.enum ?? []).map((option) => ({
+                label: option,
+                value: option,
+              })),
+            };
+          }
+        }
+
         // TODO: instead of hard-coding me, loop through the properties like above and make sure we
         //  generate enumOptions from the previewSchema items.enum property
-        draftUiSchema["example"]["ui:options"] = {
-          enumOptions: [
-            { label: "cat", value: "cat" },
-            { label: "dog", value: "dog" },
-            { label: "fish", value: "fish" },
-          ],
-        };
+        // draftUiSchema["example"]["ui:options"] = {
+        //   enumOptions: [
+        //     { label: "cat", value: "cat" },
+        //     { label: "dog", value: "dog" },
+        //     { label: "fish", value: "fish" },
+        //   ],
+        // };
       }),
     [rjsfSchema, activeField]
   );

--- a/src/pageEditor/fields/formFieldTypeOptions.ts
+++ b/src/pageEditor/fields/formFieldTypeOptions.ts
@@ -57,7 +57,7 @@ const FORM_FIELD_TYPE_OPTIONS: SelectStringOption[] = [
     value: stringifyUiType({ propertyType: "boolean" }),
   },
   {
-    label: "Checkboxes (Multi-select)",
+    label: "Checkboxes (multi-select)",
     value: stringifyUiType({
       propertyType: "array",
     }),

--- a/src/pageEditor/fields/formFieldTypeOptions.ts
+++ b/src/pageEditor/fields/formFieldTypeOptions.ts
@@ -57,6 +57,12 @@ const FORM_FIELD_TYPE_OPTIONS: SelectStringOption[] = [
     value: stringifyUiType({ propertyType: "boolean" }),
   },
   {
+    label: "Checkboxes (Multi-select)",
+    value: stringifyUiType({
+      propertyType: "array",
+    }),
+  },
+  {
     label: "Image crop",
     value: stringifyUiType({
       propertyType: "string",

--- a/src/pageEditor/fields/formFieldTypeOptions.ts
+++ b/src/pageEditor/fields/formFieldTypeOptions.ts
@@ -60,6 +60,7 @@ const FORM_FIELD_TYPE_OPTIONS: SelectStringOption[] = [
     label: "Checkboxes (multi-select)",
     value: stringifyUiType({
       propertyType: "array",
+      uiWidget: "checkboxes",
     }),
   },
   {


### PR DESCRIPTION
## What does this PR do?

- Closes #6285
- This is in draft because the form will throw an error in the following situations:
    - `FormPreview` will throw if, instead of designating the "array" field type, a variable field type is designated (rendering the value of `enum` a string instead of an expected `array`)
    - The rendered form (in the e.g. sidebar or modal) will throw on variables if the value of the variable is not an array. I think we'd ideally want to gracefully display no options, or an error?

## Demo

- Further explanation for what I'm currently working on resolving in this draft: https://www.loom.com/share/d56a953d368d45b5850b81dca1046496

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
