### PR TITLE
#7380: support background option for all triggers

### DIFF
--- a/src/bricks/util.ts
+++ b/src/bricks/util.ts
@@ -17,7 +17,7 @@
 
 import { mapValues, pickBy } from "lodash";
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import pipelineSchema from "@schemas/pipeline.json";
 import { type RegistryId } from "@/types/registryTypes";
 import { type Schema } from "@/types/schemaTypes";
@@ -27,12 +27,22 @@ import BlockIdVisitor from "@/analysis/analysisVisitors/blockIdVisitor";
 import { removeUndefined } from "@/utils/objectUtils";
 import { toExpression } from "@/utils/expressionUtils";
 
+/**
+ * Return true if the given registry id corresponds to a built-in package.
+ *
+ * Note that user-defined packages use the `@pixies` namespace.
+ *
+ * @param id the registry id
+ */
 export function isOfficial(id: RegistryId): boolean {
   return id.startsWith("@pixiebrix/");
 }
 
 /**
- * Returns the initial state for a blockConfig.
+ * Returns the initial state for a brickConfig.
+ *
+ * Applies the default values from the schema, if any.
+ *
  * @param schema the JSON Schema
  */
 export function defaultBrickConfig(schema: Schema): BrickConfig["config"] {
@@ -62,10 +72,14 @@ export function defaultBrickConfig(schema: Schema): BrickConfig["config"] {
   return {};
 }
 
-/** Return IBlocks for all blocks referenced in a pipeline, including any sub-pipelines. */
-export async function selectAllBlocks(
+/**
+ * Return Brick for all bricks referenced in a pipeline, including any sub-pipelines.
+ *
+ * Does not de-duplicate bricks.
+ */
+export async function collectAllBricks(
   config: BrickConfig | BrickPipeline,
 ): Promise<Brick[]> {
   const ids = BlockIdVisitor.collectBlockIds(config);
-  return Promise.all([...ids].map(async (id) => blockRegistry.lookup(id)));
+  return Promise.all([...ids].map(async (id) => brickRegistry.lookup(id)));
 }

--- a/src/bricks/util.ts
+++ b/src/bricks/util.ts
@@ -73,9 +73,9 @@ export function defaultBrickConfig(schema: Schema): BrickConfig["config"] {
 }
 
 /**
- * Return Brick for all bricks referenced in a pipeline, including any sub-pipelines.
+ * Return bricks for all bricks referenced in a pipeline, including any sub-pipelines.
  *
- * Does not de-duplicate bricks.
+ * NOTE: Does not de-duplicate bricks.
  */
 export async function collectAllBricks(
   config: BrickConfig | BrickPipeline,

--- a/src/pageEditor/starterBricks/trigger.ts
+++ b/src/pageEditor/starterBricks/trigger.ts
@@ -63,12 +63,14 @@ function fromNativeElement(
         rootSelector: null,
         attachMode: null,
         targetMode: null,
-        // Use "once" for reportMode, since the default is "load"
+        // Use "once" for reportMode, because the default is "load"
         reportMode: "once",
         // Show error notifications by default, to assist with development
         showErrors: true,
         intervalMillis: null,
-        background: null,
+        // Use `background: true` for the default for "load" trigger to 1) match the pre-1.8.7 behavior, and 2)
+        // cause the trigger to run by default when the mod component is installed
+        background: true,
         debounce: null,
         customEvent: null,
         reader: getImplicitReader("trigger"),

--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
@@ -112,7 +112,7 @@ const TriggerConfiguration: React.FC<{
         onChange={onTriggerChange}
         {...makeLockableFieldProps("Trigger Event", isLocked)}
       >
-        <option value="load">Page Load</option>
+        <option value="load">Page Load / Navigation</option>
         <option value="interval">Interval</option>
         <option value="initialize">Initialize</option>
         <option value="appear">Appear</option>
@@ -145,23 +145,22 @@ const TriggerConfiguration: React.FC<{
       )}
 
       {trigger === "interval" && (
-        <>
-          <ConnectedFieldTemplate
-            name={fieldName("intervalMillis")}
-            title="Interval (ms)"
-            type="number"
-            description="Interval to run the trigger in milliseconds"
-            {...makeLockableFieldProps("Interval", isLocked)}
-          />
-          <ConnectedFieldTemplate
-            name={fieldName("background")}
-            title="Run in Background"
-            as={BooleanWidget}
-            description="Run the interval in inactive tabs"
-            {...makeLockableFieldProps("Run in Background", isLocked)}
-          />
-        </>
+        <ConnectedFieldTemplate
+          name={fieldName("intervalMillis")}
+          title="Interval (ms)"
+          type="number"
+          description="Interval to run the trigger in milliseconds"
+          {...makeLockableFieldProps("Interval", isLocked)}
+        />
       )}
+
+      <ConnectedFieldTemplate
+        name={fieldName("background")}
+        title="Run in Background"
+        as={BooleanWidget}
+        description="Run the trigger in inactive tabs."
+        {...makeLockableFieldProps("Run in Background", isLocked)}
+      />
 
       {supportsSelector(trigger) && (
         <>

--- a/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
+++ b/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`TriggerConfiguration renders custom event field with known event names 
           <option
             value="load"
           >
-            Page Load
+            Page Load / Navigation
           </option>
           <option
             value="interval"
@@ -281,6 +281,55 @@ exports[`TriggerConfiguration renders custom event field with known event names 
         >
           <span>
             The custom event name. Select an event from this Mod, or type a new event name
+          </span>
+        </small>
+      </div>
+    </div>
+    <div
+      class="formGroup form-group row"
+    >
+      <div
+        class="mb-2 collapse col-12"
+      >
+        <div
+          class="annotationPlaceholder"
+        />
+      </div>
+      <label
+        class="label form-label col-form-label col-xl-2 col-lg-3"
+        for="extensionPoint.definition.background"
+      >
+        Run in Background
+      </label>
+      <div
+        class="col-xl-10 col-lg-9"
+      >
+        <div
+          class="switch btn on btn-primary"
+        >
+          <div
+            class="switch-group"
+          >
+            <span
+              class="switch-on btn btn-primary"
+            >
+               
+            </span>
+            <span
+              class="switch-off btn btn-light"
+            >
+               
+            </span>
+            <span
+              class="switch-handle btn btn-light"
+            />
+          </div>
+        </div>
+        <small
+          class="text-muted form-text"
+        >
+          <span>
+            Run the trigger in inactive tabs.
           </span>
         </small>
       </div>

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -52,7 +52,7 @@ import { selectExtensionContext } from "@/starterBricks/helpers";
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
 import { isDeploymentActive } from "@/utils/deploymentUtils";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
-import { selectAllBlocks } from "@/bricks/util";
+import { collectAllBricks } from "@/bricks/util";
 import { mergeReaders } from "@/bricks/readers/readerUtils";
 import { guessSelectedElement } from "@/utils/selectionController";
 import {
@@ -168,7 +168,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
   async getBricks(
     extension: ResolvedModComponent<ContextMenuConfig>,
   ): Promise<Brick[]> {
-    return selectAllBlocks(extension.config.action);
+    return collectAllBricks(extension.config.action);
   }
 
   override uninstall({ global = false }: { global?: boolean }): void {

--- a/src/starterBricks/menuItemExtension.ts
+++ b/src/starterBricks/menuItemExtension.ts
@@ -55,7 +55,7 @@ import apiVersionOptions, {
 } from "@/runtime/apiVersionOptions";
 import { engineRenderer } from "@/runtime/renderers";
 import { mapArgs } from "@/runtime/mapArgs";
-import { selectAllBlocks } from "@/bricks/util";
+import { collectAllBricks } from "@/bricks/util";
 import { mergeReaders } from "@/bricks/readers/readerUtils";
 import sanitize from "@/utils/sanitize";
 import { EXTENSION_POINT_DATA_ATTR } from "@/domConstants";
@@ -392,7 +392,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
   async getBricks(
     extension: ResolvedModComponent<MenuItemStarterBrickConfig>,
   ): Promise<Brick[]> {
-    return selectAllBlocks(extension.config.action);
+    return collectAllBricks(extension.config.action);
   }
 
   /**

--- a/src/starterBricks/panelExtension.ts
+++ b/src/starterBricks/panelExtension.ts
@@ -47,7 +47,7 @@ import getSvgIcon from "@/icons/getSvgIcon";
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
 import { selectEventData } from "@/telemetry/deployments";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
-import { selectAllBlocks } from "@/bricks/util";
+import { collectAllBricks } from "@/bricks/util";
 import { mergeReaders } from "@/bricks/readers/readerUtils";
 import { PIXIEBRIX_DATA_ATTR } from "@/domConstants";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
@@ -164,7 +164,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
   async getBricks(
     extension: ResolvedModComponent<PanelConfig>,
   ): Promise<Brick[]> {
-    return selectAllBlocks(extension.config.body);
+    return collectAllBricks(extension.config.body);
   }
 
   clearModComponentInterfaceAndEvents(): void {

--- a/src/starterBricks/quickBarExtension.tsx
+++ b/src/starterBricks/quickBarExtension.tsx
@@ -45,7 +45,7 @@ import { selectEventData } from "@/telemetry/deployments";
 import { selectExtensionContext } from "@/starterBricks/helpers";
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
-import { selectAllBlocks } from "@/bricks/util";
+import { collectAllBricks } from "@/bricks/util";
 import { mergeReaders } from "@/bricks/readers/readerUtils";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import Icon from "@/icons/Icon";
@@ -120,7 +120,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
   async getBricks(
     extension: ResolvedModComponent<QuickBarConfig>,
   ): Promise<Brick[]> {
-    return selectAllBlocks(extension.config.action);
+    return collectAllBricks(extension.config.action);
   }
 
   public get kind(): "quickBar" {

--- a/src/starterBricks/quickBarProviderExtension.tsx
+++ b/src/starterBricks/quickBarProviderExtension.tsx
@@ -34,7 +34,7 @@ import notify from "@/utils/notify";
 import { selectEventData } from "@/telemetry/deployments";
 import { selectExtensionContext } from "@/starterBricks/helpers";
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
-import { selectAllBlocks } from "@/bricks/util";
+import { collectAllBricks } from "@/bricks/util";
 import { mergeReaders } from "@/bricks/readers/readerUtils";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import Icon from "@/icons/Icon";
@@ -135,7 +135,7 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
   async getBricks(
     extension: ResolvedModComponent<QuickBarProviderConfig>,
   ): Promise<Brick[]> {
-    return selectAllBlocks(extension.config.generator);
+    return collectAllBricks(extension.config.generator);
   }
 
   public get kind(): "quickBarProvider" {

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -47,7 +47,7 @@ import {
 import { cloneDeep, debounce, remove } from "lodash";
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
-import { selectAllBlocks } from "@/bricks/util";
+import { collectAllBricks } from "@/bricks/util";
 import { mergeReaders } from "@/bricks/readers/readerUtils";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import { NoRendererError } from "@/errors/businessErrors";
@@ -150,7 +150,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   async getBricks(
     extension: ResolvedModComponent<SidebarConfig>,
   ): Promise<Brick[]> {
-    return selectAllBlocks(extension.config.body);
+    return collectAllBricks(extension.config.body);
   }
 
   clearModComponentInterfaceAndEvents(extensionIds: UUID[]): void {

--- a/src/starterBricks/tourExtension.ts
+++ b/src/starterBricks/tourExtension.ts
@@ -33,7 +33,7 @@ import {
 } from "lodash";
 import { checkAvailable } from "@/bricks/available";
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
-import { selectAllBlocks } from "@/bricks/util";
+import { collectAllBricks } from "@/bricks/util";
 import { mergeReaders } from "@/bricks/readers/readerUtils";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
 import "@/vendors/hoverintent";
@@ -141,7 +141,7 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
   async getBricks(
     extension: ResolvedModComponent<TourConfig>,
   ): Promise<Brick[]> {
-    return selectAllBlocks(extension.config.tour);
+    return collectAllBricks(extension.config.tour);
   }
 
   private async runExtensionTour(

--- a/src/starterBricks/triggerExtension.test.ts
+++ b/src/starterBricks/triggerExtension.test.ts
@@ -30,7 +30,7 @@ import {
 import blockRegistry from "@/bricks/registry";
 import {
   fromJS,
-  getDefaultAllowBackgroundForTrigger,
+  getDefaultAllowInactiveFramesForTrigger,
   type TriggerConfig,
   type TriggerDefinition,
 } from "@/starterBricks/triggerExtension";
@@ -90,7 +90,7 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
     definition: define<TriggerDefinition>({
       type: "trigger",
       background: derive<TriggerDefinition, boolean>((x) =>
-        getDefaultAllowBackgroundForTrigger(x.trigger),
+        getDefaultAllowInactiveFramesForTrigger(x.trigger),
       ),
       isAvailable: () => ({
         matchPatterns: ["*://*/*"],
@@ -623,15 +623,15 @@ describe("triggerExtension", () => {
 });
 
 describe("defaults", () => {
-  describe("getDefaultAllowBackgroundForTrigger", () => {
+  describe("getDefaultAllowInactiveFramesForTrigger", () => {
     it("return false for interval", () => {
-      expect(getDefaultAllowBackgroundForTrigger("interval")).toBe(false);
+      expect(getDefaultAllowInactiveFramesForTrigger("interval")).toBe(false);
     });
 
     it.each(["load", "click"])(
       "returns true for trigger: %s",
       (trigger: Trigger) => {
-        expect(getDefaultAllowBackgroundForTrigger(trigger)).toBe(true);
+        expect(getDefaultAllowInactiveFramesForTrigger(trigger)).toBe(true);
       },
     );
   });

--- a/src/starterBricks/triggerExtension.test.ts
+++ b/src/starterBricks/triggerExtension.test.ts
@@ -192,6 +192,32 @@ describe("triggerExtension", () => {
     extensionPoint.uninstall();
   });
 
+  it("runs non-background page load runs immediately if page visible", async () => {
+    hidden = false;
+
+    const extensionPoint = fromJS(
+      extensionPointFactory({
+        trigger: "load",
+        background: false,
+      })(),
+    );
+
+    extensionPoint.registerModComponent(
+      extensionFactory({
+        extensionPointId: extensionPoint.id,
+      }),
+    );
+
+    await extensionPoint.install();
+    await extensionPoint.runModComponents({
+      reason: RunReason.MANUAL,
+    });
+
+    expect(rootReader.readCount).toBe(1);
+
+    extensionPoint.uninstall();
+  });
+
   it.each([[undefined], ["once"], ["watch"]])(
     "attachMode: %s",
     async (attachMode) => {

--- a/src/starterBricks/triggerExtension.test.ts
+++ b/src/starterBricks/triggerExtension.test.ts
@@ -30,6 +30,7 @@ import {
 import blockRegistry from "@/bricks/registry";
 import {
   fromJS,
+  getDefaultAllowBackgroundForTrigger,
   type TriggerConfig,
   type TriggerDefinition,
 } from "@/starterBricks/triggerExtension";
@@ -48,6 +49,7 @@ import notify from "@/utils/notify";
 import { notifyContextInvalidated } from "@/errors/contextInvalidated";
 import reportError from "@/telemetry/reportError";
 import { screen } from "@testing-library/react";
+import type { Trigger } from "@/starterBricks/triggerExtensionTypes";
 
 // Avoid errors being interpreted as context invalidated error
 browser.runtime.id = "abcxyz";
@@ -544,5 +546,20 @@ describe("triggerExtension", () => {
 
     expect(reportErrorMock).toHaveBeenCalledTimes(2);
     expect(notifyErrorMock).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe("defaults", () => {
+  describe("getDefaultAllowBackgroundForTrigger", () => {
+    it("return false for interval", () => {
+      expect(getDefaultAllowBackgroundForTrigger("interval")).toBe(false);
+    });
+
+    it.each(["load", "click"])(
+      "returns true for trigger: %s",
+      (trigger: Trigger) => {
+        expect(getDefaultAllowBackgroundForTrigger(trigger)).toBe(true);
+      },
+    );
   });
 });

--- a/src/starterBricks/triggerExtension.test.ts
+++ b/src/starterBricks/triggerExtension.test.ts
@@ -17,7 +17,7 @@
 
 import { validateRegistryId } from "@/types/helpers";
 import { type UnknownObject } from "@/types/objectTypes";
-import { define } from "cooky-cutter";
+import { define, derive } from "cooky-cutter";
 import { type StarterBrickConfig } from "@/starterBricks/types";
 import { type Metadata } from "@/types/registryTypes";
 import { type BrickPipeline } from "@/bricks/types";
@@ -54,6 +54,16 @@ import type { Trigger } from "@/starterBricks/triggerExtensionTypes";
 // Avoid errors being interpreted as context invalidated error
 browser.runtime.id = "abcxyz";
 
+let hidden = false;
+
+// https://github.com/jsdom/jsdom/issues/2391#issuecomment-429085358
+Object.defineProperty(document, "hidden", {
+  configurable: true,
+  get() {
+    return hidden;
+  },
+});
+
 jest.mock("@/errors/contextInvalidated", () => {
   const actual = jest.requireActual("@/errors/contextInvalidated");
   return {
@@ -68,10 +78,6 @@ const reportErrorMock = jest.mocked(reportError);
 const notifyErrorMock = jest.mocked(notify.error);
 const notifyContextInvalidatedMock = jest.mocked(notifyContextInvalidated);
 
-beforeAll(() => {
-  requestIdleCallback.mock();
-});
-
 const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
   define<StarterBrickConfig<TriggerDefinition>>({
     apiVersion: "v3",
@@ -83,7 +89,9 @@ const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
       }) as Metadata,
     definition: define<TriggerDefinition>({
       type: "trigger",
-      background: false,
+      background: derive<TriggerDefinition, boolean>((x) =>
+        getDefaultAllowBackgroundForTrigger(x.trigger),
+      ),
       isAvailable: () => ({
         matchPatterns: ["*://*/*"],
       }),
@@ -107,8 +115,13 @@ const extensionFactory = define<ResolvedModComponent<TriggerConfig>>({
 
 const rootReader = new RootReader();
 
+beforeAll(() => {
+  requestIdleCallback.mock();
+});
+
 beforeEach(() => {
   ensureMocksReset();
+  hidden = false;
   window.document.body.innerHTML = "";
   document.body.innerHTML = "";
   reportErrorMock.mockReset();
@@ -144,6 +157,40 @@ describe("triggerExtension", () => {
       extensionPoint.uninstall();
     },
   );
+
+  it("runs non-background page load trigger on visibilitychange", async () => {
+    hidden = true;
+
+    const extensionPoint = fromJS(
+      extensionPointFactory({
+        trigger: "load",
+        background: false,
+      })(),
+    );
+
+    extensionPoint.registerModComponent(
+      extensionFactory({
+        extensionPointId: extensionPoint.id,
+      }),
+    );
+
+    await extensionPoint.install();
+    const runPromise = extensionPoint.runModComponents({
+      reason: RunReason.MANUAL,
+    });
+
+    expect(rootReader.readCount).toBe(0);
+
+    // Runs when the document becomes visible
+    hidden = false;
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await runPromise;
+
+    expect(rootReader.readCount).toBe(1);
+
+    extensionPoint.uninstall();
+  });
 
   it.each([[undefined], ["once"], ["watch"]])(
     "attachMode: %s",

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -444,7 +444,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
   };
 
   /**
-   * Mark a run as in-progress for an extension. Used to enforce synchronous execution of an
+   * Mark a run as in-progress for an extension. Used to enforce synchronous execution of a
    * trigger on a particular element.
    * @param modComponentId the UUID of the mod component
    * @param element the element the trigger is running against
@@ -662,7 +662,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
 
     const observer = initialize(
       this.triggerSelector,
-      (index, element: HTMLElement) => {
+      (_index, element: HTMLElement) => {
         void this.debouncedRunTriggersAndNotify([element], {
           nativeEvent: null,
         });
@@ -704,7 +704,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
       console.debug("Watching selector: %s", selector);
       const mutationObserver = initialize(
         selector,
-        (index, element) => {
+        (_index, element) => {
           console.debug("initialize: %s", selector);
           appearObserver.observe(element);
         },
@@ -891,7 +891,7 @@ export interface TriggerDefinition extends StarterBrickDefinition {
   attachMode?: AttachMode;
 
   /**
-   * Allow trigger to even when the tab/frame is not active.
+   * Allow the trigger to run even when the tab/frame is not active.
    *
    * NOTE: this property does not refer to running the trigger in the extension's background page. PixieBrix currently
    * only supports running mods in the context of a frame's content script.

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -41,7 +41,7 @@ import notify from "@/utils/notify";
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
 import { selectEventData } from "@/telemetry/deployments";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
-import { selectAllBlocks } from "@/bricks/util";
+import { collectAllBricks } from "@/bricks/util";
 import { mergeReaders } from "@/bricks/readers/readerUtils";
 import initialize from "@/vendors/initialize";
 import BackgroundLogger from "@/telemetry/BackgroundLogger";
@@ -78,8 +78,14 @@ import {
   notifyContextInvalidated,
 } from "@/errors/contextInvalidated";
 import { sleep } from "@/utils/timeUtils";
-import { $safeFind, waitAnimationFrame } from "@/utils/domUtils";
+import {
+  $safeFind,
+  runOnDocumentVisible,
+  waitAnimationFrame,
+} from "@/utils/domUtils";
 import makeServiceContextFromDependencies from "@/integrations/util/makeServiceContextFromDependencies";
+
+type TriggerTarget = Document | HTMLElement;
 
 export type TriggerConfig = {
   action: BrickPipeline | BrickConfig;
@@ -91,6 +97,16 @@ export type TriggerConfig = {
  */
 export function getDefaultReportModeForTrigger(trigger: Trigger): ReportMode {
   return USER_ACTION_TRIGGERS.includes(trigger) ? "all" : "once";
+}
+
+/**
+ * Return the default allowBackground value for the trigger type.
+ * @param trigger the trigger type
+ */
+export function getDefaultAllowBackgroundForTrigger(trigger: Trigger): boolean {
+  // Prior to 1.8.7, the `background` flag was ignored for non-interval triggers. Therefore, the effective
+  // default was `true` for non-interval triggers.
+  return trigger !== "interval";
 }
 
 async function interval({
@@ -154,12 +170,12 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
   abstract getBaseReader(): Promise<Reader>;
 
   /**
-   * Map from extension ID to elements a trigger is currently running on.
+   * Map from mod component ID to elements a trigger is currently running on.
    * @private
    */
-  private readonly runningExtensionElements = new Map<
+  private readonly runningModComponentElements = new Map<
     UUID,
-    WeakSet<Document | HTMLElement>
+    WeakSet<TriggerTarget>
   >();
 
   /**
@@ -242,9 +258,9 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
    * Return true if an event should be reported for the given extension id.
    * @private
    */
-  private shouldReportEvent(extensionId: UUID): boolean {
-    const alreadyReported = this.reportedEvents.has(extensionId);
-    this.reportedEvents.add(extensionId);
+  private shouldReportEvent(componentId: UUID): boolean {
+    const alreadyReported = this.reportedEvents.has(componentId);
+    this.reportedEvents.add(componentId);
     return this.shouldReport(alreadyReported);
   }
 
@@ -255,6 +271,11 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
         this._runTriggersAndNotify,
         waitMillis,
         options,
+      );
+    } else if (this.trigger !== "interval" && !this.allowBackground) {
+      // Since 1.8.7, respect the `background` flag for non-interval triggers.
+      this.debouncedRunTriggersAndNotify = runOnDocumentVisible(
+        this._runTriggersAndNotify,
       );
     }
 
@@ -286,7 +307,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     // NOTE: you might think we could use a WeakSet of HTMLElement to track which elements we've actually attached
     // DOM events too. However, we can't because WeakSet is not an enumerable collection
     // https://esdiscuss.org/topic/removal-of-weakmap-weakset-clear
-    const $currentElements: JQuery<HTMLElement | Document> = isEmpty(
+    const $currentElements: JQuery<TriggerTarget> = isEmpty(
       this.triggerSelector,
     )
       ? $(document)
@@ -320,9 +341,9 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
   );
 
   async getBricks(
-    extension: ResolvedModComponent<TriggerConfig>,
+    modComponent: ResolvedModComponent<TriggerConfig>,
   ): Promise<Brick[]> {
-    return selectAllBlocks(extension.config.action);
+    return collectAllBricks(modComponent.config.action);
   }
 
   override async defaultReader(): Promise<Reader> {
@@ -349,29 +370,29 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     );
   }
 
-  private async runExtension(
+  private async runModComponent(
     ctxt: JsonObject,
-    extension: ResolvedModComponent<TriggerConfig>,
+    modComponent: ResolvedModComponent<TriggerConfig>,
     root: SelectorRoot,
   ) {
-    const extensionLogger = this.logger.childLogger(
-      selectExtensionContext(extension),
+    const componentLogger = this.logger.childLogger(
+      selectExtensionContext(modComponent),
     );
 
-    const { action: actionConfig } = extension.config;
+    const { action: actionConfig } = modComponent.config;
 
     const initialValues: InitialValues = {
       input: ctxt,
       root,
       serviceContext: await makeServiceContextFromDependencies(
-        extension.integrationDependencies,
+        modComponent.integrationDependencies,
       ),
-      optionsArgs: extension.optionsArgs,
+      optionsArgs: modComponent.optionsArgs,
     };
 
     await reduceExtensionPipeline(actionConfig, initialValues, {
-      logger: extensionLogger,
-      ...apiVersionOptions(extension.apiVersion),
+      logger: componentLogger,
+      ...apiVersionOptions(modComponent.apiVersion),
     });
   }
 
@@ -381,21 +402,22 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
   private readonly eventHandler: JQuery.EventHandler<unknown> = async (
     event,
   ) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- based on available trigger types
+    let element: TriggerTarget = event.target;
+
     console.debug("TriggerExtensionPoint:eventHandler", {
       id: this.id,
       instanceNonce: this.instanceNonce,
-      target: event.target,
+      target: element,
       event,
     });
-
-    let element: HTMLElement | Document = event.target;
 
     if (this.trigger === "selectionchange") {
       element = guessSelectedElement() ?? document;
     }
 
     if (this.targetMode === "root") {
-      element = $(event.target).closest(this.triggerSelector).get(0);
+      element = $(element).closest(this.triggerSelector).get(0);
       console.debug(
         "Locating closest element for target: %s",
         this.triggerSelector,
@@ -409,21 +431,21 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
 
   /**
    * Mark a run as in-progress for an extension. Used to enforce synchronous execution of an
-   * extension on a particular element.
-   * @param extensionId the UUID of the extension
-   * @param element the element the extension is running against
+   * trigger on a particular element.
+   * @param modComponentId the UUID of the mod component
+   * @param element the element the trigger is running against
    * @private
    */
-  private markRun(extensionId: UUID, element: Document | HTMLElement): void {
-    if (this.runningExtensionElements.has(extensionId)) {
-      this.runningExtensionElements.get(extensionId).add(element);
+  private markRun(modComponentId: UUID, element: TriggerTarget): void {
+    if (this.runningModComponentElements.has(modComponentId)) {
+      this.runningModComponentElements.get(modComponentId).add(element);
     } else {
-      this.runningExtensionElements.set(extensionId, new Set([element]));
+      this.runningModComponentElements.set(modComponentId, new Set([element]));
     }
   }
 
   /**
-   * Run all extensions for a given root (i.e., handle the trigger firing).
+   * Run all mod components for a given root (i.e., handle the trigger firing).
    *
    * DO NOT CALL DIRECTLY: should only be called from runTriggersAndNotify
    */
@@ -442,7 +464,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
       // Enforce synchronous behavior for `hover` event
       extensionsToRun = extensionsToRun.filter(
         (extension) =>
-          !this.runningExtensionElements.get(extension.id)?.has(root),
+          !this.runningModComponentElements.get(extension.id)?.has(root),
       );
     }
 
@@ -476,7 +498,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
         );
         try {
           this.markRun(extension.id, root);
-          await this.runExtension(readerContext, extension, root);
+          await this.runModComponent(readerContext, extension, root);
         } catch (error) {
           if (this.shouldReportError({ extensionId: extension.id, error })) {
             // Don't need to call `reportError` because it's already reported by extensionLogger
@@ -489,7 +511,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
         } finally {
           // NOTE: if the extension is not running with synchronous behavior, there's a race condition where
           // the `delete` could be called while another extension run is still in progress
-          this.runningExtensionElements.get(extension.id).delete(root);
+          this.runningModComponentElements.get(extension.id).delete(root);
         }
 
         if (this.shouldReportEvent(extension.id)) {
@@ -518,7 +540,10 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     const results = await Promise.allSettled(promises);
 
     const errors = compact(
-      results.map((x) => (x.status === "rejected" ? x.reason : null)),
+      // :shrug: reason is `any` vs. `unknown` in the es2020 type definitions
+      results.map((x) =>
+        x.status === "rejected" ? (x.reason as unknown) : null,
+      ),
     );
 
     await this.notifyErrors(errors);
@@ -555,7 +580,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     });
   }
 
-  private async getRoot(): Promise<JQuery<HTMLElement | Document>> {
+  private async getRoot(): Promise<JQuery<TriggerTarget>> {
     const rootSelector = this.triggerSelector;
 
     // Await for the element(s) to appear on the page so that we can
@@ -615,9 +640,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     }
   }
 
-  private attachInitializeTrigger(
-    $elements: JQuery<Document | HTMLElement>,
-  ): void {
+  private attachInitializeTrigger($elements: JQuery<TriggerTarget>): void {
     this.cancelObservers();
 
     // The caller will have already waited for the element. So $element will contain at least one element
@@ -705,7 +728,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
   }
 
   private attachDOMTrigger(
-    $elements: JQuery<HTMLElement | Document>,
+    $elements: JQuery<TriggerTarget>,
     { watch = false }: { watch?: boolean },
   ): void {
     const domEventName =
@@ -762,7 +785,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
       // Watch for new elements on the page
       const mutationObserver = initialize(
         this.triggerSelector,
-        (index, element) => {
+        (_index, element) => {
           // Already watching, so don't re-watch on the recursive call
           this.attachDOMTrigger($(element as HTMLElement), { watch: false });
         },
@@ -775,9 +798,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     }
   }
 
-  private assertElement(
-    $root: JQuery<HTMLElement | Document>,
-  ): asserts $root is JQuery {
+  private assertElement($root: JQuery<TriggerTarget>): asserts $root is JQuery {
     if ($root.get(0) === document) {
       throw new Error(`Trigger ${this.trigger} requires a selector`);
     }
@@ -861,10 +882,18 @@ export interface TriggerDefinition extends StarterBrickDefinition {
   attachMode?: AttachMode;
 
   /**
-   * Allow triggers to run in the background, even when the tab is not active. Currently, only checked for intervals.
+   * Allow triggers to run in the background, even when the tab is not active.
+   *
+   * - Introduced in 1.5.3 and checked for interval triggers. The effective value was `true` for other triggers
+   *  because this value was not checked. (However, certain triggers, e.g., 'click' can only be triggered by the user
+   *  when the tab is active.)
+   * - As of 1.8.7, this value is checked for all triggers. For backward compatability, for non-interval triggers,
+   *  the default value if not provided is `true`.
+   *
    * @since 1.5.3
+   * @see getDefaultAllowBackgroundForTrigger
    */
-  background: boolean;
+  background?: boolean;
 
   /**
    * Flag to control if all trigger fires/errors for an extension are reported.
@@ -985,7 +1014,10 @@ class RemoteTriggerExtensionPoint extends TriggerStarterBrickABC {
   }
 
   get allowBackground(): boolean {
-    return this._definition.background ?? false;
+    return (
+      this._definition.background ??
+      getDefaultAllowBackgroundForTrigger(this.trigger)
+    );
   }
 
   override async getBaseReader(): Promise<Reader> {

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -274,6 +274,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
       );
     } else if (this.trigger !== "interval" && !this.allowBackground) {
       // Since 1.8.7, respect the `background` flag for non-interval triggers.
+      // @ts-expect-error -- Promise<Promise<void>> is same as Promise<void> when awaited b/c await is recursive
       this.debouncedRunTriggersAndNotify = runOnDocumentVisible(
         this._runTriggersAndNotify,
       );

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -84,6 +84,7 @@ import {
   waitAnimationFrame,
 } from "@/utils/domUtils";
 import makeServiceContextFromDependencies from "@/integrations/util/makeServiceContextFromDependencies";
+import { groupPromisesByStatus } from "@/utils/promiseUtils";
 
 type TriggerTarget = Document | HTMLElement;
 
@@ -548,13 +549,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
 
     const results = await Promise.allSettled(promises);
 
-    const errors = compact(
-      results.map((x) =>
-        // :shrug: reason is `any` vs. `unknown` in the es2020 type definitions:
-        // https://github.com/pixiebrix/pixiebrix-extension/pull/7405#discussion_r1460997028
-        x.status === "rejected" ? (x.reason as unknown) : null,
-      ),
-    );
+    const errors = groupPromisesByStatus(results).rejected;
 
     await this.notifyErrors(errors);
   };

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -153,6 +153,14 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
 
   abstract get intervalMillis(): number;
 
+  /**
+   * Allow trigger to run even when the tab is not active.
+   *
+   * NOTE: this property does not refer to running the trigger in the extension's background page. PixieBrix currently
+   * only supports running mods in the context of a frame's content script.
+   *
+   * @see TriggerDefinition.background
+   */
   abstract get allowBackground(): boolean;
 
   abstract get targetMode(): TargetMode;
@@ -541,8 +549,9 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     const results = await Promise.allSettled(promises);
 
     const errors = compact(
-      // :shrug: reason is `any` vs. `unknown` in the es2020 type definitions
       results.map((x) =>
+        // :shrug: reason is `any` vs. `unknown` in the es2020 type definitions:
+        // https://github.com/pixiebrix/pixiebrix-extension/pull/7405#discussion_r1460997028
         x.status === "rejected" ? (x.reason as unknown) : null,
       ),
     );
@@ -883,7 +892,10 @@ export interface TriggerDefinition extends StarterBrickDefinition {
   attachMode?: AttachMode;
 
   /**
-   * Allow triggers to run in the background, even when the tab is not active.
+   * Allow trigger to even when the tab is not active.
+   *
+   * NOTE: this property does not refer to running the trigger in the extension's background page. PixieBrix currently
+   * only supports running mods in the context of a frame's content script.
    *
    * - Introduced in 1.5.3 and checked for interval triggers. The effective value was `true` for other triggers
    *  because this value was not checked. (However, certain triggers, e.g., 'click' can only be triggered by the user

--- a/src/utils/domUtils.test.ts
+++ b/src/utils/domUtils.test.ts
@@ -17,7 +17,7 @@
 
 import { runOnDocumentVisible } from "@/utils/domUtils";
 
-let hidden = true;
+let hidden = false;
 
 // https://github.com/jsdom/jsdom/issues/2391#issuecomment-429085358
 Object.defineProperty(document, "hidden", {

--- a/src/utils/domUtils.test.ts
+++ b/src/utils/domUtils.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { runOnDocumentVisible } from "@/utils/domUtils";
+
+let hidden = true;
+
+// https://github.com/jsdom/jsdom/issues/2391#issuecomment-429085358
+Object.defineProperty(document, "hidden", {
+  configurable: true,
+  get() {
+    return hidden;
+  },
+});
+
+describe("runOnDocumentVisible", () => {
+  beforeEach(() => {
+    hidden = false;
+  });
+
+  it("runs immediately if visible", async () => {
+    const mock = jest.fn();
+    const fn = runOnDocumentVisible(mock);
+    await fn();
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * @jest-environment jsdom
+   * @jest-environment-options {"hidden": true}
+   */
+  it("prefer trailing invocation", async () => {
+    hidden = true;
+
+    const mock = jest.fn();
+    const fn = runOnDocumentVisible(mock);
+
+    const callPromise1 = fn(1);
+    const callPromise2 = fn(2);
+
+    hidden = false;
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await callPromise1;
+    await callPromise2;
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    // Prefers the last invocation
+    expect(mock).toHaveBeenCalledWith(2);
+  });
+});

--- a/src/utils/domUtils.test.ts
+++ b/src/utils/domUtils.test.ts
@@ -39,10 +39,6 @@ describe("runOnDocumentVisible", () => {
     expect(mock).toHaveBeenCalledTimes(1);
   });
 
-  /**
-   * @jest-environment jsdom
-   * @jest-environment-options {"hidden": true}
-   */
   it("prefer trailing invocation", async () => {
     hidden = true;
 
@@ -61,5 +57,26 @@ describe("runOnDocumentVisible", () => {
     expect(mock).toHaveBeenCalledTimes(1);
     // Prefers the last invocation
     expect(mock).toHaveBeenCalledWith(2);
+  });
+
+  it("handle multiple invocations", async () => {
+    const mock = jest.fn();
+    const fn = runOnDocumentVisible(mock);
+
+    const numCalls = 3;
+
+    for (let i = 0; i < numCalls; i++) {
+      hidden = true;
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      void fn(i);
+
+      hidden = false;
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      expect(mock).toHaveBeenCalledWith(i);
+    }
+
+    expect(mock).toHaveBeenCalledTimes(numCalls);
   });
 });

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -170,7 +170,11 @@ export function runOnDocumentVisible<Args extends unknown[], TReturn = unknown>(
         "visibilitychange",
         async () => {
           // Defensive check that the listener is only called when the document becomes visible
-          if (document.visibilityState === "visible") {
+          if (
+            document.visibilityState === "visible" &&
+            deferredPromise &&
+            trailingArgs
+          ) {
             try {
               deferredPromise.resolve(fn(...trailingArgs));
             } catch (error) {

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -25,6 +25,7 @@ import {
 import { sleep } from "@/utils/timeUtils";
 import { JQUERY_INVALID_SELECTOR_ERROR } from "@/errors/knownErrorMessages";
 import pDefer, { type DeferredPromise } from "p-defer";
+import type { Nullishable } from "@/utils/nullishUtils";
 
 /**
  * Find an element(s) by its jQuery selector. A safe alternative to $(selector), which constructs an element if it's
@@ -151,8 +152,8 @@ export function isVisible(element: HTMLElement): boolean {
 export function runOnDocumentVisible<Args extends unknown[]>(
   fn: (...args: Args) => void,
 ): (...args: Args) => Promise<void> {
-  let deferredPromise: DeferredPromise<void>;
-  let trailingArgs: Args;
+  let deferredPromise: Nullishable<DeferredPromise<void>>;
+  let trailingArgs: Nullishable<Args>;
 
   async function runOnce(...args: Args): Promise<void> {
     if (document.hidden) {
@@ -174,6 +175,7 @@ export function runOnDocumentVisible<Args extends unknown[]>(
               fn(...trailingArgs);
             } finally {
               deferredPromise.resolve();
+              deferredPromise = undefined;
               trailingArgs = undefined;
             }
           }

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -169,9 +169,11 @@ export function runOnDocumentVisible<Args extends unknown[], TReturn = unknown>(
       document.addEventListener(
         "visibilitychange",
         async () => {
-          // Defensive check that the listener is only called when the document becomes visible
           if (
+            // Defensive check that the listener is only called when the document becomes visible
             document.visibilityState === "visible" &&
+            // Defensive check for NPEs. In practice, these should always be defined because they're only unset
+            // when the lister runs. Using "!" was causing spurious TS errors.
             deferredPromise &&
             trailingArgs
           ) {

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -176,10 +176,11 @@ export function runOnDocumentVisible<Args extends unknown[], TReturn = unknown>(
           });
 
           if (
-            // Defensive check that the listener is only called when the document becomes visible
+            // Defensive check that the listener is only called when the document becomes visible. Should always be
+            // true because the listener is added when the document is hidden.
             document.visibilityState === "visible" &&
             // Defensive check for NPEs. In practice, these should always be defined because they're only unset
-            // when the lister runs. Using "!" was causing spurious TS errors.
+            // when the listener runs. Using "!" was causing spurious TS errors.
             deferredPromise &&
             trailingArgs
           ) {

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -166,9 +166,15 @@ export function runOnDocumentVisible<Args extends unknown[], TReturn = unknown>(
       deferredPromise = pDefer();
       trailingArgs = args;
 
+      console.debug("runOnDocumentVisible: waiting for visibilitychange");
+
       document.addEventListener(
         "visibilitychange",
         async () => {
+          console.debug("runOnDocumentVisible: visibilitychange", {
+            visibilityState: document.visibilityState,
+          });
+
           if (
             // Defensive check that the listener is only called when the document becomes visible
             document.visibilityState === "visible" &&

--- a/src/utils/injectIframe.tsx
+++ b/src/utils/injectIframe.tsx
@@ -37,7 +37,7 @@ export type LoadedFrame = HTMLIFrameElement & {
 /** Injects an iframe into the host page via ShadowDom */
 async function _injectIframe(
   url: string,
-  /** The style is required because you never want an unstyled iframe */
+  /** The style is required because you never want an un-styled iframe */
   style: Partial<CSSStyleDeclaration>,
 ): Promise<LoadedFrame> {
   const iframe = document.createElement("iframe");

--- a/src/utils/promiseUtils.test.ts
+++ b/src/utils/promiseUtils.test.ts
@@ -48,7 +48,7 @@ test("groupPromisesByStatus", async () => {
   expect(fulfilled).toStrictEqual([1, 2]);
   expect(rejected).toHaveLength(1);
   expect(rejected[0]).toBeInstanceOf(Error);
-  expect(rejected[0].message).toBe("something happened");
+  expect((rejected[0] as Error).message).toBe("something happened");
 });
 
 describe("retryWithJitter", () => {

--- a/src/utils/promiseUtils.ts
+++ b/src/utils/promiseUtils.ts
@@ -182,14 +182,22 @@ export async function resolveObj<T>(
   );
 }
 
+/**
+ * Partition an array of promise results into fulfilled values and rejected errors.
+ * @param results
+ */
 export function groupPromisesByStatus<T>(
   results: Array<PromiseSettledResult<T>>,
-) {
+): {
+  fulfilled: T[];
+  rejected: unknown[];
+} {
   const rejected = results
     .filter(
       (result): result is PromiseRejectedResult => result.status === "rejected",
     )
-    .map(({ reason }) => reason);
+    // `reason` has type `any` in es2020 typings: https://github.com/microsoft/TypeScript/issues/39680
+    .map(({ reason }) => reason as unknown);
   const fulfilled = results
     .filter(
       (result): result is PromiseFulfilledResult<T> =>


### PR DESCRIPTION
## What does this PR do?

- Closes #7380 
- Context: https://www.notion.so/pixiebrix/Phase-3-Add-support-for-only-running-trigger-on-visible-tab-on-mod-activation-79fcd0ee5569428c9a7b46a69a9945a4?pvs=4
- Adds support for "background" option to all triggers
- For backward compatibility, `background: true` for non-interval triggers if not provided/nullish
- Shows the "Allow in Background" option in Page Editor for all trigger types
- Refactoring:
  - `selectAllBlocks` -> `collectAllBricks`
  - `extension` -> `modComponent`

## Discussion

- There's a discrepancy in which screens call `reactivateEveryTab`. I think it's OK to address the discrepancy later:
  - Standalone Mod Component: `ActivateExtensionCard` does not call `reactivateEveryTab`
  - Mods: `useActivateRecipe` calls `reactivateEveryTab`

## Remaining Work

- [x] Fix test snapshots
- [x] Fix broken tests

## Reviewer Tips

- Functional change is in domUtils:runOnDocumentVisible and triggerExtension:install

## Demo

- https://www.loom.com/share/69f66d5b0081496a8a1c1957768c5141?sid=47b6cdaa-c609-4007-a95a-1f90d30f3e5a

## Future Work

- Fix the `reactivateEveryTab` discrepancy in `ActivateExtensionCard` vs `useActivateRecipe` behavior
- Refactor naming conventions in `ActivateExtensionCard` and `useActivateRecipe` to use modern naming

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
