### PR TITLE
Remove redundant/unnecessary brick refresh on extension console (speeds up by several seconds)

### DIFF
--- a/src/extensionConsole/App.tsx
+++ b/src/extensionConsole/App.tsx
@@ -34,7 +34,6 @@ import { ConnectedRouter } from "connected-react-router";
 import EnvironmentBanner from "@/layout/EnvironmentBanner";
 import ActivateModPage from "@/extensionConsole/pages/activateMod/ActivateModPage";
 import ActivateExtensionPage from "@/extensionConsole/pages/activateExtension/ActivateExtensionPage";
-import useRefreshRegistries from "@/hooks/useRefreshRegistries";
 import SetupPage from "@/extensionConsole/pages/onboarding/SetupPage";
 import UpdateBanner from "@/extensionConsole/pages/UpdateBanner";
 import registerBuiltinBricks from "@/bricks/registerBuiltinBricks";
@@ -55,7 +54,6 @@ import ReduxPersistenceContext, {
 } from "@/store/ReduxPersistenceContext";
 import IDBErrorDisplay from "@/extensionConsole/components/IDBErrorDisplay";
 import { DeploymentsProvider } from "@/extensionConsole/pages/deployments/DeploymentsContext";
-import Loader from "@/components/Loader";
 
 // Register the built-in bricks
 registerEditors();
@@ -73,13 +71,6 @@ const AuthenticatedContent: React.VFC = () => {
     // Start polling logs
     dispatch(logActions.pollLogs());
   }, [dispatch]);
-
-  // Get the latest brick definitions
-  const [loaded] = useRefreshRegistries();
-
-  if (!loaded) {
-    return <Loader />;
-  }
 
   return (
     <DeploymentsProvider>


### PR DESCRIPTION
## What does this PR do?

- Mentioned in https://pixiebrix.slack.com/archives/C0436P48QHY/p1706247634107659
- Saves several seconds on load
- Avoids a duplicate `fetch` of the bricks



## Demo

The before/after demos are self-explanatory. They show a page reload:

<table>
<tr>
	<th>Before
	<th>After
<tr>
<td>

https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/55d55f04-2142-427d-8c2c-7de2e882b7de
	
<td>

https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/fd01e8a4-a175-4135-ae68-4ff128217109


</table>

### Background worker requests

Note that this does not affect the Mods page, which still loads, and loads faster because it does not load the bricks twice.

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="587" alt="Screenshot 12" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/0be2665c-e6e1-44aa-af80-d5730e16cb0a">
	<td><img width="587" alt="Screenshot 13" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/6a222d95-48c8-4b8f-ac55-164258624351">
</table>


## Checklist

- [x] Designate a primary reviewer: @BLoe 
