### PR TITLE
implement jest/prefer-expect-resolves

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -128,6 +128,7 @@ module.exports = {
       rules: {
         "unicorn/prefer-spread": "off",
         "local-rules/noCrossBoundaryImports": "off",
+        "jest/prefer-expect-resolves": "error",
       },
     },
     {

--- a/src/auth/RequireAuth.test.tsx
+++ b/src/auth/RequireAuth.test.tsx
@@ -38,7 +38,9 @@ describe("RequireAuth", () => {
       </RequireAuth>,
     );
 
-    expect(await screen.findByTestId("loader")).not.toBeInTheDocument();
+    await expect(
+      screen.findByTestId("loader"),
+    ).resolves.not.toBeInTheDocument();
     expect(
       screen.getByText("Only authenticated users should see me!"),
     ).toBeVisible();
@@ -56,7 +58,7 @@ describe("RequireAuth", () => {
     );
 
     await waitFor(async () => {
-      expect(await screen.findByText("Login")).toBeVisible();
+      await expect(screen.findByText("Login")).resolves.toBeVisible();
     });
     expect(screen.queryByTestId("loader")).not.toBeInTheDocument();
     expect(

--- a/src/background/auth/getToken.test.ts
+++ b/src/background/auth/getToken.test.ts
@@ -40,18 +40,18 @@ describe("getToken", () => {
 
     const id1 = uuidv4();
     // Consecutive calls should make new requests
-    expect(await getOneToken(id1)).toBe(0);
-    expect(await getOneToken(id1)).toBe(1);
+    await expect(getOneToken(id1)).resolves.toBe(0);
+    await expect(getOneToken(id1)).resolves.toBe(1);
 
     // Parallel calls should make one request
-    expect(
-      await Promise.all([getOneToken(id1), getOneToken(id1)]),
-    ).toStrictEqual([2, 2]);
+    await expect(
+      Promise.all([getOneToken(id1), getOneToken(id1)]),
+    ).resolves.toStrictEqual([2, 2]);
 
     // Parallel calls but with different auth.id’s should make multiple requests
     const id2 = uuidv4();
-    expect(
-      await Promise.all([getOneToken(id1), getOneToken(id2)]),
-    ).toStrictEqual([3, 4]);
+    await expect(
+      Promise.all([getOneToken(id1), getOneToken(id2)]),
+    ).resolves.toStrictEqual([3, 4]);
   });
 });

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -339,7 +339,7 @@ describe("updateDeployments", () => {
     axiosMock.onPost().reply(201, [deployment]);
 
     // Make sure we're testing the case where getEditorState() returns undefined
-    expect(await getEditorState()).toBeUndefined();
+    await expect(getEditorState()).resolves.toBeUndefined();
 
     await updateDeployments();
 

--- a/src/bricks/available.test.ts
+++ b/src/bricks/available.test.ts
@@ -23,9 +23,9 @@ import { checkAvailable, testMatchPatterns } from "@/bricks/available";
 
 describe("isAvailable.urlPatterns", () => {
   test("can match hash", async () => {
-    expect(await checkAvailable({ urlPatterns: { hash: "/foo/:id" } })).toBe(
-      true,
-    );
+    await expect(
+      checkAvailable({ urlPatterns: { hash: "/foo/:id" } }),
+    ).resolves.toBe(true);
   });
 
   test("invalid baseURL", async () => {
@@ -35,26 +35,26 @@ describe("isAvailable.urlPatterns", () => {
   });
 
   test("can reject hash", async () => {
-    expect(
-      await checkAvailable({ urlPatterns: { hash: "/DIFFERENT/:id" } }),
-    ).toBe(false);
+    await expect(
+      checkAvailable({ urlPatterns: { hash: "/DIFFERENT/:id" } }),
+    ).resolves.toBe(false);
   });
 });
 
 describe("isAvailable.matchPatterns", () => {
   test("can match pattern", async () => {
-    expect(
-      await checkAvailable({ matchPatterns: "https://www.example.com/*" }),
-    ).toBe(true);
+    await expect(
+      checkAvailable({ matchPatterns: "https://www.example.com/*" }),
+    ).resolves.toBe(true);
   });
 
   test("require urlPattern and matchPattern", async () => {
-    expect(
-      await checkAvailable({
+    await expect(
+      checkAvailable({
         matchPatterns: "https://www.example.com/*",
         urlPatterns: { hash: "/DIFFERENT/:id" },
       }),
-    ).toBe(false);
+    ).resolves.toBe(false);
   });
 });
 

--- a/src/bricks/effects/InsertAtCursorEffect.test.ts
+++ b/src/bricks/effects/InsertAtCursorEffect.test.ts
@@ -25,6 +25,6 @@ const brick = new InsertAtCursorEffect();
 
 describe("InsertAtCursorEffect", () => {
   it("is root-aware", async () => {
-    expect(await brick.isRootAware()).toBe(true);
+    await expect(brick.isRootAware()).resolves.toBe(true);
   });
 });

--- a/src/components/fields/schemaFields/SchemaField.test.tsx
+++ b/src/components/fields/schemaFields/SchemaField.test.tsx
@@ -519,6 +519,6 @@ describe("SchemaField", () => {
       />,
       { initialValues: {} },
     );
-    expect(await assertion()).toBeInTheDocument();
+    await expect(assertion()).resolves.toBeInTheDocument();
   });
 });

--- a/src/components/fields/schemaFields/SchemaField.test.tsx
+++ b/src/components/fields/schemaFields/SchemaField.test.tsx
@@ -501,14 +501,15 @@ describe("SchemaField", () => {
           { const: "secondary", title: "Secondary" },
         ],
       },
-      assertion: () => screen.getByTestId("selected-variant"),
+      assertion: async () => screen.getByTestId("selected-variant"),
     },
     {
       widget: "SchemaCustomEventWidget",
       schema: {
         type: "string",
       },
-      assertion: () => screen.getByRole("combobox", { name: "Test Field" }),
+      assertion: async () =>
+        screen.getByRole("combobox", { name: "Test Field" }),
     },
   ])("renders ui:widget $widget", async ({ widget, schema, assertion }) => {
     render(
@@ -519,6 +520,7 @@ describe("SchemaField", () => {
       />,
       { initialValues: {} },
     );
+
     await expect(assertion()).resolves.toBeInTheDocument();
   });
 });

--- a/src/components/fields/schemaFields/SchemaField.test.tsx
+++ b/src/components/fields/schemaFields/SchemaField.test.tsx
@@ -485,7 +485,7 @@ describe("SchemaField", () => {
   test.each<{
     widget: keyof CustomWidgetRegistry;
     schema: Schema;
-    assertion: () => unknown;
+    assertion: () => Promise<unknown>;
   }>([
     {
       widget: "CodeEditorWidget",

--- a/src/components/fields/schemaFields/widgets/CodeEditorWidget.test.tsx
+++ b/src/components/fields/schemaFields/widgets/CodeEditorWidget.test.tsx
@@ -65,7 +65,7 @@ describe("CodeEditorWidget", () => {
       onSubmit: onSubmitMock,
     });
 
-    expect(await screen.findByRole("textbox")).toBeInTheDocument();
+    await expect(screen.findByRole("textbox")).resolves.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Submit" }));
 
     // We can't assert on the value of the AceEditor because it is not rendered in the DOM
@@ -89,7 +89,7 @@ describe("CodeEditorWidget", () => {
       },
     );
 
-    expect(await screen.findByRole("textbox")).toBeInTheDocument();
+    await expect(screen.findByRole("textbox")).resolves.toBeInTheDocument();
     // The element that holds the value is not the input itself, but a div
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     const editorInputField = container.querySelector('[class="ace_content"]');

--- a/src/components/fields/schemaFields/widgets/PasswordWidget.module.scss
+++ b/src/components/fields/schemaFields/widgets/PasswordWidget.module.scss
@@ -19,9 +19,9 @@
 
 .showHideButton {
   background: $N0;
-  border-bottom: 1px solid $input-border-color;
-  border-right: 1px solid $input-border-color;
-  border-top: 1px solid $input-border-color;
+  border-bottom: 1px solid $input-field-border-color;
+  border-right: 1px solid $input-field-border-color;
+  border-top: 1px solid $input-field-border-color;
   padding-left: 8px;
   padding-right: 8px;
 }

--- a/src/components/fields/schemaFields/widgets/PasswordWidget.module.scss
+++ b/src/components/fields/schemaFields/widgets/PasswordWidget.module.scss
@@ -19,9 +19,9 @@
 
 .showHideButton {
   background: $N0;
-  border-bottom: 1px solid $input-field-border-color;
-  border-right: 1px solid $input-field-border-color;
-  border-top: 1px solid $input-field-border-color;
+  border-bottom: 1px solid $input-border-color;
+  border-right: 1px solid $input-border-color;
+  border-top: 1px solid $input-border-color;
   padding-left: 8px;
   padding-right: 8px;
 }

--- a/src/components/integrations/AuthWidget.test.tsx
+++ b/src/components/integrations/AuthWidget.test.tsx
@@ -96,9 +96,9 @@ describe("AuthWidget", () => {
   test("given no auth options, when rendered, then shows configure and refresh buttons", async () => {
     renderContent();
 
-    expect(
-      await screen.findByRole("button", { name: "Configure" }),
-    ).toBeVisible();
+    await expect(
+      screen.findByRole("button", { name: "Configure" }),
+    ).resolves.toBeVisible();
     expect(
       screen.getByRole("button", { name: /refresh/i, exact: false }),
     ).toBeVisible();
@@ -107,7 +107,7 @@ describe("AuthWidget", () => {
   test("given 1 auth option, when rendered, then shows select dropdown and defaults to the only option", async () => {
     renderContent(authOption1);
 
-    expect(await screen.findByText("Test Option 1")).toBeVisible();
+    await expect(screen.findByText("Test Option 1")).resolves.toBeVisible();
     expect(
       screen.queryByRole("button", { name: "Configure" }),
     ).not.toBeInTheDocument();
@@ -116,7 +116,9 @@ describe("AuthWidget", () => {
   test("given multiple auth options, when rendered, then shows select dropdown but does not select an option automatically", async () => {
     renderContent(authOption1, authOption2);
 
-    expect(await screen.findByText("Select configuration...")).toBeVisible();
+    await expect(
+      screen.findByText("Select configuration..."),
+    ).resolves.toBeVisible();
     expect(
       screen.queryByRole("button", { name: "Configure" }),
     ).not.toBeInTheDocument();

--- a/src/contrib/google/sheets/core/sheetsApi.test.ts
+++ b/src/contrib/google/sheets/core/sheetsApi.test.ts
@@ -168,7 +168,9 @@ describe("error handling", () => {
 
       await expect(getAllSpreadsheets(config)).rejects.toThrow(message);
 
-      expect(await getCachedAuthData(integrationConfig.id)).toStrictEqual({
+      await expect(
+        getCachedAuthData(integrationConfig.id),
+      ).resolves.toStrictEqual({
         access_token: "NOTAREALTOKEN",
       });
       expect(deleteCachedAuthDataMock).toHaveBeenCalledOnce();
@@ -210,7 +212,9 @@ describe("error handling", () => {
 
       await expect(getAllSpreadsheets(config)).rejects.toThrow(message);
 
-      expect(await getCachedAuthData(integrationConfig.id)).toStrictEqual({
+      await expect(
+        getCachedAuthData(integrationConfig.id),
+      ).resolves.toStrictEqual({
         access_token: "NOTAREALTOKEN",
         refresh_token: "NOTAREALREFRESHTOKEN",
       });
@@ -246,7 +250,9 @@ describe("error handling", () => {
 
       await getAllSpreadsheets(config);
 
-      expect(await getCachedAuthData(integrationConfig.id)).toStrictEqual({
+      await expect(
+        getCachedAuthData(integrationConfig.id),
+      ).resolves.toStrictEqual({
         access_token: "NOTAREALTOKEN2",
         refresh_token: "NOTAREALREFRESHTOKEN2",
       });

--- a/src/contrib/google/sheets/ui/SpreadsheetPickerWidget.test.tsx
+++ b/src/contrib/google/sheets/ui/SpreadsheetPickerWidget.test.tsx
@@ -136,7 +136,7 @@ describe("SpreadsheetPickerWidget", () => {
       selectEvent.openMenu(selectInput);
     });
 
-    expect(await screen.findByText("No options")).toBeVisible();
+    await expect(screen.findByText("No options")).resolves.toBeVisible();
   });
 
   test("given google pkce dependency and string spreadsheetId, renders dropdown with test spreadsheet option selected", async () => {

--- a/src/extensionConsole/pages/activateMod/IntegrationsBody.test.tsx
+++ b/src/extensionConsole/pages/activateMod/IntegrationsBody.test.tsx
@@ -131,25 +131,27 @@ afterAll(() => {
 });
 
 async function expectServiceDescriptorVisible(service: IntegrationDefinition) {
-  expect(await screen.findByText(service.metadata.name)).toBeVisible();
-  expect(await screen.findByText(service.metadata.id)).toBeVisible();
+  await expect(screen.findByText(service.metadata.name)).resolves.toBeVisible();
+  await expect(screen.findByText(service.metadata.id)).resolves.toBeVisible();
 }
 
 async function expectRefreshButton(count?: number) {
   if (count) {
-    expect(
-      await screen.findAllByRole("button", { name: /refresh/i }),
-    ).toHaveLength(count);
+    await expect(
+      screen.findAllByRole("button", { name: /refresh/i }),
+    ).resolves.toHaveLength(count);
   } else {
-    expect(
-      await screen.findByRole("button", { name: /refresh/i }),
-    ).toBeVisible();
+    await expect(
+      screen.findByRole("button", { name: /refresh/i }),
+    ).resolves.toBeVisible();
   }
 }
 
 async function expectFieldToBeHidden(integration: IntegrationDefinition) {
   // Wait for automatic form submit button to be shown
-  expect(await screen.findByRole("button", { name: /submit/i })).toBeVisible();
+  await expect(
+    screen.findByRole("button", { name: /submit/i }),
+  ).resolves.toBeVisible();
 
   // Expect no service descriptor to be shown
   expect(screen.queryByText(integration.metadata.name)).not.toBeInTheDocument();
@@ -215,9 +217,9 @@ describe("IntegrationsBody", () => {
     });
 
     // Ensure Integrations title is shown
-    expect(
-      await screen.findByRole("heading", { name: "Integrations" }),
-    ).toBeVisible();
+    await expect(
+      screen.findByRole("heading", { name: "Integrations" }),
+    ).resolves.toBeVisible();
   });
 
   it("does not hide field with one service, no options for the service, but other options exist", async () => {

--- a/src/extensionConsole/pages/deployments/DeploymentModal.test.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentModal.test.tsx
@@ -130,7 +130,7 @@ describe("DeploymentModal", () => {
       {},
     );
 
-    expect(await screen.findAllByRole("dialog")).toMatchSnapshot();
+    await expect(screen.findAllByRole("dialog")).resolves.toMatchSnapshot();
     expect(
       screen.getByText(
         "An update to the PixieBrix browser extension is available. After updating, you will need need to reload any pages where PixieBrix is running.",
@@ -161,7 +161,7 @@ describe("DeploymentModal", () => {
     );
 
     expect(reloadMock).toHaveBeenCalledTimes(1);
-    expect(await screen.findAllByRole("dialog")).toMatchSnapshot();
+    await expect(screen.findAllByRole("dialog")).resolves.toMatchSnapshot();
     expect(screen.getByText("Remind Me Later")).toBeDisabled();
   });
 
@@ -186,7 +186,7 @@ describe("DeploymentModal", () => {
     );
 
     expect(reloadMock).toHaveBeenCalledTimes(0);
-    expect(await screen.findAllByRole("dialog")).toMatchSnapshot();
+    await expect(screen.findAllByRole("dialog")).resolves.toMatchSnapshot();
     expect(screen.getByText("Remind Me Later")).toBeDisabled();
   });
 
@@ -211,7 +211,7 @@ describe("DeploymentModal", () => {
     );
 
     expect(reloadMock).toHaveBeenCalledTimes(1);
-    expect(await screen.findAllByRole("dialog")).toMatchSnapshot();
+    await expect(screen.findAllByRole("dialog")).resolves.toMatchSnapshot();
     expect(screen.getByText("Remind Me Later")).toBeDisabled();
   });
 });

--- a/src/pageEditor/sidebar/ActivatedModComponentListItem.test.tsx
+++ b/src/pageEditor/sidebar/ActivatedModComponentListItem.test.tsx
@@ -98,9 +98,9 @@ describe("ActivatedModComponentListItem", () => {
       />,
     );
 
-    expect(
-      await screen.findByRole("img", { name: "Not available on page" }),
-    ).toBeVisible();
+    await expect(
+      screen.findByRole("img", { name: "Not available on page" }),
+    ).resolves.toBeVisible();
   });
 
   it("handles mouseover action properly for button mod components", async () => {

--- a/src/pageEditor/sidebar/ModListItem.test.tsx
+++ b/src/pageEditor/sidebar/ModListItem.test.tsx
@@ -51,7 +51,7 @@ describe("ModListItem", () => {
       </Accordion>,
     );
 
-    expect(await screen.findByText(modMetadata.name)).toBeVisible();
+    await expect(screen.findByText(modMetadata.name)).resolves.toBeVisible();
     // eslint-disable-next-line testing-library/no-node-access -- Accordion collapse state
     expect(screen.getByText("test children").parentElement).toHaveClass(
       "collapse show",
@@ -83,7 +83,7 @@ describe("ModListItem", () => {
       </Accordion>,
     );
 
-    expect(await screen.findByText(modMetadata.name)).toBeVisible();
+    await expect(screen.findByText(modMetadata.name)).resolves.toBeVisible();
     // eslint-disable-next-line testing-library/no-node-access -- Accordion collapse state
     expect(screen.getByText("test children").parentElement).toHaveClass(
       "collapse",
@@ -129,8 +129,8 @@ describe("ModListItem", () => {
     const expectedMessage =
       "You are editing version 1.0.0 of this mod, the latest version is 1.0.1.";
 
-    expect(
-      await screen.findByRole("img", { name: expectedMessage }),
-    ).toBeVisible();
+    await expect(
+      screen.findByRole("img", { name: expectedMessage }),
+    ).resolves.toBeVisible();
   });
 });

--- a/src/pageEditor/tabs/modOptionsValues/ModOptionsValuesEditor.test.tsx
+++ b/src/pageEditor/tabs/modOptionsValues/ModOptionsValuesEditor.test.tsx
@@ -144,9 +144,9 @@ describe("ModOptionsValuesEditor", () => {
     mockModDefinition(modDefinition);
     const { asFragment } = render(<ModOptionsValuesEditor />);
     await waitForEffect();
-    expect(
-      await screen.findByText("This mod does not require any configuration"),
-    ).toBeVisible();
+    await expect(
+      screen.findByText("This mod does not require any configuration"),
+    ).resolves.toBeVisible();
     expect(asFragment()).toMatchSnapshot();
   });
 
@@ -227,7 +227,7 @@ describe("ModOptionsValuesEditor", () => {
 
     selectEvent.openMenu(selectInput);
 
-    expect(await screen.findByText("No options")).toBeVisible();
+    await expect(screen.findByText("No options")).resolves.toBeVisible();
   });
 
   it("renders google sheet field with options", async () => {
@@ -288,8 +288,12 @@ describe("ModOptionsValuesEditor", () => {
 
     selectEvent.openMenu(selectInput);
 
-    expect(await screen.findByText("Spreadsheet1")).toBeVisible();
-    expect(await screen.findByText("AnotherSpreadsheet")).toBeVisible();
-    expect(await screen.findByText("One More Spreadsheet")).toBeVisible();
+    await expect(screen.findByText("Spreadsheet1")).resolves.toBeVisible();
+    await expect(
+      screen.findByText("AnotherSpreadsheet"),
+    ).resolves.toBeVisible();
+    await expect(
+      screen.findByText("One More Spreadsheet"),
+    ).resolves.toBeVisible();
   });
 });

--- a/src/sidebar/activateMod/ActivateModPanel.test.tsx
+++ b/src/sidebar/activateMod/ActivateModPanel.test.tsx
@@ -287,9 +287,9 @@ describe("ActivateModPanel", () => {
       ],
     });
 
-    expect(
-      await screen.findByText("Well done", { exact: false }),
-    ).toBeVisible();
+    await expect(
+      screen.findByText("Well done", { exact: false }),
+    ).resolves.toBeVisible();
     expect(screen.getByRole("button", { name: "Ok" })).toBeVisible();
     expect(activateRecipeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -331,9 +331,9 @@ describe("ActivateModPanel", () => {
       ],
     });
 
-    expect(
-      await screen.findByText("Well done", { exact: false }),
-    ).toBeVisible();
+    await expect(
+      screen.findByText("Well done", { exact: false }),
+    ).resolves.toBeVisible();
     expect(screen.getByRole("button", { name: "Ok" })).toBeVisible();
     expect(activateRecipeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -376,9 +376,9 @@ describe("ActivateModPanel", () => {
       ],
     });
 
-    expect(
-      await screen.findByText("Well done", { exact: false }),
-    ).toBeVisible();
+    await expect(
+      screen.findByText("Well done", { exact: false }),
+    ).resolves.toBeVisible();
     expect(screen.getByRole("button", { name: "Ok" })).toBeVisible();
     expect(activateRecipeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -420,12 +420,12 @@ describe("ActivateModPanel", () => {
       ],
     });
 
-    expect(
-      await screen.findByText(
+    await expect(
+      screen.findByText(
         "We're almost there. This mod has a few settings to configure before using.",
         { exact: false },
       ),
-    ).toBeVisible();
+    ).resolves.toBeVisible();
     expect(
       screen.getByRole("button", { name: "Finish Activating" }),
     ).toBeVisible();
@@ -466,12 +466,12 @@ describe("ActivateModPanel", () => {
       ],
     });
 
-    expect(
-      await screen.findByText(
+    await expect(
+      screen.findByText(
         "We're almost there. This mod has a few settings to configure before using.",
         { exact: false },
       ),
-    ).toBeVisible();
+    ).resolves.toBeVisible();
     expect(
       screen.getByRole("button", { name: "Finish Activating" }),
     ).toBeVisible();

--- a/src/themes/colors.scss
+++ b/src/themes/colors.scss
@@ -66,7 +66,7 @@ $W70: #b57900;
 * The following color variables are colors that belong to no particular design system
 */
 $sidebar-light-menu-icon-color: #bba8bff5;
-$input-border-color: #ebedf2ff;
+$input-field-border-color: #ebedf2ff;
 $neutral-surface-color: #f9f8fa;
 $neutral-surface-color-hover: #e9e6ed;
 $popover-header: #ddd;

--- a/src/themes/colors.scss
+++ b/src/themes/colors.scss
@@ -66,7 +66,7 @@ $W70: #b57900;
 * The following color variables are colors that belong to no particular design system
 */
 $sidebar-light-menu-icon-color: #bba8bff5;
-$input-field-border-color: #ebedf2ff;
+$input-border-color: hsl(0, 0%, 80%); // Matches react-select's border
 $neutral-surface-color: #f9f8fa;
 $neutral-surface-color-hover: #e9e6ed;
 $popover-header: #ddd;

--- a/src/themes/colors.scss
+++ b/src/themes/colors.scss
@@ -66,7 +66,7 @@ $W70: #b57900;
 * The following color variables are colors that belong to no particular design system
 */
 $sidebar-light-menu-icon-color: #bba8bff5;
-$input-border-color: hsl(0, 0%, 80%); // Matches react-select's border
+$input-border-color: #ebedf2ff;
 $neutral-surface-color: #f9f8fa;
 $neutral-surface-color-hover: #e9e6ed;
 $popover-header: #ddd;

--- a/src/utils/deploymentUtils.test.ts
+++ b/src/utils/deploymentUtils.test.ts
@@ -236,12 +236,9 @@ describe("findLocalDeploymentConfiguredIntegrationDependencies", () => {
     });
 
     const locator = async () => [] as SanitizedIntegrationConfig[];
-    expect(
-      await findLocalDeploymentConfiguredIntegrationDependencies(
-        deployment,
-        locator,
-      ),
-    ).toStrictEqual([
+    await expect(
+      findLocalDeploymentConfiguredIntegrationDependencies(deployment, locator),
+    ).resolves.toStrictEqual([
       {
         integrationId: CONTROL_ROOM_OAUTH_INTEGRATION_ID,
         outputKey: "foo",
@@ -272,12 +269,9 @@ describe("findLocalDeploymentConfiguredIntegrationDependencies", () => {
     });
 
     const locator = async () => [auth];
-    expect(
-      await findLocalDeploymentConfiguredIntegrationDependencies(
-        deployment,
-        locator,
-      ),
-    ).toStrictEqual([
+    await expect(
+      findLocalDeploymentConfiguredIntegrationDependencies(deployment, locator),
+    ).resolves.toStrictEqual([
       {
         integrationId: CONTROL_ROOM_OAUTH_INTEGRATION_ID,
         outputKey: "foo",
@@ -311,12 +305,9 @@ describe("findLocalDeploymentConfiguredIntegrationDependencies", () => {
     });
 
     const locator = async () => [auth];
-    expect(
-      await findLocalDeploymentConfiguredIntegrationDependencies(
-        deployment,
-        locator,
-      ),
-    ).toBeArrayOfSize(0);
+    await expect(
+      findLocalDeploymentConfiguredIntegrationDependencies(deployment, locator),
+    ).resolves.toBeArrayOfSize(0);
   });
 
   test("exclude pixiebrix integration", async () => {
@@ -339,12 +330,9 @@ describe("findLocalDeploymentConfiguredIntegrationDependencies", () => {
     });
 
     const locator = async () => [auth];
-    expect(
-      await findLocalDeploymentConfiguredIntegrationDependencies(
-        deployment,
-        locator,
-      ),
-    ).toBeArrayOfSize(0);
+    await expect(
+      findLocalDeploymentConfiguredIntegrationDependencies(deployment, locator),
+    ).resolves.toBeArrayOfSize(0);
   });
 });
 
@@ -373,9 +361,9 @@ describe("mergeDeploymentIntegrationDependencies", () => {
     });
 
     const locator = async () => [auth];
-    expect(
-      await mergeDeploymentIntegrationDependencies(deployment, locator),
-    ).toStrictEqual([
+    await expect(
+      mergeDeploymentIntegrationDependencies(deployment, locator),
+    ).resolves.toStrictEqual([
       {
         integrationId: registryId,
         outputKey: "foo",
@@ -406,9 +394,9 @@ describe("mergeDeploymentIntegrationDependencies", () => {
     });
 
     const locator = async () => [auth];
-    expect(
-      await mergeDeploymentIntegrationDependencies(deployment, locator),
-    ).toStrictEqual([
+    await expect(
+      mergeDeploymentIntegrationDependencies(deployment, locator),
+    ).resolves.toStrictEqual([
       {
         integrationId: CONTROL_ROOM_OAUTH_INTEGRATION_ID,
         outputKey: "foo",
@@ -496,9 +484,9 @@ describe("mergeDeploymentIntegrationDependencies", () => {
     });
 
     const locator = async () => [auth];
-    expect(
-      await mergeDeploymentIntegrationDependencies(deployment, locator),
-    ).toStrictEqual([
+    await expect(
+      mergeDeploymentIntegrationDependencies(deployment, locator),
+    ).resolves.toStrictEqual([
       {
         integrationId: PIXIEBRIX_INTEGRATION_ID,
         outputKey: "pixiebrix",

--- a/src/utils/inference/inferSingleElementSelector.test.ts
+++ b/src/utils/inference/inferSingleElementSelector.test.ts
@@ -54,13 +54,13 @@ describe("inferElementSelector", () => {
     `;
 
     const element = document.body.querySelector<HTMLElement>("#test");
-    expect(
-      await inferSingleElementSelector({
+    await expect(
+      inferSingleElementSelector({
         element,
         root: document.body,
         excludeRandomClasses: true,
       }),
-    ).toStrictEqual({
+    ).resolves.toStrictEqual({
       parent: null,
       // Site hint doesn't match, so requiredSelectors has not effect
       selectors: [
@@ -85,13 +85,13 @@ describe("inferElementSelector", () => {
     `;
 
     const element = document.body.querySelector<HTMLElement>("#test");
-    expect(
-      await inferSingleElementSelector({
+    await expect(
+      inferSingleElementSelector({
         element,
         root: document.body,
         excludeRandomClasses: true,
       }),
-    ).toStrictEqual({
+    ).resolves.toStrictEqual({
       parent: null,
       selectors: [".grandparent>.parent #test", ".grandparent>.parent div"],
       tagName: "DIV",
@@ -109,13 +109,13 @@ describe("inferElementSelector", () => {
     `;
 
     const element = document.body.querySelector<HTMLElement>(".testValue");
-    expect(
-      await inferSingleElementSelector({
+    await expect(
+      inferSingleElementSelector({
         element,
         root: document.body,
         excludeRandomClasses: true,
       }),
-    ).toStrictEqual({
+    ).resolves.toStrictEqual({
       parent: null,
       selectors: [
         '.container:has(.testLabel:contains("test label")) div',
@@ -145,13 +145,13 @@ describe("inferElementSelector", () => {
 
     expect(element.textContent).toBe("Label Value");
 
-    expect(
-      await inferSingleElementSelector({
+    await expect(
+      inferSingleElementSelector({
         element,
         root: document.body,
         excludeRandomClasses: true,
       }),
-    ).toStrictEqual({
+    ).resolves.toStrictEqual({
       parent: null,
       // Doesn't return the instantiated template, because it would match both field.
       // These selectors are not very robust. We'll fix those in future improvements to general selector generation.
@@ -188,13 +188,13 @@ describe("inferElementSelector", () => {
 
     expect(element.textContent).toBe("Label Value");
 
-    expect(
-      await inferSingleElementSelector({
+    await expect(
+      inferSingleElementSelector({
         element,
         root: document.body,
         excludeRandomClasses: true,
       }),
-    ).toStrictEqual({
+    ).resolves.toStrictEqual({
       parent: null,
       selectors: [
         '.active .container:has(.testLabel:contains("label")) div',
@@ -231,13 +231,13 @@ describe("inferElementSelector", () => {
 
     const element = $safeFind(".testValue").get(0);
 
-    expect(
-      await inferSingleElementSelector({
+    await expect(
+      inferSingleElementSelector({
         element,
         root: document.body,
         excludeRandomClasses: true,
       }),
-    ).toStrictEqual({
+    ).resolves.toStrictEqual({
       parent: null,
       selectors: [".container div", ".container .testValue"],
       tagName: "DIV",

--- a/src/utils/promiseUtils.test.ts
+++ b/src/utils/promiseUtils.test.ts
@@ -32,10 +32,12 @@ test("memoizeUntilSettled", async () => {
 
   const memoized = memoizeUntilSettled(async () => index++);
 
-  expect(await memoized()).toBe(0);
-  expect(await memoized()).toBe(1);
-  expect(await memoized()).toBe(2);
-  expect(await Promise.all([memoized(), memoized()])).toStrictEqual([3, 3]);
+  await expect(memoized()).resolves.toBe(0);
+  await expect(memoized()).resolves.toBe(1);
+  await expect(memoized()).resolves.toBe(2);
+  await expect(Promise.all([memoized(), memoized()])).resolves.toStrictEqual([
+    3, 3,
+  ]);
 });
 
 test("groupPromisesByStatus", async () => {


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/eslint-config-pixiebrix/issues/194

## Discussion

- See the case for the rule here: https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-expect-resolves.md
- ~Only manual change was adding the rule~
- Had to change `src/components/fields/schemaFields/SchemaField.test.tsx` to support `.renders`.
  - See: https://github.com/pixiebrix/pixiebrix-extension/pull/7816#issuecomment-1979226360
- All other changes was from running lint with the `--fix` flag

## Future Work

- Migrate rule to eslint-config-pixiebrix next time we merge over rules

## Checklist

- [x] Designate a primary reviewer @BLoe 
