### PR TITLE
#8206: Handle target blank in sidePanel sub-frames

### DIFF
--- a/src/background/executor.ts
+++ b/src/background/executor.ts
@@ -203,10 +203,24 @@ export async function requestRunInAllFrames(
 
 export async function openTab(
   this: MessengerMeta,
-  createProperties: Tabs.CreateCreatePropertiesType,
+  {
+    newWindow,
+    ...createProperties
+  }: Tabs.CreateCreatePropertiesType & { newWindow?: boolean },
 ): Promise<void> {
   // Natively links the new tab to its opener + opens it right next to it
   const openerTabId = this.trace[0].tab?.id;
+
+  if (newWindow) {
+    const { tabs } = await browser.windows.create(createProperties);
+
+    if (tabs?.[0]?.id) {
+      rememberOpener(tabs[0]?.id, openerTabId);
+    }
+
+    return;
+  }
+
   const newTab = await browser.tabs.create({
     ...createProperties,
     openerTabId,

--- a/src/utils/openAllLinksInPopups.ts
+++ b/src/utils/openAllLinksInPopups.ts
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { openTab } from "@/background/messenger/api";
 import excludeAltClicksEtc from "filter-altered-clicks";
 
 /**
@@ -43,7 +44,10 @@ export default function openAllLinksInPopups({
             return;
           }
 
-          window.open(eventTarget.href);
+          // Open a new window instead of a new tab because changing the tab will close the sidebar
+          // https://github.com/pixiebrix/pixiebrix-extension/pull/8216#issuecomment-2048914921
+          // TODO: Remove `newWindow` after https://github.com/microsoft/MicrosoftEdge-Extensions/issues/142
+          void openTab({ url: eventTarget.href, newWindow: true });
           event.preventDefault();
           return;
         }


### PR DESCRIPTION
> [!Note]
> Based on https://github.com/pixiebrix/pixiebrix-extension/pull/8223, please merge that one first. This is a proposal

## What does this PR do?

- Part of #8206
- Based on https://github.com/pixiebrix/pixiebrix-extension/pull/8223

I don't know we can change how Edge deals with the sidebar (https://github.com/microsoft/MicrosoftEdge-Extensions/issues/142), so this might be a solution:

- open links in a brand new window/popup

This isn't ideal, but it's better than losing the sidebar I think.

## Demo

_Untested_

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer: @fungairino 
