### PR TITLE
#8104 Do not automatically close the sidebar when saving in the Page Editor

### DIFF
--- a/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
@@ -89,7 +89,7 @@ export class ModsPage {
         timeout: 500,
       });
     }).toPass({
-      timeout: 2000,
+      timeout: 5000,
     });
 
     await expect(async () => {

--- a/end-to-end-tests/pageObjects/pageEditorPage.ts
+++ b/end-to-end-tests/pageObjects/pageEditorPage.ts
@@ -110,6 +110,10 @@ export class PageEditorPage {
     return this.page.getByText(text);
   }
 
+  getRenderPanelButton() {
+    return this.page.getByRole("button", { name: "Render Panel" });
+  }
+
   getIncrementVersionErrorToast() {
     return this.page.getByText(
       "Cannot overwrite version of a published brick. Increment the version",
@@ -117,6 +121,10 @@ export class PageEditorPage {
   }
 
   async saveStandaloneMod(modName: string) {
+    // We need to wait at least 500ms to permit the page editor to persist the mod changes to redux before saving.
+    // https://github.com/pixiebrix/pixiebrix-extension/blob/277eab74d2c85c2d16053bbcd27023d2612f9e31/src/pageEditor/panes/EditorPane.tsx#L48
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- see above
+    await this.page.waitForTimeout(600);
     const modListItem = this.page.locator(".list-group-item", {
       hasText: modName,
     });

--- a/end-to-end-tests/tests/regressions/doNotCloseSidebarOnPageEditorSave.spec.ts
+++ b/end-to-end-tests/tests/regressions/doNotCloseSidebarOnPageEditorSave.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { test, expect } from "../../fixtures/extensionBase";
+// @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
+import { type Page, test as base } from "@playwright/test";
+import { getSidebarPage } from "../../utils";
+
+test("#8104: Do not automatically close the sidebar when saving in the Page Editor", async ({
+  page,
+  newPageEditorPage,
+  extensionId,
+}) => {
+  await page.goto("/");
+  const pageEditorPage = await newPageEditorPage(page.url());
+
+  const modName = await pageEditorPage.addStarterBrick("Sidebar Panel");
+
+  const sidebar = await getSidebarPage(page, extensionId);
+  await expect(
+    sidebar.getByRole("tab", { name: "pbx.vercel.app side panel" }),
+  ).toBeVisible();
+
+  const updatedTabTitle = "Updated Tab Title";
+  await pageEditorPage.fillInBrickField("Tab Title", updatedTabTitle);
+  await pageEditorPage.getRenderPanelButton().click();
+  await expect(
+    sidebar.getByRole("tab", { name: updatedTabTitle }),
+  ).toBeVisible();
+
+  await pageEditorPage.saveStandaloneMod(modName);
+
+  await expect(
+    sidebar.getByRole("tab", { name: updatedTabTitle }),
+  ).toBeVisible();
+});

--- a/end-to-end-tests/utils.ts
+++ b/end-to-end-tests/utils.ts
@@ -126,6 +126,8 @@ export async function getSidebarPage(
   if (MV === "3") {
     let sidebarPage: Page | undefined;
 
+    await page.bringToFront(); // Ensure the tab is active before interacting with the sidebar
+
     // In MV3, the sidebar sometimes requires the user to interact with modal to open the sidebar via a user gesture
     const conditionallyPerformUserGesture = async () => {
       await page.getByRole("button", { name: "Open Sidebar" }).click();

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -409,10 +409,17 @@ async function loadPersistedExtensions(): Promise<StarterBrick[]> {
   // Exclude the following:
   // - disabled deployments: the organization admin might have disabled the deployment because via Admin Console
   // - dynamic extensions: these are already installed on the page via the Page Editor
-  const activeExtensions = options.extensions.filter(
-    (extension) =>
-      isDeploymentActive(extension) && !_editorExtensions.has(extension.id),
-  );
+  const activeExtensions = options.extensions.filter((extension) => {
+    if (_editorExtensions.has(extension.id)) {
+      const editorExtension = _editorExtensions.get(extension.id);
+      // Include sidebar (i.e. "actionPanel") starterbrick kind as those are replaced
+      // by the sidebar itself, automatically replacing old panels keyed by extension id
+      return editorExtension.kind === "actionPanel";
+    }
+
+    // Exclude disabled deployments
+    return isDeploymentActive(extension);
+  });
 
   const resolvedActiveExtensions = await logPromiseDuration(
     "loadPersistedExtensions:resolveDefinitions",


### PR DESCRIPTION
## What does this PR do?

- Closes #8104

## Discussion

- reading `lifecycle.ts` and trying to understand all the different code execution paths gives me a migraine.
- I'm not a fan of the check for sidebar kind equals "actionPanel" that we do in many different places. 
- I manually verified that the regression fixed in this PR with trigger mods running multiple times after save doesn't happen: https://github.com/pixiebrix/pixiebrix-extension/pull/5505

## Checklist

- [X] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @BLoe 
