### PR TITLE
#8166: fix draftjs set value

### DIFF
--- a/end-to-end-tests/tests/runtime/setInputValue.spec.ts
+++ b/end-to-end-tests/tests/runtime/setInputValue.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { test, expect } from "../../fixtures/extensionBase";
+import { ActivateModPage } from "../../pageObjects/modsPage";
+// @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
+import { test as base } from "@playwright/test";
+import { getSidebarPage } from "../../utils";
+import { MV } from "../../env";
+
+test("can set input value", async ({ page, extensionId }) => {
+  const modId = "@pixies/test/field-set-value";
+
+  const modActivationPage = new ActivateModPage(page, extensionId, modId);
+  await modActivationPage.goto();
+
+  await modActivationPage.clickActivateAndWaitForModsPageRedirect();
+
+  await page.goto("/advanced-fields/");
+
+  // The mod contains a trigger to open the sidebar on h1
+  await page.click("h1");
+
+  const sideBarPage = await getSidebarPage(page, extensionId);
+  await expect(
+    sideBarPage.getByRole("heading", { name: "Set Input Values" }),
+  ).toBeVisible();
+
+  // Normal text input field
+  const input = page.getByLabel("input", { exact: true });
+  await input.scrollIntoViewIfNeeded();
+  await input.click();
+  await input.pressSequentially("abc");
+
+  await sideBarPage.getByRole("button", { name: "Set Text Input" }).click();
+  await expect(input).toHaveValue("Hello world!");
+
+  // Normal textarea
+  const textarea = page.getByLabel("textarea", { exact: true });
+  await textarea.scrollIntoViewIfNeeded();
+  await textarea.click();
+  await textarea.pressSequentially("abc");
+
+  await sideBarPage
+    .getByRole("button", { name: "Set Text Area Input" })
+    .click();
+  await expect(textarea).toHaveValue("Hello world!");
+
+  // Basic content editable
+  const editable = page.locator("div[contenteditable]").first();
+  await textarea.scrollIntoViewIfNeeded();
+  await editable.click();
+  await editable.pressSequentially("abc");
+
+  await sideBarPage
+    .getByRole("button", { name: "Set Content Editable" })
+    .click();
+  await expect(editable).toHaveText("Hello world!");
+
+  // Draft.js - target by aria-label
+  // https://github.com/pixiebrix/pixiebrix-extension/issues/8166
+  const editor = page.getByLabel("rdw-editor");
+  await editor.scrollIntoViewIfNeeded();
+
+  await editor.click();
+
+  if (MV === "2") {
+    // Need to simulate the mouse entering the sidebar to track focus on MV2
+    // https://github.com/pixiebrix/pixiebrix-extension/blob/1794863937f343fbc8e3a4434eace74191f8dfbd/src/contentScript/sidebarController.tsx#L563-L563
+    const sidebarFrame = page.locator("#pixiebrix-extension");
+    await sidebarFrame.dispatchEvent("mouseenter");
+  }
+
+  await editor.click();
+  await editor.pressSequentially("abc ");
+  await editor.press("Enter");
+  await sideBarPage.getByRole("button", { name: "Set Draft.js" }).click();
+
+  await expect(editor.getByText("Hello world!", { exact: true })).toBeVisible();
+});

--- a/src/contentScript/textEditorDom.ts
+++ b/src/contentScript/textEditorDom.ts
@@ -21,7 +21,7 @@ import { getSelectorForElement } from "@/contentScript/elementReference";
 import { expectContext } from "@/utils/expectContext";
 import focusController from "@/utils/focusController";
 import {
-  dispatchPasteForDraftJs,
+  insertIntoDraftJs,
   isDraftJsField,
 } from "@/contrib/draftjs/draftJsDom";
 
