### PR TITLE
Add Page Editor dimension properties to `PageEditorSession` events

### DIFF
--- a/src/pageEditor/EditorContent.tsx
+++ b/src/pageEditor/EditorContent.tsx
@@ -92,12 +92,14 @@ const EditorContent: React.FC = () => {
       ...selectPageEditorDimensions(),
     });
 
-    return () => {
+    // Report session end before page unload instead of component unmount because closing the
+    // devtools will prevent the component from unmounting
+    window.addEventListener("beforeunload", () => {
       reportEvent(Events.PAGE_EDITOR_SESSION_END, {
         sessionId,
         ...selectPageEditorDimensions(),
       });
-    };
+    });
   }, [sessionId]);
 
   // Always show the main error if present - keep this first

--- a/src/pageEditor/EditorContent.tsx
+++ b/src/pageEditor/EditorContent.tsx
@@ -43,6 +43,7 @@ import useCurrentUrl from "@/pageEditor/hooks/useCurrentUrl";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import Alert from "@/components/Alert";
 import styles from "./EditorContent.module.scss";
+import { selectPageEditorDimensions } from "@/pageEditor/utils";
 
 const EditorContent: React.FC = () => {
   const tabHasPermissions = useSelector(selectTabHasPermissions);
@@ -88,11 +89,13 @@ const EditorContent: React.FC = () => {
   useEffect(() => {
     reportEvent(Events.PAGE_EDITOR_SESSION_START, {
       sessionId,
+      ...selectPageEditorDimensions(),
     });
 
     return () => {
       reportEvent(Events.PAGE_EDITOR_SESSION_END, {
         sessionId,
+        ...selectPageEditorDimensions(),
       });
     };
   }, [sessionId]);

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -244,3 +244,10 @@ export function getBlockAnnotations(
     return !restPath.includes(".__value__.");
   });
 }
+
+export function selectPageEditorDimensions() {
+  return {
+    pageEditorWidth: window.innerWidth,
+    pageEditorHeight: window.innerHeight,
+  };
+}

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -249,5 +249,7 @@ export function selectPageEditorDimensions() {
   return {
     pageEditorWidth: window.innerWidth,
     pageEditorHeight: window.innerHeight,
+    pageEditorOrientation:
+      window.innerWidth > window.innerHeight ? "landscape" : "portrait",
   };
 }

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -33,6 +33,7 @@ export const Events = {
   DEPLOYMENT_REJECT_PERMISSIONS: "DeploymentRejectPermissions",
 
   DEVTOOLS_OPEN: "DevToolsOpen",
+  DEVTOOLS_CLOSE: "DevToolsClose",
 
   EXTENSION_CLOUD_DELETE: "ExtensionCloudDelete",
 

--- a/src/tinyPages/devtools.ts
+++ b/src/tinyPages/devtools.ts
@@ -23,6 +23,10 @@ import { Events } from "@/telemetry/events";
 if (typeof chrome.devtools.inspectedWindow.tabId === "number") {
   reportEvent(Events.DEVTOOLS_OPEN);
 
+  window.addEventListener("beforeunload", () => {
+    reportEvent(Events.DEVTOOLS_CLOSE);
+  });
+
   chrome.devtools.panels.create(
     "PixieBrix",
     "",

--- a/src/tinyPages/devtools.ts
+++ b/src/tinyPages/devtools.ts
@@ -18,7 +18,7 @@
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 
-// Only add the Page Editor to the devtools it's being used to inspect a modifiable web page,
+// Only add the Page Editor to the devtools if it's being used to inspect a modifiable web page,
 // i.e. the Page Editor is not relevant when inspecting a background page or the devtools itself.
 if (typeof chrome.devtools.inspectedWindow.tabId === "number") {
   reportEvent(Events.DEVTOOLS_OPEN);


### PR DESCRIPTION
## What does this PR do?

- Closes #6694 
- Also fixes #6732
- I've identified that determining docking orientation of the devtools is too hacky/convoluted for the amount of value that we'd get from adding the event. @BrandonPxBx and I identified that adding the PageEditor dimensions to `PageEditorSession` events will provide similar value for less effort & complexity
- Also adds `DevToolsClose` event for extra insight into users being potentially unsuccessful with getting to the Page Editor

## Demo

- https://www.loom.com/share/1454475fe10a48cebcc5d6e74665737b

## Team Coordination

- [x] Update the Mixpanel Lexicon entry for `PageEditorSessionEnd` to flag inaccuracies in the event before & after the next Extension release

## Checklist

- [ ] Add tests
- [x] Designate a primary reviewer @grahamlangford 
