### PR TITLE
#7963: fix brick input validation for integrations with required properties

### DIFF
--- a/src/runtime/pipelineTests/validateInput.test.ts
+++ b/src/runtime/pipelineTests/validateInput.test.ts
@@ -31,16 +31,69 @@ import { BrickABC } from "@/types/brickTypes";
 import { validateRegistryId } from "@/types/helpers";
 import integrationRegistry from "@/integrations/registry";
 import { fromJS } from "@/integrations/UserDefinedIntegration";
-import { keyAuthIntegrationDefinitionFactory } from "@/testUtils/factories/integrationFactories";
+import {
+  keyAuthIntegrationDefinitionFactory,
+  sanitizedIntegrationConfigFactory,
+} from "@/testUtils/factories/integrationFactories";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
 import { ContextError } from "@/errors/genericErrors";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
+import makeServiceContextFromDependencies from "@/integrations/util/makeServiceContextFromDependencies";
+import type {
+  SanitizedConfig,
+  SanitizedIntegrationConfig,
+} from "@/integrations/integrationTypes";
+import { toExpression } from "@/utils/expressionUtils";
+import { services } from "@/background/messenger/strict/api";
+import apiVersionOptions from "@/runtime/apiVersionOptions";
+
+const locateMock = jest.mocked(services.locate);
 
 beforeEach(() => {
   integrationRegistry.clear();
   brickRegistry.clear();
   brickRegistry.register([echoBrick, contextBrick]);
+});
+
+class IntegrationBrick extends BrickABC {
+  static BRICK_ID = validateRegistryId("test/integration");
+  constructor() {
+    super(IntegrationBrick.BRICK_ID, "Integration Brick");
+  }
+
+  inputSchema = propertiesToSchema(
+    {
+      config: {
+        $ref: "https://app.pixiebrix.com/schemas/services/@scope/collection/name",
+      },
+    },
+    ["config"],
+  );
+
+  async run(args: unknown) {
+    return args;
+  }
+}
+
+const integrationDefinition = keyAuthIntegrationDefinitionFactory({
+  metadata: metadataFactory({
+    id: validateRegistryId("@scope/collection/name"),
+  }),
+  inputSchema: {
+    $schema: "https://json-schema.org/draft/2019-09/schema#",
+    type: "object",
+    properties: {
+      apiKey: {
+        $ref: "https://app.pixiebrix.com/schemas/key#",
+        title: "API Key",
+      },
+      baseURL: {
+        type: "string",
+      },
+    },
+    required: ["apiKey", "baseURL"],
+  },
 });
 
 describe("apiVersion: v1", () => {
@@ -127,61 +180,55 @@ describe.each([["v2"], ["v3"]])("apiVersion: %s", (apiVersion: ApiVersion) => {
     });
   });
 
