### PR TITLE
#8382: brick to export data url as file

### DIFF
--- a/src/bricks/effects/exportFileEffect.test.ts
+++ b/src/bricks/effects/exportFileEffect.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import ExportFileEffect from "@/bricks/effects/exportFileEffect";
+import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
+import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
+import download from "downloadjs";
+
+jest.mock("downloadjs");
+
+const downloadMock = jest.mocked(download);
+
+describe("ExportFileEffect", () => {
+  it("downloads GIF file", async () => {
+    const brick = new ExportFileEffect();
+
+    await brick.run(
+      unsafeAssumeValidArg({
+        data: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+      }),
+      brickOptionsFactory(),
+    );
+
+    expect(downloadMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/bricks/effects/exportFileEffect.ts
+++ b/src/bricks/effects/exportFileEffect.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { EffectABC } from "@/types/bricks/effectTypes";
+import type { BrickArgs } from "@/types/runtimeTypes";
+import type { Schema } from "@/types/schemaTypes";
+import type { PlatformCapability } from "@/platform/capabilities";
+import { propertiesToSchema } from "@/utils/schemaUtils";
+
+/**
+ * Brick to export a data URL as a file.
+ * @since 1.8.14
+ */
+class ExportFileEffect extends EffectABC {
+  constructor() {
+    super(
+      "@pixiebrix/export/file",
+      "[Experimental] Export as File",
+      "Export/download a data URL as a file",
+    );
+  }
+
+  inputSchema: Schema = propertiesToSchema(
+    {
+      data: {
+        type: "string",
+        description:
+          "A data URL: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs",
+      },
+      filename: {
+        type: "string",
+        description: "An optional filename, or exclude to generate",
+      },
+    },
+    ["data"],
+  );
+
+  override async getRequiredCapabilities(): Promise<PlatformCapability[]> {
+    // XXX: might introduce a "download" capability in the future, e.g., to support making the file as an artifact
+    // from a headless platform run
+    return ["dom"];
+  }
+
+  async effect({
+    filename = "exported",
+    data,
+  }: BrickArgs<{
+    filename?: string;
+    data: string;
+  }>): Promise<void> {
+    const { default: download } = await import(
+      /* webpackChunkName: "downloadjs" */ "downloadjs"
+    );
+
+    download(data, filename);
+  }
+}
+
+export default ExportFileEffect;

--- a/src/bricks/effects/getAllEffects.ts
+++ b/src/bricks/effects/getAllEffects.ts
@@ -58,6 +58,7 @@ import SetToolbarBadge from "@/bricks/effects/setToolbarBadge";
 import InsertAtCursorEffect from "@/bricks/effects/InsertAtCursorEffect";
 import AddDynamicTextSnippet from "@/bricks/effects/AddDynamicTextSnippet";
 import AddTextSnippets from "@/bricks/effects/AddTextSnippets";
+import ExportFileEffect from "@/bricks/effects/exportFileEffect";
 
 function getAllEffects(): Brick[] {
   return [
@@ -80,6 +81,7 @@ function getAllEffects(): Brick[] {
     new AssignModVariable(),
     new HideEffect(),
     new ExportCsv(),
+    new ExportFileEffect(),
     new HideSidebar(),
     new ShowSidebar(),
     new ToggleSidebar(),

--- a/src/development/headers.test.ts
+++ b/src/development/headers.test.ts
@@ -25,7 +25,7 @@ import registerBuiltinBricks from "@/bricks/registerBuiltinBricks";
 import registerContribBlocks from "@/contrib/registerContribBlocks";
 
 // Maintaining this number is a simple way to ensure bricks don't accidentally get dropped
-const EXPECTED_HEADER_COUNT = 136;
+const EXPECTED_HEADER_COUNT = 137;
 
 registerBuiltinBricks();
 registerContribBlocks();

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -117,6 +117,7 @@
     "./bricks/effects/error.ts",
     "./bricks/effects/event.ts",
     "./bricks/effects/exportCsv.ts",
+    "./bricks/effects/exportFileEffect.ts",
     "./bricks/effects/forms.ts",
     "./bricks/effects/hide.ts",
     "./bricks/effects/highlight.ts",


### PR DESCRIPTION
## What does this PR do?

- Closes #8383
- Adds brick to export data URL as a file

## Demo

- https://www.loom.com/share/65d54774fffe4fe5b17c52ca69eec8a8

## Checklist

- [x] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer: @fungairino 
