### PR TITLE
#6947: Support first load and window focus changes in restricted URL popover

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,7 @@
         "webext-patterns": "^1.3.0",
         "webext-polyfill-kinda": "^1.0.2",
         "webext-storage": "^1.2.2",
-        "webext-tools": "^1.1.4",
+        "webext-tools": "^1.2.1",
         "webextension-polyfill": "^0.10.0",
         "whatwg-mimetype": "^3.0.0",
         "yup": "^0.32.11"
@@ -26684,9 +26684,9 @@
       }
     },
     "node_modules/webext-content-scripts": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-2.5.5.tgz",
-      "integrity": "sha512-CIq1LA/nHIXE43v8qlpqNPcbsSzGuQBkeykbqOWvKJ1Rx/q7zgdZsLgxwyoonWiQcJczslVmGWCfdBY04JwIyw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-2.6.0.tgz",
+      "integrity": "sha512-RZzstGZ+opdFbfUaTp3dYQPH5dsEvbT8AJMIJv0uGptBYQgjGgHzQbF/oIgZ7SYuI7915vQlNfzxhO9+PIfcKg==",
       "dependencies": {
         "webext-patterns": "^1.3.0",
         "webext-polyfill-kinda": "^1.0.2"
@@ -26745,11 +26745,11 @@
       }
     },
     "node_modules/webext-tools": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/webext-tools/-/webext-tools-1.1.4.tgz",
-      "integrity": "sha512-z2M8TiAhQijCWXC71zzw0tQCTK/GFAo0OHobuz04AMyvGClETsufj0vBblYiXfxUkx+MDjYYWD2dTSebBiwcqQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/webext-tools/-/webext-tools-1.2.1.tgz",
+      "integrity": "sha512-/AVvyFa47qfHbJQYtuQNTrzK0zM8zAlyu1vMFckPyD5WNYq+816uBDOJAmzyf4xBdFnpSkst0bfc8W4R1ohVWQ==",
       "dependencies": {
-        "webext-content-scripts": "^2.5.5",
+        "webext-content-scripts": "^2.6.0",
         "webext-detect-page": "^4.1.1",
         "webext-polyfill-kinda": "^1.0.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,7 @@
         "webext-patterns": "^1.3.0",
         "webext-polyfill-kinda": "^1.0.2",
         "webext-storage": "^1.2.2",
-        "webext-tools": "^1.2.1",
+        "webext-tools": "^1.2.2",
         "webextension-polyfill": "^0.10.0",
         "whatwg-mimetype": "^3.0.0",
         "yup": "^0.32.11"
@@ -26745,9 +26745,9 @@
       }
     },
     "node_modules/webext-tools": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/webext-tools/-/webext-tools-1.2.1.tgz",
