### PR TITLE
Default local builds to MV3

### DIFF
--- a/src/mv3/api.ts
+++ b/src/mv3/api.ts
@@ -19,7 +19,7 @@
 
 import { type Tabs } from "webextension-polyfill";
 
-export const isMV3 = (): boolean => process.env.MV === "3";
+export const isMV3 = (): boolean => process.env.MV !== "2";
 export const browserAction =
   globalThis.chrome?.browserAction ?? globalThis.chrome?.action;
 export type Tab = Tabs.Tab | chrome.tabs.Tab;

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -279,7 +279,7 @@ const createConfig = (env, options) =>
               const manifest = JSON.parse(jsonString);
               const customizedManifest = customizeManifest(manifest, {
                 isProduction: isProd(options),
-                manifestVersion: process.env.MV === "3" ? 3 : 2, // Default to 2 if missing
+                manifestVersion: process.env.MV === "2" ? 2 : 3, // Default to 3 if missing
                 env: process.env,
               });
 


### PR DESCRIPTION
## What does this PR do?

- Changes env checks to default to MV3 instead of MV2

## Discussion

- `MV` is explicitly set in CI, so this change will not affect builds
- To test MV2, developers will need to manually set `MV=2` in `.env.development`

## Team Coordination

- [x] This PR requires a environment variable change

## Checklist

- [x] Designate a primary reviewer @fregante 
