### PR TITLE
Include details in mod error notifications 

### DIFF
--- a/src/modDefinitions/modDefinitionHooks.ts
+++ b/src/modDefinitions/modDefinitionHooks.ts
@@ -30,6 +30,7 @@ import useMemoCompare from "@/hooks/useMemoCompare";
 import deepEquals from "fast-deep-equal";
 import { loadingAsyncStateFactory } from "@/utils/asyncStateUtils";
 import useMergeAsyncState from "@/hooks/useMergeAsyncState";
+import pluralize from "@/utils/pluralize";
 
 /**
  * Lookup a mod definition from the registry by ID, or null if it doesn't exist.
@@ -98,7 +99,10 @@ export function useRequiredModDefinitions(
           (x) => !matches.some((mod) => mod.metadata.id === x),
         );
         throw new Error(
-          `Mod definition(s) not found: ${missingIds.join(", ")}`,
+          `Mod ${pluralize(
+            missingIds.length,
+            "definition",
+          )} not found: ${missingIds.join(", ")}`,
         );
       }
 

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -382,7 +382,10 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
           showNotification(DEFAULT_ACTION_RESULTS.cancel);
         } else {
           extensionLogger.error(error);
-          showNotification(DEFAULT_ACTION_RESULTS.error);
+          showNotification({
+            ...DEFAULT_ACTION_RESULTS.error,
+            error, // Include more details in the notification
+          });
         }
       }
     });

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -68,6 +68,7 @@ import { type Brick } from "@/types/brickTypes";
 import { type StarterBrick } from "@/types/starterBrickTypes";
 import { type UUID } from "@/types/stringTypes";
 import makeServiceContextFromDependencies from "@/integrations/util/makeServiceContextFromDependencies";
+import pluralize from "@/utils/pluralize";
 
 export type ContextMenuTargetMode =
   // In `legacy` mode, the target was passed to the readers but the document is passed to reducePipeline
@@ -274,7 +275,10 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
     const numErrors = results.filter((x) => x.status === "rejected").length;
     if (numErrors > 0) {
       notify.error(
-        `An error occurred adding ${numErrors} context menu item(s)`,
+        `An error occurred adding ${pluralize(
+          numErrors,
+          "$$ context menu item",
+        )}`,
       );
     }
   }

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -385,6 +385,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
           showNotification({
             ...DEFAULT_ACTION_RESULTS.error,
             error, // Include more details in the notification
+            reportError: false,
           });
         }
       }

--- a/src/starterBricks/menuItemExtension.ts
+++ b/src/starterBricks/menuItemExtension.ts
@@ -730,6 +730,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
             extensionLogger.error(error);
             showNotification({
               ...DEFAULT_ACTION_RESULTS.error,
+              error, // Include more details in the notification
               ...pick(onError, "message", "type"),
             });
           }

--- a/src/starterBricks/menuItemExtension.ts
+++ b/src/starterBricks/menuItemExtension.ts
@@ -731,6 +731,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
             showNotification({
               ...DEFAULT_ACTION_RESULTS.error,
               error, // Include more details in the notification
+              reportError: false,
               ...pick(onError, "message", "type"),
             });
           }

--- a/src/starterBricks/panelExtension.ts
+++ b/src/starterBricks/panelExtension.ts
@@ -62,6 +62,7 @@ import { type RendererOutput, type RunArgs } from "@/types/runtimeTypes";
 import { type StarterBrick } from "@/types/starterBrickTypes";
 import { boolean } from "@/utils/typeUtils";
 import makeServiceContextFromDependencies from "@/integrations/util/makeServiceContextFromDependencies";
+import pluralize from "@/utils/pluralize";
 
 export type PanelConfig = {
   heading?: string;
@@ -470,7 +471,9 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
     }
 
     if (errors.length > 0) {
-      notify.error(`An error occurred adding ${errors.length} panels(s)`);
+      notify.error(
+        `An error occurred adding ${pluralize(errors.length, "$$ panel")}`,
+      );
     }
   }
 }

--- a/src/starterBricks/quickBarExtension.tsx
+++ b/src/starterBricks/quickBarExtension.tsx
@@ -61,6 +61,7 @@ import { type Brick } from "@/types/brickTypes";
 import { type UUID } from "@/types/stringTypes";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
 import makeServiceContextFromDependencies from "@/integrations/util/makeServiceContextFromDependencies";
+import pluralize from "@/utils/pluralize";
 
 export type QuickBarTargetMode = "document" | "eventTarget";
 
@@ -190,7 +191,9 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
 
     const numErrors = results.filter((x) => x.status === "rejected").length;
     if (numErrors > 0) {
-      notify.error(`An error occurred adding ${numErrors} quick bar items(s)`);
+      notify.error(
+        `An error occurred adding ${pluralize(numErrors, "$$ quick bar item")}`,
+      );
     }
   }
 

--- a/src/starterBricks/quickBarExtension.tsx
+++ b/src/starterBricks/quickBarExtension.tsx
@@ -255,7 +255,10 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
             showNotification(DEFAULT_ACTION_RESULTS.cancel);
           } else {
             extensionLogger.error(error);
-            showNotification(DEFAULT_ACTION_RESULTS.error);
+            showNotification({
+              ...DEFAULT_ACTION_RESULTS.error,
+              error, // Include more details in the notification
+            });
           }
         }
       },

--- a/src/starterBricks/quickBarExtension.tsx
+++ b/src/starterBricks/quickBarExtension.tsx
@@ -258,6 +258,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
             showNotification({
               ...DEFAULT_ACTION_RESULTS.error,
               error, // Include more details in the notification
+              reportError: false,
             });
           }
         }

--- a/src/starterBricks/quickBarProviderExtension.tsx
+++ b/src/starterBricks/quickBarProviderExtension.tsx
@@ -62,6 +62,7 @@ import { type ResolvedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
 import makeServiceContextFromDependencies from "@/integrations/util/makeServiceContextFromDependencies";
+import pluralize from "@/utils/pluralize";
 
 export type QuickBarProviderConfig = {
   /**
@@ -228,7 +229,9 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
 
     const numErrors = results.filter((x) => x.status === "rejected").length;
     if (numErrors > 0) {
-      notify.error(`An error occurred adding ${numErrors} quick bar items(s)`);
+      notify.error(
+        `An error occurred adding ${pluralize(numErrors, "$$ quick bar item")}`,
+      );
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

While looking into https://pixiebrix.slack.com/archives/C0436P48QHY/p1705451796174779, I realized that some notifications don't really say what's wrong. Generic errors can be frustrating, we should always include more information if available.



## Before

<img width="314" alt="Screenshot" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/a8471de1-6792-407e-b87d-e63a0fb87610">


## After

<img width="314" alt="Screenshot 11" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/2e06bfb9-73d3-454c-ae47-547e702377f5">


## Future Work

This PR only affects the brick run notification error, but ideally we'd want to enforce the `error` prop in `notify.error`. There's only a handful of situations where we trigger `notify.error()` without an actual error.

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
