### PR TITLE
#7233: Avoid flash of gray icon on MV3 worker restart

### DIFF
--- a/scripts/__snapshots__/manifest.test.js.snap
+++ b/scripts/__snapshots__/manifest.test.js.snap
@@ -5,7 +5,7 @@ exports[`customizeManifest mv2 1`] = `
   "author": "PixieBrix, Inc.",
   "background": {
     "scripts": [
-      "grayIconWhileLoading.js",
+      "backgroundCanary.js",
       "background.js",
     ],
   },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -98,7 +98,7 @@
     }
   },
   "background": {
-    "scripts": ["grayIconWhileLoading.js", "background.js"]
+    "scripts": ["backgroundCanary.js", "background.js"]
   },
   "options_ui": {
     "page": "options.html",

--- a/static/background.worker.js
+++ b/static/background.worker.js
@@ -1,8 +1,8 @@
 /*
 eslint-disable import/no-unassigned-import --
-Don't include `background.worker.js` in webpack, `grayIconWhileLoading`
+Don't include `background.worker.js` in webpack, `backgroundCanary`
 must be outside the main bundle in order to catch build errors
 */
 
-import "./grayIconWhileLoading.js";
+import "./backgroundCanary.js";
 import "./background.js";

--- a/static/backgroundCanary.js
+++ b/static/backgroundCanary.js
@@ -15,20 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file This is a standalone background entry point that must run independently of the rest of extension */
+/**
+ * @file This is a standalone background entry point that must run independently of the rest of extension.
+ * It can be used to detect and handle build errors and background loading errors.
+ */
 
 if (chrome.runtime.getManifest === undefined) {
   throw new Error(
     "Chrome bug: The extension was loaded as MV2, but Chrome is still running the worker. Unregister the loader from chrome://serviceworker-internals/",
   );
 }
-
-const { icons } = chrome.runtime.getManifest();
-const inactiveIcons = {};
-for (const [size, path] of Object.entries(icons)) {
-  // eslint-disable-next-line security/detect-object-injection -- Safe
-  inactiveIcons[size] = path.replace("icons", "icons/inactive");
-}
-
-(chrome.browserAction ?? chrome.action).setIcon({ path: inactiveIcons });
-/* `activateBrowserActionIcon()` will later fix the icon if the file runs */


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/7233
- Removes some code to simplify the upcoming https://github.com/pixiebrix/pixiebrix-extension/issues/7555

## Context

This logic was created to support `web-ext run`'s loading mechanism, which involves toggling the extension on and off. When that happens, Chrome preserve's the last `setIcon` value, so this file was needed.

Full extension reloads and browser closing/reopening already work well without this (i.e. the icon starts `inactive` as defined in the manifest, and then it's activated)

This upcoming PR will eventually render `web-ext run`'s auto-reloading unnecessary:

- https://github.com/pixiebrix/pixiebrix-extension/pull/7598

## Checklist

- [x] Designate a primary reviewer: @fungairino 
