### PR TITLE
form validation errors support showing a button link

### DIFF
--- a/src/components/form/ConnectedFieldTemplate.tsx
+++ b/src/components/form/ConnectedFieldTemplate.tsx
@@ -59,11 +59,24 @@ function FormikFieldTemplate<Values>({
       typeof error === "string" &&
       !isNullOrBlank(error);
 
-    const annotation: FieldAnnotation = {
-      message: error as string,
-      type: AnnotationType.Error,
-    };
     if (showFormikError) {
+      // The error message could end in a Markdown link [label](url), which is extracted and shown as a button link.
+      const markdownLinkRegex = /\[([^\]]+)]\(([^)]+)\)$/;
+      const documentationLink = markdownLinkRegex.exec(error);
+      const annotation: FieldAnnotation = {
+        message: error.replace(markdownLinkRegex, ""),
+        type: AnnotationType.Error,
+        actions: documentationLink
+          ? [
+              {
+                caption: documentationLink[1],
+                async action() {
+                  window.open(documentationLink[2], "_blank");
+                },
+              },
+            ]
+          : undefined,
+      };
       annotations.push(annotation);
     }
 

--- a/src/components/form/ConnectedFieldTemplate.tsx
+++ b/src/components/form/ConnectedFieldTemplate.tsx
@@ -69,7 +69,7 @@ function FormikFieldTemplate<Values>({
         actions: documentationLink
           ? [
               {
-                caption: documentationLink[1],
+                caption: documentationLink[1] || "Read more",
                 async action() {
                   window.open(documentationLink[2], "_blank");
                 },

--- a/src/components/form/ConnectedFieldTemplate.tsx
+++ b/src/components/form/ConnectedFieldTemplate.tsx
@@ -22,7 +22,7 @@ import FieldTemplate, {
 } from "@/components/form/FieldTemplate";
 import { useSelector } from "react-redux";
 import type { FieldAnnotation } from "@/components/form/FieldAnnotation";
-import { isNullOrBlank } from "@/utils/stringUtils";
+import { extractMarkdownLink, isNullOrBlank } from "@/utils/stringUtils";
 import { AnnotationType } from "@/types/annotationTypes";
 import AnalysisAnnotationsContext from "@/analysis/AnalysisAnnotationsContext";
 import { makeFieldAnnotationsForValue } from "@/components/form/makeFieldAnnotationsForValue";
@@ -61,19 +61,16 @@ function FormikFieldTemplate<Values>({
 
     if (showFormikError) {
       // The error message could end in a Markdown link [label](url), which is extracted and shown as a button link.
-      const markdownLinkRegex = /\[([^\]]+)]\(([^)]+)\)$/;
-      const documentationLink = markdownLinkRegex.exec(error);
+      const documentationLink = extractMarkdownLink(error);
       const annotation: FieldAnnotation = {
-        message: documentationLink
-          ? error.replace(markdownLinkRegex, "")
-          : error,
+        message: documentationLink?.rest || error,
         type: AnnotationType.Error,
         actions: documentationLink
           ? [
               {
-                caption: documentationLink[1] || "Read more",
+                caption: documentationLink.label || "Read more",
                 async action() {
-                  window.open(documentationLink[2], "_blank");
+                  window.open(documentationLink.url, "_blank");
                 },
               },
             ]

--- a/src/components/form/ConnectedFieldTemplate.tsx
+++ b/src/components/form/ConnectedFieldTemplate.tsx
@@ -64,7 +64,9 @@ function FormikFieldTemplate<Values>({
       const markdownLinkRegex = /\[([^\]]+)]\(([^)]+)\)$/;
       const documentationLink = markdownLinkRegex.exec(error);
       const annotation: FieldAnnotation = {
-        message: error.replace(markdownLinkRegex, ""),
+        message: documentationLink
+          ? error.replace(markdownLinkRegex, "")
+          : error,
         type: AnnotationType.Error,
         actions: documentationLink
           ? [

--- a/src/components/form/Form.stories.tsx
+++ b/src/components/form/Form.stories.tsx
@@ -52,7 +52,13 @@ const componentMeta: ComponentMeta<typeof Form> = {
 const SchemaShape = yup.object().shape({
   title: yup.string().optional().oneOf(["Mr.", "Ms.", "Mrs.", "other"]),
   name: yup.string().required(),
-  age: yup.number().required("What's your age again?").positive().integer(),
+  age: yup
+    .number()
+    .required(
+      "What's your age again? [Age calculator](https://www.calculator.net/age-calculator.html)",
+    )
+    .positive()
+    .integer(),
 });
 
 const initialValues = {

--- a/src/utils/stringUtils.test.ts
+++ b/src/utils/stringUtils.test.ts
@@ -178,6 +178,17 @@ describe("extractMarkdownLink", () => {
     });
   });
 
+  it("only extracts the last Markdown link in the string", () => {
+    const text =
+      "This is a test string with two links [one](oneUrl) [two](twoUrl)";
+    const result = extractMarkdownLink(text);
+    expect(result).toEqual({
+      rest: "This is a test string with two links [one](oneUrl)",
+      label: "two",
+      url: "twoUrl",
+    });
+  });
+
   it("returns null if the string does not contain a Markdown link", () => {
     const text = "This is a test string without a Markdown link";
     const result = extractMarkdownLink(text);

--- a/src/utils/stringUtils.test.ts
+++ b/src/utils/stringUtils.test.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  extractMarkdownLink,
   matchesAnyPattern,
   smartAppendPeriod,
   splitStartingEmoji,
@@ -152,5 +153,41 @@ describe("smartAppendPeriod", () => {
         }
       }
     }
+  });
+});
+
+describe("extractMarkdownLink", () => {
+  it("extracts a Markdown link from a string", () => {
+    const text =
+      "This is a test string with a [Markdown link](https://example.com)";
+    const result = extractMarkdownLink(text);
+    expect(result).toEqual({
+      rest: "This is a test string with a",
+      label: "Markdown link",
+      url: "https://example.com",
+    });
+  });
+
+  it("extracts a Markdown link with no label or url", () => {
+    const text = "This is a test string with a []()";
+    const result = extractMarkdownLink(text);
+    expect(result).toEqual({
+      rest: "This is a test string with a",
+      label: "",
+      url: "",
+    });
+  });
+
+  it("returns null if the string does not contain a Markdown link", () => {
+    const text = "This is a test string without a Markdown link";
+    const result = extractMarkdownLink(text);
+    expect(result).toBeNull();
+  });
+
+  it("returns null if the Markdown link is not at the end of the string", () => {
+    const text =
+      "This is a [Markdown link](https://example.com) in the middle of a test string";
+    const result = extractMarkdownLink(text);
+    expect(result).toBeNull();
   });
 });

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -107,3 +107,19 @@ export function escapeSingleQuotes(str: string): string {
   // https://gist.github.com/getify/3667624
   return str.replaceAll(/\\([\S\s])|(')/g, "\\$1$2");
 }
+
+/** Extracts a label and URL from a string ending with a Markdown link. It also returns the original text without the trailing link. */
+export function extractMarkdownLink(text: string) {
+  const markdownLinkRegex = /\[(?<label>[^\]]*)]\((?<url>[^)]*)\)$/;
+  const match = markdownLinkRegex.exec(text);
+
+  if (match?.groups) {
+    return {
+      rest: text.replace(markdownLinkRegex, "").trimEnd(),
+      label: match.groups.label,
+      url: match.groups.url,
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## What does this PR do?

This PR enhances the error handling in the Pixiebrix extension's form fields. It introduces the ability to include a Markdown link in the error message, which is then extracted and displayed as a button link. This allows users to be directed to relevant documentation or resources directly from the error message. The changes are demonstrated in the form story by adding a link to an age calculator in the error message for the age field.

Part of: https://github.com/pixiebrix/pixiebrix-app/issues/5213

## Discussion

The main approach was to use a regular expression to extract a Markdown link from the error message, if present. The link is then used to create a button that opens the link in a new window when clicked.

Ideally we could have defined the button link as a separate property on the validation error, but Formik does not natively support validation errors that are not of string type.

## Future Work

Change the validation error in the app console to use this new functionality to link to the deployment docs.

## Demo

https://github.com/pixiebrix/pixiebrix-extension/assets/3498063/9f3e2946-6f03-494f-9b82-5d39b1bf6708

## Checklist

- [x] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @mnholtz 