### PR TITLE
6407: fix null pointer exception in Page Editor

### DIFF
--- a/src/components/form/widgets/RegistryIdWidget.tsx
+++ b/src/components/form/widgets/RegistryIdWidget.tsx
@@ -51,8 +51,7 @@ const RegistryIdWidget: React.VFC<{
       (organization) =>
         !isEmpty(organization.scope) && editorRoles.has(organization.role)
     )
-    .map((organization) => organization.scope)
-    .filter(Boolean); // Scope is optional
+    .map((organization) => organization.scope);
 
   const options = makeStringOptions(userScope, ...organizationScopes);
 

--- a/src/components/form/widgets/RegistryIdWidget.tsx
+++ b/src/components/form/widgets/RegistryIdWidget.tsx
@@ -51,7 +51,8 @@ const RegistryIdWidget: React.VFC<{
       (organization) =>
         !isEmpty(organization.scope) && editorRoles.has(organization.role)
     )
-    .map((organization) => organization.scope);
+    .map((organization) => organization.scope)
+    .filter(Boolean); // Scope is optional
 
   const options = makeStringOptions(userScope, ...organizationScopes);
 

--- a/src/extensionConsole/pages/mods/modals/shareModals/OwnerLabel.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/OwnerLabel.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { selectAuth } from "@/auth/authSelectors";
+import { selectShowPublishContext } from "@/extensionConsole/pages/mods/modals/modModalsSelectors";
+import useSortOrganizations from "@/extensionConsole/pages/mods/modals/shareModals/useSortOrganizations";
+import { useOptionalModDefinition } from "@/modDefinitions/modDefinitionHooks";
+import { getScopeAndId } from "@/utils/registryUtils";
+import { faUser, faUsers } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React from "react";
+import { useSelector } from "react-redux";
+
+const OwnerLabel: React.FunctionComponent = () => {
+  const { blueprintId } = useSelector(selectShowPublishContext);
+  const { scope: userScope } = useSelector(selectAuth);
+
+  const { data: recipe } = useOptionalModDefinition(blueprintId);
+
+  const sortedOrganizations = useSortOrganizations();
+
+  const [recipeScope] = getScopeAndId(recipe?.metadata.id);
+
+  if (recipeScope === userScope) {
+    return (
+      <span>
+        <FontAwesomeIcon icon={faUser} /> You
+      </span>
+    );
+  }
+
+  const ownerOrganizationIndex = sortedOrganizations.findIndex(
+    (x) => x.scope === recipeScope
+  );
+
+  if (ownerOrganizationIndex === -1) {
+    return (
+      <span>
+        <FontAwesomeIcon icon={faUsers} /> Unknown
+      </span>
+    );
+  }
+
+  // We get the owner's organization and remove it from the list of organizations (splice mutates the array)
+  const ownerOrganization = sortedOrganizations.splice(
+    ownerOrganizationIndex,
+    1
+  )[0];
+
+  return (
+    <span>
+      <FontAwesomeIcon icon={faUsers} /> {ownerOrganization.name}
+    </span>
+  );
+};
+
+export default OwnerLabel;

--- a/src/extensionConsole/pages/mods/modals/shareModals/OwnerLabel.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/OwnerLabel.tsx
@@ -43,23 +43,17 @@ const OwnerLabel: React.FunctionComponent = () => {
     );
   }
 
