### PR TITLE
#7844: fix NPE in deployments async state

### DIFF
--- a/src/__mocks__/@/telemetry/telemetryHelpers.ts
+++ b/src/__mocks__/@/telemetry/telemetryHelpers.ts
@@ -16,5 +16,9 @@
  */
 
 import { uuidv4 } from "@/types/helpers";
+import { UUID } from "@/types/stringTypes";
+import { StorageItem } from "webext-storage";
 
 export const getUUID = jest.fn().mockResolvedValue(uuidv4());
+
+export const uuidStorage = new StorageItem<UUID>("USER_UUID");

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
@@ -36,7 +36,7 @@ import { packageConfigDetailFactory } from "@/testUtils/factories/brickFactories
 import { ExtensionNotLinkedError } from "@/errors/genericErrors";
 
 const axiosMock = new MockAdapter(axios);
-axiosMock.onGet("/api/me/").reply(200, []);
+axiosMock.onGet("/api/me/").reply(200, { flags: [] });
 
 const getLinkedApiClientMock = jest.mocked(getLinkedApiClient);
 

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.test.tsx
@@ -46,6 +46,7 @@ const Component: React.FC = () => {
   const deployments = useContext(DeploymentsContext);
   return (
     <div data-testid="Component">
+      {deployments.hasUpdate && <span>Has Update</span>}
       <AsyncButton onClick={async () => deployments.update()}>
         Update
       </AsyncButton>
@@ -90,8 +91,8 @@ describe("DeploymentsContext", () => {
       expect(axiosMock.history.post).toHaveLength(1);
     });
 
-    // Permissions only requested once because user clicked update once
-    expect(requestPermissionsMock).toHaveBeenCalledTimes(1);
+    // Permissions not requested because there's no deployments to activate
+    expect(requestPermissionsMock).not.toHaveBeenCalled();
   });
 
   it("activate single deployment from empty state", async () => {
@@ -165,6 +166,7 @@ describe("DeploymentsContext", () => {
       expect(axiosMock.history.post).toHaveLength(1);
     });
 
+    expect(screen.getByText("Has Update")).toBeInTheDocument();
     await userEvent.click(screen.getByText("Update"));
 
     await waitFor(() => {
@@ -187,8 +189,9 @@ describe("DeploymentsContext", () => {
 
     await userEvent.click(screen.getByText("Update"));
 
-    // Permissions requested twice because user has clicked update twice
-    expect(requestPermissionsMock).toHaveBeenCalledTimes(2);
+    // The user already has all deployments installed, so no new fetch
+    expect(screen.queryByText("Has Update")).not.toBeInTheDocument();
+    expect(requestPermissionsMock).toHaveBeenCalledTimes(1);
 
     // Still no changes in deployments, so no new fetch even after remount
     await waitForEffect();
@@ -225,6 +228,7 @@ describe("DeploymentsContext", () => {
       expect(axiosMock.history.post).toHaveLength(1);
     });
 
+    expect(screen.getByText("Has Update")).toBeInTheDocument();
     await user.click(screen.getByText("Update"));
 
     await waitFor(() => {
@@ -254,8 +258,9 @@ describe("DeploymentsContext", () => {
 
     expect(axiosMock.history.post).toHaveLength(3);
 
-    // Permissions requested twice because user has clicked update twice
-    expect(requestPermissionsMock).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText("Has Update")).not.toBeInTheDocument();
+    // Not called because there are no new deployments
+    expect(requestPermissionsMock).toHaveBeenCalledTimes(1);
 
     jest.useRealTimers();
   });

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
@@ -189,7 +189,7 @@ function useDeployments(): DeploymentsState {
 
     if (activatableDeployments.length === 0) {
       // In practice, this code path should never get hit because the button to update deployments should be hidden
-      // if there are not deployments to activate.
+      // if there are no deployments to activate.
       notify.info("No deployments to activate");
       return;
     }

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
@@ -93,6 +93,7 @@ export type DeploymentsState = {
 
 function useDeployments(): DeploymentsState {
   const dispatch = useDispatch<Dispatch>();
+  const { data: browserIdentifier } = useBrowserIdentifier();
   const activeExtensions = useSelector(selectExtensions);
   const { state: flagsState } = useFlags();
   const activeDeployments = useMemoCompare<InstalledDeployment[]>(
@@ -100,16 +101,14 @@ function useDeployments(): DeploymentsState {
     isEqual,
   );
 
-  const { data: uuid } = useBrowserIdentifier();
-
   const deploymentsState = useGetDeploymentsQuery(
     {
-      uid: uuid,
+      uid: browserIdentifier,
       version: getExtensionVersion(),
       active: activeDeployments,
     },
     {
-      skip: !uuid, // Avoid fetching deployments until we have a UUID
+      skip: !browserIdentifier, // Avoid fetching deployments until we have a UUID
       refetchOnMountOrArgChange: 60, // 1 minute
     },
   );

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
@@ -124,14 +124,12 @@ function useDeployments(): DeploymentsState {
 
       const updatedDeployments = deployments.filter((x) => isUpdated(x));
 
-      const activatableDeployments =
-        await fetchDeploymentModDefinitions(updatedDeployments);
-
-      if (activatableDeployments.length > 0) {
+      const [activatableDeployments] = await Promise.all([
+        fetchDeploymentModDefinitions(updatedDeployments),
         // `refreshRegistries` to ensure user has the latest brick definitions before deploying. `refreshRegistries`
         // uses memoizedUntilSettled to avoid excessive calls.
-        await refreshRegistries();
-      }
+        updatedDeployments.length > 0 ? refreshRegistries() : Promise.resolve(),
+      ]);
 
       // Log performance to determine if we're having issues with messenger/IDB performance
       const { permissions } = mergePermissionsStatuses(

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
@@ -118,6 +118,10 @@ function useDeployments(): DeploymentsState {
     deploymentsState,
     async (deployments: Deployment[]) => {
       const isUpdated = makeUpdatedFilter(activeExtensions, {
+        // FIXME: the restrict reference changes when the available flags change. Currently useFlags makes an
+        //   HTTP request vs. using the app cache. So there there will be a race on whether the flags are ready for
+        //   checking. A potential solution is to ensure the App is gated until the flags are ready, e.g., via
+        //   the RequireAuth component or similar. In that case, useFlags should use a React Context vs. RTK Query.
         restricted: restrict("uninstall"),
       });
 

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import {
   ensurePermissionsFromUserGesture,
   mergePermissionsStatuses,
@@ -25,23 +25,19 @@ import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import { selectExtensions } from "@/store/extensionsSelectors";
 import notify from "@/utils/notify";
-import { getUUID } from "@/telemetry/telemetryHelpers";
 import { services } from "@/background/messenger/api";
 import { refreshRegistries } from "@/hooks/useRefreshRegistries";
 import { type Dispatch } from "@reduxjs/toolkit";
 import useFlags from "@/hooks/useFlags";
 import {
-  type InstalledDeployment,
   checkExtensionUpdateRequired,
+  type InstalledDeployment,
   makeUpdatedFilter,
   selectInstalledDeployments,
 } from "@/utils/deploymentUtils";
 import settingsSlice from "@/store/settings/settingsSlice";
 import { checkDeploymentPermissions } from "@/permissions/deploymentPermissionsHelpers";
-import useAsyncState from "@/hooks/useAsyncState";
-
 import { logPromiseDuration } from "@/utils/promiseUtils";
-
 import {
   getExtensionVersion,
   reloadIfNewVersionIsReady,
@@ -50,32 +46,13 @@ import useAutoDeploy from "@/extensionConsole/pages/deployments/useAutoDeploy";
 import { activateDeployments } from "@/extensionConsole/pages/deployments/activateDeployments";
 import { useGetDeploymentsQuery } from "@/data/service/api";
 import { fetchDeploymentModDefinitions } from "@/modDefinitions/modDefinitionRawApiCalls";
-import { deserializeError } from "serialize-error";
 import { isEqual } from "lodash";
 import useMemoCompare from "@/hooks/useMemoCompare";
-
-function getError({
-  deploymentsError,
-  modDefinitionsError,
-  permissionsError,
-}: {
-  deploymentsError: unknown;
-  modDefinitionsError: unknown;
-  permissionsError: unknown;
-}) {
-  for (const error of [deploymentsError, modDefinitionsError]) {
-    if (error) {
-      if (deserializeError(error).name === "ExtensionNotLinkedError") {
-        // Deployments and mod definitions are refetched once the Extension is linked
-        return null;
-      }
-
-      return error;
-    }
-  }
-
-  return permissionsError;
-}
+import useDeriveAsyncState from "@/hooks/useDeriveAsyncState";
+import type { Deployment } from "@/types/contract";
+import useBrowserIdentifier from "@/hooks/useBrowserIdentifier";
+import type { ActivatableDeployment } from "@/types/deploymentTypes";
+import type { Permissions } from "webextension-polyfill";
 
 export type DeploymentsState = {
   /**
@@ -123,13 +100,9 @@ function useDeployments(): DeploymentsState {
     isEqual,
   );
 
-  const { data: uuid } = useAsyncState(async () => getUUID(), []);
+  const { data: uuid } = useBrowserIdentifier();
 
-  const {
-    data: deployments,
-    isLoading: isLoadingDeployments,
-    error: deploymentsError,
-  } = useGetDeploymentsQuery(
+  const deploymentsState = useGetDeploymentsQuery(
     {
       uid: uuid,
       version: getExtensionVersion(),
@@ -141,68 +114,60 @@ function useDeployments(): DeploymentsState {
     },
   );
 
-  const updatedDeployments = useMemo(() => {
-    const isUpdated = makeUpdatedFilter(activeExtensions, {
-      restricted: restrict("uninstall"),
-    });
+  const deploymentUpdateState = useDeriveAsyncState(
+    deploymentsState,
+    async (deployments: Deployment[]) => {
+      const isUpdated = makeUpdatedFilter(activeExtensions, {
+        restricted: restrict("uninstall"),
+      });
 
-    return deployments?.filter((x) => isUpdated(x)) ?? null;
-  }, [activeExtensions, restrict, deployments]);
+      const updatedDeployments = deployments.filter((x) => isUpdated(x));
 
-  // TODO: Refactor this to use RTK query: https://github.com/pixiebrix/pixiebrix-extension/issues/7841
-  const {
-    data: activatableDeployments,
-    isLoading: isLoadingModDefinitions,
-    error: modDefinitionsError,
-  } = useAsyncState(async () => {
-    if (!updatedDeployments) {
-      return null;
-    }
+      const activatableDeployments =
+        await fetchDeploymentModDefinitions(updatedDeployments);
 
-    return fetchDeploymentModDefinitions(updatedDeployments);
-  }, [updatedDeployments]);
+      if (activatableDeployments.length > 0) {
+        // `refreshRegistries` to ensure user has the latest brick definitions before deploying. `refreshRegistries`
+        // uses memoizedUntilSettled to avoid excessive calls.
+        await refreshRegistries();
+      }
 
-  const extensionUpdateRequired = useMemo(() => {
-    if (!activatableDeployments) {
-      return false;
-    }
-
-    return checkExtensionUpdateRequired(activatableDeployments);
-  }, [activatableDeployments]);
-
-  const {
-    data: permissions,
-    isLoading: isLoadingPermissions,
-    error: permissionsError,
-  } = useAsyncState(async () => {
-    if (!activatableDeployments) {
-      return null;
-    }
-
-    // `refreshRegistries` to ensure user has the latest brick definitions. `refreshRegistries` uses
-    // memoizedUntilSettled to avoid excessive calls.
-    await refreshRegistries();
-
-    // Log performance to determine if we're having issues with messenger/IDB performance
-    const { permissions } = mergePermissionsStatuses(
-      await logPromiseDuration(
-        "useDeployments:checkDeploymentPermissions",
-        Promise.all(
-          activatableDeployments.map(async (activatableDeployment) =>
-            checkDeploymentPermissions({
-              activatableDeployment,
-              locate: services.locateAllForId,
-              // In the UI context, always prompt the user to accept permissions to ensure they get the full
-              // functionality of the mod
-              optionalPermissions: [],
-            }),
+      // Log performance to determine if we're having issues with messenger/IDB performance
+      const { permissions } = mergePermissionsStatuses(
+        await logPromiseDuration(
+          "useDeployments:checkDeploymentPermissions",
+          Promise.all(
+            activatableDeployments.map(async (activatableDeployment) =>
+              checkDeploymentPermissions({
+                activatableDeployment,
+                locate: services.locateAllForId,
+                // In the UI context, always prompt the user to accept permissions to ensure they get the full
+                // functionality of the mod
+                optionalPermissions: [],
+              }),
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    return permissions;
-  }, [activeExtensions, activatableDeployments]);
+      return {
+        activatableDeployments,
+        extensionUpdateRequired: checkExtensionUpdateRequired(
+          activatableDeployments,
+        ),
+        permissions,
+      };
+    },
+  );
+
+  // Fallback values for loading/error states
+  const { activatableDeployments, extensionUpdateRequired, permissions } =
+    deploymentUpdateState.data ?? {
+      // `useAutoDeploy` expects `null` to represent deployment loading state. It tries to activate once available
+      activatableDeployments: null as ActivatableDeployment[] | null,
+      extensionUpdateRequired: false as boolean,
+      permissions: [] as Permissions.Permissions,
+    };
 
   const { isAutoDeploying } = useAutoDeploy({
     activatableDeployments,
@@ -220,7 +185,14 @@ function useDeployments(): DeploymentsState {
     dispatch(settingsSlice.actions.resetUpdatePromptTimestamp());
 
     if (activatableDeployments == null) {
-      notify.error("Activatable deployments have not been fetched");
+      notify.error("Deployments have not been fetched");
+      return;
+    }
+
+    if (activatableDeployments.length === 0) {
+      // In practice, this code path should never get hit because the button to update deployments should be hidden
+      // if there are not deployments to activate.
+      notify.info("No deployments to activate");
       return;
     }
 
@@ -260,7 +232,7 @@ function useDeployments(): DeploymentsState {
     } catch (error) {
       notify.error({ message: "Error updating team deployments", error });
     }
-  }, [activatableDeployments, permissions, dispatch, activeExtensions]);
+  }, [dispatch, activatableDeployments, permissions, activeExtensions]);
 
   const updateExtension = useCallback(async () => {
     await reloadIfNewVersionIsReady();
@@ -270,17 +242,13 @@ function useDeployments(): DeploymentsState {
   }, []);
 
   return {
-    hasUpdate: updatedDeployments?.length > 0,
+    hasUpdate: activatableDeployments?.length > 0,
     update: handleUpdateFromUserGesture,
     updateExtension,
     extensionUpdateRequired,
-    isLoading:
-      isLoadingDeployments || isLoadingModDefinitions || isLoadingPermissions,
-    error: getError({
-      deploymentsError,
-      modDefinitionsError,
-      permissionsError,
-    }),
+    // XXX: should `isLoading` if isAutoDeploying is true?
+    isLoading: deploymentUpdateState.isLoading,
+    error: deploymentUpdateState.error,
     isAutoDeploying,
   };
 }

--- a/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
+++ b/src/extensionConsole/pages/deployments/DeploymentsContext.tsx
@@ -53,10 +53,6 @@ import type { Deployment } from "@/types/contract";
 import useBrowserIdentifier from "@/hooks/useBrowserIdentifier";
 import type { ActivatableDeployment } from "@/types/deploymentTypes";
 import type { Permissions } from "webextension-polyfill";
-import {
-  loadingAsyncStateFactory,
-  valueToAsyncState,
-} from "@/utils/asyncStateUtils";
 
 export type DeploymentsState = {
   /**
@@ -98,7 +94,7 @@ export type DeploymentsState = {
 function useDeployments(): DeploymentsState {
   const dispatch = useDispatch<Dispatch>();
   const activeExtensions = useSelector(selectExtensions);
-  const { restrict, isSuccess: isFlagsReady } = useFlags();
+  const { state: flagsState } = useFlags();
   const activeDeployments = useMemoCompare<InstalledDeployment[]>(
     selectInstalledDeployments(activeExtensions),
     isEqual,
@@ -118,16 +114,10 @@ function useDeployments(): DeploymentsState {
     },
   );
 
-  // Map flags state to standard AsyncState shape. Is savf because useDeriveAsyncState does not require that
-  // the data are serializable
-  const flagsState = isFlagsReady
-    ? valueToAsyncState(restrict)
-    : loadingAsyncStateFactory();
-
   const deploymentUpdateState = useDeriveAsyncState(
     deploymentsState,
     flagsState,
-    async (deployments: Deployment[], restrict: Restrict["restrict"]) => {
+    async (deployments: Deployment[], { restrict }: Restrict) => {
       const isUpdated = makeUpdatedFilter(activeExtensions, {
         restricted: restrict("uninstall"),
       });

--- a/src/extensionConsole/pages/deployments/useAutoDeploy.ts
+++ b/src/extensionConsole/pages/deployments/useAutoDeploy.ts
@@ -25,6 +25,7 @@ import { useState } from "react";
 import { useDispatch } from "react-redux";
 import useAsyncEffect from "use-async-effect";
 import type { ActivatableDeployment } from "@/types/deploymentTypes";
+import type { Nullishable } from "@/utils/nullishUtils";
 
 type UseAutoDeployReturn = {
   /**
@@ -38,7 +39,8 @@ function useAutoDeploy({
   installedExtensions,
   extensionUpdateRequired,
 }: {
-  activatableDeployments: ActivatableDeployment[];
+  // Expects nullish value if activatableDeployments are uninitialized/not loaded yet
+  activatableDeployments: Nullishable<ActivatableDeployment[]>;
   installedExtensions: ModComponentBase[];
   extensionUpdateRequired: boolean;
 }): UseAutoDeployReturn {

--- a/src/hooks/useBrowserIdentifier.ts
+++ b/src/hooks/useBrowserIdentifier.ts
@@ -32,10 +32,12 @@ function subscribe(callback: () => void) {
 
 /**
  * Watch the unique client identifier for this browser profile.
+ *
+ * In practice, the identifier UUID should never change during a session.
+ *
  * @see getUUID
  */
 function useBrowserIdentifier(): AsyncState<UUID> {
-  // In practice, the UUID should never change during a session, but use standard useAsyncExternalStore anyway
   return useAsyncExternalStore(subscribe, getUUID);
 }
 

--- a/src/hooks/useBrowserIdentifier.ts
+++ b/src/hooks/useBrowserIdentifier.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getUUID, uuidStorage } from "@/telemetry/telemetryHelpers";
+import useAsyncExternalStore from "@/hooks/useAsyncExternalStore";
+import type { AsyncState } from "@/types/sliceTypes";
+import type { UUID } from "@/types/stringTypes";
+
+// Keep subscribe method in here for now because useAsyncExternalStore doesn't support sharing across hooks:
+// https://github.com/pixiebrix/pixiebrix-extension/issues/7789
+function subscribe(callback: () => void) {
+  const controller = new AbortController();
+  uuidStorage.onChanged(callback, controller.signal);
+  return () => {
+    controller.abort();
+  };
+}
+
+/**
+ * Watch the unique client identifier for this browser profile.
+ * @see getUUID
+ */
+function useBrowserIdentifier(): AsyncState<UUID> {
+  // In practice, the UUID should never change during a session, but use standard useAsyncExternalStore anyway
+  return useAsyncExternalStore(subscribe, getUUID);
+}
+
+export default useBrowserIdentifier;

--- a/src/hooks/useFlags.ts
+++ b/src/hooks/useFlags.ts
@@ -36,7 +36,14 @@ type RestrictedFeature =
   | "service-url"
   | "page-editor";
 
-type Restrict = {
+export type Restrict = {
+  // XXX: Asynchronous state flags. Consider returning a standard AsyncState. Typically, AsyncState is used with
+  // serializable values, though, so there may be gotchas in some circumstances.
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  // Methods
   permit: (area: RestrictedFeature) => boolean;
   restrict: (area: RestrictedFeature) => boolean;
   flagOn: (flag: string) => boolean;
@@ -49,7 +56,14 @@ type Restrict = {
  * For permit/restrict, features will be restricted in the fetching/loading state
  */
 function useFlags(): Restrict {
-  const { data: flags, refetch } = useGetFeatureFlagsQuery();
+  const {
+    data: flags,
+    isLoading,
+    isFetching,
+    isError,
+    isSuccess,
+    refetch,
+  } = useGetFeatureFlagsQuery();
 
   useEffect(() => {
     const listener = () => {
@@ -67,6 +81,10 @@ function useFlags(): Restrict {
     const flagSet = new Set(flags);
 
     return {
+      isLoading,
+      isFetching,
+      isSuccess,
+      isError,
       permit: (area: RestrictedFeature) =>
         !flagSet.has(`${RESTRICTED_PREFIX}-${area}`),
       restrict: (area: RestrictedFeature) =>
@@ -74,7 +92,7 @@ function useFlags(): Restrict {
       flagOn: (flag: string) => flagSet.has(flag),
       flagOff: (flag: string) => !flagSet.has(flag),
     };
-  }, [flags]);
+  }, [flags, isLoading, isFetching, isError, isSuccess]);
 }
 
 export default useFlags;

--- a/src/hooks/useFlags.ts
+++ b/src/hooks/useFlags.ts
@@ -46,8 +46,9 @@ export type Restrict = {
 };
 
 type HookResult = Restrict & {
-  // The async state for use in deriving values that require valid flags. Not that the data is not serializable,
-  // so might not work with all async state utilities.
+  // The async state for use in deriving values that require valid flags. NOTE: the data is not serializable,
+  // so the state might not work with any state helpers that require serializable data (e.g., due to cloning, Immer,
+  // or Redux).
   state: AsyncState<Restrict>;
 };
 

--- a/src/telemetry/telemetryHelpers.ts
+++ b/src/telemetry/telemetryHelpers.ts
@@ -33,11 +33,15 @@ type TelemetryUser = {
   organizationId?: UUID | null;
 };
 
-const uuidStorage = new StorageItem<UUID>("USER_UUID");
+export const uuidStorage = new StorageItem<UUID>("USER_UUID");
 
 /**
  * Return a random ID for this browser profile.
  * It's persisted in storage via `chrome.storage.local` and in-memory via `once`
+ *
+ * In React code, use useBrowserIdentifier
+ *
+ * @see useBrowserIdentifier
  */
 export const getUUID = once(async (): Promise<UUID> => {
   const existingUUID = await uuidStorage.get();

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -382,6 +382,7 @@
     "./hooks/useAsyncState.ts",
     "./hooks/useAuthorizationGrantFlow.ts",
     "./hooks/useAutoFocusConfiguration.ts",
+    "./hooks/useBrowserIdentifier.ts",
     "./hooks/useContextInvalidated.ts",
     "./hooks/useDebouncedEffect.ts",
     "./hooks/useDeriveAsyncState.ts",


### PR DESCRIPTION
## What does this PR do?

- Closes #7844 
- Main functional change is to refactor DeploymentContext to use useDeriveAsyncState
- Exposes async state from useFlags hook 
- Extracts out useBrowserIdentifier hook

## Remaining Work

- [x] Resolve FIXME on use of useFlags: https://github.com/pixiebrix/pixiebrix-extension/pull/7845/files#diff-7a369df688af99125d8ddd4d69d3f405d17f6492f4e80ad99a8c923acb061f09R121
  - Have a version of useFlags that uses AsyncState (not a good fit since it returns functions though)
  - Have a FlagsContext in the tree?
- [x] Double-check why auto-deployment is not working in the Loom Demo
  - It's because I'm an admin

## Demo

- https://www.loom.com/share/e75f586bbf0e4375b87f80a043beb52a

## Checklist

- [x] Add tests: updated tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @BLoe 
