### PR TITLE
refresh AA token every 10 hours to avoid 24 hour expiration

### DIFF
--- a/src/background/partnerIntegrations.ts
+++ b/src/background/partnerIntegrations.ts
@@ -232,12 +232,14 @@ export async function safeTokenRefresh(): Promise<void> {
   }
 }
 
+const TWENTY_THREE_HOURS = 1000 * 60 * 60 * 23;
+
 /**
- * The Automation Anywhere JWT has an absolute expiry of 30 days and an inactivity expiry of 15 days.
- * Refresh the JWT every week, so it doesn't expire after the inactivity period.
+ * The Automation Anywhere JWT acess token expires every 24 hours
+ * Refresh the JWT every 23 hours to avoid
  */
 export function initPartnerTokenRefresh(): void {
   setInterval(async () => {
     await safeTokenRefresh();
-  }, 1000 * 60 * 60 * 24 * 7); // 7 days
+  }, TWENTY_THREE_HOURS);
 }

--- a/src/background/partnerIntegrations.ts
+++ b/src/background/partnerIntegrations.ts
@@ -232,14 +232,17 @@ export async function safeTokenRefresh(): Promise<void> {
   }
 }
 
-const TWENTY_THREE_HOURS = 1000 * 60 * 60 * 23;
+const TEN_HOURS = 1000 * 60 * 60 * 10;
 
 /**
- * The Automation Anywhere JWT acess token expires every 24 hours
- * Refresh the JWT every 23 hours to avoid
+ * The Automation Anywhere JWT access token expires every 24 hours
+ * The refresh token expires every 30 days, with an inactivity expiry of 15 days
+ * Refresh the JWT every 10 hours to ensure the token is always valid
+ * NOTE: this assumes the background script is always running
+ * TODO: re-architect to refresh the token in @/background/refreshToken.ts
  */
 export function initPartnerTokenRefresh(): void {
   setInterval(async () => {
     await safeTokenRefresh();
-  }, TWENTY_THREE_HOURS);
+  }, TEN_HOURS);
 }


### PR DESCRIPTION
## What does this PR do?

- Fixes #6603 

## Discussion

- Still need to confirm the token expires every 24 hours: https://pixiebrix.slack.com/archives/C042T2TBZ17/p1696957614998249

## Checklist

- [x] Designate a primary reviewer @johnnymetz 
