### PR TITLE
#8157: fix insert at cursor for draftjs editors

### DIFF
--- a/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
+++ b/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
@@ -68,18 +68,27 @@ test("8157: can insert at cursor", async ({ page, extensionId }) => {
   await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
   await expect(editable).toHaveText("aHello world!b");
 
-  // Draft.js
+  // Draft.js - target by aria-label
   const editor = page.getByLabel("rdw-editor");
   await editor.scrollIntoViewIfNeeded();
 
-  const content = editor.locator("div").nth(1);
-  await content.click();
-  await content.pressSequentially("start");
-  await expect(page.getByText("start")).toBeVisible();
+  await editor.click();
 
-  await page.getByText("start").click();
+  // Need to simulate the mouse entering the sidebar to track focus on MV2
+  // https://github.com/pixiebrix/pixiebrix-extension/blob/1794863937f343fbc8e3a4434eace74191f8dfbd/src/contentScript/sidebarController.tsx#L563-L563
+  const sidebarFrame = page.locator("#pixiebrix-extension");
+
+  if (await sidebarFrame.count()) {
+    await sidebarFrame.dispatchEvent("mouseenter");
+  }
 
   await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
 
-  await expect(page.getByText("startHello world!")).toBeVisible();
+  await expect(editor.getByText("Hello world!")).toBeVisible();
+
+  await editor.click();
+  await editor.press("ArrowLeft");
+  await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
+
+  await expect(editor.getByText("Hello worldHello world!!")).toBeVisible();
 });

--- a/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
+++ b/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
@@ -21,7 +21,7 @@ import { ActivateModPage } from "../../pageObjects/modsPage";
 import { test as base } from "@playwright/test";
 import { getSidebarPage } from "../../utils";
 
