### PR TITLE
#7855: add no matches state for text command popover

### DIFF
--- a/src/contentScript/commandPopover/CommandPopover.scss
+++ b/src/contentScript/commandPopover/CommandPopover.scss
@@ -37,6 +37,23 @@
   color: black;
 }
 
+.noResults {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  background-color: $N0;
+  justify-content: center;
+  text-align: center;
+  color: $D600;
+  font-size: 0.875em;
+
+  // Font Awesome stylesheet is not available in the Shadow DOM
+  svg {
+    width: 1.5em;
+    height: 1.5em;
+  }
+}
+
 .preview {
   color: $N400;
   overflow: hidden;

--- a/src/contentScript/commandPopover/CommandPopover.test.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import CommandPopover from "@/contentScript/commandPopover/CommandPopover";
+import CommandRegistry from "@/contentScript/commandPopover/CommandRegistry";
+import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
+
+// I couldn't get shadow-dom-testing-library working
+jest.mock("react-shadow/emotion", () => ({
+  __esModule: true,
+  default: {
+    div(props: any) {
+      return <div {...props}></div>;
+    },
+  },
+}));
+
+describe("Command Popover", () => {
+  it("renders search result", async () => {
+    const registry = new CommandRegistry();
+
+    registry.register({
+      componentId: autoUUIDSequence(),
+      title: "Test",
+      shortcut: "foo",
+      preview: "foobar",
+      handler: jest.fn(),
+    });
+
+    document.body.innerHTML = '<input type="text" value="\\f" id="input" />';
+
+    const element: HTMLInputElement = screen.getByRole("textbox");
+
+    render(
+      <CommandPopover
+        commandKey="\\"
+        registry={registry}
+        element={element}
+        onHide={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByText("We couldn't find any matching snippets"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("menuitem")).toBeInTheDocument();
+  });
+
+  it("renders no matches message for empty state", async () => {
+    const registry = new CommandRegistry();
+    document.body.innerHTML = '<input type="text" value="\\" id="input" />';
+
+    const element: HTMLInputElement = screen.getByRole("textbox");
+
+    render(
+      <CommandPopover
+        commandKey="\\"
+        registry={registry}
+        element={element}
+        onHide={jest.fn()}
+      />,
+    );
+
+    await expect(
+      screen.findByText("We couldn't find any matching snippets"),
+    ).resolves.toBeInTheDocument();
+  });
+});

--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -47,7 +47,11 @@ import {
 } from "@/contentScript/commandPopover/commandUtils";
 import type { TextCommand } from "@/platform/platformTypes/commandPopoverProtocol";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCaretDown, faCaretUp } from "@fortawesome/free-solid-svg-icons";
+import {
+  faCaretDown,
+  faCaretUp,
+  faExclamationCircle,
+} from "@fortawesome/free-solid-svg-icons";
 
 type PopoverActionCallbacks = {
   onHide: () => void;
@@ -126,18 +130,22 @@ const StatusBar: React.FunctionComponent<{
     );
   }
 
-  if (results.length === 0) {
-    return (
-      <div role="status" className="status status--empty">
-        No matches found
-      </div>
-    );
-  }
-
   return null;
 };
 
-const PopoverFooter: React.ReactElement = (
+const noResultsPane: React.ReactElement = (
+  <div className="noResults">
+    <div>
+      <div>
+        <FontAwesomeIcon icon={faExclamationCircle} />
+      </div>
+      <div>{"We couldn't find any matching snippets"}</div>
+    </div>
+  </div>
+);
+
+
+const popoverFooter: React.ReactElement = (
   // TODO: determine a11y: https://github.com/pixiebrix/pixiebrix-extension/issues/7936
   <div className="footer">
     Navigate{" "}
@@ -220,6 +228,8 @@ const CommandPopover: React.FunctionComponent<
         <div role="menu" aria-label="Text command menu" className="root">
           <StatusBar {...state} />
           <div className="results">
+            {state.results.length === 0 && noResultsPane}
+
             {state.results.map((command) => {
               const isSelected = selectedCommand?.shortcut === command.shortcut;
               return (
@@ -237,7 +247,7 @@ const CommandPopover: React.FunctionComponent<
               );
             })}
           </div>
-          {PopoverFooter}
+          {popoverFooter}
         </div>
       </Stylesheets>
     </EmotionShadowRoot>

--- a/src/themes/colors.scss
+++ b/src/themes/colors.scss
@@ -60,6 +60,9 @@ $W30: #ffc754;
 $W60: #e89c00;
 $W70: #b57900;
 
+// Danger
+$D600: #b4183f;
+
 /*
 * Misc Tokens
 *

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -291,6 +291,7 @@
     "./contentScript/activationConstants.ts",
     "./contentScript/browserActionInstantHandler.ts",
     "./contentScript/commandPopover/CommandPopover.stories.tsx",
+    "./contentScript/commandPopover/CommandPopover.test.tsx",
     "./contentScript/commandPopover/CommandPopover.tsx",
     "./contentScript/commandPopover/CommandRegistry.ts",
     "./contentScript/commandPopover/commandController.tsx",


### PR DESCRIPTION
## What does this PR do?

- Closes: #7855

## Discussion

- @BrandonPxBx is a red a little harsh for a no results state vs. an error?
- @BrandonPxBx see the icon - our FA5 pack only has the solid/filled version. Seems OK?

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/43d066cc-15da-417c-b3b3-8931be87c992)

## Future Work

- CSS/styling: will adjust font family size  in a PR for: https://github.com/pixiebrix/pixiebrix-extension/issues/7856 to work out the consistent styles. Just trying to get the main affordances in first

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @fungairino 
