### PR TITLE
#8516: include mod metadata with TextCommandRun event

### DIFF
--- a/src/bricks/effects/AddDynamicTextSnippet.test.ts
+++ b/src/bricks/effects/AddDynamicTextSnippet.test.ts
@@ -29,6 +29,7 @@ import ConsoleLogger from "@/utils/ConsoleLogger";
 import IdentityTransformer from "@/bricks/transformers/IdentityTransformer";
 import { getExampleBrickConfig } from "@/pageEditor/exampleBrickConfigs";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
+import { registryIdFactory } from "@/testUtils/factories/stringFactories";
 
 const brick = new AddDynamicTextSnippet();
 const identity = new IdentityTransformer();
@@ -47,7 +48,10 @@ describe("AddDynamicTextSnippet", () => {
     "registers snippet: %s",
     async (shortcut) => {
       const extensionId = uuidv4();
-      const logger = new ConsoleLogger({ extensionId });
+      const logger = new ConsoleLogger({
+        extensionId,
+        blueprintId: registryIdFactory(),
+      });
 
       const pipeline = {
         id: brick.id,
@@ -75,6 +79,12 @@ describe("AddDynamicTextSnippet", () => {
           preview: undefined,
           handler: expect.toBeFunction(),
           componentId: extensionId,
+          context: {
+            ...logger.context,
+            blockId: brick.id,
+            blockVersion: expect.toBeString(),
+            label: brick.name,
+          },
         },
       ]);
 
@@ -115,6 +125,12 @@ describe("AddDynamicTextSnippet", () => {
           preview,
           handler: expect.toBeFunction(),
           componentId: extensionId,
+          context: {
+            ...logger.context,
+            blockId: brick.id,
+            blockVersion: expect.toBeString(),
+            label: brick.name,
+          },
         },
       ]);
 

--- a/src/bricks/effects/AddDynamicTextSnippet.ts
+++ b/src/bricks/effects/AddDynamicTextSnippet.ts
@@ -123,6 +123,7 @@ class AddDynamicTextSnippet extends EffectABC {
 
     platform.snippetShortcutMenu.register({
       componentId: logger.context.extensionId,
+      context: logger.context,
       // Trim leading command key in shortcut to be resilient to user input
       shortcut: normalizeShortcut(shortcut),
       title,

--- a/src/bricks/effects/AddTextSnippets.test.ts
+++ b/src/bricks/effects/AddTextSnippets.test.ts
@@ -54,6 +54,7 @@ describe("AddTextSnippets", () => {
           preview: "test text",
           handler: expect.toBeFunction(),
           componentId: options.logger.context.extensionId,
+          context: options.logger.context,
         },
       ]);
 

--- a/src/bricks/effects/AddTextSnippets.ts
+++ b/src/bricks/effects/AddTextSnippets.ts
@@ -116,12 +116,13 @@ class AddTextSnippets extends EffectABC {
     }
 
     if (logger.context.extensionId == null) {
-      throw new Error("Must be run in the context of a mod");
+      throw new Error("Must be run in the context of a mod component");
     }
 
     for (const { shortcut, title, text } of snippets) {
       platform.snippetShortcutMenu.register({
         componentId: logger.context.extensionId,
+        context: logger.context,
         shortcut: normalizeShortcut(shortcut),
         title,
         preview: text,

--- a/src/contentScript/snippetShortcutMenu/SnippetShortcutMenu.stories.tsx
+++ b/src/contentScript/snippetShortcutMenu/SnippetShortcutMenu.stories.tsx
@@ -62,6 +62,7 @@ const Template: ComponentStory<typeof SnippetShortcutMenu> = ({
 
 const emailSnippet = {
   componentId: uuidv4(),
+  context: {},
   shortcut: "email",
   title: "email",
   async handler() {
@@ -71,6 +72,7 @@ const emailSnippet = {
 
 const timestampSnippet = {
   componentId: uuidv4(),
+  context: {},
   shortcut: "timestamp",
   title: "timestamp",
   async handler() {
@@ -80,6 +82,7 @@ const timestampSnippet = {
 
 const emojiSnippet = {
   componentId: uuidv4(),
+  context: {},
   shortcut: "emoji",
   title: "emoji",
   async handler() {
@@ -89,6 +92,7 @@ const emojiSnippet = {
 
 const slowErrorSnippet = {
   componentId: uuidv4(),
+  context: {},
   shortcut: "error",
   title: "error",
   async handler() {

--- a/src/contentScript/snippetShortcutMenu/SnippetShortcutMenu.test.tsx
+++ b/src/contentScript/snippetShortcutMenu/SnippetShortcutMenu.test.tsx
@@ -20,6 +20,7 @@ describe("Shortcut Snippet Menu", () => {
 
     registry.register({
       componentId: autoUUIDSequence(),
+      context: {},
       title: "Test",
       shortcut: "foo",
       preview: "foobar",

--- a/src/contentScript/snippetShortcutMenu/SnippetShortcutMenu.tsx
+++ b/src/contentScript/snippetShortcutMenu/SnippetShortcutMenu.tsx
@@ -189,7 +189,7 @@ const SnippetShortcutMenu: React.FunctionComponent<
         }),
       );
       try {
-        reportEvent(Events.SHORTCUT_SNIPPET_RUN);
+        reportEvent(Events.SHORTCUT_SNIPPET_RUN, snippetShortcut.context);
         const text = await snippetShortcut.handler(getElementText(element));
         await replaceAtCommandKey({ commandKey, query, element, text });
         onHide();

--- a/src/contentScript/snippetShortcutMenu/snippetShortcutMenuController.test.tsx
+++ b/src/contentScript/snippetShortcutMenu/snippetShortcutMenuController.test.tsx
@@ -65,6 +65,7 @@ describe("snippetShortcutMenuController", () => {
   it.skip("attach menu when user types command key", async () => {
     snippetRegistry.register({
       componentId: uuidv4(),
+      context: {},
       title: "Copy",
       shortcut: "copy",
       handler: jest.fn(),

--- a/src/contentScript/snippetShortcutMenu/snippetShortcutMenuSlice.test.ts
+++ b/src/contentScript/snippetShortcutMenu/snippetShortcutMenuSlice.test.ts
@@ -23,6 +23,7 @@ describe("snippetShortcutMenuSlice", () => {
   it.each(["test", "TeSt"])("case matches query: %s", (query) => {
     const snippetShortcut: SnippetShortcut = {
       componentId: autoUUIDSequence(),
+      context: {},
       shortcut: "test",
       title: "Test",
       handler: jest.fn(),

--- a/src/platform/platformTypes/snippetShortcutMenuProtocol.ts
+++ b/src/platform/platformTypes/snippetShortcutMenuProtocol.ts
@@ -16,6 +16,7 @@
  */
 
 import type { UUID } from "@/types/stringTypes";
+import type { MessageContext } from "@/types/loggerTypes";
 
 export type SnippetShortcut = {
   /**
@@ -40,6 +41,16 @@ export type SnippetShortcut = {
    * @param currentText current text in the editor
    */
   handler: (currentText: string) => Promise<string>;
+  /**
+   * Message context for telemetry
+   *
+   * Added so deployment managers can track the usage of snippets in their deployed.
+   *
+   * @since 2.0.1
+   */
+  // Keeping componentId separate for now because it's required for SnippetShortcut, but optional on MessageContext.
+  // If we wanted to consolidate, could Require the field on MessageContext.
+  context: MessageContext;
 };
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Closes #8516 
- Includes mod metadata with TextCommandRun event so deployment managers can see snippet shortcut engagement for their mods

## Checklist

- [x] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer: @grahamlangford 
