### PR TITLE
#7772: feature flag to make `clipboardWrite` optional in automatic deployment activation

### DIFF
--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -67,8 +67,7 @@ import { type OptionsArgs } from "@/types/runtimeTypes";
 import { checkDeploymentPermissions } from "@/permissions/deploymentPermissionsHelpers";
 import { Events } from "@/telemetry/events";
 import { allSettled } from "@/utils/promiseUtils";
-import { Manifest } from "webextension-polyfill";
-import OptionalPermission = Manifest.OptionalPermission;
+import type { Manifest } from "webextension-polyfill";
 
 // eslint-disable-next-line local-rules/persistBackgroundData -- Static
 const { reducer: optionsReducer, actions: optionsActions } = extensionsSlice;
@@ -551,14 +550,14 @@ export async function updateDeployments(): Promise<void> {
     return;
   }
 
-  // Not strictly required to use the clipboard brick, so allow it to auto-install. Behind a feature flag
-  // in case it causes problems for enterprise customers. Could use browser.runtime.getManifest().optional_permissions
-  // here, but that also technically supports the URL type so the types don't match
-  const optionalPermissions: OptionalPermission[] = profile.flags.includes(
-    "deployment-permissions-strict",
-  )
-    ? []
-    : ["clipboardWrite"];
+  // `clipboardWrite` is no strictly required to use the clipboard brick, so allow it to auto-install.
+  // Behind a feature flag in case it causes problems for enterprise customers.
+  // Could use browser.runtime.getManifest().optional_permissions here, but that also technically supports the Origin
+  // type so the types wouldn't match with checkDeploymentPermissions
+  const optionalPermissions: Manifest.OptionalPermission[] =
+    profile.flags.includes("deployment-permissions-strict")
+      ? []
+      : ["clipboardWrite"];
 
   const deploymentRequirements = await Promise.all(
     updatedDeployments.map(async (deployment) => ({

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
@@ -132,7 +132,11 @@ function useDeployments(): DeploymentsState {
         "useDeployments:checkDeploymentPermissions",
         Promise.all(
           deployments.map(async (deployment) =>
-            checkDeploymentPermissions(deployment, services.locateAllForId),
+            checkDeploymentPermissions(deployment, services.locateAllForId, {
+              // In the UI context, always prompt the user to accept permissions to ensure they get the full
+              // functionality of the mod
+              optionalPermissions: [],
+            }),
           ),
         ),
       ),

--- a/src/modDefinitions/modDefinitionPermissionsHelpers.ts
+++ b/src/modDefinitions/modDefinitionPermissionsHelpers.ts
@@ -82,7 +82,8 @@ async function collectModComponentDefinitionPermissions(
  * Returns true if the mod definition has the necessary permissions to run. Does not request the permissions.
  * @param modDefinition the mod definition
  * @param configuredDependencies mod integration dependencies with defined configs
- * @param optionalPermissions permissions to ignore when calculating hasPermissions
+ * @param optionalPermissions permissions to ignore when calculating hasPermissions. Used to allow auto-deployment
+ * of mods using `clipboardWrite` permission.
  * @see ensureModDefinitionPermissionsFromUserGesture
  */
 export async function checkModDefinitionPermissions(
@@ -109,7 +110,7 @@ export async function checkModDefinitionPermissions(
   };
 
   if (isEmpty(requiredPermissions)) {
-    // Small performance enhancement to avoid hitting background worker
+    // Small performance enhancement to avoid hitting permissions API
     return {
       hasPermissions: true,
       permissions,

--- a/src/permissions/deploymentPermissionsHelpers.ts
+++ b/src/permissions/deploymentPermissionsHelpers.ts
@@ -25,6 +25,7 @@ import {
 import { checkModDefinitionPermissions } from "@/modDefinitions/modDefinitionPermissionsHelpers";
 import { type PermissionsStatus } from "@/permissions/permissionsTypes";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
+import type { Manifest } from "webextension-polyfill/namespaces/manifest";
 
 /**
  * Return permissions required to activate a deployment.
@@ -39,6 +40,11 @@ import { type IntegrationDependency } from "@/integrations/integrationTypes";
 export async function checkDeploymentPermissions(
   deployment: Deployment,
   locate: Locate,
+  {
+    optionalPermissions,
+  }: {
+    optionalPermissions: Manifest.OptionalPermission[];
+  },
 ): Promise<PermissionsStatus> {
   const modDefinition = deployment.package.config;
   const localAuths = await findLocalDeploymentConfiguredIntegrationDependencies(
@@ -56,5 +62,7 @@ export async function checkDeploymentPermissions(
       })),
   );
 
-  return checkModDefinitionPermissions(modDefinition, integrationDependencies);
+  return checkModDefinitionPermissions(modDefinition, integrationDependencies, {
+    optionalPermissions,
+  });
 }

--- a/src/permissions/deploymentPermissionsHelpers.ts
+++ b/src/permissions/deploymentPermissionsHelpers.ts
@@ -25,7 +25,7 @@ import {
 import { checkModDefinitionPermissions } from "@/modDefinitions/modDefinitionPermissionsHelpers";
 import { type PermissionsStatus } from "@/permissions/permissionsTypes";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
-import type { Manifest } from "webextension-polyfill/namespaces/manifest";
+import type { Manifest } from "webextension-polyfill";
 
 /**
  * Return permissions required to activate a deployment.


### PR DESCRIPTION
## What does this PR do?

- Closes #7772
- By default, make `clipboardWrite` optional for deployment activation.
- Add a `deployment-permissions-strict` flag to make `clipboardWrite` required in case this breaks certain deployments

## Remaining Work

- [x] Fix imports
- [x] Add Jest test coverage

## Discussion

- I chose to make the flag make the requirement strict vs. relaxed, because feature flags are easier to opt people into vs. out of in Django/Waffle

## Future Work

- Improve the deploymentUpdater tests to move the mock boundary to `browser.` APIs vs. mocking PixieBrix methods

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
