### PR TITLE
#8237: fix visual regressions from IsolatedComponent

### DIFF
--- a/src/components/IsolatedComponent.scss
+++ b/src/components/IsolatedComponent.scss
@@ -1,15 +1,11 @@
 // Injected unminified. Don't add too much fluff
 
-:host {
+body {
   // Don't inherit any style
   all: initial;
+}
 
-  // Set a font baseline style. Bootstrap targets `body` specifically, which isn't available in a shadow DOM
-  font:
-    16px / 1.5 "Ubuntu",
-    "Trebuchet MS",
-    sans-serif;
-
+:host {
   // Set a good default for our custom `pixiebrix-widget` element
   display: block;
 


### PR DESCRIPTION
## What does this PR do?

- #8237 

## Discussion
- It looks like the `:host: { all: initial }` broke some of the styling, but setting it to `body: { all initial }` gets us the resets we want without losing the ones we want to keep

## Demo

### DocumentView
<img width="351" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/df29eaf8-3e29-4a0d-a834-bd9785e9fe8f">

### EphemeralForm (modal)
<img width="529" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/5298aacd-0687-4aef-a8d8-3fe456b77dbc">

### EphemeralForm (sidebar)
<img width="367" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/321f79ca-d407-4d14-9c53-375e026c09a4">

### CustomFormComponent
<img width="357" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/90daa003-936e-4875-9df5-8d804800750a">

### PropertyTree
<img width="350" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/30706330/f7ec53ca-9cf8-4cc8-a258-a3b252e94eef">


## Checklist

- [x] Designate a primary reviewer @BLoe 
