### PR TITLE
Fix dead-code-check failures in CI

### DIFF
--- a/knip.mjs
+++ b/knip.mjs
@@ -47,6 +47,8 @@ const knipConfig = {
     "src/vendors/page-metadata-parser/**",
     // False positive - dynamically imported in initRobot
     "src/contrib/uipath/UiPathRobot.ts",
+    // False positive - dynamically imported in src/contentScript/contentScript.ts
+    "src/contentScript/contentScriptCore.ts",
   ],
   ignoreDependencies: [
     // Browser environment types

--- a/knip.mjs
+++ b/knip.mjs
@@ -24,6 +24,8 @@ const knipConfig = {
     "src/testUtils/FixJsdomEnvironment.js",
     // Script helpers
     "scripts/manifest.mjs",
+    // Content script entry point, init() is dynamically imported in src/contentScript/contentScript.ts
+    "src/contentScript/contentScriptCore.ts",
   ],
   project: ["src/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}"],
   // https://knip.dev/guides/handling-issues#mocks-and-other-implicit-imports
@@ -47,8 +49,6 @@ const knipConfig = {
     "src/vendors/page-metadata-parser/**",
     // False positive - dynamically imported in initRobot
     "src/contrib/uipath/UiPathRobot.ts",
-    // False positive - dynamically imported in src/contentScript/contentScript.ts
-    "src/contentScript/contentScriptCore.ts",
   ],
   ignoreDependencies: [
     // Browser environment types

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -440,7 +440,6 @@ export const {
   useUpdatePackageMutation,
   useDeletePackageMutation,
   useListPackageVersionsQuery,
-  useUpdateScopeMutation,
   useGetStarterBlueprintsQuery,
   useCreateMilestoneMutation,
   util,


### PR DESCRIPTION
## What does this PR do?

- Removes an unused api export
- Adds an exception for `contentScriptCore` since the `init()` function is dynamically imported

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer - @grahamlangford 
