### PR TITLE
group all patch updates into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
     assignees:
       - grahamlangford
     groups:
+      patch:
+        patterns:
+          - "*"
+        update-types:
+          - patch
       rjsf:
         patterns:
           - "@rjsf/*"


### PR DESCRIPTION
## What does this PR do?

- Reduce the number of dependabot PR runs that run every Sunday by grouping all patch updates into a single PR
- Patch updates are very unlikely to cause an issue, and running fewer action runs will reduce the number of flaky Playwright runs
- We already auto-approve and auto-merge patch dependency updates every week

## Checklist

- [x] Designate a primary reviewer @fungairino 
