### PR TITLE
Improve @typescript-eslint/restrict-template-expressions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,7 +105,10 @@ module.exports = {
     ],
 
     // Rules that depend on https://github.com/pixiebrix/pixiebrix-extension/issues/775
-    "@typescript-eslint/restrict-template-expressions": "warn",
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
+      { allowNever: true },
+    ],
   },
   overrides: [
     {

--- a/src/background/auth/codeGrantFlow.ts
+++ b/src/background/auth/codeGrantFlow.ts
@@ -73,9 +73,9 @@ async function codeGrantFlow(
       code_challenge_method,
     );
   } else if (code_challenge_method != null) {
+    const exhaustiveCheck: never = code_challenge_method;
     throw new BusinessError(
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check; type is `never`
-      `Unsupported code challenge method: ${code_challenge_method}`,
+      `Unsupported code challenge method: ${exhaustiveCheck}`,
     );
   }
 

--- a/src/bricks/effects/clipboard.ts
+++ b/src/bricks/effects/clipboard.ts
@@ -130,8 +130,8 @@ export class CopyToClipboard extends EffectABC {
       }
 
       default: {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
-        throw new BusinessError(`Invalid content type: ${contentType}`);
+        const exhaustiveCheck: never = contentType;
+        throw new BusinessError(`Invalid content type: ${exhaustiveCheck}`);
       }
     }
   }

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -53,8 +53,8 @@ const Alert: React.FunctionComponent<AlertProps> = ({
     }
 
     default: {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamically inferring never
-      throw new Error(`Unknown variant: ${variant}`);
+      const exhaustiveCheck: never = variant;
+      throw new Error(`Unknown variant: ${exhaustiveCheck}`);
     }
   }
 

--- a/src/contentScript/contentScriptPlatform.ts
+++ b/src/contentScript/contentScriptPlatform.ts
@@ -143,8 +143,10 @@ class ContentScriptPlatform extends PlatformBase {
           }
 
           default: {
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
-            throw new BusinessError(`Unsupported template engine: ${engine}`);
+            const exhaustiveCheck: never = engine;
+            throw new BusinessError(
+              `Unsupported template engine: ${exhaustiveCheck}`,
+            );
           }
         }
       },

--- a/src/contentScript/pageEditor.ts
+++ b/src/contentScript/pageEditor.ts
@@ -237,8 +237,10 @@ export async function runRendererBlock({
         controller.abort();
       }
     } else {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
-      throw new Error(`Support for previewing in ${location} not implemented`);
+      const exhaustiveCheck: never = location;
+      throw new Error(
+        `Support for previewing in ${exhaustiveCheck} not implemented`,
+      );
     }
   }
 }

--- a/src/contentScript/pageEditor/elementPicker.ts
+++ b/src/contentScript/pageEditor/elementPicker.ts
@@ -500,8 +500,8 @@ export async function selectElement({
     }
 
     default: {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for type `never`
-      throw new Error(`Unexpected mode: ${mode}`);
+      const exhaustiveCheck: never = mode;
+      throw new Error(`Unexpected mode: ${exhaustiveCheck}`);
     }
   }
 }

--- a/src/contrib/automationanywhere/aaUtils.ts
+++ b/src/contrib/automationanywhere/aaUtils.ts
@@ -161,8 +161,10 @@ function mapBotOutput(value: OutputValue): Primitive {
     }
 
     default: {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
-      throw new BusinessError(`Type not supported by PixieBrix: ${value.type}`);
+      const exhaustiveCheck: never = value.type;
+      throw new BusinessError(
+        `Type not supported by PixieBrix: ${exhaustiveCheck}`,
+      );
     }
   }
 }

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -177,8 +177,8 @@ export function selectExtensionPointIntegrations({
     } as Schema;
   }
 
