### PR TITLE
fix invalid semver version error

### DIFF
--- a/src/background/installer.test.ts
+++ b/src/background/installer.test.ts
@@ -274,4 +274,11 @@ describe("getAvailableVersion", () => {
 
     expect(getAvailableVersion()).toBe("1.2.3");
   });
+
+  test("returns null if no version set", () => {
+    // Override type to allow for testing null _availableVersion
+    setAvailableVersion({ version: null as unknown as string });
+
+    expect(getAvailableVersion()).toBeNull();
+  });
 });

--- a/src/background/installer.test.ts
+++ b/src/background/installer.test.ts
@@ -19,6 +19,8 @@ import {
   requirePartnerAuth,
   openInstallPage,
   showInstallPage,
+  getAvailableVersion,
+  setAvailableVersion,
 } from "@/background/installer";
 import * as auth from "@/auth/authStorage";
 import { locator } from "@/background/locator";
@@ -258,4 +260,18 @@ describe("handleInstall", () => {
       expect(createTabMock).not.toHaveBeenCalled();
     },
   );
+});
+
+describe("getAvailableVersion", () => {
+  test("returns the set version", () => {
+    setAvailableVersion({ version: "1.2.3" });
+
+    expect(getAvailableVersion()).toBe("1.2.3");
+  });
+
+  test("returns the version coerced to a semver string", () => {
+    setAvailableVersion({ version: "1.2.3.4000" });
+
+    expect(getAvailableVersion()).toBe("1.2.3");
+  });
 });

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -42,6 +42,7 @@ import {
 } from "@/utils/extensionUtils";
 import { oncePerSession } from "@/mv3/SessionStorage";
 import { resetFeatureFlagsCache } from "@/auth/featureFlagStorage";
+import { normalizeSemVerString } from "@/types/helpers";
 
 /**
  * The latest version of PixieBrix available in the Chrome Web Store, or null if the version hasn't been fetched.
@@ -299,14 +300,14 @@ export async function showInstallPage({
   }
 }
 
-function setAvailableVersion({
+export function setAvailableVersion({
   version,
 }: Runtime.OnUpdateAvailableDetailsType): void {
   _availableVersion = version;
 }
 
 export function getAvailableVersion(): typeof _availableVersion {
-  return _availableVersion;
+  return normalizeSemVerString(_availableVersion, { coerce: true });
 }
 
 /**

--- a/src/background/installer.ts
+++ b/src/background/installer.ts
@@ -43,6 +43,7 @@ import {
 import { oncePerSession } from "@/mv3/SessionStorage";
 import { resetFeatureFlagsCache } from "@/auth/featureFlagStorage";
 import { normalizeSemVerString } from "@/types/helpers";
+import { type SemVerString } from "@/types/registryTypes";
 
 /**
  * The latest version of PixieBrix available in the Chrome Web Store, or null if the version hasn't been fetched.
@@ -306,7 +307,11 @@ export function setAvailableVersion({
   _availableVersion = version;
 }
 
-export function getAvailableVersion(): typeof _availableVersion {
+export function getAvailableVersion(): SemVerString | null {
+  if (!_availableVersion) {
+    return null;
+  }
+
   return normalizeSemVerString(_availableVersion, { coerce: true });
 }
 


### PR DESCRIPTION
## What does this PR do?

- Fixes `Invalid Version` error from datadog
- See https://app.datadoghq.com/logs/error-tracking/issue/d3606bc4-07c1-11ef-ad7a-da7ad0900002?from_ts=1715616006615&to_ts=1715702406615&live=true 

## Checklist

- [x] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer @BLoe 