### PR TITLE
#8147: add custom form submit reset affordance

### DIFF
--- a/src/background/contentScript.test.ts
+++ b/src/background/contentScript.test.ts
@@ -60,8 +60,8 @@ describe("waitForContentScript", () => {
     const second = waitForContentScript({ tabId: 1, frameId: 0 });
 
     await Promise.all([
-      expect(first).toFullfillWithinMilliseconds(20),
-      expect(second).toFullfillWithinMilliseconds(20),
+      expect(first).toFulfillWithinMilliseconds(20),
+      expect(second).toFulfillWithinMilliseconds(20),
     ]);
   });
 

--- a/src/bricks/renderers/CustomFormComponent.test.tsx
+++ b/src/bricks/renderers/CustomFormComponent.test.tsx
@@ -133,7 +133,6 @@ describe("CustomFormComponent", () => {
   test("can reset on submit", async () => {
     const initialValue = "";
 
-    // Testing the RjsfSubmitContext.Provider with the textarea widget which uses it to submit the form on enter
     const schema: Schema = {
       type: "object",
       properties: {
@@ -154,10 +153,8 @@ describe("CustomFormComponent", () => {
       />,
     );
 
-    // Hidden:true because Stylesheets component sets hidden unless all stylesheets are loaded
     const textBox = screen.getByRole("textbox", {
       name: "Prompt",
-      hidden: true,
     });
 
     await userEvent.type(textBox, "Some text");
@@ -181,7 +178,6 @@ describe("CustomFormComponent", () => {
   test("don't reset by default", async () => {
     const initialValue = "";
 
-    // Testing the RjsfSubmitContext.Provider with the textarea widget which uses it to submit the form on enter
     const schema: Schema = {
       type: "object",
       properties: {
@@ -201,10 +197,8 @@ describe("CustomFormComponent", () => {
       />,
     );
 
-    // Hidden:true because Stylesheets component sets hidden unless all stylesheets are loaded
     const textBox = screen.getByRole("textbox", {
       name: "Prompt",
-      hidden: true,
     });
 
     await userEvent.type(textBox, "Some text");
@@ -219,7 +213,7 @@ describe("CustomFormComponent", () => {
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
     expect(submitForm).toHaveBeenCalledWith(
-      // Called with the initial value because the form was reset
+      // Called with same value because the form was not reset
       { prompt: "Some text" },
       { submissionCount: 2 },
     );

--- a/src/bricks/renderers/CustomFormComponent.test.tsx
+++ b/src/bricks/renderers/CustomFormComponent.test.tsx
@@ -129,4 +129,99 @@ describe("CustomFormComponent", () => {
       { submissionCount: 3 },
     );
   });
+
+  test("can reset on submit", async () => {
+    const initialValue = "";
+
+    // Testing the RjsfSubmitContext.Provider with the textarea widget which uses it to submit the form on enter
+    const schema: Schema = {
+      type: "object",
+      properties: {
+        prompt: { type: "string", title: "Prompt" },
+      },
+    };
+
+    const submitForm = jest.fn();
+    render(
+      <CustomFormComponent
+        schema={schema}
+        formData={{ prompt: initialValue }}
+        uiSchema={{}}
+        submitCaption="Save"
+        autoSave={false}
+        onSubmit={submitForm}
+        resetOnSubmit
+      />,
+    );
+
+    // Hidden:true because Stylesheets component sets hidden unless all stylesheets are loaded
+    const textBox = screen.getByRole("textbox", {
+      name: "Prompt",
+      hidden: true,
+    });
+
+    await userEvent.type(textBox, "Some text");
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(submitForm).toHaveBeenCalledWith(
+      { prompt: "Some text" },
+      { submissionCount: 1 },
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(submitForm).toHaveBeenCalledWith(
+      // Called with the initial value because the form was reset
+      { prompt: initialValue },
+      { submissionCount: 2 },
+    );
+  });
+
+  test("don't reset by default", async () => {
+    const initialValue = "";
+
+    // Testing the RjsfSubmitContext.Provider with the textarea widget which uses it to submit the form on enter
+    const schema: Schema = {
+      type: "object",
+      properties: {
+        prompt: { type: "string", title: "Prompt" },
+      },
+    };
+
+    const submitForm = jest.fn();
+    render(
+      <CustomFormComponent
+        schema={schema}
+        formData={{ prompt: initialValue }}
+        uiSchema={{}}
+        submitCaption="Save"
+        autoSave={false}
+        onSubmit={submitForm}
+      />,
+    );
+
+    // Hidden:true because Stylesheets component sets hidden unless all stylesheets are loaded
+    const textBox = screen.getByRole("textbox", {
+      name: "Prompt",
+      hidden: true,
+    });
+
+    await userEvent.type(textBox, "Some text");
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(submitForm).toHaveBeenCalledWith(
+      { prompt: "Some text" },
+      { submissionCount: 1 },
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(submitForm).toHaveBeenCalledWith(
+      // Called with the initial value because the form was reset
+      { prompt: "Some text" },
+      { submissionCount: 2 },
+    );
+  });
 });

--- a/src/bricks/renderers/CustomFormComponent.tsx
+++ b/src/bricks/renderers/CustomFormComponent.tsx
@@ -76,12 +76,6 @@ const CustomFormComponent: React.FunctionComponent<{
   stylesheets: newStylesheets,
   disableParentStyles = false,
 }) => {
-  // Must use a React key to reset the form: https://github.com/rjsf-team/react-jsonschema-form/issues/953
-  const [key, setKey] = useState(0);
-  const resetForm = (): void => {
-    setKey((prev) => prev + 1);
-  };
-
   // Use useRef instead of useState because we don't need/want a re-render when count changes
   // This ref is used to track the onSubmit run number for runtime tracing
   const submissionCountRef = useRef(0);
@@ -92,6 +86,14 @@ const CustomFormComponent: React.FunctionComponent<{
     // XXX: is there a reason this is in a useEffect? Is it to prevent issues with defaulting to `{}`?
     valuesRef.current = formData ?? {};
   }, [formData]);
+
+  // Use a React key to reset the form: https://github.com/rjsf-team/react-jsonschema-form/issues/953
+  const [key, setKey] = useState(0);
+  const resetForm = (): void => {
+    // Ensure valuesRef is in sync with the initial data passed to the form
+    valuesRef.current = formData;
+    setKey((prev) => prev + 1);
+  };
 
   const { stylesheets } = useStylesheetsContextWithFormDefault({
     newStylesheets,

--- a/src/bricks/renderers/CustomFormComponent.tsx
+++ b/src/bricks/renderers/CustomFormComponent.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { type Schema, type UiSchema } from "@/types/schemaTypes";
 import { type JsonObject } from "type-fest";
 import cx from "classnames";
@@ -60,6 +60,7 @@ const CustomFormComponent: React.FunctionComponent<{
     values: UnknownObject,
     { submissionCount }: { submissionCount: number },
   ) => Promise<void>;
+  resetOnSubmit?: boolean;
   className?: string;
   stylesheets?: string[];
   disableParentStyles?: boolean;
@@ -71,14 +72,24 @@ const CustomFormComponent: React.FunctionComponent<{
   autoSave,
   className,
   onSubmit,
+  resetOnSubmit = false,
   stylesheets: newStylesheets,
   disableParentStyles = false,
 }) => {
+  // Must use a React key to reset the form: https://github.com/rjsf-team/react-jsonschema-form/issues/953
+  const [key, setKey] = useState(0);
+  const resetForm = (): void => {
+    setKey((prev) => prev + 1);
+  };
+
   // Use useRef instead of useState because we don't need/want a re-render when count changes
+  // This ref is used to track the onSubmit run number for runtime tracing
   const submissionCountRef = useRef(0);
+
   // Track values during onChange or prop updates, so we can access it our RjsfSubmitContext submitForm callback
   const valuesRef = useRef<UnknownObject>(formData);
   useEffect(() => {
+    // XXX: is there a reason this is in a useEffect? Is it to prevent issues with defaulting to `{}`?
     valuesRef.current = formData ?? {};
   }, [formData]);
 
@@ -86,6 +97,17 @@ const CustomFormComponent: React.FunctionComponent<{
     newStylesheets,
     disableParentStyles,
   });
+
+  const submitData = async (data: UnknownObject): Promise<void> => {
+    submissionCountRef.current += 1;
+    await onSubmit(data, {
+      submissionCount: submissionCountRef.current,
+    });
+
+    if (resetOnSubmit) {
+      resetForm();
+    }
+  };
 
   return (
     <div
@@ -100,14 +122,12 @@ const CustomFormComponent: React.FunctionComponent<{
           <RjsfSubmitContext.Provider
             value={{
               async submitForm() {
-                submissionCountRef.current += 1;
-                await onSubmit(valuesRef.current, {
-                  submissionCount: submissionCountRef.current,
-                });
+                await submitData(valuesRef.current);
               },
             }}
           >
             <JsonSchemaForm
+              key={key}
               // Deep clone the schema because otherwise the schema is not extensible
               // This breaks validation when @cfworker/json-schema dereferences the schema
               // See https://github.com/cfworker/cfworker/blob/263260ea661b6f8388116db7b8daa859e0d28b25/packages/json-schema/src/dereference.ts#L115
@@ -122,17 +142,11 @@ const CustomFormComponent: React.FunctionComponent<{
                 valuesRef.current = formData ?? {};
 
                 if (autoSave) {
-                  submissionCountRef.current += 1;
-                  await onSubmit(formData ?? {}, {
-                    submissionCount: submissionCountRef.current,
-                  });
+                  await submitData(formData ?? {});
                 }
               }}
               onSubmit={async ({ formData }: IChangeEvent<UnknownObject>) => {
-                submissionCountRef.current += 1;
-                await onSubmit(formData ?? {}, {
-                  submissionCount: submissionCountRef.current,
-                });
+                await submitData(formData ?? {});
               }}
             >
               {autoSave || uiSchema["ui:submitButtonOptions"]?.norender ? (

--- a/src/bricks/renderers/CustomFormComponent.tsx
+++ b/src/bricks/renderers/CustomFormComponent.tsx
@@ -83,7 +83,7 @@ const CustomFormComponent: React.FunctionComponent<{
   // Track values during onChange or prop updates, so we can access it our RjsfSubmitContext submitForm callback
   const valuesRef = useRef<UnknownObject>(formData);
   useEffect(() => {
-    // XXX: is there a reason this is in a useEffect? Is it to prevent issues with defaulting to `{}`?
+    // XXX: is there a reason this is in a useEffect? Is it to prevent issues with defaulting to a fresh `{}`?
     valuesRef.current = formData ?? {};
   }, [formData]);
 

--- a/src/bricks/renderers/customForm.ts
+++ b/src/bricks/renderers/customForm.ts
@@ -41,7 +41,7 @@ import {
 } from "@/types/runtimeTypes";
 import { RendererABC } from "@/types/bricks/rendererTypes";
 import { namespaceOptions } from "@/bricks/effects/pageState";
-import { ensureJsonObject, isObject } from "@/utils/objectUtils";
+import { assertObject, ensureJsonObject } from "@/utils/objectUtils";
 import { getOutputReference, validateOutputKey } from "@/runtime/runtimeTypes";
 import { type BrickConfig } from "@/bricks/types";
 import { isExpression } from "@/utils/expressionUtils";
@@ -66,19 +66,13 @@ export type Storage =
     }
   | StateStorage;
 
-function assertObject(value: unknown): asserts value is UnknownObject {
-  if (!isObject(value)) {
-    throw new BusinessError("Expected object for data");
-  }
-}
-
 type Context = { blueprintId: RegistryId | null; extensionId: UUID };
 
 /**
  * Action to perform after the onSubmit handler is executed.
  * @since 1.8.12
  */
-type PostSubmitAction = "save" | "reset";
+export type PostSubmitAction = "save" | "reset";
 
 export const CUSTOM_FORM_SCHEMA = {
   type: "object",
@@ -389,7 +383,7 @@ async function getInitialData(
   switch (storage.type) {
     case "localStorage": {
       const data = await dataStore.get(recordId);
-      assertObject(data);
+      assertObject(data, BusinessError);
       return data;
     }
 
@@ -416,7 +410,7 @@ async function getInitialData(
           missing_key: "blank",
         },
       });
-      assertObject(data);
+      assertObject(data, BusinessError);
       return data;
     }
 

--- a/src/components/formBuilder/edit/FieldEditor.tsx
+++ b/src/components/formBuilder/edit/FieldEditor.tsx
@@ -43,7 +43,7 @@ import SelectWidget, {
 import SwitchButtonWidget, {
   type CheckBoxLike,
 } from "@/components/form/widgets/switchButton/SwitchButtonWidget";
-import { uniq } from "lodash";
+import { uniq, partial } from "lodash";
 import { type SchemaFieldProps } from "@/components/fields/schemaFields/propTypes";
 import SchemaField from "@/components/fields/schemaFields/SchemaField";
 import databaseSchema from "@schemas/database.json";
@@ -97,14 +97,15 @@ function shouldShowPlaceholderText(uiType: UiType): boolean {
 const TextAreaFields: React.FC<{ uiOptionsPath: string }> = ({
   uiOptionsPath,
 }) => {
-  const [{ value: submitToolbar }] = useField<boolean>(
-    `${uiOptionsPath}.submitToolbar`,
+  const configName = partial(joinName, uiOptionsPath);
+  const [{ value: showSubmitToolbar = false }] = useField<boolean | null>(
+    configName("submitToolbar", "show"),
   );
 
   return (
     <>
       <SchemaField
-        name={joinName(uiOptionsPath, "rows")}
+        name={configName("rows")}
         schema={{
           type: "number",
           title: "# Rows",
@@ -113,7 +114,7 @@ const TextAreaFields: React.FC<{ uiOptionsPath: string }> = ({
         }}
       />
       <SchemaField
-        name={joinName(uiOptionsPath, "submitOnEnter")}
+        name={configName("submitOnEnter")}
         schema={{
           type: "boolean",
           title: "Submit Form on Enter?",
@@ -123,7 +124,7 @@ const TextAreaFields: React.FC<{ uiOptionsPath: string }> = ({
         isRequired
       />
       <SchemaField
-        name={joinName(uiOptionsPath, "submitToolbar", "show")}
+        name={configName("submitToolbar", "show")}
         schema={{
           type: "boolean",
           title: "Include Submit Toolbar?",
@@ -132,9 +133,9 @@ const TextAreaFields: React.FC<{ uiOptionsPath: string }> = ({
         }}
         isRequired
       />
-      <Collapse in={Boolean(submitToolbar)}>
+      <Collapse in={showSubmitToolbar}>
         <SchemaField
-          name={joinName(uiOptionsPath, "submitToolbar", "icon")}
+          name={configName("submitToolbar", "icon")}
           schema={{ $ref: "https://app.pixiebrix.com/schemas/icon#" }}
           label="Select Icon"
           description="Select the icon that appears in the bottom right of the Submit Toolbar"

--- a/src/components/formBuilder/edit/FieldEditor.tsx
+++ b/src/components/formBuilder/edit/FieldEditor.tsx
@@ -132,7 +132,7 @@ const TextAreaFields: React.FC<{ uiOptionsPath: string }> = ({
         }}
         isRequired
       />
-      <Collapse in={submitToolbar}>
+      <Collapse in={Boolean(submitToolbar)}>
         <SchemaField
           name={joinName(uiOptionsPath, "submitToolbar", "icon")}
           schema={{ $ref: "https://app.pixiebrix.com/schemas/icon#" }}

--- a/src/pageEditor/fields/FormRendererOptions.test.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.test.tsx
@@ -14,6 +14,24 @@ beforeAll(() => {
   registerDefaultWidgets();
 });
 
+// TODO: figure out how to properly add to extendedExpectations
+function expectToBeCollapsed(element: HTMLElement): void {
+  // eslint-disable-next-line testing-library/no-node-access -- traversing known React Bootstrap structure
+  const collapse = element.closest(".collapse");
+
+  expect(collapse).toBeDefined();
+  expect(collapse.classList.contains("show")).toBeFalse();
+}
+
+// TODO: figure out how to properly add to extendedExpectations
+function expectToBeExpanded(element: HTMLElement): void {
+  // eslint-disable-next-line testing-library/no-node-access -- traversing known React Bootstrap structure
+  const collapse = element.closest(".collapse");
+
+  expect(collapse).toBeDefined();
+  expect(collapse.classList.contains("show")).toBeTrue();
+}
+
 describe("FormRendererOptions", () => {
   it("smoke test", async () => {
     const brick = createNewConfiguredBrick(CustomFormRenderer.BRICK_ID);
@@ -62,16 +80,14 @@ describe("FormRendererOptions", () => {
 
     await waitForEffect();
 
-    // FIXME: is something defaulting the onSubmit pipeline to be toggled to be an empty pipeline?
-    expect(screen.queryByText(/save data/i)).not.toBeVisible();
+    expectToBeCollapsed(screen.getByText(/save data/i));
 
     await toggleBootstrapSwitch("Custom Submit Handler");
 
-    // Field defaults to save data
-    expect(screen.getByText(/save data/i)).toBeVisible();
+    expectToBeExpanded(screen.getByText(/save data/i));
 
     await toggleBootstrapSwitch("Custom Submit Handler");
 
-    expect(screen.queryByText(/save data/i)).not.toBeVisible();
+    expectToBeCollapsed(screen.getByText(/save data/i));
   });
 });

--- a/src/pageEditor/fields/FormRendererOptions.test.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.test.tsx
@@ -7,8 +7,8 @@ import React from "react";
 import { CustomFormRenderer } from "@/bricks/renderers/customForm";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
 import { waitForEffect } from "@/testUtils/testHelpers";
-import userEvent from "@testing-library/user-event";
 import FormRendererOptions from "@/pageEditor/fields/FormRendererOptions";
+import { toggleBootstrapSwitch } from "@/testUtils/userEventHelpers";
 
 beforeAll(() => {
   registerDefaultWidgets();
@@ -62,15 +62,16 @@ describe("FormRendererOptions", () => {
 
     await waitForEffect();
 
-    const element = screen.getByText("Custom Submit Handler");
+    // FIXME: is something defaulting the onSubmit pipeline to be toggled to be an empty pipeline?
+    expect(screen.queryByText(/save data/i)).not.toBeVisible();
 
-    // TODO: fix a11y of bootstrap-switch-button-react so we can target in tests
-    // eslint-disable-next-line testing-library/no-node-access -- use of bootstrap-switch-button-react is not accessible
-    const fieldGroup = element.nextSibling as HTMLElement;
-    // eslint-disable-next-line testing-library/no-node-access -- use of bootstrap-switch-button-react is not accessible
-    await userEvent.click(fieldGroup.querySelector(".switch"));
+    await toggleBootstrapSwitch("Custom Submit Handler");
 
     // Field defaults to save data
-    expect(screen.getByText(/save data/i)).toBeInTheDocument();
+    expect(screen.getByText(/save data/i)).toBeVisible();
+
+    await toggleBootstrapSwitch("Custom Submit Handler");
+
+    expect(screen.queryByText(/save data/i)).not.toBeVisible();
   });
 });

--- a/src/pageEditor/fields/FormRendererOptions.test.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.test.tsx
@@ -90,4 +90,37 @@ describe("FormRendererOptions", () => {
 
     expectToBeCollapsed(screen.getByText(/save data/i));
   });
+
+  it("toggles textarea submit toolbar", async () => {
+    const brick = createNewConfiguredBrick(CustomFormRenderer.BRICK_ID);
+
+    const initialValues = sidebarPanelFormStateFactory({}, [brick]);
+
+    render(
+      <FormRendererOptions
+        name="extension.blockPipeline.0"
+        configKey="config"
+      />,
+      {
+        initialValues,
+        setupRedux(dispatch) {
+          dispatch(editorActions.addElement(initialValues));
+          dispatch(editorActions.selectElement(initialValues.uuid));
+          dispatch(editorActions.setElementActiveNodeId(brick.instanceId));
+        },
+      },
+    );
+
+    await waitForEffect();
+
+    expectToBeCollapsed(screen.getByText(/select icon/i));
+
+    await toggleBootstrapSwitch("Include Submit Toolbar?");
+
+    expectToBeExpanded(screen.getByText(/select icon/i));
+
+    await toggleBootstrapSwitch("Include Submit Toolbar?");
+
+    expectToBeCollapsed(screen.getByText(/select icon/i));
+  });
 });

--- a/src/pageEditor/fields/FormRendererOptions.test.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.test.tsx
@@ -1,0 +1,76 @@
+import { createNewConfiguredBrick } from "@/pageEditor/exampleBrickConfigs";
+import { sidebarPanelFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import { render } from "@/pageEditor/testHelpers";
+import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
+import { screen } from "@testing-library/react";
+import React from "react";
+import { CustomFormRenderer } from "@/bricks/renderers/customForm";
+import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
+import { waitForEffect } from "@/testUtils/testHelpers";
+import userEvent from "@testing-library/user-event";
+import FormRendererOptions from "@/pageEditor/fields/FormRendererOptions";
+
+beforeAll(() => {
+  registerDefaultWidgets();
+});
+
+describe("FormRendererOptions", () => {
+  it("smoke test", async () => {
+    const brick = createNewConfiguredBrick(CustomFormRenderer.BRICK_ID);
+
+    const initialValues = sidebarPanelFormStateFactory({}, [brick]);
+
+    render(
+      <FormRendererOptions
+        name="extension.blockPipeline.0"
+        configKey="config"
+      />,
+      {
+        initialValues,
+        setupRedux(dispatch) {
+          dispatch(editorActions.addElement(initialValues));
+          dispatch(editorActions.selectElement(initialValues.uuid));
+          dispatch(editorActions.setElementActiveNodeId(brick.instanceId));
+        },
+      },
+    );
+
+    await waitForEffect();
+
+    expect(screen.getByDisplayValue("Example Notes Field")).toBeInTheDocument();
+  });
+
+  it("toggles reset field", async () => {
+    const brick = createNewConfiguredBrick(CustomFormRenderer.BRICK_ID);
+
+    const initialValues = sidebarPanelFormStateFactory({}, [brick]);
+
+    render(
+      <FormRendererOptions
+        name="extension.blockPipeline.0"
+        configKey="config"
+      />,
+      {
+        initialValues,
+        setupRedux(dispatch) {
+          dispatch(editorActions.addElement(initialValues));
+          dispatch(editorActions.selectElement(initialValues.uuid));
+          dispatch(editorActions.setElementActiveNodeId(brick.instanceId));
+        },
+      },
+    );
+
+    await waitForEffect();
+
+    const element = screen.getByText("Custom Submit Handler");
+
+    // TODO: fix a11y of bootstrap-switch-button-react so we can target in tests
+    // eslint-disable-next-line testing-library/no-node-access -- use of bootstrap-switch-button-react is not accessible
+    const fieldGroup = element.nextSibling as HTMLElement;
+    // eslint-disable-next-line testing-library/no-node-access -- use of bootstrap-switch-button-react is not accessible
+    await userEvent.click(fieldGroup.querySelector(".switch"));
+
+    // Field defaults to save data
+    expect(screen.getByText(/save data/i)).toBeInTheDocument();
+  });
+});

--- a/src/pageEditor/fields/FormRendererOptions.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.tsx
@@ -28,6 +28,7 @@ import { useField, useFormikContext } from "formik";
 import { partial } from "lodash";
 import {
   CUSTOM_FORM_SCHEMA,
+  type PostSubmitAction,
   type Storage,
 } from "@/bricks/renderers/customForm";
 import AppApiIntegrationDependencyField from "@/components/fields/schemaFields/AppApiIntegrationDependencyField";
@@ -63,15 +64,20 @@ function usePruneUnusedServiceDependencies() {
   }, [formState, setFormState]);
 }
 
-type StringOption = {
+type StringOption<Value extends string = string> = {
   label: string;
-  value: string;
+  value: Value;
 };
 
 const storageTypeOptions: Options<StringOption> = [
   { value: "state", label: "Mod Variables / Page State" },
   { value: "database", label: "Database" },
   { value: "localStorage", label: "Local Storage (Deprecated)" },
+];
+
+const postSubmitActionOptions: Options<StringOption<PostSubmitAction>> = [
+  { value: "save", label: "Save Data" },
+  { value: "reset", label: "Reset Form" },
 ];
 
 const DEFAULT_STORAGE_TYPE = "state";
@@ -175,6 +181,8 @@ const FormSubmissionOptions: React.FC<{
   makeName: (...names: string[]) => string;
 }> = ({ makeName }) => {
   const [{ value: autoSave }] = useField<boolean>(makeName("autoSave"));
+  const [{ value: postSubmitAction = "save" }, , postSubmitHelpers] =
+    useField<PostSubmitAction>(makeName("postSubmitAction"));
   const [{ value: onSubmit }] = useField<PipelineExpression | null>(
     makeName("onSubmit"),
   );
@@ -225,16 +233,30 @@ const FormSubmissionOptions: React.FC<{
 
       <PipelineToggleField
         label="Custom Submit Handler"
-        description="Toggle on to run custom actions before the data is saved/reset. Edit the actions in the Brick Actions Panel"
+        description="Toggle on to run custom actions before the data is saved or form is reset. Edit the actions in the Brick Actions Panel"
         name={makeName("onSubmit")}
+        onAfterChange={async (value) => {
+          // Clean up the postSubmitAction if the custom submit handler is disabled
+          if (!value) {
+            await postSubmitHelpers.setValue(null);
+          }
+        }}
       />
 
       {onSubmit && (
-        <SchemaField
+        <FieldTemplate
           name={makeName("postSubmitAction")}
           label="Post Submit Action"
-          schema={CUSTOM_FORM_SCHEMA.properties.postSubmitAction as Schema}
-          isRequired
+          description="The action to perform after the custom submit handler is run"
+          as={Select}
+          options={postSubmitActionOptions}
+          value={
+            postSubmitActionOptions.find((x) => x.value === postSubmitAction) ??
+            postSubmitActionOptions[0]
+          }
+          onChange={async ({ value }: StringOption<PostSubmitAction>) => {
+            await postSubmitHelpers.setValue(value);
+          }}
         />
       )}
     </>

--- a/src/pageEditor/fields/FormRendererOptions.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.tsx
@@ -43,6 +43,7 @@ import useAsyncEffect from "use-async-effect";
 import PipelineToggleField from "@/pageEditor/fields/PipelineToggleField";
 import ConnectedCollapsibleFieldSection from "@/pageEditor/fields/ConnectedCollapsibleFieldSection";
 import type { PipelineExpression } from "@/types/runtimeTypes";
+import { Collapse } from "react-bootstrap";
 
 const recordIdSchema: Schema = {
   type: "string",
@@ -243,7 +244,7 @@ const FormSubmissionOptions: React.FC<{
         }}
       />
 
-      {onSubmit && (
+      <Collapse in={Boolean(onSubmit)}>
         <FieldTemplate
           name={makeName("postSubmitAction")}
           label="Post Submit Action"
@@ -258,7 +259,7 @@ const FormSubmissionOptions: React.FC<{
             await postSubmitHelpers.setValue(value);
           }}
         />
-      )}
+      </Collapse>
     </>
   );
 };

--- a/src/pageEditor/fields/FormRendererOptions.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.tsx
@@ -41,6 +41,7 @@ import { joinName } from "@/utils/formUtils";
 import useAsyncEffect from "use-async-effect";
 import PipelineToggleField from "@/pageEditor/fields/PipelineToggleField";
 import ConnectedCollapsibleFieldSection from "@/pageEditor/fields/ConnectedCollapsibleFieldSection";
+import type { PipelineExpression } from "@/types/runtimeTypes";
 
 const recordIdSchema: Schema = {
   type: "string",
@@ -174,6 +175,10 @@ const FormSubmissionOptions: React.FC<{
   makeName: (...names: string[]) => string;
 }> = ({ makeName }) => {
   const [{ value: autoSave }] = useField<boolean>(makeName("autoSave"));
+  const [{ value: onSubmit }] = useField<PipelineExpression | null>(
+    makeName("onSubmit"),
+  );
+
   const hideSubmitButtonName = makeName(
     "uiSchema",
     "ui:submitButtonOptions",
@@ -220,9 +225,18 @@ const FormSubmissionOptions: React.FC<{
 
       <PipelineToggleField
         label="Custom Submit Handler"
-        description="Toggle on to run custom actions before the data is saved. Edit the actions in the Brick Actions Panel"
+        description="Toggle on to run custom actions before the data is saved/reset. Edit the actions in the Brick Actions Panel"
         name={makeName("onSubmit")}
       />
+
+      {onSubmit && (
+        <SchemaField
+          name={makeName("postSubmitAction")}
+          label="Post Submit Action"
+          schema={CUSTOM_FORM_SCHEMA.properties.postSubmitAction as Schema}
+          isRequired
+        />
+      )}
     </>
   );
 };

--- a/src/pageEditor/fields/PipelineToggleField.tsx
+++ b/src/pageEditor/fields/PipelineToggleField.tsx
@@ -35,7 +35,12 @@ const PipelineToggleField: React.VoidFunctionComponent<{
   name: string;
   label: string;
   description: string;
-}> = ({ name, label, description }) => {
+  /**
+   * Handler called after the value changes, e.g., to set/clean-up dependent fields.
+   * @since 1.8.12
+   */
+  onAfterChange?: (value: boolean) => void;
+}> = ({ name, label, description, onAfterChange }) => {
   const { setFieldValue } = useFormikContext<ModComponentFormState>();
   const [{ value }] = useField<PipelineExpression | null>(name);
 
@@ -52,6 +57,8 @@ const PipelineToggleField: React.VoidFunctionComponent<{
         } else {
           await setFieldValue(name, null);
         }
+
+        onAfterChange?.(target.value);
       }}
     />
   );

--- a/src/testUtils/extendedExpectations.ts
+++ b/src/testUtils/extendedExpectations.ts
@@ -28,7 +28,7 @@ declare global {
 
       /**
        * @warning This only asserts on the amount of time that passes from
-       * this toFullfillWithinMilliseconds() call, not from the promise creation.
+       * this toFulfillWithinMilliseconds() call, not from the promise creation.
        *
        * If this is troublesome, copy the `trackSettledTime` function/pattern instead:
        * https://github.com/pixiebrix/webext-messenger/blob/22eeba8b5b2efe3ecb6beb7a8c493f260c9499fb/source/test/helpers.ts#L28-L38
@@ -38,14 +38,14 @@ declare global {
        *   // Wrong: DO NOT await anything between the promise creation and the expect() call
        *   const promise = getMilk();
        *   await act(); // This will mess up the timing
-       *   await expect(promise).toFullfillWithinMilliseconds(1000);
+       *   await expect(promise).toFulfillWithinMilliseconds(1000);
        *
        *   // Correct: Await the expect() call directly
-       *   const expectation = expect(getMilk()).toFullfillWithinMilliseconds(1000);
+       *   const expectation = expect(getMilk()).toFulfillWithinMilliseconds(1000);
        *   await act();
        *   await expectation;
        */
-      toFullfillWithinMilliseconds(
+      toFulfillWithinMilliseconds(
         maximumDuration: number,
       ): Promise<CustomMatcherResult>;
     }
@@ -64,7 +64,7 @@ async function trackSettleTime(promise: Promise<unknown>): Promise<number> {
 
 expect.extend({
   // Extracted and adapted from https://github.com/pixiebrix/webext-messenger/blob/22eeba8b5b2efe3ecb6beb7a8c493f260c9499fb/source/test/helpers.ts#L40
-  async toFullfillWithinMilliseconds(
+  async toFulfillWithinMilliseconds(
     promise: Promise<unknown>,
     maximumDuration: number,
   ) {
@@ -73,7 +73,7 @@ expect.extend({
     return {
       pass: duration < maximumDuration,
       message: () =>
-        `Expected promise to be fullfilled within ${maximumDuration}ms, but it took ${duration}ms`,
+        `Expected promise to be fulfilled within ${maximumDuration}ms, but it took ${duration}ms`,
     };
   },
 

--- a/src/testUtils/factories/pageEditorFactories.ts
+++ b/src/testUtils/factories/pageEditorFactories.ts
@@ -121,7 +121,7 @@ export const triggerFormStateFactory = (
 export const sidebarPanelFormStateFactory = (
   override?: FactoryConfig<SidebarFormState>,
   pipelineOverride?: BrickPipeline,
-) => {
+): SidebarFormState => {
   const defaultTriggerProps = sidebar.fromNativeElement(
     "https://test.com",
     metadataFactory({

--- a/src/testUtils/userEventHelpers.ts
+++ b/src/testUtils/userEventHelpers.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+/**
+ * Toggle the bootstrap switch widget field with the given field label.
+ */
+export async function toggleBootstrapSwitch(fieldLabel: string): Promise<void> {
+  const element = screen.getByText(fieldLabel);
+
+  // TODO: fix a11y of bootstrap-switch-button-react so we can target in tests
+  // eslint-disable-next-line testing-library/no-node-access -- use of bootstrap-switch-button-react is not accessible
+  const fieldGroup = element.nextSibling as HTMLElement;
+
+  // eslint-disable-next-line testing-library/no-node-access -- use of bootstrap-switch-button-react is not accessible
+  const switchElement = fieldGroup.querySelector(".switch");
+
+  expect(switchElement).not.toBeNull();
+
+  await userEvent.click(switchElement);
+}

--- a/src/utils/objectUtils.test.ts
+++ b/src/utils/objectUtils.test.ts
@@ -19,7 +19,9 @@ import {
   removeUndefined,
   mapObject,
   isUnknownObjectArray,
+  assertObject,
 } from "@/utils/objectUtils";
+import { BusinessError } from "@/errors/businessErrors";
 
 describe("removeUndefined", () => {
   test("remove top-level undefined", () => {
@@ -84,5 +86,31 @@ describe("isUnknownObjectArray", () => {
 
   test("non-array", () => {
     expect(isUnknownObjectArray({ foo: "bar" })).toBe(false);
+  });
+});
+
+describe("assertObject", () => {
+  it("accepts an array", () => {
+    expect(() => {
+      assertObject([]);
+    }).not.toThrow();
+  });
+
+  it("accepts an object", () => {
+    expect(() => {
+      assertObject({ foo: "bar" });
+    }).not.toThrow();
+  });
+
+  it.each([null, undefined])("rejects nullish: %s", (value) => {
+    expect(() => {
+      assertObject(value);
+    }).toThrow(TypeError);
+  });
+
+  it("throws custom error", () => {
+    expect(() => {
+      assertObject(42, BusinessError);
+    }).toThrow(BusinessError);
   });
 });

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -68,9 +68,23 @@ export function deepPickBy(
 
 /**
  * Returns true if value is non-null and has a typeof "object". Also returns true for arrays.
+ * @see assertObject
  */
 export function isObject(value: unknown): value is UnknownObject {
   return Boolean(value) && typeof value === "object";
+}
+
+/**
+ * Asserts that the value is an object or an array
+ * @see isObject
+ */
+export function assertObject(
+  value: unknown,
+  ErrorCtor: new (...args: unknown[]) => Error = TypeError,
+): asserts value is UnknownObject {
+  if (!isObject(value)) {
+    throw new ErrorCtor("Expected object for data");
+  }
 }
 
 export function ensureJsonObject(value: UnknownObject): JsonObject {

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -83,15 +83,15 @@ export function assertObject(
   ErrorCtor: new (...args: unknown[]) => Error = TypeError,
 ): asserts value is UnknownObject {
   if (!isObject(value)) {
-    throw new ErrorCtor("Expected object for data");
+    throw new ErrorCtor("expected object");
   }
 }
 
+/**
+ * @throws {TypeError} if the value is not an object
+ */
 export function ensureJsonObject(value: UnknownObject): JsonObject {
-  if (!isObject(value)) {
-    throw new TypeError("expected object");
-  }
-
+  assertObject(value);
   return JSON.parse(safeJsonStringify(value)) as JsonObject;
 }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #8147
- Adds an affordance to reset a form when using the custom submit handler

## Remaining Work

- [x] Review form field copy with @BrandonPxBx 
- [x] Show options in title-case
- [x] Default the field to "save" in the Form Builder if not provided
- [x] Add tests
- [x] Create mod for regression testing: https://app.pixiebrix.com/activate?id%5B%5D=%40pixies%2Ftest%2Fembedded-form-submission

## Discussion

- Field naming, call it "After Submit Action" action instead of "Post Submit Action"?
- For simplicity, the field type is not toggle-able, and user can't pass a variable in via the Page Editor
- The Jest tests can cover the behavior well because it's by and large React behavior

## Demo

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/3d0963dd-17c0-41fa-92dd-2ca4c20b0263)

![image](https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/9a4f616a-1b12-4f3b-ac91-a34ea64970d0)

## Future Work

- https://github.com/pixiebrix/pixiebrix-extension/blob/7ae135304fff2a3604e1d2d8c34984e16b34aa10/src/pageEditor/fields/FormRendererOptions.test.tsx#L67-L67

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer: @grahamlangford 
