### PR TITLE
Add playwright test type detection in IntelliJ; add workshop smoke test

### DIFF
--- a/end-to-end-tests/pageObjects/workshopPage.ts
+++ b/end-to-end-tests/pageObjects/workshopPage.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type Page } from "@playwright/test";
+import { getBaseExtensionConsoleUrl } from "./constants";
+
+export class WorkshopPage {
+  private readonly extensionConsoleUrl: string;
+
+  constructor(
+    private readonly page: Page,
+    extensionId: string,
+  ) {
+    this.extensionConsoleUrl = getBaseExtensionConsoleUrl(extensionId);
+  }
+
+  async goto() {
+    await this.page.goto(this.extensionConsoleUrl);
+    await this.page
+      .getByRole("link", {
+        name: "Workshop",
+      })
+      .click();
+  }
+}

--- a/end-to-end-tests/tests/modsPageSmoke.spec.ts
+++ b/end-to-end-tests/tests/modsPageSmoke.spec.ts
@@ -19,6 +19,8 @@ import { test, expect } from "../fixtures/extensionBase";
 import { ModsPage } from "../pageObjects/modsPage";
 import AxeBuilder from "@axe-core/playwright";
 import { checkForCriticalViolations } from "../utils";
+// @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
+import { test as base } from "@playwright/test";
 
 test.describe("extension console mods page smoke test", () => {
   test("can view available mods", async ({ page, extensionId }) => {

--- a/end-to-end-tests/tests/workshopPageSmoke.spec.ts
+++ b/end-to-end-tests/tests/workshopPageSmoke.spec.ts
@@ -16,28 +16,27 @@
  */
 
 import { test, expect } from "../fixtures/extensionBase";
-import { ActivateModPage } from "../pageObjects/modsPage";
+import { WorkshopPage } from "../pageObjects/workshopPage";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { test as base } from "@playwright/test";
 
-test("can activate and use highlight keywords mod", async ({
-  page,
-  extensionId,
-}) => {
-  const modId = "@pixies/highlight-keywords";
+test.describe("extension console workshop smoke test", () => {
+  test("can navigate to workshop page without a username", async ({
+    page,
+    extensionId,
+  }) => {
+    const workshopPage = new WorkshopPage(page, extensionId);
+    await workshopPage.goto();
 
-  const modActivationPage = new ActivateModPage(page, extensionId, modId);
-  await modActivationPage.goto();
+    page.getByText("W");
 
-  await modActivationPage.clickActivateAndWaitForModsPageRedirect();
+    // User has no username set, so will be shown welcome message for username selection
+    const welcomeMessage = page.getByText("Welcome to the PixieBrix Workshop!");
+    await expect(welcomeMessage).toBeVisible();
 
-  await page.goto("/bootstrap-5");
+    const pageTitle = await page.title();
 
-  const highlightedElements = await page.locator("mark").all();
-
-  await Promise.all(
-    highlightedElements.map(async (element) => {
-      await expect(element).toHaveText("PixieBrix");
-    }),
-  );
+    // Still the Extension Console because the page workshop page is gated
+    expect(pageTitle).toBe("Extension Console | PixieBrix");
+  });
 });

--- a/end-to-end-tests/tests/workshopPageSmoke.spec.ts
+++ b/end-to-end-tests/tests/workshopPageSmoke.spec.ts
@@ -28,8 +28,6 @@ test.describe("extension console workshop smoke test", () => {
     const workshopPage = new WorkshopPage(page, extensionId);
     await workshopPage.goto();
 
-    page.getByText("W");
-
     // User has no username set, so will be shown welcome message for username selection
     const welcomeMessage = page.getByText("Welcome to the PixieBrix Workshop!");
     await expect(welcomeMessage).toBeVisible();


### PR DESCRIPTION
## What does this PR do?

- Adds support for running single test from IntelliJ (fixes test detection for existing tests)
- Adds a workshop smoke test if username doesn't have alias defined

## Discussion

- We probably should give our test user an scope/username so we can write workshop/page editor mod save/copy tests

## Future Work

- Workshop smoke tests for user with an alias
- Improve ergonomics of checkForCriticalViolations. Right now there's no quick way to create a new baseline given that you get a diff of 600+ lines of the detailed report when it fails. `absentAllowedViolations` should likely also be an error to force us to keep these lists up-to-date

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer: @fungairino 
