### PR TITLE
#8497: when installing starter mods, check existing databases before creating a new one

### DIFF
--- a/src/background/starterMods.ts
+++ b/src/background/starterMods.ts
@@ -214,6 +214,19 @@ async function activateMods(modDefinitions: ModDefinition[]): Promise<boolean> {
         optionsArgs,
         async (args) => {
           const client = await getLinkedApiClient();
+
+          // If the starter mod has been previously activated, we need to use the existing database ID
+          // Otherwise, we create a new database
+          // See:
+          const existingDatabases =
+            await client.get<Database[]>("/api/databases/");
+          const database = existingDatabases.data.find(
+            ({ name }) => name === args.name,
+          );
+          if (database) {
+            return database.id;
+          }
+
           const response = await client.post<Database>("/api/databases/", {
             name: args.name,
           });

--- a/src/background/starterMods.ts
+++ b/src/background/starterMods.ts
@@ -217,7 +217,7 @@ async function activateMods(modDefinitions: ModDefinition[]): Promise<boolean> {
 
           // If the starter mod has been previously activated, we need to use the existing database ID
           // Otherwise, we create a new database
-          // See:
+          // See: https://github.com/pixiebrix/pixiebrix-extension/pull/8499
           const existingDatabases =
             await client.get<Database[]>("/api/databases/");
           const database = existingDatabases.data.find(


### PR DESCRIPTION
## What does this PR do?

- Fixes #8497 

## Discussion

- As discussed in standup, we also considered creating an upsert endpoint
- Decided to list the databases then create if needed because we're assuming new users will have few databases anyway
    - and this way we don't have to also create and deploy an App change

## Demo

https://www.loom.com/share/797923270f844f1f92cc79358c64603c

## Checklist

- [x] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer @BLoe 
