### PR TITLE
Add margin between Comment Brick brick title and summary

### DIFF
--- a/src/pageEditor/brickSummary.module.scss
+++ b/src/pageEditor/brickSummary.module.scss
@@ -25,9 +25,10 @@
 
 .comment {
   font-style: italic;
-  max-height: 50px;
+  max-height: 54px;
   width: 100%;
   padding-right: 10px;
+  margin-top: 4px;
 
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNodeContent.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNodeContent.module.scss
@@ -59,7 +59,7 @@
 }
 
 .summary {
-  max-height: 50px;
+  max-height: 54px;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-extension/pull/7028#event-11160215568
- I accidentally forgot to add this final commit to the PR referenced above, which included this vertical margin in the demo

## Demo
**Before**
<img width="228" alt="Screen Shot 2023-12-06 at 1 28 42 PM" src="https://github.com/pixiebrix/pixiebrix-extension/assets/36575242/4712ca7a-3373-4273-ba20-f682111e433b">
**After**

<img width="225" alt="Screen Shot 2023-12-06 at 1 24 11 PM" src="https://github.com/pixiebrix/pixiebrix-extension/assets/36575242/17642cb3-46b8-42a2-a5bc-3548b804c631">


## Checklist

- [x] Designate a primary reviewer - anyone
