### PR TITLE
#7882: Avoid errors on `Selection#getRangeAt()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -141,6 +141,11 @@ module.exports = {
         selector:
           "JSXOpeningElement[name.name='div'][attributes.0.name.name='onClick']",
       },
+      {
+        message:
+          "Prefer using `getSelectionRange()` helper or check `selection.rangeCount` first: https://github.com/pixiebrix/pixiebrix-extension/pull/7989",
+        selector: "CallExpression[callee.property.name='getRangeAt']",
+      },
       // NOTE: If you add more rules, add the tests to eslint-local-rules/noRestrictedSyntax.tsx
     ],
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # https://knip.dev/overview/getting-started#without-installation
-      - run: npm install -D knip@5
+      - run: npm install -D knip@5.1.2
       # Detect dead code with enforced rules
       - run: npm run dead-code
       # Also run the remaining "warn" rules

--- a/eslint-local-rules/noRestrictedSyntax.tsx
+++ b/eslint-local-rules/noRestrictedSyntax.tsx
@@ -17,3 +17,10 @@ export const X = () => (
     onKeyPress={console.log}
   />
 );
+
+const selection = getSelection();
+// eslint-disable-next-line no-restricted-syntax
+export const range = selection?.getRangeAt(0).startContainer;
+
+// This should be allowed
+export const string = selection.toString();

--- a/src/contentScript/commandPopover/commandController.tsx
+++ b/src/contentScript/commandPopover/commandController.tsx
@@ -239,9 +239,11 @@ function getCursorPositionReference(): Nullishable<VirtualElement | Element> {
   }
 
   // Allows us to measure where the selection is on the page relative to the viewport
-  const range = window.getSelection()?.getRangeAt(0);
+  const selection = window.getSelection();
+  const range =
+    selection && selection.rangeCount > 0 && selection.getRangeAt(0);
 
