### PR TITLE
#8292: MV3 sidebar is less flaky about staying open during navigation

### DIFF
--- a/end-to-end-tests/auth.setup.ts
+++ b/end-to-end-tests/auth.setup.ts
@@ -64,6 +64,6 @@ test("authenticate", async ({ contextAndPage: { context, page } }) => {
   await ensureVisibility(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion,@typescript-eslint/no-unnecessary-type-assertion -- checked above
     extensionConsolePage!.getByText(E2E_TEST_USER_EMAIL_UNAFFILIATED),
-    { timeout: 10_000 },
+    { timeout: 12_000 },
   );
 });

--- a/end-to-end-tests/tests/runtime/sidebarNavigation.spec.ts
+++ b/end-to-end-tests/tests/runtime/sidebarNavigation.spec.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { test, expect } from "../../fixtures/extensionBase";
+import { ActivateModPage } from "../../pageObjects/extensionConsole/modsPage";
+// @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
+import { Page, test as base } from "@playwright/test";
+import { getSidebarPage, runModViaQuickBar } from "../../utils";
+import { MV, SERVICE_URL } from "../../env";
+
+test("sidebar is persistent during navigation", async ({
+  page,
+  extensionId,
+}) => {
+  test.skip(MV === "2", "Navigation is not supported for MV2 sidebar");
+  // This mod shows a simple form in the sidebar, and is enabled for the pbx.vercel.app domain and app domain.
+  const modId = "@e2e-testing/test-sidebar-navigation";
+
+  const modActivationPage = new ActivateModPage(page, extensionId, modId);
+  await modActivationPage.goto();
+
+  await modActivationPage.clickActivateAndWaitForModsPageRedirect();
+
+  await page.goto("/");
+
+  // Ensure the page is focused by clicking on an element before running the keyboard shortcut, see runModViaQuickbar
+  await page.getByText("Index of  /").click();
+  await runModViaQuickBar(page, "Open Sidebar");
+
+  const sideBarPage = (await getSidebarPage(page, extensionId)) as Page; // MV3 sidebar is a separate page
+  // Set up close listener for sidebar page
+  let sideBarPageClosed = false;
+  sideBarPage.on("close", () => {
+    sideBarPageClosed = true;
+  });
+
+  await expect(
+    sideBarPage.getByRole("heading", { name: "Sidebar 2" }), // The panel for Sidebar 2 is the one that is shown (last panel is shown by default)
+  ).toBeVisible();
+  await expect(
+    sideBarPage.getByRole("tab", { name: "Test sidebar 1" }),
+  ).toBeVisible();
+  await expect(
+    sideBarPage.getByRole("tab", { name: "Test sidebar 2" }),
+  ).toBeVisible();
+
+  const notesField = sideBarPage.getByLabel("Example Notes Field");
+  // The notes field defaults its value to the current url.
+  await expect(notesField).toContainText("https://pbx.vercel.app/");
+  await notesField.fill("Something else");
+
+  // Navigate to the "advanced-fields" subpage
+  await page.getByRole("link", { name: "advanced-fields" }).click();
+  await expect(
+    sideBarPage.getByRole("heading", { name: "Sidebar 2" }),
+  ).toBeVisible();
+  await expect(
+    sideBarPage.getByRole("tab", { name: "Test sidebar 1" }),
+  ).toBeVisible();
+  await expect(
+    sideBarPage.getByRole("tab", { name: "Test sidebar 2" }),
+  ).toBeVisible();
+  // The sidebar resets the state of the panel, so notes field resets its value to the current url.
+  await expect(notesField).toContainText(
+    "https://pbx.vercel.app/advanced-fields/",
+  );
+
+  // Navigating in the browser to another page should keep the sidebar open and reset the state of the panel.
+  await page.goto(SERVICE_URL);
+  await expect(
+    sideBarPage.getByRole("heading", { name: "Sidebar 2" }),
+  ).toBeVisible();
+  // Sidebar 1 tab is hidden since it is not enabled in this page.
+  await expect(
+    sideBarPage.getByRole("tab", { name: "Test sidebar 1" }),
+  ).not.toBeVisible();
+  await expect(
+    sideBarPage.getByRole("tab", { name: "Test sidebar 2" }),
+  ).toBeVisible();
+  await expect(notesField).toContainText(SERVICE_URL);
+
+  // Reloading also works the same way.
+  await page.reload();
+  await expect(
+    sideBarPage.getByRole("heading", { name: "Sidebar 2" }),
+  ).toBeVisible();
+  await expect(notesField).toContainText(SERVICE_URL);
+
+  // Navigating to a page where all mod sidebar panels are not enabled should close the sidebar since no panels are open.
+  await page.getByTestId("sidebarToggler").click();
+  await page.getByRole("link", { name: "Documentation" }).click();
+  await expect(() => {
+    expect(sideBarPageClosed).toBe(true);
+  }).toPass({ timeout: 5000 });
+});

