### PR TITLE
Add experimental Run Metadata brick

### DIFF
--- a/src/bricks/transformers/RunMetadataTransformer.test.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import RunMetadataTransformer from "@/bricks/transformers/RunMetadataTransformer";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+import {
+  autoUUIDSequence,
+  registryIdFactory,
+} from "@/testUtils/factories/stringFactories";
+import ConsoleLogger from "@/utils/ConsoleLogger";
+import { SemVerString } from "@/types/registryTypes";
+
+const brick = new RunMetadataTransformer();
+
+describe("RunMetadataTransformer", () => {
+  it("returns standalone mod metadata", async () => {
+    const extensionId = autoUUIDSequence();
+    const logger = new ConsoleLogger({
+      extensionId,
+    });
+
+    const result = await brick.run(
+      unsafeAssumeValidArg({}),
+      brickOptionsFactory({
+        logger,
+      }),
+    );
+
+    expect(result).toEqual({
+      componentId: extensionId,
+      deploymentId: null,
+      mod: null,
+      runId: null,
+    });
+  });
+
+  it("returns packaged mod metadata", async () => {
+    const extensionId = autoUUIDSequence();
+    const registryId = registryIdFactory();
+    const logger = new ConsoleLogger({
+      extensionId,
+      blueprintId: registryId,
+      blueprintVersion: "1.0.0" as SemVerString,
+    });
+
+    const result = await brick.run(
+      unsafeAssumeValidArg({}),
+      brickOptionsFactory({
+        logger,
+      }),
+    );
+
+    expect(result).toEqual({
+      componentId: extensionId,
+      deploymentId: null,
+      mod: {
+        id: registryId,
+        version: "1.0.0",
+      },
+      runId: null,
+    });
+  });
+});

