### PR TITLE
#8030: add slow/bad selector analysis warnings

### DIFF
--- a/src/analysis/analysisVisitors/selectorAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/selectorAnalysis.test.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import SelectorAnalysis, {
+  findJQueryExtensions,
+} from "@/analysis/analysisVisitors/selectorAnalysis";
+import {
+  menuItemFormStateFactory,
+  triggerFormStateFactory,
+} from "@/testUtils/factories/pageEditorFactories";
+import type { AttachMode } from "@/starterBricks/menuItemExtension";
+import { HighlightEffect } from "@/bricks/effects/highlight";
+import brickRegistry from "@/bricks/registry";
+import { JQueryReader } from "@/bricks/transformers/jquery/JQueryReader";
+
+const highlight = new HighlightEffect();
+const reader = new JQueryReader();
+
+beforeEach(() => {
+  brickRegistry.clear();
+  brickRegistry.register([highlight, reader]);
+});
+
+describe("findJQueryExtensions", () => {
+  it("finds all jQuery extensions in simple expression", () => {
+    expect(findJQueryExtensions('div:contains("bar")')).toStrictEqual([
+      ":contains",
+    ]);
+  });
+
+  it("handles compound", () => {
+    expect(
+      findJQueryExtensions('div:contains("bar"), button:visible'),
+    ).toStrictEqual([":contains", ":visible"]);
+  });
+
+  it("handles complex", () => {
+    expect(
+      findJQueryExtensions("span:has(> a:contains('submit'))"),
+    ).toStrictEqual([":contains"]);
+  });
+
+  it("excludes native has", () => {
+    expect(findJQueryExtensions("div:has(div.bar)")).toStrictEqual([]);
+  });
+
+  it("has some false positives :shrug:", () => {
+    expect(findJQueryExtensions("a:contains(':visible'))")).toStrictEqual([
+      ":contains",
+      // The false positive:
+      ":visible",
+    ]);
+  });
+});
+
+describe("SelectorAnalysis", () => {
+  it.each(["watch", "once"])(
+    "detects slow trigger selector for attachMode: %s",
+    async (attachMode: AttachMode) => {
+      const analysis = new SelectorAnalysis();
+
+      const component = triggerFormStateFactory();
+
+      component.extensionPoint.definition.rootSelector = 'div:contains("foo")';
+      component.extensionPoint.definition.attachMode = attachMode;
+
+      await analysis.run(component);
+
+      expect(analysis.getAnnotations()).toStrictEqual([
+        {
+          analysisId: "selector",
+          message: expect.any(String),
+          position: {
+            path: "extensionPoint.definition.rootSelector",
+          },
+          type: expect.toBeOneOf(["warning", "info"]),
+        },
+      ]);
+    },
+  );
+
+  it("detects invalid trigger selector", async () => {
+    const analysis = new SelectorAnalysis();
+
+    const component = triggerFormStateFactory();
+
+    component.extensionPoint.definition.rootSelector = '!div:contains("foo")';
+
+    await analysis.run(component);
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      {
+        analysisId: "selector",
+        message: expect.any(String),
+        position: {
+          path: "extensionPoint.definition.rootSelector",
+        },
+        type: "error",
+      },
+    ]);
+  });
+
+  it.each(["watch", "once"])(
+    "detects slow menu selector for attachMode: %s",
+    async (attachMode: AttachMode) => {
+      const analysis = new SelectorAnalysis();
+
+      const component = menuItemFormStateFactory();
+
+      component.extensionPoint.definition.containerSelector =
+        'div:contains("foo")';
+      component.extensionPoint.definition.attachMode = attachMode;
+
+      await analysis.run(component);
+
+      expect(analysis.getAnnotations()).toStrictEqual([
+        {
+          analysisId: "selector",
+          message: expect.any(String),
+          position: {
+            path: "extensionPoint.definition.containerSelector",
+          },
+          type: expect.toBeOneOf(["warning", "info"]),
+        },
+      ]);
+    },
+  );
+
+  it("detects invalid action location selector", async () => {
+    const analysis = new SelectorAnalysis();
+
+    const component = menuItemFormStateFactory();
+
+    component.extensionPoint.definition.containerSelector = "!div";
+
+    await analysis.run(component);
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      {
+        analysisId: "selector",
+        message: "Invalid selector.",
+        position: {
+          path: "extensionPoint.definition.containerSelector",
+        },
+        type: "error",
+      },
+    ]);
+  });
+
+  it("detects selectors passed to highlight brick", async () => {
+    const analysis = new SelectorAnalysis();
+
+    const component = triggerFormStateFactory();
+
+    component.extension.blockPipeline = [
+      {
+        id: highlight.id,
+        config: {
+          rootSelector: ".D232jn2921a",
+          elements: [
+            {
+              selector: ".D232jn2921a",
+            },
+          ],
+        },
+      },
+    ];
+
+    await analysis.run(component);
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      {
+        analysisId: "selector",
+        message: expect.stringMatching(
+          /Selector appears to contain random characters/,
+        ),
+        position: {
+          path: "extension.blockPipeline.0.config.rootSelector",
+        },
+        type: "warning",
+      },
+      {
+        analysisId: "selector",
+        message: expect.stringMatching(
+          /Selector appears to contain random characters/,
+        ),
+        position: {
+          path: "extension.blockPipeline.0.config.elements.0.selector",
+        },
+        type: "warning",
+      },
+    ]);
+  });
+
+  it("detects selectors passed to jquery brick", async () => {
+    const analysis = new SelectorAnalysis();
+
+    const component = triggerFormStateFactory();
+
+    component.extension.blockPipeline = [
+      {
+        id: reader.id,
+        config: {
+          selectors: {
+            simple: ".D232jn2921a",
+            complex: {
+              selector: ".D232jn2921a",
+            },
+          },
+        },
+      },
+    ];
+
+    await analysis.run(component);
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      {
+        analysisId: "selector",
+        message: expect.stringMatching(
+          /Selector appears to contain random characters/,
+        ),
+        position: {
+          path: "extension.blockPipeline.0.config.selectors.simple",
+        },
+        type: "warning",
+      },
+      {
+        analysisId: "selector",
+        message: expect.stringMatching(
+          /Selector appears to contain random characters/,
+        ),
+        position: {
+          path: "extension.blockPipeline.0.config.selectors.complex.selector",
+        },
+        type: "warning",
+      },
+    ]);
+  });
+});

