### PR TITLE
#7857: add preview to text command popover

### DIFF
--- a/src/bricks/effects/AddTextCommand.test.ts
+++ b/src/bricks/effects/AddTextCommand.test.ts
@@ -124,7 +124,7 @@ describe("AddTextCommand", () => {
     },
   );
 
-  it("includes and example", () => {
+  it("provides an example config", () => {
     expect(getExampleBrickConfig(AddTextCommand.BRICK_ID)).toStrictEqual({
       generate: toExpression("pipeline", [
         {

--- a/src/bricks/effects/AddTextCommand.test.ts
+++ b/src/bricks/effects/AddTextCommand.test.ts
@@ -24,9 +24,11 @@ import {
 } from "@/runtime/pipelineTests/pipelineTestHelpers";
 import { toExpression } from "@/utils/expressionUtils";
 import { reducePipeline } from "@/runtime/reducePipeline";
-import { uuidv4 } from "@/types/helpers";
+import { uuidv4, validateRegistryId } from "@/types/helpers";
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import IdentityTransformer from "@/bricks/transformers/IdentityTransformer";
+import { getExampleBrickConfig } from "@/pageEditor/exampleBrickConfigs";
+import { validateOutputKey } from "@/runtime/runtimeTypes";
 
 const brick = new AddTextCommand();
 const identity = new IdentityTransformer();
@@ -69,6 +71,8 @@ describe("AddTextCommand", () => {
           // Any leading slash is dropped
           shortcut: "echo",
           title: "Echo",
+          // Preview is optional
+          preview: undefined,
           handler: expect.toBeFunction(),
           componentId: extensionId,
         },
@@ -79,4 +83,60 @@ describe("AddTextCommand", () => {
       ).resolves.toBe("current text");
     },
   );
+
+  it.each(["preview text", undefined])(
+    "passes preview directly: %s",
+    async (preview) => {
+      const extensionId = uuidv4();
+      const logger = new ConsoleLogger({ extensionId });
+
+      const pipeline = {
+        id: brick.id,
+        config: {
+          shortcut: "echo",
+          preview,
+          title: "Echo",
+          generate: toExpression("pipeline", [
+            { id: identity.id, config: toExpression("var", "@currentText") },
+          ]),
+        },
+      };
+
+      await reducePipeline(pipeline, simpleInput({}), {
+        ...testOptions("v3"),
+        extensionId,
+        logger,
+      });
+
+      expect(commandRegistry.commands).toStrictEqual([
+        {
+          shortcut: "echo",
+          title: "Echo",
+          preview,
+          handler: expect.toBeFunction(),
+          componentId: extensionId,
+        },
+      ]);
+
+      await expect(
+        commandRegistry.commands[0].handler("current text"),
+      ).resolves.toBe("current text");
+    },
+  );
+
+  it("includes and example", () => {
+    expect(getExampleBrickConfig(AddTextCommand.BRICK_ID)).toStrictEqual({
+      generate: toExpression("pipeline", [
+        {
+          config: toExpression("nunjucks", ""),
+          id: validateRegistryId("@pixiebrix/identity"),
+          instanceId: expect.any(String),
+          outputKey: validateOutputKey("generatedText"),
+          rootMode: "document",
+        },
+      ]),
+      shortcut: "command",
+      title: "Example Command",
+    });
+  });
 });

--- a/src/bricks/effects/AddTextCommand.ts
+++ b/src/bricks/effects/AddTextCommand.ts
@@ -33,13 +33,17 @@ import { normalizeShortcut } from "@/bricks/effects/AddTextSnippets";
 
 type CommandArgs = {
   /**
-   * The shortcut for the text command.
+   * The shortcut for the text command
    */
   shortcut: string;
   /**
    * The title for the Text Command
    */
   title: string;
+  /**
+   * An optional preview of the text to insert
+   */
+  preview?: string;
   /**
    * The text generator to run
    */
@@ -79,6 +83,11 @@ class AddTextCommand extends EffectABC {
         type: "string",
         description: "The title for the Text Command",
       },
+      preview: {
+        type: "string",
+        title: "Text Preview",
+        description: "An optional preview of the text to insert",
+      },
       generate: {
         $ref: "https://app.pixiebrix.com/schemas/pipeline#",
         description: "The text generator to run",
@@ -92,7 +101,12 @@ class AddTextCommand extends EffectABC {
   }
 
   async effect(
-    { shortcut, title, generate: generatePipeline }: BrickArgs<CommandArgs>,
+    {
+      shortcut,
+      title,
+      preview,
+      generate: generatePipeline,
+    }: BrickArgs<CommandArgs>,
     { logger, runPipeline, platform, abortSignal }: BrickOptions,
   ): Promise<void> {
     // The runtime checks the abortSignal for each brick. But check here too to avoid flickering in the popover
@@ -112,6 +126,7 @@ class AddTextCommand extends EffectABC {
       // Trim leading command key in shortcut to be resilient to user input
       shortcut: normalizeShortcut(shortcut),
       title,
+      preview,
       async handler(currentText: string): Promise<string> {
         counter++;
 

--- a/src/bricks/effects/AddTextSnippets.test.ts
+++ b/src/bricks/effects/AddTextSnippets.test.ts
@@ -19,6 +19,7 @@ import AddTextSnippets from "@/bricks/effects/AddTextSnippets";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { commandRegistry } from "@/contentScript/commandPopover/commandController";
+import { getExampleBrickConfig } from "@/pageEditor/exampleBrickConfigs";
 
 const brick = new AddTextSnippets();
 
@@ -38,7 +39,7 @@ describe("AddTextSnippets", () => {
             {
               shortcut,
               title: "Test",
-              text: "test",
+              text: "test text",
             },
           ],
         }),
@@ -50,14 +51,27 @@ describe("AddTextSnippets", () => {
           // Leading command key is dropped
           shortcut: "test",
           title: "Test",
+          preview: "test text",
           handler: expect.toBeFunction(),
           componentId: options.logger.context.extensionId,
         },
       ]);
 
       await expect(commandRegistry.commands[0].handler("")).resolves.toBe(
-        "test",
+        "test text",
       );
     },
   );
+
+  it("includes and example", () => {
+    expect(getExampleBrickConfig(AddTextSnippets.BRICK_ID)).toStrictEqual({
+      snippets: [
+        {
+          shortcut: "example",
+          text: "Example snippet text",
+          title: "Example Snippet",
+        },
+      ],
+    });
+  });
 });

--- a/src/bricks/effects/AddTextSnippets.test.ts
+++ b/src/bricks/effects/AddTextSnippets.test.ts
@@ -63,7 +63,7 @@ describe("AddTextSnippets", () => {
     },
   );
 
-  it("includes and example", () => {
+  it("provides an example config", () => {
     expect(getExampleBrickConfig(AddTextSnippets.BRICK_ID)).toStrictEqual({
       snippets: [
         {

--- a/src/bricks/effects/AddTextSnippets.ts
+++ b/src/bricks/effects/AddTextSnippets.ts
@@ -124,6 +124,7 @@ class AddTextSnippets extends EffectABC {
         componentId: logger.context.extensionId,
         shortcut: normalizeShortcut(shortcut),
         title,
+        preview: text,
         async handler(): Promise<string> {
           return text;
         },

--- a/src/contentScript/commandPopover/CommandPopover.scss
+++ b/src/contentScript/commandPopover/CommandPopover.scss
@@ -22,8 +22,8 @@
 @import "@/themes/colors.scss";
 
 .root {
-  height: 100px;
-  width: 200px;
+  height: 200px;
+  width: 240px;
   overflow-y: auto;
 }
 
@@ -32,6 +32,13 @@
   flex-direction: column;
   background-color: $N0;
   color: black;
+}
+
+.preview {
+  color: $N400;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .result {

--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -43,6 +43,7 @@ import { Stylesheets } from "@/components/Stylesheets";
 import useIsMounted from "@/hooks/useIsMounted";
 import { replaceAtCommand } from "@/contentScript/commandPopover/commandUtils";
 import type { TextCommand } from "@/platform/platformTypes/commandPopoverProtocol";
+import type { Nullishable } from "@/utils/nullishUtils";
 
 type PopoverActionCallbacks = {
   onHide: () => void;
@@ -53,15 +54,22 @@ const CommandTitle: React.FunctionComponent<{
   shortcut: string;
   commandKey: string;
 }> = ({ query, shortcut, commandKey }) => (
-  <span>
+  <div>
     {commandKey}
     {!isEmpty(query) && (
       // Highlight the match. Use the shortcut vs. query directly because search is case-insensitive
       <span className="result__match">{shortcut.slice(0, query.length)}</span>
     )}
     {shortcut.slice(query.length)}
-  </span>
+  </div>
 );
+
+/**
+ * Remove newlines and excess whitespace from a snippet preview
+ */
+function normalizePreview(preview: Nullishable<string>): string {
+  return (preview ?? "No preview available").replaceAll(/\s+/g, " ").trim();
+}
 
 const ResultItem: React.FunctionComponent<{
   command: TextCommand;
@@ -96,6 +104,7 @@ const ResultItem: React.FunctionComponent<{
         shortcut={command.shortcut}
         commandKey={commandKey}
       />
+      <div className="preview">{normalizePreview(command.preview)}</div>
     </button>
   );
 };

--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -41,9 +41,11 @@ import { Events } from "@/telemetry/events";
 import EmotionShadowRoot from "@/components/EmotionShadowRoot";
 import { Stylesheets } from "@/components/Stylesheets";
 import useIsMounted from "@/hooks/useIsMounted";
-import { replaceAtCommand } from "@/contentScript/commandPopover/commandUtils";
+import {
+  normalizePreview,
+  replaceAtCommand,
+} from "@/contentScript/commandPopover/commandUtils";
 import type { TextCommand } from "@/platform/platformTypes/commandPopoverProtocol";
-import type { Nullishable } from "@/utils/nullishUtils";
 
 type PopoverActionCallbacks = {
   onHide: () => void;
@@ -63,13 +65,6 @@ const CommandTitle: React.FunctionComponent<{
     {shortcut.slice(query.length)}
   </div>
 );
-
-/**
- * Remove newlines and excess whitespace from a snippet preview
- */
-function normalizePreview(preview: Nullishable<string>): string {
-  return (preview ?? "No preview available").replaceAll(/\s+/g, " ").trim();
-}
 
 const ResultItem: React.FunctionComponent<{
   command: TextCommand;

--- a/src/contentScript/commandPopover/commandUtils.test.ts
+++ b/src/contentScript/commandPopover/commandUtils.test.ts
@@ -15,13 +15,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { replaceAtCommand } from "@/contentScript/commandPopover/commandUtils";
+import {
+  normalizePreview,
+  replaceAtCommand,
+} from "@/contentScript/commandPopover/commandUtils";
 
 // `jsdom` doesn't implement execCommand
 document.execCommand = jest.fn().mockReturnValue(true);
 
 // Can only do very limited testing due to lack of jsdom support for execCommand and selection/focus
-describe("commandUtils", () => {
+describe("replaceAtCommand", () => {
   it("inserts in normal text field", async () => {
     document.body.innerHTML =
       '<input type="text" value="\\hello world" id="input" />';
@@ -39,5 +42,11 @@ describe("commandUtils", () => {
       false,
       "new text",
     );
+  });
+});
+
+describe("normalizePreview", () => {
+  it("removes excess space", () => {
+    expect(normalizePreview("  hello \n\n world  ")).toBe("hello world");
   });
 });

--- a/src/contentScript/commandPopover/commandUtils.ts
+++ b/src/contentScript/commandPopover/commandUtils.ts
@@ -23,6 +23,7 @@ import {
 import { waitAnimationFrame } from "@/utils/domUtils";
 import { expectContext } from "@/utils/expectContext";
 import { insertAtCursorWithCustomEditorSupport } from "@/contentScript/textEditorDom";
+import type { Nullishable } from "@/utils/nullishUtils";
 
 /**
  * Replaces the text at the current command + query with the given text
@@ -109,4 +110,11 @@ export async function replaceAtCommand({
 
     await insertAtCursorWithCustomEditorSupport(text);
   }
+}
+
+/**
+ * Remove newlines and excess whitespace from a snippet preview.
+ */
+export function normalizePreview(preview: Nullishable<string>): string {
+  return (preview ?? "No preview available").replaceAll(/\s+/g, " ").trim();
 }

--- a/src/pageEditor/exampleBrickConfigs.ts
+++ b/src/pageEditor/exampleBrickConfigs.ts
@@ -34,6 +34,7 @@ import { toExpression } from "@/utils/expressionUtils";
 import CommentEffect from "@/bricks/effects/comment";
 import AddTextCommand from "@/bricks/effects/AddTextCommand";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
+import AddTextSnippets from "@/bricks/effects/AddTextSnippets";
 
 /**
  * Get an example brick config for a given brick id.
@@ -182,6 +183,18 @@ export function getExampleBrickConfig(
       return {
         variableName: "",
         value: toExpression("nunjucks", ""),
+      };
+    }
+
+    case AddTextSnippets.BRICK_ID: {
+      return {
+        snippets: [
+          {
+            shortcut: "example",
+            title: "Example Snippet",
+            text: "Example snippet text",
+          },
+        ],
       };
     }
 

--- a/src/pageEditor/exampleBrickConfigs.ts
+++ b/src/pageEditor/exampleBrickConfigs.ts
@@ -32,6 +32,8 @@ import IdentityTransformer from "@/bricks/transformers/IdentityTransformer";
 import { minimalUiSchemaFactory } from "@/utils/schemaUtils";
 import { toExpression } from "@/utils/expressionUtils";
 import CommentEffect from "@/bricks/effects/comment";
+import AddTextCommand from "@/bricks/effects/AddTextCommand";
+import { validateOutputKey } from "@/runtime/runtimeTypes";
 
 /**
  * Get an example brick config for a given brick id.
@@ -180,6 +182,22 @@ export function getExampleBrickConfig(
       return {
         variableName: "",
         value: toExpression("nunjucks", ""),
+      };
+    }
+
+    case AddTextCommand.BRICK_ID: {
+      return {
+        shortcut: "command",
+        title: "Example Command",
+        generate: toExpression("pipeline", [
+          {
+            ...createNewConfiguredBrick(IdentityTransformer.BRICK_ID, {
+              parentBrickId: AddTextCommand.BRICK_ID,
+            }),
+            config: toExpression("nunjucks", ""),
+            outputKey: validateOutputKey("generatedText"),
+          },
+        ]),
       };
     }
 

--- a/src/platform/platformTypes/commandPopoverProtocol.ts
+++ b/src/platform/platformTypes/commandPopoverProtocol.ts
@@ -31,6 +31,11 @@ export type TextCommand = {
    */
   title: string;
   /**
+   * An optional preview of the text to insert
+   * @since 1.8.11
+   */
+  preview?: string;
+  /**
    * The text generator
    * @param currentText current text in the editor
    */

--- a/src/utils/expressionUtils.ts
+++ b/src/utils/expressionUtils.ts
@@ -76,6 +76,9 @@ export function isNunjucksExpression(
   return isExpression(value) && value.__type__ === "nunjucks";
 }
 
+/**
+ * Returns true if value represents a brick pipeline expression
+ */
 export function isPipelineExpression(
   value: unknown,
 ): value is PipelineExpression {


### PR DESCRIPTION
## What does this PR do?

- Closes #7857 
- Adds preview to text command popover
- QoL: Adds example brick configuration for add text command brick

## Demo

- https://www.loom.com/share/a2ad66e551f9476b84a0fdd076e5317f?sid=bbd811ce-f51d-4d8b-8fa8-4dfd5f34f52a

## Future Work

- CSS/styling: will do holistically for popover in a PR for: https://github.com/pixiebrix/pixiebrix-extension/issues/7856

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @fungairino 
