### PR TITLE
#7362: Set sourcemaps value in rainforest build

### DIFF
--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -19,6 +19,11 @@ jobs:
       RAINFOREST_RUN_GROUP_MAIN: 14129
       RAINFOREST_RUN_GROUP_RELEASE: 14130
       RAINFOREST_RUN_GROUP_CWS: 14131
+      # The following environment variables are set so sourceMapPublicUrl, and there SOURCE_MAP_PUBLIC_PATH, is defined in the build
+      PUBLIC_RELEASE: true
+      SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com
+      # TODO: How do I know whether to use mv2 or mv3?
+      SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}/mv3
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -22,8 +22,8 @@ jobs:
       # The following environment variables are set so sourceMapPublicUrl, and there SOURCE_MAP_PUBLIC_PATH, is defined in the build
       PUBLIC_RELEASE: true
       SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com
-      # TODO: How do I know whether to use mv2 or mv3?
-      SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}/mv3
+      # Use mv2 because that's currently what the Rainforest build uses, see "npm run build" step below
+      SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}/mv2
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -34,6 +34,7 @@ jobs:
       - run: npm ci
       - run: npm run build
         env:
+          MV: 2
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           DATADOG_APPLICATION_ID: ${{ secrets.DATADOG_APPLICATION_ID }}
           CHROME_MANIFEST_KEY: ${{ secrets.CHROME_MANIFEST_PROD_PUBLIC_KEY }}


### PR DESCRIPTION
## What does this PR do?

- Closes #7362
- Our hypothesis is that Datadog errors with broken source maps are from Rainforest builds + runs (see [example](https://app.datadoghq.com/logs/error-tracking/issue/2a2e1d28-b599-11ee-96d2-da7ad0900002?refresh_mode=sliding&view=spans&from_ts=1705521578700&to_ts=1705607974940&live=true)). This PR sets certain env vars so `SOURCE_MAP_PUBLIC_PATH` is properly set in the Rainforest build and source maps work for errors generated during Rainforest runs.

## Discussion

- See [slack discussion](https://pixiebrix.slack.com/archives/C06DUA1HU75/p1705599443633379)

## Checklist

- [x] Designate a primary reviewer: @twschiller 
