### PR TITLE
#7956: only route google sheets API calls through the background worker (1/3)

### DIFF
--- a/src/__mocks__/@/background/messenger/api.ts
+++ b/src/__mocks__/@/background/messenger/api.ts
@@ -31,17 +31,6 @@ export const pong = jest.fn(() => ({
 }));
 
 export const clearServiceCache = jest.fn();
-export const sheets = {
-  isLoggedIn: jest.fn().mockRejectedValue(new Error("Not implemented")),
-  getAllSpreadsheets: jest.fn().mockRejectedValue(new Error("Not implemented")),
-  getSpreadsheet: jest.fn().mockRejectedValue(new Error("Not implemented")),
-  getTabNames: jest.fn().mockRejectedValue(new Error("Not implemented")),
-  getSheetProperties: jest.fn().mockRejectedValue(new Error("Not implemented")),
-  getHeaders: jest.fn().mockRejectedValue(new Error("Not implemented")),
-  getAllRows: jest.fn().mockRejectedValue(new Error("Not implemented")),
-  createTab: getMethod("GOOGLE_SHEETS_CREATE_TAB", bg),
-  appendRows: getMethod("GOOGLE_SHEETS_APPEND_ROWS", bg),
-};
 
 export const dataStore = {
   get: jest.fn().mockRejectedValue(new Error("Not implemented in mock")),

--- a/src/background/messenger/api.ts
+++ b/src/background/messenger/api.ts
@@ -43,17 +43,6 @@ export const removeExtensionForEveryTab = getNotifier(
 export const closeTab = getMethod("CLOSE_TAB", bg);
 export const clearServiceCache = getMethod("CLEAR_SERVICE_CACHE", bg);
 
-export const sheets = {
-  isLoggedIn: getMethod("GOOGLE_DRIVE_IS_LOGGED_IN", bg),
-  getUserEmail: getMethod("GOOGLE_DRIVE_GET_USER_EMAIL", bg),
-  getAllSpreadsheets: getMethod("GOOGLE_SHEETS_GET_ALL_SPREADSHEETS", bg),
-  getSpreadsheet: getMethod("GOOGLE_SHEETS_GET_SPREADSHEET", bg),
-  getHeaders: getMethod("GOOGLE_SHEETS_GET_HEADERS", bg),
-  getAllRows: getMethod("GOOGLE_SHEETS_GET_ALL_ROWS", bg),
-  createTab: getMethod("GOOGLE_SHEETS_CREATE_TAB", bg),
-  appendRows: getMethod("GOOGLE_SHEETS_APPEND_ROWS", bg),
-};
-
 /**
  * Uninstall context menu and return whether the context menu was uninstalled.
  */

--- a/src/background/messenger/registration.ts
+++ b/src/background/messenger/registration.ts
@@ -18,7 +18,6 @@
 /* Do not use `getMethod` in this file; Keep only registrations here, not implementations */
 import { registerMethods } from "webext-messenger";
 import { expectContext } from "@/utils/expectContext";
-import * as sheets from "@/contrib/google/sheets/core/sheetsApi"; // Background/messenger import
 import {
   ensureContextMenu,
   preloadContextMenus,
@@ -56,16 +55,6 @@ expectContext("background");
 
 declare global {
   interface MessengerMethods {
-    GOOGLE_DRIVE_IS_LOGGED_IN: typeof sheets.isLoggedIn;
-    GOOGLE_DRIVE_GET_USER_EMAIL: typeof sheets.getGoogleUserEmail;
-
-    GOOGLE_SHEETS_GET_ALL_SPREADSHEETS: typeof sheets.getAllSpreadsheets;
-    GOOGLE_SHEETS_GET_SPREADSHEET: typeof sheets.getSpreadsheet;
-    GOOGLE_SHEETS_GET_HEADERS: typeof sheets.getHeaders;
-    GOOGLE_SHEETS_GET_ALL_ROWS: typeof sheets.getAllRows;
-    GOOGLE_SHEETS_CREATE_TAB: typeof sheets.createTab;
-    GOOGLE_SHEETS_APPEND_ROWS: typeof sheets.appendRows;
-
     GET_AVAILABLE_VERSION: typeof getAvailableVersion;
     PRELOAD_CONTEXT_MENUS: typeof preloadContextMenus;
     UNINSTALL_CONTEXT_MENU: typeof uninstallContextMenu;
@@ -101,16 +90,6 @@ declare global {
 
 export default function registerMessenger(): void {
   registerMethods({
-    GOOGLE_DRIVE_IS_LOGGED_IN: sheets.isLoggedIn,
-    GOOGLE_DRIVE_GET_USER_EMAIL: sheets.getGoogleUserEmail,
-
-    GOOGLE_SHEETS_GET_ALL_SPREADSHEETS: sheets.getAllSpreadsheets,
-    GOOGLE_SHEETS_GET_SPREADSHEET: sheets.getSpreadsheet,
-    GOOGLE_SHEETS_GET_HEADERS: sheets.getHeaders,
-    GOOGLE_SHEETS_GET_ALL_ROWS: sheets.getAllRows,
-    GOOGLE_SHEETS_CREATE_TAB: sheets.createTab,
-    GOOGLE_SHEETS_APPEND_ROWS: sheets.appendRows,
-
     GET_PARTNER_PRINCIPALS: getPartnerPrincipals,
     LAUNCH_AUTH_INTEGRATION: launchAuthIntegration,
     SET_PARTNER_COPILOT_DATA: setCopilotProcessData,

--- a/src/background/messenger/strict/api.ts
+++ b/src/background/messenger/strict/api.ts
@@ -41,6 +41,9 @@ export const traces = {
 export const captureTab = getMethod("CAPTURE_TAB", bg);
 export const deleteCachedAuthData = getMethod("DELETE_CACHED_AUTH", bg);
 export const getCachedAuthData = getMethod("GET_CACHED_AUTH", bg);
+
+export const hasCachedAuthData = getMethod("HAS_CACHED_AUTH", bg);
+
 export const setToolbarBadge = getMethod("SET_TOOLBAR_BADGE", bg);
 export const documentReceivedFocus = getNotifier("DOCUMENT_RECEIVED_FOCUS", bg);
 

--- a/src/background/messenger/strict/registration.ts
+++ b/src/background/messenger/strict/registration.ts
@@ -33,6 +33,7 @@ import { captureTab } from "@/background/capture";
 import {
   deleteCachedAuthData,
   getCachedAuthData,
+  hasCachedAuthData,
 } from "@/background/auth/authStorage";
 import { setToolbarBadge } from "@/background/toolbarBadge";
 import { rememberFocus } from "@/utils/focusTracker";
@@ -66,6 +67,7 @@ declare global {
     CAPTURE_TAB: typeof captureTab;
     DELETE_CACHED_AUTH: typeof deleteCachedAuthData;
     GET_CACHED_AUTH: typeof getCachedAuthData;
+    HAS_CACHED_AUTH: typeof hasCachedAuthData;
     SET_TOOLBAR_BADGE: typeof setToolbarBadge;
     DOCUMENT_RECEIVED_FOCUS: typeof rememberFocus;
     WRITE_TO_CLIPBOARD_IN_FOCUSED_DOCUMENT: typeof writeToClipboardInFocusedContext;
@@ -105,6 +107,7 @@ export default function registerMessenger(): void {
     CAPTURE_TAB: captureTab,
     DELETE_CACHED_AUTH: deleteCachedAuthData,
     GET_CACHED_AUTH: getCachedAuthData,
+    HAS_CACHED_AUTH: hasCachedAuthData,
     SET_TOOLBAR_BADGE: setToolbarBadge,
     DOCUMENT_RECEIVED_FOCUS: rememberFocus,
     WRITE_TO_CLIPBOARD_IN_FOCUSED_DOCUMENT: writeToClipboardInFocusedContext,

--- a/src/contrib/google/sheets/bricks/append.test.ts
+++ b/src/contrib/google/sheets/bricks/append.test.ts
@@ -26,7 +26,7 @@ import {
   type RowValues,
   type Shape,
 } from "@/contrib/google/sheets/bricks/append";
-import { sheets } from "@/background/messenger/api";
+import * as sheets from "@/contrib/google/sheets/core/sheetsApi";
 import { sanitizedIntegrationConfigFactory } from "@/testUtils/factories/integrationFactories";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -35,6 +35,9 @@ import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import type { SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
 import type { Spreadsheet } from "@/contrib/google/sheets/core/types";
 import { produce } from "immer";
+
+// XXX: sheetsApi should likely be mocked at the network level, not the module level
+jest.mock("@/contrib/google/sheets/core/sheetsApi");
 
 describe("Infer shape", () => {
   it("Infer entries shape", () => {

--- a/src/contrib/google/sheets/bricks/append.ts
+++ b/src/contrib/google/sheets/bricks/append.ts
@@ -18,7 +18,7 @@
 import { isEmpty, isEqual, unary, uniq } from "lodash";
 import { validateRegistryId } from "@/types/helpers";
 import { normalizeHeader } from "@/contrib/google/sheets/core/sheetsHelpers";
-import { sheets } from "@/background/messenger/api";
+import * as sheets from "@/contrib/google/sheets/core/sheetsApi";
 import { BusinessError, PropError } from "@/errors/businessErrors";
 import {
   GOOGLE_OAUTH2_PKCE_INTEGRATION_ID,

--- a/src/contrib/google/sheets/bricks/lookup.test.ts
+++ b/src/contrib/google/sheets/bricks/lookup.test.ts
@@ -15,11 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { sheets } from "@/background/messenger/api";
+import * as sheets from "@/contrib/google/sheets/core/sheetsApi";
 import { GoogleSheetsLookup } from "@/contrib/google/sheets/bricks/lookup";
 import { type ValueRange } from "@/contrib/google/sheets/core/types";
 import { BusinessError, PropError } from "@/errors/businessErrors";
 import { sanitizedIntegrationConfigFactory } from "@/testUtils/factories/integrationFactories";
+
+// XXX: sheetsApi should likely be mocked at the network level, not the module level
+jest.mock("@/contrib/google/sheets/core/sheetsApi");
 
 const getAllRowsMock = jest.mocked(sheets.getAllRows);
 

--- a/src/contrib/google/sheets/bricks/lookup.ts
+++ b/src/contrib/google/sheets/bricks/lookup.ts
@@ -16,7 +16,6 @@
  */
 
 import { validateRegistryId } from "@/types/helpers";
-import { sheets } from "@/background/messenger/api";
 import { zip } from "lodash";
 import { BusinessError, PropError } from "@/errors/businessErrors";
 import {
@@ -27,7 +26,10 @@ import { type Schema } from "@/types/schemaTypes";
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { type SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
-import { type SpreadsheetTarget } from "@/contrib/google/sheets/core/sheetsApi";
+import {
+  getAllRows,
+  type SpreadsheetTarget,
+} from "@/contrib/google/sheets/core/sheetsApi";
 import { isNullOrBlank } from "@/utils/stringUtils";
 import { SERVICES_BASE_SCHEMA_URL } from "@/integrations/util/makeServiceContextFromDependencies";
 
@@ -172,7 +174,7 @@ export class GoogleSheetsLookup extends TransformerABC {
       spreadsheetId,
       tabName,
     };
-    const valueRange = await sheets.getAllRows(target);
+    const valueRange = await getAllRows(target);
     const [headers, ...rows] = valueRange?.values ?? [[], []];
 
     logger.debug(`Tab ${tabName} has headers`, { headers });

--- a/src/contrib/google/sheets/core/sheetsApi.ts
+++ b/src/contrib/google/sheets/core/sheetsApi.ts
@@ -18,8 +18,6 @@
 import { columnToLetter } from "@/contrib/google/sheets/core/sheetsHelpers";
 import { type SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
 import { type AxiosRequestConfig } from "axios";
-import { getCachedAuthData } from "@/background/messenger/strict/api";
-import { isEmpty } from "lodash";
 import { handleGoogleRequestRejection } from "@/contrib/google/sheets/core/handleGoogleRequestRejection";
 import {
   type AppendValuesResponse,
@@ -41,13 +39,6 @@ export type SpreadsheetTarget = {
   spreadsheetId: string;
   tabName?: string;
 };
-
-export async function isLoggedIn(
-  googleAccount: SanitizedIntegrationConfig,
-): Promise<boolean> {
-  const authData = await getCachedAuthData(googleAccount.id);
-  return !isEmpty(authData);
-}
 
 async function executeRequest<Response, RequestData = never>(
   requestConfig: AxiosRequestConfig<RequestData>,

--- a/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.test.tsx
@@ -28,8 +28,7 @@ import { getToggleOptions } from "@/components/fields/schemaFields/getToggleOpti
 import SpreadsheetPickerWidget from "@/contrib/google/sheets/ui/SpreadsheetPickerWidget";
 import { render } from "@/pageEditor/testHelpers";
 import { validateRegistryId } from "@/types/helpers";
-import { sheets } from "@/background/messenger/api";
-import { services } from "@/background/messenger/strict/api";
+import { hasCachedAuthData, services } from "@/background/messenger/strict/api";
 import {
   integrationDependencyFactory,
   sanitizedIntegrationConfigFactory,
@@ -38,7 +37,12 @@ import {
   type FileList,
   type Spreadsheet,
 } from "@/contrib/google/sheets/core/types";
-import { type SpreadsheetTarget } from "@/contrib/google/sheets/core/sheetsApi";
+import {
+  getAllSpreadsheets,
+  getHeaders,
+  getSpreadsheet,
+  type SpreadsheetTarget,
+} from "@/contrib/google/sheets/core/sheetsApi";
 import { useAuthOptions } from "@/hooks/auth";
 import { valueToAsyncState } from "@/utils/asyncStateUtils";
 import { type AuthOption } from "@/auth/authTypes";
@@ -53,13 +57,16 @@ import {
 } from "@/contrib/google/sheets/core/schemas";
 import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 
+// XXX: sheetsApi should likely be mocked at the network level, not the module level
+jest.mock("@/contrib/google/sheets/core/sheetsApi");
+
 jest.mock("@/hooks/auth");
 const servicesLocateMock = jest.mocked(services.locate);
 const useAuthOptionsMock = jest.mocked(useAuthOptions);
-const isLoggedInMock = jest.mocked(sheets.isLoggedIn);
-const getAllSpreadsheetsMock = jest.mocked(sheets.getAllSpreadsheets);
-const getSpreadsheetMock = jest.mocked(sheets.getSpreadsheet);
-const getHeadersMock = jest.mocked(sheets.getHeaders);
+const isLoggedInMock = jest.mocked(hasCachedAuthData);
+const getAllSpreadsheetsMock = jest.mocked(getAllSpreadsheets);
+const getSpreadsheetMock = jest.mocked(getSpreadsheet);
+const getHeadersMock = jest.mocked(getHeaders);
 
 const TEST_SPREADSHEET_ID = autoUUIDSequence();
 const OTHER_TEST_SPREADSHEET_ID = autoUUIDSequence();

--- a/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/ui/AppendSpreadsheetOptions.tsx
@@ -29,10 +29,10 @@ import { isExpression } from "@/utils/expressionUtils";
 import RequireGoogleSheet from "@/contrib/google/sheets/ui/RequireGoogleSheet";
 import { type SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
 import useAsyncEffect from "use-async-effect";
-import { sheets } from "@/background/messenger/api";
 import hash from "object-hash";
 import { isNullOrBlank } from "@/utils/stringUtils";
 import { joinName } from "@/utils/formUtils";
+import { getHeaders } from "@/contrib/google/sheets/core/sheetsApi";
 
 function headerFieldSchemaForHeaders(headers: string[]): Schema {
   const headerProperties: Record<string, Schema> = Object.fromEntries(
@@ -74,7 +74,7 @@ const RowValuesField: React.FunctionComponent<{
         return;
       }
 
-      const headers = await sheets.getHeaders({
+      const headers = await getHeaders({
         googleAccount,
         spreadsheetId,
         tabName: isExpression(tabName) ? tabName.__value__ : tabName,

--- a/src/contrib/google/sheets/ui/LookupSpreadsheetOptions.test.tsx
+++ b/src/contrib/google/sheets/ui/LookupSpreadsheetOptions.test.tsx
@@ -23,8 +23,7 @@ import { act, screen } from "@testing-library/react";
 import { validateRegistryId } from "@/types/helpers";
 import selectEvent from "react-select-event";
 import { render } from "@/pageEditor/testHelpers";
-import { sheets } from "@/background/messenger/api";
-import { services } from "@/background/messenger/strict/api";
+import { services, hasCachedAuthData } from "@/background/messenger/strict/api";
 import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 import {
   integrationDependencyFactory,
@@ -41,17 +40,24 @@ import { valueToAsyncState } from "@/utils/asyncStateUtils";
 import { type FormikValues } from "formik";
 import IntegrationsSliceModIntegrationsContextAdapter from "@/integrations/store/IntegrationsSliceModIntegrationsContextAdapter";
 import { toExpression } from "@/utils/expressionUtils";
+import {
+  getAllSpreadsheets,
+  getHeaders,
+  getSpreadsheet,
+} from "@/contrib/google/sheets/core/sheetsApi";
 
 const servicesLocateMock = jest.mocked(services.locate);
 
+// XXX: sheetsApi should likely be mocked at the network level, not the module level
+jest.mock("@/contrib/google/sheets/core/sheetsApi");
 jest.mock("@/hooks/auth");
 
 const useAuthOptionsMock = jest.mocked(useAuthOptions);
 
-const isLoggedInMock = jest.mocked(sheets.isLoggedIn);
-const getAllSpreadsheetsMock = jest.mocked(sheets.getAllSpreadsheets);
-const getSpreadsheetMock = jest.mocked(sheets.getSpreadsheet);
-const getHeadersMock = jest.mocked(sheets.getHeaders);
+const isLoggedInMock = jest.mocked(hasCachedAuthData);
+const getAllSpreadsheetsMock = jest.mocked(getAllSpreadsheets);
+const getSpreadsheetMock = jest.mocked(getSpreadsheet);
+const getHeadersMock = jest.mocked(getHeaders);
 
 const TEST_SPREADSHEET_ID = autoUUIDSequence();
 const GOOGLE_SHEET_SERVICE_ID = validateRegistryId("google/sheet");

--- a/src/contrib/google/sheets/ui/LookupSpreadsheetOptions.tsx
+++ b/src/contrib/google/sheets/ui/LookupSpreadsheetOptions.tsx
@@ -28,10 +28,10 @@ import { FormErrorContext } from "@/components/form/FormErrorContext";
 import { isExpression, toExpression } from "@/utils/expressionUtils";
 import RequireGoogleSheet from "@/contrib/google/sheets/ui/RequireGoogleSheet";
 import { type SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
-import { sheets } from "@/background/messenger/api";
 import useAsyncEffect from "use-async-effect";
 import hash from "object-hash";
 import { joinName } from "@/utils/formUtils";
+import { getHeaders } from "@/contrib/google/sheets/core/sheetsApi";
 
 function headerFieldSchemaForHeaders(headers: string[]): Schema {
   return {
@@ -63,7 +63,7 @@ const HeaderField: React.FunctionComponent<{
         return;
       }
 
-      const headers = await sheets.getHeaders({
+      const headers = await getHeaders({
         googleAccount,
         spreadsheetId,
         tabName: isExpression(tabName) ? tabName.__value__ : tabName,

--- a/src/contrib/google/sheets/ui/RequireGoogleSheet.tsx
+++ b/src/contrib/google/sheets/ui/RequireGoogleSheet.tsx
@@ -27,7 +27,6 @@ import useGoogleAccount from "@/contrib/google/sheets/core/useGoogleAccount";
 import useSpreadsheetId from "@/contrib/google/sheets/core/useSpreadsheetId";
 import useDeriveAsyncState from "@/hooks/useDeriveAsyncState";
 import { type SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
-import { sheets } from "@/background/messenger/api";
 import { type AsyncState } from "@/types/sliceTypes";
 import AsyncStateGate from "@/components/AsyncStateGate";
 import { type Except } from "type-fest";
@@ -39,6 +38,8 @@ import { AnnotationType } from "@/types/annotationTypes";
 import FieldAnnotationAlert from "@/components/annotationAlert/FieldAnnotationAlert";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { SHEET_FIELD_SCHEMA } from "@/contrib/google/sheets/core/schemas";
+import { getSpreadsheet } from "@/contrib/google/sheets/core/sheetsApi";
+import { hasCachedAuthData } from "@/background/messenger/strict/api";
 
 type GoogleSheetState = {
   googleAccount: SanitizedIntegrationConfig | null;
@@ -105,10 +106,10 @@ const RequireGoogleSheet: React.FC<{
         };
       }
 
-      if (await sheets.isLoggedIn(googleAccount)) {
+      if (await hasCachedAuthData(googleAccount.id)) {
         try {
           // Sheets API will handle legacy authentication when googleAccount is null
-          const spreadsheet = await sheets.getSpreadsheet({
+          const spreadsheet = await getSpreadsheet({
             googleAccount,
             spreadsheetId,
           });

--- a/src/contrib/google/sheets/ui/SpreadsheetPickerWidget.test.tsx
+++ b/src/contrib/google/sheets/ui/SpreadsheetPickerWidget.test.tsx
@@ -18,7 +18,6 @@
 import { render } from "@/pageEditor/testHelpers";
 import React from "react";
 import SpreadsheetPickerWidget from "@/contrib/google/sheets/ui/SpreadsheetPickerWidget";
-import { sheets } from "@/background/messenger/api";
 import { services } from "@/background/messenger/strict/api";
 import { validateRegistryId } from "@/types/helpers";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -35,8 +34,12 @@ import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/reg
 import IntegrationsSliceModIntegrationsContextAdapter from "@/integrations/store/IntegrationsSliceModIntegrationsContextAdapter";
 import selectEvent from "react-select-event";
 import { SHEET_FIELD_SCHEMA } from "@/contrib/google/sheets/core/schemas";
+import { getAllSpreadsheets } from "@/contrib/google/sheets/core/sheetsApi";
 
-const getAllSpreadsheetsMock = jest.mocked(sheets.getAllSpreadsheets);
+// XXX: sheetsApi should likely be mocked at the network level, not the module level
+jest.mock("@/contrib/google/sheets/core/sheetsApi");
+
+const getAllSpreadsheetsMock = jest.mocked(getAllSpreadsheets);
 
 let idSequence = 0;
 function newId(): UUID {

--- a/src/contrib/google/sheets/ui/SpreadsheetPickerWidget.tsx
+++ b/src/contrib/google/sheets/ui/SpreadsheetPickerWidget.tsx
@@ -16,7 +16,6 @@
  */
 
 import React, { useCallback, useState } from "react";
-import { sheets } from "@/background/messenger/api";
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import useGoogleAccount from "@/contrib/google/sheets/core/useGoogleAccount";
 import { type SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
@@ -37,6 +36,7 @@ import { useField } from "formik";
 import { type Expression } from "@/types/runtimeTypes";
 import { isExpression } from "@/utils/expressionUtils";
 import "./SpreadsheetPickerWidget.module.scss";
+import { getAllSpreadsheets } from "@/contrib/google/sheets/core/sheetsApi";
 
 const SpreadsheetPickerWidget: React.FC<SchemaFieldProps> = (props) => {
   const { name, schema: baseSchema } = props;
@@ -67,8 +67,7 @@ const SpreadsheetPickerWidget: React.FC<SchemaFieldProps> = (props) => {
           return baseSchema;
         }
 
-        const spreadsheetFileList =
-          await sheets.getAllSpreadsheets(googleAccount);
+        const spreadsheetFileList = await getAllSpreadsheets(googleAccount);
 
         if (isEmpty(spreadsheetFileList.files)) {
           return baseSchema;

--- a/src/extensionPages/extensionPagePlatform.ts
+++ b/src/extensionPages/extensionPagePlatform.ts
@@ -100,7 +100,7 @@ class ExtensionPagePlatform extends PlatformBase {
       integrationConfig.serviceId,
     );
 
-    // Use the background messenger to perform 3rd party API that may require refreshing credentials so that
+    // Use the background messenger to perform 3rd party API calls that may require refreshing credentials so that
     // the background worker can memoize the refresh calls and calls to launch the web auth flow
     if (integration.isToken || integration.isOAuth2) {
       return performConfiguredRequestInBackground(

--- a/src/extensionPages/extensionPagePlatform.ts
+++ b/src/extensionPages/extensionPagePlatform.ts
@@ -26,6 +26,13 @@ import {
   clearExtensionDebugLogs,
 } from "@/background/messenger/strict/api";
 import { PlatformBase } from "@/platform/platformBase";
+import type { Nullishable } from "@/utils/nullishUtils";
+import type { SanitizedIntegrationConfig } from "@/integrations/integrationTypes";
+import type { AxiosRequestConfig } from "axios";
+import type { RemoteResponse } from "@/types/contract";
+import { performConfiguredRequestInBackground } from "@/background/messenger/api";
+import integrationRegistry from "@/integrations/registry";
+import { performConfiguredRequest } from "@/background/requests";
 
 /**
  * The extension page platform.
@@ -41,6 +48,7 @@ class ExtensionPagePlatform extends PlatformBase {
     "toast",
     "logs",
     "debugger",
+    "http",
   ];
 
   private readonly _logger = new BackgroundLogger({
@@ -82,6 +90,26 @@ class ExtensionPagePlatform extends PlatformBase {
       showNotification,
       hideNotification,
     };
+  }
+
+  override async request<TData>(
+    integrationConfig: Nullishable<SanitizedIntegrationConfig>,
+    requestConfig: AxiosRequestConfig,
+  ): Promise<RemoteResponse<TData>> {
+    const integration = await integrationRegistry.lookup(
+      integrationConfig.serviceId,
+    );
+
+    // Use the background messenger to perform 3rd party API that may require refreshing credentials so that
+    // the background worker can memoize the refresh calls and calls to launch the web auth flow
+    if (integration.isToken || integration.isOAuth2) {
+      return performConfiguredRequestInBackground(
+        integrationConfig,
+        requestConfig,
+      );
+    }
+
+    return performConfiguredRequest(integrationConfig, requestConfig);
   }
 }
 

--- a/src/integrations/autoConfigure.ts
+++ b/src/integrations/autoConfigure.ts
@@ -23,8 +23,8 @@ import { type UUID } from "@/types/stringTypes";
 import { uuidv4 } from "@/types/helpers";
 import { type RegistryId } from "@/types/registryTypes";
 import { GOOGLE_OAUTH2_PKCE_INTEGRATION_ID } from "@/contrib/google/sheets/core/schemas";
-import { sheets } from "@/background/messenger/api";
 import { services } from "@/background/messenger/strict/api";
+import { getGoogleUserEmail } from "@/contrib/google/sheets/core/sheetsApi";
 
 /**
  * A function to automatically configure an integration config. If null is returned, the config will be deleted instead.
@@ -42,7 +42,7 @@ export const autoConfigurations: Record<
       config.id,
     );
     try {
-      const userEmail = await sheets.getUserEmail(googleAccount);
+      const userEmail = await getGoogleUserEmail(googleAccount);
       return {
         ...config,
         label: userEmail,

--- a/src/pageEditor/tabs/modOptionsValues/ModOptionsValuesEditor.test.tsx
+++ b/src/pageEditor/tabs/modOptionsValues/ModOptionsValuesEditor.test.tsx
@@ -38,9 +38,12 @@ import { sanitizedIntegrationConfigFactory } from "@/testUtils/factories/integra
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { validateRegistryId } from "@/types/helpers";
 import useGoogleAccount from "@/contrib/google/sheets/core/useGoogleAccount";
-import { sheets } from "@/background/messenger/api";
+import { getAllSpreadsheets } from "@/contrib/google/sheets/core/sheetsApi";
 
 jest.mock("@/modDefinitions/modDefinitionHooks");
+
+// XXX: sheetsApi should likely be mocked at the network level, not the module level
+jest.mock("@/contrib/google/sheets/core/sheetsApi");
 
 jest.mock("@/hooks/useFlags", () => ({
   __esModule: true,
@@ -53,7 +56,7 @@ jest.mock("@/contrib/google/sheets/core/useGoogleAccount");
 
 const useGoogleAccountMock = jest.mocked(useGoogleAccount);
 
-const getAllSpreadsheetsMock = jest.mocked(sheets.getAllSpreadsheets);
+const getAllSpreadsheetsMock = jest.mocked(getAllSpreadsheets);
 
 function mockModDefinition(modDefinition: ModDefinition): void {
   jest

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -420,7 +420,6 @@
     "./extensionConsole/pages/workshop/workshopUtils.ts",
     "./extensionConsole/toggleSidebar.tsx",
     "./extensionContext.ts",
-    "./extensionPages/extensionPagePlatform.ts",
     "./globals.d.ts",
     "./hooks/logging.ts",
     "./hooks/useAsyncExternalStore.ts",


### PR DESCRIPTION
## What does this PR do?

- Pre-req for https://github.com/pixiebrix/pixiebrix-extension/pull/7958 - without this PR the API calls are made via the background platform, not the content script platform
- Implements `request` in the ExtensionPagePlatform for Google Sheets calls made from the sidebar/page editor
- Removes the Google Sheets methods from the background API. We had previously use gapi in the background, but now that we're making normal API calls, there's no reason make the whole function call via background worker vs. just the API call
- Refactor the isLoggedIn check to `hasCachedAuthData` to the more generic check given that it works for any token-based authentication. (The name is also more accurate, given that the token may be expired)

## Reviewer Tips

- Review `ExtensionPagePlatform`
- The rest of the changes are just adjusting imports so the function calls don't go through the background worker (but the API calls will via the `getPlatform().request` call)

## Remaining Work

- [x] Fix Google Sheets test mocking

## Future Work

- Rewrite Google Sheets tests to mock at the network level instead of the API wrapper module level

## Checklist

- [x] Add tests: N/A
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer
