### PR TITLE
Knip unused class members

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
       - run: npm install -D knip
       # Do a run without an exit code. Knip's "warn" setting is not working for files and devDependencies.
       - run: npm run dead-code -- --config knip.mjs --no-exit-code
-      - run: npm run dead-code -- --config knip.mjs --include files,duplicates,dependencies,classMembers,binaries
+      - run: npm run dead-code -- --config knip.mjs --include files,duplicates,dependencies,classMembers,binaries,enumMembers,nsTypes
 
   # https://pre-commit.com/#usage-in-continuous-integration
   prettier:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
       - run: npm install -D knip
       # Do a run without an exit code. Knip's "warn" setting is not working for files and devDependencies.
       - run: npm run dead-code -- --config knip.mjs --no-exit-code
-      - run: npm run dead-code -- --config knip.mjs --include files,duplicates,dependencies
+      - run: npm run dead-code -- --config knip.mjs --include files,duplicates,dependencies,classMembers,binaries
 
   # https://pre-commit.com/#usage-in-continuous-integration
   prettier:

--- a/knip.mjs
+++ b/knip.mjs
@@ -65,14 +65,14 @@ const knipConfig = {
     exports: "warn",
     nsExports: "warn",
     types: "warn",
-    nsTypes: "warn",
-    enumMembers: "warn",
     // Incrementally enforce rules over time
     files: "error",
     duplicates: "error",
     dependencies: "error",
+    enumMembers: "error",
     classMembers: "error",
     binaries: "error",
+    nsTypes: "error",
   },
 };
 

--- a/knip.mjs
+++ b/knip.mjs
@@ -61,19 +61,18 @@ const knipConfig = {
   rules: {
     // Issue Type reference: https://knip.dev/reference/issue-types/
     unlisted: "warn",
-    binaries: "warn",
     unresolved: "warn",
     exports: "warn",
     nsExports: "warn",
     types: "warn",
     nsTypes: "warn",
     enumMembers: "warn",
-    // Warns on uiSchema/defaultOutputKey
-    classMembers: "warn",
     // Incrementally enforce rules over time
     files: "error",
     duplicates: "error",
     dependencies: "error",
+    classMembers: "error",
+    binaries: "error",
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,7 +236,6 @@
         "jest-webextension-mock": "^3.8.9",
         "jsdom": "^23.0.1",
         "jsdom-testing-mocks": "^1.11.0",
-        "knip": "^3.9.0",
         "min-document": "^2.19.0",
         "mini-css-extract-plugin": "^2.6.1",
         "mockdate": "^3.0.5",
@@ -2603,45 +2602,6 @@
       "version": "0.3.1",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
-    "node_modules/@ericcornelissen/bash-parser": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@ericcornelissen/bash-parser/-/bash-parser-0.5.2.tgz",
-      "integrity": "sha512-4pIMTa1nEFfMXitv7oaNEWOdM+zpOZavesa5GaiWTgda6Zk32CFGxjUp/iIaN0PwgUW1yTq/fztSjbpE8SLGZQ==",
-      "dev": true,
-      "dependencies": {
-        "array-last": "^1.1.1",
-        "babylon": "^6.9.1",
-        "compose-function": "^3.0.3",
-        "deep-freeze": "0.0.1",
-        "filter-iterator": "0.0.1",
-        "filter-obj": "^1.1.0",
-        "has-own-property": "^0.1.0",
-        "identity-function": "^1.0.0",
-        "is-iterable": "^1.1.0",
-        "iterable-lookahead": "^1.0.0",
-        "lodash.curry": "^4.1.1",
-        "magic-string": "^0.16.0",
-        "map-obj": "^2.0.0",
-        "object-pairs": "^0.1.0",
-        "object-values": "^1.0.0",
-        "reverse-arguments": "^1.0.0",
-        "shell-quote-word": "^1.0.1",
-        "to-pascal-case": "^1.0.0",
-        "unescape-js": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@ericcornelissen/bash-parser/node_modules/magic-string": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz",
-      "integrity": "sha512-c4BEos3y6G2qO0B9X7K0FVLOPT9uGrjYwYRLFmDqyl5YMboUviyecnXWp94fJTSMwPw2/sf+CEYt5AGpmklkkQ==",
-      "dev": true,
-      "dependencies": {
-        "vlq": "^0.2.1"
-      }
-    },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
@@ -4394,255 +4354,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@npmcli/git": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.3.tgz",
-      "integrity": "sha512-UZp9NwK+AynTrKvHn5k3KviW/hA5eENmFsu3iAPe7sWRt0lFUdsY/wXIYjpDFe7cdSNwOIzbObfwgt6eL5/2zw==",
-      "dev": true,
-      "dependencies": {
-        "@npmcli/promise-spawn": "^7.0.0",
-        "lru-cache": "^10.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "proc-log": "^3.0.0",
-        "promise-inflight": "^1.0.1",
-        "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
-        "which": "^4.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@npmcli/git/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@npmcli/git/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@npmcli/map-workspaces": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-3.0.4.tgz",
-      "integrity": "sha512-Z0TbvXkRbacjFFLpVpV0e2mheCh+WzQpcqL+4xp49uNJOxOnIAPZyXtUxZ5Qn3QBTGKA11Exjd9a5411rBrhDg==",
-      "dev": true,
-      "dependencies": {
-        "@npmcli/name-from-folder": "^2.0.0",
-        "glob": "^10.2.2",
-        "minimatch": "^9.0.0",
-        "read-package-json-fast": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@npmcli/map-workspaces/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@npmcli/name-from-folder": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-2.0.0.tgz",
-      "integrity": "sha512-pwK+BfEBZJbKdNYpHHRTNBwBoqrN/iIMO0AiGvYsp3Hoaq0WbgGSWQR6SCldZovoDpY3yje5lkFUe6gsDgJ2vg==",
-      "dev": true,
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@npmcli/package-json": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.0.tgz",
-      "integrity": "sha512-OI2zdYBLhQ7kpNPaJxiflofYIpkNLi+lnGdzqUOfRmCF3r2l1nadcjtCYMJKv/Utm/ZtlffaUuTiAktPHbc17g==",
-      "dev": true,
-      "dependencies": {
-        "@npmcli/git": "^5.0.0",
-        "glob": "^10.2.2",
-        "hosted-git-info": "^7.0.0",
-        "json-parse-even-better-errors": "^3.0.0",
-        "normalize-package-data": "^6.0.0",
-        "proc-log": "^3.0.0",
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/hosted-git-info": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
-      "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
-      "dev": true,
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/normalize-package-data": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
-      "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@npmcli/promise-spawn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.0.tgz",
-      "integrity": "sha512-wBqcGsMELZna0jDblGd7UXgOby45TQaMWmbFwWX+SEotk4HV6zG2t6rT9siyLhPk4P6YYqgfL1UO8nMWDBVJXQ==",
-      "dev": true,
-      "dependencies": {
-        "which": "^4.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@npmcli/promise-spawn/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
@@ -4662,7 +4373,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=14"
       }
@@ -4774,326 +4485,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@pnpm/constants": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@pnpm/constants/-/constants-7.1.1.tgz",
-      "integrity": "sha512-31pZqMtjwV+Vaq7MaPrT1EoDFSYwye3dp6BiHIGRJmVThCQwySRKM7hCvqqI94epNkqFAAYoWrNynWoRYosGdw==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.14"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pnpm"
-      }
-    },
-    "node_modules/@pnpm/core-loggers": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@pnpm/core-loggers/-/core-loggers-9.0.6.tgz",
-      "integrity": "sha512-iK67SGbp+06bA/elpg51wygPFjNA7JKHtKkpLxqXXHw+AjFFBC3f2OznJsCIuDK6HdGi5UhHLYqo5QxJ2gMqJQ==",
-      "dev": true,
-      "dependencies": {
-        "@pnpm/types": "9.4.2"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pnpm"
-      },
-      "peerDependencies": {
-        "@pnpm/logger": "^5.0.0"
-      }
-    },
-    "node_modules/@pnpm/error": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@pnpm/error/-/error-5.0.2.tgz",
-      "integrity": "sha512-0TEm+tWNYm+9uh6DSKyRbv8pv/6b4NL0PastLvMxIoqZbBZ5Zj1cYi332R9xsSUi31ZOsu2wpgn/bC7DA9hrjg==",
-      "dev": true,
-      "dependencies": {
-        "@pnpm/constants": "7.1.1"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pnpm"
-      }
-    },
-    "node_modules/@pnpm/fetching-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@pnpm/fetching-types/-/fetching-types-5.0.0.tgz",
-      "integrity": "sha512-o9gdO1v8Uc5P2fBBuW6GSpfTqIivQmQlqjQJdFiQX0m+tgxlrMRneIg392jZuc6fk7kFqjLheInlslgJfwY+4Q==",
-      "dev": true,
-      "dependencies": {
-        "@zkochan/retry": "^0.2.0",
-        "node-fetch": "3.0.0-beta.9"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pnpm"
-      }
-    },
-    "node_modules/@pnpm/fetching-types/node_modules/node-fetch": {
-      "version": "3.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
-      "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
-      "dev": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^2.1.1"
-      },
-      "engines": {
-        "node": "^10.17 || >=12.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/@pnpm/graceful-fs": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@pnpm/graceful-fs/-/graceful-fs-3.2.0.tgz",
-      "integrity": "sha512-vRoXJxscDpHak7YE9SqCkzfrayn+Lw+YueOeHIPEqkgokrHeYgYeONoc2kGh0ObHaRtNSsonozVfJ456kxLNvA==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.11"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pnpm"
-      }
-    },
-    "node_modules/@pnpm/logger": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@pnpm/logger/-/logger-5.0.0.tgz",
-      "integrity": "sha512-YfcB2QrX+Wx1o6LD1G2Y2fhDhOix/bAY/oAnMpHoNLsKkWIRbt1oKLkIFvxBMzLwAEPqnYWguJrYC+J6i4ywbw==",
-      "dev": true,
-      "dependencies": {
-        "bole": "^5.0.0",
-        "ndjson": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/@pnpm/npm-package-arg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pnpm/npm-package-arg/-/npm-package-arg-1.0.0.tgz",
-      "integrity": "sha512-oQYP08exi6mOPdAZZWcNIGS+KKPsnNwUBzSuAEGWuCcqwMAt3k/WVCqVIXzBxhO5sP2b43og69VHmPj6IroKqw==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
-    "node_modules/@pnpm/npm-package-arg/node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@pnpm/npm-package-arg/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@pnpm/npm-package-arg/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "node_modules/@pnpm/npm-resolver": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/@pnpm/npm-resolver/-/npm-resolver-18.0.2.tgz",
-      "integrity": "sha512-YfjSHpaFgYvqMomKNLMa49pVabGvaSeEBX3J9j1v7FGtzad7SPZ+BH7ObPLHkIm4rA9K5zvuTJ8gBwMiGQJcQg==",
-      "dev": true,
-      "dependencies": {
-        "@pnpm/core-loggers": "9.0.6",
-        "@pnpm/error": "5.0.2",
-        "@pnpm/fetching-types": "5.0.0",
-        "@pnpm/graceful-fs": "3.2.0",
-        "@pnpm/resolve-workspace-range": "5.0.1",
-        "@pnpm/resolver-base": "11.0.2",
-        "@pnpm/types": "9.4.2",
-        "@zkochan/retry": "^0.2.0",
-        "encode-registry": "^3.0.1",
-        "load-json-file": "^6.2.0",
-        "lru-cache": "^10.0.2",
-        "normalize-path": "^3.0.0",
-        "p-limit": "^3.1.0",
-        "p-memoize": "4.0.1",
-        "parse-npm-tarball-url": "^3.0.0",
-        "path-temp": "^2.1.0",
-        "ramda": "npm:@pnpm/ramda@0.28.1",
-        "rename-overwrite": "^5.0.0",
-        "semver": "^7.5.4",
-        "ssri": "10.0.5",
-        "version-selector-type": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pnpm"
-      },
-      "peerDependencies": {
-        "@pnpm/logger": "^5.0.0"
-      }
-    },
-    "node_modules/@pnpm/npm-resolver/node_modules/lru-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
-      "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
-      }
-    },
-    "node_modules/@pnpm/npm-resolver/node_modules/mem": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.1.tgz",
-      "integrity": "sha512-Ci6bIfq/UgcxPTYa8dQQ5FY3BzKkT894bwXWXxC/zqs0XgMO2cT20CGkOqda7gZNkmK5VP4x89IGZ6K7hfbn3Q==",
-      "dev": true,
-      "dependencies": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/mem?sponsor=1"
-      }
-    },
-    "node_modules/@pnpm/npm-resolver/node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@pnpm/npm-resolver/node_modules/p-memoize": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-4.0.1.tgz",
-      "integrity": "sha512-km0sP12uE0dOZ5qP+s7kGVf07QngxyG0gS8sYFvFWhqlgzOsSy+m71aUejf/0akxj5W7gE//2G74qTv6b4iMog==",
-      "dev": true,
-      "dependencies": {
-        "mem": "^6.0.1",
-        "mimic-fn": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/p-memoize?sponsor=1"
-      }
-    },
-    "node_modules/@pnpm/npm-resolver/node_modules/ramda": {
-      "name": "@pnpm/ramda",
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@pnpm/ramda/-/ramda-0.28.1.tgz",
-      "integrity": "sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@pnpm/resolve-workspace-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@pnpm/resolve-workspace-range/-/resolve-workspace-range-5.0.1.tgz",
-      "integrity": "sha512-yQ0pMthlw8rTgS/C9hrjne+NEnnSNevCjtdodd7i15I59jMBYciHifZ/vjg0NY+Jl+USTc3dBE+0h/4tdYjMKg==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pnpm"
-      }
-    },
-    "node_modules/@pnpm/resolver-base": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@pnpm/resolver-base/-/resolver-base-11.0.2.tgz",
-      "integrity": "sha512-g6VXB/LK7DugXiCPG62qmYtuypVt44nnwyXYkTv86FKudI5d5Wy1FLkYAYKCj+No9h1GG3eSSwGH1NL0y4IbYg==",
-      "dev": true,
-      "dependencies": {
-        "@pnpm/types": "9.4.2"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pnpm"
-      }
-    },
-    "node_modules/@pnpm/types": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@pnpm/types/-/types-9.4.2.tgz",
-      "integrity": "sha512-g1hcF8Nv4gd76POilz9gD4LITAPXOe5nX4ijgr8ixCbLQZfcpYiMfJ+C1RlMNRUDo8vhlNB4O3bUlxmT6EAQXA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.14"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pnpm"
-      }
-    },
-    "node_modules/@pnpm/workspace.pkgs-graph": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@pnpm/workspace.pkgs-graph/-/workspace.pkgs-graph-2.0.13.tgz",
-      "integrity": "sha512-XwpApD7dGCxL0xAwNANakxq4Ou91WMWZDF/IkMDnVGS1I3Xxh9tpQExpfpuxFPd//WofPJnxOi6AlXQS4D9bFA==",
-      "dev": true,
-      "dependencies": {
-        "@pnpm/npm-package-arg": "^1.0.0",
-        "@pnpm/npm-resolver": "18.0.2",
-        "@pnpm/resolve-workspace-range": "5.0.1",
-        "ramda": "npm:@pnpm/ramda@0.28.1"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pnpm"
-      }
-    },
-    "node_modules/@pnpm/workspace.pkgs-graph/node_modules/ramda": {
-      "name": "@pnpm/ramda",
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@pnpm/ramda/-/ramda-0.28.1.tgz",
-      "integrity": "sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@polka/url": {
@@ -5991,18 +5382,6 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
-    "node_modules/@sindresorhus/merge-streams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-1.0.0.tgz",
-      "integrity": "sha512-rUV5WyJrJLoloD4NDN1V1+LDMDWOa4OTsT4yYJwQNpTU6FWxkxHpL7eu4w+DmiH8x/EAM1otkPE1+LaspIbplw==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@sindresorhus/tsconfig": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-5.0.0.tgz",
@@ -6027,32 +5406,6 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/@snyk/github-codeowners": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@snyk/github-codeowners/-/github-codeowners-1.1.0.tgz",
-      "integrity": "sha512-lGFf08pbkEac0NYgVf4hdANpAgApRjNByLXB+WBip3qj1iendOIyAwP2GKkKbQMNVy2r1xxDf0ssfWscoiC+Vw==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^4.1.1",
-        "ignore": "^5.1.8",
-        "p-map": "^4.0.0"
-      },
-      "bin": {
-        "github-codeowners": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=8.10"
-      }
-    },
-    "node_modules/@snyk/github-codeowners/node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@storybook/addon-actions": {
@@ -9944,27 +9297,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
-    "node_modules/@zkochan/retry": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@zkochan/retry/-/retry-0.2.0.tgz",
-      "integrity": "sha512-WhB+2B/ZPlW2Xy/kMJBrMbqecWXcbDDgn0K0wKBAgO2OlBTz1iLJrRWduo+DGGn0Akvz1Lu4Xvls7dJojximWw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@zkochan/rimraf": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@zkochan/rimraf/-/rimraf-2.1.3.tgz",
-      "integrity": "sha512-mCfR3gylCzPC+iqdxEA6z5SxJeOgzgbwmyxanKriIne5qZLswDe/M43aD3p5MNzwzXRhbZg/OX+MpES6Zk1a6A==",
-      "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=12.10"
-      }
-    },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
@@ -10293,12 +9625,6 @@
         "dequal": "^2.0.3"
       }
     },
