### PR TITLE
Make worker more resilient to DOM API usage attempts

### DIFF
--- a/src/bricks/transformers/selectElement.ts
+++ b/src/bricks/transformers/selectElement.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { userSelectElement } from "@/contentScript/pageEditor/elementPicker";
+
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { propertiesToSchema } from "@/validators/generic";
@@ -53,6 +53,12 @@ export class SelectElement extends TransformerABC {
   );
 
   async transform(): Promise<unknown> {
+    // The picker uses `bootstrap-switch-button`, which does a `window` check on load and breaks
+    // the MV3 background worker. Lazy-loading it keeps the background worker from breaking.
+    const { userSelectElement } = await import(
+      /* webpackChunkName: "editorContentScript" */ "@/contentScript/pageEditor/elementPicker"
+    );
+
     const { elements } = await userSelectElement();
 
     const elementRefs = elements.map((element) =>

--- a/static/background.worker.js
+++ b/static/background.worker.js
@@ -6,16 +6,20 @@ function get() {
 	`ReferenceError: window is not defined` without pointing to the correct line.
 	This listener defines some globals so that they return `undefined` instead
 	of throwing an error on access.
-
-	This line also lets you add a breakpoint so that you can stop the debugger and
-	see where the access originated from. Or temporarily add console.trace() here.
 	*/
+
+  // Debug helpers: trace or breakable line
+
+  // There are a lot of safe `window` checks in the code so the logger cannot be enabled by default.
+  // console.trace('DOM access in worker');
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  1; // This line lets you add a breakpoint so that you can stop the debugger
 }
 
 Object.defineProperties(self, {
   document: { get },
   window: { get },
-  navigator: { get },
 });
 
 self.importScripts("./grayIconWhileLoading.js", "./background.js");

--- a/static/background.worker.js
+++ b/static/background.worker.js
@@ -1,2 +1,21 @@
 // Don't include `background.worker.js` in webpack, there's no advantage in doing so
+
+function get() {
+  /*
+	When scripts use DOM APIs, the worker will crash on load with the error
+	`ReferenceError: window is not defined` without pointing to the correct line.
+	This listener defines some globals so that they return `undefined` instead
+	of throwing an error on access.
+
+	This line also lets you add a breakpoint so that you can stop the debugger and
+	see where the access originated from. Or temporarily add console.trace() here.
+	*/
+}
+
+Object.defineProperties(self, {
+  document: { get },
+  window: { get },
+  navigator: { get },
+});
+
 self.importScripts("./grayIconWhileLoading.js", "./background.js");


### PR DESCRIPTION
## What does this PR do?

- Prevents some DOM access from breaking the MV3 extension altogether
- Lets us more easily debug such issues

The MV3 extension is failing to load due to an unchecked DOM access by the bricks. The dev tools make it difficult to find the source of this error.

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 

## Related

- https://github.com/pixiebrix/pixiebrix-extension/issues/7185#issuecomment-1870804167
- https://github.com/pixiebrix/pixiebrix-extension/pull/7381