### PR TITLE
Hide community link in extension console for restricted users

### DIFF
--- a/src/data/model/UserPartner.ts
+++ b/src/data/model/UserPartner.ts
@@ -41,6 +41,7 @@ export function transformUserPartnerResponse(
   }
 
   if (response.documentation_url) {
+    // XXX: the URL ends up in Redux as a non-serializable value
     partner.documentationUrl = new URL(response.documentation_url);
   }
 

--- a/src/extensionConsole/Sidebar.test.tsx
+++ b/src/extensionConsole/Sidebar.test.tsx
@@ -43,15 +43,19 @@ describe("Sidebar", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("link", { name: "Mods" })).toBeVisible();
-    expect(screen.getByRole("link", { name: "Workshop" })).toBeVisible();
-    expect(
-      screen.getByRole("link", { name: "Local Integrations" }),
-    ).toBeVisible();
-    expect(screen.getByRole("link", { name: "Settings" })).toBeVisible();
-    expect(screen.getByRole("link", { name: "Marketplace" })).toBeVisible();
-    expect(screen.getByRole("link", { name: "Community Slack" })).toBeVisible();
-    expect(screen.getByRole("link", { name: "Documentation" })).toBeVisible();
+    const pages = [
+      "Mods",
+      "Workshop",
+      "Local Integrations",
+      "Settings",
+      "Marketplace",
+      "Community Slack",
+      "Documentation",
+    ];
+
+    for (const page of pages) {
+      expect(screen.getByRole("link", { name: page })).toBeVisible();
+    }
   });
 
   it("hides links for restricted users", async () => {
@@ -82,20 +86,23 @@ describe("Sidebar", () => {
     // Wait for the flags call to resolve
     await waitForEffect();
 
-    expect(screen.getByRole("link", { name: "Mods" })).toBeVisible();
-    expect(
-      screen.queryByRole("link", { name: "Workshop" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "Local Integrations" }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Settings" })).toBeVisible();
-    expect(
-      screen.queryByRole("link", { name: "Marketplace" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "Community Slack" }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Documentation" })).toBeVisible();
+    const visible = ["Mods", "Settings", "Documentation"];
+
+    for (const page of visible) {
+      expect(screen.getByRole("link", { name: page })).toBeVisible();
+    }
+
+    const hidden = [
+      "Workshop",
+      "Local Integrations",
+      "Marketplace",
+      "Community Slack",
+    ];
+
+    for (const page of hidden) {
+      expect(
+        screen.queryByRole("link", { name: page }),
+      ).not.toBeInTheDocument();
+    }
   });
 });

--- a/src/extensionConsole/Sidebar.test.tsx
+++ b/src/extensionConsole/Sidebar.test.tsx
@@ -33,7 +33,6 @@ describe("Sidebar", () => {
 
   it("shows links for unrestricted users", async () => {
     await mockAuthenticatedMeApiResponse({
-      // https://github.com/pixiebrix/pixiebrix-app/blob/395c5d3672689d0a7158e3d3ef11e821f69e669d/api/tests/users/test_me.py#L68-L79
       flags: [],
     });
 
@@ -56,6 +55,55 @@ describe("Sidebar", () => {
     for (const page of pages) {
       expect(screen.getByRole("link", { name: page })).toBeVisible();
     }
+  });
+
+  it("unrestricted partner user", async () => {
+    await mockAuthenticatedMeApiResponse({
+      flags: [],
+      partner: {
+        name: "automation-anywhere",
+        theme: "automation-anywhere",
+        documentation_url: "https://docs.automationanywhere.com/",
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+
+    // Wait for the flags call to resolve
+    await waitForEffect();
+
+    const pages = [
+      "Mods",
+      "Workshop",
+      "Local Integrations",
+      "Settings",
+      "Marketplace",
+      "Documentation",
+    ];
+
+    for (const page of pages) {
+      expect(screen.getByRole("link", { name: page })).toBeVisible();
+    }
+
+    const hidden = ["Community Slack"];
+
+    for (const page of hidden) {
+      expect(
+        screen.queryByRole("link", { name: page }),
+      ).not.toBeInTheDocument();
+    }
+
+    const documentationLink = screen.getByRole("link", {
+      name: "Documentation",
+    });
+    expect(documentationLink).toHaveAttribute(
+      "href",
+      "https://docs.automationanywhere.com/",
+    );
   });
 
   it("hides links for restricted users", async () => {

--- a/src/extensionConsole/Sidebar.test.tsx
+++ b/src/extensionConsole/Sidebar.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render } from "@/extensionConsole/testHelpers";
+import Sidebar from "@/extensionConsole/Sidebar";
+import {
+  mockAuthenticatedMeApiResponse,
+  resetMeApiMocks,
+} from "@/testUtils/userMock";
+import { screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { waitForEffect } from "@/testUtils/testHelpers";
+
+describe("Sidebar", () => {
+  beforeEach(async () => {
+    await resetMeApiMocks();
+  });
+
+  it("shows links for unrestricted users", async () => {
+    await mockAuthenticatedMeApiResponse({
+      // https://github.com/pixiebrix/pixiebrix-app/blob/395c5d3672689d0a7158e3d3ef11e821f69e669d/api/tests/users/test_me.py#L68-L79
+      flags: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "Mods" })).toBeVisible();
+    expect(screen.getByRole("link", { name: "Workshop" })).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: "Local Integrations" }),
+    ).toBeVisible();
+    expect(screen.getByRole("link", { name: "Settings" })).toBeVisible();
+    expect(screen.getByRole("link", { name: "Marketplace" })).toBeVisible();
+    expect(screen.getByRole("link", { name: "Community Slack" })).toBeVisible();
+    expect(screen.getByRole("link", { name: "Documentation" })).toBeVisible();
+  });
+
+  it("hides links for restricted users", async () => {
+    await mockAuthenticatedMeApiResponse({
+      // https://github.com/pixiebrix/pixiebrix-app/blob/395c5d3672689d0a7158e3d3ef11e821f69e669d/api/tests/users/test_me.py#L68-L79
+      flags: [
+        "enterprise-telemetry",
+        "restricted-marketplace",
+        "restricted-page-editor",
+        "restricted-permissions",
+        "restricted-reset",
+        "restricted-service-url",
+        "restricted-services",
+        "restricted-uninstall",
+        "restricted-workshop",
+        "restricted-clear-token",
+        "restricted-onboarding",
+        "restricted-team",
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>,
+    );
+
+    // Wait for the flags call to resolve
+    await waitForEffect();
+
+    expect(screen.getByRole("link", { name: "Mods" })).toBeVisible();
+    expect(
+      screen.queryByRole("link", { name: "Workshop" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Local Integrations" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Settings" })).toBeVisible();
+    expect(
+      screen.queryByRole("link", { name: "Marketplace" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Community Slack" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Documentation" })).toBeVisible();
+  });
+});

--- a/src/extensionConsole/Sidebar.tsx
+++ b/src/extensionConsole/Sidebar.tsx
@@ -92,7 +92,7 @@ const Sidebar: React.FunctionComponent = () => {
               </a>
             </li>
           )}
-          {!hasPartner && (
+          {!hasPartner && permit("marketplace") && (
             // Hide for partner users because we don't support custom community links yet
             <li className="nav-item">
               <a


### PR DESCRIPTION
## What does this PR do?

- Hides the community link in extension console for restricted users

## Discussion

- There isn't a specific flag for hiding the community, so rely on the `restricted-marketplace` flag

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer: @BLoe 
