### PR TITLE
#7211: Drop overlapping URL patterns

### DIFF
--- a/scripts/__snapshots__/manifest.test.js.snap
+++ b/scripts/__snapshots__/manifest.test.js.snap
@@ -56,7 +56,7 @@ exports[`customizeManifest mv2 1`] = `
         "loadActivationEnhancements.js",
       ],
       "matches": [
-        "*://*/*",
+        "https://*/*",
       ],
       "run_at": "document_end",
     },
@@ -178,7 +178,7 @@ exports[`customizeManifest mv3 1`] = `
         "loadActivationEnhancements.js",
       ],
       "matches": [
-        "*://*/*",
+        "https://*/*",
       ],
       "run_at": "document_end",
     },

--- a/scripts/__snapshots__/manifest.test.js.snap
+++ b/scripts/__snapshots__/manifest.test.js.snap
@@ -47,20 +47,16 @@ exports[`customizeManifest mv2 1`] = `
       ],
       "match_about_blank": true,
       "matches": [
-        "https://*/*",
-        "http://*/*",
+        "*://*/*",
       ],
       "run_at": "document_idle",
     },
     {
-      "exclude_matches": [
-        "https://*.googleapis.com/*",
-      ],
       "js": [
         "loadActivationEnhancements.js",
       ],
       "matches": [
-        "https://*/*",
+        "*://*/*",
       ],
       "run_at": "document_end",
     },
@@ -97,7 +93,6 @@ exports[`customizeManifest mv2 1`] = `
     "tabs",
     "webNavigation",
     "contextMenus",
-    "*://*/*",
     "<all_urls>",
   ],
   "sandbox": {
@@ -174,20 +169,16 @@ exports[`customizeManifest mv3 1`] = `
       ],
       "match_about_blank": true,
       "matches": [
-        "https://*/*",
-        "http://*/*",
+        "*://*/*",
       ],
       "run_at": "document_idle",
     },
     {
-      "exclude_matches": [
-        "https://*.googleapis.com/*",
-      ],
       "js": [
         "loadActivationEnhancements.js",
       ],
       "matches": [
-        "https://*/*",
+        "*://*/*",
       ],
       "run_at": "document_end",
     },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,7 @@
   "content_security_policy": "script-src 'self' 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' http: https:; object-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; frame-src 'self' https:",
   "content_scripts": [
     {
-      "matches": ["https://*/*", "http://*/*"],
+      "matches": ["*://*/*"],
       "exclude_matches": ["https://*.googleapis.com/*"],
       "js": ["contentScript.js"],
       "css": ["contentScript.css"],
@@ -30,9 +30,8 @@
       "run_at": "document_idle"
     },
     {
-      "matches": ["https://*/*"],
+      "matches": ["*://*/*"],
       "js": ["loadActivationEnhancements.js"],
-      "exclude_matches": ["https://*.googleapis.com/*"],
       "run_at": "document_end"
     }
   ],
@@ -47,7 +46,6 @@
     "tabs",
     "webNavigation",
     "contextMenus",
-    "*://*/*",
     "<all_urls>"
   ],
   "devtools_page": "devtools.html",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -30,7 +30,7 @@
       "run_at": "document_idle"
     },
     {
-      "matches": ["*://*/*"],
+      "matches": ["https://*/*"],
       "js": ["loadActivationEnhancements.js"],
       "run_at": "document_end"
     }

--- a/src/testUtils/factories/modDefinitionFactories.ts
+++ b/src/testUtils/factories/modDefinitionFactories.ts
@@ -170,7 +170,7 @@ export const innerStarterBrickModDefinitionFactory = ({
         definition: {
           type: "menuItem",
           isAvailable: {
-            matchPatterns: ["*://*/*"],
+            matchPatterns: ["https://*/*"],
             urlPatterns: [],
             selectors: [],
           },

--- a/src/testUtils/factories/modDefinitionFactories.ts
+++ b/src/testUtils/factories/modDefinitionFactories.ts
@@ -170,7 +170,7 @@ export const innerStarterBrickModDefinitionFactory = ({
         definition: {
           type: "menuItem",
           isAvailable: {
-            matchPatterns: ["https://*/*"],
+            matchPatterns: ["*://*/*"],
             urlPatterns: [],
             selectors: [],
           },

--- a/src/utils/extensionUtils.ts
+++ b/src/utils/extensionUtils.ts
@@ -94,7 +94,7 @@ export class RuntimeNotFoundError extends Error {
 
 export async function getTabsWithAccess(): Promise<TabId[]> {
   const tabs = await browser.tabs.query({
-    url: ["https://*/*", "http://*/*"],
+    url: ["*://*/*"],
     discarded: false,
   });
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- The type isn't tight enough for tabs.query()


### PR DESCRIPTION
## What does this PR do?


Mentioned in the previous PR, this PR cleans up some patterns left behind during the `all_urls` change. See review for details.

If left unsolved, it could cause trouble with:

- https://github.com/pixiebrix/pixiebrix-extension/pull/6851

## Checklist

- [x] Designate a primary reviewer: @twschiller 
