### PR TITLE
#7695: QuickBar: Avoid dark scrollbar on dark websites

### DIFF
--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -148,8 +148,11 @@ const KBarComponent: React.FC = () => {
           >
             <Stylesheets href={faStyleSheet} mountOnLoad>
               <StopPropagation onKeyPress onKeyDown onKeyUp onInput>
-                <KBarSearch style={searchStyle} />
-                <QuickBarResults />
+                {/* Avoid black scrollbars on dark sites #7695 */}
+                <div style={{ colorScheme: "light" }}>
+                  <KBarSearch style={searchStyle} />
+                  <QuickBarResults />
+                </div>
               </StopPropagation>
             </Stylesheets>
           </EmotionShadowRoot.div>


### PR DESCRIPTION
## What does this PR do?

- Fixes #7695


Pretty straightforward bug and fix

## Before

<img width="957" alt="Screenshot 14" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/5a9e0598-0a2a-4700-81a1-49aa517fe8a6">

## After

<img width="957" alt="Screenshot 13" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/2bada95e-3866-424f-8478-0d0cdbf6d42e">

## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
