### PR TITLE
Use insert/enter instructions for snippet shortcut menu

### DIFF
--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -153,7 +153,7 @@ const popoverFooter: React.ReactElement = (
       &nbsp;
       <FontAwesomeIcon icon={faCaretUp} fixedWidth size="xs" />
     </span>{" "}
-    Select <span className="key">TAB</span>
+    Insert <span className="key">Enter</span>
   </div>
 );
 


### PR DESCRIPTION
## What does this PR do?

- See discussion: https://pixiebrix.slack.com/archives/C06G212E3U1/p1710876417599169?thread_ts=1710874748.453389&cid=C06G212E3U1
- Changes snippet shortcut menu to show "INSERT ENTER" instead of "SELECT TAB"

## Discussion

- Both TAB and ENTER still work for submission

## Demo

<img width="341" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/5b066519-f6d2-4bf0-aa2e-a4a1483da515">

## Checklist

- [ ] Add tests and/or storybook stories
- [x] Designate a primary reviewer: @grahamlangford 
