### PR TITLE
Don't pass undefined urls to the isScriptableUrl() library function

### DIFF
--- a/src/permissions/permissionsUtils.ts
+++ b/src/permissions/permissionsUtils.ts
@@ -183,7 +183,7 @@ async function requestPermissionsFromUserGesture(
  *
  */
 export function isScriptableUrl(url?: string): boolean {
-  return _isScriptableUrl(url);
+  return url && _isScriptableUrl(url);
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

- I happened to notice this background script error while debugging something else:
<img width="712" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/2801308/c1abafca-453f-46f5-89a6-ae0e5a4c5ac1">

The implementation in Federico's library is here: https://github.com/fregante/webext-content-scripts/blob/main/index.ts#L289

This obviously will NPE if you pass in an undefined `string`, so I fixed our shim `isScriptableUrl` function to check for this before calling the library.

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
