### PR TITLE
adds a dependabot group for datadog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,9 @@ updates:
       fontawesome:
         patterns:
           - "@fortawesome/*"
+      datadog:
+        patterns:
+          - "@datadog/*"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## What does this PR do?

- Creates a dependabot datadog group to keep datadog versions in sync

## Checklist

- [x] Designate a primary reviewer @fregante 
