### PR TITLE
#7269: Fix pageEditor sidebar buttons style

### DIFF
--- a/src/pageEditor/sidebar/Sidebar.module.scss
+++ b/src/pageEditor/sidebar/Sidebar.module.scss
@@ -39,10 +39,6 @@
     font-size: 0.875rem;
   }
 
-  button {
-    border-radius: 0;
-  }
-
   :global {
     .list-group {
       border-radius: 0;
@@ -59,6 +55,10 @@
 
 .header {
   border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+
+  button {
+    border-radius: 0;
+  }
 }
 
 .actions {


### PR DESCRIPTION
## What does this PR do?

- Caused by https://github.com/pixiebrix/pixiebrix-extension/pull/7269

## Demo

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="305" alt="Screenshot 8" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/8985e455-722d-48e4-97a8-d49f753e526d">
	<td><img width="305" alt="Screenshot 7" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/6b61f25e-8076-4b62-a9d7-1ff114a64a31">
</table>


## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
