### PR TITLE
#6784: remove `js-beautify` from end-user content script

### DIFF
--- a/src/contentScript/pageEditor/elementPicker.ts
+++ b/src/contentScript/pageEditor/elementPicker.ts
@@ -25,10 +25,7 @@ import {
 import { compact, difference, uniq } from "lodash";
 import * as pageScript from "@/pageScript/messenger/api";
 import { type SelectMode } from "@/contentScript/pageEditor/types";
-import {
-  type SelectionHandlerType,
-  showSelectionToolPopover,
-} from "@/components/selectionToolPopover/SelectionToolPopover";
+import type { SelectionHandlerType } from "@/components/selectionToolPopover/SelectionToolPopover";
 import {
   BusinessError,
   CancelError,
@@ -36,7 +33,6 @@ import {
 } from "@/errors/businessErrors";
 import { FLOATING_ACTION_BUTTON_CONTAINER_ID } from "@/components/floatingActions/floatingActionsConstants";
 import { $safeFind, findSingleElement } from "@/utils/domUtils";
-import inferSingleElementSelector from "@/utils/inference/inferSingleElementSelector";
 import { type ElementInfo } from "@/utils/inference/selectorTypes";
 
 /**
@@ -102,6 +98,12 @@ export async function userSelectElement({
   isMulti: boolean;
   shouldSelectSimilar: boolean;
 }> {
+  // Dynamically import to avoid bloating the default content script for end-users
+  const { showSelectionToolPopover } = await import(
+    /* webpackChunkName: "selectionToolPopover" */
+    "@/components/selectionToolPopover/SelectionToolPopover"
+  );
+
   return new Promise<{
     elements: HTMLElement[];
     isMulti: boolean;

--- a/src/contentScript/pageEditor/elementPicker.ts
+++ b/src/contentScript/pageEditor/elementPicker.ts
@@ -25,7 +25,10 @@ import {
 import { compact, difference, uniq } from "lodash";
 import * as pageScript from "@/pageScript/messenger/api";
 import { type SelectMode } from "@/contentScript/pageEditor/types";
-import type { SelectionHandlerType } from "@/components/selectionToolPopover/SelectionToolPopover";
+import {
+  type SelectionHandlerType,
+  showSelectionToolPopover,
+} from "@/components/selectionToolPopover/SelectionToolPopover";
 import {
   BusinessError,
   CancelError,
@@ -98,12 +101,6 @@ export async function userSelectElement({
   isMulti: boolean;
   shouldSelectSimilar: boolean;
 }> {
-  // Dynamically import to avoid bloating the default content script for end-users
-  const { showSelectionToolPopover } = await import(
-    /* webpackChunkName: "selectionToolPopover" */
-    "@/components/selectionToolPopover/SelectionToolPopover"
-  );
-
   return new Promise<{
     elements: HTMLElement[];
     isMulti: boolean;

--- a/src/contentScript/pageEditor/elementPicker.ts
+++ b/src/contentScript/pageEditor/elementPicker.ts
@@ -36,6 +36,7 @@ import {
 } from "@/errors/businessErrors";
 import { FLOATING_ACTION_BUTTON_CONTAINER_ID } from "@/components/floatingActions/floatingActionsConstants";
 import { $safeFind, findSingleElement } from "@/utils/domUtils";
+import inferSingleElementSelector from "@/utils/inference/inferSingleElementSelector";
 import { type ElementInfo } from "@/utils/inference/selectorTypes";
 
 /**

--- a/src/contentScript/pageEditor/insertButton.tsx
+++ b/src/contentScript/pageEditor/insertButton.tsx
@@ -21,7 +21,6 @@ import { uuidv4 } from "@/types/helpers";
 import { userSelectElement } from "./elementPicker";
 import * as pageScript from "@/pageScript/messenger/api";
 import { findContainer } from "@/utils/inference/selectorInference";
-import { html as beautifyHTML } from "js-beautify";
 import { PRIVATE_ATTRIBUTES_SELECTOR } from "@/domConstants";
 import { type ButtonSelectionResult } from "@/contentScript/pageEditor/types";
 import { inferButtonHTML } from "@/utils/inference/markupInference";
@@ -31,6 +30,12 @@ const DEFAULT_ACTION_CAPTION = "Action";
 export async function insertButton(
   useNewFilter = false
 ): Promise<ButtonSelectionResult> {
+  // Dynamically import because it's a large package (130kb minified) that's only used by Page Editor
+  const { html: beautifyHTML } = await import(
+    /* webpackChunkName: "js-beautify" */
+    "js-beautify"
+  );
+
   let selected;
   if (useNewFilter) {
     const { elements } = await userSelectElement({

--- a/src/contentScript/pageEditor/insertPanel.tsx
+++ b/src/contentScript/pageEditor/insertPanel.tsx
@@ -21,17 +21,22 @@ import { uuidv4 } from "@/types/helpers";
 import { userSelectElement } from "./elementPicker";
 import * as pageScript from "@/pageScript/messenger/api";
 import { findContainer } from "@/utils/inference/selectorInference";
-import { html as beautifyHTML } from "js-beautify";
 import { type PanelSelectionResult } from "@/contentScript/pageEditor/types";
 import { inferPanelHTML } from "@/utils/inference/markupInference";
 
 const DEFAULT_PANEL_HEADING = "PixieBrix Panel";
 
 export async function insertPanel(): Promise<PanelSelectionResult> {
+  // Dynamically import because it's a large package (130kb minified) that's only used by Page Editor
+  const { html: beautifyHTML } = await import(
+    /* webpackChunkName: "js-beautify" */
+    "js-beautify"
+  );
+
   const { elements: selected } = await userSelectElement();
   const { container, selectors } = findContainer(selected);
 
-  const element: PanelSelectionResult = {
+  return {
     uuid: uuidv4(),
     panel: {
       heading: DEFAULT_PANEL_HEADING,
@@ -49,6 +54,4 @@ export async function insertPanel(): Promise<PanelSelectionResult> {
     },
     containerInfo: await pageScript.getElementInfo({ selector: selectors[0] }),
   };
-
-  return element;
 }

--- a/src/utils/inference/selectorInference.ts
+++ b/src/utils/inference/selectorInference.ts
@@ -17,7 +17,7 @@
 
 import { compact, identity, intersection, sortBy, uniq } from "lodash";
 import { getCssSelector } from "css-selector-generator";
-import { type CssSelectorType } from "css-selector-generator/types/types.js";
+import type { CssSelectorType } from "css-selector-generator/types/types.js";
 import {
   CONTENT_SCRIPT_READY_ATTRIBUTE,
   EXTENSION_POINT_DATA_ATTR,


### PR DESCRIPTION
## What does this PR do?

- Part of #6784 
- Dynamically import `js-beautify` so it's not included in the end-user content script. The library is 130kb minified

## Discussion

- The content script size is likely not the main source of problems. So we can be opportunistic in trimming down the size, but need to focus on investigating potential memory leaks, etc.

## Checklist

- [x] Add tests: N/A
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
