### PR TITLE
Bump ajv from 6 to 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@rjsf/bootstrap-4": "^5.14.1",
         "@rjsf/core": "^5.14.1",
         "@rjsf/utils": "^5.15.0",
-        "@rjsf/validator-ajv6": "^5.15.0",
+        "@rjsf/validator-ajv8": "^5.15.0",
         "@types/use-sync-external-store": "^0.0.6",
         "@uipath/robot": "1.3.1",
         "@vespaiach/axios-fetch-adapter": "^0.3.1",
@@ -5285,12 +5285,13 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
-    "node_modules/@rjsf/validator-ajv6": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv6/-/validator-ajv6-5.15.0.tgz",
-      "integrity": "sha512-vf6vwNdMqFC4Eu0SSnVetBZVbyRXUjDDd4seguYcsCgWcJHGWPOQb/5MLZfq/LPrFO3fz+yAiY8S5BnMi0aktQ==",
+    "node_modules/@rjsf/validator-ajv8": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-5.15.1.tgz",
+      "integrity": "sha512-QEbjdpLTmDCq4pdmeNaCiMiq3CId7IJ/Iri5FI794fhH8mn8Geu5hWqisMBTbrptfGdItY4RapKvoIglQEZKOg==",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21"
       },
@@ -5300,6 +5301,26 @@
       "peerDependencies": {
         "@rjsf/utils": "^5.12.x"
       }
+    },
+    "node_modules/@rjsf/validator-ajv8/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@rjsf/validator-ajv8/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
@@ -9342,6 +9363,7 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9356,7 +9378,6 @@
     "node_modules/ajv-formats": {
       "version": "2.1.1",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -9372,7 +9393,6 @@
     "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.8.2",
       "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9386,8 +9406,7 @@
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -14924,7 +14943,8 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -20073,7 +20093,8 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -24428,7 +24449,6 @@
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@rjsf/bootstrap-4": "^5.14.1",
     "@rjsf/core": "^5.14.1",
     "@rjsf/utils": "^5.15.0",
-    "@rjsf/validator-ajv6": "^5.15.0",
+    "@rjsf/validator-ajv8": "^5.15.0",
     "@types/use-sync-external-store": "^0.0.6",
     "@uipath/robot": "1.3.1",
     "@vespaiach/axios-fetch-adapter": "^0.3.1",

--- a/src/bricks/renderers/CustomFormComponent.tsx
+++ b/src/bricks/renderers/CustomFormComponent.tsx
@@ -25,7 +25,7 @@ import bootstrap from "bootstrap/dist/css/bootstrap.min.css?loadAsUrl";
 import bootstrapOverrides from "@/pageEditor/sidebar/sidebarBootstrapOverrides.scss?loadAsUrl";
 import custom from "@/bricks/renderers/customForm.css?loadAsUrl";
 import JsonSchemaForm from "@rjsf/bootstrap-4";
-import validator from "@rjsf/validator-ajv6";
+import validator from "@rjsf/validator-ajv8";
 import { type IChangeEvent } from "@rjsf/core";
 import ImageCropWidget from "@/components/formBuilder/ImageCropWidget";
 import RjsfSelectWidget from "@/components/formBuilder/RjsfSelectWidget";

--- a/src/bricks/renderers/customForm.test.tsx
+++ b/src/bricks/renderers/customForm.test.tsx
@@ -20,7 +20,7 @@ import { render, screen } from "@testing-library/react";
 import ImageCropWidget from "@/components/formBuilder/ImageCropWidget";
 import DescriptionField from "@/components/formBuilder/DescriptionField";
 import JsonSchemaForm from "@rjsf/bootstrap-4";
-import validator from "@rjsf/validator-ajv6";
+import validator from "@rjsf/validator-ajv8";
 import {
   CustomFormRenderer,
   normalizeIncomingFormData,

--- a/src/bricks/transformers/ephemeralForm/EphemeralForm.tsx
+++ b/src/bricks/transformers/ephemeralForm/EphemeralForm.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useEffect } from "react";
-import validator from "@rjsf/validator-ajv6";
+import validator from "@rjsf/validator-ajv8";
 import { Theme } from "@rjsf/bootstrap-4";
 import { withTheme, getDefaultRegistry } from "@rjsf/core";
 import { useAsyncState } from "@/hooks/common";

--- a/src/components/formBuilder/preview/FormPreview.tsx
+++ b/src/components/formBuilder/preview/FormPreview.tsx
@@ -18,7 +18,7 @@
 /* eslint-disable security/detect-object-injection */
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import JsonSchemaForm from "@rjsf/bootstrap-4";
-import validator from "@rjsf/validator-ajv6";
+import validator from "@rjsf/validator-ajv8";
 import { type FieldProps } from "@rjsf/utils";
 import { type IChangeEvent } from "@rjsf/core";
 import {


### PR DESCRIPTION
## What does this PR do?

- For https://github.com/pixiebrix/pixiebrix-extension/issues/3059#issuecomment-1848855244
- See https://ajv.js.org/v6-to-v8-migration.html

The migration appears to be seamless. Tests pass and it appears to work in the preview and in the sidebar

## Future Work

- [ ] Create the suggested `CompileSchema` component

## Checklist

- [x] Designate a primary reviewer: @twschiller 
