### PR TITLE
#7174: Include "mv3" in package version

### DIFF
--- a/scripts/manifest.mjs
+++ b/scripts/manifest.mjs
@@ -26,16 +26,17 @@ function getVersion(env) {
 }
 
 function getVersionName(env, isProduction) {
+  const mv3 = env.MV === "3" ? "-mv3" : "";
   if (env.ENVIRONMENT === "staging") {
     // Staging builds (i.e., from CI) are production builds, so check ENVIRONMENT first
-    return `${getVersion(env)}-alpha+${env.SOURCE_VERSION}`;
+    return `${getVersion(env)}${mv3}-alpha+${env.SOURCE_VERSION}`;
   }
 
   if (isProduction) {
-    return env.npm_package_version;
+    return `${env.npm_package_version}${mv3}`;
   }
 
-  return `${env.npm_package_version}-local+${new Date().toISOString()}`;
+  return `${env.npm_package_version}${mv3}-local+${new Date().toISOString()}`;
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

This was mentioned as a possible solution to:

- #7174

### `npm run build:webpack`

<img width="204" alt="Screenshot 6" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/3e7b7794-5d3a-4bd4-87fc-9c0749104c88">

### `MV=3 npm run build:webpack`

Appended. Looks good?

<img width="225" alt="Screenshot" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/bad8fe96-d31c-4743-a312-767d592d05e1">


## Checklist

- [x] Designate a primary reviewer: @twschiller 
