### PR TITLE
#8273: Fix App crashing when chrome runtime is undefined

### DIFF
--- a/src/mv3/api.ts
+++ b/src/mv3/api.ts
@@ -21,7 +21,10 @@ import { type Tabs } from "webextension-polyfill";
 import { once } from "lodash";
 
 export const isMV3 = once(
-  (): boolean => chrome.runtime.getManifest().manifest_version === 3,
+  (): boolean =>
+    // Use optional chaining in case the chrome runtime is not available:
+    // https://github.com/pixiebrix/pixiebrix-extension/issues/8273
+    chrome.runtime?.getManifest().manifest_version === 3,
 );
 export const browserAction =
   globalThis.chrome?.browserAction ?? globalThis.chrome?.action;


### PR DESCRIPTION
## What does this PR do?

- Closes #8273

## Discussion

- Instead of using optional chaining we could use `isExtensionContext()`. But @grahamlangford and I decided to use optional chaining because it's simpler. Plus we will delete the `src/mv3/api.ts` file when the MV3 transition is complete so no need to create a robust solution here.

## Demo

https://www.loom.com/share/6884cee3ed74460799897b9c855b318e

## Future Work

- Bump Extension version in App. Will need to go from 1.8.11 -> 1.8.13

## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
