### PR TITLE
#6690: eliminate remaining cycle in error code

### DIFF
--- a/src/errors/businessErrors.ts
+++ b/src/errors/businessErrors.ts
@@ -16,8 +16,8 @@
  */
 
 import { truncate } from "lodash";
-import { JQUERY_INVALID_SELECTOR_ERROR } from "@/errors/errorHelpers";
 import { type AxiosResponse } from "axios";
+import { JQUERY_INVALID_SELECTOR_ERROR } from "@/errors/knownErrorMessages";
 
 /**
  * @file ONLY KEEP ACTUAL ERRORS IN HERE.

--- a/src/errors/contextInvalidated.ts
+++ b/src/errors/contextInvalidated.ts
@@ -17,11 +17,8 @@
 
 import { expectContext } from "@/utils/expectContext";
 import { once } from "lodash";
-import {
-  CONTEXT_INVALIDATED_ERROR,
-  getErrorMessage,
-  getRootCause,
-} from "./errorHelpers";
+import { getErrorMessage, getRootCause } from "./errorHelpers";
+import { CONTEXT_INVALIDATED_ERROR } from "@/errors/knownErrorMessages";
 
 /**
  * Notification id to avoid displaying the same notification multiple times.

--- a/src/errors/errorHelpers.ts
+++ b/src/errors/errorHelpers.ts
@@ -31,23 +31,13 @@ import {
   type SchemaValidationError,
 } from "@/bricks/errors";
 import { type SetRequired } from "type-fest";
-
-// From "webext-messenger". Cannot import because the webextension polyfill can only run in an extension context
-// TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/3641
-const errorTargetClosedEarly =
-  "The target was closed before receiving a response";
-const errorTabDoesntExist = "The tab doesn't exist";
+import {
+  CONTEXT_INVALIDATED_ERROR,
+  ERROR_TAB_DOES_NOT_EXIST,
+  ERROR_TARGET_CLOSED_EARLY,
+} from "@/errors/knownErrorMessages";
 
 const DEFAULT_ERROR_MESSAGE = "Unknown error";
-
-export const JQUERY_INVALID_SELECTOR_ERROR =
-  "Syntax error, unrecognized expression: ";
-
-/**
- * Some APIs like runtime.sendMessage() and storage.get() will throw this error
- * when the background page has been reloaded
- */
-export const CONTEXT_INVALIDATED_ERROR = "Extension context invalidated.";
 
 /**
  * Errors to ignore unless they've caused extension point install or brick execution to fail.
@@ -72,8 +62,8 @@ const IGNORED_ERROR_PATTERNS = [
   /No frame with id \d+ in tab \d+/,
   /^No tab with id/,
   "The tab was closed.",
-  errorTabDoesntExist,
-  errorTargetClosedEarly,
+  ERROR_TAB_DOES_NOT_EXIST,
+  ERROR_TARGET_CLOSED_EARLY,
   CONTEXT_INVALIDATED_ERROR,
 ];
 

--- a/src/errors/knownErrorMessages.ts
+++ b/src/errors/knownErrorMessages.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file Well-known error messages from the Chrome runtime and vendor libraries.
+ */
+
+// From "webext-messenger". Cannot import because the webextension polyfill can only run in an extension context
+// TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/3641
+export const ERROR_TARGET_CLOSED_EARLY =
+  "The target was closed before receiving a response";
+
+export const ERROR_TAB_DOES_NOT_EXIST = "The tab doesn't exist";
+
+export const JQUERY_INVALID_SELECTOR_ERROR =
+  "Syntax error, unrecognized expression: ";
+
+/**
+ * Some APIs like runtime.sendMessage() and storage.get() will throw this error
+ * when the background page has been reloaded
+ */
+export const CONTEXT_INVALIDATED_ERROR = "Extension context invalidated.";

--- a/src/starterBricks/starterBrickTestUtils.ts
+++ b/src/starterBricks/starterBrickTestUtils.ts
@@ -22,7 +22,7 @@ import { getReferenceForElement } from "@/contentScript/elementReference";
 import { type ElementReference } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type JsonObject } from "type-fest";
-import { CONTEXT_INVALIDATED_ERROR } from "@/errors/errorHelpers";
+import { CONTEXT_INVALIDATED_ERROR } from "@/errors/knownErrorMessages";
 
 /**
  * Helper function returns a promise that resolves after all other promise mocks, even if they are chained

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -172,6 +172,7 @@
     "./errors/errorHelpers.ts",
     "./errors/genericErrors.ts",
     "./errors/networkErrorHelpers.ts",
+    "./errors/knownErrorMessages.ts",
     "./errors/rejectOnCancelled.ts",
     "./extensionConsole/components/ServiceFieldError.tsx",
     "./extensionConsole/messenger/api.ts",

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -15,10 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  getErrorMessage,
-  JQUERY_INVALID_SELECTOR_ERROR,
-} from "@/errors/errorHelpers";
+import { getErrorMessage } from "@/errors/errorHelpers";
 import {
   BusinessError,
   InvalidSelectorError,
@@ -26,6 +23,7 @@ import {
   NoElementsFoundError,
 } from "@/errors/businessErrors";
 import { sleep } from "@/utils/timeUtils";
+import { JQUERY_INVALID_SELECTOR_ERROR } from "@/errors/knownErrorMessages";
 
 /**
  * Find an element(s) by its jQuery selector. A safe alternative to $(selector), which constructs an element if it's


### PR DESCRIPTION
## What does this PR do?

- Closes #6690 
- Eliminates the cycle in the error subfolder by extracting out the error message constants

## Discussion

- How might we prevent cycles from being introduced in the future? We run `madge` as part of CI, but it was missing this cycle. Unfortunately, the lint rule is likely to slow to run as part of CI?

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/99b870ba-ddbc-44bb-9c67-0bdd0d8b685c)

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/ae68885d-b6fd-468e-9151-f4e10faefc47)

## Checklist

- [x] Add tests: N/A
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
