### PR TITLE
Remove green text coloring

### DIFF
--- a/src/pageEditor/exampleBlockConfigs.ts
+++ b/src/pageEditor/exampleBlockConfigs.ts
@@ -135,7 +135,6 @@ export function getExampleBlockConfig(
     // Adding text to the second row
     const text = createNewElement("text");
     text.config.text = "Example text element. **Markdown** is supported.";
-    text.config.className = "text-success";
     container.children[1].children[0].children.push(text);
 
     return {


### PR DESCRIPTION
_Sorry - trying this again from a branch and not a fork._ 

Removes the default `text-success` green coloring on the text element that is added by default on the Render Document brick. 

If someone else can test this locally, that would be awesome since there's clearly something wrong with my environment.