### PR TITLE
#7900: introducing axe-core to track a11y issues

### DIFF
--- a/end-to-end-tests/tests/modsPageSmoke.spec.ts
+++ b/end-to-end-tests/tests/modsPageSmoke.spec.ts
@@ -17,6 +17,8 @@
 
 import { test, expect } from "../fixtures/extensionBase";
 import { ModsPage } from "../pageObjects/modsPage";
+import AxeBuilder from "@axe-core/playwright";
+import { checkForCriticalViolations } from "../utils";
 
 test.describe("extension console mods page smoke test", () => {
   test("can view available mods", async ({ page, extensionId }) => {
@@ -28,5 +30,21 @@ test.describe("extension console mods page smoke test", () => {
     const modTableItems = await modsPage.getAllModTableItems();
     // There is at least one mod visible
     await expect(modTableItems.nth(0)).toBeVisible();
+
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
+
+    // TODO: fix these accessibility issues
+    //   https://github.com/pixiebrix/pixiebrix-extension/issues/7900
+    checkForCriticalViolations(accessibilityScanResults, [
+      "color-contrast",
+      "heading-order",
+      "label-title-only",
+      "landmark-one-main",
+      "landmark-unique",
+      "link-in-text-block",
+      "list",
+      "page-has-heading-one",
+      "region",
+    ]);
   });
 });

--- a/end-to-end-tests/utils.ts
+++ b/end-to-end-tests/utils.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { expect } from "./fixtures/extensionBase";
+
+type PartialAxeResults = {
+  violations: Array<{
+    id: string;
+    impact?: "critical" | "serious" | "moderate" | "minor";
+  }>;
+};
+
+function criticalViolationsFromAxeResults(
+  accessibilityScanResults: PartialAxeResults,
+) {
+  return new Set(
+    accessibilityScanResults.violations.flatMap(({ id, impact }) =>
+      impact === "critical" ? [] : [id],
+    ),
+  );
+}
+
+export function checkForCriticalViolations(
+  accessibilityScanResults: PartialAxeResults,
+  allowedViolations: string[] = [],
+) {
+  const criticalViolations = [
+    ...criticalViolationsFromAxeResults(accessibilityScanResults),
+  ];
+  if (criticalViolations.some((rule) => !allowedViolations.includes(rule))) {
+    console.warn(
+      "Found Critical Accessibility Violations. Full report:",
+      JSON.stringify(accessibilityScanResults.violations, null, 2),
+    );
+  }
+
+  expect(criticalViolations).toEqual(allowedViolations);
+}

--- a/end-to-end-tests/utils.ts
+++ b/end-to-end-tests/utils.ts
@@ -16,16 +16,12 @@
  */
 
 import { expect } from "./fixtures/extensionBase";
+import type AxeBuilder from "@axe-core/playwright";
 
-type PartialAxeResults = {
-  violations: Array<{
-    id: string;
-    impact?: "critical" | "serious" | "moderate" | "minor";
-  }>;
-};
+type AxeResults = Awaited<ReturnType<typeof AxeBuilder.prototype.analyze>>;
 
 function criticalViolationsFromAxeResults(
-  accessibilityScanResults: PartialAxeResults,
+  accessibilityScanResults: AxeResults,
 ) {
   return new Set(
     accessibilityScanResults.violations.flatMap(({ id, impact }) =>
@@ -35,7 +31,7 @@ function criticalViolationsFromAxeResults(
 }
 
 export function checkForCriticalViolations(
-  accessibilityScanResults: PartialAxeResults,
+  accessibilityScanResults: AxeResults,
   allowedViolations: string[] = [],
 ) {
   const criticalViolations = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,7 @@
         "yup": "^0.32.11"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.8.5",
         "@fortawesome/fontawesome-common-types": "^0.2.36",
         "@playwright/test": "^1.42.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
@@ -364,6 +365,27 @@
       },
       "bin": {
         "x-default-browser": "bin/x-default-browser.js"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.8.5.tgz",
+      "integrity": "sha512-GFdXXAEn9uk0Vyzgl2eEP+VwvgGzas0YSnacoJ/0U237G83zWZ1PhbP/RDymm0cqevoA+xRjMo+ONzh9Q711nw==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "~4.8.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright/node_modules/axe-core": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.4.tgz",
+      "integrity": "sha512-CZLSKisu/bhJ2awW4kJndluz2HLZYIHh5Uy1+ZwDRkJi69811xgIXXfdU9HSLX0Th+ILrHj8qfL/5wzamsFtQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "yup": "^0.32.11"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.8.5",
     "@fortawesome/fontawesome-common-types": "^0.2.36",
     "@playwright/test": "^1.42.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",


### PR DESCRIPTION
## What does this PR do?

Introduces using axe-core in our playwright system tests to analyze our pages for accessibility violations.

This first set of changes only analyzes the mods page in the extension console, and I wrote some
utility code to specifically list out the current critical a11y issues.

Related issue: https://github.com/pixiebrix/pixiebrix-extension/issues/7900

## Discussion

How do we want to prioritize fixing these a11y issues?

## Future Work

Fixing the critical issues, one at a time.

## Checklist

- [X] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [X] Designate a primary reviewer @mnholtz 
