### PR TITLE
Fix case sensitive search in the mods sidebar #6839

### DIFF
--- a/src/pageEditor/sidebar/filterSidebarItems.test.ts
+++ b/src/pageEditor/sidebar/filterSidebarItems.test.ts
@@ -74,7 +74,24 @@ describe("filterSidebarItems", () => {
     expect(
       filterSidebarItems({
         sidebarItems,
-        filterText: "foo",
+        filterText: "fOo",
+        activeModId: null,
+        activeModComponentId: null,
+      }),
+    ).toEqual([sidebarItems[0]]);
+  });
+
+  it("returns sidebar items when filter text matches mod label", () => {
+    const sidebarItems = [
+      modComponentFactory({ label: "fOo" }),
+      modSidebarItemFactory({
+        modMetadata: modMetadataFactory({ name: "Bar" }),
+      }),
+    ];
+    expect(
+      filterSidebarItems({
+        sidebarItems,
+        filterText: "fOo",
         activeModId: null,
         activeModComponentId: null,
       }),
@@ -94,7 +111,7 @@ describe("filterSidebarItems", () => {
     expect(
       filterSidebarItems({
         sidebarItems,
-        filterText: "foo",
+        filterText: "fOo",
         activeModId: null,
         activeModComponentId: null,
       }),

--- a/src/pageEditor/sidebar/filterSidebarItems.ts
+++ b/src/pageEditor/sidebar/filterSidebarItems.ts
@@ -22,7 +22,6 @@ import {
 } from "@/pageEditor/sidebar/common";
 import { type RegistryId } from "@/types/registryTypes";
 import { type UUID } from "@/types/stringTypes";
-import { lowerCase } from "lodash";
 
 type FilterSidebarItemsArgs = {
   sidebarItems: SidebarItem[];
@@ -30,6 +29,9 @@ type FilterSidebarItemsArgs = {
   activeModId: RegistryId | null;
   activeModComponentId: UUID | null;
 };
+
+const caseInsensitiveIncludes = (haystack: string, needle: string) =>
+  haystack.toLowerCase().includes(needle.toLowerCase());
 
 export default function filterSidebarItems({
   sidebarItems,
@@ -46,7 +48,7 @@ export default function filterSidebarItems({
       // Don't filter out mod item if the mod is active, or the name matches the query
       if (
         sidebarItem.modMetadata.id === activeModId ||
-        lowerCase(sidebarItem.modMetadata.name).includes(filterText)
+        caseInsensitiveIncludes(sidebarItem.modMetadata.name, filterText)
       ) {
         return true;
       }
@@ -55,7 +57,7 @@ export default function filterSidebarItems({
       for (const modComponentItem of sidebarItem.modComponents) {
         if (
           getModComponentItemId(modComponentItem) === activeModComponentId ||
-          lowerCase(modComponentItem.label).includes(filterText)
+          caseInsensitiveIncludes(modComponentItem.label, filterText)
         ) {
           return true;
         }
@@ -67,7 +69,7 @@ export default function filterSidebarItems({
     // Don't filter out mod component item if the mod component is active, or the label matches the query
     return (
       getModComponentItemId(sidebarItem) === activeModComponentId ||
-      lowerCase(sidebarItem.label).includes(filterText)
+      caseInsensitiveIncludes(sidebarItem.label, filterText)
     );
   });
 }


### PR DESCRIPTION
## What does this PR do?

- Fixes #6839

## Discussion

- We should consider reviewing usages of lodash lowerCase we should replace throughout the App, as it actually
  behaves differently than the native toLowerCase (namely, it splits up a camelcased word, ex. `LinkedIn` -> `linked in`)

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [x] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [ ] Designate a primary reviewer
