### PR TITLE
Add isMV3 to blobToImageData

### DIFF
--- a/src/utils/canvasUtils.ts
+++ b/src/utils/canvasUtils.ts
@@ -47,6 +47,10 @@ async function loadBlobAsImage(
   return image;
 }
 
+function isHTMLImageElement(image: unknown): image is HTMLImageElement {
+  return !isMV3 && image instanceof HTMLImageElement;
+}
+
 /**
  * Converts a blob into ImageData.
  *
@@ -60,7 +64,7 @@ export async function blobToImageData(
   const image = await loadBlobAsImage(blob);
   // Can only check for HTMLImageElement in MV2
   // TODO: Remove this check when MV3 is the only supported version and we are using only PNGs
-  const isImageElement = !isMV3 && image instanceof HTMLImageElement;
+  const isImageElement = isHTMLImageElement(image);
 
   // SVGs might not have width/height attributes, but they likely have a viewBox
   // so their aspect ratio is natively preserved, regardless of `resizeToFit`

--- a/src/utils/canvasUtils.ts
+++ b/src/utils/canvasUtils.ts
@@ -48,7 +48,7 @@ async function loadBlobAsImage(
 }
 
 function isHTMLImageElement(image: unknown): image is HTMLImageElement {
-  return !isMV3 && image instanceof HTMLImageElement;
+  return !isMV3() && image instanceof HTMLImageElement;
 }
 
 /**

--- a/src/utils/canvasUtils.ts
+++ b/src/utils/canvasUtils.ts
@@ -17,6 +17,7 @@
 
 import axios from "axios";
 import resizeToFit from "intrinsic-scale";
+import { isMV3 } from "@/mv3/api";
 
 export async function loadImageData(
   url: string,
@@ -57,7 +58,9 @@ export async function blobToImageData(
   height: number,
 ): Promise<ImageData> {
   const image = await loadBlobAsImage(blob);
-  const isImageElement = image instanceof HTMLImageElement;
+  // Can only check for HTMLImageElement in MV2
+  // TODO: Remove this check when MV3 is the only supported version and we are using only PNGs
+  const isImageElement = !isMV3 && image instanceof HTMLImageElement;
 
   // SVGs might not have width/height attributes, but they likely have a viewBox
   // so their aspect ratio is natively preserved, regardless of `resizeToFit`


### PR DESCRIPTION
This will allow us to load PNGs in MV3, while still being
backwards compatible to load SVGs in MV2

## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-app/issues/5185
- This makes it so we don't throw an undefined error when running: `image instanceof HTMLImageElement;`

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
  - I manually verified these changes against my app changes here: https://github.com/pixiebrix/pixiebrix-app/issues/5174
  - mv2 + svg, mv2 + png, mv3 + png
- [X] Designate a primary reviewer @grahamlangford 
