### PR TITLE
Handle invalid registry bricks

### DIFF
--- a/src/bricks/registry.test.ts
+++ b/src/bricks/registry.test.ts
@@ -110,10 +110,24 @@ describe("bricksRegistry", () => {
     expect(bricksRegistry.cached).toEqual([echoBrick]);
   });
 
-  test("skips undefined block", async () => {
-    bricksRegistry.register([undefined, echoBrick]);
-    await expect(bricksRegistry.all()).resolves.toEqual([echoBrick]);
-    expect(bricksRegistry.cached).toEqual([echoBrick]);
+  test("skips invalid block", async () => {
+    const validBrick = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      ...parsePackage(starterBrickConfigFactory() as any),
+      timestamp: new Date(),
+    };
+    const invalidBrick = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      ...parsePackage(starterBrickConfigFactory() as any),
+      timestamp: new Date(),
+    };
+    // No config makes the brick invalid
+    invalidBrick.config = {};
+
+    getByKindsMock.mockResolvedValueOnce([validBrick, invalidBrick]);
+
+    const bricks = await bricksRegistry.all();
+    expect(bricks.map((x) => x.id)).toEqual([validBrick.id]);
   });
 
   test("preserves JS block on clear", async () => {

--- a/src/bricks/registry.test.ts
+++ b/src/bricks/registry.test.ts
@@ -110,6 +110,12 @@ describe("bricksRegistry", () => {
     expect(bricksRegistry.cached).toEqual([echoBrick]);
   });
 
+  test("skips undefined block", async () => {
+    bricksRegistry.register([undefined, echoBrick]);
+    await expect(bricksRegistry.all()).resolves.toEqual([echoBrick]);
+    expect(bricksRegistry.cached).toEqual([echoBrick]);
+  });
+
   test("preserves JS block on clear", async () => {
     bricksRegistry.register([echoBrick]);
     bricksRegistry.clear();

--- a/src/registry/memoryRegistry.ts
+++ b/src/registry/memoryRegistry.ts
@@ -295,7 +295,7 @@ export class MemoryRegistry<
     let changed = false;
 
     for (const item of items) {
-      if (item.id == null) {
+      if (item?.id == null) {
         console.warn("Skipping item with no id", item);
         continue;
       }

--- a/src/registry/memoryRegistry.ts
+++ b/src/registry/memoryRegistry.ts
@@ -254,7 +254,13 @@ export class MemoryRegistry<
       ...this.kinds.values(),
     ]);
 
-    const remoteItems = packages.map((raw) => this.parse(raw.config));
+    const remoteItems: Item[] = [];
+    for (const raw of packages) {
+      const item = this.parse(raw.config);
+      if (item) {
+        remoteItems.push(item);
+      }
+    }
 
     console.debug(
       "Parsed %d registry item(s) from IDB for %s",
@@ -295,7 +301,7 @@ export class MemoryRegistry<
     let changed = false;
 
     for (const item of items) {
-      if (item?.id == null) {
+      if (item.id == null) {
         console.warn("Skipping item with no id", item);
         continue;
       }


### PR DESCRIPTION
## What does this PR do?

- Closes https://github.com/pixiebrix/pixiebrix-app/issues/3878
- Handle invalid bricks by skipping the invalid brick instead of failing to load any bricks at all
- Related backend PR for preventing the invalid package from being returned in `GET /api/registry/bricks/`

## Demo

See demo video in https://github.com/pixiebrix/pixiebrix-app/pull/3941

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @twschiller because he's written most of the code in `memoryRegistry.ts` 
