### PR TITLE
Change color of default example paragraph in Render Document

### DIFF
--- a/src/pageEditor/exampleBlockConfigs.ts
+++ b/src/pageEditor/exampleBlockConfigs.ts
@@ -135,7 +135,6 @@ export function getExampleBlockConfig(
     // Adding text to the second row
     const text = createNewElement("text");
     text.config.text = "Example text element. **Markdown** is supported.";
-    text.config.className = "text-default";
     container.children[1].children[0].children.push(text);
 
     return {

--- a/src/pageEditor/exampleBlockConfigs.ts
+++ b/src/pageEditor/exampleBlockConfigs.ts
@@ -135,7 +135,7 @@ export function getExampleBlockConfig(
     // Adding text to the second row
     const text = createNewElement("text");
     text.config.text = "Example text element. **Markdown** is supported.";
-    text.config.className = "text-success";
+    text.config.className = "text-default";
     container.children[1].children[0].children.push(text);
 
     return {


### PR DESCRIPTION
## What does this PR do?

By default when you add Render Document brick, it has a green text elements. This PR changes from `text-success` to `text-default` which will make it black instead of green.  

## Reviewer Tips

- Since I'm less familiar with the code, can folks let me know if there are other considerations I need to make here? I searched for test files but didn't see anything relevant.

## Checklist

- [ ] Add tests / na
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible) (na i think?)
- [x] Designate a primary reviewer cc @BLoe or @twschiller 