--- a/src/analysis/analysisVisitors/selectorAnalysis.ts
+++ b/src/analysis/analysisVisitors/selectorAnalysis.ts
@@ -1,0 +1,330 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type {
+  ActionFormState,
+  ModComponentFormState,
+  TriggerFormState,
+} from "@/pageEditor/starterBricks/formStateTypes";
+import { AnalysisVisitorWithResolvedBricksABC } from "@/analysis/analysisVisitors/baseAnalysisVisitors";
+import { isNativeCssSelector, isValidSelector } from "@/utils/domUtils";
+import { AnnotationType } from "@/types/annotationTypes";
+import { isEmpty } from "lodash";
+import pluralize from "@/utils/pluralize";
+import type { BrickConfig, BrickPosition } from "@/bricks/types";
+import { nestedPosition, type VisitBlockExtra } from "@/bricks/PipelineVisitor";
+import { inputProperties } from "@/utils/schemaUtils";
+import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
+import { guessUsefulness } from "@/utils/detectRandomString";
+import type { Schema } from "@/types/schemaTypes";
+import { isObject } from "@/utils/objectUtils";
+
+// `jQuery` selector extension: https://api.jquery.com/category/selectors/jquery-selector-extensions/
+const jQueryExtensions = new Set([
+  ":animated",
+  ":button",
+  ":checkbox",
+  ":contains",
+  ":eq",
+  ":even",
+  ":file",
+  ":first",
+  ":gt",
+  ":header",
+  ":hidden",
+  ":image",
+  ":input",
+  ":last",
+  ":lt",
+  ":odd",
+  ":parent",
+  ":password",
+  ":radio",
+  ":reset",
+  ":selected",
+  ":submit",
+  ":text",
+  ":visible",
+]);
+
+/**
+ * Returns all jQuery extensions in the given selector.
+ */
+export function findJQueryExtensions(selector: string): string[] {
+  // Could try to use $.find.tokenize, but IMO it's not worth figuring out how to recursively parse/tokenize.
+  // The only case where string matching would report false positives is if the jQuery extension is in a
+  // string (e.g., within a :contains selector or an attribute selector)
+  return [...jQueryExtensions.values()].filter((ext) => selector.includes(ext));
+}
+
+const INVALID_SELECTOR_MESSAGE = "Invalid selector.";
+
+/**
+ * Analysis that detects bad or potentially bad selectors.
+ *
+ * Currently detected:
+ * - Invalid selectors
+ * - Non-native selector that might slow down the page
+ * - Random selector, e.g., CSS module selector
+ *
+ * Future work:
+ * - Structural selectors
+ */
+class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
+  override id = "selector";
+
+  override async run(component: ModComponentFormState): Promise<void> {
+    switch (component.type) {
+      case "menuItem": {
+        this.checkAction(component);
+        break;
+      }
+
+      case "trigger": {
+        this.checkTrigger(component);
+        break;
+      }
+
+      default:
+    }
+
+    await super.run(component);
+  }
+
+  checkAction(component: ActionFormState): void {
+    const selector = component.extensionPoint.definition.containerSelector;
+
+    const position = {
+      path: "extensionPoint.definition.containerSelector",
+    };
+
+    if (!isEmpty(selector)) {
+      this.visitSelector({
+        position,
+        selector,
+      });
+
+      if (!isValidSelector(selector)) {
+        return;
+      }
+
+      if (!isNativeCssSelector(selector)) {
+        const matches = findJQueryExtensions(selector);
+        const isWatch =
+          component.extensionPoint.definition.attachMode === "watch";
+
+        let message = isWatch
+          ? "Using a non-native CSS selector for location in watch mode. Button location selectors that use jQuery extensions may slow down the page."
+          : "Using a non-native CSS selector for location. Button location selectors that use jQuery extensions may slow down the page if the element is not available on page load.";
+
+        if (matches.length > 0) {
+          message += ` JQuery ${pluralize(
+            matches.length,
+            "extension",
+          )} found: ${matches.join(", ")}`;
+        }
+
+        this.annotations.push({
+          analysisId: this.id,
+          position,
+          message,
+          type: isWatch ? AnnotationType.Warning : AnnotationType.Info,
+        });
+      }
+    }
+  }
+
+  checkTrigger(component: TriggerFormState): void {
+    const selector = component.extensionPoint.definition.rootSelector;
+
+    const position = {
+      path: "extensionPoint.definition.rootSelector",
+    };
+
+    if (!isEmpty(selector)) {
+      this.visitSelector({
+        position,
+        selector,
+      });
+
+      if (!isValidSelector(selector)) {
+        return;
+      }
+
+      if (!isNativeCssSelector(selector)) {
+        const matches = findJQueryExtensions(selector);
+        const isWatch =
+          component.extensionPoint.definition.attachMode === "watch";
+
+        let message = isWatch
+          ? "Using a non-native CSS selector in watch mode. Watching selectors that use jQuery extensions may slow down the page."
+          : "Using a non-native CSS selector. Trigger selectors that use jQuery extensions may slow down the page if the element is not available on page load.";
+
+        if (matches.length > 0) {
+          message += ` JQuery ${pluralize(
+            matches.length,
+            "extension",
+          )} found: ${matches.join(", ")}`;
+        }
+
+        this.annotations.push({
+          analysisId: this.id,
+          position,
+          message,
+          type: isWatch ? AnnotationType.Warning : AnnotationType.Info,
+        });
+      }
+    }
+  }
+
+  visitSelector({
+    position,
+    selector,
+  }: {
+    position: BrickPosition;
+    selector: string;
+  }) {
+    if (!isValidSelector(selector)) {
+      this.annotations.push({
+        position,
+        message: INVALID_SELECTOR_MESSAGE,
+        analysisId: this.id,
+        type: AnnotationType.Error,
+      });
+    }
+
+    const usefulness = guessUsefulness(selector);
+
+    if (usefulness.isRandom) {
+      this.annotations.push({
+        position,
+        message:
+          "Selector appears to contain random characters. This may indicate a value that changes across page reloads or application updates.",
+        analysisId: this.id,
+        type: AnnotationType.Warning,
+      });
+    }
+  }
+
+  visitValue(position: BrickPosition, value: unknown, schema: Schema): void {
+    if (schema.format !== "selector") {
+      return;
+    }
+
+    let selector;
+
+    try {
+      selector = castTextLiteralOrThrow(value);
+    } catch {
+      return;
+    }
+
+    this.visitSelector({
+      position,
+      selector,
+    });
+  }
+
+  visitConfig(position: BrickPosition, config: unknown, schema: Schema): void {
+    if (
+      schema.type === "array" &&
+      Array.isArray(config) &&
+      typeof schema.items === "object" &&
+      !Array.isArray(schema.items)
+    ) {
+      for (const [index, item] of config.entries()) {
+        this.visitConfig(
+          nestedPosition(position, index.toString()),
+          item,
+          schema.items,
+        );
+      }
+    }
+
+    for (const subSchema of schema.oneOf ??
+      schema.anyOf ??
+      schema.allOf ??
+      []) {
+      // Checking each individually isn't 100% correct for oneOf/anyOf. There could be a schema where the same prop
+      // is a selector in one schema, but is allowed to be any string in another schema. In practice, there shouldn't
+      // be any cases with different formats in different sub-schemas.
+      if (typeof subSchema !== "boolean") {
+        this.visitConfig(position, config, subSchema);
+      }
+    }
+
+    if (schema.type === "string") {
+      this.visitValue(position, config, schema);
+      return;
+    }
+
+    if (schema.type !== "object" || !isObject(config)) {
+      return;
+    }
+
+    const visitedPropNames = new Set();
+
+    for (const [prop, definition] of Object.entries(inputProperties(schema))) {
+      // eslint-disable-next-line security/detect-object-injection -- from JSONSchema
+      const value = config[prop];
+
+      if (typeof definition === "boolean") {
+        continue;
+      }
+
+      this.visitConfig(nestedPosition(position, prop), value, definition);
+
+      visitedPropNames.add(prop);
+    }
+
+    if (typeof schema.additionalProperties === "object") {
+      for (const [prop, value] of Object.entries(config)) {
+        if (!visitedPropNames.has(prop)) {
+          this.visitConfig(
+            nestedPosition(position, prop),
+            value,
+            schema.additionalProperties,
+          );
+        }
+      }
+    }
+  }
+
+  override visitBrick(
+    position: BrickPosition,
+    brickConfig: BrickConfig,
+    _extra: VisitBlockExtra,
+  ): void {
+    super.visitBrick(position, brickConfig, _extra);
+
+    let brick;
+
+    try {
+      brick = this.allBlocks.get(brickConfig.id).block;
+    } catch {
+      return;
+    }
+
+    this.visitConfig(
+      nestedPosition(position, "config"),
+      brickConfig.config,
+      brick.inputSchema,
+    );
+  }
+}
+
+export default SelectorAnalysis;

