### PR TITLE
Organize form builder fields into sections

### DIFF
--- a/src/pageEditor/fields/FormModalOptions.test.tsx
+++ b/src/pageEditor/fields/FormModalOptions.test.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render } from "@/pageEditor/testHelpers";
+import FormModalOptions from "@/pageEditor/fields/FormModalOptions";
+import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
+import { createNewConfiguredBrick } from "@/pageEditor/exampleBrickConfigs";
+import { FormTransformer } from "@/bricks/transformers/ephemeralForm/formTransformer";
+import { screen } from "@testing-library/react";
+import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
+import {
+  baseExtensionStateFactory,
+  formStateFactory,
+} from "@/testUtils/factories/pageEditorFactories";
+
+beforeAll(() => {
+  registerDefaultWidgets();
+});
+
+describe("FormModalOptions", () => {
+  it("renders default values without crashing", async () => {
+    const brick = createNewConfiguredBrick(FormTransformer.BLOCK_ID);
+
+    const initialValues = formStateFactory({
+      extension: baseExtensionStateFactory({
+        blockPipeline: [brick],
+      }),
+    });
+
+    render(
+      <FormModalOptions name="extension.blockPipeline.0" configKey="config" />,
+      {
+        initialValues,
+        setupRedux(dispatch) {
+          dispatch(editorActions.addElement(initialValues));
+          dispatch(editorActions.selectElement(initialValues.uuid));
+          dispatch(editorActions.setElementActiveNodeId(brick.instanceId));
+        },
+      },
+    );
+
+    expect(screen.getByDisplayValue("Example Field")).toBeInTheDocument();
+  });
+});

--- a/src/pageEditor/fields/FormModalOptions.tsx
+++ b/src/pageEditor/fields/FormModalOptions.tsx
@@ -19,12 +19,15 @@ import React from "react";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { type Schema } from "@/types/schemaTypes";
 import { validateRegistryId } from "@/types/helpers";
-import FormEditor from "@/components/formBuilder/edit/FormEditor";
+import FormEditor, {
+  FormIntroFields,
+} from "@/components/formBuilder/edit/FormEditor";
 import useReduxState from "@/hooks/useReduxState";
 import ConfigErrorBoundary from "@/pageEditor/fields/ConfigErrorBoundary";
 import { selectNodePreviewActiveElement } from "@/pageEditor/slices/editorSelectors";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 import FORM_FIELD_TYPE_OPTIONS from "@/pageEditor/fields/formFieldTypeOptions";
+import ConnectedCollapsibleFieldSection from "@/pageEditor/fields/ConnectedCollapsibleFieldSection";
 
 export const FORM_MODAL_ID = validateRegistryId("@pixiebrix/form-modal");
 
