### PR TITLE
#7979: allow users to dismiss the login banner and fix z-index issues

### DIFF
--- a/src/contentScript/integrations/LoginBanners.scss
+++ b/src/contentScript/integrations/LoginBanners.scss
@@ -25,9 +25,15 @@
   font-size: 16px;
   padding: 0.75em 1.25em;
 
-  button {
+  .login-button {
     font-size: 13px;
     padding: 0.25em 0.5em;
     border-radius: 0.2em;
+  }
+
+  // The dismisible button uses absolute positioning by default and comes first in the DOM
+  .close {
+    position: unset;
+    order: 1;
   }
 }

--- a/src/contentScript/integrations/LoginBanners.tsx
+++ b/src/contentScript/integrations/LoginBanners.tsx
@@ -26,9 +26,11 @@ import type { DeferredLogin } from "@/contentScript/integrations/deferredLoginTy
 import { launchInteractiveOAuthFlow } from "@/background/messenger/api";
 import { type UUID } from "@/types/stringTypes";
 
-const LoginBanner: React.FC<
-  DeferredLogin & { dismissLogin: (configId: UUID) => void }
-> = ({ integration, config, dismissLogin }) => {
+const LoginBanner: React.FC<DeferredLogin & { dismissLogin: () => void }> = ({
+  integration,
+  config,
+  dismissLogin,
+}) => {
   const label = config.label ?? integration.name;
 
   return (
@@ -38,7 +40,7 @@ const LoginBanner: React.FC<
       data-configid={config.id}
       dismissible
       onClose={() => {
-        dismissLogin(config.id);
+        dismissLogin();
       }}
     >
       <div className="flex-grow-1">
@@ -74,7 +76,13 @@ const LoginBanners: React.FC<{
     <EmotionShadowRoot mode="open">
       <Stylesheets href={[bootstrapUrl, stylesUrl]}>
         {deferredLogins.map((x) => (
-          <LoginBanner key={x.config.id} {...x} dismissLogin={dismissLogin} />
+          <LoginBanner
+            key={x.config.id}
+            {...x}
+            dismissLogin={() => {
+              dismissLogin(x.config.id);
+            }}
+          />
         ))}
       </Stylesheets>
     </EmotionShadowRoot>

--- a/src/contentScript/integrations/LoginBanners.tsx
+++ b/src/contentScript/integrations/LoginBanners.tsx
@@ -39,9 +39,7 @@ const LoginBanner: React.FC<DeferredLogin & { dismissLogin: () => void }> = ({
       className="login-alert"
       data-configid={config.id}
       dismissible
-      onClose={() => {
-        dismissLogin();
-      }}
+      onClose={dismissLogin}
     >
       <div className="flex-grow-1">
         One or more mods are having a problem connecting to {label}. Please

--- a/src/contentScript/integrations/LoginBanners.tsx
+++ b/src/contentScript/integrations/LoginBanners.tsx
@@ -19,7 +19,7 @@ import React from "react";
 import AsyncButton from "@/components/AsyncButton";
 import EmotionShadowRoot from "@/components/EmotionShadowRoot";
 import { Alert } from "react-bootstrap";
-import bootstrapUrl from "bootstrap/dist/css/bootstrap.min.css?loadAsUrl";
+import bootstrapUrl from "@/vendors/bootstrapWithoutRem.css?loadAsUrl";
 import stylesUrl from "./LoginBanners.scss?loadAsUrl";
 import { Stylesheets } from "@/components/Stylesheets";
 import type { DeferredLogin } from "@/contentScript/integrations/deferredLoginTypes";
@@ -29,13 +29,22 @@ const LoginBanner: React.FC<DeferredLogin> = ({ integration, config }) => {
   const label = config.label ?? integration.name;
 
   return (
-    <Alert variant="danger" className="login-alert" data-configid={config.id}>
+    <Alert
+      variant="danger"
+      className="login-alert"
+      data-configid={config.id}
+      dismissible
+      onClose={() => {
+        console.log("Dismiss Clicked!!!");
+      }}
+    >
       <div className="flex-grow-1">
         One or more mods are having a problem connecting to {label}. Please
         login to continue
       </div>
       <div>
         <AsyncButton
+          className="login-button"
           variant="danger"
           size="sm"
           onClick={async () => {
@@ -56,6 +65,8 @@ const LoginBanners: React.FC<{ deferredLogins: DeferredLogin[] }> = ({
   if (deferredLogins.length === 0) {
     return null;
   }
+
+  console.log({ deferredLogins });
 
   return (
     <EmotionShadowRoot mode="open">

--- a/src/contentScript/integrations/LoginBanners.tsx
+++ b/src/contentScript/integrations/LoginBanners.tsx
@@ -24,8 +24,11 @@ import stylesUrl from "./LoginBanners.scss?loadAsUrl";
 import { Stylesheets } from "@/components/Stylesheets";
 import type { DeferredLogin } from "@/contentScript/integrations/deferredLoginTypes";
 import { launchInteractiveOAuthFlow } from "@/background/messenger/api";
+import { type UUID } from "@/types/stringTypes";
 
-const LoginBanner: React.FC<DeferredLogin> = ({ integration, config }) => {
+const LoginBanner: React.FC<
+  DeferredLogin & { dismissLogin: (configId: UUID) => void }
+> = ({ integration, config, dismissLogin }) => {
   const label = config.label ?? integration.name;
 
   return (
@@ -35,7 +38,7 @@ const LoginBanner: React.FC<DeferredLogin> = ({ integration, config }) => {
       data-configid={config.id}
       dismissible
       onClose={() => {
-        console.log("Dismiss Clicked!!!");
+        dismissLogin(config.id);
       }}
     >
       <div className="flex-grow-1">
@@ -59,20 +62,19 @@ const LoginBanner: React.FC<DeferredLogin> = ({ integration, config }) => {
   );
 };
 
-const LoginBanners: React.FC<{ deferredLogins: DeferredLogin[] }> = ({
-  deferredLogins,
-}) => {
+const LoginBanners: React.FC<{
+  deferredLogins: DeferredLogin[];
+  dismissLogin: (configId: UUID) => void;
+}> = ({ deferredLogins, dismissLogin }) => {
   if (deferredLogins.length === 0) {
     return null;
   }
-
-  console.log({ deferredLogins });
 
   return (
     <EmotionShadowRoot mode="open">
       <Stylesheets href={[bootstrapUrl, stylesUrl]}>
         {deferredLogins.map((x) => (
-          <LoginBanner key={x.config.id} {...x} />
+          <LoginBanner key={x.config.id} {...x} dismissLogin={dismissLogin} />
         ))}
       </Stylesheets>
     </EmotionShadowRoot>

--- a/src/contentScript/integrations/bannerDomController.tsx
+++ b/src/contentScript/integrations/bannerDomController.tsx
@@ -91,7 +91,7 @@ export function showLoginBanner(
   const { id: configId } = login.config;
 
   if (dismissedLoginBanners.has(configId)) {
-    dismissLogin(configId);
+    dismissDeferredLogin(configId);
   }
 
   if (deferredLogins.has(configId)) {

--- a/src/contentScript/integrations/bannerDomController.tsx
+++ b/src/contentScript/integrations/bannerDomController.tsx
@@ -61,6 +61,9 @@ export function showLoginBanner(login: DeferredLogin): void {
       style: "all: initial",
       position: "relative",
       width: "100%",
+      // See https://getbootstrap.com/docs/4.6/layout/overview/#z-index
+      // We want the z-index to be high as possible, but lower than the modal
+      zIndex: "1030",
     });
 
     // Insert the banner at the top of the body

--- a/src/contentScript/integrations/bannerDomController.tsx
+++ b/src/contentScript/integrations/bannerDomController.tsx
@@ -68,7 +68,10 @@ export function showLoginBanner(
   login: DeferredLogin,
   dismissDeferredLogin: (configId: UUID) => void,
 ): void {
-  dismissLogin ??= dismissDeferredLogin;
+  dismissLogin ??= (configId: UUID) => {
+    dismissDeferredLogin(configId);
+    dismissedLoginBanners.add(configId);
+  };
 
   if (!bannerContainer) {
     // Create a new banner container
@@ -91,7 +94,7 @@ export function showLoginBanner(
 
   if (dismissedLoginBanners.has(configId)) {
     // Previously dismissed, need to dismiss again
-    dismissLogin(configId);
+    dismissDeferredLogin(configId);
   }
 
   if (deferredLogins.has(configId)) {
@@ -108,7 +111,6 @@ export function showLoginBanner(
  * Hide a banner for the given integration configuration. Is a no-op if the banner is not currently showing.
  */
 export function hideLoginBanner(integrationConfigId: UUID): void {
-  dismissedLoginBanners.add(integrationConfigId);
   deferredLogins.delete(integrationConfigId);
   renderOrUnmountBanners();
 }

--- a/src/contentScript/integrations/deferredLoginController.test.tsx
+++ b/src/contentScript/integrations/deferredLoginController.test.tsx
@@ -20,6 +20,7 @@ import {
   deferLogin,
   showBannerInTopFrame,
   clearDeferredLogins,
+  dismissDeferredLogin,
 } from "@/contentScript/integrations/deferredLoginController";
 import { sanitizedIntegrationConfigFactory } from "@/testUtils/factories/integrationFactories";
 import { screen } from "@testing-library/react";
@@ -97,5 +98,25 @@ describe("deferredLoginController", () => {
     clearDeferredLogins();
     // Throws due to test cleanup
     await expect(nextPromise).rejects.toThrow();
+  });
+
+  it("dismissDeferredLogin cancels the deferredLogin and removes the banner", async () => {
+    jest
+      .mocked(showLoginBanner)
+      .mockImplementation(
+        async (_target: Target, config: SanitizedIntegrationConfig) =>
+          showBannerInTopFrame(config),
+      );
+    jest
+      .mocked(integrationRegistry.lookup)
+      .mockResolvedValue({ name: "Integration Name" } as any);
+
+    const config = sanitizedIntegrationConfigFactory({ label: "Test Config" });
+
+    const promise = deferLogin(config);
+
+    dismissDeferredLogin(config.id);
+
+    await expect(promise).rejects.toThrow("User dismissed login");
   });
 });

--- a/src/contentScript/integrations/deferredLoginController.ts
+++ b/src/contentScript/integrations/deferredLoginController.ts
@@ -38,6 +38,11 @@ import { getTopLevelFrame } from "webext-messenger";
  */
 const deferredLogins = new Map<UUID, DeferredPromise<void>>();
 
+/*
+ * Login requests that have been dismissed by the user. They should not be shown again.
+ */
+const dismissedLogins = new Set<UUID>();
+
 /**
  * Content script messenger handler to show a login banner. Should only be run in the top-level frame.
  */
@@ -52,10 +57,14 @@ export async function showBannerInTopFrame(
 
   const integration = await integrationRegistry.lookup(config.serviceId);
 
-  showLoginBanner({
-    integration,
-    config,
-  });
+  showLoginBanner(
+    {
+      integration,
+      config,
+    },
+    dismissedLogins,
+    dismissDeferredLogin,
+  );
 }
 
 /**
@@ -92,7 +101,18 @@ export function clearDeferredLogins(): void {
   }
 
   deferredLogins.clear();
-  hideAllLoginBanners();
+  hideAllLoginBanners(dismissDeferredLogin);
+}
+
+export function dismissDeferredLogin(id: UUID): void {
+  dismissedLogins.add(id);
+
+  const deferredLogin = deferredLogins.get(id);
+  if (deferredLogin) {
+    deferredLogin.reject(new CancelError("User dismissed login"));
+  }
+
+  hideLoginBanner(id, dismissDeferredLogin);
 }
 
 export function initDeferredLoginController(): void {
@@ -106,7 +126,7 @@ export function initDeferredLoginController(): void {
     for (const [id, deferredLogin] of deferredLogins.entries()) {
       if (authenticatedIds.has(id)) {
         deferredLogin.resolve();
-        hideLoginBanner(id);
+        hideLoginBanner(id, dismissDeferredLogin);
         deferredLogins.delete(id);
       }
     }
@@ -115,5 +135,6 @@ export function initDeferredLoginController(): void {
   // Clean up the UI if the extension context is invalidated
   onContextInvalidated.addListener(() => {
     clearDeferredLogins();
+    dismissedLogins.clear();
   });
 }

--- a/src/contentScript/integrations/deferredLoginController.ts
+++ b/src/contentScript/integrations/deferredLoginController.ts
@@ -101,7 +101,7 @@ export function clearDeferredLogins(): void {
   }
 
   deferredLogins.clear();
-  hideAllLoginBanners(dismissDeferredLogin);
+  hideAllLoginBanners();
 }
 
 export function dismissDeferredLogin(id: UUID): void {
@@ -112,7 +112,7 @@ export function dismissDeferredLogin(id: UUID): void {
     deferredLogin.reject(new CancelError("User dismissed login"));
   }
 
-  hideLoginBanner(id, dismissDeferredLogin);
+  hideLoginBanner(id);
 }
 
 export function initDeferredLoginController(): void {
@@ -126,7 +126,7 @@ export function initDeferredLoginController(): void {
     for (const [id, deferredLogin] of deferredLogins.entries()) {
       if (authenticatedIds.has(id)) {
         deferredLogin.resolve();
-        hideLoginBanner(id, dismissDeferredLogin);
+        hideLoginBanner(id);
         deferredLogins.delete(id);
       }
     }


### PR DESCRIPTION
## What does this PR do?

- Fixes #7979 

## Demo

https://www.loom.com/share/11c37f4a30c9484ba7924c80bde104f5

## Future Work

- The Login Banner shows on the Google Auth window when logging in. This should be addressed in a future ticket. (See Loom)
- There's a Bootstrap Alert state update happening after we call `unmountComponentAtNode`

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer @twschiller 
