### PR TITLE
Automatically reload inactive page editors on invalidation

### DIFF
--- a/src/components/InvalidatedContextGate.tsx
+++ b/src/components/InvalidatedContextGate.tsx
@@ -18,11 +18,19 @@
 import React from "react";
 import { Button } from "react-bootstrap";
 import useContextInvalidated from "@/hooks/useContextInvalidated";
+import useDocumentVisibility from "@/hooks/useDocumentVisibility";
 
 const InvalidatedContextGate: React.FunctionComponent<{
   contextNameTitleCase: string;
-}> = ({ children, contextNameTitleCase }) => {
+  autoReload?: boolean;
+}> = ({ children, contextNameTitleCase, autoReload }) => {
   const wasContextInvalidated = useContextInvalidated();
+  // Only auto-reload if the document is in the background
+  const isDocumentVisible = useDocumentVisibility();
+  if (wasContextInvalidated && autoReload && !isDocumentVisible) {
+    location.reload();
+  }
+
   return wasContextInvalidated ? (
     <div className="d-flex flex-column align-items-center justify-content-center">
       <p>

--- a/src/hooks/useDocumentVisibility.test.ts
+++ b/src/hooks/useDocumentVisibility.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { renderHook } from "@testing-library/react-hooks";
+import useDocumentVisibility from "./useDocumentVisibility";
+
+test("useDocumentVisibility", () => {
+  const addEventListenerSpy = jest.spyOn(document, "addEventListener");
+
+  const { result } = renderHook(() => useDocumentVisibility());
+  expect(result.current).toBe(true);
+
+  expect(addEventListenerSpy).toHaveBeenCalledWith(
+    "visibilitychange",
+    expect.any(Function),
+  );
+
+  addEventListenerSpy.mockRestore();
+});

--- a/src/hooks/useDocumentVisibility.ts
+++ b/src/hooks/useDocumentVisibility.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useSyncExternalStore } from "use-sync-external-store/shim";
+
+function subscribe(callback: VoidFunction) {
+  document.addEventListener("visibilitychange", callback);
+
+  return () => {
+    document.removeEventListener("visibilitychange", callback);
+  };
+}
+
+function getSnapshot() {
+  return !document.hidden;
+}
+
+export default function useDocumentVisibility(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/src/pageEditor/Panel.tsx
+++ b/src/pageEditor/Panel.tsx
@@ -47,7 +47,7 @@ const UnguardedPanel: React.VoidFunctionComponent = () => {
 };
 
 const Panel: React.VoidFunctionComponent = () => (
-  <InvalidatedContextGate contextNameTitleCase="Page Editor">
+  <InvalidatedContextGate autoReload contextNameTitleCase="Page Editor">
     <TabInspectionGate>
       <UnguardedPanel />
     </TabInspectionGate>

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -432,6 +432,8 @@
     "./hooks/useDebouncedEffect.ts",
     "./hooks/useDeriveAsyncState.ts",
     "./hooks/useDocumentSelection.ts",
+    "./hooks/useDocumentVisibility.ts",
+    "./hooks/useDocumentVisibility.test.ts",
     "./hooks/useEventListener.ts",
     "./hooks/useFlags.ts",
     "./hooks/useIsEnterpriseUser.ts",


### PR DESCRIPTION
## What does this PR do?

Minor UX/DX: reload page editor on invalidation.

Currently this only happens when the document is hidden, just to limit the PR blast radius. If there are no issues with this behavior we can consider just reloading it.

## Demo


https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/2e99814a-398e-48be-9c25-d6ee1ddad4f2



## Checklist

- [x] Add tests
- [x] New files added to `src/tsconfig.strictNullChecks.json` (if possible)
- [x] Designate a primary reviewer: @grahamlangford 