@@ -42,8 +45,11 @@ const submitCaptionSchema: Schema = {
 
 const locationSchema: Schema = {
   type: "string",
-  enum: ["modal", "sidebar"],
-  description: "The location of the form (default='modal')",
+  oneOf: [
+    { const: "modal", title: "Modal" },
+    { const: "sidebar", title: "Sidebar" },
+  ],
+  description: "The location of the form (default='Modal')",
   default: "modal",
 };
 
@@ -60,35 +66,48 @@ const FormModalOptions: React.FC<{
 
   return (
     <div>
-      <ConfigErrorBoundary>
-        <FormEditor
-          name={configName}
-          activeField={activeElement}
-          setActiveField={setActiveElement}
-          fieldTypes={FORM_FIELD_TYPE_OPTIONS}
+      <ConnectedCollapsibleFieldSection
+        title="Form Title/Description"
+        initialExpanded
+      >
+        <FormIntroFields name={configName} />
+      </ConnectedCollapsibleFieldSection>
+
+      <ConnectedCollapsibleFieldSection title="Form Submission" initialExpanded>
+        <SchemaField
+          name={`${configName}.submitCaption`}
+          label="Submit Button Text"
+          schema={submitCaptionSchema}
+          isRequired
         />
-      </ConfigErrorBoundary>
+        <SchemaField
+          name={`${configName}.cancelable`}
+          label="Cancelable?"
+          schema={cancelableSchema}
+          isRequired
+        />
+      </ConnectedCollapsibleFieldSection>
 
-      <SchemaField
-        name={`${configName}.cancelable`}
-        label="Cancelable?"
-        schema={cancelableSchema}
-        isRequired
-      />
+      <ConnectedCollapsibleFieldSection title="Form Location" initialExpanded>
+        <SchemaField
+          name={`${configName}.location`}
+          label="Location"
+          schema={locationSchema}
+          isRequired
+        />
+      </ConnectedCollapsibleFieldSection>
 
-      <SchemaField
-        name={`${configName}.submitCaption`}
-        label="Submit Button Text"
-        schema={submitCaptionSchema}
-        isRequired
-      />
-
-      <SchemaField
-        name={`${configName}.location`}
-        label="Location"
-        schema={locationSchema}
-        isRequired
-      />
+      <ConnectedCollapsibleFieldSection title="Form Fields" initialExpanded>
+        <ConfigErrorBoundary>
+          <FormEditor
+            name={configName}
+            activeField={activeElement}
+            setActiveField={setActiveElement}
+            fieldTypes={FORM_FIELD_TYPE_OPTIONS}
+            showFormIntroFields={false}
+          />
+        </ConfigErrorBoundary>
+      </ConnectedCollapsibleFieldSection>
     </div>
   );
 };

--- a/src/pageEditor/fields/FormModalOptions.tsx
+++ b/src/pageEditor/fields/FormModalOptions.tsx
@@ -28,6 +28,8 @@ import { selectNodePreviewActiveElement } from "@/pageEditor/slices/editorSelect
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 import FORM_FIELD_TYPE_OPTIONS from "@/pageEditor/fields/formFieldTypeOptions";
 import ConnectedCollapsibleFieldSection from "@/pageEditor/fields/ConnectedCollapsibleFieldSection";
+import { joinName } from "@/utils/formUtils";
+import { partial } from "lodash";
 
 export const FORM_MODAL_ID = validateRegistryId("@pixiebrix/form-modal");
 
@@ -57,12 +59,13 @@ const FormModalOptions: React.FC<{
   name: string;
   configKey: string;
 }> = ({ name, configKey }) => {
+  const baseName = joinName(name, configKey);
+  const configName = partial(joinName, baseName);
+
   const [activeElement, setActiveElement] = useReduxState(
     selectNodePreviewActiveElement,
     editorActions.setNodePreviewActiveElement,
   );
-
-  const configName = `${name}.${configKey}`;
 
   return (
     <div>
@@ -70,18 +73,18 @@ const FormModalOptions: React.FC<{
         title="Form Title/Description"
         initialExpanded
       >
-        <FormIntroFields name={configName} />
+        <FormIntroFields name={baseName} />
       </ConnectedCollapsibleFieldSection>
 
       <ConnectedCollapsibleFieldSection title="Form Submission" initialExpanded>
         <SchemaField
-          name={`${configName}.submitCaption`}
+          name={configName("submitCaption")}
           label="Submit Button Text"
           schema={submitCaptionSchema}
           isRequired
         />
         <SchemaField
-          name={`${configName}.cancelable`}
+          name={configName("cancelable")}
           label="Cancelable?"
           schema={cancelableSchema}
           isRequired
@@ -90,7 +93,7 @@ const FormModalOptions: React.FC<{
 
       <ConnectedCollapsibleFieldSection title="Form Location" initialExpanded>
         <SchemaField
-          name={`${configName}.location`}
+          name={configName("location")}
           label="Location"
           schema={locationSchema}
           isRequired
@@ -100,7 +103,7 @@ const FormModalOptions: React.FC<{
       <ConnectedCollapsibleFieldSection title="Form Fields" initialExpanded>
         <ConfigErrorBoundary>
           <FormEditor
-            name={configName}
+            name={baseName}
             activeField={activeElement}
             setActiveField={setActiveElement}
             fieldTypes={FORM_FIELD_TYPE_OPTIONS}

--- a/src/pageEditor/fields/FormRendererOptions.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.tsx
@@ -262,18 +262,18 @@ const FormRendererOptions: React.FC<{
         <FormSubmissionOptions makeName={makeName} />
       </ConnectedCollapsibleFieldSection>
 
-      <hr />
-
-      <ConfigErrorBoundary>
-        <FormEditor
-          name={configName}
-          // Showing the section above manually
-          showFormIntroFields={false}
-          activeField={activeElement}
-          setActiveField={setActiveElement}
-          fieldTypes={FORM_FIELD_TYPE_OPTIONS}
-        />
-      </ConfigErrorBoundary>
+      <ConnectedCollapsibleFieldSection title="Form Fields" initialExpanded>
+        <ConfigErrorBoundary>
+          <FormEditor
+            name={configName}
+            // Showing the section above manually
+            showFormIntroFields={false}
+            activeField={activeElement}
+            setActiveField={setActiveElement}
+            fieldTypes={FORM_FIELD_TYPE_OPTIONS}
+          />
+        </ConfigErrorBoundary>
+      </ConnectedCollapsibleFieldSection>
     </div>
   );
 };


### PR DESCRIPTION
## What does this PR do?

- Organizes temporary form builder fields into sections
- Moves form-level fields above the field definitions. Previously they were split above/below the field configuration section
- Adds section around field definition to embedded form editor for consistency
- Adds a smoke test for FormModalOptions

## Discussion

- There's only 1 field in the Location section. But it's not like the others

## Demo

- https://www.loom.com/share/3561cf5676ee445b84779542d0c1bbe9?sid=9000c191-00b1-4701-aea7-650d1f212ba4

## Team Coordination

- [ ] We may want to update some documentation screenshots: @brittanyjoiner15 

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @BLoe 
