### PR TITLE
lint rule for playwright expect.toPass matcher

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -157,11 +157,20 @@ module.exports = {
   },
   overrides: [
     {
-      // (TODO: consider packaging e2e tests in a mono-repo structure)
+      // (TODO: consider packaging e2e tests in a mono-repo structure for specific linting rules)
       files: ["end-to-end-tests/**"], // Or *.test.js
       rules: {
         "no-restricted-imports": "off",
         "unicorn/prefer-dom-node-dataset": "off",
+        "no-restricted-syntax": [
+          "error",
+          {
+            message:
+              "Define a value for the timeout options parameter to avoid waiting forever (`.toPass` by default will retry forever)",
+            selector:
+              "CallExpression[callee.property.name='toPass'][arguments.length=0]",
+          },
+        ],
       },
     },
     {

--- a/end-to-end-tests/tests/workshopPageSmoke.spec.ts
+++ b/end-to-end-tests/tests/workshopPageSmoke.spec.ts
@@ -33,7 +33,6 @@ test.describe("extension console workshop smoke test", () => {
 
     const pageTitle = await page.title();
 
-    // Still the Extension Console because the workshop page is gated
-    expect(pageTitle).toBe("Extension Console | PixieBrix");
+    expect(pageTitle).toBe("Workshop | PixieBrix");
   });
 });


### PR DESCRIPTION
## What does this PR do?

- Adds a lint rule for checking that toPass includes a timeout value to avoid tests taking forever to time out.

## Checklist

- [ ] Add tests and/or storybook stories
- [X] Designate a primary reviewer @mnholtz 
