### PR TITLE
Move variable suggestion popover into general settings and enable for all users

### DIFF
--- a/src/components/floatingActions/QuickbarButton.tsx
+++ b/src/components/floatingActions/QuickbarButton.tsx
@@ -42,7 +42,10 @@ export function QuickbarButton() {
           onClick={async () => {
             try {
               dispatch(
-                SettingsSlice.actions.setFloatingActionButtonEnabled(false)
+                SettingsSlice.actions.setFlag({
+                  flag: "isFloatingActionButtonEnabled",
+                  value: false,
+                })
               );
               reportEvent(Events.FLOATING_QUICK_BAR_BUTTON_ON_SCREEN_HIDE);
             } catch (error) {

--- a/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
+++ b/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
@@ -18,7 +18,6 @@
 import React from "react";
 // eslint-disable-next-line no-restricted-imports -- TODO: Fix over time
 import { Card, Form } from "react-bootstrap";
-import BootstrapSwitchButton from "bootstrap-switch-button-react";
 import { useDispatch, useSelector } from "react-redux";
 import settingsSlice from "@/store/settingsSlice";
 import { faFlask } from "@fortawesome/free-solid-svg-icons";
@@ -27,34 +26,7 @@ import { selectSettings } from "@/store/settingsSelectors";
 import { type SkunkworksSettings } from "@/store/settingsTypes";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
-
-const ExperimentalFeature: React.FunctionComponent<{
-  id: keyof SkunkworksSettings;
-  label: string;
-  description: string;
-  isEnabled: boolean;
-  onChange: (value: boolean) => void;
-}> = ({ id, label, description, isEnabled, onChange }) => (
-  <Form.Group controlId={id}>
-    <div>
-      <Form.Label>
-        {label} <i>{isEnabled ? "Enabled" : "Disabled"}</i>
-      </Form.Label>
-      <Form.Text muted className="mb-2">
-        {description}
-      </Form.Text>
-    </div>
-    <BootstrapSwitchButton
-      size="sm"
-      onstyle="info"
-      offstyle="light"
-      onlabel=" "
-      offlabel=" "
-      checked={isEnabled}
-      onChange={onChange}
-    />
-  </Form.Group>
-);
+import SettingToggle from "@/extensionConsole/pages/settings/SettingToggle";
 
 const ExperimentalSettings: React.FunctionComponent = () => {
   const dispatch = useDispatch();
@@ -88,38 +60,38 @@ const ExperimentalSettings: React.FunctionComponent = () => {
       </Card.Header>
       <Card.Body>
         <Form>
-          <ExperimentalFeature
-            id="suggestElements"
+          <SettingToggle
+            controlId="suggestElements"
             label="Suggest Elements in Selection Mode:"
             description="Toggle on to enable element suggestions/filtering in Page Editor
             selection mode"
             isEnabled={suggestElements}
             onChange={flagChangeHandlerFactory("suggestElements")}
           />
-          <ExperimentalFeature
-            id="excludeRandomClasses"
+          <SettingToggle
+            controlId="excludeRandomClasses"
             label="Detect and Exclude Random Classes from Selectors:"
             description="Toggle on to avoid using randomly-generated classes when picking
             elements from a website"
             isEnabled={excludeRandomClasses}
             onChange={flagChangeHandlerFactory("excludeRandomClasses")}
           />
-          <ExperimentalFeature
-            id="selectionTools"
+          <SettingToggle
+            controlId="selectionTools"
             label="Detect and Support Multi-Element Selection Tools:"
             description="Toggle on to support multi-element selection tools"
             isEnabled={selectionTools}
             onChange={flagChangeHandlerFactory("selectionTools")}
           />
-          <ExperimentalFeature
-            id="varAutosuggest"
+          <SettingToggle
+            controlId="varAutosuggest"
             label="Autosuggest Variables in Page Editor:"
             description="Toggle on to enable variable autosuggest for variable and text template entry modes"
             isEnabled={varAutosuggest}
             onChange={flagChangeHandlerFactory("varAutosuggest")}
           />
-          <ExperimentalFeature
-            id="performanceTracing"
+          <SettingToggle
+            controlId="performanceTracing"
             label="Performance Tracing:"
             description="Toggle on to trace runtime performance"
             isEnabled={performanceTracing}

--- a/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
+++ b/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
@@ -34,7 +34,6 @@ const ExperimentalSettings: React.FunctionComponent = () => {
     suggestElements,
     excludeRandomClasses,
     selectionTools,
-    varAutosuggest,
     performanceTracing,
   } = useSelector(selectSettings);
 
@@ -82,13 +81,6 @@ const ExperimentalSettings: React.FunctionComponent = () => {
             description="Toggle on to support multi-element selection tools"
             isEnabled={selectionTools}
             onChange={flagChangeHandlerFactory("selectionTools")}
-          />
-          <SettingToggle
-            controlId="varAutosuggest"
-            label="Autosuggest Variables in Page Editor:"
-            description="Toggle on to enable variable autosuggest for variable and text template entry modes"
-            isEnabled={varAutosuggest}
-            onChange={flagChangeHandlerFactory("varAutosuggest")}
           />
           <SettingToggle
             controlId="performanceTracing"

--- a/src/extensionConsole/pages/settings/GeneralSettings.tsx
+++ b/src/extensionConsole/pages/settings/GeneralSettings.tsx
@@ -18,13 +18,13 @@
 import React from "react";
 // eslint-disable-next-line no-restricted-imports -- TODO: Fix over time
 import { Card, Form } from "react-bootstrap";
-import BootstrapSwitchButton from "bootstrap-switch-button-react";
 import settingsSlice from "@/store/settingsSlice";
 import { useDispatch, useSelector } from "react-redux";
 import { selectSettings } from "@/store/settingsSelectors";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import useIsEnterpriseUser from "@/hooks/useIsEnterpriseUser";
+import SettingToggle from "@/extensionConsole/pages/settings/SettingToggle";
 
 const GeneralSettings: React.FunctionComponent = () => {
   const dispatch = useDispatch();
@@ -40,53 +40,25 @@ const GeneralSettings: React.FunctionComponent = () => {
       <Card.Header>General Settings</Card.Header>
       <Card.Body>
         <Form>
-          <Form.Group controlId="floating-action-button">
-            <div>
-              <Form.Label>
-                Floating action button:{" "}
-                <i>{checked ? "Enabled" : "Disabled"}</i>
-              </Form.Label>
-              {disableFloatingActionButton ? (
-                <Form.Text muted className="mb-2">
-                  The floating action button is not available for enterprise and
-                  partner users
-                </Form.Text>
-              ) : (
-                <Form.Text muted className="mb-2">
-                  Toggle on to enable floating button that opens the Quick Bar
-                </Form.Text>
-              )}
-            </div>
-
-            {
-              // Hide because the disabled flag is not working. Even when disabled is true, the user can
-              // still toggle the switch :shrug:
-              !disableFloatingActionButton && (
-                <BootstrapSwitchButton
-                  size="sm"
-                  onstyle="info"
-                  offstyle="light"
-                  onlabel=" "
-                  offlabel=" "
-                  disabled={disableFloatingActionButton}
-                  checked={checked}
-                  onChange={(enable) => {
-                    reportEvent(
-                      Events.FLOATING_QUICK_BAR_BUTTON_TOGGLE_SETTING,
-                      {
-                        enabled: enable,
-                      }
-                    );
-                    dispatch(
-                      settingsSlice.actions.setFloatingActionButtonEnabled(
-                        enable
-                      )
-                    );
-                  }}
-                />
-              )
+          <SettingToggle
+            controlId="floating-action-button"
+            label="Floating action button"
+            description={
+              disableFloatingActionButton
+                ? "The floating action button is not available for enterprise and partner users"
+                : "Toggle on to enable floating button that opens the Quick Bar"
             }
-          </Form.Group>
+            isEnabled={checked}
+            disabled={disableFloatingActionButton}
+            onChange={(enable) => {
+              reportEvent(Events.FLOATING_QUICK_BAR_BUTTON_TOGGLE_SETTING, {
+                enabled: enable,
+              });
+              dispatch(
+                settingsSlice.actions.setFloatingActionButtonEnabled(enable)
+              );
+            }}
+          />
         </Form>
       </Card.Body>
     </Card>

--- a/src/extensionConsole/pages/settings/LoggingSettings.tsx
+++ b/src/extensionConsole/pages/settings/LoggingSettings.tsx
@@ -21,12 +21,12 @@ import { useLoggingConfig } from "@/hooks/logging";
 import { Card, Form } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle, faTrash } from "@fortawesome/free-solid-svg-icons";
-import BootstrapSwitchButton from "bootstrap-switch-button-react";
 import Loader from "@/components/Loader";
 import AsyncButton from "@/components/AsyncButton";
 import useUserAction from "@/hooks/useUserAction";
 import { clearTraces } from "@/telemetry/trace";
 import { clearLogs } from "@/telemetry/logging";
+import SettingToggle from "@/extensionConsole/pages/settings/SettingToggle";
 
 const LoggingSettings: React.FunctionComponent = () => {
   const [config, setConfig] = useLoggingConfig();
@@ -57,24 +57,14 @@ const LoggingSettings: React.FunctionComponent = () => {
 
         {config ? (
           <Form>
-            <Form.Group controlId="logging">
-              <div>
-                <Form.Label>
-                  Log values: <i>{config.logValues ? "Enabled" : "Disabled"}</i>
-                </Form.Label>
-              </div>
-              <BootstrapSwitchButton
-                size="sm"
-                onstyle="info"
-                offstyle="light"
-                onlabel=" "
-                offlabel=" "
-                checked={config.logValues}
-                onChange={async (value) =>
-                  setConfig({ ...config, logValues: value })
-                }
-              />
-            </Form.Group>
+            <SettingToggle
+              controlId="logging"
+              label="Log values"
+              isEnabled={config.logValues}
+              onChange={async (value) =>
+                setConfig({ ...config, logValues: value })
+              }
+            />
           </Form>
         ) : (
           <Loader />

--- a/src/extensionConsole/pages/settings/PrivacySettings.tsx
+++ b/src/extensionConsole/pages/settings/PrivacySettings.tsx
@@ -20,8 +20,8 @@ import React from "react";
 import { Card, Form } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
-import BootstrapSwitchButton from "bootstrap-switch-button-react";
 import { useDNT } from "@/telemetry/dnt";
+import SettingToggle from "@/extensionConsole/pages/settings/SettingToggle";
 
 const PrivacySettings: React.FunctionComponent = () => {
   const [dnt, setDNT] = useDNT();
@@ -42,22 +42,12 @@ const PrivacySettings: React.FunctionComponent = () => {
         </Card.Text>
 
         <Form>
-          <Form.Group controlId="telemetry">
-            <div>
-              <Form.Label>
-                Telemetry: <i>{dnt ? "Disabled" : "Enabled"}</i>
-              </Form.Label>
-            </div>
-            <BootstrapSwitchButton
-              size="sm"
-              onstyle="info"
-              offstyle="light"
-              onlabel=" "
-              offlabel=" "
-              checked={!(dnt ?? false)}
-              onChange={async (value) => setDNT(!value)}
-            />
-          </Form.Group>
+          <SettingToggle
+            controlId="telemetry"
+            label="Telemetry"
+            isEnabled={!dnt}
+            onChange={async (value) => setDNT(!value)}
+          />
         </Form>
       </Card.Body>
     </Card>

--- a/src/extensionConsole/pages/settings/SettingToggle.tsx
+++ b/src/extensionConsole/pages/settings/SettingToggle.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+// eslint-disable-next-line no-restricted-imports -- TODO: Fix over time
+import { Form } from "react-bootstrap";
+import BootstrapSwitchButton from "bootstrap-switch-button-react";
+
+const SettingToggle: React.FunctionComponent<{
+  controlId: string;
+  label: string;
+  description?: string;
+  isEnabled: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+}> = ({ controlId, label, description, isEnabled, onChange, disabled }) => (
+  <Form.Group controlId={controlId}>
+    <div>
+      <Form.Label>
+        {label}: <i>{isEnabled ? "Enabled" : "Disabled"}</i>
+      </Form.Label>
+      {description && (
+        <Form.Text muted className="mb-2">
+          {description}
+        </Form.Text>
+      )}
+    </div>
+    {!disabled && (
+      <BootstrapSwitchButton
+        size="sm"
+        onstyle="info"
+        offstyle="light"
+        onlabel=" "
+        offlabel=" "
+        checked={isEnabled}
+        onChange={onChange}
+      />
+    )}
+  </Form.Group>
+);
+
+export default SettingToggle;

--- a/src/store/settingsMigrations.ts
+++ b/src/store/settingsMigrations.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type MigrationManifest } from "redux-persist/es/types";
+
+/**
+ * Migrations for the settings state based on the version found in the config.
+ * The keys represent the version number that the state is coming from. At the end of each migration,
+ * the version increments until it runs the version in the config.
+ * https://github.com/rt2zz/redux-persist#migrations
+ */
+const settingsMigrations: MigrationManifest = {
+  // Default the variable autosuggest to true after we take it out of beta
+  1: (state) => ({ ...state, varAutosuggest: true }),
+};
+
+export default settingsMigrations;

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -18,8 +18,8 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import {
   AUTH_METHODS,
+  type SettingOptions,
   type SettingsState,
-  type SkunkworksSettings,
 } from "@/store/settingsTypes";
 import reportError from "@/telemetry/reportError";
 import { isEmpty, once } from "lodash";
@@ -57,7 +57,7 @@ const settingsSlice = createSlice({
     setFlag(
       state,
       action: PayloadAction<{
-        flag: keyof SkunkworksSettings;
+        flag: keyof SettingOptions;
         value: boolean;
       }>
     ) {
@@ -71,9 +71,6 @@ const settingsSlice = createSlice({
     },
     dismissBrowserWarning(state) {
       state.browserWarningDismissed = true;
-    },
-    setFloatingActionButtonEnabled(state, { payload }: { payload: boolean }) {
-      state.isFloatingActionButtonEnabled = payload;
     },
     setPartnerId(
       state,

--- a/src/store/settingsStorage.ts
+++ b/src/store/settingsStorage.ts
@@ -25,6 +25,8 @@ import {
   setReduxStorage,
 } from "@/utils/storageUtils";
 import { initialSettingsState } from "@/store/settingsSlice";
+import settingsMigrations from "@/store/settingsMigrations";
+import { createMigrate } from "redux-persist";
 
 const SETTINGS_STORAGE_KEY = "persist:settings" as ReduxStorageKey;
 
@@ -63,5 +65,7 @@ export async function saveSettingsState(state: SettingsState): Promise<void> {
 
 export const persistSettingsConfig = {
   key: "settings",
+  version: 1,
+  migrate: createMigrate(settingsMigrations),
   storage: localStorage,
 };

--- a/src/store/settingsTypes.ts
+++ b/src/store/settingsTypes.ts
@@ -44,17 +44,24 @@ export type SkunkworksSettings = {
   selectionTools?: boolean;
 
   /**
-   * Experimental setting to support autosuggest for variables in the Page Editor
-   */
-  varAutosuggest?: boolean;
-
-  /**
    * Experimental setting to track runtime performance
    */
   performanceTracing?: boolean;
 };
 
-export type SettingsState = SkunkworksSettings & {
+export type SettingOptions = SkunkworksSettings & {
+  /**
+   * Setting to support autosuggest for variables in the Page Editor
+   */
+  varAutosuggest?: boolean;
+
+  /**
+   * Button to enable the floating action button on the page
+   */
+  isFloatingActionButtonEnabled?: boolean;
+};
+
+export type SettingsState = SettingOptions & {
   /**
    * Whether the extension is synced to the app for provisioning.
    *
@@ -81,11 +88,6 @@ export type SettingsState = SkunkworksSettings & {
    * Whether the non-Chrome browser warning has been dismissed.
    */
   browserWarningDismissed: boolean;
-
-  /**
-   * Button to enable the floating action button on the page
-   */
-  isFloatingActionButtonEnabled: boolean;
 
   /**
    * Partner id for the user, if any.


### PR DESCRIPTION
## What does this PR do?

- Closes #6319 
- Refactor: abstracted the toggle component
- Changed some types
- Removed `setFloatingActionButtonEnabled` action  since it did the same thing as `setFlag`
- Added migrations and versions to the settings config

## Demo
before:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/4734f218-55c8-4a54-a932-1533a67a6df8)

after: ![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/784a5217-9b0b-4556-94ba-ff4a63011348)

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
