### PR TITLE
Fix ci running twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,16 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - .gitignore
+      - .editorconfig
+      - LICENSE
+      - "**.iml"
+      - .idea/**
   push:
-    branches-ignore:
-      - main
+    branches:
+      - release/**
 
 env:
   # Creates and uploads sourcemaps to Application error telemetry, and save the built extension as an artifact

--- a/.github/workflows/rainforestqa.yml
+++ b/.github/workflows/rainforestqa.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches:
       - main
-      - release/*
+      - release/**
   schedule:
     - cron: "0 8 * * *" # 8am UTC -> 3am EST
 


### PR DESCRIPTION
## What does this PR do?

- Ensures CI wf only runs on PR and when pushed to a release branch
- Doesn't run on simple changes that don't affect the code


## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @grahamlangford 
