### PR TITLE
Add spacing below form builder fields

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3505,10 +3505,6 @@ exports[`Storyshots Enhancements/SelectionToolbar Emoji Buttons 1`] = `<div />`;
 
 exports[`Storyshots Enhancements/SelectionToolbar Mixed Buttons 1`] = `<div />`;
 
-exports[`Storyshots Enhancements/SelectionToolbar Emoji Buttons 1`] = `<div />`;
-
-exports[`Storyshots Enhancements/SelectionToolbar Mixed Buttons 1`] = `<div />`;
-
 exports[`Storyshots ExtensionConsole/IDBErrorDisplay Connection Error 1`] = `
 <div
   className="p-3"
@@ -6601,7 +6597,7 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                     value="Chuck"
                   />
                   <div
-                    className="field-description text-muted"
+                    className="field-description mt-1 text-muted"
                   >
                     <div
                       dangerouslySetInnerHTML={
@@ -6655,7 +6651,7 @@ exports[`Storyshots Forms/Form builder Default 1`] = `
                     value=""
                   />
                   <div
-                    className="field-description text-muted"
+                    className="field-description mt-1 text-muted"
                   >
                     <div
                       dangerouslySetInnerHTML={

--- a/src/components/formBuilder/FieldTemplate.tsx
+++ b/src/components/formBuilder/FieldTemplate.tsx
@@ -88,7 +88,10 @@ const FieldTemplate = ({
       )}
       {children}
       {displayLabel && rawDescription && (
-        <DescriptionField className="text-muted" description={rawDescription} />
+        <DescriptionField
+          className="mt-1 text-muted"
+          description={rawDescription}
+        />
       )}
       {rawErrors.length > 0 && (
         <ListGroup as="ul">

--- a/src/components/formBuilder/preview/__snapshots__/FormPreview.test.tsx.snap
+++ b/src/components/formBuilder/preview/__snapshots__/FormPreview.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`FormPreview it renders markdown in description 1`] = `
                 value=""
               />
               <div
-                class="field-description text-muted"
+                class="field-description mt-1 text-muted"
               >
                 <div>
                   <p>


### PR DESCRIPTION
## What does this PR do?

- Fixes https://pixiebrix.slack.com/archives/C023KL47XV4/p1708983799071599


## Before

<img width="186" alt="Screenshot 9" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/ed1dfc7f-f7be-452d-bd2f-60ce47505931">

## After

<img width="186" alt="Screenshot 10" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/d33a9b83-22ef-40f1-9afd-aaf119da786e">

This matches the spacing we have in the page editor:

<img width="399" alt="Screenshot 11" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/62840d25-aec5-48c5-8739-be466fb3d2f7">


## Checklist

- [x] Designate a primary reviewer: @BLoe 
