### PR TITLE
Fix the richly formatted, webhook-based Slack bricks - remove header content type hack

### DIFF
--- a/src/contrib/slack/message.ts
+++ b/src/contrib/slack/message.ts
@@ -74,10 +74,6 @@ export class SendSimpleSlackMessage extends EffectABC {
     await platform.request(null, {
       url: hookUrl,
       method: "post",
-      // https://stackoverflow.com/questions/45752537/slack-incoming-webhook-request-header-field-content-type-is-not-allowed-by-acce
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
       data: {
         text,
         icon_emoji: iconEmoji,
@@ -204,10 +200,6 @@ export class SendAdvancedSlackMessage extends EffectABC {
     await platform.request(null, {
       url: hookUrl,
       method: "post",
-      // https://stackoverflow.com/questions/45752537/slack-incoming-webhook-request-header-field-content-type-is-not-allowed-by-acce
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
       data: {
         text,
         icon_emoji: iconEmoji,


### PR DESCRIPTION
## What does this PR do?

- Removes the content type header hack on the slack bricks, looks like we don't need it anymore, and it also started breaking for some reason after our Axios upgrade in v1.8.14

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer - @grahamlangford 
