### PR TITLE
#4258: Remove extension points on context invalidated

### DIFF
--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -46,6 +46,7 @@ import {
 } from "@/utils/promiseUtils";
 import { $safeFind } from "@/utils/domUtils";
 import { onContextInvalidated } from "webext-events";
+import { ContextMenuStarterBrickABC } from "@/starterBricks/contextMenu";
 
 /**
  * True if handling the initial page load.
@@ -676,4 +677,14 @@ export async function initNavigation() {
     }),
     { signal: onContextInvalidated.signal },
   );
+
+  onContextInvalidated.addListener(() => {
+    for (const [extensionId, extensionPoint] of _persistedExtensions) {
+      if (!(extensionPoint instanceof ContextMenuStarterBrickABC)) {
+        extensionPoint.removeModComponent(extensionId);
+      }
+    }
+
+    _persistedExtensions.clear();
+  });
 }

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -679,12 +679,16 @@ export async function initNavigation() {
   );
 
   onContextInvalidated.addListener(() => {
-    for (const [extensionId, extensionPoint] of _persistedExtensions) {
+    for (const [extensionId, extensionPoint] of [
+      ..._persistedExtensions,
+      ..._editorExtensions,
+    ]) {
       if (!(extensionPoint instanceof ContextMenuStarterBrickABC)) {
         extensionPoint.removeModComponent(extensionId);
       }
     }
 
     _persistedExtensions.clear();
+    _editorExtensions.clear();
   });
 }

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -683,6 +683,8 @@ export async function initNavigation() {
       ..._persistedExtensions,
       ..._editorExtensions,
     ]) {
+      // Exclude context menu extensions because they try to contact the (non-connectable) background page.
+      // They're already removed by the browser anyway.
       if (!(extensionPoint instanceof ContextMenuStarterBrickABC)) {
         extensionPoint.removeModComponent(extensionId);
       }


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-extension/issues/4258

PixieBrix is pretty good at updating the extension points that were installed in a previous run of the extension, but this is done after the content script has finished loading.

This means that the page will keep unclickable "menu items" on the page until that process finishes (if it finishes without errors)

After this PR, the menu items will be removed immediately, and they will also be removed if the user disables the extension.

## Demo


https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/880bec87-35b0-4bda-b583-0be4f53e42fc


## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
