### PR TITLE
#6797 - Drop console logs using TerserPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -330,6 +330,9 @@ module.exports = (env, options) =>
         new TerserPlugin({
           parallel: true,
           terserOptions: {
+            compress: {
+              drop_console: true,
+            },
             // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
             // Keep error classnames because we perform name comparison (see selectSpecificError)
             // We use Action for SubmitPanelAction, AbortPanelAction, etc.


### PR DESCRIPTION
## What does this PR do?
- Adds a setting to TerserPlugin to strip console logs from production builds

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [ ] Designate a primary reviewer
