### PR TITLE
Fix `ModalProvider` to not return `null`

### DIFF
--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -87,12 +87,14 @@ const ConfirmationModal: React.FunctionComponent<
 
 type Callback = (submit: boolean) => void;
 
+const DEFAULT_MODAL_PROPS: ModalProps = {
+  message: "Are you sure?",
+};
+
 export const ModalProvider: React.FunctionComponent<{
   children: React.ReactNode;
 }> = ({ children }) => {
-  const [modalProps, setModalProps] = useState<ModalProps>({
-    message: "Are you sure?",
-  });
+  const [modalProps, setModalProps] = useState<ModalProps>(DEFAULT_MODAL_PROPS);
   const [callback, setCallback] = useState<Callback | null>();
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
   useEffect(
@@ -136,7 +138,7 @@ export const ModalProvider: React.FunctionComponent<{
         }}
         isVisible={isModalVisible}
         onExited={() => {
-          setModalProps(null);
+          setModalProps(DEFAULT_MODAL_PROPS);
         }}
       />
       {children}

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -90,7 +90,9 @@ type Callback = (submit: boolean) => void;
 export const ModalProvider: React.FunctionComponent<{
   children: React.ReactNode;
 }> = ({ children }) => {
-  const [modalProps, setModalProps] = useState<ModalProps | null>();
+  const [modalProps, setModalProps] = useState<ModalProps>({
+    message: "Are you sure?",
+  });
   const [callback, setCallback] = useState<Callback | null>();
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
   useEffect(
@@ -119,10 +121,6 @@ export const ModalProvider: React.FunctionComponent<{
     },
     [callback, setModalProps]
   );
-
-  if (!modalProps) {
-    return null;
-  }
 
   return (
     <ModalContext.Provider value={{ showConfirmation }}>


### PR DESCRIPTION
## What does this PR do?

- Fixes `ModalProvider` so it has a default message for the confirmation modal and doesn't return `null`, because that breaks the page editor

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer - @fregante 
