### PR TITLE
#8152: change manifest name for beta builds

### DIFF
--- a/scripts/__snapshots__/manifest.test.js.snap
+++ b/scripts/__snapshots__/manifest.test.js.snap
@@ -91,7 +91,7 @@ exports[`customizeManifest beta 1`] = `
   },
   "manifest_version": 3,
   "minimum_chrome_version": "116.0",
-  "name": "PixieBrix",
+  "name": "PixieBrix BETA",
   "optional_permissions": [
     "clipboardWrite",
   ],
@@ -116,7 +116,7 @@ exports[`customizeManifest beta 1`] = `
       "sandbox.html",
     ],
   },
-  "short_name": "PixieBrix",
+  "short_name": "PixieBrix BETA",
   "side_panel": {
     "default_path": "sidebar.html",
   },

--- a/scripts/manifest.mjs
+++ b/scripts/manifest.mjs
@@ -133,6 +133,7 @@ function customizeManifest(manifestV2, options = {}) {
 
   if (isBeta) {
     manifest.name = "PixieBrix BETA";
+    manifest.short_name = "PixieBrix BETA";
 
     manifest.icons["16"] = "icons/beta/logo16.png";
     manifest.icons["32"] = "icons/beta/logo32.png";

--- a/scripts/manifest.mjs
+++ b/scripts/manifest.mjs
@@ -132,6 +132,8 @@ function customizeManifest(manifestV2, options = {}) {
   }
 
   if (isBeta) {
+    manifest.name = "PixieBrix BETA";
+
     manifest.icons["16"] = "icons/beta/logo16.png";
     manifest.icons["32"] = "icons/beta/logo32.png";
     manifest.icons["48"] = "icons/beta/logo48.png";


### PR DESCRIPTION
## What does this PR do?

- Fixes #8152 
Sets the manifest name to `PixieBrix BETA` for beta cws builds

## Checklist

- [x] Designate a primary reviewer @twschiller 
