### PR TITLE
Fix AA CoPilot sidebar window messaging

### DIFF
--- a/src/contrib/automationanywhere/aaFrameProtocol.ts
+++ b/src/contrib/automationanywhere/aaFrameProtocol.ts
@@ -94,12 +94,14 @@ export async function initCopilotMessenger(): Promise<void> {
       const data = hostData.get(event.data.processId) ?? {};
 
       console.debug("Received AARI data request", {
+        location: window.location.href,
         event,
         currentProcessData: data,
       });
 
       // @ts-expect-error -- incorrect types https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#examples
-      event.source.postMessage({ data }, event.origin);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access -- See above
+      event.source.parent?.postMessage({ data }, event.origin);
     }
   });
 


### PR DESCRIPTION
## What does this PR do?

- AA changed the structure of their copilot app to have two nested iFrames now, and the receiver for our message is apparently now in the _outer_ frame and not the inner copilot one that _sends_ the message, so we need to post to the parent of the source instead

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [ ] Designate a primary reviewer
