### PR TITLE
#7774: save host page element focus when clicking into MV2 sidebar

### DIFF
--- a/src/bricks/effects/InsertAtCursorEffect.ts
+++ b/src/bricks/effects/InsertAtCursorEffect.ts
@@ -28,6 +28,7 @@ import focus from "@/utils/focusController";
 import type { PlatformCapability } from "@/platform/capabilities";
 import { insertAtCursorWithCustomEditorSupport } from "@/contentScript/textEditorDom";
 import { propertiesToSchema } from "@/utils/schemaUtils";
+import { expectContext } from "@/utils/expectContext";
 
 /**
  * Insert text at the cursor position. For use with text snippets, etc.
@@ -62,11 +63,17 @@ class InsertAtCursorEffect extends EffectABC {
 
   async effect(
     { text }: BrickArgs<{ text: string }>,
-    { root }: BrickOptions,
+    { root, logger }: BrickOptions,
   ): Promise<void> {
+    expectContext("contentScript");
+
     if (isEmpty(text)) {
+      // Skip because inserting no text is a NOP
+      logger.debug("No text provided");
       return;
     }
+
+    console.debug("InsertAtCursorEffect", { text, root, focused: focus.get() });
 
     const element = isDocument(root) ? focus.get() : root;
 

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -41,7 +41,10 @@ import initFloatingActions from "@/components/floatingActions/initFloatingAction
 import { initSidebarActivation } from "@/contentScript/sidebarActivation";
 import { initPerformanceMonitoring } from "@/contentScript/performanceMonitoring";
 import { initRuntime } from "@/runtime/reducePipeline";
-import { renderPanelsIfVisible } from "./sidebarController";
+import {
+  initSidebarFocusEvents,
+  renderPanelsIfVisible,
+} from "./sidebarController";
 import {
   isSidebarFrameVisible,
   removeSidebarFrame,
@@ -94,6 +97,7 @@ export async function init(): Promise<void> {
 
   void initNavigation();
 
+  initSidebarFocusEvents();
   void initSidebarActivation();
 
   // Notify `ensureContentScript`

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -542,8 +542,6 @@ export function sidePanelOnClose(callback: () => void): void {
 }
 
 export function initSidebarFocusEvents(): void {
-  const closeSignal = sidePanelOnCloseSignal();
-
   sidebarShowEvents.add(() => {
     const sidebar = getSidebarElement();
 
@@ -552,7 +550,9 @@ export function initSidebarFocusEvents(): void {
       return;
     }
 
-    // Can't detect clicks on the sidebar itself. So need to just watch for movement into/out of the sidebar
+    const closeSignal = sidePanelOnCloseSignal();
+
+    // Can't detect clicks in the sidebar itself. So need to just watch for enter/leave the sidebar element
     sidebar.addEventListener(
       "mouseenter",
       () => {
@@ -562,7 +562,7 @@ export function initSidebarFocusEvents(): void {
           focusController.save();
         }
       },
-      { passive: true, signal: closeSignal, capture: true },
+      { passive: true, capture: true, signal: closeSignal },
     );
 
     sidebar.addEventListener(
@@ -570,7 +570,7 @@ export function initSidebarFocusEvents(): void {
       () => {
         focusController.clear();
       },
-      { passive: true, signal: closeSignal, capture: true },
+      { passive: true, capture: true, signal: closeSignal },
     );
   });
 }

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -46,6 +46,8 @@ import { getErrorMessage } from "@/errors/errorHelpers";
 import { focusCaptureDialog } from "@/contentScript/focusCaptureDialog";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
 import { showMySidePanel } from "@/background/messenger/strict/api";
+import { getSidebarElement } from "@/contentScript/sidebarDomControllerLite";
+import focusController from "@/utils/focusController";
 
 const HIDE_SIDEBAR_EVENT_NAME = "pixiebrix:hideSidebar";
 
@@ -59,7 +61,7 @@ export const isSidePanelOpen = isMV3()
 /**
  * Determines whether the sidebar is open.
  * @returns false when it's definitely closed
- * @returns 'unknown' when it cannot be determined, beause the extra padding might be
+ * @returns 'unknown' when it cannot be determined, because the extra padding might be
  *          caused by the dev tools being open on the side or due to another sidebar
  */
 // The type cannot be `undefined` due to strictNullChecks
