### PR TITLE
fix visually-broken label in Control Room Oauth

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -8327,13 +8327,13 @@ exports[`Storyshots Onboarding/Setup/PartnerSetupCard OAuth2 1`] = `
                       />
                     </div>
                     <label
-                      className="label form-label col-form-label col-xl-2 col-lg-3"
+                      className="label form-label col-form-label col-xl-3 col-lg-4"
                       htmlFor="controlRoomUrl"
                     >
                       Control Room URL
                     </label>
                     <div
-                      className="col-xl-10 col-lg-9"
+                      className="col-xl-9 col-lg-8"
                     >
                       <input
                         className="form-control"

--- a/src/extensionConsole/pages/onboarding/partner/ControlRoomOAuthForm.tsx
+++ b/src/extensionConsole/pages/onboarding/partner/ControlRoomOAuthForm.tsx
@@ -170,6 +170,7 @@ const ControlRoomOAuthForm: React.FunctionComponent<{
         label="Control Room URL"
         type="text"
         description="Your Automation Anywhere Control Room URL, including https://"
+        widerLabel
       />
       {env === AA_STAGING_ENVIRONMENT && (
         <>


### PR DESCRIPTION
## What does this PR do?

- Part of #7511 

## Discussion

- This change increases the width for the label using our custom `widerLabel` prop (for more context see: https://github.com/pixiebrix/pixiebrix-extension/blob/a8d392018f377779a34e5a5236be5d586db205d7/src/components/form/FieldTemplate.tsx#L92

## Demo

https://www.loom.com/share/624ebf490d8a49559280b0a119658b73

## Future Work

- _Work for the issue/ticket that will be in a follow-up PR_

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer @johnnymetz 
