### PR TITLE
Fix bug in `useAsyncState` -- memoize the `refetch` function properly

### DIFF
--- a/src/hooks/useIsMounted.ts
+++ b/src/hooks/useIsMounted.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 /**
  * Returns a function that returns true if the component is still mounted.
@@ -30,7 +30,7 @@ function useIsMounted(): () => boolean {
     [],
   );
 
-  return () => isMountedRef.current;
+  return useCallback(() => isMountedRef.current, []);
 }
 
 export default useIsMounted;


### PR DESCRIPTION
## What does this PR do?

- Memoizes the return function from `useIsMounted()`, which in turn allows the async state `refetch` function to memoize properly

## Checklist

- [x] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer - @grahamlangford 
