### PR TITLE
#8143: pass explicit base URL in validateBrickInputOutput to support srcdoc iframes

### DIFF
--- a/end-to-end-tests/tests/runtime/srcdocFrames.spec.ts
+++ b/end-to-end-tests/tests/runtime/srcdocFrames.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { test, expect } from "../../fixtures/extensionBase";
+import { ActivateModPage } from "../../pageObjects/modsPage";
+// @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
+import { test as base } from "@playwright/test";
+import { range } from "lodash";
+
+test("can activate a mod with no config options", async ({
+  page,
+  extensionId,
+}) => {
+  const modId = "@pixies/test/8143-repro";
+
+  const modActivationPage = new ActivateModPage(page, extensionId, modId);
+  await modActivationPage.goto();
+
+  await modActivationPage.clickActivateAndWaitForModsPageRedirect();
+
+  await page.goto("/frame-src/");
+
+  const frameLocator = page.frameLocator("iframe");
+
+  await Promise.all(
+    range(0, 2).map(async (index) => {
+      const frame = frameLocator.nth(index);
+      const locator = frame.locator("mark").first();
+      await expect(locator).toBeVisible();
+    }),
+  );
+});

--- a/end-to-end-tests/tests/runtime/srcdocFrames.spec.ts
+++ b/end-to-end-tests/tests/runtime/srcdocFrames.spec.ts
@@ -21,10 +21,7 @@ import { ActivateModPage } from "../../pageObjects/modsPage";
 import { test as base } from "@playwright/test";
 import { range } from "lodash";
 
-test("can activate a mod with no config options", async ({
-  page,
-  extensionId,
-}) => {
+test("8143: mods can run in srcdoc iframes", async ({ page, extensionId }) => {
   const modId = "@pixies/test/8143-repro";
 
   const modActivationPage = new ActivateModPage(page, extensionId, modId);

--- a/src/validators/schemaValidator.ts
+++ b/src/validators/schemaValidator.ts
@@ -265,9 +265,12 @@ export async function validateBrickInputOutput(
   // first input argument.
   const validatorSchema = cloneDeep(schema);
 
+  // Must pass a baseUrl because otherwise $RefParser.resolve will throw when running in an `about:srcdoc` iframe
+  const baseUrl = "https://app.pixiebrix.com/schemas/base";
+
   // The @cfworker/json-schema Validator supports $ref, so we don't need to
   // dereference the schema, we can just resolve the integration and built-in refs.
-  const refs = await $RefParser.resolve(validatorSchema, {
+  const refs = await $RefParser.resolve(baseUrl, validatorSchema, {
     resolve: {
       // Exclude secret properties, because they aren't passed to the runtime
       integrationDefinitionResolver: integrationResolverFactory({


### PR DESCRIPTION
## What does this PR do?

- Closes #8143
- Fixes invalid URL error on `about:srcdoc` iframes

## Remaining Work

- [x] Get playwright test working

## Demo

- Playground: https://pbx.vercel.app/frame-src/
- Test mod: https://app.pixiebrix.com/activate?id%5B%5D=%40pixies%2Ftest%2F8143-repro
- https://www.loom.com/share/b7feb1426cea4fafa81a4e5fb8161bc3?sid=47c5f2fa-dd88-4093-94a9-8b59eef884d0

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer: @BLoe 
