### PR TITLE
Enable RUM in the Page Editor and Sidebar frames

### DIFF
--- a/src/pageEditor/pageEditor.tsx
+++ b/src/pageEditor/pageEditor.tsx
@@ -32,11 +32,13 @@ import { watchNavigation } from "@/pageEditor/protocol";
 import { initToaster } from "@/utils/notify";
 import { markAppStart } from "@/utils/performance";
 import { initRuntimeLogging } from "@/development/runtimeLogging";
+import { initPerformanceMonitoring } from "@/telemetry/performance";
 
 markAppStart();
 
 void initMessengerLogging();
 void initRuntimeLogging();
+void initPerformanceMonitoring();
 registerMessenger();
 watchNavigation();
 initToaster();

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -196,8 +196,6 @@ const DataPanel: React.FC = () => {
     return true;
   }, [activeNodeId, activeElement, traces, brickConfig]);
 
-  console.log("*** blockConfig", brickConfig);
-
   return (
     <Tab.Container activeKey={activeTabKey} onSelect={onSelectTab}>
       <div className={dataPanelStyles.tabContainer}>

--- a/src/sidebar/sidebar.tsx
+++ b/src/sidebar/sidebar.tsx
@@ -33,6 +33,7 @@ import registerContribBlocks from "@/contrib/registerContribBlocks";
 import { initToaster } from "@/utils/notify";
 import { initRuntimeLogging } from "@/development/runtimeLogging";
 import { initCopilotMessenger } from "@/contrib/automationanywhere/aaFrameProtocol";
+import { initPerformanceMonitoring } from "@/telemetry/performance";
 
 function init(): void {
   ReactDOM.render(<App />, document.querySelector("#container"));
@@ -40,6 +41,7 @@ function init(): void {
 
 void initMessengerLogging();
 void initRuntimeLogging();
+void initPerformanceMonitoring();
 registerMessenger();
 registerContribBlocks();
 registerBuiltinBlocks();

--- a/src/telemetry/performance.ts
+++ b/src/telemetry/performance.ts
@@ -35,11 +35,9 @@ const RUM_FLAG = "telemetry-performance";
 export async function initPerformanceMonitoring(): Promise<void> {
   // Require the extension context because we don't want to track performance of the host sites
   expectContext("extension");
+
   forbidContext("contentScript");
-  // DataDog issue that RUM doesn't work in browser extension contexts, e.g., DevTools
-  // https://github.com/DataDog/browser-sdk/issues/798
-  forbidContext("devTools");
-  forbidContext("sidebar");
+  forbidContext("web");
   // There's no user interactions to track in the background page
   forbidContext("background");
 
@@ -82,6 +80,10 @@ export async function initPerformanceMonitoring(): Promise<void> {
     // List the URLs/origins for sending trace headers
     // https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum#usage
     allowedTracingUrls: [baseUrl],
+
+    // https://github.com/DataDog/browser-sdk/issues/798
+    // https://docs.datadoghq.com/real_user_monitoring/guide/monitor-electron-applications-using-browser-sdk/
+    allowFallbackToLocalStorage: true,
   });
 
   datadogRum.startSessionReplayRecording();


### PR DESCRIPTION
## What does this PR do?

- Enables Datadog RUM in the Page Editor and Sidebar

## Demo

- https://app.datadoghq.com/rum/sessions

## Checklist

- [x] Add tests: N/A
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: N/A
