### PR TITLE
#7021 Don't normalize onSubmit pipeline fields

### DIFF
--- a/src/pageEditor/starterBricks/pipelineMapping.test.ts
+++ b/src/pageEditor/starterBricks/pipelineMapping.test.ts
@@ -21,10 +21,9 @@ import TryExcept from "@/bricks/transformers/controlFlow/TryExcept";
 import { type BrickConfig } from "@/bricks/types";
 import {
   echoBrick,
-  pipelineBrick,
   teapotBrick,
 } from "@/runtime/pipelineTests/pipelineTestHelpers";
-import { EMPTY_PIPELINE, toExpression } from "@/testUtils/testHelpers";
+import { toExpression } from "@/testUtils/testHelpers";
 import {
   normalizePipelineForEditor,
   omitEditorMetadata,

--- a/src/pageEditor/starterBricks/pipelineMapping.test.ts
+++ b/src/pageEditor/starterBricks/pipelineMapping.test.ts
@@ -21,6 +21,7 @@ import TryExcept from "@/bricks/transformers/controlFlow/TryExcept";
 import { type BrickConfig } from "@/bricks/types";
 import {
   echoBrick,
+  pipelineBrick,
   teapotBrick,
 } from "@/runtime/pipelineTests/pipelineTestHelpers";
 import { EMPTY_PIPELINE, toExpression } from "@/testUtils/testHelpers";
@@ -132,19 +133,18 @@ describe("normalizePipeline", () => {
       },
     ];
 
-    const actual = (await normalizePipelineForEditor(pipeline)) as any;
+    const actual = await normalizePipelineForEditor(pipeline);
 
     // Checking IF branch
     const ifConfig = actual[0].config.if;
     expect(isPipelineExpression(ifConfig)).toBeTrue();
-    for (const config of ifConfig.__value__) {
+    const ifConfigPipeline = ifConfig as PipelineExpression;
+    for (const config of ifConfigPipeline.__value__) {
       expect(config.instanceId).toBeDefined();
     }
 
     // ELSE branch should be undefined
-    const elseConfig = actual[0].config.else;
-    expect(isPipelineExpression(elseConfig)).toBeTrue();
-    expect(elseConfig).toEqual(EMPTY_PIPELINE);
+    expect(actual[0].config.else).toBeUndefined();
   });
 
   test("Try-Except block", async () => {
@@ -185,19 +185,18 @@ describe("normalizePipeline", () => {
       },
     ];
 
-    const actual = (await normalizePipelineForEditor(pipeline)) as any;
+    const actual = await normalizePipelineForEditor(pipeline);
 
     // Checking TRY branch
     const tryConfig = actual[0].config.try;
     expect(isPipelineExpression(tryConfig)).toBeTrue();
-    for (const config of tryConfig.__value__) {
+    const tryConfigPipeline = tryConfig as PipelineExpression;
+    for (const config of tryConfigPipeline.__value__) {
       expect(config.instanceId).toBeDefined();
     }
 
     // EXCEPT branch should be undefined
-    const exceptConfig = actual[0].config.except;
-    expect(isPipelineExpression(exceptConfig)).toBeTrue();
-    expect(exceptConfig).toEqual(EMPTY_PIPELINE);
+    expect(actual[0].config.except).toBeUndefined();
   });
 
   test("nested pipelines", async () => {

--- a/src/pageEditor/starterBricks/pipelineMapping.ts
+++ b/src/pageEditor/starterBricks/pipelineMapping.ts
@@ -60,7 +60,7 @@ class NormalizePipelineVisitor extends PipelineVisitor {
           ([prop, fieldSchema]) =>
             typeof fieldSchema === "object" &&
             fieldSchema.$ref === pipelineSchema.$id &&
-            prop !== "onSubmit" &&
+            prop in blockConfig.config &&
             !isPipelineExpression(blockConfig.config[prop]),
         )
         .map(([prop]) => prop);

--- a/src/pageEditor/starterBricks/pipelineMapping.ts
+++ b/src/pageEditor/starterBricks/pipelineMapping.ts
@@ -60,6 +60,7 @@ class NormalizePipelineVisitor extends PipelineVisitor {
           ([prop, fieldSchema]) =>
             typeof fieldSchema === "object" &&
             fieldSchema.$ref === pipelineSchema.$id &&
+            prop !== "onSubmit" &&
             !isPipelineExpression(blockConfig.config[prop]),
         )
         .map(([prop]) => prop);


### PR DESCRIPTION
## What does this PR do?

- Fixes #7021 

## Discussion

* I don't know what the full implications are for this change. I initially just filtered out `prop !== "onSubmit"` on the same LOC, but the current change feels more robust to me. I don't know if there are other situations where we would have a missing pipeline prop and need to "normalize" it 🤷 

## Checklist

- [x] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer - @twschiller 
