### PR TITLE
#7593 Document Builder custom styles Slice 3: Attach stylesheets to the rendered document

### DIFF
--- a/src/bricks/renderers/document.ts
+++ b/src/bricks/renderers/document.ts
@@ -28,6 +28,8 @@ import {
   DOCUMENT_ELEMENT_TYPES,
   type DocumentElement,
 } from "@/components/documentBuilder/documentBuilderTypes";
+import { compact } from "lodash";
+import { isValidUrl } from "@/utils/urlUtils";
 
 export const DOCUMENT_SCHEMA: Schema = {
   $schema: "https://json-schema.org/draft/2019-09/schema#",
@@ -44,7 +46,6 @@ export const DOCUMENT_SCHEMA: Schema = {
       type: "array",
       items: {
         type: "string",
-        format: "uri",
       },
       title: "CSS Stylesheet URLs",
       description:
@@ -91,7 +92,7 @@ export class DocumentRenderer extends RendererABC {
   async render(
     {
       body,
-      stylesheets,
+      stylesheets = [],
     }: BrickArgs<{
       body: DocumentElement[];
       stylesheets: string[];
@@ -102,6 +103,7 @@ export class DocumentRenderer extends RendererABC {
       Component: DocumentViewLazy,
       props: {
         body,
+        stylesheets: compact(stylesheets).filter((url) => isValidUrl(url)),
         options,
       },
     };

--- a/src/bricks/renderers/documentView/DocumentView.tsx
+++ b/src/bricks/renderers/documentView/DocumentView.tsx
@@ -28,7 +28,7 @@ import { joinPathParts } from "@/utils/formUtils";
 
 const DocumentView: React.FC<DocumentViewProps> = ({
   body,
-  stylesheets,
+  stylesheets = [],
   options,
   meta,
   onAction,

--- a/src/bricks/renderers/documentView/DocumentView.tsx
+++ b/src/bricks/renderers/documentView/DocumentView.tsx
@@ -28,6 +28,7 @@ import { joinPathParts } from "@/utils/formUtils";
 
 const DocumentView: React.FC<DocumentViewProps> = ({
   body,
+  stylesheets,
   options,
   meta,
   onAction,
@@ -50,7 +51,12 @@ const DocumentView: React.FC<DocumentViewProps> = ({
           // DocumentView.css is an artifact produced by webpack, see the DocumentView entrypoint included in
           // `webpack.config.mjs`. We build styles needed to render documents separately from the rest of the sidebar
           // in order to isolate the rendered document from the custom Bootstrap theme included in the Sidebar app
-          href={["/DocumentView.css", bootstrap, bootstrapOverrides]}
+          href={[
+            "/DocumentView.css",
+            bootstrap,
+            bootstrapOverrides,
+            ...stylesheets,
+          ]}
         >
           {body.map((documentElement, index) => {
             const documentBranch = buildDocumentBranch(documentElement, {

--- a/src/bricks/renderers/documentView/DocumentViewProps.tsx
+++ b/src/bricks/renderers/documentView/DocumentViewProps.tsx
@@ -29,6 +29,10 @@ export type DocumentViewProps = {
    * Top-level elements in the document.
    */
   body: DocumentElement[];
+  /**
+   * Remote stylesheets (URLs) to include in the document.
+   */
+  stylesheets?: string[];
   options: BrickOptions<BrickArgsContext>;
   meta: {
     runId: UUID;

--- a/src/sidebar/PanelBody.test.tsx
+++ b/src/sidebar/PanelBody.test.tsx
@@ -152,4 +152,80 @@ describe("PanelBody", () => {
 
     expect(screen.getByShadowText("Test")).toBeVisible();
   });
+
+  it("renders document", async () => {
+    const payload: RendererRunPayload = {
+      key: uuidv4(),
+      runId: uuidv4(),
+      extensionId,
+      blockId: validateRegistryId("@pixiebrix/document"),
+      args: {
+        body: [
+          {
+            type: "container",
+            config: {},
+            children: [
+              {
+                type: "row",
+                config: {},
+                children: [
+                  {
+                    type: "column",
+                    config: {},
+                    children: [
+                      {
+                        type: "header",
+                        config: {
+                          title: "Example document",
+                          heading: "h1",
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "row",
+                config: {},
+                children: [
+                  {
+                    type: "column",
+                    config: {},
+                    children: [
+                      {
+                        type: "text",
+                        config: {
+                          text: "Example styled text element",
+                          enableMarkdown: true,
+                          className: "override-styles",
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      ctxt: {},
+    };
+
+    render(
+      <PanelBody
+        isRootPanel
+        onAction={jest.fn()}
+        context={{ extensionId, blueprintId }}
+        payload={payload}
+      />,
+    );
+
+    const header1 = await screen.findByShadowText("Example document");
+    expect(header1).toBeInTheDocument();
+
+    const textElement = await screen.findByShadowText(
+      "Example styled text element",
+    );
+    expect(textElement).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## What does this PR do?

- Closes #7493 

## Demo

https://www.loom.com/share/c9f441bfb11146118920b3816a5328e8

## Future Work
- I spent a while trying to get a document render test working with a nested document and stylesheets applied, but couldn't figure out how to get rid of the "delayed render" effect. I tried fake timers, `await tick()`, `sleep`, and mocking out various hooks and components, but nothing seemed to work, the rendered test always had the content hidden and a loading indicator showing. So, future work is to figure that out and actually get a test working to show that the stylesheet link is rendered in the document view. I verified this manually for now.

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer - @grahamlangford 
