### PR TITLE
Page Editor: Improve shadow and fix sizing of tabs

### DIFF
--- a/src/components/tabLayout/EditorTabLayout.module.scss
+++ b/src/components/tabLayout/EditorTabLayout.module.scss
@@ -22,8 +22,8 @@
 }
 
 .nav {
-  min-height: 31px; // To match the height of the actions of the Sidebar
-  box-shadow: 0 2px 2px gray;
+  min-height: 30px; // To match the height of the actions of the Sidebar
+  box-shadow: 1px 2px 8px #00000030;
   z-index: 1; // Paint the shadow above the content below
   font-size: 0.875rem;
   padding-bottom: 0;

--- a/src/pageEditor/ElementWizard.module.scss
+++ b/src/pageEditor/ElementWizard.module.scss
@@ -18,7 +18,8 @@
 .nav {
   flex-wrap: nowrap !important;
   align-items: stretch;
-  box-shadow: 0 2px 2px gray;
+  min-height: 30px; // To match the height of the actions of the Sidebar
+  box-shadow: 1px 2px 8px #00000030;
   position: relative;
   z-index: 1; // Paint the shadow above the content below
   padding-bottom: 0;

--- a/src/pageEditor/sidebar/HomeButton.module.scss
+++ b/src/pageEditor/sidebar/HomeButton.module.scss
@@ -20,4 +20,5 @@
 .button {
   background-color: $P500;
   border: 0;
+  border-radius: 0;
 }

--- a/src/pageEditor/sidebar/Sidebar.module.scss
+++ b/src/pageEditor/sidebar/Sidebar.module.scss
@@ -5,11 +5,12 @@
   display: flex;
   justify-content: flex-start;
   height: 100%;
-  border-right: 2px solid lightgrey;
   background: white;
+  box-shadow: 1px 2px 8px #00000030;
 
   &.collapsed {
     align-items: stretch;
+    z-index: 999; // Always on top of the content, but below expanded one
   }
   &.expanded {
     flex: 0 0 270px;
@@ -55,10 +56,6 @@
 
 .header {
   border-bottom: 1px solid rgba(0, 0, 0, 0.125);
-
-  button {
-    border-radius: 0;
-  }
 }
 
 .actions {


### PR DESCRIPTION
## What does this PR do?

Minor UI improvement for the page editor, plus a couple of bugfixes.

- Adds single "editor pane" soft shadow, replacing the border/shadow combo
- Fixes  ([again](https://github.com/pixiebrix/pixiebrix-extension/pull/7269)) the home button `border-radius` on the collapsed version
- Realigns the Edit/Logs tab bar (wrong height, especially in the `EditorTabLayout` component)

## Detail

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="372" alt="Screenshot 12" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/7fc0ca3d-9925-4b46-bca3-4c0295c9eb41">
	<td><img width="372" alt="Screenshot 10" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/0d78805e-90b2-4581-94f4-dcf438332ded">
</table>





## Collapsed

<table>
<tr>
	<th>Before
	<th>After ✨ 
<tr>
	<td><img width="399" alt="Screenshot 9" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/8feac5f6-c2b3-4570-86f5-709424c3980a">
	<td><img width="399" alt="Screenshot 6" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/e88a4968-184f-42db-90ba-cdac063a4954">
</table>

## Expanded

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="399" alt="Screenshot 7" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/d4439f0a-2c11-474c-802e-35170754c626">
	<td><img width="399" alt="Screenshot 8" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/85b35088-0a99-40a3-a44b-c0621a271673">
</table>


## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
