### PR TITLE
override font-size for img BrickIcons

### DIFF
--- a/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNodeContent.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/brickNode/BrickNodeContent.module.scss
@@ -39,6 +39,7 @@
     // !important is to override the inline CSS
     width: 1.1em !important;
     height: 1.1em !important;
+    font-size: 1em;
   }
   svg {
     font-size: inherit;


### PR DESCRIPTION
## What does this PR do?

- Fixes #7736 

## Reviewer Tips

- See changes to BrickIcon here: https://github.com/pixiebrix/pixiebrix-extension/pull/7637/files#diff-827ad6c6bf920a269198235a7043dc546042a417e68494e76278694744df9a50
- FontAwesomeIcons need to be 2x, but img tags for external logos need to be sized down. 


## Demo

Before 
---
<img width="275" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/64482b98-fd2d-4189-8b9f-d2f602c6fc59">

After
---

<img width="276" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/7a0815ac-0c02-4e3f-bf27-e5957e96c4b3">

## Future Work

- _Work for the issue/ticket that will be in a follow-up PR_

## Checklist

- [x] Designate a primary reviewer @BLoe 
