### PR TITLE
#6804: debounce sidebar panels independently

### DIFF
--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -295,13 +295,13 @@ const Tabs: React.FC = () => {
         >
           {panels.map((panel: PanelEntry) => (
             <Tab.Pane
-              // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/6801
-              // PERFORMANCE: for memory footprint, ideally we'd not mount the mod panels unless the 1) tab is open
-              // for the panel, and 2) the user has opened the panel. However, that currently breaks the lifecycle
-              // of some panels and also the label that appears in the Mod Launcher (Because the header for the panel
-              // might be null.)
-              mountOnEnter={false}
-              // Keep tab state, otherwise use will lose local state when a temporary panel/form is added
+              // For memory performance, only mount the panel when the tab is 1) visible for the panel, the 2) the user
+              // has opened the panel. The panel's header/payload will still be calculated in the sidebar starter brick,
+              // but we'll save on memory footprint from any embedded content.
+              // For context, see https://github.com/pixiebrix/pixiebrix-extension/issues/6801
+              mountOnEnter={true}
+              // Keep tab state, otherwise use will lose local state when a temporary panel/form is added, e.g.,
+              // un-submitted form state/scroll position
               unmountOnExit={false}
               className={cx("full-height flex-grow", styles.paneOverrides)}
               key={panel.extensionId}

--- a/src/starterBricks/helpers.ts
+++ b/src/starterBricks/helpers.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { castArray, noop, once, stubFalse } from "lodash";
+import { castArray, noop, once } from "lodash";
 import initialize from "@/vendors/initialize";
 import { EXTENSION_POINT_DATA_ATTR } from "@/domConstants";
 import {
@@ -232,18 +232,23 @@ export function selectExtensionContext(
   };
 }
 
-export function makeShouldRunExtensionForStateChange(
+/**
+ * Returns true if the ModComponent should run for the given state change event.
+ */
+export function shouldModComponentRunForStateChange(
+  modComponent: ModComponentBase,
   event: Event
-): (extension: ModComponentBase) => boolean {
+): boolean {
   if (event instanceof CustomEvent) {
     const { detail } = event;
 
     // Ignore state changes from shared state and unrelated extensions/blueprints
-    return (extension: ModComponentBase) =>
-      detail?.extensionId === extension.id ||
-      (extension._recipe?.id != null &&
-        extension._recipe?.id === detail?.blueprintId);
+    return (
+      detail?.extensionId === modComponent.id ||
+      (modComponent._recipe?.id != null &&
+        modComponent._recipe?.id === detail?.blueprintId)
+    );
   }
 
-  return stubFalse;
+  return false;
 }

--- a/src/starterBricks/sidebarExtension.test.ts
+++ b/src/starterBricks/sidebarExtension.test.ts
@@ -252,10 +252,9 @@ describe("sidebarExtension", () => {
     $(document.body).append(`<div id="${PANEL_FRAME_ID}"></div>`);
     sidebarShowEvents.emit({ reason: RunReason.MANUAL });
 
-    await sleep(debounceMillis);
     await tick();
 
-    // Runs because statechange mods also run on manual
+    // Runs immediately because it's the first run
     expect(rootReader.readCount).toBe(1);
 
     for (let i = 0; i < 10; i++) {

--- a/src/starterBricks/sidebarExtension.test.ts
+++ b/src/starterBricks/sidebarExtension.test.ts
@@ -20,7 +20,11 @@ import { type StarterBrickConfig } from "@/starterBricks/types";
 import { validateRegistryId } from "@/types/helpers";
 import { type Metadata } from "@/types/registryTypes";
 import { type ResolvedModComponent } from "@/types/modComponentTypes";
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import {
+  autoUUIDSequence,
+  registryIdFactory,
+  uuidSequence,
+} from "@/testUtils/factories/stringFactories";
 import { type BrickPipeline } from "@/bricks/types";
 import {
   fromJS,
@@ -28,8 +32,16 @@ import {
   type SidebarDefinition,
 } from "@/starterBricks/sidebarExtension";
 import { RunReason } from "@/types/runtimeTypes";
-import { RootReader } from "@/starterBricks/starterBrickTestUtils";
-import { getReservedPanelEntries } from "@/contentScript/sidebarController";
+import { RootReader, tick } from "@/starterBricks/starterBrickTestUtils";
+import {
+  getReservedPanelEntries,
+  sidebarShowEvents,
+} from "@/contentScript/sidebarController";
+import { setPageState } from "@/contentScript/pageState";
+import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
+import { PANEL_FRAME_ID } from "@/domConstants";
+import brickRegistry from "@/bricks/registry";
+import { sleep } from "@/utils/timeUtils";
 
 const rootReader = new RootReader();
 
@@ -67,6 +79,12 @@ const extensionFactory = define<ResolvedModComponent<SidebarConfig>>({
 });
 
 describe("sidebarExtension", () => {
+  beforeEach(() => {
+    brickRegistry.clear();
+    brickRegistry.register([rootReader]);
+    rootReader.readCount = 0;
+  });
+
   it("reserves panel on load", async () => {
     const extensionPoint = fromJS(starterBrickFactory()());
 
@@ -136,6 +154,124 @@ describe("sidebarExtension", () => {
 
     // Synchronize removes the panel
     expect(getReservedPanelEntries().panels).toHaveLength(0);
+
+    extensionPoint.uninstall();
+  });
+
+  it("runs non-debounced state change trigger", async () => {
+    const extensionPoint = fromJS(
+      starterBrickFactory({
+        trigger: "statechange",
+      })()
+    );
+
+    const extension = extensionFactory({
+      extensionPointId: extensionPoint.id,
+      _recipe: modMetadataFactory(),
+    });
+
+    extensionPoint.registerModComponent(extension);
+
+    await extensionPoint.install();
+
+    expect(rootReader.readCount).toBe(0);
+
+    setPageState({
+      namespace: "blueprint",
+      data: {},
+      mergeStrategy: "replace",
+      extensionId: extension.id,
+      blueprintId: extension._recipe.id,
+    });
+
+    // Doesn't run because sidebar is not visible
+    expect(rootReader.readCount).toBe(0);
+
+    // Fake the sidebar being added to the page
+    $(document.body).append(`<div id="${PANEL_FRAME_ID}"></div>`);
+    sidebarShowEvents.emit({ reason: RunReason.MANUAL });
+
+    await tick();
+
+    // Runs because statechange mods also run on manual
+    expect(rootReader.readCount).toBe(1);
+
+    setPageState({
+      namespace: "blueprint",
+      // Data needs to be different than previous to trigger a state change event
+      data: { foo: 42 },
+      mergeStrategy: "replace",
+      extensionId: extension.id,
+      blueprintId: extension._recipe.id,
+    });
+
+    await tick();
+
+    expect(rootReader.readCount).toBe(2);
+
+    // Should ignore state change from other mod
+    setPageState({
+      namespace: "blueprint",
+      data: {},
+      mergeStrategy: "replace",
+      extensionId: autoUUIDSequence(),
+      blueprintId: registryIdFactory(),
+    });
+
+    await tick();
+
+    expect(rootReader.readCount).toBe(2);
+
+    extensionPoint.uninstall();
+  });
+
+  it("debounces the statechange trigger", async () => {
+    // :shrug: would be better to use fake timers here
+    const debounceMillis = 100;
+
+    const extensionPoint = fromJS(
+      starterBrickFactory({
+        trigger: "statechange",
+        debounce: {
+          waitMillis: debounceMillis,
+          trailing: true,
+        },
+      })()
+    );
+
+    const extension = extensionFactory({
+      extensionPointId: extensionPoint.id,
+      _recipe: modMetadataFactory(),
+    });
+
+    extensionPoint.registerModComponent(extension);
+
+    await extensionPoint.install();
+
+    // Fake the sidebar being added to the page
+    $(document.body).append(`<div id="${PANEL_FRAME_ID}"></div>`);
+    sidebarShowEvents.emit({ reason: RunReason.MANUAL });
+
+    await sleep(debounceMillis);
+    await tick();
+
+    // Runs because statechange mods also run on manual
+    expect(rootReader.readCount).toBe(1);
+
+    for (let i = 0; i < 10; i++) {
+      setPageState({
+        namespace: "blueprint",
+        data: { foo: i },
+        mergeStrategy: "replace",
+        extensionId: extension.id,
+        blueprintId: extension._recipe.id,
+      });
+    }
+
+    await sleep(debounceMillis);
+    await tick();
+
+    expect(rootReader.readCount).toBe(2);
 
     extensionPoint.uninstall();
   });

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -329,9 +329,9 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
           }
 
           await debounced(modComponent);
+        } else {
+          await this.refreshComponentPanel(modComponent);
         }
-
-        await this.refreshComponentPanel(modComponent);
       })
     );
   }

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -316,7 +316,9 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
 
           let debounced = this.debouncedRefreshPanel.get(modComponent.id);
 
-          if (!debounced) {
+          if (debounced) {
+            await debounced(modComponent);
+          } else {
             // ModComponents are debounced on separate schedules because some ModComponents may ignore certain events
             // for performance (e.g., ModComponents ignore state change events from other mods.)
             debounced = debounce(
@@ -326,9 +328,11 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
               options
             );
             this.debouncedRefreshPanel.set(modComponent.id, debounced);
-          }
 
-          await debounced(modComponent);
+            // On the first run, run immediately so that the panel doesn't show a loading indicator during the
+            // debounce interval
+            await this.refreshComponentPanel(modComponent);
+          }
         } else {
           await this.refreshComponentPanel(modComponent);
         }

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -29,7 +29,6 @@ import {
 } from "@/starterBricks/types";
 import { type Permissions } from "webextension-polyfill";
 import { checkAvailable } from "@/bricks/available";
-import notify from "@/utils/notify";
 import {
   removeExtensionPoint,
   removeExtensions,
@@ -42,10 +41,10 @@ import Mustache from "mustache";
 import { uuidv4 } from "@/types/helpers";
 import { HeadlessModeError } from "@/bricks/errors";
 import {
-  makeShouldRunExtensionForStateChange,
   selectExtensionContext,
+  shouldModComponentRunForStateChange,
 } from "@/starterBricks/helpers";
-import { cloneDeep, debounce, remove, stubTrue } from "lodash";
+import { cloneDeep, debounce, remove } from "lodash";
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { selectAllBlocks } from "@/bricks/util";
@@ -55,10 +54,7 @@ import { NoRendererError } from "@/errors/businessErrors";
 import { serializeError } from "serialize-error";
 import { isSidebarFrameVisible } from "@/contentScript/sidebarDomControllerLite";
 import { type Schema } from "@/types/schemaTypes";
-import {
-  type ModComponentBase,
-  type ResolvedModComponent,
-} from "@/types/modComponentTypes";
+import { type ResolvedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type JsonObject } from "type-fest";
 import { type UUID } from "@/types/stringTypes";
@@ -88,9 +84,28 @@ export type Trigger =
 export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConfig> {
   abstract get trigger(): Trigger;
 
+  /**
+   * Options for the `custom` trigger, if applicable.
+   */
+  abstract get customTriggerOptions(): CustomEventOptions;
+
+  /**
+   * Debounce options for the trigger.
+   *
+   * Since 1.8.2, debounce is applied per Mod Component to account for page state change events only applying to a
+   * subset of the ModComponents.
+   */
   abstract get debounceOptions(): DebounceOptions;
 
-  abstract get customTriggerOptions(): CustomEventOptions;
+  /**
+   * Map from ModComponent to debounce refresh function, so each ModComponent can be debounced independently.
+   * @private
+   */
+  // Include ModComponent in the body so the method doesn't retain a reference to the ModComponent in the closure
+  private readonly debouncedRefreshPanel = new Map<
+    UUID,
+    (modComponent: ResolvedModComponent<SidebarConfig>) => Promise<void>
+  >();
 
   readonly permissions: Permissions.Permissions = {};
 
@@ -100,6 +115,10 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
    */
   private abortController = new AbortController();
 
+  /**
+   * True if the starter brick has already installed event listeners for the trigger event, if applicable
+   * @private
+   */
   private installedListeners = false;
 
   inputSchema: Schema = propertiesToSchema(
@@ -122,7 +141,8 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   );
 
   // Historical context: in the browser API, the toolbar icon is bound to an action. This is a panel that's shown
-  // when the user toggles the toolbar icon. Hence: actionPanel
+  // when the user toggles the toolbar icon. Hence: actionPanel.
+  // See https://developer.chrome.com/docs/extensions/reference/browserAction/
   public get kind(): "actionPanel" {
     return "actionPanel";
   }
@@ -163,31 +183,31 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     sidebarShowEvents.remove(this.runModComponents);
   }
 
-  private async runExtension(
+  private async runModComponent(
     readerContext: JsonObject,
-    extension: ResolvedModComponent<SidebarConfig>
-  ) {
+    modComponent: ResolvedModComponent<SidebarConfig>
+  ): Promise<void> {
     // Generate our own run id so that we know it (to pass to upsertPanel)
     const runId = uuidv4();
 
-    const extensionLogger = this.logger.childLogger(
-      selectExtensionContext(extension)
+    const componentLogger = this.logger.childLogger(
+      selectExtensionContext(modComponent)
     );
 
     const serviceContext = await makeServiceContextFromDependencies(
-      extension.integrationDependencies
+      modComponent.integrationDependencies
     );
     const extensionContext = { ...readerContext, ...serviceContext };
 
-    const { heading: rawHeading, body } = extension.config;
+    const { heading: rawHeading, body } = modComponent.config;
 
     const heading = Mustache.render(rawHeading, extensionContext);
 
-    updateHeading(extension.id, heading);
+    updateHeading(modComponent.id, heading);
 
     const initialValues: InitialValues = {
       input: readerContext,
-      optionsArgs: extension.optionsArgs,
+      optionsArgs: modComponent.optionsArgs,
       root: document,
       serviceContext,
     };
@@ -202,8 +222,8 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     try {
       await reduceExtensionPipeline(body, initialValues, {
         headless: true,
-        logger: extensionLogger,
-        ...apiVersionOptions(extension.apiVersion),
+        logger: componentLogger,
+        ...apiVersionOptions(modComponent.apiVersion),
         runId,
       });
       // We're expecting a HeadlessModeError (or other error) to be thrown in the line above
@@ -211,14 +231,14 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       throw new NoRendererError();
     } catch (error) {
       const ref = {
-        extensionId: extension.id,
+        extensionId: modComponent.id,
         extensionPointId: this.id,
-        blueprintId: extension._recipe?.id,
+        blueprintId: modComponent._recipe?.id,
       };
 
       const meta = {
         runId,
-        extensionId: extension.id,
+        extensionId: modComponent.id,
       };
 
       if (error instanceof HeadlessModeError) {
@@ -230,7 +250,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
           ...meta,
         });
       } else {
-        extensionLogger.error(error);
+        componentLogger.error(error);
         upsertPanel(ref, heading, {
           key: uuidv4(),
           error: serializeError(error),
@@ -239,57 +259,6 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       }
     }
   }
-
-  /**
-   * DO NOT CALL DIRECTLY - call debouncedRefreshPanels
-   */
-  private readonly refreshPanels = async ({
-    shouldRunExtension = stubTrue,
-  }: {
-    shouldRunExtension?: (extension: ModComponentBase) => boolean;
-  }): Promise<void> => {
-    const extensionsToRefresh = this.modComponents.filter((extension) =>
-      shouldRunExtension(extension)
-    );
-
-    if (extensionsToRefresh.length === 0) {
-      // Skip overhead of calling reader if no extensions should run
-      return;
-    }
-
-    const reader = await this.defaultReader();
-
-    const readerContext = await reader.read(document);
-
-    const errors: unknown[] = [];
-
-    // OK to run in parallel because we've fixed the order the panels appear in reservePanels
-    await Promise.all(
-      extensionsToRefresh.map(async (extension) => {
-        try {
-          await this.runExtension(readerContext, extension);
-        } catch (error) {
-          errors.push(error);
-          this.logger
-            .childLogger({
-              deploymentId: extension._deployment?.id,
-              extensionId: extension.id,
-            })
-            .error(error);
-        }
-      })
-    );
-
-    if (errors.length > 0) {
-      notify.error(`An error occurred adding ${errors.length} panels(s)`);
-    }
-  };
-
-  /**
-   * Refresh all panels for the StarterBrick
-   * @private
-   */
-  private debouncedRefreshPanels = this.refreshPanels; // Default to un-debounced
 
   addCancelHandler(callback: () => void): void {
     this.abortController.signal.addEventListener("abort", callback);
@@ -306,17 +275,93 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   }
 
   /**
-   * Shared event handler for DOM event triggers
+   * Calculate/refresh the content for a single panel.
+   * DO NOT CALL DIRECTLY
+   * @see debouncedRefreshPanels
+   * @private
+   */
+  private async refreshComponentPanel(
+    modComponent: ResolvedModComponent<SidebarConfig>
+  ): Promise<void> {
+    // Read per-panel, because panels might be debounced on different schedules.
+    const reader = await this.defaultReader();
+    const readerContext = await reader.read(document);
+
+    try {
+      await this.runModComponent(readerContext, modComponent);
+    } catch (error) {
+      this.logger
+        .childLogger({
+          deploymentId: modComponent._deployment?.id,
+          blueprintId: modComponent._recipe?.id,
+          extensionId: modComponent.id,
+        })
+        .error(error);
+    }
+  }
+
+  /**
+   * Run/refresh the specified mod components, debouncing if applicable.
+   * @param componentsToRun the mod components to run
+   * @private
+   */
+  private async debouncedRefreshPanels(
+    componentsToRun: Array<ResolvedModComponent<SidebarConfig>>
+  ): Promise<void> {
+    // Order doesn't matter because panel positions are already reserved
+    await Promise.all(
+      componentsToRun.map(async (modComponent) => {
+        if (this.debounceOptions?.waitMillis) {
+          const { waitMillis, ...options } = this.debounceOptions;
+
+          let debounced = this.debouncedRefreshPanel.get(modComponent.id);
+
+          if (!debounced) {
+            // ModComponents are debounced on separate schedules because some ModComponents may ignore certain events
+            // for performance (e.g., ModComponents ignore state change events from other mods.)
+            debounced = debounce(
+              async (x: ResolvedModComponent<SidebarConfig>) =>
+                this.refreshComponentPanel(x),
+              waitMillis,
+              options
+            );
+            this.debouncedRefreshPanel.set(modComponent.id, debounced);
+          }
+
+          await debounced(modComponent);
+        }
+
+        await this.refreshComponentPanel(modComponent);
+      })
+    );
+  }
+
+  /**
+   * Shared event handler for DOM event triggers.
    */
   private readonly eventHandler: JQuery.EventHandler<unknown> = async (
     event
-  ) => {
-    await this.debouncedRefreshPanels({
-      shouldRunExtension:
-        this.trigger === "statechange"
-          ? makeShouldRunExtensionForStateChange(event.originalEvent)
-          : stubTrue,
-    });
+  ): Promise<void> => {
+    let relevantModComponents;
+
+    switch (this.trigger) {
+      case "statechange": {
+        // For performance, only run mod components that could be impacted by the state change.
+        // Perform the check _before_ debounce, so that the debounce timer is not impacted by state from other mods.
+        // See https://github.com/pixiebrix/pixiebrix-extension/issues/6804 for more details/considerations.
+        relevantModComponents = this.modComponents.filter((modComponent) =>
+          shouldModComponentRunForStateChange(modComponent, event.originalEvent)
+        );
+        break;
+      }
+
+      default: {
+        relevantModComponents = this.modComponents;
+        break;
+      }
+    }
+
+    await this.debouncedRefreshPanels(relevantModComponents);
   };
 
   private attachEventTrigger(eventName: string): void {
@@ -381,9 +426,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
         RunReason.PAGE_EDITOR,
       ].includes(reason)
     ) {
-      void this.debouncedRefreshPanels({
-        shouldRunExtension: stubTrue,
-      });
+      void this.debouncedRefreshPanels(this.modComponents);
     }
 
     if (!this.installedListeners) {
@@ -430,15 +473,6 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       sidebarShowEvents.add(this.runModComponents);
     } else {
       removeExtensionPoint(this.id);
-    }
-
-    if (this.debounceOptions?.waitMillis) {
-      const { waitMillis, ...options } = this.debounceOptions;
-      this.debouncedRefreshPanels = debounce(
-        this.refreshPanels,
-        waitMillis,
-        options
-      );
     }
 
     return available;


### PR DESCRIPTION
## What does this PR do?

- Closes #6804 
- Closes #6801 
- Fixes a bug where state changes in another mod could denial of service the state change trigger for a sidebar
- Moves the statechange event filter outside the debounce
- Modifies the sidebar starter brick to debounce each mod component separately
- Re-introduces `mountOnEnter` for sidebar panels in the sidebar to improve memory footprint when a panel isn't visible

## Discussion

- To enable the change, the "read" for the starter brick is now performed per mod component instead of once per trigger. I don't think there's a simple way around that because mod components are now independently debounced
- I was also considering keeping a single debounce for the starter brick, but only running the debounced refresh if _any_ mod component needed to be updated. That wouldn't completely fix the problem, though, in all cases

## Demo

- _Paste a screenshot or demo video here_

## Future Work

- In the content script, sidebar panels are still run if their tab is closed in the sidebar. Fixing this would involve: introduce better shared tracking between the content script and sidebar

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @BLoe 
