### PR TITLE
Refactoring useEffects to usePreviousValue

### DIFF
--- a/src/components/DatabaseUnresponsiveBanner.tsx
+++ b/src/components/DatabaseUnresponsiveBanner.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from "react";
+import React from "react";
 import Banner from "@/components/banner/Banner";
 import useAsyncState from "@/hooks/useAsyncState";
 import { count as pingPackageDatabase } from "@/registry/packageRegistry";
@@ -23,6 +23,7 @@ import useTimeoutState from "@/hooks/useTimeoutState";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import reportError from "@/telemetry/reportError";
+import { usePrevious } from "@/hooks/usePrevious";
 
 const errorBanner = (
   <Banner variant="warning">
@@ -48,15 +49,12 @@ const DatabaseUnresponsiveBanner: React.VoidFunctionComponent<{
   const hasWaited = useTimeoutState(timeoutMillis);
 
   const showBanner = !state.isSuccess && hasWaited;
+  const prevShowBanner = usePrevious(showBanner);
 
-  useEffect(() => {
-    if (showBanner) {
-      reportEvent(Events.IDB_UNRESPONSIVE_BANNER);
-      reportError(new Error("IDB unresponsive"));
-    }
-    // `showBanner` can only transition from false -> true once because `state` is only calculated once and
-    // hasWaited stays true after it becomes true because timeoutMillis is non-null (timeoutMillis is defaulted)
-  }, [showBanner]);
+  if (showBanner && !prevShowBanner) {
+    reportEvent(Events.IDB_UNRESPONSIVE_BANNER);
+    reportError(new Error("IDB unresponsive"));
+  }
 
   return showBanner ? errorBanner : null;
 };

--- a/src/components/DatabaseUnresponsiveBanner.tsx
+++ b/src/components/DatabaseUnresponsiveBanner.tsx
@@ -23,7 +23,7 @@ import useTimeoutState from "@/hooks/useTimeoutState";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import reportError from "@/telemetry/reportError";
-import { usePrevious } from "@/hooks/usePrevious";
+import { usePreviousValue } from "@/hooks/usePreviousValue";
 
 const errorBanner = (
   <Banner variant="warning">
@@ -49,7 +49,7 @@ const DatabaseUnresponsiveBanner: React.VoidFunctionComponent<{
   const hasWaited = useTimeoutState(timeoutMillis);
 
   const showBanner = !state.isSuccess && hasWaited;
-  const prevShowBanner = usePrevious(showBanner);
+  const prevShowBanner = usePreviousValue(showBanner);
 
   if (showBanner && !prevShowBanner) {
     reportEvent(Events.IDB_UNRESPONSIVE_BANNER);

--- a/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.ts
@@ -16,19 +16,14 @@
  */
 
 import { type KeyPath } from "react-json-tree";
-import {
-  type MutableRefObject,
-  useCallback,
-  useEffect,
-  useState,
-  useRef,
-} from "react";
+import { type MutableRefObject, useCallback, useEffect, useState } from "react";
 import {
   defaultMenuOption,
   type MenuOptions,
   moveMenuOption,
 } from "@/components/fields/schemaFields/widgets/varPopup/menuFilters";
 import { isEqual } from "lodash";
+import { usePrevious } from "@/hooks/usePrevious";
 
 /**
  * Hook to navigate the variable popover menu using the keyboard from the input field
@@ -132,14 +127,6 @@ function useResetActiveKeyPath({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only trigger when the menuOptions or likelyVariable changes
   }, [likelyVariable, menuOptions, setActiveKeyPath]);
-}
-
-function usePrevious<T>(value: T) {
-  const ref = useRef<T | null>();
-  useEffect(() => {
-    ref.current = value;
-  });
-  return ref.current;
 }
 
 export default useKeyboardNavigation;

--- a/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.ts
@@ -23,7 +23,7 @@ import {
   moveMenuOption,
 } from "@/components/fields/schemaFields/widgets/varPopup/menuFilters";
 import { isEqual } from "lodash";
-import { usePrevious } from "@/hooks/usePrevious";
+import { usePreviousValue } from "@/hooks/usePreviousValue";
 
 /**
  * Hook to navigate the variable popover menu using the keyboard from the input field
@@ -115,8 +115,8 @@ function useResetActiveKeyPath({
   likelyVariable: string;
   setActiveKeyPath: React.Dispatch<React.SetStateAction<KeyPath>>;
 }) {
-  const prevMenuOptions = usePrevious(menuOptions);
-  const prevLikelyVariable = usePrevious(likelyVariable);
+  const prevMenuOptions = usePreviousValue(menuOptions);
+  const prevLikelyVariable = usePreviousValue(likelyVariable);
 
   useEffect(() => {
     if (

--- a/src/hooks/usePrevious.ts
+++ b/src/hooks/usePrevious.ts
@@ -15,17 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import reportError from "@/telemetry/reportError";
-import { usePrevious } from "@/hooks/usePrevious";
+import { useEffect, useRef } from "react";
 
 /**
- * React hook to report an error if it's different from the previous error.
+ * React hook to get the previous value of a prop or state.
  */
-function useReportError(error: unknown): void {
-  const previousError = usePrevious(error);
-  if (error && error !== previousError) {
-    reportError(error);
-  }
+export function usePrevious<T>(value: T) {
+  const ref = useRef<T | null>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
 }
-
-export default useReportError;

--- a/src/hooks/usePreviousValue.ts
+++ b/src/hooks/usePreviousValue.ts
@@ -18,9 +18,12 @@
 import { useEffect, useRef } from "react";
 
 /**
- * React hook to get the previous value of a prop or state.
+ * React hook to get the value of a variable from the previous render.
+ * This is useful for comparing the current value of a variable with its previous value
+ * to determine how it has changed, and avoids the needs for additional useEffects and state.
+ * @param value The value to get the previous value of.
  */
-export function usePrevious<T>(value: T) {
+export function usePreviousValue<T>(value: T) {
   const ref = useRef<T | null>();
   useEffect(() => {
     ref.current = value;

--- a/src/hooks/useReportError.ts
+++ b/src/hooks/useReportError.ts
@@ -16,13 +16,13 @@
  */
 
 import reportError from "@/telemetry/reportError";
-import { usePrevious } from "@/hooks/usePrevious";
+import { usePreviousValue } from "@/hooks/usePreviousValue";
 
 /**
  * React hook to report an error if it's different from the previous error.
  */
 function useReportError(error: unknown): void {
-  const previousError = usePrevious(error);
+  const previousError = usePreviousValue(error);
   if (error && error !== previousError) {
     reportError(error);
   }

--- a/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
+++ b/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/pageEditor/slices/editorSlice";
 import runtimeSlice from "@/pageEditor/slices/runtimeSlice";
 import sessionSlice from "@/pageEditor/slices/sessionSlice";
-import { configureStore, type Store } from "@reduxjs/toolkit";
+import { configureStore } from "@reduxjs/toolkit";
 import { type TraceRecord } from "@/telemetry/trace";
 import { uuidv4 } from "@/types/helpers";
 import reportEvent from "@/telemetry/reportEvent";
@@ -35,6 +35,7 @@ import {
   traceErrorFactory,
   traceRecordFactory,
 } from "@/testUtils/factories/traceFactories";
+import { uuidSequence } from "@/testUtils/factories/stringFactories";
 
 // Override the manual mock to support `expect` assertions
 jest.mock("@/telemetry/reportEvent");
@@ -42,34 +43,39 @@ jest.mock("@/telemetry/reportEvent");
 const renderUseReportTraceError = (traces: TraceRecord[] = []) => {
   const activeElementId = uuidv4();
 
-  // @ts-ignore-error -- ignoring "Type instantiation is excessively deep and possibly infinite" for test
-  const store: Store = configureStore({
+  const getTestStore = (testTraces: TraceRecord[]) =>
     // @ts-ignore-error -- ignoring "Type instantiation is excessively deep and possibly infinite" for test
-    reducer: {
-      session: sessionSlice.reducer,
-      editor: editorSlice.reducer,
-      runtime: runtimeSlice.reducer,
-    },
-    preloadedState: {
-      editor: {
-        ...editorInitialState,
-        activeElementId,
+    configureStore({
+      // @ts-ignore-error -- ignoring "Type instantiation is excessively deep and possibly infinite" for test
+      reducer: {
+        session: sessionSlice.reducer,
+        editor: editorSlice.reducer,
+        runtime: runtimeSlice.reducer,
       },
-      runtime: {
-        // @ts-expect-error -- TS is detecting the wrong type; ignoring since this is only for testing
-        extensionTraces: {
-          [activeElementId]: traces,
+      preloadedState: {
+        editor: {
+          ...editorInitialState,
+          activeElementId,
+        },
+        runtime: {
+          // @ts-expect-error -- TS is detecting the wrong type; ignoring since this is only for testing
+          extensionTraces: {
+            [activeElementId]: testTraces,
+          },
         },
       },
-    },
-  });
+    });
 
   return renderHook(
-    () => {
+    (_rerenderProps: { rerenderTraces?: TraceRecord[] }) => {
       useReportTraceError();
     },
     {
-      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+      wrapper: ({ children, rerenderTraces }) => (
+        <Provider store={getTestStore(rerenderTraces || traces)}>
+          {children}
+        </Provider>
+      ),
     },
   );
 };
@@ -91,11 +97,24 @@ test("doesn't report when no error", () => {
   expect(reportEvent).not.toHaveBeenCalledWith();
 });
 
-test("reports the same error only once", () => {
-  const { rerender } = renderUseReportTraceError([traceErrorFactory()]);
+test("reports error from the same run id only once", () => {
+  const errorTrace = traceErrorFactory({ runId: uuidSequence(1) });
+  const { rerender } = renderUseReportTraceError([errorTrace]);
 
   // Re-render the hook
-  rerender();
+  rerender({ rerenderTraces: [errorTrace] });
 
   expect(reportEvent).toHaveBeenCalledTimes(1);
+
+  // Re-render the hook with a different error, but same run id
+  rerender({
+    rerenderTraces: [traceErrorFactory({ runId: errorTrace.runId })],
+  });
+
+  expect(reportEvent).toHaveBeenCalledTimes(1);
+
+  // Re-render the hook with a different run id
+  rerender({ rerenderTraces: [traceErrorFactory({ runId: uuidSequence(2) })] });
+
+  expect(reportEvent).toHaveBeenCalledTimes(2);
 });

--- a/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
+++ b/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
@@ -84,37 +84,46 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-test("it reports an error", () => {
-  renderUseReportTraceError([traceErrorFactory()]);
-  expect(reportEvent).toHaveBeenCalledWith(
-    "PageEditorExtensionError",
-    expect.anything(),
-  );
-});
-
-test("doesn't report when no error", () => {
-  renderUseReportTraceError([traceRecordFactory()]);
-  expect(reportEvent).not.toHaveBeenCalledWith();
-});
-
-test("reports error from the same run id only once", () => {
-  const errorTrace = traceErrorFactory({ runId: uuidSequence(1) });
-  const { rerender } = renderUseReportTraceError([errorTrace]);
-
-  // Re-render the hook
-  rerender({ rerenderTraces: [errorTrace] });
-
-  expect(reportEvent).toHaveBeenCalledTimes(1);
-
-  // Re-render the hook with a different error, but same run id
-  rerender({
-    rerenderTraces: [traceErrorFactory({ runId: errorTrace.runId })],
+describe("useReportTraceError", () => {
+  test("it reports an error", () => {
+    renderUseReportTraceError([traceErrorFactory()]);
+    expect(reportEvent).toHaveBeenCalledWith(
+      "PageEditorExtensionError",
+      expect.anything(),
+    );
   });
 
-  expect(reportEvent).toHaveBeenCalledTimes(1);
+  test("doesn't report when no error", () => {
+    renderUseReportTraceError([traceRecordFactory()]);
+    expect(reportEvent).not.toHaveBeenCalledWith();
+  });
 
-  // Re-render the hook with a different run id
-  rerender({ rerenderTraces: [traceErrorFactory({ runId: uuidSequence(2) })] });
+  test("doesn't report when error does not have a run id", () => {
+    renderUseReportTraceError([traceErrorFactory({ runId: null })]);
+    expect(reportEvent).not.toHaveBeenCalledWith();
+  });
 
-  expect(reportEvent).toHaveBeenCalledTimes(2);
+  test("reports error from the same run id only once", () => {
+    const errorTrace = traceErrorFactory({ runId: uuidSequence(1) });
+    const { rerender } = renderUseReportTraceError([errorTrace]);
+
+    // Re-render the hook
+    rerender({ rerenderTraces: [errorTrace] });
+
+    expect(reportEvent).toHaveBeenCalledTimes(1);
+
+    // Re-render the hook with a different error, but same run id
+    rerender({
+      rerenderTraces: [traceErrorFactory({ runId: errorTrace.runId })],
+    });
+
+    expect(reportEvent).toHaveBeenCalledTimes(1);
+
+    // Re-render the hook with a different run id
+    rerender({
+      rerenderTraces: [traceErrorFactory({ runId: uuidSequence(2) })],
+    });
+
+    expect(reportEvent).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/pageEditor/tabs/editTab/useReportTraceError.ts
+++ b/src/pageEditor/tabs/editTab/useReportTraceError.ts
@@ -21,7 +21,7 @@ import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import { useSelector } from "react-redux";
 import { type UUID } from "@/types/stringTypes";
-import { usePrevious } from "@/hooks/usePrevious";
+import { usePreviousValue } from "@/hooks/usePreviousValue";
 
 /**
  * React Hook that reports when there's an error in a trace. Reports the error once per runId.
@@ -34,7 +34,7 @@ function useReportTraceError(): void {
 
   const traceError = traceErrors.find((x) => x.runId);
   const runId: UUID | null = traceError?.runId;
-  const prevRunId = usePrevious(runId);
+  const prevRunId = usePreviousValue(runId);
   if (traceError && runId !== prevRunId) {
     reportEvent(Events.PAGE_EDITOR_MOD_COMPONENT_ERROR, {
       sessionId,

--- a/src/pageEditor/tabs/editTab/useReportTraceError.ts
+++ b/src/pageEditor/tabs/editTab/useReportTraceError.ts
@@ -35,7 +35,7 @@ function useReportTraceError(): void {
   const traceError = traceErrors.find((x) => x.runId);
   const runId: UUID | null = traceError?.runId;
   const prevRunId = usePreviousValue(runId);
-  if (traceError && runId !== prevRunId) {
+  if (traceError && runId && runId !== prevRunId) {
     reportEvent(Events.PAGE_EDITOR_MOD_COMPONENT_ERROR, {
       sessionId,
       extensionId: traceError.extensionId,

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -406,6 +406,7 @@
     "./hooks/useKeyboardShortcut.ts",
     "./hooks/useMemoCompare.ts",
     "./hooks/useMergeAsyncState.ts",
+    "./hooks/usePrevious.ts",
     "./hooks/useQuickbarShortcut.ts",
     "./hooks/useReduxState.ts",
     "./hooks/useReportError.ts",

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -406,7 +406,7 @@
     "./hooks/useKeyboardShortcut.ts",
     "./hooks/useMemoCompare.ts",
     "./hooks/useMergeAsyncState.ts",
-    "./hooks/usePrevious.ts",
+    "./hooks/usePreviousValue.ts",
     "./hooks/useQuickbarShortcut.ts",
     "./hooks/useReduxState.ts",
     "./hooks/useReportError.ts",


### PR DESCRIPTION
## What does this PR do?
In a couple of places we employ a useEffect where we could
instead simplify the logic by checking the previous value. This PR
simplifies a couple of these usages through the use of the shared
`usePrevious` util hook.

For motivation see: 
https://react.dev/learn/you-might-not-need-an-effect

## Discussion

- Does the original intended behavior still line up with this refactor?

## Future Work

- Consider more places where we can remove the need for useEffects

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [X] Designate a primary reviewer @twschiller 
