### PR TITLE
#6786: explicitly close IDB connections

### DIFF
--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -204,15 +204,24 @@ async function openTelemetryDB() {
 
 async function addEvent(event: UserTelemetryEvent): Promise<void> {
   const db = await openTelemetryDB();
-  await db.add(TELEMETRY_EVENT_OBJECT_STORE, event);
+
+  try {
+    await db.add(TELEMETRY_EVENT_OBJECT_STORE, event);
+  } finally {
+    db.close();
+  }
 }
 
 export async function flushEvents(): Promise<UserTelemetryEvent[]> {
   const db = await openTelemetryDB();
-  const tx = db.transaction(TELEMETRY_EVENT_OBJECT_STORE, "readwrite");
-  const allEvents = await tx.store.getAll();
-  await tx.store.clear();
-  return allEvents;
+  try {
+    const tx = db.transaction(TELEMETRY_EVENT_OBJECT_STORE, "readwrite");
+    const allEvents = await tx.store.getAll();
+    await tx.store.clear();
+    return allEvents;
+  } finally {
+    db.close();
+  }
 }
 
 /**
@@ -222,7 +231,8 @@ export async function recreateDB(): Promise<void> {
   await deleteDatabase(TELEMETRY_DB_NAME);
 
   // Open the database to recreate it
-  await openTelemetryDB();
+  const db = await openTelemetryDB();
+  db.close();
 }
 
 /**
@@ -230,7 +240,11 @@ export async function recreateDB(): Promise<void> {
  */
 export async function count(): Promise<number> {
   const db = await openTelemetryDB();
-  return db.count(TELEMETRY_EVENT_OBJECT_STORE);
+  try {
+    return await db.count(TELEMETRY_EVENT_OBJECT_STORE);
+  } finally {
+    db.close();
+  }
 }
 
 /**
@@ -238,7 +252,11 @@ export async function count(): Promise<number> {
  */
 export async function clear(): Promise<void> {
   const db = await openTelemetryDB();
-  await db.clear(TELEMETRY_EVENT_OBJECT_STORE);
+  try {
+    await db.clear(TELEMETRY_EVENT_OBJECT_STORE);
+  } finally {
+    db.close();
+  }
 }
 
 /**

--- a/src/telemetry/logging.test.ts
+++ b/src/telemetry/logging.test.ts
@@ -95,7 +95,8 @@ describe("logging", () => {
     await sweepLogs();
 
     await expect(count()).resolves.toBe(937);
-  });
+    // Increase timeout so test isn't flakey on CI due to slow append operation
+  }, 10_000);
 
   test("getLogEntries by blueprintId", async () => {
     const blueprintId = registryIdFactory();

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -549,7 +549,7 @@ async function _sweepLogs(): Promise<void> {
  */
 export const sweepLogs = memoizeUntilSettled(_sweepLogs);
 
-export function initLogSweep() {
+export function initLogSweep(): void {
   expectContext(
     "background",
     "Log sweep should only be initialized in the background page"

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -115,7 +115,7 @@ const indexKeys: IndexKey[] = [
   "authId",
 ];
 
-async function getDB() {
+async function openLoggingDB() {
   // Always return a new DB connection. IDB performance seems to be better than reusing the same connection.
   // https://stackoverflow.com/questions/21418954/is-it-bad-to-open-several-database-connections-in-indexeddb
   let database: IDBPDatabase<LogDB> | null = null;
@@ -169,8 +169,12 @@ async function getDB() {
  * @param entry the log entry to add
  */
 export async function appendEntry(entry: LogEntry): Promise<void> {
-  const db = await getDB();
-  await db.add(ENTRY_OBJECT_STORE, entry);
+  const db = await openLoggingDB();
+  try {
+    await db.add(ENTRY_OBJECT_STORE, entry);
+  } finally {
+    db.close();
+  }
 }
 
 function makeMatchEntry(
@@ -189,8 +193,12 @@ function makeMatchEntry(
  * Returns the number of log entries in the database.
  */
 export async function count(): Promise<number> {
-  const db = await getDB();
-  return db.count(ENTRY_OBJECT_STORE);
+  const db = await openLoggingDB();
+  try {
+    return await db.count(ENTRY_OBJECT_STORE);
+  } finally {
+    db.close();
+  }
 }
 
 /**
@@ -200,15 +208,20 @@ export async function recreateDB(): Promise<void> {
   await deleteDatabase(DATABASE_NAME);
 
   // Open the database to recreate it
-  await getDB();
+  const db = await openLoggingDB();
+  db.close();
 }
 
 /**
  * Clears all log entries from the database.
  */
 export async function clearLogs(): Promise<void> {
-  const db = await getDB();
-  await db.clear(ENTRY_OBJECT_STORE);
+  const db = await openLoggingDB();
+  try {
+    await db.clear(ENTRY_OBJECT_STORE);
+  } finally {
+    db.close();
+  }
 }
 
 /**
@@ -216,20 +229,24 @@ export async function clearLogs(): Promise<void> {
  * @param context the query context to clear.
  */
 export async function clearLog(context: MessageContext = {}): Promise<void> {
-  const db = await getDB();
+  const db = await openLoggingDB();
 
-  const tx = db.transaction(ENTRY_OBJECT_STORE, "readwrite");
+  try {
+    const tx = db.transaction(ENTRY_OBJECT_STORE, "readwrite");
 
-  if (isEmpty(context)) {
-    await tx.store.clear();
-    return;
-  }
-
-  const match = makeMatchEntry(context);
-  for await (const cursor of tx.store) {
-    if (match(cursor.value)) {
-      await cursor.delete();
+    if (isEmpty(context)) {
+      await tx.store.clear();
+      return;
     }
+
+    const match = makeMatchEntry(context);
+    for await (const cursor of tx.store) {
+      if (match(cursor.value)) {
+        await cursor.delete();
+      }
+    }
+  } finally {
+    db.close();
   }
 }
 
@@ -240,35 +257,40 @@ export async function clearLog(context: MessageContext = {}): Promise<void> {
 export async function getLogEntries(
   context: MessageContext = {}
 ): Promise<LogEntry[]> {
-  const db = await getDB();
-  const objectStore = db
-    .transaction(ENTRY_OBJECT_STORE, "readonly")
-    .objectStore(ENTRY_OBJECT_STORE);
+  const db = await openLoggingDB();
 
-  let indexKey: IndexKey;
-  for (const key of indexKeys) {
-    // eslint-disable-next-line security/detect-object-injection -- indexKeys is compile-time constant
-    if (context[key] != null) {
-      indexKey = key;
-      break;
+  try {
+    const objectStore = db
+      .transaction(ENTRY_OBJECT_STORE, "readonly")
+      .objectStore(ENTRY_OBJECT_STORE);
+
+    let indexKey: IndexKey;
+    for (const key of indexKeys) {
+      // eslint-disable-next-line security/detect-object-injection -- indexKeys is compile-time constant
+      if (context[key] != null) {
+        indexKey = key;
+        break;
+      }
     }
+
+    if (!indexKey) {
+      throw new Error(
+        "At least one of the known index keys must be set in the context to get logs"
+      );
+    }
+
+    // Use the index to do an initial filter on IDB, and then makeMatchEntry to apply the full filter in JS.
+    // eslint-disable-next-line security/detect-object-injection -- indexKeys is compile-time constant
+    const entries = await objectStore.index(indexKey).getAll(context[indexKey]);
+
+    const match = makeMatchEntry(context);
+    const matches = entries.filter((entry) => match(entry));
+
+    // Use both reverse and sortBy because we want insertion order if there's a tie in the timestamp
+    return sortBy(matches.reverse(), (x) => -Number.parseInt(x.timestamp, 10));
+  } finally {
+    db.close();
   }
-
-  if (!indexKey) {
-    throw new Error(
-      "At least one of the known index keys must be set in the context to get logs"
-    );
-  }
-
-  // Use the index to do an initial filter on IDB, and then makeMatchEntry to apply the full filter in JS.
-  // eslint-disable-next-line security/detect-object-injection -- indexKeys is compile-time constant
-  const entries = await objectStore.index(indexKey).getAll(context[indexKey]);
-
-  const match = makeMatchEntry(context);
-  const matches = entries.filter((entry) => match(entry));
-
-  // Use both reverse and sortBy because we want insertion order if there's a tie in the timestamp
-  return sortBy(matches.reverse(), (x) => -Number.parseInt(x.timestamp, 10));
 }
 
 /**
@@ -470,13 +492,18 @@ export async function setLoggingConfig(config: LoggingConfig): Promise<void> {
 export async function clearExtensionDebugLogs(
   extensionId: UUID
 ): Promise<void> {
-  const db = await getDB();
-  const tx = db.transaction(ENTRY_OBJECT_STORE, "readwrite");
-  const index = tx.store.index("extensionId");
-  for await (const cursor of index.iterate(extensionId)) {
-    if (cursor.value.level === "debug" || cursor.value.level === "trace") {
-      await cursor.delete();
+  const db = await openLoggingDB();
+
+  try {
+    const tx = db.transaction(ENTRY_OBJECT_STORE, "readwrite");
+    const index = tx.store.index("extensionId");
+    for await (const cursor of index.iterate(extensionId)) {
+      if (cursor.value.level === "debug" || cursor.value.level === "trace") {
+        await cursor.delete();
+      }
     }
+  } finally {
+    db.close();
   }
 }
 
@@ -494,20 +521,25 @@ async function _sweepLogs(): Promise<void> {
       numToDelete,
     });
 
-    const db = await getDB();
-    const tx = db.transaction(ENTRY_OBJECT_STORE, "readwrite");
+    const db = await openLoggingDB();
 
-    let deletedCount = 0;
+    try {
+      const tx = db.transaction(ENTRY_OBJECT_STORE, "readwrite");
 
-    // Ideally this would be ordered by timestamp to delete the oldest records, but timestamp is not an index.
-    // This might mostly "just work" if the cursor happens to iterate in insertion order
-    for await (const cursor of tx.store) {
-      await cursor.delete();
-      deletedCount++;
+      let deletedCount = 0;
 
-      if (deletedCount > numToDelete) {
-        return;
+      // Ideally this would be ordered by timestamp to delete the oldest records, but timestamp is not an index.
+      // This might mostly "just work" if the cursor happens to iterate in insertion order
+      for await (const cursor of tx.store) {
+        await cursor.delete();
+        deletedCount++;
+
+        if (deletedCount > numToDelete) {
+          return;
+        }
       }
+    } finally {
+      db.close();
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

- Part of #6786 
- Calls `db.close()` on all IDB methods to explicitly close the DB connection

## Discussion

- The close method knows how to wait for transactions to finish, so technically, we could call it without using finally in some methods: https://buildandexecute.blogspot.com/2015/07/close-connections-to-your-indexeddb.html
- This should also allow the associated events to be GC'd
- Our tests might be running slow on CI due to the memory leak:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/67b218eb-363c-4104-b716-db977c37c533)


## Demo

1.8.2-beta.2: After restarting, and clicking around to the Extension Console/Sidebar/Quick Bar:
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/3514d11c-a54f-49a8-8c80-f459713d1643)

After (Local)
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/4d6aceb7-dbb7-4731-852a-0ecc3d5bf47a)

## Future Work

- Rewrite using the new `using` operator: https://github.com/pixiebrix/pixiebrix-extension/pull/6788#issuecomment-1788265108. NOTE: can't destructure in binding pattern: https://github.com/microsoft/TypeScript/issues/55527
- Speed up composite DB operations by using a single DB connection

## Checklist

- [x] Add tests: N/A
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
