### PR TITLE
#8376 Fix show sidebar brick not refreshing panel

### DIFF
--- a/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
+++ b/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
@@ -18,7 +18,7 @@
 import { test, expect } from "../fixtures/extensionBase";
 import { ActivateModPage } from "../pageObjects/extensionConsole/modsPage";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
-import { type Page, test as base, type Frame } from "@playwright/test";
+import { test as base } from "@playwright/test";
 import {
   getSidebarPage,
   clickAndWaitForNewPage,
@@ -112,22 +112,6 @@ test("can activate a mod with built-in integration", async ({
   });
 });
 
-// Temporary hack until https://github.com/pixiebrix/pixiebrix-extension/issues/8376 is resolved
-async function reloadSidebar(
-  page: Page,
-  sideBarPage: Page | Frame,
-  extensionId: string,
-) {
-  if (MV === "3") {
-    await (sideBarPage as Page).reload();
-  } else {
-    await page.reload();
-    await runModViaQuickBar(page, "Open Sidebar");
-  }
-
-  return getSidebarPage(page, extensionId);
-}
-
 test("can activate a mod with a database", async ({ page, extensionId }) => {
   const modId = "@e2e-testing/shared-notes-sidebar";
   const note = `This is a test note ${Date.now()}`;
@@ -140,7 +124,7 @@ test("can activate a mod with a database", async ({ page, extensionId }) => {
   await page.goto("/");
 
   await runModViaQuickBar(page, "Open Sidebar");
-  let sideBarPage = await getSidebarPage(page, extensionId);
+  const sideBarPage = await getSidebarPage(page, extensionId);
 
   await sideBarPage.getByRole("button", { name: "Add note" }).click();
 
@@ -151,10 +135,6 @@ test("can activate a mod with a database", async ({ page, extensionId }) => {
     .getByRole("button", { name: "Submit" })
     .click();
 
-  // TODO: Remove when the sidebar is reloaded automatically
-  // See: https://github.com/pixiebrix/pixiebrix-extension/issues/8376
-  sideBarPage = await reloadSidebar(page, sideBarPage, extensionId);
-
   await expect(sideBarPage.getByTestId("card").getByText(note)).toBeVisible();
 
   // Get the correct container element, as the note text and delete button are wrapped in a div
@@ -162,10 +142,6 @@ test("can activate a mod with a database", async ({ page, extensionId }) => {
     .getByText(`${note} Delete Note`)
     .getByRole("button", { name: "Delete Note" })
     .click();
-
-  // TODO: Remove when the sidebar is reloaded automatically
-  // See: https://github.com/pixiebrix/pixiebrix-extension/issues/8376
-  sideBarPage = await reloadSidebar(page, sideBarPage, extensionId);
 
   await expect(sideBarPage.getByTestId("card").getByText(note)).toBeHidden();
 });

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -151,6 +151,8 @@ export async function showSidebarInTopFrame() {
   } catch (error) {
     throw new Error("The sidebar did not respond in time", { cause: error });
   }
+
+  sidebarShowEvents.emit({ reason: RunReason.MANUAL });
 }
 
 /**

--- a/src/sidebar/sidebar.tsx
+++ b/src/sidebar/sidebar.tsx
@@ -62,7 +62,7 @@ async function init(): Promise<void> {
   ReactDOM.render(<App />, document.querySelector("#container"));
 
   // XXX: Do we really want to delay the `init`? Maybe this should be last or use `getConnectedTarget().then`
-  // sidebarWasLoaded(await getConnectedTarget());
+  sidebarWasLoaded(await getConnectedTarget());
 
   initSidePanel();
   markDocumentAsFocusableByUser();

--- a/src/sidebar/sidebar.tsx
+++ b/src/sidebar/sidebar.tsx
@@ -62,7 +62,7 @@ async function init(): Promise<void> {
   ReactDOM.render(<App />, document.querySelector("#container"));
 
   // XXX: Do we really want to delay the `init`? Maybe this should be last or use `getConnectedTarget().then`
-  sidebarWasLoaded(await getConnectedTarget());
+  // sidebarWasLoaded(await getConnectedTarget());
 
   initSidePanel();
   markDocumentAsFocusableByUser();


### PR DESCRIPTION
## What does this PR do?

Fixes #8376

It removes a temporary hack that was used to reload the sidebar in the extensionConsoleActivation.spec.ts file. The hack was used to handle a situation where the sidebar was not automatically reloaded. The PR also introduces changes in the sidebarController.tsx file to ensure that the sidebar is refreshed when the "Show Sidebar brick" is triggered, even if the sidebar is already open.

## Discussion

Theres's a small chance of a race condition where the ping to check if the sidebar was initially open happens after the sidebar is actually opened, but in this case the only outcome would be that the panel modComponent would be run twice, which shouldn't really be an issue.

## Checklist

- [X] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @grahamlangford 