### PR TITLE
Match show sidebar panel heading field title to starter brick field title

### DIFF
--- a/src/bricks/effects/sidebar.ts
+++ b/src/bricks/effects/sidebar.ts
@@ -17,17 +17,11 @@
 
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
-import { type Schema } from "@/types/schemaTypes";
+import { type Schema, SCHEMA_EMPTY_OBJECT } from "@/types/schemaTypes";
 import { hideSidebar, showSidebar } from "@/contentScript/sidebarController";
 import { propertiesToSchema } from "@/validators/generic";
 
 import { logPromiseDuration } from "@/utils/promiseUtils";
-
-const NO_PARAMS: Schema = {
-  $schema: "https://json-schema.org/draft/2019-09/schema#",
-  type: "object",
-  properties: {},
-};
 
 export class ShowSidebar extends EffectABC {
   constructor() {
@@ -42,9 +36,10 @@ export class ShowSidebar extends EffectABC {
     {
       panelHeading: {
         type: "string",
-        title: "Panel Heading",
+        // Should match the field label in SidebarConfiguration
+        title: "Tab Title",
         description:
-          "The panel to show in the sidebar. If not provided, defaults to a sidebar panel in this mod",
+          "The tab to show in the sidebar. If not provided, defaults to a sidebar panel in this mod",
       },
       forcePanel: {
         type: "boolean",
@@ -89,7 +84,7 @@ export class HideSidebar extends EffectABC {
     );
   }
 
-  inputSchema: Schema = NO_PARAMS;
+  inputSchema: Schema = SCHEMA_EMPTY_OBJECT;
 
   async effect(): Promise<void> {
     hideSidebar();

--- a/src/pageEditor/tabs/sidebar/SidebarConfiguration.tsx
+++ b/src/pageEditor/tabs/sidebar/SidebarConfiguration.tsx
@@ -71,6 +71,7 @@ const SidebarConfiguration: React.FC<{
     <>
       <ConnectedFieldTemplate
         name="extension.heading"
+        // If you change this label, update the field title in ShowSidebar
         label="Tab Title"
         description="The text that will appear in the tab along the top of the Sidebar Panel"
       />

--- a/src/pageEditor/tabs/sidebar/SidebarConfiguration.tsx
+++ b/src/pageEditor/tabs/sidebar/SidebarConfiguration.tsx
@@ -71,7 +71,7 @@ const SidebarConfiguration: React.FC<{
     <>
       <ConnectedFieldTemplate
         name="extension.heading"
-        label="Tab title"
+        label="Tab Title"
         description="The text that will appear in the tab along the top of the Sidebar Panel"
       />
 

--- a/src/types/schemaTypes.ts
+++ b/src/types/schemaTypes.ts
@@ -33,6 +33,12 @@ export type UiSchema = StandardUiSchema;
  */
 export const SCHEMA_ALLOW_ANY: Schema = Object.freeze({});
 
+export const SCHEMA_EMPTY_OBJECT: Schema = Object.freeze({
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+});
+
 /**
  * Field Schema for labelled enums.
  *


### PR DESCRIPTION
## What does this PR do?

- Make the show sidebar panel heading field title match the starter brick configuration terminology
- https://pixiebrix.slack.com/archives/C042CA15AKS/p1702492971546379

# Discussion

- I didn't want to introduce a constant because I didn't want to couple the files

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/bf8d826a-ae0a-4d2a-8ecf-cea9238ea86d)

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @BLoe 
