### PR TITLE
Default MV to 3 in e2e tests

### DIFF
--- a/end-to-end-tests/README.md
+++ b/end-to-end-tests/README.md
@@ -15,7 +15,7 @@ One-time setup:
     - The test user password `E2E_TEST_USER_PASSWORD_UNAFFILIATED`
     - Uncomment `REQUIRE_OPTIONAL_PERMISSIONS_IN_MANIFEST=1`
     - Uncomment `SHADOW_DOM=open`
-  - `MV` will determine the manifest version for the both the extension and the tests.
+  - `MV` will determine the manifest version for the both the extension and the tests (defaulted to 3 if not defined.)
 - Install browsers: Execute `npx playwright install chromium chrome msedge`.
 
 1. Install dependencies: Run `npm install`

--- a/end-to-end-tests/env.ts
+++ b/end-to-end-tests/env.ts
@@ -68,7 +68,7 @@ export const {
 
 export const {
   CI,
-  MV,
+  MV = "3",
   SLOWMO,
   PWDEBUG,
   REQUIRE_OPTIONAL_PERMISSIONS_IN_MANIFEST,

--- a/end-to-end-tests/fixtures/utils.ts
+++ b/end-to-end-tests/fixtures/utils.ts
@@ -52,11 +52,15 @@ export const getExtensionId = async (context: BrowserContext) => {
 
   if (MV === "3") {
     background = context.serviceWorkers()[0];
-    background ||= await context.waitForEvent("serviceworker");
+    background ||= await context.waitForEvent("serviceworker", {
+      timeout: 3000,
+    });
   } else {
     // For manifest v2:
     background = context.backgroundPages()[0];
-    background ||= await context.waitForEvent("backgroundpage");
+    background ||= await context.waitForEvent("backgroundpage", {
+      timeout: 3000,
+    });
   }
 
   const extensionId = background.url().split("/")[2];


### PR DESCRIPTION
## What does this PR do?

- Makes it so that tests don't fail if you don't happen to have MV defined in your env (as we suggest you can do in our wiki setup guide)

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer @mnholtz 
