### PR TITLE
Improve separation/alignment of Editor Node panel

### DIFF
--- a/src/components/fields/schemaFields/genericOptionsFactory.tsx
+++ b/src/components/fields/schemaFields/genericOptionsFactory.tsx
@@ -37,7 +37,7 @@ export type BlockOptionProps = {
 };
 
 const NoOptions: React.FunctionComponent = () => (
-  <div>This brick does not require any configuration</div>
+  <div className="my-3">This brick does not require any configuration</div>
 );
 
 /**

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -1971,7 +1971,7 @@ exports[`renders the first selected node 1`] = `
                 class="coreFields"
               >
                 <div
-                  class="mb-3 gap-column-4"
+                  class="gap-column-4"
                 >
                   <div
                     class="formGroup flex-grow-1 form-group"

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -1959,103 +1959,111 @@ exports[`renders the first selected node 1`] = `
           <div
             class="configPanel"
           >
-            <h6
-              class="mb-3 d-flex justify-content-between flex-wrap gap-2"
-            >
-              Echo Brick
-            </h6>
             <div
-              class="mb-3 d-flex flex-wrap gap-column-4"
+              class="header mb-3"
             >
+              <h6
+                class="mb-3 d-flex justify-content-between flex-wrap gap-2"
+              >
+                Echo Brick
+              </h6>
               <div
-                class="formGroup flex-grow-1 form-group"
+                class="coreFields"
               >
                 <div
-                  class="mb-2 w-100 collapse"
+                  class="mb-3 gap-column-4"
                 >
                   <div
-                    class="annotationPlaceholder"
-                  />
-                </div>
-                <label
-                  class="label labelFitContent form-label"
-                  for="extension.blockPipeline.0.label"
-                >
-                  Step Name
-                </label>
-                <div
-                  class="formField"
-                >
-                  <input
-                    class="form-control"
-                    id="extension.blockPipeline.0.label"
-                    name="extension.blockPipeline.0.label"
-                    placeholder="Echo Brick"
-                    value=""
-                  />
-                </div>
-              </div>
-              <div
-                class="formGroup flex-grow-1 form-group"
-              >
-                <div
-                  class="mb-2 w-100 collapse"
-                >
-                  <div
-                    class="annotationPlaceholder"
-                  />
-                </div>
-                <label
-                  class="label labelFitContent form-label"
-                  for="extension.blockPipeline.0.outputKey"
-                >
-                  <span
-                    class="span"
-                  >
-                    <span
-                      class="label"
-                    >
-                      Output
-                    </span>
-                     
-                    <svg
-                      aria-hidden="true"
-                      class="svg-inline--fa fa-info-circle fa-w-16 "
-                      data-icon="info-circle"
-                      data-prefix="fas"
-                      focusable="false"
-                      role="img"
-                      viewBox="0 0 512 512"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                  </span>
-                </label>
-                <div
-                  class="formField"
-                >
-                  <div
-                    class="input-group"
+                    class="formGroup flex-grow-1 form-group"
                   >
                     <div
-                      class="input-group-prepend"
+                      class="mb-2 w-100 collapse"
+                    >
+                      <div
+                        class="annotationPlaceholder"
+                      />
+                    </div>
+                    <label
+                      class="label form-label"
+                      for="extension.blockPipeline.0.label"
+                    >
+                      Step Name
+                    </label>
+                    <div
+                      class="formField"
+                    >
+                      <input
+                        class="form-control"
+                        id="extension.blockPipeline.0.label"
+                        name="extension.blockPipeline.0.label"
+                        placeholder="Echo Brick"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="formGroup flex-grow-1 form-group"
+                  >
+                    <div
+                      class="mb-2 w-100 collapse"
+                    >
+                      <div
+                        class="annotationPlaceholder"
+                      />
+                    </div>
+                    <label
+                      class="label form-label"
+                      for="extension.blockPipeline.0.outputKey"
                     >
                       <span
-                        class="input-group-text"
+                        class="span"
                       >
-                        @
+                        <span
+                          class="label"
+                        >
+                          Output
+                        </span>
+                         
+                        <svg
+                          aria-hidden="true"
+                          class="svg-inline--fa fa-info-circle fa-w-16 "
+                          data-icon="info-circle"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          viewBox="0 0 512 512"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                            fill="currentColor"
+                          />
+                        </svg>
                       </span>
+                    </label>
+                    <div
+                      class="formField"
+                    >
+                      <div
+                        class="input-group"
+                      >
+                        <div
+                          class="input-group-prepend"
+                        >
+                          <span
+                            class="input-group-text"
+                          >
+                            @
+                          </span>
+                        </div>
+                        <input
+                          class="form-control"
+                          id="extension.blockPipeline.0.outputKey"
+                          name="extension.blockPipeline.0.outputKey"
+                          value="echoOutput"
+                        />
+                      </div>
                     </div>
-                    <input
-                      class="form-control"
-                      id="extension.blockPipeline.0.outputKey"
-                      name="extension.blockPipeline.0.outputKey"
-                      value="echoOutput"
-                    />
                   </div>
                 </div>
               </div>

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
@@ -20,7 +20,7 @@
   // Add a full-bleed background color to the header to create separation
   // https://github.com/pixiebrix/pixiebrix-extension/pull/7662
   margin: -15px -24px 20px;
-  padding: 15px 24px 0;
+  padding: 24px 24px 0;
   background: $field-section-header;
 }
 

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
@@ -14,6 +14,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@import "@/themes/colors.scss";
+
+.header {
+  // Add a full-bleed background color to the header to create separation
+  // https://github.com/pixiebrix/pixiebrix-extension/pull/7662
+  margin: -15px -24px 20px;
+  padding: 15px 24px 0;
+  background: $field-section-header;
+}
 
 .coreFields {
   container-name: EditorNodeConfigPanelHeader;

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.module.scss
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.coreFields {
+  container-name: EditorNodeConfigPanelHeader;
+  container-type: inline-size;
+}
+
+@container EditorNodeConfigPanelHeader (min-width: 600px) {
+  .coreFields > :first-child {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .coreFields label {
+    /* Replicate fitLabelWidth */
+    min-width: fit-content;
+    flex-grow: 0;
+  }
+}

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -31,6 +31,7 @@ import { useGetMarketplaceListingsQuery } from "@/data/service/api";
 import { MARKETPLACE_URL } from "@/urlConstants";
 import CommentsPreview from "@/pageEditor/tabs/editTab/editorNodeConfigPanel/CommentsPreview";
 import useAsyncState from "@/hooks/useAsyncState";
