### PR TITLE
Fix offscreen errors

### DIFF
--- a/end-to-end-tests/tests/telemetry/errors.spec.ts
+++ b/end-to-end-tests/tests/telemetry/errors.spec.ts
@@ -77,7 +77,11 @@ test("can report application error to telemetry service", async ({
     expect.objectContaining({
       service: "pixiebrix-browser-extension",
       manifestVersion: 3,
-      error: expect.anything(),
+      error: expect.objectContaining({
+        stack: expect.any(String),
+        message: expect.any(String),
+        kind: expect.any(String),
+      }),
     }),
   );
 });

--- a/src/telemetry/logging.test.ts
+++ b/src/telemetry/logging.test.ts
@@ -32,6 +32,7 @@ import { registryIdFactory } from "@/testUtils/factories/stringFactories";
 import { flagOn } from "@/auth/featureFlagStorage";
 import Reason = chrome.offscreen.Reason;
 import ManifestV3 = chrome.runtime.ManifestV3;
+import { serializeError } from "serialize-error";
 
 // Disable automatic __mocks__ resolution
 jest.mock("@/telemetry/logging", () => jest.requireActual("./logging.ts"));
@@ -151,7 +152,7 @@ describe("logging", () => {
       expect.objectContaining({
         target: "offscreen-doc",
         data: expect.objectContaining({
-          error: reportedError,
+          error: serializeError(reportedError),
           errorMessage: "error message",
           messageContext: expect.objectContaining({
             cause: nestedError,

--- a/src/tinyPages/offscreen.ts
+++ b/src/tinyPages/offscreen.ts
@@ -18,6 +18,8 @@
 import type { MessageContext } from "@/types/loggerTypes";
 import { type TelemetryUser } from "@/telemetry/telemetryHelpers";
 import { type SemVerString } from "@/types/registryTypes";
+import { type SerializedError } from "@/types/messengerTypes";
+import { deserializeError } from "serialize-error";
 
 // Note that only one offscreen document can be active at a time, so it's unlikely that you'll want to create an
 // additional html document for that purpose.
@@ -32,7 +34,7 @@ export type RecordErrorMessage = {
   target: "offscreen-doc";
   type: "record-error";
   data: {
-    error: Error;
+    error: SerializedError;
     errorMessage: string;
     errorReporterInitInfo: {
       versionName: string;
@@ -111,7 +113,7 @@ export const sendErrorViaErrorReporter = async (
 
   reporter.error({
     message: errorMessage,
-    error,
+    error: deserializeError(error),
     messageContext,
   });
 };


### PR DESCRIPTION
## What does this PR do?

- Fixes datadog payload for offscreen error reporting

## Reviewer Tips

- Error has to be serialized before passing between contexts
- We weren't serializing/deserializing for the offscreen doc


## Checklist

- [x] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer @johnnymetz 
