### PR TITLE
Automatically strip leading backslash in text snippet/command definition

### DIFF
--- a/src/bricks/effects/AddTextCommand.test.ts
+++ b/src/bricks/effects/AddTextCommand.test.ts
@@ -41,39 +41,42 @@ afterEach(() => {
 });
 
 describe("AddTextCommand", () => {
-  it("registers command", async () => {
-    const extensionId = uuidv4();
-    const logger = new ConsoleLogger({ extensionId });
+  it.each(["/echo", "echo", "\\echo"])(
+    "registers command: %s",
+    async (shortcut) => {
+      const extensionId = uuidv4();
+      const logger = new ConsoleLogger({ extensionId });
 
-    const pipeline = {
-      id: brick.id,
-      config: {
-        shortcut: "/echo",
-        title: "Echo",
-        generate: toExpression("pipeline", [
-          { id: identity.id, config: toExpression("var", "@currentText") },
-        ]),
-      },
-    };
+      const pipeline = {
+        id: brick.id,
+        config: {
+          shortcut,
+          title: "Echo",
+          generate: toExpression("pipeline", [
+            { id: identity.id, config: toExpression("var", "@currentText") },
+          ]),
+        },
+      };
 
-    await reducePipeline(pipeline, simpleInput({}), {
-      ...testOptions("v3"),
-      extensionId,
-      logger,
-    });
+      await reducePipeline(pipeline, simpleInput({}), {
+        ...testOptions("v3"),
+        extensionId,
+        logger,
+      });
 
-    expect(commandRegistry.commands).toStrictEqual([
-      {
-        // Leading slash is dropped
-        shortcut: "echo",
-        title: "Echo",
-        handler: expect.toBeFunction(),
-        componentId: extensionId,
-      },
-    ]);
+      expect(commandRegistry.commands).toStrictEqual([
+        {
+          // Any leading slash is dropped
+          shortcut: "echo",
+          title: "Echo",
+          handler: expect.toBeFunction(),
+          componentId: extensionId,
+        },
+      ]);
 
-    await expect(
-      commandRegistry.commands[0].handler("current text"),
-    ).resolves.toBe("current text");
-  });
+      await expect(
+        commandRegistry.commands[0].handler("current text"),
+      ).resolves.toBe("current text");
+    },
+  );
 });

