### PR TITLE
updates permissions to allow github actions to auto-merge some prs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,6 +2,7 @@ name: Dependabot auto-approve
 on: pull_request
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## What does this PR do?

Related to #7000 

## Discussion

- Missed a required token permission: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request


## Checklist

- [x] Designate a primary reviewer @BLoe 
