### PR TITLE
#7630: Fix DraftJS support on empty fields

### DIFF
--- a/src/bricks/effects/forms.ts
+++ b/src/bricks/effects/forms.ts
@@ -30,131 +30,36 @@ import { isEmpty } from "lodash";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type Logger } from "@/types/loggerTypes";
-import { setCKEditorData } from "@/pageScript/messenger/api";
-import { getSelectorForElement } from "@/contentScript/elementReference";
-import { hasCKEditorClass } from "@/contrib/ckeditor";
-import { boolean } from "@/utils/typeUtils";
 import { findSingleElement } from "@/utils/domUtils";
+import {
+  isFieldElement,
+  setFieldValue,
+  setFieldsValue,
+} from "@/utils/domFieldUtils";
 
-type SetValueData = RequireExactlyOne<
+type FindAndSetValueData = RequireExactlyOne<
   {
     form?: HTMLElement | Document;
     value: unknown;
-    selector?: string;
-    name?: string;
+    selector: string;
+    name: string;
     dispatchEvent?: boolean;
     logger: Logger;
   },
   "selector" | "name"
 >;
 
-const OPTION_FIELDS = new Set(["checkbox", "radio"]);
-
-type FieldElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
-
-function isFieldElement(element: HTMLElement): boolean {
-  return (
-    element.isContentEditable ||
-    element instanceof HTMLInputElement ||
-    element instanceof HTMLTextAreaElement ||
-    element instanceof HTMLSelectElement
-  );
-}
-
-/**
- * DraftJS doesn't handle `insertText` correctly in some cases, but it can handle this
- * event. Note that this event doesn't do anything in regular contentEditable fields.
- */
-function dispatchPasteForDraftJs(field: FieldElement, value: string) {
-  const data = new DataTransfer();
-  data.setData("text/plain", value);
-  field.dispatchEvent(
-    new ClipboardEvent("paste", {
-      clipboardData: data,
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
-}
-
-async function setFieldValue(
-  field: FieldElement,
-  value: unknown,
-  { dispatchEvent, isOption }: { dispatchEvent: boolean; isOption: boolean },
-): Promise<void> {
-  // For performance, use the contentScript-based call to determine if the element has the classname associate with
-  // CKEditor 5 instances. If it does, set the data (will error if it's not actually a CKEditor 5 instance).
-  if (hasCKEditorClass(field)) {
-    await setCKEditorData({
-      selector: getSelectorForElement(field),
-      value: String(value),
-    });
-    return;
-  }
-
-  if (field.isContentEditable) {
-    // Field needs to be focused first
-    field.focus();
-
-    // `insertText` acts as a "paste", so if no text is selected it's just appended
-    document.execCommand("selectAll");
-
-    if (field.textContent === "" && field.closest(".DraftEditor-root")) {
-      // Special handling for DraftJS if the field is empty
-      // https://github.com/pixiebrix/pixiebrix-extension/issues/7630
-      dispatchPasteForDraftJs(field, String(value));
-    } else {
-      // It automatically triggers an `input` event
-      document.execCommand("insertText", false, String(value));
-    }
-
-    return;
-  }
-
-  // `instanceof` is there as a type guard only
-  if (
-    !OPTION_FIELDS.has(field.type) ||
-    field instanceof HTMLTextAreaElement ||
-    field instanceof HTMLSelectElement
-  ) {
-    // Plain text field
-    field.value = String(value);
-  } else if (isOption) {
-    // Value-based radio/checkbox
-    field.checked = field.value === value;
-  } else {
-    // Boolean checkbox
-    field.checked = boolean(value);
-  }
-
-  if (dispatchEvent) {
-    if (
-      !(OPTION_FIELDS.has(field.type) || field instanceof HTMLSelectElement)
-    ) {
-      // Browsers normally fire these text events while typing
-      field.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true }));
-      field.dispatchEvent(new KeyboardEvent("keypress", { bubbles: true }));
-      field.dispatchEvent(new CompositionEvent("textInput", { bubbles: true }));
-      field.dispatchEvent(new InputEvent("input", { bubbles: true }));
-      field.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
-    }
-
-    // Browsers normally fire this on `blur` if it's a text field, otherwise immediately
-    field.dispatchEvent(new KeyboardEvent("change", { bubbles: true }));
-  }
-}
-
 /**
  * Set the value of an input, doing the right thing for check boxes, etc.
  */
