### PR TITLE
[WIP] experimental Extract DOM brick to support web clipper/scraping use cases

### DIFF
--- a/src/bricks/transformers/HtmlTransformer.test.ts
+++ b/src/bricks/transformers/HtmlTransformer.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import HtmlTransformer from "@/bricks/transformers/HtmlTransformer";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+
+const brick = new HtmlTransformer();
+
+describe("HtmlTransformer", () => {
+  it.each([undefined, true])(
+    "handles open shadow dom for includeShadowDOM: %s",
+    async (includeShadowDOM) => {
+      document.body.innerHTML = '<div id="container"></div>';
+      const container: HTMLElement = document.querySelector("#container");
+
+      const shadowRoot = container.attachShadow({ mode: "open" });
+      shadowRoot.innerHTML = '<div id="child">Inside Shadow DOM</div>';
+
+      const result = await brick.transform(
+        unsafeAssumeValidArg({ includeShadowDOM }),
+        {
+          ...brickOptionsFactory(),
+          root: container,
+        },
+      );
+
+      expect(result.outerHTML).toBe(
+        '<div id="container"><shadow-root><div id="child">Inside Shadow DOM</div></shadow-root></div>',
+      );
+    },
+  );
+
+  it("can't view inside closed shadow dom", async () => {
+    document.body.innerHTML = '<div id="container"></div>';
+    const container: HTMLElement = document.querySelector("#container");
+
+    const shadowRoot = container.attachShadow({ mode: "closed" });
+    shadowRoot.innerHTML = '<div id="child">Inside Shadow DOM</div>';
+
+    const result = await brick.transform(
+      unsafeAssumeValidArg({ includeShadowDOM: true }),
+      {
+        ...brickOptionsFactory(),
+        root: container,
+      },
+    );
+
+    // Can't access the closed shadow dom because shadowRoot is null for closed shadow roots
+    expect(result.outerHTML).toBe('<div id="container"></div>');
+  });
+
+  it("can remove non-visible elements", async () => {
+    const original =
+      '<div id="container"><div id="hidden" style="display: none;"></div></div>';
+    document.body.innerHTML = original;
+    const container: HTMLElement = document.querySelector("#container");
+
+    const result = await brick.transform(
+      unsafeAssumeValidArg({ includeNonVisible: false }),
+      {
+        ...brickOptionsFactory(),
+        root: container,
+      },
+    );
+
+    expect(result.outerHTML).toBe('<div id="container"></div>');
+    // Ensure the original tree is not modified
+    expect(document.body.innerHTML).toBe(original);
+  });
+
+  it("preserves non-visible elements by default", async () => {
+    document.body.innerHTML =
+      '<div id="container"><div id="hidden" style="display: none;"></div></div>';
+    const container: HTMLElement = document.querySelector("#container");
+
+    const result = await brick.transform(unsafeAssumeValidArg({}), {
+      ...brickOptionsFactory(),
+      root: container,
+    });
+
+    expect(result.outerHTML).toBe(
+      '<div id="container"><div id="hidden" style="display: none;"></div></div>',
+    );
+  });
+});

