### PR TITLE
4858 connect datadog rum and traces

### DIFF
--- a/src/extensionConsole/options.tsx
+++ b/src/extensionConsole/options.tsx
@@ -36,18 +36,18 @@ import extensionPagePlatform from "@/extensionPages/extensionPagePlatform";
 
 setPlatform(extensionPagePlatform);
 
-function init(): void {
+async function init() {
+  void initMessengerLogging();
+  void initRuntimeLogging();
+  initToaster();
+  initTelemetry();
+  try {
+    await initPerformanceMonitoring();
+  } catch (error) {
+    console.error("Failed to initialize performance monitoring", error);
+  }
+
   render(<App />, document.querySelector("#container"));
 }
 
-void initMessengerLogging();
-void initRuntimeLogging();
-initToaster();
-initTelemetry();
-initPerformanceMonitoring()
-  .then(() => {
-    init();
-  })
-  .catch((e) => {
-    console.log(e);
-  });
+void init();

--- a/src/extensionConsole/options.tsx
+++ b/src/extensionConsole/options.tsx
@@ -44,5 +44,10 @@ void initMessengerLogging();
 void initRuntimeLogging();
 initToaster();
 initTelemetry();
-void initPerformanceMonitoring();
-init();
+initPerformanceMonitoring()
+  .then(() => {
+    init();
+  })
+  .catch((e) => {
+    console.log(e);
+  });

--- a/src/pageEditor/pageEditor.tsx
+++ b/src/pageEditor/pageEditor.tsx
@@ -34,12 +34,20 @@ import { initPerformanceMonitoring } from "@/telemetry/performance";
 import { setPlatform } from "@/platform/platformContext";
 import extensionPagePlatform from "@/extensionPages/extensionPagePlatform";
 
-setPlatform(extensionPagePlatform);
+async function init() {
+  setPlatform(extensionPagePlatform);
+  void initMessengerLogging();
+  void initRuntimeLogging();
+  try {
+    await initPerformanceMonitoring();
+  } catch (error) {
+    console.error("Failed to initialize performance monitoring", error);
+  }
 
-void initMessengerLogging();
-void initRuntimeLogging();
-void initPerformanceMonitoring();
-watchNavigation();
-initToaster();
+  watchNavigation();
+  initToaster();
 
-ReactDOM.render(<Panel />, document.querySelector("#container"));
+  ReactDOM.render(<Panel />, document.querySelector("#container"));
+}
+
+void init();

--- a/src/sidebar/sidebar.tsx
+++ b/src/sidebar/sidebar.tsx
@@ -42,23 +42,30 @@ import { markDocumentAsFocusableByUser } from "@/utils/focusTracker";
 import { setPlatform } from "@/platform/platformContext";
 import extensionPagePlatform from "@/extensionPages/extensionPagePlatform";
 
-setPlatform(extensionPagePlatform);
-
 async function init(): Promise<void> {
+  setPlatform(extensionPagePlatform);
+  void initMessengerLogging();
+  void initRuntimeLogging();
+  try {
+    await initPerformanceMonitoring();
+  } catch (error) {
+    console.error("Failed to initialize performance monitoring", error);
+  }
+
+  registerMessenger();
+  registerContribBlocks();
+  registerBuiltinBricks();
+  initToaster();
+
   ReactDOM.render(<App />, document.querySelector("#container"));
+
   sidebarWasLoaded(await getConnectedTarget());
+
+  initSidePanel();
+  markDocumentAsFocusableByUser();
+
+  // Handle an embedded AA business copilot frame
+  void initCopilotMessenger();
 }
 
-void initMessengerLogging();
-void initRuntimeLogging();
-void initPerformanceMonitoring();
-registerMessenger();
-registerContribBlocks();
-registerBuiltinBricks();
-initToaster();
 void init();
-initSidePanel();
-markDocumentAsFocusableByUser();
-
-// Handle an embedded AA business copilot frame
-void initCopilotMessenger();

--- a/src/telemetry/dnt.ts
+++ b/src/telemetry/dnt.ts
@@ -26,6 +26,9 @@ async function setDNT(enable: boolean): Promise<void> {
   await dntConfig.set(enable);
 }
 
+/**
+ * DNT stands for Do Not Track, and determines whether we can enable telemetry
+ */
 export async function getDNT(): Promise<boolean> {
   // The DNT setting was stored as a string at some point, so we need to handle that too
   return boolean((await dntConfig.get()) ?? process.env.DEBUG);

--- a/src/telemetry/performance.test.ts
+++ b/src/telemetry/performance.test.ts
@@ -50,6 +50,7 @@ describe("initPerformanceMonitoring", () => {
     jest.mocked(flagOn).mockResolvedValue(true);
     process.env.DATADOG_APPLICATION_ID = "applicationId";
     process.env.DATADOG_CLIENT_TOKEN = "clientToken";
+    process.env.ENVIRONMENT = "local";
     jest.mocked(getBaseURL).mockResolvedValue("https://example.com");
     browser.runtime.getManifest = jest
       .fn()
@@ -66,7 +67,7 @@ describe("initPerformanceMonitoring", () => {
       clientToken: "clientToken",
       site: "datadoghq.com",
       service: "pixiebrix-browser-extension",
-      env: process.env.ENVIRONMENT,
+      env: "local",
       version: expect.any(String),
       sessionSampleRate: 100,
       sessionReplaySampleRate: 20,

--- a/src/telemetry/performance.test.ts
+++ b/src/telemetry/performance.test.ts
@@ -1,0 +1,91 @@
+import { initPerformanceMonitoring } from "@/telemetry/performance";
+import { getDNT } from "@/telemetry/dnt";
+import { flagOn } from "@/auth/featureFlagStorage";
+import { getBaseURL } from "@/data/service/baseService";
+import { datadogRum } from "@datadog/browser-rum";
+import { readAuthData } from "@/auth/authStorage";
+
+jest.mock("@/telemetry/dnt");
+jest.mock("@/auth/featureFlagStorage");
+jest.mock("@/data/service/baseService");
+jest.mock("@/auth/authStorage");
+jest.mock("@datadog/browser-rum");
+
+// Disable the automock for telemetryHelpers
+jest.mock("@/telemetry/telemetryHelpers", () =>
+  jest.requireActual("./telemetryHelpers.ts"),
+);
+
+describe("initPerformanceMonitoring", () => {
+  it("should not initialize if DNT is enabled", async () => {
+    jest.mocked(getDNT).mockResolvedValue(true);
+
+    await initPerformanceMonitoring();
+
+    expect(datadogRum.init).not.toHaveBeenCalled();
+  });
+
+  it("should not initialize if RUM flag is off", async () => {
+    jest.mocked(getDNT).mockResolvedValue(false);
+    jest.mocked(flagOn).mockResolvedValue(false);
+
+    await initPerformanceMonitoring();
+
+    expect(datadogRum.init).not.toHaveBeenCalled();
+  });
+
+  it("should not initialize if application ID or client token is not configured", async () => {
+    jest.mocked(getDNT).mockResolvedValue(false);
+    jest.mocked(flagOn).mockResolvedValue(true);
+    process.env.DATADOG_APPLICATION_ID = "";
+    process.env.DATADOG_CLIENT_TOKEN = "";
+
+    await initPerformanceMonitoring();
+
+    expect(datadogRum.init).not.toHaveBeenCalled();
+  });
+
+  it("should initialize performance monitoring", async () => {
+    jest.mocked(getDNT).mockResolvedValue(false);
+    jest.mocked(flagOn).mockResolvedValue(true);
+    process.env.DATADOG_APPLICATION_ID = "applicationId";
+    process.env.DATADOG_CLIENT_TOKEN = "clientToken";
+    jest.mocked(getBaseURL).mockResolvedValue("https://example.com");
+    browser.runtime.getManifest = jest
+      .fn()
+      .mockReturnValue({ version_name: "1.8.8-alpha+293128" });
+    jest.mocked(readAuthData).mockResolvedValue({
+      user: "634b1b49-4382-4292-87f4-d25c6a1db3d7",
+      organizationId: "24a7c934-a531-49d8-a15d-cdf0baa54146",
+    } as any);
+
+    await initPerformanceMonitoring();
+
+    expect(datadogRum.init).toHaveBeenCalledWith({
+      applicationId: "applicationId",
+      clientToken: "clientToken",
+      site: "datadoghq.com",
+      service: "pixiebrix-browser-extension",
+      env: process.env.ENVIRONMENT,
+      version: expect.any(String),
+      sessionSampleRate: 100,
+      sessionReplaySampleRate: 20,
+      trackUserInteractions: true,
+      trackResources: true,
+      trackLongTasks: true,
+      defaultPrivacyLevel: "mask",
+      allowedTracingUrls: ["https://example.com"],
+      allowFallbackToLocalStorage: true,
+    });
+    expect(datadogRum.setGlobalContextProperty).toHaveBeenCalledWith(
+      "code_version",
+      process.env.SOURCE_VERSION,
+    );
+    expect(datadogRum.setUser).toHaveBeenCalledWith({
+      email: undefined,
+      id: "634b1b49-4382-4292-87f4-d25c6a1db3d7",
+      organizationId: "24a7c934-a531-49d8-a15d-cdf0baa54146",
+    });
+    expect(datadogRum.startSessionReplayRecording).toHaveBeenCalled();
+  });
+});

--- a/src/telemetry/performance.ts
+++ b/src/telemetry/performance.ts
@@ -57,12 +57,16 @@ export async function initPerformanceMonitoring(): Promise<void> {
     return;
   }
 
-  if (!applicationId || !clientToken) {
-    console.warn("Datadog application ID or client token not configured");
+  const { version_name } = browser.runtime.getManifest();
+
+  if (!applicationId || !clientToken || !version_name || !environment) {
+    console.warn(
+      "Required environment variables for initializing Datadog missing:",
+      { applicationId, clientToken, version_name, environment },
+    );
     return;
   }
 
-  const { version_name } = browser.runtime.getManifest();
   const baseUrl = await getBaseURL();
 
   // https://docs.datadoghq.com/real_user_monitoring/browser/

--- a/src/telemetry/performance.ts
+++ b/src/telemetry/performance.ts
@@ -41,8 +41,6 @@ const RUM_FLAG = "telemetry-performance";
  * any user interactions or network requests are made.
  */
 export async function initPerformanceMonitoring(): Promise<void> {
-  const start = Date.now();
-  console.log("start:", start);
   // Require the extension context because we don't want to track performance of the host sites
   expectContext("extension");
 
@@ -59,20 +57,14 @@ export async function initPerformanceMonitoring(): Promise<void> {
     return;
   }
 
-  const baseUrl = await getBaseURL();
-
-  if (await getDNT()) {
-    return;
-  }
-
   if (!applicationId || !clientToken) {
     console.warn("Datadog application ID or client token not configured");
     return;
   }
 
   const { version_name } = browser.runtime.getManifest();
+  const baseUrl = await getBaseURL();
 
-  console.log("about to init:", Date.now() - start);
   // https://docs.datadoghq.com/real_user_monitoring/browser/
   datadogRum.init({
     applicationId,
@@ -100,8 +92,6 @@ export async function initPerformanceMonitoring(): Promise<void> {
     allowFallbackToLocalStorage: true,
   });
 
-  console.log("done init:", Date.now() - start);
-
   datadogRum.setGlobalContextProperty(
     "code_version",
     process.env.SOURCE_VERSION,
@@ -113,8 +103,6 @@ export async function initPerformanceMonitoring(): Promise<void> {
   datadogRum.startSessionReplayRecording();
 
   addAuthListener(updatePerson);
-
-  console.log("all done:", Date.now() - start);
 }
 
 async function updatePerson(data: UserData): Promise<void> {

--- a/src/telemetry/performance.ts
+++ b/src/telemetry/performance.ts
@@ -30,10 +30,6 @@ import {
 import type { UserData } from "@/auth/authTypes";
 import { flagOn } from "@/auth/featureFlagStorage";
 
-const environment = process.env.ENVIRONMENT;
-const applicationId = process.env.DATADOG_APPLICATION_ID;
-const clientToken = process.env.DATADOG_CLIENT_TOKEN;
-
 const RUM_FLAG = "telemetry-performance";
 
 /**
@@ -41,6 +37,10 @@ const RUM_FLAG = "telemetry-performance";
  * any user interactions or network requests are made.
  */
 export async function initPerformanceMonitoring(): Promise<void> {
+  const environment = process.env.ENVIRONMENT;
+  const applicationId = process.env.DATADOG_APPLICATION_ID;
+  const clientToken = process.env.DATADOG_CLIENT_TOKEN;
+
   // Require the extension context because we don't want to track performance of the host sites
   expectContext("extension");
 

--- a/src/telemetry/performance.ts
+++ b/src/telemetry/performance.ts
@@ -62,7 +62,12 @@ export async function initPerformanceMonitoring(): Promise<void> {
   if (!applicationId || !clientToken || !version_name || !environment) {
     console.warn(
       "Required environment variables for initializing Datadog missing:",
-      { applicationId, clientToken, version_name, environment },
+      {
+        applicationId: Boolean(applicationId),
+        clientToken: Boolean(clientToken),
+        version_name,
+        environment,
+      },
     );
     return;
   }

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -596,6 +596,8 @@
     "./telemetry/events.ts",
     "./telemetry/initErrorReporter.ts",
     "./telemetry/logging.ts",
+    "./telemetry/performance.ts",
+    "./telemetry/performance.test.ts",
     "./telemetry/reportError.ts",
     "./telemetry/reportEvent.ts",
     "./telemetry/reportUncaughtErrors.ts",


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-app/issues/4858
- This change set ensures that we initialize datadog (taking only about 10-15 ms) before we continue in initializing the rest of the UI. This makes it so that the initial requests (ex the `/me` requests) are measured and traced by datadog.

## Demo
Note the datadog headers on the first request.

![Screenshot 2024-03-05 at 4 21 17 PM](https://github.com/pixiebrix/pixiebrix-extension/assets/3498063/6b5d7b2c-7f62-41d4-af6b-21b76bb651d9)

## Future Work

Check that the tracing is being picked up by the backend app.

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [X] Designate a primary reviewer @twschiller 
