### PR TITLE
#7840: Allow legacy JQuery reader definitions with no selectors

### DIFF
--- a/contrib/readers/empty-jquery-reader.yaml
+++ b/contrib/readers/empty-jquery-reader.yaml
@@ -4,7 +4,7 @@ metadata:
   id: test/empty-jquery-reader
   version: 0.0.1
   name: Empty JQuery Reader
-  description: "Empty JQuery reader for testing purposes; Page Editor used to product reader definition"
+  description: "Empty JQuery reader for testing purposes; Page Editor used to produce reader definitions"
 definition:
   reader:
     type: jquery

--- a/contrib/readers/empty-jquery-reader.yaml
+++ b/contrib/readers/empty-jquery-reader.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: reader
+metadata:
+  id: test/empty-jquery-reader
+  version: 0.0.1
+  name: Empty JQuery Reader
+  description: "Empty JQuery reader for testing purposes; Page Editor used to product reader definition"
+definition:
+  reader:
+    type: jquery
+    selectors: {}
+outputSchema:
+  $schema: https://json-schema.org/draft-04/schema#
+  title: Inferred Schema
+  type: object
+  properties: {}

--- a/schemas/reader.json
+++ b/schemas/reader.json
@@ -176,14 +176,12 @@
                   },
                   "find": {
                     "type": "object",
-                    "additionalProperties": true,
-                    "minProperties": 1
+                    "additionalProperties": true
                   }
                 }
               }
             ]
-          },
-          "minProperties": 1
+          }
         }
       },
       "required": ["type", "selectors"]

--- a/src/validators/schemaValidator.test.ts
+++ b/src/validators/schemaValidator.test.ts
@@ -21,6 +21,11 @@ import {
 } from "@/validators/schemaValidator";
 import { loadBrickYaml } from "@/runtime/brickYaml";
 import serviceText from "@contrib/raw/hunter.txt";
+import jqueryReaderDefinition from "@contrib/readers/apartments-reader.yaml";
+import emptyJQueryReaderDefinition from "@contrib/readers/empty-jquery-reader.yaml";
+import emberJsReaderDefinition from "@contrib/readers/linkedin-organization-reader.yaml";
+import windowReader from "@contrib/readers/trello-card-reader.yaml";
+import reactReader from "@contrib/readers/redfin-reader.yaml";
 import { type Schema } from "@/types/schemaTypes";
 import { uuidv4 } from "@/types/helpers";
 import { timestampFactory } from "@/testUtils/factories/stringFactories";
@@ -30,6 +35,18 @@ describe("validateKind", () => {
   test("can validate integration definition", async () => {
     const json = loadBrickYaml(serviceText) as UnknownObject;
     const result = validatePackageDefinition("service", json);
+    expect(result.errors).toHaveLength(0);
+    expect(result.valid).toBe(true);
+  });
+
+  test.each([
+    jqueryReaderDefinition,
+    emptyJQueryReaderDefinition,
+    emberJsReaderDefinition,
+    reactReader,
+    windowReader,
+  ])("can validate reader definition: %#", (config) => {
+    const result = validatePackageDefinition("reader", config);
     expect(result.errors).toHaveLength(0);
     expect(result.valid).toBe(true);
   });


### PR DESCRIPTION
## What does this PR do?

- Fixes #7840
- Allows legacy JQuery reader definitions saved with the Page Editor that don't contain any selectors
- JQuery reader will just return empty object in these cases
- App PR is here: https://github.com/pixiebrix/pixiebrix-app/pull/4894

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @fungairino 
