### PR TITLE
#8548: switch fab to open the sidebar instead of quick bar

### DIFF
--- a/end-to-end-tests/pageObjects/floatingActionButton.ts
+++ b/end-to-end-tests/pageObjects/floatingActionButton.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type Locator, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 
 export class FloatingActionButton {
   constructor(private readonly page: Page) {}
@@ -39,13 +39,5 @@ export class FloatingActionButton {
       name: "Hide Button",
     });
     await hideButton.click();
-  }
-
-  // TODO: write a smoke test for drag/drop once we have VRTs to assert against
-  async dragFloatingActionButton(dragTo: Locator) {
-    const dragHandle = this.page.getByRole("img", {
-      name: "drag to move action button",
-    });
-    await dragHandle.dragTo(dragTo);
   }
 }

--- a/end-to-end-tests/pageObjects/floatingActionButton.ts
+++ b/end-to-end-tests/pageObjects/floatingActionButton.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type Locator, type Page } from "@playwright/test";
+
+export class FloatingActionButton {
+  constructor(private readonly page: Page) {}
+
+  async getActionButton() {
+    return this.page.getByRole("button", {
+      name: "Toggle the PixieBrix Sidebar",
+    });
+  }
+
+  async toggleSidebar() {
+    const floatingActionButton = await this.getActionButton();
+    await floatingActionButton.click();
+  }
+
+  async hideFloatingActionButton() {
+    const actionButton = await this.getActionButton();
+    await actionButton.hover();
+
+    const hideButton = this.page.getByRole("button", {
+      name: "Hide Button",
+    });
+    await hideButton.click();
+  }
+
+  // TODO: write a smoke test for drag/drop once we have VRTs to assert against
+  async dragFloatingActionButton(dragTo: Locator) {
+    const dragHandle = this.page.getByRole("img", {
+      name: "drag to move action button",
+    });
+    await dragHandle.dragTo(dragTo);
+  }
+}

--- a/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
+++ b/end-to-end-tests/tests/extensionConsoleActivation.spec.ts
@@ -30,6 +30,7 @@ import { VALID_UUID_REGEX } from "@/types/stringTypes";
 import { type Serializable } from "playwright-core/types/structs";
 import { SERVICE_URL } from "../env";
 import { ExtensionsShortcutsPage } from "end-to-end-tests/pageObjects/extensionsShortcutsPage";
