### PR TITLE
Quickbar closes on Escape

### DIFF
--- a/src/components/quickBar/QuickBarApp.test.tsx
+++ b/src/components/quickBar/QuickBarApp.test.tsx
@@ -129,6 +129,13 @@ describe("QuickBarApp", () => {
     });
 
     expect(saveSelectionMock).toHaveBeenCalledOnce();
+
+    // Verify that Escape key closes the quick bar
+    await user.keyboard("{Escape}");
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(screen.queryByTestId("quickBar")).toBeNull();
   });
 
   it("debounces action generation on typing", async () => {

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect } from "react";
+import React, { KeyboardEventHandler, useEffect } from "react";
 import ReactDOM from "react-dom";
 import {
   KBarAnimator,
@@ -94,9 +94,17 @@ const KBarComponent: React.FC = () => {
   useActions();
   useActionGenerators();
 
-  const { showing } = useKBar((state) => ({
+  const { query, showing } = useKBar((state) => ({
     showing: state.visualState !== VisualState.hidden,
   }));
+
+  const closeQuickBarOnEscape: KeyboardEventHandler<HTMLInputElement> = (
+    event,
+  ) => {
+    if (event.key === "Escape") {
+      query.toggle();
+    }
+  };
 
   useScrollLock(showing);
 
@@ -147,7 +155,10 @@ const KBarComponent: React.FC = () => {
             <Stylesheets href={faStyleSheet} mountOnLoad>
               <StopPropagation onKeyPress onKeyDown onKeyUp onInput>
                 {/* eslint-disable-next-line react/jsx-max-depth -- Not worth simplifying */}
-                <KBarSearch style={searchStyle} />
+                <KBarSearch
+                  onKeyDown={closeQuickBarOnEscape}
+                  style={searchStyle}
+                />
               </StopPropagation>
               <QuickBarResults />
             </Stylesheets>

--- a/src/components/quickBar/QuickBarApp.tsx
+++ b/src/components/quickBar/QuickBarApp.tsx
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { KeyboardEventHandler, useEffect } from "react";
+import React, { type KeyboardEventHandler, useEffect } from "react";
 import ReactDOM from "react-dom";
 import {
   KBarAnimator,


### PR DESCRIPTION
## What does this PR do?

- This change fixes a small regression introduced in https://github.com/pixiebrix/pixiebrix-extension/pull/7686 where the escape key onKeydown no longer closes the quickbar modal.

## Checklist

- [X] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @BLoe 
