### PR TITLE
introducing pageObjects and improving first smoke test

### DIFF
--- a/end-to-end-tests/auth.setup.ts
+++ b/end-to-end-tests/auth.setup.ts
@@ -21,27 +21,11 @@ import {
   E2E_TEST_USER_PASSWORD_UNAFFILIATED,
   SERVICE_URL,
 } from "./env";
-import { type Page } from "@playwright/test";
 
 const authFile = "end-to-end-tests/.auth/user.json";
 
-const waitForAdminConsoleToLoad = async (page: Page) => {
-  await expect(
-    page
-      .getByLabel("Email")
-      .or(page.getByText(E2E_TEST_USER_EMAIL_UNAFFILIATED)),
-  ).toBeVisible();
-};
-
 setup("authenticate", async ({ page }) => {
   await page.goto(`${SERVICE_URL}/login/email`);
-  await waitForAdminConsoleToLoad(page);
-
-  if (await page.getByText(E2E_TEST_USER_EMAIL_UNAFFILIATED).isVisible()) {
-    // If the user is already authenticated, reuse the existing session
-    await page.context().storageState({ path: authFile });
-    return;
-  }
 
   await page.getByLabel("Email").fill(E2E_TEST_USER_EMAIL_UNAFFILIATED);
   await page.getByLabel("Password").fill(E2E_TEST_USER_PASSWORD_UNAFFILIATED);

--- a/end-to-end-tests/pageObjects/constants.ts
+++ b/end-to-end-tests/pageObjects/constants.ts
@@ -15,16 +15,5 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { test, expect } from "../fixtures/extensionBase";
-
-test.describe("extension console smoke test", () => {
-  test("can open the extension console", async ({ page, extensionId }) => {
-    await page.goto(`chrome-extension://${extensionId}/options.html`);
-    await expect(page.getByText("Extension Console")).toBeVisible();
-    await expect(
-      page.getByRole("heading", {
-        name: "Active Mods",
-      }),
-    ).toBeVisible();
-  });
-});
+export const getBaseExtensionConsoleUrl = (extensionId: string) =>
+  `chrome-extension://${extensionId}/options.html`;

--- a/end-to-end-tests/pageObjects/modsPage.ts
+++ b/end-to-end-tests/pageObjects/modsPage.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect, type Page } from "@playwright/test";
+import { getBaseExtensionConsoleUrl } from "./constants";
+
+export class ModsPage {
+  private readonly extensionConsoleUrl: string;
+
+  constructor(
+    private readonly page: Page,
+    extensionId: string,
+  ) {
+    this.extensionConsoleUrl = getBaseExtensionConsoleUrl(extensionId);
+  }
+
+  async goto() {
+    await this.page.goto(this.extensionConsoleUrl);
+    await expect(this.page.getByText("Extension Console")).toBeVisible();
+    await expect(
+      this.page.getByRole("heading", {
+        name: "Active Mods",
+      }),
+    ).toBeVisible();
+  }
+
+  async viewAllMods() {
+    await this.page.getByTestId("all-mods-mod-tab").click();
+  }
+
+  async getAllModTableItems() {
+    return this.page.getByRole("table").locator(".list-group-item");
+  }
+}

--- a/end-to-end-tests/pageObjects/modsPage.ts
+++ b/end-to-end-tests/pageObjects/modsPage.ts
@@ -31,11 +31,12 @@ export class ModsPage {
   async goto() {
     await this.page.goto(this.extensionConsoleUrl);
     await expect(this.page.getByText("Extension Console")).toBeVisible();
-    await expect(
-      this.page.getByRole("heading", {
-        name: "Active Mods",
-      }),
-    ).toBeVisible();
+    const activeModsHeading = this.page.getByRole("heading", {
+      name: "Active Mods",
+    });
+    // `activeModsHeading` may be initially hidden, so toBeVisible() would immediately fail
+    await expect(activeModsHeading).toBeAttached();
+    await expect(activeModsHeading).not.toBeHidden();
   }
 
   async viewAllMods() {

--- a/end-to-end-tests/tests/modsPageSmoke.spec.ts
+++ b/end-to-end-tests/tests/modsPageSmoke.spec.ts
@@ -18,11 +18,8 @@
 import { test, expect } from "../fixtures/extensionBase";
 import { ModsPage } from "../pageObjects/modsPage";
 
-test.describe("extension console smoke test", () => {
-  test("can open the mods page in the extension console and view available mods", async ({
-    page,
-    extensionId,
-  }) => {
+test.describe("extension console mods page smoke test", () => {
+  test("can view available mods", async ({ page, extensionId }) => {
     const modsPage = new ModsPage(page, extensionId);
     await modsPage.goto();
     const pageTitle = await page.title();

--- a/end-to-end-tests/tests/modsPageSmoke.spec.ts
+++ b/end-to-end-tests/tests/modsPageSmoke.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { test, expect } from "../fixtures/extensionBase";
+import { ModsPage } from "../pageObjects/modsPage";
+
+test.describe("extension console smoke test", () => {
+  test("can open the mods page in the extension console and view available mods", async ({
+    page,
+    extensionId,
+  }) => {
+    const modsPage = new ModsPage(page, extensionId);
+    await modsPage.goto();
+    const pageTitle = await page.title();
+    expect(pageTitle).toBe("Mods | PixieBrix");
+    await modsPage.viewAllMods();
+    const modTableItems = await modsPage.getAllModTableItems();
+    // There is at least one mod visible
+    await expect(modTableItems.nth(0)).toBeVisible();
+  });
+});

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -761,7 +761,7 @@
     "./vendors/validateUuid.ts",
     "./components/errors/InvalidSelectorErrorDetail.tsx",
     "../end-to-end-tests/auth.setup.ts",
-    "../end-to-end-tests/tests/extensionConsoleSmoke.spec.ts",
+    "../end-to-end-tests/tests/modsPageSmoke.spec.ts",
     "../end-to-end-tests/fixtures/extensionBase.ts",
     "./utils/deploymentUtils.ts"
   ]

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -763,7 +763,7 @@
     "../end-to-end-tests/auth.setup.ts",
     "../end-to-end-tests/env.ts",
     "../end-to-end-tests/fixtures/extensionBase.ts",
-    "../end-to-end-tests/pageObjects/modsPage.ts.ts",
+    "../end-to-end-tests/pageObjects/modsPage.ts",
     "../end-to-end-tests/pageObjects/constants.ts",
     "../end-to-end-tests/tests/modsPageSmoke.spec.ts",
     "./utils/deploymentUtils.ts"

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -761,8 +761,11 @@
     "./vendors/validateUuid.ts",
     "./components/errors/InvalidSelectorErrorDetail.tsx",
     "../end-to-end-tests/auth.setup.ts",
-    "../end-to-end-tests/tests/modsPageSmoke.spec.ts",
+    "../end-to-end-tests/env.ts",
     "../end-to-end-tests/fixtures/extensionBase.ts",
+    "../end-to-end-tests/pageObjects/modsPage.ts.ts",
+    "../end-to-end-tests/pageObjects/constants.ts",
+    "../end-to-end-tests/tests/modsPageSmoke.spec.ts",
     "./utils/deploymentUtils.ts"
   ]
 }


### PR DESCRIPTION
## What does this PR do?

- Part of #7690
This change introduces pageObjects to group our locator / navigation logic following best practices:
https://playwright.dev/docs/pom

This change also improve the original smoke test for the options mod page.

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [X] Designate a primary reviewer @mnholtz 
