### PR TITLE
Use "Local Integration" terminology in Extension Console

### DIFF
--- a/src/components/integrations/IntegrationConfigEditorModal.tsx
+++ b/src/components/integrations/IntegrationConfigEditorModal.tsx
@@ -213,7 +213,7 @@ const ModalContent: React.FC<ContentProps> = ({
     <>
       <Modal.Header closeButton>
         <Modal.Title>
-          Configure Private Integration: {integration.name}
+          Configure Local Integration: {integration.name}
         </Modal.Title>
       </Modal.Header>
 

--- a/src/extensionConsole/Sidebar.tsx
+++ b/src/extensionConsole/Sidebar.tsx
@@ -62,7 +62,8 @@ const Sidebar: React.FunctionComponent = () => {
           {permit("services") && (
             <SidebarLink
               route="/services"
-              title="Integrations"
+              // Help to distinguish vs. integrations defined in the Admin Console
+              title="Local Integrations"
               icon={faCloud}
             />
           )}

--- a/src/extensionConsole/pages/integrations/IntegrationsPage.tsx
+++ b/src/extensionConsole/pages/integrations/IntegrationsPage.tsx
@@ -380,8 +380,8 @@ const IntegrationsPage: React.VFC = () => {
   return (
     <Page
       icon={faCloud}
-      title="Integrations"
-      description="Configure external accounts, resources, and APIs. Personal integrations are
+      title="Local Integrations"
+      description="Configure external accounts, resources, and APIs. Local integrations are
           stored in your browser; they are never transmitted to the PixieBrix servers or shared with your team"
       isPending={localState.isLoadingIntegrations}
       toolbar={
@@ -397,7 +397,7 @@ const IntegrationsPage: React.VFC = () => {
           caption={
             <span>
               <FontAwesomeIcon icon={faPlus} />
-              &nbsp;Add Integration
+              &nbsp;Add Local Integration
             </span>
           }
         />
@@ -422,7 +422,7 @@ const IntegrationsPage: React.VFC = () => {
       />
       <ConnectExtensionCard />
       <Card>
-        <Card.Header>Personal Integrations</Card.Header>
+        <Card.Header>Local Integrations</Card.Header>
         <PrivateIntegrationsCard
           navigate={navigate}
           integrations={localState.integrations}


### PR DESCRIPTION
## What does this PR do?

- Use consistent "Local Integration"s terminology in the Extension Console to help avoid confusion with Team Integrations in the Admin Console
- Match terminology in documentation: https://docs.pixiebrix.com/integrations/configuring-integrations

## Team Coordination

- [x] This PR requires a documentation change (link to old docs): https://docs.pixiebrix.com/integrations/configuring-integrations

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/976cf66d-6616-424a-9529-4291e9ca2034)

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
