### PR TITLE
use em instead of rem in snippet shortcut menu

### DIFF
--- a/src/contentScript/commandPopover/CommandPopover.scss
+++ b/src/contentScript/commandPopover/CommandPopover.scss
@@ -80,8 +80,8 @@
 }
 
 .footer {
-  padding: 0.5rem;
-  font-size: 0.625rem;
+  padding: 0.5em;
+  font-size: 0.625em;
   color: $S600;
   text-transform: uppercase;
   font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",


### PR DESCRIPTION
## What does this PR do?

- Fixes #7990

## Demo
![Screenshot 2024-03-20 at 10 24 00 AM](https://github.com/pixiebrix/pixiebrix-extension/assets/3498063/ba2b2752-7390-492c-a228-8483ab3aa4dd)

## Future Work

- Eslint rule to prevent use of `rem`?

## Checklist

- [ ] Add tests and/or storybook stories
- [x ] Designate a primary reviewer @grahamlangford 
