### PR TITLE
#7074: support optional chaining in variable analysis

### DIFF
--- a/src/bricks/transformers/identity.ts
+++ b/src/bricks/transformers/identity.ts
@@ -43,7 +43,7 @@ export class IdentityTransformer extends TransformerABC {
     if (isPlainObject(_config.config) && !isExpression(_config.config)) {
       return {
         type: "object",
-        // Allow any under each property
+        // Allow any type under each property
         properties: mapValues(_config.config, () => ({})),
         required: Object.keys(_config.config),
       };

--- a/src/runtime/pathHelpers.ts
+++ b/src/runtime/pathHelpers.ts
@@ -102,29 +102,29 @@ export function getPropByPath(
   for (const [index, rawPart] of rawParts.entries()) {
     const previous = value;
 
-    // Handle null coalescing syntax
+    // Handle optional chaining syntax, e.g., foo?.bar
     let part: string | number = rawPart;
-    let coalesce = false;
-    let numeric = false;
+    let isOptionalChain = false;
+    let isNumeric = false;
 
     if (rawPart.endsWith("?")) {
       part = rawPart.slice(0, -1);
-      coalesce = true;
+      isOptionalChain = true;
     }
 
     if (/^\d+$/.test(part) && Array.isArray(value)) {
       part = Number.parseInt(part, 10);
-      numeric = true;
+      isNumeric = true;
     }
 
-    if (!(typeof value == "object" || (Array.isArray(previous) && numeric))) {
+    if (!(typeof value == "object" || (Array.isArray(previous) && isNumeric))) {
       throw new InvalidPathError(`Invalid path ${path}`, path);
     }
 
     value = get(value, part);
 
     if (value == null) {
-      if (coalesce || index === rawParts.length - 1) {
+      if (isOptionalChain || index === rawParts.length - 1) {
         return null;
       }
 

--- a/src/utils/variableUtils.test.ts
+++ b/src/utils/variableUtils.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { type SafeString } from "@/types/stringTypes";
-import { freshIdentifier } from "@/utils/variableUtils";
+import { freshIdentifier, stripOptionalChaining } from "@/utils/variableUtils";
 
 test("can generate fresh identifier", () => {
   const root = "field" as SafeString;
@@ -29,4 +29,16 @@ test("can generate fresh identifier", () => {
   ).toBe("field0");
   expect(freshIdentifier(root, ["field"])).toBe("field2");
   expect(freshIdentifier(root, ["foo", "bar"])).toBe("field");
+});
+
+describe("stripOptionalChaining", () => {
+  it("strips optional chaining operator", () => {
+    expect(stripOptionalChaining("foo?")).toBe("foo");
+    // Shouldn't happen in practice because it's not a valid expression, but capturing it anyway
+    expect(stripOptionalChaining("f?oo??")).toBe("f?oo");
+  });
+
+  it("preserves original values", () => {
+    expect(stripOptionalChaining("foo")).toBe("foo");
+  });
 });

--- a/src/utils/variableUtils.ts
+++ b/src/utils/variableUtils.ts
@@ -19,6 +19,7 @@ import { type SafeString } from "@/types/stringTypes";
 import type { Expression, OutputKey } from "@/types/runtimeTypes";
 import { toExpression } from "@/utils/expressionUtils";
 import { VARIABLE_REFERENCE_PREFIX } from "@/types/runtimeTypes";
+import { trimEnd } from "lodash";
 
 /**
  * Return a fresh variable name based on the root name and array of existing identifiers.
@@ -72,4 +73,13 @@ export function getVariableExpression<TValue extends string | null>(
   }
 
   return toExpression("var", null);
+}
+
+/**
+ * Strip the optional chaining operator "?" from a path part.
+ * @param pathPart a part of a variable expression path
+ * @see getPropByPath
+ */
+export function stripOptionalChaining(pathPart: string): string {
+  return trimEnd(pathPart, "?");
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #7074 
- Fixes bug where optional chaining operator is valid in variable expressions, but gives warning in variable analysis

## Future Work

- Improve test fixtures in varAnalysis.test.s to use real bricks instead of mocking
- Improve identity brick shape inference

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
