### PR TITLE
#6549: Temporarily hide dead sidebar button

### DIFF
--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -129,6 +129,11 @@ const Tabs: React.FC = () => {
   const getExtensionFromEventKey = useSelector(selectExtensionFromEventKey);
   const closedTabs = useSelector(selectClosedTabs);
 
+  const modLauncherEventKey = eventKeyForEntry(MOD_LAUNCHER);
+  const isModLauncherOpen =
+    // eslint-disable-next-line security/detect-object-injection -- modLauncherEventKey is not user input
+    !closedTabs[modLauncherEventKey];
+
   const onSelect = (eventKey: string) => {
     reportEvent(Events.VIEW_SIDEBAR_PANEL, {
       ...selectEventData(getExtensionFromEventKey(eventKey)),
@@ -139,17 +144,14 @@ const Tabs: React.FC = () => {
   };
 
   const onOpenModLauncher = () => {
-    const modLauncherEventKey = eventKeyForEntry(MOD_LAUNCHER);
-    const isModLauncherOpen =
-      // eslint-disable-next-line security/detect-object-injection -- modLauncherEventKey is not user input
-      !closedTabs[modLauncherEventKey];
-
     reportEvent(Events.VIEW_SIDEBAR_PANEL, {
       ...selectEventData(getExtensionFromEventKey(modLauncherEventKey)),
       initialLoad: false,
       source: "modLauncher open button",
     });
 
+    // TODO: In the future we'll want to open multiple tabs instead
+    // https://github.com/pixiebrix/pixiebrix-extension/issues/6549#issuecomment-1742961879
     if (!isModLauncherOpen) {
       dispatch(sidebarSlice.actions.openTab(modLauncherEventKey));
     }
@@ -281,15 +283,17 @@ const Tabs: React.FC = () => {
               />
             </TabWithDivider>
           ))}
-          <Button
-            size="sm"
-            variant="link"
-            className={styles.addButton}
-            aria-label="open mod launcher"
-            onClick={onOpenModLauncher}
-          >
-            <FontAwesomeIcon icon={faPlus} />
-          </Button>
+          {!isModLauncherOpen && (
+            <Button
+              size="sm"
+              variant="link"
+              className={styles.addButton}
+              aria-label="open mod launcher"
+              onClick={onOpenModLauncher}
+            >
+              <FontAwesomeIcon icon={faPlus} />
+            </Button>
+          )}
         </Nav>
         <Tab.Content
           className={cx(


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/6549

## Discussion

> Ideally, multiple "mod launcher" states will eventually be able to be opened

While we wait for that behavior to be implemented, we should not have a dead button in the UI. I opened a dedicated ticket to track that feature request, while fixing this UI bug.


- [ ] https://github.com/pixiebrix/pixiebrix-extension/issues/7646

## Demo


https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/ac107e23-a35b-4ac7-8558-81b9953281a7

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [ ] Designate a primary reviewer
