### PR TITLE
#8003: prevent page styles from leaking into menus

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3501,9 +3501,25 @@ exports[`Storyshots Enhancements/CommandPopover Demo 1`] = `
 </div>
 `;
 
-exports[`Storyshots Enhancements/SelectionToolbar Emoji Buttons 1`] = `<div />`;
+exports[`Storyshots Enhancements/SelectionToolbar Emoji Buttons 1`] = `
+<div
+  style={
+    {
+      "all": "initial",
+    }
+  }
+/>
+`;
 
-exports[`Storyshots Enhancements/SelectionToolbar Mixed Buttons 1`] = `<div />`;
+exports[`Storyshots Enhancements/SelectionToolbar Mixed Buttons 1`] = `
+<div
+  style={
+    {
+      "all": "initial",
+    }
+  }
+/>
+`;
 
 exports[`Storyshots ExtensionConsole/IDBErrorDisplay Connection Error 1`] = `
 <div

--- a/src/contentScript/commandPopover/CommandPopover.tsx
+++ b/src/contentScript/commandPopover/CommandPopover.tsx
@@ -222,7 +222,8 @@ const CommandPopover: React.FunctionComponent<
   }, [query, commands, dispatch]);
 
   return (
-    <EmotionShadowRoot mode="open">
+    // Prevent page styles from leaking into the menu
+    <EmotionShadowRoot mode="open" style={{ all: "initial" }}>
       <Stylesheets href={[stylesUrl]}>
         <div role="menu" aria-label="Text command menu" className="root">
           <StatusBar {...state} />

--- a/src/contentScript/selectionTooltip/SelectionToolbar.tsx
+++ b/src/contentScript/selectionTooltip/SelectionToolbar.tsx
@@ -94,7 +94,8 @@ const SelectionToolbar: React.FC<
 
   // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role
   return (
-    <EmotionShadowRoot mode="open">
+    // Prevent page styles from leaking into the menu
+    <EmotionShadowRoot mode="open" style={{ all: "initial" }}>
       <Stylesheets href={[stylesUrl]}>
         <div
           role="menu"


### PR DESCRIPTION
## What does this PR do?

- Fixes #8003 

## Discussion

- Tried applying the styles in EmotionShadowRoot, decided to hold off in case it negatively impacts other components

## Demo

<img width="444" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/068d5010-ff19-4bbd-83f3-f8b62d5f3cd1">


## Future Work

- Standardize the `all: initial` logic. See: https://github.com/pixiebrix/pixiebrix-extension/issues/7670

## Checklist

- [x] Designate a primary reviewer @fungairino 
