### PR TITLE
#7707: text selection popover placement fixes/UI improvements

### DIFF
--- a/src/contentScript/selectionTooltip/SelectionToolbar.scss
+++ b/src/contentScript/selectionTooltip/SelectionToolbar.scss
@@ -15,14 +15,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Browsers also add base styling for [popover] attribute. E.g., Chrome adds a system border.
+
 @import "@/themes/colors.scss";
 
 .toolbar {
+  background-color: $S0;
   display: flex;
 
   height: 30px;
   font-size: 16px;
-  //line-height: 20px;
 
   padding-left: 3px;
   padding-right: 3px;

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -218,7 +218,6 @@ async function updatePosition(): Promise<void> {
           placement: "top",
           strategy: "fixed",
           // `inline` prevents from appearing detached if multiple lines selected: https://floating-ui.com/docs/inline
-
           middleware: [
             ...(supportsInline ? [inline()] : []),
             offset(10),

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -86,9 +86,14 @@ function createTooltip(): HTMLElement {
   popover.style.setProperty("width", "max-content");
   popover.style.setProperty("top", "0");
   popover.style.setProperty("left", "0");
-  // Override Chrome's based styles for [popover] attribute
+  // Override Chrome's base styles for [popover] attribute and provide a consistent look across applications that
+  // override the browser defaults (e.g., Zendesk)
   popover.style.setProperty("margin", "0");
   popover.style.setProperty("padding", "0");
+  popover.style.setProperty("border-radius", "5px");
+  // Can't use colors file because the element is being rendered directly on the host
+  popover.style.setProperty("background-color", "#ffffff"); // $S0 color
+  popover.style.setProperty("border", "2px solid #a8a1b4"); // $N200 color
 
   render(
     <SelectionToolbar registry={tooltipActionRegistry} onHide={hideTooltip} />,

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -140,15 +140,18 @@ function getPositionReference(selection: Selection): VirtualElement | Element {
           bottomCaret.top - topCaret.top + bottomCaret.height,
         );
 
+        const x = elementRect.x + topCaret.left;
+        const y = elementRect.y + topCaret.top - activeElement.scrollTop;
+
         return {
           height,
           width,
-          x: elementRect.x + topCaret.left,
-          y: elementRect.y + topCaret.top,
-          left: elementRect.x + topCaret.left,
-          top: elementRect.y + topCaret.top,
+          x,
+          y,
+          left: x,
+          top: y,
           right: elementRect.x + width,
-          bottom: elementRect.y + height,
+          bottom: elementRect.y + height - activeElement.scrollTop,
         };
       },
     } satisfies VirtualElement;

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -140,7 +140,7 @@ function getPositionReference(selection: Selection): VirtualElement | Element {
           bottomCaret.top - topCaret.top + bottomCaret.height,
         );
 
-        const x = elementRect.x + topCaret.left;
+        const x = elementRect.x + topCaret.left - activeElement.scrollLeft;
         const y = elementRect.y + topCaret.top - activeElement.scrollTop;
 
         return {
@@ -150,7 +150,7 @@ function getPositionReference(selection: Selection): VirtualElement | Element {
           y,
           left: x,
           top: y,
-          right: elementRect.x + width,
+          right: elementRect.x + width - activeElement.scrollLeft,
           bottom: elementRect.y + height - activeElement.scrollTop,
         };
       },

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -103,7 +103,6 @@ function createTooltip(): HTMLElement {
   // https://developer.mozilla.org/en-US/docs/Web/API/Popover_API
   popover.setAttribute("popover", "manual");
   popover.dataset.testid = "pixiebrix-selection-tooltip";
-  // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/showPopover -- required to add it to the top layer
   popover.style.setProperty("z-index", (MAX_Z_INDEX - 1).toString());
 
   // Must be set before positioning: https://floating-ui.com/docs/computeposition#initial-layout

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -47,7 +47,7 @@ let selectionTooltip: Nullishable<HTMLElement>;
 /**
  * AbortController fired when the popover is hidden/destroyed.
  */
-const cleanupController = new RepeatableAbortController();
+const hideController = new RepeatableAbortController();
 
 async function showTooltip(): Promise<void> {
   if (tooltipActionRegistry.actions.size === 0) {
@@ -79,7 +79,7 @@ async function showTooltip(): Promise<void> {
 function hideTooltip(): void {
   selectionTooltip?.setAttribute("aria-hidden", "true");
   selectionTooltip?.style.setProperty("display", "none");
-  cleanupController.abortAndReset();
+  hideController.abortAndReset();
 }
 
 /**
@@ -88,7 +88,7 @@ function hideTooltip(): void {
 function destroyTooltip(): void {
   selectionTooltip?.remove();
   selectionTooltip = null;
-  cleanupController.abortAndReset();
+  hideController.abortAndReset();
 }
 
 function createTooltip(): HTMLElement {
@@ -238,7 +238,7 @@ async function updatePosition(): Promise<void> {
     },
   );
 
-  cleanupController.signal.addEventListener(
+  hideController.signal.addEventListener(
     "abort",
     () => {
       cleanupAutoPosition();

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -113,8 +113,7 @@ function destroyTooltip(): void {
 }
 
 function getPositionReference(selection: Selection): VirtualElement | Element {
-  // eslint-disable-next-line prefer-destructuring -- always reports "document" when using destructuring
-  const activeElement = document.activeElement;
+  const { activeElement } = document;
 
   // Browsers don't report an accurate selection within inputs/textarea
   if (isNativeField(activeElement)) {
@@ -256,6 +255,17 @@ export const initSelectionTooltip = once(() => {
       } else {
         hideTooltip();
       }
+    },
+    { passive: true },
+  );
+
+  // For now just hide the tooltip on document scroll to avoid gotchas with floating UI's `position: fixed` strategy.
+  // See updatePosition for more context. Without this, the tooltip moves with the scroll to keep it's position
+  // in the viewport fixed.
+  document.addEventListener(
+    "scroll",
+    () => {
+      hideTooltip();
     },
     { passive: true },
   );

--- a/src/types/inputTypes.ts
+++ b/src/types/inputTypes.ts
@@ -48,7 +48,7 @@ export type TextInputElement = HTMLInputElement & {
   type: (typeof TEXT_INPUT_CONTENT_TYPES)[number];
 };
 
-type NativeField = HTMLInputElement | HTMLTextAreaElement;
+export type NativeField = HTMLInputElement | HTMLTextAreaElement;
 
 /**
  * A basic text entry element, e.g., an input or textarea element.

--- a/src/utils/textAreaUtils.ts
+++ b/src/utils/textAreaUtils.ts
@@ -19,6 +19,8 @@
 // Note that some browsers, such as Firefox, do not concatenate properties
 // into their shorthand (e.g. padding-top, padding-bottom etc. -> padding),
 // so we have to list every single property explicitly.
+import type { NativeField } from "@/types/inputTypes";
+
 const properties = [
   "direction", // RTL support
   "boxSizing",
@@ -67,10 +69,7 @@ const properties = [
  * @param element
  * @param position
  */
-export function getCaretCoordinates(
-  element: HTMLTextAreaElement | HTMLInputElement,
-  position: number,
-) {
+export function getCaretCoordinates(element: NativeField, position: number) {
   // The mirror div will replicate the textarea's style
   const div = document.createElement("div");
   div.id = "input-textarea-caret-position-mirror-div";


### PR DESCRIPTION
## What does this PR do?

- Part of #7707 
- UI Improvements
  - Fix placement bug due to textarea scroll position
  - Set popover z-index (actually implementing popover API will be more work to get positioning correct)
  - Add flip/shift floating ui middleware to ensure visible on top line of editor iframe
  - Hides the popover on scroll (document and/or active element) to avoid the popover moving with the scroll
  - Add CSS to popover to make style consistent across sites
- Refactoring
  - Use RepeatableAbortController for floating-ui autoUpdate cleanup

## Remaining Work

- [x] TextArea positioning needs to consider text area scroll position

## Discussion

- When multiple iframes are on the page with selections, each selection will have a popover in its frame. We might consider using messenger to ensure only latest selection has a popover shown even before implementing top-frame popover approach mentioned in #7707 
- See the code comments for some considerations about handling scroll with `position: fixed`. We could use `autoUpdate` to re-calculate the position. However, given that position is fixed we'd need to add our own logic on when to show/hide based on whether or not would be in the viewport or not. I tried briefly, but was running into some `NaN` in the virtual element reference height/etc.

## Demo

🧠  Inception

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/cb6341c9-1439-45f6-aa51-8b5099e0c772)

## Future Work

- Use popover API to place on top layer (see code comment in link)
- Consider using single popover on the top frame
- Nicer handling for system light/dark theme

## Checklist

- [ ] Add tests: we'll want to use Playwright, etc. for these due to jsdom limitations
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @fregante 
