### PR TITLE
#7006: variable popoover reset selection for sub property

### DIFF
--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.tsx
@@ -273,4 +273,4 @@ const VarMenu: React.FunctionComponent<VarMenuProps> = ({
   );
 };
 
-export default VarMenu;
+export default React.memo(VarMenu);

--- a/src/components/fields/schemaFields/widgets/varPopup/menuFilters.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/menuFilters.ts
@@ -348,8 +348,11 @@ export function moveMenuOption({
     head
   ] as UnknownRecord;
 
+  console.log("moveMenuOption", { offset, keyPathParts, head, rest, varMap });
+
   // User is switching between top-level variables
   if (rest.length === 0) {
+    console.log("moveMenuOption:noRest");
     const sourceIndex = options.findIndex(([x]) => x === source);
     const [, nextSourceVars] = options.at(
       (sourceIndex + offset) % options.length,

--- a/src/components/fields/schemaFields/widgets/varPopup/menuFilters.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/menuFilters.ts
@@ -348,11 +348,8 @@ export function moveMenuOption({
     head
   ] as UnknownRecord;
 
-  console.log("moveMenuOption", { offset, keyPathParts, head, rest, varMap });
-
   // User is switching between top-level variables
   if (rest.length === 0) {
-    console.log("moveMenuOption:noRest");
     const sourceIndex = options.findIndex(([x]) => x === source);
     const [, nextSourceVars] = options.at(
       (sourceIndex + offset) % options.length,

--- a/src/components/fields/schemaFields/widgets/varPopup/useAttachPopup.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useAttachPopup.ts
@@ -17,7 +17,12 @@
 
 import { useSelector } from "react-redux";
 import { selectSettings } from "@/store/settings/settingsSelectors";
-import { useEffect, useReducer, type MutableRefObject } from "react";
+import {
+  useEffect,
+  useReducer,
+  type MutableRefObject,
+  useCallback,
+} from "react";
 import {
   getLikelyVariableAtPosition,
   getVariableAtPosition,
@@ -187,13 +192,15 @@ function useAttachPopup({ inputMode, inputElementRef, value }: Props) {
     },
   );
 
+  const hideMenu = useCallback(() => {
+    dispatch(popupSlice.actions.hideMenu());
+  }, []);
+
   return {
     isMenuAvailable,
     isMenuShowing,
     likelyVariable,
-    hideMenu() {
-      dispatch(popupSlice.actions.hideMenu());
-    },
+    hideMenu,
   };
 }
 

--- a/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.test.ts
@@ -51,11 +51,8 @@ describe("useKeyboardNavigation", () => {
     expect(result.all).toHaveLength(2);
 
     rerender({
-      inputElementRef,
-      isVisible: true,
-      likelyVariable: "@inpu",
+      ...initialProps,
       menuOptions: cloneDeep(menuOptions),
-      onSelect,
     });
 
     expect(result.all).toHaveLength(3);
@@ -67,5 +64,40 @@ describe("useKeyboardNavigation", () => {
     }
 
     expect(prevResult.activeKeyPath).toBe(result.current.activeKeyPath);
+  });
+
+  test("it sets the default active key path when the likely variable changes", async () => {
+    const onSelect = jest.fn();
+    const menuOptions: MenuOptions = [
+      ["input", { "@input": { description: {}, icon: {} } }],
+    ];
+    const inputElementRef = { current: document.createElement("input") };
+
+    const initialProps = {
+      inputElementRef,
+      isVisible: true,
+      likelyVariable: "@input.",
+      menuOptions,
+      onSelect,
+    };
+
+    const { result, rerender } = renderHook(
+      (props) => useKeyboardNavigation(props),
+      {
+        initialProps,
+      },
+    );
+
+    expect(result.current.activeKeyPath).toStrictEqual([
+      "description",
+      "@input",
+    ]);
+
+    rerender({
+      ...initialProps,
+      likelyVariable: "@input",
+    });
+
+    expect(result.current.activeKeyPath).toStrictEqual(["@input"]);
   });
 });

--- a/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type MenuOptions } from "@/components/fields/schemaFields/widgets/varPopup/menuFilters";
+import useKeyboardNavigation from "@/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation";
+import { renderHook } from "@testing-library/react-hooks";
+import { cloneDeep } from "lodash";
+
+describe("useKeyboardNavigation", () => {
+  test("it only sets the default active key path when the menu options change, ignoring referential inequality", async () => {
+    const onSelect = jest.fn();
+    const menuOptions: MenuOptions = [
+      ["input", { "@input": { description: {}, icon: {} } }],
+    ];
+    const inputElementRef = { current: document.createElement("input") };
+
+    const initialProps = {
+      inputElementRef,
+      isVisible: true,
+      likelyVariable: "@input.",
+      menuOptions,
+      onSelect,
+    };
+
+    const { result, rerender } = renderHook(
+      (props) => useKeyboardNavigation(props),
+      {
+        initialProps,
+      },
+    );
+
+    expect(result.current.activeKeyPath).toStrictEqual([
+      "description",
+      "@input",
+    ]);
+
+    expect(result.all).toHaveLength(2);
+
+    rerender({
+      inputElementRef,
+      isVisible: true,
+      likelyVariable: "@inpu",
+      menuOptions: cloneDeep(menuOptions),
+      onSelect,
+    });
+
+    expect(result.all).toHaveLength(3);
+
+    const prevResult = result.all[1];
+
+    if (prevResult instanceof Error) {
+      throw new TypeError("prevResult is an error");
+    }
+
+    expect(prevResult.activeKeyPath).toBe(result.current.activeKeyPath);
+  });
+});

--- a/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.test.ts
@@ -76,7 +76,7 @@ describe("useKeyboardNavigation", () => {
     const initialProps = {
       inputElementRef,
       isVisible: true,
-      likelyVariable: "@input.",
+      likelyVariable: "@inpu",
       menuOptions,
       onSelect,
     };
@@ -88,16 +88,25 @@ describe("useKeyboardNavigation", () => {
       },
     );
 
-    expect(result.current.activeKeyPath).toStrictEqual([
-      "description",
-      "@input",
-    ]);
+    expect(result.current.activeKeyPath).toStrictEqual(["@input"]);
 
     rerender({
       ...initialProps,
       likelyVariable: "@input",
     });
 
-    expect(result.current.activeKeyPath).toStrictEqual(["@input"]);
+    expect(result.all).toHaveLength(4);
+
+    const prevResult = result.all[2];
+
+    if (prevResult instanceof Error) {
+      throw new TypeError("prevResult is an error");
+    }
+
+    // Active Key Path is deep equal, but not referentially equal
+    expect(prevResult.activeKeyPath).not.toBe(result.current.activeKeyPath);
+    expect(prevResult.activeKeyPath).toStrictEqual(
+      result.current.activeKeyPath,
+    );
   });
 });

--- a/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.ts
@@ -16,12 +16,19 @@
  */
 
 import { type KeyPath } from "react-json-tree";
-import { type MutableRefObject, useCallback, useEffect, useState } from "react";
+import {
+  type MutableRefObject,
+  useCallback,
+  useEffect,
+  useState,
+  useRef,
+} from "react";
 import {
   defaultMenuOption,
   type MenuOptions,
   moveMenuOption,
 } from "@/components/fields/schemaFields/widgets/varPopup/menuFilters";
+import { isEqual } from "lodash";
 
 /**
  * Hook to navigate the variable popover menu using the keyboard from the input field
@@ -46,10 +53,17 @@ function useKeyboardNavigation({
 }) {
   // User's current selection in the variable menu
   const [activeKeyPath, setActiveKeyPath] = useState<KeyPath | null>();
+  const prevMenuOptions = useRef(menuOptions);
 
   // Set the default active key path
+  // menuOptions is not guaranteed to be referentially equal, so we store the previous value
+  // and compare it to the current value to determine if we need to update the active key path
+  // See https://github.com/pixiebrix/pixiebrix-extension/issues/7006
   useEffect(() => {
-    setActiveKeyPath(defaultMenuOption(menuOptions, likelyVariable));
+    if (!isEqual(prevMenuOptions.current, menuOptions)) {
+      setActiveKeyPath(defaultMenuOption(menuOptions, likelyVariable));
+      prevMenuOptions.current = menuOptions;
+    }
   }, [likelyVariable, menuOptions]);
 
   const move = useCallback(

--- a/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.ts
@@ -60,11 +60,11 @@ function useKeyboardNavigation({
   // and compare it to the current value to determine if we need to update the active key path
   // See https://github.com/pixiebrix/pixiebrix-extension/issues/7006
   useEffect(() => {
-    if (!isEqual(prevMenuOptions.current, menuOptions)) {
+    if (!activeKeyPath || !isEqual(prevMenuOptions.current, menuOptions)) {
       setActiveKeyPath(defaultMenuOption(menuOptions, likelyVariable));
       prevMenuOptions.current = menuOptions;
     }
-  }, [likelyVariable, menuOptions]);
+  }, [activeKeyPath, likelyVariable, menuOptions]);
 
   const move = useCallback(
     (offset: number) => {


### PR DESCRIPTION
## What does this PR do?

- Closes #7006 

## Reviewer Tips

- The fix is contained in `useKeyboardNavigation`
- The additional memoization was from the early investigation that led to demonstrably improved performance 
  - see the screenshots in the Demo section
  - Not that the renders are both fewer in number _and_ shorter in duration

## Demo

https://www.loom.com/share/fbcffcae3a924e459bc25bce2ed090de?sid=0fee0137-4744-4826-b4da-685a59bb08f6

**Before memoization**
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/bcde1e55-2867-47a0-9a11-58bfac45daca)


**After memoization**
![image](https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/f0074637-a204-493f-8ce0-3cdff029714b)

## Checklist

- [x] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer @BLoe 
