### PR TITLE
Drop experimental menu item dependencies feature

### DIFF
--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -193,20 +193,14 @@ export enum RunReason {
    */
   MANUAL = 3,
   /**
-   * Experimental: a declared dependency of the StarterBrick changed.
-   *
-   * See MenuItemStarterBrickABC
-   */
-  DEPENDENCY_CHANGED = 4,
-  /**
    * The SPA mutated without navigating
    */
-  MUTATION = 5,
+  MUTATION = 4,
   /**
    * Page Editor updated the ModComponent
    * @since 1.7.19
    */
-  PAGE_EDITOR = 6,
+  PAGE_EDITOR = 5,
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Drops support for experimental "dependencies" feature for menu item that enabled re-rendering of menu items when another element on the page changed
- I verified the feature wasn't in use by searching for occurrences of the dependencies property in packages: `$..*[?(@=="dependencies")]`

## Discussion

- We might be able to drop the `if:` functionality too. That one might still be used in some customer deployments though, and is a bit harder to search for

## Checklist

- [x] Add tests: N/A
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @fregante 
