### PR TITLE
Automatically start case default field labels

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3679,7 +3679,7 @@ exports[`Storyshots Fields/ChildObjectField Primitive Value 1`] = `
               className="label form-label col-form-label col-xl-2 col-lg-3"
               htmlFor="childObject.InputValue"
             >
-              InputValue
+              Input Value
             </label>
             <div
               className="col-xl-10 col-lg-9"

--- a/src/components/fields/fieldUtils.test.ts
+++ b/src/components/fields/fieldUtils.test.ts
@@ -156,6 +156,10 @@ describe("isMustacheOnly()", () => {
 });
 
 describe("fieldLabel()", () => {
+  it("takes last part", () => {
+    expect(fieldLabel("foo.bar.baz")).toBe("Baz");
+  });
+
   it("title cases single word", () => {
     expect(fieldLabel("foo")).toBe("Foo");
   });

--- a/src/components/fields/fieldUtils.test.ts
+++ b/src/components/fields/fieldUtils.test.ts
@@ -17,6 +17,7 @@
 
 import { type Expression } from "@/types/runtimeTypes";
 import {
+  fieldLabel,
   getPreviewValues,
   isMustacheOnly,
 } from "@/components/fields/fieldUtils";
@@ -152,4 +153,22 @@ describe("isMustacheOnly()", () => {
       expect(isMustacheOnly(value)).toStrictEqual(expectedIsMustacheOnly);
     },
   );
+});
+
+describe("fieldLabel()", () => {
+  it("title cases single word", () => {
+    expect(fieldLabel("foo")).toBe("Foo");
+  });
+
+  it("title cases multi-part name", () => {
+    expect(fieldLabel("fooBarBaz")).toBe("Foo Bar Baz");
+  });
+
+  it("preserves acronyms", () => {
+    expect(fieldLabel("fooBARBaz")).toBe("Foo BAR Baz");
+  });
+
+  it("handles common acronym", () => {
+    expect(fieldLabel("fooUrlBar")).toBe("Foo URL Bar");
+  });
 });

--- a/src/components/fields/fieldUtils.ts
+++ b/src/components/fields/fieldUtils.ts
@@ -20,13 +20,50 @@ import { type UnknownObject } from "@/types/objectTypes";
 import { type FieldValidator } from "formik";
 import { type Draft, produce } from "immer";
 import type * as Yup from "yup";
-import { isEmpty } from "lodash";
+import { isEmpty, startCase } from "lodash";
 import { type Schema, type SchemaDefinition } from "@/types/schemaTypes";
 import { isExpression, isTemplateExpression } from "@/utils/expressionUtils";
 
+/**
+ * Acronyms to capitalize in field labels.
+ */
+const FIELD_TITLE_ACRONYMS = new Set([
+  "API",
+  "CRUD",
+  "CSS",
+  "CSV",
+  "GUI",
+  "HTML",
+  "HTTP",
+  "HTTPS",
+  "JS",
+  "JSON",
+  "REST",
+  "SAP",
+  "SDK",
+  "SQL",
+  "UI",
+  "URL",
+]);
+
+/**
+ * Returns the default label for a field with the given form name.
+ * @param name the form name, including field name separators
+ */
 export function fieldLabel(name: string): string {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Presumably the name is never empty, so there's always a "last item"
-  return name.split(".").at(-1)!;
+  const namePart = name.split(".").at(-1)!;
+
+  return startCase(namePart)
+    .split(" ")
+    .map((word) => {
+      if (FIELD_TITLE_ACRONYMS.has(word.toUpperCase())) {
+        return word.toUpperCase();
+      }
+
+      return word;
+    })
+    .join(" ");
 }
 
 type TypePredicate = (fieldDefinition: Schema) => boolean;

--- a/src/components/fields/schemaFields/BasicSchemaField.test.tsx
+++ b/src/components/fields/schemaFields/BasicSchemaField.test.tsx
@@ -27,6 +27,10 @@ import { fireTextInput } from "@/testUtils/formHelpers";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import registerDefaultWidgets from "./widgets/registerDefaultWidgets";
 import { type SchemaFieldProps } from "./propTypes";
+import {
+  makeTemplateExpression,
+  makeVariableExpression,
+} from "@/runtime/expressionCreators";
 
 beforeAll(() => {
   registerDefaultWidgets();
@@ -56,16 +60,13 @@ describe("option mode switching", () => {
       "test",
       { type: "string" },
       {
-        test: {
-          __type__: "var",
-          __value__: "@data",
-        },
+        test: makeVariableExpression("@data"),
       },
     );
 
     expectToggleMode(container, "Variable");
 
-    const inputElement = screen.getByLabelText("test");
+    const inputElement = screen.getByLabelText("Test");
     fireTextInput(inputElement, "text");
     await waitForEffect();
 
@@ -77,16 +78,13 @@ describe("option mode switching", () => {
       "test",
       { type: "string", enum: ["option 1", "option 2"] },
       {
-        test: {
-          __type__: "var",
-          __value__: "@data",
-        },
+        test: makeVariableExpression("@data"),
       },
     );
 
     expectToggleMode(container, "Variable");
 
-    const inputElement = screen.getByLabelText("test");
+    const inputElement = screen.getByLabelText("Test");
     fireTextInput(inputElement, "text");
     await waitForEffect();
 
@@ -98,16 +96,13 @@ describe("option mode switching", () => {
       "test",
       { type: "string" },
       {
-        test: {
-          __type__: "nunjucks",
-          __value__: "",
-        },
+        test: makeTemplateExpression("nunjucks", ""),
       },
     );
 
     expectToggleMode(container, "Text");
 
-    const inputElement = screen.getByLabelText("test");
+    const inputElement = screen.getByLabelText("Test");
     fireTextInput(inputElement, "@data.foo");
     await waitForEffect();
 
@@ -119,16 +114,13 @@ describe("option mode switching", () => {
       "test",
       { type: "string" },
       {
-        test: {
-          __type__: "var",
-          __value__: "@data.foo",
-        },
+        test: makeVariableExpression("@data.foo"),
       },
     );
 
     expectToggleMode(container, "Variable");
 
-    const inputElement: HTMLInputElement = screen.getByLabelText("test");
+    const inputElement: HTMLInputElement = screen.getByLabelText("Test");
     fireTextInput(inputElement, "@data.foo ");
     await waitForEffect();
 
@@ -144,10 +136,7 @@ test("omit if empty", async () => {
       type: ["string", "number", "boolean"],
     },
     {
-      test: {
-        __type__: "var",
-        __value__: "@data.foo",
-      },
+      test: makeVariableExpression("@data.foo"),
     },
     {
       omitIfEmpty: true,

--- a/src/components/fields/schemaFields/SchemaField.test.tsx
+++ b/src/components/fields/schemaFields/SchemaField.test.tsx
@@ -453,7 +453,7 @@ describe("SchemaField", () => {
       );
 
       // Renders switch HTML element
-      expect(screen.getByText(/isrootaware/i)).toBeInTheDocument();
+      expect(screen.getByText(/is root aware/i)).toBeInTheDocument();
       await expectToggleOptions("", []);
     },
   );
@@ -508,7 +508,7 @@ describe("SchemaField", () => {
       schema: {
         type: "string",
       },
-      assertion: () => screen.getByRole("combobox", { name: "testField" }),
+      assertion: () => screen.getByRole("combobox", { name: "Test Field" }),
     },
   ])("renders ui:widget $widget", async ({ widget, schema, assertion }) => {
     render(

--- a/src/components/fields/schemaFields/widgets/__snapshots__/FixedInnerObjectWidget.test.tsx.snap
+++ b/src/components/fields/schemaFields/widgets/__snapshots__/FixedInnerObjectWidget.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`FixedInnerObjectWidget handle oneOf object 1`] = `
         class="label form-label col-form-label col-xl-2 col-lg-3"
         for="test.foo"
       >
