### PR TITLE
Support markdown to plain text conversion in `@pixiebrix/convert` brick

### DIFF
--- a/src/bricks/transformers/convertDocument.test.ts
+++ b/src/bricks/transformers/convertDocument.test.ts
@@ -37,6 +37,21 @@ describe("convert document", () => {
     });
   });
 
+  it("converts markdown to TEXT", async () => {
+    const result = await brick.run(
+      unsafeAssumeValidArg({
+        input: "# hello",
+        sourceFormat: "markdown",
+        targetFormat: "text",
+      }),
+      brickOptionsFactory(),
+    );
+
+    expect(result).toEqual({
+      output: "HELLO",
+    });
+  });
+
   it("converts markdown HTML", async () => {
     const result = await brick.run(
       unsafeAssumeValidArg({

--- a/src/bricks/transformers/convertDocument.ts
+++ b/src/bricks/transformers/convertDocument.ts
@@ -53,11 +53,11 @@ async function convert({
   }
 
   if (sourceFormat === "html" && targetFormat === "text") {
-    const { convert } = await import(
+    const { convert: htmlToText } = await import(
       /* webpackChunkName: "html-to-text" */ "html-to-text"
     );
 
-    return convert(input);
+    return htmlToText(input);
   }
 
   if (sourceFormat === "markdown" && targetFormat === "html") {


### PR DESCRIPTION
## What does this PR do?

- Add support to the `@pixiebrix/convert` brick to convert markdown to text

## Discussion

- Another option would be to use a library like https://github.com/ejrbuss/markdown-to-txt#readme which uses a special marked configuration vs. chaining

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
