### PR TITLE
#7836: fix package definition validation due to updated_at and sharing metadata

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -12,3 +12,5 @@
 /jsLinters/
 # Personal extensions
 codestream.xml
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -202,6 +202,14 @@ export type RegistryPackage = Pick<
    * @see https://github.com/pixiebrix/pixiebrix-app/blob/43f0a4b81d8b7aaaf11adbe7fd8e4530ca4b8bf0/api/serializers/brick.py#L204-L204
    */
   kind: "component" | "extensionPoint" | "recipe" | "service" | "reader";
+
+  // PackageConfigListSerializer adds updated_at and sharing to the PackageConfigList response:
+  // https://github.com/pixiebrix/pixiebrix-app/blob/368a0116edad2c115ae370b651f109619e621745/api/serializers/brick.py#L139-L139
+
+  updated_at: Timestamp;
+
+  // The exact shape isn't used for now in the extension. So keep as UnknownObject
+  sharing: UnknownObject;
 };
 
 /**

--- a/src/types/modDefinitionTypes.ts
+++ b/src/types/modDefinitionTypes.ts
@@ -107,7 +107,7 @@ export interface UnsavedModDefinition extends Definition {
  * which team they were shared from
  */
 // Not exported -- use ModDefinition["sharing"] instead to reference
