### PR TITLE
Avoid shrinking drawn pipeline with long output names

### DIFF
--- a/src/pageEditor/tabs/editTab/editorNodes/PipelineFooterNode.module.scss
+++ b/src/pageEditor/tabs/editTab/editorNodes/PipelineFooterNode.module.scss
@@ -39,6 +39,7 @@ $pipeLineFooterWidth: 17px;
 }
 
 .pipelineContainer {
+  flex-shrink: 0;
   width: calc(
     #{$pipeLineOffset} + #{$pipeLineFooterWidth} - #{$pipeLineBorderWidth}
   );


### PR DESCRIPTION
## What does this PR do?

- Fixes https://pixiebrix.slack.com/archives/C0436P48QHY/p1709067617250069


## Before

<img width="242" alt="Screenshot 12" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/f8c877f5-a4b1-4505-a9bf-14cb1f833a1b">

## After

<img width="242" alt="Screenshot 13" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/e3ba1d0f-36e8-4c7a-8229-327c173a57f3">


## Checklist

- [x] Designate a primary reviewer: @bloe