-    "node_modules/arity-n": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz",
-      "integrity": "sha512-fExL2kFDC1Q2DUOx3whE/9KoN66IzkY4b4zUHUBFM1ojEYjZZYDcUW3bek/ufGionX9giIKDC5redH2IlGqcQQ==",
-      "dev": true
-    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
@@ -10334,27 +9660,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-last": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
-      "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-last/node_modules/is-number": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-      "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/array-union": {
@@ -10989,15 +10294,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true,
-      "bin": {
-        "babylon": "bin/babylon.js"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
@@ -11148,16 +10444,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
-    },
-    "node_modules/bole": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/bole/-/bole-5.0.10.tgz",
-      "integrity": "sha512-5IiUWQ8QRQ8yHf46VPQ7GH3nj0Jy7P4heaENBVmsGfHP1Gtd0wqkvK6C3iHLUMdG3SMFx2DD8FqoIQcnMpdIdQ==",
-      "dev": true,
-      "dependencies": {
-        "fast-safe-stringify": "^2.0.7",
-        "individual": "^3.0.0"
-      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -11463,15 +10749,6 @@
       "version": "3.0.0",
       "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
       "dev": true
-    },
-    "node_modules/builtins": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.0.0"
-      }
     },
     "node_modules/bundle-name": {
       "version": "3.0.0",
@@ -12007,15 +11284,6 @@
       "version": "0.12.12",
       "integrity": "sha512-wlTxz4lsIv/3o+rdyBOTZpQFFJeWPCRlYClaEXcaFe6QrAJ5qibTAgH53LyjfGQL6mmebTfjVHM0hLsxjGj+fw==",
       "dev": true
-    },
-    "node_modules/compose-function": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/compose-function/-/compose-function-3.0.3.tgz",
-      "integrity": "sha512-xzhzTJ5eC+gmIzvZq+C3kCJHsp9os6tJkrigDRZclyGtOKINbZtE8n1Tzmeh32jW+BUDPbvZpibwvJHBLGMVwg==",
-      "dev": true,
-      "dependencies": {
-        "arity-n": "^1.0.4"
-      }
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -13160,15 +12428,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
@@ -13248,12 +12507,6 @@
     "node_modules/deep-diff": {
       "version": "0.3.8",
       "integrity": "sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug=="
-    },
-    "node_modules/deep-freeze": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
-      "integrity": "sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg==",
-      "dev": true
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -13840,18 +13093,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
-    "node_modules/easy-table": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.2.0.tgz",
-      "integrity": "sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "optionalDependencies": {
-        "wcwidth": "^1.0.1"
-      }
-    },
     "node_modules/editorconfig": {
       "version": "1.0.4",
       "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
@@ -13965,18 +13206,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/encode-registry": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/encode-registry/-/encode-registry-3.0.1.tgz",
-      "integrity": "sha512-6qOwkl1g0fv0DN3Y3ggr2EaZXN71aoAqPp3p/pVaWSBSIo+YjLOWN61Fva43oVyQNPf7kgm8lkudzlzojwE2jw==",
-      "dev": true,
-      "dependencies": {
-        "mem": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -14037,12 +13266,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/err-code": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true
     },
     "node_modules/errno": {
       "version": "0.1.8",
@@ -15846,12 +15069,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
-    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
@@ -15880,20 +15097,6 @@
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
-      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==",
-      "dev": true,
-      "engines": {
-        "node": "^10.17.0 || >=12.3.0"
-      },
-      "peerDependenciesMeta": {
-        "domexception": {
-          "optional": true
-        }
       }
     },
     "node_modules/fetch-mock": {
@@ -16063,21 +15266,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/filter-iterator": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/filter-iterator/-/filter-iterator-0.0.1.tgz",
-      "integrity": "sha512-v4lhL7Qa8XpbW3LN46CEnmhGk3eHZwxfNl5at20aEkreesht4YKb/Ba3BUIbnPhAC/r3dmu7ABaGk6MAvh2alA==",
-      "dev": true
-    },
-    "node_modules/filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -17000,12 +16188,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/has-own-property": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-own-property/-/has-own-property-0.1.0.tgz",
-      "integrity": "sha512-14qdBKoonU99XDhWcFKZTShK+QV47qU97u8zzoVo9cL5TZ3BmBHXogItSt9qJjR0KUMFRhcCW8uGIGl8nkl7Aw==",
-      "dev": true
-    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.0",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
@@ -17515,12 +16697,6 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz",
       "integrity": "sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw=="
     },
-    "node_modules/identity-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/identity-function/-/identity-function-1.0.0.tgz",
-      "integrity": "sha512-kNrgUK0qI+9qLTBidsH85HjDLpZfrrS0ElquKKe/fJFdB3D7VeKdXXEvOPDUHSHOzdZKCAAaQIWWyp0l2yq6pw==",
-      "dev": true
-    },
     "node_modules/identity-obj-proxy": {
       "version": "3.0.0",
       "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
@@ -17707,12 +16883,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/individual": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
-      "integrity": "sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==",
-      "dev": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -18146,15 +17316,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-iterable": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-iterable/-/is-iterable-1.1.1.tgz",
-      "integrity": "sha512-EdOZCr0NsGE00Pot+x1ZFx9MJK3C6wy91geZpXwvwexDLJvA4nzYyZf7r+EIwSeVsOLDdBz7ATg9NqKTzuNYuQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/is-js-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
@@ -18574,15 +17735,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/iterable-lookahead": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iterable-lookahead/-/iterable-lookahead-1.0.0.tgz",
-      "integrity": "sha512-hJnEP2Xk4+44DDwJqUQGdXal5VbyeWLaPyDl2AQc242Zr7iqz4DgpQOrEzglWVMGHMDCkguLHEKxd1+rOsmgSQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/iterator.prototype": {
@@ -20580,15 +19732,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jiti": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
-      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-      "dev": true,
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
     "node_modules/jquery": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
@@ -21177,122 +20320,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/knip": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-3.9.0.tgz",
-      "integrity": "sha512-pZgJdC4bSTEU/YT+4Q9uT22HuME+V0h0HT2fsOo0TrW7KY5Ghse+2ngNwOctzUn5LeYQ0eY83Z1DhKDIbe5WkA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/webpro"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/webpro"
-        }
-      ],
-      "dependencies": {
-        "@ericcornelissen/bash-parser": "0.5.2",
-        "@npmcli/map-workspaces": "3.0.4",
-        "@npmcli/package-json": "5.0.0",
-        "@pkgjs/parseargs": "0.11.0",
-        "@pnpm/logger": "5.0.0",
-        "@pnpm/workspace.pkgs-graph": "^2.0.12",
-        "@snyk/github-codeowners": "1.1.0",
-        "chalk": "^5.3.0",
-        "easy-table": "1.2.0",
-        "fast-glob": "3.3.2",
-        "globby": "^14.0.0",
-        "jiti": "1.21.0",
-        "js-yaml": "4.1.0",
-        "micromatch": "4.0.5",
-        "minimist": "1.2.8",
-        "pretty-ms": "8.0.0",
-        "strip-json-comments": "5.0.1",
-        "summary": "2.1.0",
-        "zod": "3.22.4",
-        "zod-validation-error": "2.1.0"
-      },
-      "bin": {
-        "knip": "bin/knip.js"
-      },
-      "engines": {
-        "node": ">=18.6.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18",
-        "typescript": ">=5.0.4"
-      }
-    },
-    "node_modules/knip/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/knip/node_modules/globby": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.0.tgz",
-      "integrity": "sha512-/1WM/LNHRAOH9lZta77uGbq0dAEQM+XjNesWwhlERDVenqothRbnzTrL3/LrIoEPPjeUHC3vrS6TwoyxeHs7MQ==",
-      "dev": true,
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^1.0.0",
-        "fast-glob": "^3.3.2",
-        "ignore": "^5.2.4",
-        "path-type": "^5.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/knip/node_modules/path-type": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
-      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/knip/node_modules/slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/knip/node_modules/strip-json-comments": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
-      "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -21400,30 +20427,6 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "node_modules/load-json-file": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
-      "integrity": "sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.15",
-        "parse-json": "^5.0.0",
-        "strip-bom": "^4.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/load-json-file/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/loader-runner": {
       "version": "4.2.0",
@@ -21690,36 +20693,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
-      "dependencies": {
-        "p-defer": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/map-age-cleaner/node_modules/p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha512-TzQSV2DiMYgoF5RycneKVUzIa9bQsj/B3tTgsE3dOGqlzHnGIDaC7XBE7grnA+8kZPnfqSGFe95VHc2oc0VFUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/map-or-similar": {
       "version": "1.5.0",
       "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
@@ -21798,31 +20771,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mem": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
-      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
-      "dev": true,
-      "dependencies": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/mem?sponsor=1"
-      }
-    },
-    "node_modules/mem/node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/memfs": {
@@ -22348,34 +21296,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/ndjson": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
-      "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
-      "dev": true,
-      "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.5",
-        "readable-stream": "^3.6.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
-      },
-      "bin": {
-        "ndjson": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ndjson/node_modules/through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "3"
-      }
-    },
     "node_modules/needle": {
       "version": "3.2.0",
       "integrity": "sha512-oUvzXnyLiVyVGoianLijF9O/RecZUf7TkBfimjGrLM4eQhXyeJwM6GeAWccwfQ9aa4gMCZKqhAOuLaMIcQxajQ==",
@@ -22625,81 +21545,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm-install-checks": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.3.0.tgz",
-      "integrity": "sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-normalize-package-bin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
-      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
-      "dev": true,
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-package-arg": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.1.tgz",
-      "integrity": "sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "proc-log": "^3.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^5.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-package-arg/node_modules/hosted-git-info": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-      "dev": true,
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-pick-manifest": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.0.0.tgz",
-      "integrity": "sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==",
-      "dev": true,
-      "dependencies": {
-        "npm-install-checks": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0",
-        "npm-package-arg": "^11.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
@@ -22808,21 +21653,6 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-pairs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/object-pairs/-/object-pairs-0.1.0.tgz",
-      "integrity": "sha512-3ECr6K831I4xX/Mduxr9UC+HPOz/d6WKKYj9p4cmC8Lg8p7g8gitzsxNX5IWlSIgFWN/a4JgrJaoAMKn20oKwA==",
-      "dev": true
-    },
-    "node_modules/object-values": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
-      "integrity": "sha512-+8hwcz/JnQ9EpLIXzN0Rs7DLsBpJNT/xYehtB/jU93tHYr5BFEO8E+JGQNOSqE7opVzz5cGksKFHt7uUJVLSjQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object.assign": {
@@ -23281,45 +22111,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-ms": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
-      "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
       "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/parse-npm-tarball-url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/parse-npm-tarball-url/-/parse-npm-tarball-url-3.0.0.tgz",
-      "integrity": "sha512-InpdgIdNe5xWMEUcrVQUniQKwnggBtJ7+SCwh7zQAZwbbIYZV9XdgJyhtmDSSvykFyQXoe4BINnzKTfCwWLs5g==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=8.15"
-      }
-    },
-    "node_modules/parse-npm-tarball-url/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/parseley": {
@@ -23406,18 +22203,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-temp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-temp/-/path-temp-2.1.0.tgz",
-      "integrity": "sha512-cMMJTAZlion/RWRRC48UbrDymEIt+/YSD/l8NqjneyDw2rDOBQcP5yRkMB4CYGn47KMhZvbblBP7Z79OsMw72w==",
-      "dev": true,
-      "dependencies": {
-        "unique-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.15"
       }
     },
     "node_modules/path-to-regexp": {
@@ -24180,21 +22965,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/pretty-ms": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
-      "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
-      "dev": true,
-      "dependencies": {
-        "parse-ms": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/primeicons": {
       "version": "6.0.1",
       "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA=="
@@ -24212,15 +22982,6 @@
         "react-transition-group": {
           "optional": true
         }
-      }
-    },
-    "node_modules/proc-log": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
-      "integrity": "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==",
-      "dev": true,
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/process": {
@@ -24251,34 +23012,6 @@
       "dev": true,
       "dependencies": {
         "asap": "~2.0.6"
-      }
-    },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "dev": true
-    },
-    "node_modules/promise-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dev": true,
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/promise-retry/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/prompts": {
@@ -25331,28 +24064,6 @@
       "version": "5.2.1",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
