### PR TITLE
Avoid running CI workflow twice for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
   push:
     branches-ignore:
-      - master
+      - main
 
 env:
   # Creates and uploads sourcemaps to Application error telemetry, and save the built extension as an artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches-ignore:
+      - master
 
 env:
   # Creates and uploads sourcemaps to Application error telemetry, and save the built extension as an artifact


### PR DESCRIPTION
## What does this PR do?

- Makes it so that we don't run the CI workflow twice for every PR. Now it just runs when a PR is cut against master, or when a push is made to any other branch.

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @grahamlangford 
