### PR TITLE
#6943: add (Copy) suffix to copied mod name by default

### DIFF
--- a/src/pageEditor/sidebar/modals/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/CreateRecipeModal.tsx
@@ -286,13 +286,15 @@ function useInitialFormState({
   // extension within an existing recipe, is selected
   if (recipeMetadata) {
     let newId = generateScopeBrickId(scope, recipeMetadata.id);
+    let newName = recipeMetadata.name;
     if (newId === recipeMetadata.id) {
+      newName = `${recipeMetadata.name} (Copy)`;
       newId = validateRegistryId(newId + "-copy");
     }
 
     return {
       id: newId,
-      name: recipeMetadata.name,
+      name: newName,
       version: validateSemVerString("1.0.0"),
       description: recipeMetadata.description,
     };

--- a/src/pageEditor/sidebar/modals/CreateRecipeModal.tsx
+++ b/src/pageEditor/sidebar/modals/CreateRecipeModal.tsx
@@ -286,15 +286,13 @@ function useInitialFormState({
   // extension within an existing recipe, is selected
   if (recipeMetadata) {
     let newId = generateScopeBrickId(scope, recipeMetadata.id);
-    let newName = recipeMetadata.name;
     if (newId === recipeMetadata.id) {
-      newName = `${recipeMetadata.name} (Copy)`;
       newId = validateRegistryId(newId + "-copy");
     }
 
     return {
       id: newId,
-      name: newName,
+      name: `${recipeMetadata.name} (Copy)`,
       version: validateSemVerString("1.0.0"),
       description: recipeMetadata.description,
     };

--- a/src/pageEditor/slices/editorSlice.test.ts
+++ b/src/pageEditor/slices/editorSlice.test.ts
@@ -232,7 +232,7 @@ describe("Add/Remove Bricks", () => {
     expect(action2.payload).toEqual(
       expect.objectContaining({
         uuid: expect.not.stringMatching(source.uuid),
-        label: "Test Extension - copy",
+        label: "Test Extension (Copy)",
       }),
     );
     expect(action2.payload).not.toHaveProperty("recipe");

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -140,7 +140,7 @@ const cloneActiveExtension = createAsyncThunk<
     selectActiveElement(state),
     async (draft) => {
       draft.uuid = uuidv4();
-      draft.label += " - copy";
+      draft.label += " (Copy)";
       // Remove from its recipe, if any (the user can add it to any recipe after creation)
       delete draft.recipe;
       // Re-generate instance IDs for all the bricks in the extension


### PR DESCRIPTION
## What does this PR do?

- Closes #6943 
- Also changes copied extension suffix from `- copy` to `(Copy)` for consistency

## Demo

- https://www.loom.com/share/ee4c342d430e46bb9198718361d4db89?sid=5cba6e0a-0c2c-4a22-b8d3-a1fa3780a6f3

## Checklist

- [ ] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @mnholtz 
