### PR TITLE
Rename `resolved` prefix to `hydrated`

### DIFF
--- a/src/background/contextMenus/initContextMenus.ts
+++ b/src/background/contextMenus/initContextMenus.ts
@@ -21,7 +21,7 @@ import { handleMenuAction, notify } from "@/contentScript/messenger/api";
 import { waitForContentScript } from "@/background/contentScript";
 import { expectContext } from "@/utils/expectContext";
 import { getModComponentState } from "@/store/extensionsStorage";
-import { resolveExtensionInnerDefinitions } from "@/registry/internal";
+import { hydrateModComponentInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
 import { type UUID } from "@/types/stringTypes";
 import { allSettled } from "@/utils/promiseUtils";
 import { MENU_PREFIX } from "@/background/contextMenus/makeMenuId";
@@ -84,7 +84,7 @@ function menuListener(info: Menus.OnClickData, tab: Tabs.Tab) {
 async function preloadAllContextMenus(): Promise<void> {
   const { extensions } = await getModComponentState();
   const { fulfilled } = await allSettled(
-    extensions.map(async (x) => resolveExtensionInnerDefinitions(x)),
+    extensions.map(async (x) => hydrateModComponentInnerDefinitions(x)),
     { catch: "ignore" },
   );
   await preloadContextMenus(fulfilled);

--- a/src/background/contextMenus/preloadContextMenus.ts
+++ b/src/background/contextMenus/preloadContextMenus.ts
@@ -16,13 +16,13 @@
  */
 
 import { ContextError } from "@/errors/genericErrors";
-import { resolveExtensionInnerDefinitions } from "@/registry/internal";
+import { hydrateModComponentInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
 import { ContextMenuStarterBrickABC } from "@/starterBricks/contextMenu/contextMenuStarterBrick";
 import { type ContextMenuConfig } from "@/starterBricks/contextMenu/contextMenuTypes";
 import { selectEventData } from "@/telemetry/deployments";
 import {
   type ModComponentBase,
-  type ResolvedModComponent,
+  type HydratedModComponent,
 } from "@/types/modComponentTypes";
 import { expectContext } from "@/utils/expectContext";
 import { allSettled } from "@/utils/promiseUtils";
@@ -38,14 +38,14 @@ export async function preloadContextMenus(
 ): Promise<void> {
   expectContext("background");
   const promises = extensions.map(async (definition) => {
-    const resolved = await resolveExtensionInnerDefinitions(definition);
+    const resolved = await hydrateModComponentInnerDefinitions(definition);
 
     const extensionPoint = await extensionPointRegistry.lookup(
       resolved.extensionPointId,
     );
     if (extensionPoint instanceof ContextMenuStarterBrickABC) {
       await extensionPoint.registerMenuItem(
-        definition as unknown as ResolvedModComponent<ContextMenuConfig>,
+        definition as unknown as HydratedModComponent<ContextMenuConfig>,
         () => {
           throw new ContextError(
             "Context menu was preloaded, but no handler was registered",

--- a/src/background/deploymentUpdater.ts
+++ b/src/background/deploymentUpdater.ts
@@ -61,7 +61,7 @@ import registerContribBricks from "@/contrib/registerContribBricks";
 import { launchSsoFlow } from "@/store/enterprise/singleSignOn";
 import { readManagedStorage } from "@/store/enterprise/managedStorage";
 import { type UUID } from "@/types/stringTypes";
-import { type UnresolvedModComponent } from "@/types/modComponentTypes";
+import { type SerializedModComponent } from "@/types/modComponentTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type OptionsArgs } from "@/types/runtimeTypes";
 import { checkDeploymentPermissions } from "@/permissions/deploymentPermissionsHelpers";
@@ -115,7 +115,7 @@ function deactivateModComponentFromStates(
 }
 
 async function deactivateModComponentsAndSaveState(
-  modComponentsToDeactivate: UnresolvedModComponent[],
+  modComponentsToDeactivate: SerializedModComponent[],
   {
     editorState,
     optionsState,

--- a/src/background/modUpdater.ts
+++ b/src/background/modUpdater.ts
@@ -34,7 +34,7 @@ import type { EditorState } from "@/pageEditor/pageEditorTypes";
 import { editorSlice } from "@/pageEditor/slices/editorSlice";
 import type {
   ActivatedModComponent,
-  UnresolvedModComponent,
+  SerializedModComponent,
 } from "@/types/modComponentTypes";
 import { collectModOptions } from "@/store/extensionsUtils";
 import type { ModComponentState } from "@/store/extensionsTypes";
@@ -146,7 +146,7 @@ export async function fetchModUpdates(): Promise<BackwardsCompatibleUpdate[]> {
  * @returns the new redux state with the mod component deactivated
  */
 function deactivateModComponent(
-  modComponent: UnresolvedModComponent,
+  modComponent: SerializedModComponent,
   reduxState: ActivatedModState,
 ): ActivatedModState {
   let { options: newOptionsState, editor: newEditorState } = reduxState;

--- a/src/bricks/effects/runSubTour.test.ts
+++ b/src/bricks/effects/runSubTour.test.ts
@@ -27,7 +27,7 @@ import ConsoleLogger from "@/utils/ConsoleLogger";
 import { tick } from "@/starterBricks/starterBrickTestUtils";
 import {
   type ModComponentBase,
-  type ResolvedModComponent,
+  type HydratedModComponent,
 } from "@/types/modComponentTypes";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 
@@ -44,7 +44,7 @@ describe("runSubTour", () => {
         id: uuidv4(),
         label: "Test Extension",
         _recipe: { id: blueprintId } as ModComponentBase["_recipe"],
-      } as ResolvedModComponent,
+      } as HydratedModComponent,
       allowUserRun: false,
       run: () => ({
         promise: deferredTour.promise,

--- a/src/contentScript/lifecycle.test.ts
+++ b/src/contentScript/lifecycle.test.ts
@@ -28,7 +28,7 @@ import { type ActivatedModComponent } from "@/types/modComponentTypes";
 import { type BrickPipeline } from "@/bricks/types";
 import { RootReader, tick } from "@/starterBricks/starterBrickTestUtils";
 import blockRegistry from "@/bricks/registry";
-import { resolveExtensionInnerDefinitions } from "@/registry/internal";
+import { hydrateModComponentInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { type getModComponentState } from "@/store/extensionsStorage";
@@ -77,7 +77,7 @@ const activatedModComponentFactory = define<
   config: define<TriggerConfig>({
     action: () => [] as BrickPipeline,
   }),
-  _unresolvedModComponentBrand: null,
+  _serializedModComponentBrand: null,
   createTimestamp: new Date().toISOString(),
   updateTimestamp: new Date().toISOString(),
   active: true,
@@ -162,7 +162,7 @@ describe("lifecycle", () => {
     });
 
     starterBrick.registerModComponent(
-      await resolveExtensionInnerDefinitions(modComponent),
+      await hydrateModComponentInnerDefinitions(modComponent),
     );
 
     await lifecycleModule.runEditorExtension(modComponent.id, starterBrick);
@@ -199,7 +199,7 @@ describe("lifecycle", () => {
     expect(lifecycleModule.getActiveExtensionPoints()).toEqual([starterBrick]);
 
     starterBrick.registerModComponent(
-      await resolveExtensionInnerDefinitions(modComponent),
+      await hydrateModComponentInnerDefinitions(modComponent),
     );
 
     await lifecycleModule.runEditorExtension(modComponent.id, starterBrick);

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -24,7 +24,7 @@ import { testMatchPatterns } from "@/bricks/available";
 import reportError from "@/telemetry/reportError";
 import { compact, debounce, groupBy, intersection, uniq } from "lodash";
 import oneEvent from "one-event";
-import { resolveExtensionInnerDefinitions } from "@/registry/internal";
+import { hydrateModComponentInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
 import { traces } from "@/background/messenger/api";
 import { isDeploymentActive } from "@/utils/deploymentUtils";
 import { PromiseCancelled } from "@/errors/genericErrors";
@@ -33,7 +33,7 @@ import { type StarterBrick } from "@/types/starterBrickTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { RunReason } from "@/types/runtimeTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type SidebarStarterBrickABC } from "@/starterBricks/sidebar/sidebarStarterBrick";
 import {
   getReloadOnNextNavigate,
@@ -375,7 +375,7 @@ export async function runEditorExtension(
  * used to do that clean up at a more appropriate time, e.g. upon navigation.
  */
 function cleanUpDeactivatedExtensionPoints(
-  activeExtensionMap: Record<RegistryId, ResolvedModComponent[]>,
+  activeExtensionMap: Record<RegistryId, HydratedModComponent[]>,
 ): void {
   for (const extensionPoint of _activeExtensionPoints) {
     const hasActiveExtensions = Object.hasOwn(
@@ -428,7 +428,7 @@ async function loadPersistedExtensions(): Promise<StarterBrick[]> {
   const resolvedActiveExtensions = await logPromiseDuration(
     "loadPersistedExtensions:resolveDefinitions",
     Promise.all(
-      activeExtensions.map(async (x) => resolveExtensionInnerDefinitions(x)),
+      activeExtensions.map(async (x) => hydrateModComponentInnerDefinitions(x)),
     ),
   );
 
@@ -446,7 +446,7 @@ async function loadPersistedExtensions(): Promise<StarterBrick[]> {
       Object.entries(activeExtensionMap).map(
         async ([extensionPointId, extensions]: [
           RegistryId,
-          ResolvedModComponent[],
+          HydratedModComponent[],
         ]) => {
           try {
             const extensionPoint =

--- a/src/contentScript/pageEditor/draft/updateDraftModComponent.ts
+++ b/src/contentScript/pageEditor/draft/updateDraftModComponent.ts
@@ -20,7 +20,7 @@ import {
   runEditorExtension,
 } from "@/contentScript/lifecycle";
 import { fromJS as starterBrickFactory } from "@/starterBricks/factory";
-import { resolveExtensionInnerDefinitions } from "@/registry/internal";
+import { hydrateModComponentInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
 import { expectContext } from "@/utils/expectContext";
 import { type TriggerDefinition } from "@/starterBricks/trigger/triggerStarterBrick";
 import type { DraftModComponent } from "@/contentScript/pageEditor/types";
@@ -70,7 +70,7 @@ export async function updateDraftModComponent({
   }
 
   // In practice, should be a no-op because the Page Editor handles the extensionPoint
-  const resolved = await resolveExtensionInnerDefinitions(extensionConfig);
+  const resolved = await hydrateModComponentInnerDefinitions(extensionConfig);
 
   starterBrick.registerModComponent(resolved);
   await runEditorExtension(extensionConfig.id, starterBrick);

--- a/src/extensionConsole/pages/mods/utils/exportBlueprint.test.ts
+++ b/src/extensionConsole/pages/mods/utils/exportBlueprint.test.ts
@@ -17,13 +17,13 @@
 
 import { makeBlueprint } from "@/extensionConsole/pages/mods/utils/exportBlueprint";
 import { validateRegistryId } from "@/types/helpers";
-import { type UnresolvedModComponent } from "@/types/modComponentTypes";
+import { type SerializedModComponent } from "@/types/modComponentTypes";
 import { modComponentFactory } from "@/testUtils/factories/modComponentFactories";
 
 describe("makeBlueprint", () => {
   it("smoke test", () => {
     const result = makeBlueprint(
-      modComponentFactory() as UnresolvedModComponent,
+      modComponentFactory() as SerializedModComponent,
       {
         id: validateRegistryId("test/blueprint"),
         name: "test",
@@ -42,7 +42,7 @@ describe("makeBlueprint", () => {
       optionsArgs: {
         foo: "hello world!",
       },
-    }) as UnresolvedModComponent;
+    }) as SerializedModComponent;
 
     const result = makeBlueprint(modComponent, {
       id: validateRegistryId("test/blueprint"),

--- a/src/extensionConsole/pages/mods/utils/exportBlueprint.ts
+++ b/src/extensionConsole/pages/mods/utils/exportBlueprint.ts
@@ -25,7 +25,7 @@ import {
   type UnsavedModDefinition,
 } from "@/types/modDefinitionTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type UnresolvedModComponent } from "@/types/modComponentTypes";
+import { type SerializedModComponent } from "@/types/modComponentTypes";
 import { isInnerDefinitionRegistryId } from "@/types/helpers";
 import { isNullOrBlank } from "@/utils/stringUtils";
 
@@ -48,7 +48,7 @@ function inferOptionsSchema(
 }
 
 export function makeBlueprint(
-  extension: UnresolvedModComponent,
+  extension: SerializedModComponent,
   metadata: Metadata,
 ): UnsavedModDefinition {
   const {

--- a/src/extensionConsole/pages/settings/useDiagnostics.ts
+++ b/src/extensionConsole/pages/settings/useDiagnostics.ts
@@ -20,7 +20,7 @@ import { selectActivatedModComponents } from "@/store/extensionsSelectors";
 import useExtensionPermissions, {
   type DetailedPermissions,
 } from "@/permissions/useExtensionPermissions";
-import { type UnresolvedModComponent } from "@/types/modComponentTypes";
+import { type SerializedModComponent } from "@/types/modComponentTypes";
 import { compact, uniqBy } from "lodash";
 import { type StorageEstimate } from "@/types/browserTypes";
 import { count as registrySize } from "@/registry/packageRegistry";
@@ -36,7 +36,7 @@ async function collectDiagnostics({
   extensions,
   permissions,
 }: {
-  extensions: UnresolvedModComponent[];
+  extensions: SerializedModComponent[];
   permissions?: DetailedPermissions;
 }) {
   const { version_name } = browser.runtime.getManifest();

--- a/src/modDefinitions/modDefinitionPermissionsHelpers.ts
+++ b/src/modDefinitions/modDefinitionPermissionsHelpers.ts
@@ -17,10 +17,10 @@
 
 import {
   type ModDefinition,
-  type ResolvedModComponentDefinition,
+  type HydratedModComponentDefinition,
 } from "@/types/modDefinitionTypes";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
-import { resolveRecipeInnerDefinitions } from "@/registry/internal";
+import { hydrateModInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
 import { mergePermissions } from "@/permissions/permissionsUtils";
 import { isEmpty } from "lodash";
 import { type Permissions } from "webextension-polyfill";
@@ -32,7 +32,7 @@ import { type PermissionsStatus } from "@/permissions/permissionsTypes";
 import type { Manifest } from "webextension-polyfill/namespaces/manifest";
 
 async function collectModComponentDefinitionPermissions(
-  modComponentDefinitions: ResolvedModComponentDefinition[],
+  modComponentDefinitions: HydratedModComponentDefinition[],
   configuredDependencies: IntegrationDependency[],
 ): Promise<Permissions.Permissions> {
   const integrationsPromises = configuredDependencies.map(async (dependency) =>
@@ -44,7 +44,7 @@ async function collectModComponentDefinitionPermissions(
       id,
       permissions = {},
       config,
-    }: ResolvedModComponentDefinition) => {
+    }: HydratedModComponentDefinition) => {
       const extensionPoint = await extensionPointRegistry.lookup(id);
 
       let inner: Permissions.Permissions = {};
@@ -95,8 +95,7 @@ export async function checkModDefinitionPermissions(
     optionalPermissions?: Manifest.OptionalPermission[];
   } = {},
 ): Promise<PermissionsStatus> {
-  const extensionDefinitions =
-    await resolveRecipeInnerDefinitions(modDefinition);
+  const extensionDefinitions = await hydrateModInnerDefinitions(modDefinition);
 
   const permissions = await collectModComponentDefinitionPermissions(
     extensionDefinitions,

--- a/src/mods/useModViewItems.test.tsx
+++ b/src/mods/useModViewItems.test.tsx
@@ -18,7 +18,7 @@
 import useModViewItems from "@/mods/useModViewItems";
 import {
   type ActivatedModComponent,
-  type ResolvedModComponent,
+  type HydratedModComponent,
 } from "@/types/modComponentTypes";
 import extensionsSlice from "@/store/extensionsSlice";
 import MockAdapter from "axios-mock-adapter";
@@ -42,7 +42,7 @@ describe("useModViewItems", () => {
   });
 
   it("creates entry for ModComponentBase", async () => {
-    const modComponent = modComponentFactory() as ResolvedModComponent;
+    const modComponent = modComponentFactory() as HydratedModComponent;
 
     const { waitForEffect, result } = renderHook(
       () => useModViewItems([modComponent]),

--- a/src/mods/useMods.ts
+++ b/src/mods/useMods.ts
@@ -19,7 +19,7 @@ import { type UUID } from "@/types/stringTypes";
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
 import { selectActivatedModComponents } from "@/store/extensionsSelectors";
-import { resolveExtensionInnerDefinitions } from "@/registry/internal";
+import { hydrateModComponentInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
 import { useGetAllStandaloneModDefinitionsQuery } from "@/data/service/api";
 import { selectScope } from "@/auth/authSelectors";
 import { useAllModDefinitions } from "@/modDefinitions/modDefinitionHooks";
@@ -106,7 +106,7 @@ function useMods(): ModsState {
     async () =>
       Promise.all(
         allExtensions.map(async (extension) =>
-          resolveExtensionInnerDefinitions(extension),
+          hydrateModComponentInnerDefinitions(extension),
         ),
       ),
     [allExtensions],

--- a/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
+++ b/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
@@ -33,7 +33,7 @@ import extensionsSlice, {
 import {
   modComponentDefinitionFactory,
   modDefinitionFactory,
-  versionedModDefinitionWithResolvedModComponents,
+  versionedModDefinitionWithHydratedModComponents,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { type UnsavedModDefinition } from "@/types/modDefinitionTypes";
 import produce from "immer";
@@ -90,7 +90,7 @@ describe("useBuildAndValidateMod", () => {
         cleanModComponentCount + dirtyModComponentCount;
 
       // Create a mod
-      const modDefinition = versionedModDefinitionWithResolvedModComponents(
+      const modDefinition = versionedModDefinitionWithHydratedModComponents(
         totalModComponentCount,
       )();
 

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -30,7 +30,7 @@ import {
   PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
 } from "@/pageEditor/starterBricks/base";
 import { produce } from "immer";
-import { makeInternalId } from "@/registry/internal";
+import { selectInnerRegistryId } from "@/registry/hydrateInnerDefinitions";
 import { cloneDeep, range, uniq } from "lodash";
 import { type MenuItemDefinition } from "@/starterBricks/menuItem/menuItemTypes";
 import extensionsSlice from "@/store/extensionsSlice";
@@ -48,7 +48,7 @@ import {
 } from "@/types/modDefinitionTypes";
 import {
   type ModComponentBase,
-  type UnresolvedModComponent,
+  type SerializedModComponent,
 } from "@/types/modComponentTypes";
 import { modComponentFactory } from "@/testUtils/factories/modComponentFactories";
 import {
@@ -191,7 +191,7 @@ describe("replaceModComponent round trip", () => {
     jest.mocked(lookupExtensionPoint).mockResolvedValue({
       ...modDefinition.definitions.extensionPoint,
       metadata: {
-        id: makeInternalId(modDefinition.definitions.extensionPoint),
+        id: selectInnerRegistryId(modDefinition.definitions.extensionPoint),
         name: "Internal Starter Brick",
         version: normalizeSemVerString("1.0.0"),
       },
@@ -240,7 +240,7 @@ describe("replaceModComponent round trip", () => {
     jest.mocked(lookupExtensionPoint).mockResolvedValue({
       ...modDefinition.definitions.extensionPoint,
       metadata: {
-        id: makeInternalId(modDefinition.definitions.extensionPoint),
+        id: selectInnerRegistryId(modDefinition.definitions.extensionPoint),
         name: "Internal Starter Brick",
         version: normalizeSemVerString("1.0.0"),
       },
@@ -284,7 +284,7 @@ describe("replaceModComponent round trip", () => {
     jest.mocked(lookupExtensionPoint).mockResolvedValue({
       ...modDefinition.definitions.extensionPoint,
       metadata: {
-        id: makeInternalId(modDefinition.definitions.extensionPoint),
+        id: selectInnerRegistryId(modDefinition.definitions.extensionPoint),
         name: "Internal Starter Brick",
         version: normalizeSemVerString("1.0.0"),
       },
@@ -346,7 +346,7 @@ describe("replaceModComponent round trip", () => {
     jest.mocked(lookupExtensionPoint).mockResolvedValue({
       ...modDefinition.definitions.extensionPoint,
       metadata: {
-        id: makeInternalId(modDefinition.definitions.extensionPoint),
+        id: selectInnerRegistryId(modDefinition.definitions.extensionPoint),
         name: "Internal Starter Brick",
         version: normalizeSemVerString("1.0.0"),
       },
@@ -616,7 +616,7 @@ describe("buildNewMod", () => {
   test("Clean mod component referencing extensionPoint registry package", async () => {
     const modComponent = modComponentFactory({
       apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
-    }) as UnresolvedModComponent;
+    }) as SerializedModComponent;
 
     // Call the function under test
     const newMod = buildNewMod({
@@ -642,7 +642,7 @@ describe("buildNewMod", () => {
         integrationDependencyFactory({ integrationId, outputKey }),
       ],
       extensionPointId: starterBrick.metadata.id,
-    }) as UnresolvedModComponent;
+    }) as SerializedModComponent;
 
     const adapter = ADAPTERS.get(starterBrick.definition.type);
 
@@ -678,7 +678,7 @@ describe("buildNewMod", () => {
     const modComponents = starterBricks.map((extensionPoint) => {
       const modComponent = modComponentFactory({
         apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
-      }) as UnresolvedModComponent;
+      }) as SerializedModComponent;
 
       modComponent.definitions = {
         extensionPoint: {
@@ -720,7 +720,7 @@ describe("buildNewMod", () => {
     const modComponents = starterBricks.slice(0, 2).map((starterBrick) => {
       const modComponent = modComponentFactory({
         apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
-      }) as UnresolvedModComponent;
+      }) as SerializedModComponent;
 
       modComponent.definitions = {
         extensionPoint: starterBrick,
@@ -751,7 +751,7 @@ describe("buildNewMod", () => {
     const modComponents = range(0, 2).map(() => {
       const modComponent = modComponentFactory({
         apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
-      }) as UnresolvedModComponent;
+      }) as SerializedModComponent;
 
       modComponent.definitions = {
         extensionPoint: {

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -58,7 +58,7 @@ import {
   modDefinitionWithVersionedStarterBrickFactory,
   starterBrickDefinitionFactory,
   starterBrickInnerDefinitionFactory,
-  versionedModDefinitionWithResolvedModComponents,
+  versionedModDefinitionWithHydratedModComponents,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
 import { integrationDependencyFactory } from "@/testUtils/factories/integrationFactories";
@@ -804,7 +804,7 @@ describe("buildNewMod", () => {
         cleanModComponentCount + dirtyModComponentCount;
 
       // Create a mod
-      const modDefinition = versionedModDefinitionWithResolvedModComponents(
+      const modDefinition = versionedModDefinitionWithHydratedModComponents(
         totalModComponentCount,
       )();
 

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -30,7 +30,7 @@ import {
   PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
 } from "@/pageEditor/starterBricks/base";
 import { produce } from "immer";
-import { selectInnerRegistryId } from "@/registry/hydrateInnerDefinitions";
+import { calculateInnerRegistryId } from "@/registry/hydrateInnerDefinitions";
 import { cloneDeep, range, uniq } from "lodash";
 import { type MenuItemDefinition } from "@/starterBricks/menuItem/menuItemTypes";
 import extensionsSlice from "@/store/extensionsSlice";
@@ -191,7 +191,7 @@ describe("replaceModComponent round trip", () => {
     jest.mocked(lookupExtensionPoint).mockResolvedValue({
       ...modDefinition.definitions.extensionPoint,
       metadata: {
-        id: selectInnerRegistryId(modDefinition.definitions.extensionPoint),
+        id: calculateInnerRegistryId(modDefinition.definitions.extensionPoint),
         name: "Internal Starter Brick",
         version: normalizeSemVerString("1.0.0"),
       },
@@ -240,7 +240,7 @@ describe("replaceModComponent round trip", () => {
     jest.mocked(lookupExtensionPoint).mockResolvedValue({
       ...modDefinition.definitions.extensionPoint,
       metadata: {
-        id: selectInnerRegistryId(modDefinition.definitions.extensionPoint),
+        id: calculateInnerRegistryId(modDefinition.definitions.extensionPoint),
         name: "Internal Starter Brick",
         version: normalizeSemVerString("1.0.0"),
       },
@@ -284,7 +284,7 @@ describe("replaceModComponent round trip", () => {
     jest.mocked(lookupExtensionPoint).mockResolvedValue({
       ...modDefinition.definitions.extensionPoint,
       metadata: {
-        id: selectInnerRegistryId(modDefinition.definitions.extensionPoint),
+        id: calculateInnerRegistryId(modDefinition.definitions.extensionPoint),
         name: "Internal Starter Brick",
         version: normalizeSemVerString("1.0.0"),
       },
@@ -346,7 +346,7 @@ describe("replaceModComponent round trip", () => {
     jest.mocked(lookupExtensionPoint).mockResolvedValue({
       ...modDefinition.definitions.extensionPoint,
       metadata: {
-        id: selectInnerRegistryId(modDefinition.definitions.extensionPoint),
+        id: calculateInnerRegistryId(modDefinition.definitions.extensionPoint),
         name: "Internal Starter Brick",
         version: normalizeSemVerString("1.0.0"),
       },

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -43,7 +43,7 @@ import {
 } from "@/types/modDefinitionTypes";
 import {
   type ModComponentBase,
-  type UnresolvedModComponent,
+  type SerializedModComponent,
 } from "@/types/modComponentTypes";
 import { type SafeString } from "@/types/stringTypes";
 import { type ModMetadataFormState } from "@/pageEditor/pageEditorTypes";
@@ -367,7 +367,7 @@ function selectModComponentDefinition(
 
 export type ModParts = {
   sourceMod?: ModDefinition;
-  cleanModComponents: UnresolvedModComponent[];
+  cleanModComponents: SerializedModComponent[];
   dirtyModComponentFormStates: ModComponentFormState[];
   /**
    * Dirty/new options to save. Undefined if there are no changes.

--- a/src/pageEditor/slices/editorSlice.ts
+++ b/src/pageEditor/slices/editorSlice.ts
@@ -66,7 +66,7 @@ import {
   getInstalledExtensionPoints,
   checkAvailable,
 } from "@/contentScript/messenger/api";
-import { resolveExtensionInnerDefinitions } from "@/registry/internal";
+import { hydrateModComponentInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
 import { QuickBarStarterBrickABC } from "@/starterBricks/quickBar/quickBarStarterBrick";
 import { testMatchPatterns } from "@/bricks/available";
 import { BusinessError } from "@/errors/businessErrors";
@@ -171,7 +171,7 @@ const checkAvailableInstalledExtensions = createAsyncThunk<
   );
   const resolved = await Promise.all(
     notDeletedModComponents.map(async (modComponent) =>
-      resolveExtensionInnerDefinitions(modComponent),
+      hydrateModComponentInnerDefinitions(modComponent),
     ),
   );
   const tabUrl = await getCurrentInspectedURL();

--- a/src/pageEditor/starterBricks/adapter.ts
+++ b/src/pageEditor/starterBricks/adapter.ts
@@ -28,7 +28,7 @@ import sidebarExtension from "@/pageEditor/starterBricks/sidebar";
 import quickBarProviderExtension from "@/pageEditor/starterBricks/quickBarProvider";
 import tourExtension from "@/pageEditor/starterBricks/tour";
 import { type ModComponentFormStateAdapter } from "@/pageEditor/starterBricks/modComponentFormStateAdapter";
-import { hasInnerExtensionPointRef } from "@/registry/internal";
+import { hasInnerStarterBrickRef } from "@/registry/hydrateInnerDefinitions";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import { type DraftModComponent } from "@/contentScript/pageEditor/types";
 import { assertNotNullish } from "@/utils/nullishUtils";
@@ -49,7 +49,7 @@ export const ADAPTERS = new Map<StarterBrickType, ModComponentFormStateAdapter>(
 export async function selectType(
   extension: ModComponentBase,
 ): Promise<StarterBrickType> {
-  if (hasInnerExtensionPointRef(extension)) {
+  if (hasInnerStarterBrickRef(extension)) {
     const { extensionPointId, definitions } = extension;
     return (
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- checked by hasInnerExtensionPointRef

--- a/src/pageEditor/starterBricks/base.ts
+++ b/src/pageEditor/starterBricks/base.ts
@@ -38,7 +38,7 @@ import {
 } from "@/types/helpers";
 import { type BrickPipeline, type ReaderConfig } from "@/bricks/types";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
-import { hasInnerExtensionPointRef } from "@/registry/internal";
+import { hasInnerStarterBrickRef } from "@/registry/hydrateInnerDefinitions";
 import { normalizePipelineForEditor } from "./pipelineMapping";
 import { emptyPermissionsFactory } from "@/permissions/permissionsUtils";
 import { type ApiVersion } from "@/types/runtimeTypes";
@@ -258,7 +258,7 @@ export async function lookupExtensionPoint<
     throw new Error("config is required");
   }
 
-  if (hasInnerExtensionPointRef(config)) {
+  if (hasInnerStarterBrickRef(config)) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- checked by hasInnerExtensionPointRef
     const definition = config.definitions![config.extensionPointId];
     console.debug(

--- a/src/permissions/cloudExtensionPermissionsHelpers.ts
+++ b/src/permissions/cloudExtensionPermissionsHelpers.ts
@@ -18,8 +18,8 @@
 import { type StandaloneModDefinition } from "@/types/contract";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
 import { type PermissionsStatus } from "@/permissions/permissionsTypes";
-import { resolveExtensionInnerDefinitions } from "@/registry/internal";
-import { type ResolvedModComponentDefinition } from "@/types/modDefinitionTypes";
+import { hydrateModComponentInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
+import { type HydratedModComponentDefinition } from "@/types/modDefinitionTypes";
 import { checkModDefinitionPermissions } from "@/modDefinitions/modDefinitionPermissionsHelpers";
 
 // Separate from extensionPermissionsHelpers.ts to avoid a circular dependency with modDefinitionPermissionsHelpers.ts
@@ -33,7 +33,7 @@ export async function checkCloudExtensionPermissions(
   extension: StandaloneModDefinition,
   integrationDependencies: IntegrationDependency[],
 ): Promise<PermissionsStatus> {
-  const resolved = await resolveExtensionInnerDefinitions({
+  const resolved = await hydrateModComponentInnerDefinitions({
     ...extension,
     integrationDependencies,
   });
@@ -52,7 +52,7 @@ export async function checkCloudExtensionPermissions(
             integrationId,
           ]),
         ),
-      } as ResolvedModComponentDefinition,
+      } as HydratedModComponentDefinition,
     ],
   };
 

--- a/src/permissions/extensionPermissionsHelpers.ts
+++ b/src/permissions/extensionPermissionsHelpers.ts
@@ -17,7 +17,7 @@
 
 import { type ModComponentBase } from "@/types/modComponentTypes";
 import { type Permissions } from "webextension-polyfill";
-import { resolveExtensionInnerDefinitions } from "@/registry/internal";
+import { hydrateModComponentInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
 import extensionPointRegistry from "@/starterBricks/registry";
 import { castArray, compact } from "lodash";
 import { mergePermissions } from "@/permissions/permissionsUtils";
@@ -58,7 +58,7 @@ export async function collectExtensionPermissions(
   options: PermissionOptions = {},
 ): Promise<Permissions.Permissions> {
   const { includeExtensionPoint = true, includeServices = true } = options;
-  const resolved = await resolveExtensionInnerDefinitions(extension);
+  const resolved = await hydrateModComponentInnerDefinitions(extension);
 
   const extensionPoint =
     options.extensionPoint ??

--- a/src/registry/hydrateInnerDefinitions.ts
+++ b/src/registry/hydrateInnerDefinitions.ts
@@ -18,13 +18,13 @@
 import { produce } from "immer";
 import objectHash from "object-hash";
 import { cloneDeep, isEmpty, mapValues, pick, pickBy } from "lodash";
-import extensionPointRegistry from "@/starterBricks/registry";
+import starterBrickRegistry from "@/starterBricks/registry";
 import brickRegistry from "@/bricks/registry";
-import { fromJS as extensionPointFactory } from "@/starterBricks/factory";
+import { fromJS as starterBrickFactory } from "@/starterBricks/factory";
 import { fromJS as brickFactory } from "@/bricks/transformers/brickFactory";
 import {
   type ModDefinition,
-  type ResolvedModComponentDefinition,
+  type HydratedModComponentDefinition,
 } from "@/types/modDefinitionTypes";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { type ReaderConfig } from "@/bricks/types";
@@ -35,7 +35,7 @@ import {
 } from "@/types/registryTypes";
 import {
   type ModComponentBase,
-  type ResolvedModComponent,
+  type HydratedModComponent,
 } from "@/types/modComponentTypes";
 import { type StarterBrick } from "@/types/starterBrickTypes";
 import { type Brick } from "@/types/brickTypes";
@@ -43,24 +43,28 @@ import { resolveObj } from "@/utils/promiseUtils";
 import { isObject } from "@/utils/objectUtils";
 import { assertNotNullish } from "@/utils/nullishUtils";
 
-type InnerExtensionPoint = Pick<
+type StarterBrickInnerDefinition = Pick<
   StarterBrickDefinitionLike,
   "definition" | "kind"
 >;
-type InnerBlock<K extends "component" | "reader" = "component" | "reader"> =
-  UnknownObject & {
-    kind: K;
-  };
+type BrickInnerDefinition<
+  K extends "component" | "reader" = "component" | "reader",
+> = UnknownObject & {
+  kind: K;
+};
 
-type InnerDefinition = InnerExtensionPoint | InnerBlock;
+type InnerDefinition = StarterBrickInnerDefinition | BrickInnerDefinition;
 
-export function makeInternalId(obj: UnknownObject): RegistryId {
+/**
+ * Select a unique id for an inner definition. Definitions with the same structure will produce the same id.
+ */
+export function selectInnerRegistryId(obj: UnknownObject): RegistryId {
   const hash = objectHash(obj);
   return `${INNER_SCOPE}/${hash}` as RegistryId;
 }
 
-async function resolveBrickDefinition(
-  definitions: InnerDefinitions,
+async function hydrateBrickDefinition(
+  _definitions: InnerDefinitions,
   innerDefinition: InnerDefinition,
 ): Promise<Brick> {
   // Don't include outputSchema in because it can't affect functionality
@@ -70,7 +74,7 @@ async function resolveBrickDefinition(
     "pipeline",
     "definition",
   ]);
-  const registryId = makeInternalId(obj);
+  const registryId = selectInnerRegistryId(obj);
 
   try {
     return await brickRegistry.lookup(registryId);
@@ -91,7 +95,7 @@ async function resolveBrickDefinition(
   return item;
 }
 
-async function resolveReaderDefinition(
+async function hydrateReaderDefinition(
   definitions: InnerDefinitions,
   reader: unknown,
 ): Promise<ReaderConfig> {
@@ -105,13 +109,14 @@ async function resolveReaderDefinition(
       const definition = definitions[reader];
       if (definition?.kind !== "reader") {
         throw new TypeError(
+          // Keep extensionPoint terminology because that's what appears in the YAML/JSON
           "extensionPoint references definition that is not a reader",
         );
       }
 
-      const block = await resolveBrickDefinition(
+      const block = await hydrateBrickDefinition(
         definitions,
-        definition as InnerBlock<"component">,
+        definition as BrickInnerDefinition<"component">,
       );
       return block.id;
     }
@@ -122,13 +127,13 @@ async function resolveReaderDefinition(
 
   if (Array.isArray(reader)) {
     return Promise.all(
-      reader.map(async (x) => resolveReaderDefinition(definitions, x)),
+      reader.map(async (x) => hydrateReaderDefinition(definitions, x)),
     );
   }
 
   if (isObject(reader)) {
     return resolveObj(
-      mapValues(reader, async (x) => resolveReaderDefinition(definitions, x)),
+      mapValues(reader, async (x) => hydrateReaderDefinition(definitions, x)),
     );
   }
 
@@ -140,41 +145,42 @@ async function resolveReaderDefinition(
   throw new TypeError("Unexpected reader definition");
 }
 
-async function resolveExtensionPointDefinition(
+async function hydrateStarterBrickDefinition(
   definitions: InnerDefinitions,
-  originalInnerDefinition: InnerExtensionPoint,
+  originalInnerDefinition: StarterBrickInnerDefinition,
 ): Promise<StarterBrick> {
   const innerDefinition = cloneDeep(originalInnerDefinition);
 
   // We have to resolve the readers before computing the registry id, b/c otherwise different extension points could
   // clash if they use the same name for different readers
-  innerDefinition.definition.reader = await resolveReaderDefinition(
+  innerDefinition.definition.reader = await hydrateReaderDefinition(
     definitions,
     innerDefinition.definition.reader,
   );
 
   const obj = pick(innerDefinition, ["kind", "definition"]);
-  const internalRegistryId = makeInternalId(obj);
+  const internalRegistryId = selectInnerRegistryId(obj);
 
   try {
-    return await extensionPointRegistry.lookup(internalRegistryId);
+    return await starterBrickRegistry.lookup(internalRegistryId);
   } catch {
     // NOP - will register
   }
 
-  const item = extensionPointFactory({
+  const starterBrick = starterBrickFactory({
     ...obj,
     metadata: {
       id: internalRegistryId,
-      name: "Anonymous extensionPoint",
+      name: "Anonymous Starter Brick",
     },
   } as StarterBrickDefinitionLike);
 
-  extensionPointRegistry.register([item], {
+  starterBrickRegistry.register([starterBrick], {
     source: "internal",
     notify: false,
   });
-  return item;
+
+  return starterBrick;
 }
 
 /**
@@ -182,7 +188,7 @@ async function resolveExtensionPointDefinition(
  * @param definitions all of the definitions. Used to resolve references from innerDefinition
  * @param innerDefinition the inner definition to resolve
  */
-async function resolveInnerDefinition(
+async function hydrateInnerDefinition(
   definitions: InnerDefinitions,
   innerDefinition: InnerDefinitions[string],
 ): Promise<Brick | StarterBrick> {
@@ -192,15 +198,18 @@ async function resolveInnerDefinition(
 
   switch (innerDefinition.kind) {
     case "extensionPoint": {
-      return resolveExtensionPointDefinition(
+      return hydrateStarterBrickDefinition(
         definitions,
-        innerDefinition as InnerExtensionPoint,
+        innerDefinition as StarterBrickInnerDefinition,
       );
     }
 
     case "reader":
     case "component": {
-      return resolveBrickDefinition(definitions, innerDefinition as InnerBlock);
+      return hydrateBrickDefinition(
+        definitions,
+        innerDefinition as BrickInnerDefinition,
+      );
     }
 
     default: {
@@ -212,93 +221,95 @@ async function resolveInnerDefinition(
 }
 
 /**
- * Return a new copy of the ModComponentBase with its inner references re-written.
- * TODO: resolve/map ids for other definitions (brick, service, etc.) within the extension
+ * Return a new copy of the ModComponentBase with its inner definitions hydrated.
+ * TODO: hydrate ids for other definitions (brick, integration, etc.) within the mod component
  */
-export async function resolveExtensionInnerDefinitions<
+export async function hydrateModComponentInnerDefinitions<
   T extends UnknownObject = UnknownObject,
->(extension: ModComponentBase<T>): Promise<ResolvedModComponent<T>> {
-  if (isEmpty(extension.definitions)) {
-    return extension as ResolvedModComponent<T>;
+>(modComponent: ModComponentBase<T>): Promise<HydratedModComponent<T>> {
+  if (isEmpty(modComponent.definitions)) {
+    return modComponent as HydratedModComponent<T>;
   }
 
-  return produce(extension, async (draft) => {
+  return produce(modComponent, async (draft) => {
     const { definitions } = draft;
     assertNotNullish(definitions, "definitions must be defined");
-    // The ModComponentBase has definitions for all extensionPoints from the mod, even ones it doesn't use
+    // The ModComponentBase has definitions for all starterBricks from the mod, even ones it doesn't use
     const relevantDefinitions = pickBy(
       definitions,
       (definition, name) =>
         definition.kind !== "extensionPoint" || draft.extensionPointId === name,
     );
 
-    const resolvedDefinitions = await resolveObj(
+    const hydratedDefinitions = await resolveObj(
       mapValues(relevantDefinitions, async (definition) =>
-        resolveInnerDefinition(definitions, definition),
+        hydrateInnerDefinition(definitions, definition),
       ),
     );
 
     delete draft.definitions;
-    if (resolvedDefinitions[draft.extensionPointId] != null) {
+    if (hydratedDefinitions[draft.extensionPointId] != null) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- checked above
-      draft.extensionPointId = resolvedDefinitions[draft.extensionPointId]!.id;
+      draft.extensionPointId = hydratedDefinitions[draft.extensionPointId]!.id;
     }
-  }) as Promise<ResolvedModComponent<T>>;
+  }) as Promise<HydratedModComponent<T>>;
 }
 
 /**
- * Resolve inline extension point definitions.
- * TODO: resolve other definitions (brick, service, etc.) within the extensions
+ * Hydrate inner starter brick definitions.
+ * TODO: resolve other definitions (brick, service, etc.) within the mod definition
  */
-export async function resolveRecipeInnerDefinitions(
-  recipe: Pick<ModDefinition, "extensionPoints" | "definitions"> | undefined,
-): Promise<ResolvedModComponentDefinition[]> {
-  const extensionDefinitions = recipe?.extensionPoints;
+export async function hydrateModInnerDefinitions(
+  modDefinition:
+    | Pick<ModDefinition, "extensionPoints" | "definitions">
+    | undefined,
+): Promise<HydratedModComponentDefinition[]> {
+  const modComponentDefinitions = modDefinition?.extensionPoints;
 
-  if (isEmpty(recipe?.definitions)) {
-    return extensionDefinitions as ResolvedModComponentDefinition[];
+  if (isEmpty(modDefinition?.definitions)) {
+    return modComponentDefinitions as HydratedModComponentDefinition[];
   }
 
   const extensionPointReferences = new Set<string>(
-    recipe.extensionPoints.map((x) => x.id),
+    modDefinition.extensionPoints.map((x) => x.id),
   );
 
   // Some mods created with the Page Editor end up with irrelevant definitions in the recipe, because they aren't
   // cleaned up properly on save, etc.
   const relevantDefinitions = pickBy(
-    recipe.definitions,
+    modDefinition.definitions,
     (definition, name) =>
       definition.kind !== "extensionPoint" ||
       extensionPointReferences.has(name),
   );
 
-  const resolvedDefinitions = await resolveObj(
+  const hydratedDefinitions = await resolveObj(
     mapValues(relevantDefinitions, async (config) =>
-      resolveInnerDefinition(relevantDefinitions, config),
+      hydrateInnerDefinition(relevantDefinitions, config),
     ),
   );
 
   return (
-    extensionDefinitions?.map(
+    modComponentDefinitions?.map(
       (definition) =>
-        (definition.id in resolvedDefinitions
+        (definition.id in hydratedDefinitions
           ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- checked above
-            { ...definition, id: resolvedDefinitions[definition.id]!.id }
-          : definition) as ResolvedModComponentDefinition,
+            { ...definition, id: hydratedDefinitions[definition.id]!.id }
+          : definition) as HydratedModComponentDefinition,
     ) ?? []
   );
 }
 
 /**
- * Returns true if the extension is using an InnerDefinitionRef. _Will always return false for ResolvedExtensions._
+ * Returns true if the mod component is using an InnerDefinitionRef. _Returns false for HydratedModComponent._
  * @see InnerDefinitionRef
  * @see UnresolvedExtension
- * @see ResolvedModComponent
+ * @see HydratedModComponent
  */
-export function hasInnerExtensionPointRef(
-  extension: ModComponentBase,
+export function hasInnerStarterBrickRef(
+  modComponent: ModComponentBase,
 ): boolean {
   // XXX: should this also check for `@internal/` scope in the referenced id? The type ModComponentBase could receive a
   // ResolvedExtension, which would have the id mapped to the internal registry id
-  return extension.extensionPointId in (extension.definitions ?? {});
+  return modComponent.extensionPointId in (modComponent.definitions ?? {});
 }

--- a/src/registry/hydrateInnerDefinitions.ts
+++ b/src/registry/hydrateInnerDefinitions.ts
@@ -151,7 +151,7 @@ async function hydrateStarterBrickDefinition(
 ): Promise<StarterBrick> {
   const innerDefinition = cloneDeep(originalInnerDefinition);
 
-  // We have to resolve the readers before computing the registry id, b/c otherwise different extension points could
+  // We have to hydrate the readers before computing the registry id, b/c otherwise different extension points could
   // clash if they use the same name for different readers
   innerDefinition.definition.reader = await hydrateReaderDefinition(
     definitions,
@@ -185,8 +185,8 @@ async function hydrateStarterBrickDefinition(
 
 /**
  * Ensure inner definitions are registered in the in-memory brick registry
- * @param definitions all of the definitions. Used to resolve references from innerDefinition
- * @param innerDefinition the inner definition to resolve
+ * @param definitions all of the definitions. Used to hydrate references from innerDefinition
+ * @param innerDefinition the inner definition to hydrate
  */
 async function hydrateInnerDefinition(
   definitions: InnerDefinitions,
@@ -257,7 +257,7 @@ export async function hydrateModComponentInnerDefinitions<
 
 /**
  * Hydrate inner starter brick definitions.
- * TODO: resolve other definitions (brick, service, etc.) within the mod definition
+ * TODO: hydrate other definitions (brick, service, etc.) within the mod definition
  */
 export async function hydrateModInnerDefinitions(
   modDefinition:
@@ -303,13 +303,13 @@ export async function hydrateModInnerDefinitions(
 /**
  * Returns true if the mod component is using an InnerDefinitionRef. _Returns false for HydratedModComponent._
  * @see InnerDefinitionRef
- * @see UnresolvedExtension
+ * @see SerializedModComponent
  * @see HydratedModComponent
  */
 export function hasInnerStarterBrickRef(
   modComponent: ModComponentBase,
 ): boolean {
   // XXX: should this also check for `@internal/` scope in the referenced id? The type ModComponentBase could receive a
-  // ResolvedExtension, which would have the id mapped to the internal registry id
+  // HydratedModComponent, which would have the id mapped to the internal registry id
   return modComponent.extensionPointId in (modComponent.definitions ?? {});
 }

--- a/src/registry/hydrateInnerDefinitions.ts
+++ b/src/registry/hydrateInnerDefinitions.ts
@@ -56,9 +56,9 @@ type BrickInnerDefinition<
 type InnerDefinition = StarterBrickInnerDefinition | BrickInnerDefinition;
 
 /**
- * Select a unique id for an inner definition. Definitions with the same structure will produce the same id.
+ * Calculate the unique id for an inner definition. Definitions with the same structure will produce the same id.
  */
-export function selectInnerRegistryId(obj: UnknownObject): RegistryId {
+export function calculateInnerRegistryId(obj: UnknownObject): RegistryId {
   const hash = objectHash(obj);
   return `${INNER_SCOPE}/${hash}` as RegistryId;
 }
@@ -74,7 +74,7 @@ async function hydrateBrickDefinition(
     "pipeline",
     "definition",
   ]);
-  const registryId = selectInnerRegistryId(obj);
+  const registryId = calculateInnerRegistryId(obj);
 
   try {
     return await brickRegistry.lookup(registryId);
@@ -159,7 +159,7 @@ async function hydrateStarterBrickDefinition(
   );
 
   const obj = pick(innerDefinition, ["kind", "definition"]);
-  const internalRegistryId = selectInnerRegistryId(obj);
+  const internalRegistryId = calculateInnerRegistryId(obj);
 
   try {
     return await starterBrickRegistry.lookup(internalRegistryId);

--- a/src/registry/hydrateInnerDefinitions.ts
+++ b/src/registry/hydrateInnerDefinitions.ts
@@ -270,7 +270,7 @@ export async function hydrateModInnerDefinitions(
     return modComponentDefinitions as HydratedModComponentDefinition[];
   }
 
-  const extensionPointReferences = new Set<string>(
+  const starterBrickReferences = new Set<string>(
     modDefinition.extensionPoints.map((x) => x.id),
   );
 
@@ -279,8 +279,7 @@ export async function hydrateModInnerDefinitions(
   const relevantDefinitions = pickBy(
     modDefinition.definitions,
     (definition, name) =>
-      definition.kind !== "extensionPoint" ||
-      extensionPointReferences.has(name),
+      definition.kind !== "extensionPoint" || starterBrickReferences.has(name),
   );
 
   const hydratedDefinitions = await resolveObj(

--- a/src/runtime/runtimeUtils.ts
+++ b/src/runtime/runtimeUtils.ts
@@ -47,7 +47,7 @@ import {
 } from "@/types/runtimeTypes";
 import {
   type ModComponentBase,
-  type UnresolvedModComponent,
+  type SerializedModComponent,
 } from "@/types/modComponentTypes";
 import { excludeUndefined } from "@/utils/objectUtils";
 import { boolean } from "@/utils/typeUtils";
@@ -246,7 +246,7 @@ export function assertModComponentNotResolved<
   Config extends UnknownObject = UnknownObject,
 >(
   modComponent: ModComponentBase<Config>,
-): asserts modComponent is UnresolvedModComponent<Config> {
+): asserts modComponent is SerializedModComponent<Config> {
   if (isInnerDefinitionRegistryId(modComponent.extensionPointId)) {
     throw new Error("Expected UnresolvedModComponent");
   }

--- a/src/runtime/runtimeUtils.ts
+++ b/src/runtime/runtimeUtils.ts
@@ -248,7 +248,7 @@ export function assertModComponentNotResolved<
   modComponent: ModComponentBase<Config>,
 ): asserts modComponent is SerializedModComponent<Config> {
   if (isInnerDefinitionRegistryId(modComponent.extensionPointId)) {
-    throw new Error("Expected UnresolvedModComponent");
+    throw new Error("Expected SerializedModComponent");
   }
 }
 

--- a/src/sidebar/activateMod/ActivateModPanel.test.tsx
+++ b/src/sidebar/activateMod/ActivateModPanel.test.tsx
@@ -79,7 +79,7 @@ jest.mock("@/starterBricks/starterBrickModUtils", () => {
 
 const includesQuickBarMock = jest.mocked(includesQuickBarStarterBrick);
 
-jest.mock("@/registry/internal", () => ({
+jest.mock("@/registry/hydrateInnerDefinitions", () => ({
   // We're also mocking all the functions that this output is passed to, so we can return empty array
   resolveRecipe: jest.fn().mockResolvedValue([]),
 }));

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
@@ -23,7 +23,7 @@ import { type BrickPipeline } from "@/bricks/types";
 import { RootReader } from "@/starterBricks/starterBrickTestUtils";
 import blockRegistry from "@/bricks/registry";
 import { fromJS } from "@/starterBricks/contextMenu/contextMenuStarterBrick";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { RunReason } from "@/types/runtimeTypes";
 import {
@@ -62,9 +62,9 @@ const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const modComponentFactory = define<ResolvedModComponent<ContextMenuConfig>>({
+const modComponentFactory = define<HydratedModComponent<ContextMenuConfig>>({
   apiVersion: "v3",
-  _resolvedModComponentBrand: undefined as never,
+  _hydratedModComponentBrand: undefined as never,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
@@ -49,7 +49,7 @@ import {
 import { BusinessError, CancelError } from "@/errors/businessErrors";
 import { type Reader } from "@/types/bricks/readerTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type StarterBrick } from "@/types/starterBrickTypes";
 import { type UUID } from "@/types/stringTypes";
@@ -164,7 +164,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
   );
 
   async getBricks(
-    modComponent: ResolvedModComponent<ContextMenuConfig>,
+    modComponent: HydratedModComponent<ContextMenuConfig>,
   ): Promise<Brick[]> {
     return collectAllBricks(modComponent.config.action);
   }
@@ -234,7 +234,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
 
   async registerMenuItem(
     modComponent: Pick<
-      ResolvedModComponent<ContextMenuConfig>,
+      HydratedModComponent<ContextMenuConfig>,
       "id" | "config" | "_deployment"
     >,
     handler: (clickData: Menus.OnClickData) => Promise<void>,
@@ -322,7 +322,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
   }
 
   private async registerModComponentItem(
-    modComponent: ResolvedModComponent<ContextMenuConfig>,
+    modComponent: HydratedModComponent<ContextMenuConfig>,
   ): Promise<void> {
     const {
       action: actionConfig,

--- a/src/starterBricks/helpers.ts
+++ b/src/starterBricks/helpers.ts
@@ -20,7 +20,7 @@ import initialize from "@/vendors/jQueryInitialize";
 import { EXTENSION_POINT_DATA_ATTR } from "@/domConstants";
 import {
   type ModComponentBase,
-  type ResolvedModComponent,
+  type HydratedModComponent,
 } from "@/types/modComponentTypes";
 import { type MessageContext } from "@/types/loggerTypes";
 import { $safeFind } from "@/utils/domUtils";
@@ -186,7 +186,7 @@ export function acquireElement(
  * Returns the MessageContext associated with `modComponent`.
  */
 export function selectModComponentContext(
-  modComponent: ResolvedModComponent,
+  modComponent: HydratedModComponent,
 ): MessageContext {
   return {
     // The step label will be re-assigned later in reducePipeline

--- a/src/starterBricks/menuItem/menuItemStarterBrick.test.ts
+++ b/src/starterBricks/menuItem/menuItemStarterBrick.test.ts
@@ -29,7 +29,7 @@ import {
 } from "@/starterBricks/starterBrickTestUtils";
 import { type BrickPipeline } from "@/bricks/types";
 import { reduceModComponentPipeline } from "@/runtime/reducePipeline";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { RunReason } from "@/types/runtimeTypes";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -76,9 +76,9 @@ const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const modComponentFactory = define<ResolvedModComponent>({
+const modComponentFactory = define<HydratedModComponent>({
   apiVersion: "v3",
-  _resolvedModComponentBrand: undefined as never,
+  _hydratedModComponentBrand: undefined as never,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/menuItem/menuItemStarterBrick.ts
+++ b/src/starterBricks/menuItem/menuItemStarterBrick.ts
@@ -61,7 +61,7 @@ import {
 import { PromiseCancelled } from "@/errors/genericErrors";
 import { rejectOnCancelled } from "@/errors/rejectOnCancelled";
 import { type Schema } from "@/types/schemaTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type JsonObject } from "type-fest";
 import {
@@ -293,7 +293,7 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
   }
 
   async getBricks(
-    modComponent: ResolvedModComponent<MenuItemStarterBrickConfig>,
+    modComponent: HydratedModComponent<MenuItemStarterBrickConfig>,
   ): Promise<Brick[]> {
     return collectAllBricks(modComponent.config.action);
   }
@@ -449,13 +449,13 @@ export abstract class MenuItemStarterBrickABC extends StarterBrickABC<MenuItemSt
 
   protected abstract makeItem(
     html: string,
-    modComponent: ResolvedModComponent<MenuItemStarterBrickConfig>,
+    modComponent: HydratedModComponent<MenuItemStarterBrickConfig>,
   ): JQuery;
 
   private async runModComponent(
     menu: HTMLElement,
     ctxtPromise: Promise<JsonObject> | undefined,
-    modComponent: ResolvedModComponent<MenuItemStarterBrickConfig>,
+    modComponent: HydratedModComponent<MenuItemStarterBrickConfig>,
   ) {
     if (!modComponent.id) {
       this.logger.error(`Refusing to run mod without id for ${this.id}`);
@@ -928,7 +928,7 @@ export class RemoteMenuItemStarterBrick extends MenuItemStarterBrickABC {
 
   protected makeItem(
     unsanitizedHTML: string,
-    modComponent: ResolvedModComponent<MenuItemStarterBrickConfig>,
+    modComponent: HydratedModComponent<MenuItemStarterBrickConfig>,
   ): JQuery {
     const sanitizedHTML = sanitize(unsanitizedHTML);
 

--- a/src/starterBricks/panel/panelStarterBrick.ts
+++ b/src/starterBricks/panel/panelStarterBrick.ts
@@ -47,7 +47,7 @@ import { mergeReaders } from "@/bricks/readers/readerUtils";
 import { PIXIEBRIX_DATA_ATTR } from "@/domConstants";
 import { type UUID } from "@/types/stringTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
 import { type JsonObject } from "type-fest";
@@ -161,7 +161,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
   readonly capabilities: PlatformCapability[] = CONTENT_SCRIPT_CAPABILITIES;
 
   async getBricks(
-    modComponent: ResolvedModComponent<PanelConfig>,
+    modComponent: HydratedModComponent<PanelConfig>,
   ): Promise<Brick[]> {
     return collectAllBricks(modComponent.config.body);
   }
@@ -272,7 +272,7 @@ export abstract class PanelStarterBrickABC extends StarterBrickABC<PanelConfig> 
 
   private async runModComponent(
     readerOutput: JsonObject,
-    modComponent: ResolvedModComponent<PanelConfig>,
+    modComponent: HydratedModComponent<PanelConfig>,
   ) {
     if (this.uninstalled) {
       throw new Error("panelStarterBrick has already been destroyed");

--- a/src/starterBricks/quickBar/quickBarStarterBrick.test.ts
+++ b/src/starterBricks/quickBar/quickBarStarterBrick.test.ts
@@ -35,7 +35,7 @@ import {
   toggleQuickBar,
 } from "@/components/quickBar/QuickBarApp";
 import { mockAnimationsApi } from "jsdom-testing-mocks";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { RunReason } from "@/types/runtimeTypes";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -77,9 +77,9 @@ const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const modComponentFactory = define<ResolvedModComponent<QuickBarConfig>>({
+const modComponentFactory = define<HydratedModComponent<QuickBarConfig>>({
   apiVersion: "v3",
-  _resolvedModComponentBrand: undefined as never,
+  _hydratedModComponentBrand: undefined as never,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/quickBar/quickBarStarterBrick.tsx
+++ b/src/starterBricks/quickBar/quickBarStarterBrick.tsx
@@ -47,7 +47,7 @@ import { BusinessError, CancelError } from "@/errors/businessErrors";
 import { type StarterBrick } from "@/types/starterBrickTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type UUID } from "@/types/stringTypes";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
@@ -106,7 +106,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
   );
 
   async getBricks(
-    modComponent: ResolvedModComponent<QuickBarConfig>,
+    modComponent: HydratedModComponent<QuickBarConfig>,
   ): Promise<Brick[]> {
     return collectAllBricks(modComponent.config.action);
   }
@@ -192,7 +192,7 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
    * Add a QuickBar action for a mod component.
    */
   private async registerModComponentAction(
-    modComponent: ResolvedModComponent<QuickBarConfig>,
+    modComponent: HydratedModComponent<QuickBarConfig>,
   ): Promise<void> {
     const {
       title: name,

--- a/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.test.ts
+++ b/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.test.ts
@@ -36,7 +36,7 @@ import defaultActions, {
   pageEditorAction,
 } from "@/components/quickBar/defaultActions";
 import { waitForEffect } from "@/testUtils/testHelpers";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { RunReason } from "@/types/runtimeTypes";
 
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -67,9 +67,9 @@ const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const extensionFactory = define<ResolvedModComponent<QuickBarProviderConfig>>({
+const extensionFactory = define<HydratedModComponent<QuickBarProviderConfig>>({
   apiVersion: "v3",
-  _resolvedModComponentBrand: undefined as never,
+  _hydratedModComponentBrand: undefined as never,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.tsx
+++ b/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.tsx
@@ -47,7 +47,7 @@ import { type Reader } from "@/types/bricks/readerTypes";
 import { type StarterBrick } from "@/types/starterBrickTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type Schema } from "@/types/schemaTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
 import makeIntegrationsContextFromDependencies from "@/integrations/util/makeIntegrationsContextFromDependencies";
@@ -108,7 +108,7 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
   );
 
   async getBricks(
-    modComponent: ResolvedModComponent<QuickBarProviderConfig>,
+    modComponent: HydratedModComponent<QuickBarProviderConfig>,
   ): Promise<Brick[]> {
     return collectAllBricks(modComponent.config.generator);
   }
@@ -220,7 +220,7 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
    * Add a QuickBar action for mod component
    */
   private async registerActionProvider(
-    modComponent: ResolvedModComponent<QuickBarProviderConfig>,
+    modComponent: HydratedModComponent<QuickBarProviderConfig>,
   ): Promise<void> {
     const { generator, rootAction } = modComponent.config;
 

--- a/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
@@ -18,7 +18,7 @@ import { define } from "cooky-cutter";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { validateRegistryId } from "@/types/helpers";
 import { type Metadata } from "@/types/registryTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import {
   autoUUIDSequence,
   registryIdFactory,
@@ -70,9 +70,9 @@ const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const modComponentFactory = define<ResolvedModComponent<SidebarConfig>>({
+const modComponentFactory = define<HydratedModComponent<SidebarConfig>>({
   apiVersion: "v3",
-  _resolvedModComponentBrand: undefined as never,
+  _hydratedModComponentBrand: undefined as never,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/sidebar/sidebarStarterBrick.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.ts
@@ -41,7 +41,7 @@ import { mergeReaders } from "@/bricks/readers/readerUtils";
 import { NoRendererError } from "@/errors/businessErrors";
 import { serializeError } from "serialize-error";
 import { type Schema } from "@/types/schemaTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type JsonObject } from "type-fest";
 import { type UUID } from "@/types/stringTypes";
@@ -84,7 +84,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   private readonly debouncedRefreshPanel = new Map<
     UUID,
     (
-      modComponent: ResolvedModComponent<SidebarConfig>,
+      modComponent: HydratedModComponent<SidebarConfig>,
     ) => Promise<void> | undefined
   >();
 
@@ -124,7 +124,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   readonly capabilities: PlatformCapability[] = ["panel"];
 
   async getBricks(
-    modComponent: ResolvedModComponent<SidebarConfig>,
+    modComponent: HydratedModComponent<SidebarConfig>,
   ): Promise<Brick[]> {
     return collectAllBricks(modComponent.config.body);
   }
@@ -161,7 +161,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
 
   private async runModComponent(
     readerContext: JsonObject,
-    modComponent: ResolvedModComponent<SidebarConfig>,
+    modComponent: HydratedModComponent<SidebarConfig>,
   ): Promise<void> {
     // Generate our own run id so that we know it (to pass to upsertPanel)
     const runId = uuidv4();
@@ -247,7 +247,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
    * @see debouncedRefreshPanels
    */
   private async refreshComponentPanel(
-    modComponent: ResolvedModComponent<SidebarConfig>,
+    modComponent: HydratedModComponent<SidebarConfig>,
   ): Promise<void> {
     // Read per-panel, because panels might be debounced on different schedules.
     const reader = await this.defaultReader();
@@ -271,7 +271,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
    * @param componentsToRun the mod components to run
    */
   private async debouncedRefreshPanels(
-    componentsToRun: Array<ResolvedModComponent<SidebarConfig>>,
+    componentsToRun: Array<HydratedModComponent<SidebarConfig>>,
   ): Promise<void> {
     // Order doesn't matter because panel positions are already reserved
     await Promise.all(
@@ -287,7 +287,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
             // ModComponents are debounced on separate schedules because some ModComponents may ignore certain events
             // for performance (e.g., ModComponents ignore state change events from other mods.)
             debounced = debounce(
-              async (x: ResolvedModComponent<SidebarConfig>) =>
+              async (x: HydratedModComponent<SidebarConfig>) =>
                 this.refreshComponentPanel(x),
               waitMillis,
               options,

--- a/src/starterBricks/starterBrickModUtils.ts
+++ b/src/starterBricks/starterBrickModUtils.ts
@@ -24,7 +24,7 @@ import { type StarterBrickType } from "@/types/starterBrickTypes";
 import starterBrickRegistry from "@/starterBricks/registry";
 import { type RegistryId } from "@/types/registryTypes";
 import { compact, uniq } from "lodash";
-import { resolveRecipeInnerDefinitions } from "@/registry/internal";
+import { hydrateModInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
 import { QuickBarStarterBrickABC } from "@/starterBricks/quickBar/quickBarStarterBrick";
 import { QuickBarProviderStarterBrickABC } from "@/starterBricks/quickBarProvider/quickBarProviderStarterBrick";
 import { type ActivatedModComponent } from "@/types/modComponentTypes";
@@ -86,7 +86,7 @@ export async function includesQuickBarStarterBrick(
   modDefinition?: ModDefinition,
 ): Promise<boolean> {
   const resolvedExtensionDefinitions =
-    (await resolveRecipeInnerDefinitions(modDefinition)) ?? [];
+    (await hydrateModInnerDefinitions(modDefinition)) ?? [];
 
   for (const { id } of resolvedExtensionDefinitions) {
     // eslint-disable-next-line no-await-in-loop -- can break when we find one

--- a/src/starterBricks/tour/tourController.test.ts
+++ b/src/starterBricks/tour/tourController.test.ts
@@ -26,7 +26,7 @@ import {
 } from "@/starterBricks/tour/tourController";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import pDefer from "p-defer";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type RegistryId } from "@/types/registryTypes";
 
 describe("tourController", () => {
@@ -78,7 +78,7 @@ describe("tourController", () => {
         apiVersion: "v3",
         extensionPointId: "" as RegistryId,
         config: {},
-      } as ResolvedModComponent,
+      } as HydratedModComponent,
       allowUserRun: false,
       run: () => ({
         promise: tourPromise.promise,

--- a/src/starterBricks/tour/tourController.ts
+++ b/src/starterBricks/tour/tourController.ts
@@ -26,7 +26,7 @@ import { Events } from "@/telemetry/events";
 import { selectEventData } from "@/telemetry/deployments";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type MessageContext } from "@/types/loggerTypes";
 
 /**
@@ -121,9 +121,9 @@ export function getCurrentTour(): TourRun | undefined {
 export function markTourStart(
   nonce: UUID,
   extension: {
-    id: ResolvedModComponent["id"];
-    label: NonNullable<ResolvedModComponent["label"]>;
-    _recipe?: Pick<NonNullable<ResolvedModComponent["_recipe"]>, "id">;
+    id: HydratedModComponent["id"];
+    label: NonNullable<HydratedModComponent["label"]>;
+    _recipe?: Pick<NonNullable<HydratedModComponent["_recipe"]>, "id">;
   },
   {
     promise,
@@ -252,7 +252,7 @@ export async function registerTour({
   run,
 }: {
   blueprintId: RegistryId;
-  extension: ResolvedModComponent;
+  extension: HydratedModComponent;
   allowUserRun?: boolean;
   run: () => { promise: Promise<void>; abortController: AbortController };
 }): Promise<RegisteredTour> {

--- a/src/starterBricks/tour/tourStarterBrick.test.ts
+++ b/src/starterBricks/tour/tourStarterBrick.test.ts
@@ -30,7 +30,7 @@ import defaultActions, {
 } from "@/components/quickBar/defaultActions";
 import {
   type ModMetadata,
-  type ResolvedModComponent,
+  type HydratedModComponent,
 } from "@/types/modComponentTypes";
 import { RunReason } from "@/types/runtimeTypes";
 
@@ -70,9 +70,9 @@ const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const extensionFactory = define<ResolvedModComponent<TourConfig>>({
+const extensionFactory = define<HydratedModComponent<TourConfig>>({
   apiVersion: "v3",
-  _resolvedModComponentBrand: undefined,
+  _hydratedModComponentBrand: undefined,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/tour/tourStarterBrick.ts
+++ b/src/starterBricks/tour/tourStarterBrick.ts
@@ -48,7 +48,7 @@ import {
 } from "@/starterBricks/tour/tourController";
 import { getAll } from "@/tours/tourRunDatabase";
 import { type UUID } from "@/types/stringTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type RunArgs, RunReason } from "@/types/runtimeTypes";
@@ -121,13 +121,13 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
   );
 
   async getBricks(
-    modComponent: ResolvedModComponent<TourConfig>,
+    modComponent: HydratedModComponent<TourConfig>,
   ): Promise<Brick[]> {
     return collectAllBricks(modComponent.config.tour);
   }
 
   private async runModComponentTour(
-    modComponent: ResolvedModComponent<TourConfig>,
+    modComponent: HydratedModComponent<TourConfig>,
     abortController: AbortController,
   ): Promise<void> {
     const reader = await this.defaultReader();
@@ -158,7 +158,7 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
    * Register a tour with the tour controller.
    */
   private async registerTour(
-    modComponent: ResolvedModComponent<TourConfig>,
+    modComponent: HydratedModComponent<TourConfig>,
   ): Promise<void> {
     assertNotNullish(
       modComponent._recipe?.id,
@@ -190,7 +190,7 @@ export abstract class TourStarterBrickABC extends StarterBrickABC<TourConfig> {
    * @see autoRunSchedule
    */
   async decideAutoRunTour(): Promise<
-    Nullishable<ResolvedModComponent<TourConfig>>
+    Nullishable<HydratedModComponent<TourConfig>>
   > {
     const modComponentIds = new Set(this.modComponents.map((x) => x.id));
 

--- a/src/starterBricks/trigger/triggerStarterBrick.test.ts
+++ b/src/starterBricks/trigger/triggerStarterBrick.test.ts
@@ -37,7 +37,7 @@ import { getReferenceForElement } from "@/contentScript/elementReference";
 import userEvent from "@testing-library/user-event";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { ensureMocksReset, requestIdleCallback } from "@shopify/jest-dom-mocks";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { RunReason } from "@/types/runtimeTypes";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import {
@@ -100,9 +100,9 @@ const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
     }),
   });
 
-const modComponentFactory = define<ResolvedModComponent<TriggerConfig>>({
+const modComponentFactory = define<HydratedModComponent<TriggerConfig>>({
   apiVersion: "v3",
-  _resolvedModComponentBrand: undefined as never,
+  _hydratedModComponentBrand: undefined as never,
   id: uuidSequence,
   extensionPointId: (n: number) =>
     validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/trigger/triggerStarterBrick.ts
+++ b/src/starterBricks/trigger/triggerStarterBrick.ts
@@ -64,7 +64,7 @@ import {
 import CompositeReader from "@/bricks/readers/CompositeReader";
 import { type Reader } from "@/types/bricks/readerTypes";
 import { type UUID } from "@/types/stringTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type SelectorRoot } from "@/types/runtimeTypes";
@@ -363,7 +363,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
   );
 
   async getBricks(
-    modComponent: ResolvedModComponent<TriggerConfig>,
+    modComponent: HydratedModComponent<TriggerConfig>,
   ): Promise<Brick[]> {
     return collectAllBricks(modComponent.config.action);
   }
@@ -394,7 +394,7 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
 
   private async runModComponent(
     ctxt: JsonObject,
-    modComponent: ResolvedModComponent<TriggerConfig>,
+    modComponent: HydratedModComponent<TriggerConfig>,
     root: SelectorRoot,
   ) {
     const componentLogger = this.logger.childLogger(

--- a/src/starterBricks/types.ts
+++ b/src/starterBricks/types.ts
@@ -28,7 +28,7 @@ import {
   type StarterBrickType,
   type StarterBrick,
 } from "@/types/starterBrickTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type Logger } from "@/types/loggerTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
@@ -185,7 +185,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
   /**
    * The current registered mod components.
    */
-  protected readonly modComponents: Array<ResolvedModComponent<TConfig>> = [];
+  protected readonly modComponents: Array<HydratedModComponent<TConfig>> = [];
 
   public abstract readonly inputSchema: Schema;
 
@@ -199,7 +199,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
     return false;
   }
 
-  public get registeredModComponents(): Array<ResolvedModComponent<TConfig>> {
+  public get registeredModComponents(): Array<HydratedModComponent<TConfig>> {
     return [...this.modComponents];
   }
 
@@ -243,7 +243,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
   ): void;
 
   synchronizeModComponents(
-    components: Array<ResolvedModComponent<TConfig>>,
+    components: Array<HydratedModComponent<TConfig>>,
   ): void {
     const before = this.modComponents.map((x) => x.id);
 
@@ -270,7 +270,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
     );
   }
 
-  registerModComponent(component: ResolvedModComponent<TConfig>): void {
+  registerModComponent(component: HydratedModComponent<TConfig>): void {
     const index = this.modComponents.findIndex((x) => x.id === component.id);
     if (index >= 0) {
       console.warn(
@@ -291,7 +291,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
   }
 
   abstract getBricks(
-    extension: ResolvedModComponent<TConfig>,
+    extension: HydratedModComponent<TConfig>,
   ): Promise<Brick[]>;
 
   abstract isAvailable(): Promise<boolean>;

--- a/src/starterBricks/types.ts
+++ b/src/starterBricks/types.ts
@@ -291,7 +291,7 @@ export abstract class StarterBrickABC<TConfig extends UnknownObject>
   }
 
   abstract getBricks(
-    extension: HydratedModComponent<TConfig>,
+    modComponent: HydratedModComponent<TConfig>,
   ): Promise<Brick[]>;
 
   abstract isAvailable(): Promise<boolean>;

--- a/src/store/extensionsSlice.ts
+++ b/src/store/extensionsSlice.ts
@@ -228,7 +228,7 @@ const extensionsSlice = createSlice({
 
       const modComponent: Except<
         ActivatedModComponent,
-        "_unresolvedModComponentBrand"
+        "_serializedModComponentBrand"
       > = {
         id,
         apiVersion,

--- a/src/store/extensionsTypes.ts
+++ b/src/store/extensionsTypes.ts
@@ -18,7 +18,7 @@
 import {
   type ActivatedModComponentV1,
   type ActivatedModComponentV2,
-  type UnresolvedModComponent,
+  type SerializedModComponent,
 } from "@/types/modComponentTypes";
 
 /**
@@ -29,7 +29,7 @@ export type ModComponentStateV0 = {
   extensions: {
     // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style -- Record doesn't allow labelled keys
     [extensionPointId: string]: {
-      [extensionId: string]: UnresolvedModComponent;
+      [extensionId: string]: SerializedModComponent;
     };
   };
 };
@@ -38,7 +38,7 @@ export type ModComponentStateV0 = {
  * @deprecated - Do not use versioned state types directly
  */
 export type ModComponentStateV1 = {
-  extensions: UnresolvedModComponent[];
+  extensions: SerializedModComponent[];
 };
 
 /**

--- a/src/store/uninstallUtils.ts
+++ b/src/store/uninstallUtils.ts
@@ -23,7 +23,7 @@ import {
 import { actions as extensionActions } from "@/store/extensionsSlice";
 import { removeModComponentForEveryTab } from "@/background/messenger/api";
 import { uniq } from "lodash";
-import { type UnresolvedModComponent } from "@/types/modComponentTypes";
+import { type SerializedModComponent } from "@/types/modComponentTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type UUID } from "@/types/stringTypes";
 
@@ -43,7 +43,7 @@ import { type UUID } from "@/types/stringTypes";
  */
 export async function uninstallMod(
   modId: RegistryId,
-  modComponents: UnresolvedModComponent[],
+  modComponents: SerializedModComponent[],
   dispatch: Dispatch<unknown>,
 ): Promise<void> {
   const draftModComponentsToDeactivate =

--- a/src/testUtils/factories/modComponentFactories.ts
+++ b/src/testUtils/factories/modComponentFactories.ts
@@ -96,7 +96,7 @@ export const activatedModComponentFactory = extend<
   createTimestamp: timestampFactory,
   updateTimestamp: timestampFactory,
   active: true,
-  _unresolvedModComponentBrand: undefined as never,
+  _serializedModComponentBrand: undefined as never,
 });
 
 // StandaloneModDefinition is a type in contract.ts. But it's really defined based on the ModComponentBase type not the backend API.

--- a/src/testUtils/factories/modDefinitionFactories.ts
+++ b/src/testUtils/factories/modDefinitionFactories.ts
@@ -135,9 +135,9 @@ export const modDefinitionWithVersionedStarterBrickFactory = ({
   });
 
 /**
- * Factory to create a ModDefinition with a definitions section and resolved mod components
+ * Factory to create a ModDefinition with a definitions section and hydrated mod components
  */
-export const versionedModDefinitionWithResolvedModComponents = (
+export const versionedModDefinitionWithHydratedModComponents = (
   modComponentCount = 1,
 ) => {
   const modComponentDefinitions: ModComponentDefinition[] = [];

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -1267,7 +1267,7 @@
     "./platform/platformTypes/toastProtocol.ts",
     "./platform/state/stateController.test.ts",
     "./platform/state/stateController.ts",
-    "./registry/internal.ts",
+    "./registry/hydrateInnerDefinitions.ts",
     "./registry/memoryRegistry.ts",
     "./registry/packageRegistry.ts",
     "./runtime/apiVersionOptions.ts",

--- a/src/types/modComponentTypes.ts
+++ b/src/types/modComponentTypes.ts
@@ -40,7 +40,7 @@ import { type Nullishable } from "@/utils/nullishUtils";
  * ModMetadata that includes sharing information.
  *
  * We created this type as an alternative to Metadata in order to include information about the origin of a ModComponent,
- * e.g. on the ActiveBricks page.
+ * e.g. on the mods screen.
  *
  * @see optionsSlice
  * @see ModComponentBase._recipe
@@ -49,12 +49,12 @@ import { type Nullishable } from "@/utils/nullishUtils";
 // XXX: Usage may be clearer, but the ergonomics of (ModMetadata | undefined) are terrible to handle with strict null checks
 export type ModMetadata = Metadata & {
   /**
-   * `undefined` for recipes that were activated prior to the field being added
+   * `undefined` for mods that were activated prior to the field being added
    */
   sharing: Sharing | null;
 
   /**
-   * `undefined` for recipes that were activated prior to the field being added
+   * `undefined` for mods that were activated prior to the field being added
    * @since 1.4.8
    */
   updated_at: Timestamp | null;
@@ -142,7 +142,7 @@ export type ModComponentBaseV1<Config extends UnknownObject = UnknownObject> = {
    * - components
    * - readers
    *
-   * @see ResolvedModComponent
+   * @see HydratedModComponent
    */
   definitions?: InnerDefinitions;
 
@@ -186,31 +186,31 @@ export type ModComponentBaseV2<Config extends UnknownObject = UnknownObject> =
 export type ModComponentBase<Config extends UnknownObject = UnknownObject> =
   ModComponentBaseV2<Config>;
 
-export type UnresolvedModComponentV1<
+export type SerializedModComponentV1<
   Config extends UnknownObject = UnknownObject,
 > = ModComponentBaseV1<Config> & {
-  _unresolvedModComponentBrand: never;
+  _serializedModComponentBrand: never;
 };
 
-export type UnresolvedModComponentV2<
+export type SerializedModComponentV2<
   Config extends UnknownObject = UnknownObject,
 > = ModComponentBaseV2<Config> & {
-  _unresolvedModComponentBrand: never;
+  _serializedModComponentBrand: never;
 };
 
 /**
- * An ModComponentBase that is known not to have had its definitions resolved.
+ * An ModComponentBase that is known not to have had its inner definitions hydrated.
  *
  * NOTE: it might be the case that the ModComponent does not have a definitions section/inner definitions. This nominal
- * type is just tracking whether we've passed the instance through resolution yet.
+ * type is just tracking whether we've passed the instance through hydration yet.
  *
  * @see ModComponentBase
- * @see ResolvedModComponent
+ * @see HydratedModComponent
  */
-export type UnresolvedModComponent<
+export type SerializedModComponent<
   Config extends UnknownObject = UnknownObject,
 > = ModComponentBase<Config> & {
-  _unresolvedModComponentBrand: never;
+  _serializedModComponentBrand: never;
 };
 
 type ActivatedModComponentBase = {
@@ -236,14 +236,14 @@ type ActivatedModComponentBase = {
 
 export type ActivatedModComponentV1<
   Config extends UnknownObject = UnknownObject,
-> = UnresolvedModComponentV1<Config> & ActivatedModComponentBase;
+> = SerializedModComponentV1<Config> & ActivatedModComponentBase;
 
 export type ActivatedModComponentV2<
   Config extends UnknownObject = UnknownObject,
-> = UnresolvedModComponentV2<Config> & ActivatedModComponentBase;
+> = SerializedModComponentV2<Config> & ActivatedModComponentBase;
 
 /**
- * A ModComponent that has been saved locally
+ * A ModComponent that has been activated locally
  * @see ModComponentBase
  * @see UserExtension
  */
@@ -252,25 +252,26 @@ export type ActivatedModComponent<
 > = ActivatedModComponentV2<Config>;
 
 /**
- * An `ModComponentBase` with all inner definitions resolved.
- * @see resolveDefinitions
+ * An `ModComponentBase` with all inner definitions hydrated.
+ * @see SerializedModComponent
+ * @see hydrateModComponentInnerDefinitions
  */
-export type ResolvedModComponent<Config extends UnknownObject = UnknownObject> =
+export type HydratedModComponent<Config extends UnknownObject = UnknownObject> =
   Except<
     ModComponentBase<Config>,
-    // There's no definition section after resolution
+    // There's no definition section after hydration
     "definitions"
   > & {
     /**
-     * The registry id of the StarterBrick (will be an `@internal` scope, if the StarterBrick was originally defined
-     * internally.
+     * The registry id of the StarterBrick. Is an `@internal` scope, if the StarterBrick was defined using an
+     * internal definition.
      */
     extensionPointId: RegistryId;
 
     /**
      * Brand for nominal typing.
      */
-    _resolvedModComponentBrand: never;
+    _hydratedModComponentBrand: never;
   };
 
 /**

--- a/src/types/modDefinitionTypes.ts
+++ b/src/types/modDefinitionTypes.ts
@@ -76,14 +76,14 @@ export type ModComponentDefinition = {
 };
 
 /**
- * An ModComponentDefinition with all inner definition references resolved.
- * @see resolveDefinitions
+ * An ModComponentDefinition with all inner definition references hydrated.
+ * @see hydrateModInnerDefinitions
  */
-export type ResolvedModComponentDefinition = ModComponentDefinition & {
+export type HydratedModComponentDefinition = ModComponentDefinition & {
   // Known to be a registry id instead of an InnerDefinitionRef
   id: RegistryId;
 
-  _resolvedModComponentDefinitionBrand: never;
+  _hydratedModComponentDefinitionBrand: never;
 };
 
 /**

--- a/src/types/modTypes.ts
+++ b/src/types/modTypes.ts
@@ -17,7 +17,7 @@
 
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { type Organization } from "@/types/contract";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type Nullishable } from "@/utils/nullishUtils";
 
@@ -34,7 +34,7 @@ export type UnavailableMod = Pick<
 };
 
 // XXX: should this be UnresolvedModComponent instead of ResolvedModComponent? The old screens used ResolvedModComponent
-export type Mod = ModDefinition | ResolvedModComponent | UnavailableMod;
+export type Mod = ModDefinition | HydratedModComponent | UnavailableMod;
 
 export type SharingType =
   | "Personal"

--- a/src/types/modTypes.ts
+++ b/src/types/modTypes.ts
@@ -33,7 +33,7 @@ export type UnavailableMod = Pick<
   isStub: true;
 };
 
-// XXX: should this be UnresolvedModComponent instead of ResolvedModComponent? The old screens used ResolvedModComponent
+// XXX: should this be SerializedModComponent instead of HydratedModComponent? The old screens used ResolvedModComponent
 export type Mod = ModDefinition | HydratedModComponent | UnavailableMod;
 
 export type SharingType =

--- a/src/types/starterBrickTypes.ts
+++ b/src/types/starterBrickTypes.ts
@@ -18,7 +18,7 @@
 import { type Permissions } from "webextension-polyfill";
 import { type Schema } from "@/types/schemaTypes";
 import { type UUID } from "@/types/stringTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type RunArgs } from "@/types/runtimeTypes";
 import { type Brick } from "@/types/brickTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
@@ -120,7 +120,7 @@ export interface StarterBrick extends Metadata {
    * @see runModComponents
    * @see synchronizeModComponents
    */
-  registerModComponent(component: ResolvedModComponent): void;
+  registerModComponent(component: HydratedModComponent): void;
 
   /**
    * Run all registered ModComponents for this StarterBrick and/or add their UI to the page.
@@ -160,7 +160,7 @@ export interface StarterBrick extends Metadata {
    * @see removeModComponent
    * @see registerModComponent
    */
-  synchronizeModComponents(modComponents: ResolvedModComponent[]): void;
+  synchronizeModComponents(modComponents: HydratedModComponent[]): void;
 
   /**
    * Returns all bricks configured in provided ModComponentBase, including sub-pipelines.
@@ -168,11 +168,11 @@ export interface StarterBrick extends Metadata {
    * @param modComponent the ModComponent to get bricks for
    * @see PipelineExpression
    */
-  getBricks: (modComponent: ResolvedModComponent) => Promise<Brick[]>;
+  getBricks: (modComponent: HydratedModComponent) => Promise<Brick[]>;
 
   /**
    * The mod components currently registered with the StarterBrick.
    * @since 1.7.34
    */
-  registeredModComponents: readonly ResolvedModComponent[];
+  registeredModComponents: readonly HydratedModComponent[];
 }

--- a/src/utils/modUtils.test.ts
+++ b/src/utils/modUtils.test.ts
@@ -24,7 +24,7 @@ import {
 import { uuidv4 } from "@/types/helpers";
 import { UserRole } from "@/types/contract";
 import { type Mod, type UnavailableMod } from "@/types/modTypes";
-import { type ResolvedModComponent } from "@/types/modComponentTypes";
+import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { modComponentFactory } from "@/testUtils/factories/modComponentFactories";
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
@@ -158,7 +158,7 @@ describe("getSharingType", () => {
 
 describe("isExtension", () => {
   it("returns true for an extension", () => {
-    const mod = modComponentFactory() as ResolvedModComponent;
+    const mod = modComponentFactory() as HydratedModComponent;
     expect(isStandaloneModComponent(mod)).toBe(true);
   });
 
@@ -182,7 +182,7 @@ describe("isUnavailableMod", () => {
   });
 
   it("returns false for an extension", () => {
-    const mod = modComponentFactory() as ResolvedModComponent;
+    const mod = modComponentFactory() as HydratedModComponent;
     expect(isUnavailableMod(mod)).toBe(false);
   });
 });

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -64,7 +64,7 @@ export function isUnavailableMod(mod: Mod): mod is UnavailableMod {
 }
 
 /**
- * Returns true if the mod is a standalone ResolvedModComponent, instead of a mod definition.
+ * Returns true if the mod is a standalone HydratedModComponent, instead of a mod definition.
  */
 export function isStandaloneModComponent(
   mod: Mod,
@@ -333,7 +333,7 @@ function getOrganization(
 }
 
 /**
- * Select UnresolvedModComponents currently activated from the mod.
+ * Select ActivatedModComponents currently activated from the mod.
  */
 export const selectComponentsFromMod = createSelector(
   [selectActivatedModComponents, (_state: unknown, mod: Mod) => mod],

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -32,8 +32,8 @@ import { createSelector } from "@reduxjs/toolkit";
 import { selectActivatedModComponents } from "@/store/extensionsSelectors";
 import {
   type ModComponentBase,
-  type ResolvedModComponent,
-  type UnresolvedModComponent,
+  type HydratedModComponent,
+  type SerializedModComponent,
 } from "@/types/modComponentTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { type UUID } from "@/types/stringTypes";
@@ -68,7 +68,7 @@ export function isUnavailableMod(mod: Mod): mod is UnavailableMod {
  */
 export function isStandaloneModComponent(
   mod: Mod,
-): mod is ResolvedModComponent {
+): mod is HydratedModComponent {
   return "extensionPointId" in mod;
 }
 
@@ -178,7 +178,7 @@ function isPersonal(mod: Mod, userScope: Nullishable<string>): boolean {
 }
 
 export function getInstalledVersionNumber(
-  installedExtensions: UnresolvedModComponent[],
+  installedExtensions: SerializedModComponent[],
   mod: Mod,
 ): string | undefined {
   if (isStandaloneModComponent(mod)) {
@@ -186,7 +186,7 @@ export function getInstalledVersionNumber(
   }
 
   const installedExtension = installedExtensions.find(
-    (extension: UnresolvedModComponent) =>
+    (extension: SerializedModComponent) =>
       extension._recipe?.id === mod.metadata.id,
   );
 
@@ -195,7 +195,7 @@ export function getInstalledVersionNumber(
 
 export function isDeployment(
   mod: Mod,
-  installedComponents: UnresolvedModComponent[],
+  installedComponents: SerializedModComponent[],
 ): boolean {
   if (isStandaloneModComponent(mod)) {
     return Boolean(mod._deployment);
@@ -216,7 +216,7 @@ export function getSharingSource({
   mod: Mod;
   organizations: Organization[];
   scope: Nullishable<string>;
-  installedExtensions: UnresolvedModComponent[];
+  installedExtensions: SerializedModComponent[];
 }): SharingSource {
   let sharingType: SharingType | null = null;
   const organization = getOrganization(mod, organizations);
@@ -260,7 +260,7 @@ export function getSharingSource({
 
 export function updateAvailable(
   availableMods: Map<RegistryId, ModDefinition>,
-  activatedMods: Map<RegistryId, UnresolvedModComponent>,
+  activatedMods: Map<RegistryId, SerializedModComponent>,
   mod: Mod,
 ): boolean {
   if (isUnavailableMod(mod)) {


### PR DESCRIPTION
## What does this PR do?

- Implements refactoring: https://www.notion.so/pixiebrix/Proposal-Domain-Modelling-and-Naming-9f7c8ffc0ed4458599a67536d74bdc3a?pvs=4#9ac1bdc654864fed813bdc1ddbe7a14a
- Renames usages of `resolved` prefix to `hydrated`
- Renames usages of `unresolved` prefix to `serialized`
- Main file is `hydrateInnerDefinitions`: https://github.com/pixiebrix/pixiebrix-extension/pull/8693/files#diff-e1179d4308865fcdd271a3a018bb280118090a292613131cd71eddc690e2078d
- Renaming performed using IntelliJ

## Discussion

- Slack discussion: https://pixiebrix.slack.com/archives/C023KL47XV4/p1719320722368439
- What’s the opposite of hydrated? Is it Persisted? Serialized? We had never discussed the opposite of `hydrated`, but `serialized` seems OK-ish for now. 
- Should we be using serialized/deserialized terminology instead? 
  - https://medium.com/@ozhanli/data-basics-hydration-persistence-serialization-and-deserialization-9c88aeafcc3a
  - https://www.baeldung.com/java-object-hydration#:~:text=However%2C%20the%20important%20difference%20between,of%20a%20pre%2Dformed%20objec
    > Therefore, deserialization is object instantiation and object hydration in the same step.  
- But in any case, whatever names we pick are better than “resolved”, which is easily confused with registry lookup as an operation. And it's easy to change the naming again

## FAQs

> Could someone provide the definitions for how we’re using hydrated in this PR
* Hydrate = taking the inner/inline starter brick definitions of a mod definition/mod component, instantiating those into starter brick instances in the in-memory registry, and then rewriting the mod definition to point to the in-memory registry id. It will no longer have a definitions prop
* The “opposite” = an object that’s known not to have been hydrated yet. (But it might not have a “definitions” prop; older mod definitions won’t have a definitions prop if it only references starter bricks that are defined in the server’s package registry)

## Future Work

- Rename local variables at callsites
- Revisit naming after standalone mod re-architecture
