### PR TITLE
Throw an error on axios call from content script

### DIFF
--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -55,8 +55,9 @@ import axios from "axios";
 
 setPlatform(contentScriptPlatform);
 
-// XXX: ideally would enforce via webpack config or eslint. Enforcing via transformRequest requires including
-// axios in the content script bundle even though it won't/shouldn't be called.
+// XXX: ideally would enforce via webpack config or eslint. Enforcing via transformRequest requires importing
+// axios in the content script bundle even though it should never be called. Could we somehow conditionally import
+// checking for process.env.DEBUG?
 axios.defaults.transformRequest = () => {
   // The content Script is subject to the CSP of the page, so PixieBrix should call from background script instead
   throw new Error(

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -51,8 +51,18 @@ import { onContextInvalidated } from "webext-events";
 import { setPlatform } from "@/platform/platformContext";
 import { markDocumentAsFocusableByUser } from "@/utils/focusTracker";
 import contentScriptPlatform from "@/contentScript/contentScriptPlatform";
+import axios from "axios";
 
 setPlatform(contentScriptPlatform);
+
+// XXX: ideally would enforce via webpack config or eslint. Enforcing via transformRequest requires including
+// axios in the content script bundle even though it won't/shouldn't be called.
+axios.defaults.transformRequest = () => {
+  // The content Script is subject to the CSP of the page, so PixieBrix should call from background script instead
+  throw new Error(
+    "API calls from the content script are not allowed. Use the background messenger API/worker instead.",
+  );
+};
 
 // Must come before the default handler for ignoring errors. Otherwise, this handler might not be run
 onUncaughtError((error) => {


### PR DESCRIPTION
## What does this PR do?

- Throws an error in the content script if you try to make an API call with `axios`
- The content script is subject to the CSP of the host site

## Remaining Work 

- [x] "This might not be enough to catch apiClient. IIRC, axios.create returns a different instance that won't have this transformRequest." 

## Discussion

- The current approach ends up importing axios into the content script. (Whereas before it might only transitively be imported, but is probably already being imported at somepoint). Axios is ~19kb so not a major deal: https://bundlephobia.com/package/axios@0.27.2 

## Demo

Added this code to the contentScriptCore to test:

```
  try {
    await axios.create().get("https://httpstat.us/200");
  } catch (error) {
    console.warn(error);
  }
```

<img width="830" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/d52e6829-16ea-485a-924f-bb0e40c14b66">

## Checklist

- [ ] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