@@ -537,4 +539,38 @@ function sidePanelOnCloseSignal(): AbortSignal {
 export function sidePanelOnClose(callback: () => void): void {
   const signal = sidePanelOnCloseSignal();
   signal.addEventListener("abort", callback, { once: true });
+}
+
+export function initSidebarFocusEvents(): void {
+  const closeSignal = sidePanelOnCloseSignal();
+
+  sidebarShowEvents.add(() => {
+    const sidebar = getSidebarElement();
+
+    if (!sidebar) {
+      // Should always exist because sidebarShowEvents is called on Sidebar App initialization
+      return;
+    }
+
+    // Can't detect clicks on the sidebar itself. So need to just watch for movement into/out of the sidebar
+    sidebar.addEventListener(
+      "mouseenter",
+      () => {
+        // If the user clicks into the sidebar and then leaves the sidebar, don't set the focus to the sidebar
+        // when they re-enter the sidebar
+        if (document.activeElement !== sidebar) {
+          focusController.save();
+        }
+      },
+      { passive: true, signal: closeSignal, capture: true },
+    );
+
+    sidebar.addEventListener(
+      "mouseleave",
+      () => {
+        focusController.clear();
+      },
+      { passive: true, signal: closeSignal, capture: true },
+    );
+  });
 }

--- a/src/contentScript/sidebarDomControllerLite.ts
+++ b/src/contentScript/sidebarDomControllerLite.ts
@@ -159,7 +159,7 @@ export function insertSidebarFrame(): boolean {
   );
 
   wrapper.addEventListener(
-    "mouseeexit",
+    "mouseleave",
     () => {
       focusController.clear();
     },

--- a/src/contentScript/textEditorDom.ts
+++ b/src/contentScript/textEditorDom.ts
@@ -53,6 +53,12 @@ export async function insertAtCursorWithCustomEditorSupport({
     "contentScript context required for editor JavaScript integrations",
   );
 
+  console.debug("insertAtCursorWithCustomEditorSupport", element);
+
+  // `textFieldEdit` handles focus required to insert the text. But, force focus to enable the user to keep typing
+  window.focus();
+  element.focus();
+
   const ckeditor = ckeditorDom.selectCKEditorElement(element);
 
   if (ckeditor) {
@@ -63,10 +69,6 @@ export async function insertAtCursorWithCustomEditorSupport({
 
     return;
   }
-
-  // `textFieldEdit` handles focus required to insert the text. But, force focus to enable the user to keep typing
-  window.focus();
-  element.focus();
 
   textFieldEdit.insert(element, text);
 }

--- a/src/utils/focusController.ts
+++ b/src/utils/focusController.ts
@@ -57,13 +57,8 @@ class FocusController {
    * @note This doesn't behave as you'd expect across iframes
    */
   save(): void {
-    // Only HTMLElements can't have their focus restored, but we're currently ignoring this distinction
-    const { activeElement } = document;
-    const active = activeElement as HTMLElement;
-
-    if (active == null) {
-      return;
-    }
+    // Only HTMLElements can have their focus restored, but we're currently ignoring this distinction
+    const active = document.activeElement as HTMLElement;
 
     if (this.focusedElement != null && this.focusedElement !== active) {
       console.warn(

--- a/src/utils/focusController.ts
+++ b/src/utils/focusController.ts
@@ -17,11 +17,30 @@
 
 import { isLoadedInIframe } from "@/utils/iframeUtils";
 import { uuidv4 } from "@/types/helpers";
+import type { UUID } from "@/types/stringTypes";
+
+const FOCUS_CONTROLLER_ADDED_SYMBOL = Symbol.for("focus-controller-added");
+
+declare global {
+  interface Window {
+    [FOCUS_CONTROLLER_ADDED_SYMBOL]?: UUID;
+  }
+}
 
 class FocusController {
   private focusedElement: HTMLElement | undefined;
 
   private readonly nonce = uuidv4();
+
+  constructor() {
+    if (window[FOCUS_CONTROLLER_ADDED_SYMBOL]) {
+      console.warn(
+        `focusController(${this.nonce}): ${window[FOCUS_CONTROLLER_ADDED_SYMBOL]} already added to window`,
+      );
+    } else {
+      window[FOCUS_CONTROLLER_ADDED_SYMBOL] = this.nonce;
+    }
+  }
 
   /**
    * Saves the focus of the current focused element so that it can be restored later


### PR DESCRIPTION
## What does this PR do?

- Closes #7774
- Saves focused element when mouses into the MV2 sidebar, so we can use the element from actions the user clicks on in the sidebar

## Future Work

- Fix insertion position on DraftJS

## Checklist

- [x] Add tests: 🤷  can't test focus with JSDOM
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @fregante 
