### PR TITLE
#7071: drop gapi requirements from CSP

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
     "48": "icons/logo48.png",
     "128": "icons/logo128.png"
   },
-  "content_security_policy": "script-src 'self' https://apis.google.com 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' http: https:; object-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-src 'self' https: https://*.googleapis.com https://docs.google.com",
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' http: https:; object-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-src 'self' https:",
   "content_scripts": [
     {
       "matches": ["https://*/*", "http://*/*"],


### PR DESCRIPTION
## What does this PR do?

- Closes #7071 
- Drops gapi-related entries from CSP

## Discussion

- I think we still want to include `https://*.googleapis.com/*` in exclude matches because we know our content script should never run in that frame?

## Checklist

- [x] Add tests: will be reviewed by rainforest/regression tests for google
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @BLoe 
