### PR TITLE
 Fix `Check Updates` button in options

### DIFF
--- a/src/contentScript/sidebarDomControllerLite.ts
+++ b/src/contentScript/sidebarDomControllerLite.ts
@@ -51,7 +51,7 @@ function storeOriginalCSSOnce() {
 }
 
 function setSidebarWidth(pixels: number): void {
-  html.style.setProperty(SIDEBAR_WIDTH_CSS_PROPERTY, CSS.px(pixels));
+  html.style.setProperty(SIDEBAR_WIDTH_CSS_PROPERTY, `${pixels}px`);
 }
 
 /**

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -180,19 +180,6 @@ interface Promise<T> {
   ): Promise<T | TResult>;
 }
 
-interface ErrorOptions {
-  cause?: unknown;
-}
-
-interface Error {
-  cause?: unknown;
-}
-
-interface ErrorConstructor {
-  new (message?: string, options?: ErrorOptions): Error;
-  (message?: string, options?: ErrorOptions): Error;
-}
-
 // This changes the return value from `any` to `JsonValue`.
 // "total-typescript" sets it to `unknown` but `JsonValue` is more useful and accurate.
 interface JSON {
@@ -206,10 +193,6 @@ interface JSON {
     text: string,
     reviver?: (this: unknown, key: string, value: unknown) => unknown,
   ): import("type-fest").JsonValue;
-}
-
-declare namespace CSS {
-  function px(length: number): string;
 }
 
 // These types are unnecessarily loose

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -27,7 +27,7 @@ https://github.com/typescript-eslint/typescript-eslint/issues/3295#issuecomment-
 // Improve standard type library https://www.totaltypescript.com/ts-reset
 /// <reference types="@total-typescript/ts-reset" />
 
-type Browser = import("webextension-polyfill").Browser;
+declare const browser: import("webextension-polyfill").Browser;
 
 // https://stackoverflow.com/questions/43638454/webpack-typescript-image-import
 declare module "*.svg" {
@@ -207,29 +207,6 @@ interface JSON {
     reviver?: (this: unknown, key: string, value: unknown) => unknown,
   ): import("type-fest").JsonValue;
 }
-
-// TODO: This overrides Firefox’ types. It's possible that the return types are different between Firefox and Chrome
-interface ExtendedRuntime
-  extends Omit<Browser["runtime"], "requestUpdateCheck"> {
-  /*
-   * Requests an update check for this app/extension.
-   */
-  requestUpdateCheck(): Promise<chrome.runtime.RequestUpdateCheckStatus>;
-}
-
-// Temporary type until officially added
-type BrowserStorage = Browser["storage"];
-interface ExtendedStorage extends BrowserStorage {
-  session: Browser.storage.local;
-}
-
-// @ts-expect-error See Firefox/requestUpdateCheck-related comment above
-interface ChromeifiedBrowser extends Browser {
-  runtime: ExtendedRuntime;
-  storage: ExtendedStorage;
-}
-
-declare const browser: ChromeifiedBrowser;
 
 declare namespace CSS {
   function px(length: number): string;

--- a/src/utils/extensionUtils.ts
+++ b/src/utils/extensionUtils.ts
@@ -19,6 +19,7 @@ import pTimeout from "p-timeout";
 import { foreverPendingPromise } from "@/utils/promiseUtils";
 import { type Promisable } from "type-fest";
 import { isScriptableUrl } from "webext-content-scripts";
+import { Runtime } from "webextension-polyfill";
 
 type TabId = number;
 
@@ -71,10 +72,9 @@ export function getExtensionVersion(): string {
 }
 
 /** If no update is available and downloaded yet, it will return a string explaining why */
-export async function reloadIfNewVersionIsReady(): Promise<
-  "throttled" | "no_update"
-> {
-  const status = await browser.runtime.requestUpdateCheck();
+export async function reloadIfNewVersionIsReady(): Promise<Runtime.RequestUpdateCheckStatus> {
+  const [status] = await browser.runtime.requestUpdateCheck();
+
   if (status === "update_available") {
     browser.runtime.reload();
 
@@ -85,7 +85,7 @@ export async function reloadIfNewVersionIsReady(): Promise<
     });
   }
 
-  return status as "throttled" | "no_update";
+  return status;
 }
 
 export class RuntimeNotFoundError extends Error {

--- a/src/utils/extensionUtils.ts
+++ b/src/utils/extensionUtils.ts
@@ -19,7 +19,7 @@ import pTimeout from "p-timeout";
 import { foreverPendingPromise } from "@/utils/promiseUtils";
 import { type Promisable } from "type-fest";
 import { isScriptableUrl } from "webext-content-scripts";
-import { Runtime } from "webextension-polyfill";
+import { type Runtime } from "webextension-polyfill";
 
 type TabId = number;
 


### PR DESCRIPTION
## What does this PR do?

This method and its types were wrong and it has likely been returning the wrong result for a while. I wrote the previous code a long time ago so it's possible that something has changed in the meanwhile (potentially in the polyfill)

This resulted in the button always showing "No updates available", and never "Too many requests" (throttled) for example. Now you can correctly see the second message on the second click.

I also dropped some outdated global types while I was there.

## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
