### PR TITLE
increase operations limit to 100, run nightly

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -2,7 +2,7 @@ name: "Close stale issues and PRs"
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * SUN"
+    - cron: "0 0 * * *" # every day at midnight
 
 permissions:
   issues: write
@@ -20,3 +20,5 @@ jobs:
           close-pr-message: "This PR was closed because it has been stale for 7 days with no activity."
           days-before-issue-stale: 365
           days-before-pr-stale: 30
+          # GitHub API rate limits number of operations daily, but we can afford to run more than the default 30 times per day
+          operations-per-run: 100


### PR DESCRIPTION
## What does this PR do?

- Increases the number of operations from 30 -> 100 (There's a GitHub rate limit, but we're well under the daily limit)
- Increases frequency of the run to daily at midnight

## Future Work

- Once we have gotten the number of stale issues under control, we'll look at reducing the number of operations and the frequency of the run
- Start running the action in our other repos

## Checklist

- [x] Designate a primary reviewer @mnholtz 
