### PR TITLE
submit on enter works properly when form is externally updated

### DIFF
--- a/src/bricks/renderers/CustomFormComponent.tsx
+++ b/src/bricks/renderers/CustomFormComponent.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { type Schema, type UiSchema } from "@/types/schemaTypes";
 import { type JsonObject } from "type-fest";
 import cx from "classnames";
@@ -56,7 +56,7 @@ const CustomFormComponent: React.FunctionComponent<{
    * Form submission handler.
    * @param values the submitted values
    * @param submissionCount the number of times the form has been submitted (For tracing)
-   * UnkownObject is used instead of JsonObject because strictNullChecks throws
+   * UnknownObject is used instead of JsonObject because strictNullChecks throws
    * `Type instantiation is excessively deep and possibly infinite.`
    */
   onSubmit: (
@@ -77,8 +77,11 @@ const CustomFormComponent: React.FunctionComponent<{
 }) => {
   // Use useRef instead of useState because we don't need/want a re-render when count changes
   const submissionCountRef = useRef(0);
-  // Track values during onChange so we can access it our RjsfSubmitContext submitForm callback
+  // Track values during onChange or prop updates, so we can access it our RjsfSubmitContext submitForm callback
   const valuesRef = useRef<UnknownObject>(formData);
+  useEffect(() => {
+    valuesRef.current = formData ?? {};
+  }, [formData]);
 
   // Custom stylesheets overrides bootstrap themes
   const stylesheetUrls = isEmpty(stylesheets)

--- a/src/components/formBuilder/TextAreaWidget.test.tsx
+++ b/src/components/formBuilder/TextAreaWidget.test.tsx
@@ -64,7 +64,6 @@ describe("TextAreaWidget", () => {
   });
 
   test("it submits the form when enter key is pressed", async () => {
-    console.log(JSON.stringify(process.env));
     const submitForm = jest.fn();
     render(
       <TextAreaWidget {...defaultProps} options={{ submitOnEnter: true }} />,

--- a/src/components/formBuilder/TextAreaWidget.test.tsx
+++ b/src/components/formBuilder/TextAreaWidget.test.tsx
@@ -19,6 +19,7 @@ import React from "react";
 import TextAreaWidget from "@/components/formBuilder/TextAreaWidget";
 import { render, screen } from "@/sidebar/testHelpers";
 import RjsfSubmitContext from "@/components/formBuilder/RjsfSubmitContext";
+import userEvent from "@testing-library/user-event";
 
 describe("TextAreaWidget", () => {
   const defaultProps = {
@@ -60,5 +61,46 @@ describe("TextAreaWidget", () => {
 
     expect(screen.getByRole("textbox")).toBeInTheDocument();
     expect(screen.queryByLabelText(defaultProps.label)).not.toBeInTheDocument();
+  });
+
+  test("it submits the form when enter key is pressed", async () => {
+    console.log(JSON.stringify(process.env));
+    const submitForm = jest.fn();
+    render(
+      <TextAreaWidget {...defaultProps} options={{ submitOnEnter: true }} />,
+      {
+        wrapper: ({ children }) => (
+          <RjsfSubmitContext.Provider value={{ submitForm }}>
+            {children}
+          </RjsfSubmitContext.Provider>
+        ),
+      },
+    );
+
+    const textarea = screen.getByRole("textbox");
+    await userEvent.type(textarea, "Some text");
+    await userEvent.keyboard("{Enter}");
+    expect(submitForm).toHaveBeenCalledOnce();
+  });
+
+  test("it does not submit the form when enter key is pressed alongside a modifier key", async () => {
+    const submitForm = jest.fn();
+    render(
+      <TextAreaWidget {...defaultProps} options={{ submitOnEnter: true }} />,
+      {
+        wrapper: ({ children }) => (
+          <RjsfSubmitContext.Provider value={{ submitForm }}>
+            {children}
+          </RjsfSubmitContext.Provider>
+        ),
+      },
+    );
+
+    const textarea = screen.getByRole("textbox");
+    await userEvent.type(textarea, "Some text");
+    await userEvent.keyboard("{Control>}{Enter}{/Control}");
+    await userEvent.keyboard("{Shift>}{Enter}{/Shift}");
+    await userEvent.keyboard("{Alt>}{Enter}{/Alt}");
+    expect(submitForm).not.toHaveBeenCalled();
   });
 });

--- a/src/components/formBuilder/TextAreaWidget.tsx
+++ b/src/components/formBuilder/TextAreaWidget.tsx
@@ -43,7 +43,11 @@ const TextAreaWidget: React.FC<WidgetProps> = ({
 
   const onKeyPress = useCallback<KeyboardEventHandler<HTMLTextAreaElement>>(
     async (event) => {
-      if (options.submitOnEnter && event.key === "Enter" && !event.shiftKey) {
+      if (
+        options.submitOnEnter &&
+        event.key === "Enter" &&
+        !(event.shiftKey || event.altKey || event.ctrlKey) // Do not submit on enter when a modifier key is held
+      ) {
         event.preventDefault();
         event.stopPropagation();
         // Can submit directly without calling onChange because prior key-presses would already be synced

--- a/src/testUtils/testHelpers.tsx
+++ b/src/testUtils/testHelpers.tsx
@@ -155,7 +155,11 @@ export function createRenderWithWrappers(configureStore: ConfigureStore) {
             </Formik>
           </Provider>
         )
-      : ({ children }) => <Provider store={store}>{children}</Provider>;
+      : ({ children }) => (
+          <Provider store={store}>
+            <ExtraWrapper>{children}</ExtraWrapper>
+          </Provider>
+        );
 
     const utils = render(ui, { wrapper: Wrapper, ...renderOptions });
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #7543
- Allows users to press enter without submitting in textarea with other modifier keys (control and alt)
- Fixes an issue with the wrapper in the shared render util method

## Checklist

- [x] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer @grahamlangford 
