### PR TITLE
Improve e2e test docs and error handling

### DIFF
--- a/end-to-end-tests/README.md
+++ b/end-to-end-tests/README.md
@@ -11,8 +11,10 @@ One-time setup:
 
 - Set up your .env file:
   - Copy `.env.example` to `.env.development`.
-  - Fill in the required values for the test user password `E2E_TEST_USER_PASSWORD_UNAFFILIATED` and
-    uncomment `REQUIRE_OPTIONAL_PERMISSIONS_IN_MANIFEST=1`
+  - Fill in the required values:
+    - The test user password `E2E_TEST_USER_PASSWORD_UNAFFILIATED`
+    - Uncomment `REQUIRE_OPTIONAL_PERMISSIONS_IN_MANIFEST=1`
+    - Uncomment `SHADOW_DOM=open`
   - `MV` will determine the manifest version for the both the extension and the tests.
 - Install browsers: Execute `npx playwright install chromium chrome msedge`.
 
@@ -23,6 +25,7 @@ One-time setup:
 - To run tests in interactive UI mode, use `npm run test:e2e -- --ui`. This view shows you the entire test suite and
   allows you to run individual tests in a specific browser.
   - If this is the first time you've run the tests in interactive mode, the tests may be filtered. Expand the collapsed section next to the Filter searchbox to see the filterable "projects"
