### PR TITLE
Bump copyright year in footer

### DIFF
--- a/src/background/backgroundDomWatcher.ts
+++ b/src/background/backgroundDomWatcher.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 PixieBrix, Inc.
+ * Copyright (C) 2024 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/background/messenger/strict/api.ts
+++ b/src/background/messenger/strict/api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 PixieBrix, Inc.
+ * Copyright (C) 2024 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/background/messenger/strict/registration.ts
+++ b/src/background/messenger/strict/registration.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 PixieBrix, Inc.
+ * Copyright (C) 2024 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/background/restrictUnauthenticatedUrlAccess.test.ts
+++ b/src/background/restrictUnauthenticatedUrlAccess.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 PixieBrix, Inc.
+ * Copyright (C) 2024 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/background/restrictUnauthenticatedUrlAccess.ts
+++ b/src/background/restrictUnauthenticatedUrlAccess.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 PixieBrix, Inc.
+ * Copyright (C) 2024 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/components/documentBuilder/edit/DocumentOptions.test.tsx
+++ b/src/components/documentBuilder/edit/DocumentOptions.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 PixieBrix, Inc.
+ * Copyright (C) 2024 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/components/documentBuilder/edit/DocumentOptions.tsx
+++ b/src/components/documentBuilder/edit/DocumentOptions.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 PixieBrix, Inc.
+ * Copyright (C) 2024 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/contentScript/messenger/strict/api.ts
+++ b/src/contentScript/messenger/strict/api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 PixieBrix, Inc.
+ * Copyright (C) 2024 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/contentScript/messenger/strict/registration.ts
+++ b/src/contentScript/messenger/strict/registration.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 PixieBrix, Inc.
+ * Copyright (C) 2024 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/extensionConsole/App.tsx
+++ b/src/extensionConsole/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 PixieBrix, Inc.
+ * Copyright (C) 2024 PixieBrix, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -31,7 +31,7 @@ const Footer: React.FunctionComponent = () => {
     <footer className="footer">
       <div className="d-sm-flex justify-content-center justify-content-sm-between">
         <span className="text-muted text-center text-sm-left d-block d-sm-inline-block">
-          Copyright © 2023{" "}
+          Copyright © 2024{" "}
           <a href="https://www.pixiebrix.com">PixieBrix, Inc.</a> All rights
           reserved.
         </span>

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -31,7 +31,7 @@ const Footer: React.FunctionComponent = () => {
     <footer className="footer">
       <div className="d-sm-flex justify-content-center justify-content-sm-between">
         <span className="text-muted text-center text-sm-left d-block d-sm-inline-block">
-          Copyright © 2024{" "}
+          Copyright © {new Date().getFullYear()}{" "}
           <a href="https://www.pixiebrix.com">PixieBrix, Inc.</a> All rights
           reserved.
         </span>


### PR DESCRIPTION
## What does this PR do?

- Automatically bumps the copyright year in the footer

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
