### PR TITLE
Fix broken link in "troubleshooting network errors"

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -122,7 +122,7 @@ exports[`Storyshots Blueprints/OnboardingView Default 1`] = `
           >
             <a
               className="btn btn-primary"
-              href="https://docs.pixiebrix.com/quick-start-guide"
+              href="https://docs.pixiebrix.com/quick-start"
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -7803,7 +7803,7 @@ exports[`Storyshots ModsPage/GetStartedView Activate Blueprint 1`] = `
          
         <span>
           <a
-            href="https://docs.pixiebrix.com/quick-start-guide"
+            href="https://docs.pixiebrix.com/quick-start"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -7957,7 +7957,7 @@ exports[`Storyshots ModsPage/GetStartedView Default 1`] = `
          
         <span>
           <a
-            href="https://docs.pixiebrix.com/quick-start-guide"
+            href="https://docs.pixiebrix.com/quick-start"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/src/analysis/analysisVisitors/templateAnalysis.ts
+++ b/src/analysis/analysisVisitors/templateAnalysis.ts
@@ -32,7 +32,7 @@ import {
 } from "@/utils/expressionUtils";
 
 const TEMPLATE_ERROR_MESSAGE =
-  "Invalid text template. Read more about text templates: https://docs.pixiebrix.com/nunjucks-templates";
+  "Invalid text template. Read more about text templates: https://docs.pixiebrix.com/developing-mods/developer-concepts/text-template-guide";
 
 type PushAnnotationArgs = {
   position: BrickPosition;

--- a/src/components/errors/NetworkErrorDetail.tsx
+++ b/src/components/errors/NetworkErrorDetail.tsx
@@ -112,7 +112,7 @@ const NetworkErrorDetail: React.FunctionComponent<{
             <div>
               PixieBrix did not receive a response. See{" "}
               <a
-                href="https://docs.pixiebrix.com/network-errors"
+                href="https://docs.pixiebrix.com/how-to/troubleshooting/troubleshooting-network-errors"
                 target="_blank"
                 rel="noreferrer"
               >

--- a/src/components/errors/__snapshots__/getErrorDetails.test.tsx.snap
+++ b/src/components/errors/__snapshots__/getErrorDetails.test.tsx.snap
@@ -278,7 +278,7 @@ exports[`Network error 1`] = `
         <div>
           PixieBrix did not receive a response. See 
           <a
-            href="https://docs.pixiebrix.com/network-errors"
+            href="https://docs.pixiebrix.com/how-to/troubleshooting/troubleshooting-network-errors"
             rel="noreferrer"
             target="_blank"
           >

