### PR TITLE
#7823: fix missing return in replaceAtCommand

### DIFF
--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -156,6 +156,7 @@ const CommandPopover: React.FunctionComponent<
           dispatch(popoverSlice.actions.setCommandSuccess({ text }));
         }
       } catch (error) {
+        console.warn("Error filling at cursor", error);
         dispatch(popoverSlice.actions.setCommandError({ error }));
       }
     },

--- a/src/contentScript/commandPopover/commandUtils.test.ts
+++ b/src/contentScript/commandPopover/commandUtils.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { replaceAtCommand } from "@/contentScript/commandPopover/commandUtils";
+
+// `jsdom` doesn't implement execCommand
+document.execCommand = jest.fn().mockReturnValue(true);
+
+// Can ony do very limited testing due to lack of jsdom support for execCommand and selection/focus
+describe("commandUtils", () => {
+  it("inserts in normal text field", async () => {
+    document.body.innerHTML =
+      '<input type="text" value="\\hello world" id="input" />';
+
+    await replaceAtCommand({
+      element: document.querySelector("#input"),
+      text: "new text",
+      query: "",
+      commandKey: "\\",
+    });
+
+    expect(jest.mocked(document.execCommand)).toHaveBeenCalledWith(
+      "insertText",
+      false,
+      "new text",
+    );
+  });
+});

--- a/src/contentScript/commandPopover/commandUtils.test.ts
+++ b/src/contentScript/commandPopover/commandUtils.test.ts
@@ -27,7 +27,8 @@ describe("commandUtils", () => {
       '<input type="text" value="\\hello world" id="input" />';
 
     await replaceAtCommand({
-      element: document.querySelector("#input"),
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- defined above
+      element: document.querySelector("#input")!,
       text: "new text",
       query: "",
       commandKey: "\\",

--- a/src/contentScript/commandPopover/commandUtils.test.ts
+++ b/src/contentScript/commandPopover/commandUtils.test.ts
@@ -20,7 +20,7 @@ import { replaceAtCommand } from "@/contentScript/commandPopover/commandUtils";
 // `jsdom` doesn't implement execCommand
 document.execCommand = jest.fn().mockReturnValue(true);
 
-// Can ony do very limited testing due to lack of jsdom support for execCommand and selection/focus
+// Can only do very limited testing due to lack of jsdom support for execCommand and selection/focus
 describe("commandUtils", () => {
   it("inserts in normal text field", async () => {
     document.body.innerHTML =
@@ -34,7 +34,7 @@ describe("commandUtils", () => {
       commandKey: "\\",
     });
 
-    expect(jest.mocked(document.execCommand)).toHaveBeenCalledWith(
+    expect(document.execCommand).toHaveBeenCalledWith(
       "insertText",
       false,
       "new text",

--- a/src/contentScript/commandPopover/commandUtils.test.ts
+++ b/src/contentScript/commandPopover/commandUtils.test.ts
@@ -27,7 +27,7 @@ describe("commandUtils", () => {
       '<input type="text" value="\\hello world" id="input" />';
 
     await replaceAtCommand({
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- defined above
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- defined above
       element: document.querySelector("#input")!,
       text: "new text",
       query: "",

--- a/src/contentScript/commandPopover/commandUtils.ts
+++ b/src/contentScript/commandPopover/commandUtils.ts
@@ -68,6 +68,8 @@ export async function replaceAtCommand({
     await waitAnimationFrame();
 
     await insertAtCursorWithCustomEditorSupport(text);
+
+    return;
   }
 
   if (isNativeField(element)) {

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -296,6 +296,7 @@
     "./contentScript/commandPopover/commandController.tsx",
     "./contentScript/commandPopover/commandPopoverSlice.ts",
     "./contentScript/commandPopover/commandUtils.ts",
+    "./contentScript/commandPopover/commandUtils.test.ts",
     "./contentScript/commandPopover/useCommandRegistry.ts",
     "./contentScript/commandPopover/useKeyboardQuery.ts",
     "./contentScript/context.ts",


### PR DESCRIPTION
## What does this PR do?

- Fixes #7823 
- Fixes missing return statement in branch for native inputs

## Checklist

- [x] Add tests: jest has limited support for execCommand and focus/selection. Command Popover will be need to be covered by Playwright
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @fungairino 
