### PR TITLE
#8009: LoginBanners: Reduce chance of style conflicts

### DIFF
--- a/src/components/EmotionShadowRoot.ts
+++ b/src/components/EmotionShadowRoot.ts
@@ -17,10 +17,16 @@
 
 // eslint-disable-next-line no-restricted-imports -- All roads lead here
 import EmotionShadowRoot from "react-shadow/emotion";
+import { type CSSProperties } from "react";
 
 /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion --
 "Every property exists" (via Proxy), TypeScript doesn't offer such type
 Also strictNullChecks config mismatch */
 const ShadowRoot = EmotionShadowRoot.div!;
+
+export const styleReset: CSSProperties = {
+  all: "initial",
+  font: "16px / 1.5 sans-serif",
+};
 
 export default ShadowRoot;

--- a/src/contentScript/integrations/LoginBanners.tsx
+++ b/src/contentScript/integrations/LoginBanners.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import AsyncButton from "@/components/AsyncButton";
-import EmotionShadowRoot from "@/components/EmotionShadowRoot";
+import EmotionShadowRoot, { styleReset } from "@/components/EmotionShadowRoot";
 import { Alert } from "react-bootstrap";
 import bootstrapUrl from "@/vendors/bootstrapWithoutRem.css?loadAsUrl";
 import stylesUrl from "./LoginBanners.scss?loadAsUrl";