--- a/src/bricks/effects/AddTextCommand.ts
+++ b/src/bricks/effects/AddTextCommand.ts
@@ -108,8 +108,8 @@ class AddTextCommand extends EffectABC {
 
     platform.commandPopover.register({
       componentId: logger.context.extensionId,
-      // Trim leading slash to be resilient to user input
-      shortcut: shortcut.replace(/^\//, ""),
+      // Trim leading slashes to be resilient to user input
+      shortcut: shortcut.replace(/^[/\\]/, ""),
       title,
       async handler(currentText: string): Promise<string> {
         counter++;

--- a/src/bricks/effects/AddTextCommand.ts
+++ b/src/bricks/effects/AddTextCommand.ts
@@ -29,6 +29,7 @@ import { getSettingsState } from "@/store/settings/settingsStorage";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import type { PlatformCapability } from "@/platform/capabilities";
 import { propertiesToSchema } from "@/utils/schemaUtils";
+import { normalizeShortcut } from "@/bricks/effects/AddTextSnippets";
 
 type CommandArgs = {
   /**
@@ -108,8 +109,8 @@ class AddTextCommand extends EffectABC {
 
     platform.commandPopover.register({
       componentId: logger.context.extensionId,
-      // Trim leading slashes to be resilient to user input
-      shortcut: shortcut.replace(/^[/\\]/, ""),
+      // Trim leading command key in shortcut to be resilient to user input
+      shortcut: normalizeShortcut(shortcut),
       title,
       async handler(currentText: string): Promise<string> {
         counter++;

--- a/src/bricks/effects/AddTextSnippets.test.ts
+++ b/src/bricks/effects/AddTextSnippets.test.ts
@@ -47,7 +47,7 @@ describe("AddTextSnippets", () => {
 
       expect(commandRegistry.commands).toStrictEqual([
         {
-          // Leading slash is dropped
+          // Leading command key is dropped
           shortcut: "test",
           title: "Test",
           handler: expect.toBeFunction(),

--- a/src/bricks/effects/AddTextSnippets.test.ts
+++ b/src/bricks/effects/AddTextSnippets.test.ts
@@ -27,32 +27,37 @@ afterEach(() => {
 });
 
 describe("AddTextSnippets", () => {
-  it("add registers snippets", async () => {
-    const options = brickOptionsFactory();
+  it.each(["test", "\\test", "/test"])(
+    "add registers snippets: %s",
+    async (shortcut) => {
+      const options = brickOptionsFactory();
 
-    await brick.run(
-      unsafeAssumeValidArg({
-        snippets: [
-          {
-            shortcut: "/test",
-            title: "Test",
-            text: "test",
-          },
-        ],
-      }),
-      options,
-    );
+      await brick.run(
+        unsafeAssumeValidArg({
+          snippets: [
+            {
+              shortcut,
+              title: "Test",
+              text: "test",
+            },
+          ],
+        }),
+        options,
+      );
 
-    expect(commandRegistry.commands).toStrictEqual([
-      {
-        // Leading slash is dropped
-        shortcut: "test",
-        title: "Test",
-        handler: expect.toBeFunction(),
-        componentId: options.logger.context.extensionId,
-      },
-    ]);
+      expect(commandRegistry.commands).toStrictEqual([
+        {
+          // Leading slash is dropped
+          shortcut: "test",
+          title: "Test",
+          handler: expect.toBeFunction(),
+          componentId: options.logger.context.extensionId,
+        },
+      ]);
 
-    await expect(commandRegistry.commands[0].handler("")).resolves.toBe("test");
-  });
+      await expect(commandRegistry.commands[0].handler("")).resolves.toBe(
+        "test",
+      );
+    },
+  );
 });

--- a/src/bricks/effects/AddTextSnippets.ts
+++ b/src/bricks/effects/AddTextSnippets.ts
@@ -24,6 +24,19 @@ import { getSettingsState } from "@/store/settings/settingsStorage";
 import type { PlatformCapability } from "@/platform/capabilities";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 
+/**
+ * Regex for likely command keys to strip from shortcut definitions
+ */
+const COMMAND_KEY_REGEX = /^[/\\]/;
+
+/**
+ * Normalize a shortcut by removing the leading command key (if any)
+ * @param shortcut user-defined shortcut
+ */
+export function normalizeShortcut(shortcut: string): string {
+  return shortcut.replace(COMMAND_KEY_REGEX, "");
+}
+
 type Snippet = {
   /**
    * The shortcut for the text command.
@@ -109,8 +122,7 @@ class AddTextSnippets extends EffectABC {
     for (const { shortcut, title, text } of snippets) {
       platform.commandPopover.register({
         componentId: logger.context.extensionId,
-        // Trim leading slash to be resilient to user input
-        shortcut: shortcut.replace(/^[/\\]/, ""),
+        shortcut: normalizeShortcut(shortcut),
         title,
         async handler(): Promise<string> {
           return text;

--- a/src/bricks/effects/AddTextSnippets.ts
+++ b/src/bricks/effects/AddTextSnippets.ts
@@ -110,7 +110,7 @@ class AddTextSnippets extends EffectABC {
       platform.commandPopover.register({
         componentId: logger.context.extensionId,
         // Trim leading slash to be resilient to user input
-        shortcut: shortcut.replace(/^\//, ""),
+        shortcut: shortcut.replace(/^[/\\]/, ""),
         title,
         async handler(): Promise<string> {
           return text;


### PR DESCRIPTION
## What does this PR do?

- Also strip leading backslash (`\`) in command definition because we've switched to `\` as the default, but anticipate allowing the user to choose in the future
- As a reminder, to use the bricks, enable Text Command Popover in Settings > Skunkworks

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @mnholtz 
