### PR TITLE
Fix missing element key for map values brick

### DIFF
--- a/src/bricks/transformers/controlFlow/MapValues.ts
+++ b/src/bricks/transformers/controlFlow/MapValues.ts
@@ -23,17 +23,18 @@ import {
   type BrickOptions,
   type OutputKey,
   type PipelineExpression,
+  VARIABLE_REFERENCE_PREFIX,
 } from "@/types/runtimeTypes";
 import { validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
 
 class MapValues extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/map");
+  static BRICK_ID = validateRegistryId("@pixiebrix/map");
   defaultOutputKey = "mapped";
 
   constructor() {
     super(
-      MapValues.BLOCK_ID,
+      MapValues.BRICK_ID,
       "Map/Transform Values",
       "Map/Transform a list of values",
     );
@@ -105,7 +106,7 @@ class MapValues extends TransformerABC {
         bodyPipeline,
         { key: "body", counter: index },
         {
-          [`@${elementKey}`]: element,
+          [`${VARIABLE_REFERENCE_PREFIX}${elementKey}`]: element,
         },
       );
 

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -46,6 +46,7 @@ import {
 import { inputProperties } from "@/utils/schemaUtils";
 import { joinPathParts } from "@/utils/formUtils";
 import { CustomFormRenderer } from "@/bricks/renderers/customForm";
+import MapValues from "@/bricks/transformers/controlFlow/MapValues";
 
 export async function getCurrentURL(): Promise<string> {
   expectContext("devTools");
@@ -167,7 +168,9 @@ export function getVariableKeyForSubPipeline(
   let keyPropName: string = null;
 
   if (
-    [ForEach.BLOCK_ID, ForEachElement.BLOCK_ID].includes(brickConfig.id) &&
+    [ForEach.BLOCK_ID, ForEachElement.BLOCK_ID, MapValues.BRICK_ID].includes(
+      brickConfig.id,
+    ) &&
     pipelinePropName === "body"
   ) {
     keyPropName = "elementKey";


### PR DESCRIPTION
## What does this PR do?

- Fixes missing element key in brick outline for map values brick
- Also fixes the variable being missing in the variable popover

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/c511e684-4101-449c-8c05-245198376e1f)

## Future Work

- We'll probably want to refactor getVariableKeyForSubPipeline to use the brick definition instead of defining in a separate method. Classic https://en.wikipedia.org/wiki/Expression_problem

## Checklist

- [ ] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @BLoe 
