### PR TITLE
Drop self-referencing extension console link in sidePanel

### DIFF
--- a/src/tinyPages/RestrictedUrlPopupApp.tsx
+++ b/src/tinyPages/RestrictedUrlPopupApp.tsx
@@ -43,7 +43,7 @@ async function openInActiveTab(event: React.MouseEvent<HTMLAnchorElement>) {
   }
 }
 
-const RestrictedUrlContent: React.FC<{ extensionConsoleLink: boolean }> = ({
+const RestrictedUrlContent: React.FC<{ extensionConsoleLink?: boolean }> = ({
   children,
   extensionConsoleLink = true,
 }) => (

--- a/src/tinyPages/RestrictedUrlPopupApp.tsx
+++ b/src/tinyPages/RestrictedUrlPopupApp.tsx
@@ -43,7 +43,10 @@ async function openInActiveTab(event: React.MouseEvent<HTMLAnchorElement>) {
   }
 }
 
-const RestrictedUrlContent: React.FC = ({ children }) => (
+const RestrictedUrlContent: React.FC<{ extensionConsoleLink: boolean }> = ({
+  children,
+  extensionConsoleLink = true,
+}) => (
   <div className="p-3">
     {children}
     <div className="mt-2">
@@ -52,12 +55,14 @@ const RestrictedUrlContent: React.FC = ({ children }) => (
     </div>
     <hr />
 
-    <div className="mt-2">
-      Looking for the Extension Console?{" "}
-      <a href={getExtensionConsoleUrl()} onClick={openInActiveTab}>
-        Open the Extension Console
-      </a>
-    </div>
+    {extensionConsoleLink && (
+      <div className="mt-2">
+        Looking for the Extension Console?{" "}
+        <a href={getExtensionConsoleUrl()} onClick={openInActiveTab}>
+          Open the Extension Console
+        </a>
+      </div>
+    )}
 
     <div className="mt-2">
       Looking for the Page Editor?{" "}
@@ -82,7 +87,7 @@ const RestrictedUrlPopupApp: React.FC<{ reason: string | null }> = ({
   }, []);
 
   return reason === DISPLAY_REASON_EXTENSION_CONSOLE ? (
-    <RestrictedUrlContent>
+    <RestrictedUrlContent extensionConsoleLink={false}>
       <div className="font-weight-bold">This is the Extension Console.</div>
       <div className="mt-2">PixieBrix mods cannot run on this page.</div>
     </RestrictedUrlContent>


### PR DESCRIPTION
## What does this PR do?

When on the **extension console**, the user should not be asked if they want to visit the **extension console**.

This conflict was the reason why I had inadvertently dropped the link here https://github.com/pixiebrix/pixiebrix-extension/pull/7354#discussion_r1463863618

## Demo

This works correctly now:

![before](https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/d2cd49f9-3080-4fc7-ac2c-2b36bc5b46d6)

Also verified on MV2

<table>
<tr>
	<td><img width="444" alt="Screenshot 17" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/3d785201-339f-48ad-8910-65f96b698e5f">
	<td><img width="444" alt="Screenshot 16" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/dbdacbc8-ed59-4d44-b82f-e01ad41e3c51">
</table>







## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
