### PR TITLE
Allow exclusion from knip via `@knip` JSDoc tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,8 +169,9 @@ jobs:
       # https://knip.dev/overview/getting-started#without-installation
       - run: npm install -D knip@4
       # Do a run without an exit code. Knip's "warn" setting is not working for files and devDependencies.
-      - run: npm run dead-code -- --config knip.mjs --no-exit-code
-      - run: npm run dead-code -- --config knip.mjs --include files,duplicates,dependencies,classMembers,binaries,enumMembers,nsTypes,exports,nsExports
+      - run: npm run dead-code:base -- --no-exit-code
+      # Automatically excludes exports tagged with `@knip` in their JSDoc
+      - run: npm run dead-code
 
   # https://pre-commit.com/#usage-in-continuous-integration
   prettier:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           attempt_limit: 40
 
   build:
+    name: build-mv${{ matrix.MV }}
     runs-on: ubuntu-latest
     env:
       SOURCE_MAP_URL_BASE: https://pixiebrix-extension-source-maps.s3.amazonaws.com

--- a/knip.mjs
+++ b/knip.mjs
@@ -51,6 +51,8 @@ const knipConfig = {
     "src/vendors/page-metadata-parser/**",
     // False positive - dynamically imported in initRobot
     "src/contrib/uipath/UiPathRobot.ts",
+    // Unused, but we'll likely need this again in the future
+    "src/hooks/useContextInvalidated.ts",
   ],
   ignoreDependencies: [
     // Browser environment types

--- a/knip.mjs
+++ b/knip.mjs
@@ -12,7 +12,6 @@ const knipConfig = {
     ...Object.values(config.entry).map((x) =>
       `${x}.{ts,tsx,js,jsx}`.replace("./", ""),
     ),
-    "src/development/headers.ts",
     // App messenger and common storage
     "src/contentScript/externalProtocol.ts",
     "src/background/messenger/external/api.ts",

--- a/knip.mjs
+++ b/knip.mjs
@@ -4,7 +4,7 @@ const config = configFactory(process.env, {});
 
 // https://knip.dev/overview/configuration#customize
 const knipConfig = {
-  $schema: "https://unpkg.com/knip@3/schema.json",
+  $schema: "https://unpkg.com/knip@4/schema.json",
   webpack: {
     config: ["webpack.config.mjs", ".storybook/main.js"],
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "generate:headers": "npm run test -- src/development/headers.test.ts --no-silent",
     "storybook": "storybook dev -p 6006 -s public",
     "build-storybook": "storybook build",
-    "dead-code": "knip"
+    "dead-code": "npm run dead-code:base -- --include files,duplicates,dependencies,classMembers,binaries,enumMembers,nsTypes,exports,nsExports",
+    "dead-code:base": "knip --config knip.mjs"
   },
   "engine-strict": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "storybook": "storybook dev -p 6006 -s public",
     "build-storybook": "storybook build",
     "dead-code": "npm run dead-code:base -- --include files,duplicates,dependencies,classMembers,binaries,enumMembers,nsTypes,exports,nsExports",
-    "dead-code:base": "knip --config knip.mjs"
+    "dead-code:base": "knip --config knip.mjs --experimental-tags=-knip"
   },
   "engine-strict": true,
   "engines": {

--- a/src/__mocks__/@/hooks/useContextInvalidated.ts
+++ b/src/__mocks__/@/hooks/useContextInvalidated.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export default () => false;

--- a/src/hooks/useContextInvalidated.ts
+++ b/src/hooks/useContextInvalidated.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useSyncExternalStore } from "use-sync-external-store";
+import { onContextInvalidated, wasContextInvalidated } from "webext-events";
+
+function subscribe(callback: () => void) {
+  const unsubscribe = new AbortController();
+  onContextInvalidated.addListener(callback, { signal: unsubscribe.signal });
+  return unsubscribe.abort.bind(unsubscribe);
+}
+
+export default function useContextInvalidated(): boolean {
+  return useSyncExternalStore(subscribe, wasContextInvalidated);
+}

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -5,6 +5,7 @@
   },
   "files": [
     "./__mocks__/@/components/DelayedRender.tsx",
+    "./__mocks__/@/hooks/useContextInvalidated.ts",
     "./__mocks__/@/icons/getSvgIcon.ts",
     "./__mocks__/@/icons/list.ts",
     "./__mocks__/@/sandbox/messenger/api.ts",
@@ -280,6 +281,7 @@
     "./hooks/useAsyncState.ts",
     "./hooks/useAuthorizationGrantFlow.ts",
     "./hooks/useAutoFocusConfiguration.ts",
+    "./hooks/useContextInvalidated.ts",
     "./hooks/useDebouncedEffect.ts",
     "./hooks/useDeriveAsyncState.ts",
     "./hooks/useEventListener.ts",


### PR DESCRIPTION
## What does this PR do?

- Enables JSDoc tags in order to preserve single exports where necessary: 
  - https://knip.dev/reference/cli#--experimental-tags
- Moves the CI command into package.json so we can run the same version locally
- Restores the file as proposed in
  - https://github.com/pixiebrix/pixiebrix-extension/pull/7419#discussion_r1464775088

## Discussion

The new `@knip` tag does not work for unused files, to exclude those we have to keep adding files to the config

## Checklist

- [ ] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
