### PR TITLE
#7806: refresh flags on session start

### DIFF
--- a/src/auth/featureFlagStorage.test.ts
+++ b/src/auth/featureFlagStorage.test.ts
@@ -18,7 +18,7 @@
 import {
   fetchFeatureFlags,
   flagOn,
-  resetFeatureFlags,
+  resetFeatureFlagsCache,
   TEST_overrideFeatureFlags,
 } from "@/auth/featureFlagStorage";
 import { appApiMock } from "@/testUtils/appApiMock";
@@ -39,7 +39,7 @@ describe("featureFlags", () => {
   });
 
   afterEach(async () => {
-    await resetFeatureFlags();
+    await resetFeatureFlagsCache();
   });
 
   it("returns true if flag is present", async () => {

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -59,7 +59,7 @@ import { activatableDeploymentFactory } from "@/testUtils/factories/deploymentFa
 import { packageConfigDetailFactory } from "@/testUtils/factories/brickFactories";
 import { type RegistryPackage } from "@/types/contract";
 import { resetMeApiMocks } from "@/testUtils/userMock";
-import { resetFeatureFlags } from "@/auth/featureFlagStorage";
+import { resetFeatureFlagsCache } from "@/auth/featureFlagStorage";
 
 setContext("background");
 
@@ -134,7 +134,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await resetFeatureFlags();
+  await resetFeatureFlagsCache();
   await resetMeApiMocks();
 });
 

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -38,6 +38,7 @@ import { DEFAULT_SERVICE_URL, UNINSTALL_URL } from "@/urlConstants";
 import { CONTROL_ROOM_TOKEN_INTEGRATION_ID } from "@/integrations/constants";
 import { getExtensionConsoleUrl } from "@/utils/extensionUtils";
 import { oncePerSession } from "@/mv3/SessionStorage";
+import { resetFeatureFlagsCache } from "@/auth/featureFlagStorage";
 
 /**
  * The latest version of PixieBrix available in the Chrome Web Store, or null if the version hasn't been fetched.
@@ -349,9 +350,17 @@ const initTelemetryOncePerSession = oncePerSession(
   },
 );
 
+// eslint-disable-next-line local-rules/persistBackgroundData -- using SessionMap via oncePerSession
+const updateFlagsOncePerSession = oncePerSession(
+  "resetFeatureFlags",
+  import.meta.url,
+  resetFeatureFlagsCache,
+);
+
 function initInstaller(): void {
   void initManagedStorageOncePerSession();
   void initTelemetryOncePerSession();
+  void updateFlagsOncePerSession();
 
   browser.runtime.onInstalled.addListener(showInstallPage);
   browser.runtime.onUpdateAvailable.addListener(setAvailableVersion);

--- a/src/background/messenger/strict/registration.ts
+++ b/src/background/messenger/strict/registration.ts
@@ -18,7 +18,6 @@
 /* Do not use `getMethod` in this file; Keep only registrations here, not implementations */
 import { registerMethods } from "webext-messenger";
 import { expectContext } from "@/utils/expectContext";
-
 import { showMySidePanel } from "@/background/sidePanel";
 import { ensureContentScript } from "@/background/contentScript";
 import { getRecord, setRecord } from "@/background/dataStore";

--- a/src/background/modUpdater.test.ts
+++ b/src/background/modUpdater.test.ts
@@ -43,7 +43,7 @@ import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactorie
 import type { ModDefinition } from "@/types/modDefinitionTypes";
 import type { ActivatedModComponent } from "@/types/modComponentTypes";
 import { uninstallContextMenu } from "@/background/contextMenus";
-import { resetFeatureFlags } from "@/auth/featureFlagStorage";
+import { resetFeatureFlagsCache } from "@/auth/featureFlagStorage";
 
 const axiosMock = new MockAdapter(axios);
 jest.mock("@/telemetry/reportError");
@@ -53,7 +53,7 @@ jest.mock("@/background/contextMenus");
 const uninstallContextMenuMock = jest.mocked(uninstallContextMenu);
 
 afterEach(async () => {
-  await resetFeatureFlags();
+  await resetFeatureFlagsCache();
 });
 
 describe("getActivatedMarketplaceModVersions function", () => {

--- a/src/contentScript/contentScriptPlatform.test.ts
+++ b/src/contentScript/contentScriptPlatform.test.ts
@@ -19,7 +19,7 @@ import contentScriptPlatform from "@/contentScript/contentScriptPlatform";
 import { setPlatform } from "@/platform/platformContext";
 import { sanitizedIntegrationConfigFactory } from "@/testUtils/factories/integrationFactories";
 import { performConfiguredRequestInBackground } from "@/background/messenger/api";
-import { resetFeatureFlags } from "@/auth/featureFlagStorage";
+import { resetFeatureFlagsCache } from "@/auth/featureFlagStorage";
 import { appApiMock } from "@/testUtils/appApiMock";
 import { InteractiveLoginRequiredError } from "@/errors/authErrors";
 import { waitForEffect } from "@/testUtils/testHelpers";
@@ -42,7 +42,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   jest.clearAllMocks();
-  await resetFeatureFlags();
+  await resetFeatureFlagsCache();
 });
 
 describe("contentScriptPlatform", () => {


### PR DESCRIPTION
## What does this PR do?

- Closes #7806
- Fixed bug where reset flags call in oncePerSession wasn't actually getting called

## Demo / Discussion

On extension session start, we do a few calls `/api/me/` in the background. That's in part because the deployment updater

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/36bd75c4-32a0-4701-b88f-c1f8fb39aec0)

## Future Work

- If we plan to keep the `flags` on the`/api/me/` endpoint, consider explicitly setting the cache using the result from `/api/me` calls that might come from other locations
- Or we could route the calls through a pMemoize

## Checklist

- [ ] Add tests and/or storybook stories
- [x] Designate a primary reviewer: @fungairino 