--- a/end-to-end-tests/tests/runtime/sidebarNavigation.spec.ts
+++ b/end-to-end-tests/tests/runtime/sidebarNavigation.spec.ts
@@ -27,7 +27,8 @@ test("sidebar is persistent during navigation", async ({
   extensionId,
 }) => {
   test.skip(MV === "2", "Navigation is not supported for MV2 sidebar");
-  // This mod shows a simple form in the sidebar, and is enabled for the pbx.vercel.app domain and app domain.
+  // This mod shows two panels in the sidebar with a simple form. One is enabled for the pbx.vercel.app domain and app
+  // domain, and the other is enabled just for the pbx.vercel.app domain.
   const modId = "@e2e-testing/test-sidebar-navigation";
 
   const modActivationPage = new ActivateModPage(page, extensionId, modId);
@@ -59,7 +60,7 @@ test("sidebar is persistent during navigation", async ({
   ).toBeVisible();
 
   const notesField = sideBarPage.getByLabel("Example Notes Field");
-  // The notes field defaults its value to the current url.
+  // The notes field in this mod defaults its value to the current url.
   await expect(notesField).toContainText("https://pbx.vercel.app/");
   await notesField.fill("Something else");
 

--- a/end-to-end-tests/utils.ts
+++ b/end-to-end-tests/utils.ts
@@ -63,7 +63,7 @@ export async function ensureVisibility(
   options?: { timeout: number },
 ) {
   await expect(async () => {
-    await expect(locator).toBeVisible();
+    await expect(locator).toBeVisible({ timeout: 0 }); // Retry handling is done by the outer expect
   }).toPass({ timeout: 5000, ...options });
 }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,8 +15,10 @@ export default defineConfig<{ chromiumChannel: string }>({
   retries: CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: CI ? 1 : 2,
-  /* Timeout for each test */
-  timeout: 120_000,
+  /* Timeout for each test, if a test should take longer than this, use `test.slow()` */
+  timeout: 60_000,
+  /* Timeout for the entire test run */
+  globalTimeout: 20 * 60 * 1000, // 20 minutes
   expect: {
     /* Timeout for each assertion. If a particular interaction is timing out, adjust its specific timeout value rather than this global setting */
     timeout: 5000,

--- a/src/contentScript/contentScriptCore.ts
+++ b/src/contentScript/contentScriptCore.ts
@@ -40,10 +40,7 @@ import initFloatingActions from "@/components/floatingActions/initFloatingAction
 import { initSidebarActivation } from "@/contentScript/sidebarActivation";
 import { initPerformanceMonitoring } from "@/contentScript/performanceMonitoring";
 import { initRuntime } from "@/runtime/reducePipeline";
-import {
-  initSidebarFocusEvents,
-  renderPanelsIfVisible,
-} from "./sidebarController";
+import { initSidebarFocusEvents } from "./sidebarController";
 import {
   isSidebarFrameVisible,
   removeSidebarFrame,
@@ -55,7 +52,6 @@ import { markDocumentAsFocusableByUser } from "@/utils/focusTracker";
 import contentScriptPlatform from "@/contentScript/contentScriptPlatform";
 import axios from "axios";
 import { initDeferredLoginController } from "@/contentScript/integrations/deferredLoginController";
-import { isLoadedInIframe } from "@/utils/iframeUtils";
 
 setPlatform(contentScriptPlatform);
 
@@ -101,14 +97,6 @@ export async function init(): Promise<void> {
 
   initSidebarFocusEvents();
   void initSidebarActivation();
-
-  if (!isLoadedInIframe()) {
-    // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/8209
-    // Reset panels in `sidePanel` on content script initialization (which happens on non-SPA reload/navigation).
-    // That's the safe behavior for now to avoid showing stale data/invalid forms.
-    // Re-examine this call when we implement: https://www.notion.so/pixiebrix/0efdedb6c1e44b088e65106202e08c28
-    void renderPanelsIfVisible();
-  }
 
   // Let the partner page know
   initPartnerIntegrations();

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -48,6 +48,8 @@ import { $safeFind } from "@/utils/domUtils";
 import { onContextInvalidated } from "webext-events";
 import { ContextMenuStarterBrickABC } from "@/starterBricks/contextMenu";
 import { ReusableAbortController } from "abort-utils";
+import { isLoadedInIframe } from "@/utils/iframeUtils";
+import { renderPanelsIfVisible } from "@/contentScript/sidebarController";
 
 /**
  * True if handling the initial page load.
@@ -599,6 +601,14 @@ export async function handleNavigate({
         }),
       ),
     );
+
+    // This ensures that in the case there are mods with sidebar starter bricks whose panels are not active for the current page,
+    // the sidebar will still be updated to reflect the new page state (since otherwise, the sidebar panels would not be updated).
+    // NEXT: in slice 3 (https://github.com/pixiebrix/pixiebrix-extension/issues/8294) we will instead show
+    // stale panels with a special UX, and this bit of code will be removed.
+    if (!isLoadedInIframe()) {
+      void renderPanelsIfVisible();
+    }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #8292
- This change ensures that navigating to a new tab does not cause the current sidebar to sometimes close.
- Added a couple of unrelated changes to improve e2e flakiness.

## Discussion

See inline notes in code.

## Checklist

- [X] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @BLoe 
