### PR TITLE
Avoid errors in `loggingConfig` getter

### DIFF
--- a/src/__mocks__/@/telemetry/logging.ts
+++ b/src/__mocks__/@/telemetry/logging.ts
@@ -17,12 +17,8 @@
 
 export const logValues = true;
 
-export const loggingConfig = {
-  get() {
-    return {
-      logValues,
-    };
-  },
-};
+export const getLoggingConfig = () => ({
+  logValues,
+});
 
 export const count = jest.fn().mockResolvedValue(0);

--- a/src/hooks/logging.ts
+++ b/src/hooks/logging.ts
@@ -15,9 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { loggingConfig } from "@/telemetry/logging";
+import { getLoggingConfig, setLoggingConfig } from "@/telemetry/logging";
 import useUpdatableAsyncState from "./useUpdatableAsyncState";
 
 export function useLoggingConfig() {
-  return useUpdatableAsyncState(loggingConfig.get, loggingConfig.set);
+  return useUpdatableAsyncState(getLoggingConfig, setLoggingConfig);
 }

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -59,7 +59,7 @@ import {
 } from "@/errors/businessErrors";
 import { ContextError } from "@/errors/genericErrors";
 import { type PanelPayload } from "@/types/sidebarTypes";
-import { loggingConfig } from "@/telemetry/logging";
+import { getLoggingConfig } from "@/telemetry/logging";
 import { type UUID } from "@/types/stringTypes";
 import {
   type BrickArgs,
@@ -450,7 +450,7 @@ async function renderBlockArg(
 ): Promise<RenderedArgs> {
   const { config, type } = resolvedConfig;
 
-  const globalLoggingConfig = await loggingConfig.get();
+  const globalLoggingConfig = await getLoggingConfig();
 
   const {
     // If logValues not provided explicitly, default to the global setting
@@ -609,7 +609,7 @@ async function applyReduceDefaults({
   logger: providedLogger,
   ...overrides
 }: Partial<ReduceOptions>): Promise<ReduceOptions> {
-  const globalLoggingConfig = await loggingConfig.get();
+  const globalLoggingConfig = await getLoggingConfig();
   const logger = providedLogger ?? new ConsoleLogger();
 
   return {

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -487,11 +487,24 @@ export type LoggingConfig = {
   logValues: boolean;
 };
 
-export const loggingConfig = new StorageItem<LoggingConfig>("LOG_OPTIONS", {
+const loggingConfig = new StorageItem<LoggingConfig>("LOG_OPTIONS", {
   defaultValue: {
     logValues: false,
   },
 });
+
+export async function getLoggingConfig(): Promise<LoggingConfig> {
+  try {
+    return await loggingConfig.get();
+  } catch {
+    // The context was probably invalidated. Logging utilities shouldn't throw errors
+    return loggingConfig.defaultValue;
+  }
+}
+
+export async function setLoggingConfig(config: LoggingConfig): Promise<void> {
+  await loggingConfig.set(config);
+}
 
 /**
  * Clear all debug and trace level logs for the given extension.

--- a/src/telemetry/logging.ts
+++ b/src/telemetry/logging.ts
@@ -493,12 +493,14 @@ const loggingConfig = new StorageItem<LoggingConfig>("LOG_OPTIONS", {
   },
 });
 
+let lastValue: LoggingConfig | null = null;
 export async function getLoggingConfig(): Promise<LoggingConfig> {
   try {
-    return await loggingConfig.get();
+    lastValue = await loggingConfig.get();
+    return lastValue;
   } catch {
     // The context was probably invalidated. Logging utilities shouldn't throw errors
-    return loggingConfig.defaultValue;
+    return lastValue ?? loggingConfig.defaultValue;
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

I can't reproduce it anymore, but I was seeing issues where `chrome.storage` was not defined after a context invalidation, sending the background logger in a loop.

This makes sure that we don't throw errors while throwing errors

## Checklist

- [x] Designate a primary reviewer: @fungairino 