-    "node_modules/read-package-json-fast": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-3.0.2.tgz",
-      "integrity": "sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==",
-      "dev": true,
-      "dependencies": {
-        "json-parse-even-better-errors": "^3.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/read-package-json-fast/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
-      "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
-      "dev": true,
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
@@ -25743,33 +24454,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rename-overwrite": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rename-overwrite/-/rename-overwrite-5.0.0.tgz",
-      "integrity": "sha512-vSxE5Ww7Jnyotvaxi3Dj0vOMoojH8KMkBfs9xYeW/qNfJiLTcC1fmwTjrbGUq3mQSOCxkG0DbdcvwTUrpvBN4w==",
-      "dev": true,
-      "dependencies": {
-        "@zkochan/rimraf": "^2.1.2",
-        "fs-extra": "10.1.0"
-      },
-      "engines": {
-        "node": ">=12.10"
-      }
-    },
-    "node_modules/rename-overwrite/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -25930,12 +24614,6 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/reverse-arguments": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/reverse-arguments/-/reverse-arguments-1.0.0.tgz",
-      "integrity": "sha512-/x8uIPdTafBqakK0TmPNJzgkLP+3H+yxpUJhCQHsLBg1rYEVNR2D8BRYNWQhVBjyOd7oo1dZRVzIkwMY2oqfYQ==",
-      "dev": true
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -26450,12 +25128,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/shell-quote-word": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/shell-quote-word/-/shell-quote-word-1.0.1.tgz",
-      "integrity": "sha512-lT297f1WLAdq0A4O+AknIFRP6kkiI3s8C913eJ0XqBxJbZPGWUNkRQk2u8zk4bEAjUJ5i+fSLwB6z1HzeT+DEg==",
-      "dev": true
-    },
     "node_modules/shellwords": {
       "version": "0.1.1",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
@@ -26627,31 +25299,10 @@
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
-    "node_modules/split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
-    },
-    "node_modules/ssri": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
-      "integrity": "sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.5",
@@ -26876,12 +25527,6 @@
       "version": "8.0.0",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
-    "node_modules/string.fromcodepoint": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
-      "integrity": "sha512-n69H31OnxSGSZyZbgBlvYIXlrMhJQ0dQAX1js1QDhpaUH6zmU3QYlj07bCwCNlPOu3oRXIubGPl2gDGnHsiCqg==",
-      "dev": true
-    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
@@ -27068,12 +25713,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/summary": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/summary/-/summary-2.1.0.tgz",
-      "integrity": "sha512-nMIjMrd5Z2nuB2RZCKJfFMjgS3fygbeyGk9PxPPaJR1RIcyN9yn4A63Isovzm3ZtQuEkLBVgMdPup8UeLH7aQw==",
-      "dev": true
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -27568,21 +26207,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/to-no-case": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
-      "integrity": "sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg==",
-      "dev": true
-    },
-    "node_modules/to-pascal-case": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-pascal-case/-/to-pascal-case-1.0.0.tgz",
-      "integrity": "sha512-QGMWHqM6xPrcQW57S23c5/3BbYb0Tbe9p+ur98ckRnGDwD4wbbtDiYI38CfmMKNB5Iv0REjs5SNDntTwvDxzZA==",
-      "dev": true,
-      "dependencies": {
-        "to-space-case": "^1.0.0"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
@@ -27592,15 +26216,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/to-space-case": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
-      "integrity": "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==",
-      "dev": true,
-      "dependencies": {
-        "to-no-case": "^1.0.0"
       }
     },
     "node_modules/tocbot": {
@@ -28070,15 +26685,6 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
-    "node_modules/unescape-js": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/unescape-js/-/unescape-js-1.1.4.tgz",
-      "integrity": "sha512-42SD8NOQEhdYntEiUQdYq/1V/YHwr1HLwlHuTJB5InVVdOSbgI6xu8jK5q65yIzuFCfczzyDF/7hbGzVbyCw0g==",
-      "dev": true,
-      "dependencies": {
-        "string.fromcodepoint": "^0.2.1"
-      }
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -28117,18 +26723,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/unicorn-magic": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/uniq": {
@@ -28526,18 +27120,6 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "node_modules/validate-npm-package-name": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
-      "integrity": "sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==",
-      "dev": true,
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/validate.io-array": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
@@ -28582,24 +27164,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/version-selector-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/version-selector-type/-/version-selector-type-3.0.0.tgz",
-      "integrity": "sha512-PSvMIZS7C1MuVNBXl/CDG2pZq8EXy/NW2dHIdm3bVP5N0PC8utDK8ttXLXj44Gn3J0lQE3U7Mpm1estAOd+eiA==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.3.2"
-      },
-      "engines": {
-        "node": ">=10.13"
-      }
-    },
-    "node_modules/vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
-      "dev": true
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
@@ -29489,27 +28053,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-validation-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-2.1.0.tgz",
-      "integrity": "sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "zod": "^3.18.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,6 +236,7 @@
         "jest-webextension-mock": "^3.8.9",
         "jsdom": "^23.0.1",
         "jsdom-testing-mocks": "^1.11.0",
+        "knip": "^3.9.0",
         "min-document": "^2.19.0",
         "mini-css-extract-plugin": "^2.6.1",
         "mockdate": "^3.0.5",
@@ -2602,6 +2603,45 @@
       "version": "0.3.1",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
