### PR TITLE
Update snippet shortcut brick names

### DIFF
--- a/src/bricks/effects/AddTextCommand.test.ts
+++ b/src/bricks/effects/AddTextCommand.test.ts
@@ -136,7 +136,7 @@ describe("AddTextCommand", () => {
         },
       ]),
       shortcut: "command",
-      title: "Example Command",
+      title: "Example Dynamic Snippet",
     });
   });
 });

--- a/src/bricks/effects/AddTextCommand.ts
+++ b/src/bricks/effects/AddTextCommand.ts
@@ -58,8 +58,8 @@ class AddTextCommand extends EffectABC {
   constructor() {
     super(
       AddTextCommand.BRICK_ID,
-      "[Experimental] Add Text Command",
-      "Add a dynamic text command",
+      "[Experimental] Add Dynamic Text Snippet",
+      "Add/register a dynamic text snippet to the Snippet Shortcut Menu",
     );
   }
 

--- a/src/bricks/effects/AddTextSnippets.ts
+++ b/src/bricks/effects/AddTextSnippets.ts
@@ -58,8 +58,8 @@ class AddTextSnippets extends EffectABC {
   constructor() {
     super(
       AddTextSnippets.BRICK_ID,
-      "[Experimental] Add Text Snippets",
-      "Add text snippets",
+      "Add Text Snippets",
+      "Add/register text snippets to the Snippet Shortcut Menu",
     );
   }
 

--- a/src/pageEditor/exampleBrickConfigs.ts
+++ b/src/pageEditor/exampleBrickConfigs.ts
@@ -201,7 +201,7 @@ export function getExampleBrickConfig(
     case AddTextCommand.BRICK_ID: {
       return {
         shortcut: "command",
-        title: "Example Command",
+        title: "Example Dynamic Snippet",
         generate: toExpression("pipeline", [
           {
             ...createNewConfiguredBrick(IdentityTransformer.BRICK_ID, {


### PR DESCRIPTION
## What does this PR do?

- Updates snippet shortcut brick names
- Names:
  - Add Text Snippets
  - [Experimental] Add Dynamic Text Snippet

## Discussion

- Will key up discussion on if we want to call Dynamic Text Snippet vs. Text Command: https://pixiebrix.slack.com/archives/C02RAMRDF0R/p1711115211568019
- I'm keeping experimental on dynamic text snippet, as we may want to change the structure of the variable passed into the text generation brick

## Future Work

- DevEx work to clean up the names in the code

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer: @grahamlangford 
