### PR TITLE
#7167 Fix missing brick config warnings

### DIFF
--- a/src/components/form/useFieldAnnotations.test.tsx
+++ b/src/components/form/useFieldAnnotations.test.tsx
@@ -152,11 +152,18 @@ describe("useFieldAnnotations", () => {
   test.each([
     {
       detail: { expression: toExpression("var", "@mod.foo") },
+      expectedNumberOfAnnotations: 0,
     },
-    { detail: toExpression("nunjucks", "@mod.bar") },
+    {
+      detail: toExpression("nunjucks", "@mod.bar"),
+      expectedNumberOfAnnotations: 0,
+    },
+    {
+      expectedNumberOfAnnotations: 1,
+    },
   ])(
     "does not show analysis error annotation when the annotation detail ($detail) is for a stale field value",
-    ({ detail }) => {
+    ({ detail, expectedNumberOfAnnotations }) => {
       useFormErrorSettingsMock.mockReturnValue({
         shouldUseAnalysis: true,
         showUntouchedErrors: true, // Show untouched errors, so we don't have to mark the field touched for a test
@@ -218,7 +225,7 @@ describe("useFieldAnnotations", () => {
       const annotations = renderHook(() => useFieldAnnotations(path), {
         wrapper,
       }).result.current;
-      expect(annotations).toHaveLength(0);
+      expect(annotations).toHaveLength(expectedNumberOfAnnotations);
     },
   );
 });

--- a/src/components/form/useFieldAnnotations.ts
+++ b/src/components/form/useFieldAnnotations.ts
@@ -94,6 +94,10 @@ function useFieldAnnotations(fieldPath: string): FieldAnnotation[] {
         // Check that the value from redux matches the current formik value before showing
         // See: https://github.com/pixiebrix/pixiebrix-extension/pull/6846
         .filter((annotation) => {
+          if (!annotation.detail) {
+            return true;
+          }
+
           if (
             typeof annotation.detail === "object" &&
             "expression" in annotation.detail

--- a/src/components/form/useFieldAnnotations.ts
+++ b/src/components/form/useFieldAnnotations.ts
@@ -87,16 +87,21 @@ function useFieldAnnotations(fieldPath: string): FieldAnnotation[] {
 
     return (
       analysisAnnotations
-        .filter((x) => !ignoreAnalysisIds.includes(x.analysisId))
+        .filter(
+          (annotation) => !ignoreAnalysisIds.includes(annotation.analysisId),
+        )
         // Annotations from redux can get out of sync with the current state of the field
         // Check that the value from redux matches the current formik value before showing
         // See: https://github.com/pixiebrix/pixiebrix-extension/pull/6846
-        .filter((x) => {
-          if (typeof x.detail === "object" && "expression" in x.detail) {
-            return x.detail.expression === value;
+        .filter((annotation) => {
+          if (
+            typeof annotation.detail === "object" &&
+            "expression" in annotation.detail
+          ) {
+            return annotation.detail.expression === value;
           }
 
-          return x.detail === value;
+          return annotation.detail === value;
         })
         .map(({ message, type, actions }) => {
           const fieldAnnotation: FieldAnnotation = {


### PR DESCRIPTION
## What does this PR do?

- Fixes #7167

## Discussion

Alternative approach I considered:
- Creating a dedicated prop on `AnalysisAnnotation` that contains the data that the annotation was produced for
    - This would cause us to make a change to all of the places we create annotation objects, so I decided to favor this simple fix over that approach for now

## Demo

- https://www.loom.com/share/1189868335994dfba1ab8577fb12a32b

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @grahamlangford 
