### PR TITLE
custom eslint rule for e2e test length

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -185,6 +185,7 @@ module.exports = {
               "CallExpression[callee.property.name='toPass'][arguments.length=0]",
           },
         ],
+        "local-rules/preferUsingStepsForLongTests": "error",
       },
     },
     {

--- a/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
@@ -51,8 +51,6 @@ export class ModsPage {
     return this.page.getByRole("table").locator(".list-group-item");
   }
 
-  // TODO: remove knip comment once this method is used in a test
-  /** @knip test helper, will be used in future tests */
   searchModsInput() {
     return this.page.getByTestId("blueprints-search-input");
   }

--- a/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
+++ b/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
@@ -54,8 +54,6 @@ test("can activate a mod with built-in integration", async ({
 }) => {
   test.skip(MV === "2", "Service worker request mocking only available in MV3");
 
-  const modId = "@pixies/giphy/giphy-search";
-
   let giphyRequestPostData: Serializable;
   // The giphy search request is proxied through the PixieBrix server, which is kicked off in the background/service
   // worker. Playwright experimentally supports mocking service worker requests, see
@@ -74,6 +72,7 @@ test("can activate a mod with built-in integration", async ({
     return route.continue();
   });
 
+  const modId = "@pixies/giphy/giphy-search";
   const modActivationPage = new ActivateModPage(page, extensionId, modId);
   await modActivationPage.goto();
 

--- a/eslint-local-rules/preferUsingStepsForLongTests.js
+++ b/eslint-local-rules/preferUsingStepsForLongTests.js
@@ -1,0 +1,58 @@
+module.exports = {
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "test" &&
+          node.arguments.length > 1 &&
+          node.arguments[1].type === "ArrowFunctionExpression"
+        ) {
+          const testFunctionBody = node.arguments[1].body;
+          const isTestStepUsed = testFunctionBody.body.some(
+            (statement) =>
+              statement.type === "ExpressionStatement" &&
+              statement.expression.type === "AwaitExpression" &&
+              statement.expression.argument.type === "CallExpression" &&
+              statement.expression.argument.callee.type ===
+                "MemberExpression" &&
+              statement.expression.argument.callee.object.name === "test" &&
+              statement.expression.argument.callee.property.name === "step",
+          );
+
+          const startLine = node.arguments[1].loc.start.line;
+          const endLine = node.arguments[1].loc.end.line;
+
+          const commentLines = new Set();
+          for (const comment of sourceCode.getAllComments()) {
+            if (
+              comment.loc.start.line >= startLine &&
+              comment.loc.end.line <= endLine
+            ) {
+              for (
+                let i = comment.loc.start.line;
+                i <= comment.loc.end.line;
+                i++
+              ) {
+                commentLines.add(i);
+              }
+            }
+          }
+
+          const lineCount = endLine - startLine + 1 - commentLines.size;
+
+          if (!isTestStepUsed && lineCount > 60) {
+            context.report({
+              node,
+              message:
+                `Playwright test is over 60 lines long (${lineCount} lines, ${commentLines.size} comment lines not included), and is not split up by steps. Use \`test.step\` to split up ` +
+                "the test into smaller steps or refactor functionality into helper methods or page objects.",
+            });
+          }
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
This rule will encourage us to break up long tests using refactored page methods or `test.step`

Primary reviewer @grahamlangford 