### PR TITLE
#6522: Flag to disable rollbar reporting

### DIFF
--- a/src/telemetry/logging.test.ts
+++ b/src/telemetry/logging.test.ts
@@ -134,6 +134,6 @@ describe("logging", () => {
     expect(flagOnMock).toHaveBeenCalledExactlyOnceWith(
       "rollbar-disable-report"
     );
-    expect(rollbarErrorMock).not.toHaveBeenCalledOnce();
+    expect(rollbarErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/src/telemetry/logging.test.ts
+++ b/src/telemetry/logging.test.ts
@@ -45,9 +45,8 @@ jest.mock("@/telemetry/initRollbar", () => ({
   getRollbar: jest.fn(),
 }));
 
-const getRollbarMock = jest.mocked(getRollbar);
 const rollbarErrorMock = jest.fn();
-getRollbarMock.mockResolvedValue({
+jest.mocked(getRollbar).mockResolvedValue({
   error: rollbarErrorMock,
 } as unknown as Rollbar);
 

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -302,7 +302,7 @@ const THROTTLE_AXIOS_SERVER_ERROR_STATUS_CODES = new Set([502, 503, 504]);
 const THROTTLE_RATE_MS = 60_000; // 1 minute
 let lastAxiosServerErrorTimestamp: number = null;
 
-async function reportToRollbar(
+export async function reportToRollbar(
   // Ensure it's an Error instance before passing it to Rollbar so rollbar treats it as the error.
   // (It treats POJO as the custom data)
   // See https://docs.rollbar.com/docs/rollbarjs-configuration-reference#rollbarlog
@@ -313,7 +313,7 @@ async function reportToRollbar(
   // Business errors are now sent to the PixieBrix error service instead of Rollbar - see reportToErrorService
   if (
     hasSpecificErrorCause(error, BusinessError) ||
-    (await flagOn("skip-rollbar-report"))
+    (await flagOn("rollbar-disable-report"))
   ) {
     return;
   }

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -32,6 +32,7 @@ import {
   reportToErrorService,
   selectExtraContext,
 } from "@/services/errorService";
+import { flagOn } from "@/auth/token";
 import { BusinessError } from "@/errors/businessErrors";
 import { ContextError } from "@/errors/genericErrors";
 import { isAxiosError } from "@/errors/networkErrorHelpers";
@@ -310,7 +311,10 @@ async function reportToRollbar(
   message: string
 ): Promise<void> {
   // Business errors are now sent to the PixieBrix error service instead of Rollbar - see reportToErrorService
-  if (hasSpecificErrorCause(error, BusinessError)) {
+  if (
+    hasSpecificErrorCause(error, BusinessError) &&
+    !(await flagOn("skip-rollbar-report"))
+  ) {
     return;
   }
 

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -312,8 +312,8 @@ async function reportToRollbar(
 ): Promise<void> {
   // Business errors are now sent to the PixieBrix error service instead of Rollbar - see reportToErrorService
   if (
-    hasSpecificErrorCause(error, BusinessError) &&
-    !(await flagOn("skip-rollbar-report"))
+    hasSpecificErrorCause(error, BusinessError) ||
+    (await flagOn("skip-rollbar-report"))
   ) {
     return;
   }

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -302,6 +302,10 @@ const THROTTLE_AXIOS_SERVER_ERROR_STATUS_CODES = new Set([502, 503, 504]);
 const THROTTLE_RATE_MS = 60_000; // 1 minute
 let lastAxiosServerErrorTimestamp: number = null;
 
+/**
+ * Do not use this function directly. Use `reportError` instead: `import reportError from "@/telemetry/reportError"`
+ * It's only exported for testing.
+ */
 export async function reportToRollbar(
   // Ensure it's an Error instance before passing it to Rollbar so rollbar treats it as the error.
   // (It treats POJO as the custom data)


### PR DESCRIPTION
## What does this PR do?

- Closes #6522 
- Add a flag `rollbar-disable-report` to skip reporting errors to Rollbar

## Discussion

- Should the flag name be affirmative (e.g. `report-to-rollbar`) or negative (e.g. `rollbar-disable-report`)? I decided negative to reduce the number of flags applied to each user.

## Team Coordination

- [x] This PR requires a feature flag: `rollbar-disable-report`

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer: @BLoe 
