### PR TITLE
Fix Overflow for Rendered Components

### DIFF
--- a/src/components/formBuilder/RjsfSelectWidget.tsx
+++ b/src/components/formBuilder/RjsfSelectWidget.tsx
@@ -73,6 +73,7 @@ const RjsfSelectWidget: React.FC<WidgetProps> = ({
           options={selectOptions}
           isDisabled={disabled || readonly}
           isMulti={multiple}
+          menuPlacement="auto"
           value={selectOptions.find((option) => option.value === value)}
           onChange={_onChange}
           onBlur={_onBlur}

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -56,10 +56,7 @@ const BodyContainer: React.FC<
   BodyProps & { onAction: (action: SubmitPanelAction) => void }
 > = ({ blockId, body, onAction, meta }) => (
   // Use a shadow dom to prevent the webpage styles from affecting the sidebar
-  <EmotionShadowRoot.div
-    className="full-height overflow-hidden"
-    data-block-id={blockId}
-  >
+  <EmotionShadowRoot.div className="full-height" data-block-id={blockId}>
     <RendererComponent
       blockId={blockId}
       body={body}

--- a/src/sidebar/RendererComponent.tsx
+++ b/src/sidebar/RendererComponent.tsx
@@ -20,7 +20,7 @@ const RendererComponent: React.FunctionComponent<{
       // This is safe because if body is a string it's a SafeHTML value
       return (
         <div
-          style={{ height: "100%" }}
+          style={{ height: "100%", overflow: "hidden" }}
           dangerouslySetInnerHTML={{ __html: body }}
         />
       );

--- a/src/sidebar/__snapshots__/PanelBody.test.tsx.snap
+++ b/src/sidebar/__snapshots__/PanelBody.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`PanelBody renders cancellation 1`] = `
 exports[`PanelBody renders html brick 1`] = `
 <DocumentFragment>
   <div
-    class="full-height overflow-hidden"
+    class="full-height"
     data-block-id="@pixiebrix/html"
   />
 </DocumentFragment>


### PR DESCRIPTION
## What does this PR do?

- Fixes #6331 overflow
- I previously added `overflow: hidden;` to panels as a part of [this bug](https://github.com/pixiebrix/pixiebrix-extension/pull/6289). This was to solve a scrollbar issue for rendered components, but I didn't realize that panels were used for individual bricks so this caused other issues. So I removed that and added the `overflow: hidden;` rule to rendered components exclusively (iframes)
- Also added a `menuPlacement="auto"` to the select widget so the menu options can pop up above the input if it fits better.

## Demo

- [loom](https://www.loom.com/share/6eed28d5c709478887895052fef54355?sid=52d7bd87-2338-4420-81e4-a6b2fd9ad6e7)
- ![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/9334fb73-ce92-4036-8971-a8ecce651aa8)
- ![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/a7acce69-4a7f-4471-9fce-2a6b734115dc)

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
