### PR TITLE
Warn of DOM changes in background page

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -15,12 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// extensionContext needs to be imported before webpack-target-webextension to
-// ensure the webpack path is correct
 // eslint-disable-next-line import/no-unassigned-import -- Automatic registration
 import "webext-inject-on-install";
 import "@/extensionContext";
 import "@/development/errorsBadge";
+// eslint-disable-next-line import/no-unassigned-import -- Automatic registration
+import "@/background/backgroundDomWatcher";
 
 // Required for MV3; Service Workers don't have XMLHttpRequest
 import "@/background/axiosFetch";

--- a/src/background/backgroundDomWatcher.ts
+++ b/src/background/backgroundDomWatcher.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { isBackgroundPage } from "webext-detect-page";
+
+/** @file DO NOT alter this file to add an "init" function because it must be executed as early as possible */
+if (isBackgroundPage()) {
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      console.error("Detected added node:", ...mutation.addedNodes);
+    }
+  });
+  observer.observe(document, { childList: true, subtree: true });
+}

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -35,6 +35,7 @@
     "./background/auth/codeGrantFlow.ts",
     "./background/auth/implicitGrantFlow.ts",
     "./background/axiosFetch.ts",
+    "./background/backgroundDomWatcher.ts",
     "./background/capture.ts",
     "./background/contentScript.ts",
     "./background/dataStore.ts",


### PR DESCRIPTION
## What does this PR do?

This change warns us of unexpected changes to the background "page".

Why:

- we had issues in the past with iframes unexpectedly being added into the background page
	- https://github.com/pixiebrix/pixiebrix-extension/pull/6598
- the background worker in MV3 will throw hard errors when this happens
- we're seeing a "This target is not a frame" errors on DataDog, which might point to another iframe being added to the background page

## Demo

This is the current situation already, some component is injecting some unnecessary (but innocuous) CSS

<img width="1018" alt="Screenshot 13" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/11cdd4d3-b555-4a6c-9de1-9bb4a6a5f783">


## Future Work

- [ ] Maybe actually report the error
- [ ] Maybe detect and abort execution of content scripts in unexpected iframes (not sure if this is feasible without slowing down the content script for valid frames as well)
- [ ] Fix the console error shown above
- [ ] https://github.com/pixiebrix/webext-messenger/pull/206


## Checklist

- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
