### PR TITLE
8168: Defer loading fonts in script in sidebar to avoid render blocking

### DIFF
--- a/src/extensionConsole/options.html
+++ b/src/extensionConsole/options.html
@@ -37,10 +37,7 @@
     </div>
     <script src="loadingScreen.js"></script>
     <script src="options.js"></script>
-    <!-- Must be at the bottom https://github.com/pixiebrix/pixiebrix-extension/issues/4100 -->
-    <link
-      href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Load fonts asynchronously via script to avoid blocking loading the main content. -->
+    <script src="loadFonts.js"></script>
   </body>
 </html>

--- a/src/sidebar/sidebar.html
+++ b/src/sidebar/sidebar.html
@@ -35,10 +35,7 @@
     </div>
     <script src="loadingScreen.js"></script>
     <script src="sidebar.js"></script>
-    <!-- Must be at the bottom https://github.com/pixiebrix/pixiebrix-extension/issues/4100 -->
-    <link
-      href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Load fonts asynchronously via script to avoid blocking loading the main content. -->
+    <script src="loadFonts.js"></script>
   </body>
 </html>

--- a/src/tinyPages/walkthroughModal.html
+++ b/src/tinyPages/walkthroughModal.html
@@ -26,10 +26,7 @@
   <body>
     <div id="container"></div>
     <script src="walkthroughModal.js"></script>
-    <!-- Must be at the bottom https://github.com/pixiebrix/pixiebrix-extension/issues/4100 -->
-    <link
-      href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Load fonts asynchronously via script to avoid blocking loading the main content. -->
+    <script src="loadFonts.js"></script>
   </body>
 </html>

--- a/static/loadFonts.js
+++ b/static/loadFonts.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// This script loads the Ubuntu font from Google Fonts and applies it to the page dynamically.
+// The font is loaded via a script rather than with an inline style link to avoid render-blocking.
+// See: https://pagespeedchecklist.com/asynchronous-google-fonts
+const link = document.createElement("link");
+link.rel = "stylesheet";
+link.href =
+  "https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700";
+link.media = "print";
+link.addEventListener("load", (event) => {
+  if (event.target && event.target instanceof HTMLLinkElement) {
+    event.target.removeAttribute("media");
+  }
+});
+
+link.fetchpriority = "high";
+document.body.append(link);


### PR DESCRIPTION
## What does this PR do?

- Part of 8168

This change ensures that loading the fonts does not block rendering the
sidebar by moving the font link to be loaded dynamically in a script.


## Discussion

I don't think this fully solves the root cause of #8168, but this will slightly improve
the speed in which we render the sidebar as shown in the below reports.

## Demo
Both reports have a 1.5s delay for all calls (via devtools)

With current code (notice the warning of render blocking request and the slight wait on the scss to start loading before the `api/me` call gets kicked off).
<img width="1135" alt="Screenshot 2024-04-16 at 9 06 35 PM" src="https://github.com/pixiebrix/pixiebrix-extension/assets/3498063/f3b4902f-9729-40d4-9672-36dcb192bfc1">

Report With the deferred script approach:
<img width="1111" alt="Screenshot 2024-04-16 at 9 02 32 PM" src="https://github.com/pixiebrix/pixiebrix-extension/assets/3498063/8076391e-f84f-48ac-b491-bd76e41d2a79">

No visible impact on font rendering.

## Future Work

- Continue digging into other possible ways to improve the loading time of the sidebar. Performance Insights on Chrome points out a couple of long tasks that are executed before the DOM Content is loaded.
- Dig into other reasons that the extension could be slowing down the browser in some way

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @twschiller 
