### PR TITLE
#7619: add disableLoginTab option to disable automatically opening login tab

### DIFF
--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -185,6 +185,24 @@ describe("updateDeployments", () => {
     });
   });
 
+  test("do not launch sso flow if disableLoginTab", async () => {
+    readAuthDataMock.mockResolvedValue({
+      organizationId: null,
+    });
+
+    browserManagedStorageMock.mockResolvedValue({
+      ssoUrl: "https://sso.example.com",
+      disableLoginTab: true,
+    });
+
+    isLinkedMock.mockResolvedValue(false);
+
+    await updateDeployments();
+
+    expect(openOptionsPageMock).not.toHaveBeenCalled();
+    expect(browser.tabs.create).not.toHaveBeenCalled();
+  });
+
   test("opens options page if enterprise customer becomes unlinked", async () => {
     // `readAuthDataMock` already has organizationId "00000000-00000000-00000000-00000000"
     isLinkedMock.mockResolvedValue(false);

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -123,6 +123,7 @@ beforeEach(async () => {
   } as any);
 
   browserManagedStorageMock.mockResolvedValue({});
+  jest.mocked(browser.tabs.create).mockClear();
 
   readAuthDataMock.mockResolvedValue({
     organizationId: "00000000-00000000-00000000-00000000",

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -375,7 +375,12 @@ export async function updateDeployments(): Promise<void> {
       readManagedStorage(),
     ]);
 
-  const { campaignIds = [], managedOrganizationId, ssoUrl } = managedStorage;
+  const {
+    campaignIds = [],
+    managedOrganizationId,
+    ssoUrl,
+    disableLoginTab,
+  } = managedStorage;
 
   if (!linked) {
     // If the Browser extension is unlinked (it doesn't have the API key), one of the following must be true:
@@ -385,6 +390,11 @@ export async function updateDeployments(): Promise<void> {
     // - If the user is not an enterprise user (or has not linked their extension yet), just NOP. They likely they just
     //   need to reconnect their extension. If it's a non-enterprise user, they shouldn't have any deployments
     //   installed anyway.
+
+    if (disableLoginTab) {
+      // IT manager has disabled opening login tab automatically
+      return;
+    }
 
     if (ssoUrl != null) {
       reportEvent(Events.ORGANIZATION_EXTENSION_LINK, {

--- a/src/background/installer.test.ts
+++ b/src/background/installer.test.ts
@@ -254,7 +254,7 @@ describe("handleInstall", () => {
   });
 
   test.each([undefined, "https://sso.com"])(
-    "don't open tab on install if disableLoginTab is set: %s",
+    "don't open tab on install if disableLoginTab is set and ssoUrl is %s",
     async (ssoUrl) => {
       browserManagedStorageMock.mockResolvedValue({
         disableLoginTab: true,

--- a/src/background/installer.test.ts
+++ b/src/background/installer.test.ts
@@ -253,16 +253,21 @@ describe("handleInstall", () => {
     expect(createTabMock).not.toHaveBeenCalled();
   });
 
-  test("don't open tab on install if disableLoginTab is set", async () => {
-    // App setup tab isn't open
-    browserManagedStorageMock.mockResolvedValue({ disableLoginTab: true });
-    queryTabsMock.mockResolvedValue([]);
-    isLinkedMock.mockResolvedValue(false);
-    await handleInstall({
-      reason: "install",
-      previousVersion: undefined,
-      temporary: false,
-    });
-    expect(createTabMock).not.toHaveBeenCalled();
-  });
+  test.each([undefined, "https://sso.com"])(
+    "don't open tab on install if disableLoginTab is set: %s",
+    async (ssoUrl) => {
+      browserManagedStorageMock.mockResolvedValue({
+        disableLoginTab: true,
+        ssoUrl,
+      });
+      queryTabsMock.mockResolvedValue([]);
+      isLinkedMock.mockResolvedValue(false);
+      await handleInstall({
+        reason: "install",
+        previousVersion: undefined,
+        temporary: false,
+      });
+      expect(createTabMock).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -181,10 +181,11 @@ export async function requirePartnerAuth(): Promise<void> {
   }
 }
 
-async function install({
+// Exported for testing
+export async function handleInstall({
   reason,
   previousVersion,
-}: Runtime.OnInstalledDetailsType) {
+}: Runtime.OnInstalledDetailsType): Promise<void> {
   // https://developer.chrome.com/docs/extensions/reference/runtime/#event-onInstalled
   // https://developer.chrome.com/docs/extensions/reference/runtime/#type-OnInstalledReason
   console.debug("onInstalled", { reason, previousVersion });
@@ -218,7 +219,7 @@ async function install({
         return;
       }
 
-      void openInstallPage();
+      await openInstallPage();
     }
   } else if (reason === "update") {
     // `update` is also triggered on browser.runtime.reload() and manually reloading from the extensions page
@@ -268,7 +269,7 @@ async function setUninstallURL(): Promise<void> {
 
 function initInstaller() {
   browser.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
-  browser.runtime.onInstalled.addListener(install);
+  browser.runtime.onInstalled.addListener(handleInstall);
   browser.runtime.onStartup.addListener(initTelemetry);
   dntConfig.onChanged(() => {
     void setUninstallURL();

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -200,14 +200,21 @@ async function install({
     if (!(await isLinked())) {
       // PERFORMANCE: readManagedStorageByKey waits up to 2 seconds for managed storage to be available. Shouldn't be
       // notice-able for end-user relative to the extension download/install time
-      const { ssoUrl, partnerId, controlRoomUrl } = await readManagedStorage();
+      const { ssoUrl, partnerId, controlRoomUrl, disableLoginTab } =
+        await readManagedStorage();
+
+      if (disableLoginTab) {
+        // IT manager has disabled the login tab
+        return;
+      }
+
       if (ssoUrl) {
         // Don't launch the SSO page automatically. The SSO flow will be launched by deploymentUpdater.ts:updateDeployments
         return;
       }
 
       if (partnerId === "automation-anywhere" && isEmpty(controlRoomUrl)) {
-        // Don't launch the install page automatically if only the partner id is specified
+        // Don't launch the installation page automatically if only the partner id is specified
         return;
       }
 

--- a/src/store/enterprise/managedStorageTypes.ts
+++ b/src/store/enterprise/managedStorageTypes.ts
@@ -35,6 +35,12 @@ export type ManagedStorageState = {
    */
   enforceAuthentication?: boolean;
   /**
+   * If true, the extension will not open a login tab on install or on heartbeat if unauthenticated.
+   *
+   * @since 1.8.9
+   */
+  disableLoginTab?: boolean;
+  /**
    * PixieBrix partner ID
    */
   partnerId?: string;

--- a/static/managedStorageSchema.json
+++ b/static/managedStorageSchema.json
@@ -7,7 +7,12 @@
     },
     "enforceAuthentication": {
       "type": "boolean",
-      "description": "Enforce PixieBrix authentication on specified URLs ",
+      "description": "Enforce PixieBrix authentication on specified URLs",
+      "default": false
+    },
+    "disableLoginTab": {
+      "type": "boolean",
+      "description": "Disable opening a login tab on install and heartbeat",
       "default": false
     },
     "partnerId": {


### PR DESCRIPTION
## What does this PR do?

- Closes #7619
- Adds a `disableLoginTab` option to managed storage that prevents the extension from opening a login tab on install and heartbeat
- Login page will still show if the user hits a URL the organization has restricted

## Remaining Work

- [x] Add test for installer.ts - the `install` method currently has 0% coverage: https://app.codecov.io/gh/pixiebrix/pixiebrix-extension/blob/main/src%2Fbackground%2Finstaller.ts#L184

## Demo

- See Jest tests

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
