### PR TITLE
#8222: support auto-create databases for starter mods

### DIFF
--- a/src/activation/modOptionsHelpers.ts
+++ b/src/activation/modOptionsHelpers.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { isDatabasePreviewField } from "@/components/fields/schemaFields/fieldTypeCheckers";
+import { isEmpty } from "lodash";
+import { isUUID } from "@/types/helpers";
+import type { ModDefinition } from "@/types/modDefinitionTypes";
+import type { UUID } from "@/types/stringTypes";
+import type { OptionsArgs } from "@/types/runtimeTypes";
+import type { Schema } from "@/types/schemaTypes";
+
+/**
+ * Returns the default database name for an auto-created database.
+ */
+export function makeDatabasePreviewName(
+  modDefinition: ModDefinition,
+  optionSchema: Schema,
+  name: string,
+): string {
+  return `${modDefinition.metadata.name} - ${optionSchema.title ?? name}`;
+}
+
+/**
+ * Create databases for any mod options database fields where the schema format is "preview", and the field value
+ * is a string to use as the database name.
+ *
+ * Modifies optionsArgs in place.
+ *
+ * @param modDefinition the mod definition
+ * @param optionsArgs the current mod options
+ * @param databaseFactory function to create a database
+ * @throws {Error} if any of the databases cannot be created
+ */
+export async function autoCreateDatabaseOptionsArgsInPlace(
+  modDefinition: ModDefinition,
+  optionsArgs: OptionsArgs,
+  databaseFactory: (args: { name: string }) => Promise<UUID>,
+): Promise<OptionsArgs> {
+  const optionsProperties = Object.entries(
+    modDefinition.options?.schema?.properties ?? {},
+  )
+    .filter(
+      ([name, fieldSchema]) =>
+        isDatabasePreviewField(fieldSchema) &&
+        !isEmpty(optionsArgs[name]) &&
+        // If the value is a UUID, then it's a database ID for an existing database
+        !isUUID(optionsArgs[name] as string),
+    )
+    .map(([name]) => ({
+      name,
+      // Known to be string due to filter above
+      databaseName: optionsArgs[name] as string,
+    }));
+
+  // Create the databases in parallel
+  await Promise.all(
+    optionsProperties.map(async ({ name, databaseName }) => {
+      try {
+        optionsArgs[name] = await databaseFactory({ name: databaseName });
+      } catch (error) {
+        throw new Error("Error creating database", { cause: error });
+      }
+    }),
+  );
+
+  return optionsArgs;
+}

--- a/src/activation/useActivateModWizard.test.tsx
+++ b/src/activation/useActivateModWizard.test.tsx
@@ -16,9 +16,7 @@
  */
 
 import * as redux from "react-redux";
-import useActivateModWizard, {
-  makeDatabasePreviewName,
-} from "@/activation/useActivateModWizard";
+import useActivateModWizard from "@/activation/useActivateModWizard";
 import { renderHook } from "@testing-library/react-hooks";
 import useDatabaseOptions from "@/hooks/useDatabaseOptions";
 import { valueToAsyncState } from "@/utils/asyncStateUtils";
@@ -26,6 +24,7 @@ import { valueToAsyncState } from "@/utils/asyncStateUtils";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { propertiesToSchema } from "@/utils/schemaUtils";
+import { makeDatabasePreviewName } from "@/activation/modOptionsHelpers";
 
 jest.mock("@/components/integrations/AuthWidget", () => {});
 jest.mock("react-redux");

--- a/src/activation/useActivateModWizard.ts
+++ b/src/activation/useActivateModWizard.ts
@@ -45,6 +45,7 @@ import { isPrimitive } from "@/utils/typeUtils";
 import { inputProperties } from "@/utils/schemaUtils";
 import { PIXIEBRIX_INTEGRATION_ID } from "@/integrations/constants";
 import getUnconfiguredComponentIntegrations from "@/integrations/util/getUnconfiguredComponentIntegrations";
