### PR TITLE
#7171: Correctly build the production version for MV3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,6 +71,7 @@ jobs:
       - run: npm ci
       - run: npm run build
         env:
+          MV: ${{ matrix.MV }}
           ROLLBAR_BROWSER_ACCESS_TOKEN: ${{ secrets.ROLLBAR_BROWSER_ACCESS_TOKEN }}
           ROLLBAR_POST_SERVER_ITEM_TOKEN: ${{ secrets.ROLLBAR_POST_SERVER_ITEM_TOKEN }}
           CHROME_MANIFEST_KEY: ${{ secrets.CHROME_MANIFEST_PROD_PUBLIC_KEY }}


### PR DESCRIPTION
- Closes #7171

I forgot an ENV on that specific build. I also verified the other 2 builds (build-staging-3, build-for-store-3) and they're fine

- https://github.com/pixiebrix/pixiebrix-extension/actions/runs/7309509823
- https://github.com/pixiebrix/pixiebrix-extension/actions/runs/7309521743

<img width="458" alt="Screenshot" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/ab4f57fb-0049-41a3-a348-0408603b2b85">

<img width="458" alt="Screenshot 3" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/2903b999-e48d-4084-b7c3-41352b6fcd48">

