### PR TITLE
#8287: Improve UX for long sidebar open times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "one-event": "^4.2.0",
         "p-defer": "^4.0.1",
         "p-memoize": "^7.1.1",
+        "p-retry": "^6.2.0",
         "p-timeout": "^6.1.2",
         "papaparse": "^5.4.1",
         "path-browserify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "one-event": "^4.2.0",
     "p-defer": "^4.0.1",
     "p-memoize": "^7.1.1",
+    "p-retry": "^6.2.0",
     "p-timeout": "^6.1.2",
     "papaparse": "^5.4.1",
     "path-browserify": "^1.0.1",

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -54,7 +54,7 @@ import {
   isUserGestureRequiredError,
 } from "@/utils/sidePanelUtils";
 import pRetry from "p-retry";
-import notify from "@/utils/notify";
+import notify, { hideNotification } from "@/utils/notify";
 
 const HIDE_SIDEBAR_EVENT_NAME = "pixiebrix:hideSidebar";
 
@@ -94,16 +94,20 @@ export const isSidePanelOpen = isMV3()
 // - Throw custom error if the sidebar doesn't respond in time
 const pingSidebar = memoizeUntilSettled(
   throttle(async () => {
+    let notificationId: string;
     try {
       await pRetry(
         async () => {
           await sidebarInThisTab.pingSidebar();
+          if (notificationId) {
+            hideNotification(notificationId);
+          }
         },
         {
           retries: 3,
           onFailedAttempt({ attemptNumber }) {
             if (attemptNumber === 1) {
-              notify.info(
+              notificationId = notify.info(
                 "The Sidebar is taking longer than expected to load. Retrying...",
               );
             }

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -94,7 +94,7 @@ export const isSidePanelOpen = isMV3()
 // - Throw custom error if the sidebar doesn't respond in time
 const pingSidebar = memoizeUntilSettled(
   throttle(async () => {
-    let notificationId: string;
+    let notificationId = "";
     try {
       await pRetry(
         async () => {

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -113,13 +113,16 @@ const pingSidebar = memoizeUntilSettled(
                 message:
                   "The Sidebar is taking longer than expected to load. Retrying...",
                 dismissable: false,
-                autoDismissTimeMs: 12_000,
+                // Should timeout and be removed long before this time
+                autoDismissTimeMs: 30_000,
               });
             }
           },
         },
       );
     } catch (error) {
+      // Hide the slow loading warning before showing the error
+      hideNotification(notificationId);
       // TODO: Use TimeoutError after https://github.com/sindresorhus/p-timeout/issues/41
       throw new Error(
         "The Sidebar took too long to load. Retry your last action or reopen the Sidebar",

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -54,7 +54,7 @@ import {
   isUserGestureRequiredError,
 } from "@/utils/sidePanelUtils";
 import pRetry from "p-retry";
-import notify, { hideNotification } from "@/utils/notify";
+import { hideNotification, showNotification } from "@/utils/notify";
 
 const HIDE_SIDEBAR_EVENT_NAME = "pixiebrix:hideSidebar";
 
@@ -99,6 +99,7 @@ const pingSidebar = memoizeUntilSettled(
       await pRetry(
         async () => {
           await sidebarInThisTab.pingSidebar();
+
           if (notificationId) {
             hideNotification(notificationId);
           }
@@ -107,9 +108,13 @@ const pingSidebar = memoizeUntilSettled(
           retries: 3,
           onFailedAttempt({ attemptNumber }) {
             if (attemptNumber === 1) {
-              notificationId = notify.info(
-                "The Sidebar is taking longer than expected to load. Retrying...",
-              );
+              notificationId = showNotification({
+                type: "info",
+                message:
+                  "The Sidebar is taking longer than expected to load. Retrying...",
+                dismissable: false,
+                autoDismissTimeMs: 12_000,
+              });
             }
           },
         },


### PR DESCRIPTION
## What does this PR do?

- Closes #8287 

## Reviewer Tips

- p-retry was already a dependency through webext-messenger
- This implementation emulates the way the messenger retries: https://github.com/pixiebrix/webext-messenger/blob/33b2549687da205587deb4715240a6afaf001de0/source/sender.ts#L76

## Discussion

- ~I've not been able to get the original timeout to throw on my machine, so this isn't tested beyond verifying it doesn't break typical open/close behavior~
- Tested with a mix of sleep and throwing errors


## Checklist

- [x] Designate a primary reviewer @twschiller 
