### PR TITLE
Stop variable suggestions popup from flickering by validating on blur

### DIFF
--- a/src/components/fields/schemaFields/BasicSchemaField.tsx
+++ b/src/components/fields/schemaFields/BasicSchemaField.tsx
@@ -158,7 +158,7 @@ const BasicSchemaField: SchemaFieldComponent = ({
     validate,
   });
 
-  const annotations = useFieldAnnotations(name);
+  const [annotations, updateAnnotations] = useFieldAnnotations(name);
 
   useSetInitialValueForField({ name, isRequired, inputModeOptions });
 
@@ -180,6 +180,7 @@ const BasicSchemaField: SchemaFieldComponent = ({
   const onBlur = (event: React.FocusEvent) => {
     formikOnBlur(event);
 
+    updateAnnotations();
     if (
       omitIfEmpty &&
       (isEmpty(value) || (isExpression(value) && isEmpty(value.__value__)))

--- a/src/components/form/ConnectedFieldTemplate.tsx
+++ b/src/components/form/ConnectedFieldTemplate.tsx
@@ -31,9 +31,14 @@ function FormikFieldTemplate<Values>({
   formik,
   ...fieldProps
 }: ConnectedFieldProps<Values>) {
-  const annotations = useFieldAnnotations(fieldProps.name);
+  const [annotations, updateAnnotations] = useFieldAnnotations(fieldProps.name);
   const touched = getIn(formik.touched, fieldProps.name);
   const value = getIn(formik.values, fieldProps.name);
+
+  const onBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    formik.handleBlur(event);
+    updateAnnotations();
+  };
 
   return (
     <FieldTemplate
@@ -41,7 +46,7 @@ function FormikFieldTemplate<Values>({
       annotations={annotations}
       touched={touched}
       onChange={formik.handleChange}
-      onBlur={formik.handleBlur}
+      onBlur={onBlur}
       {...fieldProps}
     />
   );

--- a/src/components/form/FormErrorContext.ts
+++ b/src/components/form/FormErrorContext.ts
@@ -21,18 +21,12 @@ type FormErrorContextProps = {
   shouldUseAnalysis: boolean;
   showUntouchedErrors: boolean;
   showFieldActions: boolean;
-  /**
-   * An optional array of analysis ids to ignore.
-   * @since 1.7.34
-   */
-  ignoreAnalysisIds?: string[];
 };
 
 const defaultValue: FormErrorContextProps = {
   shouldUseAnalysis: false,
   showUntouchedErrors: false,
   showFieldActions: false,
-  ignoreAnalysisIds: [],
 };
 
 export const FormErrorContext =

--- a/src/components/form/useFieldAnnotations.test.tsx
+++ b/src/components/form/useFieldAnnotations.test.tsx
@@ -74,7 +74,7 @@ describe("useFieldAnnotations", () => {
         {children}
       </Formik>
     );
-    const annotations = renderHook(() => useFieldAnnotations("testField"), {
+    const [annotations] = renderHook(() => useFieldAnnotations("testField"), {
       wrapper,
     }).result.current;
     expect(annotations).toHaveLength(1);
@@ -140,8 +140,9 @@ describe("useFieldAnnotations", () => {
       </Provider>
     );
 
-    const annotations = renderHook(() => useFieldAnnotations(path), { wrapper })
-      .result.current;
+    const [annotations] = renderHook(() => useFieldAnnotations(path), {
+      wrapper,
+    }).result.current;
     expect(annotations).toHaveLength(1);
     expect(annotations[0].type).toEqual(AnnotationType.Error);
     expect(annotations[0].message).toEqual("test error annotation");

--- a/src/pageEditor/ElementWizard.tsx
+++ b/src/pageEditor/ElementWizard.tsx
@@ -27,7 +27,7 @@ import { type WizardStep } from "@/pageEditor/starterBricks/base";
 import PermissionsToolbar from "@/pageEditor/toolbar/PermissionsToolbar";
 import LogsTab, { LOGS_EVENT_KEY } from "@/pageEditor/tabs/logs/LogsTab";
 import EditTab from "@/pageEditor/tabs/editTab/EditTab";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { produce } from "immer";
 import { useAsyncEffect } from "use-async-effect";
 import { upgradePipelineToV3 } from "@/pageEditor/starterBricks/upgrade";
@@ -36,7 +36,6 @@ import LogNavItemBadge from "./tabs/logs/NavItemBadge";
 import { logActions } from "@/components/logViewer/logSlice";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import { FormErrorContext } from "@/components/form/FormErrorContext";
-import { selectVariablePopoverVisible } from "@/pageEditor/slices/editorSelectors";
 
 const EDIT_STEP_NAME = "Edit";
 const LOG_STEP_NAME = "Logs";
@@ -66,8 +65,6 @@ const ElementWizard: React.FunctionComponent<{
   element: ModComponentFormState;
 }> = ({ element }) => {
   const [step, setStep] = useState(wizard[0].step);
-
-  const isVariablePopoverVisible = useSelector(selectVariablePopoverVisible);
 
   const { isValid, status, handleReset } =
     useFormikContext<ModComponentFormState>();
@@ -115,10 +112,6 @@ const ElementWizard: React.FunctionComponent<{
           shouldUseAnalysis: true,
           showUntouchedErrors: false,
           showFieldActions: true,
-          // Hide variable/template annotations while the popover is open because the user is editing the field
-          ignoreAnalysisIds: isVariablePopoverVisible
-            ? ["var", "template"]
-            : [],
         }}
       >
         <BootstrapForm


### PR DESCRIPTION
## What does this PR do?

- Closes #6395 
- Variable suggestions caused a flickering when selecting a variable. This was because there was a rule that errors/annotations would be hidden while the popover is opened. However the validation was still happening in the background.
- This change causes validation to occur on blur instead.

## Reviewer Tips

- _What order should the reviewer review the files in?_
- _Are there any implementation approaches you want feedback on?_

## Discussion

- _Were there multiple approaches you were deciding between?_

## Demo

- _Paste a screenshot or demo video here_

## Future Work

- _Work for the issue/ticket that will be in a follow-up PR_

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [ ] Add tests
- [ ] Designate a primary reviewer
