### PR TITLE
#6400 - Filter out ResizeObserver loop errors in the Rollbar config

### DIFF
--- a/src/telemetry/initRollbar.ts
+++ b/src/telemetry/initRollbar.ts
@@ -73,6 +73,8 @@ async function initRollbar(): Promise<Rollbar> {
     // NOTE: we aren't passing ignoredMessages, because we are applying our own filtering in reportUncaughtErrors and
     // reportError
     // https://docs.rollbar.com/docs/reduce-noisy-javascript-errors#ignore-certain-types-of-messages
+    //
+    // @since 1.7.40 - We need to hard-filter out the ResizeObserver loop errors because they are flooding Rollbar
 
     return Rollbar.init({
       enabled: accessToken && accessToken !== "undefined" && !isContentScript(),
@@ -105,6 +107,7 @@ async function initRollbar(): Promise<Rollbar> {
           }
         }
       },
+      ignoredMessages: [/ResizeObserver loop/],
     });
   } catch (error) {
     console.error("Error during Rollbar init", { error });


### PR DESCRIPTION
## What does this PR do?

- Closes #6400 

## Discussion

I wish we could figure out how to reproduce this, but I haven't been able to. I think it's coming from this code: 
https://github.com/pixiebrix/pixiebrix-extension/blob/33db20ef045b78935d37b234fe0ebe66a96b39a7/src/starterBricks/menuItemExtension.ts#L295-L314


## Future Work

- We should see if there's anything we can do to prevent this error from happening

## Checklist

- [ ] Add tests - 🤷‍♂️ Not really sure how to test this
- [x] Designate a primary reviewer - @grahamlangford 
