### PR TITLE
#7690: load extension console after linking extension

### DIFF
--- a/end-to-end-tests/example.spec.ts
+++ b/end-to-end-tests/example.spec.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { test, expect } from "./fixtures";
+import { test, expect, linkBrowserExtensionViaAdminConsole } from "./fixtures";
 import { E2E_TEST_USER_EMAIL_UNAFFILIATED, SERVICE_URL } from "./env";
 
 test.describe("create-react-app", () => {
@@ -27,8 +27,11 @@ test.describe("create-react-app", () => {
   });
 
   test("can open the extension console", async ({ page, extensionId }) => {
+    await linkBrowserExtensionViaAdminConsole(page, expect);
+
     await page.goto(`chrome-extension://${extensionId}/options.html`);
     await expect(page.getByText("Extension Console")).toBeVisible();
+    await expect(page.getByText("All Mods")).toBeVisible();
   });
 
   test("has title", async ({ page }) => {

--- a/end-to-end-tests/fixtures.ts
+++ b/end-to-end-tests/fixtures.ts
@@ -17,12 +17,14 @@
 
 import {
   test as base,
+  type Expect,
   chromium,
   type BrowserContext,
   type Cookie,
+  type Page,
 } from "@playwright/test";
 import path from "node:path";
-import { MV } from "./env";
+import { E2E_TEST_USER_EMAIL_UNAFFILIATED, MV, SERVICE_URL } from "./env";
 import fs from "node:fs/promises";
 
 const getStoredCookies = async (): Promise<Cookie[]> => {
@@ -46,6 +48,27 @@ const getStoredCookies = async (): Promise<Cookie[]> => {
   };
   return cookies;
 };
+
+/**
+ * Link the Browser Extension to the user's account via the admin console.
+ * TODO: refactor into the fixture definition and figure out a way to save the
+ *  linked extension state into chrome storage so we don't have to load the admin
+ *  page for every test.
+ */
+export async function linkBrowserExtensionViaAdminConsole(
+  page: Page,
+  expect: Expect,
+) {
+  await page.goto(SERVICE_URL);
+  await expect(page.getByText(E2E_TEST_USER_EMAIL_UNAFFILIATED)).toBeVisible();
+  await expect(async () =>
+    expect(
+      page.getByText(
+        "Successfully linked the Browser Extension to your PixieBrix account",
+      ),
+    ).toBeVisible(),
+  ).toPass({ timeout: 5000 });
+}
 
 export const test = base.extend<{
   context: BrowserContext;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
   retries: CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: CI ? 1 : undefined,
+  /* Timeout for each test */
+  timeout: 30_000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html", { outputFolder: "./end-to-end-tests/.report" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
## What does this PR do?

- Part of #7690
This change now allows us to write a test that loads up the extension console that is linked.

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer @mnholtz 
