### PR TITLE
[WIP] Jeremiah interview project

### DIFF
--- a/src/hooks/useAsyncReduxStore.test.tsx
+++ b/src/hooks/useAsyncReduxStore.test.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from "react";
+import { renderHook, act } from "@testing-library/react-hooks";
+import { waitForEffect } from "@/testUtils/testHelpers";
+import useAsyncReduxStore from "./useAsyncReduxStore";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+
+describe("useAsyncReduxStore", () => {
+  test("should resolve promise", async () => {
+    
+    const store = configureStore({
+      reducer: {},
+    });
+
+    let listenerCount = 0;
+
+    const getSnapshot = async () => 42;
+    const subscribe = () => {
+      listenerCount += 1;
+      return () => {
+        listenerCount -= 1;
+      };
+    };
+
+    const view = renderHook(() => useAsyncReduxStore(subscribe, getSnapshot, "testSlice", []), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+
+    // Expect(listenerCount).toBe(1);
+
+    expect(view.result.current).toEqual(
+      expect.objectContaining({
+        isLoading: true,
+      })
+    );
+
+    await waitForEffect();
+    
+    expect(view.result.current).toEqual(
+      expect.objectContaining({
+        isSuccess: true,
+        data: 42,
+      })
+    );
+
+    view.unmount()
+
+    expect(listenerCount).toBe(1);
+  });
+
+  // It("should only fetch once when initialized twice", async () => {
+  //   let resolveCount = 0;
+  //   const getSnapshot = async () => {
+  //     resolveCount += 1;
+  //     return 42;
+  //   }
+
+  //   const subscribe = () => (() => null);
+
+  //   const wrapper1 = renderHook(() => {
+  //     useAsyncReduxStore(subscribe, getSnapshot, "testSlice", [])
+  //   });
+  //   const wrapper2 = renderHook(() => {
+  //     useAsyncReduxStore(subscribe, getSnapshot, "testSlice", [])
+  //   });
+
+  //   expect(wrapper1.result.current).toEqual(
+  //     expect.objectContaining({isLoading: true,})
+  //   );
+  //   expect(wrapper2.result.current).toEqual(
+  //     expect.objectContaining({ isLoading: true,})
+  //   );
+
+  //   expect(resolveCount).toBe(0);
+
+  //   await waitForEffect();
+
+  //   expect(wrapper1.result.current).toEqual(
+  //     expect.objectContaining({
+  //       isSuccess: true,
+  //       data: 42,
+  //     })
+  //   );
+  //   expect(wrapper2.result.current).toEqual(
+  //     expect.objectContaining({
+  //       isSuccess: true,
+  //       data: 42,
+  //     })
+  //   );
+
+  //   expect(resolveCount).toBe(1);
+  // });
+
+  // it("should refetch for different arguments", async () => {});
+});

--- a/src/hooks/useAsyncReduxStore.ts
+++ b/src/hooks/useAsyncReduxStore.ts
@@ -1,0 +1,177 @@
+import { createSlice, type PayloadAction, type Slice } from "@reduxjs/toolkit";
+import { type AsyncState } from "@/types/sliceTypes";
+import { errorToAsyncState, uninitializedAsyncStateFactory, valueToAsyncState } from "@/utils/asyncStateUtils";
+import { type UUID } from "@/types/stringTypes";
+import { useSelector, useDispatch } from "react-redux";
+import { uuidv4 } from "@/types/helpers";
+import deepEquals from "fast-deep-equal";
+import { useSyncExternalStore } from "use-sync-external-store/shim";
+import { useAsyncEffect } from "use-async-effect";
+
+
+type Subscribe = (callback: () => void) => () => void;
+
+function createAsyncStateReduxSlice<T>(sliceName: string): Slice<AsyncState<T>> {
+  // TODO(interview note) - should move this + the createSlice in
+  // useAsyncState.ts into a utility file, not doing that here
+  // to keep the PR simple.
+  return createSlice({
+    name: sliceName,
+    initialState: uninitializedAsyncStateFactory(),
+    reducers: {
+      initialize(state) {
+        // Initialize loading state
+        state.isUninitialized = false;
+        state.isFetching = true;
+        state.isLoading = true;
+      },
+      startFetchNewInputs(state) {
+        // Start fetching for new inputs. Clears currentData because the inputs changed
+        state.isFetching = true;
+        state.currentData = undefined;
+      },
+      startRefetch(state) {
+        // Start fetching for the same inputs. Keeps currentData because the inputs didn't change
+        state.isFetching = true;
+      },
+      success(state, action: PayloadAction<{ data: unknown }>) {
+        const { data } = action.payload;
+  
+        state.isLoading = false;
+        state.isFetching = false;
+        state.data = data;
+        state.currentData = data;
+        state.isError = false;
+        state.isSuccess = true;
+        state.error = undefined;
+      },
+      failure(state, action: PayloadAction<{ error: unknown }>) {
+        state.isLoading = false;
+        state.isFetching = false;
+        state.data = undefined;
+        state.isError = true;
+        state.isSuccess = false;
+        state.error = action.payload.error ?? new Error("Error producing data");
+      },
+    },
+  })
+}
+
+class StateController<T = unknown> {
+  private readonly stateListeners = new Set<() => void>();
+  private readonly slice: Slice<AsyncState<T>>;
+  private readonly state: AsyncState<T>;
+  private nonce: UUID;
+
+  private readonly dispatch = useDispatch();
+
+  // Methods to pass to useSyncExternalStore
+  readonly boundSubscribe: Subscribe;
+  readonly boundGetSnapshot: () => AsyncState<T>;
+
+  constructor(
+    readonly externalSubscribe: Subscribe,
+    readonly factory: () => Promise<T>,
+    state: AsyncState<T>,
+    sliceName: string,
+  ) {
+    this.boundSubscribe = this.internalSubscribe.bind(this);
+    this.boundGetSnapshot = this.getSnapshot.bind(this);
+    externalSubscribe(this.updateSnapshot.bind(this));
+    this.slice = createAsyncStateReduxSlice<T>(sliceName);
+    this.state = state[sliceName];
+    void this.updateSnapshot();
+  }
+
+  internalSubscribe(callback: () => void): () => void {
+    this.stateListeners.add(callback);
+
+    return () => {
+      this.stateListeners.delete(callback);
+    };
+  }
+
+  notifyAll(): void {
+    for (const listener of this.stateListeners) {
+      listener()
+    }
+  }
+
+  async updateSnapshot(): Promise<void> {
+    if (this.state.isUninitialized) {
+      this.dispatch(this.slice.actions.initialize());
+    } else {
+      this.dispatch(this.slice.actions.startFetchNewInputs());
+    }
+
+    const nonce = uuidv4();
+    this.nonce = nonce;
+
+    this.notifyAll();
+
+    try {
+      const data = await this.factory();
+
+      if (nonce !== this.nonce) {
+        return;
+      }
+
+      // Preserve reference equality if possible
+      const nextData = deepEquals(data, this.state.currentData)
+        ? this.state.currentData
+        : data;
+      this.dispatch(this.slice.actions.success({data: valueToAsyncState(nextData)}));
+    } catch (error) {
+      if (nonce !== this.nonce) {
+        return;
+      }
+
+      this.dispatch(this.slice.actions.failure({ error: errorToAsyncState(error)}));
+    }
+
+    this.notifyAll();
+  }
+
+  getSnapshot(): AsyncState<T> {
+    return this.state;
+  }
+}
+
+const stateControllerMap = new Map<string, StateController>;
+
+/**
+ * Hook to asynchronously compute a value, store it in redux, and return the state.
+ * 
+ * 
+ * @param subscribe see docs for useSyncExternalStore
+ * @param factory an async function that returns the current snapshot of the external store
+ * @param sliceName the redux slice name to use
+ * @param dependencies if the factory accepts parameters, pass them here
+ * @see useSyncExternalStore
+ * @see useAsyncExternalStore
+ */
+function useAsyncReduxStore<T>(
+  subscribe: Subscribe,
+  factory: () => Promise<T>,
+  sliceName: string,
+  dependencies: unknown[],
+): AsyncState<T> {
+  const state = useSelector(state => state[sliceName])
+  console.log(state);
+  if (!stateControllerMap.has(sliceName)) {
+    stateControllerMap.set(sliceName, new StateController<T>(subscribe, factory, state, sliceName))
+  }
+
+  const controller = stateControllerMap.get(sliceName);
+
+  useAsyncEffect(async () => {
+    await controller.updateSnapshot()
+  }, [...dependencies, sliceName]);
+  
+  return useSyncExternalStore(
+    controller.boundSubscribe,
+    controller.boundGetSnapshot
+  ) as AsyncState<T>;
+}
+
+export default useAsyncReduxStore;


### PR DESCRIPTION
## What does this PR do?

- Adds a work-in-progress react hook and tests for connecting async state sources to the redux store

WIP notes:
- The file doesn't currently pass tests, as the redux store isn't initialized properly. Due to a misunderstanding on my part, I assumed I could initialize slices on the fly and have them automatically included in the store. This means that when I try to access state from within the hook, I hit undefined. I tried to take too much of my approach from the useAsyncState.ts file, without considering fully the need to initialize the store and slice from outside of the hook.

- The basic idea of the hook is to track different slices similar to the approach in useAsyncExternalStore, but combining it with the logic used to update redux appropriately in useAsyncState. I also tried to make use of useAsyncEffect to allow the factory to re-trigger when arguments are updated. Overall, I think this approach is still viable, but I would need to do a good amount of refactoring to properly interface with the redux store.

## Reviewer Tips

- Please let me know if it appears that this approach is entirely unworkable, or if it's unclear what my intent was. I took a lot of this code in part or whole from the other files because to the best of my understanding what's needed is something of a hybrid approach between the two.

## Future Work

- Given more time I would have also liked to factor out a lot of the shared code, especially the slice creation since it's very similar to what is used in useAsyncState.

## Checklist

- [ x ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [ ] Designate a primary reviewer