+  - For faster local development, you can filter out the setup projects to skip rerunning the authentication setup by unticking the `edgeSetup` and `chromeSetup` projects.
 - You can also run specific test files in the CLI by providing a path matcher to the
   command: `npm run test:e2e -- smoke` (runs all tests with "smoke" in the path).
 - You can also run tests within the Intellij IDE by clicking on the play button next to the test definition. (
@@ -93,7 +96,8 @@ Playwright's built-in `test` object with extension-specific features.
 ### Playwright Configuration
 
 Configure test execution via `.playwright.config.ts`, including timeout and retry options. The setup
-project `./auth.setup.ts` handles user authentication and saves credentials in `./.auth/user.json`.
+projects run `./auth.setup.ts` which handles user authentication and saves the path to the logged in and linked profile
+paths in `.auth`.
 
 ### GitHub CI Integration
 

--- a/end-to-end-tests/README.md
+++ b/end-to-end-tests/README.md
@@ -28,6 +28,8 @@ One-time setup:
   - For faster local development, you can filter out the setup projects to skip rerunning the authentication setup by unticking the `edgeSetup` and `chromeSetup` projects.
 - You can also run specific test files in the CLI by providing a path matcher to the
   command: `npm run test:e2e -- smoke` (runs all tests with "smoke" in the path).
+  - You can skip the auth setup by including the `--no-deps` flag.
+  - See more cli arguments here: https://playwright.dev/docs/test-cli
 - You can also run tests within the Intellij IDE by clicking on the play button next to the test definition. (
   until [this Jetbrains issue](https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only)
   is resolved, you must include an unused playwright import as shown

--- a/end-to-end-tests/fixtures/extensionBase.ts
+++ b/end-to-end-tests/fixtures/extensionBase.ts
@@ -36,10 +36,25 @@ export const test = base.extend<{
 }>({
   chromiumChannel: ["chrome", { option: true }],
   async context({ chromiumChannel }, use) {
-    const authSetupProfileDirectory = await fs.readFile(
-      getAuthProfilePathFile(chromiumChannel),
-      "utf8",
-    );
+    let authSetupProfileDirectory: string;
+
+    try {
+      await fs.readFile(getAuthProfilePathFile(chromiumChannel), "utf8");
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        console.log(
+          "No auth setup profile found. Make sure that the `auth.setup` project has been run first to create the " +
+            "profile. (If using UI mode, make sure that the chromeSetup and/or the edgeSetup projects are not filtered out)",
+        );
+      }
+
+      throw error;
+    }
+
     const temporaryProfileDirectory = await fs.mkdtemp(
       path.join(path.dirname(authSetupProfileDirectory), "e2e-test-"),
     );

--- a/end-to-end-tests/fixtures/extensionBase.ts
+++ b/end-to-end-tests/fixtures/extensionBase.ts
@@ -39,7 +39,10 @@ export const test = base.extend<{
     let authSetupProfileDirectory: string;
 
     try {
-      await fs.readFile(getAuthProfilePathFile(chromiumChannel), "utf8");
+      authSetupProfileDirectory = await fs.readFile(
+        getAuthProfilePathFile(chromiumChannel),
+        "utf8",
+      );
     } catch (error) {
       if (
         error instanceof Error &&
@@ -56,7 +59,8 @@ export const test = base.extend<{
     }
 
     const temporaryProfileDirectory = await fs.mkdtemp(
-      path.join(path.dirname(authSetupProfileDirectory), "e2e-test-"),
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion,@typescript-eslint/no-non-null-assertion -- checked above
+      path.join(path.dirname(authSetupProfileDirectory!), "e2e-test-"),
     );
     // Copy the auth setup profile to a new temp directory to avoid modifying the original auth profile
     await fs.cp(authSetupProfileDirectory, temporaryProfileDirectory, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,7 +154,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.9.0",
         "@fortawesome/fontawesome-common-types": "^0.2.36",
-        "@playwright/test": "^1.43.0",
+        "@playwright/test": "^1.42.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "@shopify/jest-dom-mocks": "^5.0.0",
         "@sindresorhus/tsconfig": "^5.0.0",
@@ -4740,12 +4740,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.0.tgz",
-      "integrity": "sha512-Ebw0+MCqoYflop7wVKj711ccbNlrwTBCtjY5rlbiY9kHL2bCYxq+qltK6uPsVBGGAOb033H2VO0YobcQVxoW7Q==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
+      "integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.43.0"
+        "playwright": "1.42.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -24528,12 +24528,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.0.tgz",
-      "integrity": "sha512-SiOKHbVjTSf6wHuGCbqrEyzlm6qvXcv7mENP+OZon1I07brfZLGdfWV0l/efAzVx7TF3Z45ov1gPEkku9q25YQ==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
+      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.43.0"
+        "playwright-core": "1.42.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -24546,9 +24546,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.0.tgz",
-      "integrity": "sha512-iWFjyBUH97+pUFiyTqSLd8cDMMOS0r2ZYz2qEsPjH8/bX++sbIJT35MSwKnp1r/OQBAqC5XO99xFbJ9XClhf4w==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
+      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.9.0",
     "@fortawesome/fontawesome-common-types": "^0.2.36",
-    "@playwright/test": "^1.43.0",
+    "@playwright/test": "^1.42.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
     "@shopify/jest-dom-mocks": "^5.0.0",
     "@sindresorhus/tsconfig": "^5.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,18 +1,5 @@
 import { defineConfig } from "@playwright/test";
 import { CI } from "./end-to-end-tests/env";
-import fs from "node:fs";
-import { getAuthProfilePathFile } from "./end-to-end-tests/fixtures/utils";
-
-// Speed up local development by skipping the authentication setup if it's already done.
-// NOTE: You will have to restart the test runner if you need to re-run the auth setup.
-const isAuthSetupDone = (chromiumChannel: "msedge" | "chrome") => {
-  if (CI) {
-    return false;
-  }
-
-  const filePath = getAuthProfilePathFile(chromiumChannel);
-  return fs.existsSync(filePath);
-};
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -34,6 +21,7 @@ export default defineConfig<{ chromiumChannel: string }>({
     /* Timeout for each assertion. If a particular interaction is timing out, adjust its specific timeout value rather than this global setting */
     timeout: 5000,
   },
+  reportSlowTests: null,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["html", { outputFolder: "./end-to-end-tests/.report" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -65,14 +53,15 @@ export default defineConfig<{ chromiumChannel: string }>({
       use: {
         chromiumChannel: "chrome",
       },
-      dependencies: isAuthSetupDone("chrome") ? [] : ["chromeSetup"],
+      // For faster local development, you can filter out the setup project in --ui mode to skip rerunning the setup project
+      dependencies: ["chromeSetup"],
     },
     {
       name: "edge",
       use: {
         chromiumChannel: "msedge",
       },
-      dependencies: isAuthSetupDone("msedge") ? [] : ["edgeSetup"],
+      dependencies: ["edgeSetup"],
     },
   ],
 });


### PR DESCRIPTION
## What does this PR do?

- Updates the readme with more accurate setup step info
- Removes the skip local auth functionality in the config. Instead, you can use the filter functionality in UI mode. This makes skipping the auth project more intentional to avoid issues with lingering auth profiles.
- Adds better error logging when the auth profile directory files are missing

## Future Work

Why does UI mode not show the latest results??? 🤬

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @mnholtz 
