### PR TITLE
#6449: Restore and group storybook updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,11 @@ updates:
     open-pull-requests-limit: 30
     assignees:
       - grahamlangford
-    ignore:
-      # Update it manually instead https://github.com/pixiebrix/pixiebrix-extension/issues/4436
-      - dependency-name: "@storybook/*"
+    groups:
+      storybook:
+        patterns:
+          - ^@storybook/.*
+          - ^storybook$
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
- Closes #6449 
- Automates https://github.com/pixiebrix/pixiebrix-extension/issues/4436
- Replaces https://github.com/pixiebrix/pixiebrix-extension/pull/4886 

## Future

- This PR may enable https://github.com/pixiebrix/pixiebrix-extension/issues/5570

