### PR TITLE
animate fade-in for the command and selection menus

### DIFF
--- a/src/contentScript/commandPopover/commandController.tsx
+++ b/src/contentScript/commandPopover/commandController.tsx
@@ -44,6 +44,7 @@ import {
 import { expectContext } from "@/utils/expectContext";
 import { ReusableAbortController } from "abort-utils";
 import { waitAnimationFrame } from "@/utils/domUtils";
+import { prefersReducedMotion } from "@/utils/a11yUtils";
 
 const COMMAND_KEY = "\\";
 
@@ -66,23 +67,25 @@ async function showPopover(element: HTMLElement): Promise<void> {
 
   targetElement = element;
   commandPopover ??= createPopover(targetElement);
-  commandPopover.setAttribute("aria-hidden", "false");
-  commandPopover.style.setProperty("display", "block");
 
   // Check visibility to avoid re-animating the tooltip fade in as selection changes
   const isShowing = commandPopover.checkVisibility();
   if (!isShowing) {
-    commandPopover.animate(
-      [
-        { opacity: 0, margin: "8px 0" },
-        { opacity: 1, margin: "0" },
-      ],
-      {
-        easing: "ease-in-out",
-        duration: 300,
-        fill: "forwards",
-      },
-    );
+    commandPopover.setAttribute("aria-hidden", "false");
+    commandPopover.style.setProperty("display", "block");
+    if (!prefersReducedMotion()) {
+      commandPopover.animate(
+        [
+          { opacity: 0, margin: "8px 0" },
+          { opacity: 1, margin: "0" },
+        ],
+        {
+          easing: "ease-in-out",
+          duration: 300,
+          fill: "forwards",
+        },
+      );
+    }
   }
 
   // For now just destroy the tooltip on document/element scroll to avoid gotchas with floating UI's `position: fixed`

--- a/src/contentScript/commandPopover/commandController.tsx
+++ b/src/contentScript/commandPopover/commandController.tsx
@@ -69,6 +69,22 @@ async function showPopover(element: HTMLElement): Promise<void> {
   commandPopover.setAttribute("aria-hidden", "false");
   commandPopover.style.setProperty("display", "block");
 
+  // Check visibility to avoid re-animating the tooltip fade in as selection changes
+  const isShowing = commandPopover.checkVisibility();
+  if (!isShowing) {
+    commandPopover.animate(
+      [
+        { opacity: 0, margin: "8px 0" },
+        { opacity: 1, margin: "0" },
+      ],
+      {
+        easing: "ease-in-out",
+        duration: 300,
+        fill: "forwards",
+      },
+    );
+  }
+
   // For now just destroy the tooltip on document/element scroll to avoid gotchas with floating UI's `position: fixed`
   // strategy. See tooltipController.ts for more details.
   document.activeElement?.addEventListener(

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -59,6 +59,22 @@ async function showTooltip(): Promise<void> {
   selectionTooltip.setAttribute("aria-hidden", "false");
   selectionTooltip.style.setProperty("display", "block");
 
+  // Check visibility to avoid re-animating the tooltip fade in as selection changes
+  const isShowing = selectionTooltip.checkVisibility();
+  if (!isShowing) {
+    selectionTooltip.animate(
+      [
+        { opacity: 0, margin: "4px 0" },
+        { opacity: 1, margin: "0" },
+      ],
+      {
+        easing: "ease-in-out",
+        duration: 150,
+        fill: "forwards",
+      },
+    );
+  }
+
   // For now hide the tooltip on document/element scroll to avoid gotchas with floating UI's `position: fixed` strategy.
   // See updatePosition for more context. Without this, the tooltip moves with the scroll to keep its position in the
   // viewport fixed.

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -36,6 +36,7 @@ import { expectContext } from "@/utils/expectContext";
 import { onContextInvalidated } from "webext-events";
 import { isNativeField } from "@/types/inputTypes";
 import { onAbort, ReusableAbortController } from "abort-utils";
+import { prefersReducedMotion } from "@/utils/a11yUtils";
 
 const MIN_SELECTION_LENGTH_CHARS = 3;
 
@@ -56,23 +57,24 @@ async function showTooltip(): Promise<void> {
 
   selectionTooltip ??= createTooltip();
 
-  selectionTooltip.setAttribute("aria-hidden", "false");
-  selectionTooltip.style.setProperty("display", "block");
-
   // Check visibility to avoid re-animating the tooltip fade in as selection changes
   const isShowing = selectionTooltip.checkVisibility();
   if (!isShowing) {
-    selectionTooltip.animate(
-      [
-        { opacity: 0, margin: "4px 0" },
-        { opacity: 1, margin: "0" },
-      ],
-      {
-        easing: "ease-in-out",
-        duration: 150,
-        fill: "forwards",
-      },
-    );
+    selectionTooltip.setAttribute("aria-hidden", "false");
+    selectionTooltip.style.setProperty("display", "block");
+    if (!prefersReducedMotion()) {
+      selectionTooltip.animate(
+        [
+          { opacity: 0, margin: "4px 0" },
+          { opacity: 1, margin: "0" },
+        ],
+        {
+          easing: "ease-in-out",
+          duration: 150,
+          fill: "forwards",
+        },
+      );
+    }
   }
 
   // For now hide the tooltip on document/element scroll to avoid gotchas with floating UI's `position: fixed` strategy.

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -726,6 +726,7 @@
     "./urlConstants.ts",
     "./utils/ConsoleLogger.ts",
     "./utils/SimpleEventTarget.ts",
+    "./utils/a11yUtils.ts",
     "./utils/arrayUtils.ts",
     "./utils/asyncStateUtils.ts",
     "./utils/browserUtils.ts",

--- a/src/utils/a11yUtils.ts
+++ b/src/utils/a11yUtils.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Disable animations if user prefers reduced motion
+// https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
+export const prefersReducedMotion = () =>
+  window.matchMedia("(prefers-reduced-motion: reduce)").matches;


### PR DESCRIPTION
## What does this PR do?

- Adds a subtle fade-in animation for the text and command popover

## Discussion

- We should probably disable this animation if the user has `prefers-reduced-motion` enabled
- https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion

## Demo

https://www.loom.com/share/db31e1d3e55046b1b260be2a8813586b

## Checklist

- [NA] Add tests and/or storybook stories
- [X] Designate a primary reviewer @mnholtz 