-async function setValue({
+async function findAndSetValue({
   form = document,
   value,
   logger,
   name,
   selector = `[name="${name}"]`,
   dispatchEvent = true,
-}: SetValueData) {
+}: FindAndSetValueData) {
   const isNameBased = Boolean(name);
   const fields = $(form)
     .find<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>(selector)
@@ -181,18 +86,7 @@ async function setValue({
     return;
   }
 
-  // Exact matches will be picked out of many, otherwise we'll treat them as booleans
-  const isOption =
-    isNameBased &&
-    fields.some(
-      (field) => field.value === value && OPTION_FIELDS.has(field.type),
-    );
-
-  return Promise.all(
-    fields.map(async (field) =>
-      setFieldValue(field, value, { dispatchEvent, isOption }),
-    ),
-  );
+  return setFieldsValue(fields, value, { dispatchEvent, isNameBased });
 }
 
 export class SetInputValue extends EffectABC {
@@ -259,19 +153,19 @@ export class SetInputValue extends EffectABC {
             );
           }
 
-          if (!isFieldElement(target as HTMLElement)) {
+          if (!isFieldElement(target)) {
             throw new BusinessError(
               "Field is not a input field or editable element",
             );
           }
 
-          await setFieldValue(target as FieldElement, value, {
+          await setFieldValue(target, value, {
             dispatchEvent: true,
             isOption: false,
           });
         } else {
           // `setValue` works on any element that contains fields, not just forms
-          await setValue({
+          await findAndSetValue({
             selector,
             value,
             logger,
@@ -357,10 +251,10 @@ export class FormFill extends EffectABC {
 
     await Promise.all([
       ...Object.entries(fieldNames).map(async ([name, value]) =>
-        setValue({ name, value, logger, dispatchEvent: true }),
+        findAndSetValue({ name, value, logger, dispatchEvent: true }),
       ),
       ...Object.entries(fieldSelectors).map(async ([selector, value]) =>
-        setValue({ selector, value, logger, dispatchEvent: true }),
+        findAndSetValue({ selector, value, logger, dispatchEvent: true }),
       ),
     ]);
 

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -524,6 +524,7 @@
     "./utils/clipboardUtils.ts",
     "./utils/debugUtils.ts",
     "./utils/detectRandomString.ts",
+    "./utils/domFieldUtils.ts",
     "./utils/domUtils.ts",
     "./utils/enrichAxiosErrors.ts",
     "./utils/expectContext.ts",

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -525,6 +525,7 @@
     "./utils/debugUtils.ts",
     "./utils/detectRandomString.ts",
     "./utils/domFieldUtils.ts",
+    "./utils/domFieldUtils.test.ts",
     "./utils/domUtils.ts",
     "./utils/enrichAxiosErrors.ts",
     "./utils/expectContext.ts",

--- a/src/utils/domFieldUtils.test.ts
+++ b/src/utils/domFieldUtils.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { setFieldValue } from "./domFieldUtils";
+
+function createCheckableInput(type: string, checked?: boolean, value?: string) {
+  const input = document.createElement("input");
+  input.setAttribute("type", type);
+  input.setAttribute("value", value);
+  input.checked = Boolean(checked);
+  return input;
+}
+
+describe("setFieldValue", () => {
+  it("sets the value of an input", async () => {
+    const input = document.createElement("input");
+    input.setAttribute("name", "test");
+    await setFieldValue(input, "✅");
+    expect(input.value).toBe("✅");
+  });
+
+  it("sets the value of a textarea", async () => {
+    const textarea = document.createElement("textarea");
+    textarea.setAttribute("name", "test");
+    await setFieldValue(textarea, "✅");
+    expect(textarea.value).toBe("✅");
+  });
+
+  it("sets the value of a select", async () => {
+    const select = document.createElement("select");
+    select.setAttribute("name", "test");
+    const option = document.createElement("option");
+    option.setAttribute("value", "✅");
+    select.append(option);
+    await setFieldValue(select, "✅");
+    expect(select.value).toBe("✅");
+  });
+
+  it("checks checkbox", async () => {
+    const checkbox = createCheckableInput("checkbox");
+    await setFieldValue(checkbox, true);
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it("checks radio button", async () => {
+    const radio = createCheckableInput("radio");
+    await setFieldValue(radio, true);
+    expect(radio.checked).toBe(true);
+  });
+
+  it("checks a group of checkboxes by value", async () => {
+    const checkbox1 = createCheckableInput("checkbox", false, "✅");
+    const checkbox2 = createCheckableInput("checkbox", false, "🌞");
+
+    await setFieldValue(checkbox1, "✅", { isOption: true });
+    expect(checkbox1.value).toBe("✅");
+    expect(checkbox1.checked).toBe(true);
+
+    await setFieldValue(checkbox2, "✅", { isOption: true }); // No-op
+    expect(checkbox2.value).toBe("🌞"); // It should not alter the original value
+    expect(checkbox2.checked).toBe(false); // It should only be checked if the value matches
+  });
+
+  it("checks a group of radio buttons by value", async () => {
+    const radio1 = createCheckableInput("radio", false, "✅");
+    const radio2 = createCheckableInput("radio", false, "🌞");
+
+    await setFieldValue(radio1, "✅", { isOption: true });
+    expect(radio1.value).toBe("✅");
+    expect(radio1.checked).toBe(true);
+
+    await setFieldValue(radio2, "✅", { isOption: true }); // No-op
+    expect(radio2.value).toBe("🌞"); // It should not alter the original value
+    expect(radio2.checked).toBe(false); // It should only be checked if the value matches
+  });
+});

--- a/src/utils/domFieldUtils.ts
+++ b/src/utils/domFieldUtils.ts
@@ -84,7 +84,10 @@ export async function setFieldsValue(
 export async function setFieldValue(
   field: FieldElement,
   value: unknown,
-  { dispatchEvent, isOption }: { dispatchEvent: boolean; isOption: boolean },
+  {
+    dispatchEvent,
+    isOption,
+  }: { dispatchEvent?: boolean; isOption?: boolean } = {},
 ): Promise<void> {
   // For performance, use the contentScript-based call to determine if the element has the classname associate with
   // CKEditor 5 instances. If it does, set the data (will error if it's not actually a CKEditor 5 instance).

--- a/src/utils/domFieldUtils.ts
+++ b/src/utils/domFieldUtils.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { setCKEditorData } from "@/pageScript/messenger/api";
+import { getSelectorForElement } from "@/contentScript/elementReference";
+import { hasCKEditorClass } from "@/contrib/ckeditor";
+import { boolean } from "@/utils/typeUtils";
+
+export type FieldElement =
+  | HTMLInputElement
+  | HTMLTextAreaElement
+  | HTMLSelectElement;
+
+export function isFieldElement(
+  element: HTMLElement | Document,
+): element is FieldElement {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+
+  return (
+    element.isContentEditable ||
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement ||
+    element instanceof HTMLSelectElement
+  );
+}
+
+/**
+ * DraftJS doesn't handle `insertText` correctly in some cases, but it can handle this
+ * event. Note that this event doesn't do anything in regular contentEditable fields.
+ * Source: https://github.com/facebookarchive/draft-js/issues/616#issuecomment-426047799
+ */
+function dispatchPasteForDraftJs(field: FieldElement, value: string) {
+  const data = new DataTransfer();
+  data.setData("text/plain", value);
+  field.dispatchEvent(
+    new ClipboardEvent("paste", {
+      clipboardData: data,
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+const OPTION_FIELDS = new Set(["checkbox", "radio"]);
+
+export async function setFieldsValue(
+  fields: FieldElement[],
+  value: unknown,
+  {
+    dispatchEvent,
+    isNameBased,
+  }: { dispatchEvent: boolean; isNameBased: boolean },
+) {
+  // Exact matches will be picked out of many, otherwise we'll treat them as booleans
+  const isOption =
+    isNameBased &&
+    fields.some(
+      (field) => field.value === value && OPTION_FIELDS.has(field.type),
+    );
+
+  return Promise.all(
+    fields.map(async (field) =>
+      setFieldValue(field, value, { dispatchEvent, isOption }),
+    ),
+  );
+}
+
+export async function setFieldValue(
+  field: FieldElement,
+  value: unknown,
+  { dispatchEvent, isOption }: { dispatchEvent: boolean; isOption: boolean },
+): Promise<void> {
+  // For performance, use the contentScript-based call to determine if the element has the classname associate with
+  // CKEditor 5 instances. If it does, set the data (will error if it's not actually a CKEditor 5 instance).
+  if (hasCKEditorClass(field)) {
+    await setCKEditorData({
+      selector: getSelectorForElement(field),
+      value: String(value),
+    });
+    return;
+  }
+
+  if (field.isContentEditable) {
+    // Field needs to be focused first
+    field.focus();
+
+    // `insertText` acts as a "paste", so if no text is selected it's just appended
+    document.execCommand("selectAll");
+
+    if (field.textContent === "" && field.closest(".DraftEditor-root")) {
+      // Special handling for DraftJS if the field is empty
+      // https://github.com/pixiebrix/pixiebrix-extension/issues/7630
+      dispatchPasteForDraftJs(field, String(value));
+    } else {
+      // It automatically triggers an `input` event
+      document.execCommand("insertText", false, String(value));
+    }
+
+    return;
+  }
+
+  // `instanceof` is there as a type guard only
+  if (
+    !OPTION_FIELDS.has(field.type) ||
+    field instanceof HTMLTextAreaElement ||
+    field instanceof HTMLSelectElement
+  ) {
+    // Plain text field
+    field.value = String(value);
+  } else if (isOption) {
+    // Value-based radio/checkbox
+    field.checked = field.value === value;
+  } else {
+    // Boolean checkbox
+    field.checked = boolean(value);
+  }
+
+  if (dispatchEvent) {
+    if (
+      !(OPTION_FIELDS.has(field.type) || field instanceof HTMLSelectElement)
+    ) {
+      // Browsers normally fire these text events while typing
+      field.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true }));
+      field.dispatchEvent(new KeyboardEvent("keypress", { bubbles: true }));
+      field.dispatchEvent(new CompositionEvent("textInput", { bubbles: true }));
+      field.dispatchEvent(new InputEvent("input", { bubbles: true }));
+      field.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true }));
+    }
+
+    // Browsers normally fire this on `blur` if it's a text field, otherwise immediately
+    field.dispatchEvent(new KeyboardEvent("change", { bubbles: true }));
+  }
+}


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/7630

## Review tips

The actual bug fix can be seen in [`e436878` (#7644)](https://github.com/pixiebrix/pixiebrix-extension/pull/7644/commits/e4368786b87da58567bc0b1d904c4899f82784c6). The rest of the changes are to extract the utility functions and test some

## Demo

Tested on https://draftjs.org

Some fields are available on https://ghosttext.fregante.com/test/ (but not DraftJS at this point)

https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/2cc02864-8e78-46c0-acfd-9e9929ea8f86

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @BLoe 
