### PR TITLE
Add documentation link to pages

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -7838,11 +7838,9 @@ exports[`Storyshots Layout/Page Default 1`] = `
     <div
       className="flex-grow-1"
     >
-      <div
-        className="page-header"
-      >
-        <h3
-          className="page-title"
+      <div>
+        <div
+          className="page-header"
         >
           <span
             className="page-title-icon bg-gradient-primary text-white mr-2"
@@ -7865,8 +7863,97 @@ exports[`Storyshots Layout/Page Default 1`] = `
               />
             </svg>
           </span>
-          Example page
-        </h3>
+          <div>
+            <h3
+              className="page-title"
+            >
+              Example page
+            </h3>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="pb-4"
+  >
+    <p>
+      Welcome to an example page! Have a look around.
+    </p>
+  </div>
+  Hello world!
+</div>
+`;
+
+exports[`Storyshots Layout/Page Documentation Link 1`] = `
+<div>
+  <div
+    className="d-flex"
+  >
+    <div
+      className="flex-grow-1"
+    >
+      <div>
+        <div
+          className="page-header"
+        >
+          <span
+            className="page-title-icon bg-gradient-primary text-white mr-2"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-music fa-w-16 "
+              data-icon="music"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={{}}
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M470.38 1.51L150.41 96A32 32 0 0 0 128 126.51v261.41A139 139 0 0 0 96 384c-53 0-96 28.66-96 64s43 64 96 64 96-28.66 96-64V214.32l256-75v184.61a138.4 138.4 0 0 0-32-3.93c-53 0-96 28.66-96 64s43 64 96 64 96-28.65 96-64V32a32 32 0 0 0-41.62-30.49z"
+                fill="currentColor"
+                style={{}}
+              />
+            </svg>
+          </span>
+          <div>
+            <h3
+              className="page-title"
+            >
+              Page with documentation link
+            </h3>
+            <div
+              className="page-documentation"
+            >
+              <a
+                href="https://docs.pixiebrix.com/"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-external-link-alt fa-w-16 "
+                  data-icon="external-link-alt"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={{}}
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                    fill="currentColor"
+                    style={{}}
+                  />
+                </svg>
+                 View Documentation
+              </a>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -7889,11 +7976,9 @@ exports[`Storyshots Layout/Page Load Error 1`] = `
     <div
       className="flex-grow-1"
     >
-      <div
-        className="page-header"
-      >
-        <h3
-          className="page-title"
+      <div>
+        <div
+          className="page-header"
         >
           <span
             className="page-title-icon bg-gradient-primary text-white mr-2"
@@ -7916,8 +8001,14 @@ exports[`Storyshots Layout/Page Load Error 1`] = `
               />
             </svg>
           </span>
-          Example page
-        </h3>
+          <div>
+            <h3
+              className="page-title"
+            >
+              Example page
+            </h3>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -7938,6 +8029,70 @@ exports[`Storyshots Layout/Page Load Error 1`] = `
       Error loading page
     </p>
   </div>
+</div>
+`;
+
+exports[`Storyshots Layout/Page Toolbar 1`] = `
+<div>
+  <div
+    className="d-flex"
+  >
+    <div
+      className="flex-grow-1"
+    >
+      <div>
+        <div
+          className="page-header"
+        >
+          <span
+            className="page-title-icon bg-gradient-primary text-white mr-2"
+          >
+            <svg
+              aria-hidden="true"
+              className="svg-inline--fa fa-music fa-w-16 "
+              data-icon="music"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              style={{}}
+              viewBox="0 0 512 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M470.38 1.51L150.41 96A32 32 0 0 0 128 126.51v261.41A139 139 0 0 0 96 384c-53 0-96 28.66-96 64s43 64 96 64 96-28.66 96-64V214.32l256-75v184.61a138.4 138.4 0 0 0-32-3.93c-53 0-96 28.66-96 64s43 64 96 64 96-28.65 96-64V32a32 32 0 0 0-41.62-30.49z"
+                fill="currentColor"
+                style={{}}
+              />
+            </svg>
+          </span>
+          <div>
+            <h3
+              className="page-title"
+            >
+              Page with toolbar
+            </h3>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <button
+        className="btn btn-primary"
+        disabled={false}
+        type="button"
+      >
+        Example action
+      </button>
+    </div>
+  </div>
+  <div
+    className="pb-4"
+  >
+    <p>
+      Welcome to an example page! Have a look around.
+    </p>
+  </div>
+  Hello world!
 </div>
 `;
 

