### PR TITLE
Change the popover width so tooltip doesn't wrap

### DIFF
--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.module.scss
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.module.scss
@@ -28,7 +28,7 @@ $menu-padding-y: 4px;
 // Aligned with the style of react-select's menu
 .menu {
   width: 100%;
-  min-width: 200px;
+  min-width: 304px;
   height: $popover-height;
   max-height: $popover-height;
   z-index: 1;


### PR DESCRIPTION
## What does this PR do?

- Closes #6322 
- The message at the bottom of the popover was wrapping. Changes the width so it doesn't,

## Demo
before:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/597d72b0-8834-4648-9bd2-cbf1d2efe315)

after:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/5ea69c12-bc63-423b-8bb0-3204a9f966c3)

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer: @grahamlangford 
