### PR TITLE
Drop unused `mode` code

### DIFF
--- a/src/auth/RequireScope.tsx
+++ b/src/auth/RequireScope.tsx
@@ -18,12 +18,7 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import ScopeSettings from "./ScopeSettings";
-import { type SettingsState } from "@/store/settings/settingsTypes";
 import { selectScope } from "@/auth/authSelectors";
-
-type RootStateWithSettings = {
-  settings: SettingsState;
-};
 
 type RequireScopeProps = {
   // A flag to opt out of the scope check but still have the RequireScope component in the tree.
@@ -44,11 +39,7 @@ export const RequireScope: React.FunctionComponent<RequireScopeProps> = ({
 }) => {
   const scope = useSelector(selectScope);
 
-  const mode = useSelector<RootStateWithSettings, string>(
-    ({ settings }) => settings.mode,
-  );
-
-  if (isRequired && mode !== "local" && scope == null) {
+  if (isRequired && scope == null) {
     return (
       <ScopeSettings
         title={scopeSettingsTitle}

--- a/src/extensionConsole/Navbar.tsx
+++ b/src/extensionConsole/Navbar.tsx
@@ -25,12 +25,11 @@ import { Link } from "react-router-dom";
 import { getBaseURL } from "@/data/service/baseService";
 import {
   addListener as addAuthListener,
-  removeListener as removeAuthListener,
   readPartnerAuthData,
+  removeListener as removeAuthListener,
 } from "@/auth/authStorage";
 import { useSelector } from "react-redux";
 import { toggleSidebar } from "./toggleSidebar";
-import { type SettingsState } from "@/store/settings/settingsTypes";
 import cx from "classnames";
 import { selectAuth } from "@/auth/authSelectors";
 import { type ThemeLogo } from "@/themes/themeUtils";
@@ -73,12 +72,8 @@ const Navbar: React.FunctionComponent<{ logo: ThemeLogo }> = ({ logo }) => {
 
   const adminConsoleUrl = useAdminConsoleUrl();
 
-  const mode = useSelector<{ settings: SettingsState }, string>(
-    ({ settings }) => settings.mode,
-  );
-
-  // Allow `isLinkedLoading` to optimistically show the toggle
-  const showNavbarToggle = mode === "local" || isLinked || isLinkedLoading;
+  // Only show sidebar toggle if the extension is linked. Allow `isLinkedLoading` to optimistically show the toggle
+  const showNavbarToggle = isLinked || isLinkedLoading;
 
   return (
     <nav className="navbar default-layout-navbar col-lg-12 col-12 p-0 fixed-top d-flex flex-row">

--- a/src/store/settings/settingsSlice.ts
+++ b/src/store/settings/settingsSlice.ts
@@ -33,7 +33,6 @@ import { revertAll } from "@/store/commonActions";
 import { activateTheme } from "@/background/messenger/strict/api";
 
 export const initialSettingsState: SettingsState = {
-  mode: "remote",
   nextUpdate: null,
   suggestElements: false,
   browserWarningDismissed: false,
@@ -62,9 +61,6 @@ const settingsSlice = createSlice({
   name: "settings",
   initialState: initialSettingsState,
   reducers: {
-    setMode(state, { payload: { mode } }) {
-      state.mode = mode;
-    },
     setFlag(
       state,
       action: PayloadAction<{

--- a/src/store/settings/settingsTypes.ts
+++ b/src/store/settings/settingsTypes.ts
@@ -19,8 +19,6 @@ import { type ThemeName } from "@/themes/themeTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type Except } from "type-fest";
 
-type InstallMode = "local" | "remote";
-
 export const AUTH_METHODS = [
   "default",
   "pixiebrix-token",
@@ -81,13 +79,6 @@ export type SettingsFlags = SkunkworksSettingsFlags & GeneralSettingsFlags;
  */
 export type SettingsStateV1 = SkunkworksSettingsFlags &
   GeneralSettingsFlags & {
-    /**
-     * Whether the extension is synced to the app for provisioning.
-     *
-     * NOTE: `local` is broken in many places. The only current valid value is remote.
-     */
-    mode: InstallMode;
-
     /**
      * Time to snooze updates until (in milliseconds from the epoch), or null.
      *


### PR DESCRIPTION
## What does this PR do?

- Drops unused `mode` code, given that only `remote` had been a valid value for a long time
- Drops the property without a migration on settingsSlice because it doesn't hurt to have the value from other versions floating around

## Checklist

- [x] Add tests: N/A
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
