### PR TITLE
ellipsis md size

### DIFF
--- a/src/components/ellipsisMenu/EllipsisMenu.module.scss
+++ b/src/components/ellipsisMenu/EllipsisMenu.module.scss
@@ -19,9 +19,9 @@
   display: none;
 }
 
-// btn-lg is too wide for the ellipsis menu! override and make it narrower to keep
-// the same proportions as the small size.
-.toggle:global(.btn-lg) {
+// the md and lg size are too wide for the ellipsis menu! override and make it narrower
+// when it is not the small button size.
+.toggle:not(:global(.btn-sm)) {
   padding-left: 15px;
   padding-right: 15px;
 }

--- a/src/components/ellipsisMenu/EllipsisMenu.tsx
+++ b/src/components/ellipsisMenu/EllipsisMenu.tsx
@@ -142,7 +142,7 @@ const EllipsisMenu: React.FunctionComponent<EllipsisMenuProps> = ({
       <Dropdown.Toggle
         className={cx(styles.toggle, toggleClassName)}
         variant={variant}
-        size={size === "md" ? null : size}
+        size={size === "md" ? undefined : size}
       >
         <FontAwesomeIcon icon={faEllipsisV} />
       </Dropdown.Toggle>

--- a/src/components/ellipsisMenu/EllipsisMenu.tsx
+++ b/src/components/ellipsisMenu/EllipsisMenu.tsx
@@ -66,9 +66,11 @@ type EllipsisMenuProps = {
   variant?: ButtonVariant;
 
   /**
-   * The bootstrap button size for the toggle
+   * The bootstrap button size for the toggle. Note that
+   * "md" is the bootstrap style for when neither the "btn-sm"
+   * nor the "btn-lg" class is present.
    */
-  size?: "sm" | "lg";
+  size?: "sm" | "md" | "lg";
 
   /**
    * The dropdown menu options
@@ -140,7 +142,7 @@ const EllipsisMenu: React.FunctionComponent<EllipsisMenuProps> = ({
       <Dropdown.Toggle
         className={cx(styles.toggle, toggleClassName)}
         variant={variant}
-        size={size}
+        size={size === "md" ? null : size}
       >
         <FontAwesomeIcon icon={faEllipsisV} />
       </Dropdown.Toggle>


### PR DESCRIPTION
- medium size option for ellipsis menu

## What does this PR do?

- Part of #4700
- I overlooked adding a medium size option in the last PR which the app website uses for its buttons. This adds an option to specify a medium size for the menu which is the case when neither "btn-sm" nor "btn-lg" class is present.

## Demo

https://www.loom.com/share/650990bf918c4669b86f0dc16664ee29

## Future Work

- Consider relying on the container to specify the height for components in the future rather than specifying them per component.

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer @grahamlangford 
