### PR TITLE
Refactor rename extensionConsoleActivation test

### DIFF
--- a/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
+++ b/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
@@ -20,7 +20,7 @@ import { ActivateModPage } from "../pageObjects/modsPage";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { test as base } from "@playwright/test";
 
-test("can activate and use highlight keywords mod", async ({
+test("can activate a mod with no config options", async ({
   page,
   extensionId,
 }) => {


### PR DESCRIPTION
## What does this PR do?

- To kick off eliminating manual regression checklist tests, rename our existing extensionConsoleActivation test to be consistent with the first test under the "Extension Console Activation" test group on our checklist https://www.notion.so/pixiebrix/Release-1-8-12-fd8e5be965b6477fba9c06455c082dd2

## Team Coordination

- [ ] After merging, remove the "Activating a mod with no config options" manual test from the manual regression sheet template https://www.notion.so/pixiebrix/Release-Checklist-Template-6d435dbf9a464f119ac6202b05d9c3b5

## Checklist

- [x] Designate a primary reviewer @fungairino or @grahamlangford 
