### PR TITLE
Lint warning for snapshots 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,8 +39,12 @@ module.exports = {
     // Full config: https://github.com/pixiebrix/eslint-config-pixiebrix/blob/main/index.js
     "pixiebrix",
   ],
-  plugins: ["local-rules"],
+  plugins: ["local-rules", "@shopify"],
   rules: {
+    "@shopify/react-hooks-strict-return": "error",
+    "@shopify/prefer-module-scope-constants": "error",
+    "@shopify/jest/no-snapshots": "warn",
+
     "local-rules/noInvalidDataTestId": "error",
     "local-rules/notBothLabelAndLockableProps": "error",
     "import/no-restricted-paths": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,6 +154,7 @@
       },
       "devDependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.36",
+        "@shopify/eslint-plugin": "^43.0.0",
         "@shopify/jest-dom-mocks": "^5.0.0",
         "@sindresorhus/tsconfig": "^5.0.0",
         "@sinonjs/fake-timers": "^11.2.2",
@@ -421,6 +422,58 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.23.3.tgz",
+      "integrity": "sha512-9bTuNlyx7oSstodm1cR1bECj4fkiknsDa1YniISkJemMY3DGhJNYBECbe6QD/q54mp2J8VO66jW3/7uP//iFCw==",
+      "dev": true,
+      "dependencies": {
+        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/eslint-plugin": {
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.22.10.tgz",
+      "integrity": "sha512-SRZcvo3fnO5h79B9DZSV6LG2vHH7OWsSNp1huFLHsXKyytRG413byQk9zxW1VcPOhnzfx2VIUz+8aGbiE7fOkA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/eslint-parser": "^7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0"
       }
     },
     "node_modules/@babel/generator": {
@@ -4320,6 +4373,15 @@
         "tar-fs": "^2.1.1"
       }
     },
+    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
+      "version": "5.1.1-v1",
+      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
+      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-scope": "5.1.1"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
@@ -4374,6 +4436,56 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/utils": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+      "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.3.0",
+        "is-glob": "^4.0.3",
+        "open": "^9.1.0",
+        "picocolors": "^1.0.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -5225,6 +5337,64 @@
       "dev": true,
       "engines": {
         "node": "^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@shopify/eslint-plugin": {
+      "version": "43.0.0",
+      "resolved": "https://registry.npmjs.org/@shopify/eslint-plugin/-/eslint-plugin-43.0.0.tgz",
+      "integrity": "sha512-+/bLrmODh+OtPzf4YafsfpAbcdZfHOHBQGXgzoXPge6yUuyOo+NJiNvq0LOwo6jaRkaBgWQTUZB8HRlx4swHag==",
+      "dev": true,
+      "dependencies": {
+        "@babel/eslint-parser": "^7.16.3",
+        "@babel/eslint-plugin": "^7.14.5",
+        "@typescript-eslint/eslint-plugin": "^6.2.1",
+        "@typescript-eslint/parser": "^6.2.1",
+        "change-case": "^4.1.2",
+        "common-tags": "^1.8.2",
+        "doctrine": "^2.1.0",
+        "eslint-config-prettier": "^8.10.0",
+        "eslint-module-utils": "^2.7.1",
+        "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-import": "^2.28.0",
+        "eslint-plugin-jest": "^27.2.3",
+        "eslint-plugin-jest-formatting": "^3.1.0",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "eslint-plugin-promise": "^6.1.1",
+        "eslint-plugin-react": "^7.33.1",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-sort-class-members": "^1.18.0",
+        "jsx-ast-utils": "^3.2.1",
+        "pkg-dir": "^5.0.0",
+        "pluralize": "^8.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.3.0"
+      }
+    },
+    "node_modules/@shopify/eslint-plugin/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@shopify/eslint-plugin/node_modules/eslint-config-prettier": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/@shopify/jest-dom-mocks": {
@@ -10554,6 +10724,21 @@
       "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
       "dev": true
     },
+    "node_modules/bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -10680,6 +10865,17 @@
         "url": "https://www.paypal.me/kirilvatev"
       }
     },
+    "node_modules/capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz",
@@ -10707,6 +10903,26 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/char-regex": {
@@ -11058,6 +11274,15 @@
       "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
       "dev": true
     },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -11363,6 +11588,17 @@
     "node_modules/consolidated-events": {
       "version": "2.0.2",
       "integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ=="
+    },
+    "node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
@@ -12267,6 +12503,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/default-browser-id": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
@@ -12276,6 +12530,116 @@
         "bplist-parser": "^0.2.0",
         "untildify": "^4.0.0"
       },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/default-browser/node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/default-browser/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -13517,6 +13881,18 @@
         }
       }
     },
