### PR TITLE
#6533 Exclude/omit optional schema select value by default

### DIFF
--- a/src/components/fields/schemaFields/BasicSchemaField.tsx
+++ b/src/components/fields/schemaFields/BasicSchemaField.tsx
@@ -162,7 +162,11 @@ const BasicSchemaField: SchemaFieldComponent = ({
 
   useSetInitialValueForField({ name, isRequired, inputModeOptions });
 
-  const { onOmitField } = useToggleFormField(name, normalizedSchema);
+  const { onOmitField } = useToggleFormField(
+    name,
+    normalizedSchema,
+    isRequired
+  );
 
   if (isEmpty(inputModeOptions)) {
     return (

--- a/src/components/fields/schemaFields/fieldInputMode.test.ts
+++ b/src/components/fields/schemaFields/fieldInputMode.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { inferInputMode } from "@/components/fields/schemaFields/fieldInputMode";
+import googleSheetIdSchema from "@schemas/googleSheetId.json";
 
 describe("test input mode", () => {
   test("variable expression", () => {
@@ -69,5 +70,31 @@ describe("test input mode", () => {
         ],
       })
     ).toBe("select");
+  });
+
+  test("not-required, undefined value, infers omit", () => {
+    expect(
+      inferInputMode(
+        { field: undefined },
+        "field",
+        {
+          $ref: googleSheetIdSchema.$id,
+        },
+        { isRequired: false }
+      )
+    ).toBe("omit");
+  });
+
+  test("not-required, null ref value, infers string", () => {
+    expect(
+      inferInputMode(
+        { field: null },
+        "field",
+        {
+          $ref: googleSheetIdSchema.$id,
+        },
+        { isRequired: false }
+      )
+    ).toBe("string");
   });
 });

--- a/src/components/fields/schemaFields/fieldInputMode.ts
+++ b/src/components/fields/schemaFields/fieldInputMode.ts
@@ -63,11 +63,9 @@ export function inferInputMode(
 ): FieldInputMode {
   const { safeDefault = true, isRequired } = options;
 
-  const hasField = Object.hasOwn(fieldConfig, fieldName);
   // eslint-disable-next-line security/detect-object-injection -- config field names
   const value = fieldConfig[fieldName];
-
-  if (!hasField || (value == null && !isRequired)) {
+  if (value === undefined && !isRequired) {
     return "omit";
   }
 

--- a/src/components/fields/schemaFields/widgets/SchemaSelectWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/SchemaSelectWidget.tsx
@@ -75,7 +75,7 @@ const SchemaSelectWidget: React.VFC<
 
   const selectOnChange = useCallback(
     async (option: StringOption) => {
-      await setValue(option?.value ?? null);
+      await setValue(option?.value);
     },
     [setValue]
   );

--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
@@ -56,7 +56,8 @@ const TemplateToggleWidget: React.VFC<TemplateToggleWidgetProps> = ({
 
   const { inputMode, onOmitField } = useToggleFormField(
     schemaFieldProps.name,
-    schemaFieldProps.schema
+    schemaFieldProps.schema,
+    schemaFieldProps.isRequired
   );
 
   const defaultInputRef = useRef<HTMLElement>();

--- a/src/hooks/useToggleFormField.tsx
+++ b/src/hooks/useToggleFormField.tsx
@@ -48,7 +48,8 @@ export function removeField(parent: unknown, fieldName: string): void {
 
 function useToggleFormField(
   name: string,
-  schema: Schema
+  schema: Schema,
+  isRequired: boolean
 ): {
   inputMode: FieldInputMode;
   onOmitField: () => void;
@@ -61,7 +62,7 @@ function useToggleFormField(
   const value = getIn(formState, name);
 
   const inputMode = useMemo(
-    () => inferInputMode(parentValues, fieldName, schema),
+    () => inferInputMode(parentValues, fieldName, schema, { isRequired }),
     // eslint-disable-next-line -- run when value changes
     [fieldName, value, schema]
   );


### PR DESCRIPTION
## What does this PR do?

- Fixes #6533 
- Also improves the UX of IntegrationDependencyWidget in a similar way

## Demo

https://www.loom.com/share/3b33a413aeb04e09bc078de512d35daa

## Future Work

- Here's the ticket for similar changes to the (separate) integration auth widget during activation: [Slice 4.2: support optional integration configurations during activation](https://github.com/pixiebrix/pixiebrix-extension/issues/6311)

## Checklist

- [x] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer - @grahamlangford 
