### PR TITLE
Make default identity brick configuration use property to match column header in UI

### DIFF
--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -54,7 +54,7 @@ import { brickConfigFactory } from "@/testUtils/factories/brickFactories";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { CustomFormRenderer } from "@/bricks/renderers/customForm";
 import { toExpression } from "@/utils/expressionUtils";
-import { IdentityTransformer } from "@/bricks/transformers/identity";
+import IdentityTransformer from "@/bricks/transformers/IdentityTransformer";
 import { createNewConfiguredBrick } from "@/pageEditor/exampleBrickConfigs";
 
 jest.mocked(services.locate).mockResolvedValue(

--- a/src/bricks/transformers/IdentityOptions.test.tsx
+++ b/src/bricks/transformers/IdentityOptions.test.tsx
@@ -19,11 +19,12 @@ import React from "react";
 import { render } from "@/pageEditor/testHelpers";
 import IdentityOptions from "@/bricks/transformers/IdentityOptions";
 import { getExampleBrickConfig } from "@/pageEditor/exampleBrickConfigs";
-import { IdentityTransformer } from "@/bricks/transformers/identity";
+import IdentityTransformer from "@/bricks/transformers/IdentityTransformer";
 import brickRegistry from "@/bricks/registry";
 import { screen } from "@testing-library/react";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import registerEditors from "@/contrib/editors";
+import { toExpression } from "@/utils/expressionUtils";
 
 beforeAll(() => {
   brickRegistry.register([new IdentityTransformer()]);
@@ -32,6 +33,12 @@ beforeAll(() => {
 });
 
 describe("IdentityOptions", () => {
+  test("default config matches UI header", () => {
+    expect(getExampleBrickConfig(IdentityTransformer.BRICK_ID)).toEqual({
+      property: toExpression("nunjucks", ""),
+    });
+  });
+
   test("shows object widget by default", async () => {
     render(<IdentityOptions name="foo" configKey="config" />, {
       initialValues: {

--- a/src/bricks/transformers/IdentityTransformer.test.ts
+++ b/src/bricks/transformers/IdentityTransformer.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { IdentityTransformer } from "@/bricks/transformers/identity";
+import IdentityTransformer from "@/bricks/transformers/IdentityTransformer";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { validateInput } from "@/validators/generic";
 import { throwIfInvalidInput } from "@/runtime/runtimeUtils";

--- a/src/bricks/transformers/IdentityTransformer.ts
+++ b/src/bricks/transformers/IdentityTransformer.ts
@@ -23,7 +23,7 @@ import { type BrickConfig } from "@/bricks/types";
 import { isPlainObject, mapValues } from "lodash";
 import { isExpression } from "@/utils/expressionUtils";
 
-export class IdentityTransformer extends TransformerABC {
+class IdentityTransformer extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/identity");
 
   override async isPure(): Promise<boolean> {
@@ -66,3 +66,5 @@ export class IdentityTransformer extends TransformerABC {
     return args;
   }
 }
+
+export default IdentityTransformer;

--- a/src/bricks/transformers/IdentityTransformerOptions.test.tsx
+++ b/src/bricks/transformers/IdentityTransformerOptions.test.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { render } from "@/pageEditor/testHelpers";
-import IdentityOptions from "@/bricks/transformers/IdentityOptions";
+import IdentityTransformerOptions from "@/bricks/transformers/IdentityTransformerOptions";
 import { getExampleBrickConfig } from "@/pageEditor/exampleBrickConfigs";
 import IdentityTransformer from "@/bricks/transformers/IdentityTransformer";
 import brickRegistry from "@/bricks/registry";
@@ -40,7 +40,7 @@ describe("IdentityOptions", () => {
   });
 
   test("shows object widget by default", async () => {
-    render(<IdentityOptions name="foo" configKey="config" />, {
+    render(<IdentityTransformerOptions name="foo" configKey="config" />, {
       initialValues: {
         foo: {
           config: getExampleBrickConfig(IdentityTransformer.BRICK_ID),

--- a/src/bricks/transformers/IdentityTransformerOptions.tsx
+++ b/src/bricks/transformers/IdentityTransformerOptions.tsx
@@ -12,7 +12,7 @@ const ANY_SCHEMA: Schema = {
 /**
  * Page Editor fields for the @pixiebrix/identity brick.
  */
-const IdentityOptions: React.FunctionComponent<BlockOptionProps> = ({
+const IdentityTransformerOptions: React.FunctionComponent<BlockOptionProps> = ({
   name,
   configKey,
 }) => (
@@ -25,4 +25,4 @@ const IdentityOptions: React.FunctionComponent<BlockOptionProps> = ({
   />
 );
 
-export default IdentityOptions;
+export default IdentityTransformerOptions;

--- a/src/bricks/transformers/getAllTransformers.ts
+++ b/src/bricks/transformers/getAllTransformers.ts
@@ -21,7 +21,7 @@ import { GetAPITransformer } from "./httpGet";
 import { RemoteMethod } from "./remoteMethod";
 import { RegexTransformer } from "./regex";
 import { MappingTransformer } from "./mapping";
-import { IdentityTransformer } from "./identity";
+import IdentityTransformer from "./IdentityTransformer";
 import { UrlParser } from "./parseUrl";
 import { FormData } from "./FormData";
 import { Prompt } from "./prompt";

--- a/src/contrib/editors.ts
+++ b/src/contrib/editors.ts
@@ -55,7 +55,7 @@ import JQueryReaderOptions from "@/bricks/transformers/jquery/JQueryReaderOption
 import AssignModVariable from "@/bricks/effects/assignModVariable";
 import AssignModVariableOptions from "@/pageEditor/fields/AssignModVariableOptions";
 import IdentityTransformer from "@/bricks/transformers/IdentityTransformer";
-import IdentityOptions from "@/bricks/transformers/IdentityOptions";
+import IdentityTransformerOptions from "@/bricks/transformers/IdentityTransformerOptions";
 import CommentEffect from "@/bricks/effects/comment";
 import CommentOptions from "@/bricks/effects/CommentOptions";
 
@@ -82,6 +82,6 @@ export default function registerEditors() {
   optionsRegistry.set(ALERT_EFFECT_ID, AlertOptions);
   optionsRegistry.set(JQueryReader.BRICK_ID, JQueryReaderOptions);
   optionsRegistry.set(AssignModVariable.BRICK_ID, AssignModVariableOptions);
-  optionsRegistry.set(IdentityTransformer.BRICK_ID, IdentityOptions);
+  optionsRegistry.set(IdentityTransformer.BRICK_ID, IdentityTransformerOptions);
   optionsRegistry.set(CommentEffect.BRICK_ID, CommentOptions);
 }

--- a/src/contrib/editors.ts
+++ b/src/contrib/editors.ts
@@ -54,7 +54,7 @@ import { JQueryReader } from "@/bricks/transformers/jquery/JQueryReader";
 import JQueryReaderOptions from "@/bricks/transformers/jquery/JQueryReaderOptions";
 import AssignModVariable from "@/bricks/effects/assignModVariable";
 import AssignModVariableOptions from "@/pageEditor/fields/AssignModVariableOptions";
-import { IdentityTransformer } from "@/bricks/transformers/identity";
+import IdentityTransformer from "@/bricks/transformers/IdentityTransformer";
 import IdentityOptions from "@/bricks/transformers/IdentityOptions";
 import CommentEffect from "@/bricks/effects/comment";
 import CommentOptions from "@/bricks/effects/CommentOptions";

--- a/src/pageEditor/exampleBrickConfigs.ts
+++ b/src/pageEditor/exampleBrickConfigs.ts
@@ -28,7 +28,7 @@ import TourStep from "@/bricks/transformers/tourStep/tourStep";
 import { type RegistryId } from "@/types/registryTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { JavaScriptTransformer } from "@/bricks/transformers/javascript";
-import { IdentityTransformer } from "@/bricks/transformers/identity";
+import IdentityTransformer from "@/bricks/transformers/IdentityTransformer";
 import { minimalUiSchemaFactory } from "@/utils/schemaUtils";
 import { toExpression } from "@/utils/expressionUtils";
 import CommentEffect from "@/bricks/effects/comment";

--- a/src/pageEditor/exampleBrickConfigs.ts
+++ b/src/pageEditor/exampleBrickConfigs.ts
@@ -69,7 +69,8 @@ export function getExampleBrickConfig(
 
     case IdentityTransformer.BRICK_ID: {
       return {
-        value: toExpression("nunjucks", ""),
+        // Use `property` as the default because the property table has title "Property name"
+        property: toExpression("nunjucks", ""),
       };
     }
 

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -78,7 +78,7 @@
     "./bricks/transformers/component/TableReader.ts",
     "./bricks/transformers/ephemeralForm/formTypes.ts",
     "./bricks/transformers/ephemeralForm/modalUtils.tsx",
-    "./bricks/transformers/identity.ts",
+    "./bricks/transformers/IdentityTransformer.ts",
     "./bricks/transformers/jquery/JQueryReader.ts",
     "./bricks/transformers/jsonPath.ts",
     "./bricks/transformers/mapping.ts",


### PR DESCRIPTION
## What does this PR do?

- Changes the default brick configuration for the Identity Brick to use "property" vs. value
- https://pixiebrix.slack.com/archives/C042CA15AKS/p1702498096687359
- Refactoring
  - Refactors filename to be `IndentityTransformer`
  - Refactors file to use default export

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/a535291a-1a4c-4ebc-aaf3-d5f2f3b42dbd)

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