-        foo
+        Foo
       </label>
       <div
         class="col-xl-10 col-lg-9"
@@ -90,7 +90,7 @@ exports[`FixedInnerObjectWidget handle simple object 1`] = `
         class="label form-label col-form-label col-xl-2 col-lg-3"
         for="test.foo"
       >
-        foo
+        Foo
       </label>
       <div
         class="col-xl-10 col-lg-9"

--- a/src/extensionConsole/pages/integrations/IntegrationConfigEditorModal.test.tsx
+++ b/src/extensionConsole/pages/integrations/IntegrationConfigEditorModal.test.tsx
@@ -29,6 +29,7 @@ import userEvent from "@testing-library/user-event";
 import { type IntegrationConfig } from "@/integrations/integrationTypes";
 import { convertSchemaToConfigState } from "@/components/auth/AuthWidget";
 import { within } from "@testing-library/react";
+import { fieldLabel } from "@/components/fields/fieldUtils";
 
 beforeAll(() => {
   registerDefaultWidgets();
@@ -63,7 +64,9 @@ describe("IntegrationConfigEditorModal", () => {
 
     const dialogRoot = screen.getByRole("dialog");
     for (const property of Object.keys(service.schema.properties)) {
-      expect(within(dialogRoot).getByLabelText(property)).toBeVisible();
+      expect(
+        within(dialogRoot).getByLabelText(fieldLabel(property)),
+      ).toBeVisible();
     }
   });
 
@@ -85,16 +88,16 @@ describe("IntegrationConfigEditorModal", () => {
 
     await user.click(
       screen.getByRole("textbox", {
-        name: "controlRoomUrl",
+        name: "Control Room URL",
       }),
     );
     await user.type(
       screen.getByRole("textbox", {
-        name: "controlRoomUrl",
+        name: "Control Room URL",
       }),
       "https://invalid.control.room/",
     );
-    await user.click(screen.getByRole("textbox", { name: "username" }));
+    await user.click(screen.getByRole("textbox", { name: "Username" }));
 
     expect(screen.getByText("Invalid controlRoomUrl format")).toBeVisible();
   });

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -625,7 +625,7 @@ describe("validation", () => {
     await tickAsyncEffects();
 
     // By some reason, the validation doesn't fire with userEvent.type
-    fireTextInput(screen.getByLabelText("message"), "{{!");
+    fireTextInput(screen.getByLabelText("Message"), "{{!");
 
     // Run the timers of the Formik-Redux state synchronization and analysis
     await tickAsyncEffects();
@@ -670,7 +670,7 @@ describe("validation", () => {
 
     // Make invalid string template
     // This is field level error
-    fireTextInput(screen.getByLabelText("message"), "{{!");
+    fireTextInput(screen.getByLabelText("Message"), "{{!");
 
     await tickAsyncEffects();
 

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -2143,7 +2143,7 @@ exports[`renders the first selected node 1`] = `
                 class="label form-label col-form-label col-xl-2 col-lg-3"
                 for="extension.blockPipeline.0.config.message"
               >
