### PR TITLE
#7822: await initial remote registry sync on packageRegistry read operations

### DIFF
--- a/src/registry/packageRegistry.test.ts
+++ b/src/registry/packageRegistry.test.ts
@@ -94,9 +94,9 @@ describe("localRegistry", () => {
 
     deferred.resolve([200, [defaultModDefinitionFactory()]]);
 
-    // FIXME: test assertion failing
-    await expect(count()).resolves.toBe(1);
+    // `recipesPromise` must come first since it waits on syncPackages. The `count` call doesn't wait.
     await expect(recipesPromise).resolves.toHaveLength(1);
+    await expect(count()).resolves.toBe(1);
   });
 
   it("should await sync on lookup", async () => {
@@ -110,10 +110,10 @@ describe("localRegistry", () => {
 
     await expect(count()).resolves.toBe(0);
 
-    deferred.resolve([200, []]);
+    deferred.resolve([200, [defaultModDefinitionFactory()]]);
 
-    // FIXME: test assertion failing
-    await expect(count()).resolves.toBe(1);
+    // `packagePromise` must come first since it waits on syncPackages. The `count` call doesn't wait.
     await expect(packagePromise).resolves.toBeNull();
+    await expect(count()).resolves.toBe(1);
   });
 });

--- a/src/registry/packageRegistry.test.ts
+++ b/src/registry/packageRegistry.test.ts
@@ -92,9 +92,10 @@ describe("localRegistry", () => {
 
     await expect(count()).resolves.toBe(0);
 
-    deferred.resolve([defaultModDefinitionFactory()]);
+    deferred.resolve([200, defaultModDefinitionFactory()]);
 
-    await recipesPromise;
+    // FIXME: test assertion failing
+    await expect(recipesPromise).resolves.toHaveLength(1);
   });
 
   it("should await sync on lookup", async () => {
@@ -108,7 +109,7 @@ describe("localRegistry", () => {
 
     await expect(count()).resolves.toBe(0);
 
-    deferred.resolve([]);
+    deferred.resolve([200, []]);
 
     await expect(packagePromise).resolves.toBeNull();
   });

--- a/src/registry/packageRegistry.test.ts
+++ b/src/registry/packageRegistry.test.ts
@@ -23,10 +23,10 @@ import {
   count,
 } from "@/registry/packageRegistry";
 import { produce } from "immer";
-import { type SemVerString } from "@/types/registryTypes";
 import { appApiMock } from "@/testUtils/appApiMock";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import pDefer from "p-defer";
+import { validateSemVerString } from "@/types/helpers";
 
 describe("localRegistry", () => {
   beforeEach(() => {
@@ -65,7 +65,7 @@ describe("localRegistry", () => {
   it("should return latest version", async () => {
     const definition = defaultModDefinitionFactory();
     const updated = produce(definition, (draft) => {
-      draft.metadata.version = "9.9.9" as SemVerString;
+      draft.metadata.version = validateSemVerString("9.9.9");
     });
 
     appApiMock.onGet("/api/registry/bricks/").reply(200, [updated, definition]);
@@ -92,9 +92,10 @@ describe("localRegistry", () => {
 
     await expect(count()).resolves.toBe(0);
 
-    deferred.resolve([200, defaultModDefinitionFactory()]);
+    deferred.resolve([200, [defaultModDefinitionFactory()]]);
 
     // FIXME: test assertion failing
+    await expect(count()).resolves.toBe(1);
     await expect(recipesPromise).resolves.toHaveLength(1);
   });
 
@@ -111,6 +112,8 @@ describe("localRegistry", () => {
 
     deferred.resolve([200, []]);
 
+    // FIXME: test assertion failing
+    await expect(count()).resolves.toBe(1);
     await expect(packagePromise).resolves.toBeNull();
   });
 });

--- a/src/registry/packageRegistry.ts
+++ b/src/registry/packageRegistry.ts
@@ -130,6 +130,8 @@ export const syncPackages = memoizeUntilSettled(async () => {
   // The endpoint doesn't return the updated_at timestamp. So use the current local time as our timestamp.
   const timestamp = new Date();
 
+  // XXX: we currently don't have to worry about consecutive calls where the first call is unauthenticated and the
+  // second is after the user authenticates, because the extension reloads on linking
   const client = await getApiClient();
   // In the future, use the paginated endpoint?
   const { data } = await client.get<RegistryPackage[]>("/api/registry/bricks/");
@@ -299,6 +301,7 @@ export async function find(id: string): Promise<Nullishable<PackageVersion>> {
 
   try {
     const versions = await db.getAllFromIndex(BRICK_STORE, "id", id);
+
     return latestVersion(versions);
   } finally {
     db.close();

--- a/src/registry/packageRegistry.ts
+++ b/src/registry/packageRegistry.ts
@@ -195,7 +195,11 @@ async function ensurePopulated(): Promise<void> {
     return;
   }
 
+  // XXX: there's a small chance of a race here, where an existing syncPackages call finishes after the count()
+  // call resolves, before executes switches back to this method.
+
   try {
+    // `syncPackages` is memoized, so safe to call multiple times;
     await syncPackages();
   } catch {
     // NOP - call-site will handle uninitialized state

--- a/src/registry/packageRegistry.ts
+++ b/src/registry/packageRegistry.ts
@@ -24,6 +24,13 @@ import { PACKAGE_REGEX } from "@/types/helpers";
 import { memoizeUntilSettled } from "@/utils/promiseUtils";
 import { getApiClient } from "@/data/service/apiClient";
 import { type Nullishable, assertNotNullish } from "@/utils/nullishUtils";
+import pDefer from "p-defer";
+
+/**
+ * Promise to await the completion of the current sync operation.
+ */
+// eslint-disable-next-line local-rules/persistBackgroundData -- tracking in-flight sync
+let syncPromise: Promise<unknown> = Promise.resolve();
 
 const DATABASE_NAME = "BRICK_REGISTRY";
 const BRICK_STORE = "bricks";
@@ -126,6 +133,9 @@ function latestVersion(
  * @param kinds kinds of bricks
  */
 export async function getByKinds(kinds: Kind[]): Promise<PackageVersion[]> {
+  // Wait for in-flight sync to complete to ensure find sees the latest data
+  await syncPromise;
+
   const db = await openRegistryDB();
 
   try {
@@ -165,21 +175,30 @@ export async function clear(): Promise<void> {
  * Memoized to avoid multiple network requests across tabs.
  */
 export const syncPackages = memoizeUntilSettled(async () => {
+  const deferred = pDefer<unknown>();
+  syncPromise = deferred.promise;
+
   // The endpoint doesn't return the updated_at timestamp. So use the current local time as our timestamp.
   const timestamp = new Date();
 
-  const client = await getApiClient();
-  // In the future, use the paginated endpoint?
-  const { data } = await client.get<RegistryPackage[]>("/api/registry/bricks/");
+  try {
+    const client = await getApiClient();
+    // In the future, use the paginated endpoint?
+    const { data } = await client.get<RegistryPackage[]>(
+      "/api/registry/bricks/",
+    );
 
-  const packages = data.map((x) => ({
-    ...parsePackage(x),
-    // Use the timestamp the call was initiated, not the timestamp received. That prevents missing any updates
-    // that were made during the call.
-    timestamp,
-  }));
+    const packages = data.map((x) => ({
+      ...parsePackage(x),
+      // Use the timestamp the call was initiated, not the timestamp received. That prevents missing any updates
+      // that were made during the call.
+      timestamp,
+    }));
 
-  await replaceAll(packages);
+    await replaceAll(packages);
+  } finally {
+    deferred.resolve();
+  }
 });
 
 /**
@@ -199,6 +218,8 @@ export async function recreateDB(): Promise<void> {
  * Return the number of records in the registry.
  */
 export async function count(): Promise<number> {
+  await syncPromise;
+
   const db = await openRegistryDB();
   try {
     return await db.count(BRICK_STORE);
@@ -266,6 +287,9 @@ export async function find(id: string): Promise<Nullishable<PackageVersion>> {
     console.error("REGISTRY_FIND received invalid id argument", { id });
     throw new Error("invalid brick id");
   }
+
+  // Wait for in-flight sync to complete to ensure find sees the latest data
+  await syncPromise;
 
   const db = await openRegistryDB();
 

--- a/src/registry/packageRegistry.ts
+++ b/src/registry/packageRegistry.ts
@@ -185,7 +185,8 @@ export const syncPackages = memoizeUntilSettled(async () => {
 });
 
 /**
- * Helper to ensure the IDB has synced packages.
+ * Helper to ensure the IDB has synced packages. DOES NOT ensure the database has the latest package definitions --
+ * i.e., does not await any inflight syncPackages call if the database is already populated.
  */
 async function ensurePopulated(): Promise<void> {
   // Safe to assume everyone has access to at least one package


### PR DESCRIPTION
## What does this PR do?

- Closes #7822 
- Awaits the initial remote registry population attempt

## Discussion

- Does not await any pending/in-flight `syncPackages` call. I think we'd have to be careful there about delaying requests that are OK with seeing slightly stale data.
- The `count` method does not await the registry being populated

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
