### PR TITLE
skip auth setup when developing e2e tests locally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -194,6 +194,7 @@ module.exports = {
       rules: {
         "no-restricted-imports": "off",
         "unicorn/prefer-dom-node-dataset": "off",
+        "unicorn/prefer-module": "off", // `import.meta.dirname` throws "cannot use 'import meta' outside a module"
         "no-restricted-syntax": [
           "error",
           {

--- a/end-to-end-tests/fixtures/extensionBase.ts
+++ b/end-to-end-tests/fixtures/extensionBase.ts
@@ -35,6 +35,7 @@ import {
 import fs from "node:fs/promises";
 import { getBaseExtensionConsoleUrl } from "../pageObjects/constants";
 import { ensureVisibility } from "../utils";
+import * as url from "node:url";
 
 // This environment variable is used to attach the browser sidepanel window that opens automatically to Playwright.
 // see: https://github.com/microsoft/playwright/issues/26693
@@ -44,8 +45,10 @@ const getStoredCookies = async (): Promise<Cookie[]> => {
   let fileBuffer;
   try {
     fileBuffer = await fs.readFile(
-      // eslint-disable-next-line unicorn/prefer-module -- TODO: import.meta.dirname throws "cannot use 'import meta' outside a module"
-      path.join(__dirname, "../.auth/user.json"),
+      path.join(
+        path.dirname(url.fileURLToPath(import.meta.url)),
+        "../.auth/user.json",
+      ),
     );
   } catch (error) {
     // If the file does not exist, we are likely running authenticate setup for the first time. Return an empty array.

--- a/end-to-end-tests/fixtures/extensionBase.ts
+++ b/end-to-end-tests/fixtures/extensionBase.ts
@@ -35,7 +35,6 @@ import {
 import fs from "node:fs/promises";
 import { getBaseExtensionConsoleUrl } from "../pageObjects/constants";
 import { ensureVisibility } from "../utils";
-import * as url from "node:url";
 
 // This environment variable is used to attach the browser sidepanel window that opens automatically to Playwright.
 // see: https://github.com/microsoft/playwright/issues/26693
@@ -44,12 +43,7 @@ process.env.PW_CHROMIUM_ATTACH_TO_OTHER = "1";
 const getStoredCookies = async (): Promise<Cookie[]> => {
   let fileBuffer;
   try {
-    fileBuffer = await fs.readFile(
-      path.join(
-        path.dirname(url.fileURLToPath(import.meta.url)),
-        "../.auth/user.json",
-      ),
-    );
+    fileBuffer = await fs.readFile(path.join(__dirname, "../.auth/user.json"));
   } catch (error) {
     // If the file does not exist, we are likely running authenticate setup for the first time. Return an empty array.
     if (error instanceof Error && "code" in error && error.code === "ENOENT") {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,18 @@
 import { defineConfig } from "@playwright/test";
 import { CI } from "./end-to-end-tests/env";
+import fs from "node:fs";
+import path from "node:path";
+
+// Speed up local development by skipping the authentication setup if it's already done.
+// NOTE: You will have to restart the test runner if you need to re-run the auth setup.
+const isAuthSetupDone = () => {
+  if (CI) {
+    return false;
+  }
+
+  const filePath = path.join(__dirname, "./end-to-end-tests/.auth/user.json");
+  return fs.existsSync(filePath);
+};
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -42,14 +55,14 @@ export default defineConfig<{ chromiumChannel: string }>({
       use: {
         chromiumChannel: "chrome",
       },
-      dependencies: ["setup"],
+      dependencies: isAuthSetupDone() ? [] : ["setup"],
     },
     {
       name: "edge",
       use: {
         chromiumChannel: "msedge",
       },
-      dependencies: ["setup"],
+      dependencies: isAuthSetupDone() ? [] : ["setup"],
     },
   ],
 });


### PR DESCRIPTION
## What does this PR do?

- Makes local development faster by skipping auth if the auth file is still available locally

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @fregante 
