### PR TITLE
#7494 Document Builder custom styles Slice 4: Update CustomFormRenderer brick input schema and config UI

### DIFF
--- a/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.test.ts
@@ -50,7 +50,7 @@ describe("PageStateAnalysis", () => {
   it("shows info on shared page state for custom form", async () => {
     const state = formStateFactory({}, [
       {
-        id: CustomFormRenderer.BLOCK_ID,
+        id: CustomFormRenderer.BRICK_ID,
         config: {
           storage: {
             type: "state",
@@ -73,7 +73,7 @@ describe("PageStateAnalysis", () => {
   it("shows warning on mod page state for custom form if not mod", async () => {
     const state = formStateFactory({}, [
       {
-        id: CustomFormRenderer.BLOCK_ID,
+        id: CustomFormRenderer.BRICK_ID,
         config: {
           storage: {
             type: "state",

--- a/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.ts
@@ -71,7 +71,7 @@ class PageStateVisitor extends AnalysisVisitorWithResolvedBricksABC {
     }
 
     if (
-      blockConfig.id === CustomFormRenderer.BLOCK_ID &&
+      blockConfig.id === CustomFormRenderer.BRICK_ID &&
       (blockConfig.config.storage as Storage)?.type === "state"
     ) {
       const storage = blockConfig.config.storage as StateStorage;

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -1093,7 +1093,7 @@ describe("Collecting available vars", () => {
   describe("custom form renderer brick", () => {
     beforeAll(async () => {
       const customFormBlock = {
-        id: CustomFormRenderer.BLOCK_ID,
+        id: CustomFormRenderer.BRICK_ID,
         config: {
           schema: {
             type: "object",
@@ -1115,7 +1115,7 @@ describe("Collecting available vars", () => {
       jest.mocked(blockRegistry.allTyped).mockResolvedValue(
         new Map([
           [
-            CustomFormRenderer.BLOCK_ID,
+            CustomFormRenderer.BRICK_ID,
             {
               type: "renderer",
               block: new CustomFormRenderer(),

--- a/src/bricks/renderers/customForm.ts
+++ b/src/bricks/renderers/customForm.ts
@@ -75,7 +75,7 @@ function assertObject(value: unknown): asserts value is UnknownObject {
 
 type Context = { blueprintId: RegistryId | null; extensionId: UUID };
 
-export const customFormRendererSchema = {
+export const CUSTOM_FORM_SCHEMA = {
   type: "object",
   properties: {
     storage: {
@@ -169,24 +169,33 @@ export const customFormRendererSchema = {
       schema: { type: "string", format: "bootstrap-class" },
       label: "Layout/Style",
     },
+    stylesheets: {
+      type: "array",
+      items: {
+        type: "string",
+      },
+      title: "CSS Stylesheet URLs",
+      description:
+        "Stylesheets will apply to the rendered document in the order listed here",
+    },
   },
   required: ["schema"],
 };
 
 export class CustomFormRenderer extends RendererABC {
-  static BLOCK_ID = validateRegistryId("@pixiebrix/form");
+  static BRICK_ID = validateRegistryId("@pixiebrix/form");
 
   static ON_SUBMIT_VARIABLE_NAME = validateOutputKey("values");
 
   constructor() {
     super(
-      CustomFormRenderer.BLOCK_ID,
+      CustomFormRenderer.BRICK_ID,
       "Custom Form",
       "Show a custom form connected to a data source",
     );
   }
 
-  inputSchema: Schema = customFormRendererSchema as Schema;
+  inputSchema: Schema = CUSTOM_FORM_SCHEMA as Schema;
 
   override async isPageStateAware(): Promise<boolean> {
     return true;
@@ -372,7 +381,7 @@ async function getInitialData(
     default: {
       throw new PropError(
         "Invalid storage type",
-        CustomFormRenderer.BLOCK_ID,
+        CustomFormRenderer.BRICK_ID,
         "storage",
         storage,
       );
@@ -427,7 +436,7 @@ async function setData(
     default: {
       throw new PropError(
         "Invalid storage type",
-        CustomFormRenderer.BLOCK_ID,
+        CustomFormRenderer.BRICK_ID,
         "storage",
         storage,
       );

--- a/src/bricks/renderers/document.ts
+++ b/src/bricks/renderers/document.ts
@@ -92,18 +92,25 @@ export class DocumentRenderer extends RendererABC {
   async render(
     {
       body,
-      stylesheets = [],
+      stylesheets: _stylesheets = [],
     }: BrickArgs<{
       body: DocumentElement[];
       stylesheets: string[];
     }>,
     options: BrickOptions,
   ): Promise<ComponentRef> {
+    const stylesheets = compact(_stylesheets);
+    for (const url of stylesheets) {
+      if (!isValidUrl(url)) {
+        throw new Error(`Invalid Stylesheet URL: ${url}`);
+      }
+    }
+
     return {
       Component: DocumentViewLazy,
       props: {
         body,
-        stylesheets: compact(stylesheets).filter((url) => isValidUrl(url)),
+        stylesheets,
         options,
       },
     };

--- a/src/bricks/renderers/document.ts
+++ b/src/bricks/renderers/document.ts
@@ -30,6 +30,7 @@ import {
 } from "@/components/documentBuilder/documentBuilderTypes";
 import { compact } from "lodash";
 import { isValidUrl } from "@/utils/urlUtils";
+import { BusinessError } from "@/errors/businessErrors";
 
 export const DOCUMENT_SCHEMA: Schema = {
   $schema: "https://json-schema.org/draft/2019-09/schema#",
@@ -102,7 +103,7 @@ export class DocumentRenderer extends RendererABC {
     const stylesheets = compact(_stylesheets);
     for (const url of stylesheets) {
       if (!isValidUrl(url)) {
-        throw new Error(`Invalid Stylesheet URL: ${url}`);
+        throw new BusinessError(`Invalid Stylesheet URL: ${url}`);
       }
     }
 

--- a/src/bricks/renderers/documentView/DocumentView.tsx
+++ b/src/bricks/renderers/documentView/DocumentView.tsx
@@ -25,6 +25,7 @@ import { type DocumentViewProps } from "./DocumentViewProps";
 import DocumentContext from "@/components/documentBuilder/render/DocumentContext";
 import { Stylesheets } from "@/components/Stylesheets";
 import { joinPathParts } from "@/utils/formUtils";
+import { isEmpty } from "lodash";
 
 const DocumentView: React.FC<DocumentViewProps> = ({
   body,
@@ -43,21 +44,25 @@ const DocumentView: React.FC<DocumentViewProps> = ({
     throw new Error("meta.extensionId is required for DocumentView");
   }
 
+  const stylesheetUrls = [
+    // DocumentView.css is an artifact produced by webpack, see the DocumentView entrypoint included in
+    // `webpack.config.mjs`. We build styles needed to render documents separately from the rest of the sidebar
+    // in order to isolate the rendered document from the custom Bootstrap theme included in the Sidebar app
+    "/DocumentView.css",
+  ];
+
+  if (isEmpty(stylesheets)) {
+    stylesheetUrls.push(bootstrap, bootstrapOverrides);
+  } else {
+    // Custom stylesheets overrides bootstrap themes
+    stylesheetUrls.push(...stylesheets);
+  }
+
   return (
     // Wrap in a React context provider that passes BrickOptions down to any embedded bricks
     <DocumentContext.Provider value={{ options, onAction }}>
       <EmotionShadowRoot.div className="h-100">
-        <Stylesheets
-          // DocumentView.css is an artifact produced by webpack, see the DocumentView entrypoint included in
-          // `webpack.config.mjs`. We build styles needed to render documents separately from the rest of the sidebar
-          // in order to isolate the rendered document from the custom Bootstrap theme included in the Sidebar app
-          href={[
-            "/DocumentView.css",
-            bootstrap,
-            bootstrapOverrides,
-            ...stylesheets,
-          ]}
-        >
+        <Stylesheets href={stylesheetUrls}>
           {body.map((documentElement, index) => {
             const documentBranch = buildDocumentBranch(documentElement, {
               staticId: joinPathParts("body", "children"),

--- a/src/components/formBuilder/FormBuilder.test.tsx
+++ b/src/components/formBuilder/FormBuilder.test.tsx
@@ -40,7 +40,7 @@ let defaultFieldName: string;
 beforeAll(() => {
   registerDefaultWidgets();
   const { schema, uiSchema } = getExampleBrickConfig(
-    CustomFormRenderer.BLOCK_ID,
+    CustomFormRenderer.BRICK_ID,
   );
   exampleFormSchema = {
     schema,
@@ -432,7 +432,7 @@ describe("rename a field", () => {
     const FormikTemplate = createFormikTemplate(
       {
         [RJSF_SCHEMA_PROPERTY_NAME]: getExampleBrickConfig(
-          CustomFormRenderer.BLOCK_ID,
+          CustomFormRenderer.BRICK_ID,
         ),
       },
       jest.fn(),
@@ -457,7 +457,7 @@ describe("rename a field", () => {
     const FormikTemplate = createFormikTemplate(
       {
         [RJSF_SCHEMA_PROPERTY_NAME]: getExampleBrickConfig(
-          CustomFormRenderer.BLOCK_ID,
+          CustomFormRenderer.BRICK_ID,
         ),
       },
       jest.fn(),

--- a/src/contrib/editors.ts
+++ b/src/contrib/editors.ts
@@ -29,9 +29,7 @@ import { AUTOMATION_ANYWHERE_RUN_BOT_ID } from "@/contrib/automationanywhere/Run
 import FormModalOptions, {
   FORM_MODAL_ID,
 } from "@/pageEditor/fields/FormModalOptions";
-import FormRendererOptions, {
-  FORM_RENDERER_ID,
-} from "@/pageEditor/fields/FormRendererOptions";
+import FormRendererOptions from "@/pageEditor/fields/FormRendererOptions";
 import { GOOGLE_SHEETS_LOOKUP_ID } from "@/contrib/google/sheets/bricks/lookup";
 import LookupSpreadsheetOptions from "@/contrib/google/sheets/ui/LookupSpreadsheetOptions";
 import DatabaseGetOptions, {
@@ -57,6 +55,7 @@ import IdentityTransformerOptions from "@/bricks/transformers/IdentityTransforme
 import CommentEffect from "@/bricks/effects/comment";
 import CommentOptions from "@/bricks/effects/CommentOptions";
 import { DocumentRenderer } from "@/bricks/renderers/document";
+import { CustomFormRenderer } from "@/bricks/renderers/customForm";
 
 /**
  * Custom BlockConfiguration pageEditor components.
@@ -72,7 +71,7 @@ export default function registerEditors() {
   optionsRegistry.set(GOOGLE_SHEETS_LOOKUP_ID, LookupSpreadsheetOptions);
   optionsRegistry.set(AUTOMATION_ANYWHERE_RUN_BOT_ID, BotOptions);
   optionsRegistry.set(FORM_MODAL_ID, FormModalOptions);
-  optionsRegistry.set(FORM_RENDERER_ID, FormRendererOptions);
+  optionsRegistry.set(CustomFormRenderer.BRICK_ID, FormRendererOptions);
   optionsRegistry.set(DATABASE_GET_ID, DatabaseGetOptions);
   optionsRegistry.set(DATABASE_PUT_ID, DatabasePutOptions);
   optionsRegistry.set(REMOTE_METHOD_ID, RemoteMethodOptions);

--- a/src/pageEditor/exampleBrickConfigs.ts
+++ b/src/pageEditor/exampleBrickConfigs.ts
@@ -94,7 +94,7 @@ export function getExampleBrickConfig(
       };
     }
 
-    case CustomFormRenderer.BLOCK_ID: {
+    case CustomFormRenderer.BRICK_ID: {
       return {
         storage: {
           type: "state",

--- a/src/pageEditor/fields/FormRendererOptions.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.tsx
@@ -18,7 +18,6 @@
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import { type Schema } from "@/types/schemaTypes";
 import React, { useCallback, useState } from "react";
-import { validateRegistryId } from "@/types/helpers";
 import FormEditor, {
   FormIntroFields,
 } from "@/components/formBuilder/edit/FormEditor";
@@ -29,7 +28,7 @@ import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 import { useField, useFormikContext } from "formik";
 import { partial } from "lodash";
 import {
-  customFormRendererSchema,
+  CUSTOM_FORM_SCHEMA,
   type Storage,
 } from "@/bricks/renderers/customForm";
 import AppApiIntegrationDependencyField from "@/components/fields/schemaFields/AppApiIntegrationDependencyField";
@@ -43,8 +42,6 @@ import { joinName } from "@/utils/formUtils";
 import useAsyncEffect from "use-async-effect";
 import PipelineToggleField from "@/pageEditor/fields/PipelineToggleField";
 import ConnectedCollapsibleFieldSection from "@/pageEditor/fields/ConnectedCollapsibleFieldSection";
-
-export const FORM_RENDERER_ID = validateRegistryId("@pixiebrix/form");
 
 const recordIdSchema: Schema = {
   type: "string",
@@ -156,7 +153,7 @@ const FormDataBindingOptions: React.FC<{
           label="Namespace"
           isRequired
           schema={
-            customFormRendererSchema.properties.storage.oneOf[1].properties
+            CUSTOM_FORM_SCHEMA.properties.storage.oneOf[1].properties
               .namespace as Schema
           }
         />
@@ -190,7 +187,7 @@ const FormSubmissionOptions: React.FC<{
       <SchemaField
         name={makeName("autoSave")}
         label="Auto Save/Submit"
-        schema={customFormRendererSchema.properties.autoSave as Schema}
+        schema={CUSTOM_FORM_SCHEMA.properties.autoSave as Schema}
       />
 
       {!autoSave && (
@@ -210,9 +207,7 @@ const FormSubmissionOptions: React.FC<{
             <SchemaField
               name={makeName("submitCaption")}
               label="Submit Button Caption"
-              schema={
-                customFormRendererSchema.properties.submitCaption as Schema
-              }
+              schema={CUSTOM_FORM_SCHEMA.properties.submitCaption as Schema}
             />
           )}
         </>
@@ -221,7 +216,7 @@ const FormSubmissionOptions: React.FC<{
       <SchemaField
         name={makeName("successMessage")}
         label="Success Message"
-        schema={customFormRendererSchema.properties.successMessage as Schema}
+        schema={CUSTOM_FORM_SCHEMA.properties.successMessage as Schema}
       />
 
       <PipelineToggleField
@@ -273,6 +268,13 @@ const FormRendererOptions: React.FC<{
             fieldTypes={FORM_FIELD_TYPE_OPTIONS}
           />
         </ConfigErrorBoundary>
+      </ConnectedCollapsibleFieldSection>
+
+      <ConnectedCollapsibleFieldSection title={"Advanced: Theme"}>
+        <SchemaField
+          name={makeName("stylesheets")}
+          schema={CUSTOM_FORM_SCHEMA.properties.stylesheets as Schema}
+        />
       </ConnectedCollapsibleFieldSection>
     </div>
   );

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -151,7 +151,7 @@ const DataPanel: React.FC = () => {
   const { data: previewInfo } = usePreviewInfo(brickId);
 
   const showFormPreview =
-    brickId === CustomFormRenderer.BLOCK_ID ||
+    brickId === CustomFormRenderer.BRICK_ID ||
     brickId === FormTransformer.BRICK_ID;
   const showDocumentPreview = brickId === DocumentRenderer.BRICK_ID;
   const showBrickPreview = record || previewInfo?.traceOptional;

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -115,7 +115,7 @@ export function getPipelinePropNames(
       return propNames;
     }
 
-    case CustomFormRenderer.BLOCK_ID: {
+    case CustomFormRenderer.BRICK_ID: {
       const propNames = [];
 
       // Only show onSubmit if it's provided, to avoid cluttering the UI
@@ -173,7 +173,7 @@ export function getVariableKeyForSubPipeline(
   }
 
   if (
-    brickConfig.id === CustomFormRenderer.BLOCK_ID &&
+    brickConfig.id === CustomFormRenderer.BRICK_ID &&
     pipelinePropName === "onSubmit"
   ) {
     // We currently don't allow the user to rename the variable for the onSubmit pipeline because it'd add another


### PR DESCRIPTION
## What does this PR do?

- Closes #7494 
- Updates DocumentView so that custom stylesheets override bootstrap, if set
- document brick throws a BusinessError if there's an invalid stylesheet url

## Demo

<img width="1556" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/2801308/264ec0c3-372d-418e-acd9-1653e4a7cb87">

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer - @grahamlangford 
