### PR TITLE
#6897: add page editor link to template gallery

### DIFF
--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -26,6 +26,7 @@ export const cancelTemporaryPanel = getNotifier("TEMPORARY_PANEL_CANCEL");
 export const closeTemporaryPanel = getNotifier("TEMPORARY_PANEL_CLOSE");
 export const resolveTemporaryPanel = getNotifier("TEMPORARY_PANEL_RESOLVE");
 export const queueReactivateTab = getNotifier("QUEUE_REACTIVATE_TAB");
+export const navigateTab = getNotifier("NAVIGATE_TAB");
 export const reactivateTab = getNotifier("REACTIVATE_TAB");
 export const ensureExtensionPointsInstalled = getMethod(
   "ENSURE_EXTENSION_POINTS_INSTALLED"

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -54,6 +54,7 @@ import {
   runBlockPreview,
   resetTab,
   runRendererBlock,
+  navigateTab,
 } from "@/contentScript/pageEditor";
 import { checkAvailable } from "@/bricks/available";
 import notify from "@/utils/notify";
@@ -93,6 +94,7 @@ declare global {
     REACTIVATE_TAB: typeof reactivateTab;
     REMOVE_INSTALLED_EXTENSION: typeof removePersistedExtension;
 
+    NAVIGATE_TAB: typeof navigateTab;
     RESET_TAB: typeof resetTab;
 
     TOGGLE_QUICK_BAR: typeof toggleQuickBar;
@@ -158,6 +160,7 @@ export default function registerMessenger(): void {
     REMOVE_INSTALLED_EXTENSION: removePersistedExtension,
     GET_RESERVED_SIDEBAR_ENTRIES: getReservedPanelEntries,
     RESET_TAB: resetTab,
+    NAVIGATE_TAB: navigateTab,
 
     TOGGLE_QUICK_BAR: toggleQuickBar,
     HANDLE_MENU_ACTION: handleMenuAction,

--- a/src/contentScript/pageEditor.ts
+++ b/src/contentScript/pageEditor.ts
@@ -248,3 +248,11 @@ export async function resetTab(): Promise<void> {
   await clearDynamicElements({});
   await reactivateTab();
 }
+
+/**
+ * Navigate to the given URL.
+ * @param url the url to navigate to
+ */
+export async function navigateTab({ url }: { url: string }): Promise<void> {
+  window.location.href = url;
+}

--- a/src/pageEditor/sidebar/AddStarterBrickButton.tsx
+++ b/src/pageEditor/sidebar/AddStarterBrickButton.tsx
@@ -29,6 +29,9 @@ import { flagOn } from "@/auth/authUtils";
 import useAsyncState from "@/hooks/useAsyncState";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { navigateTab } from "@/contentScript/messenger/api";
+import reportEvent from "@/telemetry/reportEvent";
+import { Events } from "@/telemetry/events";
+import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 
 const sortedStarterBricks = sortBy(
   [...ADAPTERS.values()],
@@ -57,6 +60,7 @@ const DropdownEntry: React.FunctionComponent<{
 
 const AddStarterBrickButton: React.FunctionComponent = () => {
   const tabHasPermissions = useSelector(selectTabHasPermissions);
+  const sessionId = useSelector(selectSessionId);
 
   const addElement = useAddElement();
 
@@ -102,6 +106,9 @@ const AddStarterBrickButton: React.FunctionComponent = () => {
       <Dropdown.Divider />
       <Dropdown.Item
         onClick={() => {
+          reportEvent(Events.PAGE_EDITOR_VIEW_TEMPLATES, {
+            sessionId,
+          });
           navigateTab(thisTab, {
             url: "https://www.pixiebrix.com/templates-gallery?utm_source=pixiebrix&utm_medium=page_editor",
           });

--- a/src/pageEditor/sidebar/AddStarterBrickButton.tsx
+++ b/src/pageEditor/sidebar/AddStarterBrickButton.tsx
@@ -110,7 +110,7 @@ const AddStarterBrickButton: React.FunctionComponent = () => {
             sessionId,
           });
           navigateTab(thisTab, {
-            url: "https://www.pixiebrix.com/templates-gallery?utm_source=pixiebrix&utm_medium=page_editor",
+            url: "https://www.pixiebrix.com/templates-gallery?utm_source=pixiebrix&utm_medium=page_editor&utm_campaign=starter_brick_menu",
           });
         }}
       >

--- a/src/pageEditor/sidebar/AddStarterBrickButton.tsx
+++ b/src/pageEditor/sidebar/AddStarterBrickButton.tsx
@@ -23,11 +23,14 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { sortBy } from "lodash";
 import useAddElement from "@/pageEditor/hooks/useAddElement";
 import { useSelector } from "react-redux";
+import { thisTab } from "@/pageEditor/utils";
 import { selectTabHasPermissions } from "@/pageEditor/tabState/tabStateSelectors";
-import { useAsyncState } from "@/hooks/common";
 import { flagOn } from "@/auth/authUtils";
+import useAsyncState from "@/hooks/useAsyncState";
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+import { navigateTab } from "@/contentScript/messenger/api";
 
-const sortedExtensionPoints = sortBy(
+const sortedStarterBricks = sortBy(
   [...ADAPTERS.values()],
   (x) => x.displayOrder
 );
@@ -52,43 +55,39 @@ const DropdownEntry: React.FunctionComponent<{
   </Dropdown.Item>
 );
 
-const AddExtensionPointButton: React.FunctionComponent = () => {
+const AddStarterBrickButton: React.FunctionComponent = () => {
   const tabHasPermissions = useSelector(selectTabHasPermissions);
 
   const addElement = useAddElement();
 
-  const [entries] = useAsyncState<React.ReactNode>(
-    async () => {
-      const results = await Promise.all(
-        sortedExtensionPoints.map(async (config) => {
-          if (!config.flag) {
-            return true;
-          }
+  const { data: entries = [] } = useAsyncState<React.ReactNode>(async () => {
+    const results = await Promise.all(
+      sortedStarterBricks.map(async (config) => {
+        if (!config.flag) {
+          return true;
+        }
 
-          return flagOn(config.flag);
-        })
-      );
+        return flagOn(config.flag);
+      })
+    );
 
-      return (
-        sortedExtensionPoints
-          // eslint-disable-next-line security/detect-object-injection -- array index
-          .filter((_, index) => results[index])
-          .map((config) => (
-            <DropdownEntry
-              key={config.elementType}
-              caption={config.label}
-              icon={config.icon}
-              beta={Boolean(config.flag)}
-              onClick={() => {
-                addElement(config);
-              }}
-            />
-          ))
-      );
-    },
-    [],
-    []
-  );
+    return (
+      sortedStarterBricks
+        // eslint-disable-next-line security/detect-object-injection -- array index
+        .filter((_, index) => results[index])
+        .map((config) => (
+          <DropdownEntry
+            key={config.elementType}
+            caption={config.label}
+            icon={config.icon}
+            beta={Boolean(config.flag)}
+            onClick={() => {
+              addElement(config);
+            }}
+          />
+        ))
+    );
+  }, []);
 
   return (
     <DropdownButton
@@ -96,11 +95,23 @@ const AddExtensionPointButton: React.FunctionComponent = () => {
       variant="info"
       size="sm"
       title="Add"
-      id="add-extension-point"
+      id="add-starter-brick"
     >
       {entries}
+
+      <Dropdown.Divider />
+      <Dropdown.Item
+        onClick={() => {
+          navigateTab(thisTab, {
+            url: "https://www.pixiebrix.com/templates-gallery?utm_source=pixiebrix&utm_medium=page_editor",
+          });
+        }}
+      >
+        <FontAwesomeIcon icon={faExternalLinkAlt} fixedWidth />
+        &nbsp;Start with a Template
+      </Dropdown.Item>
     </DropdownButton>
   );
 };
 
-export default AddExtensionPointButton;
+export default AddStarterBrickButton;

--- a/src/pageEditor/sidebar/SidebarExpanded.tsx
+++ b/src/pageEditor/sidebar/SidebarExpanded.tsx
@@ -53,7 +53,7 @@ import useResetRecipe from "@/pageEditor/hooks/useResetRecipe";
 import useRemoveRecipe from "@/pageEditor/hooks/useRemoveRecipe";
 import Logo from "./Logo";
 import ReloadButton from "./ReloadButton";
-import AddExtensionPointButton from "./AddExtensionPointButton";
+import AddStarterBrickButton from "./AddStarterBrickButton";
 import ExtensionEntry from "./ExtensionEntry";
 import { actions } from "@/pageEditor/slices/editorSlice";
 import { measureDurationFromAppStart } from "@/utils/performance";
@@ -214,7 +214,7 @@ const SidebarExpanded: React.FunctionComponent<{
               <Logo />
             </a>
 
-            <AddExtensionPointButton />
+            <AddStarterBrickButton />
 
             {showDeveloperUI && <ReloadButton />}
           </div>

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -93,6 +93,7 @@ export const Events = {
   PAGE_EDITOR_RESET: "PageEditorReset",
   PAGE_EDITOR_SAVE: "PageEditorSave",
   PAGE_EDITOR_START: "PageEditorStart",
+  PAGE_EDITOR_VIEW_TEMPLATES: "PageEditorViewTemplates",
 
   PAGE_EDITOR_SESSION_START: "PageEditorSessionStart",
   PAGE_EDITOR_SESSION_END: "PageEditorSessionEnd",


### PR DESCRIPTION
## What does this PR do?

- Closes #6897 
- Adds a link to the template gallery to the "Add" dropdown
- Adds a `PageEditorViewTemplates` event to track the button being clicked

## Discussion

- We didn't have a way to redirect the tab from the Page Editor, so I added a method to navigate the inspected tab

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/455530c9-e2f7-4799-a7c6-901184dccf50)

## Checklist

- [ ] Add tests: TODO add a Rainforest QA test because the changes crosses boundaries
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @mnholtz 
