### PR TITLE
#8607 Refactor rename "element" in editor slice actions 

### DIFF
--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -106,7 +106,10 @@ function deactivateModComponentFromStates(
     optionsActions.removeExtension({ extensionId: modComponentId }),
   );
   const editor = editorState
-    ? editorReducer(editorState, editorActions.removeElement(modComponentId))
+    ? editorReducer(
+        editorState,
+        editorActions.removeModComponentFormState(modComponentId),
+      )
     : undefined;
   return { options, editor };
 }

--- a/src/background/modUpdater.ts
+++ b/src/background/modUpdater.ts
@@ -158,7 +158,7 @@ function deactivateModComponent(
 
   newEditorState = editorSlice.reducer(
     newEditorState,
-    editorSlice.actions.removeElement(modComponent.id),
+    editorSlice.actions.removeModComponentFormState(modComponent.id),
   );
 
   return {

--- a/src/pageEditor/hooks/useDeactivateMod.tsx
+++ b/src/pageEditor/hooks/useDeactivateMod.tsx
@@ -27,7 +27,7 @@ import { selectModComponentFormStates } from "@/pageEditor/slices/editorSelector
 import { uniq } from "lodash";
 import { useModals } from "@/components/ConfirmationModal";
 import { actions } from "@/pageEditor/slices/editorSlice";
-import { getIdForElement, getModIdForElement } from "@/pageEditor/utils";
+import { getIdForElement, getModId } from "@/pageEditor/utils";
 import { clearLog } from "@/background/messenger/api";
 
 type Config = {
@@ -57,7 +57,7 @@ function useDeactivateMod(): (useDeactivateConfig: Config) => Promise<void> {
 
       const modComponentIds = uniq(
         [...activatedModComponents, ...modComponentFormStates]
-          .filter((x) => getModIdForElement(x) === modId)
+          .filter((x) => getModId(x) === modId)
           .map((x) => getIdForElement(x)),
       );
       await Promise.all(

--- a/src/pageEditor/hooks/useDeactivateMod.tsx
+++ b/src/pageEditor/hooks/useDeactivateMod.tsx
@@ -27,7 +27,7 @@ import { selectModComponentFormStates } from "@/pageEditor/slices/editorSelector
 import { uniq } from "lodash";
 import { useModals } from "@/components/ConfirmationModal";
 import { actions } from "@/pageEditor/slices/editorSlice";
-import { getIdForElement, getModId } from "@/pageEditor/utils";
+import { getModComponentId, getModId } from "@/pageEditor/utils";
 import { clearLog } from "@/background/messenger/api";
 
 type Config = {
@@ -58,7 +58,7 @@ function useDeactivateMod(): (useDeactivateConfig: Config) => Promise<void> {
       const modComponentIds = uniq(
         [...activatedModComponents, ...modComponentFormStates]
           .filter((x) => getModId(x) === modId)
-          .map((x) => getIdForElement(x)),
+          .map((x) => getModComponentId(x)),
       );
       await Promise.all(
         modComponentIds.map(async (modComponentId) =>

--- a/src/pageEditor/hooks/useRemoveModComponentFromStorage.test.ts
+++ b/src/pageEditor/hooks/useRemoveModComponentFromStorage.test.ts
@@ -47,7 +47,7 @@ test("useRemoveModComponentFromStorage", async () => {
   const { dispatch } = getReduxStore();
 
   expect(dispatch).toHaveBeenCalledWith(
-    editorActions.removeElement(extensionId),
+    editorActions.removeModComponentFormState(extensionId),
   );
   expect(dispatch).toHaveBeenCalledWith(
     extensionsActions.removeExtension({ extensionId }),

--- a/src/pageEditor/hooks/useRemoveModComponentFromStorage.tsx
+++ b/src/pageEditor/hooks/useRemoveModComponentFromStorage.tsx
@@ -99,8 +99,8 @@ export function useRemoveModComponentFromStorage(): (
       });
 
       try {
-        // Remove from Page Editor
-        dispatch(editorActions.removeElement(extensionId));
+        // Remove the mod component form state from the Page Editor
+        dispatch(editorActions.removeModComponentFormState(extensionId));
 
         // Remove from options slice / extension storage
         dispatch(extensionsActions.removeExtension({ extensionId }));

--- a/src/pageEditor/hooks/useRemoveModComponentFromStorage.tsx
+++ b/src/pageEditor/hooks/useRemoveModComponentFromStorage.tsx
@@ -100,7 +100,6 @@ export function useRemoveModComponentFromStorage(): (
 
       try {
         // Remove from Page Editor
-        // Equivalent of @/store/dynamicElementStorage.ts:removeDynamicElements
         dispatch(editorActions.removeElement(extensionId));
 
         // Remove from options slice / extension storage

--- a/src/pageEditor/hooks/useResetExtension.ts
+++ b/src/pageEditor/hooks/useResetExtension.ts
@@ -63,7 +63,7 @@ function useResetExtension(): (useResetConfig: Config) => Promise<void> {
       try {
         const extension = installed.find((x) => x.id === extensionId);
         if (extension == null) {
-          dispatch(actions.removeElement(extensionId));
+          dispatch(actions.removeModComponentFormState(extensionId));
         } else {
           const formState = await modComponentToFormState(extension);
           initRecipeOptionsIfNeeded(formState, compact(recipes));

--- a/src/pageEditor/hooks/useSaveMod.ts
+++ b/src/pageEditor/hooks/useSaveMod.ts
@@ -172,8 +172,9 @@ function useSaveMod(): ModSaver {
     // Update the mod metadata on mod components in the options slice
     dispatch(optionsActions.updateRecipeMetadataForExtensions(newModMetadata));
 
-    // Update the mod metadata on mod component form states in the page editor slice
-    dispatch(editorActions.updateRecipeMetadataForElements(newModMetadata));
+    dispatch(
+      editorActions.updateModMetadataOnModComponentFormStates(newModMetadata),
+    );
 
     // Remove any deleted mod component form states from the extensions slice
     for (const modComponentId of getDeletedComponentIdsForMod(modId)) {

--- a/src/pageEditor/panes/save/useSavingWizard.ts
+++ b/src/pageEditor/panes/save/useSavingWizard.ts
@@ -163,7 +163,11 @@ const useSavingWizard = () => {
     });
 
     if (!error) {
-      dispatch(editorActions.removeElement(activeModComponentFormState.uuid));
+      dispatch(
+        editorActions.removeModComponentFormState(
+          activeModComponentFormState.uuid,
+        ),
+      );
       dispatch(
         optionsActions.removeExtension({
           extensionId: activeModComponentFormState.uuid,

--- a/src/pageEditor/sidebar/DynamicModComponentListItem.test.tsx
+++ b/src/pageEditor/sidebar/DynamicModComponentListItem.test.tsx
@@ -59,7 +59,7 @@ describe("DynamicModComponentListItem", () => {
             // Add new element to deactivate the previous one
             dispatch(editorActions.addModComponentFormState(formState));
             // Remove the active element and stay with one inactive item
-            dispatch(editorActions.removeElement(formState.uuid));
+            dispatch(editorActions.removeModComponentFormState(formState.uuid));
           },
         },
       ).asFragment(),

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -439,9 +439,9 @@ export const editorSlice = createSlice({
       // Force reload of Formik state
       state.selectionSeq++;
     },
-    removeElement(state, action: PayloadAction<UUID>) {
-      const uuid = action.payload;
-      removeModComponentFormState(state, uuid);
+    removeModComponentFormState(state, action: PayloadAction<UUID>) {
+      const modComponentId = action.payload;
+      removeModComponentFormState(state, modComponentId);
     },
     selectRecipeId(state, action: PayloadAction<RegistryId>) {
       const recipeId = action.payload;

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -53,7 +53,7 @@ import {
   editRecipeMetadata,
   editRecipeOptionsDefinitions,
   ensureElementUIState,
-  removeElement,
+  removeModComponentFormState,
   removeRecipeData,
   selectRecipeId,
   setActiveNodeId,
@@ -441,7 +441,7 @@ export const editorSlice = createSlice({
     },
     removeElement(state, action: PayloadAction<UUID>) {
       const uuid = action.payload;
-      removeElement(state, uuid);
+      removeModComponentFormState(state, uuid);
     },
     selectRecipeId(state, action: PayloadAction<RegistryId>) {
       const recipeId = action.payload;

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -49,7 +49,7 @@ import {
 } from "@/pageEditor/starterBricks/formStateTypes";
 import reportError from "@/telemetry/reportError";
 import {
-  activateElement,
+  makeModComponentFormStateActive,
   editRecipeMetadata,
   editRecipeOptionsDefinitions,
   ensureElementUIState,
@@ -324,7 +324,7 @@ export const editorSlice = createSlice({
       state.elements.push(modComponentFormState);
       state.dirty[modComponentFormState.uuid] = true;
 
-      activateElement(state, modComponentFormState);
+      makeModComponentFormStateActive(state, modComponentFormState);
     },
     betaError(state) {
       const error = new BusinessError("This feature is in private beta");
@@ -348,7 +348,7 @@ export const editorSlice = createSlice({
         state.elements.push(element);
       }
 
-      activateElement(state, element);
+      makeModComponentFormStateActive(state, element);
     },
     resetInstalled(state, actions: PayloadAction<ModComponentFormState>) {
       const element = actions.payload as Draft<ModComponentFormState>;
@@ -384,7 +384,7 @@ export const editorSlice = createSlice({
         throw new Error(`Unknown dynamic element: ${action.payload}`);
       }
 
-      activateElement(state, element);
+      makeModComponentFormStateActive(state, element);
     },
     markClean(state, action: PayloadAction<UUID>) {
       const element = state.elements.find((x) => action.payload === x.uuid);

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -525,7 +525,7 @@ export const editorSlice = createSlice({
       delete state.dirtyRecipeMetadataById[recipeId];
       delete state.dirtyRecipeOptionsById[recipeId];
     },
-    updateRecipeMetadataForElements(
+    updateModMetadataOnModComponentFormStates(
       state,
       action: PayloadAction<ModComponentBase["_recipe"]>,
     ) {

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -529,12 +529,13 @@ export const editorSlice = createSlice({
       state,
       action: PayloadAction<ModComponentBase["_recipe"]>,
     ) {
-      const metadata = action.payload;
-      const recipeElements = state.elements.filter(
-        (element) => element.recipe?.id === metadata?.id,
+      const modMetadata = action.payload;
+      const modComponentFormStates = state.elements.filter(
+        (modComponentFormState) =>
+          modComponentFormState.recipe?.id === modMetadata?.id,
       );
-      for (const element of recipeElements) {
-        element.recipe = metadata;
+      for (const formState of modComponentFormStates) {
+        formState.recipe = modMetadata;
       }
     },
     showAddToRecipeModal(state) {

--- a/src/pageEditor/slices/editorSliceHelpers.test.ts
+++ b/src/pageEditor/slices/editorSliceHelpers.test.ts
@@ -26,7 +26,7 @@ import { getPipelineMap } from "@/pageEditor/tabs/editTab/editHelpers";
 import {
   ensureElementUIState,
   ensureNodeUIState,
-  removeElement,
+  removeModComponentFormState,
   removeRecipeData,
   selectRecipeId,
   setActiveNodeId,
@@ -285,7 +285,7 @@ describe("removeElement", () => {
     };
 
     const newState = produce(state, (draft) => {
-      removeElement(draft, element.uuid);
+      removeModComponentFormState(draft, element.uuid);
     });
     expect(selectActiveModComponentId({ editor: newState })).toBeNull();
     expect(selectModComponentFormStates({ editor: newState })).not.toContain(
@@ -325,7 +325,7 @@ describe("removeElement", () => {
     };
 
     const newState = produce(state, (draft) => {
-      removeElement(draft, unavailableElement.uuid);
+      removeModComponentFormState(draft, unavailableElement.uuid);
     });
     expect(selectActiveModComponentId({ editor: newState })).toEqual(
       availableElement.uuid,
@@ -395,8 +395,8 @@ describe("removeRecipeData", () => {
     };
 
     const newState = produce(state, (draft) => {
-      removeElement(draft, element1.uuid);
-      removeElement(draft, element2.uuid);
+      removeModComponentFormState(draft, element1.uuid);
+      removeModComponentFormState(draft, element2.uuid);
       removeRecipeData(draft, recipe.id);
     });
     expect(selectActiveModId({ editor: newState })).toBeNull();

--- a/src/pageEditor/slices/editorSliceHelpers.ts
+++ b/src/pageEditor/slices/editorSliceHelpers.ts
@@ -210,7 +210,7 @@ export function editRecipeOptionsDefinitions(
     options as Draft<ModOptionsDefinition>;
 }
 
-export function activateElement(
+export function makeModComponentFormStateActive(
   state: Draft<EditorState>,
   element: ModComponentFormState,
 ) {

--- a/src/pageEditor/slices/editorSliceHelpers.ts
+++ b/src/pageEditor/slices/editorSliceHelpers.ts
@@ -108,18 +108,21 @@ export function setActiveNodeId(state: Draft<EditorState>, nodeId: UUID) {
 }
 
 /**
- * Remove a dynamic element from the redux state
+ * Remove a mod component form state from the Page Editor. This could result in deleting the mod component if
+ * it is not saved to the cloud as a standalone mod.
  * @param state The redux state (slice)
- * @param uuid The id for the dynamic element to remove
+ * @param uuid The id for the mod component to remove
  */
-export function removeElement(state: Draft<EditorState>, uuid: UUID) {
+export function removeModComponentFormState(
+  state: Draft<EditorState>,
+  uuid: UUID,
+) {
   if (state.activeElementId === uuid) {
     state.activeElementId = null;
   }
 
-  // This is called from the remove-recipe logic. When removing all extensions
-  // in a recipe, some of them may not have been selected by the user in the UI yet,
-  // and so may not have been moved into state.elements yet.
+  // Some mod components in a mod may not have a corresponding mod component form state due to having never been selected
+  // by the user in the UI. In this case, the mod component form state will not be in redux.
   const index = state.elements.findIndex((x) => x.uuid === uuid);
   if (index > -1) {
     state.elements.splice(index, 1);
@@ -130,7 +133,7 @@ export function removeElement(state: Draft<EditorState>, uuid: UUID) {
 
   const dynamicIndex = state.availableDynamicIds.indexOf(uuid);
   if (dynamicIndex > -1) {
-    // Element is available, update available ids
+    // Mod component is available, remove from list of available ids
     state.availableDynamicIds.splice(dynamicIndex, 1);
   }
 

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -54,10 +54,12 @@ export function getIdForElement(
   return isModComponentBase(element) ? element.id : element.uuid;
 }
 
-export function getModIdForElement(
-  element: ModComponentBase | ModComponentFormState,
+export function getModId(
+  modComponentOrFormState: ModComponentBase | ModComponentFormState,
 ): RegistryId | undefined {
-  return isModComponentBase(element) ? element._recipe?.id : element.recipe?.id;
+  return isModComponentBase(modComponentOrFormState)
+    ? modComponentOrFormState._recipe?.id
+    : modComponentOrFormState.recipe?.id;
 }
 
 /**

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -48,10 +48,12 @@ import AddDynamicTextSnippet from "@/bricks/effects/AddDynamicTextSnippet";
 import { type PackageUpsertResponse } from "@/types/contract";
 import { type UnsavedModDefinition } from "@/types/modDefinitionTypes";
 
-export function getIdForElement(
-  element: ModComponentBase | ModComponentFormState,
+export function getModComponentId(
+  modComponentOrFormState: ModComponentBase | ModComponentFormState,
 ): UUID {
-  return isModComponentBase(element) ? element.id : element.uuid;
+  return isModComponentBase(modComponentOrFormState)
+    ? modComponentOrFormState.id
+    : modComponentOrFormState.uuid;
 }
 
 export function getModId(

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -65,36 +65,36 @@ export function getModId(
 }
 
 /**
- * Return pipeline prop names for a configured block.
+ * Return pipeline prop names for a configured brick.
  *
  * Returns prop names in the order they should be displayed in the layout.
  *
- * @param block the block, or null if resolved block not available yet
- * @param blockConfig the block configuration
+ * @param brick the brick, or null if resolved block not available yet
+ * @param brickConfig the brick configuration
  *
  * @see PipelineToggleField
  */
 export function getPipelinePropNames(
-  block: Brick | null,
-  blockConfig: BrickConfig,
+  brick: Brick | null,
+  brickConfig: BrickConfig,
 ): string[] {
-  switch (blockConfig.id) {
+  switch (brickConfig.id) {
     // Special handling for tour step to avoid clutter and input type alternatives
     case TourStepTransformer.BRICK_ID: {
       const propNames = [];
 
       // Only show onBeforeShow if it's provided, to avoid cluttering the UI
-      if (blockConfig.config.onBeforeShow != null) {
+      if (brickConfig.config.onBeforeShow != null) {
         propNames.push("onBeforeShow");
       }
 
       // `body` can be a markdown value, or a pipeline
-      if (isPipelineExpression(blockConfig.config.body)) {
+      if (isPipelineExpression(brickConfig.config.body)) {
         propNames.push("body");
       }
 
       // Only show onAfterShow if it's provided, to avoid cluttering the UI
-      if (blockConfig.config.onAfterShow != null) {
+      if (brickConfig.config.onAfterShow != null) {
         propNames.push("onAfterShow");
       }
 
@@ -105,7 +105,7 @@ export function getPipelinePropNames(
       const propNames = [];
 
       // Only show onSubmit if it's provided, to avoid cluttering the UI
-      if (blockConfig.config.onSubmit != null) {
+      if (brickConfig.config.onSubmit != null) {
         propNames.push("onSubmit");
       }
 
@@ -113,18 +113,18 @@ export function getPipelinePropNames(
     }
 
     default: {
-      if (block == null) {
+      if (brick == null) {
         return [];
       }
 
       const pipelineProperties = pickBy(
-        inputProperties(block.inputSchema),
+        inputProperties(brick.inputSchema),
         (value) =>
           typeof value === "object" &&
           value.$ref === "https://app.pixiebrix.com/schemas/pipeline#",
       );
 
-      return sortedFields(pipelineProperties, block.uiSchema, {
+      return sortedFields(pipelineProperties, brick.uiSchema, {
         includePipelines: true,
         // JS control flow bricks don't define a uiSchema
         preserveSchemaOrder: true,

--- a/src/store/editorStorage.ts
+++ b/src/store/editorStorage.ts
@@ -20,7 +20,7 @@ import { type RegistryId } from "@/types/registryTypes";
 import { type EditorState } from "@/pageEditor/pageEditorTypes";
 import { produce } from "immer";
 import {
-  removeElement,
+  removeModComponentFormState,
   removeRecipeData,
 } from "@/pageEditor/slices/editorSliceHelpers";
 import {
@@ -82,7 +82,7 @@ export async function removeDynamicElements(elementIds: UUID[]): Promise<void> {
 
   const newState = produce(state, (draft) => {
     for (const id of elementIds) {
-      removeElement(draft, id);
+      removeModComponentFormState(draft, id);
     }
   });
 
@@ -114,7 +114,7 @@ export async function removeDynamicElementsForRecipe(
     for (const element of state.elements) {
       if (element.recipe?.id === recipeId) {
         removedDynamicElements.push(element.uuid);
-        removeElement(draft, element.uuid);
+        removeModComponentFormState(draft, element.uuid);
       }
     }
   });

--- a/src/store/sessionChanges/sessionChangesListenerMiddleware.ts
+++ b/src/store/sessionChanges/sessionChangesListenerMiddleware.ts
@@ -29,7 +29,7 @@ sessionChangesListenerMiddleware.startListening({
     actions.moveNode,
     actions.removeNode,
     actions.resetInstalled,
-    actions.removeElement,
+    actions.removeModComponentFormState,
     actions.editRecipeMetadata,
     actions.editRecipeOptionsDefinitions,
     actions.editRecipeOptionsValues,


### PR DESCRIPTION
## What does this PR do?

- Part #8607
- Another small chunk of replacing instances of "element" where mod component form state is meant
- See commit history for a nice summary of what I changed

## Checklist

- [x] Add jest or playwright tests and/or storybook stories - n/a
- [x] Designate a primary reviewer @grahamlangford 