-  const ownerOrganizationIndex = sortedOrganizations.findIndex(
+  const ownerOrganization = sortedOrganizations.find(
     (x) => x.scope === recipeScope
   );
 
-  if (ownerOrganizationIndex === -1) {
+  if (!ownerOrganization) {
     return (
       <span>
         <FontAwesomeIcon icon={faUsers} /> Unknown
       </span>
     );
   }
-
-  // We get the owner's organization and remove it from the list of organizations (splice mutates the array)
-  const ownerOrganization = sortedOrganizations.splice(
-    ownerOrganizationIndex,
-    1
-  )[0];
 
   return (
     <span>

--- a/src/extensionConsole/pages/mods/modals/shareModals/PublishContentLayout.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/PublishContentLayout.tsx
@@ -16,7 +16,6 @@
  */
 
 import React from "react";
-import { type UUID } from "@/types/stringTypes";
 import { Modal } from "react-bootstrap";
 import { useSelector } from "react-redux";
 import { selectShowPublishContext } from "@/extensionConsole/pages/mods/modals/modModalsSelectors";

--- a/src/extensionConsole/pages/mods/modals/shareModals/PublishContentLayout.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/PublishContentLayout.tsx
@@ -55,7 +55,7 @@ const PublishContentLayout: React.FunctionComponent<
         <span className="text-muted">Owner</span>
       </div>
       {sortedOrganizations
-        .filter((x) => recipe.sharing.organizations.includes(x.id as UUID))
+        .filter((x) => recipe.sharing.organizations.includes(x.id))
         .map((organization) => (
           <div className={styles.row} key={organization.id}>
             <span>

--- a/src/extensionConsole/pages/mods/modals/shareModals/PublishContentLayout.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/PublishContentLayout.tsx
@@ -15,29 +15,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { type ReactElement } from "react";
+import React from "react";
 import { type UUID } from "@/types/stringTypes";
 import { Modal } from "react-bootstrap";
 import { useSelector } from "react-redux";
 import { selectShowPublishContext } from "@/extensionConsole/pages/mods/modals/modModalsSelectors";
-import { sortBy } from "lodash";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faInfoCircle,
-  faUser,
-  faUsers,
-} from "@fortawesome/free-solid-svg-icons";
+import { faInfoCircle, faUsers } from "@fortawesome/free-solid-svg-icons";
 import styles from "./ShareModals.module.scss";
-import { selectAuth } from "@/auth/authSelectors";
-import { type Organization, UserRole } from "@/types/contract";
 import { useOptionalModDefinition } from "@/modDefinitions/modDefinitionHooks";
 import { RequireScope } from "@/auth/RequireScope";
-import { getScopeAndId } from "@/utils/registryUtils";
-
-const editorRoles = new Set<number>([UserRole.admin, UserRole.developer]);
-
-const sortOrganizations = (organizations: Organization[]) =>
-  sortBy(organizations, (organization) => organization.name);
+import OwnerLabel from "@/extensionConsole/pages/mods/modals/shareModals/OwnerLabel";
+import useHasEditPermissions from "@/extensionConsole/pages/mods/modals/shareModals/useHasEditPermissions";
+import useSortOrganizations from "@/extensionConsole/pages/mods/modals/shareModals/useSortOrganizations";
 
 type PublishContentLayoutProps = React.PropsWithChildren<{
   title: string;
@@ -47,47 +37,10 @@ const PublishContentLayout: React.FunctionComponent<
   PublishContentLayoutProps
 > = ({ title, children }) => {
   const { blueprintId } = useSelector(selectShowPublishContext);
-  const { scope: userScope, organizations: userOrganizations } =
-    useSelector(selectAuth);
   const { data: recipe } = useOptionalModDefinition(blueprintId);
 
-  // Sorting returns new array, so it safe to mutate it
-  const sortedOrganizations = sortOrganizations(userOrganizations);
-  const [recipeScope] = getScopeAndId(recipe?.metadata.id);
-  let ownerLabel: ReactElement;
-  let hasEditPermissions = false;
-  if (recipeScope === userScope) {
-    ownerLabel = (
-      <span>
-        <FontAwesomeIcon icon={faUser} /> You
-      </span>
-    );
-    hasEditPermissions = true;
-  } else {
-    const ownerOrganizationIndex = sortedOrganizations.findIndex(
-      (x) => x.scope === recipeScope
-    );
-
-    if (ownerOrganizationIndex === -1) {
-      ownerLabel = (
-        <span>
-          <FontAwesomeIcon icon={faUsers} /> Unknown
-        </span>
-      );
-    } else {
-      // We get the owner's organization and remove it from the list of organizations (splice mutates the array)
-      const ownerOrganization = sortedOrganizations.splice(
-        ownerOrganizationIndex,
-        1
-      )[0];
-      ownerLabel = (
-        <span>
-          <FontAwesomeIcon icon={faUsers} /> {ownerOrganization.name}
-        </span>
-      );
-      hasEditPermissions = editorRoles.has(ownerOrganization?.role);
-    }
-  }
+  const sortedOrganizations = useSortOrganizations();
+  const hasEditPermissions = useHasEditPermissions();
 
   const body = hasEditPermissions ? (
     children
@@ -98,7 +51,7 @@ const PublishContentLayout: React.FunctionComponent<
         to change sharing
       </div>
       <div className={styles.row}>
-        {ownerLabel}
+        <OwnerLabel />
         <span className="text-muted">Owner</span>
       </div>
       {sortedOrganizations

--- a/src/extensionConsole/pages/mods/modals/shareModals/ShareRecipeModalBody.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/ShareRecipeModalBody.tsx
@@ -227,7 +227,7 @@ const ShareRecipeModalBody: React.FunctionComponent = () => {
             <span className="text-muted">Owner</span>
           </div>
           {organizationsForSelect
-            .filter((x) => recipe.sharing.organizations.includes(x.id as UUID))
+            .filter((x) => recipe.sharing.organizations.includes(x.id))
             .map((organization) => (
               <div className={styles.row} key={organization.id}>
                 <span>

--- a/src/extensionConsole/pages/mods/modals/shareModals/useHasEditPermissions.ts
+++ b/src/extensionConsole/pages/mods/modals/shareModals/useHasEditPermissions.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { selectAuth } from "@/auth/authSelectors";
+import { selectShowPublishContext } from "@/extensionConsole/pages/mods/modals/modModalsSelectors";
+import useSortOrganizations from "@/extensionConsole/pages/mods/modals/shareModals/useSortOrganizations";
+import { useOptionalModDefinition } from "@/modDefinitions/modDefinitionHooks";
+import { UserRole } from "@/types/contract";
+import { getScopeAndId } from "@/utils/registryUtils";
+import { useSelector } from "react-redux";
+
+const editorRoles = new Set<number>([UserRole.admin, UserRole.developer]);
+
+export default function useHasEditPermissions() {
+  const { blueprintId } = useSelector(selectShowPublishContext);
+  const { scope: userScope } = useSelector(selectAuth);
+
+  const { data: recipe } = useOptionalModDefinition(blueprintId);
+
+  const sortedOrganizations = useSortOrganizations();
+  const [recipeScope] = getScopeAndId(recipe?.metadata.id);
+
+  let hasEditPermissions = false;
+
+  if (recipeScope === userScope) {
+    hasEditPermissions = true;
+  } else {
+    const ownerOrganizationIndex = sortedOrganizations.findIndex(
+      (x) => x.scope === recipeScope
+    );
+
+    if (ownerOrganizationIndex !== -1) {
+      const ownerOrganization = sortedOrganizations.splice(
+        ownerOrganizationIndex,
+        1
+      )[0];
+
+      hasEditPermissions = editorRoles.has(ownerOrganization?.role);
+    }
+  }
+
+  return hasEditPermissions;
+}

--- a/src/extensionConsole/pages/mods/modals/shareModals/useHasEditPermissions.ts
+++ b/src/extensionConsole/pages/mods/modals/shareModals/useHasEditPermissions.ts
@@ -39,17 +39,12 @@ export default function useHasEditPermissions() {
   if (recipeScope === userScope) {
     hasEditPermissions = true;
   } else {
-    const ownerOrganizationIndex = sortedOrganizations.findIndex(
+    const ownerOrganization = sortedOrganizations.find(
       (x) => x.scope === recipeScope
     );
 
-    if (ownerOrganizationIndex !== -1) {
-      const ownerOrganization = sortedOrganizations.splice(
-        ownerOrganizationIndex,
-        1
-      )[0];
-
-      hasEditPermissions = editorRoles.has(ownerOrganization?.role);
+    if (ownerOrganization) {
+      hasEditPermissions = editorRoles.has(ownerOrganization.role);
     }
   }
 

--- a/src/extensionConsole/pages/mods/modals/shareModals/useSortOrganizations.ts
+++ b/src/extensionConsole/pages/mods/modals/shareModals/useSortOrganizations.ts
@@ -16,16 +16,15 @@
  */
 
 import { selectAuth } from "@/auth/authSelectors";
-import { type Organization } from "@/types/contract";
 import { sortBy } from "lodash";
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
 
-const sortOrganizations = (organizations: Organization[]) =>
-  sortBy(organizations, (organization) => organization.name);
-
 export default function useSortOrganizations() {
   const { organizations } = useSelector(selectAuth);
 
-  return useMemo(() => sortOrganizations(organizations), [organizations]);
+  return useMemo(
+    () => sortBy(organizations, (organization) => organization.name),
+    [organizations]
+  );
 }

--- a/src/extensionConsole/pages/mods/modals/shareModals/useSortOrganizations.ts
+++ b/src/extensionConsole/pages/mods/modals/shareModals/useSortOrganizations.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { selectAuth } from "@/auth/authSelectors";
+import { type Organization } from "@/types/contract";
+import { sortBy } from "lodash";
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+
+const sortOrganizations = (organizations: Organization[]) =>
+  sortBy(organizations, (organization) => organization.name);
+
+export default function useSortOrganizations() {
+  const { organizations } = useSelector(selectAuth);
+
+  return useMemo(() => sortOrganizations(organizations), [organizations]);
+}

--- a/src/utils/registryUtils.test.ts
+++ b/src/utils/registryUtils.test.ts
@@ -63,4 +63,7 @@ describe("getScopeAndId", () => {
     const id = "@foo" as RegistryId;
     expect(getScopeAndId(id)).toStrictEqual(["@foo", undefined]);
   });
+  test("id is undefined", () => {
+    expect(getScopeAndId()).toStrictEqual([undefined, undefined]);
+  });
 });

--- a/src/utils/registryUtils.test.ts
+++ b/src/utils/registryUtils.test.ts
@@ -66,4 +66,7 @@ describe("getScopeAndId", () => {
   test("id is undefined", () => {
     expect(getScopeAndId()).toStrictEqual([undefined, undefined]);
   });
+  test("id is null", () => {
+    expect(getScopeAndId(null)).toStrictEqual([undefined, undefined]);
+  });
 });

--- a/src/utils/registryUtils.test.ts
+++ b/src/utils/registryUtils.test.ts
@@ -63,10 +63,7 @@ describe("getScopeAndId", () => {
     const id = "@foo" as RegistryId;
     expect(getScopeAndId(id)).toStrictEqual(["@foo", undefined]);
   });
-  test("id is undefined", () => {
-    expect(getScopeAndId()).toStrictEqual([undefined, undefined]);
-  });
-  test("id is null", () => {
+  test("id is nullish", () => {
     expect(getScopeAndId(null)).toStrictEqual([undefined, undefined]);
   });
 });

--- a/src/utils/registryUtils.ts
+++ b/src/utils/registryUtils.ts
@@ -41,8 +41,14 @@ export function generatePackageId(scope: string, label: string): RegistryId {
  * @param value the full RegistryId
  */
 export function getScopeAndId(
-  value: RegistryId
+  value?: RegistryId
 ): [string | undefined, string | undefined] {
+  // We call getScopeAndId in several places with a recipe that can be undefined
+  // @see useHasEditPermissions.ts
+  if (value == null) {
+    return [undefined, undefined];
+  }
+
   // Scope needs to start with @
   if (!value.startsWith("@")) {
     return [undefined, value];

--- a/src/utils/registryUtils.ts
+++ b/src/utils/registryUtils.ts
@@ -41,7 +41,7 @@ export function generatePackageId(scope: string, label: string): RegistryId {
  * @param value the full RegistryId
  */
 export function getScopeAndId(
-  value?: RegistryId | null
+  value: RegistryId | null
 ): [string | undefined, string | undefined] {
   // We call getScopeAndId in several places with a recipe that can be undefined
   // @see useHasEditPermissions.ts

--- a/src/utils/registryUtils.ts
+++ b/src/utils/registryUtils.ts
@@ -41,7 +41,7 @@ export function generatePackageId(scope: string, label: string): RegistryId {
  * @param value the full RegistryId
  */
 export function getScopeAndId(
-  value?: RegistryId
+  value?: RegistryId | null
 ): [string | undefined, string | undefined] {
   // We call getScopeAndId in several places with a recipe that can be undefined
   // @see useHasEditPermissions.ts


### PR DESCRIPTION
## What does this PR do?

- Fixes #6407 

## Reviewer Tips

- New files (`OwnerLabel.tsx`, `useHasEditPermissions.ts`, and `useSortOrganization.ts`) were duplicated code pulled from `PublishContentLayout.tsx` and `ShareRecipeModalBody.tsx`.
- I refactored the files to make it easier to understand how `getScopeAndId` was being used.
- The current fix is in `registryUtils.ts`.

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
