### PR TITLE
ESLint: fix missing comments for expect-expect eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     "@shopify/react-hooks-strict-return": "error",
     "@shopify/prefer-module-scope-constants": "error",
     "@shopify/jest/no-snapshots": "warn",
+    "jest/expect-expect": ["error", { assertFunctionNames: ["$expect**"] }],
     "eslint-comments/require-description": "warn",
     "react/no-array-index-key": "error",
     "react/no-unstable-nested-components": ["error", { allowAsProps: true }],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,6 @@ module.exports = {
     "@shopify/react-hooks-strict-return": "error",
     "@shopify/prefer-module-scope-constants": "error",
     "@shopify/jest/no-snapshots": "warn",
-    "jest/expect-expect": ["error", { assertFunctionNames: ["$expect**"] }],
     "eslint-comments/require-description": "warn",
     "react/no-array-index-key": "error",
     "react/no-unstable-nested-components": ["error", { allowAsProps: true }],

--- a/src/components/fields/schemaFields/BasicSchemaField.test.tsx
+++ b/src/components/fields/schemaFields/BasicSchemaField.test.tsx
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectToggleMode"] }] */
-
 import React from "react";
 import { render, screen } from "@/pageEditor/testHelpers";
 import BasicSchemaField from "@/components/fields/schemaFields/BasicSchemaField";

--- a/src/components/fields/schemaFields/BasicSchemaField.test.tsx
+++ b/src/components/fields/schemaFields/BasicSchemaField.test.tsx
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectToggleMode"] }] -- TODO: replace with native expect and it.each */
+
 import React from "react";
 import { render, screen } from "@/pageEditor/testHelpers";
 import BasicSchemaField from "@/components/fields/schemaFields/BasicSchemaField";

--- a/src/components/fields/schemaFields/ChildObjectField.test.tsx
+++ b/src/components/fields/schemaFields/ChildObjectField.test.tsx
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectToggleMode"] }] */
-
 import React from "react";
 import { type Schema } from "@/types/schemaTypes";
 import { render } from "@/pageEditor/testHelpers";

--- a/src/components/fields/schemaFields/ChildObjectField.test.tsx
+++ b/src/components/fields/schemaFields/ChildObjectField.test.tsx
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectToggleMode"] }] -- TODO: replace with native expect and it.each */
+
 import React from "react";
 import { type Schema } from "@/types/schemaTypes";
 import { render } from "@/pageEditor/testHelpers";

--- a/src/components/fields/schemaFields/SchemaField.test.tsx
+++ b/src/components/fields/schemaFields/SchemaField.test.tsx
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectToggleOptions"] }] */
-
 import React from "react";
 import { render, screen, waitFor, within } from "@/pageEditor/testHelpers";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";

--- a/src/components/fields/schemaFields/SchemaField.test.tsx
+++ b/src/components/fields/schemaFields/SchemaField.test.tsx
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectToggleOptions"] }] -- TODO: replace with native expect and it.each */
+
 import React from "react";
 import { render, screen, waitFor, within } from "@/pageEditor/testHelpers";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";

--- a/src/components/fields/schemaFields/widgets/ObjectWidget.test.tsx
+++ b/src/components/fields/schemaFields/widgets/ObjectWidget.test.tsx
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectToggleOptions"] }] -- TODO: replace with native expect and it.each */
+
 import React from "react";
 import { type Schema } from "@/types/schemaTypes";
 import { render, screen, within } from "@/pageEditor/testHelpers";

--- a/src/components/fields/schemaFields/widgets/ObjectWidget.test.tsx
+++ b/src/components/fields/schemaFields/widgets/ObjectWidget.test.tsx
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectToggleOptions"] }] */
-
 import React from "react";
 import { type Schema } from "@/types/schemaTypes";
 import { render, screen, within } from "@/pageEditor/testHelpers";

--- a/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.test.tsx
@@ -15,6 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectLegacyTestSpreadsheetLoaded", "expectTab1Selected", "expectGoogleAccountSpreadsheetTitleLoaded", "expectGoogleAccountTestSpreadsheetLoaded", "expectTabSelectWorksProperly"] }]
+-- TODO: replace with native expect and it.each */
+
 import React from "react";
 import AppendSpreadsheetOptions from "./AppendSpreadsheetOptions";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";

--- a/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.test.tsx
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectLegacyTestSpreadsheetLoaded", "expectTab1Selected", "expectGoogleAccountTestSpreadsheetLoaded", "expectTabSelectWorksProperly"] }] */
-
 import React from "react";
 import AppendSpreadsheetOptions from "./AppendSpreadsheetOptions";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
@@ -339,7 +337,6 @@ describe("AppendSpreadsheetOptions", () => {
     expect(screen.getByDisplayValue("barValue")).toBeVisible();
   });
 
-  // eslint-disable-next-line jest/expect-expect -- custom expect functions
   test("given test googleAccount and string spreadsheetId value and selected tabName and column values, when rendered, loads spreadsheet title and doesn't clear values", async () => {
     await renderWithValuesAndWait({
       config: {

--- a/src/contrib/google/sheets/ui/TabField.test.tsx
+++ b/src/contrib/google/sheets/ui/TabField.test.tsx
@@ -15,6 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectToggleOptions", "expectTab1Selected", "expectTab2Selected"] }]
+-- TODO: replace with native expect and it.each */
+
 import React from "react";
 import { expectToggleOptions } from "@/components/fields/schemaFields/fieldTestUtils";
 import { render } from "@/pageEditor/testHelpers";

--- a/src/contrib/google/sheets/ui/TabField.test.tsx
+++ b/src/contrib/google/sheets/ui/TabField.test.tsx
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectToggleOptions", "expectTab1Selected"] }] */
-
 import React from "react";
 import { expectToggleOptions } from "@/components/fields/schemaFields/fieldTestUtils";
 import { render } from "@/pageEditor/testHelpers";
@@ -343,7 +341,6 @@ describe("TabField", () => {
     expect(screen.getByText("Foo")).toBeVisible();
   });
 
-  // eslint-disable-next-line jest/expect-expect -- custom assertion function is used
   test("given string tabName value, when spreadsheet changes to null, then does not update the value", async () => {
     const { rerender } = render(
       <TabField
@@ -377,7 +374,6 @@ describe("TabField", () => {
     expectTab2Selected();
   });
 
-  // eslint-disable-next-line jest/expect-expect -- custom assertion function is used
   test("given string tabName value, when spreadsheet changes to null and back to the same spreadsheet, should not reset the value", async () => {
     const { rerender } = render(
       <TabField

--- a/src/extensionConsole/pages/mods/hooks/useModsPageActions.test.tsx
+++ b/src/extensionConsole/pages/mods/hooks/useModsPageActions.test.tsx
@@ -17,6 +17,8 @@
 
 /// <reference types="jest-extended" />
 
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectActions"] }] -- TODO: replace with native expect and it.each */
+
 import useModsPageActions, {
   type ModsPageActions,
 } from "@/extensionConsole/pages/mods/hooks/useModsPageActions";

--- a/src/extensionConsole/pages/mods/hooks/useModsPageActions.test.tsx
+++ b/src/extensionConsole/pages/mods/hooks/useModsPageActions.test.tsx
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectActions"] }] */
 /// <reference types="jest-extended" />
 
 import useModsPageActions, {

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectEditorError"] }] */
-
 import React from "react";
 import { render, screen, within } from "@/pageEditor/testHelpers";
 import EditorPane from "./EditorPane";

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -62,6 +62,8 @@ import { partnerUserFactory } from "@/testUtils/factories/authFactories";
 import { toExpression } from "@/utils/expressionUtils";
 import { PipelineFlavor } from "@/bricks/types";
 
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectEditorError"] }] -- TODO: replace with native expect and it.each */
+
 jest.setTimeout(15_000); // This test is flaky with the default timeout of 5000 ms
 
 let clock: sinonTimers.InstalledClock;

--- a/src/utils/inference/selectorInference.test.ts
+++ b/src/utils/inference/selectorInference.test.ts
@@ -15,6 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSelector", "expectRoundtripSelector", "expectSimilarElements", "expectSelectors"] }]
+-- TODO: replace with native expect and it.each */
+
 import {
   expandedCssSelector,
   generateSelector,

--- a/src/utils/inference/selectorInference.test.ts
+++ b/src/utils/inference/selectorInference.test.ts
@@ -15,8 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSelector", "expectRoundtripSelector", "expectSimilarElements", "expectSelectors"] }] */
-
 import {
   expandedCssSelector,
   generateSelector,


### PR DESCRIPTION
## What does this PR do?

~~- This removes the need for ignoring this specific rule (expect-expect) in a few places.~~
- Adding comments for all overrides of the expect-expect rule
