### PR TITLE
#8582 e2e fixture method for verifying mod definition yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
       - id: detect-private-key
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0

--- a/end-to-end-tests/fixtures/modDefinitions.ts
+++ b/end-to-end-tests/fixtures/modDefinitions.ts
@@ -19,8 +19,8 @@ import { expect } from "@playwright/test";
 import { test as pageContextFixture } from "./pageContext";
 import { WorkshopPage } from "../pageObjects/extensionConsole/workshop/workshopPage";
 
-// Removes any uuids from the text
-function normalize(string: string) {
+// Replaces any uuids in the text with a fixed value to make snapshots more stable
+function normalizeUUids(string: string) {
   return string.replaceAll(
     // eslint-disable-next-line unicorn/better-regex -- more clear this way
     /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g,
@@ -77,7 +77,7 @@ export const test = pageContextFixture.extend<{
       await workshopPage.goto();
       const editPage = await workshopPage.findAndSelectMod(modId);
 
-      const normalizedModDefinitionYaml = normalize(
+      const normalizedModDefinitionYaml = normalizeUUids(
         await editPage.editor.getValue(),
       );
       expect(normalizedModDefinitionYaml).toMatchSnapshot(snapshotName);

--- a/end-to-end-tests/pageObjects/extensionConsole/workshop/workshopPage.ts
+++ b/end-to-end-tests/pageObjects/extensionConsole/workshop/workshopPage.ts
@@ -49,12 +49,15 @@ export class WorkshopPage {
       .fill(modId);
     await this.page.getByRole("cell", { name: modId }).click();
 
-    return new EditWorkshopModPage(this.page);
+    const editPage = new EditWorkshopModPage(this.page);
+    await editPage.editor.waitForLoad();
+    return editPage;
   }
 
   async createNewModFromDefinition(modDefinitionName: string) {
     await this.createNewBrickButton.click();
     const createPage = new CreateWorkshopModPage(this.page);
+    await createPage.editor.waitForLoad();
     const modId =
       await createPage.editor.replaceWithModDefinition(modDefinitionName);
     await createPage.createBrickButton.click();

--- a/end-to-end-tests/tests/extensionConsole/activation.spec.ts
+++ b/end-to-end-tests/tests/extensionConsole/activation.spec.ts
@@ -70,7 +70,10 @@ test("can activate a mod with built-in integration", async ({
       giphyRequestPostData = route.request().postDataJSON();
 
       return route.fulfill({
-        path: path.join(__dirname, "../fixtures/responses/giphy-search.json"),
+        path: path.join(
+          __dirname,
+          "../../fixtures/responses/giphy-search.json",
+        ),
       });
     }
 

--- a/end-to-end-tests/tests/extensionConsole/activation.spec.ts
+++ b/end-to-end-tests/tests/extensionConsole/activation.spec.ts
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { test, expect } from "../fixtures/testBase";
-import { ActivateModPage } from "../pageObjects/extensionConsole/modsPage";
+import { test, expect } from "../../fixtures/testBase";
+import { ActivateModPage } from "../../pageObjects/extensionConsole/modsPage";
 // @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
 import { test as base } from "@playwright/test";
 import {
@@ -24,13 +24,13 @@ import {
   clickAndWaitForNewPage,
   runModViaQuickBar,
   getBrowserOs,
-} from "../utils";
+} from "../../utils";
 import path from "node:path";
 import { VALID_UUID_REGEX } from "@/types/stringTypes";
 import { type Serializable } from "playwright-core/types/structs";
-import { SERVICE_URL } from "../env";
-import { ExtensionsShortcutsPage } from "end-to-end-tests/pageObjects/extensionsShortcutsPage";
-import { FloatingActionButton } from "end-to-end-tests/pageObjects/floatingActionButton";
+import { SERVICE_URL } from "../../env";
+import { ExtensionsShortcutsPage } from "../../pageObjects/extensionsShortcutsPage";
+import { FloatingActionButton } from "../../pageObjects/floatingActionButton";
 
 test("can activate a mod with no config options", async ({
   page,

--- a/end-to-end-tests/tests/workshop/createMod.spec.ts
+++ b/end-to-end-tests/tests/workshop/createMod.spec.ts
@@ -26,6 +26,7 @@ test("can create a new mod from a yaml definition", async ({
   page,
   extensionId,
   createdModIds,
+  verifyModDefinitionSnapshot,
 }) => {
   // Test uses the modDefinitionNames fixture to automatically create the mod definition
   const simpleSidebarModId = createdModIds[0];
@@ -38,4 +39,9 @@ test("can create a new mod from a yaml definition", async ({
   await expect(editWorkshopModPage.editor.baseLocator).toContainText(
     simpleSidebarModId,
   );
+
+  await verifyModDefinitionSnapshot({
+    modId: simpleSidebarModId,
+    snapshotName: "simple-sidebar-panel",
+  });
 });

--- a/end-to-end-tests/tests/workshop/createMod.spec.ts-snapshots/simple-sidebar-panel-chrome-can create a new mod from a yaml definition
+++ b/end-to-end-tests/tests/workshop/createMod.spec.ts-snapshots/simple-sidebar-panel-chrome-can create a new mod from a yaml definition
@@ -1,0 +1,73 @@
+kind: recipe
+options:
+  schema:
+    type: object
+    properties: {}
+  uiSchema:
+    ui:order:
+      - "*"
+metadata:
+  id: "@extension-e2e-test-unaffiliated/simple-sidebar-panel-00000000-0000-0000-0000-000000000000"
+  name: Simple Sidebar Panel
+  version: 1.0.0
+  description: Created with the PixieBrix Page Editor
+apiVersion: v3
+definitions:
+  extensionPoint:
+    kind: extensionPoint
+    definition:
+      type: actionPanel
+      reader:
+        - "@pixiebrix/document-metadata"
+        - "@pixiebrix/document-context"
+      isAvailable:
+        matchPatterns:
+          - https://pbx.vercel.app/*
+        urlPatterns: []
+        selectors: []
+      trigger: load
+      debounce:
+        waitMillis: 250
+        leading: false
+        trailing: true
+      customEvent: null
+extensionPoints:
+  - label: Simple Sidebar Panel
+    config:
+      heading: Simple Sidebar Panel
+      body:
+        - id: "@pixiebrix/document"
+          rootMode: document
+          config:
+            body:
+              - type: container
+                config: {}
+                children:
+                  - type: row
+                    config: {}
+                    children:
+                      - type: column
+                        config: {}
+                        children:
+                          - type: header
+                            config:
+                              title: !nunjucks Simple Sidebar Panel
+                              heading: h1
+                  - type: row
+                    config: {}
+                    children:
+                      - type: column
+                        config: {}
+                        children:
+                          - type: text
+                            config:
+                              text: !nunjucks >-
+                                Simple sidebar panel for testing sidepanel
+                                open/close behavior
+                              enableMarkdown: true
+          root: null
+    permissions:
+      origins: []
+      permissions: []
+    id: extensionPoint
+    services: {}

--- a/end-to-end-tests/tests/workshop/createMod.spec.ts-snapshots/simple-sidebar-panel-edge-can create a new mod from a yaml definition
+++ b/end-to-end-tests/tests/workshop/createMod.spec.ts-snapshots/simple-sidebar-panel-edge-can create a new mod from a yaml definition
@@ -1,0 +1,73 @@
+kind: recipe
+options:
+  schema:
+    type: object
+    properties: {}
+  uiSchema:
+    ui:order:
+      - "*"
+metadata:
+  id: "@extension-e2e-test-unaffiliated/simple-sidebar-panel-00000000-0000-0000-0000-000000000000"
+  name: Simple Sidebar Panel
+  version: 1.0.0
+  description: Created with the PixieBrix Page Editor
+apiVersion: v3
+definitions:
+  extensionPoint:
+    kind: extensionPoint
+    definition:
+      type: actionPanel
+      reader:
+        - "@pixiebrix/document-metadata"
+        - "@pixiebrix/document-context"
+      isAvailable:
+        matchPatterns:
+          - https://pbx.vercel.app/*
+        urlPatterns: []
+        selectors: []
+      trigger: load
+      debounce:
+        waitMillis: 250
+        leading: false
+        trailing: true
+      customEvent: null
+extensionPoints:
+  - label: Simple Sidebar Panel
+    config:
+      heading: Simple Sidebar Panel
+      body:
+        - id: "@pixiebrix/document"
+          rootMode: document
+          config:
+            body:
+              - type: container
+                config: {}
+                children:
+                  - type: row
+                    config: {}
+                    children:
+                      - type: column
+                        config: {}
+                        children:
+                          - type: header
+                            config:
+                              title: !nunjucks Simple Sidebar Panel
+                              heading: h1
+                  - type: row
+                    config: {}
+                    children:
+                      - type: column
+                        config: {}
+                        children:
+                          - type: text
+                            config:
+                              text: !nunjucks >-
+                                Simple sidebar panel for testing sidepanel
+                                open/close behavior
+                              enableMarkdown: true
+          root: null
+    permissions:
+      origins: []
+      permissions: []
+    id: extensionPoint
+    services: {}

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -13,7 +13,7 @@
     "../end-to-end-tests/pageObjects/extensionConsole/workshop/workshopPage.ts",
     "../end-to-end-tests/setup/affiliated.setup.ts",
     "../end-to-end-tests/setup/unaffiliated.setup.ts",
-    "../end-to-end-tests/tests/extensionConsoleActivation.spec.ts",
+    "../end-to-end-tests/tests/extensionConsole/activation.spec.ts",
     "../end-to-end-tests/tests/smoke/modsPage.spec.ts",
     "../end-to-end-tests/tests/telemetry/errors.spec.ts",
     "./__mocks__/@/auth/featureFlagStorage.ts",


### PR DESCRIPTION
## What does this PR do?

Closes #8582

This PR introduces changes to the Pixiebrix extension's end-to-end testing suite. It implements snapshot testing for mod definitions, normalizing uuid strings for consistency. It also includes changes to the WorkshopModEditor and WorkshopPage classes to improve test reliability. Additionally, it removes two pre-commit hooks from the .pre-commit-config.yaml file.

## Checklist

- [X] Add jest or playwright tests and/or storybook stories