### PR TITLE
Rename RTK Query endpoints for mod definition CRUD

### DIFF
--- a/src/data/service/api.ts
+++ b/src/data/service/api.ts
@@ -30,7 +30,7 @@ import {
   type PackageUpsertResponse,
   type PackageVersionDeprecated,
   type PendingInvitation,
-  type ModDefinitionResponse,
+  type RetrieveRecipeResponse,
   type RemoteIntegrationConfig,
   type StandaloneModDefinition,
   UserRole,
@@ -275,7 +275,7 @@ export const appApi = createApi({
         method: "get",
       }),
       transformResponse(
-        baseQueryReturnValue: ModDefinitionResponse,
+        baseQueryReturnValue: RetrieveRecipeResponse,
       ): ModDefinition {
         // Pull out sharing and updated_at from response and merge into the base
         // response to create a ModDefinition

--- a/src/data/service/api.ts
+++ b/src/data/service/api.ts
@@ -30,7 +30,7 @@ import {
   type PackageUpsertResponse,
   type PackageVersionDeprecated,
   type PendingInvitation,
-  type RecipeResponse,
+  type ModDefinitionResponse,
   type RemoteIntegrationConfig,
   type StandaloneModDefinition,
   UserRole,
@@ -268,49 +268,57 @@ export const appApi = createApi({
       }),
       invalidatesTags: ["StandaloneModDefinitions"],
     }),
-    getRecipe: builder.query<ModDefinition, { recipeId: RegistryId }>({
-      query: ({ recipeId }) => ({
-        url: `/api/recipes/${encodeURIComponent(recipeId)}/`,
+    getModDefinition: builder.query<ModDefinition, { modId: RegistryId }>({
+      query: ({ modId }) => ({
+        // TODO: switch endpoint https://github.com/pixiebrix/pixiebrix-app/issues/4355
+        url: `/api/recipes/${encodeURIComponent(modId)}/`,
         method: "get",
       }),
-      transformResponse(baseQueryReturnValue: RecipeResponse): ModDefinition {
+      transformResponse(
+        baseQueryReturnValue: ModDefinitionResponse,
+      ): ModDefinition {
         // Pull out sharing and updated_at from response and merge into the base
         // response to create a ModDefinition
         const {
           sharing,
           updated_at,
-          config: unsavedRecipeDefinition,
+          config: unsavedModDefinition,
         } = baseQueryReturnValue;
         return {
-          ...unsavedRecipeDefinition,
+          ...unsavedModDefinition,
           sharing,
           updated_at,
         };
       },
       // Reminder, RTK Query caching is per-endpoint, not across endpoints. So we want to list the tags here for which
       // we want to watch for invalidation.
-      providesTags: (result, error, { recipeId }) => [
-        { type: "Package", id: recipeId },
+      providesTags: (_result, _error, { modId }) => [
+        { type: "Package", id: modId },
         "EditablePackages",
       ],
     }),
-    createRecipe: builder.mutation<
+    createModDefinition: builder.mutation<
       PackageUpsertResponse,
       {
-        recipe: UnsavedModDefinition;
+        modDefinition: UnsavedModDefinition;
         organizations: UUID[];
         public: boolean;
         shareDependencies?: boolean;
       }
     >({
-      query({ recipe, organizations, public: isPublic, shareDependencies }) {
-        const recipeConfig = dumpBrickYaml(recipe);
+      query({
+        modDefinition,
+        organizations,
+        public: isPublic,
+        shareDependencies,
+      }) {
+        const config = dumpBrickYaml(modDefinition);
 
         return {
           url: "/api/bricks/",
           method: "post",
           data: {
-            config: recipeConfig,
+            config,
             kind: "recipe" as Kind,
             organizations,
             public: isPublic,
@@ -320,24 +328,27 @@ export const appApi = createApi({
       },
       invalidatesTags: ["EditablePackages"],
     }),
-    updateRecipe: builder.mutation<
+    updateModDefinition: builder.mutation<
       PackageUpsertResponse,
-      { packageId: UUID; recipe: UnsavedModDefinition }
+      { packageId: UUID; modDefinition: UnsavedModDefinition }
     >({
-      query({ packageId, recipe }) {
-        const recipeConfig = dumpBrickYaml(recipe);
+      query({ packageId, modDefinition }) {
+        const config = dumpBrickYaml(modDefinition);
+        const sharing = (modDefinition as ModDefinition).sharing ?? {
+          public: false,
+          organizations: [],
+        };
 
         return {
           url: `/api/bricks/${packageId}/`,
           method: "put",
           data: {
             id: packageId,
-            name: recipe.metadata.id,
-            config: recipeConfig,
+            name: modDefinition.metadata.id,
+            config,
             kind: "recipe" as Kind,
-            public: Boolean((recipe as ModDefinition).sharing?.public),
-            organizations:
-              (recipe as ModDefinition).sharing?.organizations ?? [],
+            public: sharing.public,
+            organizations: sharing.organizations,
           },
         };
       },
@@ -477,9 +488,9 @@ export const {
   useDeleteStandaloneModDefinitionMutation,
   useSaveStandaloneModDefinitionMutation,
   useGetEditablePackagesQuery,
-  useGetRecipeQuery,
-  useCreateRecipeMutation,
-  useUpdateRecipeMutation,
+  useGetModDefinitionQuery,
+  useCreateModDefinitionMutation,
+  useUpdateModDefinitionMutation,
   useGetInvitationsQuery,
   useGetPackageQuery,
   useCreatePackageMutation,

--- a/src/extensionConsole/pages/activateMod/ActivateModCard.test.tsx
+++ b/src/extensionConsole/pages/activateMod/ActivateModCard.test.tsx
@@ -26,10 +26,10 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { appApiMock } from "@/testUtils/appApiMock";
-import { useGetRecipeQuery } from "@/data/service/api";
+import { useGetModDefinitionQuery } from "@/data/service/api";
 import AsyncStateGate from "@/components/AsyncStateGate";
 import { validateRegistryId } from "@/types/helpers";
-import { type RecipeResponse } from "@/types/contract";
+import { type ModDefinitionResponse } from "@/types/contract";
 import {
   modComponentDefinitionFactory,
   defaultModDefinitionFactory,
@@ -60,7 +60,7 @@ jest.mock("@/extensionConsole/pages/useRegistryIdParam", () => ({
 global.chrome.commands.getAll = jest.fn();
 
 function setupMod(modDefinition: ModDefinition) {
-  const recipeResponse: RecipeResponse = {
+  const recipeResponse: ModDefinitionResponse = {
     config: modDefinition,
     updated_at: modDefinition.updated_at,
     sharing: {
@@ -85,8 +85,8 @@ beforeEach(() => {
 
 // Activate Mod Card is always rendered when the mod has already been found
 const ModCard: React.FC = () => {
-  const recipeState = useGetRecipeQuery({
-    recipeId: testModId,
+  const recipeState = useGetModDefinitionQuery({
+    modId: testModId,
   });
   return (
     <MemoryRouter>

--- a/src/extensionConsole/pages/activateMod/ActivateModCard.test.tsx
+++ b/src/extensionConsole/pages/activateMod/ActivateModCard.test.tsx
@@ -29,7 +29,7 @@ import { appApiMock } from "@/testUtils/appApiMock";
 import { useGetModDefinitionQuery } from "@/data/service/api";
 import AsyncStateGate from "@/components/AsyncStateGate";
 import { validateRegistryId } from "@/types/helpers";
-import { type ModDefinitionResponse } from "@/types/contract";
+import { type RetrieveRecipeResponse } from "@/types/contract";
 import {
   modComponentDefinitionFactory,
   defaultModDefinitionFactory,
@@ -60,7 +60,7 @@ jest.mock("@/extensionConsole/pages/useRegistryIdParam", () => ({
 global.chrome.commands.getAll = jest.fn();
 
 function setupMod(modDefinition: ModDefinition) {
-  const recipeResponse: ModDefinitionResponse = {
+  const recipeResponse: RetrieveRecipeResponse = {
     config: modDefinition,
     updated_at: modDefinition.updated_at,
     sharing: {

--- a/src/extensionConsole/pages/activateMod/ActivateModCard.tsx
+++ b/src/extensionConsole/pages/activateMod/ActivateModCard.tsx
@@ -28,7 +28,7 @@ import { selectModHasAnyActivatedModComponents } from "@/store/extensionsSelecto
 import useRegistryIdParam from "@/extensionConsole/pages/useRegistryIdParam";
 import {
   useCreateMilestoneMutation,
-  useGetRecipeQuery,
+  useGetModDefinitionQuery,
 } from "@/data/service/api";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMagic } from "@fortawesome/free-solid-svg-icons";
@@ -83,7 +83,7 @@ const ActivateModCard: React.FC = () => {
   );
   // Page parent component is gating this content component on isFetching, so
   // recipe will always be resolved here
-  const { data: mod } = useGetRecipeQuery({ recipeId: modId });
+  const { data: mod } = useGetModDefinitionQuery({ modId });
 
   const {
     data: wizardState,

--- a/src/extensionConsole/pages/activateMod/ActivateModPage.tsx
+++ b/src/extensionConsole/pages/activateMod/ActivateModPage.tsx
@@ -24,7 +24,7 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import RequireBrickRegistry from "@/extensionConsole/components/RequireBrickRegistry";
-import { useGetRecipeQuery } from "@/data/service/api";
+import { useGetModDefinitionQuery } from "@/data/service/api";
 import { useSelector } from "react-redux";
 import { selectModHasAnyActivatedModComponents } from "@/store/extensionsSelectors";
 import useRegistryIdParam from "@/extensionConsole/pages/useRegistryIdParam";
@@ -36,10 +36,7 @@ const ActivateModPageContent: React.FC = () => {
   const modId = useRegistryIdParam();
   // Page parent component below is gating this content component on isFetching, so
   // recipe will always be resolved here
-  const { data: mod } = useGetRecipeQuery(
-    { recipeId: modId },
-    { skip: !modId },
-  );
+  const { data: mod } = useGetModDefinitionQuery({ modId }, { skip: !modId });
 
   if (mod.extensionPoints) {
     // Require that bricks have been fetched at least once before showing. Handles new installs where the bricks
@@ -78,8 +75,8 @@ const ActivateModPage: React.FunctionComponent = () => {
   const history = useHistory();
   const isReinstall = useSelector(selectModHasAnyActivatedModComponents(modId));
 
-  const { isFetching, error } = useGetRecipeQuery(
-    { recipeId: modId },
+  const { isFetching, error } = useGetModDefinitionQuery(
+    { modId },
     {
       // Force-refetch the latest data for this recipe before activation
       refetchOnMountOrArgChange: true,

--- a/src/extensionConsole/pages/mods/modals/convertToModModal/ConvertToModModal.test.tsx
+++ b/src/extensionConsole/pages/mods/modals/convertToModModal/ConvertToModModal.test.tsx
@@ -42,7 +42,7 @@ jest.mock("@/data/service/api", () => {
   return {
     ...originalModule,
     useGetAllStandaloneModDefinitionsQuery: jest.fn(),
-    useCreateRecipeMutation: jest.fn(),
+    useCreateModDefinitionMutation: jest.fn(),
     useDeleteStandaloneModDefinitionMutation: jest.fn(),
   };
 });
@@ -51,7 +51,9 @@ beforeEach(() => {
   jest.mocked(api.useGetAllStandaloneModDefinitionsQuery).mockReturnValue({
     data: [],
   } as any);
-  jest.mocked(api.useCreateRecipeMutation).mockReturnValue([jest.fn()] as any);
+  jest
+    .mocked(api.useCreateModDefinitionMutation)
+    .mockReturnValue([jest.fn()] as any);
   jest
     .mocked(api.useDeleteStandaloneModDefinitionMutation)
     .mockReturnValue([jest.fn()] as any);
@@ -128,7 +130,7 @@ describe("it renders", () => {
   ] as const)(
     "opens $name modal after converting extension to blueprint",
     async ({ sharingAction, contextToBeEmpty, sharingContext }) => {
-      jest.mocked(api.useCreateRecipeMutation).mockReturnValue([
+      jest.mocked(api.useCreateModDefinitionMutation).mockReturnValue([
         jest.fn().mockReturnValue({
           unwrap: jest.fn().mockResolvedValue({
             public: false,
@@ -183,7 +185,7 @@ describe("it renders", () => {
       data: [standaloneModDefinition],
     } as any);
     jest
-      .mocked(api.useCreateRecipeMutation)
+      .mocked(api.useCreateModDefinitionMutation)
       .mockReturnValue([
         jest.fn().mockReturnValue({ unwrap: jest.fn().mockResolvedValue({}) }),
       ] as any);

--- a/src/extensionConsole/pages/mods/modals/convertToModModal/ConvertToModModalBody.tsx
+++ b/src/extensionConsole/pages/mods/modals/convertToModModal/ConvertToModModalBody.tsx
@@ -32,7 +32,7 @@ import { pick } from "lodash";
 import Form from "@/components/form/Form";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import {
-  useCreateRecipeMutation,
+  useCreateModDefinitionMutation,
   useDeleteStandaloneModDefinitionMutation,
   useGetAllStandaloneModDefinitionsQuery,
 } from "@/data/service/api";
@@ -104,7 +104,7 @@ const selectStylesOverride: StylesConfig = {
 const ConvertToModModalBody: React.FunctionComponent = () => {
   const dispatch = useDispatch();
 
-  const [createMod] = useCreateRecipeMutation();
+  const [createMod] = useCreateModDefinitionMutation();
   const { showShareContext, showPublishContext } =
     useSelector(selectModalsContext);
   const modComponentId =
@@ -164,7 +164,7 @@ const ConvertToModModalBody: React.FunctionComponent = () => {
       });
 
       const response = await createMod({
-        recipe: unsavedModDefinition,
+        modDefinition: unsavedModDefinition,
         organizations: [],
         public: false,
         shareDependencies: true,

--- a/src/extensionConsole/pages/mods/modals/shareModals/CancelPublishContent.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/CancelPublishContent.tsx
@@ -25,7 +25,7 @@ import PublishContentLayout from "./PublishContentLayout";
 import { produce } from "immer";
 import {
   useGetEditablePackagesQuery,
-  useUpdateRecipeMutation,
+  useUpdateModDefinitionMutation,
 } from "@/data/service/api";
 import notify from "@/utils/notify";
 import { isSingleObjectBadRequestError } from "@/errors/networkErrorHelpers";
@@ -36,12 +36,12 @@ const CancelPublishContent: React.FunctionComponent = () => {
   const [error, setError] = React.useState<string | null>(null);
 
   const { blueprintId } = useSelector(selectShowPublishContext);
-  const { data: recipe, refetch: refetchRecipes } =
+  const { data: modDefinition, refetch: refetchModDefinitions } =
     useOptionalModDefinition(blueprintId);
   const { data: editablePackages, isFetching: isFetchingEditablePackages } =
     useGetEditablePackagesQuery();
 
-  const [updateRecipe] = useUpdateRecipeMutation();
+  const [updateModDefinition] = useUpdateModDefinitionMutation();
   const dispatch = useDispatch();
 
   const closeModal = () => {
@@ -53,23 +53,23 @@ const CancelPublishContent: React.FunctionComponent = () => {
     setError(null);
 
     try {
-      const newRecipe = produce(recipe, (draft) => {
+      const newModDefinition = produce(modDefinition, (draft) => {
         draft.sharing.public = false;
       });
 
       const packageId = editablePackages.find(
-        (x) => x.name === newRecipe.metadata.id,
+        (x) => x.name === newModDefinition.metadata.id,
       )?.id;
 
-      await updateRecipe({
+      await updateModDefinition({
         packageId,
-        recipe: newRecipe,
+        modDefinition: newModDefinition,
       }).unwrap();
 
       notify.success("Cancelled publish");
 
       closeModal();
-      refetchRecipes();
+      refetchModDefinitions();
     } catch (error) {
       if (
         isSingleObjectBadRequestError(error) &&

--- a/src/extensionConsole/pages/mods/modals/shareModals/PublishModContent.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/PublishModContent.tsx
@@ -23,7 +23,7 @@ import { modModalsSlice } from "@/extensionConsole/pages/mods/modals/modModalsSl
 import { getErrorMessage } from "@/errors/errorHelpers";
 import {
   useGetEditablePackagesQuery,
-  useUpdateRecipeMutation,
+  useUpdateModDefinitionMutation,
 } from "@/data/service/api";
 import notify from "@/utils/notify";
 import { produce } from "immer";
@@ -37,7 +37,7 @@ import { MARKETPLACE_URL } from "@/urlConstants";
 const PublishModContent: React.FunctionComponent = () => {
   const dispatch = useDispatch();
   const { blueprintId: modId } = useSelector(selectShowPublishContext);
-  const [updateRecipe] = useUpdateRecipeMutation();
+  const [updateModDefinition] = useUpdateModDefinitionMutation();
   const { data: editablePackages, isFetching: isFetchingEditablePackages } =
     useGetEditablePackagesQuery();
   const { data: modDefinition, refetch: refetchModDefinition } =
@@ -63,9 +63,9 @@ const PublishModContent: React.FunctionComponent = () => {
         (x) => x.name === newModDefinition.metadata.id,
       )?.id;
 
-      await updateRecipe({
+      await updateModDefinition({
         packageId,
-        recipe: newModDefinition,
+        modDefinition: newModDefinition,
       }).unwrap();
 
       notify.success("Shared brick");

--- a/src/extensionConsole/pages/mods/modals/shareModals/ShareModModalBody.tsx
+++ b/src/extensionConsole/pages/mods/modals/shareModals/ShareModModalBody.tsx
@@ -26,7 +26,7 @@ import Form from "@/components/form/Form";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import {
   useGetEditablePackagesQuery,
-  useUpdateRecipeMutation,
+  useUpdateModDefinitionMutation,
 } from "@/data/service/api";
 import { type FormikHelpers } from "formik";
 import notify from "@/utils/notify";
@@ -65,7 +65,7 @@ const ShareModModalBody: React.FunctionComponent = () => {
   const dispatch = useDispatch();
   const { blueprintId: modId } = useSelector(selectShowShareContext);
   const organizationsForSelect = useSortOrganizations();
-  const [updateModDefinition] = useUpdateRecipeMutation();
+  const [updateModDefinition] = useUpdateModDefinitionMutation();
   const { data: editablePackages, isFetching: isFetchingEditablePackages } =
     useGetEditablePackagesQuery();
   const {
@@ -108,7 +108,7 @@ const ShareModModalBody: React.FunctionComponent = () => {
 
       await updateModDefinition({
         packageId,
-        recipe: newModDefinition,
+        modDefinition: newModDefinition,
       }).unwrap();
 
       notify.success("Shared mod");

--- a/src/modDefinitions/modDefinitionsListenerMiddleware.ts
+++ b/src/modDefinitions/modDefinitionsListenerMiddleware.ts
@@ -24,8 +24,8 @@ const apiEndpoints = appApi.endpoints;
 const modDefinitionsListenerMiddleware = createListenerMiddleware();
 modDefinitionsListenerMiddleware.startListening({
   matcher: isAnyOf(
-    apiEndpoints.createRecipe.matchFulfilled,
-    apiEndpoints.updateRecipe.matchFulfilled,
+    apiEndpoints.createModDefinition.matchFulfilled,
+    apiEndpoints.updateModDefinition.matchFulfilled,
     apiEndpoints.createPackage.matchFulfilled,
     apiEndpoints.updatePackage.matchFulfilled,
     apiEndpoints.deletePackage.matchFulfilled,

--- a/src/pageEditor/hooks/useCreateModFromMod.ts
+++ b/src/pageEditor/hooks/useCreateModFromMod.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useCreateRecipeMutation } from "@/data/service/api";
+import { useCreateModDefinitionMutation } from "@/data/service/api";
 import collectExistingConfiguredDependenciesForMod from "@/integrations/util/collectExistingConfiguredDependenciesForMod";
 import useDeactivateMod from "@/pageEditor/hooks/useDeactivateMod";
 import { type ModMetadataFormState } from "@/pageEditor/pageEditorTypes";
@@ -44,7 +44,7 @@ type UseCreateModFromModReturn = {
 
 function useCreateModFromMod(): UseCreateModFromModReturn {
   const dispatch = useDispatch();
-  const [createMod] = useCreateRecipeMutation();
+  const [createMod] = useCreateModDefinitionMutation();
   const deactivateMod = useDeactivateMod();
   const getCleanComponentsAndDirtyFormStatesForMod = useSelector(
     selectGetCleanComponentsAndDirtyFormStatesForMod,
@@ -72,7 +72,7 @@ function useCreateModFromMod(): UseCreateModFromModReturn {
         });
 
         const upsertResponse = await createMod({
-          recipe: newModDefinition,
+          modDefinition: newModDefinition,
           organizations: [],
           public: false,
         }).unwrap();

--- a/src/pageEditor/hooks/useCreateModFromModComponent.ts
+++ b/src/pageEditor/hooks/useCreateModFromModComponent.ts
@@ -23,7 +23,7 @@ import { uuidv4 } from "@/types/helpers";
 import produce from "immer";
 import { useCallback } from "react";
 import { Events } from "@/telemetry/events";
-import { useCreateRecipeMutation } from "@/data/service/api";
+import { useCreateModDefinitionMutation } from "@/data/service/api";
 import { useDispatch, useSelector } from "react-redux";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 import useUpsertModComponentFormState from "@/pageEditor/hooks/useUpsertModComponentFormState";
@@ -45,7 +45,7 @@ function useCreateModFromModComponent(
 ): UseCreateModFromModReturn {
   const dispatch = useDispatch();
   const keepLocalCopy = useSelector(selectKeepLocalCopyOnCreateMod);
-  const [createMod] = useCreateRecipeMutation();
+  const [createMod] = useCreateModDefinitionMutation();
   const upsertModComponentFormState = useUpsertModComponentFormState();
   const removeModComponentFromStorage = useRemoveModComponentFromStorage();
   const { buildAndValidateMod } = useBuildAndValidateMod();
@@ -78,7 +78,7 @@ function useCreateModFromModComponent(
           });
 
           const upsertResponse = await createMod({
-            recipe: newModDefinition,
+            modDefinition: newModDefinition,
             organizations: [],
             public: false,
           }).unwrap();

--- a/src/pageEditor/hooks/useSaveMod.ts
+++ b/src/pageEditor/hooks/useSaveMod.ts
@@ -24,7 +24,7 @@ import {
 } from "@/pageEditor/slices/editorSelectors";
 import {
   useGetEditablePackagesQuery,
-  useUpdateRecipeMutation,
+  useUpdateModDefinitionMutation,
 } from "@/data/service/api";
 import notify from "@/utils/notify";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
@@ -71,7 +71,7 @@ function useSaveMod(): ModSaver {
   } = useAllModDefinitions();
   const { data: editablePackages, isLoading: isEditablePackagesLoading } =
     useGetEditablePackagesQuery();
-  const [updateMod] = useUpdateRecipeMutation();
+  const [updateMod] = useUpdateModDefinitionMutation();
   const getCleanComponentsAndDirtyFormStatesForMod = useSelector(
     selectGetCleanComponentsAndDirtyFormStatesForMod,
   );
@@ -146,7 +146,7 @@ function useSaveMod(): ModSaver {
 
     const upsertResponse = await updateMod({
       packageId,
-      recipe: newMod,
+      modDefinition: newMod,
     }).unwrap();
 
     const newModMetadata = selectModMetadata(newMod, upsertResponse);

--- a/src/pageEditor/panes/save/useSavingWizard.test.tsx
+++ b/src/pageEditor/panes/save/useSavingWizard.test.tsx
@@ -25,8 +25,8 @@ import useSavingWizard from "./useSavingWizard";
 import useUpsertFormElementMock from "@/pageEditor/hooks/useUpsertModComponentFormState";
 import useResetExtensionMock from "@/pageEditor/hooks/useResetExtension";
 import {
-  useCreateRecipeMutation as useCreateRecipeMutationMock,
-  useUpdateRecipeMutation as useUpdateRecipeMutationMock,
+  useCreateModDefinitionMutation as useCreateModDefinitionMutationMock,
+  useUpdateModDefinitionMutation as useUpdateModDefinitionMutationMock,
   useGetEditablePackagesQuery as useGetEditablePackagesQueryMock,
 } from "@/data/service/api";
 import { selectModComponentFormStates } from "@/pageEditor/slices/editorSelectors";
@@ -50,8 +50,8 @@ jest.mock("@/pageEditor/hooks/useUpsertModComponentFormState");
 jest.mock("@/pageEditor/hooks/useResetExtension");
 
 jest.mock("@/data/service/api", () => ({
-  useCreateRecipeMutation: jest.fn().mockReturnValue([]),
-  useUpdateRecipeMutation: jest.fn().mockReturnValue([]),
+  useCreateModDefinitionMutation: jest.fn().mockReturnValue([]),
+  useUpdateModDefinitionMutation: jest.fn().mockReturnValue([]),
   useGetEditablePackagesQuery: jest.fn().mockReturnValue({
     data: [],
     isLoading: false,
@@ -209,12 +209,12 @@ describe("saving a mod component", () => {
 
     const createModMock = jest.fn();
     jest
-      .mocked(useCreateRecipeMutationMock)
+      .mocked(useCreateModDefinitionMutationMock)
       .mockReturnValue([createModMock] as any);
 
     const updateModMock = jest.fn();
     jest
-      .mocked(useUpdateRecipeMutationMock)
+      .mocked(useUpdateModDefinitionMutationMock)
       .mockReturnValue([updateModMock] as any);
 
     return {

--- a/src/pageEditor/panes/save/useSavingWizard.ts
+++ b/src/pageEditor/panes/save/useSavingWizard.ts
@@ -34,9 +34,9 @@ import {
 import notify from "@/utils/notify";
 import { selectActivatedModComponents } from "@/store/extensionsSelectors";
 import {
-  useCreateRecipeMutation,
+  useCreateModDefinitionMutation,
   useGetEditablePackagesQuery,
-  useUpdateRecipeMutation,
+  useUpdateModDefinitionMutation,
 } from "@/data/service/api";
 import { replaceModComponent } from "./saveHelpers";
 import extensionsSlice from "@/store/extensionsSlice";
@@ -87,8 +87,8 @@ const useSavingWizard = () => {
 
   const { data: modDefinitions } = useAllModDefinitions();
   const { data: editablePackages } = useGetEditablePackagesQuery();
-  const [createMod] = useCreateRecipeMutation();
-  const [updateMod] = useUpdateRecipeMutation();
+  const [createMod] = useCreateModDefinitionMutation();
+  const [updateMod] = useUpdateModDefinitionMutation();
 
   const save = async () => {
     if (activeModComponentFormState.recipe == null) {
@@ -209,7 +209,7 @@ const useSavingWizard = () => {
     );
 
     const createModResponse = await createMod({
-      recipe: newModDefinition,
+      modDefinition: newModDefinition,
       // Don't share with anyone (only the author will have access)
       organizations: [],
       public: false,
@@ -280,7 +280,7 @@ const useSavingWizard = () => {
 
     const updateModResponse = await updateMod({
       packageId,
-      recipe: newMod,
+      modDefinition: newMod,
     });
 
     if ("error" in updateModResponse) {

--- a/src/pageEditor/sidebar/ActivatedModComponentListItem.tsx
+++ b/src/pageEditor/sidebar/ActivatedModComponentListItem.tsx
@@ -68,7 +68,7 @@ const ActivatedModComponentListItem: React.FunctionComponent<{
     [modComponent.extensionPointId],
   );
 
-  const [getModDefinition] = appApi.endpoints.getRecipe.useLazyQuery();
+  const [getModDefinition] = appApi.endpoints.getModDefinition.useLazyQuery();
 
   const activeModId = useSelector(selectActiveModId);
   const activeModComponentFormState = useSelector(
@@ -95,7 +95,7 @@ const ActivatedModComponentListItem: React.FunctionComponent<{
         // Initialize mod options schema if needed
         if (modComponent._recipe) {
           const { data: modDefinition } = await getModDefinition(
-            { recipeId: modComponent._recipe.id },
+            { modId: modComponent._recipe.id },
             true,
           );
           if (modDefinition) {

--- a/src/pageEditor/sidebar/ModListItem.tsx
+++ b/src/pageEditor/sidebar/ModListItem.tsx
@@ -41,7 +41,7 @@ import {
 } from "@/pageEditor/slices/editorSelectors";
 import * as semver from "semver";
 import ActionMenu from "@/pageEditor/sidebar/ActionMenu";
-import { useGetRecipeQuery } from "@/data/service/api";
+import { useGetModDefinitionQuery } from "@/data/service/api";
 
 export type ModListItemProps = PropsWithChildren<{
   modMetadata: Metadata;
@@ -72,7 +72,7 @@ const ModListItem: React.FC<ModListItemProps> = ({
 
   // TODO: Fix this so it pulls from registry, after registry single-item-api-fetch is implemented
   //        (See: https://github.com/pixiebrix/pixiebrix-extension/issues/7184)
-  const { data: modDefinition } = useGetRecipeQuery({ recipeId: modId });
+  const { data: modDefinition } = useGetModDefinitionQuery({ modId });
   const latestRecipeVersion = modDefinition?.metadata?.version;
 
   // Set the alternate background if a mod component in this mod is active

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -188,8 +188,8 @@ export type PackageConfigDetail = Except<
 };
 
 /**
- * @deprecated because ModDefinition will be used for singluar mods
  * A mod component that is not packaged inside a mod that is synced/saved to the cloud.
+ * @deprecated because ModDefinition will be used for standalone mods
  */
 export type StandaloneModDefinition<Config extends UnknownObject = JsonObject> =
   Except<ActivatedModComponent<Config>, "active"> & {
@@ -200,8 +200,10 @@ export type StandaloneModDefinition<Config extends UnknownObject = JsonObject> =
 
 /**
  * `/api/recipes/${recipeId}`
+ * @deprecated will be retired in favor of the brick endpoint
  */
-export type RecipeResponse = {
+// TODO: change shape in https://github.com/pixiebrix/pixiebrix-app/issues/4355
+export type ModDefinitionResponse = {
   // On this endpoint, the sharing and updated_at are in the envelope of the response
   config: UnsavedModDefinition;
   sharing: ModDefinition["sharing"];

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -199,11 +199,12 @@ export type StandaloneModDefinition<Config extends UnknownObject = JsonObject> =
   };
 
 /**
- * `/api/recipes/${recipeId}`
- * @deprecated will be retired in favor of the brick endpoint
+ * Response shape from `/api/recipes/${recipeId}/`
+ * @deprecated uses deprecated `/api/recipes/${recipeId}` endpoint that will be retired
  */
-// TODO: change shape in https://github.com/pixiebrix/pixiebrix-app/issues/4355
-export type ModDefinitionResponse = {
+// TODO: change shape in https://github.com/pixiebrix/pixiebrix-app/issues/4355. Keeping name as "recipe" to be clearer
+//  that is corresponds to the deprecated endpoint
+export type RetrieveRecipeResponse = {
   // On this endpoint, the sharing and updated_at are in the envelope of the response
   config: UnsavedModDefinition;
   sharing: ModDefinition["sharing"];


### PR DESCRIPTION
## What does this PR do?

- Rename RTK Query endpoints for mod CRUD to use mod definition terminology
- Main change in the RTK Query API definition: https://github.com/pixiebrix/pixiebrix-extension/pull/8668/files#diff-f9c820753f8e1322c98cc85c45858cac684e36b22d054caa13c829a4a6f63893

## Future Work

- Stop using the `/api/recipes/:id/` endpoint for retrieval: https://github.com/pixiebrix/pixiebrix-app/issues/4355

## Checklist

- [x] Add jest or playwright tests and/or storybook stories: N/A