-                message
+                Message
               </label>
               <div
                 class="col-xl-10 col-lg-9"

--- a/src/pageEditor/tabs/effect/__snapshots__/BlockConfiguration.test.tsx.snap
+++ b/src/pageEditor/tabs/effect/__snapshots__/BlockConfiguration.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`renders 1`] = `
         class="label form-label col-form-label col-xl-2 col-lg-3"
         for="extension.blockPipeline[0].config.message"
       >
-        message
+        Message
       </label>
       <div
         class="col-xl-10 col-lg-9"

--- a/src/pageEditor/tabs/recipeOptionsValues/RecipeOptionsValues.test.tsx
+++ b/src/pageEditor/tabs/recipeOptionsValues/RecipeOptionsValues.test.tsx
@@ -223,7 +223,7 @@ describe("ActivationOptions", () => {
     render(<RecipeOptionsValues />);
 
     const selectInput = await screen.findByRole("combobox", {
-      name: "mySheet",
+      name: "My Sheet",
     });
     expect(selectInput).toBeVisible();
 
@@ -284,7 +284,7 @@ describe("ActivationOptions", () => {
     render(<RecipeOptionsValues />);
 
     const selectInput = await screen.findByRole("combobox", {
-      name: "mySheet",
+      name: "My Sheet",
     });
     expect(selectInput).toBeVisible();
 

--- a/src/pageEditor/tabs/recipeOptionsValues/__snapshots__/RecipeOptionsValues.test.tsx.snap
+++ b/src/pageEditor/tabs/recipeOptionsValues/__snapshots__/RecipeOptionsValues.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`ActivationOptions renders blueprint options 1`] = `
                   class="label form-label col-form-label col-xl-2 col-lg-3"
                   for="myDatabase"
                 >
