### PR TITLE
POC Datadog error logging via api client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@cfworker/json-schema": "^1.12.8",
         "@datadog/browser-logs": "^5.15.0",
         "@datadog/browser-rum": "^5.15.0",
+        "@datadog/datadog-api-client": "^1.24.0",
         "@floating-ui/dom": "^1.6.3",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.15.4",
@@ -2538,6 +2539,31 @@
       "dependencies": {
         "@datadog/browser-core": "5.15.0"
       }
+    },
+    "node_modules/@datadog/datadog-api-client": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@datadog/datadog-api-client/-/datadog-api-client-1.24.0.tgz",
+      "integrity": "sha512-y2E8dWeJatLBV6J+SDfGIBM9If1Z/zRkvcBMl0odO6aQ2xv1MbYBOdef6jL5zXhiVWiiW6sIyOIoObc+VL02Tg==",
+      "dependencies": {
+        "@types/buffer-from": "^1.1.0",
+        "@types/node": "*",
+        "@types/pako": "^1.0.3",
+        "buffer-from": "^1.1.2",
+        "cross-fetch": "^3.1.5",
+        "es6-promise": "^4.2.8",
+        "form-data": "^4.0.0",
+        "loglevel": "^1.8.1",
+        "pako": "^2.0.4",
+        "url-parse": "^1.4.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@datadog/datadog-api-client/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -8551,6 +8577,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/buffer-from": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/buffer-from/-/buffer-from-1.1.3.tgz",
+      "integrity": "sha512-2lq4YC9uLUMGHkl2IDtX4tCXSo2+hwMpOJcY1qiIk1kybc31rIlPyM1HCVJhkPFIo75a/pOVxqyvwuf5TpCG/w==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chrome": {
       "version": "0.0.266",
       "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.266.tgz",
@@ -9073,7 +9107,6 @@
       "version": "20.12.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
       "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -9112,6 +9145,11 @@
       "version": "2.2.1",
       "integrity": "sha512-i/rtaJFCsPljrZvP/akBqEwUP2y5cZLOmvO+JaYnz01aPknrQ+hB5MRcO7iqCUsFaYfTG8kGfKUyboA07xeDHQ==",
       "dev": true
+    },
+    "node_modules/@types/pako": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-1.0.7.tgz",
+      "integrity": "sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A=="
     },
     "node_modules/@types/papaparse": {
       "version": "5.3.14",
@@ -11787,8 +11825,7 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -13100,6 +13137,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -22450,6 +22495,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -23305,9 +23362,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -23331,18 +23388,15 @@
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -25602,8 +25656,7 @@
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -26860,8 +26913,7 @@
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/reselect": {
       "version": "4.1.8",
@@ -29244,8 +29296,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unescape-js": {
       "version": "1.1.4",
@@ -29502,7 +29553,6 @@
     "node_modules/url-parse": {
       "version": "1.5.10",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@cfworker/json-schema": "^1.12.8",
     "@datadog/browser-logs": "^5.15.0",
     "@datadog/browser-rum": "^5.15.0",
+    "@datadog/datadog-api-client": "^1.24.0",
     "@floating-ui/dom": "^1.6.3",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-brands-svg-icons": "^5.15.4",

--- a/src/extensionConsole/pages/mods/ModsPageLayout.tsx
+++ b/src/extensionConsole/pages/mods/ModsPageLayout.tsx
@@ -112,6 +112,8 @@ const ModsPageLayout: React.FunctionComponent<{
   const { modViewItems, isLoading } = useModViewItems(mods);
   const { isAutoDeploying } = useContext(DeploymentsContext);
 
+  throw new Error("test");
+
   const teamFilters = useMemo(
     () =>
       uniq(modViewItems.map((mod) => mod.sharing.source.label)).filter(

--- a/src/telemetry/initErrorReporter.ts
+++ b/src/telemetry/initErrorReporter.ts
@@ -32,7 +32,6 @@ import {
 
 // eslint-disable-next-line prefer-destructuring -- process.env
 const ENVIRONMENT = process.env.ENVIRONMENT;
-const APPLICATION_ID = process.env.DATADOG_APPLICATION_ID;
 const CLIENT_TOKEN = process.env.DATADOG_CLIENT_TOKEN;
 
 const ALWAYS_IGNORED_ERROR_PATTERNS = [/ResizeObserver loop/];
@@ -57,7 +56,7 @@ async function initErrorReporter(): Promise<Nullishable<ErrorReporter>> {
     return;
   }
 
-  if (!CLIENT_TOKEN || !APPLICATION_ID) {
+  if (!CLIENT_TOKEN) {
     console.warn(
       "Error telemetry client token missing, errors won't be reported",
     );


### PR DESCRIPTION
## What does this PR do?

- Part of #8268
- This is a POC instead of a solution because I haven't figured out how to use the api client for error logging

## Discussion

- Implements this workaround to logging via service workers: https://eng.grip.security/enabling-chrome-extension-logging-with-datadog-a-journey-of-trial-and-error?utm_source=github
- The caveat is that I haven't found any documentation that describes endpoints that expose error-logging; it's possible that we'll have to use the polyfill method after all

## Checklist

- [ ] Designate a primary reviewer
