### PR TITLE
Selecting a value in the popover closes with correct tags

### DIFF
--- a/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.test.ts
@@ -278,6 +278,19 @@ describe("replaceLikelyVariable", () => {
     expect(newCursorPosition).toEqual(endOfVariableIndex);
   });
 
+  test("inserts %}", () => {
+    const { newTemplate: actual, newCursorPosition } = replaceLikelyVariable(
+      "abc {% for foo in @bar xyz",
+      18,
+      "@bar"
+    );
+    const expectedTemplate = "abc {% for foo in @bar %} xyz";
+    const endOfVariableIndex = expectedTemplate.indexOf("@bar") + "@bar".length;
+
+    expect(actual).toEqual(expectedTemplate);
+    expect(newCursorPosition).toEqual(endOfVariableIndex);
+  });
+
   test("inserts }} only in for body", () => {
     const template = `
     {% for qux in @foo %}

--- a/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.ts
@@ -117,9 +117,11 @@ export function replaceLikelyVariable(
 
   const templatePartLeftOfLikelyVariable = template.slice(0, startIndex);
   const templatePartRightOfLikelyVariable = template.slice(endIndex);
-  const blockToken = templatePartLeftOfLikelyVariable.includes("{%")
-    ? "%"
-    : "{";
+  const lastBrace = templatePartLeftOfLikelyVariable.lastIndexOf("{");
+  const lastPercent = templatePartLeftOfLikelyVariable.lastIndexOf("%");
+
+  const blockToken =
+    lastBrace > lastPercent ? "{" : lastPercent > lastBrace ? "%" : null;
 
   // Check if we need to add braces before the inserted variable
   // For instance, in the case of "@foo }}"

--- a/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.ts
@@ -117,6 +117,9 @@ export function replaceLikelyVariable(
 
   const templatePartLeftOfLikelyVariable = template.slice(0, startIndex);
   const templatePartRightOfLikelyVariable = template.slice(endIndex);
+  const blockToken = templatePartLeftOfLikelyVariable.includes("{%")
+    ? "%"
+    : "{";
 
   // Check if we need to add braces before the inserted variable
   // For instance, in the case of "@foo }}"
@@ -166,14 +169,22 @@ export function replaceLikelyVariable(
     }
   }
 
+  const leftBraces = `{${blockToken} `;
+  const rightBrances = ` ${blockToken === "%" ? "%" : "}"}}`;
+
   const replacementWithBraces = `${
-    shouldInsertBracesLeft ? "{{ " : ""
-  }${replacement}${shouldInsertBracesRight ? " }}" : ""}`;
+    shouldInsertBracesLeft ? leftBraces : ""
+  }${replacement}${shouldInsertBracesRight ? rightBrances : ""}`;
 
   const endOfVariableIndex =
     startIndex +
     replacementWithBraces.length -
     (shouldInsertBracesRight ? 3 : 0);
+  console.log({
+    templatePartLeftOfLikelyVariable,
+    replacementWithBraces,
+    templatePartRightOfLikelyVariable,
+  });
 
   return {
     newTemplate: `${templatePartLeftOfLikelyVariable}${replacementWithBraces}${templatePartRightOfLikelyVariable}`,


### PR DESCRIPTION
## What does this PR do?

- Fixes of #6454 
- Fixes issue where using the popover with `{%` opening tags closes it with `}}` closing tags

## Demo

- ![Kapture 2023-09-17 at 18 35 36](https://github.com/pixiebrix/pixiebrix-extension/assets/10778363/1ef3400a-98e4-4c24-96c8-096cf9618125)


## Checklist

- [x] Add tests
- [ ] Designate a primary reviewer