+    "node_modules/@ericcornelissen/bash-parser": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@ericcornelissen/bash-parser/-/bash-parser-0.5.2.tgz",
+      "integrity": "sha512-4pIMTa1nEFfMXitv7oaNEWOdM+zpOZavesa5GaiWTgda6Zk32CFGxjUp/iIaN0PwgUW1yTq/fztSjbpE8SLGZQ==",
+      "dev": true,
+      "dependencies": {
+        "array-last": "^1.1.1",
+        "babylon": "^6.9.1",
+        "compose-function": "^3.0.3",
+        "deep-freeze": "0.0.1",
+        "filter-iterator": "0.0.1",
+        "filter-obj": "^1.1.0",
+        "has-own-property": "^0.1.0",
+        "identity-function": "^1.0.0",
+        "is-iterable": "^1.1.0",
+        "iterable-lookahead": "^1.0.0",
+        "lodash.curry": "^4.1.1",
+        "magic-string": "^0.16.0",
+        "map-obj": "^2.0.0",
+        "object-pairs": "^0.1.0",
+        "object-values": "^1.0.0",
+        "reverse-arguments": "^1.0.0",
+        "shell-quote-word": "^1.0.1",
+        "to-pascal-case": "^1.0.0",
+        "unescape-js": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@ericcornelissen/bash-parser/node_modules/magic-string": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz",
+      "integrity": "sha512-c4BEos3y6G2qO0B9X7K0FVLOPT9uGrjYwYRLFmDqyl5YMboUviyecnXWp94fJTSMwPw2/sf+CEYt5AGpmklkkQ==",
+      "dev": true,
+      "dependencies": {
+        "vlq": "^0.2.1"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
@@ -4354,6 +4394,255 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@npmcli/git": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.3.tgz",
+      "integrity": "sha512-UZp9NwK+AynTrKvHn5k3KviW/hA5eENmFsu3iAPe7sWRt0lFUdsY/wXIYjpDFe7cdSNwOIzbObfwgt6eL5/2zw==",
+      "dev": true,
+      "dependencies": {
+        "@npmcli/promise-spawn": "^7.0.0",
+        "lru-cache": "^10.0.1",
+        "npm-pick-manifest": "^9.0.0",
+        "proc-log": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^2.0.1",
+        "semver": "^7.3.5",
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-3.0.4.tgz",
+      "integrity": "sha512-Z0TbvXkRbacjFFLpVpV0e2mheCh+WzQpcqL+4xp49uNJOxOnIAPZyXtUxZ5Qn3QBTGKA11Exjd9a5411rBrhDg==",
+      "dev": true,
+      "dependencies": {
+        "@npmcli/name-from-folder": "^2.0.0",
+        "glob": "^10.2.2",
+        "minimatch": "^9.0.0",
+        "read-package-json-fast": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/name-from-folder": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-2.0.0.tgz",
+      "integrity": "sha512-pwK+BfEBZJbKdNYpHHRTNBwBoqrN/iIMO0AiGvYsp3Hoaq0WbgGSWQR6SCldZovoDpY3yje5lkFUe6gsDgJ2vg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-5.0.0.tgz",
+      "integrity": "sha512-OI2zdYBLhQ7kpNPaJxiflofYIpkNLi+lnGdzqUOfRmCF3r2l1nadcjtCYMJKv/Utm/ZtlffaUuTiAktPHbc17g==",
+      "dev": true,
+      "dependencies": {
+        "@npmcli/git": "^5.0.0",
+        "glob": "^10.2.2",
+        "hosted-git-info": "^7.0.0",
+        "json-parse-even-better-errors": "^3.0.0",
+        "normalize-package-data": "^6.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/hosted-git-info": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/json-parse-even-better-errors": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
+      "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/normalize-package-data": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
+      "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-7.0.0.tgz",
+      "integrity": "sha512-wBqcGsMELZna0jDblGd7UXgOby45TQaMWmbFwWX+SEotk4HV6zG2t6rT9siyLhPk4P6YYqgfL1UO8nMWDBVJXQ==",
+      "dev": true,
+      "dependencies": {
+        "which": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
@@ -4373,7 +4662,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=14"
       }
@@ -4485,6 +4774,326 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pnpm/constants": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/constants/-/constants-7.1.1.tgz",
+      "integrity": "sha512-31pZqMtjwV+Vaq7MaPrT1EoDFSYwye3dp6BiHIGRJmVThCQwySRKM7hCvqqI94epNkqFAAYoWrNynWoRYosGdw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/core-loggers": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@pnpm/core-loggers/-/core-loggers-9.0.6.tgz",
+      "integrity": "sha512-iK67SGbp+06bA/elpg51wygPFjNA7JKHtKkpLxqXXHw+AjFFBC3f2OznJsCIuDK6HdGi5UhHLYqo5QxJ2gMqJQ==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/types": "9.4.2"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      },
+      "peerDependencies": {
+        "@pnpm/logger": "^5.0.0"
+      }
+    },
+    "node_modules/@pnpm/error": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/error/-/error-5.0.2.tgz",
+      "integrity": "sha512-0TEm+tWNYm+9uh6DSKyRbv8pv/6b4NL0PastLvMxIoqZbBZ5Zj1cYi332R9xsSUi31ZOsu2wpgn/bC7DA9hrjg==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/constants": "7.1.1"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/fetching-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/fetching-types/-/fetching-types-5.0.0.tgz",
+      "integrity": "sha512-o9gdO1v8Uc5P2fBBuW6GSpfTqIivQmQlqjQJdFiQX0m+tgxlrMRneIg392jZuc6fk7kFqjLheInlslgJfwY+4Q==",
+      "dev": true,
+      "dependencies": {
+        "@zkochan/retry": "^0.2.0",
+        "node-fetch": "3.0.0-beta.9"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/fetching-types/node_modules/node-fetch": {
+      "version": "3.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
+      "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
+      "dev": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^3.0.1",
+        "fetch-blob": "^2.1.1"
+      },
+      "engines": {
+        "node": "^10.17 || >=12.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@pnpm/graceful-fs": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/graceful-fs/-/graceful-fs-3.2.0.tgz",
+      "integrity": "sha512-vRoXJxscDpHak7YE9SqCkzfrayn+Lw+YueOeHIPEqkgokrHeYgYeONoc2kGh0ObHaRtNSsonozVfJ456kxLNvA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/logger": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/logger/-/logger-5.0.0.tgz",
+      "integrity": "sha512-YfcB2QrX+Wx1o6LD1G2Y2fhDhOix/bAY/oAnMpHoNLsKkWIRbt1oKLkIFvxBMzLwAEPqnYWguJrYC+J6i4ywbw==",
+      "dev": true,
+      "dependencies": {
+        "bole": "^5.0.0",
+        "ndjson": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/@pnpm/npm-package-arg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-package-arg/-/npm-package-arg-1.0.0.tgz",
+      "integrity": "sha512-oQYP08exi6mOPdAZZWcNIGS+KKPsnNwUBzSuAEGWuCcqwMAt3k/WVCqVIXzBxhO5sP2b43og69VHmPj6IroKqw==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@pnpm/npm-package-arg/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@pnpm/npm-package-arg/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@pnpm/npm-package-arg/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@pnpm/npm-resolver": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-resolver/-/npm-resolver-18.0.2.tgz",
+      "integrity": "sha512-YfjSHpaFgYvqMomKNLMa49pVabGvaSeEBX3J9j1v7FGtzad7SPZ+BH7ObPLHkIm4rA9K5zvuTJ8gBwMiGQJcQg==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/core-loggers": "9.0.6",
+        "@pnpm/error": "5.0.2",
+        "@pnpm/fetching-types": "5.0.0",
+        "@pnpm/graceful-fs": "3.2.0",
+        "@pnpm/resolve-workspace-range": "5.0.1",
+        "@pnpm/resolver-base": "11.0.2",
+        "@pnpm/types": "9.4.2",
+        "@zkochan/retry": "^0.2.0",
+        "encode-registry": "^3.0.1",
+        "load-json-file": "^6.2.0",
+        "lru-cache": "^10.0.2",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^3.1.0",
+        "p-memoize": "4.0.1",
+        "parse-npm-tarball-url": "^3.0.0",
+        "path-temp": "^2.1.0",
+        "ramda": "npm:@pnpm/ramda@0.28.1",
+        "rename-overwrite": "^5.0.0",
+        "semver": "^7.5.4",
+        "ssri": "10.0.5",
+        "version-selector-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      },
+      "peerDependencies": {
+        "@pnpm/logger": "^5.0.0"
+      }
+    },
+    "node_modules/@pnpm/npm-resolver/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@pnpm/npm-resolver/node_modules/mem": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.1.tgz",
+      "integrity": "sha512-Ci6bIfq/UgcxPTYa8dQQ5FY3BzKkT894bwXWXxC/zqs0XgMO2cT20CGkOqda7gZNkmK5VP4x89IGZ6K7hfbn3Q==",
+      "dev": true,
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
+      }
+    },
+    "node_modules/@pnpm/npm-resolver/node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@pnpm/npm-resolver/node_modules/p-memoize": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-4.0.1.tgz",
+      "integrity": "sha512-km0sP12uE0dOZ5qP+s7kGVf07QngxyG0gS8sYFvFWhqlgzOsSy+m71aUejf/0akxj5W7gE//2G74qTv6b4iMog==",
+      "dev": true,
+      "dependencies": {
+        "mem": "^6.0.1",
+        "mimic-fn": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/p-memoize?sponsor=1"
+      }
+    },
+    "node_modules/@pnpm/npm-resolver/node_modules/ramda": {
+      "name": "@pnpm/ramda",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/ramda/-/ramda-0.28.1.tgz",
+      "integrity": "sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/@pnpm/resolve-workspace-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/resolve-workspace-range/-/resolve-workspace-range-5.0.1.tgz",
+      "integrity": "sha512-yQ0pMthlw8rTgS/C9hrjne+NEnnSNevCjtdodd7i15I59jMBYciHifZ/vjg0NY+Jl+USTc3dBE+0h/4tdYjMKg==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/resolver-base": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/resolver-base/-/resolver-base-11.0.2.tgz",
+      "integrity": "sha512-g6VXB/LK7DugXiCPG62qmYtuypVt44nnwyXYkTv86FKudI5d5Wy1FLkYAYKCj+No9h1GG3eSSwGH1NL0y4IbYg==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/types": "9.4.2"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/types": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/types/-/types-9.4.2.tgz",
+      "integrity": "sha512-g1hcF8Nv4gd76POilz9gD4LITAPXOe5nX4ijgr8ixCbLQZfcpYiMfJ+C1RlMNRUDo8vhlNB4O3bUlxmT6EAQXA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/workspace.pkgs-graph": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@pnpm/workspace.pkgs-graph/-/workspace.pkgs-graph-2.0.13.tgz",
+      "integrity": "sha512-XwpApD7dGCxL0xAwNANakxq4Ou91WMWZDF/IkMDnVGS1I3Xxh9tpQExpfpuxFPd//WofPJnxOi6AlXQS4D9bFA==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/npm-package-arg": "^1.0.0",
+        "@pnpm/npm-resolver": "18.0.2",
+        "@pnpm/resolve-workspace-range": "5.0.1",
+        "ramda": "npm:@pnpm/ramda@0.28.1"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/workspace.pkgs-graph/node_modules/ramda": {
+      "name": "@pnpm/ramda",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/ramda/-/ramda-0.28.1.tgz",
+      "integrity": "sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@polka/url": {
@@ -5382,6 +5991,18 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-1.0.0.tgz",
+      "integrity": "sha512-rUV5WyJrJLoloD4NDN1V1+LDMDWOa4OTsT4yYJwQNpTU6FWxkxHpL7eu4w+DmiH8x/EAM1otkPE1+LaspIbplw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sindresorhus/tsconfig": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-5.0.0.tgz",
@@ -5406,6 +6027,32 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@snyk/github-codeowners": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@snyk/github-codeowners/-/github-codeowners-1.1.0.tgz",
+      "integrity": "sha512-lGFf08pbkEac0NYgVf4hdANpAgApRjNByLXB+WBip3qj1iendOIyAwP2GKkKbQMNVy2r1xxDf0ssfWscoiC+Vw==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^4.1.1",
+        "ignore": "^5.1.8",
+        "p-map": "^4.0.0"
+      },
+      "bin": {
+        "github-codeowners": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=8.10"
+      }
+    },
+    "node_modules/@snyk/github-codeowners/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@storybook/addon-actions": {
@@ -9297,6 +9944,27 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/@zkochan/retry": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@zkochan/retry/-/retry-0.2.0.tgz",
+      "integrity": "sha512-WhB+2B/ZPlW2Xy/kMJBrMbqecWXcbDDgn0K0wKBAgO2OlBTz1iLJrRWduo+DGGn0Akvz1Lu4Xvls7dJojximWw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@zkochan/rimraf": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@zkochan/rimraf/-/rimraf-2.1.3.tgz",
+      "integrity": "sha512-mCfR3gylCzPC+iqdxEA6z5SxJeOgzgbwmyxanKriIne5qZLswDe/M43aD3p5MNzwzXRhbZg/OX+MpES6Zk1a6A==",
+      "dev": true,
+      "dependencies": {
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=12.10"
+      }
+    },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
@@ -9625,6 +10293,12 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/arity-n": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz",
+      "integrity": "sha512-fExL2kFDC1Q2DUOx3whE/9KoN66IzkY4b4zUHUBFM1ojEYjZZYDcUW3bek/ufGionX9giIKDC5redH2IlGqcQQ==",
+      "dev": true
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
@@ -9660,6 +10334,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-last": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array-last/-/array-last-1.3.0.tgz",
+      "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-last/node_modules/is-number": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+      "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/array-union": {
@@ -10294,6 +10989,15 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true,
+      "bin": {
+        "babylon": "bin/babylon.js"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
@@ -10444,6 +11148,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
+    },
+    "node_modules/bole": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/bole/-/bole-5.0.10.tgz",
+      "integrity": "sha512-5IiUWQ8QRQ8yHf46VPQ7GH3nj0Jy7P4heaENBVmsGfHP1Gtd0wqkvK6C3iHLUMdG3SMFx2DD8FqoIQcnMpdIdQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7",
+        "individual": "^3.0.0"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -10749,6 +11463,15 @@
       "version": "3.0.0",
       "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
       "dev": true
+    },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
     },
     "node_modules/bundle-name": {
       "version": "3.0.0",
@@ -11284,6 +12007,15 @@
       "version": "0.12.12",
       "integrity": "sha512-wlTxz4lsIv/3o+rdyBOTZpQFFJeWPCRlYClaEXcaFe6QrAJ5qibTAgH53LyjfGQL6mmebTfjVHM0hLsxjGj+fw==",
       "dev": true
+    },
+    "node_modules/compose-function": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/compose-function/-/compose-function-3.0.3.tgz",
+      "integrity": "sha512-xzhzTJ5eC+gmIzvZq+C3kCJHsp9os6tJkrigDRZclyGtOKINbZtE8n1Tzmeh32jW+BUDPbvZpibwvJHBLGMVwg==",
+      "dev": true,
+      "dependencies": {
+        "arity-n": "^1.0.4"
+      }
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -12428,6 +13160,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
@@ -12507,6 +13248,12 @@
     "node_modules/deep-diff": {
       "version": "0.3.8",
       "integrity": "sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug=="
+    },
+    "node_modules/deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg==",
+      "dev": true
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -13093,6 +13840,18 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
+    "node_modules/easy-table": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.2.0.tgz",
+      "integrity": "sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "optionalDependencies": {
+        "wcwidth": "^1.0.1"
+      }
+    },
     "node_modules/editorconfig": {
       "version": "1.0.4",
       "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
@@ -13206,6 +13965,18 @@
         "node": ">= 4"
       }
     },
+    "node_modules/encode-registry": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/encode-registry/-/encode-registry-3.0.1.tgz",
+      "integrity": "sha512-6qOwkl1g0fv0DN3Y3ggr2EaZXN71aoAqPp3p/pVaWSBSIo+YjLOWN61Fva43oVyQNPf7kgm8lkudzlzojwE2jw==",
+      "dev": true,
+      "dependencies": {
+        "mem": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -13266,6 +14037,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true
     },
     "node_modules/errno": {
       "version": "0.1.8",
@@ -15069,6 +15846,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
@@ -15097,6 +15880,20 @@
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
+      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==",
+      "dev": true,
+      "engines": {
+        "node": "^10.17.0 || >=12.3.0"
+      },
+      "peerDependenciesMeta": {
+        "domexception": {
+          "optional": true
+        }
       }
     },
     "node_modules/fetch-mock": {
@@ -15266,6 +16063,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-iterator": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/filter-iterator/-/filter-iterator-0.0.1.tgz",
+      "integrity": "sha512-v4lhL7Qa8XpbW3LN46CEnmhGk3eHZwxfNl5at20aEkreesht4YKb/Ba3BUIbnPhAC/r3dmu7ABaGk6MAvh2alA==",
+      "dev": true
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -16188,6 +17000,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/has-own-property": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-own-property/-/has-own-property-0.1.0.tgz",
+      "integrity": "sha512-14qdBKoonU99XDhWcFKZTShK+QV47qU97u8zzoVo9cL5TZ3BmBHXogItSt9qJjR0KUMFRhcCW8uGIGl8nkl7Aw==",
+      "dev": true
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.0",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
@@ -16697,6 +17515,12 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz",
       "integrity": "sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw=="
     },
+    "node_modules/identity-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/identity-function/-/identity-function-1.0.0.tgz",
+      "integrity": "sha512-kNrgUK0qI+9qLTBidsH85HjDLpZfrrS0ElquKKe/fJFdB3D7VeKdXXEvOPDUHSHOzdZKCAAaQIWWyp0l2yq6pw==",
+      "dev": true
+    },
     "node_modules/identity-obj-proxy": {
       "version": "3.0.0",
       "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
@@ -16883,6 +17707,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/individual": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
+      "integrity": "sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==",
+      "dev": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -17316,6 +18146,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-iterable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-iterable/-/is-iterable-1.1.1.tgz",
+      "integrity": "sha512-EdOZCr0NsGE00Pot+x1ZFx9MJK3C6wy91geZpXwvwexDLJvA4nzYyZf7r+EIwSeVsOLDdBz7ATg9NqKTzuNYuQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/is-js-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
@@ -17735,6 +18574,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/iterable-lookahead": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iterable-lookahead/-/iterable-lookahead-1.0.0.tgz",
+      "integrity": "sha512-hJnEP2Xk4+44DDwJqUQGdXal5VbyeWLaPyDl2AQc242Zr7iqz4DgpQOrEzglWVMGHMDCkguLHEKxd1+rOsmgSQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/iterator.prototype": {
@@ -19732,6 +20580,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
+      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/jquery": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
@@ -20320,6 +21177,122 @@
         "node": ">=6"
       }
     },
