### PR TITLE
#7152 Replace instance of fetch for `/api/bricks` with RTK Query Hook

### DIFF
--- a/src/extensionConsole/pages/brickEditor/Editor.test.tsx
+++ b/src/extensionConsole/pages/brickEditor/Editor.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useOpenEditorTab } from "@/extensionConsole/pages/brickEditor/Editor";
+import { editablePackageMetadataFactory } from "@/testUtils/factories/registryFactories";
+import { renderHook } from "@testing-library/react-hooks";
+import { getExtensionConsoleUrl } from "@/utils/extensionUtils";
+import { validateRegistryId } from "@/types/helpers";
+import notify from "@/utils/notify";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+
+const editablePackage = editablePackageMetadataFactory();
+jest.mock("@/services/api", () => ({
+  appApi: {
+    endpoints: {
+      getEditablePackages: {
+        useLazyQuery: jest.fn(() => [
+          jest.fn(() => {
+            return {
+              unwrap: jest.fn(() => [editablePackage]),
+            };
+          }),
+        ]),
+      },
+    },
+  },
+}));
+describe("Editor", () => {
+  describe("useOpenEditorTab hook", () => {
+    let windowOpenSpy: jest.SpyInstance;
+    let notifyWarningSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      windowOpenSpy = jest.spyOn(window, "open");
+      notifyWarningSpy = jest.spyOn(notify, "warning");
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("returns a function that opens the edit tab when brick is editable", async () => {
+      const { result } = renderHook(() => useOpenEditorTab());
+      const openEditorTab = result.current;
+      await openEditorTab(editablePackage.name);
+      expect(windowOpenSpy).toHaveBeenCalledWith(
+        getExtensionConsoleUrl(`workshop/bricks/${editablePackage.id}`),
+      );
+    });
+
+    it("returns a function that warns and does not open the edit tab with a brick is not editable", async () => {
+      const { result } = renderHook(() => useOpenEditorTab());
+      const openEditorTab = result.current;
+      await openEditorTab(validateRegistryId("@test/non-editable-registry-id"));
+      expect(windowOpenSpy).toHaveBeenCalledTimes(0);
+      expect(notifyWarningSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/extensionConsole/pages/brickEditor/Editor.tsx
+++ b/src/extensionConsole/pages/brickEditor/Editor.tsx
@@ -40,7 +40,7 @@ import notify from "@/utils/notify";
 import BrickHistory from "@/extensionConsole/pages/brickEditor/BrickHistory";
 import { useParams } from "react-router";
 import LogCard from "@/components/logViewer/LogCard";
-import { type Metadata } from "@/types/registryTypes";
+import { type Metadata, type RegistryId } from "@/types/registryTypes";
 import { isMac } from "@/utils/browserUtils";
 import { getExtensionConsoleUrl } from "@/utils/extensionUtils";
 import { appApi } from "@/services/api";
@@ -72,12 +72,12 @@ interface OwnProps {
   showLogs?: boolean;
 }
 
-function useOpenEditorTab() {
+export function useOpenEditorTab(): (id: RegistryId) => Promise<void> {
   const [getEditablePackages] =
     appApi.endpoints.getEditablePackages.useLazyQuery();
 
   return useCallback(
-    async (id: string) => {
+    async (brickId: RegistryId) => {
       let brick;
 
       try {
@@ -85,19 +85,20 @@ function useOpenEditorTab() {
           undefined,
           true,
         ).unwrap();
-        brick = editablePackages.find((x) => x.name === id);
+        brick = editablePackages.find((x) => x.name === brickId);
       } catch (error) {
         notify.error({
-          message: `Something went wrong while opening ${id}`,
+          message: `Something went wrong while opening ${brickId}`,
           error,
         });
+        return;
       }
 
       if (brick) {
-        console.debug("Open editor for brick: %s", id, { brick });
+        console.debug("Open editor for brick: %s", brickId, { brick });
         window.open(getExtensionConsoleUrl(`workshop/bricks/${brick.id}`));
       } else {
-        notify.warning(`You cannot edit brick: ${id}`);
+        notify.warning(`You cannot edit brick: ${brickId}`);
       }
     },
     [getEditablePackages],


### PR DESCRIPTION
## What does this PR do?

- Closes #7152
- It seems like this was the only place we use `fetch` in React code?

## Demo

- https://www.loom.com/share/45310d7368d74bb2b47cdd7f92eae554

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @grahamlangford 
