### PR TITLE
#6690: split up brick registry and runtime dependency cycle

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -46,6 +46,7 @@ const config = {
   ],
   setupFilesAfterEnv: [
     "<rootDir>/src/testUtils/testAfterEnv.ts",
+    "<rootDir>/src/testUtils/injectRegistries.ts",
     "jest-extended/all",
   ],
   coverageReporters: ["json"],

--- a/src/bricks/effects/highlightText.test.ts
+++ b/src/bricks/effects/highlightText.test.ts
@@ -248,7 +248,7 @@ describe("ReplaceTextEffect", () => {
       { logger, root: document } as BrickOptions
     );
 
-    expect(document.head.innerHTML).toBe("<title>Support page</title>");
+    expect(document.title).toBe("Support page");
     expect(document.body.innerHTML).toBe(
       '<h1><mark style="background-color: yellow;">Sup</mark>erlatives Abound</h1>'
     );

--- a/src/bricks/transformers/brickFactory.test.ts
+++ b/src/bricks/transformers/brickFactory.test.ts
@@ -17,7 +17,7 @@
 
 import nytimes from "@contrib/bricks/nytimes-org.yaml";
 import trelloReader from "@contrib/readers/trello-card-reader.yaml";
-import { fromJS } from "@/bricks/transformers/brickFactory";
+import { fromJS as nativeFromJS } from "@/bricks/transformers/brickFactory";
 import { InvalidDefinitionError } from "@/errors/businessErrors";
 import { isUserDefinedBrick } from "@/types/brickTypes";
 import { MappingTransformer } from "./mapping";
@@ -30,13 +30,15 @@ import {
 } from "@/runtime/pipelineTests/pipelineTestHelpers";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import Run from "@/bricks/transformers/controlFlow/Run";
-import { cloneDeep } from "lodash";
+import { cloneDeep, partial } from "lodash";
 import { extraEmptyModStateContext } from "@/runtime/extendModVariableContext";
 import { setContext } from "@/testUtils/detectPageMock";
 import { validateRegistryId } from "@/types/helpers";
 import registerBuiltinBlocks from "@/bricks/registerBuiltinBlocks";
 
 setContext("contentScript");
+
+const fromJS = partial(nativeFromJS, blockRegistry);
 
 beforeEach(() => {
   blockRegistry.clear();

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -25,6 +25,7 @@ import registerExternalMessenger from "@/background/messenger/external/registrat
 import registerMessenger from "@/contentScript/messenger/registration";
 import registerBuiltinBlocks from "@/bricks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
+import brickRegistry from "@/bricks/registry";
 import { handleNavigate } from "@/contentScript/lifecycle";
 import { initTelemetry } from "@/background/messenger/api";
 import { ENSURE_CONTENT_SCRIPT_READY } from "@/contentScript/ready";
@@ -38,6 +39,7 @@ import { onUncaughtError } from "@/errors/errorHelpers";
 import initFloatingActions from "@/components/floatingActions/initFloatingActions";
 import { initSidebarActivation } from "@/contentScript/sidebarActivation";
 import { initPerformanceMonitoring } from "@/contentScript/performanceMonitoring";
+import { initRuntime } from "@/runtime/reducePipeline";
 
 // Must come before the default handler for ignoring errors. Otherwise, this handler might not be run
 onUncaughtError((error) => {
@@ -57,6 +59,8 @@ export async function init(): Promise<void> {
   registerExternalMessenger();
   registerBuiltinBlocks();
   registerContribBlocks();
+  // Since 1.8.2, the brick registry was de-coupled from the runtime to avoid circular dependencies
+  initRuntime(brickRegistry);
 
   initTelemetry();
   initToaster();

--- a/src/extensionConsole/pages/brickEditor/referenceTab/BrickDetail.stories.tsx
+++ b/src/extensionConsole/pages/brickEditor/referenceTab/BrickDetail.stories.tsx
@@ -19,17 +19,21 @@ import React from "react";
 import { type ComponentStory, type ComponentMeta } from "@storybook/react";
 import BrickDetail from "./BrickDetail";
 import { TableRenderer } from "@/bricks/renderers/table";
-import { fromJS } from "@/bricks/transformers/brickFactory";
+import { fromJS as nativeFromJS } from "@/bricks/transformers/brickFactory";
 import amazonSearch from "@contrib/bricks/amazon-search.yaml";
 import { brickToYaml } from "@/utils/objToYaml";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { appApi } from "@/services/api";
+import brickRegistry from "@/bricks/registry";
+import { partial } from "lodash";
 
 export default {
   title: "Components/BrickDetail",
   component: BrickDetail,
 } as ComponentMeta<typeof BrickDetail>;
+
+const fromJS = partial(nativeFromJS, brickRegistry);
 
 function optionsStore(initialState?: unknown) {
   return configureStore({

--- a/src/extensionConsole/pages/settings/useDiagnostics.test.ts
+++ b/src/extensionConsole/pages/settings/useDiagnostics.test.ts
@@ -24,10 +24,6 @@ jest.mock("downloadjs", () => ({
   default: jest.fn(),
 }));
 
-jest.mock("@/telemetry/logging", () => ({
-  count: jest.fn().mockResolvedValue(0),
-}));
-
 Object.defineProperty(navigator, "storage", {
   value: {
     estimate: jest.fn().mockResolvedValue({}),

--- a/src/registry/internal.ts
+++ b/src/registry/internal.ts
@@ -19,9 +19,9 @@ import { produce } from "immer";
 import objectHash from "object-hash";
 import { cloneDeep, isEmpty, mapValues, pick, pickBy } from "lodash";
 import extensionPointRegistry from "@/starterBricks/registry";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { fromJS as extensionPointFactory } from "@/starterBricks/factory";
-import { fromJS as blockFactory } from "@/bricks/transformers/brickFactory";
+import { fromJS as brickFactory } from "@/bricks/transformers/brickFactory";
 import {
   type ModDefinition,
   type ResolvedModComponentDefinition,
@@ -70,12 +70,12 @@ async function resolveBrickDefinition(
   const registryId = makeInternalId(obj);
 
   try {
-    return await blockRegistry.lookup(registryId);
+    return await brickRegistry.lookup(registryId);
   } catch {
     // Not in registry yet, so add it
   }
 
-  const item = blockFactory({
+  const item = brickFactory(brickRegistry, {
     ...obj,
     metadata: {
       id: registryId,
@@ -83,7 +83,7 @@ async function resolveBrickDefinition(
     },
   });
 
-  blockRegistry.register([item], { source: "internal", notify: false });
+  brickRegistry.register([item], { source: "internal", notify: false });
 
   return item;
 }

--- a/src/runtime/pipelineTests/component.test.ts
+++ b/src/runtime/pipelineTests/component.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
   blockRegistry.register([echoBrick, contextBrick]);
 });
 
-const componentBlock = fromJS({
+const componentBlock = fromJS(blockRegistry, {
   apiVersion: "v1",
   kind: "component",
   metadata: {

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -80,7 +80,7 @@ import { type RegistryId } from "@/types/registryTypes";
 import { type Brick } from "@/types/brickTypes";
 import getType from "@/runtime/getType";
 
-// Introduce a layer of indirection to avoid cycles.
+// Introduce a layer of indirection to avoid cyclical dependency between runtime and registry
 let brickRegistry: RegistryProtocol<RegistryId, Brick> = {
   async lookup(): Promise<Brick> {
     throw new Error(
@@ -98,7 +98,6 @@ export function initRuntime(
   registry: RegistryProtocol<RegistryId, Brick>
 ): void {
   brickRegistry = registry;
-  console.debug("Initialized runtime");
 }
 
 /**

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -53,7 +53,6 @@ import {
   unsafeAssumeValidArg,
 } from "@/runtime/runtimeTypes";
 import { type RunBrick } from "@/contentScript/messenger/runBrickTypes";
-import { resolveBlockConfig } from "@/bricks/registry";
 import {
   BusinessError,
   CancelError,
@@ -76,6 +75,31 @@ import { type UnknownObject } from "@/types/objectTypes";
 import { isPipelineClosureExpression } from "@/utils/expressionUtils";
 import extendModVariableContext from "@/runtime/extendModVariableContext";
 import { isObject } from "@/utils/objectUtils";
+import { type RegistryProtocol } from "@/registry/memoryRegistry";
+import { type RegistryId } from "@/types/registryTypes";
+import { type Brick } from "@/types/brickTypes";
+import getType from "@/runtime/getType";
+
+// Introduce a layer of indirection to avoid cycles.
+let brickRegistry: RegistryProtocol<RegistryId, Brick> = {
+  async lookup(): Promise<Brick> {
+    throw new Error(
+      "Runtime was not initialized. Call initRuntime before running mods."
+    );
+  },
+};
+
+/**
+ * Initialize the runtime with the given brick registry.
+ * @param registry brick registry to use for looking up bricks
+ * @since 1.8.2 introduced to eliminate circular dependency between runtime and registry
+ */
+export function initRuntime(
+  registry: RegistryProtocol<RegistryId, Brick>
+): void {
+  brickRegistry = registry;
+  console.debug("Initialized runtime");
+}
 
 /**
  * CommonOptions for running pipelines and blocks
@@ -296,6 +320,17 @@ function getPipelineLexicalEnvironment({
   return {
     ...ctxt,
     ...extraContext,
+  };
+}
+
+export async function resolveBlockConfig(
+  config: BrickConfig
+): Promise<ResolvedBrickConfig> {
+  const block = await brickRegistry.lookup(config.id);
+  return {
+    config,
+    block,
+    type: await getType(block),
   };
 }
 

--- a/src/starterBricks/triggerExtension.test.ts
+++ b/src/starterBricks/triggerExtension.test.ts
@@ -49,6 +49,9 @@ import { notifyContextInvalidated } from "@/errors/contextInvalidated";
 import reportError from "@/telemetry/reportError";
 import { screen } from "@testing-library/react";
 
+// Avoid errors being interpreted as context invalidated error
+browser.runtime.id = "abcxyz";
+
 jest.mock("@/errors/contextInvalidated", () => {
   const actual = jest.requireActual("@/errors/contextInvalidated");
   return {

--- a/src/testUtils/injectRegistries.ts
+++ b/src/testUtils/injectRegistries.ts
@@ -15,6 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * @file Test utilities for injecting registries into the runtime.
+ * @since 1.8.2 used to de-couple the brick registry from the runtime
+ */
+
 import brickRegistry from "@/bricks/registry";
 import { initRuntime } from "@/runtime/reducePipeline";
 

--- a/src/testUtils/injectRegistries.ts
+++ b/src/testUtils/injectRegistries.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import brickRegistry from "@/bricks/registry";
+import { initRuntime } from "@/runtime/reducePipeline";
+
+// Since 1.8.2, the runtime is decoupled from the brick registry.
+initRuntime(brickRegistry);

--- a/src/testUtils/loggingMock.ts
+++ b/src/testUtils/loggingMock.ts
@@ -22,3 +22,5 @@ export async function getLoggingConfig(): Promise<unknown> {
     logValues,
   };
 }
+
+export const count = jest.fn().mockResolvedValue(0);

--- a/src/testUtils/testAfterEnv.ts
+++ b/src/testUtils/testAfterEnv.ts
@@ -28,6 +28,8 @@ import * as apiClientMock from "./apiClientMock";
 import * as detectPageMock from "./detectPageMock";
 import * as loggingMock from "./loggingMock";
 import * as reportErrorMock from "./reportErrorMock";
+import brickRegistry from "@/bricks/registry";
+import { initRuntime } from "@/runtime/reducePipeline";
 
 // @ts-expect-error For testing only
 global.$ = $;
@@ -55,3 +57,6 @@ jest.setMock("webext-detect-page", detectPageMock);
 jest.setMock("@/services/apiClient", apiClientMock);
 jest.setMock("@/telemetry/logging", loggingMock);
 jest.setMock("@/telemetry/reportError", reportErrorMock);
+
+// Since 1.8.2, the runtime is decoupled from the brick registry.
+initRuntime(brickRegistry);

--- a/src/testUtils/testAfterEnv.ts
+++ b/src/testUtils/testAfterEnv.ts
@@ -28,8 +28,6 @@ import * as apiClientMock from "./apiClientMock";
 import * as detectPageMock from "./detectPageMock";
 import * as loggingMock from "./loggingMock";
 import * as reportErrorMock from "./reportErrorMock";
-import brickRegistry from "@/bricks/registry";
-import { initRuntime } from "@/runtime/reducePipeline";
 
 // @ts-expect-error For testing only
 global.$ = $;
@@ -57,6 +55,3 @@ jest.setMock("webext-detect-page", detectPageMock);
 jest.setMock("@/services/apiClient", apiClientMock);
 jest.setMock("@/telemetry/logging", loggingMock);
 jest.setMock("@/telemetry/reportError", reportErrorMock);
-
-// Since 1.8.2, the runtime is decoupled from the brick registry.
-initRuntime(brickRegistry);


### PR DESCRIPTION
## What does this PR do?

- Part of #6690 
- De-couples the brick registry and the runtime
- I took two different approaches
  - For UserDefinedBrick, I passed the registry into the constructor
  - For ReducePipeline, I'm using a module-level variable that's initialized by the contentScript/testing framework

## Remaining Work

- [x] Determine why tests are failing due the new injectRegistries file for testing: https://stackoverflow.com/questions/70007464/jest-worker-encountered-4-child-process-exceptions-exceeding-retry-limit

## Discussion

- Introducing a class + constructor for ReducePipeline would be a pain. We'd need to start passing a dependency/registry context around nearly every
- Because the brick registry is a singleton instance, injecting the dependency into the reducePipeline module seemed like the most straightforward approach
- Splitting up the cycle does not appear to have an impact on bundle size
- Introducing injectRegistries in the jest setup required me to adjust a few test's mocks/assumptions

## Future Work

- Decouple starter bricks and other bricks: https://github.com/pixiebrix/pixiebrix-extension/pull/6774#issuecomment-1786263751

## Checklist

- [x] Add tests: N/A
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
