### PR TITLE
#8068: removing unnecessary css override for the button dropdown caret

### DIFF
--- a/src/vendors/theme/assets/styles/components/_dropdowns.scss
+++ b/src/vendors/theme/assets/styles/components/_dropdowns.scss
@@ -1,24 +1,6 @@
 /* Dropdowns */
 
 .dropdown {
-  .dropdown-toggle {
-    &:after {
-      border-top: 0;
-      border-right: 0;
-      border-left: 0;
-      border-bottom: 0;
-      //font: normal normal normal 24px/1 "Material Design Icons";
-      // content: "\f140";
-      width: auto;
-      height: auto;
-      vertical-align: baseline;
-      font-size: 0.75rem;
-      .rtl & {
-        margin-left: 0;
-        margin-right: 0.255em;
-      }
-    }
-  }
   .dropdown-menu {
     margin-top: 0.75rem;
     font-size: $default-font-size;


### PR DESCRIPTION
## What does this PR do?

- Fixes #8068
- this css was hiding it, and now it can once again be displayed

## Discussion

Let me know if there are any other placesI should check these particular uses of the dropdown (seems like the Deployment modal uses it as well). 

I checked these in the PageEditor and it seems like it uses a different set of css sourced from `bootstrapWithoutRem.css`

## Demo

<img width="920" alt="Screenshot 2024-04-04 at 8 06 47 PM" src="https://github.com/pixiebrix/pixiebrix-extension/assets/3498063/4fe0d94e-75ac-4693-b883-2bee0c3b7c2f">
<img width="698" alt="Screenshot 2024-04-04 at 8 05 12 PM" src="https://github.com/pixiebrix/pixiebrix-extension/assets/3498063/969abed8-4e80-46c9-b290-15726c638773">


## Checklist

- [ ] Add tests and/or storybook stories
- [ ] Designate a primary reviewer: 
