### PR TITLE
#7640: Reduce form label size

### DIFF
--- a/src/components/form/FieldTemplate.module.scss
+++ b/src/components/form/FieldTemplate.module.scss
@@ -29,9 +29,9 @@
   align-self: stretch;
   font-size: 80%;
   flex-basis: 0;
-  flex-grow: 1;
-  min-width: 150px;
-  max-width: 300px;
+  flex-grow: 1; // XXX: This and the `flex-grow` in `formField` set the ratio of the label and field widths
+  min-width: 100px; // Last set for https://github.com/pixiebrix/pixiebrix-extension/issues/7640
+  max-width: 200px;
   // Visually align the label to the baseline of the text field.
   // It also helps space the fields out out when stacked vertically.
   padding-top: 10px;
@@ -48,7 +48,7 @@
 }
 
 .formField {
-  flex-grow: 3;
+  flex-grow: 4;
   flex-basis: 0;
   /* This will cause it to wrap when the available width is less than both `min-width`s */
   min-width: 200px;


### PR DESCRIPTION
## What does this PR do?

- Fixes #7640
- Follows https://github.com/pixiebrix/pixiebrix-extension/pull/7464

## Context: Before removal of Bootstrap columns

Before my last PR, it looked like this (sizing varied based on the viewport, even if the modal size was unchanged)


<table>
<tr>
 <td valign=top><img width="525" alt="Screenshot 18" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/aad6ff4c-69ee-45be-b6ae-e58fcab4fe39">
 <td valign=top><img width="525" alt="Screenshot 17" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/b149ff6f-9a13-4a88-acab-f07dd43beaa0">
 <td valign=top><img width="525" alt="Screenshot 19" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/94a4f82f-1535-4317-b70a-e9e1e14fdaf1">
</table>

## With this PR

Now it looks exclusively like this. We could widen the modal itself too, but it seems to be hard-coded in Bootstrap 

<img width="523" alt="Screenshot 20" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/45568433-ac86-4711-b841-0c401916adf0">



## Other changes

This also affects the page editor, arguably improving it there too.

### Before

Too wide:

<img width="1009" alt="Screenshot 21" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/bff07b46-7334-4838-85fe-b22bc98ca441">

### After

A more reasonable max-width:

<img width="1009" alt="Screenshot 22" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/31110741-c832-4088-91bd-f35677ec52fc">

And this is the new min-width

<img width="446" alt="Screenshot 23" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/5d71ef91-de4b-4dcd-996c-4f404c2cd846">

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
