### PR TITLE
fix e2e flakiness with deleting mods cleanup

### DIFF
--- a/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
@@ -30,9 +30,10 @@ export class ModsPage {
   }
 
   async goto() {
-    // When loading the mods table a second time, the cached version of the table is shown, but interacting
-    // with the table is inconsistent because once the registry request finishes, the table is re-rendered, and any row dropdowns are closed.
+    // Interacting with the table is inconsistent after loading it because once the registry request finishes,
+    // the table is re-rendered, and any row action dropdowns are closed.
     // To ensure the table is fully loaded, we wait for the registry request to finish before interacting with the table.
+    // TODO: remove once fixed: https://github.com/pixiebrix/pixiebrix-extension/issues/8458
     const registryPromise = this.page
       .context()
       .waitForEvent("requestfinished", (request) =>

--- a/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
@@ -35,9 +35,9 @@ export class ModsPage {
     // To ensure the table is fully loaded, we wait for the registry request to finish before interacting with the table.
     const registryPromise = this.page
       .context()
-      .waitForEvent("requestfinished", (request) => {
-        return request.url().includes("/api/registry/bricks/");
-      });
+      .waitForEvent("requestfinished", (request) =>
+        request.url().includes("/api/registry/bricks/"),
+      );
     await this.page.goto(this.extensionConsoleUrl);
     await expect(this.page.getByText("Extension Console")).toBeVisible();
     await registryPromise;


### PR DESCRIPTION
## What does this PR do?

This PR introduces changes to the `ModsPage` class in the `end-to-end-tests/pageObjects/extensionConsole/modsPage.ts` file. The changes include:

- Adding a mechanism to wait for the registry request to finish before interacting with the mods table. This ensures that the table is fully loaded and stable.
- Adding a check to ensure that the page content has finished loading.
- Refactoring the `deleteModByName` method to improve the handling of the mod deletion process. This includes better handling of the dropdown menu and the deletion confirmation modal.

## Reviewer Tips

The reviewer should review the changes in the `end-to-end-tests/pageObjects/extensionConsole/modsPage.ts` file.

## Discussion

The changes were made to improve the stability and reliability of the end-to-end tests, particularly when interacting with the mods table and deleting mods.

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @grahamlangford 