### PR TITLE
#7618: increase managed storage delay and link extension immediately for CWS installs

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -50,12 +50,14 @@ import { initSidePanel } from "./sidePanel";
 import initRestrictUnauthenticatedUrlAccess from "@/background/restrictUnauthenticatedUrlAccess";
 import {
   initManagedStorage,
-  watchStorageInitialization,
+  watchDelayedStorageInitialization,
 } from "@/store/enterprise/managedStorage";
 
 // Try to initialize managed storage as early as possible because it impacts background behavior
-// Call watchStorageInitialization to handle case where storage is not immediately available within timeout
-void initManagedStorage().then(async () => watchStorageInitialization());
+// Call watchDelayedStorageInitialization to handle case where storage is not immediately available within timeout.
+// We might consider putting watchStorageInitialization in initManagedStorage, but having a non-terminating
+// interval complicates testing.
+void initManagedStorage().then(async () => watchDelayedStorageInitialization());
 
 void initLocator();
 void initMessengerLogging();

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -50,6 +50,9 @@ import { initSidePanel } from "./sidePanel";
 import initRestrictUnauthenticatedUrlAccess from "@/background/restrictUnauthenticatedUrlAccess";
 import { initManagedStorage } from "@/store/enterprise/managedStorage";
 
+// Try to initialize managed storage as early as possible because it impacts background behavior
+initManagedStorage();
+
 void initLocator();
 void initMessengerLogging();
 void initRuntimeLogging();
@@ -65,7 +68,6 @@ initContextMenus();
 initContentScriptReadyListener();
 initBrowserCommands();
 initDeploymentUpdater();
-initManagedStorage();
 void activateBrowserActionIcon();
 initPartnerTheme();
 initStarterMods();

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -48,6 +48,7 @@ import { initRuntimeLogging } from "@/development/runtimeLogging";
 import initWalkthroughModalTrigger from "@/background/walkthroughModalTrigger";
 import { initSidePanel } from "./sidePanel";
 import initRestrictUnauthenticatedUrlAccess from "@/background/restrictUnauthenticatedUrlAccess";
+import { initManagedStorage } from "@/store/enterprise/managedStorage";
 
 void initLocator();
 void initMessengerLogging();
@@ -64,6 +65,7 @@ initContextMenus();
 initContentScriptReadyListener();
 initBrowserCommands();
 initDeploymentUpdater();
+initManagedStorage();
 void activateBrowserActionIcon();
 initPartnerTheme();
 initStarterMods();

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -48,10 +48,14 @@ import { initRuntimeLogging } from "@/development/runtimeLogging";
 import initWalkthroughModalTrigger from "@/background/walkthroughModalTrigger";
 import { initSidePanel } from "./sidePanel";
 import initRestrictUnauthenticatedUrlAccess from "@/background/restrictUnauthenticatedUrlAccess";
-import { initManagedStorage } from "@/store/enterprise/managedStorage";
+import {
+  initManagedStorage,
+  watchStorageInitialization,
+} from "@/store/enterprise/managedStorage";
 
 // Try to initialize managed storage as early as possible because it impacts background behavior
