### PR TITLE
ESLint: error on missing lint ignore comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,12 @@ module.exports = {
     "@shopify/react-hooks-strict-return": "error",
     "@shopify/prefer-module-scope-constants": "error",
     "@shopify/jest/no-snapshots": "warn",
+    "new-cap": [
+      "error",
+      {
+        capIsNewExceptionPattern: "(TEST_|INTERNAL_|HACK_)",
+      },
+    ],
     "eslint-comments/require-description": "warn",
     "react/no-array-index-key": "error",
     "react/no-unstable-nested-components": ["error", { allowAsProps: true }],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     "@shopify/react-hooks-strict-return": "error",
     "@shopify/prefer-module-scope-constants": "error",
     "@shopify/jest/no-snapshots": "warn",
+    "eslint-comments/require-description": "warn",
     "react/no-array-index-key": "error",
     "react/no-unstable-nested-components": ["error", { allowAsProps: true }],
     "react/forbid-elements": [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,7 @@ module.exports = {
     "new-cap": [
       "error",
       {
-        capIsNewExceptionPattern: "(TEST_|INTERNAL_|HACK_)",
+        capIsNewExceptionPattern: "(TEST_|INTERNAL_|HACK_|UNSAFE_)",
       },
     ],
     "eslint-comments/require-description": "warn",

--- a/src/analysis/analysisVisitors/varAnalysis/parseTemplateVariables.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/parseTemplateVariables.ts
@@ -30,7 +30,7 @@ const VARIABLE_START_INDEX = Symbol("#Variable_start_index");
 
 export interface VariableOptions {
   type?: string;
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define -- define type interface first
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define -- Cyclic dependency
   parent?: Variable | undefined;
   startIndex: number;
 }

--- a/src/analysis/analysisVisitors/varAnalysis/parseTemplateVariables.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/parseTemplateVariables.ts
@@ -30,7 +30,7 @@ const VARIABLE_START_INDEX = Symbol("#Variable_start_index");
 
 export interface VariableOptions {
   type?: string;
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define -- define type interface first
   parent?: Variable | undefined;
   startIndex: number;
 }

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -114,16 +114,19 @@ async function setIntegrationDependencyVars(
   contextVars: VarMap,
 ): Promise<void> {
   // Loop through all the integrations, so we can set the source for each dependency variable properly
-  for (const integrationDependency of extension.integrationDependencies ?? []) {
-    // eslint-disable-next-line no-await-in-loop
-    const serviceContext = await makeServiceContextFromDependencies([
-      integrationDependency,
-    ]);
-    contextVars.setExistenceFromValues({
-      source: `${KnownSources.SERVICE}:${integrationDependency.integrationId}`,
-      values: serviceContext,
-    });
-  }
+  await Promise.all(
+    (extension.integrationDependencies ?? []).map(
+      async (integrationDependency) => {
+        const serviceContext = await makeServiceContextFromDependencies([
+          integrationDependency,
+        ]);
+        contextVars.setExistenceFromValues({
+          source: `${KnownSources.SERVICE}:${integrationDependency.integrationId}`,
+          values: serviceContext,
+        });
+      },
+    ),
+  );
 }
 
 /**

--- a/src/auth/authUtils.ts
+++ b/src/auth/authUtils.ts
@@ -60,8 +60,8 @@ export function selectUserDataUpdate({
 
   return {
     // TODO: Review Required/Partial in Me type
-    // https://github.com/pixiebrix/pixiebrix-extension/issues/7725
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+    //  https://github.com/pixiebrix/pixiebrix-extension/issues/7725
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- email is required
     email: email!,
     organizationId: organization?.id ?? null,
     telemetryOrganizationId: telemetryOrganization?.id ?? null,

--- a/src/auth/authUtils.ts
+++ b/src/auth/authUtils.ts
@@ -61,7 +61,8 @@ export function selectUserDataUpdate({
   return {
     // TODO: Review Required/Partial in Me type
     //  https://github.com/pixiebrix/pixiebrix-extension/issues/7725
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- email is required
+    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+    -- email is always present, pending above type refactoring */
     email: email!,
     organizationId: organization?.id ?? null,
     telemetryOrganizationId: telemetryOrganization?.id ?? null,

--- a/src/auth/featureFlagStorage.test.ts
+++ b/src/auth/featureFlagStorage.test.ts
@@ -43,7 +43,6 @@ describe("featureFlags", () => {
   });
 
   it("returns true if flag is present", async () => {
-    // eslint-disable-next-line new-cap
     await TEST_overrideFeatureFlags([
       "test-flag",
       "test-other-flag",
@@ -53,7 +52,6 @@ describe("featureFlags", () => {
   });
 
   it("returns false if flag is not present", async () => {
-    // eslint-disable-next-line new-cap
     await TEST_overrideFeatureFlags(["test-other-flag", "test-other-flag-2"]);
     await expect(flagOn("test-flag")).resolves.toBe(false);
   });
@@ -68,7 +66,6 @@ describe("featureFlags", () => {
   });
 
   it("does not fetch if flags have been updated recently", async () => {
-    // eslint-disable-next-line new-cap
     await TEST_overrideFeatureFlags(["test-flag"]);
     await expect(flagOn("test-flag")).resolves.toBe(true);
     expect(appApiMock.history.get).toHaveLength(0);
@@ -95,9 +92,7 @@ describe("featureFlags", () => {
     expect(appApiMock.history.get).toHaveLength(1);
 
     const authData = tokenAuthDataFactory();
-    // eslint-disable-next-line new-cap
     await TEST_setAuthData(authData);
-    // eslint-disable-next-line new-cap
     TEST_triggerListeners(authData);
 
     // New user doesn't have secret flag

--- a/src/background/auth/authStorage.ts
+++ b/src/background/auth/authStorage.ts
@@ -62,8 +62,7 @@ export async function deleteCachedAuthData(serviceAuthId: UUID): Promise<void> {
     console.debug(
       `deleteCachedAuthData: removed data for auth ${serviceAuthId}`,
     );
-    // OK because we're guarding with hasOwn
-    // eslint-disable-next-line security/detect-object-injection
+    // eslint-disable-next-line security/detect-object-injection -- OK because we're guarding with hasOwn
     delete current[serviceAuthId];
 
     await oauth2Storage.set(current);

--- a/src/background/auth/codeGrantFlow.ts
+++ b/src/background/auth/codeGrantFlow.ts
@@ -164,15 +164,13 @@ async function codeGrantFlow(
     }
 
     const json = Object.fromEntries(parsed.entries());
-    // TODO: Fix IntegrationConfig types
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- TODO: Fix IntegrationConfig types
     await setCachedAuthData(auth.id!, json);
     return json as AuthData;
   }
 
   if (typeof data === "object") {
-    // TODO: Fix IntegrationConfig types
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- TODO: Fix IntegrationConfig types
     await setCachedAuthData(auth.id!, data);
     return data as AuthData;
   }

--- a/src/background/auth/implicitGrantFlow.ts
+++ b/src/background/auth/implicitGrantFlow.ts
@@ -98,8 +98,7 @@ async function implicitGrantFlow(
   }
 
   const data: AuthData = { access_token, ...rest } as unknown as AuthData;
-  // TODO: Fix IntegrationConfig types
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- TODO: Fix IntegrationConfig types
   await setCachedAuthData(auth.id!, data);
   return data;
 }

--- a/src/background/restrictUnauthenticatedUrlAccess.test.ts
+++ b/src/background/restrictUnauthenticatedUrlAccess.test.ts
@@ -64,13 +64,11 @@ describe("enforceAuthentication", () => {
   });
 
   afterEach(async () => {
-    // eslint-disable-next-line new-cap -- used for testing
     await INTERNAL_reset();
     await browser.storage.managed.clear();
     await browser.storage.local.clear();
     axiosMock.reset();
     jest.clearAllMocks();
-    // eslint-disable-next-line new-cap -- used for testing
     TEST_clearListeners();
   });
 
@@ -123,13 +121,11 @@ describe("enforceAuthentication", () => {
     expect(addListenerSpy).toHaveBeenCalledTimes(1);
     expect(removeListenerSpy).toHaveBeenCalledTimes(0);
 
-    // eslint-disable-next-line new-cap -- used for testing
     TEST_triggerListeners({ token: "foo" });
 
     expect(removeListenerSpy).toHaveBeenCalledTimes(1);
     addListenerSpy.mockClear();
 
-    // eslint-disable-next-line new-cap -- used for testing
     TEST_triggerListeners(undefined);
     await waitForEffect();
     expect(addListenerSpy).toHaveBeenCalledTimes(1);
@@ -173,7 +169,6 @@ describe("enforceAuthentication", () => {
       }),
     );
 
-    // eslint-disable-next-line new-cap -- used for testing
     TEST_triggerListeners({ token: "foo" });
 
     await waitForEffect();
@@ -218,7 +213,6 @@ describe("enforceAuthentication", () => {
     // Mock that tab no longer exists
     jest.mocked(browser.tabs.get).mockResolvedValue(null);
 
-    // eslint-disable-next-line new-cap -- used for testing
     TEST_triggerListeners({ token: "foo" });
 
     await waitForEffect();

--- a/src/background/setToolbarIconFromTheme.test.ts
+++ b/src/background/setToolbarIconFromTheme.test.ts
@@ -51,7 +51,7 @@ describe("setToolbarIconFromTheme", () => {
   // @ts-expect-error -- No need to mock the whole class for the test
   global.Image = class {
     src = "";
-    // eslint-disable-next-line no-restricted-syntax
+    // eslint-disable-next-line no-restricted-syntax -- This is a mock
     decode = jest.fn().mockResolvedValue(undefined);
   };
   // @ts-expect-error -- No need to mock the whole class for the test

--- a/src/background/setToolbarIconFromTheme.test.ts
+++ b/src/background/setToolbarIconFromTheme.test.ts
@@ -51,8 +51,7 @@ describe("setToolbarIconFromTheme", () => {
   // @ts-expect-error -- No need to mock the whole class for the test
   global.Image = class {
     src = "";
-    // eslint-disable-next-line no-restricted-syntax -- This is a mock
-    decode = jest.fn().mockResolvedValue(undefined);
+    decode = jest.fn();
   };
   // @ts-expect-error -- No need to mock the whole class for the test
   global.OffscreenCanvas = class {

--- a/src/background/telemetry.test.ts
+++ b/src/background/telemetry.test.ts
@@ -27,7 +27,6 @@ beforeEach(async () => {
   appApiMock.reset();
   appApiMock.onPost("/api/events/").reply(201, {});
 
-  // eslint-disable-next-line new-cap -- test file
   await TEST_flushAll();
 });
 

--- a/src/bricks/effects/pageState.test.ts
+++ b/src/bricks/effects/pageState.test.ts
@@ -24,7 +24,6 @@ import { GetPageState, SetPageState } from "@/bricks/effects/pageState";
 import { TEST_resetState } from "@/platform/state/stateController";
 
 beforeEach(() => {
-  // eslint-disable-next-line new-cap -- test method
   TEST_resetState();
 });
 

--- a/src/bricks/registry.test.ts
+++ b/src/bricks/registry.test.ts
@@ -44,7 +44,6 @@ beforeEach(() => {
   jest.clearAllMocks();
   backgroundGetByKindsMock.mockResolvedValue([]);
 
-  // eslint-disable-next-line new-cap -- test-only method
   bricksRegistry.TEST_reset();
 });
 

--- a/src/bricks/transformers/ephemeralForm/formTransformer.test.ts
+++ b/src/bricks/transformers/ephemeralForm/formTransformer.test.ts
@@ -34,7 +34,6 @@ const showModalMock = jest.mocked(showModal);
 const brick = new FormTransformer();
 
 afterEach(async () => {
-  // eslint-disable-next-line new-cap -- test method
   await TEST_cancelAll();
   jest.clearAllMocks();
 });
@@ -102,7 +101,6 @@ describe("FormTransformer", () => {
       brickOptionsFactory(),
     );
 
-    // eslint-disable-next-line new-cap -- test method
     await TEST_cancelAll();
 
     await expect(brickPromise).rejects.toThrow(CancelError);
@@ -134,7 +132,6 @@ describe("FormTransformer", () => {
       brickOptionsFactory(),
     );
 
-    // eslint-disable-next-line new-cap -- test method
     await TEST_cancelAll();
 
     await expect(brickPromise).rejects.toThrow(CancelError);

--- a/src/bricks/transformers/mapping.ts
+++ b/src/bricks/transformers/mapping.ts
@@ -74,8 +74,7 @@ export class MappingTransformer extends TransformerABC {
     }
 
     if (Object.hasOwn(mapping, key)) {
-      // Checking for hasOwn
-      // eslint-disable-next-line security/detect-object-injection
+      // eslint-disable-next-line security/detect-object-injection -- Checking for hasOwn
       return mapping[key];
     }
 

--- a/src/bricks/transformers/parseUrl.ts
+++ b/src/bricks/transformers/parseUrl.ts
@@ -127,8 +127,7 @@ export class UrlParser extends TransformerABC {
 
     const searchParams: Record<string, string> = {};
     for (const [key, value] of parsed.searchParams.entries()) {
-      // Fine because value will always be a string
-      // eslint-disable-next-line security/detect-object-injection
+      // eslint-disable-next-line security/detect-object-injection -- Fine because value will always be a string
       searchParams[key] = value;
     }
 

--- a/src/components/EmotionShadowRoot.ts
+++ b/src/components/EmotionShadowRoot.ts
@@ -18,9 +18,9 @@
 // eslint-disable-next-line no-restricted-imports -- All roads lead here
 import EmotionShadowRoot from "react-shadow/emotion";
 
-// "Every property exists" (via Proxy), TypeScript doesn't offer such type
-// Also strictNullChecks config mismatch
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion
+/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion --
+"Every property exists" (via Proxy), TypeScript doesn't offer such type
+Also strictNullChecks config mismatch */
 const ShadowRoot = EmotionShadowRoot.div!;
 
 export default ShadowRoot;

--- a/src/components/documentBuilder/documentTree.tsx
+++ b/src/components/documentBuilder/documentTree.tsx
@@ -94,7 +94,7 @@ export const buildDocumentBranch: BuildDocumentBranch = (root, tracePath) => {
   return componentDefinition;
 };
 
-// eslint-disable-next-line complexity
+// eslint-disable-next-line complexity -- We're handling a lot of different element types
 export function getComponentDefinition(
   element: DocumentElement,
   tracePath: DynamicPath,

--- a/src/components/documentBuilder/hooks/useMoveWithinParent.ts
+++ b/src/components/documentBuilder/hooks/useMoveWithinParent.ts
@@ -51,12 +51,12 @@ function useMoveWithinParent(documentBodyName: string): MoveWithinParent {
     const newElementsCollection = [...elementsCollection];
     const toIndex = direction === "up" ? elementIndex - 1 : elementIndex + 1;
 
-    /* eslint-disable security/detect-object-injection */
+    /* eslint-disable security/detect-object-injection -- swapping list elements  */
     [newElementsCollection[elementIndex], newElementsCollection[toIndex]] = [
       newElementsCollection[toIndex],
       newElementsCollection[elementIndex],
     ];
-    /* eslint-enable security/detect-object-injection */
+    /* eslint-enable security/detect-object-injection -- re-enable */
 
     await setElementsCollection(newElementsCollection);
     setActiveElement(joinPathParts(collectionName, toIndex));

--- a/src/components/documentBuilder/preview/DocumentPreview.test.tsx
+++ b/src/components/documentBuilder/preview/DocumentPreview.test.tsx
@@ -87,35 +87,34 @@ describe("Add new element", () => {
     const listElement = createNewElement("list") as ListDocumentElement;
     listElement.config.element.__value__ = createNewElement("container");
     const containerElement = createNewElement("container");
-    // There's a row in the container and a column in the row.
-    // eslint-disable-next-line testing-library/no-node-access
+    // eslint-disable-next-line testing-library/no-node-access -- There's a row in the container and a column in the row.
     containerElement.children[0].children[0].children[0] = listElement;
 
     const { container } = renderDocumentPreview(containerElement);
 
     // Select a dropdown inside a Col in List and open it
     await userEvent.click(
-      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- see test's TODO comment
       container.querySelector(".col .col .addElement button"),
     );
     expect(
-      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- see test's TODO comment
       container.querySelector(".col .col .addElement button"),
     ).toHaveAttribute("aria-expanded", "true");
 
     // Hover over the Col in the list
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- see test's TODO comment
     fireEvent.mouseOver(container.querySelector(".col .col"));
     expect(
-      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- see test's TODO comment
       container.querySelector(".col .col .addElement button"),
     ).toHaveAttribute("aria-expanded", "true");
 
     // Hover over the Container of the List, .root.root - is the Document root element
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- see test's TODO comment
     fireEvent.mouseOver(container.querySelector(".root.root > .container"));
     expect(
-      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- see test's TODO comment
       container.querySelector(".col .col .addElement button"),
     ).toHaveAttribute("aria-expanded", "true");
   });
@@ -123,7 +122,7 @@ describe("Add new element", () => {
   test("can add an element to a container", async () => {
     const { container } = renderDocumentPreview(createNewElement("container"));
 
-    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- see test's TODO comment
     await userEvent.click(container.querySelector(".col .addElement button"));
     await userEvent.click(screen.getByText("Header", { selector: "a" }));
 

--- a/src/contentScript/lifecycle.test.ts
+++ b/src/contentScript/lifecycle.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable new-cap -- using exposed TEST_ methods */
 /*
  * Copyright (C) 2024 PixieBrix, Inc.
  *

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -288,7 +288,6 @@ export function clearEditorExtension(
 
       if (extensionPoint.kind === "actionPanel" && preserveSidebar) {
         const sidebar = extensionPoint as SidebarStarterBrickABC;
-        // eslint-disable-next-line new-cap -- hack for action panels
         sidebar.HACK_uninstallExceptExtension(extensionId);
       } else {
         extensionPoint.uninstall({ global: true });

--- a/src/contentScript/loadActivationEnhancementsCore.test.ts
+++ b/src/contentScript/loadActivationEnhancementsCore.test.ts
@@ -85,7 +85,6 @@ describe("marketplace enhancements", () => {
 
   afterEach(async () => {
     jest.resetAllMocks();
-    // eslint-disable-next-line new-cap -- test method
     TEST_unloadActivationEnhancements();
   });
 

--- a/src/extensionConsole/pages/BrowserBanner.test.tsx
+++ b/src/extensionConsole/pages/BrowserBanner.test.tsx
@@ -23,7 +23,6 @@ import { screen } from "@testing-library/react";
 import { INTERNAL_reset } from "@/store/enterprise/managedStorage";
 
 beforeEach(async () => {
-  // eslint-disable-next-line new-cap -- test helper method
   await INTERNAL_reset();
   await browser.storage.managed.clear();
 });

--- a/src/hooks/useFlags.test.tsx
+++ b/src/hooks/useFlags.test.tsx
@@ -79,7 +79,6 @@ describe("useFlags", () => {
 
     const tokenData = tokenAuthDataFactory();
 
-    // eslint-disable-next-line new-cap
     await TEST_setAuthData(tokenData);
 
     render(
@@ -94,7 +93,6 @@ describe("useFlags", () => {
     expect(appApiMock.history.get).toHaveLength(1);
 
     // Simulate a change in auth data
-    // eslint-disable-next-line new-cap
     TEST_triggerListeners(tokenData);
 
     await waitForEffect();

--- a/src/integrations/useSanitizedIntegrationConfigFormikAdapter.test.ts
+++ b/src/integrations/useSanitizedIntegrationConfigFormikAdapter.test.ts
@@ -60,7 +60,6 @@ const serviceRegistryMock = jest.mocked(serviceRegistry);
 
 describe("useSanitizedIntegrationConfigFormikAdapter", () => {
   beforeEach(() => {
-    // eslint-disable-next-line new-cap -- test helper method
     INTERNAL_reset();
   });
 

--- a/src/mods/useModViewItems.test.tsx
+++ b/src/mods/useModViewItems.test.tsx
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable new-cap -- test methods */
 import useModViewItems from "@/mods/useModViewItems";
 import {
   type ActivatedModComponent,

--- a/src/mods/useMods.test.ts
+++ b/src/mods/useMods.test.ts
@@ -61,7 +61,6 @@ describe("useMods", () => {
     const wrapper = renderHook(() => useMods(), {
       setupRedux(dispatch) {
         dispatch(
-          // eslint-disable-next-line new-cap -- unsafe
           extensionsSlice.actions.UNSAFE_setExtensions([
             activatedModComponentFactory({
               _recipe: {
@@ -93,7 +92,6 @@ describe("useMods", () => {
     const wrapper = renderHook(() => useMods(), {
       setupRedux(dispatch) {
         dispatch(
-          // eslint-disable-next-line new-cap -- unsafe
           extensionsSlice.actions.UNSAFE_setExtensions(
             range(3).map(() =>
               activatedModComponentFactory({
@@ -132,7 +130,6 @@ describe("useMods", () => {
     const wrapper = renderHook(() => useMods(), {
       setupRedux(dispatch) {
         dispatch(
-          // eslint-disable-next-line new-cap -- test setup
           extensionsSlice.actions.UNSAFE_setExtensions([
             activatedModComponentFactory({
               _recipe: {
@@ -189,7 +186,6 @@ describe("useMods", () => {
     const wrapper = renderHook(() => useMods(), {
       setupRedux(dispatch) {
         dispatch(
-          // eslint-disable-next-line new-cap -- test setup
           extensionsSlice.actions.UNSAFE_setExtensions([
             // Content doesn't matter, just need to match the ID
             activatedModComponentFactory({ id: standaloneModDefinition.id }),

--- a/src/mods/useMods.test.ts
+++ b/src/mods/useMods.test.ts
@@ -61,7 +61,7 @@ describe("useMods", () => {
     const wrapper = renderHook(() => useMods(), {
       setupRedux(dispatch) {
         dispatch(
-          // eslint-disable-next-line new-cap -- unsave
+          // eslint-disable-next-line new-cap -- unsafe
           extensionsSlice.actions.UNSAFE_setExtensions([
             activatedModComponentFactory({
               _recipe: {
@@ -93,7 +93,7 @@ describe("useMods", () => {
     const wrapper = renderHook(() => useMods(), {
       setupRedux(dispatch) {
         dispatch(
-          // eslint-disable-next-line new-cap -- unsave
+          // eslint-disable-next-line new-cap -- unsafe
           extensionsSlice.actions.UNSAFE_setExtensions(
             range(3).map(() =>
               activatedModComponentFactory({

--- a/src/permissions/useExtensionPermissions.test.ts
+++ b/src/permissions/useExtensionPermissions.test.ts
@@ -47,7 +47,6 @@ function mockOrigins(...additional: string[]): void {
 
 describe("useExtensionPermissions", () => {
   beforeEach(() => {
-    // eslint-disable-next-line new-cap -- test helper method
     INTERNAL_reset();
   });
 

--- a/src/store/enterprise/managedStorage.test.ts
+++ b/src/store/enterprise/managedStorage.test.ts
@@ -25,7 +25,6 @@ import type { Timestamp } from "@/types/stringTypes";
 
 beforeEach(async () => {
   jest.clearAllMocks();
-  // eslint-disable-next-line new-cap -- test helper method
   await INTERNAL_reset();
   await browser.storage.managed.clear();
 });

--- a/src/store/enterprise/useManagedStorageState.test.ts
+++ b/src/store/enterprise/useManagedStorageState.test.ts
@@ -30,7 +30,6 @@ jest.mock("lodash", () => {
 });
 
 beforeEach(async () => {
-  // eslint-disable-next-line new-cap -- test helper method
   await INTERNAL_reset();
   await browser.storage.managed.clear();
 });

--- a/src/testUtils/userMock.ts
+++ b/src/testUtils/userMock.ts
@@ -46,7 +46,7 @@ export async function mockAuthenticatedUser(me?: Me): Promise<void> {
   const tokenData = tokenAuthDataFactory({
     ...authData,
   });
-  // eslint-disable-next-line new-cap
+
   await TEST_setAuthData(tokenData);
   useLinkStateMock.mockReturnValue(valueToAsyncState(true));
 }
@@ -62,7 +62,6 @@ async function cleanUpUserMocks() {
   console.log("TEST");
   useLinkStateMock.mockReset();
   appApiMock.reset();
-  // eslint-disable-next-line new-cap
   await TEST_setAuthData({});
 }
 

--- a/src/themes/themeStore.test.ts
+++ b/src/themes/themeStore.test.ts
@@ -69,7 +69,6 @@ describe("getActiveTheme", () => {
     });
 
     afterEach(async () => {
-      // eslint-disable-next-line new-cap -- used for testing
       await INTERNAL_reset();
       await browser.storage.managed.clear();
       await browser.storage.local.clear();


### PR DESCRIPTION
## What does this PR do?

- Starts to fix the newly enabled rule for enforcing explanations on eslint ignores
- I updated the new-cap rule so we don't have to ignore it a bunch
- There is one functional change I pointed out.

102 errors remaining
