### PR TITLE
DX - Add BETA to dev tools panel title for the beta extension build

### DIFF
--- a/src/tinyPages/devtools.ts
+++ b/src/tinyPages/devtools.ts
@@ -28,7 +28,7 @@ if (typeof chrome.devtools.inspectedWindow.tabId === "number") {
   });
 
   chrome.devtools.panels.create(
-    "PixieBrix",
+    process.env.IS_BETA ? "PixieBrix BETA" : "PixieBrix",
     "",
     `pageEditor.html?tabId=${chrome.devtools.inspectedWindow.tabId}`,
   );


### PR DESCRIPTION
## What does this PR do?

- Adds `BETA` suffix to the dev tools panel title for the beta extension build

## Demo

<img width="485" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/2801308/7a192b0f-96fc-4c75-b452-195dd4a82b0d">

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer - @grahamlangford 