-export type SharingDefinition = {
+type SharingDefinition = {
   /**
    * True fi the package has been shared publicly on PixieBrix
    */

--- a/src/types/modDefinitionTypes.ts
+++ b/src/types/modDefinitionTypes.ts
@@ -103,11 +103,11 @@ export interface UnsavedModDefinition extends Definition {
 }
 
 /**
- * Information about who a package has been shared with. Currently used only on mods in the interface to indicate
+ * Information about whom a package has been shared with. Currently used only on mods in the interface to indicate
  * which team they were shared from
  */
 // Not exported -- use ModDefinition["sharing"] instead to reference
-type SharingDefinition = {
+export type SharingDefinition = {
   /**
    * True fi the package has been shared publicly on PixieBrix
    */

--- a/src/validators/schemaValidator.test.ts
+++ b/src/validators/schemaValidator.test.ts
@@ -45,6 +45,13 @@ describe("validateKind", () => {
     expect(result.errors).toHaveLength(0);
     expect(result.valid).toBe(true);
   });
+
+  test("fails on additional unknown property", async () => {
+    const json = loadBrickYaml(serviceText) as UnknownObject;
+    json.foobar = "Hello, world!";
+    const result = validatePackageDefinition("service", json);
+    expect(result.valid).toBe(false);
+  });
 });
 
 describe("validateBrickInputOutput", () => {

--- a/src/validators/schemaValidator.test.ts
+++ b/src/validators/schemaValidator.test.ts
@@ -50,6 +50,23 @@ describe("validateKind", () => {
     const json = loadBrickYaml(serviceText) as UnknownObject;
     json.foobar = "Hello, world!";
     const result = validatePackageDefinition("service", json);
+
+    expect(result.errors).toStrictEqual([
+      {
+        error: 'Property "foobar" does not match additional properties schema.',
+        instanceLocation: "#",
+        keyword: "additionalProperties",
+        keywordLocation: "#/additionalProperties",
+      },
+      // The exact error here doesn't really matter:
+      {
+        error: "False boolean schema.",
+        instanceLocation: "#/foobar",
+        keyword: "false",
+        keywordLocation: "#/foobar",
+      },
+    ]);
+
     expect(result.valid).toBe(false);
   });
 });

--- a/src/validators/schemaValidator.test.ts
+++ b/src/validators/schemaValidator.test.ts
@@ -23,11 +23,25 @@ import { loadBrickYaml } from "@/runtime/brickYaml";
 import serviceText from "@contrib/raw/hunter.txt";
 import { type Schema } from "@/types/schemaTypes";
 import { uuidv4 } from "@/types/helpers";
+import { timestampFactory } from "@/testUtils/factories/stringFactories";
+import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 
 describe("validateKind", () => {
   test("can validate integration definition", async () => {
     const json = loadBrickYaml(serviceText) as UnknownObject;
     const result = validatePackageDefinition("service", json);
+    expect(result.errors).toHaveLength(0);
+    expect(result.valid).toBe(true);
+  });
+
+  test("can validate integration with timestamp/sharing metadata", async () => {
+    const json = loadBrickYaml(serviceText) as UnknownObject;
+
+    json.updated_at = timestampFactory();
+    json.sharing = sharingDefinitionFactory();
+
+    const result = validatePackageDefinition("service", json);
+
     expect(result.errors).toHaveLength(0);
     expect(result.valid).toBe(true);
   });

--- a/src/validators/schemaValidator.ts
+++ b/src/validators/schemaValidator.ts
@@ -266,12 +266,10 @@ export function validatePackageDefinition(
     throw new Error(`Unknown kind: ${kind}`);
   }
 
-  // The API for packages includes an updated_at and sharing property:
-  // https://github.com/pixiebrix/pixiebrix-app/blob/368a0116edad2c115ae370b651f109619e621745/api/serializers/brick.py#L67-L67
-  // These then get added to the YAML/JSON of user-defined packages
-  // TODO: track down/comment exactly where these properties are getting added and mention the corresponding typescript types.
-  //   there's on ModDefinition https://github.com/pixiebrix/pixiebrix-extension/blob/ea547eb5ce592fab537f45cf387ebb6b7c7c02e0/src/types/modDefinitionTypes.ts#L131-L131
-  //   but it's unclear where its getting added for brick definitions
+  // The API for packages add an updated_at and sharing property to config:
+  // https://github.com/pixiebrix/pixiebrix-app/blob/368a0116edad2c115ae370b651f109619e621745/api/serializers/brick.py#L139-L139
+  // It's not on RegistryPackage, though:
+  // https://github.com/pixiebrix/pixiebrix-extension/blob/ca7597fa6f3154eef4aec1cc5c306375b7926074/src/types/contract.ts#L192-L192
   const schemaWithMetadata = cloneDeep(originalSchema);
   // `properties` is always defined on these schemas. Typescript/Lint were disagreeing on adding "!" though.
   schemaWithMetadata.properties ??= {};

--- a/src/validators/schemaValidator.ts
+++ b/src/validators/schemaValidator.ts
@@ -267,7 +267,7 @@ export function validatePackageDefinition(
     throw new Error(`Unknown kind: ${kind}`);
   }
 
-  // The API for packages add an updated_at and sharing property to config:
+  // The API for packages add an updated_at and sharing property to config, which is reflected on RegistryPackage type:
   // https://github.com/pixiebrix/pixiebrix-app/blob/368a0116edad2c115ae370b651f109619e621745/api/serializers/brick.py#L139-L139
   const schemaWithMetadata = cloneDeep(originalSchema);
   // `properties` is always defined on these schemas. Typescript/Lint were disagreeing on adding "!" though.

--- a/src/validators/schemaValidator.ts
+++ b/src/validators/schemaValidator.ts
@@ -269,14 +269,15 @@ export function validatePackageDefinition(
   // The API for packages add an updated_at and sharing property to config, which is reflected on RegistryPackage type:
   // https://github.com/pixiebrix/pixiebrix-app/blob/368a0116edad2c115ae370b651f109619e621745/api/serializers/brick.py#L139-L139
   const schemaWithMetadata = cloneDeep(originalSchema);
-  // `properties` is always defined on these schemas. Typescript/Lint were disagreeing on adding "!" though.
-  schemaWithMetadata.properties ??= {};
-  schemaWithMetadata.properties.updated_at = {
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- `properties` is always defined on these schemas
+  schemaWithMetadata.properties!.updated_at = {
     type: "string",
     format: "date-time",
   };
 
-  schemaWithMetadata.properties.sharing = {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- `properties` is always defined on these schemas
+  schemaWithMetadata.properties!.sharing = {
     // Exact metadata shape doesn't matter for definition validation
     type: "object",
   };

--- a/src/validators/schemaValidator.ts
+++ b/src/validators/schemaValidator.ts
@@ -266,21 +266,26 @@ export function validatePackageDefinition(
     throw new Error(`Unknown kind: ${kind}`);
   }
 
-  // TODO: track down/comment exactly where these properties are getting added and mention the corresponding typescript types
   // The API for packages includes an updated_at and sharing property:
   // https://github.com/pixiebrix/pixiebrix-app/blob/368a0116edad2c115ae370b651f109619e621745/api/serializers/brick.py#L67-L67
-
-  const cloned = cloneDeep(originalSchema);
-  cloned.properties.updated_at = {
+  // These then get added to the YAML/JSON of user-defined packages
+  // TODO: track down/comment exactly where these properties are getting added and mention the corresponding typescript types.
+  //   there's on ModDefinition https://github.com/pixiebrix/pixiebrix-extension/blob/ea547eb5ce592fab537f45cf387ebb6b7c7c02e0/src/types/modDefinitionTypes.ts#L131-L131
+  //   but it's unclear where its getting added for brick definitions
+  const schemaWithMetadata = cloneDeep(originalSchema);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- our schemas are all object schemas with properties
+  const properties = schemaWithMetadata.properties!;
+  properties.updated_at = {
     type: "string",
     format: "date-time",
   };
 
-  cloned.properties.sharing = {
+  properties.sharing = {
+    // Exact metadata shape doesn't matter for definition validation
     type: "object",
   };
 
-  const validator = new Validator(cloned);
+  const validator = new Validator(schemaWithMetadata);
 
   // Add the schemas synchronously. Definitions do not reference any external schemas, e.g., integration definitions.
   for (const builtIn of Object.values(BUILT_IN_SCHEMAS)) {

--- a/src/validators/schemaValidator.ts
+++ b/src/validators/schemaValidator.ts
@@ -273,14 +273,14 @@ export function validatePackageDefinition(
   //   there's on ModDefinition https://github.com/pixiebrix/pixiebrix-extension/blob/ea547eb5ce592fab537f45cf387ebb6b7c7c02e0/src/types/modDefinitionTypes.ts#L131-L131
   //   but it's unclear where its getting added for brick definitions
   const schemaWithMetadata = cloneDeep(originalSchema);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- our schemas are all object schemas with properties
-  const properties = schemaWithMetadata.properties!;
-  properties.updated_at = {
+  // `properties` is always defined on these schemas. Typescript/Lint were disagreeing on adding "!" though.
+  schemaWithMetadata.properties ??= {};
+  schemaWithMetadata.properties.updated_at = {
     type: "string",
     format: "date-time",
   };
 
-  properties.sharing = {
+  schemaWithMetadata.properties.sharing = {
     // Exact metadata shape doesn't matter for definition validation
     type: "object",
   };

--- a/src/validators/schemaValidator.ts
+++ b/src/validators/schemaValidator.ts
@@ -253,7 +253,8 @@ export async function validateBrickInputOutput(
  * distribution, so they are available to be added directly.
  *
  * @param kind the package definition kind.
- * @param instance the package definition
+ * @param instance the package definition, typically a RegistryPackage
+ * @see RegistryPackage
  */
 export function validatePackageDefinition(
   kind: keyof typeof KIND_SCHEMAS,
@@ -268,8 +269,6 @@ export function validatePackageDefinition(
 
   // The API for packages add an updated_at and sharing property to config:
   // https://github.com/pixiebrix/pixiebrix-app/blob/368a0116edad2c115ae370b651f109619e621745/api/serializers/brick.py#L139-L139
-  // It's not on RegistryPackage, though:
-  // https://github.com/pixiebrix/pixiebrix-extension/blob/ca7597fa6f3154eef4aec1cc5c306375b7926074/src/types/contract.ts#L192-L192
   const schemaWithMetadata = cloneDeep(originalSchema);
   // `properties` is always defined on these schemas. Typescript/Lint were disagreeing on adding "!" though.
   schemaWithMetadata.properties ??= {};


### PR DESCRIPTION
## What does this PR do?

- Fixes #7837
- Adds support for updated_at and sharing props on the definition body getting validated

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
