### PR TITLE
Fix flaky partner theming

### DIFF
--- a/src/background/initTheme.ts
+++ b/src/background/initTheme.ts
@@ -42,6 +42,7 @@ async function setToolbarIcon(): Promise<void> {
   }
 
   const activeTheme = await getActiveTheme();
+
   await allSettled(
     [themeStorage.set(activeTheme), setToolbarIconFromTheme(activeTheme)],
     { catch: "ignore" },

--- a/src/background/initTheme.ts
+++ b/src/background/initTheme.ts
@@ -24,7 +24,6 @@ import { allSettled } from "@/utils/promiseUtils";
 
 /**
  * Set the toolbar icon based on the current theme settings.
- * @see useGetTheme
  */
 async function setToolbarIcon(): Promise<void> {
   const cachedTheme = await themeStorage.get();

--- a/src/extensionConsole/pages/onboarding/partner/PartnerSetupCard.tsx
+++ b/src/extensionConsole/pages/onboarding/partner/PartnerSetupCard.tsx
@@ -40,6 +40,7 @@ import useManagedStorageState from "@/store/enterprise/useManagedStorageState";
 import { type FetchableAsyncState } from "@/types/sliceTypes";
 import useLinkState from "@/auth/useLinkState";
 import Loader from "@/components/Loader";
+import { activateTheme } from "@/background/messenger/api";
 
 /**
  * Create the app URL for the partner start page. It shows content based on whether or not the hostname corresponds
@@ -151,6 +152,7 @@ const PartnerSetupCard: React.FunctionComponent = () => {
   useEffect(() => {
     // Ensure the partner branding is applied
     dispatch(updateLocalPartnerTheme("automation-anywhere"));
+    void activateTheme();
   }, [dispatch]);
 
   if (isLinkedLoading || isMeLoading) {

--- a/src/extensionConsole/pages/onboarding/partner/PartnerSetupCard.tsx
+++ b/src/extensionConsole/pages/onboarding/partner/PartnerSetupCard.tsx
@@ -23,13 +23,13 @@ import ControlRoomOAuthForm from "@/extensionConsole/pages/onboarding/partner/Co
 import ControlRoomTokenForm from "@/extensionConsole/pages/onboarding/partner/ControlRoomTokenForm";
 import { selectSettings } from "@/store/settings/settingsSelectors";
 import { useGetMeQuery } from "@/data/service/api";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { selectIsLoggedIn } from "@/auth/authSelectors";
 import { Button } from "react-bootstrap";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faLink } from "@fortawesome/free-solid-svg-icons";
 import { getBaseURL } from "@/data/service/baseService";
-import { updateLocalPartnerTheme } from "@/store/settings/settingsSlice";
+import { useActivatePartnerTheme } from "@/store/settings/settingsSlice";
 import { useLocation } from "react-router";
 import {
   hostnameToUrl,
@@ -40,7 +40,6 @@ import useManagedStorageState from "@/store/enterprise/useManagedStorageState";
 import { type FetchableAsyncState } from "@/types/sliceTypes";
 import useLinkState from "@/auth/useLinkState";
 import Loader from "@/components/Loader";
-import { activateTheme } from "@/background/messenger/api";
 
 /**
  * Create the app URL for the partner start page. It shows content based on whether or not the hostname corresponds
@@ -114,7 +113,7 @@ function usePartnerLoginMode(): "token" | "oauth2" {
  * Currently, supports the Automation Anywhere partner integration.
  */
 const PartnerSetupCard: React.FunctionComponent = () => {
-  const dispatch = useDispatch();
+  const activatePartnerTheme = useActivatePartnerTheme();
   // Make sure to use useLocation because the location.search are on the hash route
   const location = useLocation();
   const mode = usePartnerLoginMode();
@@ -150,10 +149,8 @@ const PartnerSetupCard: React.FunctionComponent = () => {
   };
 
   useEffect(() => {
-    // Ensure the partner branding is applied
-    dispatch(updateLocalPartnerTheme("automation-anywhere"));
-    void activateTheme();
-  }, [dispatch]);
+    activatePartnerTheme("automation-anywhere");
+  }, [activatePartnerTheme]);
 
   if (isLinkedLoading || isMeLoading) {
     return <Loader />;

--- a/src/extensionConsole/pages/settings/AdvancedSettings.tsx
+++ b/src/extensionConsole/pages/settings/AdvancedSettings.tsx
@@ -25,7 +25,7 @@ import { clearCachedAuthSecrets, clearPartnerAuth } from "@/auth/authStorage";
 import notify from "@/utils/notify";
 import useFlags from "@/hooks/useFlags";
 import settingsSlice, {
-  updateLocalPartnerTheme,
+  useActivatePartnerTheme,
 } from "@/store/settings/settingsSlice";
 import { useDispatch, useSelector } from "react-redux";
 import { assertProtocolUrl } from "@/utils/urlUtils";
@@ -51,6 +51,7 @@ const AdvancedSettings: React.FunctionComponent = () => {
   const { partnerId, authIntegrationId, authMethod } =
     useSelector(selectSettings);
   const { exportDiagnostics } = useDiagnostics();
+  const activatePartnerTheme = useActivatePartnerTheme();
 
   const [serviceURL, setServiceURL] = useConfiguredHost();
 
@@ -200,7 +201,7 @@ const AdvancedSettings: React.FunctionComponent = () => {
               placeholder="my-company"
               defaultValue={partnerId ?? ""}
               onBlur={(event: React.FocusEvent<HTMLInputElement>) => {
-                dispatch(updateLocalPartnerTheme(event.target.value));
+                activatePartnerTheme(event.target.value);
               }}
             />
             <Form.Text muted>The partner id of a PixieBrix partner</Form.Text>

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -42,7 +42,7 @@ const themeStorageSubscribe = (callback: () => void) => {
 function useTheme(): { activeTheme: ThemeAssets; isLoading: boolean } {
   // The active theme is fetched with `getActiveTheme` in the background script and cached in the themeStorage,
   // This hook subscribes to changes in themeStorage to retrieve the latest current activeTheme
-  const { data, isLoading } = useAsyncExternalStore(
+  const { data: cachedTheme, isLoading } = useAsyncExternalStore(
     themeStorageSubscribe,
     themeStorage.get,
   );
@@ -50,8 +50,9 @@ function useTheme(): { activeTheme: ThemeAssets; isLoading: boolean } {
   useEffect(() => {
     if (
       !isLoading &&
-      data &&
-      (!data.lastFetched || Date.now() > data.lastFetched + 120_000)
+      cachedTheme &&
+      (!cachedTheme.lastFetched ||
+        Date.now() > cachedTheme.lastFetched + 120_000)
     ) {
       // Re-fetch the theme if it has not been fetched in the past 2 minutes
       void activateTheme();
@@ -60,14 +61,14 @@ function useTheme(): { activeTheme: ThemeAssets; isLoading: boolean } {
   }, [isLoading]);
 
   const activeTheme = useMemo(
-    () => (!isLoading && data ? data : initialTheme),
-    [data, isLoading],
+    () => (!isLoading && cachedTheme ? cachedTheme : initialTheme),
+    [cachedTheme, isLoading],
   );
 
   useEffect(() => {
     addThemeClassToDocumentRoot(activeTheme.themeName);
     setThemeFavicon(activeTheme.themeName);
-  }, [activeTheme, data, isLoading]);
+  }, [activeTheme, cachedTheme, isLoading]);
 
   return { activeTheme, isLoading };
 }

--- a/src/store/settings/settingsSlice.ts
+++ b/src/store/settings/settingsSlice.ts
@@ -30,6 +30,9 @@ import { type RegistryId } from "@/types/registryTypes";
 import { isRegistryId } from "@/types/helpers";
 import { revertAll } from "@/store/commonActions";
 import { activateTheme } from "@/background/messenger/api";
+import { useDispatch, useSelector } from "react-redux";
+import { useCallback, useEffect } from "react";
+import { selectSettings } from "@/store/settings/settingsSelectors";
 
 export const initialSettingsState: SettingsState = {
   nextUpdate: null,
@@ -139,5 +142,25 @@ export const updateLocalPartnerTheme = createAsyncThunk<
   thunkAPI.dispatch(settingsSlice.actions.setPartnerId({ partnerId }));
   await activateTheme();
 });
+
+export const useActivatePartnerTheme = (): ((
+  partnerId: string | null,
+) => void) => {
+  const dispatch = useDispatch();
+  const { partnerId } = useSelector(selectSettings);
+
+  useEffect(() => {
+    if (partnerId) {
+      void activateTheme();
+    }
+  }, [partnerId]);
+
+  return useCallback(
+    (partnerId: string) => {
+      dispatch(settingsSlice.actions.setPartnerId({ partnerId }));
+    },
+    [dispatch],
+  );
+};
 
 export default settingsSlice;

--- a/src/store/settings/settingsSlice.ts
+++ b/src/store/settings/settingsSlice.ts
@@ -15,11 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {
-  createAsyncThunk,
-  createSlice,
-  type PayloadAction,
-} from "@reduxjs/toolkit";
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import {
   AUTH_METHODS,
   type SettingsFlags,
@@ -134,15 +130,6 @@ const settingsSlice = createSlice({
  * triggers updating themeStorage in the background script.
  * @see activateTheme
  */
-export const updateLocalPartnerTheme = createAsyncThunk<
-  void,
-  string,
-  { state: SettingsState }
->("settings/updatePartnerTheme", async (partnerId, thunkAPI) => {
-  thunkAPI.dispatch(settingsSlice.actions.setPartnerId({ partnerId }));
-  await activateTheme();
-});
-
 export const useActivatePartnerTheme = (): ((
   partnerId: string | null,
 ) => void) => {


### PR DESCRIPTION
## What does this PR do?

- Introduces `useActivatePartnerTheme` hook to address the assumption that the partner theming is broken/flaky due to the background script handling `activateTheme` before the partner theme value being available in the redux settings store
- Refactors the `PartnerSetupCard` component in `PartnerSetupCard.tsx` to use a new `useActivatePartnerTheme` hook instead of dispatching an action directly. 
- The same change is applied to the `AdvancedSettings` component in `AdvancedSettings.tsx`. 
- Some light variable name refactoring

## Discussion

- We're not 100% convinced that the delay between the `partnerId` being available in the store and the background script handling `activateTheme` is the race condition (nor are we sure what caused the test to be more flaky than it was before)
- However, in the Rainforest VM where I was able to replicate the issue, I was able to confirm the `partnerId` is always null at the point when the background script is handling `activateTheme`, despite the partnerId being dispatched in the PartnerSetupCard
- I ran Rainforest against my local build of this branch and am unable to get it to fail, e.g.: https://app.rainforestqa.com/tests/405013?run=1853860&jobGroup=20922756&job=56002885&step=39

## Checklist

- [x] Add jest or playwright tests and/or storybook stories - covered by Rainforest