@@ -71,7 +71,7 @@ const LoginBanners: React.FC<{
   }
 
   return (
-    <EmotionShadowRoot mode="open">
+    <EmotionShadowRoot mode="open" style={styleReset}>
       <Stylesheets href={[bootstrapUrl, stylesUrl]}>
         {deferredLogins.map((x) => (
           <LoginBanner

--- a/src/contentScript/integrations/bannerDomController.tsx
+++ b/src/contentScript/integrations/bannerDomController.tsx
@@ -81,7 +81,8 @@ export function showLoginBanner(
       all: "initial",
       position: "relative",
       width: "100%",
-      zIndex: MAX_Z_INDEX,
+      // `-1` keeps it under the QuickBar
+      zIndex: MAX_Z_INDEX - 1,
     });
 
     // Place before `body` to avoid margins

--- a/src/contentScript/integrations/bannerDomController.tsx
+++ b/src/contentScript/integrations/bannerDomController.tsx
@@ -20,6 +20,7 @@ import { render, unmountComponentAtNode } from "react-dom";
 import React from "react";
 import LoginBanners from "@/contentScript/integrations/LoginBanners";
 import type { DeferredLogin } from "@/contentScript/integrations/deferredLoginTypes";
+import { MAX_Z_INDEX } from "@/domConstants";
 
 let bannerContainer: HTMLDivElement | null = null;
 let dismissLogin: (configId: UUID) => void = null;
@@ -80,9 +81,7 @@ export function showLoginBanner(
       all: "initial",
       position: "relative",
       width: "100%",
-      // See https://getbootstrap.com/docs/4.6/layout/overview/#z-index
-      // We want the z-index to be high as possible, but lower than the modal
-      zIndex: "1030",
+      zIndex: MAX_Z_INDEX,
     });
 
     // Place before `body` to avoid margins

--- a/src/contentScript/integrations/bannerDomController.tsx
+++ b/src/contentScript/integrations/bannerDomController.tsx
@@ -74,11 +74,10 @@ export function showLoginBanner(
   };
 
   if (!bannerContainer) {
-    // Create a new banner container
     bannerContainer = document.createElement("div");
 
     Object.assign(bannerContainer.style, {
-      style: "all: initial",
+      all: "initial",
       position: "relative",
       width: "100%",
       // See https://getbootstrap.com/docs/4.6/layout/overview/#z-index
@@ -86,8 +85,8 @@ export function showLoginBanner(
       zIndex: "1030",
     });
 
-    // Insert the banner at the top of the body
-    document.body.insertBefore(bannerContainer, document.body.firstChild);
+    // Place before `body` to avoid margins
+    document.body.before(bannerContainer);
   }
 
   const { id: configId } = login.config;

--- a/src/contentScript/integrations/deferredLoginController.test.tsx
+++ b/src/contentScript/integrations/deferredLoginController.test.tsx
@@ -23,7 +23,6 @@ import {
   dismissDeferredLogin,
 } from "@/contentScript/integrations/deferredLoginController";
 import { sanitizedIntegrationConfigFactory } from "@/testUtils/factories/integrationFactories";
-import { screen } from "@testing-library/react";
 import { RequestSupersededError } from "@/errors/businessErrors";
 import { showLoginBanner } from "@/contentScript/messenger/api";
 import type { Target } from "@/types/messengerTypes";

--- a/src/contentScript/integrations/deferredLoginController.test.tsx
+++ b/src/contentScript/integrations/deferredLoginController.test.tsx
@@ -68,7 +68,6 @@ describe("deferredLoginController", () => {
 
     await waitForEffect();
 
-    // eslint-disable-next-line testing-library/no-node-access -- The banner lives outside `body`
     expect(document.querySelector(".login-button")).toHaveAccessibleName(
       "Log in to Test Config",
     );

--- a/src/contentScript/integrations/deferredLoginController.test.tsx
+++ b/src/contentScript/integrations/deferredLoginController.test.tsx
@@ -18,7 +18,7 @@
 import React from "react";
 import {
   deferLogin,
-  showBannerInTopFrame,
+  showBannerFromConfig,
   clearDeferredLogins,
   dismissDeferredLogin,
 } from "@/contentScript/integrations/deferredLoginController";
@@ -57,7 +57,7 @@ describe("deferredLoginController", () => {
       .mocked(showLoginBanner)
       .mockImplementation(
         async (_target: Target, config: SanitizedIntegrationConfig) =>
-          showBannerInTopFrame(config),
+          showBannerFromConfig(config),
       );
     jest
       .mocked(integrationRegistry.lookup)
@@ -69,9 +69,10 @@ describe("deferredLoginController", () => {
 
     await waitForEffect();
 
-    expect(
-      screen.getByRole("button", { name: "Log in to Test Config" }),
-    ).toBeInTheDocument();
+    // eslint-disable-next-line testing-library/no-node-access -- The banner lives outside `body`
+    expect(document.querySelector(".login-button")).toHaveAccessibleName(
+      "Log in to Test Config",
+    );
     clearDeferredLogins();
     // Throws due to test cleanup
     await expect(promise).rejects.toThrow();
@@ -82,7 +83,7 @@ describe("deferredLoginController", () => {
       .mocked(showLoginBanner)
       .mockImplementation(
         async (_target: Target, config: SanitizedIntegrationConfig) =>
-          showBannerInTopFrame(config),
+          showBannerFromConfig(config),
       );
     jest
       .mocked(integrationRegistry.lookup)
@@ -105,7 +106,7 @@ describe("deferredLoginController", () => {
       .mocked(showLoginBanner)
       .mockImplementation(
         async (_target: Target, config: SanitizedIntegrationConfig) =>
-          showBannerInTopFrame(config),
+          showBannerFromConfig(config),
       );
     jest
       .mocked(integrationRegistry.lookup)

--- a/src/contentScript/integrations/deferredLoginController.ts
+++ b/src/contentScript/integrations/deferredLoginController.ts
@@ -39,14 +39,16 @@ import { getTopLevelFrame } from "webext-messenger";
 const deferredLogins = new Map<UUID, DeferredPromise<void>>();
 
 /**
- * Content script messenger handler to show a login banner. Should only be run in the top-level frame.
+ * Content script messenger handler to show a login banner.
+ *
+ * @warning Should only be run in the top-level frame.
  */
-export async function showBannerInTopFrame(
+export async function showBannerFromConfig(
   config: SanitizedIntegrationConfig,
 ): Promise<void> {
   if (isLoadedInIframe()) {
     console.warn(
-      "showBannerInTopFrame should only be called in the top-level frame",
+      "showBannerFromConfig should only be called in the top-level frame",
     );
   }
 

--- a/src/contentScript/messenger/registration.ts
+++ b/src/contentScript/messenger/registration.ts
@@ -52,7 +52,7 @@ import {
 import { reloadActivationEnhancements } from "@/contentScript/loadActivationEnhancementsCore"; // 248 errors
 import { getAttributeExamples } from "@/contentScript/pageEditor/elementInformation"; // 246 errors
 import { getCopilotHostData } from "@/contrib/automationanywhere/SetCopilotDataEffect";
-import { showBannerInTopFrame } from "@/contentScript/integrations/deferredLoginController"; // Background/messenger import
+import { showBannerFromConfig } from "@/contentScript/integrations/deferredLoginController"; // Background/messenger import
 
 expectContext("contentScript");
 
@@ -88,7 +88,7 @@ declare global {
 
     GET_COPILOT_HOST_DATA: typeof getCopilotHostData;
 
-    SHOW_LOGIN_BANNER: typeof showBannerInTopFrame;
+    SHOW_LOGIN_BANNER: typeof showBannerFromConfig;
 
     RELOAD_MARKETPLACE_ENHANCEMENTS: typeof reloadActivationEnhancements;
   }
@@ -126,7 +126,7 @@ export default function registerMessenger(): void {
 
     GET_COPILOT_HOST_DATA: getCopilotHostData,
 
-    SHOW_LOGIN_BANNER: showBannerInTopFrame,
+    SHOW_LOGIN_BANNER: showBannerFromConfig,
 
     RELOAD_MARKETPLACE_ENHANCEMENTS: reloadActivationEnhancements,
   });

--- a/src/contentScript/sidebarDomControllerLite.ts
+++ b/src/contentScript/sidebarDomControllerLite.ts
@@ -50,6 +50,10 @@ function storeOriginalCSSOnce() {
     "margin-right",
     `calc(var(${ORIGINAL_MARGIN_CSS_PROPERTY}) + var(${SIDEBAR_WIDTH_CSS_PROPERTY}))`,
   );
+
+  // Some websites like https://www.nespresso.com/us/en/ have `width: 100%` on the HTML.
+  // This resets it as it prevents the margin from working (and it's the default already)
+  html.style.setProperty("width", "auto");
 }
 
 function setSidebarWidth(pixels: number): void {


### PR DESCRIPTION
## What does this PR do?

- Fixes #8009
- Replaces and closes https://github.com/pixiebrix/pixiebrix-extension/pull/8012

## Demo on playground

https://pbx.vercel.app/style-conflicts/ after removing the unrelated `notifier` div


### `main`

<img width="1024" alt="Screenshot 10" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/6a3e7338-6e8a-4b1d-b288-9dd21242dfb4">


### #8009

<img width="1024" alt="main" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/cb0dd4e3-4b01-49f0-a8eb-ff8dedbee503">


### This PR

<img width="1024" alt="mine" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/46b52566-d5b5-4c6e-935c-a1c5cfd885b1">



## Demo on HN


### `main`

<img width="1024" alt="Screenshot 9" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/47201c3b-51a7-4047-959b-3b48a3457cc6">




### #8009


<img width="1024" alt="Screenshot 16" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/de652d00-b5bc-4be2-90ab-8389f6dff4b0">


### This PR


<img width="1024" alt="Screenshot 12" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/23bdcb79-d6d2-45e5-a14b-9d7cebcfe21e">


## Demo on Nespresso

https://www.nespresso.com/us/en/

### `main`

<img width="1024" alt="main" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/dc5cc8d3-2a6d-402d-b21b-67df18acc214">


### #8009

<img width="1024" alt="other" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/40491237-4598-48ad-a6f4-05b25a8d674e">

### This PR

<img width="1024" alt="Screenshot" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1402241/fda5e24c-4fea-4354-a4d7-1cb508e31e3a">




## Future work

- [ ] https://github.com/pixiebrix/pixiebrix-extension/issues/7670

## For personal reference

To create a banner, I use append this to `/bannerDomController.tsx`

```is
import {uuidv4} from "@/types/helpers";

showLoginBanner(
  {
    config: { label: "Heaven" },
    integration: {
      name: "d",
    },
  },
  () => uuidv4(),
);
```

## Checklist

- [ ] Add tests and/or storybook stories
- [x] Designate a primary reviewer: @grahamlangford 
