### PR TITLE
refactor activate mod logic into page object

### DIFF
--- a/end-to-end-tests/fixtures/extensionBase.ts
+++ b/end-to-end-tests/fixtures/extensionBase.ts
@@ -26,6 +26,7 @@ import {
 import path from "node:path";
 import { E2E_TEST_USER_EMAIL_UNAFFILIATED, MV, SERVICE_URL } from "../env";
 import fs from "node:fs/promises";
+import { getBaseExtensionConsoleUrl } from "../pageObjects/constants";
 
 const getStoredCookies = async (): Promise<Cookie[]> => {
   let fileBuffer;
@@ -65,7 +66,7 @@ const linkExtensionViaAdminConsole = async (page: Page) => {
 
 const ensureExtensionIsLoaded = async (page: Page, extensionId: string) => {
   await baseExpect(async () => {
-    await page.goto(`chrome-extension://${extensionId}/options.html`);
+    await page.goto(getBaseExtensionConsoleUrl(extensionId));
     await baseExpect(page.getByText("Extension Console")).toBeVisible();
     await baseExpect(
       page.getByText(E2E_TEST_USER_EMAIL_UNAFFILIATED),

--- a/end-to-end-tests/pageObjects/modsPage.ts
+++ b/end-to-end-tests/pageObjects/modsPage.ts
@@ -44,8 +44,16 @@ export class ModsPage {
     await this.page.getByTestId("all-mods-mod-tab").click();
   }
 
-  async getAllModTableItems() {
+  async viewActiveMods() {
+    await this.page.getByTestId("active-mod-tab").click();
+  }
+
+  modTableItems() {
     return this.page.getByRole("table").locator(".list-group-item");
+  }
+
+  searchModsInput() {
+    return this.page.getByTestId("blueprints-search-input");
   }
 }
 
@@ -55,7 +63,7 @@ export class ActivateModPage {
 
   constructor(
     private readonly page: Page,
-    extensionId: string,
+    private readonly extensionId: string,
     private readonly modId: string,
   ) {
     this.baseConsoleUrl = getBaseExtensionConsoleUrl(extensionId);
@@ -75,10 +83,13 @@ export class ActivateModPage {
     return this.page.getByRole("button", { name: "Activate" });
   }
 
-  /** Successfully activating the mod will navigate to the "All Mods" page */
-  async clickActivateAndNavigateToAllMods() {
+  /** Successfully activating the mod will navigate to the "All Mods" page. */
+  async clickActivateAndWaitForModsPageRedirect() {
     await this.activateButton().click();
     await this.page.waitForURL(`${this.baseConsoleUrl}#/mods`);
-    await expect(this.page.getByText("Installed ")).toBeVisible();
+    const modsPage = new ModsPage(this.page, this.extensionId);
+    await modsPage.viewActiveMods();
+    await expect(modsPage.modTableItems().getByText(this.modId)).toBeVisible();
+    return modsPage;
   }
 }

--- a/end-to-end-tests/pageObjects/modsPage.ts
+++ b/end-to-end-tests/pageObjects/modsPage.ts
@@ -48,3 +48,37 @@ export class ModsPage {
     return this.page.getByRole("table").locator(".list-group-item");
   }
 }
+
+export class ActivateModPage {
+  private readonly baseConsoleUrl: string;
+  private readonly activateModUrl: string;
+
+  constructor(
+    private readonly page: Page,
+    extensionId: string,
+    private readonly modId: string,
+  ) {
+    this.baseConsoleUrl = getBaseExtensionConsoleUrl(extensionId);
+    this.activateModUrl = `${
+      this.baseConsoleUrl
+    }#/marketplace/activate/${encodeURIComponent(modId)}`;
+  }
+
+  async goto() {
+    await this.page.goto(this.activateModUrl);
+
+    await expect(this.page.getByText("Activate Mod")).toBeVisible();
+    await expect(this.page.getByText(this.modId)).toBeVisible();
+  }
+
+  activateButton() {
+    return this.page.getByRole("button", { name: "Activate" });
+  }
+
+  /** Successfully activating the mod will navigate to the "All Mods" page */
+  async clickActivateAndNavigateToAllMods() {
+    await this.activateButton().click();
+    await this.page.waitForURL(`${this.baseConsoleUrl}#/mods`);
+    await expect(this.page.getByText("Installed ")).toBeVisible();
+  }
+}

--- a/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
+++ b/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
@@ -22,14 +22,12 @@ test("can activate and use highlight keywords mod", async ({
   page,
   extensionId,
 }) => {
-  const modName = "Highlight Specific Keywords When Page Loads";
   const modId = "@pixies/highlight-keywords";
 
   const modActivationPage = new ActivateModPage(page, extensionId, modId);
   await modActivationPage.goto();
-  await expect(page.getByText(modName)).toBeVisible();
 
-  await modActivationPage.clickActivateAndNavigateToAllMods();
+  await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
   await page.goto("/bootstrap-5");
 

--- a/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
+++ b/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import { test, expect } from "../fixtures/extensionBase";
+import { ActivateModPage } from "../pageObjects/modsPage";
 
 test("can activate and use highlight keywords mod", async ({
   page,
@@ -24,16 +25,11 @@ test("can activate and use highlight keywords mod", async ({
   const modName = "Highlight Specific Keywords When Page Loads";
   const modId = "@pixies/highlight-keywords";
 
-  await page.goto(
-    `chrome-extension://${extensionId}/options.html#/marketplace/activate/${encodeURIComponent(
-      modId,
-    )}`,
-  );
-
-  await expect(page.getByText("Activate Mod")).toBeVisible();
+  const modActivationPage = new ActivateModPage(page, extensionId, modId);
+  await modActivationPage.goto();
   await expect(page.getByText(modName)).toBeVisible();
-  await page.click("button:has-text('Activate')");
-  await expect(page.getByText(`Installed ${modName}`)).toBeVisible();
+
+  await modActivationPage.clickActivateAndNavigateToAllMods();
 
   await page.goto("/bootstrap-5");
 

--- a/end-to-end-tests/tests/modsPageSmoke.spec.ts
+++ b/end-to-end-tests/tests/modsPageSmoke.spec.ts
@@ -27,7 +27,7 @@ test.describe("extension console mods page smoke test", () => {
     const pageTitle = await page.title();
     expect(pageTitle).toBe("Mods | PixieBrix");
     await modsPage.viewAllMods();
-    const modTableItems = await modsPage.getAllModTableItems();
+    const modTableItems = modsPage.modTableItems();
     // There is at least one mod visible
     await expect(modTableItems.nth(0)).toBeVisible();
 


### PR DESCRIPTION
## What does this PR do?

A quick refactor of the activate mod e2e test that extracts the activate mod page logic into a re-usable page object
model.

## Checklist

- [ ] Add tests
- [ ] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer @mnholtz 