+    "node_modules/knip": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-3.9.0.tgz",
+      "integrity": "sha512-pZgJdC4bSTEU/YT+4Q9uT22HuME+V0h0HT2fsOo0TrW7KY5Ghse+2ngNwOctzUn5LeYQ0eY83Z1DhKDIbe5WkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/webpro"
+        }
+      ],
+      "dependencies": {
+        "@ericcornelissen/bash-parser": "0.5.2",
+        "@npmcli/map-workspaces": "3.0.4",
+        "@npmcli/package-json": "5.0.0",
+        "@pkgjs/parseargs": "0.11.0",
+        "@pnpm/logger": "5.0.0",
+        "@pnpm/workspace.pkgs-graph": "^2.0.12",
+        "@snyk/github-codeowners": "1.1.0",
+        "chalk": "^5.3.0",
+        "easy-table": "1.2.0",
+        "fast-glob": "3.3.2",
+        "globby": "^14.0.0",
+        "jiti": "1.21.0",
+        "js-yaml": "4.1.0",
+        "micromatch": "4.0.5",
+        "minimist": "1.2.8",
+        "pretty-ms": "8.0.0",
+        "strip-json-comments": "5.0.1",
+        "summary": "2.1.0",
+        "zod": "3.22.4",
+        "zod-validation-error": "2.1.0"
+      },
+      "bin": {
+        "knip": "bin/knip.js"
+      },
+      "engines": {
+        "node": ">=18.6.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18",
+        "typescript": ">=5.0.4"
+      }
+    },
+    "node_modules/knip/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/knip/node_modules/globby": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.0.tgz",
+      "integrity": "sha512-/1WM/LNHRAOH9lZta77uGbq0dAEQM+XjNesWwhlERDVenqothRbnzTrL3/LrIoEPPjeUHC3vrS6TwoyxeHs7MQ==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^1.0.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/knip/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/knip/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/knip/node_modules/strip-json-comments": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
+      "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -20427,6 +21400,30 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/load-json-file": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
+      "integrity": "sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "parse-json": "^5.0.0",
+        "strip-bom": "^4.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/load-json-file/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/loader-runner": {
       "version": "4.2.0",
@@ -20693,6 +21690,36 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/map-age-cleaner/node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha512-TzQSV2DiMYgoF5RycneKVUzIa9bQsj/B3tTgsE3dOGqlzHnGIDaC7XBE7grnA+8kZPnfqSGFe95VHc2oc0VFUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/map-or-similar": {
       "version": "1.5.0",
       "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
@@ -20771,6 +21798,31 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "dev": true,
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
+      }
+    },
+    "node_modules/mem/node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/memfs": {
@@ -21296,6 +22348,34 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/ndjson": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
+      "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
+      "dev": true,
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.5",
+        "readable-stream": "^3.6.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      },
+      "bin": {
+        "ndjson": "cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ndjson/node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
     "node_modules/needle": {
       "version": "3.2.0",
       "integrity": "sha512-oUvzXnyLiVyVGoianLijF9O/RecZUf7TkBfimjGrLM4eQhXyeJwM6GeAWccwfQ9aa4gMCZKqhAOuLaMIcQxajQ==",
@@ -21545,6 +22625,81 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-install-checks": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.3.0.tgz",
+      "integrity": "sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-package-arg": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.1.tgz",
+      "integrity": "sha512-M7s1BD4NxdAvBKUPqqRW957Xwcl/4Zvo8Aj+ANrzvIPzGJZElrH7Z//rSaec2ORcND6FHHLnZeY8qgTpXDMFQQ==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "proc-log": "^3.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/hosted-git-info": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
+      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^5.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-pick-manifest": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-9.0.0.tgz",
+      "integrity": "sha512-VfvRSs/b6n9ol4Qb+bDwNGUXutpy76x6MARw/XssevE0TnctIKcmklJZM5Z7nqs5z5aW+0S63pgCNbpkUNNXBg==",
+      "dev": true,
+      "dependencies": {
+        "npm-install-checks": "^6.0.0",
+        "npm-normalize-package-bin": "^3.0.0",
+        "npm-package-arg": "^11.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
@@ -21653,6 +22808,21 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-pairs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-pairs/-/object-pairs-0.1.0.tgz",
+      "integrity": "sha512-3ECr6K831I4xX/Mduxr9UC+HPOz/d6WKKYj9p4cmC8Lg8p7g8gitzsxNX5IWlSIgFWN/a4JgrJaoAMKn20oKwA==",
+      "dev": true
+    },
+    "node_modules/object-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
+      "integrity": "sha512-+8hwcz/JnQ9EpLIXzN0Rs7DLsBpJNT/xYehtB/jU93tHYr5BFEO8E+JGQNOSqE7opVzz5cGksKFHt7uUJVLSjQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object.assign": {
@@ -22111,12 +23281,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
+      "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
       "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
       "dev": true,
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/parse-npm-tarball-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-npm-tarball-url/-/parse-npm-tarball-url-3.0.0.tgz",
+      "integrity": "sha512-InpdgIdNe5xWMEUcrVQUniQKwnggBtJ7+SCwh7zQAZwbbIYZV9XdgJyhtmDSSvykFyQXoe4BINnzKTfCwWLs5g==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.15"
+      }
+    },
+    "node_modules/parse-npm-tarball-url/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/parseley": {
@@ -22203,6 +23406,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-temp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-temp/-/path-temp-2.1.0.tgz",
+      "integrity": "sha512-cMMJTAZlion/RWRRC48UbrDymEIt+/YSD/l8NqjneyDw2rDOBQcP5yRkMB4CYGn47KMhZvbblBP7Z79OsMw72w==",
+      "dev": true,
+      "dependencies": {
+        "unique-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.15"
       }
     },
     "node_modules/path-to-regexp": {
@@ -22965,6 +24180,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
+      "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
+      "dev": true,
+      "dependencies": {
+        "parse-ms": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/primeicons": {
       "version": "6.0.1",
       "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA=="
@@ -22982,6 +24212,15 @@
         "react-transition-group": {
           "optional": true
         }
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
+      "integrity": "sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/process": {
@@ -23012,6 +24251,34 @@
       "dev": true,
       "dependencies": {
         "asap": "~2.0.6"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "dev": true
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/promise-retry/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/prompts": {
@@ -24064,6 +25331,28 @@
       "version": "5.2.1",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
+    "node_modules/read-package-json-fast": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-3.0.2.tgz",
+      "integrity": "sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==",
+      "dev": true,
+      "dependencies": {
+        "json-parse-even-better-errors": "^3.0.0",
+        "npm-normalize-package-bin": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-package-json-fast/node_modules/json-parse-even-better-errors": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
+      "integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
@@ -24454,6 +25743,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rename-overwrite": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rename-overwrite/-/rename-overwrite-5.0.0.tgz",
+      "integrity": "sha512-vSxE5Ww7Jnyotvaxi3Dj0vOMoojH8KMkBfs9xYeW/qNfJiLTcC1fmwTjrbGUq3mQSOCxkG0DbdcvwTUrpvBN4w==",
+      "dev": true,
+      "dependencies": {
+        "@zkochan/rimraf": "^2.1.2",
+        "fs-extra": "10.1.0"
+      },
+      "engines": {
+        "node": ">=12.10"
+      }
+    },
+    "node_modules/rename-overwrite/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -24614,6 +25930,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reverse-arguments": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reverse-arguments/-/reverse-arguments-1.0.0.tgz",
+      "integrity": "sha512-/x8uIPdTafBqakK0TmPNJzgkLP+3H+yxpUJhCQHsLBg1rYEVNR2D8BRYNWQhVBjyOd7oo1dZRVzIkwMY2oqfYQ==",
+      "dev": true
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -25128,6 +26450,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shell-quote-word": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/shell-quote-word/-/shell-quote-word-1.0.1.tgz",
+      "integrity": "sha512-lT297f1WLAdq0A4O+AknIFRP6kkiI3s8C913eJ0XqBxJbZPGWUNkRQk2u8zk4bEAjUJ5i+fSLwB6z1HzeT+DEg==",
+      "dev": true
+    },
     "node_modules/shellwords": {
       "version": "0.1.1",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
@@ -25299,10 +26627,31 @@
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
+    "node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/ssri": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
+      "integrity": "sha512-bSf16tAFkGeRlUNDjXu8FzaMQt6g2HZJrun7mtMbIPOddxt3GLMSz5VWUWcqTJUPfLEaDIepGxv+bYQW49596A==",
+      "dev": true,
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.5",
@@ -25527,6 +26876,12 @@
       "version": "8.0.0",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "node_modules/string.fromcodepoint": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
+      "integrity": "sha512-n69H31OnxSGSZyZbgBlvYIXlrMhJQ0dQAX1js1QDhpaUH6zmU3QYlj07bCwCNlPOu3oRXIubGPl2gDGnHsiCqg==",
+      "dev": true
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
@@ -25713,6 +27068,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/summary": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/summary/-/summary-2.1.0.tgz",
+      "integrity": "sha512-nMIjMrd5Z2nuB2RZCKJfFMjgS3fygbeyGk9PxPPaJR1RIcyN9yn4A63Isovzm3ZtQuEkLBVgMdPup8UeLH7aQw==",
+      "dev": true
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -26207,6 +27568,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha512-Z3g735FxuZY8rodxV4gH7LxClE4H0hTIyHNIHdk+vpQxjLm0cwnKXq/OFVZ76SOQmto7txVcwSCwkU5kqp+FKg==",
+      "dev": true
+    },
+    "node_modules/to-pascal-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-pascal-case/-/to-pascal-case-1.0.0.tgz",
+      "integrity": "sha512-QGMWHqM6xPrcQW57S23c5/3BbYb0Tbe9p+ur98ckRnGDwD4wbbtDiYI38CfmMKNB5Iv0REjs5SNDntTwvDxzZA==",
+      "dev": true,
+      "dependencies": {
+        "to-space-case": "^1.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
@@ -26216,6 +27592,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==",
+      "dev": true,
+      "dependencies": {
+        "to-no-case": "^1.0.0"
       }
     },
     "node_modules/tocbot": {
@@ -26685,6 +28070,15 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
+    "node_modules/unescape-js": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unescape-js/-/unescape-js-1.1.4.tgz",
+      "integrity": "sha512-42SD8NOQEhdYntEiUQdYq/1V/YHwr1HLwlHuTJB5InVVdOSbgI6xu8jK5q65yIzuFCfczzyDF/7hbGzVbyCw0g==",
+      "dev": true,
+      "dependencies": {
+        "string.fromcodepoint": "^0.2.1"
+      }
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -26723,6 +28117,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/uniq": {
@@ -27120,6 +28526,18 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validate-npm-package-name": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
+      "integrity": "sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/validate.io-array": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
@@ -27164,6 +28582,24 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/version-selector-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/version-selector-type/-/version-selector-type-3.0.0.tgz",
+      "integrity": "sha512-PSvMIZS7C1MuVNBXl/CDG2pZq8EXy/NW2dHIdm3bVP5N0PC8utDK8ttXLXj44Gn3J0lQE3U7Mpm1estAOd+eiA==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": ">=10.13"
+      }
+    },
+    "node_modules/vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "dev": true
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
@@ -28053,6 +29489,27 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-2.1.0.tgz",
+      "integrity": "sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -259,7 +259,6 @@
     "jest-webextension-mock": "^3.8.9",
     "jsdom": "^23.0.1",
     "jsdom-testing-mocks": "^1.11.0",
-    "knip": "^3.9.0",
     "min-document": "^2.19.0",
     "mini-css-extract-plugin": "^2.6.1",
     "mockdate": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -259,6 +259,7 @@
     "jest-webextension-mock": "^3.8.9",
     "jsdom": "^23.0.1",
     "jsdom-testing-mocks": "^1.11.0",
+    "knip": "^3.9.0",
     "min-document": "^2.19.0",
     "mini-css-extract-plugin": "^2.6.1",
     "mockdate": "^3.0.5",

--- a/src/analysis/analysisVisitors/brickTypeAnalysis.ts
+++ b/src/analysis/analysisVisitors/brickTypeAnalysis.ts
@@ -45,7 +45,7 @@ class BrickTypeAnalysis extends AnalysisVisitorWithResolvedBricksABC {
     );
 
     if (
-      blockConfig.id === TourStepTransformer.BLOCK_ID &&
+      blockConfig.id === TourStepTransformer.BRICK_ID &&
       this.extension.type !== "tour"
     ) {
       this.annotations.push({

--- a/src/analysis/analysisVisitors/requestPermissionAnalysis.ts
+++ b/src/analysis/analysisVisitors/requestPermissionAnalysis.ts
@@ -55,7 +55,7 @@ class RequestPermissionAnalysis extends AnalysisVisitorABC {
     if (
       !(
         blockConfig.id === RemoteMethod.BLOCK_ID ||
-        blockConfig.id === GetAPITransformer.BLOCK_ID
+        blockConfig.id === GetAPITransformer.BRICK_ID
       ) ||
       blockConfig.config.service != null
     ) {

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -708,7 +708,7 @@ describe("Collecting available vars", () => {
   describe("if-else brick", () => {
     beforeAll(async () => {
       const ifElseBlock = {
-        id: IfElse.BLOCK_ID,
+        id: IfElse.BRICK_ID,
         outputKey: validateOutputKey("ifOutput"),
         config: {
           condition: true,
@@ -936,7 +936,7 @@ describe("Collecting available vars", () => {
   describe("try-except brick", () => {
     beforeAll(async () => {
       const tryExceptBlock = {
-        id: TryExcept.BLOCK_ID,
+        id: TryExcept.BRICK_ID,
         outputKey: validateOutputKey("typeExcept"),
         config: {
           errorKey: "error",
@@ -976,7 +976,7 @@ describe("Collecting available vars", () => {
   describe("for-each element brick", () => {
     beforeAll(async () => {
       const forEachBlock = {
-        id: ForEachElement.BLOCK_ID,
+        id: ForEachElement.BRICK_ID,
         outputKey: validateOutputKey("forEachOutput"),
         config: {
           elementKey: "element",
@@ -1007,7 +1007,7 @@ describe("Collecting available vars", () => {
   describe("for-each brick", () => {
     beforeAll(async () => {
       const forEachBlock = {
-        id: ForEach.BLOCK_ID,
+        id: ForEach.BRICK_ID,
         outputKey: validateOutputKey("forEachOutput"),
         config: {
           elementKey: "element",

--- a/src/bricks/PipelineVisitor.test.ts
+++ b/src/bricks/PipelineVisitor.test.ts
@@ -78,7 +78,7 @@ test("should invoke the callback for the pipeline bricks", () => {
 test("should invoke the callback for the sub pipeline bricks", () => {
   const subPipeline = pipelineFactory();
   const forEachBrick = brickConfigFactory({
-    id: ForEach.BLOCK_ID,
+    id: ForEach.BRICK_ID,
     config: {
       elements: toExpression("var", "@elements"),
       body: toExpression("pipeline", subPipeline),

--- a/src/bricks/blockFilterHelpers.ts
+++ b/src/bricks/blockFilterHelpers.ts
@@ -60,12 +60,12 @@ export function getSubPipelineFlavor(
     return PipelineFlavor.NoEffect;
   }
 
-  if (parentNodeId === DisplayTemporaryInfo.BLOCK_ID) {
+  if (parentNodeId === DisplayTemporaryInfo.BRICK_ID) {
     // Temporary Info renderer shouldn't have side effects
     return PipelineFlavor.NoEffect;
   }
 
-  if (parentNodeId === TourStepTransformer.BLOCK_ID) {
+  if (parentNodeId === TourStepTransformer.BRICK_ID) {
     const pathParts = pipelinePath.split(".");
     if (pathParts.at(-2) === "body") {
       // Tour step body should have no side effects

--- a/src/bricks/effects/assignModVariable.ts
+++ b/src/bricks/effects/assignModVariable.ts
@@ -77,7 +77,7 @@ class AssignModVariable extends EffectABC {
     ["variableName", "value"],
   );
 
-  uiSchema = {
+  override uiSchema = {
     "ui:order": ["variableName", "value"],
   };
 

--- a/src/bricks/effects/customEvent.ts
+++ b/src/bricks/effects/customEvent.ts
@@ -48,7 +48,7 @@ class CustomEventEffect extends EffectABC {
     required: ["eventName"],
   };
 
-  uiSchema: UiSchema = {
+  override uiSchema: UiSchema = {
     eventName: {
       "ui:widget": "SchemaCustomEventWidget",
     },

--- a/src/bricks/effects/pageState.ts
+++ b/src/bricks/effects/pageState.ts
@@ -61,7 +61,7 @@ export class SetPageState extends TransformerABC {
     return true;
   }
 
-  defaultOutputKey = "state";
+  override defaultOutputKey = "state";
 
   inputSchema: Schema = propertiesToSchema(
     {
@@ -97,7 +97,7 @@ export class SetPageState extends TransformerABC {
     ["data"],
   );
 
-  uiSchema = {
+  override uiSchema = {
     "ui:order": ["namespace", "mergeStrategy", "data"],
   };
 
@@ -165,7 +165,7 @@ export class GetPageState extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "state";
+  override defaultOutputKey = "state";
 
   inputSchema: Schema = propertiesToSchema(
     {

--- a/src/bricks/readers/DocumentReader.ts
+++ b/src/bricks/readers/DocumentReader.ts
@@ -20,7 +20,7 @@ import { type Schema } from "@/types/schemaTypes";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
 
 class DocumentReader extends ReaderABC {
-  defaultOutputKey = "context";
+  override defaultOutputKey = "context";
 
   constructor() {
     super(

--- a/src/bricks/readers/ElementReader.ts
+++ b/src/bricks/readers/ElementReader.ts
@@ -29,7 +29,7 @@ import { isVisible } from "@/utils/domUtils";
  * @see HtmlReader
  */
 export class ElementReader extends ReaderABC {
-  defaultOutputKey = "element";
+  override defaultOutputKey = "element";
 
   constructor() {
     super(

--- a/src/bricks/readers/HtmlReader.ts
+++ b/src/bricks/readers/HtmlReader.ts
@@ -29,7 +29,7 @@ import { type SelectorRoot } from "@/types/runtimeTypes";
  * @see ElementReader
  */
 export class HtmlReader extends ReaderABC {
-  defaultOutputKey = "html";
+  override defaultOutputKey = "html";
 
   constructor() {
     super(

--- a/src/bricks/readers/ImageExifReader.ts
+++ b/src/bricks/readers/ImageExifReader.ts
@@ -45,7 +45,7 @@ async function getData(img: HTMLImageElement): Promise<ArrayBuffer> {
 }
 
 export class ImageExifReader extends ReaderABC {
-  defaultOutputKey = "image";
+  override defaultOutputKey = "image";
 
   constructor() {
     super(

--- a/src/bricks/readers/ImageReader.ts
+++ b/src/bricks/readers/ImageReader.ts
@@ -41,7 +41,7 @@ function getBase64Image(img: HTMLImageElement) {
 }
 
 export class ImageReader extends ReaderABC {
-  defaultOutputKey = "image";
+  override defaultOutputKey = "image";
 
   constructor() {
     super(

--- a/src/bricks/readers/ManifestReader.ts
+++ b/src/bricks/readers/ManifestReader.ts
@@ -19,7 +19,7 @@ import { ReaderABC } from "@/types/bricks/readerTypes";
 import { type Schema } from "@/types/schemaTypes";
 
 class ManifestReader extends ReaderABC {
-  defaultOutputKey = "manifest";
+  override defaultOutputKey = "manifest";
 
   constructor() {
     super(

--- a/src/bricks/readers/PageMetadataReader.ts
+++ b/src/bricks/readers/PageMetadataReader.ts
@@ -19,7 +19,7 @@ import { ReaderABC } from "@/types/bricks/readerTypes";
 import { type Schema } from "@/types/schemaTypes";
 
 export class PageMetadataReader extends ReaderABC {
-  defaultOutputKey = "metadata";
+  override defaultOutputKey = "metadata";
 
   constructor() {
     super(

--- a/src/bricks/readers/PageSemanticReader.ts
+++ b/src/bricks/readers/PageSemanticReader.ts
@@ -20,7 +20,7 @@ import { type JsonObject } from "type-fest";
 import { type Schema } from "@/types/schemaTypes";
 
 export class PageSemanticReader extends ReaderABC {
-  defaultOutputKey = "metadata";
+  override defaultOutputKey = "metadata";
 
   constructor() {
     super(

--- a/src/bricks/readers/ProfileReader.ts
+++ b/src/bricks/readers/ProfileReader.ts
@@ -21,7 +21,7 @@ import { type Schema } from "@/types/schemaTypes";
 import { type UserData } from "@/auth/authTypes";
 
 class ProfileReader extends ReaderABC {
-  defaultOutputKey = "profile";
+  override defaultOutputKey = "profile";
 
   constructor() {
     super(

--- a/src/bricks/readers/SelectionReader.ts
+++ b/src/bricks/readers/SelectionReader.ts
@@ -29,7 +29,7 @@ export class SelectionReader extends ReaderABC {
     );
   }
 
-  defaultOutputKey = "selection";
+  override defaultOutputKey = "selection";
 
   override async isRootAware(): Promise<boolean> {
     return false;

--- a/src/bricks/readers/SessionReader.ts
+++ b/src/bricks/readers/SessionReader.ts
@@ -22,7 +22,7 @@ import { type JsonObject } from "type-fest";
 import { type Schema } from "@/types/schemaTypes";
 
 class SessionReader extends ReaderABC {
-  defaultOutputKey = "session";
+  override defaultOutputKey = "session";
 
   constructor() {
     super(

--- a/src/bricks/readers/TimestampReader.ts
+++ b/src/bricks/readers/TimestampReader.ts
@@ -19,7 +19,7 @@ import { ReaderABC } from "@/types/bricks/readerTypes";
 import { type Schema } from "@/types/schemaTypes";
 
 class TimestampReader extends ReaderABC {
-  defaultOutputKey = "instant";
+  override defaultOutputKey = "instant";
 
   constructor() {
     super(

--- a/src/bricks/transformers/FormData.ts
+++ b/src/bricks/transformers/FormData.ts
@@ -32,7 +32,7 @@ function isCheckbox(
 }
 
 export class FormData extends TransformerABC {
-  defaultOutputKey = "form";
+  override defaultOutputKey = "form";
 
   constructor() {
     super(

--- a/src/bricks/transformers/RunMetadataTransformer.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.ts
@@ -40,7 +40,7 @@ class RunMetadataTransformer extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "meta";
+  override defaultOutputKey = "meta";
 
   inputSchema: Schema = SCHEMA_EMPTY_OBJECT;
 

--- a/src/bricks/transformers/brickFactory.ts
+++ b/src/bricks/transformers/brickFactory.ts
@@ -34,7 +34,7 @@ import {
   type ApiVersion,
   type BrickArgs,
   type BrickOptions,
-  OutputKey,
+  type OutputKey,
   validateBrickArgsContext,
 } from "@/types/runtimeTypes";
 import {

--- a/src/bricks/transformers/brickFactory.ts
+++ b/src/bricks/transformers/brickFactory.ts
@@ -34,6 +34,7 @@ import {
   type ApiVersion,
   type BrickArgs,
   type BrickOptions,
+  OutputKey,
   validateBrickArgsContext,
 } from "@/types/runtimeTypes";
 import {
@@ -141,8 +142,6 @@ class UserDefinedBrick extends BrickABC {
 
   readonly inputSchema: Schema;
 
-  readonly uiSchema?: UiSchema;
-
   readonly version: SemVerString;
 
   constructor(
@@ -158,16 +157,17 @@ class UserDefinedBrick extends BrickABC {
     this.uiSchema = this.component.uiSchema;
     this.outputSchema = this.component.outputSchema;
     this.version = version;
+    this.defaultOutputKey = UserDefinedBrick.parseDefaultOutputKey(component);
   }
 
-  get defaultOutputKey(): string | null {
-    if (!this.component.defaultOutputKey) {
+  private static parseDefaultOutputKey(definition: BrickDefinition): OutputKey {
+    if (!definition.defaultOutputKey) {
       return null;
     }
 
     try {
       // Already validated in the JSON Schema, but be defensive
-      return validateOutputKey(this.component.defaultOutputKey);
+      return validateOutputKey(definition.defaultOutputKey);
     } catch {
       return null;
     }

--- a/src/bricks/transformers/component/ComponentReader.ts
+++ b/src/bricks/transformers/component/ComponentReader.ts
@@ -38,7 +38,7 @@ export class ComponentReader extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "data";
+  override defaultOutputKey = "data";
 
   inputSchema: Schema = {
     type: "object",

--- a/src/bricks/transformers/component/TableReader.ts
+++ b/src/bricks/transformers/component/TableReader.ts
@@ -39,7 +39,7 @@ export class TableReader extends TransformerABC {
     super(TABLE_READER_ID, "Table Reader", "Extract data from table");
   }
 
-  defaultOutputKey = "table";
+  override defaultOutputKey = "table";
 
   inputSchema: Schema = {
     type: "object",
@@ -121,7 +121,7 @@ export class TablesReader extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "tables";
+  override defaultOutputKey = "tables";
 
   inputSchema: Schema = {
     type: "object",

--- a/src/bricks/transformers/controlFlow/ForEach.ts
+++ b/src/bricks/transformers/controlFlow/ForEach.ts
@@ -28,12 +28,12 @@ import { validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
 
 class ForEach extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/for-each");
-  defaultOutputKey = "forEachOutput";
+  static BRICK_ID = validateRegistryId("@pixiebrix/for-each");
+  override defaultOutputKey = "forEachOutput";
 
   constructor() {
     super(
-      ForEach.BLOCK_ID,
+      ForEach.BRICK_ID,
       "For-Each Loop",
       "Loop over elements in a list/array, returning the value of the last iteration",
     );

--- a/src/bricks/transformers/controlFlow/ForEachElement.ts
+++ b/src/bricks/transformers/controlFlow/ForEachElement.ts
@@ -31,12 +31,12 @@ import { PropError } from "@/errors/businessErrors";
 import { $safeFind } from "@/utils/domUtils";
 
 class ForEachElement extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/for-each-element");
-  defaultOutputKey = "forEachResult";
+  static BRICK_ID = validateRegistryId("@pixiebrix/for-each-element");
+  override defaultOutputKey = "forEachResult";
 
   constructor() {
     super(
-      ForEachElement.BLOCK_ID,
+      ForEachElement.BRICK_ID,
       "For-Each Element",
       "Loop over elements on the page, returning the value of the last iteration",
     );

--- a/src/bricks/transformers/controlFlow/IfElse.ts
+++ b/src/bricks/transformers/controlFlow/IfElse.ts
@@ -27,12 +27,12 @@ import { validateRegistryId } from "@/types/helpers";
 import { boolean } from "@/utils/typeUtils";
 
 class IfElse extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/if-else");
-  defaultOutputKey = "ifElseOutput";
+  static BRICK_ID = validateRegistryId("@pixiebrix/if-else");
+  override defaultOutputKey = "ifElseOutput";
 
   constructor() {
     super(
-      IfElse.BLOCK_ID,
+      IfElse.BRICK_ID,
       "If-Else",
       "Run multiple bricks if a condition is met",
     );

--- a/src/bricks/transformers/controlFlow/MapValues.ts
+++ b/src/bricks/transformers/controlFlow/MapValues.ts
@@ -30,7 +30,7 @@ import { type Schema } from "@/types/schemaTypes";
 
 class MapValues extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/map");
-  defaultOutputKey = "mapped";
+  override defaultOutputKey = "mapped";
 
   constructor() {
     super(

--- a/src/bricks/transformers/controlFlow/Retry.ts
+++ b/src/bricks/transformers/controlFlow/Retry.ts
@@ -28,11 +28,11 @@ import { BusinessError } from "@/errors/businessErrors";
 import { sleep } from "@/utils/timeUtils";
 
 class Retry extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/retry");
-  defaultOutputKey = "retryOutput";
+  static BRICK_ID = validateRegistryId("@pixiebrix/retry");
+  override defaultOutputKey = "retryOutput";
 
   constructor() {
-    super(Retry.BLOCK_ID, "Retry", "Retry bricks on error");
+    super(Retry.BRICK_ID, "Retry", "Retry bricks on error");
   }
 
   override async isPure(): Promise<boolean> {

--- a/src/bricks/transformers/controlFlow/Run.ts
+++ b/src/bricks/transformers/controlFlow/Run.ts
@@ -33,12 +33,12 @@ import { validateRegistryId } from "@/types/helpers";
  * - Performance tracing
  */
 class Run extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/run");
-  defaultOutputKey = "runOutput";
+  static BRICK_ID = validateRegistryId("@pixiebrix/run");
+  override defaultOutputKey = "runOutput";
 
   constructor() {
     super(
-      Run.BLOCK_ID,
+      Run.BRICK_ID,
       "Run Bricks",
       "Run one or more bricks synchronously or asynchronously",
     );

--- a/src/bricks/transformers/controlFlow/TryExcept.ts
+++ b/src/bricks/transformers/controlFlow/TryExcept.ts
@@ -29,12 +29,12 @@ import { validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
 
 class TryExcept extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/try-catch");
-  defaultOutputKey = "tryExceptOutput";
+  static BRICK_ID = validateRegistryId("@pixiebrix/try-catch");
+  override defaultOutputKey = "tryExceptOutput";
 
   constructor() {
     super(
-      TryExcept.BLOCK_ID,
+      TryExcept.BRICK_ID,
       "Try-Except",
       "Try to run a brick, and recover on error",
     );

--- a/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
+++ b/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
@@ -83,7 +83,7 @@ export class WithAsyncModVariable extends TransformerABC {
     ["body", "stateKey"],
   );
 
-  defaultOutputKey = "async";
+  override defaultOutputKey = "async";
 
   override outputSchema: Schema = {
     type: "object",

--- a/src/bricks/transformers/convertDocument.ts
+++ b/src/bricks/transformers/convertDocument.ts
@@ -100,7 +100,7 @@ class ConvertDocument extends TransformerABC {
     return true;
   }
 
-  defaultOutputKey = "document";
+  override defaultOutputKey = "document";
 
   inputSchema: Schema = propertiesToSchema(
     {

--- a/src/bricks/transformers/detect.ts
+++ b/src/bricks/transformers/detect.ts
@@ -25,7 +25,7 @@ import {
 } from "@/bricks/rootModeHelpers";
 
 export class DetectElement extends TransformerABC {
-  defaultOutputKey = "match";
+  override defaultOutputKey = "match";
 
   constructor() {
     super(

--- a/src/bricks/transformers/encode.ts
+++ b/src/bricks/transformers/encode.ts
@@ -20,7 +20,7 @@ import { type BrickArgs } from "@/types/runtimeTypes";
 import { propertiesToSchema } from "@/validators/generic";
 
 export class Base64Encode extends TransformerABC {
-  defaultOutputKey = "encoded";
+  override defaultOutputKey = "encoded";
 
   override async isPure(): Promise<boolean> {
     return true;
@@ -53,7 +53,7 @@ export class Base64Encode extends TransformerABC {
 }
 
 export class Base64Decode extends TransformerABC {
-  defaultOutputKey = "decoded";
+  override defaultOutputKey = "decoded";
 
   constructor() {
     super(

--- a/src/bricks/transformers/ephemeralForm/formTransformer.ts
+++ b/src/bricks/transformers/ephemeralForm/formTransformer.ts
@@ -54,12 +54,12 @@ export async function createFrameSource(
 }
 
 export class FormTransformer extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/form-modal");
-  defaultOutputKey = "form";
+  static BRICK_ID = validateRegistryId("@pixiebrix/form-modal");
+  override defaultOutputKey = "form";
 
   constructor() {
     super(
-      FormTransformer.BLOCK_ID,
+      FormTransformer.BRICK_ID,
       "Show a modal or sidebar form",
       "Show a form as a modal or in the sidebar, and return the input",
       "faCode",

--- a/src/bricks/transformers/extensionDiagnostics.ts
+++ b/src/bricks/transformers/extensionDiagnostics.ts
@@ -23,7 +23,7 @@ import { getDiagnostics as collectFrameDiagnostics } from "@/contentScript/perfo
 import { collectPerformanceDiagnostics as collectExtensionDiagnostics } from "@/background/messenger/api";
 
 class ExtensionDiagnostics extends TransformerABC {
-  defaultOutputKey = "diagnostics";
+  override defaultOutputKey = "diagnostics";
 
   constructor() {
     super(

--- a/src/bricks/transformers/httpGet.ts
+++ b/src/bricks/transformers/httpGet.ts
@@ -27,18 +27,18 @@ import { type AxiosRequestConfig } from "axios";
 import { isNullOrBlank } from "@/utils/stringUtils";
 
 export class GetAPITransformer extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/get");
+  static BRICK_ID = validateRegistryId("@pixiebrix/get");
 
   constructor() {
     super(
-      GetAPITransformer.BLOCK_ID,
+      GetAPITransformer.BRICK_ID,
       "[Deprecated] HTTP GET",
       "Fetch data from an API",
       "faCloud",
     );
   }
 
-  defaultOutputKey = "response";
+  override defaultOutputKey = "response";
 
   inputSchema: Schema = propertiesToSchema(
     {

--- a/src/bricks/transformers/javascript.ts
+++ b/src/bricks/transformers/javascript.ts
@@ -61,7 +61,7 @@ export class JavaScriptTransformer extends TransformerABC {
     ["function"],
   );
 
-  uiSchema: UiSchema = {
+  override uiSchema: UiSchema = {
     function: {
       "ui:widget": "CodeEditorWidget",
     },

--- a/src/bricks/transformers/jquery/JQueryReader.ts
+++ b/src/bricks/transformers/jquery/JQueryReader.ts
@@ -35,7 +35,7 @@ export class JQueryReader extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "data";
+  override defaultOutputKey = "data";
 
   inputSchema: Schema = {
     type: "object",

--- a/src/bricks/transformers/mapping.ts
+++ b/src/bricks/transformers/mapping.ts
@@ -22,7 +22,7 @@ import { BusinessError } from "@/errors/businessErrors";
 import { type UnknownObject } from "@/types/objectTypes";
 
 export class MappingTransformer extends TransformerABC {
-  defaultOutputKey = "value";
+  override defaultOutputKey = "value";
 
   override async isPure(): Promise<boolean> {
     return true;

--- a/src/bricks/transformers/parseDate.ts
+++ b/src/bricks/transformers/parseDate.ts
@@ -46,7 +46,7 @@ export class ParseDate extends TransformerABC {
     return true;
   }
 
-  defaultOutputKey = "parsedDate";
+  override defaultOutputKey = "parsedDate";
 
   constructor() {
     super(

--- a/src/bricks/transformers/parseUrl.ts
+++ b/src/bricks/transformers/parseUrl.ts
@@ -45,7 +45,7 @@ export class UrlParser extends TransformerABC {
     return true;
   }
 
-  defaultOutputKey = "parsedUrl";
+  override defaultOutputKey = "parsedUrl";
 
   constructor() {
     super(

--- a/src/bricks/transformers/prompt.ts
+++ b/src/bricks/transformers/prompt.ts
@@ -31,7 +31,7 @@ export class Prompt extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "userInput";
+  override defaultOutputKey = "userInput";
 
   inputSchema: Schema = propertiesToSchema(
     {

--- a/src/bricks/transformers/randomNumber.ts
+++ b/src/bricks/transformers/randomNumber.ts
@@ -31,7 +31,7 @@ export class RandomNumber extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "random";
+  override defaultOutputKey = "random";
 
   override async isPure(): Promise<boolean> {
     return false;

--- a/src/bricks/transformers/readable.ts
+++ b/src/bricks/transformers/readable.ts
@@ -31,7 +31,7 @@ export class Readable extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "article";
+  override defaultOutputKey = "article";
 
   override async isPure(): Promise<boolean> {
     // Technically is not pure, because value depends on document state. But it generally won't change

--- a/src/bricks/transformers/regex.ts
+++ b/src/bricks/transformers/regex.ts
@@ -47,7 +47,7 @@ export class RegexTransformer extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "extracted";
+  override defaultOutputKey = "extracted";
 
   inputSchema: Schema = propertiesToSchema(
     {

--- a/src/bricks/transformers/remoteMethod.ts
+++ b/src/bricks/transformers/remoteMethod.ts
@@ -75,7 +75,7 @@ export class RemoteMethod extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "response";
+  override defaultOutputKey = "response";
 
   inputSchema: Schema = propertiesToSchema(inputProperties, ["url"]);
 

--- a/src/bricks/transformers/screenshotTab.ts
+++ b/src/bricks/transformers/screenshotTab.ts
@@ -45,7 +45,7 @@ export class ScreenshotTab extends TransformerABC {
     },
   };
 
-  defaultOutputKey = "screenshot";
+  override defaultOutputKey = "screenshot";
 
   async transform(): Promise<unknown> {
     try {

--- a/src/bricks/transformers/searchText.ts
+++ b/src/bricks/transformers/searchText.ts
@@ -160,7 +160,7 @@ export class SearchText extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "matches";
+  override defaultOutputKey = "matches";
 
   override async isPure(): Promise<boolean> {
     return true;

--- a/src/bricks/transformers/selectElement.ts
+++ b/src/bricks/transformers/selectElement.ts
@@ -29,7 +29,7 @@ export class SelectElement extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "selected";
+  override defaultOutputKey = "selected";
 
   // In the future, can add options for selecting multiple elements, providing instructions to the user, filtering
   // valid elements, etc.

--- a/src/bricks/transformers/splitText.ts
+++ b/src/bricks/transformers/splitText.ts
@@ -31,7 +31,7 @@ export class SplitText extends TransformerABC {
     return true;
   }
 
-  defaultOutputKey = "split";
+  override defaultOutputKey = "split";
 
   constructor() {
     super(

--- a/src/bricks/transformers/template.ts
+++ b/src/bricks/transformers/template.ts
@@ -30,7 +30,7 @@ import { BusinessError } from "@/errors/businessErrors";
  * Transformer that fills a template using the current context.
  */
 export class TemplateTransformer extends TransformerABC {
-  defaultOutputKey = "filled";
+  override defaultOutputKey = "filled";
 
   override async isPure(): Promise<boolean> {
     return true;

--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.ts
@@ -327,12 +327,12 @@ export async function displayTemporaryInfo({
 }
 
 class DisplayTemporaryInfo extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/display");
-  defaultOutputKey = "infoOutput";
+  static BRICK_ID = validateRegistryId("@pixiebrix/display");
+  override defaultOutputKey = "infoOutput";
 
   constructor() {
     super(
-      DisplayTemporaryInfo.BLOCK_ID,
+      DisplayTemporaryInfo.BRICK_ID,
       "Display Temporary Information",
       "Display a document in a temporary sidebar panel",
     );

--- a/src/bricks/transformers/tourStep/TourStepOptions.test.tsx
+++ b/src/bricks/transformers/tourStep/TourStepOptions.test.tsx
@@ -30,7 +30,7 @@ function makeBaseState() {
   // Extension type doesn't really matter here...
   const baseFormState = menuItemFormStateFactory();
   baseFormState.extension.blockPipeline = [
-    createNewConfiguredBrick(TourStep.BLOCK_ID),
+    createNewConfiguredBrick(TourStep.BRICK_ID),
   ];
   return baseFormState;
 }

--- a/src/bricks/transformers/tourStep/TourStepOptions.tsx
+++ b/src/bricks/transformers/tourStep/TourStepOptions.tsx
@@ -92,7 +92,7 @@ const TourStepOptions: React.FunctionComponent<BlockOptionProps> = ({
                   configName("body"),
                   toExpression("pipeline", [
                     createNewConfiguredBrick(DocumentRenderer.BLOCK_ID, {
-                      parentBrickId: TourStepTransformer.BLOCK_ID,
+                      parentBrickId: TourStepTransformer.BRICK_ID,
                     }),
                   ]),
                 );

--- a/src/bricks/transformers/tourStep/tourStep.ts
+++ b/src/bricks/transformers/tourStep/tourStep.ts
@@ -289,17 +289,17 @@ function markdownPipeline(markdown: string): PipelineExpression {
 }
 
 class TourStepTransformer extends TransformerABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/tour/step");
+  static BRICK_ID = validateRegistryId("@pixiebrix/tour/step");
 
   constructor() {
     super(
-      TourStepTransformer.BLOCK_ID,
+      TourStepTransformer.BRICK_ID,
       "Show Tour Step",
       "Show a step in a tour",
     );
   }
 
-  defaultOutputKey = "step";
+  override defaultOutputKey = "step";
 
   override async isRootAware(): Promise<boolean> {
     return true;

--- a/src/bricks/transformers/url.ts
+++ b/src/bricks/transformers/url.ts
@@ -58,14 +58,13 @@ export class UrlParams extends TransformerABC {
     return true;
   }
 
-  defaultOutputKey = "url";
+  override defaultOutputKey = "url";
 
   constructor() {
     super(
       "@pixiebrix/url-params",
       "Construct URL",
       "Construct a URL with encoded search parameter",
-      "faCode",
     );
   }
 

--- a/src/components/documentBuilder/preview/DocumentPreview.test.tsx
+++ b/src/components/documentBuilder/preview/DocumentPreview.test.tsx
@@ -151,7 +151,7 @@ describe("Show live preview", () => {
     const documentElement = createNewElement("container");
     const formState = formStateFactory(undefined, [
       {
-        id: DisplayTemporaryInfo.BLOCK_ID,
+        id: DisplayTemporaryInfo.BRICK_ID,
         instanceId: uuidSequence(1),
         config: {
           title: toExpression("nunjucks", "Test Tab"),

--- a/src/components/documentBuilder/preview/DocumentPreview.tsx
+++ b/src/components/documentBuilder/preview/DocumentPreview.tsx
@@ -78,7 +78,7 @@ const DocumentPreview = ({
   const activeNodeId = useSelector(selectActiveNodeId);
   const parentBlockInfo = useSelector(selectParentBlockInfo(activeNodeId));
   const showPreviewButton =
-    parentBlockInfo?.blockId === DisplayTemporaryInfo.BLOCK_ID;
+    parentBlockInfo?.blockId === DisplayTemporaryInfo.BRICK_ID;
 
   const {
     error: previewError,

--- a/src/contrib/automationanywhere/RunBot.ts
+++ b/src/contrib/automationanywhere/RunBot.ts
@@ -152,7 +152,7 @@ export class RunBot extends TransformerABC {
     ],
   };
 
-  defaultOutputKey = "bot";
+  override defaultOutputKey = "bot";
 
   override outputSchema: Schema = {
     $schema: "https://json-schema.org/draft/2019-09/schema#",

--- a/src/contrib/editors.ts
+++ b/src/contrib/editors.ts
@@ -78,7 +78,7 @@ export default function registerEditors() {
   optionsRegistry.set(DATABASE_PUT_ID, DatabasePutOptions);
   optionsRegistry.set(REMOTE_METHOD_ID, RemoteMethodOptions);
   optionsRegistry.set(DOCUMENT_ID, DocumentOptions);
-  optionsRegistry.set(TourStepTransformer.BLOCK_ID, TourStepOptions);
+  optionsRegistry.set(TourStepTransformer.BRICK_ID, TourStepOptions);
   optionsRegistry.set(ALERT_EFFECT_ID, AlertOptions);
   optionsRegistry.set(JQueryReader.BRICK_ID, JQueryReaderOptions);
   optionsRegistry.set(AssignModVariable.BRICK_ID, AssignModVariableOptions);

--- a/src/contrib/google/sheets/bricks/lookup.ts
+++ b/src/contrib/google/sheets/bricks/lookup.ts
@@ -139,7 +139,7 @@ export class GoogleSheetsLookup extends TransformerABC {
     );
   }
 
-  defaultOutputKey = "row";
+  override defaultOutputKey = "row";
 
   inputSchema: Schema = LOOKUP_SCHEMA;
 

--- a/src/pageEditor/exampleBrickConfigs.ts
+++ b/src/pageEditor/exampleBrickConfigs.ts
@@ -74,7 +74,7 @@ export function getExampleBrickConfig(
       };
     }
 
-    case FormTransformer.BLOCK_ID: {
+    case FormTransformer.BRICK_ID: {
       return {
         schema: {
           title: "Example Form",
@@ -183,7 +183,7 @@ export function getExampleBrickConfig(
       };
     }
 
-    case DisplayTemporaryInfo.BLOCK_ID: {
+    case DisplayTemporaryInfo.BRICK_ID: {
       return {
         title: "Example Info",
         location: "panel",
@@ -194,7 +194,7 @@ export function getExampleBrickConfig(
       };
     }
 
-    case TourStep.BLOCK_ID: {
+    case TourStep.BRICK_ID: {
       return {
         title: "Example Step",
         body: "Step content. **Markdown** is supported.",

--- a/src/pageEditor/fields/FormModalOptions.test.tsx
+++ b/src/pageEditor/fields/FormModalOptions.test.tsx
@@ -34,7 +34,7 @@ beforeAll(() => {
 
 describe("FormModalOptions", () => {
   it("renders default values without crashing", async () => {
-    const brick = createNewConfiguredBrick(FormTransformer.BLOCK_ID);
+    const brick = createNewConfiguredBrick(FormTransformer.BRICK_ID);
 
     const initialValues = formStateFactory({
       extension: baseExtensionStateFactory({

--- a/src/pageEditor/starterBricks/pipelineMapping.test.ts
+++ b/src/pageEditor/starterBricks/pipelineMapping.test.ts
@@ -73,7 +73,7 @@ describe("normalizePipeline", () => {
   test("For-Each block", async () => {
     const pipeline: BrickConfig[] = [
       {
-        id: ForEach.BLOCK_ID,
+        id: ForEach.BRICK_ID,
         config: {
           elements: toExpression("var", "@input"),
           body: toExpression("pipeline", [echoBlockConfig, teapotBlockConfig]),
@@ -94,7 +94,7 @@ describe("normalizePipeline", () => {
   test("If-Else block", async () => {
     const pipeline: BrickConfig[] = [
       {
-        id: IfElse.BLOCK_ID,
+        id: IfElse.BRICK_ID,
         config: {
           condition: true,
           if: toExpression("pipeline", [echoBlockConfig]),
@@ -123,7 +123,7 @@ describe("normalizePipeline", () => {
   test("If-Else block with only If branch", async () => {
     const pipeline: BrickConfig[] = [
       {
-        id: IfElse.BLOCK_ID,
+        id: IfElse.BRICK_ID,
         config: {
           condition: true,
           if: toExpression("pipeline", [echoBlockConfig, teapotBlockConfig]),
@@ -148,7 +148,7 @@ describe("normalizePipeline", () => {
   test("Try-Except block", async () => {
     const pipeline: BrickConfig[] = [
       {
-        id: TryExcept.BLOCK_ID,
+        id: TryExcept.BRICK_ID,
         config: {
           try: toExpression("pipeline", [echoBlockConfig]),
           except: toExpression("pipeline", [teapotBlockConfig]),
@@ -176,7 +176,7 @@ describe("normalizePipeline", () => {
   test("Try-Except block with only Try branch", async () => {
     const pipeline: BrickConfig[] = [
       {
-        id: TryExcept.BLOCK_ID,
+        id: TryExcept.BRICK_ID,
         config: {
           try: toExpression("pipeline", [echoBlockConfig, teapotBlockConfig]),
         },
@@ -201,7 +201,7 @@ describe("normalizePipeline", () => {
     const createForEachBlock: (body: BrickConfig[]) => BrickConfig = (
       body,
     ) => ({
-      id: ForEach.BLOCK_ID,
+      id: ForEach.BRICK_ID,
       config: {
         elements: toExpression("var", "@input"),
         body: toExpression("pipeline", body),
@@ -268,7 +268,7 @@ describe("omitEditorMetadata", () => {
   test("For-Each block", () => {
     const pipeline: BrickConfig[] = [
       {
-        id: ForEach.BLOCK_ID,
+        id: ForEach.BRICK_ID,
         instanceId: uuidSequence(3),
         config: {
           elements: toExpression("var", "@input"),
@@ -288,7 +288,7 @@ describe("omitEditorMetadata", () => {
   test("If-Else block", () => {
     const pipeline: BrickConfig[] = [
       {
-        id: IfElse.BLOCK_ID,
+        id: IfElse.BRICK_ID,
         instanceId: uuidSequence(3),
         config: {
           condition: true,
@@ -316,7 +316,7 @@ describe("omitEditorMetadata", () => {
   test("Try-Except block", () => {
     const pipeline: BrickConfig[] = [
       {
-        id: TryExcept.BLOCK_ID,
+        id: TryExcept.BRICK_ID,
         instanceId: uuidSequence(3),
         config: {
           try: toExpression("pipeline", [echoBlockConfig]),
@@ -345,7 +345,7 @@ describe("omitEditorMetadata", () => {
       n: number,
       body: BrickConfig[],
     ) => BrickConfig = (n, body) => ({
-      id: ForEach.BLOCK_ID,
+      id: ForEach.BRICK_ID,
       instanceId: uuidSequence(n),
       config: {
         elements: toExpression("var", "@input"),

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -152,7 +152,7 @@ const DataPanel: React.FC = () => {
 
   const showFormPreview =
     brickId === CustomFormRenderer.BLOCK_ID ||
-    brickId === FormTransformer.BLOCK_ID;
+    brickId === FormTransformer.BRICK_ID;
   const showDocumentPreview = brickId === DocumentRenderer.BLOCK_ID;
   const showBrickPreview = record || previewInfo?.traceOptional;
 

--- a/src/pageEditor/tabs/editTab/editHelpers.test.ts
+++ b/src/pageEditor/tabs/editTab/editHelpers.test.ts
@@ -64,7 +64,7 @@ describe("getPipelineMap", () => {
   test("should map pipeline with sub pipeline", () => {
     const subPipeline = pipelineFactory();
     const forEachBrick = brickConfigFactory({
-      id: ForEach.BLOCK_ID,
+      id: ForEach.BRICK_ID,
       config: {
         elements: toExpression("var", "@elements"),
         body: toExpression("pipeline", subPipeline),
@@ -171,12 +171,12 @@ describe("generateFreshOutputKey", () => {
 
   it("should use declared key", async () => {
     class TransformerBrick extends TransformerABC {
-      static BLOCK_ID = validateRegistryId("test/transformer");
+      static BRICK_ID = validateRegistryId("test/transformer");
       constructor() {
-        super(TransformerBrick.BLOCK_ID, "Transformer Brick");
+        super(TransformerBrick.BRICK_ID, "Transformer Brick");
       }
 
-      defaultOutputKey = "foo";
+      override defaultOutputKey = "foo";
 
       inputSchema = {};
 

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -102,7 +102,7 @@ export function getPipelinePropNames(
 ): string[] {
   switch (blockConfig.id) {
     // Special handling for tour step to avoid clutter and input type alternatives
-    case TourStepTransformer.BLOCK_ID: {
+    case TourStepTransformer.BRICK_ID: {
       const propNames = [];
 
       // Only show onBeforeShow if it's provided, to avoid cluttering the UI
@@ -168,7 +168,7 @@ export function getVariableKeyForSubPipeline(
   let keyPropName: string = null;
 
   if (
-    [ForEach.BLOCK_ID, ForEachElement.BLOCK_ID, MapValues.BRICK_ID].includes(
+    [ForEach.BRICK_ID, ForEachElement.BRICK_ID, MapValues.BRICK_ID].includes(
       brickConfig.id,
     ) &&
     pipelinePropName === "body"
@@ -176,7 +176,7 @@ export function getVariableKeyForSubPipeline(
     keyPropName = "elementKey";
   }
 
-  if (brickConfig.id === TryExcept.BLOCK_ID && pipelinePropName === "except") {
+  if (brickConfig.id === TryExcept.BRICK_ID && pipelinePropName === "except") {
     keyPropName = "errorKey";
   }
 

--- a/src/types/brickTypes.ts
+++ b/src/types/brickTypes.ts
@@ -148,6 +148,10 @@ export abstract class BrickABC implements Brick {
 
   abstract readonly inputSchema: Schema;
 
+  uiSchema?: UiSchema = undefined;
+
+  defaultOutputKey?: string = undefined;
+
   outputSchema?: Schema = undefined;
 
   readonly permissions = {};
@@ -188,7 +192,7 @@ export abstract class BrickABC implements Brick {
    */
   getPipelineVariableSchema(
     _config: BrickConfig,
-    pipelineName: string,
+    _pipelineName: string,
   ): Schema | undefined {
     return undefined;
   }


### PR DESCRIPTION
## What does this PR do?

- Enforce knip unused `classMembers`
- Enforce knip unused `binaries`, `enumMembers`, `nsTypes` (we had no violations)
- Changes:
  - Marks uiSchema and defaultOutputKey as `override` the Brick class property
  - Renames `BLOCK_ID` -> `BRICK_ID` in files touched

## Reviewer Notes

- There's a lot of files touched, see above for the changes made

## Checklist

- [x] Add tests: N/A
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
