### PR TITLE
#7835: save focus on sidebar load

### DIFF
--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -554,6 +554,13 @@ export function initSidebarFocusEvents(): void {
         return;
       }
 
+      // Save focus on initial load, because the user may have `mouseenter`ed the sidebar before the React App
+      // fired the sidebarShowEvent event./For example, if they user clicked the browserAction toolbar button and
+      // immediately `mouseenter`ed the sidebar (because the top of the sidebar is very close to the top browserAction)
+      if (document.activeElement !== sidebar) {
+        focusController.save();
+      }
+
       const closeSignal = sidePanelOnCloseSignal();
 
       // Can't detect clicks in the sidebar itself. So need to just watch for enter/leave the sidebar element

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -555,7 +555,7 @@ export function initSidebarFocusEvents(): void {
       }
 
       // Save focus on initial load, because the user may have `mouseenter`ed the sidebar before the React App
-      // fired the sidebarShowEvent event./For example, if they user clicked the browserAction toolbar button and
+      // fired the sidebarShowEvent event. For example, if the user clicked the browserAction toolbar button and
       // immediately `mouseenter`ed the sidebar (because the top of the sidebar is very close to the top browserAction)
       if (document.activeElement !== sidebar) {
         focusController.save();


### PR DESCRIPTION
## What does this PR do?

- Fixes #7835 
- Saves focus via focusController automatically when the sidebar is shown to handle case where user `mouseenter`s the sidebar before the React App fires the ready event

## Demo

- https://www.loom.com/share/eb5c700c97644eb9bde31bbc2a312560

## Future Work

- Zendesk/CKEditor is still impacted by: https://github.com/pixiebrix/pixiebrix-extension/issues/7779

## Checklist

- 😞: Add tests: will require E2E test due to reliance on focus/editors
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
