### PR TITLE
#8636: fix search/insert for variable popover using optional chaining

### DIFF
--- a/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarPopup.tsx
@@ -17,10 +17,12 @@
 
 import React, { useCallback, useEffect } from "react";
 import { type FieldInputMode } from "@/components/fields/schemaFields/fieldInputMode";
-import { replaceLikelyVariable } from "./likelyVariableUtils";
+import {
+  getFullVariableName,
+  replaceLikelyVariable,
+} from "./likelyVariableUtils";
 import VarMenu from "./VarMenu";
 import fitTextarea from "fit-textarea";
-import { getPathFromArray } from "@/runtime/pathHelpers";
 import useAttachPopup from "@/components/fields/schemaFields/widgets/varPopup/useAttachPopup";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
@@ -71,7 +73,10 @@ const VarPopup: React.FunctionComponent<VarPopupProps> = ({
     (selectedPath: string[]) => {
       reportEvent(Events.VAR_POPOVER_SELECT);
 
-      const fullVariableName = getPathFromArray(selectedPath);
+      const fullVariableName = getFullVariableName(
+        likelyVariable,
+        selectedPath,
+      );
 
       switch (inputMode) {
         case "var": {
@@ -117,7 +122,7 @@ const VarPopup: React.FunctionComponent<VarPopupProps> = ({
 
       hideMenu();
     },
-    [hideMenu, inputElementRef, inputMode, setValue, value],
+    [hideMenu, inputElementRef, inputMode, setValue, value, likelyVariable],
   );
 
   if (!isMenuShowing) {

--- a/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.test.ts
@@ -327,6 +327,15 @@ describe("getFullVariableName", () => {
 
   it("handles optional chaining with bracket notation", () => {
     expect(
+      getFullVariableName('@foo.bar["hello world?"]?', [
+        "@foo",
+        "bar",
+        "hello world?",
+        "qux",
+      ]),
+    ).toBe('@foo.bar["hello world?"]?.qux');
+
+    expect(
       getFullVariableName("@foo.bar?.[42]", ["@foo", "bar", "42", "qux"]),
     ).toBe("@foo.bar?.[42].qux");
     expect(
@@ -336,12 +345,11 @@ describe("getFullVariableName", () => {
       getFullVariableName('@foo.bar[""]?', ["@foo", "bar", "", "qux"]),
     ).toBe('@foo.bar[""]?.qux');
     expect(
-      getFullVariableName('@foo.bar["hello world?"]?', [
+      getFullVariableName('@foo?.["hello world?"]', [
         "@foo",
-        "bar",
         "hello world?",
-        "qux",
+        "bar",
       ]),
-    ).toBe('@foo.bar["hello world?"]?.qux');
+    ).toBe('@foo?.["hello world?"].bar');
   });
 });

--- a/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.test.ts
@@ -325,7 +325,8 @@ describe("getFullVariableName", () => {
     );
   });
 
-  it("handles optional chaining with bracket notation", () => {
+  // TODO: #8638: https://github.com/pixiebrix/pixiebrix-extension/issues/8638
+  it.skip("#8638: handle ? in property accessor", () => {
     expect(
       getFullVariableName('@foo.bar["hello world?"]?', [
         "@foo",
@@ -334,7 +335,9 @@ describe("getFullVariableName", () => {
         "qux",
       ]),
     ).toBe('@foo.bar["hello world?"]?.qux');
+  });
 
+  it("handles optional chaining with bracket notation", () => {
     expect(
       getFullVariableName("@foo.bar?.[42]", ["@foo", "bar", "42", "qux"]),
     ).toBe("@foo.bar?.[42].qux");

--- a/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.test.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  getFullVariableName,
   getLikelyVariableAtPosition,
   replaceLikelyVariable,
 } from "./likelyVariableUtils";
@@ -312,5 +313,35 @@ describe("replaceLikelyVariable", () => {
 
     expect(actual).toEqual(expectedTemplate);
     expect(newCursorPosition).toEqual(endOfVariableIndex);
+  });
+});
+
+describe("getFullVariableName", () => {
+  it("preserves optional chaining", () => {
+    expect(getFullVariableName("@foo", ["@foo", "bar"])).toBe("@foo.bar");
+    expect(getFullVariableName("@foo?", ["@foo", "bar"])).toBe("@foo?.bar");
+    expect(getFullVariableName("@foo?.bar?", ["@foo", "bar", "baz"])).toBe(
+      "@foo?.bar?.baz",
+    );
+  });
+
+  it("handles optional chaining with bracket notation", () => {
+    expect(
+      getFullVariableName("@foo.bar?.[42]", ["@foo", "bar", "42", "qux"]),
+    ).toBe("@foo.bar?.[42].qux");
+    expect(
+      getFullVariableName("@foo.bar[42]?", ["@foo", "bar", "42", "qux"]),
+    ).toBe("@foo.bar[42]?.qux");
+    expect(
+      getFullVariableName('@foo.bar[""]?', ["@foo", "bar", "", "qux"]),
+    ).toBe('@foo.bar[""]?.qux');
+    expect(
+      getFullVariableName('@foo.bar["hello world?"]?', [
+        "@foo",
+        "bar",
+        "hello world?",
+        "qux",
+      ]),
+    ).toBe('@foo.bar["hello world?"]?.qux');
   });
 });

--- a/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.ts
@@ -211,7 +211,8 @@ export function getFullVariableName(
     const base: string = pathWithChainElements[i]!;
 
     if (pathWithChainElements[i + 1] === "?") {
-      // FIXME: if the path is `["hello world?"]` this results in ??, which is incorrect
+      // TODO: #8637: https://github.com/pixiebrix/pixiebrix-extension/issues/8638
+      //  if the path is `["hello world?"]` this results in ??, which is incorrect. See test case.
       likelyPath.push(base + "?");
       i++;
     } else {

--- a/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.ts
@@ -207,8 +207,8 @@ export function getFullVariableName(
 
   const likelyPath: string[] = [];
   for (let i = 0; i < pathWithChainElements.length; i++) {
-    // eslint-disable-next-line security/detect-object-injection -- numeric index
-    const base: string = pathWithChainElements[i];
+    // eslint-disable-next-line security/detect-object-injection,@typescript-eslint/no-unnecessary-type-assertion,@typescript-eslint/no-non-null-assertion -- numeric index
+    const base: string = pathWithChainElements[i]!;
 
     if (pathWithChainElements[i + 1] === "?") {
       // FIXME: if the path is `["hello world?"]` this results in ??, which is incorrect

--- a/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/likelyVariableUtils.ts
@@ -208,9 +208,10 @@ export function getFullVariableName(
   const likelyPath: string[] = [];
   for (let i = 0; i < pathWithChainElements.length; i++) {
     // eslint-disable-next-line security/detect-object-injection -- numeric index
-    const base: string = pathWithChainElements[i]!;
+    const base: string = pathWithChainElements[i];
 
     if (pathWithChainElements[i + 1] === "?") {
+      // FIXME: if the path is `["hello world?"]` this results in ??, which is incorrect
       likelyPath.push(base + "?");
       i++;
     } else {
@@ -220,10 +221,13 @@ export function getFullVariableName(
 
   return getPathFromArray(
     selectedPath.map((part, index) => {
-      // Preserve optional chaining from what the use has typed so far
+      // eslint-disable-next-line security/detect-object-injection -- numeric index
+      const current = likelyPath[index] ?? "";
+
+      // Preserve optional chaining from what the user has typed so far
       if (
-        // eslint-disable-next-line security/detect-object-injection -- numeric index
-        likelyPath[index]?.endsWith("?") &&
+        current.endsWith("?") &&
+        !/[ .]/.test(current) &&
         index !== selectedPath.length - 1
       ) {
         return { part, isOptional: true };

--- a/src/components/fields/schemaFields/widgets/varPopup/menuFilters.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/menuFilters.test.ts
@@ -91,6 +91,15 @@ describe("filterVarMapByVariable", () => {
       }),
     );
 
+    // Exact match with chaining
+    expect(filterVarMapByVariable(inputMap, "@input?.foo")).toEqual(
+      expect.objectContaining({
+        "@input": expect.objectContaining({
+          foo: expect.toBeObject(),
+        }),
+      }),
+    );
+
     // Empty because trailing period indicates final variable name
     expect(filterVarMapByVariable(inputMap, "@input.fo.")).toEqual(
       expect.objectContaining({

--- a/src/components/fields/schemaFields/widgets/varPopup/menuFilters.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/menuFilters.ts
@@ -34,7 +34,7 @@ export type MenuOptions = Array<[string, UnknownRecord]>;
 /**
  * Returns true if the value is null or is likely plain text (i.e., not a variable).
  */
-function isTextOrNull(value: string | null): boolean {
+function isTextOrNullVar(value: string | null): boolean {
   return value == null || value === "@" || !value.startsWith("@");
 }
 
@@ -42,7 +42,11 @@ function isTextOrNull(value: string | null): boolean {
  * Convert a variable to a normalized variable path, removing optional chaining. Result is suitable for filtering
  * by path prefix.
  */
-function toVarPath(value: string): string[] {
+function toVarPath(value: string | null): string[] {
+  if (value == null) {
+    return [];
+  }
+
   return toPath(value.replaceAll("?.", "."));
 }
 
@@ -69,7 +73,7 @@ export function filterOptionsByVariable(
   options: MenuOptions,
   likelyVariable: string,
 ): MenuOptions {
-  if (isTextOrNull(likelyVariable)) {
+  if (isTextOrNullVar(likelyVariable)) {
     return options;
   }
 
@@ -125,7 +129,7 @@ export function filterVarMapByVariable(
   varMap: UnknownRecord,
   likelyVariable: string,
 ): UnknownRecord {
-  if (isTextOrNull(likelyVariable)) {
+  if (isTextOrNullVar(likelyVariable)) {
     return varMap;
   }
 
@@ -141,7 +145,7 @@ export function expandCurrentVariableLevel(
   varMap: UnknownRecord,
   likelyVariable: string,
 ): ShouldExpandNodeInitially {
-  if (isTextOrNull(likelyVariable)) {
+  if (isTextOrNullVar(likelyVariable)) {
     return () => false;
   }
 
@@ -244,7 +248,9 @@ export function defaultMenuOption(
     return null;
   }
 
-  if (isTextOrNull(likelyVariable) || toVarPath(likelyVariable).length === 0) {
+  const parts = toVarPath(likelyVariable);
+
+  if (isTextOrNullVar(likelyVariable) || parts.length === 0) {
     // Must always have at least one option (e.g., the `@input`)
     // Prefer the last option, because that's the latest output
 
@@ -252,8 +258,6 @@ export function defaultMenuOption(
     const first = Object.keys(vars)[0];
     return [first];
   }
-
-  const parts = toVarPath(likelyVariable);
 
   const [head, ...rest] = parts;
 

--- a/src/components/fields/schemaFields/widgets/varPopup/menuFilters.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/menuFilters.ts
@@ -32,7 +32,7 @@ import { getIn } from "formik";
 export type MenuOptions = Array<[string, UnknownRecord]>;
 
 /**
- * Returns true if the value is null or is likely plain text/not a variable.
+ * Returns true if the value is null or is likely plain text (i.e., not a variable).
  */
 function isTextOrNull(value: string | null): boolean {
   return value == null || value === "@" || !value.startsWith("@");

--- a/src/runtime/pathHelpers.test.ts
+++ b/src/runtime/pathHelpers.test.ts
@@ -191,7 +191,7 @@ describe("getPathFromArray", () => {
         { part: 0, isOptional: true },
         "name",
       ]),
-    ).toBe('users["foo bar?"].[0]?.name');
+    ).toBe('users["foo bar?"][0]?.name');
   });
 });
 

--- a/src/runtime/pathHelpers.test.ts
+++ b/src/runtime/pathHelpers.test.ts
@@ -145,35 +145,54 @@ describe("getFieldNamesFromPathString", () => {
   });
 });
 
-test("getPathFromArray", () => {
-  const expectMatch = (
-    pathArray: Array<number | string>,
-    expectedPathString: string,
-  ) => {
-    const pathString = getPathFromArray(pathArray);
-    const lodashArray = toPath(pathString);
+describe("getPathFromArray", () => {
+  test("required path parts", () => {
+    const expectMatch = (
+      pathArray: Array<number | string>,
+      expectedPathString: string,
+    ) => {
+      const pathString = getPathFromArray(pathArray);
+      const lodashArray = toPath(pathString);
 
-    // Compare the array to the expected string
-    expect(pathString).toBe(expectedPathString);
+      // Compare the array to the expected string
+      expect(pathString).toBe(expectedPathString);
 
-    // Expect the same input, except that lodash only returns strings even for numbers
-    expect(lodashArray).toEqual(pathArray.map(String));
-  };
+      // Expect the same input, except that lodash only returns strings even for numbers
+      expect(lodashArray).toEqual(pathArray.map(String));
+    };
 
-  expectMatch(["user"], "user");
-  expectMatch(["users", 0], "users[0]");
-  expectMatch(["users", 0, "name"], "users[0].name");
-  expectMatch(["users", ""], 'users[""]');
-  expectMatch(["names", "Dante Alighieri"], 'names["Dante Alighieri"]');
-  expectMatch(
-    ["Ugo Foscolo", "User Location"],
-    '["Ugo Foscolo"]["User Location"]',
-  );
-  expectMatch(["User List", 100, "id"], '["User List"][100].id');
-  expectMatch(
-    ["User List", 100_000_000, "The name"],
-    '["User List"][100000000]["The name"]',
-  );
+    expectMatch(["user"], "user");
+    expectMatch(["users", 0], "users[0]");
+    expectMatch(["users", 0, "name"], "users[0].name");
+    expectMatch(["users", ""], 'users[""]');
+    expectMatch(["names", "Dante Alighieri"], 'names["Dante Alighieri"]');
+    expectMatch(
+      ["Ugo Foscolo", "User Location"],
+      '["Ugo Foscolo"]["User Location"]',
+    );
+    expectMatch(["User List", 100, "id"], '["User List"][100].id');
+    expectMatch(
+      ["User List", 100_000_000, "The name"],
+      '["User List"][100000000]["The name"]',
+    );
+  });
+
+  test("optional chaining path parts", () => {
+    expect(
+      getPathFromArray(["users", { part: 0, isOptional: true }, "name"]),
+    ).toBe("users[0]?.name");
+    expect(
+      getPathFromArray(["users?", { part: 0, isOptional: true }, "name"]),
+    ).toBe("users?.[0]?.name");
+    expect(
+      getPathFromArray([
+        "users",
+        "foo bar?",
+        { part: 0, isOptional: true },
+        "name",
+      ]),
+    ).toBe('users["foo bar?"].[0]?.name');
+  });
 });
 
 test.each([

--- a/src/runtime/pathHelpers.ts
+++ b/src/runtime/pathHelpers.ts
@@ -205,6 +205,7 @@ function normalizePart(
  *
  * @example getPathFromArray(["user", "name"]) // => "user.name"
  * @example getPathFromArray(["title", "Divine Comedy"]) // => "title["Divine Comedy"]"
+ * @example getPathFromArray([{part: "title", isOptional: true}, "Divine Comedy"]) // => "title?.["Divine Comedy"]"
  */
 export function getPathFromArray(
   parts: Array<

--- a/src/runtime/pathHelpers.ts
+++ b/src/runtime/pathHelpers.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { identity, toPath } from "lodash";
+import { identity, toPath, trimEnd } from "lodash";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { cleanValue, isObject } from "@/utils/objectUtils";
 import { joinName } from "@/utils/formUtils";
@@ -151,6 +151,52 @@ export function getFieldNamesFromPathString(
   return [parentFieldName, fieldName];
 }
 
+/**
+ * Normalize an array of parts into an explicit format simpler for joining the path back together.
+ */
+function normalizePart(
+  partOrRecord:
+    | string
+    | number
+    | { part: string | number; isOptional: boolean },
+): { part: string; isOptional: boolean; isBrackets: boolean } {
+  if (typeof partOrRecord === "string") {
+    if (partOrRecord === "" || /[ .]/.test(partOrRecord)) {
+      return {
+        part: `["${partOrRecord}"]`,
+        isOptional: false,
+        isBrackets: true,
+      };
+    }
+
+    // Treat numeric strings as array access
+    if (/\d+/.test(partOrRecord)) {
+      return {
+        part: `[${partOrRecord}]`,
+        isOptional: false,
+        isBrackets: true,
+      };
+    }
+
+    return {
+      part: trimEnd(partOrRecord, "?"),
+      isOptional: partOrRecord.endsWith("?"),
+      isBrackets: false,
+    };
+  }
+
+  if (typeof partOrRecord === "number") {
+    return { part: `[${partOrRecord}]`, isOptional: false, isBrackets: true };
+  }
+
+  const normalized = normalizePart(partOrRecord.part);
+
+  return {
+    ...normalized,
+    isOptional: partOrRecord.isOptional || normalized.isOptional,
+  };
+}
+
 // Counterpart to _.toPath: https://lodash.com/docs/4.17.15#toPath
 // `fromPath` Missing from lodash: https://github.com/lodash/lodash/issues/2169
 /**
@@ -160,18 +206,25 @@ export function getFieldNamesFromPathString(
  * @example getPathFromArray(["user", "name"]) // => "user.name"
  * @example getPathFromArray(["title", "Divine Comedy"]) // => "title["Divine Comedy"]"
  */
-export function getPathFromArray(parts: Array<string | number>): string {
-  return parts
-    .map((part, index) => {
-      if (part === "" || (typeof part === "string" && /[ .]/.test(part))) {
-        return `["${part}"]`;
+export function getPathFromArray(
+  parts: Array<
+    string | number | { part: string | number; isOptional: boolean }
+  >,
+): string {
+  const normalizedParts = parts.map((x) => normalizePart(x));
+
+  return normalizedParts
+    .map(({ part, isOptional, isBrackets }, index) => {
+      let modified = part;
+
+      if (isOptional) {
+        modified = `${part}?`;
       }
 
-      if (typeof part === "number" || /^\d+$/.test(part)) {
-        return `[${part}]`;
-      }
-
-      return index === 0 ? part : `.${part}`;
+      return index === 0 ||
+        (isBrackets && !normalizedParts[index - 1]?.isOptional)
+        ? modified
+        : `.${modified}`;
     })
     .join("");
 }


### PR DESCRIPTION
## What does this PR do?

- Closes #8636
- Follow up to https://github.com/pixiebrix/pixiebrix-extension/pull/8635
- Ignores `?` during filtering
- Attempts to preserve existing `?` when a value is selected from the popover

## Discussion

- Eventually we probably want to do real lexing/parsing to generate an AST that can also be used to re-generate the expression

## Future Work

- https://github.com/pixiebrix/pixiebrix-extension/issues/8638

## Checklist

- [x] Add jest or playwright tests and/or storybook stories
- [x] Designate a primary reviewer: @fungairino 
