### PR TITLE
Don't mutate uiSchema in normalizeModOptionsDefinition

### DIFF
--- a/src/utils/modUtils.test.ts
+++ b/src/utils/modUtils.test.ts
@@ -30,6 +30,7 @@ import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactorie
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { InvalidTypeError } from "@/errors/genericErrors";
 import { type ModOptionsDefinition } from "@/types/modDefinitionTypes";
+import { freeze } from "@/utils/objectUtils";
 
 describe("getSharingType", () => {
   test("throws on invalid type", () => {
@@ -201,12 +202,12 @@ describe("normalizeModOptionsDefinition", () => {
 
   it("normalizes frozen object with no ui:order", () => {
     // Root cause of https://github.com/pixiebrix/pixiebrix-app/issues/5396
-    const original = Object.freeze({
+    const original = freeze({
       schema: {
         type: "object",
-        properties: Object.freeze({}),
+        properties: freeze({}),
       },
-      uiSchema: Object.freeze({}),
+      uiSchema: freeze({}),
     }) satisfies ModOptionsDefinition;
 
     expect(normalizeModOptionsDefinition(original)).toStrictEqual({

--- a/src/utils/modUtils.test.ts
+++ b/src/utils/modUtils.test.ts
@@ -29,6 +29,7 @@ import { modComponentFactory } from "@/testUtils/factories/modComponentFactories
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { InvalidTypeError } from "@/errors/genericErrors";
+import { type ModOptionsDefinition } from "@/types/modDefinitionTypes";
 
 describe("getSharingType", () => {
   test("throws on invalid type", () => {
@@ -188,6 +189,27 @@ describe("isUnavailableMod", () => {
 describe("normalizeModOptionsDefinition", () => {
   it("normalizes null", () => {
     expect(normalizeModOptionsDefinition(null)).toStrictEqual({
+      schema: {
+        type: "object",
+        properties: {},
+      },
+      uiSchema: {
+        "ui:order": ["*"],
+      },
+    });
+  });
+
+  it("normalizes frozen object with no ui:order", () => {
+    // Root cause of https://github.com/pixiebrix/pixiebrix-app/issues/5396
+    const original = Object.freeze({
+      schema: {
+        type: "object",
+        properties: Object.freeze({}),
+      },
+      uiSchema: Object.freeze({}),
+    }) satisfies ModOptionsDefinition;
+
+    expect(normalizeModOptionsDefinition(original)).toStrictEqual({
       schema: {
         type: "object",
         properties: {},

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -44,7 +44,7 @@ import {
   minimalUiSchemaFactory,
   propertiesToSchema,
 } from "@/utils/schemaUtils";
-import { mapValues, sortBy } from "lodash";
+import { cloneDeep, mapValues, sortBy } from "lodash";
 import { isNullOrBlank } from "@/utils/stringUtils";
 import {
   type Schema,
@@ -387,7 +387,7 @@ export function normalizeModOptionsDefinition(
           Object.keys(modDefinitionSchema as SchemaProperties),
         );
 
-  const uiSchema: UiSchema = optionsDefinition.uiSchema ?? {};
+  const uiSchema: UiSchema = cloneDeep(optionsDefinition.uiSchema ?? {});
 
   uiSchema["ui:order"] ??= [
     ...sortBy(Object.keys(schema.properties ?? {})),

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -178,6 +178,11 @@ export function isUnknownObjectArray(value: unknown): value is UnknownObject[] {
   return Array.isArray(value) && value.every((element) => isObject(element));
 }
 
+/**
+ * Type helper for Object.freeze. Note that this only freezes the top level of the object.
+ * @see Object.freeze
+ */
 export function freeze<T>(value: T): T {
+  // Consider supporting deep freeze a la: https://www.npmjs.com/package/deep-freeze-strict
   return Object.freeze(value);
 }


### PR DESCRIPTION
## What does this PR do?

- Extension change for https://github.com/pixiebrix/pixiebrix-app/issues/5396
- Fixes `normalizeModOptionsDefinition` so that it doesn't mutate its input

## Checklist

- [x] Add jest or playwright tests and/or storybook stories

