### PR TITLE
Add CI instructions when strictNullChecks fails due to Messenger

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,53 @@
 name: PR
 on: pull_request
 jobs:
+  # TODO: remove after https://github.com/pixiebrix/pixiebrix-extension/issues/6526
+  strictNullMessenger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+      - run: npm ci
+      - id: tsc
+        run: |
+          npm run build:strictNullChecks -- --explainFiles > LOG || {
+            if grep -q "keyof MessengerMethods" LOG; then
+              grep -Pazo "\nsrc/(background|contentScript)/messenger/api.ts(\n  .+)+" LOG > REASON
+              cat REASON
+              {
+                echo 'reason<<EOF'
+                # Drop null character at the end caused by -z
+                cat REASON | sed 's/.$/\n/'
+                echo 'EOF'
+              } >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+          }
+      - name: Hide previous comment if resolved
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: strictNullChecksMessenger # Unique identifier for the comment
+          hide: true
+      - name: Add comment with more info if failed
+        if: failure()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: strictNullChecksMessenger # Unique identifier for the comment
+          recreate: true
+          message: |
+            It looks like one of the non-strict `messenger/api.ts` files ended up being imported by one of the strict files. Don't be fooled by "just a few type errors", this hides hundreds of type errors.
+
+            See details and solutions in: https://github.com/pixiebrix/pixiebrix-extension/issues/6526#issuecomment-1926391817
+
+            There might be further information about how the non-strict Messenger files are ending up in the strict config:
+
+            ```
+             ${{ steps.tsc.outputs.reason }}
+            ```
+
   strictNullChecks:
     runs-on: ubuntu-latest
     steps:

--- a/src/background/messenger/strict/registration.ts
+++ b/src/background/messenger/strict/registration.ts
@@ -82,7 +82,6 @@ declare global {
     CLEAR_EXTENSION_DEBUG_LOGS: typeof clearExtensionDebugLogs;
   }
 }
-import { fetchFeatureFlagsInBackground } from "@/background/messenger/api";
 
 export default function registerMessenger(): void {
   registerMethods({

--- a/src/background/messenger/strict/registration.ts
+++ b/src/background/messenger/strict/registration.ts
@@ -82,6 +82,7 @@ declare global {
     CLEAR_EXTENSION_DEBUG_LOGS: typeof clearExtensionDebugLogs;
   }
 }
+import { fetchFeatureFlagsInBackground } from "@/background/messenger/api";
 
 export default function registerMessenger(): void {
   registerMethods({


### PR DESCRIPTION
## What does this PR do?

Instead of having to ask around, I figured I'd encode these instructions into the CI. Similar to:

- https://github.com/pixiebrix/pixiebrix-extension/pull/7746/files

See the hidden message below for an example. It's hidden automatically when the issue is resolved.

## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
