### PR TITLE
#7475 Refactor deploymentUpdater

### DIFF
--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -244,9 +244,9 @@ describe("syncDeployments", () => {
 
     await syncDeployments();
 
-    const { extensions } = await getModComponentState();
+    const { extensions: activatedModComponents } = await getModComponentState();
 
-    expect(extensions).toHaveLength(1);
+    expect(activatedModComponents).toHaveLength(1);
     expect(saveSettingsStateMock).toHaveBeenCalledTimes(1);
   });
 
@@ -291,7 +291,7 @@ describe("syncDeployments", () => {
 
     await syncDeployments();
 
-    const { extensions } = await getModComponentState();
+    const { extensions: activatedModComponents } = await getModComponentState();
 
     expect(jest.mocked(checkDeploymentPermissions).mock.calls[0]).toStrictEqual(
       [
@@ -306,10 +306,10 @@ describe("syncDeployments", () => {
       ],
     );
 
-    expect(extensions).toHaveLength(1);
+    expect(activatedModComponents).toHaveLength(1);
   });
 
-  test("ignore other user extensions", async () => {
+  test("ignore other mod components", async () => {
     isLinkedMock.mockResolvedValue(true);
 
     const starterBrick = starterBrickConfigFactory();
@@ -361,8 +361,8 @@ describe("syncDeployments", () => {
 
     await syncDeployments();
 
-    const { extensions } = await getModComponentState();
-    expect(extensions).toBeArrayOfSize(2);
+    const { extensions: activatedModComponents } = await getModComponentState();
+    expect(activatedModComponents).toBeArrayOfSize(2);
     const foo = await getEditorState();
     // Expect unrelated dynamic element not to be removed
     expect(foo.elements).toBeArrayOfSize(1);
@@ -411,9 +411,11 @@ describe("syncDeployments", () => {
 
     await syncDeployments();
 
-    const { extensions } = await getModComponentState();
-    expect(extensions).toBeArrayOfSize(1);
-    expect(extensions[0]._recipe.version).toBe(deployment.package.version);
+    const { extensions: activatedModComponents } = await getModComponentState();
+    expect(activatedModComponents).toBeArrayOfSize(1);
+    expect(activatedModComponents[0]._recipe.version).toBe(
+      deployment.package.version,
+    );
   });
 
   test("uninstall existing recipe mod component with dynamic element", async () => {
@@ -474,12 +476,14 @@ describe("syncDeployments", () => {
 
     await syncDeployments();
 
-    const { extensions } = await getModComponentState();
-    expect(extensions).toBeArrayOfSize(1);
+    const { extensions: activatedModComponents } = await getModComponentState();
+    expect(activatedModComponents).toBeArrayOfSize(1);
     const { elements } = await getEditorState();
     // Expect dynamic element to be removed
     expect(elements).toBeArrayOfSize(0);
-    expect(extensions[0]._recipe.version).toBe(deployment.package.version);
+    expect(activatedModComponents[0]._recipe.version).toBe(
+      deployment.package.version,
+    );
   });
 
   test("opens options page if deployment does not have necessary permissions", async () => {
@@ -510,9 +514,9 @@ describe("syncDeployments", () => {
 
     await syncDeployments();
 
-    const { extensions } = await getModComponentState();
+    const { extensions: activatedModComponents } = await getModComponentState();
 
-    expect(extensions).toHaveLength(0);
+    expect(activatedModComponents).toHaveLength(0);
     expect(openOptionsPageMock.mock.calls).toHaveLength(1);
   });
 
@@ -557,7 +561,7 @@ describe("syncDeployments", () => {
 
     await syncDeployments();
 
-    const { extensions } = await getModComponentState();
+    const { extensions: activatedModComponents } = await getModComponentState();
 
     expect(jest.mocked(checkDeploymentPermissions).mock.calls[0]).toStrictEqual(
       [
@@ -572,7 +576,7 @@ describe("syncDeployments", () => {
       ],
     );
 
-    expect(extensions).toHaveLength(0);
+    expect(activatedModComponents).toHaveLength(0);
     expect(openOptionsPageMock.mock.calls).toHaveLength(1);
   });
 
@@ -780,11 +784,11 @@ describe("syncDeployments", () => {
 
     await syncDeployments();
 
-    const { extensions } = await getModComponentState();
+    const { extensions: activatedModComponents } = await getModComponentState();
 
-    expect(extensions).toHaveLength(2);
+    expect(activatedModComponents).toHaveLength(2);
 
-    const installedIds = extensions.map((x) => x.id);
+    const installedIds = activatedModComponents.map((x) => x.id);
     expect(installedIds).toContain(personalModComponent.id);
     expect(installedIds).toContain(recipeModComponent.id);
 

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -368,7 +368,7 @@ describe("syncDeployments", () => {
     expect(foo.elements).toBeArrayOfSize(1);
   });
 
-  test("uninstall existing recipe mod component with no dynamic elements", async () => {
+  test("deactivate existing mod with no dynamic elements", async () => {
     isLinkedMock.mockResolvedValue(true);
 
     const { deployment, modDefinition } = activatableDeploymentFactory();
@@ -418,7 +418,7 @@ describe("syncDeployments", () => {
     );
   });
 
-  test("uninstall existing recipe mod component with dynamic element", async () => {
+  test("deactivate existing mod with dynamic element", async () => {
     isLinkedMock.mockResolvedValue(true);
 
     const { deployment, modDefinition } = activatableDeploymentFactory();
@@ -580,7 +580,7 @@ describe("syncDeployments", () => {
     expect(openOptionsPageMock.mock.calls).toHaveLength(1);
   });
 
-  test("skip update and uninstall if not linked", async () => {
+  test("skip update and deactivation if not linked", async () => {
     isLinkedMock.mockResolvedValue(false);
     readAuthDataMock.mockResolvedValue({} as any);
 
@@ -711,7 +711,7 @@ describe("syncDeployments", () => {
 
     await syncDeployments();
 
-    // Unmatched deployments are always uninstalled if snoozed
+    // Unassigned deployments are always deactivated if snoozed
     expect(isUpdateAvailableMock.mock.calls).toHaveLength(0);
     expect(refreshRegistriesMock.mock.calls).toHaveLength(0);
     expect(openOptionsPageMock.mock.calls).toHaveLength(0);

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -586,13 +586,13 @@ describe("syncDeployments", () => {
 
     jest.doMock("@/background/deploymentUpdater");
 
-    const { uninstallAllDeployments } = await import(
+    const { deactivateAllDeployedMods } = await import(
       "@/background/deploymentUpdater"
     );
 
     await syncDeployments();
 
-    expect(jest.mocked(uninstallAllDeployments).mock.calls).toHaveLength(0);
+    expect(jest.mocked(deactivateAllDeployedMods).mock.calls).toHaveLength(0);
     expect(refreshRegistriesMock.mock.calls).toHaveLength(0);
     expect(saveSettingsStateMock).toHaveBeenCalledTimes(0);
   }, 10_000);
@@ -717,14 +717,14 @@ describe("syncDeployments", () => {
     expect(openOptionsPageMock.mock.calls).toHaveLength(0);
   });
 
-  test("can uninstall all deployments", async () => {
+  test("can deactivate all deployed mods", async () => {
     const personalStarterBrick = starterBrickConfigFactory();
     const personalBrick = {
       ...parsePackage(personalStarterBrick as unknown as RegistryPackage),
       timestamp: new Date(),
     };
 
-    const personalModComponent = modComponentFactory({
+    const standaloneModComponent = modComponentFactory({
       extensionPointId: personalStarterBrick.metadata.id,
     }) as ActivatedModComponent;
 
@@ -756,7 +756,7 @@ describe("syncDeployments", () => {
 
     const personalElement = (await ADAPTERS.get(
       personalStarterBrick.definition.type,
-    ).fromExtension(personalModComponent)) as ActionFormState;
+    ).fromExtension(standaloneModComponent)) as ActionFormState;
     editorState = editorSlice.reducer(
       editorState,
       editorSlice.actions.addElement(personalElement),
@@ -772,7 +772,7 @@ describe("syncDeployments", () => {
 
     await saveModComponentState({
       extensions: [
-        personalModComponent,
+        standaloneModComponent,
         deploymentModComponent,
         recipeModComponent,
       ],
@@ -788,9 +788,9 @@ describe("syncDeployments", () => {
 
     expect(activatedModComponents).toHaveLength(2);
 
-    const installedIds = activatedModComponents.map((x) => x.id);
-    expect(installedIds).toContain(personalModComponent.id);
-    expect(installedIds).toContain(recipeModComponent.id);
+    const activatedModComponentIds = activatedModComponents.map((x) => x.id);
+    expect(activatedModComponentIds).toContain(standaloneModComponent.id);
+    expect(activatedModComponentIds).toContain(recipeModComponent.id);
 
     const { elements } = await getEditorState();
     expect(elements).toBeArrayOfSize(1);

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -146,25 +146,27 @@ export async function deactivateAllDeployedMods(): Promise<void> {
     getModComponentState(),
     getEditorState(),
   ]);
-  const installed = selectActivatedModComponents({ options: optionsState });
+  const activatedModComponents = selectActivatedModComponents({
+    options: optionsState,
+  });
 
-  const toUninstall = installed.filter(
-    (extension) => !isEmpty(extension._deployment),
+  const modComponentsToDeactivate = activatedModComponents.filter(
+    (activatedModComponent) => !isEmpty(activatedModComponent._deployment),
   );
 
-  if (toUninstall.length === 0) {
+  if (modComponentsToDeactivate.length === 0) {
     // Short-circuit to skip reporting telemetry
     return;
   }
 
-  await uninstallExtensionsAndSaveState(toUninstall, {
+  await uninstallExtensionsAndSaveState(modComponentsToDeactivate, {
     editorState,
     optionsState,
   });
 
   reportEvent("DeploymentDeactivateAll", {
     auto: true,
-    deployments: toUninstall.map((x) => x._deployment.id),
+    deployments: modComponentsToDeactivate.map((x) => x._deployment.id),
   });
 }
 

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -234,7 +234,7 @@ async function deactivateMod(
   return { options, editor };
 }
 
-async function installDeployment({
+async function activateDeployment({
   optionsState,
   editorState,
   activatableDeployment,
@@ -250,11 +250,12 @@ async function installDeployment({
   let editor = editorState;
   const { deployment, modDefinition } = activatableDeployment;
 
-  const isReinstall = optionsState.extensions.some(
-    (x) => x._deployment?.id === deployment.id,
+  const isAlreadyActivated = optionsState.extensions.some(
+    (activatedModComponent) =>
+      activatedModComponent._deployment?.id === deployment.id,
   );
 
-  // Uninstall existing versions of the extensions
+  // Deactivate existing mod component versions
   const result = await deactivateMod(
     deployment.package.package_id,
     options,
@@ -264,7 +265,7 @@ async function installDeployment({
   options = result.options;
   editor = result.editor;
 
-  // Install the deployment's blueprint with the service definition
+  // Activate the deployed mod with the service definition
   options = optionsReducer(
     options,
     optionsActions.activateMod({
@@ -277,7 +278,7 @@ async function installDeployment({
       // Assume backend properly validates the options
       optionsArgs: deployment.options_config as OptionsArgs,
       screen: "background",
-      isReactivate: isReinstall,
+      isReactivate: isAlreadyActivated,
     }),
   );
 
@@ -303,7 +304,7 @@ async function installDeployments(
 
   for (const activatableDeployment of activatableDeployments) {
     // eslint-disable-next-line no-await-in-loop -- running reducer, need to update states serially
-    const result = await installDeployment({
+    const result = await activateDeployment({
       optionsState,
       editorState,
       activatableDeployment,

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -291,10 +291,10 @@ async function activateDeployment({
 }
 
 /**
- * Install all deployments
+ * Activate a list of deployments
  * @param activatableDeployments deployments that PixieBrix already has permission to run
  */
-async function installDeployments(
+async function activateDeployments(
   activatableDeployments: ActivatableDeployment[],
 ): Promise<void> {
   let [optionsState, editorState] = await Promise.all([
@@ -635,7 +635,7 @@ async function activateDeploymentsInBackground({
 
   if (automatic.length > 0) {
     try {
-      await installDeployments(automatic.map((x) => x.activatableDeployment));
+      await activateDeployments(automatic.map((x) => x.activatableDeployment));
     } catch (error) {
       reportError(error);
       automaticError = true;

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -642,7 +642,7 @@ async function activateDeploymentsInBackground({
   }
 
   if (deploymentsToManuallyActivate.length === 0) {
-    void removeDeploymentUpdatePrompt();
+    void hideUpdatePromptUntilNextAvailableUpdate();
   }
 
   // We only want to call openOptionsPage a single time
@@ -653,14 +653,17 @@ async function activateDeploymentsInBackground({
 
 /**
  * There is a prompt in the UI shown to the user to encourage them to manually activate and/or update deployments,
- * controlled by updatePromptTimestamp. Set updatePromptTimestamp to null to effectively hide the prompt.
+ * partially controlled by updatePromptTimestamp. Set updatePromptTimestamp to null to hide the modal until
+ * deployment updates are next available.
  *
  * - If there was a Browser Extension update, it would have been applied
  * - We don't currently separately track timestamps for showing an update modal for deployments vs. browser extension
  * upgrades. However, in enterprise scenarios where enforceUpdateMillis is set, the IT policy is generally such
  * that IT can't reset the extension.
+ *
+ * @see DeploymentModal
  */
-async function removeDeploymentUpdatePrompt() {
+async function hideUpdatePromptUntilNextAvailableUpdate() {
   const settings = await getSettingsState();
   const next = settingsSlice.reducer(
     settings,
@@ -675,7 +678,7 @@ function initDeploymentUpdater(): void {
   registerContribBlocks();
 
   setInterval(syncDeployments, UPDATE_INTERVAL_MS);
-  void removeDeploymentUpdatePrompt();
+  void hideUpdatePromptUntilNextAvailableUpdate();
   void syncDeployments();
 }
 

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -88,7 +88,9 @@ const locateAllForService = locator.locateAllForService.bind(locator);
 
 const UPDATE_INTERVAL_MS = 5 * 60 * 1000;
 
-async function setExtensionsState(state: ModComponentState): Promise<void> {
+async function saveModComponentStateAndReactivateTabs(
+  state: ModComponentState,
+): Promise<void> {
   await saveModComponentState(state);
   await forEachTab(queueReactivateTab);
 }
@@ -133,12 +135,12 @@ async function deactivateModComponentsAndSaveState(
     { catch: "ignore" },
   );
 
-  await setExtensionsState(optionsState);
+  await saveModComponentStateAndReactivateTabs(optionsState);
   await saveEditorState(editorState);
 }
 
 /**
- * Deactivate all deployed mods by deactivating all mod components associated with a deployment.
+ * Deactivate all deployed mods by deactivating all mod components associated with a deployment
  */
 export async function deactivateAllDeployedMods(): Promise<void> {
   const [optionsState, editorState] = await Promise.all([
@@ -310,7 +312,7 @@ async function installDeployments(
     editorState = result.editor;
   }
 
-  await setExtensionsState(optionsState);
+  await saveModComponentStateAndReactivateTabs(optionsState);
   await saveEditorState(editorState);
 }
 

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -324,14 +324,14 @@ type DeploymentConstraint = {
 };
 
 /**
- * Return true if the deployment can be automatically installed.
+ * Return true if the deployment can be automatically activated.
  *
- * For automatic install, the following must be true:
+ * For automatic activation, the following must be true:
  * 1. PixieBrix already has permissions for the required pages/APIs
- * 2. The user has a version of the PixieBrix browser extension compatible with the deployment
+ * 2. The user has a version of the PixieBrix Extension compatible with the deployment
  * 3. The user has exactly one (1) personal configuration for each unbound service for the deployment
  */
-async function canAutomaticallyInstall({
+async function canAutoActivate({
   activatableDeployment,
   hasPermissions,
   extensionVersion,
@@ -620,7 +620,7 @@ async function activateDeploymentsInBackground({
     deploymentRequirements.map(
       async ({ activatableDeployment, hasPermissions }) => ({
         activatableDeployment,
-        isAutomatic: await canAutomaticallyInstall({
+        isAutomatic: await canAutoActivate({
           activatableDeployment,
           hasPermissions,
           extensionVersion,

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -208,24 +208,22 @@ async function deactivateUnassignedDeployments(
   });
 }
 
-async function uninstallRecipe(
+async function deactivateMod(
+  modId: RegistryId,
   optionsState: ModComponentState,
   editorState: EditorState | undefined,
-  recipeId: RegistryId,
-): Promise<{
-  options: ModComponentState;
-  editor: EditorState | undefined;
-}> {
+): Promise<{ options: ModComponentState; editor: EditorState | undefined }> {
   let options = optionsState;
   let editor = editorState;
 
-  const recipeOptionsSelector = selectModComponentsForMod(recipeId);
-  const recipeExtensions = recipeOptionsSelector({ options: optionsState });
+  const modComponentsForModSelector = selectModComponentsForMod(modId);
+  const activatedModComponentsForMod = modComponentsForModSelector({
+    options: optionsState,
+  });
 
-  // Uninstall existing versions of the extensions
-  for (const extension of recipeExtensions) {
+  for (const activatedModComponent of activatedModComponentsForMod) {
     const result = deactivateModComponentFromStates(
-      extension.id,
+      activatedModComponent.id,
       options,
       editor,
     );
@@ -257,10 +255,10 @@ async function installDeployment({
   );
 
   // Uninstall existing versions of the extensions
-  const result = await uninstallRecipe(
+  const result = await deactivateMod(
+    deployment.package.package_id,
     options,
     editor,
-    deployment.package.package_id,
   );
 
   options = result.options;

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -407,7 +407,7 @@ export async function syncDeployments(): Promise<void> {
     //   so PixieBrix cleared it out, 2) something removed the local storage entry
     // - If the user is not an enterprise user (or has not linked their extension yet), just NOP. They likely they just
     //   need to reconnect their extension. If it's a non-enterprise user, they shouldn't have any deployments
-    //   installed anyway.
+    //   activated anyway.
 
     if (disableLoginTab) {
       // IT manager has disabled opening login tab automatically
@@ -418,7 +418,7 @@ export async function syncDeployments(): Promise<void> {
       reportEvent(Events.ORGANIZATION_EXTENSION_LINK, {
         organizationId,
         managedOrganizationId,
-        // Initial marks whether this is the initial background deployment install
+        // Initial marks whether this is the initial background deployment activation
         initial: !organizationId,
         campaignIds,
         sso: true,
@@ -433,7 +433,7 @@ export async function syncDeployments(): Promise<void> {
       reportEvent(Events.ORGANIZATION_EXTENSION_LINK, {
         organizationId,
         managedOrganizationId,
-        // Initial marks whether this is the initial background deployment install
+        // Initial marks whether this is the initial background deployment activation
         initial: !organizationId,
         campaignIds,
         sso: false,
@@ -459,7 +459,7 @@ export async function syncDeployments(): Promise<void> {
   // Always get the freshest options slice from the local storage
   const { extensions: activatedModComponents } = await getModComponentState();
 
-  // This is the "heartbeat". The old behavior was to only send if the user had at least one deployment installed.
+  // This is the "heartbeat". The old behavior was to only send if the user had at least one deployment activated.
   // Now we're always sending in order to help team admins understand any gaps between number of registered users
   // and amount of activity when using deployments
   const client = await maybeGetLinkedApiClient();

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -139,9 +139,9 @@ async function uninstallExtensionsAndSaveState(
 }
 
 /**
- * Uninstall all deployments by uninstalling all extensions associated with a deployment.
+ * Deactivate all deployed mods by deactivating all mod components associated with a deployment.
  */
-export async function uninstallAllDeployments(): Promise<void> {
+export async function deactivateAllDeployedMods(): Promise<void> {
   const [optionsState, editorState] = await Promise.all([
     getModComponentState(),
     getEditorState(),
@@ -451,7 +451,7 @@ export async function syncDeployments(): Promise<void> {
     // 1) has never been a member of an organization,
     // 2) has left their organization,
     // 3) linked their extension to a non-organization profile
-    await uninstallAllDeployments();
+    await deactivateAllDeployedMods();
     return;
   }
 

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -213,8 +213,8 @@ async function deactivateMod(
   optionsState: ModComponentState,
   editorState: EditorState | undefined,
 ): Promise<{ options: ModComponentState; editor: EditorState | undefined }> {
-  let options = optionsState;
-  let editor = editorState;
+  let _optionsState = optionsState;
+  let _editorState = editorState;
 
   const modComponentsForModSelector = selectModComponentsForMod(modId);
   const activatedModComponentsForMod = modComponentsForModSelector({
@@ -224,14 +224,14 @@ async function deactivateMod(
   for (const activatedModComponent of activatedModComponentsForMod) {
     const result = deactivateModComponentFromStates(
       activatedModComponent.id,
-      options,
-      editor,
+      _optionsState,
+      _editorState,
     );
-    options = result.options;
-    editor = result.editor;
+    _optionsState = result.options;
+    _editorState = result.editor;
   }
 
-  return { options, editor };
+  return { options: _optionsState, editor: _editorState };
 }
 
 async function activateDeployment({
@@ -246,8 +246,8 @@ async function activateDeployment({
   options: ModComponentState;
   editor: EditorState | undefined;
 }> {
-  let options = optionsState;
-  let editor = editorState;
+  let _optionsState = optionsState;
+  let _editorState = editorState;
   const { deployment, modDefinition } = activatableDeployment;
 
   const isAlreadyActivated = optionsState.extensions.some(
@@ -258,16 +258,16 @@ async function activateDeployment({
   // Deactivate existing mod component versions
   const result = await deactivateMod(
     deployment.package.package_id,
-    options,
-    editor,
+    _optionsState,
+    _editorState,
   );
 
-  options = result.options;
-  editor = result.editor;
+  _optionsState = result.options;
+  _editorState = result.editor;
 
   // Activate the deployed mod with the service definition
-  options = optionsReducer(
-    options,
+  _optionsState = optionsReducer(
+    _optionsState,
     optionsActions.activateMod({
       modDefinition,
       deployment,
@@ -287,7 +287,7 @@ async function activateDeployment({
     auto: true,
   });
 
-  return { options, editor };
+  return { options: _optionsState, editor: _editorState };
 }
 
 /**

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -112,25 +112,27 @@ function uninstallExtensionFromStates(
 }
 
 async function deactivateModComponentsAndSaveState(
-  toUninstall: UnresolvedModComponent[],
+  modComponentsToDeactivate: UnresolvedModComponent[],
   {
     editorState,
     optionsState,
   }: { editorState: EditorState; optionsState: ModComponentState },
 ): Promise<void> {
-  // Uninstall existing versions of the extensions
-  for (const extension of toUninstall) {
+  // Deactivate existing mod components
+  for (const modComponent of modComponentsToDeactivate) {
     const result = uninstallExtensionFromStates(
       optionsState,
       editorState,
-      extension.id,
+      modComponent.id,
     );
     optionsState = result.options;
     editorState = result.editor;
   }
 
   await allSettled(
-    toUninstall.map(async ({ id }) => removeExtensionForEveryTab(id)),
+    modComponentsToDeactivate.map(async ({ id }) =>
+      removeExtensionForEveryTab(id),
+    ),
     { catch: "ignore" },
   );
 

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -111,7 +111,7 @@ function uninstallExtensionFromStates(
   return { options, editor };
 }
 
-async function uninstallExtensionsAndSaveState(
+async function deactivateModComponentsAndSaveState(
   toUninstall: UnresolvedModComponent[],
   {
     editorState,
@@ -159,7 +159,7 @@ export async function deactivateAllDeployedMods(): Promise<void> {
     return;
   }
 
-  await uninstallExtensionsAndSaveState(modComponentsToDeactivate, {
+  await deactivateModComponentsAndSaveState(modComponentsToDeactivate, {
     editorState,
     optionsState,
   });
@@ -194,7 +194,7 @@ async function uninstallUnmatchedDeployments(
     return;
   }
 
-  await uninstallExtensionsAndSaveState(toUninstall, {
+  await deactivateModComponentsAndSaveState(toUninstall, {
     editorState,
     optionsState,
   });

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -93,20 +93,17 @@ async function setExtensionsState(state: ModComponentState): Promise<void> {
   await forEachTab(queueReactivateTab);
 }
 
-function uninstallExtensionFromStates(
+function deactivateModComponentFromStates(
+  modComponentId: UUID,
   optionsState: ModComponentState,
   editorState: EditorState | undefined,
-  extensionId: UUID,
-): {
-  options: ModComponentState;
-  editor: EditorState;
-} {
+): { options: ModComponentState; editor: EditorState } {
   const options = optionsReducer(
     optionsState,
-    optionsActions.removeExtension({ extensionId }),
+    optionsActions.removeExtension({ extensionId: modComponentId }),
   );
   const editor = editorState
-    ? editorReducer(editorState, editorActions.removeElement(extensionId))
+    ? editorReducer(editorState, editorActions.removeElement(modComponentId))
     : undefined;
   return { options, editor };
 }
@@ -120,10 +117,10 @@ async function deactivateModComponentsAndSaveState(
 ): Promise<void> {
   // Deactivate existing mod components
   for (const modComponent of modComponentsToDeactivate) {
-    const result = uninstallExtensionFromStates(
+    const result = deactivateModComponentFromStates(
+      modComponent.id,
       optionsState,
       editorState,
-      modComponent.id,
     );
     optionsState = result.options;
     editorState = result.editor;
@@ -223,7 +220,11 @@ async function uninstallRecipe(
 
   // Uninstall existing versions of the extensions
   for (const extension of recipeExtensions) {
-    const result = uninstallExtensionFromStates(options, editor, extension.id);
+    const result = deactivateModComponentFromStates(
+      extension.id,
+      options,
+      editor,
+    );
     options = result.options;
     editor = result.editor;
   }

--- a/src/store/settings/settingsTypes.ts
+++ b/src/store/settings/settingsTypes.ts
@@ -87,7 +87,9 @@ export type SettingsStateV1 = SkunkworksSettingsFlags &
     nextUpdate: number | null;
 
     /**
-     * Timestamps the update modal was first shown. Used to calculate time remaining for enforceUpdateMillis
+     * Controls a prompt in the UI that prompts the user to manually activate and/or update deployed mods.
+     * This represents the timestamp the update modal was first shown. Set to null to show the modal for the first time.
+     * Used to calculate time remaining for enforceUpdateMillis.
      *
      * @since 1.7.1
      * @see AuthState.enforceUpdateMillis

--- a/src/store/settings/settingsTypes.ts
+++ b/src/store/settings/settingsTypes.ts
@@ -87,12 +87,15 @@ export type SettingsStateV1 = SkunkworksSettingsFlags &
     nextUpdate: number | null;
 
     /**
-     * Controls a prompt in the UI that prompts the user to manually activate and/or update deployed mods.
-     * This represents the timestamp the update modal was first shown. Set to null to show the modal for the first time.
+     * Partially controls a modal in the UI that prompts the user to manually activate and/or update deployed mods.
+     * Represents the timestamp this update modal was first shown. Set to null to hide the modal until updates
+     * are next available.
+     *
      * Used to calculate time remaining for enforceUpdateMillis.
      *
      * @since 1.7.1
      * @see AuthState.enforceUpdateMillis
+     * @see DeploymentModal
      */
     updatePromptTimestamp: number | null;
 


### PR DESCRIPTION
## What does this PR do?

- Part of #7475 (preliminary refactor before starting)
- Renames instances of extension -> modComponent
- Renames instances of install -> activate
- Consolidates redundant abstraction for resetting the updatePromptTimestamp

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer @BLoe 
