### PR TITLE
#8141: Ignore `updateDynamicElement` in iframes for `actionPanel`

### DIFF
--- a/src/contentScript/pageEditor/dynamic.ts
+++ b/src/contentScript/pageEditor/dynamic.ts
@@ -34,6 +34,7 @@ import { type JsonObject } from "type-fest";
 import { type SelectorRoot } from "@/types/runtimeTypes";
 import { type UUID } from "@/types/stringTypes";
 import { $safeFind } from "@/utils/domUtils";
+import { isLoadedInIframe } from "@/utils/iframeUtils";
 
 let _overlay: Overlay | null = null;
 
@@ -100,6 +101,15 @@ export async function updateDynamicElement({
   extensionPointConfig,
   extension: extensionConfig,
 }: DynamicDefinition): Promise<void> {
+  // Iframes should not attempt to control the sidebar
+  // https://github.com/pixiebrix/pixiebrix-extension/pull/8226
+  if (
+    isLoadedInIframe() &&
+    extensionPointConfig.definition.type === "actionPanel"
+  ) {
+    return;
+  }
+
   expectContext("contentScript");
 
   // HACK: adjust behavior when using the Page Editor

--- a/src/contentScript/pageEditor/dynamic.ts
+++ b/src/contentScript/pageEditor/dynamic.ts
@@ -101,6 +101,8 @@ export async function updateDynamicElement({
   extensionPointConfig,
   extension: extensionConfig,
 }: DynamicDefinition): Promise<void> {
+  expectContext("contentScript");
+
   // Iframes should not attempt to control the sidebar
   // https://github.com/pixiebrix/pixiebrix-extension/pull/8226
   if (
@@ -109,8 +111,6 @@ export async function updateDynamicElement({
   ) {
     return;
   }
-
-  expectContext("contentScript");
 
   // HACK: adjust behavior when using the Page Editor
   if (extensionPointConfig.definition.type === "trigger") {

--- a/src/pageEditor/toolbar/ReloadToolbar.tsx
+++ b/src/pageEditor/toolbar/ReloadToolbar.tsx
@@ -27,7 +27,10 @@ import { Events } from "@/telemetry/events";
 import { useSelector } from "react-redux";
 import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 import useKeyboardShortcut from "@/hooks/useKeyboardShortcut";
-import { allFramesInInspectedTab } from "@/pageEditor/context/connection";
+import {
+  allFramesInInspectedTab,
+  inspectedTab,
+} from "@/pageEditor/context/connection";
 
 const DEFAULT_RELOAD_MILLIS = 350;
 
@@ -97,7 +100,10 @@ const ReloadToolbar: React.FunctionComponent<{
 
   const run = useCallback(async () => {
     const { asDynamicElement: factory } = ADAPTERS.get(element.type);
-    updateDynamicElement(allFramesInInspectedTab, factory(element));
+    // Iframes don't control the sidebar, so they should not receive messages regarding it
+    const target =
+      element.type === "actionPanel" ? inspectedTab : allFramesInInspectedTab;
+    updateDynamicElement(target, factory(element));
   }, [element]);
 
   const manualRun = async () => {

--- a/src/pageEditor/toolbar/ReloadToolbar.tsx
+++ b/src/pageEditor/toolbar/ReloadToolbar.tsx
@@ -27,10 +27,7 @@ import { Events } from "@/telemetry/events";
 import { useSelector } from "react-redux";
 import { selectSessionId } from "@/pageEditor/slices/sessionSelectors";
 import useKeyboardShortcut from "@/hooks/useKeyboardShortcut";
-import {
-  allFramesInInspectedTab,
-  inspectedTab,
-} from "@/pageEditor/context/connection";
+import { allFramesInInspectedTab } from "@/pageEditor/context/connection";
 
 const DEFAULT_RELOAD_MILLIS = 350;
 
@@ -100,10 +97,7 @@ const ReloadToolbar: React.FunctionComponent<{
 
   const run = useCallback(async () => {
     const { asDynamicElement: factory } = ADAPTERS.get(element.type);
-    // Iframes don't control the sidebar, so they should not receive messages regarding it
-    const target =
-      element.type === "actionPanel" ? inspectedTab : allFramesInInspectedTab;
-    updateDynamicElement(target, factory(element));
+    updateDynamicElement(allFramesInInspectedTab, factory(element));
   }, [element]);
 
   const manualRun = async () => {


### PR DESCRIPTION
## What does this PR do?

- Fixes https://github.com/pixiebrix/pixiebrix-extension/issues/8141



## Discussion

As suggested in https://github.com/pixiebrix/pixiebrix-extension/pull/8225, maybe all we need is to _not_ message the iframes. This is a quicker change than to change all the behaviors related to the page editor sidebar, "Render Panel", auto-run, etc. which I had initially suggested.

## Repro


This is tested and it appears to work:

1. Open https://ephiframe.vercel.app/Pixie?iframe=https://extra-ephiframe.vercel.app/Brix%3Fiframe%3Dhttps%3A%2F%2Fephiframe.vercel.app%2FPixie
2. Open page editor
3. Click on an existing Sidebar Panel in the page editor sidebar


Expected: the sidebar should open, no modals should appear 



## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer
