### PR TITLE
Temporarily modify workshop smoke test to prep for adding scope to test user account

### DIFF
--- a/end-to-end-tests/tests/workshopPageSmoke.spec.ts
+++ b/end-to-end-tests/tests/workshopPageSmoke.spec.ts
@@ -28,13 +28,12 @@ test.describe("extension console workshop smoke test", () => {
     const workshopPage = new WorkshopPage(page, extensionId);
     await workshopPage.goto();
 
-    // User has no username set, so will be shown welcome message for username selection
-    const welcomeMessage = page.getByText("Welcome to the PixieBrix Workshop!");
-    await expect(welcomeMessage).toBeVisible();
+    // TODO: Add test assertions after adding scope to test user in
+    //  fix for https://github.com/pixiebrix/pixiebrix-extension/issues/8057
 
     const pageTitle = await page.title();
 
-    // Still the Extension Console because the page workshop page is gated
+    // Still the Extension Console because the workshop page is gated
     expect(pageTitle).toBe("Extension Console | PixieBrix");
   });
 });


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-extension/issues/8057
- We need to add a scope to our test user in order to write e2e tests for standalone mod components (needed for issue referenced above)
- This test will fail in CI if we modify the test user as-is, so let's temporarily modify it in order to update the test user scope

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer @fungairino 
