### PR TITLE
ESLint: jsx-max-depth

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
         ],
       },
     ],
+    "react/jsx-max-depth": ["error", { max: 5 }],
     "local-rules/noNullRtkQueryArgs": "error",
     "local-rules/noInvalidDataTestId": "error",
     "local-rules/noExpressionLiterals": "error",


### PR DESCRIPTION
## What does this PR do?

- Last rule in https://github.com/pixiebrix/eslint-config-pixiebrix/issues/194

## Discussion

- Opening to encourage discussion about the rule
- See https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-max-depth.md
- Discouraging deeply nested jsx makes components easier to read
- Anything deeper than 5 gets very difficult to reason about
- We have a lot of violations that would need to be cleaned up, might make sense to set this rule to warn?

## Future Work

- Once rule is implemented completely, migrate to eslint-config-pixiebrix

## Checklist

- [ ] Designate a primary reviewer
