### PR TITLE
#8543: Adding detect-secrets precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@
 exclude: __snapshots__/|package-lock.json
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v3.2.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -20,6 +20,6 @@ repos:
         args: ["--baseline", ".secrets.baseline"]
         exclude: package.lock.json
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: v3.1.0
     hooks:
       - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,18 @@
 exclude: __snapshots__/|package-lock.json
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.6.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: detect-private-key
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+        exclude: package.lock.json
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,248 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    ".github/workflows/beta-release.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/beta-release.yaml",
+        "hashed_secret": "f005950536ad2edca6cfc2d6f52ad663d0a17b46",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    ".github/workflows/ci.yml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "97ed79340d21c99620980bc3a2ecf3a4064ae75c",
+        "is_verified": false,
+        "line_number": 197
+      }
+    ],
+    ".github/workflows/release.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/release.yaml",
+        "hashed_secret": "97ed79340d21c99620980bc3a2ecf3a4064ae75c",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "contrib/integrations/automation-anywhere-oauth2.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "contrib/integrations/automation-anywhere-oauth2.yaml",
+        "hashed_secret": "259951dbfc8c70b30adf53d75c95475e6b318e36",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
+    "contrib/integrations/google-oauth2-pkce.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "contrib/integrations/google-oauth2-pkce.yaml",
+        "hashed_secret": "239aaa39a20ce6fa6a174f6fe52c0531df7cebae",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "contrib/integrations/google-oauth2-pkce.yaml",
+        "hashed_secret": "239aaa39a20ce6fa6a174f6fe52c0531df7cebae",
+        "is_verified": false,
+        "line_number": 21
+      }
+    ],
+    "end-to-end-tests/fixtures/responses/giphy-search.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "end-to-end-tests/fixtures/responses/giphy-search.json",
+        "hashed_secret": "10bdb1e0522901090a20c26458541b46caae745e",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "end-to-end-tests/fixtures/responses/giphy-search.json",
+        "hashed_secret": "f7086e591a2708a2898303a48138a6fb9364de3f",
+        "is_verified": false,
+        "line_number": 187
+      }
+    ],
+    "public/mockServiceWorker.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "public/mockServiceWorker.js",
+        "hashed_secret": "c8bae45540711f4d8b2351291e2d2239c50a5fa4",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "src/bricks/transformers/parseDataUrl.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/bricks/transformers/parseDataUrl.test.ts",
+        "hashed_secret": "f3fcea318d4573f952a4c821c736bf6ac01e96f2",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
+    "src/integrations/sanitizeIntegrationConfig.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/integrations/sanitizeIntegrationConfig.test.ts",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
+    "src/runtime/pipelineTests/validateInput.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/runtime/pipelineTests/validateInput.test.ts",
+        "hashed_secret": "0ba9927dc8deb33a61c711371f7ace3407591191",
+        "is_verified": false,
+        "line_number": 274
+      }
+    ],
+    "src/testUtils/factories/authFactories.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/testUtils/factories/authFactories.ts",
+        "hashed_secret": "d15e5a27160ace913d22871497c05a7e5bbbe2ef",
+        "is_verified": false,
+        "line_number": 157
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/testUtils/factories/authFactories.ts",
+        "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
+        "is_verified": false,
+        "line_number": 172
+      }
+    ]
+  },
+  "generated_at": "2024-06-03T21:32:34Z"
+}


### PR DESCRIPTION
## What does this PR do?

- Closes #8543

## Team Coordination

The new pre-commit hook should auto-install on next commit

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer @johnnymetz 
