### PR TITLE
#6363 Add reserved sidebar entries to to useHideEmptySidebar logic

### DIFF
--- a/src/sidebar/Tabs.test.tsx
+++ b/src/sidebar/Tabs.test.tsx
@@ -59,8 +59,25 @@ async function setupPanelsAndRender(
   return renderResult;
 }
 
+// Mock getReservedSidebarEntries so that we can use mockImplementation in tests
+jest.mock("@/contentScript/messenger/api", () => ({
+  ...jest.requireActual("@/contentScript/messenger/api"),
+  getReservedSidebarEntries: jest.fn(),
+}));
+
 describe("Tabs", () => {
   const panel = sidebarEntryFactory("panel");
+
+  beforeEach(() => {
+    (messengerApi.getReservedSidebarEntries as jest.Mock).mockImplementation(
+      () => ({
+        panels: [],
+        temporaryPanels: [],
+        forms: [],
+        modActivationPanel: null,
+      })
+    );
+  });
 
   test("renders", () => {
     const { asFragment } = render(<Tabs />);

--- a/src/sidebar/Tabs.test.tsx
+++ b/src/sidebar/Tabs.test.tsx
@@ -223,8 +223,6 @@ describe("Tabs", () => {
       ).toBeInTheDocument();
     });
 
-    // We are essentially testing to ensure that Sidebar preview re-renders don't
-    // cause the Sidebar to close
     test("sidebar doesn't close if visible reserved panel available", async () => {
       hideSidebarSpy.mockReset();
       await setupPanelsAndRender({


### PR DESCRIPTION
## What does this PR do?

- Fixes #6363
- In draft while I write some unit test coverage

## Reviewer Tips

- For reviewer context, `getReservedSidebarEntries` is a method exposed on the content script API in order to identify panels that will need to be rendered, even if they haven't been rendered yet. 
- The contentScript knows what panels will need to be rendered (because it runs all the bricks active for the current page), but lives in a different context than the sidebar, which doesn't have access to that information. We used to achieve this communication with the [event listeners added to ConnectedSidebar](https://github.com/pixiebrix/pixiebrix-extension/blob/9f004c4770c3a7cff05cdf8fe6cb40227513a019/src/sidebar/ConnectedSidebar.tsx#L52-L52)
- We originally introduced `getReservedSidebarEntries` in order to fix a race condition with the event listener not being ready before the content script started triggering the events for panel rendering
- Essentially the logic I'm implementing is
    - "if there are no visible sidebar panels that are currently rendered, but there _are_ visible panels that need to be rendered, don't close the sidebar"
    - or "only close the sidebar if there are no panels that are visible, even ones that will be rendered soon"

## Demo

- https://www.loom.com/share/fc66292fc036446d94a8dc2bc8aa7ddb

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @grahamlangford 