-test("8157: can insert in draftjs editor", async ({ page, extensionId }) => {
+test("8157: can insert at cursor", async ({ page, extensionId }) => {
   const modId = "@pixies/test/insert-at-cursor";
 
   const modActivationPage = new ActivateModPage(page, extensionId, modId);
@@ -57,6 +57,16 @@ test("8157: can insert in draftjs editor", async ({ page, extensionId }) => {
 
   await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
   await expect(textarea).toHaveValue("aHello world!b");
+
+  // Basic content editable
+  const editable = page.locator("div[contenteditable]").first();
+  await textarea.scrollIntoViewIfNeeded();
+  await editable.click();
+  await editable.pressSequentially("ab");
+  await editable.press("ArrowLeft");
+
+  await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
+  await expect(editable).toHaveText("aHello world!b");
 
   // Draft.js
   const editor = page.getByLabel("rdw-editor");

--- a/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
+++ b/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
@@ -20,6 +20,7 @@ import { ActivateModPage } from "../../pageObjects/modsPage";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { test as base } from "@playwright/test";
 import { getSidebarPage } from "../../utils";
+import { MV } from "../../env";
 
 test("8157: can insert at cursor", async ({ page, extensionId }) => {
   const modId = "@pixies/test/insert-at-cursor";
@@ -74,11 +75,10 @@ test("8157: can insert at cursor", async ({ page, extensionId }) => {
 
   await editor.click();
 
-  // Need to simulate the mouse entering the sidebar to track focus on MV2
-  // https://github.com/pixiebrix/pixiebrix-extension/blob/1794863937f343fbc8e3a4434eace74191f8dfbd/src/contentScript/sidebarController.tsx#L563-L563
-  const sidebarFrame = page.locator("#pixiebrix-extension");
-
-  if (await sidebarFrame.count()) {
+  if (MV === "2") {
+    // Need to simulate the mouse entering the sidebar to track focus on MV2
+    // https://github.com/pixiebrix/pixiebrix-extension/blob/1794863937f343fbc8e3a4434eace74191f8dfbd/src/contentScript/sidebarController.tsx#L563-L563
+    const sidebarFrame = page.locator("#pixiebrix-extension");
     await sidebarFrame.dispatchEvent("mouseenter");
   }
 

--- a/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
+++ b/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { test, expect } from "../../fixtures/extensionBase";
+import { ActivateModPage } from "../../pageObjects/modsPage";
+// @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
+import { test as base } from "@playwright/test";
+import { getSidebarPage } from "../../utils";
+
+test("8157: can insert in draftjs editor", async ({ page, extensionId }) => {
+  const modId = "@pixies/test/insert-at-cursor";
+
+  const modActivationPage = new ActivateModPage(page, extensionId, modId);
+  await modActivationPage.goto();
+
+  await modActivationPage.clickActivateAndWaitForModsPageRedirect();
+
+  await page.goto("/advanced-fields/");
+
+  // The mod contains a trigger to open the sidebar on h1
+  await page.click("h1");
+
+  const sideBarPage = await getSidebarPage(page, extensionId);
+  await expect(
+    sideBarPage.getByRole("heading", { name: "Insert at Cursor" }),
+  ).toBeVisible();
+
+  // Normal text input field
+  const input = page.getByLabel("input", { exact: true });
+  await input.scrollIntoViewIfNeeded();
+  await input.click();
+  await input.pressSequentially("a");
+
+  await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
+  await expect(input).toHaveValue("aHello world!");
+
+  // Normal textarea
+  const textarea = page.getByLabel("textarea", { exact: true });
+  await textarea.scrollIntoViewIfNeeded();
+  await textarea.click();
+  await textarea.pressSequentially("ab");
+  await textarea.press("ArrowLeft");
+
+  await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
+  await expect(textarea).toHaveValue("aHello world!b");
+
+  // Draft.js
+  const editor = page.getByLabel("rdw-editor");
+  await editor.scrollIntoViewIfNeeded();
+
+  const content = editor.locator("div").nth(1);
+  await content.click();
+  await content.pressSequentially("start");
+  await expect(page.getByText("start")).toBeVisible();
+
+  await page.getByText("start").click();
+
+  await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
+
+  await expect(page.getByText("startHello world!")).toBeVisible();
+});

--- a/src/contentScript/textEditorDom.ts
+++ b/src/contentScript/textEditorDom.ts
@@ -19,8 +19,21 @@ import * as ckeditorDom from "@/contrib/ckeditor/ckeditorDom";
 import * as pageScript from "@/pageScript/messenger/api";
 import { getSelectorForElement } from "@/contentScript/elementReference";
 import { expectContext } from "@/utils/expectContext";
-import { dispatchPasteForDraftJs } from "@/utils/domFieldUtils";
 import focusController from "@/utils/focusController";
+import {
+  dispatchPasteForDraftJs,
+  isDraftJsField,
+} from "@/contrib/draftjs/draftJsDom";
+
+/**
+ * @file Text Editor DOM utilities that might call the pageScript.
+ *
+ * Historically, we've preferred to use `contentScript` except for calls that must be made from the `pageScript`. The
+ * advantage is that 1) we don't have pageScript injection cold-start, and 2) there's less of a chance of the host page
+ * interfering with our calls.
+ *
+ * However, we might consider consolidating the logic in the pageScript to simplify calling conventions.
+ */
 
 /**
  * Error to be thrown when document.execCommand fails.
@@ -40,21 +53,12 @@ export class ExecCommandError extends Error {
 }
 
 /**
- * @file Text Editor DOM utilities that might call the pageScript.
- *
- * Historically, we've preferred to use `contentScript` except for calls that must be made from the `pageScript`. The
- * advantage is that 1) we don't have pageScript injection coldstart, and 2) there's less of a chance of the host page
- * interfering with our calls.
- *
- * However, we might consider consolidating the logic in the pageScript to simplify calling conventions.
- */
-
-/**
  * Inserts text at the current cursor position in the given element, with support for custom editors, e.g., CKEditor.
  *
  * Current support:
  * - Plain content editable (Gmail, etc.)
  * - CKEditor 4/5
+ * - Draft.js
  *
  * @throws {ExecCommandError} if the text could not be inserted with InsertTextError
  */
@@ -76,9 +80,11 @@ export async function insertAtCursorWithCustomEditorSupport(text: string) {
     return;
   }
 
-  if (element.textContent === "" && element.closest(".DraftEditor-root")) {
-    // Special handling for DraftJS if the field is empty
-    // https://github.com/pixiebrix/pixiebrix-extension/issues/7630
+  if (isDraftJsField(element)) {
+    // Must always use paste. Otherwise, the editor will become corrupted
+    // More information/context:
+    // - https://github.com/pixiebrix/pixiebrix-extension/issues/7630
+    // - https://github.com/pixiebrix/pixiebrix-extension/issues/8157
     dispatchPasteForDraftJs(element, text);
     return;
   }

--- a/src/contrib/draftjs/draftJsDom.ts
+++ b/src/contrib/draftjs/draftJsDom.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * DraftJS doesn't handle `insertText` correctly in most cases, but it can handle this
+ * event. Note that this event doesn't do anything in regular contentEditable fields.
+ * Source: https://github.com/facebookarchive/draft-js/issues/616#issuecomment-426047799
+ */
+export function dispatchPasteForDraftJs(field: HTMLElement, value: string) {
+  const data = new DataTransfer();
+  data.setData("text/plain", value);
+  field.dispatchEvent(
+    new ClipboardEvent("paste", {
+      clipboardData: data,
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
+export function isDraftJsField(element: HTMLElement): boolean {
+  return Boolean(element.closest(".DraftEditor-root"));
+}

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -354,6 +354,7 @@
     "./contrib/ckeditor/ckeditor.test.ts",
     "./contrib/ckeditor/ckeditorDom.ts",
     "./contrib/ckeditor/ckeditorProtocol.ts",
+    "./contrib/draftjs/draftJsDom.ts",
     "./contrib/google/sheets/core/getSheetIdIntegrationOutputKey.ts",
     "./contrib/google/sheets/core/handleGoogleRequestRejection.ts",
     "./contrib/google/sheets/core/schemas.ts",

--- a/src/utils/domFieldUtils.ts
+++ b/src/utils/domFieldUtils.ts
@@ -98,6 +98,7 @@ export async function setFieldValue(
     if (field.textContent === "" && isDraftJsField(field)) {
       // Special handling for DraftJS if the field is empty
       // https://github.com/pixiebrix/pixiebrix-extension/issues/7630
+      // XXX: should this just always send a paste command for Draft.js fields?
       dispatchPasteForDraftJs(field, String(value));
     } else {
       // It automatically triggers an `input` event

--- a/src/utils/domFieldUtils.ts
+++ b/src/utils/domFieldUtils.ts
@@ -19,6 +19,10 @@ import { setCKEditorData } from "@/pageScript/messenger/api";
 import { getSelectorForElement } from "@/contentScript/elementReference";
 import { hasCKEditorClass } from "@/contrib/ckeditor/ckeditorDom";
 import { boolean } from "@/utils/typeUtils";
+import {
+  dispatchPasteForDraftJs,
+  isDraftJsField,
+} from "@/contrib/draftjs/draftJsDom";
 
 export type FieldElement =
   | HTMLInputElement
@@ -37,23 +41,6 @@ export function isFieldElement(
     element instanceof HTMLInputElement ||
     element instanceof HTMLTextAreaElement ||
     element instanceof HTMLSelectElement
-  );
-}
-
-/**
- * DraftJS doesn't handle `insertText` correctly in some cases, but it can handle this
- * event. Note that this event doesn't do anything in regular contentEditable fields.
- * Source: https://github.com/facebookarchive/draft-js/issues/616#issuecomment-426047799
- */
-export function dispatchPasteForDraftJs(field: HTMLElement, value: string) {
-  const data = new DataTransfer();
-  data.setData("text/plain", value);
-  field.dispatchEvent(
-    new ClipboardEvent("paste", {
-      clipboardData: data,
-      bubbles: true,
-      cancelable: true,
-    }),
   );
 }
 
@@ -108,7 +95,7 @@ export async function setFieldValue(
     // `insertText` acts as a "paste", so if no text is selected it's just appended
     document.execCommand("selectAll");
 
-    if (field.textContent === "" && field.closest(".DraftEditor-root")) {
+    if (field.textContent === "" && isDraftJsField(field)) {
       // Special handling for DraftJS if the field is empty
       // https://github.com/pixiebrix/pixiebrix-extension/issues/7630
       dispatchPasteForDraftJs(field, String(value));


### PR DESCRIPTION
## What does this PR do?

- Closes #8157 
- Consolidates draftjs-specific logic
- Always use paste event to insert text into draftjs

## Remaining Work

- [x] Figure out how to interact with draftjs with playwright and complete tests
- [x] Test on other other live draft.js editors: https://github.com/nikgraf/awesome-draft-js?tab=readme-ov-file#standalone-editors-built-on-draftjs

## Demo

- See playwright test

## Checklist

- [x] Add tests and/or storybook stories: playwright tests
- [x] Designate a primary reviewer: @fungairino 
