### PR TITLE
Avoid injecting into API-only frames

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,6 +22,7 @@
   "content_scripts": [
     {
       "matches": ["https://*/*", "http://*/*"],
+      "exclude_matches": ["https://*.googleapis.com/*"],
       "js": ["contentScript.js"],
       "css": ["contentScript.css"],
       "all_frames": true,
@@ -31,6 +32,7 @@
     {
       "matches": ["https://*/*"],
       "js": ["loadActivationEnhancements.js"],
+      "exclude_matches": ["https://*.googleapis.com/*"],
       "run_at": "document_end"
     }
   ],


### PR DESCRIPTION
This should avoid unnecessary bugs and confusing logging in unrelated contexts. Mentioned in https://github.com/pixiebrix/pixiebrix-extension/issues/6596#issuecomment-1746746672 and https://pixiebrix.slack.com/archives/C023KL47XV4/p1696421570974149

It also appears to fix https://github.com/pixiebrix/pixiebrix-extension/issues/6596, at least for this specific instance. I'm sure it will still appear on other sites with similar CSP.

## Before

<img width="562" alt="Screenshot 4" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/23459e51-bbad-422f-b1d3-21b30d3b7f89">

## After

<img width="562" alt="Screenshot" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/28908d38-f91f-4671-a036-875a70f11afa">
