### PR TITLE
#7268: Fix editor sidebar logo sizing

### DIFF
--- a/src/pageEditor/sidebar/HomeButton.module.scss
+++ b/src/pageEditor/sidebar/HomeButton.module.scss
@@ -18,16 +18,6 @@
 @import "@/themes/colors.scss";
 
 .button {
-  &,
-  &:active,
-  &:hover {
-    // Override native blue
-    background-color: $P500;
-    border-color: $P500;
-  }
-
-  &:hover {
-    background-color: $P500;
-    filter: brightness(0.75);
-  }
+  background-color: $P500;
+  border-color: $P500;
 }

--- a/src/pageEditor/sidebar/HomeButton.module.scss
+++ b/src/pageEditor/sidebar/HomeButton.module.scss
@@ -19,5 +19,5 @@
 
 .button {
   background-color: $P500;
-  border-color: $P500;
+  border: 0;
 }

--- a/src/pageEditor/sidebar/HomeButton.module.scss
+++ b/src/pageEditor/sidebar/HomeButton.module.scss
@@ -18,9 +18,16 @@
 @import "@/themes/colors.scss";
 
 .button {
-  background-color: $P500;
-  border-color: $P500;
+  &,
+  &:active,
+  &:hover {
+    // Override native blue
+    background-color: $P500;
+    border-color: $P500;
+  }
 
-  display: flex;
-  align-items: center;
+  &:hover {
+    background-color: $P500;
+    filter: brightness(0.75);
+  }
 }

--- a/src/pageEditor/sidebar/HomeButton.tsx
+++ b/src/pageEditor/sidebar/HomeButton.tsx
@@ -23,7 +23,10 @@ import home from "@img/home.svg";
 import styles from "./HomeButton.module.scss";
 import { Button } from "react-bootstrap";
 
