### PR TITLE
#7057: Fix image sizing bug in builder

### DIFF
--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -143,7 +143,6 @@ export function getComponentDefinition(
     case "image": {
       const { url, ...props } = config;
       props.src = url;
-      props.height = props.height ?? 50;
       return { Component: Image, props };
     }
 

--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -143,6 +143,14 @@ export function getComponentDefinition(
     case "image": {
       const { url, ...props } = config;
       props.src = url;
+      if (!props.height && !props.width) {
+        // Fit image to screen of the size hasn't been defined
+        // Defining it conditionally lets the user override it if the want the image to be in its natural size
+        props.style = {
+          maxWidth: "100%",
+        } satisfies Partial<CSSStyleDeclaration>;
+      }
+
       return { Component: Image, props };
     }
 


### PR DESCRIPTION

## What does this PR do?

- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/7057
- This was initially defined in https://github.com/pixiebrix/pixiebrix-extension/pull/3655

## Before

<img width="1058" alt="Screenshot 2" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/e775c01f-d010-440b-b0bb-95acf627435a">


## After

<img width="1058" alt="Screenshot 1" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/12b84806-26e9-4754-9f23-a2e0b3aa6f4c">

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