+import { makeDatabasePreviewName } from "@/activation/modOptionsHelpers";
 
 const STEPS: WizardStep[] = [
   { key: "services", label: "Integrations", Component: IntegrationsBody },
@@ -69,14 +70,6 @@ export type UseActivateRecipeWizardResult = {
   initialValues: WizardValues;
   validationSchema: Yup.AnyObjectSchema;
 };
-
-export function makeDatabasePreviewName(
-  recipe: ModDefinition,
-  optionSchema: Schema,
-  name: string,
-): string {
-  return `${recipe.metadata.name} - ${optionSchema.title ?? name}`;
-}
 
 export function wizardStateFactory({
   modDefinition,

--- a/src/background/starterMods.test.ts
+++ b/src/background/starterMods.test.ts
@@ -53,9 +53,11 @@ import { type StarterBrickDefinition } from "@/starterBricks/types";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { type StarterBrickType } from "@/types/starterBrickTypes";
 import {
-  PIXIEBRIX_INTEGRATION_CONFIG_ID,
   PIXIEBRIX_INTEGRATION_ID,
+  PIXIEBRIX_INTEGRATION_CONFIG_ID,
 } from "@/integrations/constants";
+import { databaseFactory } from "@/testUtils/factories/databaseFactories";
+import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 
 const axiosMock = new MockAdapter(axios);
 
@@ -365,7 +367,7 @@ describe("debouncedActivateStarterMods", () => {
     expect(dependency2.configId).toBe(builtInIntegrationConfigs[1].id);
   });
 
-  test("activate starter mods required pixiebrix integration", async () => {
+  test("activate starter mod with required pixiebrix integration", async () => {
     isLinkedMock.mockResolvedValue(true);
 
     const { modDefinition } = getModDefinitionWithBuiltInIntegrationConfigs();
@@ -402,5 +404,64 @@ describe("debouncedActivateStarterMods", () => {
 
     // As of 1.8.13, a sentinel value is used for the configId of the integration to simplify strict null checks
     expect(dependency.configId).toBe(PIXIEBRIX_INTEGRATION_CONFIG_ID);
+  });
+
+  test("activate starter mod with required pixiebrix database", async () => {
+    isLinkedMock.mockResolvedValue(true);
+
+    const { modDefinition } = getModDefinitionWithBuiltInIntegrationConfigs();
+
+    (modDefinition.metadata as any).name = "Test Mod";
+
+    modDefinition.options = {
+      schema: {
+        properties: {
+          database: {
+            $ref: "https://app.pixiebrix.com/schemas/database#",
+            title: "Test Database",
+            format: "preview",
+          },
+        },
+        required: ["database"],
+      },
+    };
+
+    modDefinition.extensionPoints[0].services = {
+      type: "object",
+      properties: {
+        service: {
+          $ref: `https://app.pixiebrix.com/schemas/services/${PIXIEBRIX_INTEGRATION_ID}`,
+        },
+      },
+      required: ["service"],
+    };
+
+    axiosMock.onGet("/api/services/shared/?meta=1").reply(200, []);
+
+    axiosMock
+      .onGet("/api/onboarding/starter-blueprints/")
+      .reply(200, [modDefinition]);
+
+    const databaseId = autoUUIDSequence();
+
+    axiosMock.onPost("/api/databases/").reply((args) => {
+      const data = JSON.parse(args.data) as UnknownObject;
+      expect(data).toStrictEqual({ name: "Test Mod - Test Database" });
+
+      return [
+        201,
+        databaseFactory({ id: databaseId, name: data.name as string }),
+      ];
+    });
+
+    await debouncedActivateStarterMods();
+    const { extensions: activatedModComponents } = await getModComponentState();
+
+    expect(activatedModComponents).toBeArrayOfSize(1);
+
+    expect(activatedModComponents[0].optionsArgs).toStrictEqual({
+      // Activated with the ID of the database created
+      database: databaseId,
+    });
   });
 });

--- a/src/background/starterMods.ts
+++ b/src/background/starterMods.ts
@@ -17,7 +17,10 @@
 
 import extensionsSlice from "@/store/extensionsSlice";
 import sidebarSlice from "@/store/sidebar/sidebarSlice";
-import { maybeGetLinkedApiClient } from "@/data/service/apiClient";
+import {
+  getLinkedApiClient,
+  maybeGetLinkedApiClient,
+} from "@/data/service/apiClient";
 import {
   getModComponentState,
   saveModComponentState,
@@ -29,7 +32,7 @@ import { type ModComponentState } from "@/store/extensionsTypes";
 import reportError from "@/telemetry/reportError";
 import { debounce } from "lodash";
 import { refreshRegistries } from "./refreshRegistries";
-import { type RemoteIntegrationConfig } from "@/types/contract";
+import type { Database, RemoteIntegrationConfig } from "@/types/contract";
 import { getSharingType } from "@/hooks/auth";
 import { memoizeUntilSettled } from "@/utils/promiseUtils";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
@@ -47,9 +50,17 @@ import { type SidebarState } from "@/types/sidebarTypes";
 import { getEventKeyForPanel } from "@/store/sidebar/eventKeyUtils";
 import { type UUID } from "@/types/stringTypes";
 import {
-  PIXIEBRIX_INTEGRATION_CONFIG_ID,
   PIXIEBRIX_INTEGRATION_ID,
+  PIXIEBRIX_INTEGRATION_CONFIG_ID,
 } from "@/integrations/constants";
+import {
+  autoCreateDatabaseOptionsArgsInPlace,
+  makeDatabasePreviewName,
+} from "@/activation/modOptionsHelpers";
+import type { OptionsArgs } from "@/types/runtimeTypes";
+import { isDatabasePreviewField } from "@/components/fields/schemaFields/fieldTypeCheckers";
+import { isRequired } from "@/utils/schemaUtils";
+import type { Schema } from "@/types/schemaTypes";
 
 // eslint-disable-next-line local-rules/persistBackgroundData -- no state; destructuring reducer and actions
 const { reducer: extensionsReducer, actions: extensionsActions } =
@@ -85,13 +96,21 @@ export async function getBuiltInIntegrationConfigs(): Promise<
 
 function activateModInOptionsState(
   state: ModComponentState,
-  modDefinition: ModDefinition,
-  configuredDependencies: IntegrationDependency[],
+  {
+    modDefinition,
+    configuredDependencies,
+    optionsArgs,
+  }: {
+    modDefinition: ModDefinition;
+    configuredDependencies: IntegrationDependency[];
+    optionsArgs: OptionsArgs;
+  },
 ): ModComponentState {
   return extensionsReducer(
     state,
     extensionsActions.activateMod({
       modDefinition,
+      optionsArgs,
       configuredDependencies,
       screen: "starterMod",
       isReactivate: false,
@@ -139,10 +158,24 @@ function closeStarterModTabs({
   return sidebarState;
 }
 
+function initialOptionsArgs(modDefinition: ModDefinition): OptionsArgs {
+  return Object.fromEntries(
+    Object.entries(modDefinition.options?.schema?.properties ?? {})
+      .filter(
+        ([name, fieldSchema]) =>
+          isDatabasePreviewField(fieldSchema) &&
+          isRequired(modDefinition.options.schema, name),
+      )
+      .map(([name, fieldSchema]) => [
+        name,
+        makeDatabasePreviewName(modDefinition, fieldSchema as Schema, name),
+      ]),
+  );
+}
+
 async function activateMods(modDefinitions: ModDefinition[]): Promise<boolean> {
-  let activated = false;
   if (modDefinitions.length === 0) {
-    return activated;
+    return false;
   }
 
   const unconfiguredIntegrationDependencies =
@@ -152,6 +185,7 @@ async function activateMods(modDefinitions: ModDefinition[]): Promise<boolean> {
 
   const builtInIntegrationConfigs = await getBuiltInIntegrationConfigs();
 
+  // XXX: do we want to fail all starter mod activations if one starter mod is invalid?
   const builtInDependencies = unconfiguredIntegrationDependencies.map(
     (unconfiguredDependency) => {
       if (unconfiguredDependency.integrationId === PIXIEBRIX_INTEGRATION_ID) {
@@ -185,25 +219,49 @@ async function activateMods(modDefinitions: ModDefinition[]): Promise<boolean> {
     getSidebarState(),
   ]);
 
-  for (const modDefinition of modDefinitions) {
-    const modAlreadyActivated = optionsState.extensions.some(
-      (mod) => mod._recipe?.id === modDefinition.metadata.id,
-    );
+  const newMods = modDefinitions.filter(
+    (modDefinition) =>
+      !optionsState.extensions.some(
+        (mod) => mod._recipe?.id === modDefinition.metadata.id,
+      ),
+  );
 
-    if (!modAlreadyActivated) {
-      optionsState = activateModInOptionsState(
-        optionsState,
+  // XXX: do we want to fail all starter mod activations if a DB fails to get created?
+  const newModConfigs = await Promise.all(
+    newMods.map(async (modDefinition) => {
+      const optionsArgs = initialOptionsArgs(modDefinition);
+
+      await autoCreateDatabaseOptionsArgsInPlace(
         modDefinition,
-        builtInDependencies,
+        optionsArgs,
+        async (args) => {
+          const client = await getLinkedApiClient();
+          const response = await client.post<Database>("/api/databases/", {
+            name: args.name,
+          });
+          return response.data.id;
+        },
       );
-      activated = true;
 
-      sidebarState = closeStarterModTabs({
+      return {
         modDefinition,
-        optionsState,
-        sidebarState,
-      });
-    }
+        optionsArgs,
+      };
+    }),
+  );
+
+  for (const { modDefinition, optionsArgs } of newModConfigs) {
+    optionsState = activateModInOptionsState(optionsState, {
+      modDefinition,
+      configuredDependencies: builtInDependencies,
+      optionsArgs,
+    });
+
+    sidebarState = closeStarterModTabs({
+      modDefinition,
+      optionsState,
+      sidebarState,
+    });
   }
 
   await Promise.all([
@@ -211,7 +269,7 @@ async function activateMods(modDefinitions: ModDefinition[]): Promise<boolean> {
     saveSidebarState(sidebarState),
   ]);
   await forEachTab(queueReactivateTab);
-  return activated;
+  return newModConfigs.length > 0;
 }
 
 async function getStarterMods(): Promise<ModDefinition[]> {

--- a/src/components/fields/schemaFields/fieldTypeCheckers.ts
+++ b/src/components/fields/schemaFields/fieldTypeCheckers.ts
@@ -20,6 +20,7 @@ import { type Expression } from "@/types/runtimeTypes";
 import {
   type LabelledEnumSchema,
   type Schema,
+  type SchemaDefinition,
   type UiSchema,
 } from "@/types/schemaTypes";
 import { get, isEmpty } from "lodash";
@@ -89,6 +90,22 @@ export function isKeyStringField(schema: Schema): boolean {
 
 export function isDatabaseField(schema: Schema): boolean {
   return schema.$ref === databaseSchema.$id;
+}
+
+type DataPreviewFieldSchema = {
+  $ref: typeof databaseSchema.$id;
+  format: "preview";
+};
+
+// Provide generic to support additional properties on the schema (e.g., title)
+export function isDatabasePreviewField<T extends DataPreviewFieldSchema>(
+  schema: SchemaDefinition,
+): schema is T {
+  return (
+    typeof schema !== "boolean" &&
+    isDatabaseField(schema) &&
+    schema.format === "preview"
+  );
 }
 
 export function isIconField(schema: Schema): boolean {

--- a/src/store/sidebar/sidebarStorage.ts
+++ b/src/store/sidebar/sidebarStorage.ts
@@ -29,13 +29,13 @@ export const STORAGE_KEY = validateReduxStorageKey("persist:sidebar");
 
 // The subset of the sidebar state that we persist
 // See persistSidebarConfig.whitelist
-type SidebarPeristedState = Pick<SidebarState, "closedTabs">;
+type SidebarPersistedState = Pick<SidebarState, "closedTabs">;
 
 /**
  * Reads the current state of the sidebar from storage (without going through redux-persist)
  */
 export async function getSidebarState(): Promise<SidebarState> {
-  const persistedSidebarState = await readReduxStorage<SidebarPeristedState>(
+  const persistedSidebarState = await readReduxStorage<SidebarPersistedState>(
     STORAGE_KEY,
     {},
     initialSidebarState,
@@ -46,7 +46,7 @@ export async function getSidebarState(): Promise<SidebarState> {
 }
 
 export async function saveSidebarState(
-  state: SidebarPeristedState,
+  state: SidebarPersistedState,
 ): Promise<void> {
   await setReduxStorage(STORAGE_KEY, state, 0);
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #8222 
- Extracts DB creation logic from useActivateRecipe into a helper function

## Discussion

- DB names general come from [the activation link](https://github.com/pixiebrix/pixiebrix-extension/blob/a9edeb6a92531aecdc775733256cbf1d20c66d2a/src/activation/activationLinkUtils.ts#L165). We need to figure out a way to pass DB names for starter mods

## Remaining Work

- [x] Fix broken mocking for useActivateRecipe test -- switched to use axios mock adapter
- [x] Add tests

## Future Work

- Rename useActivateRecipe to useActivateMod

## Checklist

- [x] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer: @BLoe 