-  test("validate integration configuration", async () => {
-    class IntegrationBrick extends BrickABC {
-      static BRICK_ID = validateRegistryId("test/integration");
-      constructor() {
-        super(IntegrationBrick.BRICK_ID, "Integration Brick");
-      }
-
-      inputSchema = propertiesToSchema(
-        {
-          config: {
-            $ref: "https://app.pixiebrix.com/schemas/services/@scope/collection/name",
-          },
-        },
-        ["config"],
-      );
-
-      async run() {}
-    }
-
-    const integrationDefinition = keyAuthIntegrationDefinitionFactory({
-      metadata: metadataFactory({
-        id: validateRegistryId("@scope/collection/name"),
-      }),
-      inputSchema: {
-        $schema: "https://json-schema.org/draft/2019-09/schema#",
-        type: "object",
-        properties: {
-          apiKey: {
-            $ref: "https://app.pixiebrix.com/schemas/key#",
-            title: "API Key",
-          },
-          baseURL: {
-            type: "string",
-          },
-        },
-        required: ["apiKey", "baseURL"],
-      },
-    });
+  async function testConfig(
+    config: SanitizedIntegrationConfig,
+    apiVersion: ApiVersion,
+  ) {
+    locateMock.mockResolvedValue(config);
 
     integrationRegistry.register([fromJS(integrationDefinition)]);
     brickRegistry.register([new IntegrationBrick()]);
+
+    const serviceContext = await makeServiceContextFromDependencies([
+      {
+        integrationId: integrationDefinition.metadata.id,
+        configId: config.id,
+        outputKey: validateOutputKey("foo"),
+      },
+    ]);
 
     const pipeline = [
       {
         id: IntegrationBrick.BRICK_ID,
         config: {
-          config: {},
+          config: apiVersionOptions(apiVersion).explicitRender
+            ? toExpression("var", "@foo")
+            : "@foo",
         },
       },
     ];
 
+    return reducePipeline(
+      pipeline,
+      {
+        ...simpleInput({}),
+        serviceContext,
+      },
+      testOptions(apiVersion),
+    );
+  }
+
+  test("rejects invalid integration configuration", async () => {
+    const config = sanitizedIntegrationConfigFactory({
+      serviceId: integrationDefinition.metadata.id,
+      // Intentionally leave off both properties
+      config: {} as unknown as SanitizedConfig,
+    });
+
     let actualError: unknown;
 
     try {
-      await reducePipeline(pipeline, simpleInput({}), testOptions(apiVersion));
+      await testConfig(config, apiVersion);
     } catch (error) {
       actualError = error;
     }
@@ -205,13 +252,33 @@ describe.each([["v2"], ["v3"]])("apiVersion: %s", (apiVersion: ApiVersion) => {
         keywordLocation: "#/properties/config/$ref",
       },
       {
-        // No error for apiKey because secrets are stripped out
-        error: 'Instance does not have required property "baseURL".',
+        error: 'Property "config" does not match schema.',
         instanceLocation: "#/config",
+        keyword: "properties",
+        keywordLocation: "#/properties/config/$ref/properties",
+      },
+      // No error for apiKey because secrets are stripped out
+      {
+        error: 'Instance does not have required property "baseURL".',
+        instanceLocation: "#/config/config",
         keyword: "required",
-        keywordLocation: "#/properties/config/$ref/required",
+        keywordLocation: "#/properties/config/$ref/properties/config/required",
       },
     ]);
+  });
+
+  test("accepts valid integration configuration", async () => {
+    const config = sanitizedIntegrationConfigFactory({
+      serviceId: integrationDefinition.metadata.id,
+      config: {
+        apiKey: "not-a-real-key",
+        baseURL: "https://example.com",
+      } as unknown as SanitizedConfig,
+    });
+
+    await expect(testConfig(config, apiVersion)).resolves.toStrictEqual({
+      config,
+    });
   });
 
   test("validate multiple database configuration", async () => {

--- a/src/validators/schemaValidator.test.ts
+++ b/src/validators/schemaValidator.test.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  dereference,
   validateBrickInputOutput,
   validatePackageDefinition,
 } from "@/validators/schemaValidator";
@@ -27,9 +28,17 @@ import emberJsReaderDefinition from "@contrib/readers/linkedin-organization-read
 import windowReader from "@contrib/readers/trello-card-reader.yaml";
 import reactReader from "@contrib/readers/redfin-reader.yaml";
 import { type Schema } from "@/types/schemaTypes";
-import { uuidv4 } from "@/types/helpers";
+import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { timestampFactory } from "@/testUtils/factories/stringFactories";
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
+import { keyAuthIntegrationDefinitionFactory } from "@/testUtils/factories/integrationFactories";
+import integrationRegistry from "@/integrations/registry";
+import { fromJS } from "@/integrations/UserDefinedIntegration";
+import { metadataFactory } from "@/testUtils/factories/metadataFactory";
+
+beforeEach(() => {
+  integrationRegistry.clear();
+});
 
 describe("validateKind", () => {
   test("can validate integration definition", async () => {
@@ -106,5 +115,62 @@ describe("validateBrickInputOutput", () => {
     const result = await validateBrickInputOutput(inputSchema, inputInstance);
     expect(result.errors).toHaveLength(0);
     expect(result.valid).toBe(true);
+  });
+});
+
+describe("dereference", () => {
+  test("can dereference schema with an integration", async () => {
+    const integrationDefinition = keyAuthIntegrationDefinitionFactory({
+      metadata: metadataFactory({
+        id: validateRegistryId("@scope/collection/name"),
+      }),
+      inputSchema: {
+        $schema: "https://json-schema.org/draft/2019-09/schema#",
+        type: "object",
+        properties: {
+          apiKey: {
+            $ref: "https://app.pixiebrix.com/schemas/key#",
+            title: "API Key",
+          },
+          baseURL: {
+            type: "string",
+          },
+        },
+        required: ["apiKey", "baseURL"],
+      },
+    });
+
+    integrationRegistry.register([fromJS(integrationDefinition)]);
+
+    await expect(
+      dereference(
+        {
+          type: "object",
+          properties: {
+            service: {
+              $ref: "https://app.pixiebrix.com/schemas/services/@scope/collection/name",
+            },
+          },
+        },
+        {
+          sanitizeIntegrationDefinitions: true,
+        },
+      ),
+    ).resolves.toStrictEqual({
+      properties: {
+        service: {
+          $id: "https://app.pixiebrix.com/schemas/services/@scope/collection/name",
+          properties: {
+            // `apiKey` is stripped because sanitizeIntegrationDefinitions is true
+            baseURL: {
+              type: "string",
+            },
+          },
+          required: ["baseURL"],
+          type: "object",
+        },
+      },
+      type: "object",
+    });
   });
 });

--- a/src/validators/schemaValidator.test.ts
+++ b/src/validators/schemaValidator.test.ts
@@ -118,28 +118,28 @@ describe("validateBrickInputOutput", () => {
   });
 });
 
-describe("dereference", () => {
-  test("can dereference schema with an integration", async () => {
-    const integrationDefinition = keyAuthIntegrationDefinitionFactory({
-      metadata: metadataFactory({
-        id: validateRegistryId("@scope/collection/name"),
-      }),
-      inputSchema: {
-        $schema: "https://json-schema.org/draft/2019-09/schema#",
-        type: "object",
-        properties: {
-          apiKey: {
-            $ref: "https://app.pixiebrix.com/schemas/key#",
-            title: "API Key",
-          },
-          baseURL: {
-            type: "string",
-          },
-        },
-        required: ["apiKey", "baseURL"],
+const integrationDefinition = keyAuthIntegrationDefinitionFactory({
+  metadata: metadataFactory({
+    id: validateRegistryId("@scope/collection/name"),
+  }),
+  inputSchema: {
+    $schema: "https://json-schema.org/draft/2019-09/schema#",
+    type: "object",
+    properties: {
+      apiKey: {
+        $ref: "https://app.pixiebrix.com/schemas/key#",
+        title: "API Key",
       },
-    });
+      baseURL: {
+        type: "string",
+      },
+    },
+    required: ["apiKey", "baseURL"],
+  },
+});
 
+describe("dereference", () => {
+  test("can dereference and sanitize schema with an integration", async () => {
     integrationRegistry.register([fromJS(integrationDefinition)]);
 
     await expect(
@@ -168,6 +168,34 @@ describe("dereference", () => {
           },
           required: ["baseURL"],
           type: "object",
+        },
+      },
+      type: "object",
+    });
+  });
+
+  test("can dereference schema without an integration", async () => {
+    integrationRegistry.register([fromJS(integrationDefinition)]);
+
+    await expect(
+      dereference(
+        {
+          type: "object",
+          properties: {
+            service: {
+              $ref: "https://app.pixiebrix.com/schemas/services/@scope/collection/name",
+            },
+          },
+        },
+        {
+          sanitizeIntegrationDefinitions: false,
+        },
+      ),
+    ).resolves.toStrictEqual({
+      properties: {
+        service: {
+          ...integrationDefinition.inputSchema,
+          $id: "https://app.pixiebrix.com/schemas/services/@scope/collection/name",
         },
       },
       type: "object",

--- a/src/validators/schemaValidator.ts
+++ b/src/validators/schemaValidator.ts
@@ -133,21 +133,18 @@ function integrationResolverFactory({
         }
 
         switch (mode) {
+          // NOTE: including the $id cause duplicate schema errors when validating a dereferenced schema if the
+          // reference is used in multiple places. But including an $id is useful for preserving field toggling
+          // based on well-known schema $ids and it's safe to use in our code to convert JSON Schema to Yup schema.
           case "properties": {
             return {
               ...propertiesSchema,
-              // NOTE: including the $id cause duplicate schema errors when validating a dereferenced schema if the
-              // reference is used in multiple places. But including an $id is useful for preserving field toggling
-              // based on well-known schema $ids.
               $id: file.url,
             };
           }
 
           case "configuration": {
             return {
-              // NOTE: including the $id cause duplicate schema errors when validating a dereferenced schema if the
-              // reference is used in multiple places. But including an $id is useful for preserving field toggling
-              // based on well-known schema $ids.
               $id: file.url,
               type: "object",
               properties: {

--- a/src/validators/schemaValidator.ts
+++ b/src/validators/schemaValidator.ts
@@ -80,11 +80,17 @@ export const KIND_SCHEMAS: Readonly<Record<string, ValidatorSchema>> =
 /**
  * $ref resolver factory that fetches the integration definition from the integration definition registry.
  * @param sanitize true to exclude properties associated with secrets
+ * @param mode properties to include only the properties of the schema, configuration to match an
+ *  IntegrationConfiguration
+ * @see IntegrationConfig
+ * @see SanitizedIntegrationConfig
  */
 function integrationResolverFactory({
   sanitize,
+  mode,
 }: {
   sanitize: boolean;
+  mode: "properties" | "configuration";
 }): ResolverOptions {
   return {
     order: 1,
@@ -114,11 +120,7 @@ function integrationResolverFactory({
               x.$ref == null || !REF_SECRETS.includes(trimEnd(x.$ref, "#")),
           );
 
-          return {
-            // NOTE: including the $id cause duplicate schema errors when validating a dereferenced schema if the
-            // reference is used in multiple places. But including an $id is useful for preserving field toggling
-            // based on well-known schema $ids.
-            $id: file.url,
+          const propertiesSchema = {
             type: "object",
             // Strip out the properties containing secrets because those are excluded during runtime execution
             properties: sanitizedProperties,
@@ -126,6 +128,38 @@ function integrationResolverFactory({
               (x) => x in sanitizedProperties,
             ),
           };
+
+          switch (mode) {
+            case "properties": {
+              return {
+                // NOTE: including the $id cause duplicate schema errors when validating a dereferenced schema if the
+                // reference is used in multiple places. But including an $id is useful for preserving field toggling
+                // based on well-known schema $ids.
+                $id: file.url,
+                ...propertiesSchema,
+              };
+            }
+
+            case "configuration": {
+              return {
+                // NOTE: including the $id cause duplicate schema errors when validating a dereferenced schema if the
+                // reference is used in multiple places. But including an $id is useful for preserving field toggling
+                // based on well-known schema $ids.
+                $id: file.url,
+                type: "object",
+                properties: {
+                  config: {
+                    ...propertiesSchema,
+                  },
+                },
+              };
+            }
+
+            default: {
+              const modeNever: never = mode;
+              throw new Error(`Unknown mode: ${modeNever}`);
+            }
+          }
         }
 
         return {
@@ -189,6 +223,8 @@ export async function dereference(
       resolve: {
         integrationDefinitionResolver: integrationResolverFactory({
           sanitize: sanitizeIntegrationDefinitions,
+          // When dereferencing to generate a configuration UI, we only want the properties
+          mode: "properties",
         }),
         builtInSchemaResolver,
         // Disable built-in resolvers: https://apitools.dev/json-schema-ref-parser/docs/options.html
@@ -226,6 +262,8 @@ export async function validateBrickInputOutput(
       // Exclude secret properties, because they aren't passed to the runtime
       integrationDefinitionResolver: integrationResolverFactory({
         sanitize: true,
+        // The runtime passes the whole configuration
+        mode: "configuration",
       }),
       builtInSchemaResolver,
       // Disable built-in resolvers: https://apitools.dev/json-schema-ref-parser/docs/options.html

--- a/src/validators/schemaValidator.ts
+++ b/src/validators/schemaValidator.ts
@@ -148,10 +148,13 @@ function integrationResolverFactory({
                 $id: file.url,
                 type: "object",
                 properties: {
-                  config: {
-                    ...propertiesSchema,
+                  serviceId: {
+                    type: "string",
+                    const: integrationId,
                   },
+                  config: propertiesSchema,
                 },
+                required: ["serviceId", "config"],
               };
             }
 

--- a/src/validators/schemaValidator.ts
+++ b/src/validators/schemaValidator.ts
@@ -112,6 +112,8 @@ function integrationResolverFactory({
           validateRegistryId(integrationId),
         );
 
+        let propertiesSchema = integrationDefinition.schema;
+
         if (sanitize) {
           const sanitizedProperties = pickBy(
             inputProperties(integrationDefinition.schema),
@@ -120,7 +122,7 @@ function integrationResolverFactory({
               x.$ref == null || !REF_SECRETS.includes(trimEnd(x.$ref, "#")),
           );
 
-          const propertiesSchema = {
+          propertiesSchema = {
             type: "object",
             // Strip out the properties containing secrets because those are excluded during runtime execution
             properties: sanitizedProperties,
@@ -128,47 +130,42 @@ function integrationResolverFactory({
               (x) => x in sanitizedProperties,
             ),
           };
-
-          switch (mode) {
-            case "properties": {
-              return {
-                // NOTE: including the $id cause duplicate schema errors when validating a dereferenced schema if the
-                // reference is used in multiple places. But including an $id is useful for preserving field toggling
-                // based on well-known schema $ids.
-                $id: file.url,
-                ...propertiesSchema,
-              };
-            }
-
-            case "configuration": {
-              return {
-                // NOTE: including the $id cause duplicate schema errors when validating a dereferenced schema if the
-                // reference is used in multiple places. But including an $id is useful for preserving field toggling
-                // based on well-known schema $ids.
-                $id: file.url,
-                type: "object",
-                properties: {
-                  serviceId: {
-                    type: "string",
-                    const: integrationId,
-                  },
-                  config: propertiesSchema,
-                },
-                required: ["serviceId", "config"],
-              };
-            }
-
-            default: {
-              const modeNever: never = mode;
-              throw new Error(`Unknown mode: ${modeNever}`);
-            }
-          }
         }
 
-        return {
-          ...integrationDefinition.schema,
-          $id: file.url,
-        };
+        switch (mode) {
+          case "properties": {
+            return {
+              ...propertiesSchema,
+              // NOTE: including the $id cause duplicate schema errors when validating a dereferenced schema if the
+              // reference is used in multiple places. But including an $id is useful for preserving field toggling
+              // based on well-known schema $ids.
+              $id: file.url,
+            };
+          }
+
+          case "configuration": {
+            return {
+              // NOTE: including the $id cause duplicate schema errors when validating a dereferenced schema if the
+              // reference is used in multiple places. But including an $id is useful for preserving field toggling
+              // based on well-known schema $ids.
+              $id: file.url,
+              type: "object",
+              properties: {
+                serviceId: {
+                  type: "string",
+                  const: integrationId,
+                },
+                config: propertiesSchema,
+              },
+              required: ["serviceId", "config"],
+            };
+          }
+
+          default: {
+            const modeNever: never = mode;
+            throw new Error(`Unknown mode: ${modeNever}`);
+          }
+        }
       } catch (error) {
         console.warn("Error resolving integration definition schema", error);
         // Don't block on lookup failure


### PR DESCRIPTION
## What does this PR do?

- Closes #7963 
- There's a quirk I had overlooked with integrations where:
  - When generating UI, we want the properties
  - When validating brick inputs, we want an integration configuration 

## Discussion

- Implemented as a "mode" option instead of as a separate resolver
- I don't think this is related to https://github.com/pixiebrix/pixiebrix-extension/issues/7895 given the dereference behavior was already correct, but including @BLoe as reviewer for visibility/FYI

## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible): N/A
- [x] Designate a primary reviewer: @grahamlangford 
