### PR TITLE
#8206: Avoid Edge crash when opening user links

### DIFF
--- a/src/utils/openAllLinksInPopups.ts
+++ b/src/utils/openAllLinksInPopups.ts
@@ -18,11 +18,14 @@
 import excludeAltClicksEtc from "filter-altered-clicks";
 
 const listener = excludeAltClicksEtc((event: MouseEvent) => {
-  // `event.target` can sometimes be an SVG path element and not an HTMLElement
-  const link = event.target instanceof Element && event.target.closest("a");
-  if (link) {
-    window.open(link.href);
-    event.preventDefault();
+  // `composedPath` is used to support clicks in an `open` Shadow DOM
+  // https://github.com/pixiebrix/pixiebrix-extension/issues/8206
+  for (const eventTarget of event.composedPath()) {
+    if (eventTarget instanceof HTMLAnchorElement) {
+      window.open(eventTarget.href);
+      event.preventDefault();
+      return;
+    }
   }
 });
 
@@ -33,5 +36,5 @@ const listener = excludeAltClicksEtc((event: MouseEvent) => {
  * https://github.com/pixiebrix/pixiebrix-extension/issues/7809
  */
 export default function openAllLinksInPopups(signal?: AbortSignal) {
-  document.body.addEventListener("click", listener, { signal });
+  document.body.addEventListener("click", listener, { signal, capture: true });
 }


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-extension/issues/8206

I was curious as to why it wasn't catching the event and here's what I found:

- some events are lost if you don't use `capture: true`
- `target` is the shadow DOM container even when the shadow DOM is set to `open`

The fix was quick enough

## Future work

- [ ] Add Playwright tests

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer: @fungairino 
