### PR TITLE
#7691: Address e2e test flakiness due to Extension reload and Extension Console loading times

### DIFF
--- a/end-to-end-tests/fixtures/extensionBase.ts
+++ b/end-to-end-tests/fixtures/extensionBase.ts
@@ -112,7 +112,7 @@ export const test = base.extend<{
     await linkExtensionViaAdminConsole(page);
 
     // After linking, the Extension will reload, causing errors if the Extension Console is accessed too soon.
-    // Wait for the Extension Console to be visible before proceeding.
+    // Wait for the Extension Console to be available before proceeding.
     await ensureExtensionIsLoaded(page, extensionId);
 
     await use(page);

--- a/end-to-end-tests/fixtures/extensionBase.ts
+++ b/end-to-end-tests/fixtures/extensionBase.ts
@@ -21,7 +21,7 @@ import {
   chromium,
   type BrowserContext,
   type Cookie,
-  Page,
+  type Page,
 } from "@playwright/test";
 import path from "node:path";
 import { E2E_TEST_USER_EMAIL_UNAFFILIATED, MV, SERVICE_URL } from "../env";
@@ -47,6 +47,20 @@ const getStoredCookies = async (): Promise<Cookie[]> => {
     cookies: Cookie[];
   };
   return cookies;
+};
+
+const linkExtensionViaAdminConsole = async (page: Page) => {
+  await page.goto(SERVICE_URL);
+  await baseExpect(
+    page.getByText(E2E_TEST_USER_EMAIL_UNAFFILIATED),
+  ).toBeVisible();
+  await baseExpect(async () => {
+    await baseExpect(
+      page.getByText(
+        "Successfully linked the Browser Extension to your PixieBrix account",
+      ),
+    ).toBeVisible();
+  }).toPass({ timeout: 5000 });
 };
 
 const ensureExtensionIsLoaded = async (page: Page, extensionId: string) => {
@@ -95,17 +109,7 @@ export const test = base.extend<{
     // TODO: figure out a way to save the linked extension state into chrome
     //  storage so we don't have to load the admin page for every test.
     //  https://github.com/pixiebrix/pixiebrix-extension/issues/7898
-    await page.goto(SERVICE_URL);
-    await baseExpect(
-      page.getByText(E2E_TEST_USER_EMAIL_UNAFFILIATED),
-    ).toBeVisible();
-    await baseExpect(async () => {
-      await baseExpect(
-        page.getByText(
-          "Successfully linked the Browser Extension to your PixieBrix account",
-        ),
-      ).toBeVisible();
-    }).toPass({ timeout: 5000 });
+    await linkExtensionViaAdminConsole(page);
 
     // After linking, the Extension will reload, causing errors if the Extension Console is accessed too soon.
     // Wait for the Extension Console to be visible before proceeding.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
   workers: CI ? 1 : undefined,
   /* Timeout for each test */
   timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html", { outputFolder: "./end-to-end-tests/.report" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   /* Timeout for each test */
   timeout: 30_000,
   expect: {
+    /* Timeout for each assertion. Increased from the default of 5000 due to Extension Console loading times. */
     timeout: 10_000,
   },
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-extension/issues/7691
- After manually linking the extension, the extensionBase fixture will wait for the Extension Console to be available (essentially ensure that the Extension console is done reloading) before proceeding with the test
- Also increases the test assertion timeout to 10s, because I was seeing flakiness with the Extension Console taking longer than 5s to load in some cases

## Checklist

- [x] Add tests
- [x] Designate a primary reviewer @fungairino 
 