### PR TITLE
#7157: fix regression in required field for HtmlRenderer

### DIFF
--- a/src/activation/useActivateRecipeWizard.test.tsx
+++ b/src/activation/useActivateRecipeWizard.test.tsx
@@ -57,9 +57,12 @@ describe("useActivateRecipeWizard", () => {
         defaultModDefinitionFactory({
           // Page Editor produces normalized form
           options: {
-            schema: propertiesToSchema({
-              foo: { type: "string" },
-            }),
+            schema: propertiesToSchema(
+              {
+                foo: { type: "string" },
+              },
+              ["foo"],
+            ),
           },
         }),
       ),
@@ -101,13 +104,16 @@ describe("useActivateRecipeWizard", () => {
 
   test("sets database preview initial value", async () => {
     const name = "Database";
-    const optionSchema = propertiesToSchema({
-      [name]: {
-        $ref: "https://app.pixiebrix.com/schemas/database#",
-        title: "Database",
-        format: "preview",
+    const optionSchema = propertiesToSchema(
+      {
+        [name]: {
+          $ref: "https://app.pixiebrix.com/schemas/database#",
+          title: "Database",
+          format: "preview",
+        },
       },
-    });
+      [name],
+    );
     const modDefinition = defaultModDefinitionFactory({
       options: {
         schema: optionSchema,
@@ -125,13 +131,16 @@ describe("useActivateRecipeWizard", () => {
 
   test("selects existing preview database", () => {
     const name = "Database";
-    const optionSchema = propertiesToSchema({
-      [name]: {
-        $ref: "https://app.pixiebrix.com/schemas/database#",
-        title: "Database",
-        format: "preview",
+    const optionSchema = propertiesToSchema(
+      {
+        [name]: {
+          $ref: "https://app.pixiebrix.com/schemas/database#",
+          title: "Database",
+          format: "preview",
+        },
       },
-    });
+      [name],
+    );
     const modDefinition = defaultModDefinitionFactory({
       options: {
         schema: optionSchema,

--- a/src/bricks/effects/tabs.ts
+++ b/src/bricks/effects/tabs.ts
@@ -29,7 +29,7 @@ export class ActivateTabEffect extends EffectABC {
     );
   }
 
-  inputSchema: Schema = propertiesToSchema({});
+  inputSchema: Schema = propertiesToSchema({}, []);
 
   async effect(): Promise<void> {
     await activateTab();
@@ -41,7 +41,7 @@ export class CloseTabEffect extends EffectABC {
     super("@pixiebrix/browser/close-tab", "Close browser tab", "Close the tab");
   }
 
-  inputSchema: Schema = propertiesToSchema({});
+  inputSchema: Schema = propertiesToSchema({}, []);
 
   async effect(): Promise<void> {
     await closeTab();

--- a/src/bricks/renderers/HtmlRenderer.ts
+++ b/src/bricks/renderers/HtmlRenderer.ts
@@ -33,23 +33,26 @@ class HtmlRenderer extends RendererABC {
     );
   }
 
-  inputSchema = propertiesToSchema({
-    html: {
-      title: "HTML",
-      type: "string",
-      description: "The HTML string to render",
+  inputSchema = propertiesToSchema(
+    {
+      html: {
+        title: "HTML",
+        type: "string",
+        description: "The HTML string to render",
+      },
+      /**
+       * @since 1.8.5
+       */
+      allowIFrames: {
+        title: "Allow IFrames",
+        type: "boolean",
+        description:
+          "Toggle to allow the iframe tag and generally safe frame attributes",
+        default: false,
+      },
     },
-    /**
-     * @since 1.8.5
-     */
-    allowIFrames: {
-      title: "Allow IFrames",
-      type: "boolean",
-      description:
-        "Toggle to allow the iframe tag and generally safe frame attributes",
-      default: false,
-    },
-  });
+    ["html"],
+  );
 
   async render({
     html,

--- a/src/bricks/transformers/parseCsv.ts
+++ b/src/bricks/transformers/parseCsv.ts
@@ -35,35 +35,41 @@ export class ParseCsv extends TransformerABC {
     return true;
   }
 
-  inputSchema: Schema = propertiesToSchema({
-    content: {
-      type: "string",
-      description: "The contents of the CSV file",
-    },
-  });
-
-  override outputSchema: Schema = propertiesToSchema({
-    data: {
-      type: "array",
-      description:
-        "The rows of the CSV, with a property for each header/column",
-      items: {
-        type: "object",
-        additionalProperties: true,
+  inputSchema: Schema = propertiesToSchema(
+    {
+      content: {
+        type: "string",
+        description: "The contents of the CSV file",
       },
     },
-    meta: {
-      type: "object",
-      properties: {
-        fieldNames: {
-          type: "array",
-          items: {
-            type: "string",
+    ["content"],
+  );
+
+  override outputSchema: Schema = propertiesToSchema(
+    {
+      data: {
+        type: "array",
+        description:
+          "The rows of the CSV, with a property for each header/column",
+        items: {
+          type: "object",
+          additionalProperties: true,
+        },
+      },
+      meta: {
+        type: "object",
+        properties: {
+          fieldNames: {
+            type: "array",
+            items: {
+              type: "string",
+            },
           },
         },
       },
     },
-  });
+    ["data", "meta"],
+  );
 
   async transform(
     { content }: BrickArgs<{ content: string }>,

--- a/src/bricks/transformers/parseDataUrl.ts
+++ b/src/bricks/transformers/parseDataUrl.ts
@@ -59,20 +59,23 @@ export class ParseDataUrl extends TransformerABC {
     ["url"],
   );
 
-  override outputSchema: Schema = propertiesToSchema({
-    mimeType: {
-      type: "string",
-      description: "The MIME media type",
+  override outputSchema: Schema = propertiesToSchema(
+    {
+      mimeType: {
+        type: "string",
+        description: "The MIME media type",
+      },
+      encoding: {
+        type: "string",
+        description: "The encoding used to decode the body",
+      },
+      body: {
+        type: "string",
+        description: "The body, decoded if decode flag was set",
+      },
     },
-    encoding: {
-      type: "string",
-      description: "The encoding used to decode the body",
-    },
-    body: {
-      type: "string",
-      description: "The body, decoded if decode flag was set",
-    },
-  });
+    ["mimeType", "encoding", "body"],
+  );
 
   // Pass true for decodeText to maintain backward compatability
   async transform({

--- a/src/bricks/transformers/prompt.ts
+++ b/src/bricks/transformers/prompt.ts
@@ -48,12 +48,15 @@ export class Prompt extends TransformerABC {
     ["message"],
   );
 
-  override outputSchema: Schema = propertiesToSchema({
-    value: {
-      type: "string",
-      description: "The user-provided value",
+  override outputSchema: Schema = propertiesToSchema(
+    {
+      value: {
+        type: "string",
+        description: "The user-provided value",
+      },
     },
-  });
+    ["value"],
+  );
 
   async transform({
     message,

--- a/src/bricks/transformers/randomNumber.ts
+++ b/src/bricks/transformers/randomNumber.ts
@@ -58,11 +58,14 @@ export class RandomNumber extends TransformerABC {
     [],
   );
 
-  override outputSchema = propertiesToSchema({
-    value: {
-      type: "number",
+  override outputSchema = propertiesToSchema(
+    {
+      value: {
+        type: "number",
+      },
     },
-  });
+    ["value"],
+  );
 
   async transform({
     lower = 0,

--- a/src/bricks/transformers/readable.ts
+++ b/src/bricks/transformers/readable.ts
@@ -43,27 +43,30 @@ export class Readable extends TransformerABC {
     return true;
   }
 
-  inputSchema: Schema = propertiesToSchema({});
+  inputSchema: Schema = propertiesToSchema({}, []);
 
-  override outputSchema: Schema = propertiesToSchema({
-    content: {
-      type: "string",
-      description: "HTML string of processed article content",
+  override outputSchema: Schema = propertiesToSchema(
+    {
+      content: {
+        type: "string",
+        description: "HTML string of processed article content",
+      },
+      textContent: {
+        type: "string",
+        description:
+          "Text content of the article, with all the HTML tags removed",
+      },
+      length: {
+        type: "number",
+        description: "Length of an article, in characters",
+      },
+      lang: {
+        type: "string",
+        description: "Language of the article",
+      },
     },
-    textContent: {
-      type: "string",
-      description:
-        "Text content of the article, with all the HTML tags removed",
-    },
-    length: {
-      type: "number",
-      description: "Length of an article, in characters",
-    },
-    lang: {
-      type: "string",
-      description: "Language of the article",
-    },
-  });
+    ["content", "textContent", "length", "lang"],
+  );
 
   async transform(
     _args: never,

--- a/src/bricks/transformers/selectElement.ts
+++ b/src/bricks/transformers/selectElement.ts
@@ -39,15 +39,18 @@ export class SelectElement extends TransformerABC {
     additionalProperties: false,
   };
 
-  override outputSchema: Schema = propertiesToSchema({
-    elements: {
-      type: "array",
-      description: "The array of element references selected",
-      items: {
-        $ref: "https://app.pixiebrix.com/schemas/element#",
+  override outputSchema: Schema = propertiesToSchema(
+    {
+      elements: {
+        type: "array",
+        description: "The array of element references selected",
+        items: {
+          $ref: "https://app.pixiebrix.com/schemas/element#",
+        },
       },
     },
-  });
+    ["elements"],
+  );
 
   async transform(): Promise<unknown> {
     // Include here to avoid error during header generation (which runs in node environment)

--- a/src/bricks/transformers/traverseElements.ts
+++ b/src/bricks/transformers/traverseElements.ts
@@ -43,34 +43,37 @@ export class TraverseElements extends TransformerABC {
     );
   }
 
-  inputSchema: Schema = propertiesToSchema({
-    selector: {
-      type: "string",
-      format: "selector",
-      description: "The selector/filter for the traversal",
+  inputSchema: Schema = propertiesToSchema(
+    {
+      selector: {
+        type: "string",
+        format: "selector",
+        description: "The selector/filter for the traversal",
+      },
+      traversal: {
+        type: "string",
+        description:
+          "jQuery traversal type: https://api.jquery.com/category/traversing/tree-traversal/",
+        default: "find",
+        enum: [
+          "closest",
+          "children",
+          "find",
+          "next",
+          "nextAll",
+          "nextUntil",
+          "parent",
+          "parents",
+          "parentsUntil",
+          "prev",
+          "prevAll",
+          "prevUntil",
+          "siblings",
+        ],
+      },
     },
-    traversal: {
-      type: "string",
-      description:
-        "jQuery traversal type: https://api.jquery.com/category/traversing/tree-traversal/",
-      default: "find",
-      enum: [
-        "closest",
-        "children",
-        "find",
-        "next",
-        "nextAll",
-        "nextUntil",
-        "parent",
-        "parents",
-        "parentsUntil",
-        "prev",
-        "prevAll",
-        "prevUntil",
-        "siblings",
-      ],
-    },
-  });
+    ["selector", "traversal"],
+  );
 
   override outputSchema: Schema = {
     $schema: "https://json-schema.org/draft/2019-09/schema#",

--- a/src/contrib/google/geocode.ts
+++ b/src/contrib/google/geocode.ts
@@ -110,16 +110,19 @@ export class GeocodeTransformer extends TransformerABC {
     );
   }
 
-  inputSchema: Schema = propertiesToSchema({
-    service: {
-      $ref: "https://app.pixiebrix.com/schemas/services/google/geocode-api",
-      description: "A Google Geocode service to authenticate the request",
+  inputSchema: Schema = propertiesToSchema(
+    {
+      service: {
+        $ref: "https://app.pixiebrix.com/schemas/services/google/geocode-api",
+        description: "A Google Geocode service to authenticate the request",
+      },
+      address: {
+        type: "string",
+        description: "The address or partial address",
+      },
     },
-    address: {
-      type: "string",
-      description: "The address or partial address",
-    },
-  });
+    ["service", "address"],
+  );
 
   async transform({
     service,

--- a/src/pageEditor/starterBricks/upgrade.test.ts
+++ b/src/pageEditor/starterBricks/upgrade.test.ts
@@ -56,11 +56,14 @@ describe("upgradePipelineToV3 tests", () => {
     "upgrade %s var",
     async (type) => {
       const id = defineBlock(
-        propertiesToSchema({
-          prop: {
-            type: type as any,
+        propertiesToSchema(
+          {
+            prop: {
+              type: type as any,
+            },
           },
-        }),
+          ["prop"],
+        ),
       );
 
       const upgraded = await upgradePipelineToV3([
@@ -85,14 +88,17 @@ describe("upgradePipelineToV3 tests", () => {
 
   test("upgrade literals", async () => {
     const id = defineBlock(
-      propertiesToSchema({
-        booleanProp: {
-          type: "boolean",
+      propertiesToSchema(
+        {
+          booleanProp: {
+            type: "boolean",
+          },
+          numberProp: {
+            type: "number",
+          },
         },
-        numberProp: {
-          type: "number",
-        },
-      }),
+        ["booleanProp", "numberProp"],
+      ),
     );
 
     const config = {
@@ -111,7 +117,7 @@ describe("upgradePipelineToV3 tests", () => {
   });
 
   test("upgrade conditional", async () => {
-    const id = defineBlock(propertiesToSchema({}));
+    const id = defineBlock(propertiesToSchema({}, []));
 
     const upgraded = await upgradePipelineToV3([
       { id, config: {}, if: "@foo" },
@@ -127,7 +133,7 @@ describe("upgradePipelineToV3 tests", () => {
   });
 
   test("upgrade nunjucks conditional", async () => {
-    const id = defineBlock(propertiesToSchema({}));
+    const id = defineBlock(propertiesToSchema({}, []));
 
     const upgraded = await upgradePipelineToV3([
       { id, config: {}, if: "{{ @foo }}", templateEngine: "nunjucks" },
@@ -144,12 +150,15 @@ describe("upgradePipelineToV3 tests", () => {
 
   test("ignore selector", async () => {
     const id = defineBlock(
-      propertiesToSchema({
-        selector: {
-          type: "string",
-          format: "selector",
+      propertiesToSchema(
+        {
+          selector: {
+            type: "string",
+            format: "selector",
+          },
         },
-      }),
+        ["selector"],
+      ),
     );
 
     const config = {
@@ -168,16 +177,19 @@ describe("upgradePipelineToV3 tests", () => {
 
   test("nested object", async () => {
     const id = defineBlock(
-      propertiesToSchema({
-        parent: {
-          type: "object",
-          properties: {
-            childString: {
-              type: "string",
+      propertiesToSchema(
+        {
+          parent: {
+            type: "object",
+            properties: {
+              childString: {
+                type: "string",
+              },
             },
           },
         },
-      }),
+        ["parent"],
+      ),
     );
 
     const upgraded = await upgradePipelineToV3([
@@ -374,19 +386,22 @@ describe("upgradePipelineToV3 tests", () => {
 
   test("nested array", async () => {
     const id = defineBlock(
-      propertiesToSchema({
-        parent: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              itemString: {
-                type: "string",
+      propertiesToSchema(
+        {
+          parent: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                itemString: {
+                  type: "string",
+                },
               },
             },
           },
         },
-      }),
+        ["parent"],
+      ),
     );
 
     const upgraded = await upgradePipelineToV3([
@@ -414,24 +429,27 @@ describe("upgradePipelineToV3 tests", () => {
 
   test("nested array with items array", async () => {
     const id = defineBlock(
-      propertiesToSchema({
-        parent: {
-          type: "array",
-          items: [
-            {
-              type: "string",
-            },
-            {
-              type: "object",
-              properties: {
-                itemString: {
-                  type: "string",
+      propertiesToSchema(
+        {
+          parent: {
+            type: "array",
+            items: [
+              {
+                type: "string",
+              },
+              {
+                type: "object",
+                properties: {
+                  itemString: {
+                    type: "string",
+                  },
                 },
               },
-            },
-          ],
+            ],
+          },
         },
-      }),
+        ["parent"],
+      ),
     );
 
     const upgraded = await upgradePipelineToV3([
@@ -465,24 +483,27 @@ describe("upgradePipelineToV3 tests", () => {
 
   test("nested array with items array and additionalItems", async () => {
     const id = defineBlock(
-      propertiesToSchema({
-        parent: {
-          type: "array",
-          items: [
-            {
-              type: "object",
-              properties: {
-                itemString: {
-                  type: "string",
+      propertiesToSchema(
+        {
+          parent: {
+            type: "array",
+            items: [
+              {
+                type: "object",
+                properties: {
+                  itemString: {
+                    type: "string",
+                  },
                 },
               },
+            ],
+            additionalItems: {
+              type: "string",
             },
-          ],
-          additionalItems: {
-            type: "string",
           },
         },
-      }),
+        ["parent"],
+      ),
     );
 
     const upgraded = await upgradePipelineToV3([
@@ -518,21 +539,24 @@ describe("upgradePipelineToV3 tests", () => {
 
   test("nested array with additionalItems and oneOf", async () => {
     const id = defineBlock(
-      propertiesToSchema({
-        parent: {
-          type: "array",
-          additionalItems: {
-            oneOf: [
-              {
-                type: "string",
-              },
-              {
-                type: "number",
-              },
-            ],
+      propertiesToSchema(
+        {
+          parent: {
+            type: "array",
+            additionalItems: {
+              oneOf: [
+                {
+                  type: "string",
+                },
+                {
+                  type: "number",
+                },
+              ],
+            },
           },
         },
-      }),
+        ["parent"],
+      ),
     );
 
     const upgraded = await upgradePipelineToV3([

--- a/src/pageEditor/tabs/effect/BrickConfiguration.test.tsx
+++ b/src/pageEditor/tabs/effect/BrickConfiguration.test.tsx
@@ -165,11 +165,14 @@ test.each`
   async ({ propertyName, expected }) => {
     const brick = brickFactory({
       [propertyName]: jest.fn(),
-      inputSchema: propertiesToSchema({
-        message: {
-          type: "string",
+      inputSchema: propertiesToSchema(
+        {
+          message: {
+            type: "string",
+          },
         },
-      }),
+        ["message"],
+      ),
     });
 
     brickRegistry.register([brick]);

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -37,7 +37,7 @@ export class ContextBrick extends BrickABC {
     ContextBrick.contexts = [];
   }
 
-  inputSchema = propertiesToSchema({});
+  inputSchema = propertiesToSchema({}, []);
 
   async run(_arg: BrickArgs, { ctxt }: BrickOptions) {
     ContextBrick.contexts.push(ctxt);
@@ -61,7 +61,7 @@ export class OptionsBrick extends BrickABC {
     OptionsBrick.options = [];
   }
 
-  inputSchema = propertiesToSchema({});
+  inputSchema = propertiesToSchema({}, []);
 
   async run(_arg: BrickArgs, options: BrickOptions): Promise<JsonValue> {
     OptionsBrick.options.push(options);
@@ -78,11 +78,14 @@ export class EchoBrick extends BrickABC {
     super(EchoBrick.BLOCK_ID, "Echo Brick");
   }
 
-  inputSchema = propertiesToSchema({
-    message: {
-      type: "string",
+  inputSchema = propertiesToSchema(
+    {
+      message: {
+        type: "string",
+      },
     },
-  });
+    ["message"],
+  );
 
   async run({ message }: BrickArgs<{ message: string }>) {
     return { message };
@@ -97,11 +100,14 @@ export class DeferredEchoBrick extends BrickABC {
     this.promiseOrFactory = promiseOrFactory;
   }
 
-  inputSchema = propertiesToSchema({
-    message: {
-      type: "string",
+  inputSchema = propertiesToSchema(
+    {
+      message: {
+        type: "string",
+      },
     },
-  });
+    ["message"],
+  );
 
   async run({ message }: BrickArgs<{ message: string }>) {
     if (isPromise(this.promiseOrFactory)) {
@@ -120,7 +126,7 @@ class RootAwareBrick extends BrickABC {
     super("test/root-aware", "Root Aware");
   }
 
-  inputSchema = propertiesToSchema({});
+  inputSchema = propertiesToSchema({}, []);
 
   async run(_arg: BrickArgs, { root }: BrickOptions) {
     return {
@@ -138,7 +144,7 @@ class TeapotBrick extends BrickABC {
     super("test/teapot", "Teapot Brick");
   }
 
-  inputSchema = propertiesToSchema({});
+  inputSchema = propertiesToSchema({}, []);
 
   async run() {
     return { prop: "I'm a teapot" };
@@ -150,9 +156,12 @@ class IdentityBrick extends BrickABC {
     super("test/identity", "Identity Brick");
   }
 
-  inputSchema = propertiesToSchema({
-    data: {},
-  });
+  inputSchema = propertiesToSchema(
+    {
+      data: {},
+    },
+    ["data"],
+  );
 
   async run(arg: BrickArgs) {
     return arg;
@@ -187,7 +196,7 @@ class ArrayBrick extends BrickABC {
     super("test/array", "Array Brick");
   }
 
-  inputSchema = propertiesToSchema({});
+  inputSchema = propertiesToSchema({}, []);
 
   async run() {
     return [{ value: "foo" }, { value: "bar" }];
@@ -228,9 +237,12 @@ class PipelineBrick extends BrickABC {
     super("test/pipeline", "Pipeline Brick");
   }
 
-  inputSchema = propertiesToSchema({
-    pipeline: pipelineSchema,
-  });
+  inputSchema = propertiesToSchema(
+    {
+      pipeline: pipelineSchema,
+    },
+    ["pipeline"],
+  );
 
   async run({ pipeline }: BrickArgs<{ pipeline: PipelineExpression }>) {
     return {

--- a/src/runtime/pipelineTests/root.test.ts
+++ b/src/runtime/pipelineTests/root.test.ts
@@ -39,7 +39,7 @@ class RootAwareBlock extends BrickABC {
     super("block/root-aware", "Root Aware Brick");
   }
 
-  inputSchema = propertiesToSchema({});
+  inputSchema = propertiesToSchema({}, []);
 
   override async isRootAware(): Promise<boolean> {
     return true;
@@ -58,7 +58,7 @@ class RootAwareReader extends ReaderABC {
     super("reader/root-aware", "Root Aware Reader");
   }
 
-  override inputSchema = propertiesToSchema({});
+  override inputSchema = propertiesToSchema({}, []);
 
   override async isRootAware(): Promise<boolean> {
     return true;

--- a/src/sidebar/activateMod/ActivateModPanel.test.tsx
+++ b/src/sidebar/activateMod/ActivateModPanel.test.tsx
@@ -159,18 +159,21 @@ describe("ActivateModPanel", () => {
 
     const { asFragment } = setupMocksAndRender({
       options: {
-        schema: propertiesToSchema({
-          foo: {
-            type: "string",
+        schema: propertiesToSchema(
+          {
+            foo: {
+              type: "string",
+            },
+            bar: {
+              type: "number",
+            },
+            testDatabase: {
+              $ref: "https://app.pixiebrix.com/schemas/database#",
+              title: "Test Database",
+            },
           },
-          bar: {
-            type: "number",
-          },
-          testDatabase: {
-            $ref: "https://app.pixiebrix.com/schemas/database#",
-            title: "Test Database",
-          },
-        }),
+          ["foo", "bar", "testDatabase"],
+        ),
       },
     });
 
@@ -202,13 +205,16 @@ describe("ActivateModPanel", () => {
   it("activates mod with database preview automatically and renders well-done page", async () => {
     const { asFragment } = setupMocksAndRender({
       options: {
-        schema: propertiesToSchema({
-          testDatabase: {
-            $ref: "https://app.pixiebrix.com/schemas/database#",
-            title: "Database",
-            format: "preview",
+        schema: propertiesToSchema(
+          {
+            testDatabase: {
+              $ref: "https://app.pixiebrix.com/schemas/database#",
+              title: "Database",
+              format: "preview",
+            },
           },
-        }),
+          ["testDatabase"],
+        ),
       },
     });
 

--- a/src/starterBricks/tourExtension.ts
+++ b/src/starterBricks/tourExtension.ts
@@ -129,11 +129,14 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
     unregisterTours(this.modComponents.map((x) => x.id));
   }
 
-  inputSchema: Schema = propertiesToSchema({
-    tour: {
-      $ref: "https://app.pixiebrix.com/schemas/effect#",
+  inputSchema: Schema = propertiesToSchema(
+    {
+      tour: {
+        $ref: "https://app.pixiebrix.com/schemas/effect#",
+      },
     },
-  });
+    ["tour"],
+  );
 
   async getBricks(
     extension: ResolvedModComponent<TourConfig>,

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -310,11 +310,14 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     this.modComponents.length = 0;
   }
 
-  inputSchema: Schema = propertiesToSchema({
-    action: {
-      $ref: "https://app.pixiebrix.com/schemas/effect#",
+  inputSchema: Schema = propertiesToSchema(
+    {
+      action: {
+        $ref: "https://app.pixiebrix.com/schemas/effect#",
+      },
     },
-  });
+    ["action"],
+  );
 
   async getBricks(
     extension: ResolvedModComponent<TriggerConfig>,

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -395,7 +395,10 @@ export function normalizeModOptionsDefinition(
       ? modDefinitionSchema
       : // Handle case where schema is just the properties. That's the old format. Technically, this isn't possible
         // given the type signature. But be defensive because this method processes user-defined mod definitions.
-        propertiesToSchema(modDefinitionSchema as SchemaProperties);
+        propertiesToSchema(
+          modDefinitionSchema as SchemaProperties,
+          Object.keys(modDefinitionSchema as SchemaProperties),
+        );
 
   const uiSchema: UiSchema = optionsDefinition.uiSchema ?? {};
 

--- a/src/validators/generic.ts
+++ b/src/validators/generic.ts
@@ -22,7 +22,7 @@ import {
 } from "@cfworker/json-schema";
 import { type Schema, type SchemaProperties } from "@/types/schemaTypes";
 import serviceRegistry from "@/integrations/registry";
-import { isEmpty, pickBy } from "lodash";
+import { pickBy } from "lodash";
 import { type UnknownObject } from "@/types/objectTypes";
 import urljoin from "url-join";
 import $RefParser from "@apidevtools/json-schema-ref-parser";
@@ -159,16 +159,13 @@ export async function validateInput(
  */
 export function propertiesToSchema(
   properties: SchemaProperties,
-  required?: string[],
+  required: string[],
 ): Schema {
   return {
     $schema: "https://json-schema.org/draft/2019-09/schema#",
     type: "object",
     properties,
-    required:
-      required === undefined && !isEmpty(properties)
-        ? Object.keys(properties)
-        : required,
+    required,
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #7157 

## Remaining Work

- [ ] Update tests to check for backward compatability

## Discussion

- The problem was caused by not passing the `required` arg to `propertiesToSchema`. We default the args to all be required in that case. 
- By making the arg required, we remove the possibility of this mistake being made again

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [ ] Designate a primary reviewer