+import { FloatingActionButton } from "end-to-end-tests/pageObjects/floatingActionButton";
 
 test("can activate a mod with no config options", async ({
   page,
@@ -86,10 +87,10 @@ test("can activate a mod with built-in integration", async ({
   await modActivationPage.clickActivateAndWaitForModsPageRedirect();
   await page.goto("/");
 
+  const floatingActionButton = new FloatingActionButton(page);
+
   // Ensure the QuickBar is ready
-  await expect(
-    page.getByRole("button", { name: "open the PixieBrix quick bar" }),
-  ).toBeVisible();
+  await expect(await floatingActionButton.getActionButton()).toBeVisible();
 
   await runModViaQuickBar(page, "GIPHY Search");
 

--- a/end-to-end-tests/tests/smoke/floatingActionButton.spec.ts
+++ b/end-to-end-tests/tests/smoke/floatingActionButton.spec.ts
@@ -25,15 +25,10 @@ test.describe("sidebar page smoke test", () => {
     page,
     extensionId,
   }) => {
-    const modId = "@pixies/ai/writer-assist";
+    const modId = "@e2e-testing/simple-sidebar-panel";
 
     const modActivationPage = new ActivateModPage(page, extensionId, modId);
     await modActivationPage.goto();
-    // The default integration values are not immediately loaded and are temporarily empty.
-    // If we try activating too fast, the activation will fail due to missing configuration, so we wait for the values to load.
-    await expect(
-      page.getByText("OpenAI — ✨ Built-in", { exact: true }),
-    ).toBeVisible();
     await modActivationPage.clickActivateAndWaitForModsPageRedirect();
 
     await page.goto("/bootstrap-5");
@@ -43,7 +38,7 @@ test.describe("sidebar page smoke test", () => {
 
     const sideBarPage = await getSidebarPage(page, extensionId);
     await expect(
-      sideBarPage.getByRole("heading", { name: "✍️ Write Assist" }),
+      sideBarPage.getByRole("heading", { name: "Simple Sidebar Panel" }),
     ).toBeVisible();
 
     await floatingActionButton.toggleSidebar();
@@ -61,6 +56,10 @@ test.describe("sidebar page smoke test", () => {
     await expect(actionButton).toBeVisible();
 
     await floatingActionButton.hideFloatingActionButton();
+
+    await expect(actionButton).toBeHidden();
+
+    await page.reload();
 
     await expect(actionButton).toBeHidden();
   });

--- a/end-to-end-tests/tests/smoke/floatingActionButton.spec.ts
+++ b/end-to-end-tests/tests/smoke/floatingActionButton.spec.ts
@@ -61,6 +61,9 @@ test.describe("sidebar page smoke test", () => {
 
     await page.reload();
 
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- Give the page time to mount the floating action button if it's going to
+    await page.waitForTimeout(1000);
+
     await expect(actionButton).toBeHidden();
   });
 });

--- a/end-to-end-tests/tests/smoke/floatingActionButton.spec.ts
+++ b/end-to-end-tests/tests/smoke/floatingActionButton.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { test, expect } from "../../fixtures/extensionBase";
+import { ActivateModPage } from "../../pageObjects/extensionConsole/modsPage";
+import { FloatingActionButton } from "../../pageObjects/floatingActionButton";
+import { getSidebarPage, isSidebarOpen } from "../../utils";
+
+test.describe("sidebar page smoke test", () => {
+  test("can toggle the sidebar from the floating action button and view the related mod's sidebar panel", async ({
+    page,
+    extensionId,
+  }) => {
+    const modId = "@pixies/ai/writer-assist";
+
+    const modActivationPage = new ActivateModPage(page, extensionId, modId);
+    await modActivationPage.goto();
+    // The default integration values are not immediately loaded and are temporarily empty.
+    // If we try activating too fast, the activation will fail due to missing configuration, so we wait for the values to load.
+    await expect(
+      page.getByText("OpenAI — ✨ Built-in", { exact: true }),
+    ).toBeVisible();
+    await modActivationPage.clickActivateAndWaitForModsPageRedirect();
+
+    await page.goto("/bootstrap-5");
+
+    const floatingActionButton = new FloatingActionButton(page);
+    await floatingActionButton.toggleSidebar();
+
+    const sideBarPage = await getSidebarPage(page, extensionId);
+    await expect(
+      sideBarPage.getByRole("heading", { name: "✍️ Write Assist" }),
+    ).toBeVisible();
+
+    await floatingActionButton.toggleSidebar();
+
+    await expect(() => {
+      expect(isSidebarOpen(page, extensionId)).toBe(false);
+    }).toPass({ timeout: 5000 });
+  });
+
+  test("can hide the floating action button", async ({ page, extensionId }) => {
+    await page.goto("/bootstrap-5");
+
+    const floatingActionButton = new FloatingActionButton(page);
+    const actionButton = await floatingActionButton.getActionButton();
+    await expect(actionButton).toBeVisible();
+
+    await floatingActionButton.hideFloatingActionButton();
+
+    await expect(actionButton).toBeHidden();
+  });
+});

--- a/src/components/floatingActions/ActionButton.tsx
+++ b/src/components/floatingActions/ActionButton.tsx
@@ -68,7 +68,7 @@ export function ActionButton() {
           <img
             src={logoUrl}
             className="logo"
-            alt="open the PixieBrix Sidebar"
+            alt="Toggle the PixieBrix Sidebar"
           />
         </Button>
       </div>

--- a/src/components/floatingActions/ActionButton.tsx
+++ b/src/components/floatingActions/ActionButton.tsx
@@ -18,24 +18,25 @@
 import React from "react";
 import logoUrl from "@/icons/custom-icons/logo.svg";
 import { Button } from "react-bootstrap";
-import { toggleQuickBar } from "@/components/quickBar/QuickBarApp";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import AsyncButton from "@/components/AsyncButton";
 import notify from "@/utils/notify";
 import { useDispatch } from "react-redux";
 import SettingsSlice from "@/store/settings/settingsSlice";
+// eslint-disable-next-line local-rules/noCrossBoundaryImports -- TODO: remove floatingActions folder from src/components in follow-PR
+import { toggleSidebar } from "@/contentScript/sidebarController";
 
 /**
- * Opens the quickbar menu
+ * Opens the action menu
  */
-export function QuickbarButton() {
+export function ActionButton() {
   const dispatch = useDispatch();
 
   return (
     // Using standard css here because the shadow dom in `FloatingActions.tsx`
     // prevents us from using regular css modules.
-    <div className="quickbar-button-container">
+    <div className="action-button-container">
       <div className="hide-button-container">
         <AsyncButton
           className="hide-button"
@@ -44,7 +45,7 @@ export function QuickbarButton() {
               dispatch(
                 SettingsSlice.actions.setFloatingActionButtonEnabled(false),
               );
-              reportEvent(Events.FLOATING_QUICK_BAR_BUTTON_ON_SCREEN_HIDE);
+              reportEvent(Events.FLOATING_ACTION_BUTTON_ON_SCREEN_HIDE);
             } catch (error) {
               notify.error({ message: "Error saving settings", error });
             }
@@ -56,10 +57,10 @@ export function QuickbarButton() {
       </div>
       <div>
         <Button
-          className="quickbar-button"
+          className="action-button"
           onClick={() => {
-            reportEvent(Events.FLOATING_QUICK_BAR_BUTTON_CLICK);
-            void toggleQuickBar();
+            reportEvent(Events.FLOATING_ACTION_BUTTON_CLICK);
+            void toggleSidebar();
           }}
         >
           {/* <img> tag since we're using a different svg than the <Logo> component and it overrides all the styles
@@ -67,7 +68,7 @@ export function QuickbarButton() {
           <img
             src={logoUrl}
             className="logo"
-            alt="open the PixieBrix quick bar"
+            alt="open the PixieBrix Sidebar"
           />
         </Button>
       </div>

--- a/src/components/floatingActions/FloatingActions.scss
+++ b/src/components/floatingActions/FloatingActions.scss
@@ -58,7 +58,7 @@
   transform: scale(1.4) translateX(9px);
 }
 
-.quickbar-button-container {
+.action-button-container {
   display: flex;
   flex-direction: column;
   .hide-button-container {
@@ -89,7 +89,7 @@
     max-height: 200px;
   }
 
-  .quickbar-button {
+  .action-button {
     padding: 7px;
     border: none;
     overflow: hidden;

--- a/src/components/floatingActions/FloatingActions.tsx
+++ b/src/components/floatingActions/FloatingActions.tsx
@@ -21,7 +21,7 @@ import bootstrap from "@/vendors/bootstrapWithoutRem.css?loadAsUrl";
 import React from "react";
 import styles from "./FloatingActions.scss?loadAsUrl";
 import ReactDOM from "react-dom";
-import { QuickbarButton } from "@/components/floatingActions/QuickbarButton";
+import { ActionButton } from "@/components/floatingActions/ActionButton";
 import store, { persistor } from "@/components/floatingActions/store";
 import Draggable from "react-draggable";
 import dragIcon from "@/icons/drag-handle.svg";
@@ -39,7 +39,7 @@ function reportReposition() {
   // Check here to prevent reporting the event twice on the same page. We just want to know
   // whether users are repositioning on the page at all.
   if (!dragReported) {
-    reportEvent(Events.FLOATING_QUICK_BAR_BUTTON_REPOSITIONED);
+    reportEvent(Events.FLOATING_ACTION_BUTTON_REPOSITIONED);
     dragReported = true;
   }
 }
@@ -54,12 +54,12 @@ function FloatingActions() {
           <img
             src={dragIcon}
             className="drag-handle"
-            alt="drag to move quick bar button"
+            alt="drag to move action button"
             // Setting draggable=false prevents browser default drag events on images
             draggable={false}
           />
           <div className="content-container">
-            <QuickbarButton />
+            <ActionButton />
           </div>
         </div>
       </div>

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -47,12 +47,10 @@ export const Events = {
 
   FACTORY_RESET: "FactoryReset",
 
-  FLOATING_QUICK_BAR_BUTTON_CLICK: "FloatingQuickBarButtonClick",
-  FLOATING_QUICK_BAR_BUTTON_REPOSITIONED: "FloatingQuickBarButtonRepositioned",
-  FLOATING_QUICK_BAR_BUTTON_ON_SCREEN_HIDE:
-    "FloatingQuickBarButtonOnScreenHide",
-  FLOATING_QUICK_BAR_BUTTON_TOGGLE_SETTING:
-    "ToggleFloatingQuickBarButtonSetting",
+  FLOATING_ACTION_BUTTON_CLICK: "FloatingQuickBarButtonClick",
+  FLOATING_ACTION_BUTTON_REPOSITIONED: "FloatingQuickBarButtonRepositioned",
+  FLOATING_ACTION_BUTTON_ON_SCREEN_HIDE: "FloatingQuickBarButtonOnScreenHide",
+  FLOATING_ACTION_BUTTON_TOGGLE_SETTING: "ToggleFloatingQuickBarButtonSetting",
 
   GOOGLE_FILE_PICKER_EVENT: "GoogleFilePickerEvent",
 

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -495,7 +495,7 @@
     "./components/fields/schemaFields/widgets/widgetUtils.ts",
     "./components/fields/schemaFields/widgets/widgetsRegistry.ts",
     "./components/floatingActions/FloatingActions.tsx",
-    "./components/floatingActions/QuickbarButton.tsx",
+    "./components/floatingActions/ActionButton.tsx",
     "./components/floatingActions/floatingActionsConstants.ts",
     "./components/floatingActions/initFloatingActions.ts",
     "./components/floatingActions/store.ts",


### PR DESCRIPTION
## What does this PR do?

- Closes #8548 
- Adds Playwright tests and POM for the FAB 

## Demo

https://www.loom.com/share/0209389a01e548598daece92c04f91d3

## Future Work

- Move the FAB out of `src/components`
    - Didn't do it during this PR to preserve history/make the changes obvious


## Checklist

- [x] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer @fungairino 
