### PR TITLE
#7690: reduce flakiness of page fixture

### DIFF
--- a/end-to-end-tests/fixtures/extensionBase.ts
+++ b/end-to-end-tests/fixtures/extensionBase.ts
@@ -59,6 +59,9 @@ export const test = base.extend<{
     const pathToExtension = path.join(__dirname, "../../dist");
 
     const context = await chromium.launchPersistentContext("", {
+      // Test against the branded Chrome browser
+      // See: https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
+      channel: "chrome",
       headless: false,
       args: [
         `--disable-extensions-except=${pathToExtension}`,

--- a/end-to-end-tests/pageObjects/modsPage.ts
+++ b/end-to-end-tests/pageObjects/modsPage.ts
@@ -34,9 +34,10 @@ export class ModsPage {
     const activeModsHeading = this.page.getByRole("heading", {
       name: "Active Mods",
     });
-    // `activeModsHeading` may be initially hidden, so toBeVisible() would immediately fail
-    await expect(activeModsHeading).toBeAttached();
-    await expect(activeModsHeading).not.toBeHidden();
+    // `activeModsHeading` may be initially be detached and hidden, so toBeVisible() would immediately fail
+    await expect(async () => {
+      await expect(activeModsHeading).toBeVisible();
+    }).toPass();
   }
 
   async viewAllMods() {


### PR DESCRIPTION
## What does this PR do?

Fixes flakiness where sometimes the expected header is not attached to the dom (but still present).

See: https://github.com/pixiebrix/pixiebrix-extension/actions/runs/8267597585/job/22618402796