--- a/src/analysis/analysisVisitors/templateAnalysis.ts
+++ b/src/analysis/analysisVisitors/templateAnalysis.ts
@@ -44,7 +44,7 @@ type PushAnnotationArgs = {
 class TemplateAnalysis extends PipelineExpressionVisitor implements Analysis {
   // XXX: for now we handle asynchronous pipeline traversal by gathering all the promises and awaiting them all
   // see discussion https://github.com/pixiebrix/pixiebrix-extension/pull/4013#discussion_r944690969
-  private readonly nunjuckValidationPromises: Array<Promise<void>> = [];
+  private readonly nunjucksValidationPromises: Array<Promise<void>> = [];
 
   get id() {
     return "template";
@@ -60,7 +60,7 @@ class TemplateAnalysis extends PipelineExpressionVisitor implements Analysis {
       extensionPointType: extension.type,
     });
 
-    await Promise.all(this.nunjuckValidationPromises);
+    await Promise.all(this.nunjucksValidationPromises);
   }
 
   private pushErrorAnnotation({
@@ -100,7 +100,7 @@ class TemplateAnalysis extends PipelineExpressionVisitor implements Analysis {
         expression,
       });
     } else if (isNunjucksExpression(expression)) {
-      this.nunjuckValidationPromises.push(
+      this.nunjucksValidationPromises.push(
         (async () => {
           try {
             await validateNunjucksTemplate(expression.__value__);

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -105,10 +105,16 @@ declare module "canvas-confetti" {
   export default confetti;
 }
 
+type Token = {
+  value: string;
+  type: "PSEUDO" | "TAG" | string;
+  matches: string[];
+};
+
 interface JQueryStatic {
   find: (() => JQuery) & {
     /** Partial type for `$.find.tokenize */
-    tokenize: (selector: string) => string[];
+    tokenize: (selector: string) => Token[][];
   };
 }
 

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -44,6 +44,7 @@ import { getPageState } from "@/contentScript/messenger/strict/api";
 import HttpRequestAnalysis from "@/analysis/analysisVisitors/httpRequestAnalysis";
 import ModVariableNames from "@/analysis/analysisVisitors/pageStateAnalysis/modVariableSchemasVisitor";
 import { inspectedTab } from "@/pageEditor/context/connection";
+import SelectorAnalysis from "@/analysis/analysisVisitors/selectorAnalysis";
 
 const runtimeActions = runtimeSlice.actions;
 
@@ -135,6 +136,11 @@ pageEditorAnalysisManager.registerAnalysisEffect(
     matcher: isAnyOf(...nodeListMutationActions),
   },
 );
+
+pageEditorAnalysisManager.registerAnalysisEffect(() => new SelectorAnalysis(), {
+  // Slow Selector Analysis currently checks the starter brick definition
+  matcher: isAnyOf(editorActions.editElement),
+});
 
 pageEditorAnalysisManager.registerAnalysisEffect(() => new TemplateAnalysis(), {
   matcher: isAnyOf(editorActions.editElement, ...nodeListMutationActions),

--- a/src/utils/domUtils.test.ts
+++ b/src/utils/domUtils.test.ts
@@ -109,6 +109,13 @@ describe("isValidSelector", () => {
     },
   );
 
+  it.each(['div:contains("foo")', "div:visible"])(
+    "returns true for valid jquery selector: %s",
+    (selector) => {
+      expect(isValidSelector(selector)).toBeTrue();
+    },
+  );
+
   it.each(["!foo"])("returns false for invalid selector: %s", (selector) => {
     expect(isValidSelector(selector)).toBeFalse();
   });

--- a/src/utils/domUtils.test.ts
+++ b/src/utils/domUtils.test.ts
@@ -15,7 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { runOnDocumentVisible } from "@/utils/domUtils";
+import {
+  isNativeCssSelector,
+  isValidSelector,
+  runOnDocumentVisible,
+} from "@/utils/domUtils";
 
 let hidden = false;
 
@@ -78,5 +82,34 @@ describe("runOnDocumentVisible", () => {
     }
 
     expect(mock).toHaveBeenCalledTimes(numCalls);
+  });
+});
+
+describe("isNativeCssSelector", () => {
+  it.each(["div", ".foo:has(.bar)"])(
+    "returns true for native CSS selector: %s",
+    (selector) => {
+      expect(isNativeCssSelector(selector)).toBeTrue();
+    },
+  );
+
+  it.each(['div:contains("foo")', "div:visible"])(
+    "returns false for JQuery selector: %s",
+    (selector) => {
+      expect(isNativeCssSelector(selector)).toBeFalse();
+    },
+  );
+});
+
+describe("isValidSelector", () => {
+  it.each(["div", ".foo:has(.bar)", 'div:contains("foo")'])(
+    "returns true for valid selector: %s",
+    (selector) => {
+      expect(isValidSelector(selector)).toBeTrue();
+    },
+  );
+
+  it.each(["!foo"])("returns false for invalid selector: %s", (selector) => {
+    expect(isValidSelector(selector)).toBeFalse();
   });
 });

--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -208,3 +208,31 @@ export function getSelectionRange(): Range | undefined {
   // eslint-disable-next-line no-restricted-syntax -- The rule points to this helper
   return selection?.rangeCount ? selection.getRangeAt(0) : undefined;
 }
+
+/**
+ * Returns true if the selector is a native CSS selector, or false if it's a jQuery selector or invalid selector
+ */
+export function isNativeCssSelector(selector: string): boolean {
+  try {
+    document.querySelectorAll(selector);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true if the selector is a valid selector (CSS or jQuery)
+ */
+export function isValidSelector(selector: string): boolean {
+  try {
+    $safeFind(selector);
+    return true;
+  } catch (error) {
+    if (error instanceof InvalidSelectorError) {
+      return false;
+    }
+
+    throw error;
+  }
+}

--- a/src/utils/schemaUtils.ts
+++ b/src/utils/schemaUtils.ts
@@ -117,7 +117,7 @@ export function inputProperties(inputSchema: Schema): SchemaProperties {
  * Returns true if the schema uses anyOf/oneOf/allOf/not.
  * @param schema the JSON Schema
  */
-export function isComplexSchema(schema: Schema): boolean {
+function isComplexSchema(schema: Schema): boolean {
   // https://json-schema.org/understanding-json-schema/reference/combining.html
   return (
     Boolean(schema.anyOf) ||

--- a/src/utils/schemaUtils.ts
+++ b/src/utils/schemaUtils.ts
@@ -117,7 +117,7 @@ export function inputProperties(inputSchema: Schema): SchemaProperties {
  * Returns true if the schema uses anyOf/oneOf/allOf/not.
  * @param schema the JSON Schema
  */
-function isComplexSchema(schema: Schema): boolean {
+export function isComplexSchema(schema: Schema): boolean {
   // https://json-schema.org/understanding-json-schema/reference/combining.html
   return (
     Boolean(schema.anyOf) ||

--- a/src/vendors/jQueryInitialize.js
+++ b/src/vendors/jQueryInitialize.js
@@ -197,12 +197,12 @@ msobservers.initialize = function (selector, callback, options) {
   });
 
   // Observe the target element.
-  var defaultObeserverOpts = {
+  var defaultObserverOpts = {
     childList: true,
     subtree: true,
     attributes: msobserver.isComplex,
   };
-  observer.observe(options.target, options.observer || defaultObeserverOpts);
+  observer.observe(options.target, options.observer || defaultObserverOpts);
 
   return observer;
 };


### PR DESCRIPTION
## What does this PR do?

- Closes #8030 
- Adds selector analysis warnings:
  - Invalid selector: Error
  - Selector with random characters: Warning
  - Selector that might slow down the page: Warning

## Reviewer Notes

- Vendor check fails due to fixed typo. That particular file is one we've made some modifications to
- Strict null checks not possible due to dependency on the registry

## Discussion

- Uses the pre-existing randomness detection we had prototyped for the "Exclude Random Classes" skunkworks feature (which has never been turned on for all users)
- JQuery doesn't report what's invalid about the selector when it throws its error. Otherwise it'd be nice to explain where the syntax/invalid selector is
- Based on dogfooding, we might choose to make the randomness check an info instead of warning

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/f5898185-41e0-4cc0-ab70-cc6347cc5dfb)

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/d35019b9-137d-451f-ba70-cae18a95e34b)

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/76d59c6f-1d41-4e5c-a548-f20bda9be512)

## Future Work

- Generalize the schema recursion to be available in other analyses. (We have a generic visitExpression, but that is not schema-aware)
- Consider warning on use of known unstable selectors: https://github.com/pixiebrix/pixiebrix-extension/blob/641e53922db0ed76d56916a0d0eeed13a570c014/src/utils/inference/selectorInference.ts#L79-L79
- Consider warning on excessive structural selectors (e.g., `:nth-child`)
- Consider info on using contains (because it's not robust to translation)

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer: @fungairino 
