### PR TITLE
#6332: add element visibility flag

### DIFF
--- a/src/bricks/readers/ElementReader.test.ts
+++ b/src/bricks/readers/ElementReader.test.ts
@@ -26,4 +26,20 @@ describe("ElementReader", () => {
     const { ref } = await reader.read(div);
     expect(validateUUID(ref)).not.toBeNull();
   });
+
+  test("isVisible: false for element not in document", async () => {
+    const div = document.createElement("div");
+    const { isVisible } = await reader.read(div);
+    expect(isVisible).toBe(false);
+  });
+
+  // eslint-disable-next-line jest/no-disabled-tests -- https://github.com/jsdom/jsdom/issues/135
+  test.skip("isVisible: true for element in document", async () => {
+    const div = document.createElement("div");
+    div.innerHTML = "<p>Some text</p>";
+    document.body.append(div);
+
+    const { isVisible } = await reader.read(div);
+    expect(isVisible).toBe(true);
+  });
 });

--- a/src/bricks/readers/ElementReader.ts
+++ b/src/bricks/readers/ElementReader.ts
@@ -20,6 +20,7 @@ import { getReferenceForElement } from "@/contentScript/elementReference";
 import { ReaderABC } from "@/types/bricks/readerTypes";
 import { type SelectorRoot } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
+import { isVisible } from "@/utils/domUtils";
 
 /**
  * Read attributes, text, etc. from an HTML element.
@@ -47,6 +48,7 @@ export class ElementReader extends ReaderABC {
 
     return {
       ref: getReferenceForElement(element),
+      isVisible: isVisible(element),
       tagName: element.tagName,
       attrs: Object.fromEntries(
         Object.values(element.attributes).map((x) => [x.name, x.value])
@@ -83,8 +85,12 @@ export class ElementReader extends ReaderABC {
         type: "object",
         additionalProperties: true,
       },
+      isVisible: {
+        type: "boolean",
+        description: "True if the element is visible",
+      },
     },
-    required: ["tagName", "attrs", "data", "text", "ref"],
+    required: ["tagName", "attrs", "data", "text", "ref", "isVisible"],
     additionalProperties: false,
   };
 

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -131,3 +131,12 @@ export async function waitForBody(): Promise<void> {
     await sleep(20);
   }
 }
+
+export function isVisible(element: HTMLElement): boolean {
+  // https://github.com/jquery/jquery/blob/c66d4700dcf98efccb04061d575e242d28741223/src/css/hiddenVisibleSelectors.js#L9C1-L9C1
+  return Boolean(
+    element.offsetWidth ||
+      element.offsetHeight ||
+      element.getClientRects().length > 0
+  );
+}


### PR DESCRIPTION
## What does this PR do?

- Closes #6332 
- Adds an isVisible field to Element Reader output

## Reviewer Notes

- The visibility check doesn't work with jsdom, but leaving in test as documentation

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
