### PR TITLE
EsLint: add no-unstable-nested-components and forbid-elements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,16 @@ module.exports = {
     "@shopify/prefer-module-scope-constants": "error",
     "@shopify/jest/no-snapshots": "warn",
     "react/no-array-index-key": "error",
+    "react/no-unstable-nested-components": ["error", { allowAsProps: true }],
+    "react/forbid-elements": [
+      "error",
+      {
+        forbid: [
+          { element: "b", message: "use <strong> instead" },
+          { element: "i", message: "use <em> instead" },
+        ],
+      },
+    ],
     "local-rules/noNullRtkQueryArgs": "error",
     "local-rules/noInvalidDataTestId": "error",
     "local-rules/noExpressionLiterals": "error",

--- a/src/extensionConsole/pages/brickEditor/SharingTable.tsx
+++ b/src/extensionConsole/pages/brickEditor/SharingTable.tsx
@@ -48,7 +48,7 @@ const SharingTable: React.FunctionComponent = () => {
               <span>
                 <FontAwesomeIcon icon={faGlobe} /> Public{" "}
                 <span className="text-primary">
-                  <i> &ndash; visible to all PixieBrix users</i>
+                  <em> &ndash; visible to all PixieBrix users</em>
                 </span>
               </span>
             ) : (

--- a/src/extensionConsole/pages/settings/FactoryResetSettings.tsx
+++ b/src/extensionConsole/pages/settings/FactoryResetSettings.tsx
@@ -55,10 +55,10 @@ const FactoryResetSettings: React.FunctionComponent = () => {
       <Card.Body className="text-danger">
         <p className="card-text">
           Click here to reset your local PixieBrix data.{" "}
-          <b>
+          <strong>
             This will deactivate any mods you&apos;ve activated and reset all
             browser extension settings.
-          </b>
+          </strong>
         </p>
         <AsyncButton
           variant="danger"

--- a/src/extensionConsole/pages/settings/SettingToggle.tsx
+++ b/src/extensionConsole/pages/settings/SettingToggle.tsx
@@ -75,7 +75,7 @@ const SettingToggle: React.FunctionComponent<SettingToggleProps> = ({
     <Form.Group controlId={controlId}>
       <div>
         <Form.Label>
-          {label}: <i>{isEnabled ? "Enabled" : "Disabled"}</i>
+          {label}: <em>{isEnabled ? "Enabled" : "Disabled"}</em>
         </Form.Label>
         {description && (
           <Form.Text muted className="mb-2">

--- a/src/pageEditor/fields/SelectorMatchField.tsx
+++ b/src/pageEditor/fields/SelectorMatchField.tsx
@@ -29,7 +29,7 @@ type SelectorMatchFieldProps = {
 const defaultDescription = (
   <span>
     Selectors restricting when this starter brick runs. If provided, at least
-    one of the selectors must match <i>on page load</i> for this starter brick
+    one of the selectors must match <em>on page load</em> for this starter brick
     to run.
   </span>
 );

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -1175,9 +1175,9 @@ exports[`renders an extension with sub pipeline 1`] = `
                     >
                       <span>
                         Selectors restricting when this starter brick runs. If provided, at least one of the selectors must match 
-                        <i>
+                        <em>
                           on page load
-                        </i>
+                        </em>
                          for this starter brick to run.
                       </span>
                     </small>

--- a/src/pageEditor/panes/insert/InsertMenuItemPane.tsx
+++ b/src/pageEditor/panes/insert/InsertMenuItemPane.tsx
@@ -42,9 +42,10 @@ const InsertMenuItemPane: React.FunctionComponent<{ cancel: () => void }> = ({
 
       <div>
         <Alert variant="info">
-          <FontAwesomeIcon icon={faInfo} /> <b>Tip:</b> to increase the accuracy
-          of detection, you can Shift+Click one or more buttons in the button
-          group. Click a button without holding Shift to complete placement.
+          <FontAwesomeIcon icon={faInfo} /> <strong>Tip:</strong> to increase
+          the accuracy of detection, you can Shift+Click one or more buttons in
+          the button group. Click a button without holding Shift to complete
+          placement.
         </Alert>
       </div>
     </div>

--- a/src/pageEditor/panes/insert/InsertPanelPane.tsx
+++ b/src/pageEditor/panes/insert/InsertPanelPane.tsx
@@ -43,8 +43,8 @@ const InsertPanelPane: React.FunctionComponent<{
       <div>
         <Alert variant="warning">
           <FontAwesomeIcon icon={faExclamationTriangle} /> Automatic panel
-          placement is currently in <b>Alpha</b> and typically requires manual
-          configuration/adjustment
+          placement is currently in <strong>Alpha</strong> and typically
+          requires manual configuration/adjustment
         </Alert>
       </div>
     </div>

--- a/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
+++ b/src/pageEditor/tabs/__snapshots__/MatchRulesSection.test.tsx.snap
@@ -112,9 +112,9 @@ exports[`MatchRulesSection render empty section 1`] = `
             >
               <span>
                 Selectors restricting when this starter brick runs. If provided, at least one of the selectors must match 
-                <i>
+                <em>
                   on page load
-                </i>
+                </em>
                  for this starter brick to run.
               </span>
             </small>
@@ -656,9 +656,9 @@ exports[`MatchRulesSection render populated section 1`] = `
             >
               <span>
                 Selectors restricting when this starter brick runs. If provided, at least one of the selectors must match 
-                <i>
+                <em>
                   on page load
-                </i>
+                </em>
                  for this starter brick to run.
               </span>
             </small>

--- a/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
+++ b/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
@@ -903,9 +903,9 @@ exports[`TriggerConfiguration renders custom event field with known event names 
             >
               <span>
                 Selectors restricting when this starter brick runs. If provided, at least one of the selectors must match 
-                <i>
+                <em>
                   on page load
-                </i>
+                </em>
                  for this starter brick to run.
               </span>
             </small>


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/eslint-config-pixiebrix/issues/194

## Discussion

- Only violations for `no-unstable-nested-components` were for renderProp components for 3rd party libraries
- Also implemented `forbid-elements` to use `<strong>` and `<em>` instead of `<b>` and `<em>`
  - See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b

## Future Work

- Migrate rules to `eslint-config-pixiebrix`

## Checklist

- [x] Designate a primary reviewer @mnholtz 
