### PR TITLE
#7196: Improve build artifacts naming for MV3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,11 @@ jobs:
 
     strategy:
       matrix:
-        MV: [2, 3]
+        include:
+          - MV: 2
+            PUBLIC_NAME: ""
+          - MV: 3
+            PUBLIC_NAME: "-beta"
 
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +81,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ fromJSON(env.PUBLIC_RELEASE)}}
         with:
-          name: build-staging-${{ matrix.MV }}
+          name: build-staging${{ matrix.PUBLIC_NAME }}
           path: |
             dist
             !dist/**/*.map

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           - MV: 2
             PUBLIC_NAME: ""
           - MV: 3
-            PUBLIC_NAME: "-beta"
+            PUBLIC_NAME: "-mv3"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,11 @@ jobs:
 
     strategy:
       matrix:
-        MV: [2, 3]
+        include:
+          - MV: 2
+            PUBLIC_NAME: ""
+          - MV: 3
+            PUBLIC_NAME: "-beta"
 
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +49,7 @@ jobs:
       - name: Save extension
         uses: actions/upload-artifact@v4
         with:
-          name: build-for-store-${{ matrix.MV }}
+          name: build-for-store${{ matrix.PUBLIC_NAME }}
           path: |
             dist
             !dist/**/*.map
@@ -60,7 +64,11 @@ jobs:
 
     strategy:
       matrix:
-        MV: [2, 3]
+        include:
+          - MV: 2
+            PUBLIC_NAME: ""
+          - MV: 3
+            PUBLIC_NAME: "-beta"
 
     steps:
       - uses: actions/checkout@v4
@@ -85,7 +93,7 @@ jobs:
       - name: Save extension
         uses: actions/upload-artifact@v4
         with:
-          name: build-production-${{ matrix.MV }}
+          name: build-production${{ matrix.PUBLIC_NAME }}
           path: |
             dist
             !dist/**/*.map

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
           - MV: 2
             PUBLIC_NAME: ""
           - MV: 3
-            PUBLIC_NAME: "-beta"
+            PUBLIC_NAME: "-mv3"
 
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
           - MV: 2
             PUBLIC_NAME: ""
           - MV: 3
-            PUBLIC_NAME: "-beta"
+            PUBLIC_NAME: "-mv3"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/7196

I think this makes it clear that the mv3 version is a beta/future/testing version and that mv2 is "normal"

