### PR TITLE
#7362: Fix source map path

### DIFF
--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -23,7 +23,7 @@ jobs:
       PUBLIC_RELEASE: true
       SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com
       # Use mv2 because that's currently what the Rainforest build uses, see "npm run build" step below
-      SOURCE_MAP_PATH: sourcemaps/${{ github.job }}/${{ github.sha }}/mv2
+      SOURCE_MAP_PATH: sourcemaps/build/${{ github.sha }}/mv2
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## What does this PR do?

- Part of #7362 
- See [slack](https://pixiebrix.slack.com/archives/C06DUA1HU75/p1705677566610569?thread_ts=1705631686.175459&cid=C06DUA1HU75)

## Discussion

- I think we should be okay to continue using `github.hash`. The [docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context:~:text=github.com.-,github.sha,-string) define it as:

> The commit SHA that triggered the workflow. The value of this commit SHA depends on the event that triggered the workflow. For more information, see "[Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)." For example, ffac537e6cbbf934b08745a378932722df287a53.

We'll have to test it to be sure.

## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
