### PR TITLE
Sidepanel open check failing in some browsers

### DIFF
--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -69,7 +69,6 @@ const pingSidebar = memoizeUntilSettled(
   }, 1000) as () => Promise<void>,
 );
 
-// This method is exclusive to the content script, don't export it
 async function isSidePanelOpenMv3() {
   try {
     await pingSidebar();

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -74,7 +74,7 @@ async function isSidePanelOpenMv3() {
       } catch {
         return false;
       }
-    }, 1000) as () => Promise<boolean>,
+    }, 500) as () => Promise<boolean>,
   );
 }
 
@@ -89,7 +89,7 @@ const pingSidebar = memoizeUntilSettled(
       // TODO: Use TimeoutError after https://github.com/sindresorhus/p-timeout/issues/41
       throw new Error("The sidebar did not respond in time", { cause: error });
     }
-  }, 500) as () => Promise<void>,
+  }, 1000) as () => Promise<void>,
 );
 
 /**

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -60,33 +60,8 @@ export const isSidePanelOpen = isMV3()
   ? isSidePanelOpenMv3
   : sidebarMv2.isSidebarFrameVisible;
 
-/**
- * Determines whether the sidebar is open.
- * @returns false when it's definitely closed or 'unknown' when it cannot be determined,
- * because the extra padding might be caused by the dev tools being open on the side
- * or due to another sidebar
- */
-// The type cannot be `undefined` due to strictNullChecks
-function isSidePanelOpenSync(): false | "unknown" {
-  if (!isMV3()) {
-    throw new Error("isSidePanelOpenSync is only available in MV3");
-  }
-
-  if (!globalThis.window) {
-    return "unknown";
-  }
-
-  return window.outerWidth - window.innerWidth > MINIMUM_SIDEBAR_WIDTH
-    ? "unknown"
-    : false;
-}
-
 // This method is exclusive to the content script, don't export it
 async function isSidePanelOpenMv3(): Promise<boolean> {
-  if (isSidePanelOpenSync() === false) {
-    return false;
-  }
-
   try {
     await messenger(
       "SIDEBAR_PING",
@@ -511,6 +486,27 @@ export function getReservedPanelEntries(): {
     forms: getFormPanelSidebarEntries(),
     modActivationPanel: modActivationPanelEntry,
   };
+}
+
+/**
+ * Determines whether the sidebar is open.
+ * @returns false when it's definitely closed or 'unknown' when it cannot be determined,
+ * because the extra padding might be caused by the dev tools being open on the side
+ * or due to another sidebar
+ */
+// The type cannot be `undefined` due to strictNullChecks
+function isSidePanelOpenSync(): false | "unknown" {
+  if (!isMV3()) {
+    throw new Error("isSidePanelOpenSync is only available in MV3");
+  }
+
+  if (!globalThis.window) {
+    return "unknown";
+  }
+
+  return window.outerWidth - window.innerWidth > MINIMUM_SIDEBAR_WIDTH
+    ? "unknown"
+    : false;
 }
 
 function sidePanelOnCloseSignal(): AbortSignal {

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -490,6 +490,8 @@ export function getReservedPanelEntries(): {
 
 /**
  * Determines whether the sidebar is open.
+ * Caution, this function is known to be flaky in some cases. Only use when you absolutely must
+ * check the sidebar state synchronously. If asynchronous checks are acceptable, use `isSidePanelOpen` instead.
  * @returns false when it's definitely closed or 'unknown' when it cannot be determined,
  * because the extra padding might be caused by the dev tools being open on the side
  * or due to another sidebar

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -38,10 +38,8 @@ import type {
 } from "@/types/sidebarTypes";
 import { getTemporaryPanelSidebarEntries } from "@/platform/panels/panelController";
 import { getFormPanelSidebarEntries } from "@/platform/forms/formController";
-import { getSidebarTargetForCurrentTab } from "@/utils/sidePanelUtils";
 import { memoizeUntilSettled } from "@/utils/promiseUtils";
 import { getTimedSequence } from "@/types/helpers";
-import { messenger } from "webext-messenger";
 import { isMV3 } from "@/mv3/api";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { focusCaptureDialog } from "@/contentScript/focusCaptureDialog";
@@ -52,9 +50,6 @@ import focusController from "@/utils/focusController";
 import selectionController from "@/utils/selectionController";
 
 const HIDE_SIDEBAR_EVENT_NAME = "pixiebrix:hideSidebar";
-
-/* Approximate sidebar width in pixels. Used to determine whether it's open */
-const MINIMUM_SIDEBAR_WIDTH = 300;
 
 export const isSidePanelOpen = isMV3()
   ? isSidePanelOpenMv3
@@ -482,29 +477,6 @@ export function getReservedPanelEntries(): {
     forms: getFormPanelSidebarEntries(),
     modActivationPanel: modActivationPanelEntry,
   };
-}
-
-/**
- * Determines whether the sidebar is open.
- * Caution, this function is known to be flaky in some cases. Only use when you absolutely must
- * check the sidebar state synchronously. If asynchronous checks are acceptable, use `isSidePanelOpen` instead.
- * @returns false when it's definitely closed or 'unknown' when it cannot be determined,
- * because the extra padding might be caused by the dev tools being open on the side
- * or due to another sidebar
- */
-// The type cannot be `undefined` due to strictNullChecks
-function isSidePanelOpenSync(): false | "unknown" {
-  if (!isMV3()) {
-    throw new Error("isSidePanelOpenSync is only available in MV3");
-  }
-
-  if (!globalThis.window) {
-    return "unknown";
-  }
-
-  return window.outerWidth - window.innerWidth > MINIMUM_SIDEBAR_WIDTH
-    ? "unknown"
-    : false;
 }
 
 function sidePanelOnCloseSignal(): AbortSignal {


### PR DESCRIPTION
## What does this PR do?

- Potentially fixes an issue where the side panel would hang in a loading state with the reserved panels showing

## Discussion

- I've never been able to reproduce the issue (on Mac or Windows via Parallel)
- When the width check ever returns false, side panel hangs
- In customer calls, we were able to determine that  the sidebar was being reported as not visible

#### Important
- I'm not sure about the performance implications of always pinging
    - `SIDEBAR_PING` is a `noop`, but we're still increasing the number of messenger calls
    - We always ping using the messenger when we think the side panel might be open, though, so it's probably ok
- Alternatively, we could try reducing the `MINIMUM_SIDEBAR_WIDTH`, but as it is already 300, I don't think that would help. It's possible that something is going wrong with the inner and outer width checks 

## Checklist

- [x] Designate a primary reviewer @twschiller 
