### PR TITLE
#6895: rjsf custom textarea missing labels

### DIFF
--- a/src/components/formBuilder/TextAreaWidget.test.tsx
+++ b/src/components/formBuilder/TextAreaWidget.test.tsx
@@ -19,51 +19,51 @@ import React from "react";
 import TextAreaWidget from "@/components/formBuilder/TextAreaWidget";
 import { render, screen } from "@/sidebar/testHelpers";
 import RjsfSubmitContext from "@/components/formBuilder/RjsfSubmitContext";
+import { type WidgetProps } from "@rjsf/core";
 
 describe("TextAreaWidget", () => {
+  const defaultProps: WidgetProps = {
+    id: "rjsf-textarea",
+    label: "RJSF Textarea",
+    placeholder: "",
+    value: "",
+    options: {},
+    schema: {},
+    uiSchema: {},
+    required: false,
+    disabled: false,
+    readonly: false,
+    autofocus: false,
+    multiple: false,
+    onChange: jest.fn(),
+    onBlur: jest.fn(),
+    onFocus: jest.fn(),
+    rawErrors: [],
+    WidgetProps: {},
+    formContext: {},
+    registry: {
+      fields: {},
+      widgets: {},
+      definitions: {},
+      formContext: {},
+      rootSchema: {},
+    },
+  };
+
   test("renders the textarea with a label", () => {
-    render(
-      <TextAreaWidget
-        id="rjsf-textarea"
-        label="RJSF Textarea"
-        placeholder=""
-        value=""
-        options={{}}
-        schema={{}}
-        uiSchema={{}}
-        required={false}
-        disabled={false}
-        readonly={false}
-        autofocus={false}
-        multiple={false}
-        onChange={jest.fn()}
-        onBlur={jest.fn()}
-        onFocus={jest.fn()}
-        rawErrors={[]}
-        WidgetProps={{}}
-        formContext={{}}
-        registry={{
-          fields: {},
-          widgets: {},
-          definitions: {},
-          formContext: {},
-          rootSchema: {},
-        }}
-      />,
-      {
-        wrapper: ({ children }) => (
-          <RjsfSubmitContext.Provider
-            value={{
-              async submitForm() {
-                jest.fn();
-              },
-            }}
-          >
-            {children}
-          </RjsfSubmitContext.Provider>
-        ),
-      }
-    );
+    render(<TextAreaWidget {...defaultProps} />, {
+      wrapper: ({ children }) => (
+        <RjsfSubmitContext.Provider
+          value={{
+            async submitForm() {
+              jest.fn();
+            },
+          }}
+        >
+          {children}
+        </RjsfSubmitContext.Provider>
+      ),
+    });
 
     expect(screen.getByLabelText("RJSF Textarea")).toBeInTheDocument();
   });

--- a/src/components/formBuilder/TextAreaWidget.test.tsx
+++ b/src/components/formBuilder/TextAreaWidget.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import TextAreaWidget from "@/components/formBuilder/TextAreaWidget";
+import { render, screen } from "@/sidebar/testHelpers";
+import RjsfSubmitContext from "@/components/formBuilder/RjsfSubmitContext";
+
+describe("TextAreaWidget", () => {
+  test("renders the textarea with a label", () => {
+    render(
+      <TextAreaWidget
+        id="rjsf-textarea"
+        label="RJSF Textarea"
+        placeholder=""
+        value=""
+        options={{}}
+        schema={{}}
+        uiSchema={{}}
+        required={false}
+        disabled={false}
+        readonly={false}
+        autofocus={false}
+        multiple={false}
+        onChange={jest.fn()}
+        onBlur={jest.fn()}
+        onFocus={jest.fn()}
+        rawErrors={[]}
+        WidgetProps={{}}
+        formContext={{}}
+        registry={{
+          fields: {},
+          widgets: {},
+          definitions: {},
+          formContext: {},
+          rootSchema: {},
+        }}
+      />,
+      {
+        wrapper: ({ children }) => (
+          <RjsfSubmitContext.Provider
+            value={{
+              async submitForm() {
+                jest.fn();
+              },
+            }}
+          >
+            {children}
+          </RjsfSubmitContext.Provider>
+        ),
+      }
+    );
+
+    expect(screen.getByLabelText("RJSF Textarea")).toBeInTheDocument();
+  });
+});

--- a/src/components/formBuilder/TextAreaWidget.tsx
+++ b/src/components/formBuilder/TextAreaWidget.tsx
@@ -76,8 +76,8 @@ const TextAreaWidget: React.FC<WidgetProps> = ({
 
   // @see @rjsf/core/lib/components/widgets/TextareaWidget.js
   return (
-    <FormGroup controlId={id}>
-      <FormLabel>{label}</FormLabel>
+    <>
+      <FormLabel htmlFor={id}>{label}</FormLabel>
       <textarea
         id={id}
         className="form-control"
@@ -92,7 +92,7 @@ const TextAreaWidget: React.FC<WidgetProps> = ({
         onFocus={onFocusHandler}
         onBlur={onBlurHandler}
       />
-    </FormGroup>
+    </>
   );
 };
 

--- a/src/components/formBuilder/TextAreaWidget.tsx
+++ b/src/components/formBuilder/TextAreaWidget.tsx
@@ -25,6 +25,7 @@ import React, {
 import { type WidgetProps } from "@rjsf/core";
 import { isNumber } from "lodash";
 import RjsfSubmitContext from "@/components/formBuilder/RjsfSubmitContext";
+import { FormGroup, FormLabel } from "react-bootstrap";
 
 const TextAreaWidget: React.FC<WidgetProps> = ({
   id,
@@ -37,6 +38,7 @@ const TextAreaWidget: React.FC<WidgetProps> = ({
   onChange,
   onFocus,
   onBlur,
+  label,
 }) => {
   const { submitForm } = useContext(RjsfSubmitContext);
 
@@ -74,20 +76,23 @@ const TextAreaWidget: React.FC<WidgetProps> = ({
 
   // @see @rjsf/core/lib/components/widgets/TextareaWidget.js
   return (
-    <textarea
-      id={id}
-      className="form-control"
-      value={String(value ?? "")}
-      placeholder={placeholder}
-      required={required}
-      disabled={disabled}
-      readOnly={readonly}
-      rows={isNumber(options.rows) ? options.rows : undefined}
-      onKeyPress={onKeyPress}
-      onChange={onChangeHandler}
-      onFocus={onFocusHandler}
-      onBlur={onBlurHandler}
-    />
+    <FormGroup controlId={id}>
+      <FormLabel>{label}</FormLabel>
+      <textarea
+        id={id}
+        className="form-control"
+        value={String(value ?? "")}
+        placeholder={placeholder}
+        required={required}
+        disabled={disabled}
+        readOnly={readonly}
+        rows={isNumber(options.rows) ? options.rows : undefined}
+        onKeyPress={onKeyPress}
+        onChange={onChangeHandler}
+        onFocus={onFocusHandler}
+        onBlur={onBlurHandler}
+      />
+    </FormGroup>
   );
 };
 

--- a/src/components/formBuilder/TextAreaWidget.tsx
+++ b/src/components/formBuilder/TextAreaWidget.tsx
@@ -25,7 +25,7 @@ import React, {
 import { type WidgetProps } from "@rjsf/core";
 import { isNumber } from "lodash";
 import RjsfSubmitContext from "@/components/formBuilder/RjsfSubmitContext";
-import { FormGroup, FormLabel } from "react-bootstrap";
+import { FormLabel } from "react-bootstrap";
 
 const TextAreaWidget: React.FC<WidgetProps> = ({
   id,
@@ -75,6 +75,7 @@ const TextAreaWidget: React.FC<WidgetProps> = ({
   );
 
   // @see @rjsf/core/lib/components/widgets/TextareaWidget.js
+  // @see https://github.com/pixiebrix/pixiebrix-extension/pull/6899 for why we added the label
   return (
     <>
       <FormLabel htmlFor={id}>{label}</FormLabel>


### PR DESCRIPTION
## What does this PR do?

- Fixes #6895 

## Discussion

- Our other custom widgets have FormLabels
- This appears to be due to the fact that the custom FieldTemplate used by the Custom Form brick doesn't include a label
- It appears that only custom widgets use the custom FieldTemplate

## Demo

<img width="400" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/36c89f9d-c9b6-49c7-bb48-be0e64bb7dea">

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @BLoe 
