### PR TITLE
#8418: make RJSF select clearable in Form Builder

### DIFF
--- a/src/components/formBuilder/RjsfSelectWidget.test.tsx
+++ b/src/components/formBuilder/RjsfSelectWidget.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { render } from "@/sidebar/testHelpers";
+import CustomFormComponent from "@/bricks/renderers/CustomFormComponent";
+import type { Schema } from "@/types/schemaTypes";
+import selectEvent from "react-select-event";
+import { act, screen } from "@testing-library/react";
+
+describe("RjsfSelectWidget", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("CustomFormComponent renders clearable widget", async () => {
+    const schema: Schema = {
+      type: "object",
+      properties: {
+        fruit: {
+          type: "string",
+          title: "Fruit",
+          enum: ["apple", "banana", "cherry"],
+        },
+      },
+    };
+
+    render(
+      <CustomFormComponent
+        schema={schema}
+        formData={{}}
+        uiSchema={{}}
+        submitCaption="Submit"
+        autoSave={false}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    const select = screen.getByRole("combobox");
+
+    await act(async () => {
+      await selectEvent.select(select, "banana");
+    });
+
+    await act(async () => {
+      await selectEvent.clearAll(select);
+    });
+  });
+
+  test("CustomFormComponent renders required widget", async () => {
+    const schema: Schema = {
+      type: "object",
+      properties: {
+        fruit: {
+          type: "string",
+          title: "Fruit",
+          enum: ["apple", "banana", "cherry"],
+        },
+      },
+      required: ["fruit"],
+    };
+
+    render(
+      <CustomFormComponent
+        schema={schema}
+        formData={{}}
+        uiSchema={{}}
+        submitCaption="Submit"
+        autoSave={false}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    const select = screen.getByRole("combobox");
+
+    await act(async () => {
+      await selectEvent.select(select, "banana");
+    });
+
+    // Should fail because the clear all can't be found
+    await expect(selectEvent.clearAll(select)).rejects.toThrow();
+  });
+});

--- a/src/components/formBuilder/RjsfSelectWidget.tsx
+++ b/src/components/formBuilder/RjsfSelectWidget.tsx
@@ -35,8 +35,8 @@ const RjsfSelectWidget: React.FC<WidgetProps> = ({
   multiple,
 }) => {
   const _onChange = (option: OptionType | null) => {
-    // FIXME: this will pass "" when the value is cleared, but the form may expect undefined/null
-    onChange(option ? option.value : "");
+    // Pass `undefined` on clear to indicate no value is selected. In JSON Schema validation, `null` is a type
+    onChange(option ? option.value : undefined);
   };
 
   const _onBlur = () => {

--- a/src/components/formBuilder/RjsfSelectWidget.tsx
+++ b/src/components/formBuilder/RjsfSelectWidget.tsx
@@ -23,7 +23,6 @@ type OptionType = { label: string; value: string };
 const DEFAULT_OPTION: OptionType[] = [];
 
 const RjsfSelectWidget: React.FC<WidgetProps> = ({
-  schema,
   id,
   options,
   value,
@@ -33,11 +32,10 @@ const RjsfSelectWidget: React.FC<WidgetProps> = ({
   onChange,
   onBlur,
   onFocus,
-  rawErrors,
-  label,
   multiple,
 }) => {
   const _onChange = (option: OptionType | null) => {
+    // FIXME: this will pass "" when the value is cleared, but the form may expect undefined/null
     onChange(option ? option.value : "");
   };
 
@@ -64,6 +62,7 @@ const RjsfSelectWidget: React.FC<WidgetProps> = ({
     <div data-testid="formbuilder-select-wrapper">
       <Select
         id={id}
+        isClearable={!required}
         options={selectOptions}
         isDisabled={disabled || readonly}
         isMulti={multiple}


### PR DESCRIPTION
## What does this PR do?

- Closes #8418
- Make RJSF select widget clearable if the field is not required

## Remaining Work

- [x] Decide value on clear: `""` vs. `null` vs. `undefined`
- [x] Add Jest tests

## Demo

- See Jest test. Can't record Loom from plane

## Future Work

- https://github.com/pixiebrix/pixiebrix-extension/issues/8422

## Checklist

- [x] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer: @BLoe 
