### PR TITLE
#7693: add background platform for http requests to fix Google API calls

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -55,6 +55,8 @@ import activateBrowserActionIcon from "./activateBrowserActionIcon";
 import { setPlatform } from "@/platform/platformContext";
 import backgroundPlatform from "@/background/backgroundPlatform";
 
+// The background "platform" currently is used to execute API requests from Google Sheets/Automation Anywhere.
+// In the future, it might also run other background tasks from mods (e.g., background intervals)
 setPlatform(backgroundPlatform);
 
 // Try to initialize managed storage as early as possible because it impacts background behavior

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -52,6 +52,10 @@ import {
   watchDelayedStorageInitialization,
 } from "@/store/enterprise/managedStorage";
 import activateBrowserActionIcon from "./activateBrowserActionIcon";
+import { setPlatform } from "@/platform/platformContext";
+import backgroundPlatform from "@/background/backgroundPlatform";
+
+setPlatform(backgroundPlatform);
 
 // Try to initialize managed storage as early as possible because it impacts background behavior
 // Call watchDelayedStorageInitialization to handle case where storage is not immediately available within timeout.

--- a/src/background/backgroundPlatform.ts
+++ b/src/background/backgroundPlatform.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { PlatformBase } from "@/platform/platformProtocol";
+import type { PlatformCapability } from "@/platform/capabilities";
+import type { Nullishable } from "@/utils/nullishUtils";
+import type { SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
+import type { AxiosRequestConfig } from "axios";
+import type { RemoteResponse } from "@/types/contract";
+import { performConfiguredRequest } from "@/background/requests";
+
+/**
+ * Background platform implementation. Currently, just makes API requests.
+ * @since 1.8.10
+ */
+class BackgroundPlatform extends PlatformBase {
+  // For now, the only capability we have the background is to run API requests.
+  // In MV2, the background page has a DOM. In MV3, the background must use EventPages for DOM access
+  override capabilities: PlatformCapability[] = ["http"];
+
+  constructor() {
+    super("background");
+  }
+
+  override async request<TData>(
+    integrationConfig: Nullishable<SanitizedIntegrationConfig>,
+    requestConfig: AxiosRequestConfig,
+  ): Promise<RemoteResponse<TData>> {
+    return performConfiguredRequest(integrationConfig, requestConfig);
+  }
+}
+
+// eslint-disable-next-line local-rules/persistBackgroundData -- platform implementation
+const backgroundPlatform = new BackgroundPlatform();
+export default backgroundPlatform;

--- a/src/contrib/google/sheets/core/sheetsApi.test.ts
+++ b/src/contrib/google/sheets/core/sheetsApi.test.ts
@@ -35,6 +35,8 @@ import {
   getCachedAuthData,
   setCachedAuthData,
 } from "@/background/auth/authStorage";
+import { setPlatform } from "@/platform/platformContext";
+import backgroundPlatform from "@/background/backgroundPlatform";
 
 const axiosMock = new MockAdapter(axios);
 
@@ -68,6 +70,11 @@ jest.mock("@/integrations/registry", () => {
       throw new Error(`Integration id not mocked: ${id}`);
     }),
   };
+});
+
+beforeEach(() => {
+  // `sheetsApi` uses the ambient platform context to make requests
+  setPlatform(backgroundPlatform);
 });
 
 describe("error handling", () => {


### PR DESCRIPTION
## What does this PR do?

- Closes #7693 
- Adds/sets a platform for the background page/worker to fix bug where Google Sheets (and AA calls) were erroring

## Checklist

- [ ] Add tests: N/A - I updated the test file to set the implicit platform
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible): adding `backgroundPlatform.ts` yields 30+ errors. We'd need to make the requests handle more strict first
- [x] Designate a primary reviewer: @grahamlangford 
