### PR TITLE
#7858: add text command popover navigation footer

### DIFF
--- a/src/contentScript/commandPopover/CommandPopover.scss
+++ b/src/contentScript/commandPopover/CommandPopover.scss
@@ -24,11 +24,14 @@
 .root {
   height: 200px;
   width: 240px;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .results {
+  flex-grow: 1;
   display: flex;
+  overflow-y: auto;
   flex-direction: column;
   background-color: $N0;
   color: black;
@@ -39,6 +42,24 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.footer {
+  padding: 0.5rem;
+  font-size: 0.625rem;
+  color: #9c9fa6;
+  text-transform: uppercase;
+  font-family: monospace;
+
+  .key {
+    color: $P600;
+  }
+
+  // Font Awesome stylesheet is not available in the Shadow DOM
+  svg {
+    width: 1em;
+    height: 1em;
+  }
 }
 
 .result {

--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -46,6 +46,8 @@ import {
   replaceAtCommand,
 } from "@/contentScript/commandPopover/commandUtils";
 import type { TextCommand } from "@/platform/platformTypes/commandPopoverProtocol";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCaretDown, faCaretUp } from "@fortawesome/free-solid-svg-icons";
 
 type PopoverActionCallbacks = {
   onHide: () => void;
@@ -135,6 +137,18 @@ const StatusBar: React.FunctionComponent<{
   return null;
 };
 
+const PopoverFooter: React.ReactElement = (
+  <div className="footer">
+    Navigate{" "}
+    <span className="key">
+      <FontAwesomeIcon icon={faCaretDown} fixedWidth size="xs" />
+      &nbsp;
+      <FontAwesomeIcon icon={faCaretUp} fixedWidth size="xs" />
+    </span>{" "}
+    Select <span className="key">TAB</span>
+  </div>
+);
+
 const CommandPopover: React.FunctionComponent<
   {
     commandKey: string;
@@ -222,6 +236,7 @@ const CommandPopover: React.FunctionComponent<
               );
             })}
           </div>
+          {PopoverFooter}
         </div>
       </Stylesheets>
     </EmotionShadowRoot>

--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -138,7 +138,7 @@ const StatusBar: React.FunctionComponent<{
 };
 
 const PopoverFooter: React.ReactElement = (
-  <div className="footer">
+  <div className="footer" role="navigation" aria-label="Text command">
     Navigate{" "}
     <span className="key">
       <FontAwesomeIcon icon={faCaretDown} fixedWidth size="xs" />

--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -91,6 +91,7 @@ const ResultItem: React.FunctionComponent<{
       disabled={disabled}
       key={command.shortcut}
       aria-label={command.title}
+      aria-selected={isSelected}
       title={command.title}
       role="menuitem"
       className={cx("result", { "result--selected": isSelected })}

--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -138,7 +138,8 @@ const StatusBar: React.FunctionComponent<{
 };
 
 const PopoverFooter: React.ReactElement = (
-  <div className="footer" role="navigation" aria-label="Text commands">
+  // TODO: determine a11y: https://github.com/pixiebrix/pixiebrix-extension/issues/7936
+  <div className="footer">
     Navigate{" "}
     <span className="key">
       <FontAwesomeIcon icon={faCaretDown} fixedWidth size="xs" />

--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -141,7 +141,7 @@ const PopoverFooter: React.ReactElement = (
   <div className="footer" role="navigation" aria-label="Text commands">
     Navigate{" "}
     <span className="key">
-      <FontAwesomeIcon icon={faCaretDown} fixedWidth size="xs" aria-label="" />
+      <FontAwesomeIcon icon={faCaretDown} fixedWidth size="xs" />
       &nbsp;
       <FontAwesomeIcon icon={faCaretUp} fixedWidth size="xs" />
     </span>{" "}

--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -138,10 +138,10 @@ const StatusBar: React.FunctionComponent<{
 };
 
 const PopoverFooter: React.ReactElement = (
-  <div className="footer" role="navigation" aria-label="Text command">
+  <div className="footer" role="navigation" aria-label="Text commands">
     Navigate{" "}
     <span className="key">
-      <FontAwesomeIcon icon={faCaretDown} fixedWidth size="xs" />
+      <FontAwesomeIcon icon={faCaretDown} fixedWidth size="xs" aria-label="" />
       &nbsp;
       <FontAwesomeIcon icon={faCaretUp} fixedWidth size="xs" />
     </span>{" "}

--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -91,7 +91,6 @@ const ResultItem: React.FunctionComponent<{
       disabled={disabled}
       key={command.shortcut}
       aria-label={command.title}
-      aria-selected={isSelected}
       title={command.title}
       role="menuitem"
       className={cx("result", { "result--selected": isSelected })}


### PR DESCRIPTION
## What does this PR do?

- Closes #7858 

## Remaining Work

- [x] Re-run GitHub actions due to flake

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/8f5619d1-87d4-475b-9f1f-ab5958f7f2b5)

## Future Work

- CSS/styling: will do holistically for popover in a PR for: https://github.com/pixiebrix/pixiebrix-extension/issues/7856. Just trying to get the main affordances in first

## Checklist

- [x] Add tests: N/A - it's a static footer
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @fungairino 