-  if (range == null) {
+  if (!range) {
     return;
   }
 
@@ -342,7 +344,9 @@ function isTextSelected(target: unknown): boolean {
   }
 
   if (isContentEditableElement(target)) {
-    const range = window.getSelection()?.getRangeAt(0);
+    const selection = window.getSelection();
+    const range =
+      selection && selection.rangeCount > 0 && selection.getRangeAt(0);
     return range != null && range.toString().length > 0;
   }
 

--- a/src/contentScript/commandPopover/commandController.tsx
+++ b/src/contentScript/commandPopover/commandController.tsx
@@ -43,7 +43,7 @@ import {
 } from "@/types/inputTypes";
 import { expectContext } from "@/utils/expectContext";
 import { ReusableAbortController } from "abort-utils";
-import { getFirstSelectionRange, waitAnimationFrame } from "@/utils/domUtils";
+import { getSelectionRange, waitAnimationFrame } from "@/utils/domUtils";
 import { prefersReducedMotion } from "@/utils/a11yUtils";
 
 const COMMAND_KEY = "\\";
@@ -239,7 +239,7 @@ function getCursorPositionReference(): Nullishable<VirtualElement | Element> {
   }
 
   // Allows us to measure where the selection is on the page relative to the viewport
-  const range = getFirstSelectionRange();
+  const range = getSelectionRange();
 
   if (range == null) {
     return;
@@ -342,7 +342,7 @@ function isTextSelected(target: unknown): boolean {
   }
 
   if (isContentEditableElement(target)) {
-    const range = getFirstSelectionRange();
+    const range = getSelectionRange();
     return range != null && range.toString().length > 0;
   }
 

--- a/src/contentScript/commandPopover/commandController.tsx
+++ b/src/contentScript/commandPopover/commandController.tsx
@@ -43,7 +43,7 @@ import {
 } from "@/types/inputTypes";
 import { expectContext } from "@/utils/expectContext";
 import { ReusableAbortController } from "abort-utils";
-import { waitAnimationFrame } from "@/utils/domUtils";
+import { getFirstSelectionRange, waitAnimationFrame } from "@/utils/domUtils";
 import { prefersReducedMotion } from "@/utils/a11yUtils";
 
 const COMMAND_KEY = "\\";
@@ -239,11 +239,9 @@ function getCursorPositionReference(): Nullishable<VirtualElement | Element> {
   }
 
   // Allows us to measure where the selection is on the page relative to the viewport
-  const selection = window.getSelection();
-  const range =
-    selection && selection.rangeCount > 0 && selection.getRangeAt(0);
+  const range = getFirstSelectionRange();
 
-  if (!range) {
+  if (range == null) {
     return;
   }
 
@@ -344,9 +342,7 @@ function isTextSelected(target: unknown): boolean {
   }
 
   if (isContentEditableElement(target)) {
-    const selection = window.getSelection();
-    const range =
-      selection && selection.rangeCount > 0 && selection.getRangeAt(0);
+    const range = getFirstSelectionRange();
     return range != null && range.toString().length > 0;
   }
 

--- a/src/contentScript/commandPopover/commandUtils.ts
+++ b/src/contentScript/commandPopover/commandUtils.ts
@@ -20,7 +20,7 @@ import {
   isSelectableTextControlElement,
   type SelectableTextEditorElement,
 } from "@/types/inputTypes";
-import { waitAnimationFrame } from "@/utils/domUtils";
+import { getFirstSelectionRange, waitAnimationFrame } from "@/utils/domUtils";
 import { expectContext } from "@/utils/expectContext";
 import { insertAtCursorWithCustomEditorSupport } from "@/contentScript/textEditorDom";
 import type { Nullishable } from "@/utils/nullishUtils";
@@ -79,10 +79,9 @@ export async function replaceAtCommand({
   }
 
   // Content Editable
-  const selection = window.getSelection();
-  const range = selection.rangeCount > 0 && selection?.getRangeAt(0);
+  const range = getFirstSelectionRange();
 
-  if (range && range?.startContainer.nodeType === Node.TEXT_NODE) {
+  if (range?.startContainer.nodeType === Node.TEXT_NODE) {
     if (range.startOffset !== range.endOffset) {
       // Shouldn't happen in practice because commandController hides the popover on selection
       throw new Error("Expected a single cursor position");

--- a/src/contentScript/commandPopover/commandUtils.ts
+++ b/src/contentScript/commandPopover/commandUtils.ts
@@ -80,9 +80,9 @@ export async function replaceAtCommand({
 
   // Content Editable
   const selection = window.getSelection();
-  const range = selection?.getRangeAt(0);
+  const range = selection.rangeCount > 0 && selection?.getRangeAt(0);
 
-  if (range?.startContainer.nodeType === Node.TEXT_NODE) {
+  if (range && range?.startContainer.nodeType === Node.TEXT_NODE) {
     if (range.startOffset !== range.endOffset) {
       // Shouldn't happen in practice because commandController hides the popover on selection
       throw new Error("Expected a single cursor position");

--- a/src/contentScript/commandPopover/commandUtils.ts
+++ b/src/contentScript/commandPopover/commandUtils.ts
@@ -20,7 +20,7 @@ import {
   isSelectableTextControlElement,
   type SelectableTextEditorElement,
 } from "@/types/inputTypes";
-import { getFirstSelectionRange, waitAnimationFrame } from "@/utils/domUtils";
+import { getSelectionRange, waitAnimationFrame } from "@/utils/domUtils";
 import { expectContext } from "@/utils/expectContext";
 import { insertAtCursorWithCustomEditorSupport } from "@/contentScript/textEditorDom";
 import type { Nullishable } from "@/utils/nullishUtils";
@@ -79,7 +79,7 @@ export async function replaceAtCommand({
   }
 
   // Content Editable
-  const range = getFirstSelectionRange();
+  const range = getSelectionRange();
 
   if (range?.startContainer.nodeType === Node.TEXT_NODE) {
     if (range.startOffset !== range.endOffset) {

--- a/src/contentScript/commandPopover/useKeyboardQuery.ts
+++ b/src/contentScript/commandPopover/useKeyboardQuery.ts
@@ -22,6 +22,7 @@ import {
   isContentEditableElement,
 } from "@/types/inputTypes";
 import { useEffect, useRef, useState } from "react";
+import { getSelectionRange } from "@/utils/domUtils";
 
 /**
  * Set of keys that clear the query/hide the popover.
@@ -83,7 +84,7 @@ function selectActiveQuery({
   }
 
   if (isContentEditableElement(element)) {
-    const range = window.getSelection()?.getRangeAt(0);
+    const range = getSelectionRange();
     if (range?.startContainer.nodeType === Node.TEXT_NODE) {
       const { data } = range.startContainer as Text;
 

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -207,7 +207,8 @@ function getPositionReference(selection: Selection): VirtualElement | Element {
 async function updatePosition(): Promise<void> {
   const selection = window.getSelection();
 
-  if (!selectionTooltip || !selection) {
+  if (!selectionTooltip || !selection || selection.rangeCount === 0) {
+    hideTooltip();
     // Guard against race condition
     return;
   }

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -37,7 +37,7 @@ import { onContextInvalidated } from "webext-events";
 import { isNativeField } from "@/types/inputTypes";
 import { onAbort, ReusableAbortController } from "abort-utils";
 import { prefersReducedMotion } from "@/utils/a11yUtils";
-import { getFirstSelectionRange } from "@/utils/domUtils";
+import { getSelectionRange } from "@/utils/domUtils";
 
 const MIN_SELECTION_LENGTH_CHARS = 3;
 
@@ -207,7 +207,7 @@ function getPositionReference(range: Range): VirtualElement | Element {
 }
 
 async function updatePosition(): Promise<void> {
-  const selectionRange = getFirstSelectionRange();
+  const selectionRange = getSelectionRange();
 
   if (!selectionTooltip || selectionRange == null) {
     hideTooltip();

--- a/src/contentScript/selectionTooltip/tooltipController.tsx
+++ b/src/contentScript/selectionTooltip/tooltipController.tsx
@@ -209,7 +209,7 @@ function getPositionReference(range: Range): VirtualElement | Element {
 async function updatePosition(): Promise<void> {
   const selectionRange = getSelectionRange();
 
-  if (!selectionTooltip || selectionRange == null) {
+  if (!selectionTooltip || !selectionRange) {
     hideTooltip();
     // Guard against race condition
     return;

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -203,8 +203,8 @@ export function runOnDocumentVisible<Args extends unknown[], TReturn = unknown>(
   return runOnce;
 }
 
-export const getSelectionRange = (): Range | null => {
+export function getSelectionRange(): Range | null {
   const selection = window.getSelection();
   // eslint-disable-next-line no-restricted-syntax -- The rule points to this helper
   return selection?.rangeCount ? selection.getRangeAt(0) : null;
-};
+}

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -202,3 +202,8 @@ export function runOnDocumentVisible<Args extends unknown[], TReturn = unknown>(
 
   return runOnce;
 }
+
+export const getFirstSelectionRange = (): Range | null => {
+  const selection = window.getSelection();
+  return selection?.rangeCount ? selection?.getRangeAt(0) : null;
+};

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -203,8 +203,8 @@ export function runOnDocumentVisible<Args extends unknown[], TReturn = unknown>(
   return runOnce;
 }
 
-export function getSelectionRange(): Range | null {
+export function getSelectionRange(): Range | undefined {
   const selection = window.getSelection();
   // eslint-disable-next-line no-restricted-syntax -- The rule points to this helper
-  return selection?.rangeCount ? selection.getRangeAt(0) : null;
+  return selection?.rangeCount ? selection.getRangeAt(0) : undefined;
 }

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -203,7 +203,8 @@ export function runOnDocumentVisible<Args extends unknown[], TReturn = unknown>(
   return runOnce;
 }
 
-export const getFirstSelectionRange = (): Range | null => {
+export const getSelectionRange = (): Range | null => {
   const selection = window.getSelection();
-  return selection?.rangeCount ? selection?.getRangeAt(0) : null;
+  // eslint-disable-next-line no-restricted-syntax -- The rule points to this helper
+  return selection?.rangeCount ? selection.getRangeAt(0) : null;
 };

--- a/src/utils/selectionController.ts
+++ b/src/utils/selectionController.ts
@@ -39,10 +39,7 @@ export function guessSelectedElement(): HTMLElement | null {
 
   const start = range.startContainer.parentElement ?? document.documentElement;
   const end = range.endContainer.parentElement ?? document.documentElement;
-  const node = getCommonAncestor(start, end);
-  if (node instanceof HTMLElement) {
-    return node;
-  }
+  return getCommonAncestor(start, end);
 }
 
 /**
@@ -54,7 +51,7 @@ let selectionOverride: Range | undefined;
 const selectionController = {
   save(): void {
     // It must be set to "undefined" even if there are no selections
-    selectionOverride = getSelectionRange() ?? undefined;
+    selectionOverride = getSelectionRange();
   },
   restore(): void {
     selectionController.restoreWithoutClearing();

--- a/src/vendors/page-metadata-parser/url-utils.js
+++ b/src/vendors/page-metadata-parser/url-utils.js
@@ -4,6 +4,7 @@
 // - Dropped Node fallback
 // See: https://github.com/pixiebrix/pixiebrix-extension/issues/6889
 
+/** @knip Used in @/vendors/page-metadata-parser/parser.js */
 module.exports = {
   makeUrlAbsolute(base, relative) {
     try {


### PR DESCRIPTION
## What does this PR do?

- Fixes #7882
It seems like the sticky popover menus were being caused by unhandled errors being thrown because we
tried calling `.getSelection` when there was no Range`s in the selection (`rangeCount === 0`)

## Demo

Demo of the fixed issue:
https://www.loom.com/share/65f41d1c89d14df7907ad8dd83425794

The popovers no longer get reset to coordinates 0,0.
## Checklist

- [ ] Add tests and/or storybook stories
- [X] Designate a primary reviewer @twschiller 
