### PR TITLE
automatically mark stale issues and prs weekly

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: "This issue is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 7 days."
-          stale-pr-message: "This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days."
-          close-issue-message: "This issue was closed because it has been stalled for 7 days with no activity."
-          close-pr-message: "This PR was closed because it has been stalled for 7 days with no activity."
+          stale-issue-message: "This issue will be closed in 7 days unless the stale label is removed, or a comment is added to the issue."
+          stale-pr-message: "This PR will be closed in 7 days unless the stale label is removed, or a comment is added to the PR."
+          close-issue-message: "This issue was closed because it has been stale for 7 days with no activity."
+          close-pr-message: "This PR was closed because it has been stale for 7 days with no activity."
           days-before-issue-stale: 365
           days-before-pr-stale: 30

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "0 0 * * SUN"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -1,0 +1,17 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "0 0 * * SUN"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: "This issue is stale because it has been open 365 days with no activity. Remove stale label or comment or this will be closed in 7 days."
+          stale-pr-message: "This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days."
+          close-issue-message: "This issue was closed because it has been stalled for 7 days with no activity."
+          close-pr-message: "This PR was closed because it has been stalled for 7 days with no activity."
+          days-before-issue-stale: 365
+          days-before-pr-stale: 30


### PR DESCRIPTION
## What does this PR do?

- Creates a regularly scheduled action to automatically label/close stale issues and prs after the configured timeframe

## Discussion

- Issues and PRs marked stale will be closed after 7 days if there is no activity (updates, comments, stale label removed, etc.)
- Issues are marked stale after 365 days of inactivity (will likely narrow that window over time)
- PRs are marked stale after 30 days of inactivity (will likely also narrow this window over time)

## Checklist

- [x] Designate a primary reviewer @mnholtz 
