### PR TITLE
#8161: fix selector analysis false positives and improve warning text

### DIFF
--- a/src/analysis/analysisVisitors/selectorAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/selectorAnalysis.test.ts
@@ -185,9 +185,7 @@ describe("SelectorAnalysis", () => {
     expect(analysis.getAnnotations()).toStrictEqual([
       {
         analysisId: "selector",
-        message: expect.stringMatching(
-          /Selector appears to contain random characters/,
-        ),
+        message: expect.stringMatching(/Selector appears to contain generated/),
         position: {
           path: "extension.blockPipeline.0.config.rootSelector",
         },
@@ -195,9 +193,7 @@ describe("SelectorAnalysis", () => {
       },
       {
         analysisId: "selector",
-        message: expect.stringMatching(
-          /Selector appears to contain random characters/,
-        ),
+        message: expect.stringMatching(/Selector appears to contain generated/),
         position: {
           path: "extension.blockPipeline.0.config.elements.0.selector",
         },
@@ -230,9 +226,7 @@ describe("SelectorAnalysis", () => {
     expect(analysis.getAnnotations()).toStrictEqual([
       {
         analysisId: "selector",
-        message: expect.stringMatching(
-          /Selector appears to contain random characters/,
-        ),
+        message: expect.stringMatching(/Selector appears to contain generated/),
         position: {
           path: "extension.blockPipeline.0.config.selectors.simple",
         },
@@ -240,9 +234,7 @@ describe("SelectorAnalysis", () => {
       },
       {
         analysisId: "selector",
-        message: expect.stringMatching(
-          /Selector appears to contain random characters/,
-        ),
+        message: expect.stringMatching(/Selector appears to contain generated/),
         position: {
           path: "extension.blockPipeline.0.config.selectors.complex.selector",
         },

--- a/src/analysis/analysisVisitors/selectorAnalysis.ts
+++ b/src/analysis/analysisVisitors/selectorAnalysis.ts
@@ -213,7 +213,7 @@ class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
       this.annotations.push({
         position,
         message:
-          "Selector appears to contain random characters. This may indicate a value that changes across page reloads or application updates.",
+          "Selector appears to contain generated or utility values. This may indicate a value that changes across page reloads or application updates.",
         analysisId: this.id,
         type: AnnotationType.Warning,
       });

--- a/src/utils/detectRandomString.test.ts
+++ b/src/utils/detectRandomString.test.ts
@@ -15,52 +15,108 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { guessUsefulness } from "./detectRandomString";
+import { guessUsefulness, selectorTypes } from "./detectRandomString";
 
-test("guessUsefulness", () => {
-  expect(guessUsefulness(".Nav-item")).toMatchInlineSnapshot(`
-    {
-      "detectorFactor": 0.13,
-      "isRandom": false,
-      "isSuspicious": false,
-      "lettersFactor": 0.22,
-      "string": ".Nav-item",
-    }
-  `);
-  expect(guessUsefulness(".ePGuZuxBTv9BWrjZL4l3")).toMatchInlineSnapshot(`
-    {
-      "detectorFactor": 0.55,
-      "isRandom": true,
-      "isSuspicious": true,
-      "lettersFactor": 0.19,
-      "string": ".ePGuZuxBTv9BWrjZL4l3",
-    }
-  `);
-  expect(guessUsefulness("._s2dF")).toMatchInlineSnapshot(`
-    {
-      "detectorFactor": 0.2,
-      "isRandom": true,
-      "isSuspicious": true,
-      "lettersFactor": 0.5,
-      "string": "._s2dF",
-    }
-  `);
-  expect(guessUsefulness(".Nav-wd32")).toMatchInlineSnapshot(`
-    {
-      "detectorFactor": 0.38,
-      "isRandom": false,
-      "isSuspicious": false,
-      "lettersFactor": 0.44,
-      "string": ".Nav-wd32",
-    }
-  `);
-  expect(guessUsefulness(".footerlink")).toMatchInlineSnapshot(`
-    {
-      "detectorFactor": 0.3,
-      "isRandom": false,
-      "isSuspicious": false,
-      "lettersFactor": 0.09,
-      "string": ".footerlink",
-    }
-  `);
+describe("guessUsefulness", () => {
+  it("handles good class name", () => {
+    expect(guessUsefulness(".Nav-item")).toMatchInlineSnapshot(`
+      {
+        "detectorFactor": 0.13,
+        "isRandom": false,
+        "isSuspicious": false,
+        "lettersFactor": 0.22,
+        "string": ".Nav-item",
+      }
+    `);
+    expect(guessUsefulness(".footerlink")).toMatchInlineSnapshot(`
+      {
+        "detectorFactor": 0.3,
+        "isRandom": false,
+        "isSuspicious": false,
+        "lettersFactor": 0.09,
+        "string": ".footerlink",
+      }
+    `);
+  });
+  it("handles css module name", () => {
+    expect(guessUsefulness(".ePGuZuxBTv9BWrjZL4l3")).toMatchInlineSnapshot(`
+      {
+        "detectorFactor": 0.55,
+        "isRandom": true,
+        "isSuspicious": true,
+        "lettersFactor": 0.19,
+        "string": ".ePGuZuxBTv9BWrjZL4l3",
+      }
+    `);
+    expect(guessUsefulness("._s2dF")).toMatchInlineSnapshot(`
+      {
+        "detectorFactor": 0.2,
+        "isRandom": true,
+        "isSuspicious": true,
+        "lettersFactor": 0.5,
+        "string": "._s2dF",
+      }
+    `);
+
+    // XXX: .Nav-wd32 should likely be flagged as suspicious
+    expect(guessUsefulness(".Nav-wd32")).toMatchInlineSnapshot(`
+      {
+        "detectorFactor": 0.38,
+        "isRandom": false,
+        "isSuspicious": false,
+        "lettersFactor": 0.44,
+        "string": ".Nav-wd32",
+      }
+    `);
+  });
+  it("handles tag name", () => {
+    expect(guessUsefulness("h1")).toMatchInlineSnapshot(`
+      {
+        "detectorFactor": 0,
+        "isRandom": false,
+        "isSuspicious": false,
+        "lettersFactor": 0.5,
+        "string": "h1",
+      }
+    `);
+  });
+
+  it("handles utility class name", () => {
+    // XXX: .mt-3 should ideally be flagged a suspicious, not random
+    expect(guessUsefulness(".mt-3")).toMatchInlineSnapshot(`
+      {
+        "detectorFactor": 0.25,
+        "isRandom": true,
+        "isSuspicious": false,
+        "lettersFactor": 0.6,
+        "string": ".mt-3",
+      }
+    `);
+
+    // XXX: h1.mt-3 should ideally be flagged a suspicious, not random
+    expect(guessUsefulness("h1.mt-3")).toMatchInlineSnapshot(`
+      {
+        "detectorFactor": 0.17,
+        "isRandom": true,
+        "isSuspicious": false,
+        "lettersFactor": 0.57,
+        "string": "h1.mt-3",
+      }
+    `);
+  });
+});
+
+describe("selectorTypes", () => {
+  test("it detects simple selector", () => {
+    expect(selectorTypes(".nav")).toStrictEqual(["CLASS"]);
+    expect(selectorTypes("nav")).toStrictEqual(["TAG"]);
+  });
+
+  test("it detects combo selector", () => {
+    expect(selectorTypes("nav.nav")).toStrictEqual(["TAG", "CLASS"]);
+  });
+
+  test("it returns empty array for invalid selector", () => {
+    expect(selectorTypes("! nav")).toStrictEqual([]);
+  });
 });


### PR DESCRIPTION
## What does this PR do?

- Closes #8161 
- Don't flag on tag names (h1, etc.) that have bad character/number ratios
- Improve warning to accommodate utility classes being flagged

## Discussion

- New language is "Selector appears to contain generated or utility values. This may indicate a value that changes across page reloads or application updates."

## Future Work

- Improve analysis for utility classes (e.g., `.mt-3`) - they should be flagged as suspicious, not random?

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer: @grahamlangford 
