### PR TITLE
#7788: preserve input border color without changing non-inputs

### DIFF
--- a/src/vendors/theme/assets/styles/_variables.scss
+++ b/src/vendors/theme/assets/styles/_variables.scss
@@ -4,7 +4,7 @@
 $content-bg: $neutral-surface-color;
 $footer-bg: $neutral-surface-color;
 $footer-color: color(dark);
-$border-color: hsl(0, 0%, 80%); // Matches react-select's border
+$border-color: $neutral-surface-color;
 $circle-border: $white;
 
 ////////// COLOR VARIABLES //////////
@@ -153,6 +153,7 @@ $tooltip-border-radius: 0.375rem;
 
 $input-bg: color(white);
 $input-border-radius: 2px;
+$input-border-color: hsl(0, 0%, 80%); // Matches react-select's border
 $input-placeholder-color: #c9c8c8;
 $input-font-size: 0.8125rem;
 

--- a/src/vendors/theme/assets/styles/components/_forms.scss
+++ b/src/vendors/theme/assets/styles/components/_forms.scss
@@ -28,7 +28,7 @@
 }
 
 .form-control {
-  border: 1px solid $border-color;
+  border: 1px solid $input-border-color;
   font-size: $input-font-size;
 }
 

--- a/src/vendors/theme/assets/styles/components/_forms.scss
+++ b/src/vendors/theme/assets/styles/components/_forms.scss
@@ -10,7 +10,7 @@
   width: auto;
   border: none;
   .input-group-text {
-    border-color: $border-color;
+    border-color: $input-border-color;
     padding: 0.575rem 0.75rem;
     color: $input-placeholder-color;
   }
@@ -36,10 +36,10 @@ select {
   &.form-control {
     padding: 0.4375rem 0.75rem;
     border: 0;
-    outline: 1px solid $border-color;
+    outline: 1px solid $input-border-color;
     color: $input-placeholder-color;
     &:focus {
-      outline: 1px solid $border-color;
+      outline: 1px solid $input-border-color;
     }
     @each $color, $value in $theme-colors {
       &.border-#{$color} {
@@ -78,7 +78,7 @@ select {
   }
   .custom-file-label {
     background: $input-bg;
-    border: 1px solid $border-color;
+    border: 1px solid $input-border-color;
     height: calc(2.25rem + 2px);
     font-weight: normal;
     font-size: 0.875rem;


### PR DESCRIPTION
## What does this PR do?

- Fixes #7788
-  Relates to #7764 

## Discussion

- Override the border color of _only_ form controls.
- Might find that there are other places we also need to update the border color for, but this covers the initial ask for $7764

## Demo

Inputs still fixed:
<img width="207" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/6d6e43ac-6b73-4b5d-a117-84103dc11f4f">

Workshop Table fixed:
<img width="1038" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/653d8d70-dfe4-477d-b789-49603ebe366d">

Mods Page hr:
<img width="198" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/065a5c55-46e5-46b7-bdac-959c73ae2b66">

Password:
<img width="400" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/4bc74045-9a85-4de2-9668-6c7f17b82e7d">

## Checklist

- [x] Designate a primary reviewer @mnholtz 