+import cx from "classnames";
 
 const EditorNodeConfigPanel: React.FC = () => {
   const {
@@ -72,35 +73,37 @@ const EditorNodeConfigPanel: React.FC = () => {
 
   return (
     <>
-      <AnalysisResult className="mb-3" />
+      <div className={cx(styles.header, "mb-3")}>
+        <AnalysisResult className="mb-3" />
 
-      <h6 className="mb-3 d-flex justify-content-between flex-wrap gap-2">
-        {brickInfo?.block.name}
-        {showDocumentationLink && (
-          <a
-            href={`${MARKETPLACE_URL}${listingId}/?utm_source=pixiebrix&utm_medium=page_editor&utm_campaign=docs&utm_content=view_docs_link`}
-          >
-            View Documentation
-          </a>
-        )}
-      </h6>
+        <h6 className="mb-3 d-flex justify-content-between flex-wrap gap-2">
+          {brickInfo?.block.name}
+          {showDocumentationLink && (
+            <a
+              href={`${MARKETPLACE_URL}${listingId}/?utm_source=pixiebrix&utm_medium=page_editor&utm_campaign=docs&utm_content=view_docs_link`}
+            >
+              View Documentation
+            </a>
+          )}
+        </h6>
 
-      <div className={styles.header}>
-        {/* Do not merge divs, the outer div is a CSS @container */}
-        <div className="mb-3 gap-column-4">
-          <ConnectedFieldTemplate
-            name={`${brickFieldName}.label`}
-            label="Step Name"
-            className="flex-grow-1"
-            placeholder={brickInfo?.block.name}
-          />
-          <ConnectedFieldTemplate
-            name={`${brickFieldName}.outputKey`}
-            label={PopoverOutputLabel}
-            className="flex-grow-1"
-            disabled={isOutputDisabled}
-            as={KeyNameWidget}
-          />
+        <div className={styles.coreFields}>
+          {/* Do not merge divs, the outer div is a CSS @container */}
+          <div className="mb-3 gap-column-4">
+            <ConnectedFieldTemplate
+              name={`${brickFieldName}.label`}
+              label="Step Name"
+              className="flex-grow-1"
+              placeholder={brickInfo?.block.name}
+            />
+            <ConnectedFieldTemplate
+              name={`${brickFieldName}.outputKey`}
+              label={PopoverOutputLabel}
+              className="flex-grow-1"
+              disabled={isOutputDisabled}
+              as={KeyNameWidget}
+            />
+          </div>
         </div>
       </div>
 

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React from "react";
+import styles from "./EditorNodeConfigPanel.module.scss";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import BrickConfiguration from "@/pageEditor/tabs/effect/BrickConfiguration";
 import blockRegistry from "@/bricks/registry";
@@ -84,22 +85,23 @@ const EditorNodeConfigPanel: React.FC = () => {
         )}
       </h6>
 
-      <div className="mb-3 d-flex flex-wrap gap-column-4">
-        <ConnectedFieldTemplate
-          name={`${brickFieldName}.label`}
-          label="Step Name"
-          className="flex-grow-1"
-          fitLabelWidth
-          placeholder={brickInfo?.block.name}
-        />
-        <ConnectedFieldTemplate
-          name={`${brickFieldName}.outputKey`}
-          label={PopoverOutputLabel}
-          className="flex-grow-1"
-          fitLabelWidth
-          disabled={isOutputDisabled}
-          as={KeyNameWidget}
-        />
+      <div className={styles.header}>
+        {/* Do not merge divs, the outer div is a CSS @container */}
+        <div className="mb-3 gap-column-4">
+          <ConnectedFieldTemplate
+            name={`${brickFieldName}.label`}
+            label="Step Name"
+            className="flex-grow-1"
+            placeholder={brickInfo?.block.name}
+          />
+          <ConnectedFieldTemplate
+            name={`${brickFieldName}.outputKey`}
+            label={PopoverOutputLabel}
+            className="flex-grow-1"
+            disabled={isOutputDisabled}
+            as={KeyNameWidget}
+          />
+        </div>
       </div>
 
       {comments && <CommentsPreview comments={comments} />}

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -89,7 +89,7 @@ const EditorNodeConfigPanel: React.FC = () => {
 
         <div className={styles.coreFields}>
           {/* Do not merge divs, the outer div is a CSS @container */}
-          <div className="mb-3 gap-column-4">
+          <div className="gap-column-4">
             <ConnectedFieldTemplate
               name={`${brickFieldName}.label`}
               label="Step Name"


### PR DESCRIPTION
## What does this PR do?

- Mentioned in https://pixiebrix.slack.com/archives/C03CA2M4RCM/p1707565424228409

In short, the sizing and alignment of the labels in this component, seem off because there's no visual separation between this component and the following fields:

<img width="886" alt="Screenshot 13" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/973371f6-adcb-4869-a1b2-874103ed28ca">




## Demo

<details>


<summary>oudated demo</summary>



I noticed that Mods use the Card style:

<img width="886" alt="Screenshot 15" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/a0f281c9-7f12-4b96-ac68-2d1c88438952">

So I thought I'd reuse it here:


<img width="886" alt="Screenshot 14" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/818f4468-c4b5-451e-b696-fdf02fd6ed0f">



</details>

## Discussion

- I tried using the same style as `CollapsibleFieldSection`, but it's impossible because some fields _already_ wrap their own options in multiple sections, while simple ones don't.

## Review tips

- "Hide whitespace changes" 

## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