--- a/src/bricks/transformers/HtmlTransformer.ts
+++ b/src/bricks/transformers/HtmlTransformer.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { isHTMLElement } from "@/bricks/readers/frameworkReader";
+import { type Schema } from "@/types/schemaTypes";
+import { type JsonObject } from "type-fest";
+import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
+import { TransformerABC } from "@/types/bricks/transformerTypes";
+import { propertiesToSchema } from "@/validators/generic";
+import { isElement, isVisible } from "@/utils/domUtils";
+
+/**
+ * Recursively replace the shadow DOM with a <shadow-root> tag.
+ *
+ * cloneNode(true) doesn't work because it doesn't clone the shadow DOM, even if it's open.
+ *
+ * Doesn't work with closed shadow DOM. Closed roots are not accessible from JavaScript:
+ * https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/mode
+ *
+ * @param node the node to process
+ */
+function serializeShadowDOM<T extends Node>(node: T): Node {
+  // Replace the shadow DOM with a <shadow-root> tag
+  if (isElement(node) && node.shadowRoot) {
+    const processed = [...node.shadowRoot.childNodes].map((child) =>
+      serializeShadowDOM(child),
+    );
+
+    const clone = node.cloneNode(false) as Element;
+    const root = document.createElement("shadow-root");
+    root.append(...processed);
+    clone.append(root);
+
+    return clone;
+  }
+
+  if (isElement(node)) {
+    const clone = node.cloneNode(true) as Element;
+
+    // Clear children from clone
+    while (clone.lastChild) {
+      // eslint-disable-next-line unicorn/prefer-dom-node-remove -- keep on the original tree
+      clone.removeChild(clone.lastChild);
+    }
+
+    for (const childNode of node.childNodes) {
+      clone.append(serializeShadowDOM(childNode));
+    }
+
+    return clone;
+  }
+
+  return node;
+}
+
+/**
+ * Remove non-visible elements from the tree. Modifies the tree in place.
+ * @param node the node to process
+ */
+function removeNonVisibleElements(node: Node): Node {
+  if (isElement(node)) {
+    const style = window.getComputedStyle(node);
+
+    // Discussion: https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom
+    if (
+      !isVisible(node as HTMLElement) ||
+      style.display === "none" ||
+      style.visibility !== "hidden"
+    ) {
+      node.remove();
+    }
+
+    // eslint-disable-next-line unicorn/no-useless-spread -- shallow clone because we're modifying the children in place
+    for (const child of [...node.children]) {
+      removeNonVisibleElements(child);
+    }
+  }
+
+  return node;
+}
+
+/**
+ * An HTML Transformer brick to support scraping and automation use cases.
+ *
+ * As compared to HtmlReader, this brick includes controls for the HTML output. Introduced because the HtmlReader is a
+ * reader so doesn't support configured options.
+ *
+ * The philosophy of this brick is to provide affordances that require access to the original DOM.
+ *
+ * Transformations not requiring the DOM, can be implemented via the JavaScript brick. For example:
+ * - Excluding comments
+ * - Excluding tags (e.g., img, svg, etc.)
+ * - Excluding attributes (e.g., class, etc.)
+ *
+ * @see HtmlReader
+ * @since 1.8.6
+ */
+class HtmlTransformer extends TransformerABC {
+  defaultOutputKey = "html";
+
+  constructor() {
+    super(
+      "@pixiebrix/html/extract",
+      "[Experimental] Extract DOM",
+      "Extract the DOM for an element/document",
+    );
+  }
+
+  override inputSchema: Schema = propertiesToSchema({
+    includeNonVisible: {
+      type: "boolean",
+      description: "Whether to include non-visible elements",
+      default: true,
+    },
+    includeShadowDOM: {
+      type: "boolean",
+      description: "Whether to include open Shadow DOM",
+      // Default to false, because it produces a tag placeholder
+      default: true,
+    },
+  });
+
+  override outputSchema: Schema = {
+    $schema: "https://json-schema.org/draft/2019-09/schema#",
+    type: "object",
+    properties: {
+      html: {
+        type: "string",
+        description: "The HTML including the element/document",
+      },
+    },
+    required: ["innerHTML", "outerHTML"],
+  };
+
+  override async isPure(): Promise<boolean> {
+    return true;
+  }
+
+  override async isRootAware(): Promise<boolean> {
+    // To support reading HTML from current/inherited element
+    return true;
+  }
+
+  async transform(
+    {
+      includeShadowDOM = true,
+      includeNonVisible = true,
+    }: BrickArgs<{ includeShadowDOM?: boolean; includeNonVisible?: boolean }>,
+    { root }: BrickOptions,
+  ): Promise<JsonObject> {
+    let element = isHTMLElement(root) ? root : document.documentElement;
+
+    if (includeShadowDOM) {
+      element = serializeShadowDOM(element) as HTMLElement;
+    }
+
+    if (!includeNonVisible) {
+      element = removeNonVisibleElements(
+        element.cloneNode(true),
+      ) as HTMLElement;
+    }
+
+    return {
+      outerHTML: element.outerHTML,
+      innerHTML: element.innerHTML,
+    };
+  }
+}
+
+export default HtmlTransformer;

