### PR TITLE
#4000: lazy load sidebar content/modules

### DIFF
--- a/src/extensionConsole/App.tsx
+++ b/src/extensionConsole/App.tsx
@@ -52,7 +52,7 @@ import { DeploymentsProvider } from "@/extensionConsole/pages/deployments/Deploy
 // Dynamically fetch the non-essential pages
 
 const IntegrationsPage = lazy(
-  () =>
+  async () =>
     import(
       /* @webpackChunkName "IntegrationsPage" */
       "@/extensionConsole/pages/integrations/IntegrationsPage"
@@ -60,7 +60,7 @@ const IntegrationsPage = lazy(
 );
 
 const ActivateModPage = lazy(
-  () =>
+  async () =>
     import(
       /* @webpackChunkName "ActivatePage" */
       "@/extensionConsole/pages/activateRecipe/ActivateRecipePage"
@@ -68,7 +68,7 @@ const ActivateModPage = lazy(
 );
 
 const ActivateModComponentPage = lazy(
-  () =>
+  async () =>
     import(
       /* @webpackChunkName "ActivatePage" */
       "@/extensionConsole/pages/activateExtension/ActivateExtensionPage"
@@ -76,7 +76,7 @@ const ActivateModComponentPage = lazy(
 );
 
 const BrickCreatePage = lazy(
-  () =>
+  async () =>
     import(
       /* @webpackChunkName "WorkshopPage" */
       "@/extensionConsole/pages/brickEditor/CreatePage"
@@ -84,7 +84,7 @@ const BrickCreatePage = lazy(
 );
 
 const BrickEditPage = lazy(
-  () =>
+  async () =>
     import(
       /* @webpackChunkName "WorkshopPage" */
       "@/extensionConsole/pages/brickEditor/EditPage"
@@ -92,7 +92,7 @@ const BrickEditPage = lazy(
 );
 
 const WorkshopPage = lazy(
-  () =>
+  async () =>
     import(
       /* @webpackChunkName "WorkshopPage" */
       "./pages/workshop/WorkshopPage"
@@ -100,7 +100,7 @@ const WorkshopPage = lazy(
 );
 
 const SettingsPage = lazy(
-  () =>
+  async () =>
     import(
       /* @webpackChunkName "SettingsPage" */
       "@/extensionConsole/pages/settings/SettingsPage"

--- a/src/extensionConsole/App.tsx
+++ b/src/extensionConsole/App.tsx
@@ -54,7 +54,7 @@ import { DeploymentsProvider } from "@/extensionConsole/pages/deployments/Deploy
 const IntegrationsPage = lazy(
   async () =>
     import(
-      /* webpackChunkName "IntegrationsPage" */
+      /* webpackChunkName: "IntegrationsPage" */
       "@/extensionConsole/pages/integrations/IntegrationsPage"
     )
 );
@@ -62,7 +62,7 @@ const IntegrationsPage = lazy(
 const ActivateModPage = lazy(
   async () =>
     import(
-      /* webpackChunkName "ActivatePage" */
+      /* webpackChunkName: "ActivatePage" */
       "@/extensionConsole/pages/activateRecipe/ActivateRecipePage"
     )
 );
@@ -70,7 +70,7 @@ const ActivateModPage = lazy(
 const ActivateModComponentPage = lazy(
   async () =>
     import(
-      /* webpackChunkName "ActivatePage" */
+      /* webpackChunkName: "ActivatePage" */
       "@/extensionConsole/pages/activateExtension/ActivateExtensionPage"
     )
 );
@@ -78,7 +78,7 @@ const ActivateModComponentPage = lazy(
 const BrickCreatePage = lazy(
   async () =>
     import(
-      /* webpackChunkName "WorkshopPage" */
+      /* webpackChunkName: "WorkshopPage" */
       "@/extensionConsole/pages/brickEditor/CreatePage"
     )
 );
@@ -86,7 +86,7 @@ const BrickCreatePage = lazy(
 const BrickEditPage = lazy(
   async () =>
     import(
-      /* webpackChunkName "WorkshopPage" */
+      /* webpackChunkName: "WorkshopPage" */
       "@/extensionConsole/pages/brickEditor/EditPage"
     )
 );
@@ -94,7 +94,7 @@ const BrickEditPage = lazy(
 const WorkshopPage = lazy(
   async () =>
     import(
-      /* webpackChunkName "WorkshopPage" */
+      /* webpackChunkName: "WorkshopPage" */
       "./pages/workshop/WorkshopPage"
     )
 );
@@ -102,7 +102,7 @@ const WorkshopPage = lazy(
 const SettingsPage = lazy(
   async () =>
     import(
-      /* webpackChunkName "SettingsPage" */
+      /* webpackChunkName: "SettingsPage" */
       "@/extensionConsole/pages/settings/SettingsPage"
     )
 );

--- a/src/extensionConsole/App.tsx
+++ b/src/extensionConsole/App.tsx
@@ -49,12 +49,12 @@ import ReduxPersistenceContext, {
 import IDBErrorDisplay from "@/extensionConsole/components/IDBErrorDisplay";
 import { DeploymentsProvider } from "@/extensionConsole/pages/deployments/DeploymentsContext";
 
-// Dynamically fetch the non-essential pages
+// Dynamically fetch the non-essential pages to reduce baseline resource footprint
 
 const IntegrationsPage = lazy(
   async () =>
     import(
-      /* @webpackChunkName "IntegrationsPage" */
+      /* webpackChunkName "IntegrationsPage" */
       "@/extensionConsole/pages/integrations/IntegrationsPage"
     )
 );
@@ -62,7 +62,7 @@ const IntegrationsPage = lazy(
 const ActivateModPage = lazy(
   async () =>
     import(
-      /* @webpackChunkName "ActivatePage" */
+      /* webpackChunkName "ActivatePage" */
       "@/extensionConsole/pages/activateRecipe/ActivateRecipePage"
     )
 );
@@ -70,7 +70,7 @@ const ActivateModPage = lazy(
 const ActivateModComponentPage = lazy(
   async () =>
     import(
-      /* @webpackChunkName "ActivatePage" */
+      /* webpackChunkName "ActivatePage" */
       "@/extensionConsole/pages/activateExtension/ActivateExtensionPage"
     )
 );
@@ -78,7 +78,7 @@ const ActivateModComponentPage = lazy(
 const BrickCreatePage = lazy(
   async () =>
     import(
-      /* @webpackChunkName "WorkshopPage" */
+      /* webpackChunkName "WorkshopPage" */
       "@/extensionConsole/pages/brickEditor/CreatePage"
     )
 );
@@ -86,7 +86,7 @@ const BrickCreatePage = lazy(
 const BrickEditPage = lazy(
   async () =>
     import(
-      /* @webpackChunkName "WorkshopPage" */
+      /* webpackChunkName "WorkshopPage" */
       "@/extensionConsole/pages/brickEditor/EditPage"
     )
 );
@@ -94,7 +94,7 @@ const BrickEditPage = lazy(
 const WorkshopPage = lazy(
   async () =>
     import(
-      /* @webpackChunkName "WorkshopPage" */
+      /* webpackChunkName "WorkshopPage" */
       "./pages/workshop/WorkshopPage"
     )
 );
@@ -102,7 +102,7 @@ const WorkshopPage = lazy(
 const SettingsPage = lazy(
   async () =>
     import(
-      /* @webpackChunkName "SettingsPage" */
+      /* webpackChunkName "SettingsPage" */
       "@/extensionConsole/pages/settings/SettingsPage"
     )
 );

--- a/src/extensionConsole/App.tsx
+++ b/src/extensionConsole/App.tsx
@@ -15,25 +15,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from "react";
+import React, { lazy, Suspense, useEffect } from "react";
 import store, { hashHistory, persistor } from "@/store/optionsStore";
 import { Provider, useDispatch } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 import { Container } from "react-bootstrap";
 import ErrorBoundary from "@/components/ErrorBoundary";
-import ServicesEditor from "@/extensionConsole/pages/integrations/IntegrationsPage";
-import BrickCreatePage from "@/extensionConsole/pages/brickEditor/CreatePage";
-import BrickEditPage from "@/extensionConsole/pages/brickEditor/EditPage";
 import ModsPage from "@/extensionConsole/pages/mods/ModsPage";
-import SettingsPage from "@/extensionConsole/pages/settings/SettingsPage";
 import Navbar from "@/extensionConsole/Navbar";
 import Footer from "@/layout/Footer";
 import Sidebar from "@/extensionConsole/Sidebar";
 import { Route, Switch } from "react-router-dom";
 import { ConnectedRouter } from "connected-react-router";
 import EnvironmentBanner from "@/layout/EnvironmentBanner";
-import ActivateRecipePage from "@/extensionConsole/pages/activateRecipe/ActivateRecipePage";
-import ActivateExtensionPage from "@/extensionConsole/pages/activateExtension/ActivateExtensionPage";
 import useRefreshRegistries from "@/hooks/useRefreshRegistries";
 import SetupPage from "@/extensionConsole/pages/onboarding/SetupPage";
 import UpdateBanner from "@/extensionConsole/pages/UpdateBanner";
@@ -42,7 +36,6 @@ import registerContribBlocks from "@/contrib/registerContribBlocks";
 import registerEditors from "@/contrib/editors";
 import DeploymentBanner from "@/extensionConsole/pages/deployments/DeploymentBanner";
 import { ModalProvider } from "@/components/ConfirmationModal";
-import WorkshopPage from "./pages/workshop/WorkshopPage";
 import InvitationBanner from "@/extensionConsole/pages/InvitationBanner";
 import BrowserBanner from "./pages/BrowserBanner";
 import useFlags from "@/hooks/useFlags";
@@ -55,6 +48,64 @@ import ReduxPersistenceContext, {
 } from "@/store/ReduxPersistenceContext";
 import IDBErrorDisplay from "@/extensionConsole/components/IDBErrorDisplay";
 import { DeploymentsProvider } from "@/extensionConsole/pages/deployments/DeploymentsContext";
+
+// Dynamically fetch the non-essential pages
+
+const IntegrationsPage = lazy(
+  () =>
+    import(
+      /* @webpackChunkName "IntegrationsPage" */
+      "@/extensionConsole/pages/integrations/IntegrationsPage"
+    )
+);
+
+const ActivateModPage = lazy(
+  () =>
+    import(
+      /* @webpackChunkName "ActivatePage" */
+      "@/extensionConsole/pages/activateRecipe/ActivateRecipePage"
+    )
+);
+
+const ActivateModComponentPage = lazy(
+  () =>
+    import(
+      /* @webpackChunkName "ActivatePage" */
+      "@/extensionConsole/pages/activateExtension/ActivateExtensionPage"
+    )
+);
+
+const BrickCreatePage = lazy(
+  () =>
+    import(
+      /* @webpackChunkName "WorkshopPage" */
+      "@/extensionConsole/pages/brickEditor/CreatePage"
+    )
+);
+
+const BrickEditPage = lazy(
+  () =>
+    import(
+      /* @webpackChunkName "WorkshopPage" */
+      "@/extensionConsole/pages/brickEditor/EditPage"
+    )
+);
+
+const WorkshopPage = lazy(
+  () =>
+    import(
+      /* @webpackChunkName "WorkshopPage" */
+      "./pages/workshop/WorkshopPage"
+    )
+);
+
+const SettingsPage = lazy(
+  () =>
+    import(
+      /* @webpackChunkName "SettingsPage" */
+      "@/extensionConsole/pages/settings/SettingsPage"
+    )
+);
 
 // Register the built-in bricks
 registerEditors();
@@ -97,56 +148,62 @@ const Layout = () => {
                 <DeploymentBanner />
                 <InvitationBanner />
                 <div className="content-wrapper">
-                  <ErrorBoundary ErrorComponent={IDBErrorDisplay}>
-                    <Switch>
-                      <Route
-                        exact
-                        path="/extensions/install/:extensionId"
-                        component={ActivateExtensionPage}
-                      />
-                      <Route
-                        exact
-                        path="/:sourcePage/activate/:recipeId"
-                        component={ActivateRecipePage}
-                      />
-
-                      <Route exact path="/settings" component={SettingsPage} />
-
-                      {permit("services") && (
-                        <Route
-                          path="/services/:id?"
-                          component={ServicesEditor}
-                        />
-                      )}
-
-                      {/* Switch does not support consolidating Routes using a React fragment */}
-                      {permit("workshop") && (
+                  <Suspense fallback={<div></div>}>
+                    <ErrorBoundary ErrorComponent={IDBErrorDisplay}>
+                      <Switch>
                         <Route
                           exact
-                          path="/workshop"
-                          component={WorkshopPage}
+                          path="/extensions/install/:extensionId"
+                          component={ActivateModComponentPage}
                         />
-                      )}
-
-                      {permit("workshop") && (
                         <Route
                           exact
-                          path="/workshop/create/"
-                          component={BrickCreatePage}
+                          path="/:sourcePage/activate/:recipeId"
+                          component={ActivateModPage}
                         />
-                      )}
 
-                      {permit("workshop") && (
                         <Route
                           exact
-                          path="/workshop/bricks/:id/"
-                          component={BrickEditPage}
+                          path="/settings"
+                          component={SettingsPage}
                         />
-                      )}
 
-                      <Route component={ModsPage} />
-                    </Switch>
-                  </ErrorBoundary>
+                        {permit("services") && (
+                          <Route
+                            path="/services/:id?"
+                            component={IntegrationsPage}
+                          />
+                        )}
+
+                        {/* Switch does not support consolidating Routes using a React fragment */}
+                        {permit("workshop") && (
+                          <Route
+                            exact
+                            path="/workshop"
+                            component={WorkshopPage}
+                          />
+                        )}
+
+                        {permit("workshop") && (
+                          <Route
+                            exact
+                            path="/workshop/create/"
+                            component={BrickCreatePage}
+                          />
+                        )}
+
+                        {permit("workshop") && (
+                          <Route
+                            exact
+                            path="/workshop/bricks/:id/"
+                            component={BrickEditPage}
+                          />
+                        )}
+
+                        <Route component={ModsPage} />
+                      </Switch>
+                    </ErrorBoundary>
+                  </Suspense>
                 </div>
                 <Footer />
               </div>

--- a/src/sidebar/Tabs.test.tsx
+++ b/src/sidebar/Tabs.test.tsx
@@ -216,6 +216,8 @@ describe("Tabs", () => {
         screen.queryByRole("tab", { name: /panel test 1/i })
       ).not.toBeInTheDocument();
 
+      await waitForEffect();
+
       screen.getByRole("heading", { name: /panel test 1/i }).click();
 
       expect(

--- a/src/sidebar/Tabs.test.tsx
+++ b/src/sidebar/Tabs.test.tsx
@@ -102,6 +102,9 @@ describe("Tabs", () => {
         },
       });
 
+      // Wait for effect because module is lazily loaded
+      await waitForEffect();
+
       expect(asFragment()).toMatchSnapshot();
     });
 

--- a/src/sidebar/Tabs.test.tsx
+++ b/src/sidebar/Tabs.test.tsx
@@ -27,6 +27,9 @@ import { waitForEffect } from "@/testUtils/testHelpers";
 import userEvent from "@testing-library/user-event";
 import * as messengerApi from "@/contentScript/messenger/api";
 import { eventKeyForEntry } from "@/sidebar/eventKeyUtils";
+import { mockAllApiEndpoints } from "@/testUtils/appApiMock";
+
+mockAllApiEndpoints();
 
 const cancelFormSpy = jest.spyOn(messengerApi, "cancelForm");
 const hideSidebarSpy = jest.spyOn(messengerApi, "hideSidebar");

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -95,7 +95,7 @@ const TabWithDivider = ({
   return isPanelHidden ? null : (
     <Nav.Item className={cx(styles.tabWrapper, { [styles.active]: active })}>
       {/* added `target="_self"` due to stopPropogation on onCloseStaticPanel
-       * without it, the default behavior of the ancher tag (Nav.Link) is triggered
+       * without it, the default behavior of the anchor tag (Nav.Link) is triggered
        * and a new tab is opened
        */}
       <Nav.Link
@@ -177,6 +177,7 @@ const Tabs: React.FC = () => {
       });
     },
     // Only run on initial mount, other views are handled by onSelect
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
     []
   );
 
@@ -289,6 +290,10 @@ const Tabs: React.FC = () => {
         >
           {panels.map((panel: PanelEntry) => (
             <Tab.Pane
+              // Avoid memory overhead until panel is opened
+              mountOnEnter
+              // Keep tab state, otherwise use will lose local state when a temporary panel/form is added
+              unmountOnExit={false}
               className={cx("full-height flex-grow", styles.paneOverrides)}
               key={panel.extensionId}
               eventKey={eventKeyForEntry(panel)}
@@ -342,6 +347,9 @@ const Tabs: React.FC = () => {
 
           {modActivationPanel && (
             <Tab.Pane
+              mountOnEnter
+              // Don't lose any state when switching away from the panel
+              unmountOnExit={false}
               className={cx("h-100", styles.paneOverrides)}
               key={eventKeyForEntry(modActivationPanel)}
               eventKey={eventKeyForEntry(modActivationPanel)}
@@ -375,6 +383,11 @@ const Tabs: React.FC = () => {
 
           {staticPanels.map((staticPanel) => (
             <Tab.Pane
+              // Avoid loading mod definitions into memory / fetching from marketplace until the tab is opened.
+              // They can be quite large  for users with access to many mods
+              mountOnEnter
+              // Allow the user to quickly switch back to the panel
+              unmountOnExit={false}
               className={cx("h-100", styles.paneOverrides)}
               key={staticPanel.key}
               eventKey={eventKeyForEntry(staticPanel)}

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -94,13 +94,12 @@ const TabWithDivider = ({
 
   return isPanelHidden ? null : (
     <Nav.Item className={cx(styles.tabWrapper, { [styles.active]: active })}>
-      {/* added `target="_self"` due to stopPropogation on onCloseStaticPanel
-       * without it, the default behavior of the anchor tag (Nav.Link) is triggered
-       * and a new tab is opened
-       */}
       <Nav.Link
         {...props}
         className={styles.tabHeader}
+        // Added `target="_self"` due to stopPropagation on onCloseStaticPanel
+        // without it, the default behavior of the anchor tag (Nav.Link) is triggered
+        // and a new tab is opened
         target="_self"
         eventKey={eventKey}
       >
@@ -154,6 +153,8 @@ const Tabs: React.FC = () => {
     event: MouseEvent<HTMLButtonElement>,
     panel: SidebarEntry
   ) => {
+    // Default is to navigate to `#` hash which causes an error in the background page
+    event.preventDefault();
     // Without stopPropagation, the onSelect handler will be called and the panel will be reopened
     event.stopPropagation();
     reportEvent(Events.SIDEBAR_TAB_CLOSE, { panel: JSON.stringify(panel) });

--- a/src/sidebar/staticPanelUtils.tsx
+++ b/src/sidebar/staticPanelUtils.tsx
@@ -1,5 +1,12 @@
-import React, { type ReactNode } from "react";
-import ModLauncher from "@/sidebar/modLauncher/ModLauncher";
+import React, { lazy, type ReactNode } from "react";
+
+const ModLauncher = lazy(
+  async () =>
+    import(
+      /* webpackChunkName: "ModLauncher" */
+      "@/sidebar/modLauncher/ModLauncher"
+    )
+);
 
 export const STATIC_PANEL_BODY_MAP: Record<string, ReactNode> = {
   modLauncher: <ModLauncher />,


### PR DESCRIPTION
## What does this PR do?

- Part of #4000
- Lazy load sidebar content/modules as-needed to reduce de-facto memory footprint
- Puts the following sidebar content behind lazy load/suspense:
  - [x] Mod Launcher 
  - [x] Activate Mod panels
- Don't mount tab content in sidebar until they become active for first time
  - Mod Launcher: important because it hydrates modDefinitions slice and makes call to marketplace
  - Persistent Mod Panels (i.e., Sidebar Starter Brick): important because panels may re-import bootstrap, etc.

## Discussion

- Previously this PR also split out the Extension Console screens. See future work

## Remaining Work
 
- [x] Fix broken test: "can open a closed panel when mod launcher is available"
- [x] Fix background error when using close tab (seems related to default action on anchor?): https://www.loom.com/share/0b56e5890e1043de86aec7bf4efe736d?sid=bd28dbcb-995e-4a0c-ace9-d86b856fde70 -- I added a preventDefault on the close action
- [ ] Fix broken test on CI (is working locally): "Tabs › Mod Launcher › renders with mod launcher"

## Future Work

- The sidebar loads a lot of content into memory (e.g., complete Mod Definitions for all mods available to the user) that doesn't end up getting used
- Module split the Extension Console Screens. I was getting aa Chrome errors in the background for "Uncaught (in promise) Error: Cannot access contents of url "chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/options.html#/". Extension manifest must request permission to access this host." error. (This might be due to an automatic redirect?)

## Checklist

- [x] Add tests: N/A
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