-initManagedStorage();
+// Call watchStorageInitialization to handle case where storage is not immediately available within timeout
+void initManagedStorage().then(async () => watchStorageInitialization());
 
 void initLocator();
 void initMessengerLogging();

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -416,7 +416,7 @@ describe("updateDeployments", () => {
     expect(jest.mocked(uninstallAllDeployments).mock.calls).toHaveLength(0);
     expect(refreshRegistriesMock.mock.calls).toHaveLength(0);
     expect(saveSettingsStateMock).toHaveBeenCalledTimes(0);
-  });
+  }, 10_000);
 
   test("do not open options page on update if restricted-version flag not set", async () => {
     isLinkedMock.mockResolvedValue(true);

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -421,7 +421,7 @@ export async function updateDeployments(): Promise<void> {
         sso: false,
       });
 
-      void browser.runtime.openOptionsPage();
+      await browser.runtime.openOptionsPage();
 
       return;
     }

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -233,6 +233,8 @@ export async function handleInstall({
       // If an end-user appears to be installing, jump to linking directly vs. waiting for readManagedStorage because
       // readManagedStorage will wait until a timeout for managed storage to be available.
       if (!isManagedStorageInitialized() && (await isEndUserInstall())) {
+        console.debug("Skipping readManagedStorage for end-user install");
+
         await openInstallPage();
         return;
       }

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -47,7 +47,7 @@ let _availableVersion: string | null = null;
  * Returns true if this appears to be a Chrome Web Store install and/or the user has an app URL where they're
  * authenticated so the extension can be linked.
  */
-async function isEndUserInstall(): Promise<boolean> {
+async function isLikelyEndUserInstall(): Promise<boolean> {
   // Query existing app/CWS tabs: https://developer.chrome.com/docs/extensions/reference/api/tabs#method-query
   // `browser.tabs.query` supports https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns
   const likelyOnboardingTabs = await browser.tabs.query({
@@ -233,14 +233,14 @@ export async function handleInstall({
     if (!(await isLinked())) {
       // If an end-user appears to be installing, jump to linking directly vs. waiting for readManagedStorage because
       // readManagedStorage will wait until a timeout for managed storage to be available.
-      if (!isManagedStorageInitialized() && (await isEndUserInstall())) {
+      if (!isManagedStorageInitialized() && (await isLikelyEndUserInstall())) {
         console.debug("Skipping readManagedStorage for end-user install");
 
         await openInstallPage();
         return;
       }
 
-      // Reminder: readManagedStorageByKey waits up to 4.5 seconds for managed storage to be available
+      // Reminder: readManagedStorage waits up to 4.5 seconds for managed storage to be available
       const {
         ssoUrl,
         partnerId,

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -54,9 +54,10 @@ async function isEndUserInstall(): Promise<boolean> {
     // Can't use SERVICE_URL directly because it contains a port number during development, resulting in an
     // invalid URL match pattern
     url: [
-      // App Setup / Authenticated URLs
+      // Setup page is page before sending user to the CWS
       new URL("setup", DEFAULT_SERVICE_URL).href,
-      DEFAULT_SERVICE_URL,
+      // Base page is extension linking page. Needs path to be a valid URL match pattern
+      new URL("", DEFAULT_SERVICE_URL).href,
       // Known CWS URLs: https://docs.pixiebrix.com/enterprise-it-setup/network-email-firewall-configuration
       "https://chromewebstore.google.com/*",
       "https://chrome.google.com/webstore/*",

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -27,7 +27,10 @@ import { getExtensionToken, getUserData, isLinked } from "@/auth/token";
 import { isCommunityControlRoom } from "@/contrib/automationanywhere/aaUtils";
 import { isEmpty } from "lodash";
 import { expectContext } from "@/utils/expectContext";
-import { readManagedStorage } from "@/store/enterprise/managedStorage";
+import {
+  readManagedStorage,
+  isInitialized as isManagedStorageInitialized,
+} from "@/store/enterprise/managedStorage";
 import { Events } from "@/telemetry/events";
 
 import { DEFAULT_SERVICE_URL, UNINSTALL_URL } from "@/urlConstants";
@@ -222,7 +225,7 @@ export async function handleInstall({
     if (!(await isLinked())) {
       // If an end-user appears to be installing, jump to linking directly vs. waiting for readManagedStorage because
       // readManagedStorage will wait until a timeout for managed storage to be available.
-      if (await isEndUserInstall()) {
+      if (!isManagedStorageInitialized() && (await isEndUserInstall())) {
         await openInstallPage();
         return;
       }

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -158,7 +158,7 @@ export async function openInstallPage() {
       active: true,
     });
   } else {
-    // Case 3: there's no Admin Console onboarding tab open
+    // Case 3: there's no Admin Console onboarding tab open.
     //
     // Open a new Admin Console tab which will automatically "links" the extension (by passing the native PixieBrix
     // token to the extension).
@@ -240,16 +240,21 @@ export async function handleInstall({
       }
 
       // Reminder: readManagedStorageByKey waits up to 4.5 seconds for managed storage to be available
-      const { ssoUrl, partnerId, controlRoomUrl, disableLoginTab } =
-        await readManagedStorage();
+      const {
+        ssoUrl,
+        partnerId,
+        controlRoomUrl,
+        disableLoginTab,
+        managedOrganizationId,
+      } = await readManagedStorage();
 
       if (disableLoginTab) {
         // IT manager has disabled the login tab
         return;
       }
 
-      if (ssoUrl) {
-        // Don't launch the SSO page automatically. The SSO flow will be launched by deploymentUpdater.ts:updateDeployments
+      if (ssoUrl || managedOrganizationId) {
+        // Don't launch the page automatically. The SSO flow will be launched by deploymentUpdater.ts:updateDeployments
         return;
       }
 

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -50,7 +50,7 @@ let _availableVersion: string | null = null;
 async function isEndUserInstall(): Promise<boolean> {
   // Query existing app/CWS tabs: https://developer.chrome.com/docs/extensions/reference/api/tabs#method-query
   // `browser.tabs.query` supports https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns
-  const onboardingTabs = await browser.tabs.query({
+  const likelyOnboardingTabs = await browser.tabs.query({
     // Can't use SERVICE_URL directly because it contains a port number during development, resulting in an
     // invalid URL match pattern
     url: [
@@ -64,7 +64,7 @@ async function isEndUserInstall(): Promise<boolean> {
   });
 
   // The CWS install URL differs based on the extension listing slug. So instead, only match on the runtime id.
-  return onboardingTabs.some(
+  return likelyOnboardingTabs.some(
     (tab) =>
       tab.url.includes(DEFAULT_SERVICE_URL) ||
       tab.url.includes(browser.runtime.id),

--- a/src/store/enterprise/managedStorage.test.ts
+++ b/src/store/enterprise/managedStorage.test.ts
@@ -20,6 +20,7 @@ import {
   readManagedStorage,
   readManagedStorageByKey,
 } from "@/store/enterprise/managedStorage";
+import { sleep } from "@/utils/timeUtils";
 
 beforeEach(async () => {
   // eslint-disable-next-line new-cap -- test helper method
@@ -51,4 +52,18 @@ describe("readManagedStorageByKey", () => {
       "taco-bell",
     );
   });
+});
+
+describe("watchStorageInitialization", () => {
+  it("watches initialization", async () => {
+    await expect(readManagedStorageByKey("partnerId")).resolves.toBeUndefined();
+
+    await sleep(4000);
+
+    await browser.storage.managed.set({ partnerId: "taco-bell" });
+
+    await expect(readManagedStorageByKey("partnerId")).resolves.toBe(
+      "taco-bell",
+    );
+  }, 10_000);
 });

--- a/src/store/enterprise/managedStorage.test.ts
+++ b/src/store/enterprise/managedStorage.test.ts
@@ -20,7 +20,6 @@ import {
   readManagedStorage,
   readManagedStorageByKey,
 } from "@/store/enterprise/managedStorage";
-import { sleep } from "@/utils/timeUtils";
 
 beforeEach(async () => {
   // eslint-disable-next-line new-cap -- test helper method
@@ -52,18 +51,4 @@ describe("readManagedStorageByKey", () => {
       "taco-bell",
     );
   });
-});
-
-describe("watchStorageInitialization", () => {
-  it("watches initialization", async () => {
-    await expect(readManagedStorageByKey("partnerId")).resolves.toBeUndefined();
-
-    await sleep(4000);
-
-    await browser.storage.managed.set({ partnerId: "taco-bell" });
-
-    await expect(readManagedStorageByKey("partnerId")).resolves.toBe(
-      "taco-bell",
-    );
-  }, 10_000);
 });

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -27,7 +27,7 @@ import pMemoize, { pMemoizeClear } from "p-memoize";
 import { pollUntilTruthy } from "@/utils/promiseUtils";
 import type { Nullishable } from "@/utils/nullishUtils";
 
-// 2024-02-15: bumped to 4.5s because 2s was too short: https://github.com/pixiebrix/pixiebrix-extension/issues/7618
+// 1.8.9: bumped to 4.5s because 2s was too short: https://github.com/pixiebrix/pixiebrix-extension/issues/7618
 //   Privacy Badger uses 4.5s timeout, but thinks policy should generally be available within 2.5s. In installer.ts,
 //   skip waiting for managed storage before linking the Extension if the user appears to be installing from the CWS.
 const MAX_MANAGED_STORAGE_WAIT_MILLIS = 4500;

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -105,6 +105,8 @@ export async function watchDelayedStorageInitialization(): Promise<void> {
     return;
   }
 
+  // Use setInterval instead of pollUntilTruthy to clear on browser.storage.onChanged. pollUntilTruthy doesn't
+  // currently directly support an abort signal.
   initializationInterval = setInterval(
     async () => {
       const values = await readPopulatedManagedStorage();

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -100,7 +100,7 @@ async function readPopulatedManagedStorage(): Promise<
 export async function watchStorageInitialization(): Promise<void> {
   const values = await readPopulatedManagedStorage();
 
-  if (values) {
+  if (values != null) {
     // Already initialized
     return;
   }

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -27,9 +27,10 @@ import pMemoize, { pMemoizeClear } from "p-memoize";
 import { pollUntilTruthy } from "@/utils/promiseUtils";
 import type { Nullishable } from "@/utils/nullishUtils";
 
-// 2024-02-15: bumped to 3.5s because 2s was too short: https://github.com/pixiebrix/pixiebrix-extension/issues/7618
-//   Privacy Badger uses 4.5s timeout, but thinks policy should generally be available within 2.5s
-const MAX_MANAGED_STORAGE_WAIT_MILLIS = 3500;
+// 2024-02-15: bumped to 4.5s because 2s was too short: https://github.com/pixiebrix/pixiebrix-extension/issues/7618
+//   Privacy Badger uses 4.5s timeout, but thinks policy should generally be available within 2.5s. In installer.ts,
+//   we check for app tabs to skip the linking wait if the user appears to be installing from the web store.
+const MAX_MANAGED_STORAGE_WAIT_MILLIS = 4500;
 
 /**
  * Interval for checking managed storage initialization that takes longer than MAX_MANAGED_STORAGE_WAIT_MILLIS seconds.
@@ -87,9 +88,12 @@ async function readPopulatedManagedStorage(): Promise<
 }
 
 /**
- * Watch for managed storage initialization that occurs after waitForInitialManagedStorage
+ * Watch for managed storage initialization that occurs after waitForInitialManagedStorage.
  *
  * We can't use `browser.storage.onChanged` because it doesn't fire on initialization.
+ *
+ * Required because other modules are using the values in managedStorageSnapshot vs. calling browser.storage.managed.get
+ * directly.
  *
  * @see waitForInitialManagedStorage
  */

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -226,6 +226,14 @@ export async function readManagedStorage(): Promise<ManagedStorageState> {
 }
 
 /**
+ * Returns true if managed storage has been initialized.
+ * @see waitForInitialManagedStorage
+ */
+export function isInitialized(): boolean {
+  return managedStorageSnapshot != null;
+}
+
+/**
  * Get a _synchronous_ snapshot of the managed storage state.
  * @see useManagedStorageState
  * @see readManagedStorage

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -97,7 +97,7 @@ async function readPopulatedManagedStorage(): Promise<
  *
  * @see waitForInitialManagedStorage
  */
-export async function watchStorageInitialization(): Promise<void> {
+export async function watchDelayedStorageInitialization(): Promise<void> {
   const values = await readPopulatedManagedStorage();
 
   if (values != null) {

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -29,7 +29,7 @@ import type { Nullishable } from "@/utils/nullishUtils";
 
 // 2024-02-15: bumped to 4.5s because 2s was too short: https://github.com/pixiebrix/pixiebrix-extension/issues/7618
 //   Privacy Badger uses 4.5s timeout, but thinks policy should generally be available within 2.5s. In installer.ts,
-//   we check for app tabs to skip the linking wait if the user appears to be installing from the web store.
+//   skip waiting for managed storage before linking the Extension if the user appears to be installing from the CWS.
 const MAX_MANAGED_STORAGE_WAIT_MILLIS = 4500;
 
 /**

--- a/src/store/enterprise/useManagedStorageState.ts
+++ b/src/store/enterprise/useManagedStorageState.ts
@@ -22,10 +22,11 @@ import {
   subscribe,
 } from "@/store/enterprise/managedStorage";
 import { useEffect } from "react";
-import { type ManagedStorageState } from "@/store/enterprise/managedStorageTypes";
+import type { ManagedStorageState } from "@/store/enterprise/managedStorageTypes";
+import type { Nullishable } from "@/utils/nullishUtils";
 
 type HookState = {
-  data: ManagedStorageState | undefined;
+  data: Nullishable<ManagedStorageState>;
   isLoading: boolean;
 };
 

--- a/src/store/enterprise/useManagedStorageState.ts
+++ b/src/store/enterprise/useManagedStorageState.ts
@@ -35,7 +35,7 @@ type HookState = {
  */
 function useManagedStorageState(): HookState {
   useEffect(() => {
-    initManagedStorage();
+    void initManagedStorage();
   }, []);
 
   const data = useSyncExternalStore(subscribe, getSnapshot);

--- a/src/utils/promiseUtils.ts
+++ b/src/utils/promiseUtils.ts
@@ -105,6 +105,12 @@ export async function awaitValue<T>(
   throw new TimeoutError(`Value not found after ${waitMillis} milliseconds`);
 }
 
+/**
+ * Poll until the looper returns a truthy value. If the timeout is reached, return undefined.
+ * @param looper the value generator
+ * @param maxWaitMillis maximium time to wait for the value
+ * @param intervalMillis time between each call to looper
+ */
 export async function pollUntilTruthy<T>(
   looper: (...args: unknown[]) => Promise<T> | T,
   { maxWaitMillis = Number.MAX_SAFE_INTEGER, intervalMillis = 100 },


### PR DESCRIPTION
## What does this PR do?

- Closes #7618 
- Bumps initialization delay to 4.5s, which is what Privacy Badger uses for Chrome
- Adds an interval to watch for delayed managed policy initialization
- Modifies `handleInstall` to call `openInstallPage` immediately if the installation appears to be an end-user installation
- Fixes a bug where extension console + login page would be opened if managedOrganizationId was set in policy, but ssoUrl was not set in policy

## Remaining Work

- [x] Fix strict null checks
- [x] Modify `handleInstall` to immediately look for app onboarding page, which indicates user is not an enterprise user
- [x] E2E users without policy (see demo)
- [x] E2E test users with policy (see demo)
- [ ] Write storage and install jest tests - see future work

## Discussion

- This PR causes some tests that are using real timers with managed storage to time out. We need to shift those tests over to using fake timers in future DevEx work
- It would be nice to re-write uses of managed storage (e.g., restricted URLs) to recover from delayed policy initialization. But it's much simpler to assume the policy at profile startup is the policy
- I opened a w3c working group issue here: https://github.com/w3c/webextensions/issues/547
- I want to get this PR merged for RainforestQA testing and can follow up with Jest tests (they're a bit complicated due to needing to mock timers)

## Demo

- [Skip waiting for managed storage on CWS installs](https://www.loom.com/share/6529642e0d84485cb96fc8742ea7eaa0)
- [Bug Fix for multiple tabs opening when managedOrganizationId but no ssoUrl set](https://www.loom.com/share/1d88ec9599b24001a2d3b8085c2bb09a)

## Future Work

- Modify functionality that uses managed policy (e.g., theme/restricted URLs) to handle late initialization/policy changes after the initial extension startup. It shouldn't be needed with 4.5 second startup delay, but we can revisit as necessary

## Checklist

- [ ] Add tests: see discussion
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @mnholtz 
