### PR TITLE
Try bun on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,11 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v1
         with:
-          node-version-file: package.json
-          cache: npm
-      - run: npm ci
-      - run: npm run test -- --coverage
+          bun-version: latest
+      - run: bun install
+      - run: bun run test -- --coverage
       - uses: actions/upload-artifact@v3
         with:
           name: extension-test-coverage
@@ -53,12 +52,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v1
         with:
-          node-version-file: package.json
-          cache: npm
-      - run: npm ci
-      - run: npm run build:webpack
+          bun-version: latest
+      - run: bun install
+      - run: bun run build:webpack
         env:
           ENVIRONMENT: staging
           EXTERNALLY_CONNECTABLE: ${{ secrets.STAGING_SERVICE_URL }}*,http://127.0.0.1/*
@@ -114,13 +112,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v1
         with:
-          node-version-file: package.json
-          cache: npm
-      - run: npm ci
-      - run: npm run build:scripts
-      - run: npm run generate:headers
+          bun-version: latest
+      - run: bun install
+      - run: bun run build:scripts
+      - run: bun run generate:headers
       - uses: actions/upload-artifact@v3
         name: Save headers.json
         with:
@@ -135,26 +132,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v1
         with:
-          node-version-file: package.json
-          cache: npm
-      - run: npm ci
-      - run: npm run build:typescript
+          bun-version: latest
+      - run: bun install
+      - run: bun run build:typescript
       # Prevent regressions in the files that have already been made strictNullCheck-compliant
-      - run: npm run build:strictNullChecks
+      - run: bun run build:strictNullChecks
 
   lint:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: oven-sh/setup-bun@v1
         with:
-          node-version-file: package.json
-          cache: npm
-      - run: npm ci
-      - run: npm run lint:full
+          bun-version: latest
+      - run: bun install
+      - run: bun run lint:full
 
   # https://pre-commit.com/#usage-in-continuous-integration
   prettier:


### PR DESCRIPTION
**This is not necessarily meant to be merged, it's just a test to see how bun performs on CI.**

Finally it works and it's definitely faster, 1 minute faster in some cases.

<table>
<tr>
 <th>Node
 <th>Bun
<tr>
 <td><img width="308" alt="Screenshot 2" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/d2d6cb29-e65c-4b5e-b6ae-e70bfa452619">
 <td><img width="308" alt="Screenshot 1" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/0afedddd-94c9-42ad-9655-45a3adc6f1c6">
</table>

The bigger changes will come once Bun is able to actually run eslint, webpack or tests directly (this is unlikely anytime soon, but that'd bring a literal 20x speed improvement on the slowest part)

Technically nothing is stopping us from using Bun locally as well, but my guess is that it's too early.