### PR TITLE
Fix Identity Brick options in Page Editor and allow any value

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3220,7 +3220,7 @@ exports[`Storyshots Editor/LogTable Populated 1`] = `
               @pixiebrix/system/notification
             </td>
             <td>
-              Invalid inputs for block
+              Invalid inputs for brick
             </td>
           </tr>
         </tbody>

--- a/src/bricks/transformers/IdentityOptions.test.tsx
+++ b/src/bricks/transformers/IdentityOptions.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render } from "@/pageEditor/testHelpers";
+import IdentityOptions from "@/bricks/transformers/IdentityOptions";
+import { getExampleBlockConfig } from "@/pageEditor/exampleBlockConfigs";
+import { IdentityTransformer } from "@/bricks/transformers/identity";
+import brickRegistry from "@/bricks/registry";
+import { screen } from "@testing-library/react";
+import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
+import registerEditors from "@/contrib/editors";
+import { waitForEffect } from "@/testUtils/testHelpers";
+
+beforeAll(() => {
+  brickRegistry.register([new IdentityTransformer()]);
+  registerDefaultWidgets();
+  registerEditors();
+});
+
+describe("IdentityOptions", () => {
+  test("shows object widget by default", async () => {
+    render(<IdentityOptions name="foo" configKey="config" />, {
+      initialValues: {
+        foo: {
+          config: getExampleBlockConfig(IdentityTransformer.BRICK_ID),
+        },
+      },
+    });
+
+    await waitForEffect();
+
+    expect(
+      screen.getByRole("button", { name: "Add Property" })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/bricks/transformers/IdentityOptions.test.tsx
+++ b/src/bricks/transformers/IdentityOptions.test.tsx
@@ -24,7 +24,6 @@ import brickRegistry from "@/bricks/registry";
 import { screen } from "@testing-library/react";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import registerEditors from "@/contrib/editors";
-import { waitForEffect } from "@/testUtils/testHelpers";
 
 beforeAll(() => {
   brickRegistry.register([new IdentityTransformer()]);
@@ -41,8 +40,6 @@ describe("IdentityOptions", () => {
         },
       },
     });
-
-    await waitForEffect();
 
     await expect(
       screen.findByRole("button", { name: "Add Property" })

--- a/src/bricks/transformers/IdentityOptions.test.tsx
+++ b/src/bricks/transformers/IdentityOptions.test.tsx
@@ -44,8 +44,8 @@ describe("IdentityOptions", () => {
 
     await waitForEffect();
 
-    expect(
-      screen.getByRole("button", { name: "Add Property" })
-    ).toBeInTheDocument();
+    await expect(
+      screen.findByRole("button", { name: "Add Property" })
+    ).resolves.toBeInTheDocument();
   });
 });

--- a/src/bricks/transformers/IdentityOptions.tsx
+++ b/src/bricks/transformers/IdentityOptions.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { type BlockOptionProps } from "@/components/fields/schemaFields/genericOptionsFactory";
+import { type Schema } from "@/types/schemaTypes";
+import SchemaField from "@/components/fields/schemaFields/SchemaField";
+import { joinName } from "@/utils/formUtils";
+
+const ANY_SCHEMA: Schema = {
+  title: "Value",
+  description: "The value to return",
+};
+
+/**
+ * Page Editor fields for the @pixiebrix/identity brick.
+ */
+const IdentityOptions: React.FunctionComponent<BlockOptionProps> = ({
+  name,
+  configKey,
+}) => (
+  <SchemaField
+    label="Value"
+    name={joinName(name, configKey)}
+    schema={ANY_SCHEMA}
+    // Mark as required so the widget defaults to showing the number entry
+    isRequired
+  />
+);
+
+export default IdentityOptions;

--- a/src/bricks/transformers/identity.test.ts
+++ b/src/bricks/transformers/identity.test.ts
@@ -19,8 +19,20 @@ import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { IdentityTransformer } from "@/bricks/transformers/identity";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { makeVariableExpression } from "@/runtime/expressionCreators";
+import { validateInput } from "@/validators/generic";
 
 const brick = new IdentityTransformer();
+
+describe("IdentityTransformer.schema", () => {
+  it.each([null, "hello", 42, [], {}])("allows: %s", async (value) => {
+    await expect(
+      validateInput(brick.inputSchema, value)
+    ).resolves.toStrictEqual({
+      errors: [],
+      valid: true,
+    });
+  });
+});
 
 describe("IdentityTransformer.run", () => {
   test("it returns same value", async () => {

--- a/src/bricks/transformers/identity.test.ts
+++ b/src/bricks/transformers/identity.test.ts
@@ -18,10 +18,11 @@
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { IdentityTransformer } from "@/bricks/transformers/identity";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+import { makeVariableExpression } from "@/runtime/expressionCreators";
 
 const brick = new IdentityTransformer();
 
-describe("IdentityTransformer", () => {
+describe("IdentityTransformer.run", () => {
   test("it returns same value", async () => {
     const value = { foo: "bar" };
     const result = await brick.run(
@@ -45,5 +46,44 @@ describe("IdentityTransformer", () => {
       brickOptionsFactory()
     );
     expect(result).toStrictEqual([]);
+  });
+});
+
+describe("IdentityTransformer.getOutputSchema", () => {
+  it("returns schema for plain object", () => {
+    const schema = brick.getOutputSchema({
+      id: IdentityTransformer.BRICK_ID,
+      config: {
+        foo: "bar",
+      },
+    });
+    expect(schema).toStrictEqual({
+      type: "object",
+      // Allow any under each property
+      properties: {
+        foo: {},
+      },
+      required: ["foo"],
+    });
+  });
+
+  it("returns undefined for expression", () => {
+    const schema = brick.getOutputSchema({
+      id: IdentityTransformer.BRICK_ID,
+      config: makeVariableExpression("@foo"),
+    });
+    expect(schema).toBeUndefined();
+  });
+
+  it("returns array type", () => {
+    const schema = brick.getOutputSchema({
+      id: IdentityTransformer.BRICK_ID,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- config technically accepts anything
+      config: [] as any,
+    });
+    expect(schema).toStrictEqual({
+      type: "array",
+      items: {},
+    });
   });
 });

--- a/src/bricks/transformers/identity.test.ts
+++ b/src/bricks/transformers/identity.test.ts
@@ -20,18 +20,31 @@ import { IdentityTransformer } from "@/bricks/transformers/identity";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { makeVariableExpression } from "@/runtime/expressionCreators";
 import { validateInput } from "@/validators/generic";
+import { throwIfInvalidInput } from "@/runtime/runtimeUtils";
 
 const brick = new IdentityTransformer();
 
 describe("IdentityTransformer.schema", () => {
-  it.each([null, "hello", 42, [], {}])("allows: %s", async (value) => {
-    await expect(
-      validateInput(brick.inputSchema, value)
-    ).resolves.toStrictEqual({
-      errors: [],
-      valid: true,
-    });
-  });
+  it.each([null, "hello", 42, [], {}])(
+    "allows validateInput: %s",
+    async (value) => {
+      await expect(
+        validateInput(brick.inputSchema, value)
+      ).resolves.toStrictEqual({
+        errors: [],
+        valid: true,
+      });
+    }
+  );
+
+  it.each([null, "hello", 42, [], {}])(
+    "allow throwIfInvalidInput: %s",
+    async (value) => {
+      await expect(
+        throwIfInvalidInput(brick, unsafeAssumeValidArg(value))
+      ).resolves.toBeUndefined();
+    }
+  );
 });
 
 describe("IdentityTransformer.run", () => {

--- a/src/bricks/transformers/identity.test.ts
+++ b/src/bricks/transformers/identity.test.ts
@@ -30,4 +30,20 @@ describe("IdentityTransformer", () => {
     );
     expect(result).toStrictEqual(value);
   });
+
+  test("it accepts null", async () => {
+    const result = await brick.run(
+      unsafeAssumeValidArg(null),
+      brickOptionsFactory()
+    );
+    expect(result).toBeNull();
+  });
+
+  test("it accepts array", async () => {
+    const result = await brick.run(
+      unsafeAssumeValidArg([]),
+      brickOptionsFactory()
+    );
+    expect(result).toStrictEqual([]);
+  });
 });

--- a/src/bricks/transformers/identity.ts
+++ b/src/bricks/transformers/identity.ts
@@ -19,12 +19,35 @@ import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { validateRegistryId } from "@/types/helpers";
+import { type BrickConfig } from "@/bricks/types";
+import { isPlainObject, mapValues } from "lodash";
+import { isExpression } from "@/utils/expressionUtils";
 
 export class IdentityTransformer extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/identity");
 
   override async isPure(): Promise<boolean> {
     return true;
+  }
+
+  override getOutputSchema(_config: BrickConfig): Schema | undefined {
+    if (isPlainObject(_config.config) && !isExpression(_config.config)) {
+      return {
+        type: "object",
+        // Allow any under each property
+        properties: mapValues(_config.config, () => ({})),
+        required: Object.keys(_config.config),
+      };
+    }
+
+    if (Array.isArray(_config.config)) {
+      return {
+        type: "array",
+        items: {},
+      };
+    }
+
+    return undefined;
   }
 
   constructor() {

--- a/src/bricks/transformers/identity.ts
+++ b/src/bricks/transformers/identity.ts
@@ -18,24 +18,27 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
+import { validateRegistryId } from "@/types/helpers";
 
 export class IdentityTransformer extends TransformerABC {
+  static BRICK_ID = validateRegistryId("@pixiebrix/identity");
+
   override async isPure(): Promise<boolean> {
     return true;
   }
 
   constructor() {
     super(
-      "@pixiebrix/identity",
-      "Identity function",
-      "Returns the object passed into it",
+      IdentityTransformer.BRICK_ID,
+      "Identity Function",
+      "Returns the value passed into it. Use to construct return values/event data.",
       "faCode"
     );
   }
 
+  // Empty schema matches any input
   inputSchema: Schema = {
-    type: "object",
-    additionalProperties: true,
+    title: "Value",
   };
 
   async transform(arg: BrickArgs): Promise<BrickArgs> {

--- a/src/bricks/transformers/identity.ts
+++ b/src/bricks/transformers/identity.ts
@@ -31,7 +31,7 @@ export class IdentityTransformer extends TransformerABC {
     super(
       IdentityTransformer.BRICK_ID,
       "Identity Function",
-      "Returns the value passed into it. Use to construct return values/event data.",
+      "Returns/echoes the value passed into it. Use to construct return values/event data.",
       "faCode"
     );
   }

--- a/src/bricks/transformers/identity.ts
+++ b/src/bricks/transformers/identity.ts
@@ -30,6 +30,15 @@ export class IdentityTransformer extends TransformerABC {
     return true;
   }
 
+  constructor() {
+    super(
+      IdentityTransformer.BRICK_ID,
+      "Identity Function",
+      "Return/echo the value passed into it. Use to construct return values/event data.",
+      "faCode"
+    );
+  }
+
   override getOutputSchema(_config: BrickConfig): Schema | undefined {
     if (isPlainObject(_config.config) && !isExpression(_config.config)) {
       return {
@@ -50,21 +59,12 @@ export class IdentityTransformer extends TransformerABC {
     return undefined;
   }
 
-  constructor() {
-    super(
-      IdentityTransformer.BRICK_ID,
-      "Identity Function",
-      "Returns/echoes the value passed into it. Use to construct return values/event data.",
-      "faCode"
-    );
-  }
-
   // Empty schema matches any input
   inputSchema: Schema = {
     title: "Value",
   };
 
-  async transform(arg: BrickArgs): Promise<BrickArgs> {
-    return arg;
+  async transform(args: BrickArgs): Promise<BrickArgs> {
+    return args;
   }
 }

--- a/src/bricks/transformers/identity.ts
+++ b/src/bricks/transformers/identity.ts
@@ -60,9 +60,7 @@ export class IdentityTransformer extends TransformerABC {
   }
 
   // Empty schema matches any input
-  inputSchema: Schema = {
-    title: "Value",
-  };
+  inputSchema: Schema = {};
 
   async transform(args: BrickArgs): Promise<BrickArgs> {
     return args;

--- a/src/components/errors/getErrorDetails.test.tsx
+++ b/src/components/errors/getErrorDetails.test.tsx
@@ -94,13 +94,13 @@ test("Input validation error", () => {
           'Instance type "object" is invalid. Expected "string", "number", "boolean".',
       },
     ],
-    message: "Invalid inputs for block",
+    message: "Invalid inputs for brick",
     stack:
-      "InputValidationError: Invalid inputs for block\n    at throwIfInvalidInput (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/contentScript.js:56223:15)\n    at async runBlock (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/contentScript.js:55809:9)\n    at async blockReducer (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/contentScript.js:55879:20)\n    at async reducePipeline (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/contentScript.js:55989:26)\n    at async HTMLAnchorElement.<anonymous> (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/contentScript.js:51535:17)",
+      "InputValidationError: Invalid inputs for brick\n    at throwIfInvalidInput (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/contentScript.js:56223:15)\n    at async runBlock (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/contentScript.js:55809:9)\n    at async blockReducer (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/contentScript.js:55879:20)\n    at async reducePipeline (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/contentScript.js:55989:26)\n    at async HTMLAnchorElement.<anonymous> (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/contentScript.js:51535:17)",
   };
 
   const { title, detailsElement } = getErrorDetails(error);
-  expect(title).toBe("Invalid inputs for block");
+  expect(title).toBe("Invalid inputs for brick");
   expect(render(detailsElement).asFragment()).toMatchSnapshot();
 });
 

--- a/src/components/errors/getErrorDetails.tsx
+++ b/src/components/errors/getErrorDetails.tsx
@@ -38,7 +38,7 @@ export default function getErrorDetails(error: ErrorObject): ErrorDetails {
   const inputValidationError = selectSpecificError(error, InputValidationError);
   if (inputValidationError) {
     return {
-      title: "Invalid inputs for block",
+      title: "Invalid inputs for brick",
       detailsElement: (
         <InputValidationErrorDetail error={inputValidationError} />
       ),
@@ -51,7 +51,7 @@ export default function getErrorDetails(error: ErrorObject): ErrorDetails {
   );
   if (outputValidationError) {
     return {
-      title: "Invalid output for block",
+      title: "Invalid output for brick",
       detailsElement: (
         <OutputValidationErrorDetail error={outputValidationError} />
       ),

--- a/src/components/fields/schemaFields/schemaUtils.test.ts
+++ b/src/components/fields/schemaFields/schemaUtils.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { castSchema } from "@/components/fields/schemaFields/schemaUtils";
+
+describe("castSchema", () => {
+  it("casts an object to an object schema", () => {
+    expect(castSchema({ foo: {} })).toStrictEqual({
+      type: "object",
+      properties: {
+        foo: {},
+      },
+    });
+  });
+
+  it("returns empty schema", () => {
+    expect(castSchema({})).toStrictEqual({});
+  });
+
+  it("returns array schema", () => {
+    expect(castSchema({ type: "array" })).toStrictEqual({ type: "array" });
+  });
+});

--- a/src/components/fields/schemaFields/schemaUtils.ts
+++ b/src/components/fields/schemaFields/schemaUtils.ts
@@ -47,6 +47,7 @@ export function arraySchema(itemSchema: Schema): Schema {
 export function castSchema(
   schemaOrProperties: Schema | SchemaProperties
 ): Schema {
+  // XXX: this isn't quite right -- the check won't work if there's a title/description for the empty schema
   if (isEmpty(schemaOrProperties)) {
     // Empty schema means allow anything
     return {} as Schema;

--- a/src/components/fields/schemaFields/schemaUtils.ts
+++ b/src/components/fields/schemaFields/schemaUtils.ts
@@ -16,6 +16,7 @@
  */
 
 import { type Schema } from "@/types/schemaTypes";
+import { isEmpty } from "lodash";
 
 type SchemaProperties = Record<string, Schema>;
 
@@ -41,11 +42,21 @@ export function arraySchema(itemSchema: Schema): Schema {
 }
 
 /**
- * Return as an object schema
+ * Returns a Schema. If an normal object is passed in, casts it to an object Schema.
  */
 export function castSchema(
   schemaOrProperties: Schema | SchemaProperties
 ): Schema {
+  if (isEmpty(schemaOrProperties)) {
+    // Empty schema means allow anything
+    return {} as Schema;
+  }
+
+  if (schemaOrProperties.type && schemaOrProperties.type !== "object") {
+    // Is another type of schema
+    return schemaOrProperties;
+  }
+
   if (schemaOrProperties.type && schemaOrProperties.properties) {
     return schemaOrProperties as Schema;
   }

--- a/src/components/logViewer/LogTable.stories.tsx
+++ b/src/components/logViewer/LogTable.stories.tsx
@@ -107,7 +107,7 @@ const sampleSchema: Schema = {
 };
 
 const validationError = new InputValidationError(
-  "Invalid inputs for block",
+  "Invalid inputs for brick",
   sampleSchema,
   {},
   [
@@ -123,14 +123,14 @@ const validationError = new InputValidationError(
 const CONTEXT_ERROR_MESSAGE: LogEntry = {
   uuid: uuidv4(),
   timestamp: MESSAGE_DATE.toString(),
-  message: "Invalid inputs for block",
+  message: "Invalid inputs for brick",
   level: "error",
   context: {
     // Just the context that will show up in the table
     blockId,
   },
   error: serializeError(
-    new ContextError("Invalid inputs for block", {
+    new ContextError("Invalid inputs for brick", {
       cause: validationError,
       context: {
         blockId,

--- a/src/contrib/editors.ts
+++ b/src/contrib/editors.ts
@@ -57,6 +57,8 @@ import { JQueryReader } from "@/bricks/transformers/jquery/JQueryReader";
 import JQueryReaderOptions from "@/bricks/transformers/jquery/JQueryReaderOptions";
 import AssignModVariable from "@/bricks/effects/assignModVariable";
 import AssignModVariableOptions from "@/pageEditor/fields/AssignModVariableOptions";
+import { IdentityTransformer } from "@/bricks/transformers/identity";
+import IdentityOptions from "@/bricks/transformers/IdentityOptions";
 
 /**
  * Custom BlockConfiguration pageEditor components.
@@ -82,4 +84,5 @@ export default function registerEditors() {
   optionsRegistry.set(ALERT_EFFECT_ID, AlertOptions);
   optionsRegistry.set(JQueryReader.BRICK_ID, JQueryReaderOptions);
   optionsRegistry.set(AssignModVariable.BRICK_ID, AssignModVariableOptions);
+  optionsRegistry.set(IdentityTransformer.BRICK_ID, IdentityOptions);
 }

--- a/src/pageEditor/exampleBlockConfigs.ts
+++ b/src/pageEditor/exampleBlockConfigs.ts
@@ -34,6 +34,7 @@ import { getMinimalUiSchema } from "@/components/formBuilder/formBuilderHelpers"
 import { type RegistryId } from "@/types/registryTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { JavaScriptTransformer } from "@/bricks/transformers/javascript";
+import { IdentityTransformer } from "@/bricks/transformers/identity";
 
 /**
  * Get a default block config for a block
@@ -60,6 +61,12 @@ export function getExampleBlockConfig(
             isMulti: false,
           },
         },
+      };
+    }
+
+    case IdentityTransformer.BRICK_ID: {
+      return {
+        value: makeTemplateExpression("nunjucks", ""),
       };
     }
 


### PR DESCRIPTION
## What does this PR do?

- Fixes Page Editor field(s) for Identity Brick
- The Identity brick should be used instead of jq/javascript for constructing a value from other values
- Fixes identity brick to work with non-object values
- Adds variable popover hints for object/array form of input

## Remaining Work

- [x] Our brick input validation is overzealous and is rejecting non-object inputs to the brick despite the flexible schema

## Demo

- https://www.loom.com/share/f1f3dbd9b6b54b30a8b0f97f365fc707?sid=8ab71fa6-ec0d-4a70-b671-82c7d878b77f

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires a documentation change (link to old docs): @mthek10 @brittanyjoiner15 
- [ ] Update marketplace listing: @brittanyjoiner15 to ensure it shows up under transform data

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