-  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- future-proofing
-  throw new Error(`Unknown ModDependencyApiVersion: ${apiVersion}`);
+  const exhaustiveCheck: never = apiVersion;
+  throw new Error(`Unknown ModDependencyApiVersion: ${exhaustiveCheck}`);
 }
 
 /**

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/EditorNodeLayout.tsx
@@ -60,8 +60,8 @@ const EditorNodeLayout: React.FC = () => {
 
           default: {
             // Impossible code branch
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
-            throw new Error(`Unexpected type: ${type}`);
+            const exhaustiveCheck: never = type;
+            throw new Error(`Unexpected type: ${exhaustiveCheck}`);
           }
         }
       })}

--- a/src/platform/state/stateController.ts
+++ b/src/platform/state/stateController.ts
@@ -53,8 +53,8 @@ function mergeState(
     }
 
     default: {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never type
-      throw new BusinessError(`Unknown merge strategy: ${strategy}`);
+      const exhaustiveCheck: never = strategy;
+      throw new BusinessError(`Unknown merge strategy: ${exhaustiveCheck}`);
     }
   }
 }

--- a/src/runtime/runtimeUtils.ts
+++ b/src/runtime/runtimeUtils.ts
@@ -213,8 +213,8 @@ export async function selectBlockRootElement(
     }
 
     default: {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check
-      throw new BusinessError(`Invalid rootMode: ${rootMode}`);
+      const exhaustiveCheck: never = rootMode;
+      throw new BusinessError(`Invalid rootMode: ${exhaustiveCheck}`);
     }
   }
 

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -316,8 +316,8 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
       }
 
       default: {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
-        throw new BusinessError(`Unknown targetMode: ${this.targetMode}`);
+        const exhaustiveCheck: never = this.targetMode;
+        throw new BusinessError(`Unknown targetMode: ${exhaustiveCheck}`);
       }
     }
   }
@@ -334,8 +334,8 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
       }
 
       default: {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
-        throw new BusinessError(`Unknown targetMode: ${this.targetMode}`);
+        const exhaustiveCheck: never = this.targetMode;
+        throw new BusinessError(`Unknown targetMode: ${exhaustiveCheck}`);
       }
     }
   }

--- a/src/starterBricks/factory.ts
+++ b/src/starterBricks/factory.ts
@@ -40,8 +40,8 @@ const TYPE_MAP = {
 export function fromJS(config: StarterBrickConfig): StarterBrick {
   if (config.kind !== "extensionPoint") {
     // Is `never` due to check, but needed because this method is called dynamically
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    throw new Error(`Expected kind extensionPoint, got ${config.kind}`);
+    const exhaustiveCheck: never = config.kind;
+    throw new Error(`Expected kind extensionPoint, got ${exhaustiveCheck}`);
   }
 
   if (!Object.hasOwn(TYPE_MAP, config.definition.type)) {

--- a/src/starterBricks/panelExtension.ts
+++ b/src/starterBricks/panelExtension.ts
@@ -557,8 +557,8 @@ class RemotePanelExtensionPoint extends PanelStarterBrickABC {
 
       default: {
         // Type is `never` due to checks above
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        throw new Error(`Unexpected position: ${position}`);
+        const exhaustiveCheck: never = position;
+        throw new Error(`Unexpected position: ${exhaustiveCheck}`);
       }
     }
   }

--- a/src/starterBricks/quickBarExtension.tsx
+++ b/src/starterBricks/quickBarExtension.tsx
@@ -169,8 +169,8 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
       }
 
       default: {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
-        throw new BusinessError(`Unknown targetMode: ${this.targetMode}`);
+        const exhaustiveCheck: never = this.targetMode;
+        throw new BusinessError(`Unknown targetMode: ${exhaustiveCheck}`);
       }
     }
   }

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -230,8 +230,8 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
       }
 
       default: {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- dynamic check for never
-        throw new BusinessError(`Invalid reportMode: ${this.reportMode}`);
+        const exhaustiveCheck: never = this.reportMode;
+        throw new BusinessError(`Invalid reportMode: ${exhaustiveCheck}`);
       }
     }
   }

--- a/src/testUtils/factories/sidebarEntryFactories.ts
+++ b/src/testUtils/factories/sidebarEntryFactories.ts
@@ -129,6 +129,6 @@ export function sidebarEntryFactory<T = SidebarEntry>(
     return staticPanelEntryFactory(override as FactoryConfig<StaticPanelEntry>);
   }
 
-  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- allow never, future-proof for new types
-  throw new Error(`Unknown entry type: ${type}`);
+  const exhaustiveCheck: never = type;
+  throw new Error(`Unknown entry type: ${exhaustiveCheck}`);
 }


### PR DESCRIPTION
## What does this PR do?

- Enforces rule (previously set to warn)
- No longer need to eslint disable when passing type `never` to a template literal

## Discussion

- This change does require us to make an exhaustive check intermediary variable, so whether this is something we desire is up for debate.
- I prefer this style because it is more explicit and because I would rather rely on ts throwing an error than on the linter flagging an unnecessarily disabled rule.

## Checklist

- [x] Designate a primary reviewer @fregante 
