### PR TITLE
fix variable popover not repositioning when clicking between variables

### DIFF
--- a/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
+++ b/src/components/fields/schemaFields/widgets/TemplateToggleWidget.tsx
@@ -166,7 +166,12 @@ const TemplateToggleWidget: React.VFC<TemplateToggleWidgetProps> = ({
         {renderVarPopup ? (
           <VarPopup
             inputMode={inputMode}
-            inputElementRef={inputRef}
+            // FIXME: define elementRef type from the SchemaField definition rather than inferring from inputMode
+            inputElementRef={
+              inputRef as React.MutableRefObject<
+                HTMLInputElement | HTMLTextAreaElement
+              >
+            }
             value={stringValue}
             setValue={setNewValueFromString}
           />

--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.test.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.test.tsx
@@ -65,6 +65,7 @@ describe("VarMenu", () => {
             onClose={jest.fn()}
             onVarSelect={jest.fn()}
             likelyVariable="@foo"
+            variablePosition={3}
           />
         )}
       />,
@@ -94,6 +95,7 @@ describe("VarMenu", () => {
             onClose={jest.fn()}
             onVarSelect={jest.fn()}
             likelyVariable="@foo"
+            variablePosition={3}
           />
         )}
       />,
@@ -138,6 +140,7 @@ describe("VarMenu", () => {
             onClose={jest.fn()}
             onVarSelect={jest.fn()}
             likelyVariable="@inp"
+            variablePosition={3}
           />
         )}
       />,
@@ -174,6 +177,7 @@ describe("VarMenu", () => {
     // @inp matches @input
     expect(screen.getByText("@input")).toBeInTheDocument();
 
+    // eslint-disable-next-line @shopify/jest/no-snapshots -- verifies the menu is rendered as expected
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.tsx
@@ -51,11 +51,17 @@ type VarMenuProps = {
   /**
    * The underlying var or text input element.
    */
-  inputElementRef: React.MutableRefObject<HTMLElement>;
+  inputElementRef: React.MutableRefObject<
+    HTMLTextAreaElement | HTMLInputElement
+  >;
   /**
    * The likely variable the user is interacting with.
    */
   likelyVariable: string | null;
+  /** The start index of the likelyVariable - used to
+   * identify when the menu needs to be repositioned
+   */
+  variablePosition: number | null;
   /**
    * Callback to close the menu.
    */
@@ -69,9 +75,11 @@ type VarMenuProps = {
 function usePositionVarPopup({
   knownVars,
   inputElementRef,
+  variablePosition,
 }: {
   knownVars: VarMap;
   inputElementRef: VarMenuProps["inputElementRef"];
+  variablePosition: number;
 }) {
   const dispatch = useDispatch();
   const rootElementRef = useRef<HTMLDivElement>(null);
@@ -104,9 +112,9 @@ function usePositionVarPopup({
       return;
     }
 
-    // Create a virtual element for the selected line
+    // Virtual element for the selected line
     const selectedLineBorderBox = getSelectedLineVirtualElement(
-      inputElementRef.current as HTMLTextAreaElement,
+      inputElementRef.current,
     );
 
     const position = await computePosition(
@@ -130,9 +138,9 @@ function usePositionVarPopup({
     rootElementRef.current.style.transform = `translate3d(0, ${position.y}px, 0)`;
     setPositioned(true);
 
-    // While the position does not rely on the knownVars or the resize state,
+    // While the menu position does not rely on the knownVars, the resize state or the variable position
     // we need to recompute the position when either of these change.
-  }, [knownVars, dispatch, resize]);
+  }, [knownVars, dispatch, resize, variablePosition]); // Add a dependency here... either position, line number or variable
 
   return { rootElementRef, positioned };
 }
@@ -142,6 +150,7 @@ const VarMenu: React.FunctionComponent<VarMenuProps> = ({
   onClose,
   onVarSelect,
   likelyVariable,
+  variablePosition,
 }) => {
   const dispatch = useDispatch();
   const activeElement = useSelector(selectActiveElement);
@@ -152,6 +161,7 @@ const VarMenu: React.FunctionComponent<VarMenuProps> = ({
   const { rootElementRef, positioned } = usePositionVarPopup({
     knownVars,
     inputElementRef,
+    variablePosition,
   });
 
   const trace = useSelector(selectActiveNodeTrace);

--- a/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
@@ -33,7 +33,9 @@ type VarPopupProps = {
   /**
    * Reference to the underlying input element/textarea.
    */
-  inputElementRef: React.MutableRefObject<HTMLElement>;
+  inputElementRef: React.MutableRefObject<
+    HTMLTextAreaElement | HTMLInputElement
+  >;
   /**
    * The current field value.
    */
@@ -50,11 +52,12 @@ const VarPopup: React.FunctionComponent<VarPopupProps> = ({
   value,
   setValue,
 }) => {
-  const { hideMenu, isMenuShowing, likelyVariable } = useAttachPopup({
-    inputMode,
-    inputElementRef,
-    value,
-  });
+  const { hideMenu, isMenuShowing, likelyVariable, variablePosition } =
+    useAttachPopup({
+      inputMode,
+      inputElementRef,
+      value,
+    });
 
   useEffect(() => {
     if (isMenuShowing) {
@@ -72,11 +75,13 @@ const VarPopup: React.FunctionComponent<VarPopupProps> = ({
 
       switch (inputMode) {
         case "var": {
+          // "var" input type is a HTMLInputElement
           setValue(fullVariableName);
           break;
         }
 
         case "string": {
+          // "string" input type is a HTMLTextAreaElement
           const textElement = inputElementRef.current as HTMLTextAreaElement;
           if (textElement == null) {
             return;
@@ -125,6 +130,7 @@ const VarPopup: React.FunctionComponent<VarPopupProps> = ({
       onVarSelect={onVarSelect}
       onClose={hideMenu}
       likelyVariable={likelyVariable}
+      variablePosition={variablePosition}
     />
   );
 };

--- a/src/components/fields/schemaFields/widgets/varPopup/utils.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/utils.ts
@@ -23,7 +23,7 @@ import { getTextareaCaretCoordinates } from "@/utils/textAreaUtils";
  * Used to position the floating UI menu.
  */
 export function getSelectedLineVirtualElement(
-  textarea: HTMLTextAreaElement,
+  textarea: HTMLTextAreaElement | HTMLInputElement,
 ): VirtualElement {
   const inputRect = textarea.getBoundingClientRect();
 

--- a/src/utils/textAreaUtils.ts
+++ b/src/utils/textAreaUtils.ts
@@ -68,7 +68,7 @@ const properties = [
  * @param position
  */
 export function getTextareaCaretCoordinates(
-  element: HTMLTextAreaElement,
+  element: HTMLTextAreaElement | HTMLInputElement,
   position: number,
 ) {
   // The mirror div will replicate the textarea's style
@@ -82,7 +82,7 @@ export function getTextareaCaretCoordinates(
 
   // Default textarea styles
   style.whiteSpace = "pre-wrap";
-  if (!isInput) style.wordWrap = "break-word"; // Only for textarea-s
+  if (!isInput) style.overflowWrap = "break-word"; // Only for textarea-s
 
   // Position off-screen
   style.position = "absolute"; // Required to return coordinates properly


### PR DESCRIPTION
This change also tightens up the typing for the inputElement for the
various variable popover components and utils.

## What does this PR do?

- Closes/Fixes/Part of #123
- _Are there other changes (e.g., refactoring) included that aren’t from the ticket?_

## Reviewer Tips

- _What order should the reviewer review the files in?_
- _Are there any implementation approaches you want feedback on?_

## Discussion

- _Were there multiple approaches you were deciding between?_

## Demo

- _Paste a screenshot or demo video here_

## Future Work

- _Work for the issue/ticket that will be in a follow-up PR_

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [ ] Designate a primary reviewer
