### PR TITLE
#7784: skip waiting for managed storage after initial wait

### DIFF
--- a/src/__mocks__/browserMock.mjs
+++ b/src/__mocks__/browserMock.mjs
@@ -17,6 +17,7 @@
 
 export default {
   runtime: {
+    id: "abcxyz",
     getManifest: () => ({
       homepage_url: "https://www.pixiebrix.com/",
     }),

--- a/src/auth/useLinkState.ts
+++ b/src/auth/useLinkState.ts
@@ -23,7 +23,7 @@ import {
 import useAsyncExternalStore from "@/hooks/useAsyncExternalStore";
 import type { AsyncState } from "@/types/sliceTypes";
 
-// NOTE: can't share subscribe methods across generators currently for useAsyncExternalStore, because it maintains
+// NOTE: can't share subscribe methods across generators currently for useAsyncExternalStore because it maintains
 // a map of subscriptions to state controllers. See https://github.com/pixiebrix/pixiebrix-extension/issues/7789
 const subscribe = (callback: () => void) => {
   addAuthListener(callback);

--- a/src/auth/usePartnerAuthData.ts
+++ b/src/auth/usePartnerAuthData.ts
@@ -24,7 +24,7 @@ import useAsyncExternalStore from "@/hooks/useAsyncExternalStore";
 import type { AsyncState } from "@/types/sliceTypes";
 import type { PartnerAuthData } from "@/auth/authTypes";
 
-// NOTE: can't share subscribe methods across generators currently for useAsyncExternalStore, because it maintains
+// NOTE: can't share subscribe methods across generators currently for useAsyncExternalStore because it maintains
 // a map of subscriptions to state controllers. See https://github.com/pixiebrix/pixiebrix-extension/issues/7789
 const subscribe = (callback: () => void) => {
   addAuthListener(callback);

--- a/src/auth/useRequiredPartnerAuth.ts
+++ b/src/auth/useRequiredPartnerAuth.ts
@@ -239,21 +239,6 @@ function useRequiredPartnerAuth(): RequiredPartnerState {
     authMethodOverride === "partner-oauth2" ||
     authMethodOverride === "partner-token";
 
-  console.debug("useRequiredPartnerAuth", {
-    partnerAuthState,
-    hasPartner,
-    requiresIntegration,
-    isMeLoading,
-    isLinkedLoading,
-    meError,
-    partnerKey: partner?.theme ?? managedPartnerId,
-    hasConfiguredIntegration: {
-      requiresIntegration,
-      partnerConfiguration,
-      isMissingPartnerJwt,
-    },
-  });
-
   return {
     hasPartner,
     partnerKey: partner?.theme ?? managedPartnerId,

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -47,22 +47,12 @@ import { initRuntimeLogging } from "@/development/runtimeLogging";
 import initWalkthroughModalTrigger from "@/background/walkthroughModalTrigger";
 import { initSidePanel } from "./sidePanel";
 import initRestrictUnauthenticatedUrlAccess from "@/background/restrictUnauthenticatedUrlAccess";
-import {
-  initManagedStorage,
-  watchDelayedStorageInitialization,
-} from "@/store/enterprise/managedStorage";
 import { setPlatform } from "@/platform/platformContext";
 import backgroundPlatform from "@/background/backgroundPlatform";
 
 // The background "platform" currently is used to execute API requests from Google Sheets/Automation Anywhere.
 // In the future, it might also run other background tasks from mods (e.g., background intervals)
 setPlatform(backgroundPlatform);
-
-// Try to initialize managed storage as early as possible because it impacts background behavior
-// Call watchDelayedStorageInitialization to handle case where storage is not immediately available within timeout.
-// We might consider putting watchStorageInitialization in initManagedStorage, but having a non-terminating
-// interval complicates testing.
-void initManagedStorage().then(async () => watchDelayedStorageInitialization());
 
 void initLocator();
 void initMessengerLogging();

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -123,7 +123,7 @@ beforeEach(async () => {
     organizationId: "00000000-00000000-00000000-00000000",
   } as any);
 
-  resetManagedStorage();
+  await resetManagedStorage();
 });
 
 describe("updateDeployments", () => {

--- a/src/background/installer.test.ts
+++ b/src/background/installer.test.ts
@@ -56,9 +56,9 @@ const getUserData = jest.mocked(auth.getUserData);
 const locateAllForServiceMock = jest.mocked(locator.locateAllForService);
 const browserManagedStorageMock = jest.mocked(browser.storage.managed.get);
 
-afterEach(() => {
+afterEach(async () => {
   jest.clearAllMocks();
-  resetManagedStorage();
+  await resetManagedStorage();
 });
 
 describe("openInstallPage", () => {

--- a/src/background/installer.test.ts
+++ b/src/background/installer.test.ts
@@ -18,7 +18,7 @@
 import {
   requirePartnerAuth,
   openInstallPage,
-  handleInstall,
+  showInstallPage,
 } from "@/background/installer";
 import * as auth from "@/auth/authStorage";
 import { locator } from "@/background/locator";
@@ -230,7 +230,7 @@ describe("handleInstall", () => {
     // App setup tab isn't open
     queryTabsMock.mockResolvedValue([]);
     isLinkedMock.mockResolvedValue(false);
-    await handleInstall({
+    await showInstallPage({
       reason: "install",
       previousVersion: undefined,
       temporary: false,
@@ -243,7 +243,7 @@ describe("handleInstall", () => {
     // App setup tab isn't open
     queryTabsMock.mockResolvedValue([]);
     isLinkedMock.mockResolvedValue(true);
-    await handleInstall({
+    await showInstallPage({
       reason: "install",
       previousVersion: undefined,
       temporary: false,
@@ -260,7 +260,7 @@ describe("handleInstall", () => {
       });
       queryTabsMock.mockResolvedValue([]);
       isLinkedMock.mockResolvedValue(false);
-      await handleInstall({
+      await showInstallPage({
         reason: "install",
         previousVersion: undefined,
         temporary: false,

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -327,7 +327,7 @@ async function setUninstallURL(): Promise<void> {
 // Using our own session value vs. webext-events because onExtensionStart has a 100ms delay
 // https://github.com/fregante/webext-events/blob/main/source/on-extension-start.ts#L56
 // eslint-disable-next-line local-rules/persistBackgroundData -- using SessionMp via oncePerSession
-const initManagedStorageOnce = oncePerSession(
+const initManagedStorageOncePerSession = oncePerSession(
   "initManagedStorage",
   import.meta.url,
   async () => {
@@ -338,7 +338,7 @@ const initManagedStorageOnce = oncePerSession(
 );
 
 // eslint-disable-next-line local-rules/persistBackgroundData -- using SessionMp via oncePerSession
-const initTelemetryOnce = oncePerSession(
+const initTelemetryOncePerSession = oncePerSession(
   "initTelemetry",
   import.meta.url,
   async () => {
@@ -350,8 +350,8 @@ const initTelemetryOnce = oncePerSession(
 );
 
 function initInstaller(): void {
-  void initManagedStorageOnce();
-  void initTelemetryOnce();
+  void initManagedStorageOncePerSession();
+  void initTelemetryOncePerSession();
 
   browser.runtime.onInstalled.addListener(showInstallPage);
   browser.runtime.onUpdateAvailable.addListener(setAvailableVersion);

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -29,6 +29,8 @@ import { expectContext } from "@/utils/expectContext";
 import {
   readManagedStorage,
   isInitialized as isManagedStorageInitialized,
+  resetInitializationTimestamp as resetManagedStorageInitializationState,
+  initManagedStorage,
 } from "@/store/enterprise/managedStorage";
 import { Events } from "@/telemetry/events";
 
@@ -321,9 +323,14 @@ async function setUninstallURL(): Promise<void> {
 }
 
 function initInstaller() {
+  browser.runtime.onStartup.addListener(async () => {
+    await resetManagedStorageInitializationState();
+    await initManagedStorage();
+  });
   browser.runtime.onUpdateAvailable.addListener(onUpdateAvailable);
   browser.runtime.onInstalled.addListener(handleInstall);
   browser.runtime.onStartup.addListener(initTelemetry);
+
   dntConfig.onChanged(() => {
     void setUninstallURL();
   });

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -326,7 +326,7 @@ async function setUninstallURL(): Promise<void> {
 
 // Using our own session value vs. webext-events because onExtensionStart has a 100ms delay
 // https://github.com/fregante/webext-events/blob/main/source/on-extension-start.ts#L56
-// eslint-disable-next-line local-rules/persistBackgroundData -- using SessionMp via oncePerSession
+// eslint-disable-next-line local-rules/persistBackgroundData -- using SessionMap via oncePerSession
 const initManagedStorageOncePerSession = oncePerSession(
   "initManagedStorage",
   import.meta.url,
@@ -337,7 +337,7 @@ const initManagedStorageOncePerSession = oncePerSession(
   },
 );
 
-// eslint-disable-next-line local-rules/persistBackgroundData -- using SessionMp via oncePerSession
+// eslint-disable-next-line local-rules/persistBackgroundData -- using SessionMap via oncePerSession
 const initTelemetryOncePerSession = oncePerSession(
   "initTelemetry",
   import.meta.url,

--- a/src/background/restrictUnauthenticatedUrlAccess.test.ts
+++ b/src/background/restrictUnauthenticatedUrlAccess.test.ts
@@ -65,7 +65,7 @@ describe("enforceAuthentication", () => {
 
   afterEach(async () => {
     // eslint-disable-next-line new-cap -- used for testing
-    INTERNAL_reset();
+    await INTERNAL_reset();
     await browser.storage.managed.clear();
     await browser.storage.local.clear();
     axiosMock.reset();

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -17,7 +17,6 @@
 
 import { type JsonObject } from "type-fest";
 import { compact, debounce, throttle, uniq } from "lodash";
-import { isLinked } from "@/auth/authStorage";
 import { getModComponentState } from "@/store/extensionsStorage";
 import {
   getLinkedApiClient,
@@ -305,8 +304,9 @@ async function collectUserSummary(): Promise<UserSummary> {
 }
 
 async function init(): Promise<void> {
-  if ((await isLinked()) && (await allowsTrack())) {
-    const client = await getLinkedApiClient();
+  const client = await maybeGetLinkedApiClient();
+
+  if (client && (await allowsTrack())) {
     await client.post("/api/identify/", {
       uid: await getUUID(),
       data: await collectUserSummary(),
@@ -321,7 +321,7 @@ export const initTelemetry = throttle(init, 30 * 60 * 1000, {
 });
 
 /**
- * @deprecated Only allowed in @/background files. Otherwise use: `import reportEvent from "@/telemetry/reportEvent"`
+ * @deprecated Only allowed in @/background files. Otherwise, use: `import reportEvent from "@/telemetry/reportEvent"`
  */
 export async function recordEvent({
   event,

--- a/src/components/logViewer/LogTable.stories.tsx
+++ b/src/components/logViewer/LogTable.stories.tsx
@@ -26,8 +26,6 @@ import { InputValidationError } from "@/bricks/errors";
 import { type Schema } from "@/types/schemaTypes";
 import type { LogEntry } from "@/telemetry/logging";
 
-Object.assign(global, { chrome: { runtime: { id: 42 } } });
-
 export default {
   title: "Editor/LogTable",
   component: LogTable,

--- a/src/extensionConsole/Navbar.tsx
+++ b/src/extensionConsole/Navbar.tsx
@@ -38,7 +38,7 @@ import useLinkState from "@/auth/useLinkState";
 import { DEFAULT_SERVICE_URL } from "@/urlConstants";
 import useAsyncExternalStore from "@/hooks/useAsyncExternalStore";
 
-// NOTE: can't share subscribe methods across generators currently for useAsyncExternalStore, because it maintains
+// NOTE: can't share subscribe methods across generators currently for useAsyncExternalStore because it maintains
 // a map of subscriptions to state controllers. See https://github.com/pixiebrix/pixiebrix-extension/issues/7789
 const subscribe = (callback: () => void) => {
   addAuthListener(callback);

--- a/src/extensionConsole/pages/BrowserBanner.test.tsx
+++ b/src/extensionConsole/pages/BrowserBanner.test.tsx
@@ -24,7 +24,7 @@ import { INTERNAL_reset } from "@/store/enterprise/managedStorage";
 
 beforeEach(async () => {
   // eslint-disable-next-line new-cap -- test helper method
-  INTERNAL_reset();
+  await INTERNAL_reset();
   await browser.storage.managed.clear();
 });
 

--- a/src/extensionConsole/pages/onboarding/SetupPage.test.tsx
+++ b/src/extensionConsole/pages/onboarding/SetupPage.test.tsx
@@ -66,7 +66,7 @@ jest.mock("@/data/service/baseService", () => ({
 
 beforeEach(async () => {
   jest.clearAllMocks();
-  resetManagedStorage();
+  await resetManagedStorage();
   await browser.storage.managed.clear();
 });
 

--- a/src/mv3/SessionStorage.test.ts
+++ b/src/mv3/SessionStorage.test.ts
@@ -23,21 +23,49 @@ test("SessionMap", async () => {
 
   await map.set("alpha", 1);
   await expect(map.get("alpha")).resolves.toBe(1);
+  await expect(map.has("alpha")).resolves.toBeTrue();
 
   // Other props should be left untouched
   await expect(map.get("beta")).resolves.toBeUndefined();
 
+  await map.delete("alpha");
+  await expect(map.get("alpha")).resolves.toBeUndefined();
+  await expect(map.has("alpha")).resolves.toBeFalse();
+});
+
+test("SessionMap accepts undefined", async () => {
+  const map = new SessionMap("jester", import.meta.url);
+  await expect(map.get("alpha")).resolves.toBeUndefined();
+
+  await map.set("alpha", 1);
+  await expect(map.get("alpha")).resolves.toBe(1);
+  await expect(map.has("alpha")).resolves.toBeTrue();
+
+  // `undefined` is a type-error because it's not a JsonValue. Keeping this test just to document the current behavior.
   await map.set("alpha", undefined);
   await expect(map.get("alpha")).resolves.toBeUndefined();
+  // SessionMap will unset the value
+  await expect(map.has("alpha")).resolves.toBeFalse();
 });
 
 test("SessionValue", async () => {
-  const map = new SessionValue("jester", import.meta.url);
-  await expect(map.get()).resolves.toBeUndefined();
+  const value = new SessionValue("jester", import.meta.url);
+  await expect(value.get()).resolves.toBeUndefined();
 
-  await map.set(1);
-  await expect(map.get()).resolves.toBe(1);
+  await value.set(1);
+  await expect(value.get()).resolves.toBe(1);
 
-  await map.set(undefined);
-  await expect(map.get()).resolves.toBeUndefined();
+  await value.unset();
+  await expect(value.get()).resolves.toBeUndefined();
+});
+
+test("SessionValue allows setting undefined", async () => {
+  const value = new SessionValue("jester", import.meta.url);
+
+  await value.set(1);
+  await expect(value.get()).resolves.toBe(1);
+
+  // `undefined` is a type-error because it's not a JsonValue. Keeping this test just to document the current behavior.
+  await value.set(undefined);
+  await expect(value.get()).resolves.toBeUndefined();
 });

--- a/src/mv3/SessionStorage.ts
+++ b/src/mv3/SessionStorage.ts
@@ -67,7 +67,9 @@ export class SessionMap<Value extends JsonValue> {
     }
 
     const result = await browser.storage.session.get(rawStorageKey);
-    return rawStorageKey in result;
+    // OK to use `undefined` because undefined is not a valid storage value
+    // eslint-disable-next-line security/detect-object-injection -- `getRawStorageKey` ensures the format
+    return result[rawStorageKey] !== undefined;
   }
 
   async get(secondaryKey: string): Promise<Value | undefined> {

--- a/src/mv3/SessionStorage.ts
+++ b/src/mv3/SessionStorage.ts
@@ -126,6 +126,12 @@ export class SessionValue<Value extends OmitIndexSignature<JsonValue>> {
   }
 }
 
+/**
+ * Helper to run a method at most once per session from the background page.
+ * @param key the SessionMap key
+ * @param url the ImportMeta.url of the file
+ * @param fn the function to run once per session
+ */
 export const oncePerSession = (
   key: string,
   url: string,

--- a/src/store/enterprise/managedStorage.test.ts
+++ b/src/store/enterprise/managedStorage.test.ts
@@ -22,8 +22,9 @@ import {
 } from "@/store/enterprise/managedStorage";
 
 beforeEach(async () => {
+  jest.clearAllMocks();
   // eslint-disable-next-line new-cap -- test helper method
-  INTERNAL_reset();
+  await INTERNAL_reset();
   await browser.storage.managed.clear();
 });
 
@@ -35,6 +36,9 @@ describe("readManagedStorage", () => {
   it("reads managed storage", async () => {
     await browser.storage.managed.set({ partnerId: "taco-bell" });
     await expect(readManagedStorage()).resolves.toStrictEqual({
+      // `jest-webextension-mock`'s storage is shared across sources, the call ends up with the managed storage
+      // and the local storage mixed together. See https://github.com/clarkbw/jest-webextension-mock/issues/183
+      managedStorageInitTimestamp: expect.any(String),
       partnerId: "taco-bell",
     });
   });

--- a/src/store/enterprise/managedStorage.test.ts
+++ b/src/store/enterprise/managedStorage.test.ts
@@ -16,10 +16,12 @@
  */
 
 import {
+  initializationTimestamp,
   INTERNAL_reset,
   readManagedStorage,
   readManagedStorageByKey,
 } from "@/store/enterprise/managedStorage";
+import type { Timestamp } from "@/types/stringTypes";
 
 beforeEach(async () => {
   jest.clearAllMocks();
@@ -29,6 +31,18 @@ beforeEach(async () => {
 });
 
 describe("readManagedStorage", () => {
+  it("reads immediately if managed storage is already initialized", async () => {
+    await initializationTimestamp.set(new Date().toISOString() as Timestamp);
+    await expect(readManagedStorage()).resolves.toStrictEqual({
+      // `jest-webextension-mock`'s storage is shared across sources, the call ends up with the managed storage
+      // and the local storage mixed together. See https://github.com/clarkbw/jest-webextension-mock/issues/183
+      managedStorageInitTimestamp: expect.any(String),
+    });
+
+    // Should only be called once vs. polling
+    expect(browser.storage.managed.get).toHaveBeenCalledOnce();
+  });
+
   it("reads uninitialized managed storage", async () => {
     await expect(readManagedStorage()).resolves.toStrictEqual({});
   });

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -27,7 +27,7 @@ import pMemoize, { pMemoizeClear } from "p-memoize";
 import { pollUntilTruthy } from "@/utils/promiseUtils";
 import { SimpleEventTarget } from "@/utils/SimpleEventTarget";
 import type { Nullishable } from "@/utils/nullishUtils";
-import { RepeatableAbortController } from "abort-utils";
+import { mergeSignals, RepeatableAbortController } from "abort-utils";
 import { StorageItem } from "webext-storage";
 import type { Timestamp } from "@/types/stringTypes";
 import { PromiseCancelled } from "@/errors/genericErrors";
@@ -36,11 +36,6 @@ import { PromiseCancelled } from "@/errors/genericErrors";
 //   Privacy Badger uses 4.5s timeout, but thinks policy should generally be available within 2.5s. In installer.ts,
 //   skip waiting for managed storage before linking the Extension if the user appears to be installing from the CWS.
 const MAX_MANAGED_STORAGE_WAIT_MILLIS = 4500;
-
-/**
- * Interval for checking managed storage initialization that takes longer than MAX_MANAGED_STORAGE_WAIT_MILLIS seconds.
- */
-let initializationInterval: ReturnType<typeof setTimeout> | undefined;
 
 /**
  * The managedStorageState, or undefined if it hasn't been initialized yet.
@@ -52,10 +47,14 @@ const controller = new RepeatableAbortController();
 
 /**
  * The initialization timestamp of managed storage, or null/undefined if it hasn't been initialized yet for the
- * current browser session. Introduced to avoid waiting MAX_MANAGED_STORAGE_WAIT_MILLIS on every page.
+ * current browser session. Available from all extension contexts.
  *
- * Currently, using StorageItem because it's compatible with MV2 and MV3. After the switchover to MV3 can use
- * in-memory session storage directly.
+ * Uses StorageItem instead of SessionValue in order to be available to all extension contexts. The background
+ * script clears the timestamp on session startup. After the switchover to MV3 can use SessionValue directly.
+ **
+ * Introduced to avoid waiting MAX_MANAGED_STORAGE_WAIT_MILLIS on every page.
+ *
+ * @see
  *
  * @since 1.8.10
  */
@@ -63,7 +62,10 @@ export const initializationTimestamp = new StorageItem<Timestamp>(
   "managedStorageInitTimestamp",
 );
 
-export const manageStorageStateChanges =
+/**
+ * Event for managed storage state changes. Also emitted when managed storage is initialized.
+ */
+export const managedStorageStateChange =
   new SimpleEventTarget<ManagedStorageState>();
 
 /**
@@ -94,44 +96,65 @@ async function readPopulatedManagedStorage(): Promise<
 }
 
 /**
- * Watch for managed storage initialization that occurs after waitForInitialManagedStorage.
+ * Clear the initializationTimestamp. For use in background script installer.
+ *
+ * After switchover to MV3, won't be required if we switch initializationTimestamp to in-memory session storage, because
+ * session storage is automatically reset across browser sessions.
+ */
+export async function resetInitializationTimestamp(): Promise<void> {
+  expectContext(
+    "background",
+    "Should only be called from background session initialization code",
+  );
+  await initializationTimestamp.remove();
+}
+
+/**
+ * Background method to watch for managed storage initialization that takes longer than MAX_MANAGED_STORAGE_WAIT_MILLIS.
  *
  * We can't use `browser.storage.onChanged` because it doesn't fire on initialization.
  *
  * Required because other modules are using the values in managedStorageSnapshot vs. calling browser.storage.managed.get
- * directly.
+ * directly, so we need to ensure `managedStorageSnapshot` contains the values of manages storage.
  *
  * @see waitForInitialManagedStorage
  */
-export async function watchDelayedStorageInitialization(): Promise<void> {
-  expectContext("background");
+export async function watchForDelayedStorageInitialization(): Promise<void> {
+  expectContext(
+    "background",
+    "Should only be called from background session initialization code",
+  );
 
-  const values = await readPopulatedManagedStorage();
+  let values = await readPopulatedManagedStorage();
 
   if (values != null) {
-    // Already initialized
+    // NOP - already initialized
     return;
   }
 
-  // Use setInterval instead of pollUntilTruthy to clear on browser.storage.onChanged. pollUntilTruthy doesn't
-  // currently directly support an abort signal.
-  initializationInterval = setInterval(
-    async () => {
-      const values = await readPopulatedManagedStorage();
-      if (values != null) {
-        managedStorageSnapshot = values;
+  // Abort on managed storage change, because it indicates that it must be initialized
+  const changeController = new AbortController();
+  browser.storage.onChanged.addListener(async (_changes, area) => {
+    if (area === "managed") {
+      changeController.abort();
+    }
+  });
 
-        if (initializationInterval) {
-          clearInterval(initializationInterval);
-          initializationInterval = undefined;
-        }
+  try {
+    values = await pollUntilTruthy(readPopulatedManagedStorage, {
+      signal: mergeSignals(changeController.signal, controller.signal),
+      // If `waitForInitialManagedStorage` didn't find a policy, then there's most likely no policy.
+      // So only check once every 2.5 seconds to not consume resources
+      intervalMillis: 2500,
+    });
+  } catch {
+    // NOP - most likely was aborted
+  }
 
-        manageStorageStateChanges.emit(managedStorageSnapshot);
-      }
-    },
-    // Most likely there's no policy. So only check once every 2.5 seconds to not consume resources
-    2500,
-  );
+  if (values != null) {
+    managedStorageSnapshot = values;
+    managedStorageStateChange.emit(managedStorageSnapshot);
+  }
 }
 
 // It's possible that managed storage is not available on the initial installation event
@@ -144,19 +167,24 @@ export async function watchDelayedStorageInitialization(): Promise<void> {
 // - https://github.com/gorhill/uBlock/commit/32bd47f05368557044dd3441dcaa414b7b009b39
 const waitForInitialManagedStorage = pMemoize(async () => {
   if (await initializationTimestamp.get()) {
-    // The extension has waited already this session, so don't wait again
+    // The extension has waited already this session in another context (typically the background worker)
     console.debug("Managed storage already initialized this session");
     managedStorageSnapshot = (await readManagedStorageImmediately()) ?? {};
   } else {
     console.debug(
       `Managed storage not initialized yet, polling for ${MAX_MANAGED_STORAGE_WAIT_MILLIS}ms`,
     );
+
+    // Controller that observes initializationTimestamp to see if another context finishes waiting in order
+    // to quit waiting early. For example:
+    // 1. Background worker starts waiting
+    // 2. Extension Console starts waiting
+    // 3. Background worker finishes waiting and sets initializationTimestamp
+    // 4. Abort signal fires, enabling Extension Console to quit waiting early
     const waitController = new AbortController();
-    // Skip polling if it becomes initialized while waiting
-    initializationTimestamp.onChanged(
-      waitController.abort,
-      waitController.signal,
-    );
+    initializationTimestamp.onChanged(() => {
+      waitController.abort(new PromiseCancelled());
+    }, waitController.signal);
 
     try {
       managedStorageSnapshot = await pollUntilTruthy<
@@ -185,7 +213,7 @@ const waitForInitialManagedStorage = pMemoize(async () => {
     await initializationTimestamp.set(new Date().toISOString() as Timestamp);
   }
 
-  manageStorageStateChanges.emit(managedStorageSnapshot);
+  managedStorageStateChange.emit(managedStorageSnapshot);
 
   return managedStorageSnapshot;
 });
@@ -201,24 +229,21 @@ export const initManagedStorage = once(async () => {
     // `onChanged` is only called when the policy changes, not on initialization
     // `browser.storage.managed.onChanged` might also exist, but it's not available in testing
     // See: https://github.com/clarkbw/jest-webextension-mock/issues/170
-    browser.storage.onChanged.addListener(async (changes, area) => {
-      if (area === "managed") {
-        // If browser.storage.onChanged fires, it means storage must already be initialized
-        if (initializationInterval) {
-          clearInterval(initializationInterval);
-          initializationInterval = undefined;
+    browser.storage.onChanged.addListener(
+      async (changes, area) => {
+        if (area === "managed") {
+          // If browser.storage.onChanged fires, it means storage must already be initialized
+          managedStorageSnapshot = await readManagedStorageImmediately();
+          managedStorageStateChange.emit(managedStorageSnapshot);
         }
-
-        managedStorageSnapshot = await readManagedStorageImmediately();
-        manageStorageStateChanges.emit(managedStorageSnapshot);
-      }
-    });
+      },
+      {
+        signal: controller.signal,
+      },
+    );
   } catch (error) {
     // Handle Opera: https://github.com/pixiebrix/pixiebrix-extension/issues/4069
-    console.warn(
-      "Not listening for managed storage changes because managed storage is not supported",
-      { error },
-    );
+    console.warn("Managed storage is not supported in your browser", { error });
   }
 
   await waitForInitialManagedStorage();
@@ -288,28 +313,11 @@ export function getSnapshot(): Nullishable<ManagedStorageState> {
 }
 
 /**
- * Clear the initializationTimestamp. For use in background script installer.
- *
- * After switchover to MV3, won't be required if we switch initializationTimestamp to in-memory session storage, because
- * session storage is automatically reset across browser sessions.
- */
-export async function resetInitializationTimestamp(): Promise<void> {
-  expectContext(
-    "background",
-    "resetInitializationTimestamp should only be called from background session initialization code",
-  );
-  await initializationTimestamp.remove();
-}
-
-/**
  * Helper method for resetting the module for testing.
  */
 export async function INTERNAL_reset(): Promise<void> {
   controller.abortAndReset();
   managedStorageSnapshot = undefined;
-
-  clearInterval(initializationInterval);
-  initializationInterval = undefined;
 
   pMemoizeClear(waitForInitialManagedStorage);
   await resetInitializationTimestamp();

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -54,8 +54,7 @@ const controller = new RepeatableAbortController();
  **
  * Introduced to avoid waiting MAX_MANAGED_STORAGE_WAIT_MILLIS on every page.
  *
- * @see
- *
+ * @see initManagedStorageOncePerSession
  * @since 1.8.10
  */
 export const initializationTimestamp = new StorageItem<Timestamp>(

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -59,7 +59,7 @@ const controller = new RepeatableAbortController();
  *
  * @since 1.8.10
  */
-const initializationTimestamp = new StorageItem<Timestamp>(
+export const initializationTimestamp = new StorageItem<Timestamp>(
   "managedStorageInitTimestamp",
 );
 

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -63,7 +63,8 @@ export const initializationTimestamp = new StorageItem<Timestamp>(
   "managedStorageInitTimestamp",
 );
 
-const manageStorageStateChanges = new SimpleEventTarget<ManagedStorageState>();
+export const manageStorageStateChanges =
+  new SimpleEventTarget<ManagedStorageState>();
 
 /**
  * Read managed storage immediately, returns {} if managed storage is unavailable/uninitialized.
@@ -287,31 +288,16 @@ export function getSnapshot(): Nullishable<ManagedStorageState> {
 }
 
 /**
- * Subscribe to changes in the managed storage state.
- *
- * @param callback to receive the updated state.
- * @see useManagedStorageState
- */
-export function subscribe(
-  callback: (state: ManagedStorageState) => void,
-): () => void {
-  expectContext("extension");
-
-  manageStorageStateChanges.add(callback);
-
-  return () => {
-    manageStorageStateChanges.remove(callback);
-  };
-}
-
-/**
- * Clear the initializationTimestamp. For use in onStartup in the background script.
+ * Clear the initializationTimestamp. For use in background script installer.
  *
  * After switchover to MV3, won't be required if we switch initializationTimestamp to in-memory session storage, because
- * that's automatically reset across browser sessions.
+ * session storage is automatically reset across browser sessions.
  */
 export async function resetInitializationTimestamp(): Promise<void> {
-  expectContext("background");
+  expectContext(
+    "background",
+    "resetInitializationTimestamp should only be called from background session initialization code",
+  );
   await initializationTimestamp.remove();
 }
 

--- a/src/store/enterprise/managedStorage.ts
+++ b/src/store/enterprise/managedStorage.ts
@@ -322,7 +322,7 @@ export function getSnapshot(): Nullishable<ManagedStorageState> {
  * Helper method for resetting the module for testing.
  */
 export async function INTERNAL_reset(): Promise<void> {
-  controller.abortAndReset(new Error("Internal test cleanup"));
+  controller.abortAndReset(new PromiseCancelled("Internal test cleanup"));
   managedStorageSnapshot = undefined;
   pMemoizeClear(waitForInitialManagedStorage);
   await resetInitializationTimestamp();

--- a/src/store/enterprise/useManagedStorageState.test.ts
+++ b/src/store/enterprise/useManagedStorageState.test.ts
@@ -49,8 +49,9 @@ describe("useManagedStorageState", () => {
           data: {},
           isLoading: false,
         });
-        // Must be longer than MAX_MANAGED_STORAGE_WAIT_MILLIS
       },
+      // XXX: figure out how to use fake timers to avoid slowing down test suite
+      // Must be longer than MAX_MANAGED_STORAGE_WAIT_MILLIS
       { timeout: 5000 },
     );
   });

--- a/src/store/enterprise/useManagedStorageState.test.ts
+++ b/src/store/enterprise/useManagedStorageState.test.ts
@@ -21,7 +21,7 @@ import useManagedStorageState from "@/store/enterprise/useManagedStorageState";
 
 beforeEach(async () => {
   // eslint-disable-next-line new-cap -- test helper method
-  INTERNAL_reset();
+  await INTERNAL_reset();
   await browser.storage.managed.clear();
 });
 

--- a/src/store/enterprise/useManagedStorageState.test.ts
+++ b/src/store/enterprise/useManagedStorageState.test.ts
@@ -18,6 +18,16 @@
 import { INTERNAL_reset } from "@/store/enterprise/managedStorage";
 import { renderHook } from "@testing-library/react-hooks";
 import useManagedStorageState from "@/store/enterprise/useManagedStorageState";
+import { waitFor } from "@testing-library/react";
+
+jest.mock("lodash", () => {
+  const lodash = jest.requireActual("lodash");
+  return {
+    ...lodash,
+    // Handle multiple calls to managedStorage:initManagedStorage across tests
+    once: (fn: any) => fn,
+  };
+});
 
 beforeEach(async () => {
   // eslint-disable-next-line new-cap -- test helper method
@@ -26,20 +36,34 @@ beforeEach(async () => {
 });
 
 describe("useManagedStorageState", () => {
-  it("handles state initialization", async () => {
+  it("waits on uninitialized state", async () => {
     const { result } = renderHook(() => useManagedStorageState());
     expect(result.current).toStrictEqual({
       data: undefined,
       isLoading: true,
     });
+
+    await waitFor(
+      () => {
+        expect(result.current).toStrictEqual({
+          data: {},
+          isLoading: false,
+        });
+        // Must be longer than MAX_MANAGED_STORAGE_WAIT_MILLIS
+      },
+      { timeout: 5000 },
+    );
   });
 
   it("handles already initialized state", async () => {
     await browser.storage.managed.set({ partnerId: "taco-bell" });
+
     const { result, waitForNextUpdate } = renderHook(() =>
       useManagedStorageState(),
     );
+
     await waitForNextUpdate();
+
     expect(result.current).toStrictEqual({
       data: {
         // `jest-webextension-mock`'s storage is shared across sources, the call ends up with the managed storage

--- a/src/store/enterprise/useManagedStorageState.test.ts
+++ b/src/store/enterprise/useManagedStorageState.test.ts
@@ -41,7 +41,12 @@ describe("useManagedStorageState", () => {
     );
     await waitForNextUpdate();
     expect(result.current).toStrictEqual({
-      data: { partnerId: "taco-bell" },
+      data: {
+        // `jest-webextension-mock`'s storage is shared across sources, the call ends up with the managed storage
+        // and the local storage mixed together. See https://github.com/clarkbw/jest-webextension-mock/issues/183
+        managedStorageInitTimestamp: expect.any(String),
+        partnerId: "taco-bell",
+      },
       isLoading: false,
     });
   });

--- a/src/store/enterprise/useManagedStorageState.ts
+++ b/src/store/enterprise/useManagedStorageState.ts
@@ -19,22 +19,36 @@ import { useSyncExternalStore } from "use-sync-external-store/shim";
 import {
   getSnapshot,
   initManagedStorage,
-  subscribe,
+  manageStorageStateChanges,
 } from "@/store/enterprise/managedStorage";
 import { useEffect } from "react";
 import type { ManagedStorageState } from "@/store/enterprise/managedStorageTypes";
 import type { Nullishable } from "@/utils/nullishUtils";
+import { expectContext } from "@/utils/expectContext";
 
 type HookState = {
   data: Nullishable<ManagedStorageState>;
   isLoading: boolean;
 };
 
+// NOTE: can't share subscribe methods across generators currently for useAsyncExternalStore because it maintains
+// a map of subscriptions to state controllers. See https://github.com/pixiebrix/pixiebrix-extension/issues/7789
+function subscribe(callback: () => void): () => void {
+  expectContext("extension");
+
+  manageStorageStateChanges.add(callback);
+
+  return () => {
+    manageStorageStateChanges.remove(callback);
+  };
+}
+
 /**
  * React hook to get the current state of managed storage.
  */
 function useManagedStorageState(): HookState {
   useEffect(() => {
+    // `initManagedStorage` is wrapped in once, so safe to call from multiple locations in the tree.
     void initManagedStorage();
   }, []);
 

--- a/src/store/enterprise/useManagedStorageState.ts
+++ b/src/store/enterprise/useManagedStorageState.ts
@@ -19,7 +19,7 @@ import { useSyncExternalStore } from "use-sync-external-store/shim";
 import {
   getSnapshot,
   initManagedStorage,
-  manageStorageStateChanges,
+  managedStorageStateChange,
 } from "@/store/enterprise/managedStorage";
 import { useEffect } from "react";
 import type { ManagedStorageState } from "@/store/enterprise/managedStorageTypes";
@@ -36,10 +36,10 @@ type HookState = {
 function subscribe(callback: () => void): () => void {
   expectContext("extension");
 
-  manageStorageStateChanges.add(callback);
+  managedStorageStateChange.add(callback);
 
   return () => {
-    manageStorageStateChanges.remove(callback);
+    managedStorageStateChange.remove(callback);
   };
 }
 

--- a/src/testUtils/testAfterEnv.ts
+++ b/src/testUtils/testAfterEnv.ts
@@ -49,4 +49,17 @@ browser.tabs.onRemoved = {
   hasListeners: jest.fn(),
 };
 
+// FIXME: getting test errors Cannot read properties of undefined (reading 'onChanged')
+// `jest-webextension-mock` is missing mocks for onChanged: https://github.com/clarkbw/jest-webextension-mock/issues/170
+// `webext-storage` uses the chrome namespace: https://github.com/fregante/webext-storage/blob/main/source/storage-item.ts#L63
+chrome.storage.onChanged = {
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  hasListener: jest.fn(),
+  hasListeners: jest.fn(),
+  getRules: jest.fn(),
+  removeRules: jest.fn(),
+  addRules: jest.fn(),
+};
+
 jest.setMock("webext-detect-page", detectPageMock);

--- a/src/testUtils/testAfterEnv.ts
+++ b/src/testUtils/testAfterEnv.ts
@@ -62,3 +62,12 @@ chrome.storage.onChanged = {
 };
 
 jest.setMock("webext-detect-page", detectPageMock);
+
+// For some reason, throwIfAborted is not available in Jest environment even though it appears to be in JSDOM
+// https://github.com/jsdom/jsdom/blob/2f8a7302a43fff92f244d5f3426367a8eb2b8896/lib/jsdom/living/aborting/AbortSignal-impl.js#L24
+AbortSignal.prototype.throwIfAborted = function () {
+  if (this.aborted) {
+    // eslint-disable-next-line @typescript-eslint/no-throw-literal -- copy implementation from JSDOM
+    throw this.reason;
+  }
+};

--- a/src/testUtils/testAfterEnv.ts
+++ b/src/testUtils/testAfterEnv.ts
@@ -62,12 +62,3 @@ chrome.storage.onChanged = {
 };
 
 jest.setMock("webext-detect-page", detectPageMock);
-
-// For some reason, throwIfAborted is not available in Jest environment even though it appears to be in JSDOM
-// https://github.com/jsdom/jsdom/blob/2f8a7302a43fff92f244d5f3426367a8eb2b8896/lib/jsdom/living/aborting/AbortSignal-impl.js#L24
-AbortSignal.prototype.throwIfAborted = function () {
-  if (this.aborted) {
-    // eslint-disable-next-line @typescript-eslint/no-throw-literal -- copy implementation from JSDOM
-    throw this.reason;
-  }
-};

--- a/src/testUtils/testAfterEnv.ts
+++ b/src/testUtils/testAfterEnv.ts
@@ -49,7 +49,6 @@ browser.tabs.onRemoved = {
   hasListeners: jest.fn(),
 };
 
-// FIXME: getting test errors Cannot read properties of undefined (reading 'onChanged')
 // `jest-webextension-mock` is missing mocks for onChanged: https://github.com/clarkbw/jest-webextension-mock/issues/170
 // `webext-storage` uses the chrome namespace: https://github.com/fregante/webext-storage/blob/main/source/storage-item.ts#L63
 chrome.storage.onChanged = {

--- a/src/testUtils/testEnv.js
+++ b/src/testUtils/testEnv.js
@@ -52,3 +52,12 @@ global.AbortSignal.timeout ??= (milliseconds) => {
   }, milliseconds);
   return controller.signal;
 };
+
+// For some reason, throwIfAborted is not available in Jest environment even though it appears to be in JSDOM
+// https://github.com/jsdom/jsdom/blob/2f8a7302a43fff92f244d5f3426367a8eb2b8896/lib/jsdom/living/aborting/AbortSignal-impl.js#L24
+AbortSignal.prototype.throwIfAborted ??= function () {
+  if (this.aborted) {
+    // eslint-disable-next-line @typescript-eslint/no-throw-literal -- copy implementation from JSDOM
+    throw this.reason;
+  }
+};

--- a/src/themes/themeStore.test.ts
+++ b/src/themes/themeStore.test.ts
@@ -70,7 +70,7 @@ describe("getActiveTheme", () => {
 
     afterEach(async () => {
       // eslint-disable-next-line new-cap -- used for testing
-      INTERNAL_reset();
+      await INTERNAL_reset();
       await browser.storage.managed.clear();
       await browser.storage.local.clear();
     });

--- a/src/utils/promiseUtils.test.ts
+++ b/src/utils/promiseUtils.test.ts
@@ -218,7 +218,7 @@ describe("pollUntilTruthy", () => {
   it("doesn't call generator if already aborted", async () => {
     const generator = jest.fn().mockResolvedValue(true);
     const controller = new AbortController();
-    controller.abort();
+    controller.abort(new PromiseCancelled());
 
     const pollPromise = pollUntilTruthy(generator, {
       signal: controller.signal,
@@ -237,7 +237,7 @@ describe("pollUntilTruthy", () => {
       signal: controller.signal,
     });
 
-    controller.abort();
+    controller.abort(new PromiseCancelled());
     deferred.resolve(true);
 
     expect(generator).toHaveBeenCalledOnce();

--- a/src/utils/promiseUtils.test.ts
+++ b/src/utils/promiseUtils.test.ts
@@ -21,7 +21,10 @@ import {
   memoizeUntilSettled,
   retryWithJitter,
   asyncMapValues,
+  pollUntilTruthy,
 } from "@/utils/promiseUtils";
+import { PromiseCancelled } from "@/errors/genericErrors";
+import pDefer from "p-defer";
 
 // From https://github.com/sindresorhus/p-memoize/blob/52fe6052ff2287f528c954c4c67fc5a61ff21360/test.ts#LL198
 test("memoizeUntilSettled", async () => {
@@ -194,5 +197,50 @@ describe("asyncMapValues", () => {
       a: 2,
       b: 4,
     });
+  });
+});
+
+describe("pollUntilTruthy", () => {
+  it("returns truthy value", async () => {
+    const generator = jest.fn().mockResolvedValue(true);
+    await expect(pollUntilTruthy(generator)).resolves.toBe(true);
+  });
+
+  it("returns undefined for falsy value", async () => {
+    const generator = jest.fn().mockResolvedValue(false);
+    await expect(
+      pollUntilTruthy(generator, { maxWaitMillis: 0, intervalMillis: 1 }),
+    ).resolves.toBeUndefined();
+    // Still calls even if maxWaitMillis is 0
+    expect(generator).toHaveBeenCalledOnce();
+  });
+
+  it("doesn't call generator if already aborted", async () => {
+    const generator = jest.fn().mockResolvedValue(true);
+    const controller = new AbortController();
+    controller.abort();
+
+    const pollPromise = pollUntilTruthy(generator, {
+      signal: controller.signal,
+    });
+
+    await expect(pollPromise).rejects.toThrow(PromiseCancelled);
+    expect(generator).not.toHaveBeenCalled();
+  });
+
+  it("prefers abort signal", async () => {
+    const deferred = pDefer();
+    const generator = jest.fn().mockResolvedValue(deferred.promise);
+    const controller = new AbortController();
+
+    const pollPromise = pollUntilTruthy(generator, {
+      signal: controller.signal,
+    });
+
+    controller.abort();
+    deferred.resolve(true);
+
+    expect(generator).toHaveBeenCalledOnce();
+    await expect(pollPromise).rejects.toThrow(PromiseCancelled);
   });
 });

--- a/src/utils/promiseUtils.ts
+++ b/src/utils/promiseUtils.ts
@@ -124,7 +124,7 @@ export async function pollUntilTruthy<T>(
     maxWaitMillis?: number;
     intervalMillis?: number;
     signal?: AbortSignal;
-  },
+  } = {},
 ): Promise<T | undefined> {
   const endBy = Date.now() + maxWaitMillis;
   do {


### PR DESCRIPTION
## What does this PR do?

- Closes #7784 
- Adds a timestamp to local storage to enable contexts to skip waiting for managed storage after the initial delay
- Fixes use of onStartup handler in favor of a method that runs once per browser session

## Remaining Work

- [x] Handle onChanged test failures?:

```
/Users/tschiller/projects/pixiebrix-extension/node_modules/webext-storage/distribution/storage-item.js:39
        chrome.storage.onChanged.addListener(changeHandler);
                       ^

TypeError: Cannot read properties of undefined (reading 'onChanged')
```

- [x] Fix test failures due to cleanup abort controller cleanup

## Reviewer Tips

- Review `managedStorage.ts`
- Review `installer.ts`

## Future Work

- Figure out how to use jest fake timers during tests to avoid incurring the delay
- Submit PR to split storages in the jest-webextension-mock project: https://github.com/clarkbw/jest-webextension-mock/issues/183
- After switch to MV3, can just store the flag/timestamp in session storage (but the current local storage approach will still work)

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @fregante 
