### PR TITLE
#8546: Add an error-once, and never report mode for trigger extensions

### DIFF
--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
@@ -245,16 +245,16 @@ const TriggerConfiguration: React.FC<{
         title="Telemetry Mode"
         description={
           <p>
-            Events/errors to report telemetry. Select &ldquo;Report All Events
-            and Errors&rdquo; to report all runs and errors. Select
-            &ldquo;Report First Event and Error&rdquo; to only report the first
-            run and first error.
+            Configures which events (also known as runs) and errors to report in
+            mod telemetry.
           </p>
         }
         {...makeLockableFieldProps("Telemetry Mode", isLocked)}
       >
         <option value="all">Report All Events and Errors</option>
         <option value="once">Report First Event and Error</option>
+        <option value="error-once">Report First Error</option>
+        <option value="never">Never Report Events and Errors</option>
       </ConnectedFieldTemplate>
 
       <MatchRulesSection isLocked={isLocked} />

--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.tsx
@@ -254,7 +254,7 @@ const TriggerConfiguration: React.FC<{
         <option value="all">Report All Events and Errors</option>
         <option value="once">Report First Event and Error</option>
         <option value="error-once">Report First Error</option>
-        <option value="never">Never Report Events and Errors</option>
+        <option value="never">Never Report Events or Errors</option>
       </ConnectedFieldTemplate>
 
       <MatchRulesSection isLocked={isLocked} />

--- a/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
+++ b/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
@@ -843,7 +843,7 @@ exports[`TriggerConfiguration renders custom event field with known event names 
           <option
             value="never"
           >
-            Never Report Events and Errors
+            Never Report Events or Errors
           </option>
         </select>
         <small

--- a/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
+++ b/src/pageEditor/tabs/trigger/__snapshots__/TriggerConfiguration.test.tsx.snap
@@ -835,12 +835,22 @@ exports[`TriggerConfiguration renders custom event field with known event names 
           >
             Report First Event and Error
           </option>
+          <option
+            value="error-once"
+          >
+            Report First Error
+          </option>
+          <option
+            value="never"
+          >
+            Never Report Events and Errors
+          </option>
         </select>
         <small
           class="text-muted form-text"
         >
           <p>
-            Events/errors to report telemetry. Select “Report All Events and Errors” to report all runs and errors. Select “Report First Event and Error” to only report the first run and first error.
+            Configures which events (also known as runs) and errors to report in mod telemetry.
           </p>
         </small>
       </div>

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -346,7 +346,6 @@ export const contextBrick = new ContextBrick();
 export const optionsBrick = new OptionsBrick();
 export const identityBrick = new IdentityBrick();
 export const throwBrick = new ThrowBrick();
-export const throwTwiceBrick = new ThrowTwiceBrick();
 export const teapotBrick = new TeapotBrick();
 export const arrayBrick = new ArrayBrick();
 export const pipelineBrick = new PipelineBrick();

--- a/src/runtime/pipelineTests/pipelineTestHelpers.ts
+++ b/src/runtime/pipelineTests/pipelineTestHelpers.ts
@@ -190,6 +190,39 @@ export class ThrowBrick extends BrickABC {
   }
 }
 
+export class ThrowTwiceBrick extends BrickABC {
+  static BRICK_ID = validateRegistryId("test/throw-twice");
+  private timesThrown: number;
+  private get maxThrows() {
+    return 2;
+  }
+
+  constructor() {
+    super(ThrowTwiceBrick.BRICK_ID, "Throw Twice Brick");
+    this.timesThrown = 0;
+  }
+
+  inputSchema = propertiesToSchema(
+    {
+      message: {
+        type: "string",
+      },
+    },
+    [],
+  );
+
+  async run({
+    message = "Default Business Error",
+  }: BrickArgs<{ message?: string }>) {
+    if (this.maxThrows && this.timesThrown >= this.maxThrows) {
+      return { prop: "no error!" };
+    }
+
+    this.timesThrown += 1;
+    throw new BusinessError(message);
+  }
+}
+
 class ArrayBrick extends BrickABC {
   constructor() {
     super("test/array", "Array Brick");
@@ -313,6 +346,7 @@ export const contextBrick = new ContextBrick();
 export const optionsBrick = new OptionsBrick();
 export const identityBrick = new IdentityBrick();
 export const throwBrick = new ThrowBrick();
+export const throwTwiceBrick = new ThrowTwiceBrick();
 export const teapotBrick = new TeapotBrick();
 export const arrayBrick = new ArrayBrick();
 export const pipelineBrick = new PipelineBrick();

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -221,7 +221,13 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
    * @param alreadyReported true if the event or error has already been reported
    * @param isError true if reporting an error
    */
-  private shouldReport(alreadyReported: boolean, isError: boolean): boolean {
+  private shouldReport({
+    alreadyReported,
+    isError,
+  }: {
+    alreadyReported: boolean;
+    isError: boolean;
+  }): boolean {
     switch (this.reportMode) {
       case "once": {
         return !alreadyReported;
@@ -268,7 +274,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     if (extensionId) {
       const alreadyReported = this.reportedErrors.has(extensionId);
       this.reportedErrors.add(extensionId);
-      return this.shouldReport(alreadyReported, true);
+      return this.shouldReport({ alreadyReported, isError: true });
     }
 
     return true;
@@ -280,7 +286,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
   private shouldReportEvent(componentId: UUID): boolean {
     const alreadyReported = this.reportedEvents.has(componentId);
     this.reportedEvents.add(componentId);
-    return this.shouldReport(alreadyReported, false);
+    return this.shouldReport({ alreadyReported, isError: false });
   }
 
   async install(): Promise<boolean> {

--- a/src/starterBricks/triggerExtension.ts
+++ b/src/starterBricks/triggerExtension.ts
@@ -100,7 +100,9 @@ export type TriggerConfig = {
 export function getDefaultReportModeForTrigger(
   trigger: Nullishable<Trigger>,
 ): ReportMode {
-  return trigger && USER_ACTION_TRIGGERS.includes(trigger) ? "all" : "once";
+  return trigger && USER_ACTION_TRIGGERS.includes(trigger)
+    ? "all"
+    : "error-once";
 }
 
 /**
@@ -215,13 +217,22 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
   readonly capabilities: PlatformCapability[] = ["dom", "state"];
 
   /**
-   * Returns true if an event should be reported, given whether it has already been reported.
-   * @param alreadyReported true if the event has already been reported
+   * Returns true if an event or error should be reported, given whether it has already been reported.
+   * @param alreadyReported true if the event or error has already been reported
+   * @param isError true if reporting an error
    */
-  private shouldReport(alreadyReported: boolean): boolean {
+  private shouldReport(alreadyReported: boolean, isError: boolean): boolean {
     switch (this.reportMode) {
       case "once": {
         return !alreadyReported;
+      }
+
+      case "error-once": {
+        return isError && !alreadyReported;
+      }
+
+      case "never": {
+        return false;
       }
 
       case "all": {
@@ -257,7 +268,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
     if (extensionId) {
       const alreadyReported = this.reportedErrors.has(extensionId);
       this.reportedErrors.add(extensionId);
-      return this.shouldReport(alreadyReported);
+      return this.shouldReport(alreadyReported, true);
     }
 
     return true;
@@ -269,7 +280,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
   private shouldReportEvent(componentId: UUID): boolean {
     const alreadyReported = this.reportedEvents.has(componentId);
     this.reportedEvents.add(componentId);
-    return this.shouldReport(alreadyReported);
+    return this.shouldReport(alreadyReported, false);
   }
 
   async install(): Promise<boolean> {

--- a/src/starterBricks/triggerExtensionTypes.ts
+++ b/src/starterBricks/triggerExtensionTypes.ts
@@ -35,6 +35,10 @@ export type TargetMode =
 export type ReportMode =
   // Events (trigger/error) reported only once per extension per page
   | "once"
+  // Only errors are reported once per extension per page
+  | "error-once"
+  // Never reports events
+  | "never"
   // Report all events
   | "all";
 


### PR DESCRIPTION
## What does this PR do?

- Closes #8546

This PR introduces changes to the trigger reporting options. It adds two new options for the `ReportMode` in the `TriggerConfig`:

- `error-once`: Only errors are reported once per extension per page.
- `never`: Never reports events.

The changes are reflected in the `TriggerConfiguration.tsx` file where the options for telemetry reporting are defined. The PR also includes updates to the corresponding test files to ensure the new options are working as expected.

## Checklist

- [x] Tests added
- [x] Primary reviewer assigned: @grahamlangford 