### PR TITLE
#6687: Fix Control Room OAuth error

### DIFF
--- a/src/extensionConsole/pages/onboarding/partner/ControlRoomOAuthForm.tsx
+++ b/src/extensionConsole/pages/onboarding/partner/ControlRoomOAuthForm.tsx
@@ -105,7 +105,7 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
         const existingIntegrationConfig = integrationConfigs.find(
           (x) => x.integrationId === authIntegrationId
         );
-        const configId = existingIntegrationConfig?.id;
+        let configId = existingIntegrationConfig?.id;
         const secretsConfig = {
           controlRoomUrl: normalizeControlRoomUrl(values.controlRoomUrl),
           authConfigOrigin: values.authConfigOrigin,
@@ -117,8 +117,9 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
           !configId ||
           !isEqual(existingIntegrationConfig?.config, secretsConfig)
         ) {
+          configId = configId ?? uuidv4();
           const newIntegrationConfig = {
-            id: configId ?? uuidv4(),
+            id: configId,
             integrationId: CONTROL_ROOM_OAUTH_INTEGRATION_ID,
             label: "Primary AARI Account",
             config: secretsConfig,


### PR DESCRIPTION
## What does this PR do?

- Closes #6687 
- This fixes the bug because `configId` is used later in the func (see `collectIntegrationOriginPermissions`) so we need to set it to the variable correctly

## Demo

https://www.loom.com/share/051fb7e9f59c4a309dcb6eb61eeffacf

## Checklist

- [x] Add tests: We already have Rainforest tests for this
- [x] Designate a primary reviewer: @grahamlangford 