-      "integrity": "sha512-/AVvyFa47qfHbJQYtuQNTrzK0zM8zAlyu1vMFckPyD5WNYq+816uBDOJAmzyf4xBdFnpSkst0bfc8W4R1ohVWQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/webext-tools/-/webext-tools-1.2.2.tgz",
+      "integrity": "sha512-l8JjBXoaBIXfUK98KICmpYCW6U7bPpT60S/8bU1nAddseLPI3l1aqUZ+5jpmNyGleuPNb0JwdyQD9eUu2Oa99Q==",
       "dependencies": {
         "webext-content-scripts": "^2.6.0",
         "webext-detect-page": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "webext-patterns": "^1.3.0",
     "webext-polyfill-kinda": "^1.0.2",
     "webext-storage": "^1.2.2",
-    "webext-tools": "^1.1.4",
+    "webext-tools": "^1.2.1",
     "webextension-polyfill": "^0.10.0",
     "whatwg-mimetype": "^3.0.0",
     "yup": "^0.32.11"

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "webext-patterns": "^1.3.0",
     "webext-polyfill-kinda": "^1.0.2",
     "webext-storage": "^1.2.2",
-    "webext-tools": "^1.2.1",
+    "webext-tools": "^1.2.2",
     "webextension-polyfill": "^0.10.0",
     "whatwg-mimetype": "^3.0.0",
     "yup": "^0.32.11"

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -87,16 +87,16 @@ async function handleBrowserAction(tab: Tab): Promise<void> {
  * Show a popover on restricted URLs because we're unable to inject content into the page. Previously we'd open
  * the Extension Console, but that was confusing because the action was inconsistent with how the button behaves
  * other pages.
- * @param url the url of the tab, or null if not accessible
+ * @param tabUrl the url of the tab, or null if not accessible
  */
-function getPopover(url: string | null): string | null {
+function getPopoverUrl(tabUrl: string | null): string | null {
   const popoverUrl = browser.runtime.getURL("restrictedUrlPopup.html");
 
-  if (url && url.startsWith(getExtensionConsoleUrl())) {
+  if (tabUrl?.startsWith(getExtensionConsoleUrl())) {
     return `${popoverUrl}?reason=${DISPLAY_REASON_EXTENSION_CONSOLE}`;
   }
 
-  if (!isScriptableUrl(url)) {
+  if (!isScriptableUrl(tabUrl)) {
     return `${popoverUrl}?reason=${DISPLAY_REASON_RESTRICTED_URL}`;
   }
 
@@ -110,5 +110,5 @@ export default function initBrowserAction(): void {
 
   // Track the active tab URL. We need to update the popover every time status the active tab/active URL changes.
   // https://github.com/facebook/react/blob/bbb9cb116dbf7b6247721aa0c4bcb6ec249aa8af/packages/react-devtools-extensions/src/background/tabsManager.js#L29
-  setActionPopup(getPopover);
+  setActionPopup(getPopoverUrl);
 }

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -89,7 +89,7 @@ async function handleBrowserAction(tab: Tab): Promise<void> {
  * other pages.
  * @param url the url of the tab, or null if not accessible
  */
-async function getPopover(url: string | null): Promise<string | undefined> {
+function getPopover(url: string | null): string | null {
   const popoverUrl = browser.runtime.getURL("restrictedUrlPopup.html");
 
   if (url && url.startsWith(getExtensionConsoleUrl())) {
@@ -102,6 +102,7 @@ async function getPopover(url: string | null): Promise<string | undefined> {
 
   // The popup is disabled, and the extension will receive browserAction.onClicked events.
   // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setPopup#popup
+  return null;
 }
 
 export default function initBrowserAction(): void {

--- a/src/background/browserAction.ts
+++ b/src/background/browserAction.ts
@@ -88,7 +88,10 @@ async function handleBrowserAction(tab: Tab): Promise<void> {
  * other pages.
  * @param url the url of the tab, or null if not accessible
  */
-async function updatePopover(url: string | null): Promise<void> {
+async function updatePopover(
+  url: string | null,
+  tabId: number | null
+): Promise<void> {
   // The URL might not be available in certain circumstances. This silences these
   // cases and just treats them as "not allowed on this page"
   const normalizedUrl = String(url);
@@ -98,16 +101,19 @@ async function updatePopover(url: string | null): Promise<void> {
   if (normalizedUrl.startsWith(getExtensionConsoleUrl())) {
     await browser.browserAction.setPopup({
       popup: `${popoverUrl}?reason=${DISPLAY_REASON_EXTENSION_CONSOLE}`,
+      tabId,
     });
   } else if (isScriptableUrl(normalizedUrl)) {
     await browser.browserAction.setPopup({
       // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setPopup#popup
       // If an empty string ("") is passed here, the popup is disabled, and the extension will receive browserAction.onClicked events.
       popup: "",
+      tabId,
     });
   } else {
     await browser.browserAction.setPopup({
       popup: `${popoverUrl}?reason=${DISPLAY_REASON_RESTRICTED_URL}`,
+      tabId,
     });
   }
 }
@@ -115,18 +121,25 @@ async function updatePopover(url: string | null): Promise<void> {
 export default function initBrowserAction(): void {
   browserAction.onClicked.addListener(handleBrowserAction);
 
-  // Track the active tab URL. MV2 doesn't support setting popover on a per-tab basis, so we need to update the popover
-  // every time status the active tab/active URL changes.
+  // Track the active tab URL. We need to update the popover every time status the active tab/active URL changes.
   // https://github.com/facebook/react/blob/bbb9cb116dbf7b6247721aa0c4bcb6ec249aa8af/packages/react-devtools-extensions/src/background/tabsManager.js#L29
 
   chrome.tabs.onActivated.addListener(async (activeInfo) => {
     const tab = await browser.tabs.get(activeInfo.tabId);
-    await updatePopover(tab.url);
+    await updatePopover(tab.url, tab.id);
   });
 
-  browser.tabs.onUpdated.addListener(async (_tabId, _changeInfo, tab) => {
-    if (tab.active) {
-      await updatePopover(tab.url);
+  chrome.windows.onFocusChanged.addListener(async (windowId) => {
+    const [tab] = await browser.tabs.query({
+      active: true,
+      windowId,
+    });
+    await updatePopover(tab.url, tab.id);
+  });
+
+  browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+    if (tab.active && changeInfo.url) {
+      await updatePopover(changeInfo.url, tabId);
     }
   });
 }

--- a/src/tinyPages/restrictedUrlPopup.html
+++ b/src/tinyPages/restrictedUrlPopup.html
@@ -23,7 +23,7 @@
     <style>
       html,
       body {
-        min-width: 386px;
+        min-width: 420px;
         min-height: 33px;
       }
     </style>

--- a/src/tinyPages/restrictedUrlPopup.html
+++ b/src/tinyPages/restrictedUrlPopup.html
@@ -15,12 +15,15 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
+    <meta charset="utf-8" />
+    <title>PixieBrix</title>
     <style>
       html,
       body {
-        min-width: 286px;
+        min-width: 386px;
         min-height: 33px;
       }
     </style>


### PR DESCRIPTION
## What does this PR do?

- Continues #6947 

There were two situations that the previous code did not catch. All the changes:

- Catch window focus changes:
	1. Open `chrome://something` in a window
	2. Open `https://example.com` in another window
	3. Switch between the two and see the popup not being updated
- Catch first extension/browser load and successive reloads. If no "tab change" event is fired, no popup was set
- Limit `tab.onUpdated` events to URL changes (the event fires a lot more than we need)
- Make the pop slightly wider to reduce wrapping
- I liked this API, so I added it to [webext-tools](https://github.com/fregante/webext-tools#setactionpopupgetpopupurl) and used it here as a high-level API. I can revert the last commit here if you prefer.

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td><img width="288" alt="Screenshot 5" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/a981ba07-5bc9-4c3d-8a8e-02a9fffcb649">
 <td><img width="422" alt="Screenshot 4" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/560fe73c-a1f9-4294-b240-3f4d5f69908e">
</table>

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @twschiller 
