### PR TITLE
Enable `drop_console` in TerserPlugin, and fix first-class usages in code

### DIFF
--- a/src/background/contentScript.ts
+++ b/src/background/contentScript.ts
@@ -26,8 +26,15 @@ import {
 } from "@/contentScript/ready";
 import { memoizeUntilSettled } from "@/utils/promiseUtils";
 import { type Runtime } from "webextension-polyfill";
+import { noop } from "lodash";
 
-const debug = console.debug.bind(console, "ensureContentScript:");
+// CAUTION: We need to account for console.* to possibly be stripped out
+// const debug = console.debug ? console.debug.bind(console, "ensureContentScript:") : noop;
+function debug(...args: any[]) {
+  const log = console.debug ?? noop;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log("ensureContentScript:", ...args);
+}
 
 /**
  * @see makeSenderKey

--- a/src/bricks/effects/logger.ts
+++ b/src/bricks/effects/logger.ts
@@ -19,14 +19,16 @@ import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { propertiesToSchema } from "@/validators/generic";
+import { noop } from "lodash";
 
 type Level = "debug" | "info" | "warn" | "error";
 
-const LEVEL_MAP = new Map<Level, typeof console.debug>([
-  ["debug", console.debug],
-  ["warn", console.warn],
-  ["info", console.info],
-  ["error", console.error],
+// CAUTION: We need to account for console.* to possibly be stripped out
+const LEVEL_MAP = new Map<Level, (...data: any[]) => void>([
+  ["debug", console.debug ?? noop],
+  ["warn", console.warn ?? noop],
+  ["info", console.info ?? noop],
+  ["error", console.error ?? noop],
 ]);
 
 export class LogEffect extends EffectABC {
@@ -67,7 +69,8 @@ export class LogEffect extends EffectABC {
     }: BrickArgs<{ message: string; level: Level; data: unknown }>,
     { ctxt }: BrickOptions
   ): Promise<void> {
-    const logMethod = LEVEL_MAP.get(level) ?? console.info;
+    // CAUTION: We need to account for console.* to possibly be stripped out
+    const logMethod = LEVEL_MAP.get(level) ?? console.info ?? noop;
     logMethod(message, data ?? ctxt);
   }
 }

--- a/src/utils/postMessage.ts
+++ b/src/utils/postMessage.ts
@@ -44,7 +44,10 @@ type Payload = JsonValue;
 // Disable logging by default
 let log = (...args: unknown[]) => {};
 void messengerLogging.get().then((setting) => {
-  log = setting ? console.debug : () => {};
+  // CAUTION: We need to account for console.* to possibly be stripped out
+  if (console.debug) {
+    log = setting ? console.debug : () => {};
+  }
 });
 
 export type RequestPacket = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -330,6 +330,9 @@ module.exports = (env, options) =>
         new TerserPlugin({
           parallel: true,
           terserOptions: {
+            compress: {
+              drop_console: true,
+            },
             // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
             // Keep error classnames because we perform name comparison (see selectSpecificError)
             // We use Action for SubmitPanelAction, AbortPanelAction, etc.


### PR DESCRIPTION
## What does this PR do?

- Enables the setting for `TerserPlugin` to strip out usages of `console.*`
  - This essentially turns `console` into an empty object
- Fixes any call-sites where this causes NPE due to referencing `console.*` in a "first-class function" way

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [ ] Designate a primary reviewer
