### PR TITLE
Clarify MV3 zombie worker error

### DIFF
--- a/static/background.worker.js
+++ b/static/background.worker.js
@@ -1,5 +1,11 @@
 // Don't include `background.worker.js` in webpack, there's no advantage in doing so
 
+if (chrome.runtime.getManifest === undefined) {
+  throw new Error(
+    "Chrome bug: The extension was loaded as MV2, but Chrome is still running the worker. Unregister the loader from chrome://serviceworker-internals/",
+  );
+}
+
 function get() {
   /*
 	When scripts use DOM APIs, the worker will crash on load with the error


### PR DESCRIPTION
## What does this PR do?

I've had the background dev tools throw an error regarding `chrome.runtime.getManifest` being undefined and wondering how that could be possible.

It turns out that when switching between MV2 and MV3 versions, Chrome may decide to not unregister the worker, so both stay registered.

This is purely a DX fix that serves to avoid confusion and time waste.

## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
