### PR TITLE
Box shadow for text selection popover

### DIFF
--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -55,6 +55,13 @@ async function showTooltip(): Promise<void> {
   }
 
   selectionTooltip ??= createTooltip();
+
+  Object.assign(selectionTooltip.style, {
+    border: "0",
+    "box-shadow":
+      "rgba(15, 15, 15, 0.05) 0px 0px 0px 1px, rgba(15, 15, 15, 0.1) 0px 3px 6px, rgba(15, 15, 15, 0.2) 0px 9px 24px",
+  });
+
   selectionTooltip.setAttribute("aria-hidden", "false");
   selectionTooltip.style.setProperty("display", "block");
 


### PR DESCRIPTION
## What does this PR do?

- Tries swaps the border for a box-shadow -- based on feedback from @MMirandi 

## Discussion

- Trying the same box shadow as Notion's text toolbar. It's very faint (see demo), or I might not be using it correctly (maybe missing a border somewhere?)
- I prefer having the border because it provides contract across more color background situations
- I'm not particularly knowledgeable about how to create good box shadows on my own, so will need to pull someone else in if we're trying to play around with it

## Demo

Before:

<img width="524" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/cf031300-e109-4ee2-8643-19c66bae106c">


After: 
<img width="436" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/642dd190-19ad-4e52-be75-92ae473bf7fa">

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [ ] Designate a primary reviewer
