### PR TITLE
centers the sidebar logo in MV3 builds

### DIFF
--- a/src/sidebar/Header.tsx
+++ b/src/sidebar/Header.tsx
@@ -54,8 +54,10 @@ const Header: React.FunctionComponent = () => {
       {showSidebarLogo && (
         <div
           className={cx({
+            // Flexbox centering works because there's a button to the left of the logo
             "align-self-center": showCloseButton,
-            "mr-auto ml-auto": !showCloseButton,
+            // Use mx-auto because the button is removed in MV3
+            "mx-auto": !showCloseButton,
           })}
         >
           <img

--- a/src/sidebar/Header.tsx
+++ b/src/sidebar/Header.tsx
@@ -52,7 +52,12 @@ const Header: React.FunctionComponent = () => {
         </Button>
       )}
       {showSidebarLogo && (
-        <div className="align-self-center">
+        <div
+          className={cx({
+            "align-self-center": showCloseButton,
+            "mr-auto ml-auto": !showCloseButton,
+          })}
+        >
           <img
             src={customSidebarLogo ?? logo.regular}
             alt={customSidebarLogo ? "Custom logo" : "PixieBrix logo"}


### PR DESCRIPTION
## What does this PR do?

- Centers the sidebar logo in MV3 builds

## Demo

Before
---
<img width="729" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/b6c40432-fc4c-4775-9ce0-1f025d8f1d2b">

After 
---
<img width="719" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/6cd6fe04-61d2-4b78-9ff5-50121a7cf2aa">

## Checklist

- [x] Designate a primary reviewer @fungairino 
