### PR TITLE
#7813: Remove `rootAware` support from insert-text brick and improve focus logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,6 @@
         "simple-icons": "^5.8.0",
         "slugify": "^1.6.6",
         "stemmer": "^2.0.1",
-        "text-field-edit": "^4.1.1",
         "timezone-mock": "^1.3.6",
         "uint8array-extras": "^1.1.0",
         "url-join": "^5.0.0",
@@ -27004,17 +27003,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/text-field-edit": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/text-field-edit/-/text-field-edit-4.1.1.tgz",
-      "integrity": "sha512-bgvsU5CFdBm8YuDdpLALNqS7Th8bVaRD5cww9VMYaBYab324iN3XOXvuQxTxp9JSPhHHF6zGCDEyF08JUV2hPw==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fregante"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "simple-icons": "^5.8.0",
     "slugify": "^1.6.6",
     "stemmer": "^2.0.1",
-    "text-field-edit": "^4.1.1",
     "timezone-mock": "^1.3.6",
     "uint8array-extras": "^1.1.0",
     "url-join": "^5.0.0",

--- a/src/bricks/effects/InsertAtCursorEffect.test.ts
+++ b/src/bricks/effects/InsertAtCursorEffect.test.ts
@@ -25,6 +25,6 @@ const brick = new InsertAtCursorEffect();
 
 describe("InsertAtCursorEffect", () => {
   it("is root-aware", async () => {
-    await expect(brick.isRootAware()).resolves.toBe(true);
+    await expect(brick.isRootAware()).resolves.toBe(false);
   });
 });

--- a/src/bricks/effects/InsertAtCursorEffect.ts
+++ b/src/bricks/effects/InsertAtCursorEffect.ts
@@ -16,15 +16,9 @@
  */
 
 import { EffectABC } from "@/types/bricks/effectTypes";
-import {
-  type BrickArgs,
-  type BrickOptions,
-  isDocument,
-} from "@/types/runtimeTypes";
+import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { BusinessError } from "@/errors/businessErrors";
 import { isEmpty } from "lodash";
-import focus from "@/utils/focusController";
 import selectionController from "@/utils/selectionController";
 import type { PlatformCapability } from "@/platform/capabilities";
 import { insertAtCursorWithCustomEditorSupport } from "@/contentScript/textEditorDom";
@@ -59,12 +53,12 @@ class InsertAtCursorEffect extends EffectABC {
   }
 
   override async isRootAware(): Promise<boolean> {
-    return true;
+    return false;
   }
 
   async effect(
     { text }: BrickArgs<{ text: string }>,
-    { root, logger }: BrickOptions,
+    { logger }: BrickOptions,
   ): Promise<void> {
     expectContext("contentScript");
 
@@ -74,22 +68,13 @@ class InsertAtCursorEffect extends EffectABC {
       return;
     }
 
-    const element = isDocument(root) ? focus.get() : root;
-
     // When calling this brick from the sidebar, some editors intentionally clear the selection
     // so we need to restore it before inserting the text. This isn't necessary on native
     // input fields and contenteditable elements for example.
     // https://github.com/pixiebrix/pixiebrix-extension/pull/7827#issuecomment-1979884573
     selectionController.restoreWithoutClearing();
 
-    if (!element) {
-      throw new BusinessError("No active element");
-    }
-
-    await insertAtCursorWithCustomEditorSupport({
-      element,
-      text,
-    });
+    await insertAtCursorWithCustomEditorSupport(text);
   }
 }
 

--- a/src/bricks/effects/InsertAtCursorEffect.ts
+++ b/src/bricks/effects/InsertAtCursorEffect.ts
@@ -53,6 +53,7 @@ class InsertAtCursorEffect extends EffectABC {
   }
 
   override async isRootAware(): Promise<boolean> {
+    // Always targets the active field/editor
     return false;
   }
 
@@ -68,7 +69,7 @@ class InsertAtCursorEffect extends EffectABC {
       return;
     }
 
-    // When calling this brick from the sidebar, some editors intentionally clear the selection
+    // When calling this brick from the sidebar, some editors intentionally clear the selection,
     // so we need to restore it before inserting the text. This isn't necessary on native
     // input fields and contenteditable elements for example.
     // https://github.com/pixiebrix/pixiebrix-extension/pull/7827#issuecomment-1979884573

