### PR TITLE
#7631: fix iframed modal form regression

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,7 @@ const config = {
     "^.+\\.txt$": "<rootDir>/src/testUtils/rawJestTransformer.mjs",
   },
   transformIgnorePatterns: [
-    "node_modules/(?!@cfworker|escape-string-regex|filename-reserved-regex|filenamify|idb|webext-|p-timeout|p-retry|p-defer|p-memoize|serialize-error|strip-outer|trim-repeated|mimic-fn|urlpattern-polyfill|url-join|uuid|nanoid|use-debounce|copy-text-to-clipboard|linkify-urls|create-html-element|stringify-attributes|escape-goat|stemmer|uint8array-extras|one-event|abort-utils|batched-function)",
+    "node_modules/(?!@cfworker|escape-string-regex|filename-reserved-regex|filenamify|idb|webext-|p-timeout|p-retry|p-defer|p-memoize|serialize-error|strip-outer|trim-repeated|mimic-fn|urlpattern-polyfill|url-join|uuid|nanoid|use-debounce|copy-text-to-clipboard|linkify-urls|create-html-element|stringify-attributes|escape-goat|stemmer|uint8array-extras|one-event|abort-utils|batched-function|is-network-error)",
   ],
   setupFiles: [
     "dotenv/config",

--- a/src/__mocks__/webext-messenger.js
+++ b/src/__mocks__/webext-messenger.js
@@ -19,5 +19,12 @@ export const getMethod = jest.fn(() => jest.fn());
 export const getNotifier = jest.fn(() => jest.fn());
 export const backgroundTarget = { page: "background" };
 
-export const getTopLevelFrame = async () => ({ tabId: 1, frameId: 0 });
+let frameId = 0;
+
+export const getTopLevelFrame = async () => ({ tabId: 1, frameId });
+
 export const getThisFrame = getTopLevelFrame;
+
+export function setFrameId(newFrameId) {
+  frameId = newFrameId;
+}

--- a/src/bricks/transformers/ephemeralForm/formTransformer.ts
+++ b/src/bricks/transformers/ephemeralForm/formTransformer.ts
@@ -37,6 +37,7 @@ import { type FormDefinition } from "@/bricks/transformers/ephemeralForm/formTyp
 import { isExpression } from "@/utils/expressionUtils";
 import { getThisFrame } from "webext-messenger";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
+import { BusinessError } from "@/errors/businessErrors";
 
 // The modes for createFrameSource are different from the location argument for FormTransformer. The mode for the frame
 // just determines the layout container of the form
@@ -149,6 +150,13 @@ export class FormTransformer extends TransformerABC {
   ): Promise<unknown> {
     expectContext("contentScript");
 
+    if (location === "sidebar" && isLoadedInIframe()) {
+      // Validate before registerForm to avoid an uncaught promise rejection
+      throw new BusinessError(
+        "Cannot show sidebar in a frame. To use the sidebar, set the target to Top-level Frame",
+      );
+    }
+
     // Future improvements:
     // - Support draggable modals. This will require showing the modal header on the host page so there's a drag handle?
 
@@ -184,7 +192,7 @@ export class FormTransformer extends TransformerABC {
 
     if (location === "sidebar") {
       if (isLoadedInIframe()) {
-        throw new Error(
+        throw new BusinessError(
           "Cannot show sidebar in a frame. To use the sidebar, set the target to Top-level Frame",
         );
       }

--- a/src/bricks/transformers/ephemeralForm/formTransformer.ts
+++ b/src/bricks/transformers/ephemeralForm/formTransformer.ts
@@ -191,12 +191,6 @@ export class FormTransformer extends TransformerABC {
     });
 
     if (location === "sidebar") {
-      if (isLoadedInIframe()) {
-        throw new BusinessError(
-          "Cannot show sidebar in a frame. To use the sidebar, set the target to Top-level Frame",
-        );
-      }
-
       // Ensure the sidebar is visible (which may also be showing persistent panels)
       await showSidebar();
 

--- a/src/contentScript/ephemeralFormProtocol.ts
+++ b/src/contentScript/ephemeralFormProtocol.ts
@@ -93,7 +93,7 @@ export async function registerForm({
 /**
  * Helper method to unregister the deferred promise for the form.
  */
-function unregisterForm(formNonce: UUID) {
+function unregisterForm(formNonce: UUID): void {
   expectContext("contentScript");
 
   forms.delete(formNonce);
@@ -139,4 +139,8 @@ export async function cancelForm(...formNonces: UUID[]): Promise<void> {
     form?.registration.reject(new CancelError("User cancelled the action"));
     unregisterForm(formNonce);
   }
+}
+
+export async function TEST_cancelAll(): Promise<void> {
+  await cancelForm(...forms.keys());
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #7631 
- Fixes bug where createFrameSource for form running in iframe was passing the top-level frame as the opener
- Modifies the Show Form brick to throw a `BusinessError` if `location: sidebar` and brick is running in a frame

## Remaining Work

- [x] Write Jest tests
- [x] Add RainforestQA test for `@pixies/test/7631-bug-repro`: https://app.rainforestqa.com/tests/418113

## Discussion

- @fregante are there any other places we need to watch out for? It looks like Display Temporary information is working OK

## Demo

- https://www.loom.com/share/13a223ac82ef42d7a54104836a54216e

## Future Work

- This will be a good candidate for Playwright in the future

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @fregante 
- [ ] Post-merge: Update the RainforestQA test when this PR is merged to main. Currently it's asserting the error message is shown (so we're reminded to update it)
