### PR TITLE
Warn of wrong lockfile changes in PR

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,8 @@
 name: Dependabot auto-approve
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - package-lock.json
 
 permissions:
   contents: write

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,3 +38,45 @@ jobs:
               });
               process.exitCode = 1;
             }
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: package-lock.json
+      - name: Detect changes
+        id: stats
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          STAT="$(git diff --numstat origin/${{ github.base_ref }}..HEAD -- package-lock.json)"
+          DELETED=$(echo $STAT | cut -d " " -f 1)
+          ADDED=$(echo $STAT | cut -d " " -f 2)
+          TOTAL_CHANGES=$((DELETED + ADDED))
+          echo "STAT=$STAT"
+          echo "DELETED=$DELETED"
+          echo "ADDED=$ADDED"
+          echo "TOTAL_CHANGES=$TOTAL_CHANGES"
+          echo "changes=$TOTAL_CHANGES" >> $GITHUB_OUTPUT
+      - if: steps.stats.outputs.changes <= 1000
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: lockfile # Unique identifier for the comment
+          hide: true
+      - if: steps.stats.outputs.changes > 1000
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: lockfile # Unique identifier for the comment
+          recreate: true
+          message: |
+            ## ⚠️ Large diff for package-lock.json
+
+            There are ${{ steps.stats.outputs.changes }} line changes in package-lock.json. This should not happen unless you're updating a lot of dependencies at once. Regenerating the lockfile should not be necessary.
+
+            If you're seeing Vercel deployment failures, this is likely the cause. Run these commands to reset these changes:
+
+            ```sh
+            git checkout origin/main -- package-lock.json
+            npm install
+            ```
+      - if: steps.stats.outputs.changes > 1000
+        run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,11 +72,15 @@ jobs:
 
             There are ${{ steps.stats.outputs.changes }} line changes in package-lock.json. This should not happen unless you're updating a lot of dependencies at once. Regenerating the lockfile should not be necessary.
 
-            If you're seeing Vercel deployment failures, this is likely the cause. Run these commands to reset these changes:
+            If you're seeing Vercel deployment failures, this is likely the cause.
+
+            Run these commands to reset these changes:
 
             ```sh
             git checkout origin/main -- package-lock.json
             npm install
             ```
+
+            You might want to click on "Update branch" first so that the results are accurate.
       - if: steps.stats.outputs.changes > 1000
         run: exit 1


### PR DESCRIPTION
## What does this PR do?

This keeps happening and it seems that it's wasting the team's time to fix it.

<img width="571" alt="Screenshot" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/0780cde5-88d7-44e6-b105-1c45edb7d269">

> From https://github.com/pixiebrix/pixiebrix-extension/pull/7734

## Demo

This should raise concerns:

<img width="199" alt="Screenshot 2" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/48482b52-cf1a-40c5-a61a-427ded243ba8">

This is a normal PR/fixed:

<img width="183" alt="Screenshot 4" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/63dae9a8-8dde-471e-bee3-8a14d1ab0c0d">


## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
