### PR TITLE
Removing usage of lodash lowerCase

### DIFF
--- a/src/bricks/transformers/component/TableReader.ts
+++ b/src/bricks/transformers/component/TableReader.ts
@@ -28,7 +28,6 @@ import {
   parseDefinitionList,
   getAllDefinitionLists,
 } from "@/utils/parseDefinitionList";
-import { lowerCase } from "lodash";
 import { findSingleElement } from "@/utils/domUtils";
 
 const TABLE_READER_ID = validateRegistryId("@pixiebrix/table-reader");
@@ -105,9 +104,7 @@ export class TableReader extends TransformerABC {
     }
 
     throw new TypeError(
-      `Selector does not match a table or definition list (dl) element, found: <${lowerCase(
-        table.nodeName,
-      )}>`,
+      `Selector does not match a table or definition list (dl) element, found: <${table.nodeName.toLowerCase()}>`,
     );
   }
 }

--- a/src/pageEditor/sidebar/SidebarExpanded.tsx
+++ b/src/pageEditor/sidebar/SidebarExpanded.tsx
@@ -53,7 +53,6 @@ import AddStarterBrickButton from "./AddStarterBrickButton";
 import ModComponentListItem from "./ModComponentListItem";
 import { actions } from "@/pageEditor/slices/editorSlice";
 import { useDebounce } from "use-debounce";
-import { lowerCase } from "lodash";
 import filterSidebarItems from "@/pageEditor/sidebar/filterSidebarItems";
 
 const SidebarExpanded: React.FunctionComponent<{
@@ -75,7 +74,7 @@ const SidebarExpanded: React.FunctionComponent<{
     flagOn("page-editor-developer");
 
   const [filterQuery, setFilterQuery] = useState("");
-  const [debouncedFilterQuery] = useDebounce(lowerCase(filterQuery), 250, {
+  const [debouncedFilterQuery] = useDebounce(filterQuery.toLowerCase(), 250, {
     trailing: true,
     leading: false,
   });

--- a/src/pageEditor/sidebar/arrangeSidebarItems.ts
+++ b/src/pageEditor/sidebar/arrangeSidebarItems.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { lowerCase, sortBy } from "lodash";
+import { sortBy } from "lodash";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type ModComponentBase } from "@/types/modComponentTypes";
@@ -75,7 +75,7 @@ function arrangeSidebarItems({
 
   for (const modSidebarItem of Object.values(modSidebarItems)) {
     modSidebarItem.modComponents.sort((a, b) =>
-      lowerCase(a.label).localeCompare(lowerCase(b.label)),
+      a.label.toLowerCase().localeCompare(b.label.toLowerCase()),
     );
   }
 
@@ -83,8 +83,8 @@ function arrangeSidebarItems({
     [...Object.values(modSidebarItems), ...orphanSidebarItems],
     (item) =>
       isModSidebarItem(item)
-        ? lowerCase(item.modMetadata.name)
-        : lowerCase(item.label),
+        ? item.modMetadata.name.toLowerCase()
+        : item.label.toLowerCase(),
   );
 }
 


### PR DESCRIPTION
## What does this PR do?

- Removes usage of the lodash lowerCase method which has weird behavior for camelCased strings, splitting them. This is a follow-up to:  https://github.com/pixiebrix/pixiebrix-extension/pull/7418

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer @grahamlangford 
