### PR TITLE
Removes internal chrome.storage.session mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -242,7 +242,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "jest-extended": "^4.0.2",
         "jest-location-mock": "^2.0.0",
-        "jest-webextension-mock": "^3.8.16",
+        "jest-webextension-mock": "^3.9.0",
         "jsdom": "^24.0.0",
         "jsdom-testing-mocks": "^1.13.0",
         "knip": "^5.16.0",
@@ -20793,9 +20793,9 @@
       }
     },
     "node_modules/jest-webextension-mock": {
-      "version": "3.8.16",
-      "resolved": "https://registry.npmjs.org/jest-webextension-mock/-/jest-webextension-mock-3.8.16.tgz",
-      "integrity": "sha512-bFEaRBuF+QZkPsprJfCXGuTTCvBm368y9ComlwIu30Z1ia2B+cHqHr45qABgRvTwb0eojbhsawJliqhiRypQwA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/jest-webextension-mock/-/jest-webextension-mock-3.9.0.tgz",
+      "integrity": "sha512-cknPFLO3cD2GwsgpVWwcsW+s2CoKKsEHCDNDw1ZNrA5+9R28/g4UOC2CEPc+Z+MwvoNjvIsEsowJy7L6MldBYg==",
       "dev": true
     },
     "node_modules/jest-worker": {

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-extended": "^4.0.2",
     "jest-location-mock": "^2.0.0",
-    "jest-webextension-mock": "^3.8.16",
+    "jest-webextension-mock": "^3.9.0",
     "jsdom": "^24.0.0",
     "jsdom-testing-mocks": "^1.13.0",
     "knip": "^5.16.0",

--- a/src/mv3/SessionStorage.test.ts
+++ b/src/mv3/SessionStorage.test.ts
@@ -17,30 +17,6 @@
 
 import { SessionMap, SessionValue } from "./SessionStorage";
 
-const _map = new Map();
-
-// Workaround until https://github.com/RickyMarou/jest-webextension-mock/issues/6 is resolved
-browser.storage.session = {
-  get: jest.fn(async (key: string) => ({ [key]: _map.get(key) })),
-  set: jest.fn(async (obj) => {
-    _map.set(...Object.entries(obj)[0]!);
-  }),
-  remove: jest.fn(async (key) => {
-    _map.delete(key);
-  }),
-  clear: jest.fn(),
-  onChanged: {
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-    hasListener: jest.fn(),
-    hasListeners: jest.fn(),
-  },
-};
-
-beforeEach(() => {
-  _map.clear();
-});
-
 test("SessionMap", async () => {
   const map = new SessionMap("jester", import.meta.url);
   await expect(map.get("alpha")).resolves.toBeUndefined();

--- a/src/mv3/SessionStorage.ts
+++ b/src/mv3/SessionStorage.ts
@@ -15,13 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * @file Store data in a Map with fallback to storage.session, if present.
- * The alternative would be to use `chrome.storage.local` as a polyfill, but
- * then we'd have to manually keep track of this data and clean it up,
- * potentially leaving data behind.
- */
-
 import { expectContext } from "@/utils/expectContext";
 import { type OmitIndexSignature, type JsonValue } from "type-fest";
 import { type ManualStorageKey } from "@/utils/storageUtils";
@@ -36,8 +29,7 @@ function validateContext(): void {
 }
 
 /**
- * MV3-compatible Map-like storage, this helps transition to chrome.storage.session
- * and provide some type safety.
+ * Wrapper for chrome.storage.session with added type safety.
  */
 export class SessionMap<Value extends JsonValue> {
   constructor(
@@ -97,8 +89,8 @@ export class SessionMap<Value extends JsonValue> {
 }
 
 /**
- * MV3-compatible single-value storage.
- * This helps transition to chrome.storage.session and provide some type safety.
+ * Single-value storage leveraging chrome.storage.session.
+ * Adds some additional type safety.
  */
 // "OmitIndexSignature" is because of https://github.com/sindresorhus/type-fest/issues/815
 export class SessionValue<Value extends OmitIndexSignature<JsonValue>> {


### PR DESCRIPTION
## What does this PR do?

- Removes chrome.storage.session mock now that jest-webextension-mock handles it
- See https://github.com/RickyMarou/jest-webextension-mock/pull/7

## Checklist

- [x] Designate a primary reviewer @fungairino 
