### PR TITLE
Add feature flag to remotely enable text selection popover

### DIFF
--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -81,6 +81,7 @@ jest.mock("@/auth/authStorage", () => ({
   }),
   isLinked: jest.fn().mockResolvedValue(true),
   async updateUserData() {},
+  addListener: jest.fn(),
 }));
 
 jest.mock("@/background/installer", () => ({

--- a/src/background/starterMods.test.ts
+++ b/src/background/starterMods.test.ts
@@ -47,6 +47,7 @@ jest.mock("@/auth/authStorage", () => ({
     return {};
   },
   isLinked: jest.fn().mockResolvedValue(true),
+  addListener: jest.fn(),
 }));
 
 jest.mock("@/utils/extensionUtils");

--- a/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
+++ b/src/extensionConsole/pages/settings/ExperimentalSettings.tsx
@@ -24,8 +24,11 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { selectSettings } from "@/store/settings/settingsSelectors";
 import SettingToggle from "@/extensionConsole/pages/settings/SettingToggle";
 import { isMV3 } from "@/mv3/api";
+import useFlags from "@/hooks/useFlags";
 
 const ExperimentalSettings: React.FunctionComponent = () => {
+  const { flagOn } = useFlags();
+
   const {
     suggestElements,
     excludeRandomClasses,
@@ -74,13 +77,25 @@ const ExperimentalSettings: React.FunctionComponent = () => {
               flag="sandboxedCode"
             />
           )}
-          <SettingToggle
-            controlId="selectionPopover"
-            label="Selection Popover"
-            description="Show context menu items in a selection popover"
-            isEnabled={selectionPopover}
-            flag="selectionPopover"
-          />
+          {flagOn("text-selection-popover-force") ? (
+            // We're doing limited rollouts of the text selection popover via feature flag
+            <SettingToggle
+              controlId="selectionPopover"
+              label="Selection Popover"
+              description="Show context menu items in a selection popover."
+              isEnabled={true}
+              disabled={true}
+              flag="selectionPopover"
+            />
+          ) : (
+            <SettingToggle
+              controlId="selectionPopover"
+              label="Selection Popover"
+              description="Show context menu items in a selection popover"
+              isEnabled={selectionPopover}
+              flag="selectionPopover"
+            />
+          )}
           <SettingToggle
             controlId="textCommandPopover"
             label="Text Command Popover"

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -69,6 +69,7 @@ import type { Except } from "type-fest";
 import type { PlatformProtocol } from "@/platform/platformProtocol";
 import { type MessageConfig } from "@/utils/notify";
 import { DEFAULT_ACTION_RESULTS } from "@/starterBricks/starterBrickConstants";
+import { flagOn } from "@/auth/featureFlagStorage";
 
 const DEFAULT_MENU_ITEM_TITLE = "Untitled menu item";
 
@@ -222,8 +223,13 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
     installMouseHandlerOnce();
 
     if (this.contexts.includes("selection") || this.contexts.includes("all")) {
-      const { selectionPopover } = await getSettingsState();
-      if (selectionPopover) {
+      const [{ selectionPopover: isPopoverSettingEnabled }, isPopoverFlagOn] =
+        await Promise.all([
+          getSettingsState(),
+          flagOn("text-selection-popover-force"),
+        ]);
+
+      if (isPopoverSettingEnabled || isPopoverFlagOn) {
         initSelectionTooltip();
       }
     }


### PR DESCRIPTION
## What does this PR do?

- Adds a feature flag `text-selection-popover-force` to remotely enable text selection popover
- We're going to be piloting the feature with some enterprise clients and don't want to require their users to enable manually via the experimental settings 
- Flag is here: https://app.pixiebrix.com/admin/waffle/flag/175/change/

## Remaining Work

- [ ] Fix tests

## Checklist

- [ ] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
