### PR TITLE
Fix error telemetry e2e test flakiness

### DIFF
--- a/end-to-end-tests/tests/telemetry/errors.spec.ts
+++ b/end-to-end-tests/tests/telemetry/errors.spec.ts
@@ -49,7 +49,7 @@ test("can report application error to telemetry service", async ({
           .startsWith(`chrome-extension://${extensionId}/offscreen.html`),
       );
 
-    expect(offscreenPage.url()).toBeDefined();
+    expect(offscreenPage?.url()).toBeDefined();
   }).toPass({ timeout: 5000 });
 
   // TODO: due to Datadog SDK implementation, it will take ~30 seconds for the


### PR DESCRIPTION
## What does this PR do?

- I think this should fix flakiness with the error telemetry test I introduced recently - I thought I'd added this nullish operator in my original PR, but it seems to be missing on main

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [ ] Designate a primary reviewer @BLoe or @fungairino 
