### PR TITLE
#8283: webext-messenger -> 0.28.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
         "webext-detect-page": "^5.0.0",
         "webext-events": "^3.0.0",
         "webext-inject-on-install": "^2.1.0",
-        "webext-messenger": "^0.27.0",
+        "webext-messenger": "^0.28.0",
         "webext-patterns": "^1.4.0",
         "webext-permissions": "^3.1.3",
         "webext-polyfill-kinda": "^1.0.2",
@@ -23539,6 +23539,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -29149,13 +29163,14 @@
       }
     },
     "node_modules/webext-messenger": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.27.0.tgz",
-      "integrity": "sha512-7LC1hvWmNwCOJj34YItGf8O6sTFw+izl8fIF47OHYjbPgHcx/kZKu8h5rfOfkYQIptvSA2oP9VyM0aTPhfDz3A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/webext-messenger/-/webext-messenger-0.28.0.tgz",
+      "integrity": "sha512-u2vdeLE5Sp7DnmMXHoI8iuzpaEJsJ/hoiAwL1nA/QQLtsMz/KS2Bww07JPKkzV7Rsc3zZ5j8Vnd4bP9BIQSplA==",
       "dependencies": {
+        "p-event": "^6.0.1",
         "p-retry": "^6.2.0",
         "serialize-error": "^11.0.3",
-        "type-fest": "^4.13.0",
+        "type-fest": "^4.18.3",
         "webext-detect-page": "^5.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "webext-detect-page": "^5.0.0",
     "webext-events": "^3.0.0",
     "webext-inject-on-install": "^2.1.0",
-    "webext-messenger": "^0.27.0",
+    "webext-messenger": "^0.28.0",
     "webext-patterns": "^1.4.0",
     "webext-permissions": "^3.1.3",
     "webext-polyfill-kinda": "^1.0.2",


### PR DESCRIPTION
## What does this PR do?

Fixes #8283

This PR updates the version of the `webext-messenger` package from `0.27.0` to `0.28.0` in the Pixiebrix browser extension. It also introduces a new dependency, `p-event` version `6.0.1`.

I verified that this upgraded dependency fixes the issue linked above by using a mod that shows a temporary form on page load. With this change, preloading the page (by typing the url in search bar and waiting a sec) does not cause the `FORM_GET_DEFINITION` to pop up.

## Team Coordination

The new dependency, p-event is MIT license. 

## Checklist

- [ ] Add jest or playwright tests and/or storybook stories
- [X] Designate a primary reviewer @twschiller 