+    "node_modules/eslint-plugin-jest-formatting": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-formatting/-/eslint-plugin-jest-formatting-3.1.0.tgz",
+      "integrity": "sha512-XyysraZ1JSgGbLSDxjj5HzKKh0glgWf+7CkqxbTqb7zEhW7X2WHo5SBQ8cGhnszKN+2Lj3/oevBlHNbHezoc/A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
+    },
     "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
@@ -13697,6 +14073,35 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.1.tgz",
+      "integrity": "sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-promise": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
@@ -13813,6 +14218,18 @@
       "dev": true,
       "dependencies": {
         "safe-regex": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-sort-class-members": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.19.0.tgz",
+      "integrity": "sha512-YayvASA1bavdPeRU9FMPnale2+Oi3aMcHGVC5EUm9b671oxm7ahvR+q8BfsU2aV+KAFezNfu47VPgdZK6gwYPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
       }
     },
     "node_modules/eslint-plugin-storybook": {
@@ -14610,6 +15027,12 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true
     },
     "node_modules/fast-equals": {
       "version": "2.0.4",
@@ -15888,6 +16311,16 @@
         "he": "bin/he"
       }
     },
+    "node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dev": true,
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/headers-polyfill": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
@@ -16852,6 +17285,39 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -21648,6 +22114,16 @@
       "version": "1.0.1",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
+    "node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dev": true,
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
@@ -22386,6 +22862,18 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-error": {
@@ -24154,6 +24642,21 @@
       "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
       "dev": true
     },
+    "node_modules/run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
@@ -24433,6 +24936,17 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
     },
     "node_modules/serialize-error": {
       "version": "11.0.3",
@@ -25379,6 +25893,22 @@
       "integrity": "sha512-qImOD23aDfnIDNqlG1NOehdB9IYsn1V9oByPjKY1nakv2MQYCEMyX033/q+aEtYCpmYK1cv2+NTmlH+ra6GA5A==",
       "dev": true
     },
+    "node_modules/synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
@@ -25680,6 +26210,18 @@
       "version": "1.0.3",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "node_modules/titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
@@ -25908,8 +26450,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.2",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -26339,6 +26882,24 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/uppercamelcase": {

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
   },
   "devDependencies": {
     "@fortawesome/fontawesome-common-types": "^0.2.36",
+    "@shopify/eslint-plugin": "^43.0.0",
     "@shopify/jest-dom-mocks": "^5.0.0",
     "@sindresorhus/tsconfig": "^5.0.0",
     "@sinonjs/fake-timers": "^11.2.2",

--- a/src/bricks/available.test.ts
+++ b/src/bricks/available.test.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * @jest-environment-options { "url": "https://www.example.com/#/foo/42" }
  */
 

--- a/src/bricks/readers/jquery.ts
+++ b/src/bricks/readers/jquery.ts
@@ -134,12 +134,12 @@ async function processFind(
   );
 }
 
