### PR TITLE
#5676: Restore sandbox for nunjucks and handlebars

### DIFF
--- a/src/runtime/renderers.ts
+++ b/src/runtime/renderers.ts
@@ -23,7 +23,7 @@ import { type JsonObject } from "type-fest";
 import {
   renderHandlebarsTemplate,
   renderNunjucksTemplate,
-} from "@/sandbox/messenger/executor";
+} from "@/sandbox/messenger/api";
 import { type UnknownObject } from "@/types/objectTypes";
 import { containsTemplateExpression } from "@/utils/expressionUtils";
 


### PR DESCRIPTION
## What does this PR do?

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/5676

This was added last year but was disabled due to issues with JQ (https://github.com/pixiebrix/pixiebrix-extension/issues/4964). JQ has since been removed from the sandbox (https://github.com/pixiebrix/pixiebrix-extension/pull/6579).

In any case the memory issue didn't appear to be solvable via Transferable objects (because only ArrayBuffer is transferable, and we'd need to **duplicate** the object into it before transferring it, voiding any possible memory savings)

## Discussion

- Is this all that's needed here?

## Demo


https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/3665a088-a557-498f-b088-70c098e8ecc9



## Future work

- https://github.com/pixiebrix/pixiebrix-extension/issues/6580

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @twschiller 