-const HomeButton: React.FunctionComponent = () => {
+const HomeButton: React.FunctionComponent<{ onClick?: VoidCallback }> = ({
+  onClick,
+  children,
+}) => {
   const dispatch = useDispatch();
 
   return (
@@ -31,11 +34,14 @@ const HomeButton: React.FunctionComponent = () => {
       size="sm"
       className={styles.button}
       title="Home"
-      onClick={() => {
-        dispatch(editorSlice.actions.showHomePane());
-      }}
+      onClick={
+        onClick ??
+        (() => {
+          dispatch(editorSlice.actions.showHomePane());
+        })
+      }
     >
-      <img src={home} alt="Return to Page Editor Home" />
+      {children ?? <img src={home} alt="Return to Page Editor Home" />}
     </Button>
   );
 };

--- a/src/pageEditor/sidebar/HomeButton.tsx
+++ b/src/pageEditor/sidebar/HomeButton.tsx
@@ -16,18 +16,28 @@
  */
 
 import React from "react";
+import { useDispatch } from "react-redux";
+import { editorSlice } from "@/pageEditor/slices/editorSlice";
 import home from "@img/home.svg";
 
 import styles from "./HomeButton.module.scss";
 import { Button } from "react-bootstrap";
 
-const HomeButton: React.FunctionComponent<{ onClick: VoidCallback }> = ({
-  onClick,
-  children,
-}) => (
-  <Button size="sm" className={styles.button} title="Home" onClick={onClick}>
-    {children ?? <img src={home} alt="Return to Page Editor Home" />}
-  </Button>
-);
+const HomeButton: React.FunctionComponent = () => {
+  const dispatch = useDispatch();
+
+  return (
+    <Button
+      size="sm"
+      className={styles.button}
+      title="Home"
+      onClick={() => {
+        dispatch(editorSlice.actions.showHomePane());
+      }}
+    >
+      <img src={home} alt="Return to Page Editor Home" />
+    </Button>
+  );
+};
 
 export default HomeButton;

--- a/src/pageEditor/sidebar/HomeButton.tsx
+++ b/src/pageEditor/sidebar/HomeButton.tsx
@@ -16,34 +16,18 @@
  */
 
 import React from "react";
-import { useDispatch } from "react-redux";
-import { editorSlice } from "@/pageEditor/slices/editorSlice";
 import home from "@img/home.svg";
 
 import styles from "./HomeButton.module.scss";
 import { Button } from "react-bootstrap";
 
-const HomeButton: React.FunctionComponent<{ onClick?: VoidCallback }> = ({
+const HomeButton: React.FunctionComponent<{ onClick: VoidCallback }> = ({
   onClick,
   children,
-}) => {
-  const dispatch = useDispatch();
-
-  return (
-    <Button
-      size="sm"
-      className={styles.button}
-      title="Home"
-      onClick={
-        onClick ??
-        (() => {
-          dispatch(editorSlice.actions.showHomePane());
-        })
-      }
-    >
-      {children ?? <img src={home} alt="Return to Page Editor Home" />}
-    </Button>
-  );
-};
+}) => (
+  <Button size="sm" className={styles.button} title="Home" onClick={onClick}>
+    {children ?? <img src={home} alt="Return to Page Editor Home" />}
+  </Button>
+);
 
 export default HomeButton;

--- a/src/pageEditor/sidebar/ReloadButton.tsx
+++ b/src/pageEditor/sidebar/ReloadButton.tsx
@@ -44,7 +44,7 @@ const ReloadButton: React.FunctionComponent = () => (
     className="mt-auto"
     onClick={onReload}
   >
-    <FontAwesomeIcon icon={faSync} />
+    <FontAwesomeIcon icon={faSync} fixedWidth />
   </Button>
 );
 

--- a/src/pageEditor/sidebar/Sidebar.module.scss
+++ b/src/pageEditor/sidebar/Sidebar.module.scss
@@ -78,6 +78,10 @@
 
 .actionsLeft {
   display: flex;
+  :global(.btn) {
+    // Matches the height of the nav-tabs on its right
+    border: 0;
+  }
   > :global(.dropdown) {
     // Makes the Add button fit the height of the action bar
     display: flex;

--- a/src/pageEditor/sidebar/Sidebar.module.scss
+++ b/src/pageEditor/sidebar/Sidebar.module.scss
@@ -1,5 +1,4 @@
 @import "@/themes/colors.scss";
-$logoSize: 31px;
 
 .root {
   flex-direction: column;
@@ -10,8 +9,7 @@ $logoSize: 31px;
   background: white;
 
   &.collapsed {
-    flex: 0 0 $logoSize;
-    align-items: center;
+    align-items: stretch;
   }
   &.expanded {
     flex: 0 0 270px;
@@ -41,6 +39,10 @@ $logoSize: 31px;
     font-size: 0.875rem;
   }
 
+  button {
+    border-radius: 0;
+  }
+
   :global {
     .list-group {
       border-radius: 0;
@@ -52,16 +54,6 @@ $logoSize: 31px;
         font-size: 0.875rem;
       }
     }
-  }
-}
-
-.logo {
-  background-color: #6462aa; // Make logo icon look square
-  width: $logoSize;
-  height: $logoSize;
-
-  :hover > & {
-    filter: brightness(0.75);
   }
 }
 
@@ -86,12 +78,15 @@ $logoSize: 31px;
 
 .actionsLeft {
   display: flex;
+  > :global(.dropdown) {
+    // Makes the Add button fit the height of the action bar
+    display: flex;
+  }
 }
 
 .toggle {
   border: none !important;
   border-radius: 0 !important;
-  width: $logoSize;
   padding: 0 !important;
   background: transparent !important;
 

--- a/src/pageEditor/sidebar/SidebarCollapsed.tsx
+++ b/src/pageEditor/sidebar/SidebarCollapsed.tsx
@@ -36,15 +36,9 @@ const SidebarCollapsed: React.VoidFunctionComponent<{
 
   return (
     <div className={cx(styles.root, styles.collapsed)}>
-      <Button
-        variant="light"
-        className={styles.toggle}
-        type="button"
-        onClick={expandSidebar}
-      >
-        <HomeButton />
-        <FontAwesomeIcon icon={faAngleDoubleRight} />
-      </Button>
+      <HomeButton onClick={expandSidebar}>
+        <FontAwesomeIcon icon={faAngleDoubleRight} fixedWidth />
+      </HomeButton>
       {showDeveloperUI && <ReloadButton />}
     </div>
   );

--- a/src/pageEditor/sidebar/SidebarCollapsed.tsx
+++ b/src/pageEditor/sidebar/SidebarCollapsed.tsx
@@ -17,6 +17,7 @@
 
 import styles from "./Sidebar.module.scss";
 import React from "react";
+import { Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDoubleRight } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";
@@ -35,9 +36,15 @@ const SidebarCollapsed: React.VoidFunctionComponent<{
 
   return (
     <div className={cx(styles.root, styles.collapsed)}>
-      <HomeButton onClick={expandSidebar}>
-        <FontAwesomeIcon icon={faAngleDoubleRight} fixedWidth />
-      </HomeButton>
+      <HomeButton />
+      <Button
+        variant="light"
+        className={styles.toggle}
+        type="button"
+        onClick={expandSidebar}
+      >
+        <FontAwesomeIcon icon={faAngleDoubleRight} />
+      </Button>
       {showDeveloperUI && <ReloadButton />}
     </div>
   );

--- a/src/pageEditor/sidebar/SidebarCollapsed.tsx
+++ b/src/pageEditor/sidebar/SidebarCollapsed.tsx
@@ -17,7 +17,6 @@
 
 import styles from "./Sidebar.module.scss";
 import React from "react";
-import { Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDoubleRight } from "@fortawesome/free-solid-svg-icons";
 import cx from "classnames";

--- a/src/pageEditor/sidebar/SidebarExpanded.tsx
+++ b/src/pageEditor/sidebar/SidebarExpanded.tsx
@@ -51,7 +51,7 @@ import HomeButton from "./HomeButton";
 import ReloadButton from "./ReloadButton";
 import AddStarterBrickButton from "./AddStarterBrickButton";
 import ModComponentListItem from "./ModComponentListItem";
-import { actions } from "@/pageEditor/slices/editorSlice";
+import { actions, editorSlice } from "@/pageEditor/slices/editorSlice";
 import { useDebounce } from "use-debounce";
 import { lowerCase } from "lodash";
 import filterSidebarItems from "@/pageEditor/sidebar/filterSidebarItems";
@@ -158,7 +158,9 @@ const SidebarExpanded: React.FunctionComponent<{
       <div className={styles.header}>
         <div className={styles.actions}>
           <div className={styles.actionsLeft}>
-            <HomeButton />
+            <HomeButton
+              onClick={() => dispatch(editorSlice.actions.showHomePane())}
+            />
 
             <AddStarterBrickButton />
 

--- a/src/pageEditor/sidebar/SidebarExpanded.tsx
+++ b/src/pageEditor/sidebar/SidebarExpanded.tsx
@@ -51,7 +51,7 @@ import HomeButton from "./HomeButton";
 import ReloadButton from "./ReloadButton";
 import AddStarterBrickButton from "./AddStarterBrickButton";
 import ModComponentListItem from "./ModComponentListItem";
-import { actions, editorSlice } from "@/pageEditor/slices/editorSlice";
+import { actions } from "@/pageEditor/slices/editorSlice";
 import { useDebounce } from "use-debounce";
 import { lowerCase } from "lodash";
 import filterSidebarItems from "@/pageEditor/sidebar/filterSidebarItems";
@@ -158,9 +158,7 @@ const SidebarExpanded: React.FunctionComponent<{
       <div className={styles.header}>
         <div className={styles.actions}>
           <div className={styles.actionsLeft}>
-            <HomeButton
-              onClick={() => dispatch(editorSlice.actions.showHomePane())}
-            />
+            <HomeButton />
 
             <AddStarterBrickButton />
 

--- a/src/pageEditor/sidebar/SidebarExpanded.tsx
+++ b/src/pageEditor/sidebar/SidebarExpanded.tsx
@@ -170,7 +170,7 @@ const SidebarExpanded: React.FunctionComponent<{
             type="button"
             onClick={collapseSidebar}
           >
-            <FontAwesomeIcon icon={faAngleDoubleLeft} />
+            <FontAwesomeIcon icon={faAngleDoubleLeft} fixedWidth />
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/7268
- Prevents further size mismatches


| Before | After |
|--------|--------|
| <img width="67" alt="Screenshot 10" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/5d1b87b4-9350-483e-b0a9-a266ad871934"> | <img width="67" alt="Screenshot 11" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/9f5e2e49-315d-40ba-a9ce-8116a8c2e9cd"> |

In the collapsed sidebar, I dropped the house icon altogether because it doesn't really match the behavior of the button. Also it was the easiest solution instead of keeping the awkward dual-icon dual-color button.

The expanded sidebar is unchanged (except some sizing improvements that reduce the code require for all of this)


## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
