### PR TITLE
Pass CI even if new files aren't added to strictNullChecks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,5 +36,4 @@ jobs:
                 title: 'strictNullChecks',
                 file: newFile,
               });
-              process.exitCode = 1;
             }


### PR DESCRIPTION
## What does this PR do?

Requested by @twschiller in https://pixiebrix.slack.com/archives/C023KL47XV4/p1708692115049379

I'm not a fan of this change but I'm opening this PR to decide what to do with it. Merge or close at will.


## What changes

- The PR will no longer have a ❌ status if new files aren't added to `tsconfig.strictNullChecks.json`

## What does _not_ change

- Annotations will still appear
- PRs can still be merged regardless of the status
- Only "CREATED" files are ever annotated. Modified/deleted files are not affected