### PR TITLE
#6648: Update iframes from page editor without full page reload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,7 +142,7 @@
         "webext-detect-page": "^5.0.0",
         "webext-events": "^2.1.0",
         "webext-inject-on-install": "^2.0.1",
-        "webext-messenger": "^0.25.2",
+        "webext-messenger": "^0.26.0",
         "webext-patterns": "^1.4.0",
         "webext-permissions": "^3.1.2",
         "webext-polyfill-kinda": "^1.0.2",
@@ -27589,9 +27589,9 @@
       }
     },
     "node_modules/webext-messenger": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.25.2.tgz",
-      "integrity": "sha512-GtZ3FVAy7piOEwUAYgBCA2C9oQgZ2mf67pnIWAncIqT9wwOpBjJd3y7eb3XNaS9ZwtkqClwYbjAzND4XziCsCg==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.26.0.tgz",
+      "integrity": "sha512-WuWoZkFmd0P4iiUD8Hc7frcn7NCnPjVKddijwlw7vZgLXA2ueiwwCpv+r2dlRCGyDTQiiGfo8g2XVZZ+IOY4QQ==",
       "dependencies": {
         "p-retry": "^6.2.0",
         "serialize-error": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "webext-detect-page": "^5.0.0",
     "webext-events": "^2.1.0",
     "webext-inject-on-install": "^2.0.1",
-    "webext-messenger": "^0.25.2",
+    "webext-messenger": "^0.26.0",
     "webext-patterns": "^1.4.0",
     "webext-permissions": "^3.1.2",
     "webext-polyfill-kinda": "^1.0.2",

--- a/src/background/removeExtensionForEveryTab.ts
+++ b/src/background/removeExtensionForEveryTab.ts
@@ -14,10 +14,11 @@ export async function removeExtensionForEveryTab(
 ): Promise<void> {
   console.debug("Remove extension for all tabs", { extensionId });
 
-  await forEachTab(async (tab) => {
-    removeInstalledExtension(tab, extensionId);
-    await clearDynamicElements(tab, { uuid: extensionId });
-    await removeSidebars(tab, [extensionId]);
+  await forEachTab(async ({ tabId }) => {
+    const allFrames = { tabId, frameId: "allFrames" } as const;
+    removeInstalledExtension(allFrames, extensionId);
+    clearDynamicElements(allFrames, { uuid: extensionId });
+    await removeSidebars({ tabId }, [extensionId]);
   });
   await uninstallContextMenu({ extensionId });
   await clearExtensionTraces(extensionId);

--- a/src/contentScript/messenger/api.ts
+++ b/src/contentScript/messenger/api.ts
@@ -37,8 +37,8 @@ export const getAttributeExamples = getMethod("GET_ATTRIBUTE_EXAMPLES");
 export const runBlock = getMethod("RUN_SINGLE_BLOCK");
 export const runRendererBlock = getMethod("RUN_RENDERER_BLOCK");
 
-export const clearDynamicElements = getMethod("CLEAR_DYNAMIC_ELEMENTS");
-export const updateDynamicElement = getMethod("UPDATE_DYNAMIC_ELEMENT");
+export const clearDynamicElements = getNotifier("CLEAR_DYNAMIC_ELEMENTS");
+export const updateDynamicElement = getNotifier("UPDATE_DYNAMIC_ELEMENT");
 export const runExtensionPointReader = getMethod("RUN_EXTENSION_POINT_READER");
 export const enableOverlay = getMethod("ENABLE_OVERLAY");
 export const disableOverlay = getMethod("DISABLE_OVERLAY");

--- a/src/pageEditor/PanelContent.tsx
+++ b/src/pageEditor/PanelContent.tsx
@@ -28,7 +28,7 @@ import LoginCard from "@/pageEditor/components/LoginCard";
 import EditorLayout from "@/pageEditor/EditorLayout";
 import { PersistGate } from "redux-persist/integration/react";
 import { logActions } from "@/components/logViewer/logSlice";
-import { thisTab } from "@/pageEditor/utils";
+import { allFramesInThisTab } from "@/pageEditor/utils";
 import {
   removeInstalledExtension,
   updateDynamicElement,
@@ -60,7 +60,7 @@ const cleanUpStarterBrickForElement = (
     return;
   }
 
-  removeInstalledExtension(thisTab, element.uuid);
+  removeInstalledExtension(allFramesInThisTab, element.uuid);
 };
 
 const PanelContent: React.FC = () => {
@@ -72,7 +72,7 @@ const PanelContent: React.FC = () => {
 
     if (activeElement != null && shouldAutoRun(activeElement)) {
       const dynamicElement = formStateToDynamicElement(activeElement);
-      void updateDynamicElement(thisTab, dynamicElement);
+      updateDynamicElement(allFramesInThisTab, dynamicElement);
     }
   }, [dispatch, activeElement]);
 

--- a/src/pageEditor/hooks/useAddElement.ts
+++ b/src/pageEditor/hooks/useAddElement.ts
@@ -22,7 +22,7 @@ import { actions } from "@/pageEditor/slices/editorSlice";
 import { internalStarterBrickMetaFactory } from "@/pageEditor/starterBricks/base";
 import { isSpecificError } from "@/errors/errorHelpers";
 import { type ElementConfig } from "@/pageEditor/starterBricks/elementConfig";
-import { getCurrentURL, thisTab } from "@/pageEditor/utils";
+import { allFramesInThisTab, getCurrentURL, thisTab } from "@/pageEditor/utils";
 import { updateDynamicElement } from "@/contentScript/messenger/api";
 import { type SettingsState } from "@/store/settings/settingsTypes";
 import useFlags from "@/hooks/useFlags";
@@ -65,8 +65,8 @@ function useAddElement(): AddElement {
 
         const initialState = config.fromNativeElement(url, metadata, element);
 
-        await updateDynamicElement(
-          thisTab,
+        updateDynamicElement(
+          allFramesInThisTab,
           config.asDynamicElement(initialState),
         );
 

--- a/src/pageEditor/hooks/useRemoveModComponentFromStorage.tsx
+++ b/src/pageEditor/hooks/useRemoveModComponentFromStorage.tsx
@@ -29,7 +29,7 @@ import notify from "@/utils/notify";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 import { actions as extensionsActions } from "@/store/extensionsSlice";
 import { clearDynamicElements } from "@/contentScript/messenger/api";
-import { thisTab } from "@/pageEditor/utils";
+import { allFramesInThisTab } from "@/pageEditor/utils";
 import { removeExtensionsFromAllTabs } from "@/store/uninstallUtils";
 
 type Config = {
@@ -108,7 +108,7 @@ export function useRemoveModComponentFromStorage(): (
 
         // Remove from the host page
         try {
-          await clearDynamicElements(thisTab, {
+          clearDynamicElements(allFramesInThisTab, {
             uuid: extensionId,
           });
         } catch (error) {

--- a/src/pageEditor/panes/insert/useAutoInsert.ts
+++ b/src/pageEditor/panes/insert/useAutoInsert.ts
@@ -1,6 +1,6 @@
 import { useDispatch } from "react-redux";
 import { useAsyncEffect } from "use-async-effect";
-import { getCurrentURL, thisTab } from "@/pageEditor/utils";
+import { getCurrentURL, allFramesInThisTab } from "@/pageEditor/utils";
 import { internalStarterBrickMetaFactory } from "@/pageEditor/starterBricks/base";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import { getExampleBrickPipeline } from "@/pageEditor/exampleStarterBrickConfigs";
@@ -47,7 +47,10 @@ function useAutoInsert(type: StarterBrickType): void {
 
       // Don't auto-run tours on selection in Page Editor
       if (config.elementType !== "tour") {
-        await updateDynamicElement(thisTab, config.asDynamicElement(formState));
+        updateDynamicElement(
+          allFramesInThisTab,
+          config.asDynamicElement(formState),
+        );
       }
 
       // TODO: report if created new, or using existing foundation

--- a/src/pageEditor/protocol.ts
+++ b/src/pageEditor/protocol.ts
@@ -16,7 +16,7 @@
  */
 
 import { resetTab } from "@/contentScript/messenger/api";
-import { thisTab } from "./utils";
+import { allFramesInThisTab } from "./utils";
 import { type Target } from "@/types/messengerTypes";
 import { updatePageEditor } from "./events";
 
@@ -38,7 +38,7 @@ async function onNavigation(target: Target): Promise<void> {
 }
 
 function onEditorClose(): void {
-  resetTab(thisTab);
+  resetTab(allFramesInThisTab);
 }
 
 export function watchNavigation(): void {

--- a/src/pageEditor/toolbar/ReloadToolbar.tsx
+++ b/src/pageEditor/toolbar/ReloadToolbar.tsx
@@ -21,7 +21,7 @@ import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import ToggleField from "@/pageEditor/components/ToggleField";
 import { Button } from "react-bootstrap";
 import { updateDynamicElement } from "@/contentScript/messenger/api";
-import { thisTab } from "@/pageEditor/utils";
+import { allFramesInThisTab } from "@/pageEditor/utils";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
@@ -97,7 +97,7 @@ const ReloadToolbar: React.FunctionComponent<{
 
   const run = useCallback(async () => {
     const { asDynamicElement: factory } = ADAPTERS.get(element.type);
-    await updateDynamicElement(thisTab, factory(element));
+    updateDynamicElement(allFramesInThisTab, factory(element));
   }, [element]);
 
   const manualRun = async () => {

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -32,7 +32,7 @@ import { type AnalysisAnnotation } from "@/analysis/analysisTypes";
 import { PIPELINE_BLOCKS_FIELD_NAME } from "./consts";
 import { expectContext } from "@/utils/expectContext";
 import TourStepTransformer from "@/bricks/transformers/tourStep/tourStep";
-import { type Target } from "@/types/messengerTypes";
+import { type Target } from "webext-messenger";
 import { type ModComponentBase } from "@/types/modComponentTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
@@ -59,12 +59,17 @@ export async function getCurrentURL(): Promise<string> {
  *
  * The Page Editor only supports editing the top-level frame.
  */
-export const thisTab: Target = {
+export const thisTab = {
   // This code might end up (unused) in non-dev bundles, so use `?.` to avoid errors from undefined values
   tabId: globalThis.chrome?.devtools?.inspectedWindow?.tabId ?? 0,
   // The top-level frame
   frameId: 0,
-};
+} satisfies Target;
+
+export const allFramesInThisTab = {
+  tabId: thisTab.tabId,
+  frameId: "allFrames",
+} satisfies Target;
 
 export function getIdForElement(
   element: ModComponentBase | ModComponentFormState,


### PR DESCRIPTION
## What does this PR do?

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/6648
- Includes  https://github.com/pixiebrix/webext-messenger/pull/209

Pretty straightforward change both in the Messenger and here. It comes "free" from the browser because "message all frames" is actually the default behavior of `tabs.sendMessage`

## Demo


Test URL: https://ephiframe.vercel.app/Outer?iframe=https://extra-ephiframe.vercel.app/Cross-domain-iframe%3Fiframe%3D./nested

Supports:

- Added after permission change
- Removed after permission change
- Updated after mod change
- Removed after mod removal

https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/510317ff-b4bc-4cac-8151-3f8a40268965


## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
