### PR TITLE
Reuse ErrorBoundary component

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -15,12 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Component } from "react";
+import React, { Component, type ErrorInfo } from "react";
 import { Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faRedo } from "@fortawesome/free-solid-svg-icons";
 import { getErrorMessage } from "@/errors/errorHelpers";
-import { type UnknownObject } from "@/types/objectTypes";
 import { isEmpty } from "lodash";
 
 interface DisplayProps {
@@ -55,6 +54,8 @@ interface BoundaryProps extends DisplayProps {
    * Custom error display component
    */
   ErrorComponent?: React.FC<DisplayProps & ErrorState>;
+
+  onError?: (error?: Error, errorInfo?: ErrorInfo) => void;
 }
 
 /**
@@ -105,16 +106,15 @@ export const DefaultErrorComponent: React.FC<ErrorDisplayProps> = ({
   </div>
 );
 
-class ErrorBoundary extends Component<BoundaryProps, ErrorState> {
-  constructor(props: UnknownObject) {
-    super(props);
-    this.state = {
-      hasError: false,
-      error: undefined,
-      errorMessage: undefined,
-      stack: undefined,
-    };
-  }
+class ErrorBoundary<
+  Props extends BoundaryProps = BoundaryProps
+> extends Component<Props, ErrorState> {
+  override state: ErrorState = {
+    error: undefined,
+    hasError: false,
+    errorMessage: undefined,
+    stack: undefined,
+  };
 
   static getDerivedStateFromError(error: Error) {
     // Update state so the next render will show the fallback UI.

--- a/src/extensionConsole/pages/mods/gridView/GridCardErrorBoundary.tsx
+++ b/src/extensionConsole/pages/mods/gridView/GridCardErrorBoundary.tsx
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Component } from "react";
+import React from "react";
 import { Card } from "react-bootstrap";
-import { getErrorMessage } from "@/errors/errorHelpers";
 import { type ModViewItem } from "@/types/modTypes";
+import GenericErrorBoundary from "@/components/ErrorBoundary";
 
 import styles from "./GridCard.module.scss";
 import cx from "classnames";
@@ -35,28 +35,7 @@ type Props = {
   modViewItem: ModViewItem;
 };
 
-type State = {
-  hasError: boolean;
-  errorMessage: string | undefined;
-  stack: string | undefined;
-};
-
-class GridCardErrorBoundary extends Component<Props, State> {
-  override state: State = {
-    hasError: false,
-    errorMessage: undefined,
-    stack: undefined,
-  };
-
-  static getDerivedStateFromError(error: Error) {
-    // Update state so the next render will show the fallback UI.
-    return {
-      hasError: true,
-      errorMessage: getErrorMessage(error),
-      stack: error.stack,
-    };
-  }
-
+class GridCardErrorBoundary extends GenericErrorBoundary<Props> {
   override render(): React.ReactNode {
     if (this.state.hasError) {
       return (

--- a/src/extensionConsole/pages/mods/listView/ListItemErrorBoundary.tsx
+++ b/src/extensionConsole/pages/mods/listView/ListItemErrorBoundary.tsx
@@ -15,9 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Component } from "react";
+import React from "react";
 import { ListGroup } from "react-bootstrap";
-import { getErrorMessage } from "@/errors/errorHelpers";
 import { type ModViewItem } from "@/types/modTypes";
 
 import styles from "./ListItem.module.scss";
@@ -25,6 +24,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import { DEFAULT_TEXT_ICON_COLOR } from "@/mods/ModIcon";
 import cx from "classnames";
+import GenericErrorBoundary from "@/components/ErrorBoundary";
 
 type Props = {
   /**
@@ -37,28 +37,7 @@ type Props = {
   style: React.CSSProperties;
 };
 
-type State = {
-  hasError: boolean;
-  errorMessage: string | undefined;
-  stack: string | undefined;
-};
-
-class ListItemErrorBoundary extends Component<Props, State> {
-  override state: State = {
-    hasError: false,
-    errorMessage: undefined,
-    stack: undefined,
-  };
-
-  static getDerivedStateFromError(error: Error) {
-    // Update state so the next render will show the fallback UI.
-    return {
-      hasError: true,
-      errorMessage: getErrorMessage(error),
-      stack: error.stack,
-    };
-  }
-
+class ListItemErrorBoundary extends GenericErrorBoundary<Props> {
   override render(): React.ReactNode {
     if (this.state.hasError) {
       return (

--- a/src/pageEditor/fields/ConfigErrorBoundary.tsx
+++ b/src/pageEditor/fields/ConfigErrorBoundary.tsx
@@ -15,39 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Component } from "react";
-import { getErrorMessage } from "@/errors/errorHelpers";
+import React from "react";
 import reportError from "@/telemetry/reportError";
-import { type UnknownObject } from "@/types/objectTypes";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { isEmpty } from "lodash";
+import GenericErrorBoundary from "@/components/ErrorBoundary";
 
 // eslint-disable-next-line prefer-destructuring -- process.env substitution
 const DEBUG = process.env.DEBUG;
 
-interface State {
-  hasError: boolean;
-  errorMessage: string | undefined;
-  stack: string | undefined;
-}
-
-class ConfigErrorBoundary extends Component<UnknownObject, State> {
-  override state: State = {
-    hasError: false,
-    errorMessage: undefined,
-    stack: undefined,
-  };
-
-  static getDerivedStateFromError(error: Error) {
-    // Update state so the next render will show the fallback UI.
-    return {
-      hasError: true,
-      errorMessage: getErrorMessage(error),
-      stack: error.stack,
-    };
-  }
-
+class ConfigErrorBoundary extends GenericErrorBoundary {
   override componentDidCatch(error: Error): void {
     reportError(error);
   }

--- a/src/sidebar/ErrorBoundary.tsx
+++ b/src/sidebar/ErrorBoundary.tsx
@@ -15,8 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Component, type ErrorInfo } from "react";
-import { getErrorMessage } from "@/errors/errorHelpers";
+import React, { type ErrorInfo } from "react";
 import { isEmpty } from "lodash";
 import { faRedo } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -24,33 +23,9 @@ import { Alert, Button } from "react-bootstrap";
 import { reloadSidebar } from "@/contentScript/messenger/api";
 import { getTopLevelFrame } from "webext-messenger";
 import reportError from "@/telemetry/reportError";
+import GenericErrorBoundary from "@/components/ErrorBoundary";
 
-interface State {
-  hasError: boolean;
-  errorMessage: string | undefined;
-  stack: string | undefined;
-}
-
-interface Props {
-  onError?: (error?: Error, errorInfo?: ErrorInfo) => void;
-}
-
-class ErrorBoundary extends Component<Props, State> {
-  override state: State = {
-    hasError: false,
-    errorMessage: undefined,
-    stack: undefined,
-  };
-
-  static getDerivedStateFromError(error: Error) {
-    // Update state so the next render will show the fallback UI.
-    return {
-      hasError: true,
-      errorMessage: getErrorMessage(error),
-      stack: error.stack,
-    };
-  }
-
+class ErrorBoundary extends GenericErrorBoundary {
   override componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.props.onError?.(error, errorInfo);
     reportError(error);


### PR DESCRIPTION
## What does this PR do?

- Follows: https://github.com/pixiebrix/pixiebrix-extension/pull/6908#discussion_r1399475024

## Discussion

No behavior changes were made, this PR purely deduplicates code at this point, unless otherwise requested.

One thing to note is that the "new" error state includes the whole Error object. Would that be an issue at all with RTK in this scenario?

## Checklist

- [x] Designate a primary reviewer: @BLoe 