-                  myDatabase
+                  My Database
                 </label>
                 <div
                   class="col-xl-10 col-lg-9"
@@ -96,7 +96,7 @@ exports[`ActivationOptions renders blueprint options 1`] = `
                   class="label form-label col-form-label col-xl-2 col-lg-3"
                   for="myBool"
                 >
-                  myBool
+                  My Bool
                 </label>
                 <div
                   class="col-xl-10 col-lg-9"
@@ -152,7 +152,7 @@ exports[`ActivationOptions renders blueprint options 1`] = `
                   class="label form-label col-form-label col-xl-2 col-lg-3"
                   for="myNum"
                 >
-                  myNum
+                  My Num
                 </label>
                 <div
                   class="col-xl-10 col-lg-9"
@@ -208,7 +208,7 @@ exports[`ActivationOptions renders blueprint options 1`] = `
                   class="label form-label col-form-label col-xl-2 col-lg-3"
                   for="myArray"
                 >
-                  myArray
+                  My Array
                 </label>
                 <div
                   class="col-xl-10 col-lg-9"
@@ -264,7 +264,7 @@ exports[`ActivationOptions renders blueprint options 1`] = `
                   class="label form-label col-form-label col-xl-2 col-lg-3"
                   for="myGoogleSheet"
                 >
-                  myGoogleSheet
+                  My Google Sheet
                 </label>
                 <div
                   class="col-xl-10 col-lg-9"
@@ -320,7 +320,7 @@ exports[`ActivationOptions renders blueprint options 1`] = `
                   class="label form-label col-form-label col-xl-2 col-lg-3"
                   for="myObject"
                 >
-                  myObject
+                  My Object
                 </label>
                 <div
                   class="col-xl-10 col-lg-9"
@@ -376,7 +376,7 @@ exports[`ActivationOptions renders blueprint options 1`] = `
                   class="label form-label col-form-label col-xl-2 col-lg-3"
                   for="myStr"
                 >
-                  myStr
+                  My Str
                 </label>
                 <div
                   class="col-xl-10 col-lg-9"
@@ -467,7 +467,7 @@ exports[`ActivationOptions renders blueprint options with additional props 1`] =
                   class="label form-label col-form-label col-xl-2 col-lg-3"
                   for="additionalProperties"
                 >
-                  additionalProperties
+                  Additional Properties
                 </label>
                 <div
                   class="col-xl-10 col-lg-9"

--- a/src/sidebar/activateRecipe/__snapshots__/ActivateModPanel.test.tsx.snap
+++ b/src/sidebar/activateRecipe/__snapshots__/ActivateModPanel.test.tsx.snap
@@ -595,7 +595,7 @@ exports[`ActivateRecipePanel renders with options, permissions info 1`] = `
               class="label form-label col-form-label col-xl-2 col-lg-3"
               for="optionsArgs.bar"
             >
-              bar
+              Bar
             </label>
             <div
               class="col-xl-10 col-lg-9"
@@ -652,7 +652,7 @@ exports[`ActivateRecipePanel renders with options, permissions info 1`] = `
               class="label form-label col-form-label col-xl-2 col-lg-3"
               for="optionsArgs.foo"
             >
-              foo
+              Foo
             </label>
             <div
               class="col-xl-10 col-lg-9"


### PR DESCRIPTION
## What does this PR do?

- Automatically start case field names in brick configuration
- Includes hard-coded list of acronyms to capitalize
- Bricks can provide a `title` that overrides the default

## Remaining Work

- [x] Update snapshots/test selectors

## Discussion

- Some of our brick titles use sentence case, so there's still a bit of inconsistency

## Checklist

- [x] Add tests: 
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
