### PR TITLE
#6815: Add timeout to Jest tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-
+    # The tests currently take ~16 minutes to run. Anything longer is probably due to a flaky test.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/src/testUtils/testEnv.js
+++ b/src/testUtils/testEnv.js
@@ -24,8 +24,11 @@ import "urlpattern-polyfill";
 process.env.SERVICE_URL = "https://app.pixiebrix.com";
 process.env.MARKETPLACE_URL = "https://www.pixiebrix.com/marketplace/";
 
+// Drop after https://github.com/jsdom/jsdom/issues/2524
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+
+// TODO: Drop after https://github.com/jsdom/jsdom/issues/2401
 global.PromiseRejectionEvent = class PromiseRejectionEvent extends Event {
   constructor(type, init) {
     super(type);


### PR DESCRIPTION
## What does this PR do?

- For #6815

CI may start failing and stall for hours. I think that it should have a timeout, even if this specific issue is eventually resolved.

## Checklist

- [x] Designate a primary reviewer: @mnholtz 
