### PR TITLE
#7775: confirm delete in the workshop

### DIFF
--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -43,7 +43,12 @@ const initialModalState: ModalContextProps = {
   },
 };
 
-const ModalContext = createContext<ModalContextProps>(initialModalState);
+/**
+ * Exported for passing mocks during testing. Prefer ModalProvider.
+ * @see ModalProvider
+ * @deprecated
+ */
+export const ModalContext = createContext<ModalContextProps>(initialModalState);
 
 const ConfirmationModal: React.FunctionComponent<
   ConfirmationModalProps & {

--- a/src/extensionConsole/pages/brickEditor/EditPage.tsx
+++ b/src/extensionConsole/pages/brickEditor/EditPage.tsx
@@ -111,6 +111,8 @@ const EditForm: React.FC<{ id: UUID; data: Package }> = ({ id, data }) => {
     config: rawConfig,
   } = useParseBrick(data.config);
 
+  const name = rawConfig.metadata?.name;
+
   const { submit, validate, remove } = useSubmitBrick({
     create: false,
   });
@@ -120,7 +122,7 @@ const EditForm: React.FC<{ id: UUID; data: Package }> = ({ id, data }) => {
   const [isRemoving, setIsRemovingBrick] = useState(false);
   const onRemove = async () => {
     setIsRemovingBrick(true);
-    await remove(id);
+    await remove({ id, name });
 
     // If the brick has been removed, the app will navigate away from this page,
     // so we need to check if the component is still mounted
@@ -131,7 +133,6 @@ const EditForm: React.FC<{ id: UUID; data: Package }> = ({ id, data }) => {
 
   useLogContext(data.config);
 
-  const name = rawConfig.metadata?.name;
   useSetDocumentTitle(
     name ? `Edit ${truncate(name, { length: 15 })}` : "Edit Brick",
   );

--- a/src/extensionConsole/pages/brickEditor/useSubmitBrick.test.tsx
+++ b/src/extensionConsole/pages/brickEditor/useSubmitBrick.test.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import useSubmitBrick from "@/extensionConsole/pages/brickEditor/useSubmitBrick";
-import { renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react-hooks";
 import { Provider } from "react-redux";
 import { type AuthState } from "@/auth/authTypes";
 import integrationsSlice, {
@@ -31,7 +31,6 @@ import settingsSlice from "@/store/settings/settingsSlice";
 import pipedriveYaml from "@contrib/integrations/pipedrive.yaml?loadAsText";
 import { appApi } from "@/data/service/api";
 import { brickToYaml } from "@/utils/objToYaml";
-import { act } from "react-dom/test-utils";
 import testMiddleware, {
   actionTypes,
   resetTestMiddleware,
@@ -39,9 +38,9 @@ import testMiddleware, {
 import notify from "@/utils/notify";
 import { appApiMock } from "@/testUtils/appApiMock";
 import { uuidv4 } from "@/types/helpers";
+import { ModalContext } from "@/components/ConfirmationModal";
 
 jest.mock("@/utils/notify");
-
 jest.mock("@/extensionConsole/pages/mods/utils/useReinstall");
 
 const errorMock = jest.mocked(notify.error);
@@ -166,5 +165,29 @@ describe("useSubmitBrick", () => {
       message: "Invalid organizations",
       error: expect.toBeObject(),
     });
+  });
+
+  it("shows delete confirmation modal", async () => {
+    const store = testStore();
+
+    resetTestMiddleware();
+
+    const showConfirmation = jest.fn().mockResolvedValue(false);
+
+    const { result } = renderHook(() => useSubmitBrick({ create: false }), {
+      wrapper: ({ children }) => (
+        <ModalContext.Provider value={{ showConfirmation }}>
+          <Provider store={store}>{children}</Provider>
+        </ModalContext.Provider>
+      ),
+    });
+
+    const id = uuidv4();
+
+    await act(async () => {
+      await result.current.remove({ id, name: "Test" });
+    });
+
+    expect(showConfirmation).toHaveBeenCalledOnce();
   });
 });

--- a/src/extensionConsole/pages/brickEditor/useSubmitBrick.ts
+++ b/src/extensionConsole/pages/brickEditor/useSubmitBrick.ts
@@ -79,7 +79,7 @@ function useSubmitBrick({ create = false }: SubmitOptions): SubmitCallbacks {
         title: "Permanently Delete Brick",
         message: `Permanently delete ${
           name ?? "brick"
-        } from the server? This action cannot be undone`,
+        } from the server? This action cannot be undone.`,
         cancelCaption: "Cancel",
         submitCaption: "Permanently Delete",
         submitVariant: "danger",

--- a/src/extensionConsole/pages/brickEditor/useSubmitBrick.ts
+++ b/src/extensionConsole/pages/brickEditor/useSubmitBrick.ts
@@ -25,7 +25,6 @@ import { type BrickValidationResult, validateSchema } from "./validate";
 import useRefreshRegistries from "@/hooks/useRefreshRegistries";
 import useReinstall from "@/extensionConsole/pages/mods/utils/useReinstall";
 import notify from "@/utils/notify";
-import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import {
   clearServiceCache,
@@ -41,6 +40,9 @@ import { isSingleObjectBadRequestError } from "@/errors/networkErrorHelpers";
 import { type UUID } from "@/types/stringTypes";
 import { type UnsavedModDefinition } from "@/types/modDefinitionTypes";
 import { type Definition } from "@/types/registryTypes";
+import useUserAction from "@/hooks/useUserAction";
+import { useModals } from "@/components/ConfirmationModal";
+import { CancelError } from "@/errors/businessErrors";
 
 type SubmitOptions = {
   create: boolean;
@@ -48,7 +50,7 @@ type SubmitOptions = {
 
 type SubmitCallbacks = {
   validate: (values: EditorValues) => Promise<BrickValidationResult>;
-  remove: (id: UUID) => Promise<void>;
+  remove: ({ id, name }: { id: UUID; name: string }) => Promise<void>;
   submit: (
     values: EditorValues & { id: UUID },
     helpers: { setErrors: (errors: unknown) => void },
@@ -57,6 +59,7 @@ type SubmitCallbacks = {
 
 function useSubmitBrick({ create = false }: SubmitOptions): SubmitCallbacks {
   const [, refresh] = useRefreshRegistries({ refreshOnMount: false });
+  const modals = useModals();
   const reinstall = useReinstall();
   const history = useHistory();
   const dispatch = useDispatch();
@@ -70,21 +73,32 @@ function useSubmitBrick({ create = false }: SubmitOptions): SubmitCallbacks {
   const [updatePackage] = useUpdatePackageMutation();
   const [deletePackage] = useDeletePackageMutation();
 
-  const remove = useCallback(
-    async (id: UUID) => {
-      try {
-        await deletePackage({ id }).unwrap();
-      } catch (error) {
-        notify.error({ message: "Error deleting brick", error });
-        return;
+  const remove = useUserAction(
+    async ({ id, name }: { id: UUID; name?: string }) => {
+      const confirm = await modals.showConfirmation({
+        title: "Permanently Delete Brick",
+        message: `Permanently delete ${
+          name ?? "brick"
+        } from the server? This action cannot be undone`,
+        cancelCaption: "Cancel",
+        submitCaption: "Permanently Delete",
+        submitVariant: "danger",
+      });
+
+      if (!confirm) {
+        throw new CancelError("User cancelled delete");
       }
 
-      notify.success("Deleted brick");
-      reportEvent(Events.BRICK_DELETE);
+      await deletePackage({ id }).unwrap();
 
       dispatch(push("/workshop"));
     },
-    [dispatch, deletePackage],
+    {
+      successMessage: "Deleted brick",
+      errorMessage: "Error deleting brick",
+      event: Events.BRICK_DELETE,
+    },
+    [dispatch, deletePackage, modals],
   );
 
   const submit = useCallback(


### PR DESCRIPTION
## What does this PR do?

- Closes #7775
- Adds confirmation modal when deleting a brick in the workshop

## Demo

<img width="522" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/29ec67f2-ea6b-44c8-889c-aef2c63a891d">

## Future Work

- Move the "Delete" button behind a 3-dot menu to prevent accidental clicks
- Add a text entry box, to have the user type the id of the brick to confirm deletion
- Update language in Workshop UI to "package" instead of "brick" to be less confusing when working with mods and integration definitions

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @fungairino 
