### PR TITLE
Fix mv2 permissions

### DIFF
--- a/scripts/__snapshots__/manifest.test.js.snap
+++ b/scripts/__snapshots__/manifest.test.js.snap
@@ -107,9 +107,9 @@ exports[`customizeManifest release builds beta 1`] = `
     "webNavigation",
     "contextMenus",
     "alarms",
-    "offscreen",
     "devtools",
     "scripting",
+    "offscreen",
     "sidePanel",
   ],
   "sandbox": {
@@ -255,7 +255,6 @@ exports[`customizeManifest release builds mv2 1`] = `
     "contextMenus",
     "<all_urls>",
     "alarms",
-    "offscreen",
   ],
   "sandbox": {
     "pages": [
@@ -393,9 +392,9 @@ exports[`customizeManifest release builds mv3 1`] = `
     "webNavigation",
     "contextMenus",
     "alarms",
-    "offscreen",
     "devtools",
     "scripting",
+    "offscreen",
     "sidePanel",
   ],
   "sandbox": {

--- a/scripts/manifest.mjs
+++ b/scripts/manifest.mjs
@@ -69,7 +69,7 @@ function updateManifestToV3(manifestV2) {
 
   // Extract host permissions
   const { permissions, origins } = normalizeManifestPermissions(manifest);
-  manifest.permissions = [...permissions, "scripting"];
+  manifest.permissions = [...permissions, "scripting", "offscreen"];
   manifest.host_permissions = origins;
   // Sidebar Panel open() is only available in Chrome 116+
   // https://developer.chrome.com/docs/extensions/reference/api/sidePanel#method-open

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -52,8 +52,7 @@
     "webNavigation",
     "contextMenus",
     "<all_urls>",
-    "alarms",
-    "offscreen"
+    "alarms"
   ],
   "devtools_page": "devtools.html",
   "externally_connectable": {


### PR DESCRIPTION
## What does this PR do?

- Removes the invalid `offscreen` permission from mv2 manifests
- Ensures the `offscreen` permission is still added to mv3 manifests

## Checklist

- [x] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer @mnholtz 
