### PR TITLE
#7054: fix mod options saving regression

### DIFF
--- a/src/pageEditor/hooks/useSaveRecipe.test.ts
+++ b/src/pageEditor/hooks/useSaveRecipe.test.ts
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { renderHook } from "@/pageEditor/testHelpers";
+import useSaveRecipe from "@/pageEditor/hooks/useSaveRecipe";
+import { validateRegistryId } from "@/types/helpers";
+import { act } from "@testing-library/react-hooks";
+import { appApiMock } from "@/testUtils/appApiMock";
+import { editablePackageMetadataFactory } from "@/testUtils/factories/registryFactories";
+import notify from "@/utils/notify";
+import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { type SemVerString } from "@/types/registryTypes";
+import modDefinitionRegistry from "@/modDefinitions/registry";
+import { loadBrickYaml } from "@/runtime/brickYaml";
+import { type ModDefinition } from "@/types/modDefinitionTypes";
+import type { components } from "@/types/swagger";
+import { editorSlice } from "@/pageEditor/slices/editorSlice";
+
+const modId = validateRegistryId("@test/mod");
+
+jest.mock("@/utils/notify", () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+jest.mock("@/components/ConfirmationModal", () => ({
+  __esModule: true,
+  useModals: () => ({
+    showConfirmation: jest.fn().mockResolvedValue(true),
+  }),
+}));
+
+describe("useSaveRecipe", () => {
+  it("saves with no dirty changes", async () => {
+    appApiMock.reset();
+
+    const editablePackage = editablePackageMetadataFactory({
+      name: modId,
+    });
+
+    const definition = defaultModDefinitionFactory({
+      metadata: {
+        id: editablePackage.name,
+        name: editablePackage.verbose_name,
+        version: editablePackage.version as SemVerString,
+      },
+    });
+
+    // Register directly in modDefinitionRegistry because background call to sync with "/api/registry/bricks/" is mocked
+    modDefinitionRegistry.register([
+      {
+        id: modId,
+        ...definition,
+      },
+    ]);
+
+    appApiMock.onGet("/api/bricks/").reply(200, [editablePackage]);
+
+    appApiMock.onPut(`/api/bricks/${editablePackage.id}/`).reply(200, {});
+
+    const { result, waitForEffect } = renderHook(() => useSaveRecipe(), {});
+
+    await waitForEffect();
+
+    await act(async () => {
+      await result.current.save(modId);
+    });
+
+    expect(notify.success).toHaveBeenCalledWith("Saved mod");
+    expect(notify.error).not.toHaveBeenCalled();
+  });
+
+  it("preserves original options if no dirty options", async () => {
+    appApiMock.reset();
+
+    const editablePackage = editablePackageMetadataFactory({
+      name: modId,
+    });
+
+    const definition = defaultModDefinitionFactory({
+      metadata: {
+        id: editablePackage.name,
+        name: editablePackage.verbose_name,
+        version: editablePackage.version as SemVerString,
+      },
+      options: {
+        schema: {
+          type: "object",
+          properties: {
+            test: {
+              type: "string",
+            },
+          },
+        },
+      },
+    });
+
+    // Register directly in modDefinitionRegistry because background call to sync with "/api/registry/bricks/" is mocked
+    // This data structure is not quite what happens in practice because the modDefinitionRegistry factory calls
+    // normalizeModOptionsDefinition during hydration.
+    modDefinitionRegistry.register([
+      {
+        id: modId,
+        ...definition,
+      },
+    ]);
+
+    appApiMock.onGet("/api/bricks/").reply(200, [editablePackage]);
+
+    const putMock = appApiMock
+      .onPut(`/api/bricks/${editablePackage.id}/`)
+      .reply(200, {});
+
+    const { result, waitForEffect } = renderHook(() => useSaveRecipe(), {});
+
+    await waitForEffect();
+
+    await act(async () => {
+      await result.current.save(modId);
+    });
+
+    expect(notify.success).toHaveBeenCalledWith("Saved mod");
+
+    const yamlConfig = (
+      JSON.parse(
+        putMock.history.put[0].data,
+      ) as components["schemas"]["Package"]
+    ).config;
+
+    expect((loadBrickYaml(yamlConfig) as ModDefinition).options).toStrictEqual({
+      schema: {
+        type: "object",
+        properties: {
+          test: {
+            type: "string",
+          },
+        },
+      },
+    });
+  });
+
+  it("saves dirty options", async () => {
+    appApiMock.reset();
+
+    const editablePackage = editablePackageMetadataFactory({
+      name: modId,
+    });
+
+    const definition = defaultModDefinitionFactory({
+      metadata: {
+        id: editablePackage.name,
+        name: editablePackage.verbose_name,
+        version: editablePackage.version as SemVerString,
+      },
+    });
+
+    // Register directly in modDefinitionRegistry because background call to sync with "/api/registry/bricks/" is mocked
+    // This data structure is not quite what happens in practice because the modDefinitionRegistry factory calls
+    // normalizeModOptionsDefinition during hydration.
+    modDefinitionRegistry.register([
+      {
+        id: modId,
+        ...definition,
+      },
+    ]);
+
+    appApiMock.onGet("/api/bricks/").reply(200, [editablePackage]);
+
+    const putMock = appApiMock
+      .onPut(`/api/bricks/${editablePackage.id}/`)
+      .reply(200, {});
+
+    const { result, waitForEffect } = renderHook(() => useSaveRecipe(), {
+      setupRedux(dispatch) {
+        dispatch(editorSlice.actions.selectRecipeId(modId));
+        dispatch(
+          editorSlice.actions.editRecipeOptionsDefinitions({
+            schema: {
+              type: "object",
+              properties: {
+                test: {
+                  type: "string",
+                },
+              },
+            },
+          }),
+        );
+      },
+    });
+
+    await waitForEffect();
+
+    await act(async () => {
+      await result.current.save(modId);
+    });
+
+    expect(notify.success).toHaveBeenCalledWith("Saved mod");
+
+    const yamlConfig = (
+      JSON.parse(
+        putMock.history.put[0].data,
+      ) as components["schemas"]["Package"]
+    ).config;
+
+    expect((loadBrickYaml(yamlConfig) as ModDefinition).options).toStrictEqual({
+      schema: {
+        type: "object",
+        properties: {
+          test: {
+            type: "string",
+          },
+        },
+      },
+      uiSchema: {
+        "ui:order": ["test", "*"],
+      },
+    });
+  });
+});

--- a/src/pageEditor/hooks/useSaveRecipe.ts
+++ b/src/pageEditor/hooks/useSaveRecipe.ts
@@ -43,7 +43,6 @@ import { type RegistryId } from "@/types/registryTypes";
 import { useAllModDefinitions } from "@/modDefinitions/modDefinitionHooks";
 import { reactivateEveryTab } from "@/background/messenger/api";
 import { ensureElementPermissionsFromUserGesture } from "@/pageEditor/editorPermissionsHelpers";
-import { normalizeModOptionsDefinition } from "@/utils/modUtils";
 
 const { actions: optionsActions } = extensionsSlice;
 
@@ -124,11 +123,9 @@ function useSaveRecipe(): RecipeSaver {
         !deletedElementIds.has(extension.id),
     );
 
-    // Dirty options/metadata or null if there are not staged changes. `buildRecipe` expects nullish instead of default
-    const dirtyOptions = dirtyRecipeOptions[recipeId]
-      ? // eslint-disable-next-line security/detect-object-injection -- recipe IDs are sanitized in the form validation
-        normalizeModOptionsDefinition(dirtyRecipeOptions[recipeId])
-      : undefined;
+    // Dirty options/metadata or null if there are no staged changes.
+    // eslint-disable-next-line security/detect-object-injection -- recipe IDs are sanitized in the form validation
+    const dirtyOptions = dirtyRecipeOptions[recipeId];
     // eslint-disable-next-line security/detect-object-injection -- recipe IDs are sanitized in the form validation
     const dirtyMetadata = dirtyRecipeMetadata[recipeId];
 

--- a/src/pageEditor/hooks/useSaveRecipe.ts
+++ b/src/pageEditor/hooks/useSaveRecipe.ts
@@ -120,19 +120,21 @@ function useSaveRecipe(): RecipeSaver {
         !deletedElementIds.has(extension.id),
     );
 
-    const newOptions = normalizeModOptionsDefinition(
-      // eslint-disable-next-line security/detect-object-injection -- new recipe IDs are sanitized in the form validation
-      dirtyRecipeOptions[recipeId],
-    );
-    // eslint-disable-next-line security/detect-object-injection -- new recipe IDs are sanitized in the form validation
-    const newMetadata = dirtyRecipeMetadata[recipeId];
+    // Dirty options/metadata or null if there are not staged changes. `buildRecipe` expects nullish instead of default
+    const dirtyOptions =
+      // eslint-disable-next-line security/detect-object-injection -- recipe IDs are sanitized in the form validation
+      dirtyRecipeOptions[recipeId]
+        ? normalizeModOptionsDefinition(dirtyRecipeOptions[recipeId])
+        : undefined;
+    // eslint-disable-next-line security/detect-object-injection -- recipe IDs are sanitized in the form validation
+    const dirtyMetadata = dirtyRecipeMetadata[recipeId];
 
     const newRecipe = buildRecipe({
       sourceRecipe: recipe,
       cleanRecipeExtensions,
       dirtyRecipeElements,
-      options: newOptions,
-      metadata: newMetadata,
+      options: dirtyOptions,
+      metadata: dirtyMetadata,
     });
 
     const packageId = editablePackages.find(

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -65,10 +65,7 @@ import {
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
 import { integrationDependencyFactory } from "@/testUtils/factories/integrationFactories";
 import { SERVICES_BASE_SCHEMA_URL } from "@/integrations/util/makeServiceContextFromDependencies";
-import {
-  minimalSchemaFactory,
-  minimalUiSchemaFactory,
-} from "@/utils/schemaUtils";
+import { minimalUiSchemaFactory } from "@/utils/schemaUtils";
 import { emptyModOptionsDefinitionFactory } from "@/utils/modUtils";
 
 jest.mock("@/background/contextMenus");

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -69,6 +69,7 @@ import {
   minimalSchemaFactory,
   minimalUiSchemaFactory,
 } from "@/utils/schemaUtils";
+import { emptyModOptionsDefinitionFactory } from "@/utils/modUtils";
 
 jest.mock("@/background/contextMenus");
 
@@ -459,10 +460,7 @@ describe("blueprint options", () => {
   }
 
   test("doesn't add empty schema when blueprint options is empty", async () => {
-    const emptyOptions = {
-      schema: minimalSchemaFactory(),
-      uiSchema: minimalUiSchemaFactory(),
-    };
+    const emptyOptions = emptyModOptionsDefinitionFactory();
 
     const updatedRecipe = await runReplaceRecipeExtensions(
       undefined,
@@ -542,10 +540,8 @@ describe("blueprint options", () => {
       uiSchema: minimalUiSchemaFactory(),
     };
 
-    const elementOptions: ModOptionsDefinition = {
-      schema: minimalSchemaFactory(),
-      uiSchema: minimalUiSchemaFactory(),
-    };
+    const elementOptions: ModOptionsDefinition =
+      emptyModOptionsDefinitionFactory();
 
     const updatedRecipe = await runReplaceRecipeExtensions(
       blueprintOptions,

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -353,7 +353,13 @@ type RecipeParts = {
   sourceRecipe?: ModDefinition;
   cleanRecipeExtensions: UnresolvedModComponent[];
   dirtyRecipeElements: ModComponentFormState[];
+  /**
+   * Dirty/new options to save. Undefined if there are no changes.
+   */
   options?: ModOptionsDefinition;
+  /**
+   * Dirty/new metadata to save. Undefined if there are no changes.
+   */
   metadata?: ModMetadataFormState;
 };
 

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -55,7 +55,10 @@ import {
 } from "@/integrations/integrationTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { SERVICES_BASE_SCHEMA_URL } from "@/integrations/util/makeServiceContextFromDependencies";
-import { isModOptionsSchemaEmpty } from "@/utils/modUtils";
+import {
+  isModOptionsSchemaEmpty,
+  normalizeModOptionsDefinition,
+} from "@/utils/modUtils";
 
 /**
  * Generate a new registry id from an existing registry id by adding/replacing the scope.
@@ -372,10 +375,7 @@ const emptyRecipe: UnsavedModDefinition = {
   },
   extensionPoints: [],
   definitions: {},
-  options: {
-    schema: {},
-    uiSchema: {},
-  },
+  options: normalizeModOptionsDefinition(null),
 };
 
 /**
@@ -387,8 +387,8 @@ const emptyRecipe: UnsavedModDefinition = {
  * @param sourceRecipe the original recipe, or undefined for new recipes
  * @param cleanRecipeExtensions the recipe's unchanged, installed extensions
  * @param dirtyRecipeElements the recipe's extension form states (i.e., submitted via Formik)
- * @param options the recipe's options form state
- * @param metadata the recipe's metadata form state
+ * @param options the recipe's options form state, or nullish if there are no dirty options
+ * @param metadata the recipe's metadata form state, or nullish if there are no dirty options
  */
 export function buildRecipe({
   sourceRecipe,
@@ -404,7 +404,9 @@ export function buildRecipe({
   return produce(recipe, (draft: UnsavedModDefinition): void => {
     // Options dirty state is only populated if a change is made
     if (options) {
-      draft.options = isModOptionsSchemaEmpty(options) ? undefined : options;
+      draft.options = isModOptionsSchemaEmpty(options)
+        ? undefined
+        : normalizeModOptionsDefinition(options);
     }
 
     // Metadata dirty state is only populated if a change is made

--- a/src/pageEditor/slices/editorSelectors.ts
+++ b/src/pageEditor/slices/editorSelectors.ts
@@ -123,8 +123,8 @@ const dirtyOptionDefinitionsForRecipeIdSelector = createSelector(
       return normalizeModOptionsDefinition(options);
     }
 
-    // Return undefined if the options aren't dirty. Returning nullish instead of an empty options allows the
-    // caller to default to the non-dirty options easily.
+    // Return undefined if the options aren't dirty. Returning nullish instead of a default empty options allows the
+    // caller to distinguish no dirty options vs. options that have been reverted to the default.
   },
 );
 

--- a/src/pageEditor/slices/editorSelectors.ts
+++ b/src/pageEditor/slices/editorSelectors.ts
@@ -120,6 +120,7 @@ const dirtyOptionDefinitionsForRecipeIdSelector = createSelector(
     const options = dirtyRecipeOptionDefinitionsById[recipeId];
 
     if (options) {
+      // Provide a consistent shape of the options
       return normalizeModOptionsDefinition(options);
     }
 

--- a/src/pageEditor/starterBricks/base.ts
+++ b/src/pageEditor/starterBricks/base.ts
@@ -64,6 +64,7 @@ import {
   minimalSchemaFactory,
   minimalUiSchemaFactory,
 } from "@/utils/schemaUtils";
+import { emptyModOptionsDefinitionFactory } from "@/utils/modUtils";
 
 export interface WizardStep {
   step: string;
@@ -122,7 +123,9 @@ export function baseFromExtension<T extends StarterBrickType>(
   };
 }
 
-// Add the recipe options to the form state if the extension is a part of a recipe
+/**
+ * Add the recipe options to the form state if the extension is a part of a recipe
+ */
 export function initRecipeOptionsIfNeeded<TElement extends BaseFormState>(
   element: TElement,
   recipes: ModDefinition[],
@@ -131,10 +134,7 @@ export function initRecipeOptionsIfNeeded<TElement extends BaseFormState>(
     const recipe = recipes?.find((x) => x.metadata.id === element.recipe.id);
 
     if (recipe?.options == null) {
-      element.optionsDefinition = {
-        schema: minimalSchemaFactory(),
-        uiSchema: minimalUiSchemaFactory(),
-      };
+      element.optionsDefinition = emptyModOptionsDefinitionFactory();
     } else {
       element.optionsDefinition = {
         schema: recipe.options.schema.properties

--- a/src/pageEditor/starterBricks/base.ts
+++ b/src/pageEditor/starterBricks/base.ts
@@ -60,10 +60,6 @@ import {
   type BaseFormState,
   type SingleLayerReaderConfig,
 } from "@/pageEditor/baseFormStateTypes";
-import {
-  minimalSchemaFactory,
-  minimalUiSchemaFactory,
-} from "@/utils/schemaUtils";
 import { emptyModOptionsDefinitionFactory } from "@/utils/modUtils";
 
 export interface WizardStep {

--- a/src/pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor.tsx
@@ -46,10 +46,7 @@ import { getErrorMessage } from "@/errors/errorHelpers";
 import { useOptionalModDefinition } from "@/modDefinitions/modDefinitionHooks";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { type Schema } from "@/types/schemaTypes";
-import {
-  minimalSchemaFactory,
-  minimalUiSchemaFactory,
-} from "@/utils/schemaUtils";
+import { emptyModOptionsDefinitionFactory } from "@/utils/modUtils";
 
 const fieldTypes = [
   ...FORM_FIELD_TYPE_OPTIONS.filter(
@@ -86,13 +83,6 @@ const formRuntimeContext: RuntimeContext = {
   allowExpressions: false,
 };
 
-export const EMPTY_MOD_OPTIONS_DEFINITION: ModOptionsDefinition = Object.freeze(
-  {
-    schema: minimalSchemaFactory(),
-    uiSchema: minimalUiSchemaFactory(),
-  },
-);
-
 const ModOptionsDefinitionEditor: React.VFC = () => {
   const [activeField, setActiveField] = useState<string>();
   const modId = useSelector(selectActiveRecipeId);
@@ -104,7 +94,7 @@ const ModOptionsDefinitionEditor: React.VFC = () => {
   );
 
   const optionsDefinition =
-    dirtyOptions ?? savedOptions ?? EMPTY_MOD_OPTIONS_DEFINITION;
+    dirtyOptions ?? savedOptions ?? emptyModOptionsDefinitionFactory();
 
   const initialValues = { optionsDefinition };
 

--- a/src/pageEditor/tabs/modOptionsValues/ModOptionsValuesEditor.tsx
+++ b/src/pageEditor/tabs/modOptionsValues/ModOptionsValuesEditor.tsx
@@ -39,13 +39,13 @@ import {
   inferRecipeDependencies,
   inferRecipeOptions,
 } from "@/store/extensionsUtils";
-import { EMPTY_MOD_OPTIONS_DEFINITION } from "@/pageEditor/tabs/modOptionsDefinitions/ModOptionsDefinitionEditor";
 import useAsyncRecipeOptionsValidationSchema from "@/hooks/useAsyncRecipeOptionsValidationSchema";
 import Effect from "@/components/Effect";
 import { actions } from "@/pageEditor/slices/editorSlice";
 import { type OptionsArgs } from "@/types/runtimeTypes";
 import { DEFAULT_RUNTIME_API_VERSION } from "@/runtime/apiVersionOptions";
 import ModIntegrationsContext from "@/mods/ModIntegrationsContext";
+import { emptyModOptionsDefinitionFactory } from "@/utils/modUtils";
 
 const OPTIONS_FIELD_RUNTIME_CONTEXT: RuntimeContext = {
   apiVersion: DEFAULT_RUNTIME_API_VERSION,
@@ -78,7 +78,7 @@ const ModOptionsValuesContent: React.FC = () => {
       return dirtyRecipeOptions;
     }
 
-    return recipe?.options ?? EMPTY_MOD_OPTIONS_DEFINITION;
+    return recipe?.options ?? emptyModOptionsDefinitionFactory();
   }, [dirtyRecipeOptions, recipe?.options]);
 
   const {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -284,7 +284,7 @@ export const appApi = createApi({
         const recipeConfig = dumpBrickYaml(recipe);
 
         return {
-          url: `api/bricks/${packageId}/`,
+          url: `/api/bricks/${packageId}/`,
           method: "put",
           data: {
             id: packageId,

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -484,7 +484,6 @@
     "./utils/injectScriptTag.tsx",
     "./utils/injectStylesheet.tsx",
     "./utils/legacyMessengerUtils.ts",
-    "./utils/modUtils.ts",
     "./utils/notify.tsx",
     "./utils/objToYaml.ts",
     "./utils/objectUtils.ts",

--- a/src/utils/modUtils.test.ts
+++ b/src/utils/modUtils.test.ts
@@ -19,6 +19,7 @@ import {
   getSharingSource,
   isResolvedModComponent,
   isUnavailableMod,
+  normalizeModOptionsDefinition,
 } from "./modUtils";
 import { uuidv4 } from "@/types/helpers";
 import { UserRole } from "@/types/contract";
@@ -181,5 +182,45 @@ describe("isUnavailableMod", () => {
   it("returns false for an extension", () => {
     const mod = modComponentFactory() as ResolvedModComponent;
     expect(isUnavailableMod(mod)).toBe(false);
+  });
+});
+
+describe("normalizeModOptionsDefinition", () => {
+  it("normalizes null", () => {
+    expect(normalizeModOptionsDefinition(null)).toStrictEqual({
+      schema: {
+        type: "object",
+        properties: {},
+      },
+      uiSchema: {
+        "ui:order": ["*"],
+      },
+    });
+  });
+
+  it("normalizes legacy schema", () => {
+    expect(
+      normalizeModOptionsDefinition({
+        schema: {
+          foo: {
+            type: "string",
+          },
+        },
+      } as any),
+    ).toStrictEqual({
+      schema: {
+        type: "object",
+        $schema: "https://json-schema.org/draft/2019-09/schema#",
+        properties: {
+          foo: {
+            type: "string",
+          },
+        },
+        required: ["foo"],
+      },
+      uiSchema: {
+        "ui:order": ["foo", "*"],
+      },
+    });
   });
 });

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -15,7 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type ModDefinition } from "@/types/modDefinitionTypes";
+import {
+  type ModDefinition,
+  type ModOptionsDefinition,
+} from "@/types/modDefinitionTypes";
 import * as semver from "semver";
 import { type MarketplaceListing, type Organization } from "@/types/contract";
 import {
@@ -364,6 +367,16 @@ export const selectComponentsFromMod = createSelector(
 );
 
 /**
+ * Returns a minimal mod options definition in a normalized format.
+ */
+export function emptyModOptionsDefinitionFactory(): Required<ModOptionsDefinition> {
+  return {
+    schema: minimalSchemaFactory(),
+    uiSchema: minimalUiSchemaFactory(),
+  };
+}
+
+/**
  * Normalize the `options` section of a mod definition, ensuring that it has a schema and uiSchema.
  * @since 1.8.5
  */
@@ -371,10 +384,7 @@ export function normalizeModOptionsDefinition(
   optionsDefinition: ModDefinition["options"] | null,
 ): Required<ModDefinition["options"]> {
   if (!optionsDefinition) {
-    return {
-      schema: minimalSchemaFactory(),
-      uiSchema: minimalUiSchemaFactory(),
-    };
+    return emptyModOptionsDefinitionFactory();
   }
 
   const modDefinitionSchema = optionsDefinition.schema ?? {};
@@ -383,7 +393,8 @@ export function normalizeModOptionsDefinition(
     modDefinitionSchema.type === "object" &&
     "properties" in modDefinitionSchema
       ? modDefinitionSchema
-      : // Handle case where schema is just the properties. That's the old format
+      : // Handle case where schema is just the properties. That's the old format. Technically, this isn't possible
+        // given the type signature. But be defensive because this method processes user-defined mod definitions.
         propertiesToSchema(modDefinitionSchema as SchemaProperties);
 
   const uiSchema: UiSchema = optionsDefinition.uiSchema ?? {};

--- a/src/utils/schemaUtils.ts
+++ b/src/utils/schemaUtils.ts
@@ -57,8 +57,10 @@ export function missingProperties(
 ): string[] {
   const acc = [];
   for (const propertyKey of schema.required ?? []) {
+    // eslint-disable-next-line security/detect-object-injection -- for-of loop
     const property = schema.properties?.[propertyKey];
     if (typeof property === "object" && property?.type === "string") {
+      // eslint-disable-next-line security/detect-object-injection -- for-of loop over the schema
       const value = obj[propertyKey];
       if (isNullOrBlank(value)) {
         acc.push(propertyKey);
@@ -211,7 +213,9 @@ export function unionSchemaDefinitionTypes(
 }
 
 /**
- * Factory for a minimal JSON Schema for an object.
+ * Factory for a minimal JSON Schema for an object. Can be used with RJSF forms and mod options.
+ *
+ * @see emptyModOptionsDefinitionFactory
  */
 export const minimalSchemaFactory: () => Schema = () => ({
   type: "object",
@@ -219,7 +223,9 @@ export const minimalSchemaFactory: () => Schema = () => ({
 });
 
 /**
- * Factory for a minimal RJSF UI Schema for an object.
+ * Factory for a minimal RJSF UI Schema for an object. Can be used with RJSF forms and mod options.
+ *
+ * @see emptyModOptionsDefinitionFactory
  */
 export const minimalUiSchemaFactory: () => UiSchema = () => ({
   [UI_ORDER]: ["*"],


### PR DESCRIPTION
## What does this PR do?

- Closes #7054
- Fixes a bug where options would be cleared if there were no dirty options because the new options would default to an empty options shape
- Consolidates mod normalization code into `normalizeModOptionsDefinition`
- Adds basic test file for `useSaveRecipe`

## Remaining Work

- [x] Write test for `useSaveRecipe` -- there were no tests yet; tests require some mocking
- [x] Fix strict null checks - @grahamlangford I dropped modUtils from strict null checks

## Future Work

- Increase test coverage useSaveRecipe (e.g., mod metadata dirty/clean scenarios, etc.)
- Rename the useSaveRecipe hook and related hooks. I didn't re-name because I wanted to make the function code changes clearer because this is a regression bugfix PR

## Checklist

- [x] Add tests: see comment -- may leave as follow up PR
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @BLoe 
