### PR TITLE
8154: fix selection menu causing lost focus of selected element

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,5 +34,5 @@ _Leave all that are relevant and check off as completed_
 
 ## Checklist
 
-- [ ] Add tests and/or storybook stories
+- [ ] Add jest or playwright tests and/or storybook stories
 - [ ] Designate a primary reviewer

--- a/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
+++ b/end-to-end-tests/tests/runtime/insertAtCursor.spec.ts
@@ -19,76 +19,112 @@ import { test, expect } from "../../fixtures/extensionBase";
 import { ActivateModPage } from "../../pageObjects/modsPage";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { test as base } from "@playwright/test";
-import { getSidebarPage } from "../../utils";
+import { ensureVisibility, getSidebarPage } from "../../utils";
 import { MV } from "../../env";
 
-test("8157: can insert at cursor", async ({ page, extensionId }) => {
-  const modId = "@pixies/test/insert-at-cursor";
+test.describe("Insert at Cursor", () => {
+  test("8157: can insert at cursor from side bar", async ({
+    page,
+    extensionId,
+  }) => {
+    const modId = "@pixies/test/insert-at-cursor";
 
-  const modActivationPage = new ActivateModPage(page, extensionId, modId);
-  await modActivationPage.goto();
+    const modActivationPage = new ActivateModPage(page, extensionId, modId);
+    await modActivationPage.goto();
 
-  await modActivationPage.clickActivateAndWaitForModsPageRedirect();
+    await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
-  await page.goto("/advanced-fields/");
+    await page.goto("/advanced-fields/");
 
-  // The mod contains a trigger to open the sidebar on h1
-  await page.click("h1");
+    // The mod contains a trigger to open the sidebar on h1
+    await page.click("h1");
 
-  const sideBarPage = await getSidebarPage(page, extensionId);
-  await expect(
-    sideBarPage.getByRole("heading", { name: "Insert at Cursor" }),
-  ).toBeVisible();
+    const sideBarPage = await getSidebarPage(page, extensionId);
+    await expect(
+      sideBarPage.getByRole("heading", { name: "Insert at Cursor" }),
+    ).toBeVisible();
 
-  // Normal text input field
-  const input = page.getByLabel("input", { exact: true });
-  await input.scrollIntoViewIfNeeded();
-  await input.click();
-  await input.pressSequentially("a");
+    // Normal text input field
+    const input = page.getByLabel("input", { exact: true });
+    await input.scrollIntoViewIfNeeded();
+    await input.click();
+    await input.pressSequentially("a");
 
-  await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
-  await expect(input).toHaveValue("aHello world!");
+    await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
+    await expect(input).toHaveValue("aHello world!");
 
-  // Normal textarea
-  const textarea = page.getByLabel("textarea", { exact: true });
-  await textarea.scrollIntoViewIfNeeded();
-  await textarea.click();
-  await textarea.pressSequentially("ab");
-  await textarea.press("ArrowLeft");
+    // Normal textarea
+    const textarea = page.getByLabel("textarea", { exact: true });
+    await textarea.scrollIntoViewIfNeeded();
+    await textarea.click();
+    await textarea.pressSequentially("ab");
+    await textarea.press("ArrowLeft");
 
-  await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
-  await expect(textarea).toHaveValue("aHello world!b");
+    await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
+    await expect(textarea).toHaveValue("aHello world!b");
 
-  // Basic content editable
-  const editable = page.locator("div[contenteditable]").first();
-  await textarea.scrollIntoViewIfNeeded();
-  await editable.click();
-  await editable.pressSequentially("ab");
-  await editable.press("ArrowLeft");
+    // Basic content editable
+    const editable = page.locator("div[contenteditable]").first();
+    await textarea.scrollIntoViewIfNeeded();
+    await editable.click();
+    await editable.pressSequentially("ab");
+    await editable.press("ArrowLeft");
 
-  await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
-  await expect(editable).toHaveText("aHello world!b");
+    await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
+    await expect(editable).toHaveText("aHello world!b");
 
-  // Draft.js - target by aria-label
-  const editor = page.getByLabel("rdw-editor");
-  await editor.scrollIntoViewIfNeeded();
+    // Draft.js - target by aria-label
+    const editor = page.getByLabel("rdw-editor");
+    await editor.scrollIntoViewIfNeeded();
 
-  await editor.click();
+    await editor.click();
 
-  if (MV === "2") {
-    // Need to simulate the mouse entering the sidebar to track focus on MV2
-    // https://github.com/pixiebrix/pixiebrix-extension/blob/1794863937f343fbc8e3a4434eace74191f8dfbd/src/contentScript/sidebarController.tsx#L563-L563
-    const sidebarFrame = page.locator("#pixiebrix-extension");
-    await sidebarFrame.dispatchEvent("mouseenter");
-  }
+    if (MV === "2") {
+      // Need to simulate the mouse entering the sidebar to track focus on MV2
+      // https://github.com/pixiebrix/pixiebrix-extension/blob/1794863937f343fbc8e3a4434eace74191f8dfbd/src/contentScript/sidebarController.tsx#L563-L563
+      const sidebarFrame = page.locator("#pixiebrix-extension");
+      await sidebarFrame.dispatchEvent("mouseenter");
+    }
 
-  await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
+    await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
 
-  await expect(editor.getByText("Hello world!")).toBeVisible();
+    await expect(editor.getByText("Hello world!")).toBeVisible();
 
-  await editor.click();
-  await editor.press("ArrowLeft");
-  await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
+    await editor.click();
+    await editor.press("ArrowLeft");
+    await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
 
-  await expect(editor.getByText("Hello worldHello world!!")).toBeVisible();
+    await expect(editor.getByText("Hello worldHello world!!")).toBeVisible();
+  });
+
+  test("8154: can insert at cursor after opening sidebar from selection menu", async ({
+    page,
+    extensionId,
+  }) => {
+    // This mod opens the sidebar with a selection menu option, and then inserts "Hello world!" at the cursor from the sidebar
+    const modId = "@pixies/test/insert-at-cursor-with-selection-menu";
+
+    const modActivationPage = new ActivateModPage(page, extensionId, modId);
+    await modActivationPage.goto();
+
+    await modActivationPage.clickActivateAndWaitForModsPageRedirect();
+
+    await page.goto("/advanced-fields/");
+
+    // Testing with CKEditor 5
+    const ckeditorEditingArea = page.getByLabel("Editor editing area: main");
+    await ckeditorEditingArea.scrollIntoViewIfNeeded();
+
+    await ckeditorEditingArea.getByText("This is an editor").selectText();
+    const insertAtCursorMenuItem = page.getByRole("menuitem", { name: "⬇️" });
+    await ensureVisibility(insertAtCursorMenuItem);
+    await insertAtCursorMenuItem.click();
+
+    const sideBarPage = await getSidebarPage(page, extensionId);
+    await sideBarPage.getByRole("button", { name: "Insert at Cursor" }).click();
+
+    await expect(ckeditorEditingArea.getByRole("paragraph")).toContainText(
+      "Hello world!",
+    );
+  });
 });

--- a/src/contentScript/textSelectionMenu/SelectionMenu.tsx
+++ b/src/contentScript/textSelectionMenu/SelectionMenu.tsx
@@ -68,7 +68,9 @@ const ToolbarItem: React.FC<
       fontSize: `${ICON_SIZE_PX}px`,
     }}
     title={selectButtonTitle(title, selection)}
-    onMouseDown={() => {
+    onMouseDown={(event) => {
+      event.preventDefault(); // Prevent the selection element from losing focus
+
       // Some websites like Gmail might change the selection on mousedown, so we save it before that happens:
       // https://github.com/pixiebrix/pixiebrix-extension/issues/7729
 
@@ -77,7 +79,6 @@ const ToolbarItem: React.FC<
       lastKnownSelection = getSelection().toString();
     }}
     onClick={() => {
-      // Add fallback just in case the mousedown event didn't fire
       handler(lastKnownSelection ?? getSelection().toString());
       onHide();
     }}


### PR DESCRIPTION
## What does this PR do?

- Fixes #8154
- Clicking on the selection menu item shouldn't cause the focus of the underlying element to be lost and reset to the document.

## Demo

See included playwright test (I verified it failed when the `preventDefault` wasn't included)

## Checklist

- [x] Add tests and/or storybook stories
- [x] Designate a primary reviewer @fregante 
