### PR TITLE
Report DevToolsOpen event when dev tools are opened

### DIFF
--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -407,6 +407,8 @@ export async function recordEvent({
       },
     };
 
+    console.log("*** Recording event:", event);
+
     await addEvent(telemetryEvent);
     void debouncedFlush();
   }

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -407,8 +407,6 @@ export async function recordEvent({
       },
     };
 
-    console.log("*** Recording event:", event);
-
     await addEvent(telemetryEvent);
     void debouncedFlush();
   }

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -32,6 +32,8 @@ export const Events = {
   DEPLOYMENT_REJECT_VERSION: "DeploymentRejectVersion",
   DEPLOYMENT_REJECT_PERMISSIONS: "DeploymentRejectPermissions",
 
+  DEVTOOLS_OPEN: "DevToolsOpen",
+
   EXTENSION_CLOUD_DELETE: "ExtensionCloudDelete",
 
   FACTORY_RESET: "FactoryReset",

--- a/src/tinyPages/devtools.ts
+++ b/src/tinyPages/devtools.ts
@@ -18,9 +18,9 @@
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 
-if (typeof chrome.devtools.inspectedWindow.tabId === "number") {
-  reportEvent(Events.DEVTOOLS_OPEN);
+reportEvent(Events.DEVTOOLS_OPEN);
 
+if (typeof chrome.devtools.inspectedWindow.tabId === "number") {
   chrome.devtools.panels.create(
     "PixieBrix",
     "",

--- a/src/tinyPages/devtools.ts
+++ b/src/tinyPages/devtools.ts
@@ -15,7 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import reportEvent from "@/telemetry/reportEvent";
+import { Events } from "@/telemetry/events";
+
 if (typeof chrome.devtools.inspectedWindow.tabId === "number") {
+  reportEvent(Events.DEVTOOLS_OPEN);
+
   chrome.devtools.panels.create(
     "PixieBrix",
     "",

--- a/src/tinyPages/devtools.ts
+++ b/src/tinyPages/devtools.ts
@@ -18,9 +18,11 @@
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 
-reportEvent(Events.DEVTOOLS_OPEN);
-
+// Only add the Page Editor to the devtools it's being used to inspect a modifiable web page,
+// i.e. the Page Editor is not relevant when inspecting a background page or the devtools itself.
 if (typeof chrome.devtools.inspectedWindow.tabId === "number") {
+  reportEvent(Events.DEVTOOLS_OPEN);
+
   chrome.devtools.panels.create(
     "PixieBrix",
     "",

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -298,7 +298,6 @@
     "./themes/light.ts",
     "./themes/themeTypes.ts",
     "./themes/themeUtils.ts",
-    "./tinyPages/devtools.ts",
     "./tours/tourRunDatabase.ts",
     "./types/annotationTypes.ts",
     "./types/browserTypes.ts",


### PR DESCRIPTION
## What does this PR do?

- Part of #6694

## How does this work?

- Per [chrome developer documentation](https://developer.chrome.com/docs/extensions/mv3/devtools/#devtools-page):

> When a DevTools window opens, a DevTools extension creates an instance of its DevTools page that exists as long as the window is open.

- i.e. the instance is created even if the DevTools extension panel (the Page Editor, in this case) is not open

## Demo

https://www.loom.com/share/1683c39d36984bbfa96e353ce7981932

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer @grahamlangford 
