### PR TITLE
#6192 - Google Sheets slice 4.3 - Allow auto-activation with optional integrations

### DIFF
--- a/src/contentScript/loadActivationEnhancements.ts
+++ b/src/contentScript/loadActivationEnhancements.ts
@@ -104,10 +104,6 @@ export async function loadActivationEnhancements(): Promise<void> {
     button.addEventListener("click", async (event) => {
       event.preventDefault();
 
-      // The button href may have changed since the listener was added
-      const url = new URL(button.href);
-      const modIds = extractIdsFromUrl(url.searchParams);
-
       const isContentScriptReady = await pollUntilTruthy(
         isReadyInThisDocument,
         {
@@ -119,7 +115,11 @@ export async function loadActivationEnhancements(): Promise<void> {
       if (isContentScriptReady) {
         window.dispatchEvent(
           new CustomEvent("ActivateMods", {
-            detail: { modIds, activateUrl: button.href },
+            // The button href may have changed since the listener was added, extract ids again
+            detail: {
+              modIds: extractIdsFromUrl(new URL(button.href).searchParams),
+              activateUrl: button.href,
+            },
           })
         );
       } else {

--- a/src/contentScript/loadActivationEnhancements.ts
+++ b/src/contentScript/loadActivationEnhancements.ts
@@ -89,9 +89,7 @@ export async function loadActivationEnhancements(): Promise<void> {
 
   for (const button of activateButtonLinks) {
     const url = new URL(button.href);
-
     const modIds = extractIdsFromUrl(url.searchParams);
-
     if (modIds.length === 0) {
       continue;
     }
@@ -105,6 +103,10 @@ export async function loadActivationEnhancements(): Promise<void> {
     // Replace the default click handler with direct mod activation
     button.addEventListener("click", async (event) => {
       event.preventDefault();
+
+      // The button href may have changed since the listener was added
+      const url = new URL(button.href);
+      const modIds = extractIdsFromUrl(url.searchParams);
 
       const isContentScriptReady = await pollUntilTruthy(
         isReadyInThisDocument,

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -50,10 +50,10 @@ import { type ModMetadataFormState } from "@/pageEditor/pageEditorTypes";
 import { type EditablePackageMetadata } from "@/types/contract";
 import { freshIdentifier } from "@/utils/variableUtils";
 import {
-  IntegrationDependency,
-  ModDependencyAPIVersion,
+  type IntegrationDependency,
+  type ModDependencyAPIVersion,
 } from "@/types/integrationTypes";
-import { Schema } from "@/types/schemaTypes";
+import { type Schema } from "@/types/schemaTypes";
 import { SERVICE_BASE_SCHEMA } from "@/services/serviceUtils";
 
 /**

--- a/src/sidebar/activateRecipe/RequireMods.tsx
+++ b/src/sidebar/activateRecipe/RequireMods.tsx
@@ -28,7 +28,7 @@ import useDeriveAsyncState from "@/hooks/useDeriveAsyncState";
 import { isDatabaseField } from "@/components/fields/schemaFields/fieldTypeCheckers";
 import { useSelector } from "react-redux";
 import { selectExtensions } from "@/store/extensionsSelectors";
-import { getIntegrationIds } from "@/utils/modDefinitionUtils";
+import { getUnconfiguredComponentIntegrations } from "@/utils/modDefinitionUtils";
 import { includesQuickBarStarterBrick } from "@/starterBricks/starterBrickModUtils";
 
 export type RequiredModDefinition = {
@@ -102,15 +102,14 @@ export function requiresUserConfiguration(
       return requiredOptions.includes(name);
     });
 
-  const modIntegrationIds = getIntegrationIds(modDefinition);
-
-  const needsServiceInputs = modIntegrationIds.some((serviceId) => {
-    if (serviceId === PIXIEBRIX_INTEGRATION_ID) {
+  const modIntegrationIds = getUnconfiguredComponentIntegrations(modDefinition);
+  const needsServiceInputs = modIntegrationIds.some(({ id, isOptional }) => {
+    if (id === PIXIEBRIX_INTEGRATION_ID || isOptional) {
       return false;
     }
 
     // eslint-disable-next-line security/detect-object-injection -- serviceId is a registry ID
-    const defaultOption = defaultAuthOptionsByIntegrationId[serviceId];
+    const defaultOption = defaultAuthOptionsByIntegrationId[id];
 
     // Needs user configuration if there are any non-built-in options available
     return defaultOption?.sharingType !== "built-in";

--- a/src/testUtils/factories/integrationFactories.ts
+++ b/src/testUtils/factories/integrationFactories.ts
@@ -18,7 +18,7 @@
 import { define } from "cooky-cutter";
 import {
   type IntegrationConfig,
-  IntegrationDependency,
+  type IntegrationDependency,
   type SanitizedConfig,
   type SanitizedIntegrationConfig,
   type SecretsConfig,

--- a/src/testUtils/factories/integrationFactories.ts
+++ b/src/testUtils/factories/integrationFactories.ts
@@ -18,6 +18,7 @@
 import { define } from "cooky-cutter";
 import {
   type IntegrationConfig,
+  IntegrationDependency,
   type SanitizedConfig,
   type SanitizedIntegrationConfig,
   type SecretsConfig,
@@ -25,6 +26,7 @@ import {
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { validateRegistryId } from "@/types/helpers";
 import { type RemoteIntegrationConfig } from "@/types/contract";
+import { validateOutputKey } from "@/runtime/runtimeTypes";
 
 export const sanitizedIntegrationConfigFactory =
   define<SanitizedIntegrationConfig>({
@@ -71,3 +73,14 @@ export const remoteIntegrationConfigurationFactory =
       } as SanitizedConfig),
     service: remoteIntegrationServiceFactory,
   });
+
+export const integrationDependencyFactory = define<IntegrationDependency>({
+  id(n: number) {
+    return validateRegistryId(`@test/integration${n}`);
+  },
+  outputKey(n: number) {
+    return validateOutputKey(`testIntegration${n}`);
+  },
+  isOptional: false,
+  apiVersion: "v1",
+});

--- a/src/types/integrationTypes.ts
+++ b/src/types/integrationTypes.ts
@@ -23,6 +23,18 @@ import { type BrickIcon } from "@/types/iconTypes";
 import { type JsonObject, type JsonValue } from "type-fest";
 import { type Metadata, type RegistryId } from "@/types/registryTypes";
 
+/**
+ * The integration dependency format for saving mod components.
+ *
+ * Incremented when breaking-changes are made to the 'services' field
+ *
+ * - v1: original, services is a key-value Record of OutputKey to RegistryId of the integration
+ * - v2: services is a json-schema format, with a properties field and a required field. Property
+ *       keys are OutputKeys, and values are integration $ref URLs. Required is an array of keys
+ *       for required properties.
+ */
+export type ModDependencyAPIVersion = "v1" | "v2";
+
 export interface IntegrationDependency {
   /**
    * The registry id of the integration.
@@ -44,6 +56,12 @@ export interface IntegrationDependency {
    * @since 1.7.37 - added to facilitate optional integrations during activation
    */
   isOptional?: boolean;
+
+  /**
+   * The dependency format version that should be used to save this dependency
+   * @since 1.7.37 - Optional for backwards compat, logic will assume v1 for undefined
+   */
+  apiVersion?: ModDependencyAPIVersion;
 }
 
 type SanitizedBrand = { _sanitizedConfigBrand: null };

--- a/src/utils/deploymentUtils.test.ts
+++ b/src/utils/deploymentUtils.test.ts
@@ -246,6 +246,7 @@ describe("findPersonalServiceConfigurations", () => {
         id: CONTROL_ROOM_OAUTH_INTEGRATION_ID,
         outputKey: "foo",
         isOptional: false,
+        apiVersion: "v1",
         configs: [],
       },
     ]);
@@ -281,6 +282,7 @@ describe("findPersonalServiceConfigurations", () => {
         id: CONTROL_ROOM_OAUTH_INTEGRATION_ID,
         outputKey: "foo",
         isOptional: false,
+        apiVersion: "v1",
         configs: [auth],
       },
     ]);
@@ -379,6 +381,7 @@ describe("mergeDeploymentServiceConfigurations", () => {
         outputKey: "foo",
         config: boundId,
         isOptional: false,
+        apiVersion: "v1",
       },
     ]);
   });
@@ -411,6 +414,7 @@ describe("mergeDeploymentServiceConfigurations", () => {
         outputKey: "foo",
         config: auth.id,
         isOptional: false,
+        apiVersion: "v1",
       },
     ]);
   });

--- a/src/utils/deploymentUtils.ts
+++ b/src/utils/deploymentUtils.ts
@@ -28,7 +28,7 @@ import {
 } from "@/types/integrationTypes";
 import { getUnconfiguredComponentIntegrations } from "@/utils/modDefinitionUtils";
 import { validateUUID } from "@/types/helpers";
-import { type OutputKey } from "@/types/runtimeTypes";
+import { type Except } from "type-fest";
 
 /**
  * Returns `true` if a managed deployment is active (i.e., has not been remotely paused by an admin)
@@ -175,12 +175,11 @@ export async function findLocalDeploymentConfiguredIntegrationDependencies(
   deployment: Deployment,
   locate: Locate
 ): Promise<
-  Array<{
-    id: RegistryId;
-    outputKey: OutputKey;
-    isOptional?: boolean;
-    configs: SanitizedIntegrationConfig[];
-  }>
+  Array<
+    Except<IntegrationDependency, "config"> & {
+      configs: SanitizedIntegrationConfig[];
+    }
+  >
 > {
   const deploymentIntegrations = getUnconfiguredComponentIntegrations(
     deployment.package.config

--- a/src/utils/modDefinitionUtils.ts
+++ b/src/utils/modDefinitionUtils.ts
@@ -51,6 +51,7 @@ function getIntegrationsFromSchema(services: Schema): IntegrationDependency[] {
       id,
       outputKey: validateOutputKey(key),
       isOptional: services.required != null && !services.required.includes(key),
+      apiVersion: "v2",
     }));
   });
 }
@@ -62,12 +63,14 @@ function getIntegrationsFromRecord(
     id,
     outputKey: validateOutputKey(key),
     isOptional: false,
+    apiVersion: "v1",
   }));
 }
 
 /**
  * Return an array of unique integrations used by a given collection of mod components, without their config filled in
  * @param extensionPoints the mod component definitions from which to extract integrations
+ * @see selectExtensionPointConfig in saveHelpers.ts for the reverse logic
  */
 export function getUnconfiguredComponentIntegrations({
   extensionPoints: modComponentDefinitions = [],


### PR DESCRIPTION
## What does this PR do?

- Closes #6192 

## Demo

* Auto-activation works with optional services: https://www.loom.com/share/54d0c23e3644450286288600abc63c91
* Page editor doesn't change the `services` field format now: https://www.loom.com/share/d90cb20321bb4972a315b2510e997a67

## Checklist

- [x] Add tests
- [ ] Designate a primary reviewer
