### PR TITLE
#8084 fix not being able to click on command snippets

### DIFF
--- a/src/contentScript/shortcutSnippetMenu/ShortcutSnippetMenu.scss
+++ b/src/contentScript/shortcutSnippetMenu/ShortcutSnippetMenu.scss
@@ -111,7 +111,8 @@
   color: $S800;
   background-color: $N0;
 
-  &--selected {
+  &--selected,
+  &:hover {
     background-color: $S200;
   }
 

--- a/src/contentScript/shortcutSnippetMenu/shortcutSnippetMenuController.tsx
+++ b/src/contentScript/shortcutSnippetMenu/shortcutSnippetMenuController.tsx
@@ -72,13 +72,12 @@ async function showMenu(element: HTMLElement): Promise<void> {
   const isShowing = shortcutSnippetMenu.checkVisibility();
   if (!isShowing) {
     shortcutSnippetMenu.setAttribute("aria-hidden", "false");
-    if (prefersReducedMotion()) {
-      shortcutSnippetMenu.style.setProperty("display", "block");
-    } else {
+    shortcutSnippetMenu.style.setProperty("display", "block");
+    if (!prefersReducedMotion()) {
       shortcutSnippetMenu.animate(
         [
-          { opacity: 0, margin: "8px 0", display: "block" },
-          { opacity: 1, margin: "0", display: "block" },
+          { opacity: 0, margin: "8px 0" },
+          { opacity: 1, margin: "0" },
         ],
         {
           easing: "ease-in-out",


### PR DESCRIPTION
## What does this PR do?

- Fixes #8084
Adds a little bonus - onhover will now highlight the snippet item to make it more clear you can click on it.

## Demo


https://github.com/pixiebrix/pixiebrix-extension/assets/3498063/61e70a49-f383-4b0d-a4e1-6c89b81a5490


## Checklist

- [ ] Add tests and/or storybook stories
- [X] Designate a primary reviewer @mnholtz 
