### PR TITLE
#6531 Fix tab names field for gsheets

### DIFF
--- a/src/auth/authConstants.ts
+++ b/src/auth/authConstants.ts
@@ -16,6 +16,7 @@
  */
 
 import { type AuthState } from "./authTypes";
+import { type ManualStorageKey } from "@/utils/storageUtils";
 
 export const anonAuth: AuthState = Object.freeze({
   userId: undefined,
@@ -31,3 +32,4 @@ export const anonAuth: AuthState = Object.freeze({
   groups: [],
   enforceUpdateMillis: null,
 });
+export const OAUTH2_STORAGE_KEY = "OAUTH2" as ManualStorageKey;

--- a/src/background/auth/authStorage.ts
+++ b/src/background/auth/authStorage.ts
@@ -15,16 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  type ManualStorageKey,
-  readStorage,
-  setStorage,
-} from "@/utils/storageUtils";
+import { readStorage, setStorage } from "@/utils/storageUtils";
 import { type UUID } from "@/types/stringTypes";
 import { expectContext } from "@/utils/expectContext";
 import { type AuthData } from "@/types/integrationTypes";
-
-export const OAUTH2_STORAGE_KEY = "OAUTH2" as ManualStorageKey;
+import { OAUTH2_STORAGE_KEY } from "@/auth/authConstants";
 
 export async function setCachedAuthData<TAuthData extends Partial<AuthData>>(
   serviceAuthId: UUID,

--- a/src/contrib/google/sheets/core/useSpreadsheetId.ts
+++ b/src/contrib/google/sheets/core/useSpreadsheetId.ts
@@ -28,7 +28,7 @@ import useAsyncState from "@/hooks/useAsyncState";
 import hash from "object-hash";
 import { type FetchableAsyncState } from "@/types/sliceTypes";
 import { joinName } from "@/utils/formUtils";
-import { useContext } from "react";
+import { useContext, useRef } from "react";
 import ModIntegrationsContext from "@/mods/ModIntegrationsContext";
 
 async function findSpreadsheetIdFromFieldValue(
@@ -115,6 +115,8 @@ function useSpreadsheetId(
 
   const [{ value: optionsArgs }] = useField<OptionsArgs>("optionsArgs");
 
+  const lastGoodSpreadsheetId = useRef<string | null>();
+
   return useAsyncState<string | null>(async () => {
     try {
       const result = await findSpreadsheetIdFromFieldValue(
@@ -123,7 +125,11 @@ function useSpreadsheetId(
         optionsArgs
       );
       setError(null);
-      return result;
+      if (result != null) {
+        lastGoodSpreadsheetId.current = result;
+      }
+
+      return lastGoodSpreadsheetId.current;
     } catch (error: unknown) {
       setError(getErrorMessage(error));
       return null;

--- a/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.tsx
@@ -140,7 +140,7 @@ const AppendSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
         />
       )}
       <RequireGoogleSheet blockConfigPath={blockConfigPath}>
-        {({ googleAccount, spreadsheet, spreadsheetFieldSchema }) => (
+        {({ googleAccount, spreadsheet }) => (
           <>
             <FormErrorContext.Provider
               value={{
@@ -149,11 +149,6 @@ const AppendSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
                 showFieldActions: false,
               }}
             >
-              <SchemaField
-                name={joinName(blockConfigPath, "spreadsheetId")}
-                schema={spreadsheetFieldSchema}
-                isRequired
-              />
               {
                 // The problem with including this inside the nested FormErrorContext.Provider is that we
                 // would like analysis to run if this is in text/template mode, but not if it's in select mode.

--- a/src/contrib/google/sheets/ui/LookupSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/ui/LookupSpreadsheetOptions.tsx
@@ -143,7 +143,7 @@ const LookupSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
         />
       )}
       <RequireGoogleSheet blockConfigPath={blockConfigPath}>
-        {({ googleAccount, spreadsheet, spreadsheetFieldSchema }) => (
+        {({ googleAccount, spreadsheet }) => (
           <>
             <FormErrorContext.Provider
               value={{
@@ -152,11 +152,6 @@ const LookupSpreadsheetOptions: React.FunctionComponent<BlockOptionProps> = ({
                 showFieldActions: false,
               }}
             >
-              <SchemaField
-                name={joinName(blockConfigPath, "spreadsheetId")}
-                schema={spreadsheetFieldSchema}
-                isRequired
-              />
               {
                 // The problem with including these inside the nested FormErrorContext.Provider is that we
                 // would like analysis to run if they are in text/template mode, but not in select mode.

--- a/src/contrib/google/sheets/ui/RequireGoogleSheet.tsx
+++ b/src/contrib/google/sheets/ui/RequireGoogleSheet.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { type ReactElement } from "react";
+import React, { type ReactElement, useEffect, useState } from "react";
 import { type Spreadsheet } from "@/contrib/google/sheets/core/types";
 import { type Schema } from "@/types/schemaTypes";
 import useGoogleAccount from "@/contrib/google/sheets/core/useGoogleAccount";
@@ -24,19 +24,30 @@ import useAsyncState from "@/hooks/useAsyncState";
 import { dereference } from "@/validators/generic";
 import { BASE_SHEET_SCHEMA } from "@/contrib/google/sheets/core/schemas";
 import useDeriveAsyncState from "@/hooks/useDeriveAsyncState";
-import { type SanitizedIntegrationConfig } from "@/types/integrationTypes";
+import {
+  type AuthData,
+  type SanitizedIntegrationConfig,
+} from "@/types/integrationTypes";
 import { sheets } from "@/background/messenger/api";
 import { type AsyncState } from "@/types/sliceTypes";
 import AsyncStateGate from "@/components/AsyncStateGate";
 import { type Except } from "type-fest";
 import { joinName } from "@/utils/formUtils";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
+import { type UUID } from "@/types/stringTypes";
+import { isEmpty } from "lodash";
+import { OAUTH2_STORAGE_KEY } from "@/auth/authConstants";
 
 type GoogleSheetState = {
   googleAccount: SanitizedIntegrationConfig | null;
   spreadsheet: Spreadsheet | null;
   spreadsheetFieldSchema: Schema;
 };
+
+type LoginListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  areaName: string
+) => void;
 
 const RequireGoogleSheet: React.FC<{
   blockConfigPath: string;
@@ -46,13 +57,50 @@ const RequireGoogleSheet: React.FC<{
 }> = ({ blockConfigPath, children }) => {
   const googleAccountAsyncState = useGoogleAccount();
   const spreadsheetIdAsyncState = useSpreadsheetId(blockConfigPath);
-
   const baseSchemaAsyncState = useAsyncState(
     dereference(BASE_SHEET_SCHEMA),
     [],
     {
       initialValue: BASE_SHEET_SCHEMA,
     }
+  );
+
+  const [loginListener, setLoginListener] = useState<LoginListener | null>(
+    null
+  );
+
+  function listenForLogin(googleAccount: SanitizedIntegrationConfig) {
+    const listener: LoginListener = (changes, areaName) => {
+      if (areaName !== "local") {
+        return;
+      }
+
+      if (OAUTH2_STORAGE_KEY in changes) {
+        // eslint-disable-next-line security/detect-object-injection -- UUID, not user input
+        const newValue = changes[OAUTH2_STORAGE_KEY].newValue as Record<
+          UUID,
+          AuthData
+        >;
+        if (!isEmpty(newValue[googleAccount.id])) {
+          googleAccountAsyncState.refetch();
+          browser.storage.onChanged.removeListener(listener);
+        }
+      }
+    };
+
+    browser.storage.onChanged.addListener(listener);
+    setLoginListener(listener);
+  }
+
+  // Clean up the listener on unmount if it hasn't fired yet
+  useEffect(
+    () => () => {
+      if (loginListener) {
+        browser.storage.onChanged.removeListener(loginListener);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount/unmount
+    []
   );
 
   const resultAsyncState: AsyncState<GoogleSheetState> = useDeriveAsyncState(
@@ -72,7 +120,10 @@ const RequireGoogleSheet: React.FC<{
         };
       }
 
-      if (!googleAccount || (await sheets.isLoggedIn(googleAccount))) {
+      const isLoggedIn =
+        googleAccount && (await sheets.isLoggedIn(googleAccount));
+
+      if (!googleAccount || isLoggedIn) {
         return {
           googleAccount,
           // Sheets API will handle legacy authentication when googleAccount is null
@@ -83,6 +134,8 @@ const RequireGoogleSheet: React.FC<{
           spreadsheetFieldSchema: baseSchema,
         };
       }
+
+      listenForLogin(googleAccount);
 
       return {
         googleAccount,

--- a/src/contrib/google/sheets/ui/RequireGoogleSheet.tsx
+++ b/src/contrib/google/sheets/ui/RequireGoogleSheet.tsx
@@ -120,10 +120,7 @@ const RequireGoogleSheet: React.FC<{
         };
       }
 
-      const isLoggedIn =
-        googleAccount && (await sheets.isLoggedIn(googleAccount));
-
-      if (!googleAccount || isLoggedIn) {
+      if (!googleAccount || (await sheets.isLoggedIn(googleAccount))) {
         return {
           googleAccount,
           // Sheets API will handle legacy authentication when googleAccount is null

--- a/src/contrib/google/sheets/ui/RequireGoogleSheet.tsx
+++ b/src/contrib/google/sheets/ui/RequireGoogleSheet.tsx
@@ -28,6 +28,9 @@ import { type SanitizedIntegrationConfig } from "@/types/integrationTypes";
 import { sheets } from "@/background/messenger/api";
 import { type AsyncState } from "@/types/sliceTypes";
 import AsyncStateGate from "@/components/AsyncStateGate";
+import { type Except } from "type-fest";
+import { joinName } from "@/utils/formUtils";
+import SchemaField from "@/components/fields/schemaFields/SchemaField";
 
 type GoogleSheetState = {
   googleAccount: SanitizedIntegrationConfig | null;
@@ -37,7 +40,9 @@ type GoogleSheetState = {
 
 const RequireGoogleSheet: React.FC<{
   blockConfigPath: string;
-  children: (props: GoogleSheetState) => ReactElement;
+  children: (
+    props: Except<GoogleSheetState, "spreadsheetFieldSchema">
+  ) => ReactElement;
 }> = ({ blockConfigPath, children }) => {
   const googleAccountAsyncState = useGoogleAccount();
   const spreadsheetIdAsyncState = useSpreadsheetId(blockConfigPath);
@@ -89,7 +94,16 @@ const RequireGoogleSheet: React.FC<{
 
   return (
     <AsyncStateGate state={resultAsyncState}>
-      {({ data }) => children(data)}
+      {({ data: { spreadsheetFieldSchema, ...others } }) => (
+        <>
+          <SchemaField
+            name={joinName(blockConfigPath, "spreadsheetId")}
+            schema={spreadsheetFieldSchema}
+            isRequired
+          />
+          {children(others)}
+        </>
+      )}
     </AsyncStateGate>
   );
 };

--- a/src/contrib/google/sheets/ui/TabField.test.tsx
+++ b/src/contrib/google/sheets/ui/TabField.test.tsx
@@ -59,6 +59,11 @@ function expectTab1Selected() {
   expect(screen.queryByText("Tab2")).not.toBeInTheDocument();
 }
 
+function expectTab2Selected() {
+  expect(screen.getByText("Tab2")).toBeVisible();
+  expect(screen.queryByText("Tab1")).not.toBeInTheDocument();
+}
+
 describe("TabField", () => {
   it("Renders select and variable toggle options", async () => {
     render(
@@ -167,8 +172,6 @@ describe("TabField", () => {
     );
 
     await waitForEffect();
-
-    screen.debug();
 
     expect(screen.queryByText("Foo")).not.toBeInTheDocument();
     expect(screen.getByText("InvalidTab")).toBeVisible();
@@ -338,5 +341,87 @@ describe("TabField", () => {
     // Should have selected first tab automatically
     expect(screen.queryByText("Tab1")).not.toBeInTheDocument();
     expect(screen.getByText("Foo")).toBeVisible();
+  });
+
+  // eslint-disable-next-line jest/expect-expect -- custom assertion function is used
+  test("given string tabName value, when spreadsheet changes to null, then does not update the value", async () => {
+    const { rerender } = render(
+      <TabField
+        name="tabName"
+        schema={{}} // Does not currently check the passed-in schema
+        spreadsheet={TEST_SPREADSHEET}
+      />,
+      {
+        initialValues: {
+          tabName: "Tab2",
+        },
+      }
+    );
+
+    await waitForEffect();
+
+    expectTab2Selected();
+
+    // Change spreadsheet
+    rerender(
+      <TabField
+        name="tabName"
+        schema={{}} // Does not currently check the passed-in schema
+        spreadsheet={null}
+      />
+    );
+
+    await waitForEffect();
+
+    // Tab name should not be cleared yet
+    expectTab2Selected();
+  });
+
+  // eslint-disable-next-line jest/expect-expect -- custom assertion function is used
+  test("given string tabName value, when spreadsheet changes to null and back to the same spreadsheet, should not reset the value", async () => {
+    const { rerender } = render(
+      <TabField
+        name="tabName"
+        schema={{}} // Does not currently check the passed-in schema
+        spreadsheet={TEST_SPREADSHEET}
+      />,
+      {
+        initialValues: {
+          tabName: "Tab2",
+        },
+      }
+    );
+
+    await waitForEffect();
+
+    expectTab2Selected();
+
+    // Change spreadsheet to null (simulate google login)
+    rerender(
+      <TabField
+        name="tabName"
+        schema={{}} // Does not currently check the passed-in schema
+        spreadsheet={null}
+      />
+    );
+
+    await waitForEffect();
+
+    // Tab name should not be cleared yet
+    expectTab2Selected();
+
+    // Change spreadsheet back
+    rerender(
+      <TabField
+        name="tabName"
+        schema={{}} // Does not currently check the passed-in schema
+        spreadsheet={TEST_SPREADSHEET}
+      />
+    );
+
+    await waitForEffect();
+
+    // Tab2 should still be selected
+    expectTab2Selected();
   });
 });

--- a/src/contrib/google/sheets/ui/TabField.tsx
+++ b/src/contrib/google/sheets/ui/TabField.tsx
@@ -39,17 +39,22 @@ const TabField: React.FC<
     string | Expression
   >(name);
 
-  const tabNames =
-    spreadsheet?.sheets?.map((sheet) => sheet.properties.title) ??
-    emptyTabNames;
+  const lastGoodTabNames = useRef(emptyTabNames);
+
+  if (spreadsheet) {
+    lastGoodTabNames.current =
+      spreadsheet.sheets?.map((sheet) => sheet.properties.title) ??
+      emptyTabNames;
+  }
+
   const fieldSchema: Schema = {
     type: "string",
     title: "Tab Name",
     description: "The spreadsheet tab",
-    enum: tabNames,
+    enum: lastGoodTabNames.current,
   };
 
-  const allTabNames = tabNames.join(",");
+  const allTabNames = lastGoodTabNames.current.join(",");
   useAsyncEffect(
     async () => {
       // Don't modify the field if it's currently focused
@@ -61,6 +66,8 @@ const TabField: React.FC<
       if (isExpression(tabName) && !isEmpty(tabName.__value__)) {
         return;
       }
+
+      const tabNames = lastGoodTabNames.current;
 
       // Set to empty nunjucks expression if no tab names have loaded
       if (isEmpty(tabNames)) {

--- a/src/extensionConsole/pages/integrations/IntegrationEditorModal.tsx
+++ b/src/extensionConsole/pages/integrations/IntegrationEditorModal.tsx
@@ -74,8 +74,8 @@ const IntegrationEditorModal: React.FunctionComponent<OwnProps> = ({
   const onSubmit = useCallback<OnSubmit<IntegrationConfig>>(
     async (values, helpers) => {
       helpers.setSubmitting(true);
-      await onSave(values);
       onClose();
+      await onSave(values);
     },
     [onSave, onClose]
   );


### PR DESCRIPTION
## What does this PR do?

- Fixes #6531 

## Discussion

* I tried to figure out a way to fire the listeners from the background script when `setCachedAuthData()` is called, but couldn't figure anything out that wasn't a giant hairy mess of messenger code back and forth, so I went with the simple-if-slightly-hacky method of monitoring local storage directly from the React component

## Checklist

- [x] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer - @grahamlangford 
