### PR TITLE
fix focusCaptureDialog call location -- should be called in catch

### DIFF
--- a/src/utils/clipboardUtils.ts
+++ b/src/utils/clipboardUtils.ts
@@ -58,14 +58,14 @@ async function interactiveWriteToClipboard(
     if (!isDocumentFocusError(error)) {
       throw error;
     }
+
+    await focusCaptureDialog(
+      `Please click "OK" to allow PixieBrix to copy ${type} to your clipboard.`,
+    );
+
+    // Let the error be caught by the caller if it still fails
+    await navigator.clipboard.write(clipboardItems);
   }
-
-  await focusCaptureDialog(
-    `Please click "OK" to allow PixieBrix to copy ${type} to your clipboard.`,
-  );
-
-  // Let the error be caught by the caller if it still fails
-  await navigator.clipboard.write(clipboardItems);
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Fixes https://pixiebrix.slack.com/archives/C0436P48QHY/p1707170433127319

## Checklist

- [x] Designate a primary reviewer @twschiller 
