### PR TITLE
#7801: move propertiesToSchema to schemaUtils and fix inputProperties schema detection

### DIFF
--- a/src/activation/useActivateModWizard.test.tsx
+++ b/src/activation/useActivateModWizard.test.tsx
@@ -20,12 +20,12 @@ import useActivateModWizard, {
   makeDatabasePreviewName,
 } from "@/activation/useActivateModWizard";
 import { renderHook } from "@testing-library/react-hooks";
-import { propertiesToSchema } from "@/validators/generic";
 import useDatabaseOptions from "@/hooks/useDatabaseOptions";
 import { valueToAsyncState } from "@/utils/asyncStateUtils";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 jest.mock("@/components/integrations/AuthWidget", () => {});
 jest.mock("react-redux");

--- a/src/bricks/effects/AddQuickBarAction.tsx
+++ b/src/bricks/effects/AddQuickBarAction.tsx
@@ -16,7 +16,6 @@
  */
 
 import { validateRegistryId } from "@/types/helpers";
-import { propertiesToSchema } from "@/validators/generic";
 import Icon from "@/icons/Icon";
 import React from "react";
 import {
@@ -31,6 +30,7 @@ import type { BrickConfig } from "@/bricks/types";
 import type { PlatformCapability } from "@/platform/capabilities";
 import { uniq } from "lodash";
 import type { CustomAction } from "@/platform/platformTypes/quickBarProtocol";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 type ActionConfig = {
   /**

--- a/src/bricks/effects/AddTextCommand.ts
+++ b/src/bricks/effects/AddTextCommand.ts
@@ -16,7 +16,6 @@
  */
 
 import { validateRegistryId } from "@/types/helpers";
-import { propertiesToSchema } from "@/validators/generic";
 import type {
   BrickArgs,
   BrickOptions,
@@ -29,6 +28,7 @@ import { BusinessError } from "@/errors/businessErrors";
 import { getSettingsState } from "@/store/settings/settingsStorage";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import type { PlatformCapability } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 type CommandArgs = {
   /**

--- a/src/bricks/effects/AddTextSnippets.ts
+++ b/src/bricks/effects/AddTextSnippets.ts
@@ -16,13 +16,13 @@
  */
 
 import { validateRegistryId } from "@/types/helpers";
-import { propertiesToSchema } from "@/validators/generic";
 import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { initCommandController } from "@/contentScript/commandPopover/commandController";
 import { getSettingsState } from "@/store/settings/settingsStorage";
 import type { PlatformCapability } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 type Snippet = {
   /**

--- a/src/bricks/effects/InsertAtCursorEffect.ts
+++ b/src/bricks/effects/InsertAtCursorEffect.ts
@@ -22,12 +22,12 @@ import {
   isDocument,
 } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { BusinessError } from "@/errors/businessErrors";
 import { isEmpty } from "lodash";
 import focus from "@/utils/focusController";
 import type { PlatformCapability } from "@/platform/capabilities";
 import { insertAtCursorWithCustomEditorSupport } from "@/contentScript/textEditorDom";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 /**
  * Insert text at the cursor position. For use with text snippets, etc.

--- a/src/bricks/effects/ToggleQuickbarEffect.ts
+++ b/src/bricks/effects/ToggleQuickbarEffect.ts
@@ -17,7 +17,8 @@
 
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
+
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class ToggleQuickbarEffect extends EffectABC {
   constructor() {

--- a/src/bricks/effects/alert.ts
+++ b/src/bricks/effects/alert.ts
@@ -15,12 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { propertiesToSchema } from "@/validators/generic";
 import { validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
 import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
 import { EffectABC } from "@/types/bricks/effectTypes";
 import type { PlatformCapability } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export const ALERT_EFFECT_ID = validateRegistryId("@pixiebrix/browser/alert");
 

--- a/src/bricks/effects/assignModVariable.ts
+++ b/src/bricks/effects/assignModVariable.ts
@@ -1,12 +1,12 @@
 import { type Schema } from "@/types/schemaTypes";
 import { validateRegistryId } from "@/types/helpers";
-import { propertiesToSchema } from "@/validators/generic";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type JsonObject, type JsonPrimitive } from "type-fest";
 import { setState } from "@/platform/state/stateController";
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickConfig } from "@/bricks/types";
 import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 /**
  * A simple brick to assign a value to a Mod Variable.

--- a/src/bricks/effects/attachAutocomplete.ts
+++ b/src/bricks/effects/attachAutocomplete.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { propertiesToSchema } from "@/validators/generic";
 import { type AutocompleteItem } from "autocompleter";
 import {
   $safeFindElementsWithRootMode,
@@ -26,6 +25,7 @@ import injectStylesheet from "@/utils/injectStylesheet";
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class AttachAutocomplete extends EffectABC {
   constructor() {

--- a/src/bricks/effects/comment.ts
+++ b/src/bricks/effects/comment.ts
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { propertiesToSchema } from "@/validators/generic";
 import { validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
 import { EffectABC } from "@/types/bricks/effectTypes";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class CommentEffect extends EffectABC {
   // Use an effect so PixieBrix doesn't show an output

--- a/src/bricks/effects/disable.ts
+++ b/src/bricks/effects/disable.ts
@@ -17,13 +17,13 @@
 
 import { EffectABC } from "@/types/bricks/effectTypes";
 
-import { propertiesToSchema } from "@/validators/generic";
 import {
   IS_ROOT_AWARE_BRICK_PROPS,
   $safeFindElementsWithRootMode,
 } from "@/bricks/rootModeHelpers";
 import { type Schema } from "@/types/schemaTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class DisableEffect extends EffectABC {
   constructor() {

--- a/src/bricks/effects/enable.ts
+++ b/src/bricks/effects/enable.ts
@@ -18,11 +18,11 @@
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import {
   IS_ROOT_AWARE_BRICK_PROPS,
   $safeFindElementsWithRootMode,
 } from "@/bricks/rootModeHelpers";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class EnableEffect extends EffectABC {
   constructor() {

--- a/src/bricks/effects/hide.ts
+++ b/src/bricks/effects/hide.ts
@@ -18,11 +18,11 @@
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import {
   $safeFindElementsWithRootMode,
   IS_ROOT_AWARE_BRICK_PROPS,
 } from "@/bricks/rootModeHelpers";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class HideEffect extends EffectABC {
   constructor() {

--- a/src/bricks/effects/highlight.ts
+++ b/src/bricks/effects/highlight.ts
@@ -19,9 +19,9 @@
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { boolean } from "@/utils/typeUtils";
 import { $safeFind } from "@/utils/domUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 type ColorRule =
   | string

--- a/src/bricks/effects/insertHtml.ts
+++ b/src/bricks/effects/insertHtml.ts
@@ -18,12 +18,12 @@
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import sanitize from "@/utils/sanitize";
 import { PIXIEBRIX_DATA_ATTR } from "@/domConstants";
 import { escape } from "lodash";
 import { BusinessError } from "@/errors/businessErrors";
 import { $safeFind } from "@/utils/domUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 type Position = "before" | "prepend" | "append" | "after";
 

--- a/src/bricks/effects/logger.ts
+++ b/src/bricks/effects/logger.ts
@@ -18,8 +18,8 @@
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { realConsole } from "@/development/runtimeLogging";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 type Level = "debug" | "info" | "warn" | "error";
 

--- a/src/bricks/effects/pageState.ts
+++ b/src/bricks/effects/pageState.ts
@@ -17,7 +17,6 @@
 
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { type JsonObject } from "type-fest";
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { validateRegistryId } from "@/types/helpers";
@@ -25,6 +24,7 @@ import { type BrickConfig } from "@/bricks/types";
 import { isObject } from "@/utils/objectUtils";
 import { mapValues } from "lodash";
 import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 type MergeStrategy = "shallow" | "replace" | "deep";
 export type Namespace = "blueprint" | "extension" | "shared";

--- a/src/bricks/effects/runSubTour.ts
+++ b/src/bricks/effects/runSubTour.ts
@@ -18,10 +18,10 @@
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { runSubTour } from "@/starterBricks/tourController";
 import { isEmpty } from "lodash";
 import { BusinessError } from "@/errors/businessErrors";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class RunSubTourEffect extends EffectABC {
   constructor() {

--- a/src/bricks/effects/scrollIntoView.ts
+++ b/src/bricks/effects/scrollIntoView.ts
@@ -18,10 +18,10 @@
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { $safeFindElementsWithRootMode } from "@/bricks/rootModeHelpers";
 
 import { assertSingleElement } from "@/utils/domUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class ScrollIntoViewEffect extends EffectABC {
   constructor() {

--- a/src/bricks/effects/setToolbarBadge.ts
+++ b/src/bricks/effects/setToolbarBadge.ts
@@ -16,11 +16,11 @@
  */
 
 import { EffectABC } from "@/types/bricks/effectTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
 import { BusinessError } from "@/errors/businessErrors";
 import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
 import type { PlatformCapability } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class SetToolbarBadge extends EffectABC {
   constructor() {

--- a/src/bricks/effects/show.ts
+++ b/src/bricks/effects/show.ts
@@ -18,11 +18,11 @@
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import {
   $safeFindElementsWithRootMode,
   IS_ROOT_AWARE_BRICK_PROPS,
 } from "@/bricks/rootModeHelpers";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class ShowEffect extends EffectABC {
   constructor() {

--- a/src/bricks/effects/sidebar.ts
+++ b/src/bricks/effects/sidebar.ts
@@ -25,7 +25,6 @@ import {
 } from "@/contentScript/sidebarController";
 import sidebarInThisTab from "@/sidebar/messenger/api";
 import { isMV3 } from "@/mv3/api";
-import { propertiesToSchema } from "@/validators/generic";
 import { logPromiseDuration } from "@/utils/promiseUtils";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
 import {
@@ -33,6 +32,7 @@ import {
   type PlatformCapability,
 } from "@/platform/capabilities";
 import { expectContext } from "@/utils/expectContext";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class ShowSidebar extends EffectABC {
   constructor() {

--- a/src/bricks/effects/sound.ts
+++ b/src/bricks/effects/sound.ts
@@ -18,8 +18,8 @@
 import { EffectABC } from "@/types/bricks/effectTypes";
 import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import type { PlatformCapability } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class SoundEffect extends EffectABC {
   constructor() {

--- a/src/bricks/effects/tabs.ts
+++ b/src/bricks/effects/tabs.ts
@@ -17,12 +17,12 @@
 
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { activateTab, closeTab } from "@/background/messenger/api";
 import {
   CONTENT_SCRIPT_CAPABILITIES,
   type PlatformCapability,
 } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class ActivateTabEffect extends EffectABC {
   constructor() {

--- a/src/bricks/effects/tourEffect.ts
+++ b/src/bricks/effects/tourEffect.ts
@@ -18,7 +18,6 @@
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import injectStylesheet from "@/utils/injectStylesheet";
 import stylesheetUrl from "@/vendors/intro.js/introjs.scss?loadAsUrl";
 import pDefer from "p-defer";
@@ -34,6 +33,7 @@ import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { isEmpty } from "lodash";
 import { $safeFind } from "@/utils/domUtils";
 import { type TooltipPosition } from "intro.js/src/core/steps";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 type Step = {
   title: string;

--- a/src/bricks/renderers/HtmlRenderer.ts
+++ b/src/bricks/renderers/HtmlRenderer.ts
@@ -16,11 +16,11 @@
  */
 
 import { RendererABC } from "@/types/bricks/rendererTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import sanitize, { ADD_IFRAME_CONFIG } from "@/utils/sanitize";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type SafeHTML } from "@/types/stringTypes";
 import { validateRegistryId } from "@/types/helpers";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class HtmlRenderer extends RendererABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/html");

--- a/src/bricks/renderers/MarkdownRenderer.ts
+++ b/src/bricks/renderers/MarkdownRenderer.ts
@@ -16,11 +16,11 @@
  */
 
 import { RendererABC } from "@/types/bricks/rendererTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { validateRegistryId } from "@/types/helpers";
 import MarkdownLazy from "@/components/Markdown";
 import { type BrickArgs, type ComponentRef } from "@/types/runtimeTypes";
 import { ADD_IFRAME_CONFIG } from "@/utils/sanitize";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class MarkdownRenderer extends RendererABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/markdown");

--- a/src/bricks/renderers/propertyTable.tsx
+++ b/src/bricks/renderers/propertyTable.tsx
@@ -17,10 +17,10 @@
 
 import React from "react";
 import { RendererABC } from "@/types/bricks/rendererTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { sortBy, isPlainObject } from "lodash";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { isValidUrl } from "@/utils/urlUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 interface Item {
   key: string;

--- a/src/bricks/renderers/table.tsx
+++ b/src/bricks/renderers/table.tsx
@@ -16,7 +16,6 @@
  */
 
 import { RendererABC } from "@/types/bricks/rendererTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import makeDataTable, {
   type ColumnDefinition,
   type Row,
@@ -26,6 +25,7 @@ import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type SafeHTML } from "@/types/stringTypes";
 import { isNullOrBlank } from "@/utils/stringUtils";
 import { isObject } from "@/utils/objectUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 function makeLinkRenderer(href: string) {
   return (value: unknown, row: Row) => {

--- a/src/bricks/transformers/FormData.ts
+++ b/src/bricks/transformers/FormData.ts
@@ -18,12 +18,12 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { compact } from "lodash";
 import {
   $safeFindElementsWithRootMode,
   IS_ROOT_AWARE_BRICK_PROPS,
 } from "@/bricks/rootModeHelpers";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 function isCheckbox(
   element: HTMLInputElement | HTMLTextAreaElement,

--- a/src/bricks/transformers/GetBrickInterfaceTransformer.ts
+++ b/src/bricks/transformers/GetBrickInterfaceTransformer.ts
@@ -18,12 +18,12 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { validateRegistryId } from "@/types/helpers";
 import type { RegistryProtocol } from "@/registry/memoryRegistry";
 import type { RegistryId } from "@/types/registryTypes";
 import type { Brick } from "@/types/brickTypes";
 import { BusinessError, PropError } from "@/errors/businessErrors";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 /**
  * An experimental brick that returns the interface of a brick by its registry ID.

--- a/src/bricks/transformers/ParseJson.ts
+++ b/src/bricks/transformers/ParseJson.ts
@@ -18,11 +18,11 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { BusinessError } from "@/errors/businessErrors";
 import { sortBy } from "lodash";
 import { type JsonValue } from "type-fest";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 function extractJsonString(content: string): string {
   // https://regex101.com/library/sjOfeq?orderBy=MOST_POINTS&page=3&search=json

--- a/src/bricks/transformers/RunBrickByIdTransformer.ts
+++ b/src/bricks/transformers/RunBrickByIdTransformer.ts
@@ -22,13 +22,13 @@ import {
   type RenderedArgs,
 } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { validateRegistryId } from "@/types/helpers";
 import type { RegistryProtocol } from "@/registry/memoryRegistry";
 import type { RegistryId } from "@/types/registryTypes";
 import type { Brick } from "@/types/brickTypes";
 import { BusinessError, PropError } from "@/errors/businessErrors";
 import { throwIfInvalidInput } from "@/runtime/runtimeUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 /**
  * An experimental brick that runs a brick by its registry ID.

--- a/src/bricks/transformers/RunMetadataTransformer.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.ts
@@ -18,8 +18,8 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
 import { type Schema, SCHEMA_EMPTY_OBJECT } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { validateRegistryId } from "@/types/helpers";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 /**
  * Returns metadata for the current run.

--- a/src/bricks/transformers/controlFlow/ForEach.ts
+++ b/src/bricks/transformers/controlFlow/ForEach.ts
@@ -16,7 +16,6 @@
  */
 
 import { TransformerABC } from "@/types/bricks/transformerTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import {
   type BrickArgs,
@@ -26,6 +25,7 @@ import {
 } from "@/types/runtimeTypes";
 import { validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class ForEach extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/for-each");

--- a/src/bricks/transformers/controlFlow/ForEachElement.ts
+++ b/src/bricks/transformers/controlFlow/ForEachElement.ts
@@ -22,13 +22,13 @@ import {
   type PipelineExpression,
 } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { validateRegistryId } from "@/types/helpers";
 import { castArray } from "lodash";
 import { getReferenceForElement } from "@/contentScript/elementReference";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import { PropError } from "@/errors/businessErrors";
 import { $safeFind } from "@/utils/domUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class ForEachElement extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/for-each-element");

--- a/src/bricks/transformers/controlFlow/IfElse.ts
+++ b/src/bricks/transformers/controlFlow/IfElse.ts
@@ -22,9 +22,9 @@ import {
   type PipelineExpression,
 } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { validateRegistryId } from "@/types/helpers";
 import { boolean } from "@/utils/typeUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class IfElse extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/if-else");

--- a/src/bricks/transformers/controlFlow/MapValues.ts
+++ b/src/bricks/transformers/controlFlow/MapValues.ts
@@ -16,7 +16,6 @@
  */
 
 import { TransformerABC } from "@/types/bricks/transformerTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import {
   type BrickArgs,
@@ -27,6 +26,7 @@ import {
 } from "@/types/runtimeTypes";
 import { validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class MapValues extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/map");

--- a/src/bricks/transformers/controlFlow/Retry.ts
+++ b/src/bricks/transformers/controlFlow/Retry.ts
@@ -22,10 +22,10 @@ import {
   type PipelineExpression,
 } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { validateRegistryId } from "@/types/helpers";
 import { BusinessError } from "@/errors/businessErrors";
 import { sleep } from "@/utils/timeUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class Retry extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/retry");

--- a/src/bricks/transformers/controlFlow/Run.ts
+++ b/src/bricks/transformers/controlFlow/Run.ts
@@ -22,8 +22,8 @@ import {
   type PipelineExpression,
 } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { validateRegistryId } from "@/types/helpers";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 /**
  * A brick that runs one or more bricks synchronously or asynchronously. Used to group bricks and/or develop custom

--- a/src/bricks/transformers/controlFlow/TryExcept.ts
+++ b/src/bricks/transformers/controlFlow/TryExcept.ts
@@ -16,7 +16,6 @@
  */
 
 import { TransformerABC } from "@/types/bricks/transformerTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import { serializeError } from "serialize-error";
 import {
@@ -27,6 +26,7 @@ import {
 } from "@/types/runtimeTypes";
 import { validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class TryExcept extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/try-catch");

--- a/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
+++ b/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
@@ -18,7 +18,6 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { getState, setState } from "@/platform/state/stateController";
 import {
   type BrickArgs,
@@ -33,6 +32,7 @@ import { isEmpty } from "lodash";
 import { PropError } from "@/errors/businessErrors";
 import { type BrickConfig } from "@/bricks/types";
 import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 /**
  * Map to keep track of the current execution nonce for each Mod Variable. Used to ignore stale request results.

--- a/src/bricks/transformers/convertDocument.ts
+++ b/src/bricks/transformers/convertDocument.ts
@@ -35,9 +35,9 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import sanitize from "@/utils/sanitize";
 import { BusinessError } from "@/errors/businessErrors";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 async function convert({
   input,

--- a/src/bricks/transformers/detect.ts
+++ b/src/bricks/transformers/detect.ts
@@ -18,11 +18,11 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import {
   $safeFindElementsWithRootMode,
   IS_ROOT_AWARE_BRICK_PROPS,
 } from "@/bricks/rootModeHelpers";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class DetectElement extends TransformerABC {
   override defaultOutputKey = "match";

--- a/src/bricks/transformers/encode.ts
+++ b/src/bricks/transformers/encode.ts
@@ -17,8 +17,8 @@
 
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { stringToBase64 } from "uint8array-extras";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class Base64Encode extends TransformerABC {
   override defaultOutputKey = "encoded";

--- a/src/bricks/transformers/extensionDiagnostics.ts
+++ b/src/bricks/transformers/extensionDiagnostics.ts
@@ -17,9 +17,9 @@
 
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { getDiagnostics as collectFrameDiagnostics } from "@/contentScript/performanceMonitoring";
 import { collectPerformanceDiagnostics as collectExtensionDiagnostics } from "@/background/messenger/api";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class ExtensionDiagnostics extends TransformerABC {
   override defaultOutputKey = "diagnostics";

--- a/src/bricks/transformers/httpGet.ts
+++ b/src/bricks/transformers/httpGet.ts
@@ -16,7 +16,6 @@
  */
 
 import { TransformerABC } from "@/types/bricks/transformerTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { PropError } from "@/errors/businessErrors";
 import { validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
@@ -25,6 +24,7 @@ import { type SanitizedIntegrationConfig } from "@/integrations/integrationTypes
 import { type AxiosRequestConfig } from "axios";
 import { isNullOrBlank } from "@/utils/stringUtils";
 import type { PlatformCapability } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class GetAPITransformer extends TransformerABC {
   static BRICK_ID = validateRegistryId("@pixiebrix/get");

--- a/src/bricks/transformers/javascript.ts
+++ b/src/bricks/transformers/javascript.ts
@@ -19,10 +19,10 @@ import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { validateRegistryId } from "@/types/helpers";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type UiSchema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { type JSONSchema7 } from "json-schema";
 import { type JsonObject } from "type-fest";
 import type { PlatformCapability } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class JavaScriptTransformer extends TransformerABC {
   static readonly BRICK_ID = validateRegistryId("@pixiebrix/javascript");

--- a/src/bricks/transformers/jq.ts
+++ b/src/bricks/transformers/jq.ts
@@ -18,13 +18,13 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { InputValidationError } from "@/bricks/errors";
 import { getErrorMessage, isErrorObject } from "@/errors/errorHelpers";
 import { BusinessError } from "@/errors/businessErrors";
 import { isNullOrBlank } from "@/utils/stringUtils";
 import { retryWithJitter } from "@/utils/promiseUtils";
 import { type JsonValue } from "type-fest";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 const jqStacktraceRegexp = /jq: error \(at \/dev\/stdin:0\): (?<message>.*)/;
 

--- a/src/bricks/transformers/parseCsv.ts
+++ b/src/bricks/transformers/parseCsv.ts
@@ -18,8 +18,8 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { BusinessError } from "@/errors/businessErrors";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class ParseCsv extends TransformerABC {
   constructor() {

--- a/src/bricks/transformers/parseDataUrl.ts
+++ b/src/bricks/transformers/parseDataUrl.ts
@@ -18,11 +18,11 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { truncate } from "lodash";
 import { getEncodingName } from "@/vendors/encodings";
 import parseDataUrl from "@/utils/parseDataUrl";
 import { PropError } from "@/errors/businessErrors";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 /**
  * Length to trim URLs to in error messages.

--- a/src/bricks/transformers/parseDate.ts
+++ b/src/bricks/transformers/parseDate.ts
@@ -18,9 +18,9 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { isEmpty } from "lodash";
 import { PropError } from "@/errors/businessErrors";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export function getLocalISOString(date: Date): string {
   let offsetInMinutes = date.getTimezoneOffset();

--- a/src/bricks/transformers/parseUrl.ts
+++ b/src/bricks/transformers/parseUrl.ts
@@ -18,7 +18,6 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { pick } from "lodash";
 
 // Methods imported async in the brick
@@ -26,6 +25,7 @@ import type { ParsedDomain } from "psl";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { BusinessError } from "@/errors/businessErrors";
 import { isNullOrBlank } from "@/utils/stringUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 const URL_PROPERTIES = [
   "port",

--- a/src/bricks/transformers/prompt.ts
+++ b/src/bricks/transformers/prompt.ts
@@ -18,9 +18,9 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { CancelError } from "@/errors/businessErrors";
 import type { PlatformCapability } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class Prompt extends TransformerABC {
   constructor() {

--- a/src/bricks/transformers/randomNumber.ts
+++ b/src/bricks/transformers/randomNumber.ts
@@ -16,10 +16,10 @@
  */
 
 import { TransformerABC } from "@/types/bricks/transformerTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { random } from "lodash";
 import { BusinessError } from "@/errors/businessErrors";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class RandomNumber extends TransformerABC {
   constructor() {

--- a/src/bricks/transformers/readable.ts
+++ b/src/bricks/transformers/readable.ts
@@ -17,9 +17,9 @@
 
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { BusinessError } from "@/errors/businessErrors";
 import { type BrickOptions } from "@/types/runtimeTypes";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class Readable extends TransformerABC {
   constructor() {

--- a/src/bricks/transformers/regex.ts
+++ b/src/bricks/transformers/regex.ts
@@ -18,13 +18,13 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { isArray, unary } from "lodash";
 import { PropError } from "@/errors/businessErrors";
 import { type BrickConfig } from "@/bricks/types";
 import { extractRegexLiteral } from "@/analysis/analysisVisitors/regexAnalysis";
 
 import { isNunjucksExpression } from "@/utils/expressionUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 function extractNamedCaptureGroups(pattern: string): string[] {
   // Create new regex on each analysis call to avoid state issues with test

--- a/src/bricks/transformers/remoteMethod.ts
+++ b/src/bricks/transformers/remoteMethod.ts
@@ -18,12 +18,12 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { type AxiosRequestConfig } from "axios";
 import { PropError } from "@/errors/businessErrors";
 import { validateRegistryId } from "@/types/helpers";
 import { type SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
 import type { PlatformCapability } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export const inputProperties: Record<string, Schema> = {
   url: {

--- a/src/bricks/transformers/searchText.ts
+++ b/src/bricks/transformers/searchText.ts
@@ -18,9 +18,9 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { castArray } from "lodash";
 import { stemmer } from "stemmer";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 /**
  * A text search match.

--- a/src/bricks/transformers/selectElement.ts
+++ b/src/bricks/transformers/selectElement.ts
@@ -17,12 +17,12 @@
 
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import {
   CONTENT_SCRIPT_CAPABILITIES,
   type PlatformCapability,
 } from "@/platform/capabilities";
 import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class SelectElement extends TransformerABC {
   constructor() {

--- a/src/bricks/transformers/splitText.ts
+++ b/src/bricks/transformers/splitText.ts
@@ -18,7 +18,8 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
+
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 interface SplitArgs {
   text: string;

--- a/src/bricks/transformers/template.ts
+++ b/src/bricks/transformers/template.ts
@@ -22,9 +22,9 @@ import {
   type BrickOptions,
 } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import Mustache from "mustache";
 import { BusinessError } from "@/errors/businessErrors";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 /**
  * Transformer that fills a template using the current context.

--- a/src/bricks/transformers/tourStep/tourStep.ts
+++ b/src/bricks/transformers/tourStep/tourStep.ts
@@ -22,7 +22,6 @@ import {
   type PipelineExpression,
 } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import {
   BusinessError,
   MultipleElementsFoundError,
@@ -48,6 +47,7 @@ import {
   type PlatformCapability,
 } from "@/platform/capabilities";
 import { expectContext } from "@/utils/expectContext";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export type StepInputs = {
   title: string;

--- a/src/bricks/transformers/traverseElements.ts
+++ b/src/bricks/transformers/traverseElements.ts
@@ -17,13 +17,13 @@
 
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { getReferenceForElement } from "@/contentScript/elementReference";
-import { propertiesToSchema } from "@/validators/generic";
 import { type Schema } from "@/types/schemaTypes";
 import {
   type BrickArgs,
   type BrickOptions,
   type ElementReference,
 } from "@/types/runtimeTypes";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 const traversalTypes = [
   "closest",

--- a/src/contrib/automationanywhere/SetCopilotDataEffect.ts
+++ b/src/contrib/automationanywhere/SetCopilotDataEffect.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { propertiesToSchema } from "@/validators/generic";
 import { validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
 import { type BrickArgs } from "@/types/runtimeTypes";
@@ -23,6 +22,7 @@ import { EffectABC } from "@/types/bricks/effectTypes";
 import { setPartnerCopilotData } from "@/background/messenger/api";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
 import { BusinessError } from "@/errors/businessErrors";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 type ProcessDataMap = Record<string, UnknownObject>;
 

--- a/src/contrib/google/geocode.ts
+++ b/src/contrib/google/geocode.ts
@@ -17,12 +17,12 @@
 
 import { isEmpty } from "lodash";
 import { TransformerABC } from "@/types/bricks/transformerTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { type SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
 import { type Schema } from "@/types/schemaTypes";
 import type { BrickArgs, BrickOptions } from "@/types/runtimeTypes";
 import type { PlatformCapability } from "@/platform/capabilities";
 import type { PlatformProtocol } from "@/platform/platformProtocol";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 interface GeocodedAddress {
   state?: string;

--- a/src/contrib/google/sheets/bricks/append.ts
+++ b/src/contrib/google/sheets/bricks/append.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { propertiesToSchema } from "@/validators/generic";
 import { isEmpty, isEqual, unary, uniq } from "lodash";
 import { validateRegistryId } from "@/types/helpers";
 import { normalizeHeader } from "@/contrib/google/sheets/core/sheetsHelpers";
@@ -33,6 +32,7 @@ import { type SpreadsheetTarget } from "@/contrib/google/sheets/core/sheetsApi";
 import { isNullOrBlank } from "@/utils/stringUtils";
 import { isObject } from "@/utils/objectUtils";
 import { SERVICES_BASE_SCHEMA_URL } from "@/integrations/util/makeServiceContextFromDependencies";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 type CellValue = string | number | null;
 

--- a/src/contrib/pipedrive/create.ts
+++ b/src/contrib/pipedrive/create.ts
@@ -16,11 +16,11 @@
  */
 
 import { EffectABC } from "@/types/bricks/effectTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { BusinessError } from "@/errors/businessErrors";
 import { type SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import type { PlatformCapability } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class AddOrganization extends EffectABC {
   // https://developers.pipedrive.com/docs/api/v1/#!/Organizations/post_organizations

--- a/src/pageEditor/starterBricks/upgrade.test.ts
+++ b/src/pageEditor/starterBricks/upgrade.test.ts
@@ -22,10 +22,10 @@ import {
 } from "@/pageEditor/starterBricks/upgrade";
 import blockRegistry from "@/bricks/registry";
 import { BrickABC } from "@/types/brickTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { type Schema } from "@/types/schemaTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { toExpression } from "@/utils/expressionUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 beforeEach(() => {
   blockRegistry.clear();

--- a/src/pageEditor/tabs/effect/BrickConfiguration.test.tsx
+++ b/src/pageEditor/tabs/effect/BrickConfiguration.test.tsx
@@ -21,7 +21,6 @@ import brickRegistry from "@/bricks/registry";
 import { echoBrick } from "@/runtime/pipelineTests/pipelineTestHelpers";
 import { screen } from "@testing-library/react";
 import { waitForEffect } from "@/testUtils/testHelpers";
-import { propertiesToSchema } from "@/validators/generic";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import { render } from "@/pageEditor/testHelpers";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
@@ -39,6 +38,7 @@ import {
   brickFactory,
 } from "@/testUtils/factories/brickFactories";
 import CommentEffect from "@/bricks/effects/comment";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 beforeAll(() => {
   registerDefaultWidgets();

--- a/src/pageEditor/tabs/modOptionsValues/ModOptionsValuesEditor.test.tsx
+++ b/src/pageEditor/tabs/modOptionsValues/ModOptionsValuesEditor.test.tsx
@@ -133,6 +133,7 @@ describe("ModOptionsValuesEditor", () => {
     const modDefinition = defaultModDefinitionFactory({
       options: {
         schema: {
+          // Interpreted as a schema because it has type: object
           type: "object",
           additionalProperties: {
             type: "string",
@@ -143,6 +144,9 @@ describe("ModOptionsValuesEditor", () => {
     mockModDefinition(modDefinition);
     const { asFragment } = render(<ModOptionsValuesEditor />);
     await waitForEffect();
+    expect(
+      await screen.findByText("This mod does not require any configuration"),
+    ).toBeVisible();
     expect(asFragment()).toMatchSnapshot();
   });
 

--- a/src/pageEditor/tabs/modOptionsValues/__snapshots__/ModOptionsValuesEditor.test.tsx.snap
+++ b/src/pageEditor/tabs/modOptionsValues/__snapshots__/ModOptionsValuesEditor.test.tsx.snap
@@ -20,61 +20,8 @@ exports[`ModOptionsValuesEditor renders blueprint options with additional props 
         <div
           class="card-body"
         >
-          <div
-            class="formGroup form-group"
-          >
-            <div
-              class="mb-2 w-100 collapse"
-            >
-              <div
-                class="annotationPlaceholder"
-              />
-            </div>
-            <label
-              class="label form-label"
-              for="additionalProperties"
-            >
-              Additional Properties
-            </label>
-            <div
-              class="formField"
-            >
-              <div
-                class="root"
-              >
-                <div
-                  class="field"
-                >
-                  <input
-                    class="form-control"
-                    id="additionalProperties"
-                    name="additionalProperties"
-                    readonly=""
-                    value=""
-                  />
-                </div>
-                <div
-                  class="dropdown dropdown"
-                  data-test-selected="Exclude"
-                  data-testid="toggle-additionalProperties"
-                >
-                  <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="dropdown-toggle btn btn-link"
-                    type="button"
-                  >
-                    <span
-                      class="symbol"
-                    >
-                      <test-file-stub
-                        classname="root"
-                      />
-                    </span>
-                  </button>
-                </div>
-              </div>
-            </div>
+          <div>
+            This mod does not require any configuration
           </div>
         </div>
       </div>

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -1,5 +1,4 @@
 import ConsoleLogger from "@/utils/ConsoleLogger";
-import { propertiesToSchema } from "@/validators/generic";
 import { type InitialValues } from "@/runtime/reducePipeline";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { mapArgs } from "@/runtime/mapArgs";
@@ -17,6 +16,7 @@ import { type Schema } from "@/types/schemaTypes";
 import { isDeferExpression } from "@/utils/expressionUtils";
 import isPromise from "is-promise";
 import { type JsonValue } from "type-fest";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 const logger = new ConsoleLogger();
 

--- a/src/runtime/pipelineTests/root.test.ts
+++ b/src/runtime/pipelineTests/root.test.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { propertiesToSchema } from "@/validators/generic";
 import blockRegistry from "@/bricks/registry";
 import {
   echoBrick,
@@ -33,6 +32,7 @@ import {
 } from "@/types/runtimeTypes";
 import { BrickABC } from "@/types/brickTypes";
 import { toExpression } from "@/utils/expressionUtils";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 class RootAwareBlock extends BrickABC {
   constructor() {

--- a/src/sidebar/activateMod/ActivateModPanel.test.tsx
+++ b/src/sidebar/activateMod/ActivateModPanel.test.tsx
@@ -21,7 +21,6 @@ import { render, screen } from "@/sidebar/testHelpers";
 import ActivateModPanel from "@/sidebar/activateMod/ActivateModPanel";
 import sidebarSlice from "@/sidebar/sidebarSlice";
 import { waitForEffect } from "@/testUtils/testHelpers";
-import { propertiesToSchema } from "@/validators/generic";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import useQuickbarShortcut from "@/hooks/useQuickbarShortcut";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
@@ -55,6 +54,7 @@ import useActivateRecipe, {
 import brickRegistry from "@/bricks/registry";
 import { registryIdFactory } from "@/testUtils/factories/stringFactories";
 import { registry } from "@/background/messenger/strict/api";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 jest.mock("@/modDefinitions/modDefinitionHooks");
 jest.mock("@/sidebar/sidebarSelectors");

--- a/src/starterBricks/contextMenu.ts
+++ b/src/starterBricks/contextMenu.ts
@@ -19,7 +19,6 @@ import {
   type InitialValues,
   reduceExtensionPipeline,
 } from "@/runtime/reducePipeline";
-import { propertiesToSchema } from "@/validators/generic";
 import {
   type Manifest,
   type Menus,
@@ -70,6 +69,7 @@ import type { PlatformProtocol } from "@/platform/platformProtocol";
 import { type MessageConfig } from "@/utils/notify";
 import { DEFAULT_ACTION_RESULTS } from "@/starterBricks/starterBrickConstants";
 import { flagOn } from "@/auth/featureFlagStorage";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 const DEFAULT_MENU_ITEM_TITLE = "Untitled menu item";
 

--- a/src/starterBricks/menuItemExtension.ts
+++ b/src/starterBricks/menuItemExtension.ts
@@ -36,7 +36,6 @@ import {
   type StarterBrickDefinition,
 } from "@/starterBricks/types";
 import { type Metadata } from "@/types/registryTypes";
-import { propertiesToSchema } from "@/validators/generic";
 import { type Permissions } from "webextension-polyfill";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
@@ -87,6 +86,7 @@ import {
 } from "@/platform/capabilities";
 import type { PlatformProtocol } from "@/platform/platformProtocol";
 import { DEFAULT_ACTION_RESULTS } from "@/starterBricks/starterBrickConstants";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 interface ShadowDOM {
   mode?: "open" | "closed";

--- a/src/starterBricks/panelExtension.ts
+++ b/src/starterBricks/panelExtension.ts
@@ -36,7 +36,6 @@ import {
   type StarterBrickConfig,
   type StarterBrickDefinition,
 } from "@/starterBricks/types";
-import { propertiesToSchema } from "@/validators/generic";
 import { render } from "@/starterBricks/dom";
 import { type Permissions } from "webextension-polyfill";
 import reportEvent from "@/telemetry/reportEvent";
@@ -66,6 +65,7 @@ import {
 } from "@/platform/capabilities";
 import { RepeatableAbortController } from "abort-utils";
 import type { PlatformProtocol } from "@/platform/platformProtocol";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export type PanelConfig = {
   heading?: string;

--- a/src/starterBricks/quickBarExtension.tsx
+++ b/src/starterBricks/quickBarExtension.tsx
@@ -20,7 +20,6 @@ import {
   type InitialValues,
   reduceExtensionPipeline,
 } from "@/runtime/reducePipeline";
-import { propertiesToSchema } from "@/validators/generic";
 import {
   type Manifest,
   type Menus,
@@ -61,6 +60,7 @@ import { allSettled } from "@/utils/promiseUtils";
 import type { PlatformCapability } from "@/platform/capabilities";
 import type { PlatformProtocol } from "@/platform/platformProtocol";
 import { DEFAULT_ACTION_RESULTS } from "@/starterBricks/starterBrickConstants";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export type QuickBarTargetMode = "document" | "eventTarget";
 

--- a/src/starterBricks/quickBarProviderExtension.tsx
+++ b/src/starterBricks/quickBarProviderExtension.tsx
@@ -16,7 +16,6 @@
  */
 
 import React from "react";
-import { propertiesToSchema } from "@/validators/generic";
 import {
   type Manifest,
   type Menus,
@@ -64,6 +63,7 @@ import pluralize from "@/utils/pluralize";
 import { allSettled } from "@/utils/promiseUtils";
 import type { PlatformCapability } from "@/platform/capabilities";
 import type { PlatformProtocol } from "@/platform/platformProtocol";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export type QuickBarProviderConfig = {
   /**

--- a/src/starterBricks/sidebarExtension.ts
+++ b/src/starterBricks/sidebarExtension.ts
@@ -19,7 +19,6 @@ import {
   type InitialValues,
   reduceExtensionPipeline,
 } from "@/runtime/reducePipeline";
-import { propertiesToSchema } from "@/validators/generic";
 import {
   type CustomEventOptions,
   type DebounceOptions,
@@ -56,6 +55,7 @@ import makeServiceContextFromDependencies from "@/integrations/util/makeServiceC
 import { RepeatableAbortController } from "abort-utils";
 import type { PlatformCapability } from "@/platform/capabilities";
 import type { PlatformProtocol } from "@/platform/platformProtocol";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export type SidebarConfig = {
   heading: string;

--- a/src/starterBricks/tourExtension.ts
+++ b/src/starterBricks/tourExtension.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { propertiesToSchema } from "@/validators/generic";
 import {
   StarterBrickABC,
   type StarterBrickConfig,
@@ -62,6 +61,7 @@ import {
   type PlatformCapability,
 } from "@/platform/capabilities";
 import type { PlatformProtocol } from "@/platform/platformProtocol";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export type TourConfig = {
   /**

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -20,7 +20,6 @@ import {
   reduceExtensionPipeline,
 } from "@/runtime/reducePipeline";
 import { RepeatableAbortController } from "abort-utils";
-import { propertiesToSchema } from "@/validators/generic";
 import {
   type CustomEventOptions,
   type DebounceOptions,
@@ -85,6 +84,7 @@ import makeServiceContextFromDependencies from "@/integrations/util/makeServiceC
 import { allSettled } from "@/utils/promiseUtils";
 import type { PlatformCapability } from "@/platform/capabilities";
 import type { PlatformProtocol } from "@/platform/platformProtocol";
+import { propertiesToSchema } from "@/utils/schemaUtils";
 
 type TriggerTarget = Document | HTMLElement;
 

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -42,6 +42,7 @@ import { assertNotNullish } from "./nullishUtils";
 import {
   minimalSchemaFactory,
   minimalUiSchemaFactory,
+  propertiesToSchema,
 } from "@/utils/schemaUtils";
 import { isEmpty, sortBy } from "lodash";
 import { isNullOrBlank } from "@/utils/stringUtils";
@@ -50,7 +51,6 @@ import {
   type SchemaProperties,
   type UiSchema,
 } from "@/types/schemaTypes";
-import { propertiesToSchema } from "@/validators/generic";
 
 /**
  * Returns true if the mod is an UnavailableMod

--- a/src/utils/schemaUtils.test.ts
+++ b/src/utils/schemaUtils.test.ts
@@ -15,8 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { unionSchemaDefinitionTypes } from "@/utils/schemaUtils";
-import { type Schema } from "@/types/schemaTypes";
+import {
+  inputProperties,
+  propertiesToSchema,
+  unionSchemaDefinitionTypes,
+} from "@/utils/schemaUtils";
+import type { Schema, SchemaProperties } from "@/types/schemaTypes";
 
 const fooObjectSchema: Schema = {
   type: "object",
@@ -133,5 +137,29 @@ describe("unionSchemaDefinitionTypes", () => {
     ).toEqual({
       anyOf: [fooObjectSchema, { type: "number" }],
     });
+  });
+});
+
+describe("inputProperties", () => {
+  it("returns properties if present", () => {
+    expect(inputProperties(fooObjectSchema)).toStrictEqual(
+      fooObjectSchema.properties,
+    );
+  });
+
+  it("returns properties if type: object", () => {
+    expect(inputProperties({ type: "object" })).toStrictEqual({});
+  });
+
+  it("returns argument if no properties", () => {
+    // Legacy behavior handling brick
+    expect(inputProperties({ foo: 42 } as any)).toStrictEqual({ foo: 42 });
+  });
+
+  it("round trips", () => {
+    const original: SchemaProperties = { foo: { type: "string" } };
+    expect(inputProperties(propertiesToSchema(original, []))).toStrictEqual(
+      original,
+    );
   });
 });

--- a/src/utils/schemaUtils.test.ts
+++ b/src/utils/schemaUtils.test.ts
@@ -141,6 +141,10 @@ describe("unionSchemaDefinitionTypes", () => {
 });
 
 describe("inputProperties", () => {
+  it("returns empty object for null", () => {
+    expect(inputProperties(null as any)).toStrictEqual({});
+  });
+
   it("returns properties if present", () => {
     expect(inputProperties(fooObjectSchema)).toStrictEqual(
       fooObjectSchema.properties,

--- a/src/utils/schemaUtils.test.ts
+++ b/src/utils/schemaUtils.test.ts
@@ -160,10 +160,22 @@ describe("inputProperties", () => {
     expect(inputProperties({ foo: 42 } as any)).toStrictEqual({ foo: 42 });
   });
 
-  it("round trips", () => {
+  it("round trips with propertiesToSchema", () => {
     const original: SchemaProperties = { foo: { type: "string" } };
     expect(inputProperties(propertiesToSchema(original, []))).toStrictEqual(
       original,
     );
+  });
+});
+
+describe("propertiesToSchema", () => {
+  it("passes through required fields", () => {
+    // No additionalProperties property is added
+    expect(propertiesToSchema({ foo: { type: "string" } }, ["foo"])).toEqual({
+      type: "object",
+      $schema: "https://json-schema.org/draft/2019-09/schema#",
+      properties: { foo: { type: "string" } },
+      required: ["foo"],
+    });
   });
 });

--- a/src/utils/schemaUtils.ts
+++ b/src/utils/schemaUtils.ts
@@ -93,13 +93,13 @@ export function propertiesToSchema(
  * @see propertiesToSchema
  */
 export function inputProperties(inputSchema: Schema): SchemaProperties {
-  // Dynamic checks to handle bad casts of user-provided definitions
-  if (inputSchema == null || typeof inputSchema !== "object") {
-    throw new Error("Expected object");
-  }
-
   // NOTE: returning the argument is UNSAFE and is not consistent with the parameter type `Schema`.
   // In the past, PixieBrix definitions have supported shorthand of providing the properties directly.
+
+  // Handle unchecked casts of invalid user-provided definitions
+  if (inputSchema == null || typeof inputSchema !== "object") {
+    return {} as SchemaProperties;
+  }
 
   // It looks like a Schema, even it properties are not provided
   if ("$schema" in inputSchema || inputSchema.type === "object") {

--- a/src/utils/schemaUtils.ts
+++ b/src/utils/schemaUtils.ts
@@ -72,15 +72,41 @@ export function missingProperties(
 }
 
 /**
+ * Convert JSON Schema properties value to a top-level JSON Schema.
+ * @see inputProperties
+ */
+export function propertiesToSchema(
+  properties: SchemaProperties,
+  required: string[],
+): Schema {
+  return {
+    $schema: "https://json-schema.org/draft/2019-09/schema#",
+    type: "object",
+    properties,
+    required,
+  };
+}
+
+/**
  * Return the names of top-level properties in a JSON Schema or object.
- * @param inputSchema the schema or object
+ * @param inputSchema the input schema
+ * @see propertiesToSchema
  */
 export function inputProperties(inputSchema: Schema): SchemaProperties {
-  if (
-    typeof inputSchema === "object" &&
-    "properties" in inputSchema &&
-    inputSchema.properties != null
-  ) {
+  // Dynamic checks to handle bad casts of user-provided definitions
+  if (inputSchema == null || typeof inputSchema !== "object") {
+    throw new Error("Expected object");
+  }
+
+  // NOTE: returning the argument is UNSAFE and is not consistent with the parameter type `Schema`.
+  // In the past, PixieBrix definitions have supported shorthand of providing the properties directly.
+
+  // It looks like a Schema, even it properties are not provided
+  if ("$schema" in inputSchema || inputSchema.type === "object") {
+    return inputSchema.properties ?? {};
+  }
+
+  if (inputSchema.properties != null) {
     return inputSchema.properties;
   }
 

--- a/src/utils/schemaUtils.ts
+++ b/src/utils/schemaUtils.ts
@@ -101,7 +101,7 @@ export function inputProperties(inputSchema: Schema): SchemaProperties {
     return {} as SchemaProperties;
   }
 
-  // It looks like a Schema, even it properties are not provided
+  // It looks like a Schema, even if `properties` property is not provided
   if ("$schema" in inputSchema || inputSchema.type === "object") {
     return inputSchema.properties ?? {};
   }

--- a/src/validators/generic.ts
+++ b/src/validators/generic.ts
@@ -20,7 +20,7 @@ import {
   type ValidationResult,
   Validator,
 } from "@cfworker/json-schema";
-import { type Schema, type SchemaProperties } from "@/types/schemaTypes";
+import { type Schema } from "@/types/schemaTypes";
 import serviceRegistry from "@/integrations/registry";
 import { pickBy } from "lodash";
 import urljoin from "url-join";
@@ -152,21 +152,6 @@ export async function validateInput(
   }
 
   return validator.validate(instance ?? null);
-}
-
-/**
- * Convert JSON Schema properties value to a top-level JSONSchema.
- */
-export function propertiesToSchema(
-  properties: SchemaProperties,
-  required: string[],
-): Schema {
-  return {
-    $schema: "https://json-schema.org/draft/2019-09/schema#",
-    type: "object",
-    properties,
-    required,
-  };
 }
 
 // eslint-disable-next-line local-rules/persistBackgroundData -- Static


### PR DESCRIPTION
## What does this PR do?

- Part of #7801 
- Split off from #7802 because that PR was touching so many files
- Move `propertiesToSchema` to `schemaUtils` to co-locate it with `inputProperties`
- Add commentary/historical context to `inputProperties` and improve detection of Schema vs. passing through legacy properties definition

## Reviewer Tips

- Review `schemaUtils` first

## Remaining Work

- [x] Fix broken test due to `inputProperties` change. See comment on file

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