--- a/src/extensionConsole/pages/activateExtension/ActivateExtensionPage.tsx
+++ b/src/extensionConsole/pages/activateExtension/ActivateExtensionPage.tsx
@@ -49,6 +49,7 @@ const ActivateExtensionPage: React.FunctionComponent = () => {
     <Page
       title="Activate Mod"
       icon={faCloudDownloadAlt}
+      documentationUrl="https://docs.pixiebrix.com/activating-mods"
       error={error}
       isPending={isFetching || authOptions == null}
     >

--- a/src/extensionConsole/pages/activateMod/ActivateModPage.tsx
+++ b/src/extensionConsole/pages/activateMod/ActivateModPage.tsx
@@ -110,6 +110,7 @@ const ActivateModPage: React.FunctionComponent = () => {
     <Page
       title={`${isReinstall ? "Reactivate" : "Activate"} Mod`}
       icon={faStoreAlt}
+      documentationUrl="https://docs.pixiebrix.com/activating-mods"
       isPending={isFetching}
       error={error}
     >

--- a/src/extensionConsole/pages/activateMod/__snapshots__/ActivateModCard.test.tsx.snap
+++ b/src/extensionConsole/pages/activateMod/__snapshots__/ActivateModCard.test.tsx.snap
@@ -9,11 +9,9 @@ exports[`ActivateModCard activate mod definition permissions 1`] = `
       <div
         class="flex-grow-1"
       >
-        <div
-          class="page-header"
-        >
-          <h3
-            class="page-title"
+        <div>
+          <div
+            class="page-header"
           >
             <span
               class="page-title-icon bg-gradient-primary text-white mr-2"
@@ -34,8 +32,40 @@ exports[`ActivateModCard activate mod definition permissions 1`] = `
                 />
               </svg>
             </span>
-            Activate Mod
-          </h3>
+            <div>
+              <h3
+                class="page-title"
+              >
+                Activate Mod
+              </h3>
+              <div
+                class="page-documentation"
+              >
+                <a
+                  href="https://docs.pixiebrix.com/activating-mods"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-external-link-alt fa-w-16 "
+                    data-icon="external-link-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                   View Documentation
+                </a>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -164,11 +194,9 @@ exports[`ActivateModCard activate mod definition with missing required mod defin
       <div
         class="flex-grow-1"
       >
-        <div
-          class="page-header"
-        >
-          <h3
-            class="page-title"
+        <div>
+          <div
+            class="page-header"
           >
             <span
               class="page-title-icon bg-gradient-primary text-white mr-2"
@@ -189,8 +217,40 @@ exports[`ActivateModCard activate mod definition with missing required mod defin
                 />
               </svg>
             </span>
-            Activate Mod
-          </h3>
+            <div>
+              <h3
+                class="page-title"
+              >
+                Activate Mod
+              </h3>
+              <div
+                class="page-documentation"
+              >
+                <a
+                  href="https://docs.pixiebrix.com/activating-mods"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-external-link-alt fa-w-16 "
+                    data-icon="external-link-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                   View Documentation
+                </a>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -459,11 +519,9 @@ exports[`ActivateModCard renders 1`] = `
       <div
         class="flex-grow-1"
       >
-        <div
-          class="page-header"
-        >
-          <h3
-            class="page-title"
+        <div>
+          <div
+            class="page-header"
           >
             <span
               class="page-title-icon bg-gradient-primary text-white mr-2"
@@ -484,8 +542,40 @@ exports[`ActivateModCard renders 1`] = `
                 />
               </svg>
             </span>
-            Activate Mod
-          </h3>
+            <div>
+              <h3
+                class="page-title"
+              >
+                Activate Mod
+              </h3>
+              <div
+                class="page-documentation"
+              >
+                <a
+                  href="https://docs.pixiebrix.com/activating-mods"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-external-link-alt fa-w-16 "
+                    data-icon="external-link-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                   View Documentation
+                </a>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -614,11 +704,9 @@ exports[`ActivateModCard renders instructions 1`] = `
       <div
         class="flex-grow-1"
       >
-        <div
-          class="page-header"
-        >
-          <h3
-            class="page-title"
+        <div>
+          <div
+            class="page-header"
           >
             <span
               class="page-title-icon bg-gradient-primary text-white mr-2"
@@ -639,8 +727,40 @@ exports[`ActivateModCard renders instructions 1`] = `
                 />
               </svg>
             </span>
-            Activate Mod
-          </h3>
+            <div>
+              <h3
+                class="page-title"
+              >
+                Activate Mod
+              </h3>
+              <div
+                class="page-documentation"
+              >
+                <a
+                  href="https://docs.pixiebrix.com/activating-mods"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-external-link-alt fa-w-16 "
+                    data-icon="external-link-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                   View Documentation
+                </a>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -781,11 +901,9 @@ exports[`ActivateModCard renders successfully with null services property 1`] = 
       <div
         class="flex-grow-1"
       >
-        <div
-          class="page-header"
-        >
-          <h3
-            class="page-title"
+        <div>
+          <div
+            class="page-header"
           >
             <span
               class="page-title-icon bg-gradient-primary text-white mr-2"
@@ -806,8 +924,40 @@ exports[`ActivateModCard renders successfully with null services property 1`] = 
                 />
               </svg>
             </span>
-            Activate Mod
-          </h3>
+            <div>
+              <h3
+                class="page-title"
+              >
+                Activate Mod
+              </h3>
+              <div
+                class="page-documentation"
+              >
+                <a
+                  href="https://docs.pixiebrix.com/activating-mods"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-external-link-alt fa-w-16 "
+                    data-icon="external-link-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                   View Documentation
+                </a>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/extensionConsole/pages/brickEditor/CreatePage.tsx
+++ b/src/extensionConsole/pages/brickEditor/CreatePage.tsx
@@ -45,7 +45,11 @@ const CreatePage: React.FunctionComponent = () => {
         <Form noValidate onSubmit={handleSubmit} autoComplete="off">
           <div className="d-flex">
             <div className="flex-grow-1">
-              <PageTitle icon={faHammer} title="Create New Brick" />
+              <PageTitle
+                icon={faHammer}
+                title="Create New Brick"
+                documentationUrl="https://docs.pixiebrix.com/developing-mods/advanced-workshop"
+              />
             </div>
             <div className="flex-grow-1 text-right">
               <Button disabled={!isValid} type="submit">

--- a/src/extensionConsole/pages/brickEditor/EditPage.tsx
+++ b/src/extensionConsole/pages/brickEditor/EditPage.tsx
@@ -156,7 +156,11 @@ const EditForm: React.FC<{ id: UUID; data: Package }> = ({ id, data }) => {
             <Form noValidate onSubmit={handleSubmit} autoComplete="off">
               <div className="d-flex">
                 <div className="flex-grow-1">
-                  <PageTitle icon={faHammer} title="Edit Brick" />
+                  <PageTitle
+                    icon={faHammer}
+                    title="Edit Brick"
+                    documentationUrl="https://docs.pixiebrix.com/developing-mods/advanced-workshop"
+                  />
                 </div>
                 <div className="flex-grow-1 EditPage__toolbar">
                   <div className="d-flex justify-content-end">

--- a/src/extensionConsole/pages/integrations/IntegrationsPage.tsx
+++ b/src/extensionConsole/pages/integrations/IntegrationsPage.tsx
@@ -419,6 +419,7 @@ const IntegrationsPage: React.VFC = () => {
       description="Configure external accounts, resources, and APIs. Local integrations are
           stored in your browser; they are never transmitted to the PixieBrix servers or shared with your team"
       isPending={localState.isLoadingIntegrations}
+      documentationUrl="https://docs.pixiebrix.com/integrations/configuring-integrations"
       toolbar={
         <BrickModal
           onSelect={onSelectIntegrationForNewConfig}

--- a/src/extensionConsole/pages/settings/SettingsPage.tsx
+++ b/src/extensionConsole/pages/settings/SettingsPage.tsx
@@ -46,6 +46,7 @@ const SettingsPage: React.FunctionComponent = () => {
       className="max-550"
       icon={faCogs}
       title="Extension Settings"
+      documentationUrl="https://docs.pixiebrix.com/platform-overview/extension-console#settings"
       description={
         <p>
           Settings for the PixieBrix browser extension. To edit the settings for

--- a/src/extensionConsole/pages/workshop/WorkshopPage.tsx
+++ b/src/extensionConsole/pages/workshop/WorkshopPage.tsx
@@ -258,6 +258,7 @@ const WorkshopPage: React.FunctionComponent<NavigateProps> = ({ navigate }) => (
           created in the Page Editor can also be edited here.
         </p>
       }
+      documentationUrl="https://docs.pixiebrix.com/developing-mods/advanced-workshop"
       toolbar={
         <Button
           variant="info"

--- a/src/extensionConsole/pages/workshop/__snapshots__/WorkshopPage.test.tsx.snap
+++ b/src/extensionConsole/pages/workshop/__snapshots__/WorkshopPage.test.tsx.snap
@@ -9,11 +9,9 @@ exports[`WorkshopPage renders empty workshop 1`] = `
       <div
         class="flex-grow-1"
       >
-        <div
-          class="page-header"
-        >
-          <h3
-            class="page-title"
+        <div>
+          <div
+            class="page-header"
           >
             <span
               class="page-title-icon bg-gradient-primary text-white mr-2"
@@ -34,8 +32,40 @@ exports[`WorkshopPage renders empty workshop 1`] = `
                 />
               </svg>
             </span>
-            Workshop
-          </h3>
+            <div>
+              <h3
+                class="page-title"
+              >
+                Workshop
+              </h3>
+              <div
+                class="page-documentation"
+              >
+                <a
+                  href="https://docs.pixiebrix.com/developing-mods/advanced-workshop"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-external-link-alt fa-w-16 "
+                    data-icon="external-link-alt"
+                    data-prefix="fas"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                   View Documentation
+                </a>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
       <div>

--- a/src/layout/Page.stories.tsx
+++ b/src/layout/Page.stories.tsx
@@ -18,6 +18,7 @@
 import React from "react";
 import Page from "@/layout/Page";
 import { type ComponentStory, type ComponentMeta } from "@storybook/react";
+import { Button } from "react-bootstrap";
 
 export default {
   component: Page,
@@ -33,6 +34,22 @@ Default.args = {
   icon: "music",
   title: "Example page",
   description: "Welcome to an example page! Have a look around.",
+};
+
+export const DocumentationLink = Template.bind({});
+DocumentationLink.args = {
+  icon: "music",
+  title: "Page with documentation link",
+  documentationUrl: "https://docs.pixiebrix.com/",
+  description: "Welcome to an example page! Have a look around.",
+};
+
+export const Toolbar = Template.bind({});
+Toolbar.args = {
+  icon: "music",
+  title: "Page with toolbar",
+  description: "Welcome to an example page! Have a look around.",
+  toolbar: <Button>Example action</Button>,
 };
 
 export const Loading = Template.bind({});

--- a/src/layout/Page.tsx
+++ b/src/layout/Page.tsx
@@ -21,20 +21,36 @@ import { type IconProp } from "@fortawesome/fontawesome-svg-core";
 import useSetDocumentTitle from "@/hooks/useSetDocumentTitle";
 import Loader from "@/components/Loader";
 import { ErrorDisplay } from "./ErrorDisplay";
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 
 export const PageTitle: React.FunctionComponent<{
   title: React.ReactNode;
+  documentationUrl?: string;
   icon?: IconProp;
-}> = ({ title, icon }) => (
-  <div className="page-header">
-    <h3 className="page-title">
+}> = ({ title, icon, documentationUrl }) => (
+  <div>
+    <div className="page-header">
       {icon && (
         <span className="page-title-icon bg-gradient-primary text-white mr-2">
           <FontAwesomeIcon icon={icon} />
         </span>
       )}
-      {title}
-    </h3>
+      <div>
+        <h3 className="page-title">{title}</h3>
+        {documentationUrl && (
+          <div className="page-documentation">
+            <a
+              href={documentationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <FontAwesomeIcon icon={faExternalLinkAlt} />
+              &nbsp;View Documentation
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
   </div>
 );
 
@@ -46,6 +62,11 @@ const Page: React.FunctionComponent<{
   breadcrumb?: React.ReactNode;
   toolbar?: React.ReactNode;
   children: React.ReactNode;
+
+  /**
+   * An optional documentation URL.
+   */
+  documentationUrl?: string;
 
   /**
    * True to show a loader for the main page content.
@@ -66,6 +87,7 @@ const Page: React.FunctionComponent<{
   toolbar,
   description = null,
   children,
+  documentationUrl,
 }) => {
   useSetDocumentTitle(title);
 
@@ -85,7 +107,11 @@ const Page: React.FunctionComponent<{
     <div className={className}>
       <div className="d-flex">
         <div className="flex-grow-1">
-          <PageTitle icon={icon} title={title} />
+          <PageTitle
+            icon={icon}
+            title={title}
+            documentationUrl={documentationUrl}
+          />
         </div>
         {toolbar && <div>{toolbar}</div>}
       </div>

--- a/src/vendors/theme/assets/styles/_misc.scss
+++ b/src/vendors/theme/assets/styles/_misc.scss
@@ -118,5 +118,6 @@ code {
 }
 
 .page-documentation {
-  font-size: 0.75em;
+  margin-top: 0.2rem;
+  font-size: 0.75rem;
 }

--- a/src/vendors/theme/assets/styles/_misc.scss
+++ b/src/vendors/theme/assets/styles/_misc.scss
@@ -90,18 +90,13 @@ code {
 
 .page-header {
   @extend .d-flex;
-  @extend .justify-content-between;
   @extend .align-items-center;
   margin: 0 0 1.5rem 0;
   .breadcrumb {
     border: 0;
     margin-bottom: 0;
   }
-}
-.page-title {
-  color: $black;
-  font-size: 1.125rem;
-  margin-bottom: 0;
+
   .page-title-icon {
     display: inline-block;
     width: 36px;
@@ -114,4 +109,14 @@ code {
       line-height: 36px;
     }
   }
+}
+
+.page-title {
+  color: $black;
+  font-size: 1.125rem;
+  margin-bottom: 0;
+}
+
+.page-documentation {
+  font-size: 0.75em;
 }


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-app/issues/5003
- Add affordance for documentation link to `Page` component

## Reviewer Notes

- Modifies the CSS in the vendored admin/extension console theme

## Discussion

- User interface
  - Includes external link icon to indicate link will open in a new tab. Might not be necessary. (It was not in the original design: https://github.com/pixiebrix/pixiebrix-app/issues/5003#issuecomment-2037489500). 
  - We might instead consider https://fontawesome.com/v5/icons/question-circle?f=classic&s=regular
  - Or just leaving off the icon, as in the original design. (Might be best given it's next to the page icon)
- @brittanyjoiner15 are there certain UTM tags we should be using here? Or do we not use since it's coming from within our ecosystem?

## Demo

See Storybook:

<img width="568" alt="image" src="https://github.com/pixiebrix/pixiebrix-extension/assets/1879821/32953ed1-0e27-42f7-825a-ced5ccc616d1">

## Future Work

- Add links in Admin Console after re-pinning: https://github.com/pixiebrix/pixiebrix-app/issues/5003

## Checklist

- [x] Add jest or playwright tests and/or storybook stories (Storyshots)
- [x] Designate a primary reviewer: @mnholtz 
