### PR TITLE
Use `console.debug` instead of `console.trace` in trigger cancelObserver method

### DIFF
--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -295,7 +295,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
   }
 
   cancelObservers(): void {
-    console.trace("TriggerExtensionPoint:cancelObservers", {
+    console.debug("TriggerExtensionPoint:cancelObservers", {
       id: this.id,
       instanceNonce: this.instanceNonce,
     });


### PR DESCRIPTION
## What does this PR do?

- Use debug instead of trace to avoid cluttering console
- The trace call is expanded by default in the Chrome Dev Tools

## Before

<img width="1131" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/c27973a4-9428-40f1-9acb-c01e57d82472">

