### PR TITLE
#7100: Don't show error if context menu "contexts" isn't specified

### DIFF
--- a/src/background/contextMenus.ts
+++ b/src/background/contextMenus.ts
@@ -155,7 +155,9 @@ async function _ensureContextMenu({
   const updateProperties = {
     type: "normal",
     title,
-    contexts,
+    // At least one context type must be specified
+    // https://github.com/pixiebrix/pixiebrix-extension/issues/7100
+    contexts: contexts?.length ? contexts : ["all"],
     documentUrlPatterns,
   } satisfies Menus.UpdateUpdatePropertiesType;
 


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/7100

The code has a default for `["all"]` in a couple of places, but that default is not applied when the `contexts` is `[]`

This PR simply enforces that default at the last possible moment, in order to avoid errors at the chrome API level.

I think that ideally the brick should be in an "invalid" state but this solution:

- is quick
- avoids repeating errors when the page loads and one of the context menus is invalid
- still needs to be there to catch all existing invalid mods

## Future Work

- [ ] Ideally the starter brick should not be executed at all and the page editor should show an error

## Demo

Before this PR, the content script would immediately show a notification error after removing the last context.


https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/da183e11-ecf2-4a89-8f31-3e13ed4f636a



## Checklist

- [x] Designate a primary reviewer: @BLoe 
