### PR TITLE
#8496: add default value to handle empty storage

### DIFF
--- a/src/background/messenger/external/_implementation.ts
+++ b/src/background/messenger/external/_implementation.ts
@@ -39,6 +39,7 @@ const HACK_EXTENSION_LINK_RELOAD_DELAY_MS = 100;
 const activationStorage = new StorageItem<ModActivationConfig[]>(
   // Keeping key for backwards compatibility
   "activatingBlueprintId",
+  { defaultValue: [] },
 );
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Fixes #8496 

## Reviewer Tips

- Issue caused by #8469
    - Previously defaulted to `[]`  https://github.com/pixiebrix/pixiebrix-extension/pull/8469/files#diff-8c5c6da446cff9fc924710d7913f17f53fc94e3abe23d05cca2d83176d5a6c50L58-L60:~:text=if%20(!value,%7D
- Resolved by adding the default value

## Discussion
- Confirmed that this is not the cause of #8497 

## Checklist

- [x] Designate a primary reviewer @BLoe 
