### PR TITLE
#7143: disable variable popover trigger in mod options to prevent crash when typing `@`

### DIFF
--- a/src/components/fields/schemaFields/widgets/varPopup/useAttachPopup.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useAttachPopup.ts
@@ -22,17 +22,19 @@ import {
   useReducer,
   type MutableRefObject,
   useCallback,
+  useContext,
 } from "react";
 import {
   getLikelyVariableAtPosition,
   getVariableAtPosition,
 } from "@/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils";
 import { type FieldInputMode } from "@/components/fields/schemaFields/fieldInputMode";
-import { type UnknownObject } from "@/types/objectTypes";
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import useDebouncedEffect from "@/hooks/useDebouncedEffect";
 
 import { waitAnimationFrame } from "@/utils/domUtils";
+import FieldRuntimeContext from "@/components/fields/schemaFields/FieldRuntimeContext";
+import type { UnknownObject } from "@/types/objectTypes";
 
 type Props = {
   inputMode: FieldInputMode;
@@ -86,13 +88,16 @@ const selectAnalysisSliceExists = (state: UnknownObject) =>
  */
 function useAttachPopup({ inputMode, inputElementRef, value }: Props) {
   const analysisSliceExists = useSelector(selectAnalysisSliceExists);
+  const { allowExpressions } = useContext(FieldRuntimeContext);
   const { varAutosuggest } = useSelector(selectSettings);
+
   const [{ isMenuShowing, likelyVariable }, dispatch] = useReducer(
     popupSlice.reducer,
     initialState,
   );
 
-  const autosuggestEnabled = varAutosuggest && analysisSliceExists;
+  const autosuggestEnabled =
+    varAutosuggest && allowExpressions && analysisSliceExists;
 
   const isMenuAvailable =
     (inputMode === "var" || inputMode === "string") && autosuggestEnabled;

--- a/src/components/fields/schemaFields/widgets/varPopup/useAttachPopup.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useAttachPopup.ts
@@ -78,8 +78,8 @@ const popupSlice = createSlice({
   },
 });
 
-// A bit of hack to determine if we're in a context where autosuggest is supported. Used to prevent autosuggest from
-// breaking service configuration.
+// Shouldn't be necessary given FieldRuntimeContext. But it's a good safety check because allowExpressions defaults
+// to true in the FieldRuntimeContext.
 const selectAnalysisSliceExists = (state: UnknownObject) =>
   Boolean(state.analysis);
 


### PR DESCRIPTION
## What does this PR do?

- Closes #7143 
- Disables the variable popover in contexts where expressions are not allowed

## Discussion

- The mod options editor uses: https://github.com/pixiebrix/pixiebrix-extension/blob/c0a22d7025a82894e2170b0d9011c23c5dd363f8/src/pageEditor/tabs/modOptionsValues/ModOptionsValuesEditor.tsx#L50-L50
- I considered adding a "allowVariablePopover" to the React Context. But using a combination of allowExpressions and the presence of the analysisSlice seems to cover our bases well

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/db341a60-b952-493d-8a61-0afed2646cc0)

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/882afdf4-a36e-4831-8c2d-1ce337d0ef16)

## Future Work

- NOTE: this bug still impacts the Current Inputs form: https://github.com/pixiebrix/pixiebrix-extension/issues/7148

## Checklist

- [ ] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @BLoe 
