### PR TITLE
#7225: sort mod launcher panels in alphabetical order

### DIFF
--- a/src/sidebar/modLauncher/ActiveSidebarModsList.tsx
+++ b/src/sidebar/modLauncher/ActiveSidebarModsList.tsx
@@ -16,14 +16,14 @@
  */
 import styles from "@/sidebar/modLauncher/ActiveSidebarModsList.module.scss";
 
-import React from "react";
+import React, { useMemo } from "react";
 import { type Mod, type ModViewItem } from "@/types/modTypes";
 import { ListGroup, Row } from "react-bootstrap";
 import useModViewItems from "@/mods/useModViewItems";
 import { type Column, useTable } from "react-table";
 import Loader from "@/components/Loader";
 import ActiveSidebarModsListItem from "@/sidebar/modLauncher/ActiveSidebarModsListItem";
-import { isEmpty } from "lodash";
+import { isEmpty, sortBy } from "lodash";
 import workshopIllustration from "@img/workshop.svg";
 
 import { MARKETPLACE_URL } from "@/urlConstants";
@@ -36,6 +36,7 @@ import {
   isUnavailableMod,
 } from "@/utils/modUtils";
 import useIsEnterpriseUser from "@/hooks/useIsEnterpriseUser";
+import { splitStartingEmoji } from "@/utils/stringUtils";
 
 const columns: Array<Column<PanelEntry>> = [
   {
@@ -139,9 +140,17 @@ export const ActiveSidebarModsList: React.FunctionComponent<{
       modViewItem.status === "Active" && !modViewItem.unavailable,
   );
 
+  const sortedSidebarPanels = useMemo(
+    () =>
+      sortBy(sidebarPanels, (panel) =>
+        splitStartingEmoji(panel.heading).rest.trim(),
+      ),
+    [sidebarPanels],
+  );
+
   const tableInstance = useTable<PanelEntry>({
     columns,
-    data: sidebarPanels,
+    data: sortedSidebarPanels,
   });
 
   const renderBody = isEmpty(sidebarPanels) ? (

--- a/src/sidebar/modLauncher/ModLauncher.test.tsx
+++ b/src/sidebar/modLauncher/ModLauncher.test.tsx
@@ -49,4 +49,28 @@ describe("ModLauncher", () => {
     await expect(screen.findByText("🎁")).resolves.toBeInTheDocument();
     expect(screen.queryByText("🎁 Test Mod")).toBeNull();
   });
+
+  it("sorts panels", async () => {
+    render(<ModLauncher />, {
+      setupRedux(dispatch) {
+        dispatch(
+          sidebarSlice.actions.setPanels({
+            panels: [
+              sidebarEntryFactory("panel", { heading: "🎁 Test Mod" }),
+              sidebarEntryFactory("panel", { heading: "AAA Mod" }),
+            ],
+          }),
+        );
+      },
+    });
+
+    const testMod = await screen.findByText("Test Mod");
+    const aaaMod = await screen.findByText("AAA Mod");
+
+    // Reports the position of its argument node relative to the node on which it is called.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
+    expect(aaaMod.compareDocumentPosition(testMod)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
 });


### PR DESCRIPTION
## What does this PR do?

- Closes #7225 
- Sorts panels in launcher in alphabetical order (ignoring emoji)

## Future Work

- Consider adding matcher for asserting relative position: https://github.com/testing-library/jest-dom/issues/459

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @BLoe 
