### PR TITLE
Refactor starter brick definition type names

### DIFF
--- a/src/activation/useActivateRecipe.test.ts
+++ b/src/activation/useActivateRecipe.test.ts
@@ -19,7 +19,7 @@ import { type WizardValues } from "@/activation/wizardTypes";
 import { renderHook } from "@/pageEditor/testHelpers";
 import useActivateRecipe from "./useActivateRecipe";
 import { validateRegistryId } from "@/types/helpers";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { type ContextMenuDefinition } from "@/starterBricks/contextMenu/types";
 import { uninstallRecipe } from "@/store/uninstallUtils";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
@@ -31,7 +31,7 @@ import databaseSchema from "@schemas/database.json";
 import { set } from "lodash";
 import {
   modComponentDefinitionFactory,
-  starterBrickConfigFactory,
+  starterBrickDefinitionFactory,
   defaultModDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
@@ -60,7 +60,7 @@ function setupInputs(): {
   const modComponentDefinition = modComponentDefinitionFactory({
     id: extensionPointId,
   });
-  const starterBrickConfig = starterBrickConfigFactory({
+  const starterBrickDefinition = starterBrickDefinitionFactory({
     metadata: metadataFactory({
       id: extensionPointId,
       name: "Text Starter Brick 1",
@@ -74,15 +74,15 @@ function setupInputs(): {
       },
       reader: [validateRegistryId("@pixiebrix/document-metadata")],
     },
-  }) as StarterBrickConfig<ContextMenuDefinition>;
-  starterBrickConfig.definition.targetMode = "eventTarget";
-  starterBrickConfig.definition.contexts = ["all"];
-  starterBrickConfig.definition.documentUrlPatterns = ["*://*/*"];
+  }) as StarterBrickDefinitionLike<ContextMenuDefinition>;
+  starterBrickDefinition.definition.targetMode = "eventTarget";
+  starterBrickDefinition.definition.contexts = ["all"];
+  starterBrickDefinition.definition.documentUrlPatterns = ["*://*/*"];
 
   const modDefinition = defaultModDefinitionFactory({
     extensionPoints: [modComponentDefinition],
     definitions: {
-      [extensionPointId]: starterBrickConfig,
+      [extensionPointId]: starterBrickDefinition,
     } as unknown as InnerDefinitions,
   });
 

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -135,7 +135,7 @@ async function setInputVars(
   contextVars: VarMap,
 ): Promise<void> {
   const adapter = ADAPTERS.get(extension.extensionPoint.definition.type);
-  const config = adapter.selectExtensionPointConfig(extension);
+  const config = adapter.selectStarterBrickDefinition(extension);
 
   const extensionPoint = fromJS(config);
 

--- a/src/background/contextMenus/initContextMenus.test.ts
+++ b/src/background/contextMenus/initContextMenus.test.ts
@@ -18,12 +18,12 @@
 import extensionPointRegistry from "@/starterBricks/registry";
 import { fromJS } from "@/starterBricks/contextMenu/contextMenu";
 import * as backgroundApi from "@/background/messenger/strict/api";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { type ModComponentBase } from "@/types/modComponentTypes";
 import chromeP from "webext-polyfill-kinda";
 import { TEST_setContext } from "webext-detect-page";
 import { modComponentFactory } from "@/testUtils/factories/modComponentFactories";
-import { starterBrickConfigFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { starterBrickDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { getPlatform } from "@/platform/platformContext";
 import {
   type ContextMenuDefinition,
@@ -69,7 +69,7 @@ describe("contextMenus", () => {
 
   it("preload context menu", async () => {
     const extensionPoint =
-      starterBrickConfigFactory() as unknown as StarterBrickConfig<ContextMenuDefinition>;
+      starterBrickDefinitionFactory() as unknown as StarterBrickDefinitionLike<ContextMenuDefinition>;
     extensionPoint.definition.type = "contextMenu";
     extensionPoint.definition.contexts = ["all"];
 

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -52,7 +52,7 @@ import {
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import {
   modComponentDefinitionFactory,
-  starterBrickConfigFactory,
+  starterBrickDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 
 import { activatableDeploymentFactory } from "@/testUtils/factories/deploymentFactories";
@@ -313,7 +313,7 @@ describe("syncDeployments", () => {
   test("ignore other mod components", async () => {
     isLinkedMock.mockResolvedValue(true);
 
-    const starterBrick = starterBrickConfigFactory();
+    const starterBrick = starterBrickDefinitionFactory();
     const brick = {
       ...parsePackage(starterBrick as unknown as RegistryPackage),
       timestamp: new Date(),
@@ -425,7 +425,7 @@ describe("syncDeployments", () => {
     const { deployment, modDefinition } = activatableDeploymentFactory();
     const registryId = deployment.package.package_id;
 
-    const starterBrick = starterBrickConfigFactory();
+    const starterBrick = starterBrickDefinitionFactory();
     const brick = {
       ...parsePackage(starterBrick as unknown as RegistryPackage),
       timestamp: new Date(),
@@ -719,7 +719,7 @@ describe("syncDeployments", () => {
   });
 
   test("can deactivate all deployed mods", async () => {
-    const personalStarterBrick = starterBrickConfigFactory();
+    const personalStarterBrick = starterBrickDefinitionFactory();
     const personalBrick = {
       ...parsePackage(personalStarterBrick as unknown as RegistryPackage),
       timestamp: new Date(),
@@ -733,7 +733,7 @@ describe("syncDeployments", () => {
       _recipe: modMetadataFactory(),
     }) as ActivatedModComponent;
 
-    const deploymentStarterBrick = starterBrickConfigFactory();
+    const deploymentStarterBrick = starterBrickDefinitionFactory();
     const deploymentsBrick = {
       ...parsePackage(deploymentStarterBrick as unknown as RegistryPackage),
       timestamp: new Date(),

--- a/src/background/modUpdater.test.ts
+++ b/src/background/modUpdater.test.ts
@@ -34,7 +34,7 @@ import {
 } from "@/testUtils/factories/modComponentFactories";
 import type { RegistryId, SemVerString } from "@/types/registryTypes";
 import {
-  starterBrickConfigFactory,
+  starterBrickDefinitionFactory,
   modDefinitionWithVersionedStarterBrickFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { getEditorState } from "@/store/editorStorage";
@@ -277,7 +277,7 @@ describe("deactivateMod function", () => {
   });
 
   it("should do nothing if mod id does not have any activated mod components", async () => {
-    const extensionPoint = starterBrickConfigFactory();
+    const extensionPoint = starterBrickDefinitionFactory();
     const extension = activatedModComponentFactory({
       extensionPointId: extensionPoint.metadata.id,
       _recipe: modMetadataFactory({}),

--- a/src/background/starterMods.test.ts
+++ b/src/background/starterMods.test.ts
@@ -46,7 +46,7 @@ import {
   getEventKeyForPanel,
 } from "@/store/sidebar/eventKeyUtils";
 import produce from "immer";
-import { type StarterBrickDefinition } from "@/starterBricks/types";
+import { type StarterBrickDefinitionProp } from "@/starterBricks/types";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { type StarterBrickType } from "@/types/starterBrickTypes";
 import {
@@ -97,7 +97,8 @@ describe("debouncedActivateStarterMods", () => {
   ) {
     return produce(modDefinition, (draft) => {
       (
-        draft.definitions.extensionPoint.definition as StarterBrickDefinition
+        draft.definitions.extensionPoint
+          .definition as StarterBrickDefinitionProp
       ).type = type;
     });
   }

--- a/src/bricks/available.ts
+++ b/src/bricks/available.ts
@@ -17,10 +17,10 @@
 
 import { doesUrlMatchPatterns, isValidPattern } from "webext-patterns";
 import { castArray } from "lodash";
-import { type Availability } from "@/bricks/types";
 import { type Entries } from "type-fest";
 import { BusinessError } from "@/errors/businessErrors";
 import { $safeFind } from "@/utils/domUtils";
+import { type Availability } from "@/types/availabilityTypes";
 
 export function testMatchPatterns(
   patterns: string[],

--- a/src/bricks/readers/factory.ts
+++ b/src/bricks/readers/factory.ts
@@ -29,7 +29,7 @@ import {
   type PlatformCapability,
 } from "@/platform/capabilities";
 import { validatePackageDefinition } from "@/validators/schemaValidator";
-import { Availability } from "@/types/availabilityTypes";
+import { type Availability } from "@/types/availabilityTypes";
 
 export interface ReaderTypeConfig {
   type: string;

--- a/src/bricks/readers/factory.ts
+++ b/src/bricks/readers/factory.ts
@@ -16,7 +16,7 @@
  */
 
 import { checkAvailable } from "@/bricks/available";
-import type { Availability, BrickConfig } from "@/bricks/types";
+import type { BrickConfig } from "@/bricks/types";
 import { cloneDeep } from "lodash";
 import { InvalidDefinitionError } from "@/errors/businessErrors";
 import { type ApiVersion, type SelectorRoot } from "@/types/runtimeTypes";
@@ -29,6 +29,7 @@ import {
   type PlatformCapability,
 } from "@/platform/capabilities";
 import { validatePackageDefinition } from "@/validators/schemaValidator";
+import { Availability } from "@/types/availabilityTypes";
 
 export interface ReaderTypeConfig {
   type: string;

--- a/src/bricks/types.ts
+++ b/src/bricks/types.ts
@@ -24,51 +24,6 @@ import {
 } from "@/types/runtimeTypes";
 import { type UUID } from "@/types/stringTypes";
 
-/**
- * @see https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API
- * @since 1.4.10
- */
-type URLPattern = string | URLPatternInit;
-
-/**
- * An availability rule. For a rule to match, there must be match from each of the provided entries.
- *
- * An empty value (null, empty array, etc.) matches any site.
- *
- * @see checkAvailable
- */
-export type Availability = {
-  /**
-   * Used to request permissions from the browser
-   */
-  matchPatterns?: string | string[];
-  /**
-   * NOTE: the urlPatterns must be a subset of matchPatterns (i.e., more restrictive). If not, PixieBrix may not have
-   * access to the page
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API
-   * @since 1.4.10
-   */
-  urlPatterns?: URLPattern | URLPattern[];
-  /**
-   * A selector that must be available on the page in order for the extension to be run.
-   *
-   * NOTE: the selector must be available at the time the contentScript is installed. While the contentScript is loaded
-   * on document_idle, for SPAs this may lead to races between the selector check and rendering of the front-end.
-   */
-  selectors?: string | string[];
-};
-
-/**
- * Availability with consistent shape (i.e., all fields are arrays if provided)
- * @see Availability
- */
-export type NormalizedAvailability = {
-  matchPatterns?: string[];
-  urlPatterns?: URLPattern[];
-  selectors?: string[];
-};
-
 export type ReaderConfig =
   | RegistryId
   | { [key: string]: ReaderConfig }

--- a/src/contentScript/lifecycle.test.ts
+++ b/src/contentScript/lifecycle.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { define } from "cooky-cutter";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import {
   fromJS,
   type TriggerConfig,
@@ -43,8 +43,10 @@ let getModComponentStateMock: jest.MockedFunctionDeep<
 
 const rootReader = new RootReader();
 
-const starterBrickConfigFactory = (definitionOverrides: UnknownObject = {}) =>
-  define<StarterBrickConfig<TriggerDefinition>>({
+const starterBrickDefinitionFactory = (
+  definitionOverrides: UnknownObject = {},
+) =>
+  define<StarterBrickDefinitionLike<TriggerDefinition>>({
     apiVersion: "v3",
     kind: "extensionPoint",
     metadata: (n: number) =>
@@ -126,7 +128,7 @@ describe("lifecycle", () => {
   it("installs persisted trigger on first run", async () => {
     const starterBrick = fromJS(
       getPlatform(),
-      starterBrickConfigFactory({
+      starterBrickDefinitionFactory({
         trigger: "load",
       })(),
     );
@@ -150,7 +152,7 @@ describe("lifecycle", () => {
   it("runEditorExtension", async () => {
     const starterBrick = fromJS(
       getPlatform(),
-      starterBrickConfigFactory({
+      starterBrickDefinitionFactory({
         trigger: "load",
       })(),
     );
@@ -173,7 +175,7 @@ describe("lifecycle", () => {
   it("runEditorExtension removes existing", async () => {
     const starterBrick = fromJS(
       getPlatform(),
-      starterBrickConfigFactory({
+      starterBrickDefinitionFactory({
         trigger: "load",
       })(),
     );
@@ -219,7 +221,7 @@ describe("lifecycle", () => {
   it("Removes starter bricks from deactivated mods", async () => {
     const starterBrick = fromJS(
       getPlatform(),
-      starterBrickConfigFactory({
+      starterBrickDefinitionFactory({
         trigger: "load",
       })(),
     );
@@ -240,7 +242,7 @@ describe("lifecycle", () => {
 
     const updatedStarterBrick = fromJS(
       getPlatform(),
-      starterBrickConfigFactory({
+      starterBrickDefinitionFactory({
         trigger: "initialize",
       })(),
     );

--- a/src/contentScript/messenger/runBrickTypes.ts
+++ b/src/contentScript/messenger/runBrickTypes.ts
@@ -15,10 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type Availability } from "@/bricks/types";
 import { type MessageContext } from "@/types/loggerTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type BrickArgs, type RunMetadata } from "@/types/runtimeTypes";
+import { Availability } from "@/types/availabilityTypes";
 
 /**
  * @see BrickOptions

--- a/src/contentScript/messenger/runBrickTypes.ts
+++ b/src/contentScript/messenger/runBrickTypes.ts
@@ -18,7 +18,7 @@
 import { type MessageContext } from "@/types/loggerTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type BrickArgs, type RunMetadata } from "@/types/runtimeTypes";
-import { Availability } from "@/types/availabilityTypes";
+import { type Availability } from "@/types/availabilityTypes";
 
 /**
  * @see BrickOptions

--- a/src/contentScript/pageEditor/types.ts
+++ b/src/contentScript/pageEditor/types.ts
@@ -16,8 +16,8 @@
  */
 
 import {
-  type StarterBrickConfig,
-  type StarterBrickDefinition,
+  type StarterBrickDefinitionLike,
+  type StarterBrickDefinitionProp,
 } from "@/starterBricks/types";
 import { type StarterBrickType } from "@/types/starterBrickTypes";
 import { type Except } from "type-fest";
@@ -36,11 +36,12 @@ import { type ApiVersion, type BrickArgsContext } from "@/types/runtimeTypes";
 import { type BrickConfig } from "@/bricks/types";
 
 export interface DynamicDefinition<
-  TExtensionPoint extends StarterBrickDefinition = StarterBrickDefinition,
+  TExtensionPoint extends
+    StarterBrickDefinitionProp = StarterBrickDefinitionProp,
   TExtension extends UnknownObject = UnknownObject,
 > {
   type: StarterBrickType;
-  extensionPointConfig: StarterBrickConfig<TExtensionPoint>;
+  extensionPointConfig: StarterBrickDefinitionLike<TExtensionPoint>;
   extension: ModComponentBase<TExtension>;
 }
 

--- a/src/modDefinitions/modDefinitionPermissionsHelpers.test.ts
+++ b/src/modDefinitions/modDefinitionPermissionsHelpers.test.ts
@@ -1,7 +1,7 @@
 import { checkModDefinitionPermissions } from "@/modDefinitions/modDefinitionPermissionsHelpers";
 import {
   modDefinitionFactory,
-  starterBrickConfigFactory,
+  starterBrickDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import starterBrickRegistry from "@/starterBricks/registry";
 import { fromJS } from "@/starterBricks/factory";
@@ -22,7 +22,7 @@ describe("checkModDefinitionPermissions", () => {
     modDefinition.extensionPoints[0].permissions.permissions = [
       "clipboardWrite",
     ];
-    const starterBrick = fromJS(starterBrickConfigFactory());
+    const starterBrick = fromJS(starterBrickDefinitionFactory());
     starterBrickRegistry.register([starterBrick]);
     modDefinition.extensionPoints[0].id = starterBrick.id;
 
@@ -50,7 +50,7 @@ describe("checkModDefinitionPermissions", () => {
     modDefinition.extensionPoints[0].permissions.permissions = [
       "clipboardWrite",
     ];
-    const starterBrick = fromJS(starterBrickConfigFactory());
+    const starterBrick = fromJS(starterBrickDefinitionFactory());
     starterBrickRegistry.register([starterBrick]);
     modDefinition.extensionPoints[0].id = starterBrick.id;
 

--- a/src/pageEditor/baseFormStateTypes.ts
+++ b/src/pageEditor/baseFormStateTypes.ts
@@ -29,7 +29,7 @@ import { type ModComponentBase } from "@/types/modComponentTypes";
 import { type ModOptionsDefinition } from "@/types/modDefinitionTypes";
 import { type BrickPipeline } from "@/bricks/types";
 import { type Metadata, type RegistryId } from "@/types/registryTypes";
-import { NormalizedAvailability } from "@/types/availabilityTypes";
+import { type NormalizedAvailability } from "@/types/availabilityTypes";
 
 /**
  * A simplified type for ReaderConfig to prevent TypeScript reporting problems with infinite type instantiation

--- a/src/pageEditor/baseFormStateTypes.ts
+++ b/src/pageEditor/baseFormStateTypes.ts
@@ -27,11 +27,9 @@ import { type StarterBrickType } from "@/types/starterBrickTypes";
 import { type Permissions } from "webextension-polyfill";
 import { type ModComponentBase } from "@/types/modComponentTypes";
 import { type ModOptionsDefinition } from "@/types/modDefinitionTypes";
-import {
-  type BrickPipeline,
-  type NormalizedAvailability,
-} from "@/bricks/types";
+import { type BrickPipeline } from "@/bricks/types";
 import { type Metadata, type RegistryId } from "@/types/registryTypes";
+import { NormalizedAvailability } from "@/types/availabilityTypes";
 
 /**
  * A simplified type for ReaderConfig to prevent TypeScript reporting problems with infinite type instantiation

--- a/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
+++ b/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
@@ -24,8 +24,8 @@ import {
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import { hookAct, renderHook } from "@/pageEditor/testHelpers";
 import {
-  type StarterBrickConfig,
-  type StarterBrickDefinition,
+  type StarterBrickDefinitionLike,
+  type StarterBrickDefinitionProp,
 } from "@/starterBricks/types";
 import extensionsSlice, {
   actions as extensionsActions,
@@ -51,10 +51,10 @@ jest.mock("@/pageEditor/starterBricks/base", () => ({
 describe("useBuildAndValidateMod", () => {
   function selectExtensionPoints(
     modDefinition: UnsavedModDefinition,
-  ): StarterBrickConfig[] {
+  ): StarterBrickDefinitionLike[] {
     return modDefinition.extensionPoints.map(({ id }) => {
       const definition = modDefinition.definitions[id]
-        .definition as StarterBrickDefinition;
+        .definition as StarterBrickDefinitionProp;
       return {
         apiVersion: modDefinition.apiVersion,
         metadata: internalStarterBrickMetaFactory(),

--- a/src/pageEditor/hooks/useCheckModStarterBrickInvariants.test.ts
+++ b/src/pageEditor/hooks/useCheckModStarterBrickInvariants.test.ts
@@ -19,7 +19,7 @@ import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories"
 import {
   modComponentDefinitionFactory,
   modDefinitionFactory,
-  starterBrickConfigFactory,
+  starterBrickDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import {
   type ModComponentDefinition,
@@ -113,7 +113,7 @@ describe("useCheckModStarterBrickInvariants", () => {
           cleanModComponentDefinitions.push(modComponentDefinition);
           cleanModInnerDefinitions[extensionPointId] = {
             kind: "extensionPoint",
-            definition: starterBrickConfigFactory().definition,
+            definition: starterBrickDefinitionFactory().definition,
           };
         }
 
@@ -125,7 +125,7 @@ describe("useCheckModStarterBrickInvariants", () => {
           dirtyModComponentDefinitions.push(modComponentDefinition);
           dirtyModInnerDefinitions[extensionPointId] = {
             kind: "extensionPoint",
-            definition: starterBrickConfigFactory().definition,
+            definition: starterBrickDefinitionFactory().definition,
           };
         }
 
@@ -162,7 +162,7 @@ describe("useCheckModStarterBrickInvariants", () => {
         newModComponentDefinitions.push(modComponentDefinition);
         newModInnerDefinitions[extensionPointId] = {
           kind: "extensionPoint",
-          definition: starterBrickConfigFactory().definition,
+          definition: starterBrickDefinitionFactory().definition,
         };
       }
 
@@ -246,7 +246,7 @@ describe("useCheckModStarterBrickInvariants", () => {
     });
     modInnerDefinitions[extensionPointId] = {
       kind: "extensionPoint",
-      definition: starterBrickConfigFactory().definition,
+      definition: starterBrickDefinitionFactory().definition,
     };
 
     const resultModDefinition = modDefinitionFactory({
@@ -286,7 +286,7 @@ describe("useCheckModStarterBrickInvariants", () => {
     });
     modInnerDefinitions[extensionPointId] = {
       kind: "extensionPoint",
-      definition: starterBrickConfigFactory().definition,
+      definition: starterBrickDefinitionFactory().definition,
     };
     const modForComponent = modDefinitionFactory({
       metadata: modMetadata,

--- a/src/pageEditor/hooks/useCheckModStarterBrickInvariants.ts
+++ b/src/pageEditor/hooks/useCheckModStarterBrickInvariants.ts
@@ -78,10 +78,10 @@ function useCheckModStarterBrickInvariants(): (
           continue;
         }
 
-        const { selectExtensionPointConfig } = ADAPTERS.get(formState.type);
+        const { selectStarterBrickDefinition } = ADAPTERS.get(formState.type);
         const definitionFromComponent = {
           kind: "extensionPoint",
-          definition: selectExtensionPointConfig(formState).definition,
+          definition: selectStarterBrickDefinition(formState).definition,
         };
         if (
           !definitionsFromMod.some((definitionFromMod) =>

--- a/src/pageEditor/hooks/useUpsertModComponentFormState.ts
+++ b/src/pageEditor/hooks/useUpsertModComponentFormState.ts
@@ -158,7 +158,7 @@ function useUpsertModComponentFormState(): SaveCallback {
         if (!isLocked) {
           try {
             const extensionPointConfig =
-              adapter.selectExtensionPointConfig(element);
+              adapter.selectStarterBrickDefinition(element);
             const packageId = element.installed
               ? editablePackages.find(
                   // Bricks endpoint uses "name" instead of id
@@ -190,7 +190,7 @@ function useUpsertModComponentFormState(): SaveCallback {
 
         if (hasInnerExtensionPoint) {
           const extensionPointConfig =
-            adapter.selectExtensionPointConfig(element);
+            adapter.selectStarterBrickDefinition(element);
           modComponent = extensionWithInnerDefinitions(
             modComponent,
             extensionPointConfig.definition,

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -35,8 +35,8 @@ import { cloneDeep, range, uniq } from "lodash";
 import { type MenuItemDefinition } from "@/starterBricks/menuItem/types";
 import extensionsSlice from "@/store/extensionsSlice";
 import {
-  type StarterBrickConfig,
-  type StarterBrickDefinition,
+  type StarterBrickDefinitionLike,
+  type StarterBrickDefinitionProp,
 } from "@/starterBricks/types";
 import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
@@ -56,7 +56,7 @@ import {
   innerStarterBrickModDefinitionFactory,
   modComponentDefinitionFactory,
   modDefinitionWithVersionedStarterBrickFactory,
-  starterBrickConfigFactory,
+  starterBrickDefinitionFactory,
   versionedModDefinitionWithResolvedModComponents,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
@@ -89,7 +89,7 @@ describe("generatePersonalBrickId", () => {
 
 describe("replaceModComponent round trip", () => {
   test("single mod component with versioned extensionPoint", async () => {
-    const starterBrick = starterBrickConfigFactory();
+    const starterBrick = starterBrickDefinitionFactory();
     const modDefinition = modDefinitionWithVersionedStarterBrickFactory({
       extensionPointId: starterBrick.metadata.id,
     })();
@@ -127,7 +127,7 @@ describe("replaceModComponent round trip", () => {
   });
 
   test("does not modify other starter brick", async () => {
-    const starterBrick = starterBrickConfigFactory();
+    const starterBrick = starterBrickDefinitionFactory();
 
     const modDefinition = modDefinitionWithVersionedStarterBrickFactory({
       extensionPointId: starterBrick.metadata.id,
@@ -326,7 +326,7 @@ describe("replaceModComponent round trip", () => {
   });
 
   test("updates Mod API version with single mod component", async () => {
-    const starterBrick = starterBrickConfigFactory({
+    const starterBrick = starterBrickDefinitionFactory({
       apiVersion: "v2",
     });
 
@@ -376,7 +376,7 @@ describe("replaceModComponent round trip", () => {
   });
 
   test("throws when API version mismatch and cannot update mod", async () => {
-    const starterBrick = starterBrickConfigFactory();
+    const starterBrick = starterBrickDefinitionFactory();
     const modDefinition = modDefinitionWithVersionedStarterBrickFactory({
       extensionPointId: starterBrick.metadata.id,
     })({
@@ -545,10 +545,10 @@ describe("mod options", () => {
 
 function selectExtensionPoints(
   modDefinition: UnsavedModDefinition,
-): StarterBrickConfig[] {
+): StarterBrickDefinitionLike[] {
   return modDefinition.extensionPoints.map(({ id }) => {
     const definition = modDefinition.definitions[id]
-      .definition as StarterBrickDefinition;
+      .definition as StarterBrickDefinitionProp;
     return {
       apiVersion: modDefinition.apiVersion,
       metadata: internalStarterBrickMetaFactory(),
@@ -580,7 +580,7 @@ describe("buildNewMod", () => {
     const outputKey = validateOutputKey("pixiebrix");
 
     // Load the adapter for this mod component
-    const starterBrick = starterBrickConfigFactory();
+    const starterBrick = starterBrickDefinitionFactory();
 
     const modComponent = modComponentFactory({
       apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
@@ -617,8 +617,8 @@ describe("buildNewMod", () => {
   test("Preserve distinct starter brick definitions", async () => {
     // Load the adapter for this mod component
     const starterBricks = [
-      starterBrickConfigFactory().definition,
-      starterBrickConfigFactory().definition,
+      starterBrickDefinitionFactory().definition,
+      starterBrickDefinitionFactory().definition,
     ];
 
     const modComponents = starterBricks.map((extensionPoint) => {
@@ -656,7 +656,7 @@ describe("buildNewMod", () => {
 
   test("Coalesce duplicate starter brick definitions", async () => {
     // Load the adapter for this mod component
-    const starterBrick = starterBrickConfigFactory().definition;
+    const starterBrick = starterBrickDefinitionFactory().definition;
 
     const modComponents = range(0, 2).map(() => {
       const modComponent = modComponentFactory({

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -58,6 +58,7 @@ import {
   normalizeModOptionsDefinition,
 } from "@/utils/modUtils";
 import { SERVICES_BASE_SCHEMA_URL } from "@/integrations/constants";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 
 /**
  * Generate a new registry id from an existing registry id by adding/replacing the scope.
@@ -240,7 +241,7 @@ export function replaceModComponent(
       activatedModComponent,
     );
 
-    const { selectExtension, selectExtensionPointConfig } = ADAPTERS.get(
+    const { selectExtension, selectStarterBrickDefinition } = ADAPTERS.get(
       newModComponent.type,
     );
     const rawModComponent = selectExtension(newModComponent);
@@ -266,7 +267,8 @@ export function replaceModComponent(
     }
 
     if (hasInnerExtensionPoint) {
-      const extensionPointConfig = selectExtensionPointConfig(newModComponent);
+      const extensionPointConfig =
+        selectStarterBrickDefinition(newModComponent);
 
       const originalInnerId =
         sourceMod.extensionPoints.at(modComponentIndex).id;
@@ -300,7 +302,7 @@ export function replaceModComponent(
           draft.definitions[freshId] = {
             kind: "extensionPoint",
             definition: extensionPointConfig.definition,
-          };
+          } satisfies StarterBrickDefinitionLike;
         }
       } else {
         // There's only one, can re-use without breaking the other definition
@@ -308,7 +310,7 @@ export function replaceModComponent(
         draft.definitions[originalInnerId] = {
           kind: "extensionPoint",
           definition: extensionPointConfig.definition,
-        };
+        } satisfies StarterBrickDefinitionLike;
       }
 
       // eslint-disable-next-line security/detect-object-injection -- false positive for number
@@ -432,20 +434,20 @@ export function buildNewMod({
 
     const unsavedModComponents: ModComponentBase[] =
       dirtyModComponentFormStates.map((modComponentFormState) => {
-        const { selectExtension, selectExtensionPointConfig } = ADAPTERS.get(
+        const { selectExtension, selectStarterBrickDefinition } = ADAPTERS.get(
           modComponentFormState.type,
         );
         const unsavedModComponent = selectExtension(modComponentFormState);
 
         if (isInnerDefinitionRegistryId(unsavedModComponent.extensionPointId)) {
-          const extensionPointConfig = selectExtensionPointConfig(
+          const extensionPointConfig = selectStarterBrickDefinition(
             modComponentFormState,
           );
           unsavedModComponent.definitions = {
             [unsavedModComponent.extensionPointId]: {
               kind: "extensionPoint",
               definition: extensionPointConfig.definition,
-            },
+            } satisfies StarterBrickDefinitionLike,
           };
         }
 

--- a/src/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod.test.ts
+++ b/src/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod.test.ts
@@ -28,7 +28,7 @@ import { modComponentToFormState } from "@/pageEditor/starterBricks/adapter";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { selectGetCleanComponentsAndDirtyFormStatesForMod } from "@/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod";
 import type { InnerDefinitionRef } from "@/types/registryTypes";
-import { starterBrickConfigFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { starterBrickDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 let extensionPointCount = 0;
 function newExtensionPointId(): InnerDefinitionRef {
@@ -104,7 +104,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
           definitions: {
             [extensionPointId]: {
               kind: "extensionPoint",
-              definition: starterBrickConfigFactory().definition,
+              definition: starterBrickDefinitionFactory().definition,
             },
           },
         });
@@ -122,7 +122,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
           definitions: {
             [extensionPointId]: {
               kind: "extensionPoint",
-              definition: starterBrickConfigFactory().definition,
+              definition: starterBrickDefinitionFactory().definition,
             },
           },
         });
@@ -142,7 +142,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
           definitions: {
             [extensionPointId]: {
               kind: "extensionPoint",
-              definition: starterBrickConfigFactory().definition,
+              definition: starterBrickDefinitionFactory().definition,
             },
           },
         });
@@ -162,7 +162,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
           definitions: {
             [extensionPointId]: {
               kind: "extensionPoint",
-              definition: starterBrickConfigFactory().definition,
+              definition: starterBrickDefinitionFactory().definition,
             },
           },
         });
@@ -200,7 +200,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
           definitions: {
             [extensionPointId]: {
               kind: "extensionPoint",
-              definition: starterBrickConfigFactory().definition,
+              definition: starterBrickDefinitionFactory().definition,
             },
           },
         });

--- a/src/pageEditor/starterBricks/adapter.ts
+++ b/src/pageEditor/starterBricks/adapter.ts
@@ -17,7 +17,7 @@
 
 import { type ModComponentBase } from "@/types/modComponentTypes";
 import { registry } from "@/background/messenger/strict/api";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { type StarterBrickType } from "@/types/starterBrickTypes";
 import menuItemExtension from "@/pageEditor/starterBricks/menuItem";
 import quickBarExtension from "@/pageEditor/starterBricks/quickBar";
@@ -50,7 +50,7 @@ export async function selectType(
     return (
       extension.definitions[
         extension.extensionPointId
-      ] as unknown as StarterBrickConfig
+      ] as unknown as StarterBrickDefinitionLike
     ).definition.type;
   }
 
@@ -63,7 +63,7 @@ export async function selectType(
     throw new Error("Cannot find starter brick");
   }
 
-  const extensionPoint = brick.config as unknown as StarterBrickConfig;
+  const extensionPoint = brick.config as unknown as StarterBrickDefinitionLike;
   return extensionPoint.definition.type;
 }
 

--- a/src/pageEditor/starterBricks/base.test.ts
+++ b/src/pageEditor/starterBricks/base.test.ts
@@ -23,7 +23,7 @@ import {
 import { type StarterBrickType } from "@/types/starterBrickTypes";
 import { type ReaderConfig } from "@/bricks/types";
 import { validateRegistryId } from "@/types/helpers";
-import { starterBrickConfigFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { starterBrickDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { toExpression } from "@/utils/expressionUtils";
 
 describe("removeEmptyValues()", () => {
@@ -74,7 +74,7 @@ describe("removeEmptyValues()", () => {
 
 describe("selectIsAvailable", () => {
   it("normalizes matchPatterns", () => {
-    const extensionPoint = starterBrickConfigFactory();
+    const extensionPoint = starterBrickDefinitionFactory();
     extensionPoint.definition.isAvailable.matchPatterns =
       "https://www.example.com";
     delete extensionPoint.definition.isAvailable.selectors;

--- a/src/pageEditor/starterBricks/base.ts
+++ b/src/pageEditor/starterBricks/base.ts
@@ -56,7 +56,7 @@ import {
 } from "@/pageEditor/baseFormStateTypes";
 import { emptyModOptionsDefinitionFactory } from "@/utils/modUtils";
 import { registry } from "@/background/messenger/strict/api";
-import { NormalizedAvailability } from "@/types/availabilityTypes";
+import { type NormalizedAvailability } from "@/types/availabilityTypes";
 
 export interface WizardStep {
   step: string;

--- a/src/pageEditor/starterBricks/base.ts
+++ b/src/pageEditor/starterBricks/base.ts
@@ -22,9 +22,9 @@ import {
 } from "@/types/registryTypes";
 import { castArray, cloneDeep, isEmpty } from "lodash";
 import {
-  assertStarterBrickConfig,
-  type StarterBrickConfig,
-  type StarterBrickDefinition,
+  assertStarterBrickDefinitionLike,
+  type StarterBrickDefinitionLike,
+  type StarterBrickDefinitionProp,
 } from "@/starterBricks/types";
 import { type StarterBrickType } from "@/types/starterBrickTypes";
 import type React from "react";
@@ -36,11 +36,7 @@ import {
   validateRegistryId,
   normalizeSemVerString,
 } from "@/types/helpers";
-import {
-  type BrickPipeline,
-  type NormalizedAvailability,
-  type ReaderConfig,
-} from "@/bricks/types";
+import { type BrickPipeline, type ReaderConfig } from "@/bricks/types";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { hasInnerExtensionPointRef } from "@/registry/internal";
 import { normalizePipelineForEditor } from "./pipelineMapping";
@@ -60,6 +56,7 @@ import {
 } from "@/pageEditor/baseFormStateTypes";
 import { emptyModOptionsDefinitionFactory } from "@/utils/modUtils";
 import { registry } from "@/background/messenger/strict/api";
+import { NormalizedAvailability } from "@/types/availabilityTypes";
 
 export interface WizardStep {
   step: string;
@@ -209,9 +206,9 @@ export function internalStarterBrickMetaFactory(): Metadata {
  * Map availability from extension point configuration to state for the page editor.
  */
 export function selectIsAvailable(
-  extensionPoint: StarterBrickConfig,
+  extensionPoint: StarterBrickDefinitionLike,
 ): NormalizedAvailability {
-  assertStarterBrickConfig(extensionPoint);
+  assertStarterBrickDefinitionLike(extensionPoint);
 
   const availability: NormalizedAvailability = {};
 
@@ -256,13 +253,15 @@ export function cleanIsAvailable({
 }
 
 export async function lookupExtensionPoint<
-  TDefinition extends StarterBrickDefinition,
+  TDefinition extends StarterBrickDefinitionProp,
   TConfig extends UnknownObject,
   TType extends string,
 >(
   config: ModComponentBase<TConfig>,
   type: TType,
-): Promise<StarterBrickConfig<TDefinition> & { definition: { type: TType } }> {
+): Promise<
+  StarterBrickDefinitionLike<TDefinition> & { definition: { type: TType } }
+> {
   if (!config) {
     throw new Error("config is required");
   }
@@ -278,11 +277,11 @@ export async function lookupExtensionPoint<
       kind: "extensionPoint",
       metadata: internalStarterBrickMetaFactory(),
       ...definition,
-    } as unknown as StarterBrickConfig<TDefinition> & {
+    } as unknown as StarterBrickDefinitionLike<TDefinition> & {
       definition: { type: TType };
     };
 
-    assertStarterBrickConfig(innerExtensionPoint);
+    assertStarterBrickDefinitionLike(innerExtensionPoint);
     return innerExtensionPoint;
   }
 
@@ -294,19 +293,19 @@ export async function lookupExtensionPoint<
   }
 
   const extensionPoint =
-    brick.config as unknown as StarterBrickConfig<TDefinition>;
+    brick.config as unknown as StarterBrickDefinitionLike<TDefinition>;
   if (extensionPoint.definition.type !== type) {
     throw new Error(`Expected ${type} starter brick type`);
   }
 
-  return extensionPoint as StarterBrickConfig<TDefinition> & {
+  return extensionPoint as StarterBrickDefinitionLike<TDefinition> & {
     definition: { type: TType };
   };
 }
 
 export function baseSelectExtensionPoint(
   formState: BaseFormState,
-): Except<StarterBrickConfig, "definition"> {
+): Except<StarterBrickDefinitionLike, "definition"> {
   const { metadata } = formState.extensionPoint;
 
   return {
@@ -327,7 +326,7 @@ export function baseSelectExtensionPoint(
 
 export function extensionWithInnerDefinitions(
   extension: ModComponentBase,
-  extensionPointDefinition: StarterBrickDefinition,
+  extensionPointDefinition: StarterBrickDefinitionProp,
 ): ModComponentBase {
   if (isInnerDefinitionRegistryId(extension.extensionPointId)) {
     const extensionPointId = freshIdentifier(

--- a/src/pageEditor/starterBricks/contextMenu.ts
+++ b/src/pageEditor/starterBricks/contextMenu.ts
@@ -30,7 +30,7 @@ import {
   removeEmptyValues,
   selectIsAvailable,
 } from "@/pageEditor/starterBricks/base";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { ContextMenuStarterBrickABC } from "@/starterBricks/contextMenu/contextMenu";
 import { faBars } from "@fortawesome/free-solid-svg-icons";
 import { type ElementConfig } from "@/pageEditor/starterBricks/elementConfig";
@@ -79,9 +79,9 @@ function fromNativeElement(
   };
 }
 
-function selectExtensionPointConfig(
+function selectStarterBrickDefinition(
   formState: ContextMenuFormState,
-): StarterBrickConfig<ContextMenuDefinition> {
+): StarterBrickDefinitionLike<ContextMenuDefinition> {
   const { extensionPoint } = formState;
   const {
     definition: {
@@ -165,7 +165,7 @@ function asDynamicElement(element: ContextMenuFormState): DynamicDefinition {
   return {
     type: "contextMenu",
     extension: selectExtension(element, { includeInstanceIds: true }),
-    extensionPointConfig: selectExtensionPointConfig(element),
+    extensionPointConfig: selectStarterBrickDefinition(element),
   };
 }
 
@@ -179,7 +179,7 @@ const config: ElementConfig<undefined, ContextMenuFormState> = {
   icon: faBars,
   fromNativeElement,
   asDynamicElement,
-  selectExtensionPointConfig,
+  selectStarterBrickDefinition,
   selectExtension,
   fromExtension,
 };

--- a/src/pageEditor/starterBricks/elementConfig.ts
+++ b/src/pageEditor/starterBricks/elementConfig.ts
@@ -18,7 +18,7 @@
 import type React from "react";
 import { type IconProp } from "@fortawesome/fontawesome-svg-core";
 import { type Metadata } from "@/types/registryTypes";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { type StarterBrickType } from "@/types/starterBrickTypes";
 import type { DynamicDefinition } from "@/contentScript/pageEditor/types";
 import { type ModComponentBase } from "@/types/modComponentTypes";
@@ -39,7 +39,7 @@ export interface ElementConfig<
 
   /**
    * The StarterBrickConfig class corresponding to the extension point
-   * @see StarterBrickConfig
+   * @see StarterBrickDefinitionLike
    */
   // eslint-disable-next-line @typescript-eslint/ban-types -- we want to Ctor here for the extension point
   readonly baseClass: Function;
@@ -104,7 +104,9 @@ export interface ElementConfig<
   /**
    * Returns the extension point configuration corresponding to the FormState.
    */
-  readonly selectExtensionPointConfig: (element: TState) => StarterBrickConfig;
+  readonly selectStarterBrickDefinition: (
+    element: TState,
+  ) => StarterBrickDefinitionLike;
 
   /**
    * Returns the extension configuration corresponding to the FormState.

--- a/src/pageEditor/starterBricks/formStateTypes.ts
+++ b/src/pageEditor/starterBricks/formStateTypes.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type NormalizedAvailability } from "@/bricks/types";
 import { type ElementInfo } from "@/utils/inference/selectorTypes";
 import {
   type ContextMenuConfig,
@@ -60,6 +59,7 @@ import {
   type BaseFormState,
   type SingleLayerReaderConfig,
 } from "@/pageEditor/baseFormStateTypes";
+import { NormalizedAvailability } from "@/types/availabilityTypes";
 
 // ActionFormState
 type ActionExtensionState = BaseExtensionState &

--- a/src/pageEditor/starterBricks/formStateTypes.ts
+++ b/src/pageEditor/starterBricks/formStateTypes.ts
@@ -59,7 +59,7 @@ import {
   type BaseFormState,
   type SingleLayerReaderConfig,
 } from "@/pageEditor/baseFormStateTypes";
-import { NormalizedAvailability } from "@/types/availabilityTypes";
+import { type NormalizedAvailability } from "@/types/availabilityTypes";
 
 // ActionFormState
 type ActionExtensionState = BaseExtensionState &

--- a/src/pageEditor/starterBricks/menuItem.ts
+++ b/src/pageEditor/starterBricks/menuItem.ts
@@ -32,7 +32,7 @@ import {
 } from "@/pageEditor/starterBricks/base";
 import { omitEditorMetadata } from "./pipelineMapping";
 import { MenuItemStarterBrickABC } from "@/starterBricks/menuItem/menuItemExtension";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { identity, pickBy } from "lodash";
 import { getDomain } from "@/permissions/patterns";
 import { faMousePointer } from "@fortawesome/free-solid-svg-icons";
@@ -85,9 +85,9 @@ function fromNativeElement(
   };
 }
 
-function selectExtensionPointConfig(
+function selectStarterBrickDefinition(
   formState: ActionFormState,
-): StarterBrickConfig<MenuItemDefinition> {
+): StarterBrickDefinitionLike<MenuItemDefinition> {
   const { extensionPoint } = formState;
   const {
     definition: {
@@ -174,7 +174,7 @@ function asDynamicElement(element: ActionFormState): ButtonDefinition {
   return {
     type: "menuItem",
     extension: selectExtension(element, { includeInstanceIds: true }),
-    extensionPointConfig: selectExtensionPointConfig(element),
+    extensionPointConfig: selectStarterBrickDefinition(element),
   };
 }
 
@@ -188,7 +188,7 @@ const config: ElementConfig<ButtonSelectionResult, ActionFormState> = {
   selectNativeElement: insertButton,
   fromNativeElement,
   asDynamicElement,
-  selectExtensionPointConfig,
+  selectStarterBrickDefinition,
   selectExtension,
   fromExtension,
 };

--- a/src/pageEditor/starterBricks/panel.ts
+++ b/src/pageEditor/starterBricks/panel.ts
@@ -31,7 +31,7 @@ import {
   selectIsAvailable,
 } from "@/pageEditor/starterBricks/base";
 import { omitEditorMetadata } from "./pipelineMapping";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { PanelStarterBrickABC } from "@/starterBricks/panel/panelExtension";
 import { getDomain } from "@/permissions/patterns";
 import { faWindowMaximize } from "@fortawesome/free-solid-svg-icons";
@@ -82,9 +82,9 @@ function fromNativeElement(
   };
 }
 
-function selectExtensionPointConfig(
+function selectStarterBrickDefinition(
   formState: PanelFormState,
-): StarterBrickConfig<PanelDefinition> {
+): StarterBrickDefinitionLike<PanelDefinition> {
   const { extensionPoint } = formState;
   const {
     definition: { isAvailable, position, template, reader, containerSelector },
@@ -126,7 +126,7 @@ function asDynamicElement(element: PanelFormState): DynamicDefinition {
   return {
     type: "panel",
     extension: selectExtension(element, { includeInstanceIds: true }),
-    extensionPointConfig: selectExtensionPointConfig(element),
+    extensionPointConfig: selectStarterBrickDefinition(element),
   };
 }
 
@@ -181,7 +181,7 @@ const config: ElementConfig<PanelSelectionResult, PanelFormState> = {
   EditorNode: PanelConfiguration,
   fromNativeElement,
   asDynamicElement,
-  selectExtensionPointConfig,
+  selectStarterBrickDefinition,
   selectExtension,
   fromExtension,
 };

--- a/src/pageEditor/starterBricks/quickBar.ts
+++ b/src/pageEditor/starterBricks/quickBar.ts
@@ -31,7 +31,7 @@ import {
   selectIsAvailable,
 } from "@/pageEditor/starterBricks/base";
 import { omitEditorMetadata } from "./pipelineMapping";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { faThLarge } from "@fortawesome/free-solid-svg-icons";
 import { type ElementConfig } from "@/pageEditor/starterBricks/elementConfig";
 import { QuickBarStarterBrickABC } from "@/starterBricks/quickBar/quickBarExtension";
@@ -75,9 +75,9 @@ function fromNativeElement(url: string, metadata: Metadata): QuickBarFormState {
   };
 }
 
-function selectExtensionPointConfig(
+function selectStarterBrickDefinition(
   formState: QuickBarFormState,
-): StarterBrickConfig<QuickBarDefinition> {
+): StarterBrickDefinitionLike<QuickBarDefinition> {
   const { extensionPoint } = formState;
   const {
     definition: {
@@ -162,7 +162,7 @@ function asDynamicElement(element: QuickBarFormState): DynamicDefinition {
   return {
     type: "quickBar",
     extension: selectExtension(element, { includeInstanceIds: true }),
-    extensionPointConfig: selectExtensionPointConfig(element),
+    extensionPointConfig: selectStarterBrickDefinition(element),
   };
 }
 
@@ -176,7 +176,7 @@ const config: ElementConfig<undefined, QuickBarFormState> = {
   icon: faThLarge,
   fromNativeElement,
   asDynamicElement,
-  selectExtensionPointConfig,
+  selectStarterBrickDefinition,
   selectExtension,
   fromExtension,
 };

--- a/src/pageEditor/starterBricks/quickBarProvider.ts
+++ b/src/pageEditor/starterBricks/quickBarProvider.ts
@@ -31,7 +31,7 @@ import {
   selectIsAvailable,
 } from "@/pageEditor/starterBricks/base";
 import { omitEditorMetadata } from "./pipelineMapping";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { faPlusSquare } from "@fortawesome/free-solid-svg-icons";
 import { type ElementConfig } from "@/pageEditor/starterBricks/elementConfig";
 import type { DynamicDefinition } from "@/contentScript/pageEditor/types";
@@ -76,9 +76,9 @@ function fromNativeElement(
   };
 }
 
-function selectExtensionPointConfig(
+function selectStarterBrickDefinition(
   formState: QuickBarProviderFormState,
-): StarterBrickConfig<QuickBarProviderDefinition> {
+): StarterBrickDefinitionLike<QuickBarProviderDefinition> {
   const { extensionPoint } = formState;
   const {
     definition: { isAvailable, documentUrlPatterns, reader },
@@ -154,7 +154,7 @@ function asDynamicElement(
   return {
     type: "quickBarProvider",
     extension: selectExtension(element, { includeInstanceIds: true }),
-    extensionPointConfig: selectExtensionPointConfig(element),
+    extensionPointConfig: selectStarterBrickDefinition(element),
   };
 }
 
@@ -169,7 +169,7 @@ const config: ElementConfig<undefined, QuickBarProviderFormState> = {
   flag: "pageeditor-quickbar-provider",
   fromNativeElement,
   asDynamicElement,
-  selectExtensionPointConfig,
+  selectStarterBrickDefinition,
   selectExtension,
   fromExtension,
 };

--- a/src/pageEditor/starterBricks/sidebar.ts
+++ b/src/pageEditor/starterBricks/sidebar.ts
@@ -31,7 +31,7 @@ import {
   selectIsAvailable,
 } from "@/pageEditor/starterBricks/base";
 import { omitEditorMetadata } from "./pipelineMapping";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { SidebarStarterBrickABC } from "@/starterBricks/sidebar/sidebarExtension";
 import { getDomain } from "@/permissions/patterns";
 import { faColumns } from "@fortawesome/free-solid-svg-icons";
@@ -79,9 +79,9 @@ function fromNativeElement(url: string, metadata: Metadata): SidebarFormState {
   };
 }
 
-function selectExtensionPointConfig(
+function selectStarterBrickDefinition(
   formState: SidebarFormState,
-): StarterBrickConfig {
+): StarterBrickDefinitionLike {
   const { extensionPoint } = formState;
   const {
     definition: { isAvailable, reader, trigger, debounce, customEvent },
@@ -120,7 +120,7 @@ function asDynamicElement(element: SidebarFormState): DynamicDefinition {
   return {
     type: "actionPanel",
     extension: selectExtension(element, { includeInstanceIds: true }),
-    extensionPointConfig: selectExtensionPointConfig(element),
+    extensionPointConfig: selectStarterBrickDefinition(element),
   };
 }
 
@@ -174,7 +174,7 @@ const config: ElementConfig<never, SidebarFormState> = {
   icon: faColumns,
   fromNativeElement,
   asDynamicElement,
-  selectExtensionPointConfig,
+  selectStarterBrickDefinition,
   selectExtension,
   fromExtension,
   EditorNode: SidebarConfiguration,

--- a/src/pageEditor/starterBricks/tour.ts
+++ b/src/pageEditor/starterBricks/tour.ts
@@ -30,7 +30,7 @@ import {
   selectIsAvailable,
 } from "@/pageEditor/starterBricks/base";
 import { omitEditorMetadata } from "./pipelineMapping";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { identity, pickBy } from "lodash";
 import { getDomain } from "@/permissions/patterns";
 import { faMapSigns } from "@fortawesome/free-solid-svg-icons";
@@ -70,9 +70,9 @@ function fromNativeElement(
   };
 }
 
-function selectExtensionPointConfig(
+function selectStarterBrickDefinition(
   formState: TourFormState,
-): StarterBrickConfig<TourDefinition> {
+): StarterBrickDefinitionLike<TourDefinition> {
   const { extensionPoint } = formState;
   const {
     definition: { isAvailable, reader },
@@ -107,7 +107,7 @@ function asDynamicElement(element: TourFormState): DynamicDefinition {
   return {
     type: "tour",
     extension: selectExtension(element, { includeInstanceIds: true }),
-    extensionPointConfig: selectExtensionPointConfig(element),
+    extensionPointConfig: selectStarterBrickDefinition(element),
   };
 }
 
@@ -155,7 +155,7 @@ const config: ElementConfig<undefined, TourFormState> = {
   icon: faMapSigns,
   fromNativeElement,
   asDynamicElement,
-  selectExtensionPointConfig,
+  selectStarterBrickDefinition,
   selectExtension,
   fromExtension,
 };

--- a/src/pageEditor/starterBricks/trigger.ts
+++ b/src/pageEditor/starterBricks/trigger.ts
@@ -36,7 +36,7 @@ import {
   type TriggerDefinition,
   TriggerStarterBrickABC,
 } from "@/starterBricks/triggerExtension";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { identity, pickBy } from "lodash";
 import { getDomain } from "@/permissions/patterns";
 import { faBolt } from "@fortawesome/free-solid-svg-icons";
@@ -83,9 +83,9 @@ function fromNativeElement(
   };
 }
 
-function selectExtensionPointConfig(
+function selectStarterBrickDefinition(
   formState: TriggerFormState,
-): StarterBrickConfig<TriggerDefinition> {
+): StarterBrickDefinitionLike<TriggerDefinition> {
   const { extensionPoint } = formState;
   const {
     definition: {
@@ -144,7 +144,7 @@ function asDynamicElement(element: TriggerFormState): DynamicDefinition {
   return {
     type: "trigger",
     extension: selectExtension(element, { includeInstanceIds: true }),
-    extensionPointConfig: selectExtensionPointConfig(element),
+    extensionPointConfig: selectStarterBrickDefinition(element),
   };
 }
 
@@ -213,7 +213,7 @@ const config: ElementConfig<undefined, TriggerFormState> = {
   icon: faBolt,
   fromNativeElement,
   asDynamicElement,
-  selectExtensionPointConfig,
+  selectStarterBrickDefinition,
   selectExtension,
   fromExtension,
 };

--- a/src/registry/internal.ts
+++ b/src/registry/internal.ts
@@ -26,7 +26,7 @@ import {
   type ModDefinition,
   type ResolvedModComponentDefinition,
 } from "@/types/modDefinitionTypes";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { type ReaderConfig } from "@/bricks/types";
 import {
   INNER_SCOPE,
@@ -42,7 +42,10 @@ import { type Brick } from "@/types/brickTypes";
 import { resolveObj } from "@/utils/promiseUtils";
 import { isObject } from "@/utils/objectUtils";
 
-type InnerExtensionPoint = Pick<StarterBrickConfig, "definition" | "kind">;
+type InnerExtensionPoint = Pick<
+  StarterBrickDefinitionLike,
+  "definition" | "kind"
+>;
 type InnerBlock<K extends "component" | "reader" = "component" | "reader"> =
   UnknownObject & {
     kind: K;
@@ -164,7 +167,7 @@ async function resolveExtensionPointDefinition(
       id: internalRegistryId,
       name: "Anonymous extensionPoint",
     },
-  } as StarterBrickConfig);
+  } as StarterBrickDefinitionLike);
 
   extensionPointRegistry.register([item], {
     source: "internal",

--- a/src/starterBricks/contextMenu/contextMenu.test.ts
+++ b/src/starterBricks/contextMenu/contextMenu.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { define } from "cooky-cutter";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { validateRegistryId } from "@/types/helpers";
 import { type Metadata } from "@/types/registryTypes";
 import { type BrickPipeline } from "@/bricks/types";
@@ -42,7 +42,7 @@ const ensureContextMenuMock = jest.mocked(ensureContextMenu);
 const rootReader = new RootReader();
 
 const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
-  define<StarterBrickConfig<ContextMenuDefinition>>({
+  define<StarterBrickDefinitionLike<ContextMenuDefinition>>({
     apiVersion: "v3",
     kind: "extensionPoint",
     metadata: (n: number) =>

--- a/src/starterBricks/contextMenu/contextMenu.ts
+++ b/src/starterBricks/contextMenu/contextMenu.ts
@@ -27,7 +27,7 @@ import {
 import ArrayCompositeReader from "@/bricks/readers/ArrayCompositeReader";
 import {
   StarterBrickABC,
-  type StarterBrickConfig,
+  type StarterBrickDefinitionLike,
 } from "@/starterBricks/types";
 import { castArray, cloneDeep, compact, isEmpty, pick, uniq } from "lodash";
 import { checkAvailable } from "@/bricks/available";
@@ -418,11 +418,11 @@ class RemoteContextMenuExtensionPoint extends ContextMenuStarterBrickABC {
 
   public readonly contexts: Menus.ContextType[];
 
-  public readonly rawConfig: StarterBrickConfig<ContextMenuDefinition>;
+  public readonly rawConfig: StarterBrickDefinitionLike<ContextMenuDefinition>;
 
   constructor(
     platform: PlatformProtocol,
-    config: StarterBrickConfig<ContextMenuDefinition>,
+    config: StarterBrickDefinitionLike<ContextMenuDefinition>,
   ) {
     // `cloneDeep` to ensure we have an isolated copy (since proxies could get revoked)
     const cloned = cloneDeep(config);
@@ -475,7 +475,7 @@ class RemoteContextMenuExtensionPoint extends ContextMenuStarterBrickABC {
 
 export function fromJS(
   platform: PlatformProtocol,
-  config: StarterBrickConfig<ContextMenuDefinition>,
+  config: StarterBrickDefinitionLike<ContextMenuDefinition>,
 ): StarterBrick {
   const { type } = config.definition;
   if (type !== "contextMenu") {

--- a/src/starterBricks/contextMenu/types.ts
+++ b/src/starterBricks/contextMenu/types.ts
@@ -16,7 +16,7 @@
  */
 
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
-import { type StarterBrickDefinition } from "@/starterBricks/types";
+import { type StarterBrickDefinitionProp } from "@/starterBricks/types";
 import { type MessageConfig } from "@/utils/notify";
 import { type Manifest, type Menus } from "webextension-polyfill";
 
@@ -47,7 +47,7 @@ export interface MenuDefaultOptions {
   [key: string]: string | string[] | undefined;
 }
 
-export interface ContextMenuDefinition extends StarterBrickDefinition {
+export interface ContextMenuDefinition extends StarterBrickDefinitionProp {
   documentUrlPatterns?: Manifest.MatchPattern[];
   contexts: Menus.ContextType[];
   targetMode: ContextMenuTargetMode;

--- a/src/starterBricks/factory.ts
+++ b/src/starterBricks/factory.ts
@@ -24,7 +24,7 @@ import { fromJS as deserializeQuickBar } from "@/starterBricks/quickBar/quickBar
 import { fromJS as deserializeQuickBarProvider } from "@/starterBricks/quickBarProvider/quickBarProviderExtension";
 import { fromJS as deserializeTour } from "@/starterBricks/tour/tourExtension";
 import { type StarterBrick } from "@/types/starterBrickTypes";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { getPlatform } from "@/platform/platformContext";
 
 const TYPE_MAP = {
@@ -38,7 +38,7 @@ const TYPE_MAP = {
   tour: deserializeTour,
 };
 
-export function fromJS(config: StarterBrickConfig): StarterBrick {
+export function fromJS(config: StarterBrickDefinitionLike): StarterBrick {
   if (config.kind !== "extensionPoint") {
     // Is `never` due to check, but needed because this method is called dynamically
     const exhaustiveCheck: never = config.kind;

--- a/src/starterBricks/menuItem/menuItemExtension.test.ts
+++ b/src/starterBricks/menuItem/menuItemExtension.test.ts
@@ -19,7 +19,7 @@ import { fromJS } from "@/starterBricks/menuItem/menuItemExtension";
 import { validateRegistryId } from "@/types/helpers";
 import { type Metadata } from "@/types/registryTypes";
 import { define } from "cooky-cutter";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import blockRegistry from "@/bricks/registry";
 import { getReferenceForElement } from "@/contentScript/elementReference";
 import {
@@ -56,7 +56,7 @@ globalThis.requestAnimationFrame = jest.fn((callback) => {
 const rootReaderId = validateRegistryId("test/root-reader");
 
 const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
-  define<StarterBrickConfig<MenuItemDefinition>>({
+  define<StarterBrickDefinitionLike<MenuItemDefinition>>({
     apiVersion: "v3",
     kind: "extensionPoint",
     metadata: (n: number) =>

--- a/src/starterBricks/menuItem/menuItemExtension.ts
+++ b/src/starterBricks/menuItem/menuItemExtension.ts
@@ -32,7 +32,7 @@ import {
 } from "@/starterBricks/helpers";
 import {
   StarterBrickABC,
-  type StarterBrickConfig,
+  type StarterBrickDefinitionLike,
 } from "@/starterBricks/types";
 import { type Metadata } from "@/types/registryTypes";
 import { type Permissions } from "webextension-polyfill";
@@ -760,7 +760,7 @@ export class RemoteMenuItemExtensionPoint extends MenuItemStarterBrickABC {
 
   public readonly permissions: Permissions.Permissions;
 
-  public readonly rawConfig: StarterBrickConfig<MenuItemDefinition>;
+  public readonly rawConfig: StarterBrickDefinitionLike<MenuItemDefinition>;
 
   public override get defaultOptions(): {
     caption: string;
@@ -775,7 +775,7 @@ export class RemoteMenuItemExtensionPoint extends MenuItemStarterBrickABC {
 
   constructor(
     platform: PlatformProtocol,
-    config: StarterBrickConfig<MenuItemDefinition>,
+    config: StarterBrickDefinitionLike<MenuItemDefinition>,
   ) {
     // `cloneDeep` to ensure we have an isolated copy (since proxies could get revoked)
     const cloned = cloneDeep(config);
@@ -934,7 +934,7 @@ export class RemoteMenuItemExtensionPoint extends MenuItemStarterBrickABC {
 
 export function fromJS(
   platform: PlatformProtocol,
-  config: StarterBrickConfig<MenuItemDefinition>,
+  config: StarterBrickDefinitionLike<MenuItemDefinition>,
 ): StarterBrick {
   const { type } = config.definition;
   if (type !== "menuItem") {

--- a/src/starterBricks/menuItem/types.ts
+++ b/src/starterBricks/menuItem/types.ts
@@ -16,7 +16,7 @@
  */
 
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
-import { type StarterBrickDefinition } from "@/starterBricks/types";
+import { type StarterBrickDefinitionProp } from "@/starterBricks/types";
 import { type IconConfig } from "@/types/iconTypes";
 import { type MessageConfig } from "@/utils/notify";
 
@@ -99,7 +99,7 @@ interface MenuDefaultOptions {
 /**
  * @since 1.7.16
  */
-export interface MenuItemDefinition extends StarterBrickDefinition {
+export interface MenuItemDefinition extends StarterBrickDefinitionProp {
   type: "menuItem";
   /**
    * The HTML template to render the button/menu item.

--- a/src/starterBricks/panel/panelExtension.ts
+++ b/src/starterBricks/panel/panelExtension.ts
@@ -33,7 +33,7 @@ import {
 import { type Metadata } from "@/types/registryTypes";
 import {
   StarterBrickABC,
-  type StarterBrickConfig,
+  type StarterBrickDefinitionLike,
 } from "@/starterBricks/types";
 import { render } from "@/starterBricks/dom";
 import { type Permissions } from "webextension-polyfill";
@@ -484,11 +484,11 @@ class RemotePanelExtensionPoint extends PanelStarterBrickABC {
 
   public readonly permissions: Permissions.Permissions;
 
-  public readonly rawConfig: StarterBrickConfig<PanelDefinition>;
+  public readonly rawConfig: StarterBrickDefinitionLike<PanelDefinition>;
 
   constructor(
     platform: PlatformProtocol,
-    config: StarterBrickConfig<PanelDefinition>,
+    config: StarterBrickDefinitionLike<PanelDefinition>,
   ) {
     // `cloneDeep` to ensure we have an isolated copy (since proxies could get revoked)
     const cloned = cloneDeep(config);
@@ -556,7 +556,7 @@ class RemotePanelExtensionPoint extends PanelStarterBrickABC {
 
 export function fromJS(
   platform: PlatformProtocol,
-  config: StarterBrickConfig<PanelDefinition>,
+  config: StarterBrickDefinitionLike<PanelDefinition>,
 ): StarterBrick {
   const { type } = config.definition;
   if (type !== "panel") {

--- a/src/starterBricks/panel/types.ts
+++ b/src/starterBricks/panel/types.ts
@@ -16,7 +16,7 @@
  */
 
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
-import { type StarterBrickDefinition } from "@/starterBricks/types";
+import { type StarterBrickDefinitionProp } from "@/starterBricks/types";
 import { type IconConfig } from "@/types/iconTypes";
 
 export type PanelConfig = {
@@ -40,7 +40,7 @@ interface PanelDefaultOptions {
   [key: string]: string | boolean | number | undefined;
 }
 
-export interface PanelDefinition extends StarterBrickDefinition {
+export interface PanelDefinition extends StarterBrickDefinitionProp {
   template: string;
   position?: PanelPosition;
   containerSelector: string;

--- a/src/starterBricks/quickBar/quickBarExtension.test.ts
+++ b/src/starterBricks/quickBar/quickBarExtension.test.ts
@@ -17,7 +17,7 @@
 
 import { validateRegistryId } from "@/types/helpers";
 import { define } from "cooky-cutter";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { type Metadata } from "@/types/registryTypes";
 import { type BrickPipeline } from "@/bricks/types";
 import {
@@ -57,7 +57,7 @@ jest.mock("@/auth/featureFlagStorage", () => ({
 }));
 
 const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
-  define<StarterBrickConfig<QuickBarDefinition>>({
+  define<StarterBrickDefinitionLike<QuickBarDefinition>>({
     apiVersion: "v3",
     kind: "extensionPoint",
     metadata: (n: number) =>

--- a/src/starterBricks/quickBar/quickBarExtension.tsx
+++ b/src/starterBricks/quickBar/quickBarExtension.tsx
@@ -27,7 +27,7 @@ import {
 } from "webextension-polyfill";
 import {
   StarterBrickABC,
-  type StarterBrickConfig,
+  type StarterBrickDefinitionLike,
 } from "@/starterBricks/types";
 import { castArray, cloneDeep, isEmpty } from "lodash";
 import { checkAvailable, testMatchPatterns } from "@/bricks/available";
@@ -292,11 +292,11 @@ export class RemoteQuickBarExtensionPoint extends QuickBarStarterBrickABC {
 
   public readonly contexts: Menus.ContextType[];
 
-  public readonly rawConfig: StarterBrickConfig<QuickBarDefinition>;
+  public readonly rawConfig: StarterBrickDefinitionLike<QuickBarDefinition>;
 
   constructor(
     platform: PlatformProtocol,
-    config: StarterBrickConfig<QuickBarDefinition>,
+    config: StarterBrickDefinitionLike<QuickBarDefinition>,
   ) {
     // `cloneDeep` to ensure we have an isolated copy (since proxies could get revoked)
     const cloned = cloneDeep(config);
@@ -353,7 +353,7 @@ export class RemoteQuickBarExtensionPoint extends QuickBarStarterBrickABC {
 
 export function fromJS(
   platform: PlatformProtocol,
-  config: StarterBrickConfig<QuickBarDefinition>,
+  config: StarterBrickDefinitionLike<QuickBarDefinition>,
 ): StarterBrick {
   const { type } = config.definition;
   if (type !== "quickBar") {

--- a/src/starterBricks/quickBar/types.ts
+++ b/src/starterBricks/quickBar/types.ts
@@ -16,7 +16,7 @@
  */
 
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
-import { type StarterBrickDefinition } from "@/starterBricks/types";
+import { type StarterBrickDefinitionProp } from "@/starterBricks/types";
 import { type IconConfig } from "@/types/iconTypes";
 import { type Manifest, type Menus } from "webextension-polyfill";
 
@@ -41,7 +41,7 @@ export type QuickBarDefaultOptions = {
   [key: string]: string | string[] | undefined;
 };
 
-export interface QuickBarDefinition extends StarterBrickDefinition {
+export interface QuickBarDefinition extends StarterBrickDefinitionProp {
   documentUrlPatterns?: Manifest.MatchPattern[];
   contexts: Menus.ContextType[];
   targetMode: QuickBarTargetMode;

--- a/src/starterBricks/quickBarProvider/quickBarProviderExtension.tsx
+++ b/src/starterBricks/quickBarProvider/quickBarProviderExtension.tsx
@@ -23,7 +23,7 @@ import {
 } from "webextension-polyfill";
 import {
   StarterBrickABC,
-  type StarterBrickConfig,
+  type StarterBrickDefinitionLike,
 } from "@/starterBricks/types";
 import { castArray, cloneDeep, isEmpty } from "lodash";
 import { checkAvailable, testMatchPatterns } from "@/bricks/available";
@@ -320,11 +320,11 @@ class RemoteQuickBarProviderExtensionPoint extends QuickBarProviderStarterBrickA
 
   public readonly contexts: Menus.ContextType[];
 
-  public readonly rawConfig: StarterBrickConfig<QuickBarProviderDefinition>;
+  public readonly rawConfig: StarterBrickDefinitionLike<QuickBarProviderDefinition>;
 
   constructor(
     platform: PlatformProtocol,
-    config: StarterBrickConfig<QuickBarProviderDefinition>,
+    config: StarterBrickDefinitionLike<QuickBarProviderDefinition>,
   ) {
     // `cloneDeep` to ensure we have an isolated copy (since proxies could get revoked)
     const cloned = cloneDeep(config);
@@ -370,7 +370,7 @@ class RemoteQuickBarProviderExtensionPoint extends QuickBarProviderStarterBrickA
 
 export function fromJS(
   platform: PlatformProtocol,
-  config: StarterBrickConfig<QuickBarProviderDefinition>,
+  config: StarterBrickDefinitionLike<QuickBarProviderDefinition>,
 ): StarterBrick {
   const { type } = config.definition;
   if (type !== "quickBarProvider") {

--- a/src/starterBricks/quickBarProvider/quickbarProviderExtension.test.ts
+++ b/src/starterBricks/quickBarProvider/quickbarProviderExtension.test.ts
@@ -40,7 +40,7 @@ import { type ResolvedModComponent } from "@/types/modComponentTypes";
 import { RunReason } from "@/types/runtimeTypes";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
-import { starterBrickConfigFactory as genericExtensionPointFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { starterBrickDefinitionFactory as genericExtensionPointFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { act } from "@testing-library/react";
 import { getPlatform } from "@/platform/platformContext";
 import {

--- a/src/starterBricks/quickBarProvider/types.ts
+++ b/src/starterBricks/quickBarProvider/types.ts
@@ -16,7 +16,7 @@
  */
 
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
-import { type StarterBrickDefinition } from "@/starterBricks/types";
+import { type StarterBrickDefinitionProp } from "@/starterBricks/types";
 import { type IconConfig } from "@/types/iconTypes";
 import { type Manifest } from "webextension-polyfill";
 
@@ -49,7 +49,7 @@ export type QuickBarProviderConfig = {
 
 export type QuickBarProviderDefaultOptions = Record<string, string | string[]>;
 
-export interface QuickBarProviderDefinition extends StarterBrickDefinition {
+export interface QuickBarProviderDefinition extends StarterBrickDefinitionProp {
   documentUrlPatterns?: Manifest.MatchPattern[];
   defaultOptions?: QuickBarProviderDefaultOptions;
 }

--- a/src/starterBricks/sidebar/sidebarExtension.test.ts
+++ b/src/starterBricks/sidebar/sidebarExtension.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { define } from "cooky-cutter";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { validateRegistryId } from "@/types/helpers";
 import { type Metadata } from "@/types/registryTypes";
 import { type ResolvedModComponent } from "@/types/modComponentTypes";
@@ -52,7 +52,7 @@ const isSidePanelOpenMock = jest.mocked(isSidePanelOpen);
 const rootReader = new RootReader();
 
 const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
-  define<StarterBrickConfig<SidebarDefinition>>({
+  define<StarterBrickDefinitionLike<SidebarDefinition>>({
     apiVersion: "v3",
     kind: "extensionPoint",
     metadata: (n: number) =>

--- a/src/starterBricks/sidebar/sidebarExtension.ts
+++ b/src/starterBricks/sidebar/sidebarExtension.ts
@@ -23,7 +23,7 @@ import {
   type CustomEventOptions,
   type DebounceOptions,
   StarterBrickABC,
-  type StarterBrickConfig,
+  type StarterBrickDefinitionLike,
 } from "@/starterBricks/types";
 import { type Permissions } from "webextension-polyfill";
 import { checkAvailable } from "@/bricks/available";
@@ -434,9 +434,9 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
 class RemotePanelExtensionPoint extends SidebarStarterBrickABC {
   private readonly definition: SidebarDefinition;
 
-  public readonly rawConfig: StarterBrickConfig;
+  public readonly rawConfig: StarterBrickDefinitionLike;
 
-  constructor(platform: PlatformProtocol, config: StarterBrickConfig) {
+  constructor(platform: PlatformProtocol, config: StarterBrickDefinitionLike) {
     // `cloneDeep` to ensure we have an isolated copy (since proxies could get revoked)
     const cloned = cloneDeep(config);
     super(platform, cloned.metadata);
@@ -475,7 +475,7 @@ class RemotePanelExtensionPoint extends SidebarStarterBrickABC {
 
 export function fromJS(
   platform: PlatformProtocol,
-  config: StarterBrickConfig,
+  config: StarterBrickDefinitionLike,
 ): StarterBrick {
   const { type } = config.definition;
   if (type !== "actionPanel") {

--- a/src/starterBricks/sidebar/types.ts
+++ b/src/starterBricks/sidebar/types.ts
@@ -17,7 +17,7 @@
 
 import { type BrickConfig, type BrickPipeline } from "@/bricks/types";
 import {
-  type StarterBrickDefinition,
+  type StarterBrickDefinitionProp,
   type CustomEventOptions,
   type DebounceOptions,
 } from "@/starterBricks/types";
@@ -39,7 +39,7 @@ export type Trigger =
   // A custom event configured by the user
   | "custom";
 
-export interface SidebarDefinition extends StarterBrickDefinition {
+export interface SidebarDefinition extends StarterBrickDefinitionProp {
   /**
    * The trigger to refresh the panel
    *

--- a/src/starterBricks/starterBrickModUtils.ts
+++ b/src/starterBricks/starterBrickModUtils.ts
@@ -19,7 +19,7 @@ import {
   type ModComponentDefinition,
   type ModDefinition,
 } from "@/types/modDefinitionTypes";
-import { type StarterBrickDefinition } from "@/starterBricks/types";
+import { type StarterBrickDefinitionProp } from "@/starterBricks/types";
 import { type StarterBrickType } from "@/types/starterBrickTypes";
 import starterBrickRegistry from "@/starterBricks/registry";
 import { type RegistryId } from "@/types/registryTypes";
@@ -36,9 +36,9 @@ async function getStarterBrickType(
 ): Promise<StarterBrickType | null> {
   // Look up the extension point in recipe inner definitions first
   if (modDefinition.definitions?.[modComponentDefinition.id]) {
-    const definition: StarterBrickDefinition = modDefinition.definitions[
+    const definition: StarterBrickDefinitionProp = modDefinition.definitions[
       modComponentDefinition.id
-    ].definition as StarterBrickDefinition;
+    ].definition as StarterBrickDefinitionProp;
     const extensionPointType = definition?.type;
 
     if (extensionPointType) {
@@ -59,9 +59,9 @@ export function getAllModComponentDefinitionsWithType(
   type: StarterBrickType,
 ): ModComponentDefinition[] {
   return modDefinition.extensionPoints.filter((extensionPoint) => {
-    const definition: StarterBrickDefinition = modDefinition.definitions?.[
+    const definition: StarterBrickDefinitionProp = modDefinition.definitions?.[
       extensionPoint.id
-    ]?.definition as StarterBrickDefinition;
+    ]?.definition as StarterBrickDefinitionProp;
     return definition?.type === type;
   });
 }

--- a/src/starterBricks/tour/tourExtension.test.ts
+++ b/src/starterBricks/tour/tourExtension.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { define } from "cooky-cutter";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { validateRegistryId } from "@/types/helpers";
 import { type Metadata } from "@/types/registryTypes";
 import { type BrickPipeline } from "@/bricks/types";
@@ -46,7 +46,7 @@ jest.mock("@/auth/featureFlagStorage", () => ({
 }));
 
 const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
-  define<StarterBrickConfig<TourDefinition>>({
+  define<StarterBrickDefinitionLike<TourDefinition>>({
     apiVersion: "v3",
     kind: "extensionPoint",
     metadata: (n: number) =>

--- a/src/starterBricks/tour/tourExtension.ts
+++ b/src/starterBricks/tour/tourExtension.ts
@@ -17,7 +17,7 @@
 
 import {
   StarterBrickABC,
-  type StarterBrickConfig,
+  type StarterBrickDefinitionLike,
 } from "@/starterBricks/types";
 import { type Permissions } from "webextension-polyfill";
 import {
@@ -272,7 +272,7 @@ class RemoteTourExtensionPoint extends TourStarterBrickABC {
 
   public readonly permissions: Permissions.Permissions;
 
-  public readonly rawConfig: StarterBrickConfig<TourDefinition>;
+  public readonly rawConfig: StarterBrickDefinitionLike<TourDefinition>;
 
   public override get defaultOptions(): UnknownObject {
     return this._definition.defaultOptions ?? { allowUserRun: true };
@@ -280,7 +280,7 @@ class RemoteTourExtensionPoint extends TourStarterBrickABC {
 
   constructor(
     platform: PlatformProtocol,
-    config: StarterBrickConfig<TourDefinition>,
+    config: StarterBrickDefinitionLike<TourDefinition>,
   ) {
     // `cloneDeep` to ensure we have an isolated copy (since proxies could get revoked)
     const cloned = cloneDeep(config);
@@ -313,7 +313,7 @@ class RemoteTourExtensionPoint extends TourStarterBrickABC {
 
 export function fromJS(
   platform: PlatformProtocol,
-  config: StarterBrickConfig<TourDefinition>,
+  config: StarterBrickDefinitionLike<TourDefinition>,
 ): StarterBrick {
   const { type } = config.definition;
   if (type !== "tour") {

--- a/src/starterBricks/tour/types.ts
+++ b/src/starterBricks/tour/types.ts
@@ -16,7 +16,7 @@
  */
 
 import { type BrickPipeline, type BrickConfig } from "@/bricks/types";
-import { type StarterBrickDefinition } from "@/starterBricks/types";
+import { type StarterBrickDefinitionProp } from "@/starterBricks/types";
 
 export type TourConfig = {
   /**
@@ -26,7 +26,7 @@ export type TourConfig = {
   tour: BrickPipeline | BrickConfig;
 };
 
-export interface TourDefinition extends StarterBrickDefinition {
+export interface TourDefinition extends StarterBrickDefinitionProp {
   defaultOptions?: UnknownObject;
 
   /**

--- a/src/starterBricks/triggerExtension.test.ts
+++ b/src/starterBricks/triggerExtension.test.ts
@@ -17,7 +17,7 @@
 
 import { validateRegistryId } from "@/types/helpers";
 import { define, derive } from "cooky-cutter";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { type Metadata } from "@/types/registryTypes";
 import { type BrickPipeline } from "@/bricks/types";
 import {
@@ -76,7 +76,7 @@ const showNotificationMock = jest.mocked(showNotification);
 const notifyContextInvalidatedMock = jest.mocked(notifyContextInvalidated);
 
 const extensionPointFactory = (definitionOverrides: UnknownObject = {}) =>
-  define<StarterBrickConfig<TriggerDefinition>>({
+  define<StarterBrickDefinitionLike<TriggerDefinition>>({
     apiVersion: "v3",
     kind: "extensionPoint",
     metadata: (n: number) =>

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -24,8 +24,8 @@ import {
   type CustomEventOptions,
   type DebounceOptions,
   StarterBrickABC,
-  type StarterBrickConfig,
-  type StarterBrickDefinition,
+  type StarterBrickDefinitionLike,
+  type StarterBrickDefinitionProp,
 } from "@/starterBricks/types";
 import { type Permissions } from "webextension-polyfill";
 import { castArray, cloneDeep, compact, debounce, isEmpty, noop } from "lodash";
@@ -856,7 +856,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
 
 type TriggerDefinitionOptions = Record<string, string>;
 
-export interface TriggerDefinition extends StarterBrickDefinition {
+export interface TriggerDefinition extends StarterBrickDefinitionProp {
   defaultOptions?: TriggerDefinitionOptions;
 
   /**
@@ -946,7 +946,7 @@ class RemoteTriggerExtensionPoint extends TriggerStarterBrickABC {
 
   public readonly permissions: Permissions.Permissions;
 
-  public readonly rawConfig: StarterBrickConfig<TriggerDefinition>;
+  public readonly rawConfig: StarterBrickDefinitionLike<TriggerDefinition>;
 
   public override get defaultOptions(): Record<string, string> {
     return this._definition.defaultOptions ?? {};
@@ -954,7 +954,7 @@ class RemoteTriggerExtensionPoint extends TriggerStarterBrickABC {
 
   constructor(
     platform: PlatformProtocol,
-    config: StarterBrickConfig<TriggerDefinition>,
+    config: StarterBrickDefinitionLike<TriggerDefinition>,
   ) {
     // `cloneDeep` to ensure we have an isolated copy (since proxies could get revoked)
     const cloned = cloneDeep(config);
@@ -1029,7 +1029,7 @@ class RemoteTriggerExtensionPoint extends TriggerStarterBrickABC {
 
 export function fromJS(
   platform: PlatformProtocol,
-  config: StarterBrickConfig<TriggerDefinition>,
+  config: StarterBrickDefinitionLike<TriggerDefinition>,
 ): StarterBrick {
   const { type } = config.definition;
   if (type !== "trigger") {

--- a/src/starterBricks/types.ts
+++ b/src/starterBricks/types.ts
@@ -15,11 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type Availability, type ReaderConfig } from "@/bricks/types";
+import { type ReaderConfig } from "@/bricks/types";
 import { type Permissions } from "webextension-polyfill";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
-import { type ApiVersion, type RunArgs } from "@/types/runtimeTypes";
-import { type RegistryId, type Metadata } from "@/types/registryTypes";
+import { type RunArgs } from "@/types/runtimeTypes";
+import {
+  type RegistryId,
+  type Metadata,
+  type Definition,
+} from "@/types/registryTypes";
 import {
   type StarterBrickType,
   type StarterBrick,
@@ -32,6 +36,7 @@ import { type Brick } from "@/types/brickTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type PlatformCapability } from "@/platform/capabilities";
 import { type PlatformProtocol } from "@/platform/platformProtocol";
+import { type Availability } from "@/types/availabilityTypes";
 
 /**
  * Follows the semantics of lodash's debounce: https://lodash.com/docs/4.17.15#debounce
@@ -64,50 +69,65 @@ export type CustomEventOptions = {
   eventName: string;
 };
 
-export interface StarterBrickDefinition {
+/**
+ * `definition` property of a starter brick definition.
+ * @see StarterBrickDefinitionLike
+ */
+export type StarterBrickDefinitionProp = {
   type: StarterBrickType;
   isAvailable: Availability;
   reader: ReaderConfig;
-}
+};
 
-export interface StarterBrickConfig<
-  T extends StarterBrickDefinition = StarterBrickDefinition,
+/**
+ * A registry package or inner definition of a starter brick.
+ *
+ * Does not extend `Definition` because apiVersion and metadata fields are not provided for inner definitions.
+ *
+ * @see Definition
+ */
+export interface StarterBrickDefinitionLike<
+  T extends StarterBrickDefinitionProp = StarterBrickDefinitionProp,
 > {
-  apiVersion?: ApiVersion;
-  metadata: Metadata;
+  apiVersion?: Definition["apiVersion"];
+  metadata?: Definition["metadata"];
   definition: T;
   kind: "extensionPoint";
 }
 
-export function assertStarterBrickConfig(
-  maybeStarterBrickConfig: unknown,
-): asserts maybeStarterBrickConfig is StarterBrickConfig {
-  const errorContext = { value: maybeStarterBrickConfig };
+export function assertStarterBrickDefinitionLike(
+  value: unknown,
+): asserts value is StarterBrickDefinitionLike {
+  const errorContext = { value };
 
-  if (typeof maybeStarterBrickConfig !== "object") {
+  if (typeof value !== "object") {
     console.warn("Expected extension point", errorContext);
-    throw new TypeError("Expected object for StarterBrickConfig");
+    throw new TypeError("Expected object for StarterBrickDefinitionLike");
   }
 
-  const config = maybeStarterBrickConfig as UnknownObject;
+  const config = value as UnknownObject;
 
   if (config.kind !== "extensionPoint") {
     console.warn("Expected extension point", errorContext);
     throw new TypeError(
-      "Expected kind 'extensionPoint' for StarterBrickConfig",
+      "Expected kind 'extensionPoint' for StarterBrickDefinitionLike",
     );
   }
 
   if (typeof config.definition !== "object") {
     console.warn("Expected extension point", errorContext);
-    throw new TypeError("Expected object for definition in StarterBrickConfig");
+    throw new TypeError(
+      "Expected object for definition in StarterBrickDefinitionLike",
+    );
   }
 
-  const definition = config.definition as StarterBrickDefinition;
+  const definition = config.definition as StarterBrickDefinitionProp;
 
   if (typeof definition.isAvailable !== "object") {
     console.warn("Expected object for definition.isAvailable", errorContext);
-    throw new TypeError("Invalid definition in StarterBrickConfig");
+    throw new TypeError(
+      "Invalid definition prop in StarterBrickDefinitionLike",
+    );
   }
 }
 

--- a/src/store/checkActiveElementAvailability.test.ts
+++ b/src/store/checkActiveElementAvailability.test.ts
@@ -25,12 +25,12 @@ import { type RegistryId } from "@/types/registryTypes";
 import { checkAvailable } from "@/contentScript/messenger/api";
 import { type Target } from "@/types/messengerTypes";
 import { type PageTarget } from "webext-messenger";
-import { type Availability } from "@/bricks/types";
 import { checkAvailable as backgroundCheckAvailable } from "@/bricks/available";
 import { selectModComponentAvailability } from "@/pageEditor/slices/editorSelectors";
 import { produce } from "immer";
 import { menuItemFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { getCurrentInspectedURL } from "@/pageEditor/context/connection";
+import { Availability } from "@/types/availabilityTypes";
 
 jest.mock("@/contentScript/messenger/api");
 jest.mock("@/pageEditor/context/connection");

--- a/src/store/checkActiveElementAvailability.test.ts
+++ b/src/store/checkActiveElementAvailability.test.ts
@@ -30,7 +30,7 @@ import { selectModComponentAvailability } from "@/pageEditor/slices/editorSelect
 import { produce } from "immer";
 import { menuItemFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { getCurrentInspectedURL } from "@/pageEditor/context/connection";
-import { Availability } from "@/types/availabilityTypes";
+import { type Availability } from "@/types/availabilityTypes";
 
 jest.mock("@/contentScript/messenger/api");
 jest.mock("@/pageEditor/context/connection");

--- a/src/store/checkAvailableDynamicElements.test.ts
+++ b/src/store/checkAvailableDynamicElements.test.ts
@@ -29,7 +29,7 @@ import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import extensionsSlice from "@/store/extensionsSlice";
 import { menuItemFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { getCurrentInspectedURL } from "@/pageEditor/context/connection";
-import { Availability } from "@/types/availabilityTypes";
+import { type Availability } from "@/types/availabilityTypes";
 
 jest.mock("@/contentScript/messenger/api");
 

--- a/src/store/checkAvailableDynamicElements.test.ts
+++ b/src/store/checkAvailableDynamicElements.test.ts
@@ -25,11 +25,11 @@ import { checkAvailable } from "@/contentScript/messenger/api";
 import { checkAvailable as backgroundCheckAvailable } from "@/bricks/available";
 import { type Target } from "@/types/messengerTypes";
 import { type PageTarget } from "webext-messenger";
-import { type Availability } from "@/bricks/types";
 import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import extensionsSlice from "@/store/extensionsSlice";
 import { menuItemFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { getCurrentInspectedURL } from "@/pageEditor/context/connection";
+import { Availability } from "@/types/availabilityTypes";
 
 jest.mock("@/contentScript/messenger/api");
 

--- a/src/store/checkAvailableInstalledExtensions.test.ts
+++ b/src/store/checkAvailableInstalledExtensions.test.ts
@@ -24,10 +24,10 @@ import { selectModComponentAvailability } from "@/pageEditor/slices/editorSelect
 import { getInstalledExtensionPoints } from "@/contentScript/messenger/api";
 import { validateRegistryId } from "@/types/helpers";
 import { RemoteMenuItemExtensionPoint } from "@/starterBricks/menuItem/menuItemExtension";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { type Metadata } from "@/types/registryTypes";
 import { RemoteQuickBarExtensionPoint } from "@/starterBricks/quickBar/quickBarExtension";
-import { starterBrickConfigFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { starterBrickDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { standaloneModDefinitionFactory } from "@/testUtils/factories/modComponentFactories";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
 import { getCurrentInspectedURL } from "@/pageEditor/context/connection";
@@ -63,51 +63,54 @@ describe("checkAvailableInstalledExtensions", () => {
       extensionPointId: unavailableQbId,
     });
 
-    const availableButtonStarterBrickConfig = starterBrickConfigFactory({
-      metadata(): Metadata {
-        return metadataFactory({
-          id: availableButtonId,
-        });
+    const availableButtonStarterBrickDefinition = starterBrickDefinitionFactory(
+      {
+        metadata(): Metadata {
+          return metadataFactory({
+            id: availableButtonId,
+          });
+        },
+        definition(): MenuItemDefinition {
+          return {
+            type: "menuItem",
+            containerSelector: "",
+            template: "",
+            isAvailable: {
+              matchPatterns: [testUrl],
+            },
+            reader: validateRegistryId("@pixiebrix/document-context"),
+          };
+        },
       },
-      definition(): MenuItemDefinition {
-        return {
-          type: "menuItem",
-          containerSelector: "",
-          template: "",
-          isAvailable: {
-            matchPatterns: [testUrl],
-          },
-          reader: validateRegistryId("@pixiebrix/document-context"),
-        };
-      },
-    }) as StarterBrickConfig<MenuItemDefinition>;
+    ) as StarterBrickDefinitionLike<MenuItemDefinition>;
     const availableButtonExtensionPoint = new RemoteMenuItemExtensionPoint(
       getPlatform(),
-      availableButtonStarterBrickConfig,
+      availableButtonStarterBrickDefinition,
     );
 
-    const availableQuickbarStarterBrickConfig = starterBrickConfigFactory({
-      metadata(): Metadata {
-        return metadataFactory({
-          id: availableQbId,
-        });
-      },
-      definition(): QuickBarDefinition {
-        return {
-          type: "quickBar",
-          contexts: ["all"],
-          documentUrlPatterns: [testUrl],
-          isAvailable: {
-            matchPatterns: [testUrl],
-          },
-          reader: validateRegistryId("@pixiebrix/document-context"),
-          targetMode: "document",
-        };
-      },
-    }) as StarterBrickConfig<QuickBarDefinition>;
+    const availableQuickbarStarterBrickDefinition =
+      starterBrickDefinitionFactory({
+        metadata(): Metadata {
+          return metadataFactory({
+            id: availableQbId,
+          });
+        },
+        definition(): QuickBarDefinition {
+          return {
+            type: "quickBar",
+            contexts: ["all"],
+            documentUrlPatterns: [testUrl],
+            isAvailable: {
+              matchPatterns: [testUrl],
+            },
+            reader: validateRegistryId("@pixiebrix/document-context"),
+            targetMode: "document",
+          };
+        },
+      }) as StarterBrickDefinitionLike<QuickBarDefinition>;
     const availableQuickbarExtensionPoint = new RemoteQuickBarExtensionPoint(
       getPlatform(),
-      availableQuickbarStarterBrickConfig,
+      availableQuickbarStarterBrickDefinition,
     );
     jest
       .mocked(getInstalledExtensionPoints)

--- a/src/testUtils/factories/modDefinitionFactories.ts
+++ b/src/testUtils/factories/modDefinitionFactories.ts
@@ -32,8 +32,8 @@ import { type BrickPipeline } from "@/bricks/types";
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { validateRegistryId, validateTimestamp } from "@/types/helpers";
 import {
-  type StarterBrickConfig,
-  type StarterBrickDefinition,
+  type StarterBrickDefinitionLike,
+  type StarterBrickDefinitionProp,
 } from "@/starterBricks/types";
 import { type StarterBrickType } from "@/types/starterBrickTypes";
 import { DEFAULT_EXTENSION_POINT_VAR } from "@/pageEditor/starterBricks/base";
@@ -70,25 +70,27 @@ export const modDefinitionFactory = define<ModDefinition>({
   extensionPoints: array(modComponentDefinitionFactory, 1),
 });
 
-export const starterBrickConfigFactory = define<StarterBrickConfig>({
-  kind: "extensionPoint",
-  apiVersion: "v3",
-  metadata: (n: number) =>
-    metadataFactory({
-      id: validateRegistryId(`test/starter-brick-${n}`),
-      name: `Starter Brick ${n}`,
-    }),
-  definition(n: number) {
-    const definition: StarterBrickDefinition = {
-      type: "menuItem" as StarterBrickType,
-      isAvailable: {
-        matchPatterns: [`https://www.mySite${n}.com/*`],
-      },
-      reader: validateRegistryId("@pixiebrix/document-context"),
-    };
-    return definition;
+export const starterBrickDefinitionFactory = define<StarterBrickDefinitionLike>(
+  {
+    kind: "extensionPoint",
+    apiVersion: "v3",
+    metadata: (n: number) =>
+      metadataFactory({
+        id: validateRegistryId(`test/starter-brick-${n}`),
+        name: `Starter Brick ${n}`,
+      }),
+    definition(n: number) {
+      const definition: StarterBrickDefinitionProp = {
+        type: "menuItem" as StarterBrickType,
+        isAvailable: {
+          matchPatterns: [`https://www.mySite${n}.com/*`],
+        },
+        reader: validateRegistryId("@pixiebrix/document-context"),
+      };
+      return definition;
+    },
   },
-});
+);
 
 type ExternalStarterBrickParams = {
   extensionPointId?: RegistryId;
@@ -142,8 +144,8 @@ export const versionedModDefinitionWithResolvedModComponents = (
   for (const modComponentDefinition of modComponentDefinitions) {
     definitions[modComponentDefinition.id] = {
       kind: "extensionPoint",
-      definition: starterBrickConfigFactory().definition,
-    };
+      definition: starterBrickDefinitionFactory().definition,
+    } satisfies StarterBrickDefinitionLike;
   }
 
   return extend<ModDefinition, ModDefinition>(modDefinitionFactory, {

--- a/src/testUtils/factories/pageEditorFactories.ts
+++ b/src/testUtils/factories/pageEditorFactories.ts
@@ -31,9 +31,9 @@ import {
 } from "@/types/runtimeTypes";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
-import { type StarterBrickConfig } from "@/starterBricks/types";
+import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { type StarterBrickType } from "@/types/starterBrickTypes";
-import { starterBrickConfigFactory } from "@/testUtils/factories/modDefinitionFactories";
+import { starterBrickDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
 import { type BrickPipeline } from "@/bricks/types";
 import contextMenu from "@/pageEditor/starterBricks/contextMenu";
@@ -55,7 +55,10 @@ export const baseExtensionStateFactory = define<BaseExtensionState>({
 });
 const internalFormStateFactory = define<
   ModComponentFormState & {
-    extensionPoint: DerivedFunction<ModComponentFormState, StarterBrickConfig>;
+    extensionPoint: DerivedFunction<
+      ModComponentFormState,
+      StarterBrickDefinitionLike
+    >;
   }
 >({
   apiVersion: "v3" as ApiVersion,
@@ -70,9 +73,9 @@ const internalFormStateFactory = define<
   label: (i: number) => `Element ${i}`,
   extension: baseExtensionStateFactory,
   // @ts-expect-error -- TODO: verify typings
-  extensionPoint: derive<ModComponentFormState, StarterBrickConfig>(
+  extensionPoint: derive<ModComponentFormState, StarterBrickDefinitionLike>(
     ({ type }) => {
-      const starterBrick = starterBrickConfigFactory();
+      const starterBrick = starterBrickDefinitionFactory();
       starterBrick.definition.type = type;
       return starterBrick;
     },

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -1013,6 +1013,7 @@
     "./tours/tourRunDatabase.test.ts",
     "./tours/tourRunDatabase.ts",
     "./types/annotationTypes.ts",
+    "./types/availabilityTypes.ts",
     "./types/brickTypes.ts",
     "./types/bricks/effectTypes.ts",
     "./types/bricks/readerTypes.ts",

--- a/src/types/availabilityTypes.ts
+++ b/src/types/availabilityTypes.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API
+ * @since 1.4.10
+ */
+type URLPattern = string | URLPatternInit;
+
+/**
+ * An availability rule. For a rule to match, there must be match from each of the provided entries.
+ *
+ * An empty value (null, empty array, etc.) matches any site.
+ *
+ * @see checkAvailable
+ */
+export type Availability = {
+  /**
+   * Used to request permissions from the browser.
+   *
+   * See https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns for valid match patterns.
+   */
+  matchPatterns?: string | string[];
+  /**
+   * NOTE: the urlPatterns must be a subset of matchPatterns (i.e., more restrictive). If not, PixieBrix may not have
+   * access to the page
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API
+   * @since 1.4.10
+   */
+  urlPatterns?: URLPattern | URLPattern[];
+  /**
+   * A selector that must be available on the page in order for the extension to be run.
+   *
+   * NOTE: the selector must be available at the time the contentScript is installed. While the contentScript is loaded
+   * on document_idle, for SPAs this may lead to races between the selector check and rendering of the front-end.
+   */
+  selectors?: string | string[];
+};
+
+/**
+ * Availability with consistent shape (i.e., all fields are arrays if provided)
+ * @see Availability
+ */
+export type NormalizedAvailability = {
+  /**
+   * Used to request permissions from the browser.
+   *
+   * See https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns for valid match patterns.
+   */
+  matchPatterns?: string[];
+  /**
+   * NOTE: the urlPatterns must be a subset of matchPatterns (i.e., more restrictive). If not, PixieBrix may not have
+   * access to the page
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API
+   * @since 1.4.10
+   */
+  urlPatterns?: URLPattern[];
+  /**
+   * A selector that must be available on the page in order for the extension to be run.
+   *
+   * NOTE: the selector must be available at the time the contentScript is installed. While the contentScript is loaded
+   * on document_idle, for SPAs this may lead to races between the selector check and rendering of the front-end.
+   */
+  selectors?: string[];
+};


### PR DESCRIPTION
## What does this PR do?

- Refactoring prep work for save helper bug fixes. No functional changes
- Refactors/clarifies starter brick type names:
  - `StarterBrickConfig` -> `StarterBrickDefinitionLike`
  - `StarterBrickDefinition` -> `StarterBrickDefinitionProp`
- Extracts `Availability` and `NormalizedAvailability` to their own file in the types directory

## Discussion

- I chose `StarterBrickDefinitionLike` vs. `StarterBrickDefinition` because the type doesn't strictly extend `Definition`
- We could consider not having an explicit `StarterBrickDefinitionProp` and instead refer to it as `StarterBrickDefinition["definition"]` in casts, etc. It'd be easy for use to change to that approach in the future

## Future Work

- Rename remaining uses of extensionPointConfig, etc.

## Checklist

- [x] Designate a primary reviewer: @grahamlangford 