--- a/src/bricks/transformers/getAllTransformers.ts
+++ b/src/bricks/transformers/getAllTransformers.ts
@@ -58,6 +58,7 @@ import ConvertDocument from "@/bricks/transformers/convertDocument";
 import { SearchText } from "@/bricks/transformers/searchText";
 import { WithAsyncModVariable } from "@/bricks/transformers/controlFlow/WithAsyncModVariable";
 import { JavaScriptTransformer } from "@/bricks/transformers/javascript";
+import HtmlTransformer from "@/bricks/transformers/HtmlTransformer";
 
 function getAllTransformers(): Brick[] {
   return [
@@ -81,6 +82,7 @@ function getAllTransformers(): Brick[] {
     new UrlParams(),
     new SplitText(),
     new SearchText(),
+    new HtmlTransformer(),
     new JQueryReader(),
     new Readable(),
     new ComponentReader(),

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -25,7 +25,7 @@ import registerBuiltinBlocks from "@/bricks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 126;
+const EXPECTED_HEADER_COUNT = 127;
 
 registerBuiltinBlocks();
 registerContribBlocks();

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -116,6 +116,10 @@ export async function waitForBody(): Promise<void> {
   }
 }
 
+/**
+ * Returns true if the element is visible. Copied from jQuery's `:visible` selector.
+ * @param element the HTML element to check
+ */
 export function isVisible(element: HTMLElement): boolean {
   // https://github.com/jquery/jquery/blob/c66d4700dcf98efccb04061d575e242d28741223/src/css/hiddenVisibleSelectors.js#L9C1-L9C1
   return Boolean(
@@ -123,4 +127,12 @@ export function isVisible(element: HTMLElement): boolean {
       element.offsetHeight ||
       element.getClientRects().length > 0,
   );
+}
+
+/**
+ * Returns true if the node is an HTMLElement.
+ * @param node the node to check
+ */
+export function isElement(node: Node): node is Element {
+  return node.nodeType === Node.ELEMENT_NODE;
 }


### PR DESCRIPTION
## What does this PR do?

- Adds a Extract DOM brick to support web clipper/scraping use cases
- The Extract DOM brick provides affordances that need access to the original DOM
  - Serializing open shadow roots
  - Excluding non-visible elements

## Remaining Work

- [ ] Serialize slots
- [ ] One of the transformations is modifying the original DOM tree. Test page is the score box on Rotten Tomatoes: https://www.rottentomatoes.com/m/wonka

## Reviewer Tips

- _What order should the reviewer review the files in?_
- _Are there any implementation approaches you want feedback on?_

## Discussion

- Will probably change name to "serialize DOM"
- Need to determine best way to clarify use of this brick vs. existing HTML Reader brick. The Extract DOM brick has defaults to support scraping whereas the HTML Reader brick uses the native innerHTML/outputHTML web APIs so will be more performant for general use
- We might be able to deprecate the HTML Reader brick. Originally I thought that was used as the default reader for starter bricks, but that's actually the `@pixiebrix/html/element` brick: https://github.com/pixiebrix/pixiebrix-extension/blob/25841e322f5a0707ea169724b1214195d79ae368/src/pageEditor/starterBricks/base.ts#L376-L376

## Demo

- _Paste a screenshot or demo video here_

## Future Work

- Consider adding affordance to tag elements with unique `data-element-ref` attributes to support LLM automation use-cases. (So the LLM doesn't need access to the full DOM to determine automation actions.) If the LLM doesn't have access to the full DOM, it can't generate selectors. See demo video in https://github.com/pixiebrix/pixiebrix-extension/pull/7125

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [ ] Designate a primary reviewer
