### PR TITLE
#8065 Add browser version to event telemetry

### DIFF
--- a/src/background/telemetry.test.ts
+++ b/src/background/telemetry.test.ts
@@ -34,6 +34,15 @@ beforeEach(async () => {
   appApiMock.reset();
   appApiMock.onPost("/api/events/").reply(201, {});
 
+  Object.defineProperty(global, "navigator", {
+    value: {
+      ...global.navigator,
+      userAgent: "Chrome",
+      vendor: "Google Inc.",
+    },
+    writable: true,
+  });
+
   browser.runtime.id = EXPECTED_RUNTIME_ID;
   browser.runtime.getManifest = jest
     .fn()

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -25,13 +25,14 @@ import {
 import { allowsTrack } from "@/telemetry/dnt";
 import { type DBSchema, type IDBPDatabase, openDB } from "idb";
 import { deleteDatabase } from "@/utils/idbUtils";
-import { detectBrowser } from "@/vendors/mixpanelDetectBrowser";
+import { detectBrowser } from "@/vendors/mixpanelBrowser";
 import { count as registrySize } from "@/registry/packageRegistry";
 import { count as logSize } from "@/telemetry/logging";
 import { count as traceSize } from "@/telemetry/trace";
 import { getUUID } from "@/telemetry/telemetryHelpers";
 import { getTabsWithAccess } from "@/utils/extensionUtils";
 import { type Event } from "@/telemetry/events";
+import { utils } from "mixpanel-browser";
 
 const EVENT_BUFFER_DEBOUNCE_MS = 2000;
 const EVENT_BUFFER_MAX_MS = 10_000;

--- a/src/background/telemetry.ts
+++ b/src/background/telemetry.ts
@@ -25,14 +25,13 @@ import {
 import { allowsTrack } from "@/telemetry/dnt";
 import { type DBSchema, type IDBPDatabase, openDB } from "idb";
 import { deleteDatabase } from "@/utils/idbUtils";
-import { detectBrowser } from "@/vendors/mixpanelBrowser";
+import { browserVersion, detectBrowser } from "@/vendors/mixpanelBrowser";
 import { count as registrySize } from "@/registry/packageRegistry";
 import { count as logSize } from "@/telemetry/logging";
 import { count as traceSize } from "@/telemetry/trace";
 import { getUUID } from "@/telemetry/telemetryHelpers";
 import { getTabsWithAccess } from "@/utils/extensionUtils";
 import { type Event } from "@/telemetry/events";
-import { utils } from "mixpanel-browser";
 
 const EVENT_BUFFER_DEBOUNCE_MS = 2000;
 const EVENT_BUFFER_MAX_MS = 10_000;
@@ -103,6 +102,11 @@ interface UserSummary {
    * The detected browser.
    */
   $browser: string;
+
+  /**
+   * The detected browser version.
+   */
+  $browser_version: number;
 }
 
 /**
@@ -301,6 +305,7 @@ async function collectUserSummary(): Promise<UserSummary> {
     // https://docs.mixpanel.com/docs/tracking/reference/default-properties#web
     $os: os,
     $browser: detectBrowser(navigator.userAgent, navigator.vendor),
+    $browser_version: browserVersion(navigator.userAgent, navigator.vendor),
   };
 }
 

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -808,7 +808,7 @@
     "./vendors/encodings.ts",
     "./vendors/hoverintent.d.ts",
     "./vendors/jQueryInitialize.d.ts",
-    "./vendors/mixpanelDetectBrowser.ts",
+    "./vendors/mixpanelBrowser.ts",
     "./vendors/page-metadata-parser/parser.d.ts",
     "./vendors/pkce.ts",
     "./vendors/randomStringDetection/detector.ts",

--- a/src/vendors/mixpanelBrowser.ts
+++ b/src/vendors/mixpanelBrowser.ts
@@ -4,8 +4,9 @@
  * include key words used in later checks.
  * @param userAgent
  * @param vendor
+ *
+ * @see https://github.com/mixpanel/mixpanel-js/blob/master/src/utils.js#L1489
  */
-// https://github.com/mixpanel/mixpanel-js/blob/master/src/utils.js#L1489
 export function detectBrowser(
   userAgent: string,
   vendor: string | null,
@@ -56,4 +57,42 @@ export function detectBrowser(
   } else {
     return "";
   }
+}
+
+/**
+ * Detects the browser version that is running this script.
+ * @param userAgent
+ * @param vendor
+ *
+ * @see https://github.com/mixpanel/mixpanel-js/blob/master/src/utils.js#L1542C21-L1571C7
+ */
+export function browserVersion(userAgent: string, vendor: string | null) {
+  var browser = detectBrowser(userAgent, vendor);
+  var versionRegexs = {
+    "Internet Explorer Mobile": /rv:(\d+(\.\d+)?)/,
+    "Microsoft Edge": /Edge?\/(\d+(\.\d+)?)/,
+    Chrome: /Chrome\/(\d+(\.\d+)?)/,
+    "Chrome iOS": /CriOS\/(\d+(\.\d+)?)/,
+    "UC Browser": /(UCBrowser|UCWEB)\/(\d+(\.\d+)?)/,
+    Safari: /Version\/(\d+(\.\d+)?)/,
+    "Mobile Safari": /Version\/(\d+(\.\d+)?)/,
+    Opera: /(Opera|OPR)\/(\d+(\.\d+)?)/,
+    Firefox: /Firefox\/(\d+(\.\d+)?)/,
+    "Firefox iOS": /FxiOS\/(\d+(\.\d+)?)/,
+    Konqueror: /Konqueror:(\d+(\.\d+)?)/,
+    BlackBerry: /BlackBerry (\d+(\.\d+)?)/,
+    "Android Mobile": /android\s(\d+(\.\d+)?)/,
+    "Samsung Internet": /SamsungBrowser\/(\d+(\.\d+)?)/,
+    "Internet Explorer": /(rv:|MSIE )(\d+(\.\d+)?)/,
+    Mozilla: /rv:(\d+(\.\d+)?)/,
+  };
+  var regex = versionRegexs[browser];
+  if (regex === undefined) {
+    return null;
+  }
+  var matches = userAgent.match(regex);
+  if (!matches) {
+    return null;
+  }
+  return parseFloat(matches[matches.length - 2]);
 }

--- a/src/vendors/mixpanelBrowser.ts
+++ b/src/vendors/mixpanelBrowser.ts
@@ -1,7 +1,7 @@
 /**
  * This function detects which browser is running this script.
  * The order of the checks are important since many user agents
- * include key words used in later checks.
+ * include keywords used in later checks.
  * @param userAgent
  * @param vendor
  *
@@ -67,8 +67,10 @@ export function detectBrowser(
  * @see https://github.com/mixpanel/mixpanel-js/blob/master/src/utils.js#L1542C21-L1571C7
  */
 export function browserVersion(userAgent: string, vendor: string | null) {
-  var browser = detectBrowser(userAgent, vendor);
-  var versionRegexs = {
+  const browser = detectBrowser(userAgent, vendor);
+  const versionRegexes: {
+    [key: string]: RegExp;
+  } = {
     "Internet Explorer Mobile": /rv:(\d+(\.\d+)?)/,
     "Microsoft Edge": /Edge?\/(\d+(\.\d+)?)/,
     Chrome: /Chrome\/(\d+(\.\d+)?)/,
@@ -86,11 +88,11 @@ export function browserVersion(userAgent: string, vendor: string | null) {
     "Internet Explorer": /(rv:|MSIE )(\d+(\.\d+)?)/,
     Mozilla: /rv:(\d+(\.\d+)?)/,
   };
-  var regex = versionRegexs[browser];
+  const regex = versionRegexes[browser];
   if (regex === undefined) {
     return null;
   }
-  var matches = userAgent.match(regex);
+  const matches = userAgent.match(regex);
   if (!matches) {
     return null;
   }

--- a/src/vendors/mixpanelBrowser.ts
+++ b/src/vendors/mixpanelBrowser.ts
@@ -96,5 +96,12 @@ export function browserVersion(userAgent: string, vendor: string | null) {
   if (!matches) {
     return null;
   }
-  return parseFloat(matches[matches.length - 2]);
+
+  const versionString = matches[matches.length - 2];
+
+  if (versionString === undefined) {
+    return null;
+  }
+
+  return parseFloat(versionString);
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #8065
- Adds browser version to event telemetry

## Discussion

- Followed existing pattern observed with the `$browser` property by copying the vendor code utility from `mixpanel-browser`

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer @grahamlangford 