--- a/src/components/errors/getErrorDetails.test.tsx
+++ b/src/components/errors/getErrorDetails.test.tsx
@@ -136,7 +136,7 @@ test("Network error", async () => {
     name: "ClientNetworkError",
     message: "Network error. No response received.",
     stack:
-      "ClientNetworkError: No response received. Your browser may have blocked the request. See https://docs.pixiebrix.com/network-errors for troubleshooting information\n    at enrichBusinessRequestError (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/background.js:54834:12)\n    at async serializableAxiosRequest (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/background.js:43429:15)\n    at async handleMessage (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/background.js:67712:22)",
+      "ClientNetworkError: No response received. Your browser may have blocked the request. See https://docs.pixiebrix.com/how-to/troubleshooting/troubleshooting-network-errors for troubleshooting information\n    at enrichBusinessRequestError (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/background.js:54834:12)\n    at async serializableAxiosRequest (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/background.js:43429:15)\n    at async handleMessage (chrome-extension://mpjjildhmpddojocokjkgmlkkkfjnepo/background.js:67712:22)",
   };
 
   const { title, detailsElement } = getErrorDetails(error);

--- a/src/components/fields/schemaFields/WorkshopMessage.tsx
+++ b/src/components/fields/schemaFields/WorkshopMessage.tsx
@@ -28,7 +28,7 @@ const WorkshopMessage: React.FC = () => (
       This brick configuration uses advanced features not yet supported in the
       Page Editor. To make changes, please open the mod in the Workshop.{" "}
       <a
-        href="https://docs.pixiebrix.com/platform-overview/extension-console#workshop"
+        href="https://docs.pixiebrix.com/developing-mods/advanced-workshop"
         target="_blank"
         rel="noreferrer"
       >

--- a/src/components/fields/schemaFields/WorkshopMessage.tsx
+++ b/src/components/fields/schemaFields/WorkshopMessage.tsx
@@ -21,6 +21,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import { Alert } from "react-bootstrap";
 
+// We need to update this link but we don't have docs for workshop yet
 const WorkshopMessage: React.FC = () => (
   <Alert variant="info" className={styles.alert}>
     <FontAwesomeIcon icon={faExclamationCircle} size="lg" className="mt-1" />

--- a/src/components/fields/schemaFields/WorkshopMessage.tsx
+++ b/src/components/fields/schemaFields/WorkshopMessage.tsx
@@ -21,7 +21,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import { Alert } from "react-bootstrap";
 
-// We need to update this link but we don't have docs for workshop yet
 const WorkshopMessage: React.FC = () => (
   <Alert variant="info" className={styles.alert}>
     <FontAwesomeIcon icon={faExclamationCircle} size="lg" className="mt-1" />
@@ -29,7 +28,7 @@ const WorkshopMessage: React.FC = () => (
       This brick configuration uses advanced features not yet supported in the
       Page Editor. To make changes, please open the mod in the Workshop.{" "}
       <a
-        href="https://docs.pixiebrix.com/developer-guide"
+        href="https://docs.pixiebrix.com/platform-overview/extension-console#workshop"
         target="_blank"
         rel="noreferrer"
       >

--- a/src/components/quickBar/defaultActions.tsx
+++ b/src/components/quickBar/defaultActions.tsx
@@ -64,7 +64,7 @@ const defaultActions: Action[] = [
     icon: <FontAwesomeIcon icon={faAppleAlt} fixedWidth />,
     priority: Priority.LOW,
     perform() {
-      window.location.href = "https://docs.pixiebrix.com/quick-start-guide";
+      window.location.href = "https://docs.pixiebrix.com/quick-start";
     },
   },
   {

--- a/src/errors/networkErrorHelpers.ts
+++ b/src/errors/networkErrorHelpers.ts
@@ -41,7 +41,7 @@ export function isAxiosError(error: unknown): error is SerializableAxiosError {
 export const NO_INTERNET_MESSAGE =
   "No response received. You are not connected to the internet.";
 export const NO_RESPONSE_MESSAGE =
-  "No response received. Your browser may have blocked the request. See https://docs.pixiebrix.com/how-to/troubleshooting-network-errors for troubleshooting information";
+  "No response received. Your browser may have blocked the request. See https://docs.pixiebrix.com/how-to/troubleshooting/troubleshooting-network-errors for troubleshooting information";
 
 /**
  * @deprecated DO NOT CALL DIRECTLY. Call getErrorMessage

--- a/src/errors/networkErrorHelpers.ts
+++ b/src/errors/networkErrorHelpers.ts
@@ -41,7 +41,7 @@ export function isAxiosError(error: unknown): error is SerializableAxiosError {
 export const NO_INTERNET_MESSAGE =
   "No response received. You are not connected to the internet.";
 export const NO_RESPONSE_MESSAGE =
-  "No response received. Your browser may have blocked the request. See https://docs.pixiebrix.com/network-errors for troubleshooting information";
+  "No response received. Your browser may have blocked the request. See https://docs.pixiebrix.com/how-to/troubleshooting-network-errors for troubleshooting information";
 
 /**
  * @deprecated DO NOT CALL DIRECTLY. Call getErrorMessage

--- a/src/extensionConsole/pages/activateMod/PermissionsBody.tsx
+++ b/src/extensionConsole/pages/activateMod/PermissionsBody.tsx
@@ -54,7 +54,7 @@ const QuickBarAlert = () => (
       <u>configured your Quick Bar shortcut</u>.
     </a>{" "}
     Learn more about{" "}
-    <a href="https://docs.pixiebrix.com/quick-bar-setup">
+    <a href="https://docs.pixiebrix.com/how-to/changing-the-quick-bar-shortcut">
       <u>configuring keyboard shortcuts</u>
     </a>
   </Alert>

--- a/src/extensionConsole/pages/mods/GetStartedView.tsx
+++ b/src/extensionConsole/pages/mods/GetStartedView.tsx
@@ -137,7 +137,7 @@ const GetStartedView: React.VoidFunctionComponent<{
             Visit the{" "}
             <ExternalLink
               linkText="Quick Start Guide"
-              url="https://docs.pixiebrix.com/quick-start-guide"
+              url="https://docs.pixiebrix.com/quick-start"
             />{" "}
             or ask questions in the{" "}
             <ExternalLink

--- a/src/extensionConsole/pages/mods/__snapshots__/ModsPageLayout.test.tsx.snap
+++ b/src/extensionConsole/pages/mods/__snapshots__/ModsPageLayout.test.tsx.snap
@@ -271,7 +271,7 @@ exports[`ModsPageLayout renders 1`] = `
                 Visit the 
                 <span>
                   <a
-                    href="https://docs.pixiebrix.com/quick-start-guide"
+                    href="https://docs.pixiebrix.com/quick-start"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/src/extensionConsole/pages/mods/onboardingView/OnboardingView.tsx
+++ b/src/extensionConsole/pages/mods/onboardingView/OnboardingView.tsx
@@ -102,7 +102,7 @@ const UnaffiliatedColumn: React.VoidFunctionComponent = () => (
     <div className="align-self-center">
       <a
         className="btn btn-primary"
-        href="https://docs.pixiebrix.com/quick-start-guide"
+        href="https://docs.pixiebrix.com/quick-start"
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -121,7 +121,7 @@ const CreateBrickColumn: React.VoidFunctionComponent = () => (
     </p>
     <a
       className="btn btn-info btn-sm"
-      href="https://docs.pixiebrix.com/quick-start-guide"
+      href="https://docs.pixiebrix.com/quick-start"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/src/pageEditor/NonScriptablePage.tsx
+++ b/src/pageEditor/NonScriptablePage.tsx
@@ -41,7 +41,7 @@ const NeedHelp: React.FunctionComponent = () => (
     <p>
       Visit the{" "}
       <a
-        href="https://docs.pixiebrix.com/quick-start-guide"
+        href="https://docs.pixiebrix.com/quick-start"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -625,7 +625,7 @@ describe("validation", () => {
 
     expectEditorError(
       container,
-      "Invalid text template. Read more about text templates: https://docs.pixiebrix.com/nunjucks-templates",
+      "Invalid text template. Read more about text templates: https://docs.pixiebrix.com/developing-mods/developer-concepts/text-template-guide",
     );
   });
 
@@ -723,7 +723,7 @@ describe("validation", () => {
 
     expectEditorError(
       container,
-      "Invalid text template. Read more about text templates: https://docs.pixiebrix.com/nunjucks-templates",
+      "Invalid text template. Read more about text templates: https://docs.pixiebrix.com/developing-mods/developer-concepts/text-template-guide",
     );
   });
 

--- a/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`NonScriptablePage it renders 1`] = `
             <p>
               Visit the 
               <a
-                href="https://docs.pixiebrix.com/quick-start-guide"
+                href="https://docs.pixiebrix.com/quick-start"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -128,7 +128,7 @@ exports[`NonScriptablePage it renders http snapshot 1`] = `
             <p>
               Visit the 
               <a
-                href="https://docs.pixiebrix.com/quick-start-guide"
+                href="https://docs.pixiebrix.com/quick-start"
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/src/pageEditor/tabs/editTab/UnsupportedApiV1.tsx
+++ b/src/pageEditor/tabs/editTab/UnsupportedApiV1.tsx
@@ -20,6 +20,7 @@ import React from "react";
 import { Alert, Card } from "react-bootstrap";
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 
+// Need to update this link but we don't have workshop docs in gitbook yet
 const UnsupportedApiV1: React.FC = () => (
   <Card>
     <Card.Header>Unsupported Extension Runtime Version</Card.Header>

--- a/src/pageEditor/tabs/editTab/UnsupportedApiV1.tsx
+++ b/src/pageEditor/tabs/editTab/UnsupportedApiV1.tsx
@@ -20,7 +20,6 @@ import React from "react";
 import { Alert, Card } from "react-bootstrap";
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 
-// Need to update this link but we don't have workshop docs in gitbook yet
 const UnsupportedApiV1: React.FC = () => (
   <Card>
     <Card.Header>Unsupported Extension Runtime Version</Card.Header>
@@ -33,7 +32,7 @@ const UnsupportedApiV1: React.FC = () => (
       <p>
         Use the Workshop to edit this mod.{" "}
         <a
-          href="https://docs.pixiebrix.com/runtime"
+          href="https://docs.pixiebrix.com/developing-mods/developer-concepts/advanced-brick-runtime"
           target="_blank"
           rel="noreferrer"
         >

--- a/src/pageEditor/tabs/editTab/UpgradedToApiV3.tsx
+++ b/src/pageEditor/tabs/editTab/UpgradedToApiV3.tsx
@@ -32,6 +32,7 @@ const UpgradedToApiV3: React.FC = () => {
   const showMessage = useSelector(selectShowV3UpgradeMessageForActiveElement);
   const dispatch = useDispatch();
 
+  // Need to update this link but we don't have workshop docs in gitbook yet
   return (
     showMessage && (
       <Alert variant="info" className={styles.alert}>

--- a/src/pageEditor/tabs/editTab/UpgradedToApiV3.tsx
+++ b/src/pageEditor/tabs/editTab/UpgradedToApiV3.tsx
@@ -32,7 +32,6 @@ const UpgradedToApiV3: React.FC = () => {
   const showMessage = useSelector(selectShowV3UpgradeMessageForActiveElement);
   const dispatch = useDispatch();
 
-  // Need to update this link but we don't have workshop docs in gitbook yet
   return (
     showMessage && (
       <Alert variant="info" className={styles.alert}>
@@ -46,7 +45,7 @@ const UpgradedToApiV3: React.FC = () => {
           API v2. We&apos;ve attempted to automatically convert this mod to
           runtime API v3.{" "}
           <a
-            href="https://docs.pixiebrix.com/runtime"
+            href="https://docs.pixiebrix.com/developing-mods/developer-concepts/advanced-brick-runtime"
             target="_blank"
             rel="noreferrer"
           >

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
@@ -89,7 +89,7 @@ const PageStateTab: React.VFC = () => {
         </div>
         <div className="ml-2">
           <a
-            href="https://docs.pixiebrix.com/page-state"
+            href="https://docs.pixiebrix.com/developing-mods/developer-concepts/data-context/using-page-state-advanced"
             target="_blank"
             rel="noreferrer"
           >

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/PageStateTab.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/PageStateTab.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`PageStateTab it renders with orphan extension 1`] = `
         class="ml-2"
       >
         <a
-          href="https://docs.pixiebrix.com/page-state"
+          href="https://docs.pixiebrix.com/developing-mods/developer-concepts/data-context/using-page-state-advanced"
           rel="noreferrer"
           target="_blank"
         >
@@ -271,7 +271,7 @@ exports[`PageStateTab it renders with recipe extension 1`] = `
         class="ml-2"
       >
         <a
-          href="https://docs.pixiebrix.com/page-state"
+          href="https://docs.pixiebrix.com/developing-mods/developer-concepts/data-context/using-page-state-advanced"
           rel="noreferrer"
           target="_blank"
         >

--- a/src/sidebar/DefaultPanel.tsx
+++ b/src/sidebar/DefaultPanel.tsx
@@ -56,7 +56,7 @@ const OnboardingContent: React.FunctionComponent = () => (
         <p>
           Visit the{" "}
           <a
-            href="https://docs.pixiebrix.com/quick-start-guide"
+            href="https://docs.pixiebrix.com/quick-start"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
The existing link in docs was not migrated to gitbook. I've created the new page in Gitbook in the how-to/troubleshooting folder and updated the link. 

Only consideration is if we hate how long this link is, or if we think we will change the structure in the future, Gitbook will change the slug, so we may want to think through if we're happy with this sitting in the `troubleshooting` folder in `how-to` or if we want to put somewhere else. cc @twschiller if you have a preference?

Otherwise should be good to go!