### PR TITLE
#7641: Organization toolbarIcon takes precedence over partner id theme

### DIFF
--- a/src/background/initTheme.ts
+++ b/src/background/initTheme.ts
@@ -29,7 +29,7 @@ import { getActiveTheme } from "@/themes/themeStore";
 async function setToolbarIcon(): Promise<void> {
   const { themeName: activeThemeName, toolbarIcon } = await getActiveTheme();
 
-  if (activeThemeName === DEFAULT_THEME) {
+  if (toolbarIcon || activeThemeName === DEFAULT_THEME) {
     await activateBrowserActionIcon(toolbarIcon);
   } else {
     const themeLogo = getThemeLogo(activeThemeName);


### PR DESCRIPTION
Organization icon/logo take precedence. (Conceptually, partner branding just changes the base theme)

## What does this PR do?

- Fixes #7641

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [ ] Designate a primary reviewer @twschiller 
