### PR TITLE
Fix tracing for pipelines passed to user-defined bricks; fix stale sub-pipeline status indicators in Page Editor

### DIFF
--- a/src/background/executor.test.ts
+++ b/src/background/executor.test.ts
@@ -16,11 +16,16 @@
  */
 
 import { requestRunInAllFrames } from "@/background/executor";
-import { registryIdFactory } from "@/testUtils/factories/stringFactories";
-import { type BrickArgs } from "@/types/runtimeTypes";
+import {
+  registryIdFactory,
+  uuidSequence,
+} from "@/testUtils/factories/stringFactories";
 import { type MessengerMeta, type Sender } from "webext-messenger";
 import { runBrick } from "@/contentScript/messenger/api";
 import { type WebNavigation } from "webextension-polyfill";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { define, derive } from "cooky-cutter";
+import { type RemoteBrickOptions } from "@/contentScript/messenger/runBrickTypes";
 
 type GetAllFramesCallbackDetailsItemType =
   WebNavigation.GetAllFramesCallbackDetailsItemType;
@@ -33,6 +38,21 @@ jest.mock("@/contentScript/messenger/api", () => ({
 
 const getAllFramesMock = jest.mocked(browser.webNavigation.getAllFrames);
 const runBrickMock = jest.mocked(runBrick);
+
+const optionsFactory = define<RemoteBrickOptions>({
+  ctxt: () => ({}),
+  messageContext: (i: number) => ({
+    extensionId: uuidSequence(i),
+  }),
+  meta: derive<RemoteBrickOptions, RemoteBrickOptions["meta"]>(
+    (options) => ({
+      extensionId: options.messageContext.extensionId,
+      runId: null,
+      branches: [],
+    }),
+    "messageContext"
+  ),
+});
 
 beforeEach(() => {
   runBrickMock.mockClear();
@@ -56,13 +76,9 @@ describe("requestRunInAllFrames", () => {
 
     const promise = requestRunInAllFrames.call(meta, {
       blockId: registryIdFactory(),
-      blockArgs: {} as BrickArgs,
-      options: {
-        ctxt: {},
-        messageContext: {},
-      },
+      blockArgs: unsafeAssumeValidArg({}),
+      options: optionsFactory(),
     });
-
     await expect(promise).resolves.toStrictEqual([]);
   });
 
@@ -85,11 +101,8 @@ describe("requestRunInAllFrames", () => {
 
     const promise = requestRunInAllFrames.call(meta, {
       blockId: registryIdFactory(),
-      blockArgs: {} as BrickArgs,
-      options: {
-        ctxt: {},
-        messageContext: {},
-      },
+      blockArgs: unsafeAssumeValidArg({}),
+      options: optionsFactory(),
     });
 
     await expect(promise).resolves.toStrictEqual([]);
@@ -116,11 +129,8 @@ describe("requestRunInAllFrames", () => {
 
     const promise = requestRunInAllFrames.call(meta, {
       blockId: registryIdFactory(),
-      blockArgs: {} as BrickArgs,
-      options: {
-        ctxt: {},
-        messageContext: {},
-      },
+      blockArgs: unsafeAssumeValidArg({}),
+      options: optionsFactory(),
     });
 
     await expect(promise).resolves.toStrictEqual([{ foo: 42 }]);

--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -26,7 +26,7 @@ import { runBrick } from "@/contentScript/messenger/api";
 import { type Target } from "@/types/messengerTypes";
 import pDefer from "p-defer";
 import { getErrorMessage } from "@/errors/errorHelpers";
-import type { RunBrick } from "@/contentScript/messenger/runBrickTypes";
+import type { RunBrickRequest } from "@/contentScript/messenger/runBrickTypes";
 import { BusinessError } from "@/errors/businessErrors";
 import { canAccessTab } from "@/permissions/permissionsUtils";
 import { SessionMap } from "@/mv3/SessionStorage";
@@ -51,7 +51,7 @@ function rememberOpener(newTabId: TabId, openerTabId: TabId): void {
 
 async function safelyRunBrick(
   { tabId, frameId }: Target,
-  request: RunBrick
+  request: RunBrickRequest
 ): Promise<unknown> {
   try {
     return await runBrick({ tabId, frameId }, request);
@@ -93,7 +93,7 @@ export async function waitForTargetByUrl(url: string): Promise<Target> {
  */
 export async function requestRunInOpener(
   this: MessengerMeta,
-  request: RunBrick
+  request: RunBrickRequest
 ): Promise<unknown> {
   let { id: sourceTabId, openerTabId } = this.trace[0].tab;
 
@@ -119,7 +119,7 @@ export async function requestRunInOpener(
  */
 export async function requestRunInTarget(
   this: MessengerMeta,
-  request: RunBrick
+  request: RunBrickRequest
 ): Promise<unknown> {
   const sourceTabId = this.trace[0].tab.id;
   const target = await tabToTarget.get(String(sourceTabId));
@@ -140,7 +140,7 @@ export async function requestRunInTarget(
  */
 export async function requestRunInTop(
   this: MessengerMeta,
-  request: RunBrick
+  request: RunBrickRequest
 ): Promise<unknown> {
   const sourceTabId = this.trace[0].tab.id;
 
@@ -157,7 +157,7 @@ export async function requestRunInTop(
  */
 export async function requestRunInOtherTabs(
   this: MessengerMeta,
-  request: RunBrick
+  request: RunBrickRequest
 ): Promise<unknown[]> {
   const sourceTabId = this.trace[0].tab.id;
   const subRequest = { ...request, sourceTabId };
@@ -183,7 +183,7 @@ export async function requestRunInOtherTabs(
 
 export async function requestRunInAllFrames(
   this: MessengerMeta,
-  request: RunBrick
+  request: RunBrickRequest
 ): Promise<unknown[]> {
   const sourceTabId = this.trace[0].tab.id;
   const subRequest = { ...request, sourceTabId };

--- a/src/bricks/effects/AddQuickBarAction.test.ts
+++ b/src/bricks/effects/AddQuickBarAction.test.ts
@@ -20,7 +20,7 @@ import quickbarRegistry from "@/components/quickBar/quickBarRegistry";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
-import { type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new AddQuickBarAction();
 
@@ -55,11 +55,14 @@ describe("AddQuickBarAction", () => {
   test("adds root action", async () => {
     const abortController = new AbortController();
 
-    await brick.run(unsafeAssumeValidArg({ title: "test" }), {
-      logger,
-      root: document,
-      abortSignal: abortController.signal,
-    } as BrickOptions);
+    await brick.run(
+      unsafeAssumeValidArg({ title: "test" }),
+      brickOptionsFactory({
+        logger,
+        root: document,
+        abortSignal: abortController.signal,
+      })
+    );
     expect(addActionMock).toHaveBeenCalledWith({
       id: expect.toBeString(),
       extensionPointId: logger.context.extensionPointId,

--- a/src/bricks/effects/alert.test.ts
+++ b/src/bricks/effects/alert.test.ts
@@ -17,8 +17,8 @@
 
 import { AlertEffect } from "@/bricks/effects/alert";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { validateInput } from "@/validators/generic";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new AlertEffect();
 
@@ -36,7 +36,7 @@ describe("AlertEffect", () => {
     window.alert = jest.fn();
     await brick.run(
       unsafeAssumeValidArg({ message: "Hello, world!" }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
     expect(window.alert).toHaveBeenCalledWith("Hello, world!");
   });

--- a/src/bricks/effects/assignModVariable.test.ts
+++ b/src/bricks/effects/assignModVariable.test.ts
@@ -17,12 +17,12 @@
 
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import { validateRegistryId } from "@/types/helpers";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import AssignModVariable from "@/bricks/effects/assignModVariable";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { getPageState, setPageState } from "@/contentScript/pageState";
 import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 import { validateInput } from "@/validators/generic";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const extensionId = autoUUIDSequence();
 const blueprintId = validateRegistryId("test/123");
@@ -34,7 +34,7 @@ const logger = new ConsoleLogger({
   blueprintId,
 });
 
-const brickOptions = { logger } as BrickOptions;
+const brickOptions = brickOptionsFactory({ logger });
 
 beforeEach(() => {
   setPageState({

--- a/src/bricks/effects/attachAutocomplete.test.ts
+++ b/src/bricks/effects/attachAutocomplete.test.ts
@@ -17,10 +17,9 @@
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { AttachAutocomplete } from "@/bricks/effects/attachAutocomplete";
-
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new AttachAutocomplete();
 
@@ -49,10 +48,13 @@ describe("AttachAutocomplete", () => {
   });
 
   test("it attaches autocomplete", async () => {
-    await brick.run(unsafeAssumeValidArg({ selector: "[name='name']" }), {
-      root: document,
-      logger,
-    } as unknown as BrickOptions);
+    await brick.run(
+      unsafeAssumeValidArg({ selector: "[name='name']" }),
+      brickOptionsFactory({
+        root: document,
+        logger,
+      })
+    );
 
     expect(document.querySelector("[name='name']").getAttribute("role")).toBe(
       "combobox"
@@ -62,10 +64,10 @@ describe("AttachAutocomplete", () => {
   test("it is root aware", async () => {
     await brick.run(
       unsafeAssumeValidArg({ selector: "[name='name']", isRootAware: true }),
-      {
-        root: document.querySelector("#noForm"),
+      brickOptionsFactory({
+        root: document.querySelector<HTMLElement>("#noForm"),
         logger,
-      } as unknown as BrickOptions
+      })
     );
 
     expect(
@@ -74,10 +76,10 @@ describe("AttachAutocomplete", () => {
 
     await brick.run(
       unsafeAssumeValidArg({ selector: "[name='name']", isRootAware: true }),
-      {
-        root: document.querySelector("#hasForm"),
+      brickOptionsFactory({
+        root: document.querySelector<HTMLElement>("#hasForm"),
         logger,
-      } as unknown as BrickOptions
+      })
     );
 
     expect(document.querySelector("[name='name']").getAttribute("role")).toBe(

--- a/src/bricks/effects/cancel.test.ts
+++ b/src/bricks/effects/cancel.test.ts
@@ -18,14 +18,14 @@
 import { CancelEffect } from "@/bricks/effects/cancel";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { CancelError } from "@/errors/businessErrors";
-import { type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new CancelEffect();
 
 describe("CancelEffect", () => {
   test("it throws CancelError", async () => {
     await expect(
-      brick.run(unsafeAssumeValidArg({}), {} as BrickOptions)
+      brick.run(unsafeAssumeValidArg({}), brickOptionsFactory())
     ).rejects.toThrow(CancelError);
   });
 });

--- a/src/bricks/effects/clipboard.test.ts
+++ b/src/bricks/effects/clipboard.test.ts
@@ -19,7 +19,7 @@ import { CopyToClipboard } from "@/bricks/effects/clipboard";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { PropError } from "@/errors/businessErrors";
 import userEvent from "@testing-library/user-event";
-import { type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new CopyToClipboard();
 
@@ -51,14 +51,14 @@ describe("CopyToClipboard", () => {
 
   it("copies to clipboard", async () => {
     const text = "Hello, world!";
-    await brick.run(unsafeAssumeValidArg({ text }), {} as BrickOptions);
+    await brick.run(unsafeAssumeValidArg({ text }), brickOptionsFactory());
     expect(writeTextMock).toHaveBeenCalledWith(text);
   });
 
   it("copies null to clipboard", async () => {
     await brick.run(
       unsafeAssumeValidArg({ text: null, contentType: "infer" }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
     expect(writeTextMock).toHaveBeenCalledWith("null");
   });
@@ -66,7 +66,7 @@ describe("CopyToClipboard", () => {
   it("copies boolean clipboard", async () => {
     await brick.run(
       unsafeAssumeValidArg({ text: false, contentType: "infer" }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
     expect(writeTextMock).toHaveBeenCalledWith("false");
   });
@@ -74,7 +74,7 @@ describe("CopyToClipboard", () => {
   it("copies image to clipboard", async () => {
     await brick.run(
       unsafeAssumeValidArg({ text: SMALL_RED_DOT_URI, contentType: "infer" }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
     expect(writeTextMock).not.toHaveBeenCalled();
     expect(writeMock).toHaveBeenCalled();
@@ -87,7 +87,7 @@ describe("CopyToClipboard", () => {
     await expect(async () =>
       brick.run(
         unsafeAssumeValidArg({ text: false, contentType: "image" }),
-        {} as BrickOptions
+        brickOptionsFactory()
       )
     ).rejects.toThrow(PropError);
   });
@@ -97,7 +97,7 @@ describe("CopyToClipboard", () => {
 
     const brickPromise = brick.run(
       unsafeAssumeValidArg({ text: SMALL_RED_DOT_URI, contentType: "image" }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
 
     writeMock.mockResolvedValue();
@@ -115,7 +115,7 @@ describe("CopyToClipboard", () => {
 
     const brickPromise = brick.run(
       unsafeAssumeValidArg({ text: SMALL_RED_DOT_URI, contentType: "image" }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
 
     await userEvent.click(document.body);

--- a/src/bricks/effects/customEvent.test.ts
+++ b/src/bricks/effects/customEvent.test.ts
@@ -17,10 +17,9 @@
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import CustomEventEffect from "@/bricks/effects/customEvent";
-
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new CustomEventEffect();
 
@@ -49,10 +48,13 @@ describe("CustomEventEffect", () => {
     const eventHandler = jest.fn();
     document.querySelector("button").addEventListener("foo", eventHandler);
 
-    await brick.run(unsafeAssumeValidArg({ eventName: "foo" }), {
-      root: document.querySelector("button"),
-      logger,
-    } as unknown as BrickOptions);
+    await brick.run(
+      unsafeAssumeValidArg({ eventName: "foo" }),
+      brickOptionsFactory({
+        root: document.querySelector("button"),
+        logger,
+      })
+    );
 
     expect(eventHandler).toHaveBeenCalled();
   });
@@ -61,10 +63,13 @@ describe("CustomEventEffect", () => {
     const eventHandler = jest.fn();
     document.querySelector("div").addEventListener("foo", eventHandler);
 
-    await brick.run(unsafeAssumeValidArg({ eventName: "foo" }), {
-      root: document.querySelector("button"),
-      logger,
-    } as unknown as BrickOptions);
+    await brick.run(
+      unsafeAssumeValidArg({ eventName: "foo" }),
+      brickOptionsFactory({
+        root: document.querySelector("button"),
+        logger,
+      })
+    );
 
     expect(eventHandler).toHaveBeenCalled();
   });

--- a/src/bricks/effects/disable.test.ts
+++ b/src/bricks/effects/disable.test.ts
@@ -16,17 +16,10 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { DisableEffect } from "@/bricks/effects/disable";
-
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new DisableEffect();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidSequence(0),
-});
 
 describe("DisableEffect", () => {
   beforeEach(() => {
@@ -48,7 +41,9 @@ describe("DisableEffect", () => {
     async (isRootAware) => {
       await brick.run(
         unsafeAssumeValidArg({ selector: "button", isRootAware }),
-        { root: document, logger } as BrickOptions
+        brickOptionsFactory({
+          root: document,
+        })
       );
 
       expect(document.querySelector("button")).toBeDisabled();
@@ -56,10 +51,12 @@ describe("DisableEffect", () => {
   );
 
   test("it disables element for isRootAware: true", async () => {
-    await brick.run(unsafeAssumeValidArg({ isRootAware: true }), {
-      root: document.querySelector("button"),
-      logger,
-    } as unknown as BrickOptions);
+    await brick.run(
+      unsafeAssumeValidArg({ isRootAware: true }),
+      brickOptionsFactory({
+        root: document.querySelector("button"),
+      })
+    );
 
     expect(document.querySelector("button")).toBeDisabled();
   });

--- a/src/bricks/effects/enable.test.ts
+++ b/src/bricks/effects/enable.test.ts
@@ -17,16 +17,9 @@
 
 import { EnableEffect } from "@/bricks/effects/enable";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type BrickOptions } from "@/types/runtimeTypes";
-
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new EnableEffect();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidSequence(0),
-});
 
 describe("EnableEffect", () => {
   beforeEach(() => {
@@ -44,7 +37,7 @@ describe("EnableEffect", () => {
     async (isRootAware) => {
       await brick.run(
         unsafeAssumeValidArg({ selector: "button", isRootAware }),
-        { root: document, logger } as BrickOptions
+        brickOptionsFactory()
       );
 
       expect(document.querySelector("button")).not.toBeDisabled();
@@ -52,10 +45,10 @@ describe("EnableEffect", () => {
   );
 
   test("it enables element for isRootAware: true", async () => {
-    await brick.run(unsafeAssumeValidArg({ isRootAware: true }), {
-      root: document.querySelector("button"),
-      logger,
-    } as unknown as BrickOptions);
+    await brick.run(
+      unsafeAssumeValidArg({ isRootAware: true }),
+      brickOptionsFactory({ root: document.querySelector("button") })
+    );
 
     expect(document.querySelector("button")).not.toBeDisabled();
   });

--- a/src/bricks/effects/error.test.ts
+++ b/src/bricks/effects/error.test.ts
@@ -17,15 +17,15 @@
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { BusinessError } from "@/errors/businessErrors";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { ErrorEffect } from "@/bricks/effects/error";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new ErrorEffect();
 
 describe("ErrorEffect", () => {
   test("it throws BusinessError", async () => {
     await expect(
-      brick.run(unsafeAssumeValidArg({}), {} as BrickOptions)
+      brick.run(unsafeAssumeValidArg({}), brickOptionsFactory())
     ).rejects.toThrow(BusinessError);
   });
 });

--- a/src/bricks/effects/event.test.ts
+++ b/src/bricks/effects/event.test.ts
@@ -16,17 +16,10 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { ElementEvent } from "@/bricks/effects/event";
-
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new ElementEvent();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidSequence(0),
-});
 
 describe("ElementEvent", () => {
   beforeEach(() => {
@@ -55,7 +48,7 @@ describe("ElementEvent", () => {
           isRootAware,
           event: "click",
         }),
-        { root: document, logger } as BrickOptions
+        brickOptionsFactory()
       );
 
       expect(clickHandler).toHaveBeenCalled();
@@ -71,10 +64,7 @@ describe("ElementEvent", () => {
         isRootAware: true,
         event: "click",
       }),
-      {
-        root: document.querySelector("button"),
-        logger,
-      } as unknown as BrickOptions
+      brickOptionsFactory({ root: document.querySelector("button") })
     );
 
     expect(clickHandler).toHaveBeenCalled();

--- a/src/bricks/effects/forms.test.ts
+++ b/src/bricks/effects/forms.test.ts
@@ -33,19 +33,12 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { FormFill, SetInputValue } from "@/bricks/effects/forms";
 import { BusinessError, NoElementsFoundError } from "@/errors/businessErrors";
-
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const setInputValueBrick = new SetInputValue();
 const formFillBrick = new FormFill();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidSequence(0),
-});
 
 describe("SetInputValue", () => {
   beforeEach(() => {
@@ -72,7 +65,7 @@ describe("SetInputValue", () => {
       unsafeAssumeValidArg({
         inputs: [{ selector: "[name='name']", value: "Bob Smith" }],
       }),
-      { root: document, logger } as unknown as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.querySelector("[name='name']")).toHaveValue("Bob Smith");
@@ -84,10 +77,9 @@ describe("SetInputValue", () => {
         inputs: [{ selector: "[name='name']", value: "Bob Smith" }],
         isRootAware: true,
       }),
-      {
-        root: document.querySelector("#noForm"),
-        logger,
-      } as unknown as BrickOptions
+      brickOptionsFactory({
+        root: document.querySelector<HTMLElement>("#noForm"),
+      })
     );
 
     // Will have original value because root it on the other path
@@ -98,10 +90,9 @@ describe("SetInputValue", () => {
         inputs: [{ selector: "[name='name']", value: "Bob Smith" }],
         isRootAware: true,
       }),
-      {
-        root: document.querySelector("#hasForm"),
-        logger,
-      } as unknown as BrickOptions
+      brickOptionsFactory({
+        root: document.querySelector<HTMLElement>("#hasForm"),
+      })
     );
 
     expect(document.querySelector("[name='name']")).toHaveValue("Bob Smith");
@@ -113,10 +104,7 @@ describe("SetInputValue", () => {
         inputs: [{ value: "Bob Smith" }],
         isRootAware: true,
       }),
-      {
-        root: document.querySelector("input"),
-        logger,
-      } as unknown as BrickOptions
+      brickOptionsFactory({ root: document.querySelector("input") })
     );
 
     expect(document.querySelector("[name='name']")).toHaveValue("Bob Smith");
@@ -128,9 +116,7 @@ describe("SetInputValue", () => {
         inputs: [{ value: "Bob Smith" }],
         isRootAware: false,
       }),
-      {
-        logger,
-      } as unknown as BrickOptions
+      brickOptionsFactory()
     );
 
     await expect(promise).rejects.toThrow(BusinessError);
@@ -142,10 +128,7 @@ describe("SetInputValue", () => {
         inputs: [{ value: "Bob Smith" }],
         isRootAware: true,
       }),
-      {
-        logger,
-        root: document.querySelector("div"),
-      } as unknown as BrickOptions
+      brickOptionsFactory({ root: document.querySelector("div") })
     );
 
     await expect(promise).rejects.toThrow(BusinessError);
@@ -178,7 +161,7 @@ describe("FormFill", () => {
         formSelector: "form",
         fieldNames: { name: "Bob Smith" },
       }),
-      { root: document, logger } as unknown as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.querySelector("[name='name']")).toHaveValue("Bob Smith");
@@ -191,10 +174,9 @@ describe("FormFill", () => {
         fieldNames: { name: "Bob Smith" },
         isRootAware: true,
       }),
-      {
-        root: document.querySelector("#noForm"),
-        logger,
-      } as unknown as BrickOptions
+      brickOptionsFactory({
+        root: document.querySelector<HTMLElement>("#noForm"),
+      })
     );
 
     await expect(promise).rejects.toThrow(NoElementsFoundError);
@@ -205,10 +187,9 @@ describe("FormFill", () => {
         fieldNames: { name: "Bob Smith" },
         isRootAware: true,
       }),
-      {
-        root: document.querySelector("#hasForm"),
-        logger,
-      } as unknown as BrickOptions
+      brickOptionsFactory({
+        root: document.querySelector<HTMLElement>("#hasForm"),
+      })
     );
 
     expect(document.querySelector("[name='name']")).toHaveValue("Bob Smith");

--- a/src/bricks/effects/hide.test.ts
+++ b/src/bricks/effects/hide.test.ts
@@ -16,17 +16,10 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { HideEffect } from "@/bricks/effects/hide";
-
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new HideEffect();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidSequence(0),
-});
 
 describe("HideEffect", () => {
   beforeEach(() => {
@@ -48,7 +41,7 @@ describe("HideEffect", () => {
     async (isRootAware) => {
       await brick.run(
         unsafeAssumeValidArg({ selector: "button", isRootAware }),
-        { root: document, logger } as BrickOptions
+        brickOptionsFactory()
       );
 
       expect(document.querySelector("button")).not.toBeVisible();
@@ -56,10 +49,10 @@ describe("HideEffect", () => {
   );
 
   test("it hides element for isRootAware: true", async () => {
-    await brick.run(unsafeAssumeValidArg({ isRootAware: true }), {
-      root: document.querySelector("button"),
-      logger,
-    } as unknown as BrickOptions);
+    await brick.run(
+      unsafeAssumeValidArg({ isRootAware: true }),
+      brickOptionsFactory({ root: document.querySelector("button") })
+    );
 
     expect(document.querySelector("button")).not.toBeVisible();
   });
@@ -67,10 +60,7 @@ describe("HideEffect", () => {
   test("it removes element", async () => {
     await brick.run(
       unsafeAssumeValidArg({ isRootAware: true, mode: "remove" }),
-      {
-        root: document.querySelector("button"),
-        logger,
-      } as unknown as BrickOptions
+      brickOptionsFactory({ root: document.querySelector("button") })
     );
 
     expect(document.querySelector("button")).toBeNull();

--- a/src/bricks/effects/highlight.test.ts
+++ b/src/bricks/effects/highlight.test.ts
@@ -16,15 +16,8 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { HighlightEffect } from "@/bricks/effects/highlight";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
-
-const logger = new ConsoleLogger({
-  extensionId: uuidSequence(0),
-});
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 describe("highlight", () => {
   test.each([[undefined], ["yellow"]])(
@@ -42,7 +35,7 @@ describe("highlight", () => {
           rootSelector: ".a",
           color,
         }),
-        { logger, root: document } as BrickOptions
+        brickOptionsFactory()
       );
 
       expect(document.body.innerHTML).toMatchSnapshot();
@@ -66,7 +59,9 @@ describe("highlight", () => {
         rootSelector: "span",
         rootMode: "inherit",
       }),
-      { logger, root: document.querySelector("#tree") } as BrickOptions
+      brickOptionsFactory({
+        root: document.querySelector<HTMLElement>("#tree"),
+      })
     );
 
     expect(document.body.innerHTML).toMatchSnapshot();
@@ -91,7 +86,9 @@ describe("highlight", () => {
           rootSelector: "span",
           rootMode,
         }),
-        { logger, root: document.querySelector("#tree") } as BrickOptions
+        brickOptionsFactory({
+          root: document.querySelector<HTMLElement>("#tree"),
+        })
       );
 
       expect(document.body.innerHTML).toMatchSnapshot();

--- a/src/bricks/effects/highlightText.test.ts
+++ b/src/bricks/effects/highlightText.test.ts
@@ -15,15 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { uuidv4 } from "@/types/helpers";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import HighlightText from "@/bricks/effects/highlightText";
-import { type BrickOptions } from "@/types/runtimeTypes";
-
-const logger = new ConsoleLogger({
-  extensionId: uuidv4(),
-});
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 describe("ReplaceTextEffect", () => {
   test("can iterate body", () => {
@@ -47,7 +41,7 @@ describe("ReplaceTextEffect", () => {
           pattern: "foo",
           color,
         }),
-        { logger, root: document } as BrickOptions
+        brickOptionsFactory()
       );
 
       expect(document.body.innerHTML).toBe(
@@ -64,7 +58,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         isCaseInsensitive: true,
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe(
@@ -79,7 +73,7 @@ describe("ReplaceTextEffect", () => {
       unsafeAssumeValidArg({
         pattern: "foo",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe("<div>fOobAr</div>");
@@ -93,7 +87,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "[foo]",
         isCaseInsensitive: true,
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe(
@@ -108,7 +102,7 @@ describe("ReplaceTextEffect", () => {
       unsafeAssumeValidArg({
         pattern: "bar",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe(
@@ -123,7 +117,7 @@ describe("ReplaceTextEffect", () => {
       unsafeAssumeValidArg({
         pattern: "oba",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe(
@@ -141,7 +135,7 @@ describe("ReplaceTextEffect", () => {
         unsafeAssumeValidArg({
           pattern: "foo",
         }),
-        { logger, root: document } as BrickOptions
+        brickOptionsFactory()
       );
     }
 
@@ -159,7 +153,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         selector: "div",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe(
@@ -176,7 +170,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "[fo]+",
         isRegex: true,
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe(
@@ -193,7 +187,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         color: "#A020F0",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe(
@@ -211,7 +205,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "[fo]+",
         isRegex: true,
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe(
@@ -228,7 +222,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "[fo]+",
         isRegex: true,
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe(
@@ -245,7 +239,7 @@ describe("ReplaceTextEffect", () => {
       unsafeAssumeValidArg({
         pattern: "Sup",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.title).toBe("Support page");
@@ -264,7 +258,7 @@ describe("ReplaceTextEffect", () => {
         isRegex: true,
         color: '"<script>alert("xss")</script>',
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe("<div><mark>foo</mark>bar</div>");
@@ -281,7 +275,7 @@ describe("ReplaceTextEffect", () => {
         pattern: ".+",
         isRegex: true,
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe(
@@ -300,7 +294,7 @@ describe("ReplaceTextEffect", () => {
       unsafeAssumeValidArg({
         pattern: "foo",
       }),
-      { logger, root } as BrickOptions
+      brickOptionsFactory({ root })
     );
 
     expect(document.body.innerHTML).toBe(
@@ -317,7 +311,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foobar",
         isAcrossElements: true,
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe(

--- a/src/bricks/effects/pageState.test.ts
+++ b/src/bricks/effects/pageState.test.ts
@@ -18,8 +18,8 @@
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { makeTemplateExpression } from "@/runtime/expressionCreators";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 beforeEach(() => {
   // Isolate extension state between test
@@ -35,7 +35,10 @@ describe("@pixiebrix/state/get", () => {
       extensionId: uuidv4(),
       blueprintId: validateRegistryId("test/123"),
     });
-    await brick.transform(unsafeAssumeValidArg({}), { logger } as BrickOptions);
+    await brick.transform(
+      unsafeAssumeValidArg({}),
+      brickOptionsFactory({ logger })
+    );
   });
 
   test("is page state aware", async () => {
@@ -57,13 +60,13 @@ describe("@pixiebrix/state/set", () => {
 
     let result = await brick.transform(
       { data: { foo: 42, bar: 42 } } as any,
-      { logger } as BrickOptions
+      brickOptionsFactory({ logger })
     );
     expect(result).toStrictEqual({ foo: 42, bar: 42 });
 
     result = await brick.transform(
-      { data: { foo: 1 }, mergeStrategy: "shallow" } as any,
-      { logger } as BrickOptions
+      unsafeAssumeValidArg({ data: { foo: 1 }, mergeStrategy: "shallow" }),
+      brickOptionsFactory({ logger })
     );
     expect(result).toStrictEqual({ foo: 1, bar: 42 });
   });
@@ -86,12 +89,12 @@ describe("@pixiebrix/state/set", () => {
 
     let result = await brick.transform(
       { data: original } as any,
-      { logger } as BrickOptions
+      brickOptionsFactory({ logger })
     );
     expect(result).toStrictEqual(original);
 
     result = await brick.transform(
-      {
+      unsafeAssumeValidArg({
         data: {
           primitiveArray: [1],
           primitive: 1,
@@ -99,8 +102,8 @@ describe("@pixiebrix/state/set", () => {
           objectArray: [{ b: 1 }, { a: 2 }],
         },
         mergeStrategy: "deep",
-      } as any,
-      { logger } as BrickOptions
+      }),
+      brickOptionsFactory({ logger })
     );
 
     // NOTE: lodash's `merge` behavior is different from deepmerge from Python. Lodash will zip the list items together
@@ -168,24 +171,25 @@ describe("set and get", () => {
     });
 
     await setState.transform(
-      { data: { foo: 42 } } as any,
-      { logger } as BrickOptions
+      unsafeAssumeValidArg({ data: { foo: 42 } }),
+      brickOptionsFactory({ logger })
     );
-    let result = await getState.transform(unsafeAssumeValidArg({}), {
-      logger,
-    } as BrickOptions);
+    let result = await getState.transform(
+      unsafeAssumeValidArg({}),
+      brickOptionsFactory({ logger })
+    );
 
     expect(result).toStrictEqual({ foo: 42 });
 
     result = await getState.transform(
       unsafeAssumeValidArg({ namespace: "extension" }),
-      { logger } as BrickOptions
+      brickOptionsFactory({ logger })
     );
     expect(result).toStrictEqual({});
 
     result = await getState.transform(
       unsafeAssumeValidArg({ namespace: "shared" }),
-      { logger } as BrickOptions
+      brickOptionsFactory({ logger })
     );
     expect(result).toStrictEqual({});
   });
@@ -202,24 +206,25 @@ describe("set and get", () => {
     });
 
     await setState.transform(
-      { data: { foo: 42 } } as any,
-      { logger } as BrickOptions
+      unsafeAssumeValidArg({ data: { foo: 42 } }),
+      brickOptionsFactory({ logger })
     );
-    let result = await getState.transform(unsafeAssumeValidArg({}), {
-      logger,
-    } as BrickOptions);
+    let result = await getState.transform(
+      unsafeAssumeValidArg({}),
+      brickOptionsFactory({ logger })
+    );
 
     expect(result).toStrictEqual({ foo: 42 });
 
     result = await getState.transform(
       unsafeAssumeValidArg({ namespace: "extension" }),
-      { logger } as BrickOptions
+      brickOptionsFactory({ logger })
     );
     expect(result).toStrictEqual({});
 
     result = await getState.transform(
       unsafeAssumeValidArg({ namespace: "shared" }),
-      { logger } as BrickOptions
+      brickOptionsFactory({ logger })
     );
     expect(result).toStrictEqual({ foo: 42 });
   });

--- a/src/bricks/effects/postMessage.test.ts
+++ b/src/bricks/effects/postMessage.test.ts
@@ -17,7 +17,7 @@
 
 import PostMessageEffect from "@/bricks/effects/postMessage";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new PostMessageEffect();
 
@@ -37,7 +37,7 @@ describe("postMessage", () => {
         selector: "iframe",
         message: { text: "Hello, frame!" },
       }),
-      { root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(frame.contentWindow.postMessage).toHaveBeenCalledWith(

--- a/src/bricks/effects/replaceText.test.ts
+++ b/src/bricks/effects/replaceText.test.ts
@@ -40,7 +40,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         replacement: "bar",
       }),
-      brickOptionsFactory()
+      brickOptionsFactory({ root: document })
     );
 
     expect(document.body.innerHTML).toBe("<div>bar</div>");
@@ -54,7 +54,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         replacement: "bar",
       }),
-      brickOptionsFactory()
+      brickOptionsFactory({ root: document })
     );
 
     expect(document.body.innerHTML).toBe("<div>barbar</div>");
@@ -68,7 +68,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         replacement: "bar",
       }),
-      brickOptionsFactory()
+      brickOptionsFactory({ root: document })
     );
 
     expect(document.body.innerHTML).toBe("<div>FOO</div>");
@@ -81,7 +81,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         replacement: "bar",
       }),
-      brickOptionsFactory()
+      brickOptionsFactory({ root: document })
     );
     expect(document.body.innerHTML).toBe("<div>bar <span>bar</span></div>");
   });
@@ -94,7 +94,7 @@ describe("ReplaceTextEffect", () => {
         replacement: "bar",
         selector: "span",
       }),
-      brickOptionsFactory()
+      brickOptionsFactory({ root: document })
     );
     expect(document.body.innerHTML).toBe("<div>foo <span>bar</span></div>");
   });
@@ -107,7 +107,7 @@ describe("ReplaceTextEffect", () => {
         replacement: "foobar",
         selector: "div",
       }),
-      brickOptionsFactory()
+      brickOptionsFactory({ root: document })
     );
     expect(document.body.innerHTML).toBe("<div>foobar <div>foobar</div></div>");
   });
@@ -133,7 +133,7 @@ describe("ReplaceTextEffect", () => {
         replacement: "###-###-####",
         isRegex: true,
       }),
-      brickOptionsFactory()
+      brickOptionsFactory({ root: document })
     );
     expect(document.body.innerHTML).toBe("<div>###-###-####</div>");
   });
@@ -146,7 +146,7 @@ describe("ReplaceTextEffect", () => {
         replacement: "$<numbers>",
         isRegex: true,
       }),
-      brickOptionsFactory()
+      brickOptionsFactory({ root: document })
     );
     expect(document.body.innerHTML).toBe("<div>123</div>");
   });
@@ -158,7 +158,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "^(\\+\\d{1,2}\\s)?\\(?\\d{3}\\)?[\\s.-]\\d{3}[\\s.-]\\d{4}",
         replacement: "###-###-####",
       }),
-      brickOptionsFactory()
+      brickOptionsFactory({ root: document })
     );
     expect(document.body.innerHTML).toBe("<div>123-456-7890</div>");
   });
@@ -174,7 +174,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "Sup",
         replacement: "Foo",
       }),
-      brickOptionsFactory()
+      brickOptionsFactory({ root: document })
     );
 
     expect(document.head.innerHTML).toBe("<title>Support page</title>");

--- a/src/bricks/effects/replaceText.test.ts
+++ b/src/bricks/effects/replaceText.test.ts
@@ -15,12 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { JSDOM } from "jsdom";
 import ReplaceTextEffect from "@/bricks/effects/replaceText";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 beforeEach(() => {
   // Isolate extension state between test
@@ -33,11 +31,6 @@ function getDocument(html: string): Document {
 
 const brick = new ReplaceTextEffect();
 
-const logger = new ConsoleLogger({
-  extensionId: uuidv4(),
-  blueprintId: validateRegistryId("test/123"),
-});
-
 describe("ReplaceTextEffect", () => {
   test("replace text shallow document", async () => {
     const document = getDocument("<div>foo</div>");
@@ -47,7 +40,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         replacement: "bar",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe("<div>bar</div>");
@@ -61,7 +54,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         replacement: "bar",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe("<div>barbar</div>");
@@ -75,7 +68,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         replacement: "bar",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.body.innerHTML).toBe("<div>FOO</div>");
@@ -88,7 +81,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         replacement: "bar",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
     expect(document.body.innerHTML).toBe("<div>bar <span>bar</span></div>");
   });
@@ -101,7 +94,7 @@ describe("ReplaceTextEffect", () => {
         replacement: "bar",
         selector: "span",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
     expect(document.body.innerHTML).toBe("<div>foo <span>bar</span></div>");
   });
@@ -114,7 +107,7 @@ describe("ReplaceTextEffect", () => {
         replacement: "foobar",
         selector: "div",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
     expect(document.body.innerHTML).toBe("<div>foobar <div>foobar</div></div>");
   });
@@ -127,7 +120,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "foo",
         replacement: "bar",
       }),
-      { logger, root: span } as BrickOptions
+      brickOptionsFactory({ root: span })
     );
     expect(document.body.innerHTML).toBe("<div>foo <span>bar</span></div>");
   });
@@ -140,7 +133,7 @@ describe("ReplaceTextEffect", () => {
         replacement: "###-###-####",
         isRegex: true,
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
     expect(document.body.innerHTML).toBe("<div>###-###-####</div>");
   });
@@ -153,7 +146,7 @@ describe("ReplaceTextEffect", () => {
         replacement: "$<numbers>",
         isRegex: true,
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
     expect(document.body.innerHTML).toBe("<div>123</div>");
   });
@@ -165,7 +158,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "^(\\+\\d{1,2}\\s)?\\(?\\d{3}\\)?[\\s.-]\\d{3}[\\s.-]\\d{4}",
         replacement: "###-###-####",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
     expect(document.body.innerHTML).toBe("<div>123-456-7890</div>");
   });
@@ -181,7 +174,7 @@ describe("ReplaceTextEffect", () => {
         pattern: "Sup",
         replacement: "Foo",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(document.head.innerHTML).toBe("<title>Support page</title>");

--- a/src/bricks/effects/runSubTour.test.ts
+++ b/src/bricks/effects/runSubTour.test.ts
@@ -26,7 +26,7 @@ import {
   type ModComponentBase,
   type ResolvedModComponent,
 } from "@/types/modComponentTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 describe("runSubTour", () => {
   test("it runs a sub-tour", async () => {
@@ -53,7 +53,7 @@ describe("runSubTour", () => {
 
     const promise = brick.run(
       unsafeAssumeValidArg({ tour: "Test Extension" }),
-      { logger: new ConsoleLogger({ blueprintId }) } as BrickOptions
+      brickOptionsFactory({ logger: new ConsoleLogger({ blueprintId }) })
     );
 
     await tick();

--- a/src/bricks/effects/scrollToElement.test.ts
+++ b/src/bricks/effects/scrollToElement.test.ts
@@ -16,17 +16,10 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import ScrollIntoViewEffect from "@/bricks/effects/scrollIntoView";
-
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new ScrollIntoViewEffect();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidSequence(0),
-});
 
 Element.prototype.scrollIntoView = jest.fn();
 
@@ -55,19 +48,19 @@ describe("ScrollToElementEffect", () => {
   });
 
   test("it scrolls for selector", async () => {
-    await brick.run(unsafeAssumeValidArg({ selector: "button" }), {
-      root: document,
-      logger,
-    } as BrickOptions);
+    await brick.run(
+      unsafeAssumeValidArg({ selector: "button" }),
+      brickOptionsFactory()
+    );
 
     expect(scrollIntoViewMock).toHaveBeenCalled();
   });
 
   test("it scrolls to element for element for isRootAware: true", async () => {
-    await brick.run(unsafeAssumeValidArg({}), {
-      root: document.querySelector("button"),
-      logger,
-    } as unknown as BrickOptions);
+    await brick.run(
+      unsafeAssumeValidArg({}),
+      brickOptionsFactory({ root: document.querySelector("button") })
+    );
 
     expect(scrollIntoViewMock).toHaveBeenCalled();
   });

--- a/src/bricks/effects/show.test.ts
+++ b/src/bricks/effects/show.test.ts
@@ -16,17 +16,10 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { ShowEffect } from "@/bricks/effects/show";
-
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new ShowEffect();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidSequence(0),
-});
 
 describe("ShowEffect", () => {
   beforeEach(() => {
@@ -50,7 +43,7 @@ describe("ShowEffect", () => {
 
       await brick.run(
         unsafeAssumeValidArg({ selector: "button", isRootAware }),
-        { root: document, logger } as BrickOptions
+        brickOptionsFactory()
       );
 
       expect(document.querySelector("button")).toBeVisible();
@@ -58,10 +51,10 @@ describe("ShowEffect", () => {
   );
 
   test("it shows element for isRootAware: true", async () => {
-    await brick.run(unsafeAssumeValidArg({ isRootAware: true }), {
-      root: document.querySelector("button"),
-      logger,
-    } as unknown as BrickOptions);
+    await brick.run(
+      unsafeAssumeValidArg({ isRootAware: true }),
+      brickOptionsFactory({ root: document.querySelector("button") })
+    );
 
     expect(document.querySelector("button")).toBeVisible();
   });

--- a/src/bricks/effects/tourEffect.test.ts
+++ b/src/bricks/effects/tourEffect.test.ts
@@ -17,17 +17,11 @@
 
 import { TourEffect } from "@/bricks/effects/tourEffect";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { uuidv4 } from "@/types/helpers";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { CancelError, PropError } from "@/errors/businessErrors";
 import { tick } from "@/starterBricks/starterBrickTestUtils";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new TourEffect();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidv4(),
-});
 
 describe("TourEffect", () => {
   test("isRootAware", async () => {
@@ -37,10 +31,8 @@ describe("TourEffect", () => {
   test("require step", async () => {
     document.body.innerHTML = "<div>Test</div>";
 
-    const promise = brick.run(unsafeAssumeValidArg({}), {
-      logger,
-      root: document,
-    } as BrickOptions);
+    const promise = brick.run(unsafeAssumeValidArg({}), brickOptionsFactory());
+
     await expect(promise).rejects.toThrow(PropError);
   });
 
@@ -49,7 +41,7 @@ describe("TourEffect", () => {
 
     const promise = brick.run(
       unsafeAssumeValidArg({ steps: [{ intro: "test content" }] }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     await tick();
@@ -69,11 +61,10 @@ describe("TourEffect", () => {
 
     const promise = brick.run(
       unsafeAssumeValidArg({ steps: [{ intro: "test content" }] }),
-      {
-        logger,
+      brickOptionsFactory({
         root: document,
         abortSignal: abortController.signal,
-      } as BrickOptions
+      })
     );
 
     await tick();

--- a/src/bricks/effects/wait.test.ts
+++ b/src/bricks/effects/wait.test.ts
@@ -16,13 +16,10 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { WaitElementEffect } from "@/bricks/effects/wait";
 import { BusinessError } from "@/errors/businessErrors";
 import { ensureMocksReset, requestIdleCallback } from "@shopify/jest-dom-mocks";
-
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 beforeAll(() => {
   requestIdleCallback.mock();
@@ -33,10 +30,6 @@ beforeEach(() => {
 });
 
 const brick = new WaitElementEffect();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidSequence(0),
-});
 
 describe("WaitElementEffect", () => {
   beforeEach(() => {
@@ -61,7 +54,7 @@ describe("WaitElementEffect", () => {
     async (isRootAware) => {
       await brick.run(
         unsafeAssumeValidArg({ selector: "button", isRootAware }),
-        { root: document, logger } as BrickOptions
+        brickOptionsFactory()
       );
     }
   );
@@ -69,10 +62,9 @@ describe("WaitElementEffect", () => {
   test("it wait element for isRootAware: true", async () => {
     await brick.run(
       unsafeAssumeValidArg({ selector: "button", isRootAware: true }),
-      {
-        root: document.querySelector("#hasButton"),
-        logger,
-      } as unknown as BrickOptions
+      brickOptionsFactory({
+        root: document.querySelector<HTMLElement>("#hasButton"),
+      })
     );
   });
 
@@ -83,10 +75,9 @@ describe("WaitElementEffect", () => {
         maxWaitMillis: 1,
         isRootAware: true,
       }),
-      {
-        root: document.querySelector("#noButton"),
-        logger,
-      } as unknown as BrickOptions
+      brickOptionsFactory({
+        root: document.querySelector<HTMLElement>("#noButton"),
+      })
     );
 
     await expect(promise).rejects.toThrow(BusinessError);
@@ -95,7 +86,7 @@ describe("WaitElementEffect", () => {
   test("array of selectors", async () => {
     await brick.run(
       unsafeAssumeValidArg({ selector: ["#hasButton", "button"] }),
-      { root: document, logger } as unknown as BrickOptions
+      brickOptionsFactory()
     );
   });
 });

--- a/src/bricks/renderers/customForm.test.tsx
+++ b/src/bricks/renderers/customForm.test.tsx
@@ -28,12 +28,10 @@ import {
 } from "./customForm";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import userEvent from "@testing-library/user-event";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { uuidv4 } from "@/types/helpers";
 
 import { dataStore } from "@/background/messenger/api";
 import { type Schema } from "@/types/schemaTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const dataStoreGetMock = dataStore.get as jest.MockedFunction<
   typeof dataStore.get
@@ -220,11 +218,7 @@ describe("CustomFormRenderer", () => {
           },
         },
       } as any,
-      {
-        logger: new ConsoleLogger({
-          extensionId: uuidv4(),
-        }),
-      } as BrickOptions
+      brickOptionsFactory()
     );
 
     render(<Component {...props} />);

--- a/src/bricks/renderers/documentView/DocumentView.tsx
+++ b/src/bricks/renderers/documentView/DocumentView.tsx
@@ -44,12 +44,13 @@ const DocumentView: React.FC<DocumentViewProps> = ({
 
   return (
     // Wrap in a React context provider that passes BrickOptions down to any embedded bricks
-    <DocumentContext.Provider value={{ options, meta, onAction }}>
+    <DocumentContext.Provider value={{ options, onAction }}>
       <EmotionShadowRoot.div className="h-100">
         <Stylesheets href={[bootstrap, bootstrapOverrides]}>
           {body.map((documentElement, index) => {
             const documentBranch = buildDocumentBranch(documentElement, {
               staticId: joinPathParts("body", "children"),
+              // Root of the document, so no branches taken yet
               branches: [],
             });
 

--- a/src/bricks/renderers/table.test.ts
+++ b/src/bricks/renderers/table.test.ts
@@ -26,7 +26,7 @@ describe("parse compile error", () => {
         data: null,
         columns: [{ label: "label", property: "property" }],
       }),
-      brickOptionsFactory()
+      brickOptionsFactory({ ctxt: [] })
     );
 
     expect(result).toMatchSnapshot();

--- a/src/bricks/renderers/table.test.ts
+++ b/src/bricks/renderers/table.test.ts
@@ -17,8 +17,7 @@
 
 import { TableRenderer } from "./table";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { neverPromise } from "@/testUtils/testHelpers";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 describe("parse compile error", () => {
   test("null data", async () => {
@@ -27,13 +26,7 @@ describe("parse compile error", () => {
         data: null,
         columns: [{ label: "label", property: "property" }],
       }),
-      {
-        ctxt: {},
-        root: null,
-        logger: new ConsoleLogger(),
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     expect(result).toMatchSnapshot();
@@ -45,13 +38,7 @@ describe("parse compile error", () => {
         data: [{ property: "Foo" }],
         columns: [{ label: "label", property: "property" }],
       }),
-      {
-        ctxt: {},
-        root: null,
-        logger: new ConsoleLogger(),
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     expect(result).toMatchSnapshot();

--- a/src/bricks/transformers/FormData.test.ts
+++ b/src/bricks/transformers/FormData.test.ts
@@ -16,9 +16,9 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { neverPromise } from "@/testUtils/testHelpers";
 import { FormData } from "./FormData";
 import { html } from "code-tag";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 describe("FormData block", () => {
   test("Basic form serialization", async () => {
@@ -46,13 +46,7 @@ describe("FormData block", () => {
 
     const arg = unsafeAssumeValidArg({ selector: "#serialize" });
 
-    const result = await brick.run(arg, {
-      ctxt: null,
-      logger: null,
-      root: null,
-      runPipeline: neverPromise,
-      runRendererPipeline: neverPromise,
-    });
+    const result = await brick.run(arg, brickOptionsFactory());
 
     expect(result).toEqual({
       "no-value": "",
@@ -83,13 +77,7 @@ describe("FormData block", () => {
 
     const arg = unsafeAssumeValidArg({ selector: "#logout-form" });
 
-    const result = await brick.run(arg, {
-      ctxt: null,
-      logger: null,
-      root: null,
-      runPipeline: neverPromise,
-      runRendererPipeline: neverPromise,
-    });
+    const result = await brick.run(arg, brickOptionsFactory());
 
     expect(result).toEqual({
       csrfmiddlewaretoken: "redacted",
@@ -111,13 +99,12 @@ describe("FormData block", () => {
 
     const arg = unsafeAssumeValidArg({ isRootAware: true });
 
-    const result = await brick.run(arg, {
-      ctxt: null,
-      logger: null,
-      root: document.querySelector<HTMLElement>("#fooForm"),
-      runPipeline: neverPromise,
-      runRendererPipeline: neverPromise,
-    });
+    const result = await brick.run(
+      arg,
+      brickOptionsFactory({
+        root: document.querySelector<HTMLElement>("#fooForm"),
+      })
+    );
 
     expect(result).toEqual({
       foo: "42",
@@ -139,13 +126,7 @@ describe("FormData block", () => {
 
     const arg = unsafeAssumeValidArg({ selector: "form" });
 
-    const result = await brick.run(arg, {
-      ctxt: null,
-      logger: null,
-      root: null,
-      runPipeline: neverPromise,
-      runRendererPipeline: neverPromise,
-    });
+    const result = await brick.run(arg, brickOptionsFactory());
 
     expect(result).toEqual({
       foo: "42",

--- a/src/bricks/transformers/brickFactory.ts
+++ b/src/bricks/transformers/brickFactory.ts
@@ -326,14 +326,15 @@ class UserDefinedBrick extends BrickABC {
     };
 
     if (isContentScript()) {
-      // Already in the contentScript, run the pipeline directly.
+      // Already in the contentScript, run the pipeline directly for performance
       return reducePipeline(this.component.pipeline, initialValues, {
         logger: options.logger,
         headless: options.headless,
         // The component uses its declared version of the runtime API, regardless of what version of the runtime
         // is used to call the component
         ...apiVersionOptions(this.component.apiVersion),
-        runId: options.meta.runId,
+        // Provide the run metadata (runId, branches) so that calls to pipeline functions trace correctly
+        ...options.meta,
       });
     }
 
@@ -355,6 +356,7 @@ class UserDefinedBrick extends BrickABC {
         pipeline: castArray(this.component.pipeline),
         options: apiVersionOptions(this.apiVersion),
         messageContext: options.logger.context,
+        // Provide the run metadata (runId, branches) so that calls to pipeline functions trace correctly
         meta: options.meta,
       });
     } catch (error) {

--- a/src/bricks/transformers/component/TableReader.test.ts
+++ b/src/bricks/transformers/component/TableReader.test.ts
@@ -22,7 +22,7 @@ import {
   unsafeAssumeValidArg,
   validateOutputKey,
 } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const tableReaderBlock = new TableReader();
 
@@ -64,7 +64,7 @@ describe("TableReader", () => {
 
     const result = await tableReaderBlock.run(
       unsafeAssumeValidArg(blockConfig.config),
-      { root } as unknown as BrickOptions
+      brickOptionsFactory({ root })
     );
 
     expect(result).toStrictEqual(expected);
@@ -89,9 +89,10 @@ describe("TableReader", () => {
     `;
 
     const getResult = async () =>
-      tableReaderBlock.run(unsafeAssumeValidArg(blockConfig.config), {
-        root,
-      } as unknown as BrickOptions);
+      tableReaderBlock.run(
+        unsafeAssumeValidArg(blockConfig.config),
+        brickOptionsFactory({ root })
+      );
 
     await expect(getResult).rejects.toThrow(TypeError);
   });
@@ -116,7 +117,7 @@ describe("TableReader", () => {
 
     const result = await tableReaderBlock.run(
       unsafeAssumeValidArg(blockConfig.config),
-      { root: document.querySelector("table") } as unknown as BrickOptions
+      brickOptionsFactory({ root: document.querySelector("table") })
     );
 
     expect(result).toStrictEqual(expected);

--- a/src/bricks/transformers/convertDocument.test.ts
+++ b/src/bricks/transformers/convertDocument.test.ts
@@ -17,7 +17,7 @@
 
 import ConvertDocument from "@/bricks/transformers/convertDocument";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new ConvertDocument();
 
@@ -29,7 +29,7 @@ describe("convert document", () => {
         sourceFormat: "html",
         targetFormat: "text",
       }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(result).toEqual({
@@ -44,7 +44,7 @@ describe("convert document", () => {
         sourceFormat: "markdown",
         targetFormat: "html",
       }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(result).toEqual({

--- a/src/bricks/transformers/detect.test.ts
+++ b/src/bricks/transformers/detect.test.ts
@@ -16,17 +16,10 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { DetectElement } from "@/bricks/transformers/detect";
-
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new DetectElement();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidSequence(0),
-});
 
 describe("DetectElement", () => {
   beforeEach(() => {
@@ -51,7 +44,7 @@ describe("DetectElement", () => {
     async (isRootAware) => {
       const result = await brick.run(
         unsafeAssumeValidArg({ selector: "button", isRootAware }),
-        { root: document, logger } as BrickOptions
+        brickOptionsFactory()
       );
 
       expect(result).toStrictEqual({
@@ -64,10 +57,9 @@ describe("DetectElement", () => {
   test("it uses root if isRootAware: true", async () => {
     const result = await brick.run(
       unsafeAssumeValidArg({ selector: "button", isRootAware: true }),
-      {
-        root: document.querySelector("#noButton"),
-        logger,
-      } as unknown as BrickOptions
+      brickOptionsFactory({
+        root: document.querySelector<HTMLElement>("#noButton"),
+      })
     );
 
     expect(result).toStrictEqual({

--- a/src/bricks/transformers/identity.test.ts
+++ b/src/bricks/transformers/identity.test.ts
@@ -16,8 +16,8 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { IdentityTransformer } from "@/bricks/transformers/identity";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new IdentityTransformer();
 
@@ -26,7 +26,7 @@ describe("IdentityTransformer", () => {
     const value = { foo: "bar" };
     const result = await brick.run(
       unsafeAssumeValidArg(value),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
     expect(result).toStrictEqual(value);
   });

--- a/src/bricks/transformers/javascript.test.ts
+++ b/src/bricks/transformers/javascript.test.ts
@@ -16,9 +16,9 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { JavaScriptTransformer } from "@/bricks/transformers/javascript";
 import { runUserJs } from "@/sandbox/messenger/api";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 jest.mock("@/sandbox/messenger/api", () => ({
   runUserJs: jest.fn(),
@@ -36,7 +36,7 @@ describe("JavaScriptTransformer", () => {
   test("executes the JavaScript function", async () => {
     const value = { function: "function () { return 1 + 1; };" };
 
-    await brick.transform(unsafeAssumeValidArg(value), {} as BrickOptions);
+    await brick.transform(unsafeAssumeValidArg(value), brickOptionsFactory());
 
     expect(runUserJsMock).toHaveBeenCalledWith({
       blockId: "@pixiebrix/javascript",
@@ -50,7 +50,7 @@ describe("JavaScriptTransformer", () => {
       arguments: { x: 1 },
     };
 
-    await brick.transform(unsafeAssumeValidArg(value), {} as BrickOptions);
+    await brick.transform(unsafeAssumeValidArg(value), brickOptionsFactory());
 
     expect(runUserJsMock).toHaveBeenCalledWith({
       blockId: "@pixiebrix/javascript",
@@ -64,7 +64,7 @@ describe("JavaScriptTransformer", () => {
     const value = { function: "function () { throw new Error('test'); };" };
 
     await expect(
-      brick.transform(unsafeAssumeValidArg(value), {} as BrickOptions)
+      brick.transform(unsafeAssumeValidArg(value), brickOptionsFactory())
     ).rejects.toThrow("test");
   });
 });

--- a/src/bricks/transformers/jq.test.ts
+++ b/src/bricks/transformers/jq.test.ts
@@ -17,26 +17,19 @@
 
 import { JQTransformer } from "@/bricks/transformers/jq";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
 import { InputValidationError } from "@/bricks/errors";
-import { neverPromise } from "@/testUtils/testHelpers";
 import { BusinessError } from "@/errors/businessErrors";
 import { serializeError } from "serialize-error";
 import { throwIfInvalidInput } from "@/runtime/runtimeUtils";
 import { type RenderedArgs } from "@/types/runtimeTypes";
 import { range } from "lodash";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 describe("smoke tests", () => {
   test("passes input to filter", async () => {
     const promise = new JQTransformer().transform(
       unsafeAssumeValidArg({ filter: ".foo", data: { foo: 42 } }),
-      {
-        ctxt: {},
-        root: null,
-        logger: new ConsoleLogger(),
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     await expect(promise).resolves.toBe(42);
@@ -55,13 +48,7 @@ describe("smoke tests", () => {
             filter: ".foo.data",
             data: { foo: { data: number } },
           }),
-          {
-            ctxt: {},
-            root: null,
-            logger: new ConsoleLogger(),
-            runPipeline: neverPromise,
-            runRendererPipeline: neverPromise,
-          }
+          brickOptionsFactory()
         )
       )
     );
@@ -75,13 +62,7 @@ describe("ctxt", () => {
   test.each([[null], [""]])("pass context if data is %s", async (data) => {
     const promise = new JQTransformer().transform(
       unsafeAssumeValidArg({ filter: ".foo", data }),
-      {
-        ctxt: { foo: 42 },
-        root: null,
-        logger: new ConsoleLogger(),
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     await expect(promise).resolves.toBe(42);
@@ -92,13 +73,7 @@ describe("json", () => {
   test("string data is not interpreted", async () => {
     const promise = new JQTransformer().transform(
       unsafeAssumeValidArg({ filter: ".", data: "[]" }),
-      {
-        ctxt: {},
-        root: null,
-        logger: new ConsoleLogger(),
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     // String is returned as-is, not as a JSON array
@@ -143,13 +118,7 @@ describe("jq compilation errors", () => {
     try {
       await new JQTransformer().transform(
         unsafeAssumeValidArg({ filter: '"', data: {} }),
-        {
-          ctxt: {},
-          root: null,
-          logger: new ConsoleLogger(),
-          runPipeline: neverPromise,
-          runRendererPipeline: neverPromise,
-        }
+        brickOptionsFactory()
       );
     } catch (error) {
       expect(serializeError(error)).toStrictEqual({
@@ -174,13 +143,7 @@ describe("jq compilation errors", () => {
     // https://github.com/pixiebrix/pixiebrix-extension/issues/3216
     const promise = new JQTransformer().transform(
       unsafeAssumeValidArg({ filter: "{", data: {} }),
-      {
-        ctxt: {},
-        root: null,
-        logger: new ConsoleLogger(),
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     await expect(promise).rejects.toThrow(InputValidationError);
@@ -193,13 +156,7 @@ describe("jq compilation errors", () => {
     // https://github.com/pixiebrix/pixiebrix-extension/issues/3216
     const promise = new JQTransformer().transform(
       unsafeAssumeValidArg({ filter: "a | b", data: {} }),
-      {
-        ctxt: {},
-        root: null,
-        logger: new ConsoleLogger(),
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     await expect(promise).rejects.toThrow(InputValidationError);
@@ -214,13 +171,7 @@ describe("jq execution errors", () => {
     // https://github.com/pixiebrix/pixiebrix-extension/issues/3216
     const promise = new JQTransformer().transform(
       unsafeAssumeValidArg({ filter: ".foo[]", data: {} }),
-      {
-        ctxt: {},
-        root: null,
-        logger: new ConsoleLogger(),
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     await expect(promise).rejects.toThrow(BusinessError);
@@ -231,13 +182,7 @@ describe("jq execution errors", () => {
     // https://github.com/pixiebrix/pixiebrix-extension/issues/3216
     const promise = new JQTransformer().transform(
       unsafeAssumeValidArg({ filter: '"" | fromdate', data: {} }),
-      {
-        ctxt: {},
-        root: null,
-        logger: new ConsoleLogger(),
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     await expect(promise).rejects.toThrow(BusinessError);
@@ -252,13 +197,7 @@ describe("known jq-web bugs and quirks", () => {
     // https://github.com/fiatjaf/jq-web/issues/32
     const promise = new JQTransformer().transform(
       unsafeAssumeValidArg({ filter: ".[] | .Title", data: [] }),
-      {
-        ctxt: {},
-        root: null,
-        logger: new ConsoleLogger(),
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     await expect(promise).rejects.toThrow(BusinessError);
@@ -279,13 +218,7 @@ describe("known jq-web bugs and quirks", () => {
             filter: ".foo.data",
             data: { foo: { data: number } },
           }),
-          {
-            ctxt: {},
-            root: null,
-            logger: new ConsoleLogger(),
-            runPipeline: neverPromise,
-            runRendererPipeline: neverPromise,
-          }
+          brickOptionsFactory()
         )
       )
     );
@@ -297,13 +230,7 @@ describe("known jq-web bugs and quirks", () => {
     // https://github.com/fiatjaf/jq-web/issues/19
     const promise = new JQTransformer().transform(
       unsafeAssumeValidArg({ filter: "1 % 1", data: [] }),
-      {
-        ctxt: {},
-        root: null,
-        logger: new ConsoleLogger(),
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     await expect(promise).rejects.toThrow(BusinessError);

--- a/src/bricks/transformers/jq.test.ts
+++ b/src/bricks/transformers/jq.test.ts
@@ -62,7 +62,7 @@ describe("ctxt", () => {
   test.each([[null], [""]])("pass context if data is %s", async (data) => {
     const promise = new JQTransformer().transform(
       unsafeAssumeValidArg({ filter: ".foo", data }),
-      brickOptionsFactory()
+      brickOptionsFactory({ ctxt: { foo: 42 } })
     );
 
     await expect(promise).resolves.toBe(42);

--- a/src/bricks/transformers/parseDataUrl.test.ts
+++ b/src/bricks/transformers/parseDataUrl.test.ts
@@ -16,7 +16,8 @@
  */
 
 import { ParseDataUrl } from "@/bricks/transformers/parseDataUrl";
-import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 
 const block = new ParseDataUrl();
 
@@ -27,11 +28,11 @@ describe("parseDataUrl", () => {
     ["data:,Hello%2C%20World%21"],
   ])("text-decodes URL: %s", async (url) => {
     const result = await block.run(
-      {
+      unsafeAssumeValidArg({
         url,
         decode: true,
-      } as unknown as BrickArgs,
-      {} as BrickOptions
+      }),
+      brickOptionsFactory()
     );
 
     expect(result).toStrictEqual({
@@ -47,11 +48,11 @@ describe("parseDataUrl", () => {
     const url = `data:image/png;base64,${base64}`;
 
     const result = await block.run(
-      {
+      unsafeAssumeValidArg({
         url,
         decodeText: false,
-      } as unknown as BrickArgs,
-      {} as BrickOptions
+      }),
+      brickOptionsFactory()
     );
 
     expect(result).toStrictEqual({

--- a/src/bricks/transformers/parseDate.test.ts
+++ b/src/bricks/transformers/parseDate.test.ts
@@ -19,8 +19,8 @@ import { getLocalISOString, ParseDate } from "@/bricks/transformers/parseDate";
 import { register, type TimeZone, unregister } from "timezone-mock";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { validateOutput } from "@/validators/generic";
-import { neverPromise } from "@/testUtils/testHelpers";
 import { BusinessError } from "@/errors/businessErrors";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const refDate = "2021-12-07T06:17:09.258Z";
 
@@ -57,13 +57,7 @@ describe("ParseDate block", () => {
       date: "Thursday, December 9th 2021, 10pm, EST",
     });
 
-    const result = await brick.run(arg, {
-      ctxt: null,
-      logger: null,
-      root: null,
-      runPipeline: neverPromise,
-      runRendererPipeline: neverPromise,
-    });
+    const result = await brick.run(arg, brickOptionsFactory());
 
     expect(result).toMatchSnapshot();
 
@@ -75,13 +69,10 @@ describe("ParseDate block", () => {
     const brick = new ParseDate();
 
     await expect(async () => {
-      await brick.run(unsafeAssumeValidArg({ date: "   " }), {
-        ctxt: null,
-        logger: null,
-        root: null,
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      });
+      await brick.run(
+        unsafeAssumeValidArg({ date: "   " }),
+        brickOptionsFactory()
+      );
     }).rejects.toThrow(BusinessError);
   });
 
@@ -89,13 +80,10 @@ describe("ParseDate block", () => {
     const brick = new ParseDate();
 
     await expect(async () => {
-      await brick.run(unsafeAssumeValidArg({ date: "foo" }), {
-        ctxt: null,
-        logger: null,
-        root: null,
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      });
+      await brick.run(
+        unsafeAssumeValidArg({ date: "foo" }),
+        brickOptionsFactory()
+      );
     }).rejects.toThrow(BusinessError);
   });
 
@@ -106,13 +94,7 @@ describe("ParseDate block", () => {
       date: "Thursday, December 9th 2021, 3am, GMT",
     });
 
-    const result = await brick.run(arg, {
-      ctxt: null,
-      logger: null,
-      root: null,
-      runPipeline: neverPromise,
-      runRendererPipeline: neverPromise,
-    });
+    const result = await brick.run(arg, brickOptionsFactory());
 
     expect(result).toMatchSnapshot();
 

--- a/src/bricks/transformers/parseJson.test.ts
+++ b/src/bricks/transformers/parseJson.test.ts
@@ -17,8 +17,8 @@
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import ParseJson from "@/bricks/transformers/ParseJson";
-import { neverPromise } from "@/testUtils/testHelpers";
 import { BusinessError } from "@/errors/businessErrors";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 describe("ParseJson block", () => {
   test("Parse object", async () => {
@@ -26,13 +26,7 @@ describe("ParseJson block", () => {
 
     const arg = unsafeAssumeValidArg({ content: '{"foo": 42}' });
 
-    const result = await brick.run(arg, {
-      ctxt: null,
-      logger: null,
-      root: null,
-      runPipeline: neverPromise,
-      runRendererPipeline: neverPromise,
-    });
+    const result = await brick.run(arg, brickOptionsFactory());
 
     expect(result).toEqual({
       foo: 42,
@@ -43,13 +37,7 @@ describe("ParseJson block", () => {
     const brick = new ParseJson();
     const result = await brick.run(
       unsafeAssumeValidArg({ content: '{"foo": 42,}' }),
-      {
-        ctxt: null,
-        logger: null,
-        root: null,
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     expect(result).toEqual({
@@ -60,13 +48,10 @@ describe("ParseJson block", () => {
   test("Throw BusinessError on invalid JSON", async () => {
     const brick = new ParseJson();
     await expect(async () => {
-      await brick.run(unsafeAssumeValidArg({ content: '{"foo":}' }), {
-        ctxt: null,
-        logger: null,
-        root: null,
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      });
+      await brick.run(
+        unsafeAssumeValidArg({ content: '{"foo":}' }),
+        brickOptionsFactory()
+      );
     }).rejects.toThrow(BusinessError);
   });
 
@@ -75,13 +60,7 @@ describe("ParseJson block", () => {
     await expect(async () => {
       await brick.run(
         unsafeAssumeValidArg({ content: '{"foo": 42,}', allowJson5: false }),
-        {
-          ctxt: null,
-          logger: null,
-          root: null,
-          runPipeline: neverPromise,
-          runRendererPipeline: neverPromise,
-        }
+        brickOptionsFactory()
       );
     }).rejects.toThrow(BusinessError);
   });
@@ -90,13 +69,7 @@ describe("ParseJson block", () => {
     const brick = new ParseJson();
     const result = await brick.run(
       unsafeAssumeValidArg({ content: "{foo: 42}" }),
-      {
-        ctxt: null,
-        logger: null,
-        root: null,
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     expect(result).toEqual({
@@ -111,13 +84,7 @@ describe("ParseJson block", () => {
         lenient: true,
         content: 'Sure, here\'s your response: {"foo": 42}. What do you think?',
       }),
-      {
-        ctxt: null,
-        logger: null,
-        root: null,
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     expect(result).toEqual({
@@ -133,13 +100,7 @@ describe("ParseJson block", () => {
           lenient: true,
           content: 'abc {"foo": 42} {"bar": 421}',
         }),
-        {
-          ctxt: null,
-          logger: null,
-          root: null,
-          runPipeline: neverPromise,
-          runRendererPipeline: neverPromise,
-        }
+        brickOptionsFactory()
       );
     }).rejects.toThrow(BusinessError);
   });
@@ -151,13 +112,7 @@ describe("ParseJson block", () => {
         lenient: true,
         content: 'abc [{"foo": 42}, {"bar": 421}] def',
       }),
-      {
-        ctxt: null,
-        logger: null,
-        root: null,
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     expect(result).toEqual([
@@ -175,13 +130,7 @@ describe("ParseJson block", () => {
         lenient: true,
         content: 'abc [[{"foo": 42}], {"bar": 421}] def',
       }),
-      {
-        ctxt: null,
-        logger: null,
-        root: null,
-        runPipeline: neverPromise,
-        runRendererPipeline: neverPromise,
-      }
+      brickOptionsFactory()
     );
 
     expect(result).toEqual([

--- a/src/bricks/transformers/readable.test.ts
+++ b/src/bricks/transformers/readable.test.ts
@@ -17,7 +17,7 @@
 
 import { Readable } from "@/bricks/transformers/readable";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new Readable();
 
@@ -27,7 +27,7 @@ describe("readable", () => {
 
     const article = await brick.run(
       unsafeAssumeValidArg({}),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(article).toEqual(
@@ -43,9 +43,10 @@ describe("readable", () => {
 
     const element = document.querySelector("div");
 
-    const article = brick.run(unsafeAssumeValidArg({}), {
-      root: element,
-    } as unknown as BrickOptions);
+    const article = brick.run(
+      unsafeAssumeValidArg({}),
+      brickOptionsFactory({ root: element })
+    );
 
     await expect(article).rejects.toThrow();
   });

--- a/src/bricks/transformers/searchText.test.ts
+++ b/src/bricks/transformers/searchText.test.ts
@@ -17,7 +17,7 @@
 
 import { createStemMap, SearchText } from "@/bricks/transformers/searchText";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new SearchText();
 
@@ -42,7 +42,7 @@ describe("Search", () => {
         text: "the rain in spain",
         query: "rain",
       }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(result).toEqual({
@@ -59,7 +59,7 @@ describe("Search", () => {
           query: "rain",
           stemWords,
         }),
-        {} as BrickOptions
+        brickOptionsFactory()
       );
 
       expect(result).toEqual({
@@ -78,7 +78,7 @@ describe("Search", () => {
         query: "rain",
         stemWords: true,
       }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(result).toEqual({
@@ -93,7 +93,7 @@ describe("Search", () => {
         query: "raining",
         stemWords: true,
       }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(result).toEqual({
@@ -107,7 +107,7 @@ describe("Search", () => {
         text: "I have rain on my brain",
         query: "rain",
       }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(result).toEqual({
@@ -122,7 +122,7 @@ describe("Search", () => {
         query: "rain in spain",
         stemWords: true,
       }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(result).toEqual({

--- a/src/bricks/transformers/splitText.test.ts
+++ b/src/bricks/transformers/splitText.test.ts
@@ -17,7 +17,7 @@
 
 import { SplitText } from "@/bricks/transformers/splitText";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new SplitText();
 
@@ -29,7 +29,7 @@ describe("Split", () => {
         chunkSize: 8,
         chunkOverlap: 2,
       }),
-      {} as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(result).toStrictEqual({

--- a/src/bricks/transformers/tourStep/tourStep.test.ts
+++ b/src/bricks/transformers/tourStep/tourStep.test.ts
@@ -26,6 +26,7 @@ import { MultipleElementsFoundError } from "@/errors/businessErrors";
 import { showModal } from "@/bricks/transformers/ephemeralForm/modalUtils";
 import { showPopover } from "@/bricks/transformers/temporaryInfo/popoverUtils";
 import { ensureMocksReset, requestIdleCallback } from "@shopify/jest-dom-mocks";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 beforeAll(() => {
   requestIdleCallback.mock();
@@ -79,16 +80,12 @@ function makeOptions({
   root = document,
   signal = undefined,
 }: { root?: HTMLElement | Document; signal?: AbortSignal } = {}): BrickOptions {
-  return {
+  return brickOptionsFactory({
     logger,
     root,
     runRendererPipeline: jest.fn().mockResolvedValue(undefined),
-    runPipeline: jest.fn().mockImplementation(async () => {
-      throw new Error("Not implemented");
-    }),
-    ctxt: {},
     abortSignal: signal,
-  };
+  });
 }
 
 describe("tourStep", () => {

--- a/src/bricks/transformers/tourStep/tourStep.test.ts
+++ b/src/bricks/transformers/tourStep/tourStep.test.ts
@@ -83,7 +83,7 @@ function makeOptions({
   return brickOptionsFactory({
     logger,
     root,
-    runRendererPipeline: jest.fn().mockResolvedValue(undefined),
+    runRendererPipeline: (_i: number) => jest.fn().mockResolvedValue(undefined),
     abortSignal: signal,
   });
 }

--- a/src/bricks/transformers/traverseElements.test.ts
+++ b/src/bricks/transformers/traverseElements.test.ts
@@ -15,19 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { uuidv4, validateRegistryId } from "@/types/helpers";
 import TraverseElements from "@/bricks/transformers/traverseElements";
-import ConsoleLogger from "@/utils/ConsoleLogger";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { getReferenceForElement } from "@/contentScript/elementReference";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 const brick = new TraverseElements();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidv4(),
-  blueprintId: validateRegistryId("test/123"),
-});
 
 describe("TraverseElements", () => {
   test("find", async () => {
@@ -38,7 +31,7 @@ describe("TraverseElements", () => {
         selector: "div",
         traversal: "find",
       }),
-      { logger, root: document } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(result).toStrictEqual({
@@ -55,7 +48,7 @@ describe("TraverseElements", () => {
         selector: "div",
         traversal: "closest",
       }),
-      { logger, root: div } as unknown as BrickOptions
+      brickOptionsFactory({ root: div })
     );
 
     expect(result).toStrictEqual({

--- a/src/bricks/types.ts
+++ b/src/bricks/types.ts
@@ -219,16 +219,6 @@ export type BrickConfig = {
 export type BrickPipeline = BrickConfig[];
 
 /**
- * A control flow branch, for tracing. The array of branches is used to correlate runs of the same brick in a pipeline
- * @see TraceMetadata.blockInstanceId
- * @see TraceMetadata.branches
- */
-export type Branch = {
-  key: string;
-  counter: number;
-};
-
-/**
  * Defines the position of the brick in the extension
  * ex. "extension.brickPipeline.0.config.body.__value__.0",
  * "extension.brickPipeline.0.config.body.0.children.0.config.onClick.__value__.0"

--- a/src/components/documentBuilder/documentTree.test.tsx
+++ b/src/components/documentBuilder/documentTree.test.tsx
@@ -22,7 +22,7 @@ import React from "react";
 import blockRegistry from "@/bricks/registry";
 import { MarkdownRenderer } from "@/bricks/renderers/markdown";
 import * as contentScriptAPI from "@/contentScript/messenger/api";
-import { UNSET_UUID, uuidv4 } from "@/types/helpers";
+import { uuidv4 } from "@/types/helpers";
 import { buildDocumentBranch } from "./documentTree";
 import {
   type DocumentElement,
@@ -57,10 +57,6 @@ describe("When rendered in panel", () => {
       <DocumentContext.Provider
         value={{
           ...initialValue,
-          meta: {
-            extensionId: UNSET_UUID,
-            runId: UNSET_UUID,
-          },
         }}
       >
         {children}

--- a/src/components/documentBuilder/render/BlockElement.tsx
+++ b/src/components/documentBuilder/render/BlockElement.tsx
@@ -41,8 +41,7 @@ type BlockElementProps = {
  */
 const BlockElement: React.FC<BlockElementProps> = ({ pipeline, tracePath }) => {
   const {
-    meta,
-    options: { ctxt, logger },
+    options: { ctxt, logger, meta },
     onAction,
   } = useContext(DocumentContext);
 
@@ -61,7 +60,7 @@ const BlockElement: React.FC<BlockElementProps> = ({ pipeline, tracePath }) => {
         meta: {
           ...meta,
           // The pipeline is static, so don't need to maintain run counter on branches
-          branches: mapPathToTraceBranches(tracePath),
+          branches: [...meta.branches, ...mapPathToTraceBranches(tracePath)],
         },
         // TODO: pass runtime version via DocumentContext instead of hard-coding it. This will break for v4+
         options: apiVersionOptions("v3"),

--- a/src/components/documentBuilder/render/ButtonElement.tsx
+++ b/src/components/documentBuilder/render/ButtonElement.tsx
@@ -29,6 +29,7 @@ import { getRootCause, hasSpecificErrorCause } from "@/errors/errorHelpers";
 import { SubmitPanelAction } from "@/bricks/errors";
 import cx from "classnames";
 import { boolean } from "@/utils/typeUtils";
+import { mapPathToTraceBranches } from "@/components/documentBuilder/utils";
 
 type ButtonElementProps = Except<AsyncButtonProps, "onClick"> & {
   onClick: BrickPipeline;
@@ -50,8 +51,7 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
 }) => {
   const {
     onAction,
-    meta,
-    options: { ctxt, logger },
+    options: { ctxt, logger, meta },
   } = useContext(DocumentContext);
 
   const [counter, setCounter] = useState(0);
@@ -78,10 +78,8 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
         meta: {
           ...meta,
           branches: [
-            ...tracePath.branches.map(({ staticId, index }) => ({
-              key: staticId,
-              counter: index,
-            })),
+            ...meta.branches,
+            ...mapPathToTraceBranches(tracePath),
             { key: "onClick", counter: currentCounter },
           ],
         },

--- a/src/components/documentBuilder/render/DocumentContext.tsx
+++ b/src/components/documentBuilder/render/DocumentContext.tsx
@@ -19,16 +19,11 @@ import React from "react";
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import { BusinessError } from "@/errors/businessErrors";
 import { type JsonObject } from "type-fest";
-import { type UUID } from "@/types/stringTypes";
 import { type BrickArgsContext, type BrickOptions } from "@/types/runtimeTypes";
+import { UNSET_UUID } from "@/types/helpers";
 
 type DocumentState = {
   onAction: (action: { type: string; detail: JsonObject }) => void;
-
-  meta: {
-    runId: UUID;
-    extensionId: UUID;
-  };
   options: BrickOptions<BrickArgsContext>;
 };
 
@@ -41,14 +36,16 @@ export const initialValue: DocumentState = {
   onAction() {
     throw new BusinessError("Panel actions not available for panel type");
   },
-  meta: {
-    runId: null,
-    extensionId: null,
-  },
   options: {
+    meta: {
+      runId: null,
+      extensionId: UNSET_UUID,
+      branches: [],
+    },
     ctxt: blankContext,
     // The root should correspond to the host page's content script. If we passed document here, it would end up being
     // the document what's rendering the document (e.g., the sidebar panel's iframe document)
+    // XXX: BrickOptions.root is not nullable, so we'll need to adjust the type or behavior when introducing null checks
     root: null,
     logger: new ConsoleLogger(),
     headless: true,

--- a/src/components/documentBuilder/utils.ts
+++ b/src/components/documentBuilder/utils.ts
@@ -16,7 +16,7 @@
  */
 
 import { type DynamicPath } from "@/components/documentBuilder/documentBuilderTypes";
-import { type Branch } from "@/bricks/types";
+import { type Branch } from "@/types/runtimeTypes";
 
 export function mapPathToTraceBranches(tracePath: DynamicPath): Branch[] {
   return tracePath.branches.map(({ staticId, index }) => ({

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -32,6 +32,7 @@ export async function runBrick(request: RunBrick): Promise<unknown> {
   try {
     return await block.run(blockArgs, {
       ctxt: options.ctxt,
+      meta: options.meta,
       logger,
       root: document,
       async runPipeline() {
@@ -48,7 +49,7 @@ export async function runBrick(request: RunBrick): Promise<unknown> {
   } catch (error) {
     // Provide extra logging on the tab because `handlers` doesn't report errors. It's also nice to log here because
     // we still have the original (non-serialized) error
-    console.info("Error running remote block on tab", {
+    console.info("Error running remote brick on tab", {
       request,
       error,
     });

--- a/src/contentScript/executor.ts
+++ b/src/contentScript/executor.ts
@@ -17,13 +17,13 @@
 
 import blockRegistry from "@/bricks/registry";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
-import { type RunBrick } from "@/contentScript/messenger/runBrickTypes";
+import { type RunBrickRequest } from "@/contentScript/messenger/runBrickTypes";
 import { BusinessError } from "@/errors/businessErrors";
 
 /**
  * Handle a remote brick run request from another tab/frame.
  */
-export async function runBrick(request: RunBrick): Promise<unknown> {
+export async function runBrick(request: RunBrickRequest): Promise<unknown> {
   // XXX: validate sourceTabId? Can't use childTabs because we also support `window: broadcast`
   const { blockId, blockArgs, options } = request;
   const block = await blockRegistry.lookup(blockId);

--- a/src/contentScript/messenger/runBrickTypes.ts
+++ b/src/contentScript/messenger/runBrickTypes.ts
@@ -20,15 +20,27 @@ import { type MessageContext } from "@/types/loggerTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type BrickArgs, type RunMetadata } from "@/types/runtimeTypes";
 
+/**
+ * @see BrickOptions
+ */
 export interface RemoteBrickOptions {
+  /**
+   * Available variables for the brick execution.
+   */
   ctxt: unknown;
+  /**
+   * Run metadata for the brick execution.
+   */
+  meta: RunMetadata;
+  /**
+   * Logging context for the brick execution.
+   */
   messageContext: MessageContext;
   maxRetries?: number;
   isAvailable?: Availability;
-  meta: RunMetadata;
 }
 
-export interface RunBrick {
+export interface RunBrickRequest {
   sourceTabId?: number;
   nonce?: string;
   blockId: RegistryId;

--- a/src/contentScript/messenger/runBrickTypes.ts
+++ b/src/contentScript/messenger/runBrickTypes.ts
@@ -18,13 +18,14 @@
 import { type Availability } from "@/bricks/types";
 import { type MessageContext } from "@/types/loggerTypes";
 import { type RegistryId } from "@/types/registryTypes";
-import { type BrickArgs } from "@/types/runtimeTypes";
+import { type BrickArgs, type RunMetadata } from "@/types/runtimeTypes";
 
 export interface RemoteBrickOptions {
   ctxt: unknown;
   messageContext: MessageContext;
   maxRetries?: number;
   isAvailable?: Availability;
+  meta: RunMetadata;
 }
 
 export interface RunBrick {

--- a/src/contentScript/pipelineProtocol.ts
+++ b/src/contentScript/pipelineProtocol.ts
@@ -1,4 +1,4 @@
-import { type BrickPipeline, type Branch } from "@/bricks/types";
+import { type BrickPipeline } from "@/bricks/types";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { expectContext } from "@/utils/expectContext";
 import { HeadlessModeError } from "@/bricks/errors";
@@ -11,27 +11,13 @@ import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import { type UUID } from "@/types/stringTypes";
 import {
   type BrickArgsContext,
+  type RunMetadata,
   type ServiceContext,
 } from "@/types/runtimeTypes";
 import { type MessageContext } from "@/types/loggerTypes";
 import { type RendererRunPayload } from "@/types/rendererTypes";
 import extendModVariableContext from "@/runtime/extendModVariableContext";
 import { type RegistryId } from "@/types/registryTypes";
-
-type RunMetadata = {
-  /**
-   * The extension id.
-   */
-  extensionId: UUID;
-  /**
-   * The extension runId
-   */
-  runId: UUID;
-  /**
-   * The accumulated trace branches
-   */
-  branches: Branch[];
-};
 
 type RunPipelineParams = {
   nonce: UUID;

--- a/src/contrib/automationanywhere/RunBot.test.ts
+++ b/src/contrib/automationanywhere/RunBot.test.ts
@@ -17,21 +17,18 @@
 
 import { RunBot } from "@/contrib/automationanywhere/RunBot";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import ConsoleLogger from "@/utils/ConsoleLogger";
 import { uuidv4 } from "@/types/helpers";
 import {
-  performConfiguredRequestInBackground,
   getCachedAuthData,
   getUserData,
+  performConfiguredRequestInBackground,
 } from "@/background/messenger/api";
-import { type BrickOptions } from "@/types/runtimeTypes";
 import { type AuthData } from "@/integrations/integrationTypes";
-
-import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import {
   CONTROL_ROOM_OAUTH_INTEGRATION_ID,
   CONTROL_ROOM_TOKEN_INTEGRATION_ID,
 } from "@/integrations/constants";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 jest.mock("@/background/messenger/api", () => ({
   performConfiguredRequestInBackground: jest.fn().mockResolvedValue({
@@ -50,10 +47,6 @@ const getCachedAuthDataMock = jest.mocked(getCachedAuthData);
 const getUserDataMock = jest.mocked(getUserData);
 
 const brick = new RunBot();
-
-const logger = new ConsoleLogger({
-  extensionId: uuidSequence(0),
-});
 
 const tokenAuthId = uuidv4();
 
@@ -97,7 +90,7 @@ describe("Automation Anywhere - RunBot", () => {
         fileId: FILE_ID,
         data: {},
       }),
-      { logger } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(performConfiguredRequestInBackgroundMock).toHaveBeenCalledWith(
@@ -156,7 +149,7 @@ describe("Automation Anywhere - RunBot", () => {
         runAsUserIds: [UNATTENDED_RUN_AS_USER_ID],
         data: {},
       }),
-      { logger } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(getCachedAuthDataMock).not.toHaveBeenCalled();
@@ -220,7 +213,7 @@ describe("Automation Anywhere - RunBot", () => {
         fileId: FILE_ID,
         data: {},
       }),
-      { logger } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(getCachedAuthDataMock).toHaveBeenCalledWith(tokenAuthId);
@@ -285,7 +278,7 @@ describe("Automation Anywhere - RunBot", () => {
         data: {},
         runAsUserIds: [UNATTENDED_RUN_AS_USER_ID],
       }),
-      { logger } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(performConfiguredRequestInBackgroundMock).toHaveBeenCalledWith(
@@ -350,7 +343,7 @@ describe("Automation Anywhere - RunBot", () => {
         fileId: FILE_ID,
         data: {},
       }),
-      { logger } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(performConfiguredRequestInBackgroundMock).toHaveBeenCalledWith(
@@ -459,7 +452,7 @@ describe("Automation Anywhere - RunBot", () => {
         runAsUserIds: [UNATTENDED_RUN_AS_USER_ID],
         awaitResult: true,
       }),
-      { logger } as BrickOptions
+      brickOptionsFactory()
     );
 
     expect(performConfiguredRequestInBackgroundMock).toHaveBeenCalledWith(

--- a/src/contrib/uipath/embedApp.ts
+++ b/src/contrib/uipath/embedApp.ts
@@ -25,11 +25,12 @@ import pTimeout from "p-timeout";
 import { type RegistryId } from "@/types/registryTypes";
 import { RendererABC } from "@/types/bricks/rendererTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type SafeHTML } from "@/types/stringTypes";
+import { type SafeHTML, type UUID } from "@/types/stringTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type UnknownObject } from "@/types/objectTypes";
 
 interface RunDetails {
+  extensionId: UUID;
   blockId: RegistryId;
   inputs: unknown;
   url: URL;
@@ -37,6 +38,7 @@ interface RunDetails {
 
 async function runInFrame({
   blockId,
+  extensionId,
   inputs,
   url,
 }: RunDetails): Promise<unknown> {
@@ -65,6 +67,11 @@ async function runInFrame({
       ctxt: {},
       messageContext: {
         blockId,
+      },
+      meta: {
+        extensionId,
+        runId: null,
+        branches: [],
       },
     },
   });
@@ -123,7 +130,7 @@ export class UiPathAppRenderer extends RendererABC {
       height = 400,
       width = "100%",
     }: BrickArgs,
-    { logger }: BrickOptions
+    { logger, meta }: BrickOptions
   ): Promise<SafeHTML> {
     const nonce = uuidv4();
 
@@ -139,6 +146,7 @@ export class UiPathAppRenderer extends RendererABC {
     if (!isEmpty(inputs)) {
       void runInFrame({
         blockId: this.id,
+        extensionId: meta.extensionId,
         url: subframeUrl,
         inputs,
       })

--- a/src/pageEditor/slices/runtimeSelectors.ts
+++ b/src/pageEditor/slices/runtimeSelectors.ts
@@ -20,7 +20,7 @@ import { type RuntimeState } from "@/pageEditor/slices/runtimeSliceTypes";
 import { isTraceError, type TraceRecord } from "@/telemetry/trace";
 import { type EditorState } from "@/pageEditor/pageEditorTypes";
 import { createSelector } from "reselect";
-import { getLatestCall } from "@/telemetry/traceHelpers";
+import { getLatestBrickCall } from "@/telemetry/traceHelpers";
 import { selectActiveNodeId } from "./editorSelectors";
 
 type RootState = { runtime: RuntimeState; editor: EditorState };
@@ -64,12 +64,10 @@ export function makeSelectBlockTrace(
   blockInstanceId: UUID
 ): EditorSelector<{ record: TraceRecord | null }> {
   return ({ runtime, editor }: RootState) => {
-    const callRecords = (
-      runtime.extensionTraces[editor.activeElementId] ?? []
-    ).filter((x) => x.blockInstanceId === blockInstanceId);
+    const records = runtime.extensionTraces[editor.activeElementId] ?? [];
 
     return {
-      record: getLatestCall(callRecords),
+      record: getLatestBrickCall(records, blockInstanceId),
     };
   };
 }

--- a/src/pageEditor/tabs/editTab/useReportTraceError.ts
+++ b/src/pageEditor/tabs/editTab/useReportTraceError.ts
@@ -21,13 +21,19 @@ import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import { useEffect } from "react";
 import { useSelector } from "react-redux";
+import { type UUID } from "@/types/stringTypes";
 
-function useReportTraceError() {
+/**
+ * React Hook that reports when there's an error in a trace.
+ *
+ * Too many trace errors may indicate the user is having trouble creating/editing a mod.
+ */
+function useReportTraceError(): void {
   const sessionId = useSelector(selectSessionId);
   const traceErrors = useSelector(selectTraceErrors);
 
   const traceError = traceErrors.find((x) => x.runId);
-  const runId = traceError?.runId ?? null;
+  const runId: UUID | null = traceError?.runId;
 
   useEffect(() => {
     if (traceError) {
@@ -36,7 +42,7 @@ function useReportTraceError() {
         extensionId: traceError.extensionId,
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- traceError is not required, runId is sufficient
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- report trace error once per run
   }, [runId, sessionId]);
 }
 

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -17,9 +17,13 @@ import { type UnknownObject } from "@/types/objectTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { isDeferExpression } from "@/utils/expressionUtils";
 import isPromise from "is-promise";
+import { JsonValue } from "type-fest";
 
 const logger = new ConsoleLogger();
 
+/**
+ * A test helper brick that returns and stores the BrickOptions.context.
+ */
 export class ContextBrick extends BrickABC {
   static BLOCK_ID = validateRegistryId("test/context");
 
@@ -35,12 +39,39 @@ export class ContextBrick extends BrickABC {
 
   inputSchema = propertiesToSchema({});
 
-  async run(arg: BrickArgs, { ctxt }: BrickOptions) {
+  async run(_arg: BrickArgs, { ctxt }: BrickOptions) {
     ContextBrick.contexts.push(ctxt);
     return ctxt;
   }
 }
 
+/**
+ * A test helper brick that returns and stores the brick options it was called with.
+ */
+export class OptionsBrick extends BrickABC {
+  static BLOCK_ID = validateRegistryId("test/options");
+
+  static options: BrickOptions[] = [];
+
+  constructor() {
+    super(OptionsBrick.BLOCK_ID, "Return Options");
+  }
+
+  static clearOptions() {
+    OptionsBrick.options = [];
+  }
+
+  inputSchema = propertiesToSchema({});
+
+  async run(_arg: BrickArgs, options: BrickOptions): Promise<JsonValue> {
+    OptionsBrick.options.push(options);
+    return JSON.parse(JSON.stringify(options));
+  }
+}
+
+/**
+ * A test helper brick that echos a message.
+ */
 export class EchoBrick extends BrickABC {
   static BLOCK_ID = validateRegistryId("test/echo");
   constructor() {
@@ -53,7 +84,7 @@ export class EchoBrick extends BrickABC {
     },
   });
 
-  async run({ message }: BrickArgs) {
+  async run({ message }: BrickArgs<{ message: string }>) {
     return { message };
   }
 }
@@ -72,7 +103,7 @@ export class DeferredEchoBrick extends BrickABC {
     },
   });
 
-  async run({ message }: BrickArgs) {
+  async run({ message }: BrickArgs<{ message: string }>) {
     if (isPromise(this.promiseOrFactory)) {
       await this.promiseOrFactory;
     } else {
@@ -267,6 +298,7 @@ class DeferBrick extends BrickABC {
 export const echoBrick = new EchoBrick();
 
 export const contextBrick = new ContextBrick();
+export const optionsBrick = new OptionsBrick();
 export const identityBrick = new IdentityBrick();
 export const throwBrick = new ThrowBrick();
 export const teapotBrick = new TeapotBrick();

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -17,7 +17,7 @@ import { type UnknownObject } from "@/types/objectTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { isDeferExpression } from "@/utils/expressionUtils";
 import isPromise from "is-promise";
-import { JsonValue } from "type-fest";
+import { type JsonValue } from "type-fest";
 
 const logger = new ConsoleLogger();
 

--- a/src/runtime/pipelineTests/trace.test.ts
+++ b/src/runtime/pipelineTests/trace.test.ts
@@ -63,7 +63,7 @@ describe("Trace normal exit", () => {
         instanceId,
       },
       simpleInput({ inputArg: "hello" }),
-      testOptions("v3")
+      { ...testOptions("v3"), runId: uuidv4() }
     );
 
     expect(result).toStrictEqual({ message: "hello" });
@@ -87,6 +87,27 @@ describe("Trace normal exit", () => {
     // Should not record brick run when tracing is enabled
     expect(recordBrickRunMock).toHaveBeenCalledTimes(0);
   });
+
+  test("skip trace by default", async () => {
+    const instanceId = uuidv4();
+
+    const result = await reducePipeline(
+      {
+        id: echoBrick.id,
+        config: {
+          message: makeTemplateExpression("nunjucks", "{{@input.inputArg}}"),
+        },
+        instanceId,
+      },
+      simpleInput({ inputArg: "hello" }),
+      // `runId` defaults to null
+      testOptions("v3")
+    );
+
+    expect(result).toStrictEqual({ message: "hello" });
+
+    expect(traces.addEntry).toHaveBeenCalledTimes(0);
+  });
 });
 
 describe("Trace render error", () => {
@@ -103,7 +124,7 @@ describe("Trace render error", () => {
           instanceId,
         },
         simpleInput({ inputArg: "hello" }),
-        testOptions("v3")
+        { ...testOptions("v3"), runId: uuidv4() }
       )
     ).rejects.toThrow(/doesNotExist/);
 
@@ -139,7 +160,7 @@ describe("Trace render error", () => {
         instanceId,
       },
       simpleInput({ inputArg: "hello" }),
-      testOptions("v3")
+      { ...testOptions("v3"), runId: uuidv4() }
     );
 
     expect(traces.addEntry).toHaveBeenCalledTimes(1);
@@ -184,7 +205,7 @@ describe("Trace conditional execution", () => {
         },
       ],
       simpleInput({ inputArg: "hello" }),
-      testOptions("v3")
+      { ...testOptions("v3"), runId: uuidv4() }
     );
 
     expect(traces.addEntry).toHaveBeenCalledTimes(2);

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -52,7 +52,7 @@ import {
   type ResolvedBrickConfig,
   unsafeAssumeValidArg,
 } from "@/runtime/runtimeTypes";
-import { type RunBrick } from "@/contentScript/messenger/runBrickTypes";
+import { type RunBrickRequest } from "@/contentScript/messenger/runBrickTypes";
 import {
   BusinessError,
   CancelError,
@@ -325,7 +325,7 @@ async function executeBlockWithValidatedProps(
     messageContext: options.logger.context,
   };
 
-  const request: RunBrick = {
+  const request: RunBrickRequest = {
     blockId: config.id,
     blockArgs: args,
     options: {

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -70,7 +70,7 @@ import {
   type ServiceContext,
   type OptionsArgs,
   type PipelineExpression,
-  type Branch,
+  type RunMetadata,
 } from "@/types/runtimeTypes";
 import { type UnknownObject } from "@/types/objectTypes";
 import { isPipelineClosureExpression } from "@/utils/expressionUtils";
@@ -126,23 +126,6 @@ type CommonOptions = ApiVersionOptions & {
    * @since 1.7.19
    */
   abortSignal?: AbortSignal;
-};
-
-export type RunMetadata = {
-  /**
-   * The extension that's running the brick. Used to correlate trace records across all runs/branches.
-   * @since 1.7.0
-   */
-  extensionId: UUID;
-  /**
-   * A unique run id to correlate trace records across branches for a run, or null to disable tracing.
-   */
-  runId: UUID | null;
-  /**
-   * The control flow branch to correlate trace record for a brick.
-   * @since 1.7.0
-   */
-  branches: Branch[];
 };
 
 export type ReduceOptions = CommonOptions & RunMetadata;

--- a/src/runtime/runtimeTypes.ts
+++ b/src/runtime/runtimeTypes.ts
@@ -46,6 +46,10 @@ export function unsafeAssumeValidArg<T extends Record<string, unknown>>(
 
 const OUTPUT_KEY_REGEX = /[A-Z_a-z]\w{0,30}/;
 
+/**
+ * Validates and returns if `key` is a valid brick output key (i.e., variable name), or throws a TypeError.
+ * @param key the key to test
+ */
 export function validateOutputKey(key: string): OutputKey {
   if (OUTPUT_KEY_REGEX.test(key)) {
     return key as OutputKey;

--- a/src/runtime/runtimeTypes.ts
+++ b/src/runtime/runtimeTypes.ts
@@ -35,6 +35,8 @@ export type ResolvedBrickConfig = {
  * Assume that a value matches the expected arg for any brick.
  *
  * For use in tests and JavaScript bricks that manually create a call to an individual brick.
+ *
+ * @see brickOptionsFactory
  */
 export function unsafeAssumeValidArg<T extends Record<string, unknown>>(
   value: unknown

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -168,6 +168,11 @@ const PanelBody: React.FunctionComponent<{
             ...context,
             blockId,
           }),
+          meta: {
+            extensionId,
+            runId,
+            branches: [],
+          },
           async runPipeline() {
             throw new BusinessError(
               "Support for running pipelines in panels not implemented"

--- a/src/sidebar/RendererComponent.test.tsx
+++ b/src/sidebar/RendererComponent.test.tsx
@@ -25,6 +25,7 @@ import { screen } from "shadow-dom-testing-library";
 import { SubmitPanelAction } from "@/bricks/errors";
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import { runHeadlessPipeline } from "@/contentScript/messenger/api";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
 jest.mock("@/contentScript/messenger/api", () => ({
   runHeadlessPipeline: jest
@@ -32,9 +33,7 @@ jest.mock("@/contentScript/messenger/api", () => ({
     .mockRejectedValue(new Error("not implemented")),
 }));
 
-const runHeadlessPipelineMock = runHeadlessPipeline as jest.MockedFunction<
-  typeof runHeadlessPipeline
->;
+const runHeadlessPipelineMock = jest.mocked(runHeadlessPipeline);
 
 describe("RendererComponent", () => {
   beforeEach(() => {
@@ -65,7 +64,14 @@ describe("RendererComponent", () => {
 
     const props = {
       body: [config],
-      options: { ctxt: {}, logger: new ConsoleLogger() },
+      options: brickOptionsFactory({
+        logger: new ConsoleLogger({ extensionId }),
+        meta: {
+          runId,
+          extensionId,
+          branches: [],
+        },
+      }),
     };
 
     render(

--- a/src/telemetry/trace.ts
+++ b/src/telemetry/trace.ts
@@ -23,7 +23,11 @@ import objectHash from "object-hash";
 import { type ErrorObject } from "serialize-error";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
-import { type OutputKey, type RenderedArgs } from "@/types/runtimeTypes";
+import {
+  type Branch,
+  type OutputKey,
+  type RenderedArgs,
+} from "@/types/runtimeTypes";
 import { deleteDatabase } from "@/utils/idbUtils";
 
 const DATABASE_NAME = "TRACE";
@@ -52,16 +56,7 @@ export type TraceRecordMeta = {
    *
    * @since 1.7.0
    */
-  branches: Array<{
-    /**
-     * Identifier for the branch. (Distinct from other branch ids for blockInstanceId, but not globally unique)
-     */
-    key: string;
-    /**
-     * Monotonically increasing counter
-     */
-    counter: number;
-  }>;
+  branches: Branch[];
 
   /**
    * Unique id to identify the block in the Page Editor across runs.

--- a/src/telemetry/traceHelpers.ts
+++ b/src/telemetry/traceHelpers.ts
@@ -17,7 +17,8 @@
 
 import { type TraceRecord } from "@/telemetry/trace";
 import { isEqual, reverse, sortBy } from "lodash";
-import { type Branch } from "@/bricks/types";
+import { type UUID } from "@/types/stringTypes";
+import { type Branch } from "@/types/runtimeTypes";
 
 /**
  * Given records for a single runId and blockInstanceId, return the latest call to a given blockInstanceId.
@@ -30,6 +31,28 @@ export function getLatestCall(records: TraceRecord[]): TraceRecord | undefined {
   return reverse(ascending)[0];
 }
 
+/**
+ * Returns trace record for the latest call to the given brickInstanceId, or undefined if one does not exist
+ * @param records the trace records
+ * @param blockInstanceId the block instanceid
+ */
+export function getLatestBrickCall(
+  records: TraceRecord[],
+  blockInstanceId: UUID
+): TraceRecord | undefined {
+  return getLatestCall(
+    records.filter(
+      // Use first block in pipeline to determine the latest run
+      (trace) => trace.blockInstanceId === blockInstanceId
+    )
+  );
+}
+
+/**
+ * Returns true if a trace record matches the given branch prefix
+ * @param prefix the branch prefix
+ * @param record the trace record
+ */
 export function hasBranchPrefix(
   prefix: Branch[],
   record: TraceRecord
@@ -41,6 +64,11 @@ export function hasBranchPrefix(
   );
 }
 
+/**
+ * Returns trace records with a branch prefix that matches callBranches
+ * @param records the trace records
+ * @param callBranches the branch prefix to filter by
+ */
 export function filterTracesByCall(
   records: TraceRecord[],
   callBranches: Branch[] | null

--- a/src/testUtils/factories/runtimeFactories.ts
+++ b/src/testUtils/factories/runtimeFactories.ts
@@ -33,10 +33,10 @@ export const brickOptionsFactory = define<BrickOptions>({
     new ConsoleLogger({
       extensionId: uuidSequence(i),
     }),
-  root: document,
-  runPipeline: () =>
+  root: (_i: number) => document,
+  runPipeline: (_i: number) =>
     jest.fn().mockRejectedValue(new Error("runPipeline mock not implemented")),
-  runRendererPipeline: () =>
+  runRendererPipeline: (_i: number) =>
     jest
       .fn()
       .mockRejectedValue(new Error("runRendererPipeline mock not implemented")),

--- a/src/testUtils/factories/runtimeFactories.ts
+++ b/src/testUtils/factories/runtimeFactories.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type BrickOptions, type RunMetadata } from "@/types/runtimeTypes";
+import { define, derive } from "cooky-cutter";
+import ConsoleLogger from "@/utils/ConsoleLogger";
+import { uuidSequence } from "@/testUtils/factories/stringFactories";
+
+/**
+ * Factory for BrickOptions to pass to Brick.run method.
+ *
+ * For creating brick arguments for testing, see unsafeAssumeValidArg.
+ *
+ * @see unsafeAssumeValidArg
+ */
+export const brickOptionsFactory = define<BrickOptions>({
+  ctxt: null,
+  logger: (i: number) =>
+    new ConsoleLogger({
+      extensionId: uuidSequence(i),
+    }),
+  root: document,
+  runPipeline: () =>
+    jest.fn().mockRejectedValue(new Error("runPipeline mock not implemented")),
+  runRendererPipeline: () =>
+    jest
+      .fn()
+      .mockRejectedValue(new Error("runRendererPipeline mock not implemented")),
+  meta: derive<BrickOptions, RunMetadata>(
+    (options) => ({
+      runId: null,
+      extensionId: options.logger.context.extensionId,
+      branches: [],
+    }),
+    "logger"
+  ),
+});

--- a/src/types/brickTypes.ts
+++ b/src/types/brickTypes.ts
@@ -190,7 +190,7 @@ export abstract class BrickABC implements Brick {
  * @see ExternalBlock
  */
 export function isUserDefinedBrick(brick: Brick): boolean {
-  // YAML-defined bricks have a .component property added by the ExternalBlock class
+  // YAML-defined bricks have a .component property added by the UserDefinedBrick class
   // We don't want to introduce circular dependency
   return brick && "component" in brick && Boolean(brick.component);
 }

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -43,7 +43,9 @@ export function isUUID(uuid: string): uuid is UUID {
   return validUuidRegex.test(uuid);
 }
 
-// Sentinel UUID
+/**
+ * A sentinel UUID to serve as a default value/initial state for required UUID parameters.
+ */
 export const UNSET_UUID = validateUUID("00000000-0000-4000-A000-000000000000");
 
 export function validateUUID(uuid: unknown): UUID {

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -255,7 +255,41 @@ export type ServiceContext = Record<
   }
 >;
 
-// Using "any" for now so that bricks don't have to assert/cast all their argument types. We're checking
+/**
+ * An execution branch (defer, pipeline, etc.).
+ * @since 1.7.0
+ */
+export type Branch = {
+  /**
+   * A static identifier for the branch.
+   * @since 1.7.0
+   */
+  key: string;
+  /**
+   * A monotonically increasing counter for executions of branch with key
+   * @since 1.7.0
+   */
+  counter: number;
+};
+
+export interface RunMetadata {
+  /**
+   * The extension that's running the brick. Used to correlate trace records across all runs/branches.
+   * @since 1.7.0
+   */
+  extensionId: UUID;
+  /**
+   * A unique run id to correlate trace records across branches for a run, or null to disable tracing.
+   */
+  runId: UUID | null;
+  /**
+   * The control flow branch to correlate trace record for a brick.
+   * @since 1.7.0
+   */
+  branches: Branch[];
+}
+
+// Using "any" so bricks don't have to assert/cast all their argument types. We're checking
 // the inputs using yup/jsonschema, so the types should match what's expected.
 export type BrickOptions<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
@@ -318,4 +352,16 @@ export type BrickOptions<
    * @since 1.7.19
    */
   abortSignal?: AbortSignal;
+
+  /**
+   * Trace metadata.
+   *
+   * Added to enable the UserDefinedBrick to pass the runId to the runtime because it can't make direct calls
+   * to BrickOptions.runPipeline or BrickOptions.runRendererPipeline.
+   *
+   * In general, you should not need to use this information.
+   *
+   * @since 1.8.4
+   */
+  meta: RunMetadata;
 };

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -262,6 +262,9 @@ export type ServiceContext = Record<
 export type Branch = {
   /**
    * A static identifier for the branch.
+   *
+   * In practice, will typically be the name of the pipeline in the brick, e.g., "if", "else", "try", "body", etc.
+   *
    * @since 1.7.0
    */
   key: string;
@@ -272,6 +275,9 @@ export type Branch = {
   counter: number;
 };
 
+/**
+ * Metadata about the current run.
+ */
 export interface RunMetadata {
   /**
    * The extension that's running the brick. Used to correlate trace records across all runs/branches.
@@ -283,7 +289,7 @@ export interface RunMetadata {
    */
   runId: UUID | null;
   /**
-   * The control flow branch to correlate trace record for a brick.
+   * The control flow branch to correlate trace records for a brick.
    * @since 1.7.0
    */
   branches: Branch[];

--- a/src/types/sidebarTypes.ts
+++ b/src/types/sidebarTypes.ts
@@ -26,7 +26,7 @@ import {
 import { type MessageContext } from "@/types/loggerTypes";
 import { type ModComponentState } from "@/store/extensionsTypes";
 import { isObject } from "@/utils/objectUtils";
-import { RunMetadata } from "@/types/runtimeTypes";
+import { type RunMetadata } from "@/types/runtimeTypes";
 
 /**
  * Entry types supported by the sidebar.

--- a/src/types/sidebarTypes.ts
+++ b/src/types/sidebarTypes.ts
@@ -26,6 +26,7 @@ import {
 import { type MessageContext } from "@/types/loggerTypes";
 import { type ModComponentState } from "@/store/extensionsTypes";
 import { isObject } from "@/utils/objectUtils";
+import { RunMetadata } from "@/types/runtimeTypes";
 
 /**
  * Entry types supported by the sidebar.
@@ -330,10 +331,7 @@ export type ActivatePanelOptions = {
  * Metadata about the extension that produced the panel content
  * @since 1.7.0
  */
-export type PanelRunMeta = {
-  runId: UUID;
-  extensionId: UUID;
-};
+export type PanelRunMeta = Pick<RunMetadata, "runId" | "extensionId">;
 
 export type SidebarState = SidebarEntries & {
   activeKey: string;


### PR DESCRIPTION
## What does this PR do?

- 🐛  Fixes tracing tracing for pipeline arguments to user-defined bricks. Previously pipeline arguments would be run with a fresh runId but the same extensionId causing those bricks to appear to PixieBrix tracing as if they were a new starter brick run
  - Fixes `applyReduceDefaults` to not assign a random runId
  - Fixes UserDefinedBrick to pass along run metadata 
- 🐛 Fixes a bug in usePipelineNodes where stale results would show from deeply nested pipelines where the parent pipeline hadn't started executing yet
- Adds `meta` field to BrickOptions to enable runId/extensionId/branch to be passed through during user-defined brick execution
- Adds a `brickOptionsFactory` test factory to standardize `BrickOptions` in tests
- Refactoring
  - Removes the `meta` field from DocumentState because it's now on options
  - Consolidates some duplicate `Branch` and `RunMetadata` type definitions
  - Improves name of `RunBrick` to `RunBrickRequest`

## Reviewer Tips

- The PR size is scary due to the `brickOptionsFactory` refactoring. You can skim over the test files
- Files to focus on for the runId fix:
   1. `runtimeTypes.ts`
   2. `reducePipeline.ts`
   3. `brickFactory.ts` and `brickFactory.test.ts`
   4.  Document Builder places where information must be forwarded: `ButtonElement`, `BlockElement`
- Files to focus on for the stale brick status bug:
   1. `usePipelineNodes`

## Discussion

- Some relevant background code about tracing:
  - [getLatestRunByExtensionId](https://github.com/pixiebrix/pixiebrix-extension/blob/c56a83dfe855e157a8c759e89d8571573954e781/src/telemetry/trace.ts#L339-L339)
  - [decideBackgroundStatus](https://github.com/pixiebrix/pixiebrix-extension/blob/c56a83dfe855e157a8c759e89d8571573954e781/src/pageEditor/tabs/editTab/editorNodeLayout/decideStatus.ts#L28-L28)
  - [mapBlockToNodes](https://github.com/pixiebrix/pixiebrix-extension/blob/c56a83dfe855e157a8c759e89d8571573954e781/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx#L268-L268)
  - [getLatestCall](https://github.com/pixiebrix/pixiebrix-extension/blob/c56a83dfe855e157a8c759e89d8571573954e781/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx#L629-L629)

## Demo

- https://www.loom.com/share/606d7011beab4e69a872b876f7684ff9

Screenshot of branches in IDB:

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/6e47e040-c375-46f7-92c5-9c70f3289926)


## Checklist

- [x] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
