### PR TITLE
Extend production build retention

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
           name: build-production
           directory: dist
           exclusions: "*.map"
-          retention-days: 5
+          retention-days: 30
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
         env:


### PR DESCRIPTION
## What does this PR do?

- Extends the retention of release builds from 5 days to 30
- Requested by @MMirandi to make it easier to test/install releases

## Checklist

- [x] Designate a primary reviewer @mnholtz 
