### PR TITLE
#4258: Remove element picker after invalidation

### DIFF
--- a/src/contentScript/pageEditor/elementPicker.ts
+++ b/src/contentScript/pageEditor/elementPicker.ts
@@ -17,6 +17,7 @@
  */
 
 import Overlay from "@/vendors/Overlay";
+import ReactDOM from "react-dom";
 import {
   expandedCssSelector,
   findContainer,
@@ -38,6 +39,7 @@ import { FLOATING_ACTION_BUTTON_CONTAINER_ID } from "@/components/floatingAction
 import { $safeFind, findSingleElement } from "@/utils/domUtils";
 import inferSingleElementSelector from "@/utils/inference/inferSingleElementSelector";
 import { type ElementInfo } from "@/utils/inference/selectorTypes";
+import { onContextInvalidated } from "webext-events";
 
 /**
  * Primary overlay that moved with the user's mouse/selection.
@@ -167,6 +169,7 @@ export async function userSelectElement({
 
       highlightRoots();
       prehiglightItems();
+      onContextInvalidated.addListener(cancel);
     }
 
     function handleDone(target?: HTMLElement) {
@@ -367,14 +370,7 @@ export async function userSelectElement({
     }
 
     function removeInspectingModeStyles() {
-      if (!styleElement) {
-        return;
-      }
-
-      if (styleElement.parentNode) {
-        styleElement.remove();
-      }
-
+      styleElement?.remove();
       styleElement = null;
     }
 
@@ -401,16 +397,11 @@ export async function userSelectElement({
 
     function removeMultiSelectionTool() {
       $(`#${FLOATING_ACTION_BUTTON_CONTAINER_ID}`).show();
-
-      if (!multiSelectionToolElement) {
-        return;
+      if (multiSelectionToolElement) {
+        ReactDOM.unmountComponentAtNode(multiSelectionToolElement);
+        multiSelectionToolElement?.remove();
+        multiSelectionToolElement = null;
       }
-
-      if (multiSelectionToolElement.parentNode) {
-        multiSelectionToolElement.remove();
-      }
-
-      multiSelectionToolElement = null;
     }
 
     startInspectingNative();


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-extension/issues/4258
- Sibling PR to https://github.com/pixiebrix/pixiebrix-extension/pull/7446

This solves a few issues that arise from stale quicker instances. 

## Element picker field ✅ 

https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/4d11791b-9685-4af0-973c-99b54856a14a

## Insert menu item 🥹 

This works well, except that the screen stays visible because it's part of the editor state. The editor state cannot be cleared after the context is invalidated.

To fix this issue:

- [ ] Exclude this state from the stored editor state  (I don't know how)

https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/75a19c5a-e427-46ff-80f8-672e4186c473


## Checklist

- [x] Designate a primary reviewer: @BLoe 
