### PR TITLE
Add additional optional chaining to prevent import errors when chrome api not available

### DIFF
--- a/src/mv3/api.ts
+++ b/src/mv3/api.ts
@@ -20,12 +20,15 @@
 import { type Tabs } from "webextension-polyfill";
 import { once } from "lodash";
 
-export const isMV3 = once(
-  (): boolean =>
-    // Use optional chaining in case the chrome runtime is not available:
-    // https://github.com/pixiebrix/pixiebrix-extension/issues/8273
-    chrome.runtime?.getManifest().manifest_version === 3,
-);
+export const isMV3 = once((): boolean => {
+  if (!chrome.runtime?.getManifest) {
+    return false;
+  }
+
+  // Use optional chaining in case the chrome runtime is not available:
+  // https://github.com/pixiebrix/pixiebrix-extension/issues/8273
+  return chrome.runtime.getManifest().manifest_version === 3;
+});
 export const browserAction =
   globalThis.chrome?.browserAction ?? globalThis.chrome?.action;
 export type Tab = Tabs.Tab | chrome.tabs.Tab;

--- a/src/tinyPages/offscreen.ts
+++ b/src/tinyPages/offscreen.ts
@@ -26,7 +26,7 @@ let createOffscreenDocumentPromise: Promise<void> | null = null;
 
 // Use optional chaining in case the chrome runtime is not available:
 // https://github.com/pixiebrix/pixiebrix-extension/issues/8397
-chrome.runtime?.onMessage.addListener(handleMessages);
+chrome.runtime?.onMessage?.addListener(handleMessages);
 
 export type RecordErrorMessage = {
   target: "offscreen-doc";


### PR DESCRIPTION
## What does this PR do?

- Follow-up of https://github.com/pixiebrix/pixiebrix-extension/pull/8275
- It looks like optional chaining that we added was not enough to prevent import errors. 

## Discussion

- For some reason, the changes made in the previous PR were passing cypress tests in headless mode (and local builds looked fine) but Misha's cypress tests are failing in UI mode, and staging is down
- We should seriously consider adding smoke tests to dev and staging

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer @johnnymetz 