--- a/src/bricks/transformers/RunMetadataTransformer.test.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.test.ts
@@ -42,7 +42,7 @@ describe("RunMetadataTransformer", () => {
     );
 
     expect(result).toEqual({
-      componentId: extensionId,
+      modComponentId: extensionId,
       deploymentId: null,
       mod: null,
       runId: null,
@@ -66,13 +66,49 @@ describe("RunMetadataTransformer", () => {
     );
 
     expect(result).toEqual({
-      componentId: extensionId,
+      modComponentId: extensionId,
       deploymentId: null,
       mod: {
         id: registryId,
         version: "1.0.0",
       },
       runId: null,
+    });
+  });
+
+  it("returns deployed mod metadata", async () => {
+    const extensionId = autoUUIDSequence();
+    const deploymentId = autoUUIDSequence();
+    const registryId = registryIdFactory();
+    const runId = autoUUIDSequence();
+
+    const logger = new ConsoleLogger({
+      extensionId,
+      blueprintId: registryId,
+      blueprintVersion: "1.0.0" as SemVerString,
+      deploymentId,
+    });
+
+    const result = await brick.run(
+      unsafeAssumeValidArg({}),
+      brickOptionsFactory({
+        logger,
+        meta: {
+          runId,
+          extensionId,
+          branches: [],
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      modComponentId: extensionId,
+      deploymentId,
+      mod: {
+        id: registryId,
+        version: "1.0.0",
+      },
+      runId,
     });
   });
 });

--- a/src/bricks/transformers/RunMetadataTransformer.test.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.test.ts
@@ -23,7 +23,7 @@ import {
   registryIdFactory,
 } from "@/testUtils/factories/stringFactories";
 import ConsoleLogger from "@/utils/ConsoleLogger";
-import { SemVerString } from "@/types/registryTypes";
+import type { SemVerString } from "@/types/registryTypes";
 
 const brick = new RunMetadataTransformer();
 

--- a/src/bricks/transformers/RunMetadataTransformer.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { TransformerABC } from "@/types/bricks/transformerTypes";
+import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
+import { type Schema, SCHEMA_EMPTY_OBJECT } from "@/types/schemaTypes";
+import { propertiesToSchema } from "@/validators/generic";
+import { validateRegistryId } from "@/types/helpers";
+
+/**
+ * Returns metadata for the current run.
+ *
+ * Introduced to support providing context for audit use cases.
+ *
+ * @since 1.8.6
+ */
+class RunMetadataTransformer extends TransformerABC {
+  static BRICK_ID = validateRegistryId("@pixiebrix/reflect/run-metadata");
+
+  constructor() {
+    super(
+      "@pixiebrix/reflect/run-metadata",
+      "[Experimental] Run Metadata",
+      "Returns metadata for the current run",
+      "faCode",
+    );
+  }
+
+  defaultOutputKey = "meta";
+
+  inputSchema: Schema = SCHEMA_EMPTY_OBJECT;
+
+  override async isPure(): Promise<boolean> {
+    return true;
+  }
+
+  override async isRootAware(): Promise<boolean> {
+    return false;
+  }
+
+  override outputSchema: Schema = propertiesToSchema(
+    {
+      componentId: {
+        type: "string",
+        format: "uuid",
+        description: "The mod component id",
+      },
+      runId: {
+        type: ["string", "null"],
+        format: "uuid",
+        description: "The run id, or null if run id is not tracked for run",
+      },
+      mod: {
+        type: ["object", "null"],
+        description: "Mod metadata, or null if not running in a packaged mod",
+        properties: {
+          id: {
+            type: "string",
+            description: "The mod registry id",
+          },
+          version: {
+            type: "string",
+            description: "The mod version",
+          },
+        },
+      },
+      deploymentId: {
+        type: ["string", "null"],
+        format: "uuid",
+        description:
+          "The deployment id, or null if not running as part of a deployment",
+      },
+    },
+    ["componentId"],
+  );
+
+  async transform(
+    _args: BrickArgs<unknown>,
+    { logger, meta }: BrickOptions,
+  ): Promise<unknown> {
+    const { context } = logger;
+
+    return {
+      mod:
+        context.blueprintId == null
+          ? null
+          : {
+              id: context.blueprintId,
+              version: context.blueprintVersion,
+            },
+      deploymentId: context.deploymentId ?? null,
+      componentId: context.extensionId,
+      runId: meta.runId,
+    };
+  }
+}
+
+export default RunMetadataTransformer;

--- a/src/bricks/transformers/RunMetadataTransformer.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.ts
@@ -54,7 +54,7 @@ class RunMetadataTransformer extends TransformerABC {
 
   override outputSchema: Schema = propertiesToSchema(
     {
-      componentId: {
+      modComponentId: {
         type: "string",
         format: "uuid",
         description: "The mod component id",
@@ -77,6 +77,7 @@ class RunMetadataTransformer extends TransformerABC {
             description: "The mod version",
           },
         },
+        required: ["id", "version"],
       },
       deploymentId: {
         type: ["string", "null"],
@@ -85,7 +86,7 @@ class RunMetadataTransformer extends TransformerABC {
           "The deployment id, or null if not running as part of a deployment",
       },
     },
-    ["componentId"],
+    ["modComponentId"],
   );
 
   async transform(
@@ -103,7 +104,7 @@ class RunMetadataTransformer extends TransformerABC {
               version: context.blueprintVersion,
             },
       deploymentId: context.deploymentId ?? null,
-      componentId: context.extensionId,
+      modComponentId: context.extensionId,
       runId: meta.runId,
     };
   }

--- a/src/bricks/transformers/getAllTransformers.ts
+++ b/src/bricks/transformers/getAllTransformers.ts
@@ -58,6 +58,7 @@ import ConvertDocument from "@/bricks/transformers/convertDocument";
 import { SearchText } from "@/bricks/transformers/searchText";
 import { WithAsyncModVariable } from "@/bricks/transformers/controlFlow/WithAsyncModVariable";
 import { JavaScriptTransformer } from "@/bricks/transformers/javascript";
+import RunMetadataTransformer from "@/bricks/transformers/RunMetadataTransformer";
 
 function getAllTransformers(): Brick[] {
   return [
@@ -95,6 +96,9 @@ function getAllTransformers(): Brick[] {
     new TraverseElements(),
     new SelectElement(),
     new ExtensionDiagnostics(),
+
+    // Reflection
+    new RunMetadataTransformer(),
 
     // Control Flow Bricks
     new ForEach(),

--- a/src/development/headers.ts
+++ b/src/development/headers.ts
@@ -25,7 +25,7 @@ import registerBuiltinBlocks from "@/bricks/registerBuiltinBlocks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 126;
+const EXPECTED_HEADER_COUNT = 127;
 
 registerBuiltinBlocks();
 registerContribBlocks();


### PR DESCRIPTION
## What does this PR do?

- Adds an experimental Run Metadata brick
- We have some user-defined bricks for auditing/alerting use-cases (e.g., `@pixiebrix/deployments/message`) that would benefit from being deployment aware. Currently the deploymentId has to be hard-coded or passed in as a mod option
- Other PR with reflection related bricks: https://github.com/pixiebrix/pixiebrix-extension/pull/7125

## Discussion

- Uses `mod` vs. `blueprint` terminology
- Uses `componentId` vs. `extensionId` terminology
- Uses a transformer vs. a reader, because we're moving away from the the reader brick type

## Checklist

- [x] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
