### PR TITLE
Make Extension Console "Get Started" view consistent with other views

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -7784,7 +7784,7 @@ exports[`Storyshots Layout/Page Load Error 1`] = `
 
 exports[`Storyshots ModsPage/GetStartedView Activate Blueprint 1`] = `
 <div
-  className="root"
+  className="root card"
   style={
     {
       "height": "500px",
@@ -7793,144 +7793,148 @@ exports[`Storyshots ModsPage/GetStartedView Activate Blueprint 1`] = `
   }
 >
   <div
-    className="infoRow"
+    className="max-950 card-body"
   >
-    <h4>
-      Want to create a new mod?
-    </h4>
-    <ul>
-      <li>
-        Start by opening a new browser tab and navigating to the webpage you want to modify.
-      </li>
-      <li>
-        Open the Page Editor by selecting the PixieBrix tab via the
+    <div
+      className="infoRow"
+    >
+      <h4>
+        Want to create a new mod?
+      </h4>
+      <ul>
+        <li>
+          Start by opening a new browser tab and navigating to the webpage you want to modify.
+        </li>
+        <li>
+          Open the Page Editor by selecting the PixieBrix tab via the
+           
+          <strong>
+            Chrome DevTools
+          </strong>
+           using
+           
+          <kbd>
+            Ctrl + Shift + C
+          </kbd>
+           
+          or 
+          <kbd>
+            F12
+          </kbd>
+           and start editing your page.
+        </li>
+        <li>
+          Save your mod in the Page Editor, and you'll see it here as a personal mod.
+        </li>
+      </ul>
+    </div>
+    <div
+      className="infoRow"
+    >
+      <h4>
+        Need more help?
+      </h4>
+      <p>
+        Visit the
          
-        <strong>
-          Chrome DevTools
-        </strong>
-         using
+        <span>
+          <a
+            href="https://docs.pixiebrix.com/quick-start"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Quick Start Guide
+          </a>
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
+            data-icon="external-link-alt"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={{}}
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              fill="currentColor"
+              style={{}}
+            />
+          </svg>
+        </span>
          
-        <kbd>
-          Ctrl + Shift + C
-        </kbd>
+        or ask questions in the
          
-        or 
-        <kbd>
-          F12
-        </kbd>
-         and start editing your page.
-      </li>
-      <li>
-        Save your mod in the Page Editor, and you'll see it here as a personal mod.
-      </li>
-    </ul>
-  </div>
-  <div
-    className="infoRow"
-  >
-    <h4>
-      Need more help?
-    </h4>
-    <p>
-      Visit the
-       
-      <span>
-        <a
-          href="https://docs.pixiebrix.com/quick-start"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Quick Start Guide
-        </a>
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
-          data-icon="external-link-alt"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={{}}
-          viewBox="0 0 512 512"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-            fill="currentColor"
+        <span>
+          <a
+            href="https://pixiebrixcommunity.slack.com/join/shared_invite/zt-13gmwdijb-Q5nVsSx5wRLmRwL3~lsDww#/shared-invite/email"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Slack Community
+          </a>
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
+            data-icon="external-link-alt"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
             style={{}}
-          />
-        </svg>
-      </span>
-       
-      or ask questions in the
-       
-      <span>
-        <a
-          href="https://pixiebrixcommunity.slack.com/join/shared_invite/zt-13gmwdijb-Q5nVsSx5wRLmRwL3~lsDww#/shared-invite/email"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Slack Community
-        </a>
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
-          data-icon="external-link-alt"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={{}}
-          viewBox="0 0 512 512"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-            fill="currentColor"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              fill="currentColor"
+              style={{}}
+            />
+          </svg>
+        </span>
+        .
+      </p>
+      <p>
+         
+        Visit the
+         
+        <span>
+          <a
+            href="https://www.pixiebrix.com/marketplace/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            PixieBrix Marketplace
+          </a>
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
+            data-icon="external-link-alt"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
             style={{}}
-          />
-        </svg>
-      </span>
-      .
-    </p>
-    <p>
-       
-      Visit the
-       
-      <span>
-        <a
-          href="https://www.pixiebrix.com/marketplace/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          PixieBrix Marketplace
-        </a>
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
-          data-icon="external-link-alt"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={{}}
-          viewBox="0 0 512 512"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-            fill="currentColor"
-            style={{}}
-          />
-        </svg>
-      </span>
-       
-      for ideas.
-    </p>
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              fill="currentColor"
+              style={{}}
+            />
+          </svg>
+        </span>
+         
+        for ideas.
+      </p>
+    </div>
   </div>
 </div>
 `;
 
 exports[`Storyshots ModsPage/GetStartedView Default 1`] = `
 <div
-  className="root"
+  className="root card"
   style={
     {
       "height": "500px",
@@ -7939,137 +7943,141 @@ exports[`Storyshots ModsPage/GetStartedView Default 1`] = `
   }
 >
   <div
-    className="infoRow"
+    className="max-950 card-body"
   >
-    <h4>
-      Want to create a new mod?
-    </h4>
-    <ul>
-      <li>
-        Start by opening a new browser tab and navigating to the webpage you want to modify.
-      </li>
-      <li>
-        Open the Page Editor by selecting the PixieBrix tab via the
+    <div
+      className="infoRow"
+    >
+      <h4>
+        Want to create a new mod?
+      </h4>
+      <ul>
+        <li>
+          Start by opening a new browser tab and navigating to the webpage you want to modify.
+        </li>
+        <li>
+          Open the Page Editor by selecting the PixieBrix tab via the
+           
+          <strong>
+            Chrome DevTools
+          </strong>
+           using
+           
+          <kbd>
+            Ctrl + Shift + C
+          </kbd>
+           
+          or 
+          <kbd>
+            F12
+          </kbd>
+           and start editing your page.
+        </li>
+        <li>
+          Save your mod in the Page Editor, and you'll see it here as a personal mod.
+        </li>
+      </ul>
+    </div>
+    <div
+      className="infoRow"
+    >
+      <h4>
+        Need more help?
+      </h4>
+      <p>
+        Visit the
          
-        <strong>
-          Chrome DevTools
-        </strong>
-         using
+        <span>
+          <a
+            href="https://docs.pixiebrix.com/quick-start"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Quick Start Guide
+          </a>
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
+            data-icon="external-link-alt"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
+            style={{}}
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              fill="currentColor"
+              style={{}}
+            />
+          </svg>
+        </span>
          
-        <kbd>
-          Ctrl + Shift + C
-        </kbd>
+        or ask questions in the
          
-        or 
-        <kbd>
-          F12
-        </kbd>
-         and start editing your page.
-      </li>
-      <li>
-        Save your mod in the Page Editor, and you'll see it here as a personal mod.
-      </li>
-    </ul>
-  </div>
-  <div
-    className="infoRow"
-  >
-    <h4>
-      Need more help?
-    </h4>
-    <p>
-      Visit the
-       
-      <span>
-        <a
-          href="https://docs.pixiebrix.com/quick-start"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Quick Start Guide
-        </a>
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
-          data-icon="external-link-alt"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={{}}
-          viewBox="0 0 512 512"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-            fill="currentColor"
+        <span>
+          <a
+            href="https://pixiebrixcommunity.slack.com/join/shared_invite/zt-13gmwdijb-Q5nVsSx5wRLmRwL3~lsDww#/shared-invite/email"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Slack Community
+          </a>
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
+            data-icon="external-link-alt"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
             style={{}}
-          />
-        </svg>
-      </span>
-       
-      or ask questions in the
-       
-      <span>
-        <a
-          href="https://pixiebrixcommunity.slack.com/join/shared_invite/zt-13gmwdijb-Q5nVsSx5wRLmRwL3~lsDww#/shared-invite/email"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Slack Community
-        </a>
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
-          data-icon="external-link-alt"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={{}}
-          viewBox="0 0 512 512"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-            fill="currentColor"
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              fill="currentColor"
+              style={{}}
+            />
+          </svg>
+        </span>
+        .
+      </p>
+      <p>
+         
+        Visit the
+         
+        <span>
+          <a
+            href="https://www.pixiebrix.com/marketplace/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            PixieBrix Marketplace
+          </a>
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
+            data-icon="external-link-alt"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
             style={{}}
-          />
-        </svg>
-      </span>
-      .
-    </p>
-    <p>
-       
-      Visit the
-       
-      <span>
-        <a
-          href="https://www.pixiebrix.com/marketplace/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          PixieBrix Marketplace
-        </a>
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
-          data-icon="external-link-alt"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={{}}
-          viewBox="0 0 512 512"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-            fill="currentColor"
-            style={{}}
-          />
-        </svg>
-      </span>
-       
-      for ideas.
-    </p>
+            viewBox="0 0 512 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+              fill="currentColor"
+              style={{}}
+            />
+          </svg>
+        </span>
+         
+        for ideas.
+      </p>
+    </div>
   </div>
 </div>
 `;

--- a/src/extensionConsole/pages/mods/GetStartedView.module.scss
+++ b/src/extensionConsole/pages/mods/GetStartedView.module.scss
@@ -18,25 +18,21 @@
 @import "@/themes/colors";
 
 .root {
+  flex: 1 1 auto;
   li,
   p {
     font-size: 16px;
   }
 
   kbd {
-    color: $N900;
-    background: $N0;
-    border-radius: 4px;
-    padding: 4.5px 6px;
-    margin: 0 12px;
+    margin-inline: 12px;
   }
 
   a {
     color: $N900;
     font-weight: 500;
-    padding-bottom: 1px;
-    border-bottom: 2px solid $P500;
-    text-decoration: none;
+    text-decoration: underline solid 2px $P500;
+    text-underline-offset: 5px;
   }
 
   .externalLinkIcon {

--- a/src/extensionConsole/pages/mods/GetStartedView.tsx
+++ b/src/extensionConsole/pages/mods/GetStartedView.tsx
@@ -27,6 +27,7 @@ import { useOptionalModDefinition } from "@/modDefinitions/modDefinitionHooks";
 import ModIcon from "@/mods/ModIcon";
 import { isMac } from "@/utils/browserUtils";
 import { MARKETPLACE_URL } from "@/urlConstants";
+import { Card } from "react-bootstrap";
 
 const ExternalLink: React.VoidFunctionComponent<{
   linkText: string;
@@ -67,90 +68,92 @@ const GetStartedView: React.VoidFunctionComponent<{
   const marketplaceUrl = `${homepageUrl}/marketplace/${onboardingModListing?.id}/`;
 
   return (
-    <div
+    <Card
       style={{ height: `${height}px`, width: `${width}px` }}
       className={styles.root}
     >
-      {onboardingModListing && (
-        <div className={styles.infoRow}>
-          <h4>
-            Success!{" "}
-            {!isFetchingRecipe && (
-              <>
-                <ModIcon mod={recipe} />{" "}
-              </>
-            )}
-            <ExternalLink
-              linkText={onboardingModListing.package.verbose_name}
-              url={marketplaceUrl}
-            />{" "}
-            is ready to use.
-          </h4>
-          <ul>
-            <li>
-              Time to try this mod in the wild! You can navigate to a webpage
-              this mod enhances to see it in action.
-            </li>
-            <li>
-              Check out the &quot;How to Use&quot; section for{" "}
+      <Card.Body className="max-950">
+        {onboardingModListing && (
+          <div className={styles.infoRow}>
+            <h4>
+              Success!{" "}
+              {!isFetchingRecipe && (
+                <>
+                  <ModIcon mod={recipe} />{" "}
+                </>
+              )}
               <ExternalLink
-                linkText={`${onboardingModListing.package.verbose_name}`}
+                linkText={onboardingModListing.package.verbose_name}
                 url={marketplaceUrl}
               />{" "}
-              in the Marketplace for more details about how to use this mod.
+              is ready to use.
+            </h4>
+            <ul>
+              <li>
+                Time to try this mod in the wild! You can navigate to a webpage
+                this mod enhances to see it in action.
+              </li>
+              <li>
+                Check out the &quot;How to Use&quot; section for{" "}
+                <ExternalLink
+                  linkText={`${onboardingModListing.package.verbose_name}`}
+                  url={marketplaceUrl}
+                />{" "}
+                in the Marketplace for more details about how to use this mod.
+              </li>
+            </ul>
+          </div>
+        )}
+        <div className={styles.infoRow}>
+          <h4>Want to create a new mod?</h4>
+          <ul>
+            <li>
+              Start by opening a new browser tab and navigating to the webpage
+              you want to modify.
+            </li>
+            <li>
+              Open the Page Editor by selecting the PixieBrix tab via the{" "}
+              <strong>Chrome DevTools</strong> using{" "}
+              {isMac() ? (
+                <kbd>Cmd + Option + C</kbd>
+              ) : (
+                <kbd>Ctrl + Shift + C</kbd>
+              )}{" "}
+              or <kbd>F12</kbd> and start editing your page.
+            </li>
+            <li>
+              Save your mod in the Page Editor, and you&apos;ll see it here as a
+              personal mod.
             </li>
           </ul>
         </div>
-      )}
-      <div className={styles.infoRow}>
-        <h4>Want to create a new mod?</h4>
-        <ul>
-          <li>
-            Start by opening a new browser tab and navigating to the webpage you
-            want to modify.
-          </li>
-          <li>
-            Open the Page Editor by selecting the PixieBrix tab via the{" "}
-            <strong>Chrome DevTools</strong> using{" "}
-            {isMac() ? (
-              <kbd>Cmd + Option + C</kbd>
-            ) : (
-              <kbd>Ctrl + Shift + C</kbd>
-            )}{" "}
-            or <kbd>F12</kbd> and start editing your page.
-          </li>
-          <li>
-            Save your mod in the Page Editor, and you&apos;ll see it here as a
-            personal mod.
-          </li>
-        </ul>
-      </div>
-      <div className={styles.infoRow}>
-        <h4>Need more help?</h4>
-        <p>
-          Visit the{" "}
-          <ExternalLink
-            linkText="Quick Start Guide"
-            url="https://docs.pixiebrix.com/quick-start"
-          />{" "}
-          or ask questions in the{" "}
-          <ExternalLink
-            linkText="Slack Community"
-            url="https://pixiebrixcommunity.slack.com/join/shared_invite/zt-13gmwdijb-Q5nVsSx5wRLmRwL3~lsDww#/shared-invite/email"
-          />
-          .
-        </p>
-        <p>
-          {" "}
-          Visit the{" "}
-          <ExternalLink
-            linkText="PixieBrix Marketplace"
-            url={MARKETPLACE_URL}
-          />{" "}
-          for ideas.
-        </p>
-      </div>
-    </div>
+        <div className={styles.infoRow}>
+          <h4>Need more help?</h4>
+          <p>
+            Visit the{" "}
+            <ExternalLink
+              linkText="Quick Start Guide"
+              url="https://docs.pixiebrix.com/quick-start"
+            />{" "}
+            or ask questions in the{" "}
+            <ExternalLink
+              linkText="Slack Community"
+              url="https://pixiebrixcommunity.slack.com/join/shared_invite/zt-13gmwdijb-Q5nVsSx5wRLmRwL3~lsDww#/shared-invite/email"
+            />
+            .
+          </p>
+          <p>
+            {" "}
+            Visit the{" "}
+            <ExternalLink
+              linkText="PixieBrix Marketplace"
+              url={MARKETPLACE_URL}
+            />{" "}
+            for ideas.
+          </p>
+        </div>
+      </Card.Body>
+    </Card>
   );
 };
 

--- a/src/extensionConsole/pages/mods/__snapshots__/ModsPageLayout.test.tsx.snap
+++ b/src/extensionConsole/pages/mods/__snapshots__/ModsPageLayout.test.tsx.snap
@@ -221,126 +221,130 @@ exports[`ModsPageLayout renders 1`] = `
         style="flex: 1 1 auto;"
       >
         <div
-          class="root"
+          class="root card"
           style="height: 600px; width: 600px;"
         >
           <div
-            class="infoRow"
+            class="max-950 card-body"
           >
-            <h4>
-              Want to create a new mod?
-            </h4>
-            <ul>
-              <li>
-                Start by opening a new browser tab and navigating to the webpage you want to modify.
-              </li>
-              <li>
-                Open the Page Editor by selecting the PixieBrix tab via the 
-                <strong>
-                  Chrome DevTools
-                </strong>
-                 using 
-                <kbd>
-                  Ctrl + Shift + C
-                </kbd>
-                 or 
-                <kbd>
-                  F12
-                </kbd>
-                 and start editing your page.
-              </li>
-              <li>
-                Save your mod in the Page Editor, and you'll see it here as a personal mod.
-              </li>
-            </ul>
-          </div>
-          <div
-            class="infoRow"
-          >
-            <h4>
-              Need more help?
-            </h4>
-            <p>
-              Visit the 
-              <span>
-                <a
-                  href="https://docs.pixiebrix.com/quick-start"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Quick Start Guide
-                </a>
-                <svg
-                  aria-hidden="true"
-                  class="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
-                  data-icon="external-link-alt"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
-                  viewBox="0 0 512 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
-               or ask questions in the 
-              <span>
-                <a
-                  href="https://pixiebrixcommunity.slack.com/join/shared_invite/zt-13gmwdijb-Q5nVsSx5wRLmRwL3~lsDww#/shared-invite/email"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Slack Community
-                </a>
-                <svg
-                  aria-hidden="true"
-                  class="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
-                  data-icon="external-link-alt"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
-                  viewBox="0 0 512 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
-              .
-            </p>
-            <p>
-               Visit the 
-              <span>
-                <a
-                  href="https://www.pixiebrix.com/marketplace/"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  PixieBrix Marketplace
-                </a>
-                <svg
-                  aria-hidden="true"
-                  class="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
-                  data-icon="external-link-alt"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
-                  viewBox="0 0 512 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
-               for ideas.
-            </p>
+            <div
+              class="infoRow"
+            >
+              <h4>
+                Want to create a new mod?
+              </h4>
+              <ul>
+                <li>
+                  Start by opening a new browser tab and navigating to the webpage you want to modify.
+                </li>
+                <li>
+                  Open the Page Editor by selecting the PixieBrix tab via the 
+                  <strong>
+                    Chrome DevTools
+                  </strong>
+                   using 
+                  <kbd>
+                    Ctrl + Shift + C
+                  </kbd>
+                   or 
+                  <kbd>
+                    F12
+                  </kbd>
+                   and start editing your page.
+                </li>
+                <li>
+                  Save your mod in the Page Editor, and you'll see it here as a personal mod.
+                </li>
+              </ul>
+            </div>
+            <div
+              class="infoRow"
+            >
+              <h4>
+                Need more help?
+              </h4>
+              <p>
+                Visit the 
+                <span>
+                  <a
+                    href="https://docs.pixiebrix.com/quick-start"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Quick Start Guide
+                  </a>
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
+                    data-icon="external-link-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+                 or ask questions in the 
+                <span>
+                  <a
+                    href="https://pixiebrixcommunity.slack.com/join/shared_invite/zt-13gmwdijb-Q5nVsSx5wRLmRwL3~lsDww#/shared-invite/email"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Slack Community
+                  </a>
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
+                    data-icon="external-link-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+                .
+              </p>
+              <p>
+                 Visit the 
+                <span>
+                  <a
+                    href="https://www.pixiebrix.com/marketplace/"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    PixieBrix Marketplace
+                  </a>
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-external-link-alt fa-w-16 fa-xs externalLinkIcon"
+                    data-icon="external-link-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+                 for ideas.
+              </p>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Context

Here are some views from the extension console, currently:


<img width="1256" alt="Screenshot 26" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/c6bc95d8-934a-4f9b-85ee-e9886df2ac3b">

<img width="1256" alt="Screenshot 27" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/fba33712-5a1d-48d6-af22-ca5c28aa90ea">

<img width="1256" alt="Screenshot 28" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/919bc78f-c1ca-4ab5-b090-196a8b102a48">

<img width="1256" alt="Screenshot 29" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/3eb1ce2e-44a4-45e3-8983-77dd6962cc24">

## What does this PR do?

- It brings that Get Started view up to par with the other views
- Drops some unnecessary micro-adjustments made to its style (e.g. the CSS was changing the padding of the keyboard shortcuts from 5px to 4.5px)
- Adds a maximum width so that the text doesn't get too long

<img width="1256" alt="Screenshot 25" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/19cb5308-fee5-44d6-a64a-d474b1bb0031">


Note that the keyboard shortcut color matches what we have elsewhere. If we don't like that, it should be changed across the extension

<img width="755" alt="Screenshot 30" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/4eed11eb-fb19-4111-92c2-00c0291c8d45">


## Checklist

- [x] Designate a primary reviewer: @mnholtz @BrandonPxBx 

## Related

- Extracted from https://github.com/pixiebrix/pixiebrix-extension/pull/7443