@@ -81,11 +81,7 @@ export async function insertAtCursorWithCustomEditorSupport(text: string) {
   }
 
   if (isDraftJsField(element)) {
-    // Must always use paste. Otherwise, the editor will become corrupted
-    // More information/context:
-    // - https://github.com/pixiebrix/pixiebrix-extension/issues/7630
-    // - https://github.com/pixiebrix/pixiebrix-extension/issues/8157
-    dispatchPasteForDraftJs(element, text);
+    insertIntoDraftJs(element, text);
     return;
   }
 

--- a/src/contrib/draftjs/draftJsDom.ts
+++ b/src/contrib/draftjs/draftJsDom.ts
@@ -22,16 +22,17 @@
  */
 
 /**
- * DraftJS doesn't handle `insertText` correctly in most cases, but it can handle this
- * event. Note that this event doesn't do anything in regular contentEditable fields.
- * Source: https://github.com/facebookarchive/draft-js/issues/616#issuecomment-426047799
+ * Insert text into a Draft.js field at the cursor.
  */
 export function insertIntoDraftJs(field: HTMLElement, value: string): void {
-  // Using execCommand causes data corruption. See:
+  // Using execCommand with `insertText` causes data corruption. See:
   // - https://github.com/pixiebrix/pixiebrix-extension/issues/7630
   // - https://github.com/pixiebrix/pixiebrix-extension/issues/8157
+  // Draft.js can handle the Clipboard `paste` event. Which doesn't work in general contentEditable fields.
+  // Source: https://github.com/facebookarchive/draft-js/issues/616#issuecomment-426047799
   const data = new DataTransfer();
   data.setData("text/plain", value);
+  // Note that this event doesn't do anything in regular contentEditable fields.
   field.dispatchEvent(
     new ClipboardEvent("paste", {
       clipboardData: data,
@@ -39,6 +40,22 @@ export function insertIntoDraftJs(field: HTMLElement, value: string): void {
       cancelable: true,
     }),
   );
+}
+
+/**
+ * Set the current value of a Draft.js field.
+ */
+export function setDraftJs(field: HTMLElement, value: string): void {
+  // FIXME: selectAll doesn't seem to do anything on our demo site. Might have to mess with the Draft.js API in the
+  //   page script.
+  // https://github.com/facebookarchive/draft-js/issues/1386#issuecomment-341420754
+  field.focus();
+  field.click();
+  document.execCommand("selectAll", false);
+
+  // At first, document.execCommand "insertText" appears to work. However, backspace, etc. won't work because the field
+  // is corrupted.
+  insertIntoDraftJs(field, value);
 }
 
 /**

--- a/src/contrib/draftjs/draftJsDom.ts
+++ b/src/contrib/draftjs/draftJsDom.ts
@@ -16,11 +16,20 @@
  */
 
 /**
+ * @file This file contains utility functions for interacting with Draft.js editors.
+ * - See {@link https://draftjs.org/} for more information.
+ * - See example for regression testing at {@link https://pbx.vercel.app/advanced-fields/}
+ */
+
+/**
  * DraftJS doesn't handle `insertText` correctly in most cases, but it can handle this
  * event. Note that this event doesn't do anything in regular contentEditable fields.
  * Source: https://github.com/facebookarchive/draft-js/issues/616#issuecomment-426047799
  */
-export function dispatchPasteForDraftJs(field: HTMLElement, value: string) {
+export function insertIntoDraftJs(field: HTMLElement, value: string): void {
+  // Using execCommand causes data corruption. See:
+  // - https://github.com/pixiebrix/pixiebrix-extension/issues/7630
+  // - https://github.com/pixiebrix/pixiebrix-extension/issues/8157
   const data = new DataTransfer();
   data.setData("text/plain", value);
   field.dispatchEvent(
@@ -32,6 +41,9 @@ export function dispatchPasteForDraftJs(field: HTMLElement, value: string) {
   );
 }
 
+/**
+ * Return true if the element is or is contained inside a DraftJS field.
+ */
 export function isDraftJsField(element: HTMLElement): boolean {
   return Boolean(element.closest(".DraftEditor-root"));
 }

--- a/src/utils/domFieldUtils.ts
+++ b/src/utils/domFieldUtils.ts
@@ -20,7 +20,7 @@ import { getSelectorForElement } from "@/contentScript/elementReference";
 import { hasCKEditorClass } from "@/contrib/ckeditor/ckeditorDom";
 import { boolean } from "@/utils/typeUtils";
 import {
-  dispatchPasteForDraftJs,
+  insertIntoDraftJs,
   isDraftJsField,
 } from "@/contrib/draftjs/draftJsDom";
 
@@ -93,13 +93,12 @@ export async function setFieldValue(
     field.focus();
 
     // `insertText` acts as a "paste", so if no text is selected it's just appended
-    document.execCommand("selectAll");
+    // FIXME: selectAll is not working on draftjs fields when run from an action in the MV2 sidebar because
+    //  the field.focus() doesn't appear to focus the field
+    document.execCommand("selectAll", false);
 
-    if (field.textContent === "" && isDraftJsField(field)) {
-      // Special handling for DraftJS if the field is empty
-      // https://github.com/pixiebrix/pixiebrix-extension/issues/7630
-      // XXX: should this just always send a paste command for Draft.js fields?
-      dispatchPasteForDraftJs(field, String(value));
+    if (isDraftJsField(field)) {
+      insertIntoDraftJs(field, String(value));
     } else {
       // It automatically triggers an `input` event
       document.execCommand("insertText", false, String(value));

--- a/src/utils/domFieldUtils.ts
+++ b/src/utils/domFieldUtils.ts
@@ -84,7 +84,7 @@ export async function setFieldValue(
   }
 
   if (isDraftJsField(field)) {
-    setDraftJs(field, String(value));
+    await setDraftJs(field, String(value));
     return;
   }
 

--- a/src/utils/domFieldUtils.ts
+++ b/src/utils/domFieldUtils.ts
@@ -19,10 +19,7 @@ import { setCKEditorData } from "@/pageScript/messenger/api";
 import { getSelectorForElement } from "@/contentScript/elementReference";
 import { hasCKEditorClass } from "@/contrib/ckeditor/ckeditorDom";
 import { boolean } from "@/utils/typeUtils";
-import {
-  insertIntoDraftJs,
-  isDraftJsField,
-} from "@/contrib/draftjs/draftJsDom";
+import { isDraftJsField, setDraftJs } from "@/contrib/draftjs/draftJsDom";
 
 export type FieldElement =
   | HTMLInputElement
@@ -86,6 +83,11 @@ export async function setFieldValue(
     return;
   }
 
+  if (isDraftJsField(field)) {
+    setDraftJs(field, String(value));
+    return;
+  }
+
   if (field.isContentEditable) {
     // XXX: Maybe use text-field-edit so that the focus is not altered
 
@@ -93,16 +95,10 @@ export async function setFieldValue(
     field.focus();
 
     // `insertText` acts as a "paste", so if no text is selected it's just appended
-    // FIXME: selectAll is not working on draftjs fields when run from an action in the MV2 sidebar because
-    //  the field.focus() doesn't appear to focus the field
     document.execCommand("selectAll", false);
 
-    if (isDraftJsField(field)) {
-      insertIntoDraftJs(field, String(value));
-    } else {
-      // It automatically triggers an `input` event
-      document.execCommand("insertText", false, String(value));
-    }
+    // It automatically triggers an `input` event
+    document.execCommand("insertText", false, String(value));
 
     return;
   }


### PR DESCRIPTION
## What does this PR do?

- Closes #8166
- Refactors/fixes logic for setting draftjs field value
- Adds test mod for regression testing with playwright: `@pixies/test/field-set-value`

## Remaining Work

- [x] https://github.com/pixiebrix/pixiebrix-extension/pull/8167/files#diff-67182696ad604551dcea9a43993a92d8b13edc698c3be3a275534c4b07c97154R96

## Discussion

- We might try using the Draft.js API instead of sending browser events

## Checklist

- [x] Add tests and/or storybook stories: adds playwright test
- [x] Designate a primary reviewer: @fungairino 
