### PR TITLE
Restore content script due to duplicate Messenger registration

### DIFF
--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -25,7 +25,6 @@ import {
   reactivateTab,
   removePersistedExtension,
 } from "@/contentScript/lifecycle";
-import { resolveForm } from "@/contentScript/ephemeralFormProtocol";
 import { insertPanel } from "@/contentScript/pageEditor/insertPanel";
 import { insertButton } from "@/contentScript/pageEditor/insertButton";
 import {
@@ -60,8 +59,6 @@ expectContext("contentScript");
 
 declare global {
   interface MessengerMethods {
-    FORM_RESOLVE: typeof resolveForm;
-
     QUEUE_REACTIVATE_TAB: typeof queueReactivateTab;
     REACTIVATE_TAB: typeof reactivateTab;
     REMOVE_INSTALLED_EXTENSION: typeof removePersistedExtension;
@@ -101,8 +98,6 @@ declare global {
 
 export default function registerMessenger(): void {
   registerMethods({
-    FORM_RESOLVE: resolveForm,
-
     QUEUE_REACTIVATE_TAB: queueReactivateTab,
     REACTIVATE_TAB: reactivateTab,
     REMOVE_INSTALLED_EXTENSION: removePersistedExtension,


### PR DESCRIPTION
This issue was introduced the last PR:

- https://github.com/pixiebrix/pixiebrix-extension/pull/7519

In short: the same method was registered in both the strict and non-strict messenger registration files.

This wouldn't be an issue, but I forgot I had made the Messenger throw when the same method was registered twice (even if TypeScript already prevents incompatible registrations)