### PR TITLE
#7174 add manifest version and runtime id to error telemetry

### DIFF
--- a/src/data/service/errorService.test.ts
+++ b/src/data/service/errorService.test.ts
@@ -26,9 +26,7 @@ import {
 } from "@/data/service/errorService";
 import { serializeError } from "serialize-error";
 import { InteractiveLoginRequiredError } from "@/errors/authErrors";
-import { appApiMock } from "@/testUtils/appApiMock";
 import { TEST_flushAll } from "@/background/telemetry";
-import { AnnotationType } from "@/types/annotationTypes";
 
 const EXPECTED_RUNTIME_ID = "abc123";
 const expectedManifestValues = {

--- a/src/data/service/errorService.test.ts
+++ b/src/data/service/errorService.test.ts
@@ -26,7 +26,6 @@ import {
 } from "@/data/service/errorService";
 import { serializeError } from "serialize-error";
 import { InteractiveLoginRequiredError } from "@/errors/authErrors";
-import { TEST_flushAll } from "@/background/telemetry";
 
 const EXPECTED_RUNTIME_ID = "abc123";
 const expectedManifestValues = {
@@ -65,8 +64,6 @@ describe("selectExtraContext", () => {
     browser.runtime.getManifest = jest
       .fn()
       .mockReturnValue(expectedManifestValues);
-
-    await TEST_flushAll();
   });
 
   it("should return the expected extension context", async () => {

--- a/src/data/service/errorService.test.ts
+++ b/src/data/service/errorService.test.ts
@@ -20,9 +20,22 @@ import {
   CancelError,
   RequestSupersededError,
 } from "@/errors/businessErrors";
-import { shouldIgnoreError } from "@/data/service/errorService";
+import {
+  selectExtraContext,
+  shouldIgnoreError,
+} from "@/data/service/errorService";
 import { serializeError } from "serialize-error";
 import { InteractiveLoginRequiredError } from "@/errors/authErrors";
+import { appApiMock } from "@/testUtils/appApiMock";
+import { TEST_flushAll } from "@/background/telemetry";
+import { AnnotationType } from "@/types/annotationTypes";
+
+const EXPECTED_RUNTIME_ID = "abc123";
+const expectedManifestValues = {
+  version_name: "1.0.0",
+  version: "1.0.0",
+  manifest_version: "3",
+};
 
 describe("shouldIgnoreError", () => {
   it.each([CancelError, RequestSupersededError])(
@@ -46,4 +59,24 @@ describe("shouldIgnoreError", () => {
       ).toBeFalse();
     },
   );
+});
+
+describe("selectExtraContext", () => {
+  beforeEach(async () => {
+    browser.runtime.id = EXPECTED_RUNTIME_ID;
+    browser.runtime.getManifest = jest
+      .fn()
+      .mockReturnValue(expectedManifestValues);
+
+    await TEST_flushAll();
+  });
+
+  it("should return the expected extension context", async () => {
+    await expect(selectExtraContext(new Error("foo"))).resolves.toStrictEqual(
+      expect.objectContaining({
+        extensionVersion: expectedManifestValues.version,
+        manifestVersion: expectedManifestValues.manifest_version,
+      }),
+    );
+  });
 });

--- a/src/data/service/errorService.test.ts
+++ b/src/data/service/errorService.test.ts
@@ -76,6 +76,7 @@ describe("selectExtraContext", () => {
       expect.objectContaining({
         extensionVersion: expectedManifestValues.version,
         manifestVersion: expectedManifestValues.manifest_version,
+        runtimeId: EXPECTED_RUNTIME_ID,
       }),
     );
   });

--- a/src/data/service/errorService.ts
+++ b/src/data/service/errorService.ts
@@ -75,10 +75,12 @@ async function flush(): Promise<void> {
 export async function selectExtraContext(
   error: Error | SerializedError,
 ): Promise<UnknownObject & { extensionVersion: SemVerString }> {
-  const { version } = browser.runtime.getManifest();
+  const { version, manifest_version: manifestVersion } =
+    browser.runtime.getManifest();
   const extensionVersion = validateSemVerString(version);
   const extraContext: UnknownObject & { extensionVersion: SemVerString } = {
     extensionVersion,
+    manifestVersion,
   };
 
   if (!isObject(error)) {

--- a/src/data/service/errorService.ts
+++ b/src/data/service/errorService.ts
@@ -81,6 +81,7 @@ export async function selectExtraContext(
   const extraContext: UnknownObject & { extensionVersion: SemVerString } = {
     extensionVersion,
     manifestVersion,
+    runtimeId: browser.runtime.id,
   };
 
   if (!isObject(error)) {


### PR DESCRIPTION
## What does this PR do?

- Closes #7174 
- Adds `manifestVersion` and `runtimeId` to shared utility method for extracting context for errors sent to DataDog and our in-house error telemetry

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer @grahamlangford 
