### PR TITLE
fix automation-anywhere theme not shown on first login

### DIFF
--- a/src/extensionConsole/pages/settings/AdvancedSettings.tsx
+++ b/src/extensionConsole/pages/settings/AdvancedSettings.tsx
@@ -39,7 +39,6 @@ import AsyncButton from "@/components/AsyncButton";
 import { reloadIfNewVersionIsReady } from "@/utils/extensionUtils";
 import { DEFAULT_SERVICE_URL } from "@/urlConstants";
 import { PIXIEBRIX_INTEGRATION_ID } from "@/integrations/constants";
-import { activateTheme } from "@/background/messenger/strict/api";
 
 const SAVING_URL_NOTIFICATION_ID = uuidv4();
 const SAVING_URL_TIMEOUT_MS = 4000;
@@ -204,8 +203,6 @@ const AdvancedSettings: React.FunctionComponent = () => {
                     partnerId: event.target.value,
                   }),
                 );
-                // `activateTheme` in background script triggers updating themeStorage
-                void activateTheme();
               }}
             />
             <Form.Text muted>The partner id of a PixieBrix partner</Form.Text>

--- a/src/store/settings/settingsSlice.ts
+++ b/src/store/settings/settingsSlice.ts
@@ -26,6 +26,7 @@ import { DEFAULT_THEME } from "@/themes/themeTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { isRegistryId } from "@/types/helpers";
 import { revertAll } from "@/store/commonActions";
+import { activateTheme } from "@/background/messenger/strict/api";
 
 export const initialSettingsState: SettingsState = {
   mode: "remote",
@@ -86,6 +87,8 @@ const settingsSlice = createSlice({
       { payload: { partnerId } }: { payload: { partnerId: string } },
     ) {
       state.partnerId = partnerId;
+      // `activateTheme` in background script triggers updating themeStorage
+      void activateTheme();
     },
     setAuthIntegrationId(
       state,


### PR DESCRIPTION
This fixes an edge case where the partner theme wasn't loaded
on first login - fixing a failing rainforest qa test

## What does this PR do?

- Closes/Fixes/Part of #123
- _Are there other changes (e.g., refactoring) included that aren’t from the ticket?_

## Reviewer Tips

- _What order should the reviewer review the files in?_
- _Are there any implementation approaches you want feedback on?_

## Discussion

- _Were there multiple approaches you were deciding between?_

## Demo

- _Paste a screenshot or demo video here_

## Future Work

- _Work for the issue/ticket that will be in a follow-up PR_

## Team Coordination

_Leave all that are relevant and check off as completed_

- [ ] This PR requires security review
- [ ] This PR introduces a new library: double check it's MIT/Apache2/permissively licensed
- [ ] This PR requires a node/npm version update: let the team know on #engineering
- [ ] This PR requires a documentation change (link to old docs)
- [ ] This PR requires a tutorial update (link to old tutorials)
- [ ] This PR requires a feature flag
- [ ] This PR requires a environment variable change

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [ ] Designate a primary reviewer