--- a/src/bricks/effects/attachAutocomplete.ts
+++ b/src/bricks/effects/attachAutocomplete.ts
@@ -24,7 +24,11 @@ import autocompleterStyleUrl from "autocompleter/autocomplete.css?loadAsUrl";
 import injectStylesheet from "@/utils/injectStylesheet";
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
+import {
+  isDocument,
+  type BrickArgs,
+  type BrickOptions,
+} from "@/types/runtimeTypes";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 
 export class AttachAutocomplete extends EffectABC {
@@ -78,7 +82,7 @@ export class AttachAutocomplete extends EffectABC {
 
     const inputs = $elements
       .toArray()
-      .filter((x) => !(x instanceof Document) && x.tagName === "INPUT");
+      .filter((x) => !isDocument(x) && x.tagName === "INPUT");
 
     if (inputs.length === 0) {
       logger.warn("No input elements found", {

--- a/src/contentScript/commandPopover/commandUtils.ts
+++ b/src/contentScript/commandPopover/commandUtils.ts
@@ -67,10 +67,7 @@ export async function replaceAtCommand({
     // Ensure the selection update has propagated
     await waitAnimationFrame();
 
-    await insertAtCursorWithCustomEditorSupport({
-      element,
-      text,
-    });
+    await insertAtCursorWithCustomEditorSupport(text);
   }
 
   if (isNativeField(element)) {
@@ -108,9 +105,6 @@ export async function replaceAtCommand({
       throw new Error("Selection has no parent element");
     }
 
-    await insertAtCursorWithCustomEditorSupport({
-      element: parentElement,
-      text,
-    });
+    await insertAtCursorWithCustomEditorSupport(text);
   }
 }

--- a/src/contentScript/textEditorDom.ts
+++ b/src/contentScript/textEditorDom.ts
@@ -46,8 +46,6 @@ export async function insertAtCursorWithCustomEditorSupport(text: string) {
     "contentScript context required for editor JavaScript integrations",
   );
 
-  // TODO: Some fields might require: getSelection()?.anchorNode?.parentElement;
-  //   https://github.com/pixiebrix/pixiebrix-extension/issues/7779#issuecomment-1994463140
   const element = focusController.get();
 
   const ckeditor = ckeditorDom.selectCKEditorElement(element);

--- a/src/contrib/ckeditor/ckeditorDom.ts
+++ b/src/contrib/ckeditor/ckeditorDom.ts
@@ -17,8 +17,6 @@
 
 /** @file CKEditor methods that don't require pageScript access to the CKEditor instance */
 
-import type { Nullishable } from "@/utils/nullishUtils";
-
 /**
  * Returns true if the element appears to be a CKEditor 5 instance based on its class name.
  * Can be called from either the contentScript or web/pageScript context.
@@ -30,12 +28,16 @@ export function hasCKEditorClass(element: HTMLElement): boolean {
 }
 
 /**
- * Returns the CKEditor element that contains the given element, or null if the element is not in a CKEditor instance.
+ * Returns the CKEditor 5 element that contains the given element, or null if the element is not in a CKEditor instance.
  * Can be called from either the contentScript or web/pageScript context.
  */
 export function selectCKEditorElement(
-  element: HTMLElement,
-): Nullishable<HTMLElement> {
+  element: HTMLElement | undefined,
+): HTMLElement | null {
+  if (!element) {
+    return null;
+  }
+
   // Likely faster than repeatedly calling hasCKEditorClass
   return element.closest<HTMLElement>(".ck-editor__editable");
 }

--- a/src/utils/domFieldUtils.ts
+++ b/src/utils/domFieldUtils.ts
@@ -100,6 +100,8 @@ export async function setFieldValue(
   }
 
   if (field.isContentEditable) {
+    // XXX: Maybe use text-field-edit so that the focus is not altered
+
     // Field needs to be focused first
     field.focus();
 

--- a/src/utils/focusController.ts
+++ b/src/utils/focusController.ts
@@ -95,10 +95,6 @@ const focusController = {
   get(): HTMLElement {
     return focusedElement ?? (document.activeElement as HTMLElement);
   },
-
-  wasSaved(): boolean {
-    return focusedElement != null;
-  },
 } as const;
 
 export default focusController;

--- a/src/utils/focusController.ts
+++ b/src/utils/focusController.ts
@@ -68,13 +68,20 @@ const focusController = {
    *  https://github.com/pixiebrix/pixiebrix-extension/issues/7774#issuecomment-1980041738
    */
   restore(): void {
+    focusController.restoreWithoutClearing();
+    focusController.clear();
+  },
+
+  restoreWithoutClearing(): void {
+    if (!focusedElement) {
+      return;
+    }
+
     // `focusedElement === body`: This restores its focus. `body.focus()` doesn't do anything
     (document.activeElement as HTMLElement)?.blur?.();
 
     // `focusedElement === HTMLElement`: Restore focus if it's an HTMLElement, otherwise silently ignore it
-    focusedElement?.focus?.();
-
-    focusedElement = undefined;
+    focusedElement.focus?.();
   },
 
   /** Clear saved value without restoring focus */
@@ -87,6 +94,10 @@ const focusController = {
    */
   get(): HTMLElement {
     return focusedElement ?? (document.activeElement as HTMLElement);
+  },
+
+  wasSaved(): boolean {
+    return focusedElement != null;
   },
 } as const;
 


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/7813#issuecomment-1983367821

The root-aware part was mentioned in https://github.com/pixiebrix/pixiebrix-extension/issues/7813#issuecomment-1983367821


## From MV2 sidebar


https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/21d46e84-f199-44ec-aff7-ed1a6dc66486

## From QuickBar


https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/576deac5-94fc-4f29-be4a-9e3725c2953c



## Via interval (shows stable focus)

https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/977be720-b198-455c-bc68-6e954c732503



## Checklist

- ❌  Add tests: can't test execCommand in JSDom
- [x] Designate a primary reviewer: @twschiller 
