### PR TITLE
#6902: relax connect-src CSP to allow `http:` API calls

### DIFF
--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -41,7 +41,7 @@ import {
   ProxiedRemoteServiceError,
 } from "@/errors/businessErrors";
 import { ContextError, ExtensionNotLinkedError } from "@/errors/genericErrors";
-import { assertUrlProtocol } from "@/errors/assertUrlProtocol";
+import { assertProtocolUrl } from "@/errors/assertProtocolUrl";
 import {
   isAxiosError,
   safeGuessStatusText,
@@ -125,7 +125,7 @@ export async function serializableAxiosRequest<T>(
   );
 
   // Axios does not perform validation, so call before the axios call.
-  assertUrlProtocol(config.url, ["https:", "http:"], {
+  assertProtocolUrl(config.url, ["https:", "http:"], {
     baseUrl: config.baseURL,
   });
 

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -41,7 +41,7 @@ import {
   ProxiedRemoteServiceError,
 } from "@/errors/businessErrors";
 import { ContextError, ExtensionNotLinkedError } from "@/errors/genericErrors";
-import { assertHttpsUrl } from "@/errors/assertHttpsUrl";
+import { assertUrlProtocol } from "@/errors/assertUrlProtocol";
 import {
   isAxiosError,
   safeGuessStatusText,
@@ -125,7 +125,9 @@ export async function serializableAxiosRequest<T>(
   );
 
   // Axios does not perform validation, so call before the axios call.
-  assertHttpsUrl(config.url, config.baseURL);
+  assertUrlProtocol(config.url, ["https:", "http:"], {
+    baseUrl: config.baseURL,
+  });
 
   const response = await axios(config);
 

--- a/src/errors/assertProtocolUrl.ts
+++ b/src/errors/assertProtocolUrl.ts
@@ -28,7 +28,7 @@ import { isAbsoluteUrl, safeParseUrl } from "@/utils/urlUtils";
  * @return the URL instance
  * @throws BusinessError if the URL is invalid
  */
-export function assertUrlProtocol(
+export function assertProtocolUrl(
   url: string,
   allowedProtocols: string[],
   {

--- a/src/errors/assertUrlProtocol.ts
+++ b/src/errors/assertUrlProtocol.ts
@@ -21,40 +21,39 @@ import { BusinessError } from "@/errors/businessErrors";
 import { isAbsoluteUrl, safeParseUrl } from "@/utils/urlUtils";
 
 /**
- * Returns an https: schema URL, or throws a BusinessError
+ * Returns a URL with one of the allow-listed schemas, or throws a BusinessError
  * @param url an absolute or relative URL
+ * @param allowedProtocols the protocol allow-list, including the colon (e.g., "https:")
  * @param baseUrl the baseUrl to use if url is relative
  * @return the URL instance
  * @throws BusinessError if the URL is invalid
  */
-export function assertHttpsUrl(
+export function assertUrlProtocol(
   url: string,
-  // Don't default baseUrl to location.href here. API calls are always routed through a chrome-extension:// page (e.g.,
-  // the background page. So they would always be flagged as having an invalid schema)
-  baseUrl?: string
+  allowedProtocols: string[],
+  {
+    baseUrl,
+  }: {
+    // Don't default baseUrl to location.href here. API calls are always routed through a chrome-extension:// page (e.g.,
+    // the background page. So they would always be flagged as having an invalid schema)
+    baseUrl?: string;
+  } = {}
 ): URL {
   const parsedUrl = safeParseUrl(url, baseUrl);
 
-  // Allow local non-HTTPS URLs when testing locally
-  if (process.env.DEBUG && parsedUrl.protocol === "http:") {
+  if (allowedProtocols.includes(parsedUrl.protocol)) {
     return parsedUrl;
   }
 
-  switch (parsedUrl.protocol) {
-    case "https:": {
-      return parsedUrl;
-    }
-
-    case "invalid-url:": {
-      baseUrl =
-        isAbsoluteUrl(url) || isEmpty(baseUrl) ? "" : ` (base URL: ${baseUrl})`;
-      throw new BusinessError(`Invalid URL: ${url}${baseUrl}`);
-    }
-
-    default: {
-      throw new BusinessError(
-        `Unsupported protocol: ${parsedUrl.protocol}. Use https:`
-      );
-    }
+  if (parsedUrl.protocol === "invalid-url:") {
+    baseUrl =
+      isAbsoluteUrl(url) || isEmpty(baseUrl) ? "" : ` (base URL: ${baseUrl})`;
+    throw new BusinessError(`Invalid URL: ${url}${baseUrl}`);
   }
+
+  throw new BusinessError(
+    `Unsupported protocol: ${parsedUrl.protocol}. Use ${allowedProtocols.join(
+      ", "
+    )}`
+  );
 }

--- a/src/extensionConsole/pages/settings/AdvancedSettings.tsx
+++ b/src/extensionConsole/pages/settings/AdvancedSettings.tsx
@@ -26,7 +26,7 @@ import notify from "@/utils/notify";
 import useFlags from "@/hooks/useFlags";
 import settingsSlice from "@/store/settings/settingsSlice";
 import { useDispatch, useSelector } from "react-redux";
-import { assertHttpsUrl } from "@/errors/assertHttpsUrl";
+import { assertUrlProtocol } from "@/errors/assertUrlProtocol";
 import { selectSettings } from "@/store/settings/settingsSelectors";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import pTimeout from "p-timeout";
@@ -101,7 +101,7 @@ const AdvancedSettings: React.FunctionComponent = () => {
       try {
         // Ensure it's a valid URL
         if (newPixiebrixUrl) {
-          assertHttpsUrl(newPixiebrixUrl);
+          assertUrlProtocol(newPixiebrixUrl, ["https:"]);
         }
       } catch (error) {
         notify.error({

--- a/src/extensionConsole/pages/settings/AdvancedSettings.tsx
+++ b/src/extensionConsole/pages/settings/AdvancedSettings.tsx
@@ -26,7 +26,7 @@ import notify from "@/utils/notify";
 import useFlags from "@/hooks/useFlags";
 import settingsSlice from "@/store/settings/settingsSlice";
 import { useDispatch, useSelector } from "react-redux";
-import { assertUrlProtocol } from "@/errors/assertUrlProtocol";
+import { assertProtocolUrl } from "@/errors/assertProtocolUrl";
 import { selectSettings } from "@/store/settings/settingsSelectors";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import pTimeout from "p-timeout";
@@ -101,7 +101,7 @@ const AdvancedSettings: React.FunctionComponent = () => {
       try {
         // Ensure it's a valid URL
         if (newPixiebrixUrl) {
-          assertUrlProtocol(newPixiebrixUrl, ["https:"]);
+          assertProtocolUrl(newPixiebrixUrl, ["https:"]);
         }
       } catch (error) {
         notify.error({

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
     "48": "icons/logo48.png",
     "128": "icons/logo128.png"
   },
-  "content_security_policy": "script-src 'self' https://apis.google.com 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https:; object-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-src 'self' https: https://*.googleapis.com https://docs.google.com",
+  "content_security_policy": "script-src 'self' https://apis.google.com 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' http: https:; object-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-src 'self' https: https://*.googleapis.com https://docs.google.com",
   "content_scripts": [
     {
       "matches": ["https://*/*", "http://*/*"],

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -203,7 +203,7 @@
     "./development/useMessengerLogging.ts",
     "./development/visualInjection.ts",
     "./domConstants.ts",
-    "./errors/assertUrlProtocol.ts",
+    "./errors/assertProtocolUrl.ts",
     "./errors/businessErrors.ts",
     "./errors/clientRequestErrors.ts",
     "./errors/contextInvalidated.ts",

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -203,7 +203,7 @@
     "./development/useMessengerLogging.ts",
     "./development/visualInjection.ts",
     "./domConstants.ts",
-    "./errors/assertHttpsUrl.ts",
+    "./errors/assertUrlProtocol.ts",
     "./errors/businessErrors.ts",
     "./errors/clientRequestErrors.ts",
     "./errors/contextInvalidated.ts",

--- a/src/utils/enrichAxiosErrors.ts
+++ b/src/utils/enrichAxiosErrors.ts
@@ -23,7 +23,7 @@ import {
   ClientNetworkPermissionError,
   RemoteServiceError,
 } from "@/errors/clientRequestErrors";
-import { assertHttpsUrl } from "@/errors/assertHttpsUrl";
+import { assertUrlProtocol } from "@/errors/assertUrlProtocol";
 import {
   isAxiosError,
   NO_INTERNET_MESSAGE,
@@ -50,7 +50,9 @@ async function enrichBusinessRequestError(error: unknown): Promise<never> {
   console.trace("enrichBusinessRequestError", { error });
 
   // This should have already been called before attempting the request because Axios does not actually catch invalid URLs
-  const url = assertHttpsUrl(error.config.url, error.config.baseURL);
+  const url = assertUrlProtocol(error.config.url, ["https:", "http:"], {
+    baseUrl: error.config.baseURL,
+  });
 
   // In case of a CORS permission error, response.status can be 0. This case is handled below
   if (error.response != null && error.response.status !== 0) {

--- a/src/utils/enrichAxiosErrors.ts
+++ b/src/utils/enrichAxiosErrors.ts
@@ -23,7 +23,7 @@ import {
   ClientNetworkPermissionError,
   RemoteServiceError,
 } from "@/errors/clientRequestErrors";
-import { assertUrlProtocol } from "@/errors/assertUrlProtocol";
+import { assertProtocolUrl } from "@/errors/assertProtocolUrl";
 import {
   isAxiosError,
   NO_INTERNET_MESSAGE,
@@ -50,7 +50,7 @@ async function enrichBusinessRequestError(error: unknown): Promise<never> {
   console.trace("enrichBusinessRequestError", { error });
 
   // This should have already been called before attempting the request because Axios does not actually catch invalid URLs
-  const url = assertUrlProtocol(error.config.url, ["https:", "http:"], {
+  const url = assertProtocolUrl(error.config.url, ["https:", "http:"], {
     baseUrl: error.config.baseURL,
   });
 

--- a/src/utils/urlUtils.test.ts
+++ b/src/utils/urlUtils.test.ts
@@ -15,55 +15,55 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { assertUrlProtocol } from "@/errors/assertUrlProtocol";
+import { assertProtocolUrl } from "@/errors/assertProtocolUrl";
 import { BusinessError } from "@/errors/businessErrors";
 import { makeURL } from "@/utils/urlUtils";
 
 describe("assertHttpsUrl", () => {
   test("parses HTTPS URLs", () => {
-    expect(assertUrlProtocol("https://example.com", ["https:"])).toStrictEqual(
+    expect(assertProtocolUrl("https://example.com", ["https:"])).toStrictEqual(
       new URL("https://example.com")
     );
   });
   test("rejects HTTP URLs if not specified", () => {
-    expect(() => assertUrlProtocol("http://example.com", ["https:"])).toThrow(
+    expect(() => assertProtocolUrl("http://example.com", ["https:"])).toThrow(
       new BusinessError("Unsupported protocol: http:. Use https:")
     );
   });
   test("allows HTTP URLs if specified", () => {
-    expect(assertUrlProtocol("https://example.com", ["https:"])).toStrictEqual(
+    expect(assertProtocolUrl("https://example.com", ["https:"])).toStrictEqual(
       new URL("http://example.com")
     );
   });
   test("rejects unsupported protocol", () => {
     expect(() =>
-      assertUrlProtocol("file://foo.txt", ["http:", "https:"])
+      assertProtocolUrl("file://foo.txt", ["http:", "https:"])
     ).toThrow(
       new BusinessError("Unsupported protocol: file:. Use http:, https:")
     );
   });
   test("rejects invalid URLs", () => {
-    expect(() => assertUrlProtocol("https::/example.com", ["https:"])).toThrow(
+    expect(() => assertProtocolUrl("https::/example.com", ["https:"])).toThrow(
       new BusinessError("Invalid URL: https::/example.com")
     );
   });
   test("parses relative URLs with a base", () => {
     expect(
-      assertUrlProtocol("/cool/path", ["https:"], {
+      assertProtocolUrl("/cool/path", ["https:"], {
         baseUrl: "https://example.com/page",
       })
     ).toStrictEqual(new URL("https://example.com/cool/path"));
   });
   test("rejects relative HTTP URLs", () => {
     expect(() =>
-      assertUrlProtocol("/cool/path", ["https:"], {
+      assertProtocolUrl("/cool/path", ["https:"], {
         baseUrl: "http://example.com/page",
       })
     ).toThrow(new BusinessError("Unsupported protocol: http:. Use https:"));
   });
   test("rejects invalid base URLs", () => {
     expect(() =>
-      assertUrlProtocol("/cool/path", ["http:"], {
+      assertProtocolUrl("/cool/path", ["http:"], {
         baseUrl: "https::/example.com",
       })
     ).toThrow(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -208,8 +208,6 @@ function customizeManifest(manifest, isProduction) {
 
   const policy = new Policy(manifest.content_security_policy);
 
-  policy.add("connect-src", process.env.SERVICE_URL);
-
   if (!isProduction) {
     // React Dev Tools app. See https://github.com/pixiebrix/pixiebrix-extension/wiki/Development-commands#react-dev-tools
     policy.add("script-src", "http://localhost:8097");


### PR DESCRIPTION
## What does this PR do?

- Closes #6902 
- Relaxes the CSP
- Fixes error enrichment that assumed http API calls aren't allowed

## Discussion

- In MV2, the CSP applies to all extension pages and the background script
- This may impact our https://crxcavator.io/ score

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/4307bb8d-89a4-4c42-9542-d6461c6e1df1)

## Future Work

- Consider disabling by default, and exposing a toggle in the Settings > Developer Settings. (We'd block in our API call method vs. HTTP)
- In MV3, make the extension page CSP stricter: https://developer.chrome.com/docs/extensions/mv3/manifest/content_security_policy/

## Remaining Work

- [ ] Verify that the manifest change doesn't require browser extension restart: https://www.notion.so/pixiebrix/Testing-Manifest-json-changes-c60283073fba40d98ee28cdeab19b04a?pvs=4

## Checklist

- [x] Add tests: N/A
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
