### PR TITLE
Add 'Filter Rows' field to Google sheets lookup brick and fix a bug

### DIFF
--- a/src/bricks/util.test.ts
+++ b/src/bricks/util.test.ts
@@ -19,7 +19,7 @@ import { defaultBlockConfig, isOfficial } from "./util";
 import { type RegistryId } from "@/types/registryTypes";
 import IfElse from "./transformers/controlFlow/IfElse";
 import { EMPTY_PIPELINE } from "@/testUtils/testHelpers";
-import { LOOKUP_SCHEMA } from "@/contrib/google/sheets/bricks/lookup";
+import { type Schema } from "@/types/schemaTypes";
 
 describe("isOfficial", () => {
   test("returns true for an official block", () => {
@@ -40,7 +40,18 @@ describe("defaultBlockConfig", () => {
   });
 
   test("handles explicit default value of false", () => {
-    const config = defaultBlockConfig(LOOKUP_SCHEMA);
-    expect(config.filterRows).toStrictEqual(false);
+    const schema = {
+      $schema: "https://json-schema.org/draft/2019-09/schema#",
+      type: "object",
+      properties: {
+        myProp: {
+          title: "My Property",
+          type: "boolean",
+          default: false,
+        },
+      },
+    } as Schema;
+    const config = defaultBlockConfig(schema);
+    expect(config.myProp).toStrictEqual(false);
   });
 });

--- a/src/bricks/util.test.ts
+++ b/src/bricks/util.test.ts
@@ -19,6 +19,7 @@ import { defaultBlockConfig, isOfficial } from "./util";
 import { type RegistryId } from "@/types/registryTypes";
 import IfElse from "./transformers/controlFlow/IfElse";
 import { EMPTY_PIPELINE } from "@/testUtils/testHelpers";
+import { LOOKUP_SCHEMA } from "@/contrib/google/sheets/bricks/lookup";
 
 describe("isOfficial", () => {
   test("returns true for an official block", () => {
@@ -36,5 +37,10 @@ describe("defaultBlockConfig", () => {
 
     expect(actual.if).toEqual(EMPTY_PIPELINE);
     expect(actual.else).toEqual(EMPTY_PIPELINE);
+  });
+
+  test("handles explicit default value of false", () => {
+    const config = defaultBlockConfig(LOOKUP_SCHEMA);
+    expect(config.filterRows).toStrictEqual(false);
   });
 });

--- a/src/bricks/util.ts
+++ b/src/bricks/util.ts
@@ -42,7 +42,7 @@ export function defaultBlockConfig(schema: Schema): UnknownObject {
           schema.properties,
           (x) =>
             typeof x !== "boolean" &&
-            ((x.default !== undefined && !x.anyOf && !x.oneOf) ||
+            ((x.default != null && !x.anyOf && !x.oneOf) ||
               x.$ref === pipelineSchema.$id)
         ),
         (propertySchema: Schema) => {

--- a/src/bricks/util.ts
+++ b/src/bricks/util.ts
@@ -42,7 +42,7 @@ export function defaultBlockConfig(schema: Schema): UnknownObject {
           schema.properties,
           (x) =>
             typeof x !== "boolean" &&
-            ((x.default && !x.anyOf && !x.oneOf) ||
+            ((x.default !== undefined && !x.anyOf && !x.oneOf) ||
               x.$ref === pipelineSchema.$id)
         ),
         (propertySchema: Schema) => {

--- a/src/contrib/google/sheets/bricks/lookup.test.ts
+++ b/src/contrib/google/sheets/bricks/lookup.test.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { sheets } from "@/background/messenger/api";
+import { GoogleSheetsLookup } from "@/contrib/google/sheets/bricks/lookup";
+import { type ValueRange } from "@/contrib/google/sheets/core/types";
+import { type UnknownObject } from "@/types/objectTypes";
+import { BusinessError } from "@/errors/businessErrors";
+
+const getAllRowsMock = jest.mocked(sheets.getAllRows);
+
+describe("Google sheets lookup brick logic", () => {
+  const lookupBrick = new GoogleSheetsLookup();
+  type InputType = Parameters<typeof lookupBrick.transform>[0];
+
+  async function runLookup(
+    input: Record<string, any>
+  ): Promise<UnknownObject | UnknownObject[]> {
+    return lookupBrick.transform(
+      {
+        spreadsheetId: "abc",
+        tabName: "Sheet1",
+        ...input,
+      } as InputType,
+      // @ts-expect-error -- lookupBrick.transform() only uses the logger
+      { logger: { debug: jest.fn() } }
+    );
+  }
+
+  it("throws error if query is set and filterRows is undefined and header is not found", async () => {
+    const rows: ValueRange = {
+      values: [
+        ["ColumnFoo", "ColumnBar"],
+        ["A", "1"],
+        ["B", "2"],
+        ["C", "3"],
+      ],
+    };
+    getAllRowsMock.mockResolvedValue(rows);
+
+    await expect(
+      runLookup({
+        header: "ColumnA",
+        query: "testQuery",
+        multi: false,
+      })
+    ).rejects.toThrowWithMessage(BusinessError, "Header ColumnA not found");
+  });
+
+  it("throws error if query is set and filterRows is true and header is not found", async () => {
+    const rows: ValueRange = {
+      values: [
+        ["ColumnFoo", "ColumnBar"],
+        ["A", "1"],
+        ["B", "2"],
+        ["C", "3"],
+      ],
+    };
+    getAllRowsMock.mockResolvedValue(rows);
+
+    await expect(
+      runLookup({
+        filterRows: true,
+        header: "ColumnA",
+        query: "testQuery",
+        multi: false,
+      })
+    ).rejects.toThrowWithMessage(BusinessError, "Header ColumnA not found");
+  });
+
+  it("only returns first row when multi is false", async () => {
+    const rows: ValueRange = {
+      values: [
+        ["ColumnFoo", "ColumnBar"],
+        ["A", "1"],
+        ["A", "2"],
+        ["B", "3"],
+      ],
+    };
+    getAllRowsMock.mockResolvedValue(rows);
+
+    const result = await runLookup({
+      header: "ColumnFoo",
+      query: "A",
+      multi: false,
+    });
+
+    expect(result).toEqual({ ColumnFoo: "A", ColumnBar: "1" });
+  });
+
+  it("returns all matches when multi is true", async () => {
+    const rows: ValueRange = {
+      values: [
+        ["ColumnFoo", "ColumnBar"],
+        ["A", "1"],
+        ["A", "2"],
+        ["B", "3"],
+        ["C", "4"],
+      ],
+    };
+    getAllRowsMock.mockResolvedValue(rows);
+
+    const result = await runLookup({
+      header: "ColumnFoo",
+      query: "A",
+      multi: true,
+    });
+
+    expect(result).toEqual([
+      { ColumnFoo: "A", ColumnBar: "1" },
+      { ColumnFoo: "A", ColumnBar: "2" },
+    ]);
+  });
+
+  it("returns all rows when filterRows is false", async () => {
+    const rows: ValueRange = {
+      values: [
+        ["ColumnFoo", "ColumnBar"],
+        ["A", "1"],
+        ["A", "2"],
+        ["B", "3"],
+        ["C", "4"],
+      ],
+    };
+    getAllRowsMock.mockResolvedValue(rows);
+
+    const result = await runLookup({
+      filterRows: false,
+    });
+
+    expect(result).toEqual([
+      { ColumnFoo: "A", ColumnBar: "1" },
+      { ColumnFoo: "A", ColumnBar: "2" },
+      { ColumnFoo: "B", ColumnBar: "3" },
+      { ColumnFoo: "C", ColumnBar: "4" },
+    ]);
+  });
+
+  it("returns all rows when filterRows is false even if header and query are set", async () => {
+    const rows: ValueRange = {
+      values: [
+        ["ColumnFoo", "ColumnBar"],
+        ["A", "1"],
+        ["A", "2"],
+        ["B", "3"],
+        ["C", "4"],
+      ],
+    };
+    getAllRowsMock.mockResolvedValue(rows);
+
+    const result = await runLookup({
+      filterRows: false,
+      header: "ColumnFoo",
+      query: "A",
+      multi: false,
+    });
+
+    expect(result).toEqual([
+      { ColumnFoo: "A", ColumnBar: "1" },
+      { ColumnFoo: "A", ColumnBar: "2" },
+      { ColumnFoo: "B", ColumnBar: "3" },
+      { ColumnFoo: "C", ColumnBar: "4" },
+    ]);
+  });
+});

--- a/src/contrib/google/sheets/ui/LookupSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/ui/LookupSpreadsheetOptions.tsx
@@ -124,6 +124,14 @@ const LookupSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
     joinName(blockConfigPath, "tabName")
   );
 
+  const filterRowsFieldPath = joinName(blockConfigPath, "filterRows");
+  const [{ value: filterRows }] = useField<boolean | undefined>(
+    filterRowsFieldPath
+  );
+
+  // For backwards compatibility, we want to show the filters if the field is undefined.
+  const showFilters = filterRows === undefined || filterRows;
+
   const { flagOn } = useFlags();
 
   return (
@@ -159,29 +167,40 @@ const LookupSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
                     schema={LOOKUP_SCHEMA.properties.tabName as Schema}
                     spreadsheet={spreadsheet}
                   />
-                  <HeaderField
-                    name={joinName(blockConfigPath, "header")}
-                    googleAccount={googleAccount}
-                    spreadsheetId={spreadsheet?.spreadsheetId}
-                    tabName={tabName}
+                  <SchemaField
+                    name={filterRowsFieldPath}
+                    schema={LOOKUP_SCHEMA.properties.filterRows as Schema}
+                    defaultType="boolean"
                   />
+                  {showFilters && (
+                    <HeaderField
+                      name={joinName(blockConfigPath, "header")}
+                      googleAccount={googleAccount}
+                      spreadsheetId={spreadsheet?.spreadsheetId}
+                      tabName={tabName}
+                    />
+                  )}
                 </>
               }
             </FormErrorContext.Provider>
-            <SchemaField
-              name={joinName(blockConfigPath, "query")}
-              label="Query"
-              description="Value to search for in the column"
-              schema={LOOKUP_SCHEMA.properties.query as Schema}
-              isRequired
-            />
-            <SchemaField
-              name={joinName(blockConfigPath, "multi")}
-              label="All Matches"
-              description="Toggle on to return an array of matches"
-              schema={LOOKUP_SCHEMA.properties.multi as Schema}
-              isRequired
-            />
+            {showFilters && (
+              <>
+                <SchemaField
+                  name={joinName(blockConfigPath, "query")}
+                  label="Query"
+                  description="Value to search for in the column"
+                  schema={LOOKUP_SCHEMA.properties.query as Schema}
+                  isRequired
+                />
+                <SchemaField
+                  name={joinName(blockConfigPath, "multi")}
+                  label="All Matches"
+                  description="Toggle on to return an array of matches"
+                  schema={LOOKUP_SCHEMA.properties.multi as Schema}
+                  isRequired
+                />
+              </>
+            )}
           </>
         )}
       </RequireGoogleSheet>

--- a/src/contrib/google/sheets/ui/__snapshots__/LookupSpreadsheetOptions.test.tsx.snap
+++ b/src/contrib/google/sheets/ui/__snapshots__/LookupSpreadsheetOptions.test.tsx.snap
@@ -265,6 +265,62 @@ exports[`LookupSpreadsheetOptions given empty googleAccount and string spreadshe
       >
         <label
           class="label form-label col-form-label col-xl-2 col-lg-3"
+          for="config.filterRows"
+        >
+          Filter Rows
+        </label>
+        <div
+          class="col-xl-10 col-lg-9"
+        >
+          <div
+            class="root"
+          >
+            <div
+              class="field"
+            >
+              <input
+                class="form-control"
+                id="config.filterRows"
+                name="config.filterRows"
+                readonly=""
+                value=""
+              />
+            </div>
+            <div
+              class="dropdown dropdown"
+              data-test-selected="Exclude"
+              data-testid="toggle-config.filterRows"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-link"
+                type="button"
+              >
+                <span
+                  class="symbol"
+                >
+                  <test-file-stub
+                    classname="root"
+                  />
+                </span>
+              </button>
+            </div>
+          </div>
+          <small
+            class="text-muted form-text"
+          >
+            <span>
+              True to show the row filter controls.
+            </span>
+          </small>
+        </div>
+      </div>
+      <div
+        class="formGroup form-group row"
+      >
+        <label
+          class="label form-label col-form-label col-xl-2 col-lg-3"
           for="config.header"
         >
           Column Header
@@ -781,6 +837,62 @@ exports[`LookupSpreadsheetOptions given empty googleAccount and string spreadshe
       >
         <label
           class="label form-label col-form-label col-xl-2 col-lg-3"
+          for="config.filterRows"
+        >
+          Filter Rows
+        </label>
+        <div
+          class="col-xl-10 col-lg-9"
+        >
+          <div
+            class="root"
+          >
+            <div
+              class="field"
+            >
+              <input
+                class="form-control"
+                id="config.filterRows"
+                name="config.filterRows"
+                readonly=""
+                value=""
+              />
+            </div>
+            <div
+              class="dropdown dropdown"
+              data-test-selected="Exclude"
+              data-testid="toggle-config.filterRows"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-link"
+                type="button"
+              >
+                <span
+                  class="symbol"
+                >
+                  <test-file-stub
+                    classname="root"
+                  />
+                </span>
+              </button>
+            </div>
+          </div>
+          <small
+            class="text-muted form-text"
+          >
+            <span>
+              True to show the row filter controls.
+            </span>
+          </small>
+        </div>
+      </div>
+      <div
+        class="formGroup form-group row"
+      >
+        <label
+          class="label form-label col-form-label col-xl-2 col-lg-3"
           for="config.header"
         >
           Column Header
@@ -1241,6 +1353,62 @@ exports[`LookupSpreadsheetOptions given feature flag off and string spreadsheetI
           >
             <span>
               The spreadsheet tab
+            </span>
+          </small>
+        </div>
+      </div>
+      <div
+        class="formGroup form-group row"
+      >
+        <label
+          class="label form-label col-form-label col-xl-2 col-lg-3"
+          for="config.filterRows"
+        >
+          Filter Rows
+        </label>
+        <div
+          class="col-xl-10 col-lg-9"
+        >
+          <div
+            class="root"
+          >
+            <div
+              class="field"
+            >
+              <input
+                class="form-control"
+                id="config.filterRows"
+                name="config.filterRows"
+                readonly=""
+                value=""
+              />
+            </div>
+            <div
+              class="dropdown dropdown"
+              data-test-selected="Exclude"
+              data-testid="toggle-config.filterRows"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-link"
+                type="button"
+              >
+                <span
+                  class="symbol"
+                >
+                  <test-file-stub
+                    classname="root"
+                  />
+                </span>
+              </button>
+            </div>
+          </div>
+          <small
+            class="text-muted form-text"
+          >
+            <span>
+              True to show the row filter controls.
             </span>
           </small>
         </div>
@@ -1977,6 +2145,62 @@ exports[`LookupSpreadsheetOptions given test googleAccount and string spreadshee
       >
         <label
           class="label form-label col-form-label col-xl-2 col-lg-3"
+          for="config.filterRows"
+        >
+          Filter Rows
+        </label>
+        <div
+          class="col-xl-10 col-lg-9"
+        >
+          <div
+            class="root"
+          >
+            <div
+              class="field"
+            >
+              <input
+                class="form-control"
+                id="config.filterRows"
+                name="config.filterRows"
+                readonly=""
+                value=""
+              />
+            </div>
+            <div
+              class="dropdown dropdown"
+              data-test-selected="Exclude"
+              data-testid="toggle-config.filterRows"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-link"
+                type="button"
+              >
+                <span
+                  class="symbol"
+                >
+                  <test-file-stub
+                    classname="root"
+                  />
+                </span>
+              </button>
+            </div>
+          </div>
+          <small
+            class="text-muted form-text"
+          >
+            <span>
+              True to show the row filter controls.
+            </span>
+          </small>
+        </div>
+      </div>
+      <div
+        class="formGroup form-group row"
+      >
+        <label
+          class="label form-label col-form-label col-xl-2 col-lg-3"
           for="config.header"
         >
           Column Header
@@ -2695,6 +2919,62 @@ exports[`LookupSpreadsheetOptions given test googleAccount and string spreadshee
           >
             <span>
               The spreadsheet tab
+            </span>
+          </small>
+        </div>
+      </div>
+      <div
+        class="formGroup form-group row"
+      >
+        <label
+          class="label form-label col-form-label col-xl-2 col-lg-3"
+          for="config.filterRows"
+        >
+          Filter Rows
+        </label>
+        <div
+          class="col-xl-10 col-lg-9"
+        >
+          <div
+            class="root"
+          >
+            <div
+              class="field"
+            >
+              <input
+                class="form-control"
+                id="config.filterRows"
+                name="config.filterRows"
+                readonly=""
+                value=""
+              />
+            </div>
+            <div
+              class="dropdown dropdown"
+              data-test-selected="Exclude"
+              data-testid="toggle-config.filterRows"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle btn btn-link"
+                type="button"
+              >
+                <span
+                  class="symbol"
+                >
+                  <test-file-stub
+                    classname="root"
+                  />
+                </span>
+              </button>
+            </div>
+          </div>
+          <small
+            class="text-muted form-text"
+          >
+            <span>
+              True to show the row filter controls.
             </span>
           </small>
         </div>


### PR DESCRIPTION
## What does this PR do?

- Adds a new field to the Google Sheets lookup brick that allows looking up all rows in a sheet without using a column/query "hack" on all rows

## Demo

https://www.loom.com/share/67551718811a42f0a107c431f4d880af

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer
