### PR TITLE
enforce comments when we ignore lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     "@shopify/react-hooks-strict-return": "error",
     "@shopify/prefer-module-scope-constants": "error",
     "@shopify/jest/no-snapshots": "warn",
+    "eslint-comments/require-description": "warn",
     "react/no-array-index-key": "error",
     "react/no-unstable-nested-components": ["error", { allowAsProps: true }],
     "react/forbid-elements": [


### PR DESCRIPTION
## What does this PR do?

Turns on warn for the `require-description` lint rule to start enforcing comments when we intentionally ignore a lint rule. Currently we have 133 instances of lint rules ignored without a comment.