-function processElement($elements: JQuery, selector: SingleSelector) {
-  const CONTENT_TYPES: Record<string, number | undefined> = {
-    text: Node.TEXT_NODE,
-    comment: Node.COMMENT_NODE,
-  };
+const CONTENT_TYPES: Record<string, number | undefined> = {
+  text: Node.TEXT_NODE,
+  comment: Node.COMMENT_NODE,
+};
 
+function processElement($elements: JQuery, selector: SingleSelector) {
   let value;
   if (selector.attr) {
     value = $elements.attr(selector.attr);

--- a/src/bricks/readers/jquery.ts
+++ b/src/bricks/readers/jquery.ts
@@ -134,10 +134,10 @@ async function processFind(
   );
 }
 
-const CONTENT_TYPES: Record<string, number | undefined> = {
-  text: Node.TEXT_NODE,
-  comment: Node.COMMENT_NODE,
-};
+const CONTENT_TYPES = {
+  text: globalThis.Node?.TEXT_NODE,
+  comment: globalThis.Node?.COMMENT_NODE,
+} as const;
 
 function processElement($elements: JQuery, selector: SingleSelector) {
   let value;

--- a/src/bricks/transformers/tourStep/overlay.ts
+++ b/src/bricks/transformers/tourStep/overlay.ts
@@ -24,13 +24,13 @@
 
 /**
  * Generates the svg path data for a rounded rectangle overlay
- * @param {Object} dimension - Dimensions of rectangle.
- * @param {number} width - Width.
- * @param {number} height - Height.
- * @param {number} [x=0] - Offset from top left corner in x axis. default 0.
- * @param {number} [y=0] - Offset from top left corner in y axis. default 0.
- * @param {number | { topLeft: number, topRight: number, bottomRight: number, bottomLeft: number }} [r=0] - Corner Radius. Keep this smaller than half of width or height.
- * @returns {string} - Rounded rectangle overlay path data.
+ * @param dimension - Dimensions of rectangle.
+ * @param width - Width.
+ * @param height - Height.
+ * @param [x=0] - Offset from top left corner in x axis. default 0.
+ * @param [y=0] - Offset from top left corner in y axis. default 0.
+ * @param [r=0] - Corner Radius. Keep this smaller than half of width or height.
+ * @returns - Rounded rectangle overlay path data.
  */
 export function makeOverlayPath({
   width,

--- a/src/contentScript/ready.ts
+++ b/src/contentScript/ready.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @shopify/prefer-module-scope-constants -- Dangerous here, contains copy-pasted code, serialized functions */
 /*
  * Copyright (C) 2023 PixieBrix, Inc.
  *

--- a/src/contrib/google/sheets/core/useCurrentOrigin.test.ts
+++ b/src/contrib/google/sheets/core/useCurrentOrigin.test.ts
@@ -80,16 +80,16 @@ describe("useCurrentOrigin", () => {
   });
 
   test("if other page, should return current tab url", async () => {
-    const OTHER_URL = "https://www.pixiebrix.com";
+    const otherUrl = "https://www.pixiebrix.com";
     setContext("web");
     queryMock.mockResolvedValue([
       {
-        url: OTHER_URL,
+        url: otherUrl,
       } as Tab,
     ]);
     const { result } = renderHook(() => useCurrentOrigin());
     // Wait for origin to load (async state)
     await waitForEffect();
-    expect(result.current).toBe(OTHER_URL);
+    expect(result.current).toBe(otherUrl);
   });
 });

--- a/src/errors/errorHelpers.test.tsx
+++ b/src/errors/errorHelpers.test.tsx
@@ -329,15 +329,15 @@ describe("formatSchemaValidationMessage", () => {
 });
 
 describe("getErrorMessageWithCauses", () => {
-  const FIRST_ERROR = "There was an error while fetching the page";
-  const SECOND_ERROR = "Maybe you are not connected to the internet?";
-  const THIRD_ERROR = "The network request failed (NO_NETWORK)";
+  const firstError = "There was an error while fetching the page";
+  const secondError = "Maybe you are not connected to the internet?";
+  const thirdError = "The network request failed (NO_NETWORK)";
   test("handles string", () => {
-    expect(getErrorMessageWithCauses(FIRST_ERROR)).toBe(FIRST_ERROR);
+    expect(getErrorMessageWithCauses(firstError)).toBe(firstError);
   });
 
   test("handles vanilla error", () => {
-    expect(getErrorMessageWithCauses(new Error(FIRST_ERROR))).toBe(FIRST_ERROR);
+    expect(getErrorMessageWithCauses(new Error(firstError))).toBe(firstError);
   });
 
   test("handles null/undefined", () => {
@@ -348,7 +348,7 @@ describe("getErrorMessageWithCauses", () => {
   test("handles good causes", () => {
     expect(
       getErrorMessageWithCauses(
-        new Error(FIRST_ERROR, { cause: new Error(SECOND_ERROR) })
+        new Error(firstError, { cause: new Error(secondError) })
       )
     ).toMatchInlineSnapshot(`
       "There was an error while fetching the page.
@@ -356,8 +356,8 @@ describe("getErrorMessageWithCauses", () => {
     `);
     expect(
       getErrorMessageWithCauses(
-        new Error(FIRST_ERROR, {
-          cause: new Error(SECOND_ERROR, { cause: new Error(THIRD_ERROR) }),
+        new Error(firstError, {
+          cause: new Error(secondError, { cause: new Error(thirdError) }),
         })
       )
     ).toMatchInlineSnapshot(`
@@ -369,17 +369,17 @@ describe("getErrorMessageWithCauses", () => {
 
   test("handles questionable causes", () => {
     expect(
-      getErrorMessageWithCauses(new Error(FIRST_ERROR, { cause: null }))
-    ).toBe(FIRST_ERROR);
+      getErrorMessageWithCauses(new Error(firstError, { cause: null }))
+    ).toBe(firstError);
     expect(
-      getErrorMessageWithCauses(new Error(FIRST_ERROR, { cause: undefined }))
-    ).toBe(FIRST_ERROR);
-    expect(getErrorMessageWithCauses(new Error(FIRST_ERROR, { cause: "idk" })))
+      getErrorMessageWithCauses(new Error(firstError, { cause: undefined }))
+    ).toBe(firstError);
+    expect(getErrorMessageWithCauses(new Error(firstError, { cause: "idk" })))
       .toMatchInlineSnapshot(`
         "There was an error while fetching the page.
         idk."
       `);
-    expect(getErrorMessageWithCauses(new Error(FIRST_ERROR, { cause: 420 })))
+    expect(getErrorMessageWithCauses(new Error(firstError, { cause: 420 })))
       .toMatchInlineSnapshot(`
         "There was an error while fetching the page.
         420."
@@ -389,9 +389,9 @@ describe("getErrorMessageWithCauses", () => {
   test("ignores duplicate error messages", () => {
     expect(
       getErrorMessageWithCauses(
-        new Error(FIRST_ERROR, { cause: new Error(FIRST_ERROR) })
+        new Error(firstError, { cause: new Error(firstError) })
       )
-    ).toBe(`${FIRST_ERROR}.`);
+    ).toBe(`${firstError}.`);
   });
 });
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -31,41 +31,41 @@ type Browser = import("webextension-polyfill").Browser;
 
 // https://stackoverflow.com/questions/43638454/webpack-typescript-image-import
 declare module "*.svg" {
-  const CONTENT: string;
-  export default CONTENT;
+  const content: string;
+  export default content;
 }
 
 declare module "*.png" {
-  const CONTENT: string;
-  export default CONTENT;
+  const content: string;
+  export default content;
 }
 
 declare module "*?loadAsUrl" {
-  const CONTENT: string;
-  export default CONTENT;
+  const content: string;
+  export default content;
 }
 
 declare module "*?loadAsText" {
-  const CONTENT: string;
-  export default CONTENT;
+  const content: string;
+  export default content;
 }
 
 // Loading svg as React component using @svgr
 declare module "*.svg?loadAsComponent" {
   import type React from "react";
 
-  const SVG: React.FC<React.SVGProps<SVGSVGElement>>;
-  export default SVG;
+  const svg: React.FC<React.SVGProps<SVGSVGElement>>;
+  export default svg;
 }
 
 declare module "*.txt" {
-  const CONTENT: string;
-  export default CONTENT;
+  const content: string;
+  export default content;
 }
 
 declare module "*.yaml" {
-  const CONTENT: Record<string, unknown>;
-  export default CONTENT;
+  const content: Record<string, unknown>;
+  export default content;
 }
 
 declare module "*.module.css" {

--- a/src/hooks/common.ts
+++ b/src/hooks/common.ts
@@ -115,6 +115,7 @@ export function useAsyncState<T>(
     }
   }, dependencies);
 
+  // eslint-disable-next-line @shopify/react-hooks-strict-return -- Deprecated hook already
   return [data as T, isLoading, error, recalculate];
 }
 

--- a/src/utils/injectIframe.test.tsx
+++ b/src/utils/injectIframe.test.tsx
@@ -1,4 +1,4 @@
-/**
+/*
  * @jest-environment-options {"resources": "usable" }
  */
 /*

--- a/src/utils/postMessage.test.ts
+++ b/src/utils/postMessage.test.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * @jest-environment-options {"resources": "usable", "runScripts": "dangerously"}
  */
 /*


### PR DESCRIPTION
## What does this PR do?

- Enables `jest/no-snapshots` rule as warning as discussed
	- https://pixiebrix.slack.com/archives/C023KL47XV4/p1700369600717069
	- https://pixiebrix.slack.com/archives/C023KL47XV4/p1700494177288439
- Enables https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/docs/rules/prefer-module-scope-constants.md
- Enables https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/docs/rules/react-hooks-strict-return.md
	- Reported only in one (deprecated) hook. It makes sense as a rule, but should we keep it enabled?


## Discussion

Full list: https://github.com/Shopify/web-configs/tree/main/packages/eslint-plugin#plugin-provided-rules

I also tried a couple more rules but they aren't great:

- `prefer-class-properties`: [buggy](https://github.com/Shopify/web-configs/issues/387)
- `return-early`: it warns on single statements like [`if (cond) something()`](https://togithub.com/sindresorhus/eslint-plugin-unicorn/issues/16#issuecomment-1823216600), which make code more verbose without substantial improvement (`if (!cond) {return} something()`)
- `webpack/no-unnamed-dynamic-imports`: we already have it as part of `eslint-plugin-import`
- `jsx-prefer-fragment-wrappers`: sounds nice, but it's not clear at this point of our `<div>`s are actually necessary in the UI

## Future Work


I added the plugin here for discussion, but I will:

- [ ]  move it to the shared config after approval

## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
