### PR TITLE
#8716: introduce constants for renamed strings

### DIFF
--- a/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.test.ts
@@ -22,6 +22,7 @@ import { AnnotationType } from "@/types/annotationTypes";
 import { registryIdFactory } from "@/testUtils/factories/stringFactories";
 import { CustomFormRenderer } from "@/bricks/renderers/customForm";
 import { type BaseFormState } from "@/pageEditor/baseFormStateTypes";
+import { StateNamespaces } from "@/platform/state/stateController";
 
 describe("PageStateAnalysis", () => {
   it.each([SetPageState.BRICK_ID, GetPageState.BRICK_ID])(
@@ -77,7 +78,7 @@ describe("PageStateAnalysis", () => {
         config: {
           storage: {
             type: "state",
-            namespace: "blueprint",
+            namespace: StateNamespaces.MOD,
           },
         },
       },
@@ -100,7 +101,7 @@ describe("PageStateAnalysis", () => {
         {
           id: registryId,
           config: {
-            namespace: "blueprint",
+            namespace: StateNamespaces.MOD,
           },
         },
       ]);
@@ -123,7 +124,7 @@ describe("PageStateAnalysis", () => {
         {
           id: registryId,
           config: {
-            namespace: "blueprint",
+            namespace: StateNamespaces.MOD,
           },
         },
       ]);

--- a/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.ts
@@ -26,6 +26,7 @@ import {
   type StateStorage,
   type Storage,
 } from "@/bricks/renderers/customForm";
+import { StateNamespaces } from "@/platform/state/stateController";
 
 const fallbackMessage =
   "This brick is not in a Mod. It will fall back to Public state, which other Mods can read and overwrite.";
@@ -53,14 +54,17 @@ class PageStateVisitor extends AnalysisVisitorWithResolvedBricksABC {
       blockConfig.id === SetPageState.BRICK_ID ||
       blockConfig.id === GetPageState.BRICK_ID
     ) {
-      if (blockConfig.config.namespace === "blueprint" && !this.isInMod) {
+      if (
+        blockConfig.config.namespace === StateNamespaces.MOD &&
+        !this.isInMod
+      ) {
         this.annotations.push({
           position: nestedPosition(position, "config", "namespace"),
           message: fallbackMessage,
           analysisId: this.id,
           type: AnnotationType.Warning,
         });
-      } else if (blockConfig.config.namespace === "shared") {
+      } else if (blockConfig.config.namespace === StateNamespaces.PUBLIC) {
         this.annotations.push({
           position: nestedPosition(position, "config", "namespace"),
           message: publicMessage,
@@ -75,14 +79,14 @@ class PageStateVisitor extends AnalysisVisitorWithResolvedBricksABC {
       (blockConfig.config.storage as Storage)?.type === "state"
     ) {
       const storage = blockConfig.config.storage as StateStorage;
-      if (storage.namespace === "blueprint" && !this.isInMod) {
+      if (storage.namespace === StateNamespaces.MOD && !this.isInMod) {
         this.annotations.push({
           position: nestedPosition(position, "config", "storage", "namespace"),
           message: fallbackMessage,
           analysisId: this.id,
           type: AnnotationType.Warning,
         });
-      } else if (storage.namespace === "shared") {
+      } else if (storage.namespace === StateNamespaces.PUBLIC) {
         this.annotations.push({
           position: nestedPosition(position, "config", "storage", "namespace"),
           message: publicMessage,

--- a/src/analysis/analysisVisitors/renderersAnalysis.ts
+++ b/src/analysis/analysisVisitors/renderersAnalysis.ts
@@ -27,6 +27,7 @@ import {
 } from "@/bricks/PipelineVisitor";
 import { AnnotationType } from "@/types/annotationTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { BrickTypes } from "@/runtime/runtimeTypes";
 
 export const MULTIPLE_RENDERERS_ERROR_MESSAGE =
   "A panel can only have one renderer. There are one or more other renderers configured for this mod.";
@@ -59,7 +60,7 @@ class RenderersAnalysis extends AnalysisVisitorWithResolvedBricksABC {
       const brickType = this.allBlocks.get(pipelineBlock.id)?.type;
       const brickErrors = [];
 
-      if (brickType !== "renderer") {
+      if (brickType !== BrickTypes.RENDERER) {
         continue;
       }
 

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -21,7 +21,7 @@ import VarAnalysis, {
   NO_VARIABLE_PROVIDED_MESSAGE,
 } from "./varAnalysis";
 import { validateRegistryId } from "@/types/helpers";
-import { validateOutputKey } from "@/runtime/runtimeTypes";
+import { BrickTypes, validateOutputKey } from "@/runtime/runtimeTypes";
 import IfElse from "@/bricks/transformers/controlFlow/IfElse";
 import ForEach from "@/bricks/transformers/controlFlow/ForEach";
 import { EchoBrick } from "@/runtime/pipelineTests/pipelineTestHelpers";
@@ -786,7 +786,7 @@ describe("Collecting available vars", () => {
           [
             IdentityTransformer.BRICK_ID,
             {
-              type: "transform",
+              type: BrickTypes.TRANSFORM,
               block: new IdentityTransformer(),
             },
           ],

--- a/src/bricks/brickFilterHelpers.ts
+++ b/src/bricks/brickFilterHelpers.ts
@@ -19,7 +19,7 @@ import { type TypedBrickPair } from "@/bricks/registry";
 import { type StarterBrickType } from "@/types/starterBrickTypes";
 import { stubTrue } from "lodash";
 import { DocumentRenderer } from "@/bricks/renderers/document";
-import { type BrickType } from "@/runtime/runtimeTypes";
+import { type BrickType, BrickTypes } from "@/runtime/runtimeTypes";
 import DisplayTemporaryInfo from "@/bricks/transformers/temporaryInfo/DisplayTemporaryInfo";
 import { type RegistryId } from "@/types/registryTypes";
 import TourStepTransformer from "@/bricks/transformers/tourStep/tourStep";
@@ -90,12 +90,12 @@ export function makeIsBrickAllowedForPipeline(
 
   switch (pipelineFlavor) {
     case PipelineFlavor.NoEffect: {
-      excludedType = "effect";
+      excludedType = BrickTypes.EFFECT;
       break;
     }
 
     case PipelineFlavor.NoRenderer: {
-      excludedType = "renderer";
+      excludedType = BrickTypes.RENDERER;
       break;
     }
 

--- a/src/bricks/effects/assignModVariable.test.ts
+++ b/src/bricks/effects/assignModVariable.test.ts
@@ -19,7 +19,12 @@ import ConsoleLogger from "@/utils/ConsoleLogger";
 import { validateRegistryId } from "@/types/helpers";
 import AssignModVariable from "@/bricks/effects/assignModVariable";
 import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
-import { getState, setState } from "@/platform/state/stateController";
+import {
+  getState,
+  MergeStrategies,
+  setState,
+  StateNamespaces,
+} from "@/platform/state/stateController";
 import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 import { validateBrickInputOutput } from "@/validators/schemaValidator";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
@@ -38,10 +43,10 @@ const brickOptions = brickOptionsFactory({ logger });
 
 beforeEach(() => {
   setState({
-    namespace: "blueprint",
+    namespace: StateNamespaces.MOD,
     blueprintId,
     extensionId,
-    mergeStrategy: "replace",
+    mergeStrategy: MergeStrategies.REPLACE,
     data: {},
   });
 });
@@ -59,7 +64,7 @@ describe("@pixiebrix/state/assign", () => {
     );
 
     expect(
-      getState({ namespace: "blueprint", blueprintId, extensionId }),
+      getState({ namespace: StateNamespaces.MOD, blueprintId, extensionId }),
     ).toEqual({ foo: { bar: 42 } });
   });
 
@@ -89,7 +94,7 @@ describe("@pixiebrix/state/assign", () => {
     );
 
     expect(
-      getState({ namespace: "blueprint", blueprintId, extensionId }),
+      getState({ namespace: StateNamespaces.MOD, blueprintId, extensionId }),
     ).toEqual({ foo: null });
   });
 
@@ -105,7 +110,7 @@ describe("@pixiebrix/state/assign", () => {
     );
 
     expect(
-      getState({ namespace: "blueprint", blueprintId, extensionId }),
+      getState({ namespace: StateNamespaces.MOD, blueprintId, extensionId }),
     ).toEqual({ foo: 42, bar: 0 });
   });
 

--- a/src/bricks/effects/assignModVariable.ts
+++ b/src/bricks/effects/assignModVariable.ts
@@ -2,7 +2,11 @@ import { type Schema } from "@/types/schemaTypes";
 import { validateRegistryId } from "@/types/helpers";
 import { type BrickArgs, type BrickOptions } from "@/types/runtimeTypes";
 import { type JsonObject, type JsonPrimitive } from "type-fest";
-import { setState } from "@/platform/state/stateController";
+import {
+  MergeStrategies,
+  setState,
+  StateNamespaces,
+} from "@/platform/state/stateController";
 import { EffectABC } from "@/types/bricks/effectTypes";
 import { type BrickConfig } from "@/bricks/types";
 import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
@@ -95,9 +99,9 @@ class AssignModVariable extends EffectABC {
     const { blueprintId, extensionId } = logger.context;
 
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: { [variableName]: value },
-      mergeStrategy: "shallow",
+      mergeStrategy: MergeStrategies.SHALLOW,
       extensionId,
       blueprintId,
     });

--- a/src/bricks/effects/pageState.test.ts
+++ b/src/bricks/effects/pageState.test.ts
@@ -21,7 +21,10 @@ import { unsafeAssumeValidArg } from "@/runtime/runtimeTypes";
 import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 import { toExpression } from "@/utils/expressionUtils";
 import { GetPageState, SetPageState } from "@/bricks/effects/pageState";
-import { TEST_resetState } from "@/platform/state/stateController";
+import {
+  MergeStrategies,
+  TEST_resetState,
+} from "@/platform/state/stateController";
 
 beforeEach(() => {
   TEST_resetState();
@@ -61,7 +64,10 @@ describe("@pixiebrix/state/set", () => {
     expect(result).toStrictEqual({ foo: 42, bar: 42 });
 
     result = await brick.transform(
-      unsafeAssumeValidArg({ data: { foo: 1 }, mergeStrategy: "shallow" }),
+      unsafeAssumeValidArg({
+        data: { foo: 1 },
+        mergeStrategy: MergeStrategies.SHALLOW,
+      }),
       brickOptionsFactory({ logger }),
     );
     expect(result).toStrictEqual({ foo: 1, bar: 42 });
@@ -97,7 +103,7 @@ describe("@pixiebrix/state/set", () => {
           obj: { b: 1 },
           objectArray: [{ b: 1 }, { a: 2 }],
         },
-        mergeStrategy: "deep",
+        mergeStrategy: MergeStrategies.DEEP,
       }),
       brickOptionsFactory({ logger }),
     );

--- a/src/bricks/effects/pageState.ts
+++ b/src/bricks/effects/pageState.ts
@@ -26,6 +26,7 @@ import { mapValues } from "lodash";
 import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
 import { propertiesToSchema } from "@/utils/schemaUtils";
 import {
+  MergeStrategies,
   type MergeStrategy,
   type StateNamespace,
   StateNamespaces,
@@ -84,15 +85,21 @@ export class SetPageState extends TransformerABC {
         title: "Merge Strategy",
         type: "string",
         oneOf: [
-          { const: "shallow", title: "Shallow: replace existing properties" },
-          { const: "replace", title: "Replace: replace the entire state" },
           {
-            const: "deep",
+            const: MergeStrategies.SHALLOW,
+            title: "Shallow: replace existing properties",
+          },
+          {
+            const: MergeStrategies.REPLACE,
+            title: "Replace: replace the entire state",
+          },
+          {
+            const: MergeStrategies.DEEP,
             title: "Deep: recursively merge data with existing state",
           },
         ],
         description: "Strategy for merging the data with existing state.",
-        default: "shallow",
+        default: MergeStrategies.SHALLOW,
       },
     },
     ["data"],
@@ -134,7 +141,7 @@ export class SetPageState extends TransformerABC {
   async transform(
     {
       data,
-      mergeStrategy = "shallow",
+      mergeStrategy = MergeStrategies.SHALLOW,
       namespace = StateNamespaces.MOD,
     }: BrickArgs<{
       data: JsonObject;

--- a/src/bricks/effects/pageState.ts
+++ b/src/bricks/effects/pageState.ts
@@ -25,20 +25,22 @@ import { isObject } from "@/utils/objectUtils";
 import { mapValues } from "lodash";
 import { castTextLiteralOrThrow } from "@/utils/expressionUtils";
 import { propertiesToSchema } from "@/utils/schemaUtils";
-
-type MergeStrategy = "shallow" | "replace" | "deep";
-export type Namespace = "blueprint" | "extension" | "shared";
+import {
+  type MergeStrategy,
+  type StateNamespace,
+  StateNamespaces,
+} from "@/platform/state/stateController";
 
 /**
  * Namespace options for use in oneOf.
  */
 export const namespaceOptions = [
-  { const: "blueprint", title: "Mod" },
+  { const: StateNamespaces.MOD, title: "Mod" },
   {
-    const: "extension",
+    const: StateNamespaces.PRIVATE,
     title: "Private",
   },
-  { const: "shared", title: "Public" },
+  { const: StateNamespaces.PUBLIC, title: "Public" },
 ] as Schema[];
 
 export class SetPageState extends TransformerABC {
@@ -76,7 +78,7 @@ export class SetPageState extends TransformerABC {
         description:
           "Where to set the data. If set to Mod and this Starter Brick is not part of a Mod, behaves as Public.",
         oneOf: namespaceOptions,
-        default: "blueprint",
+        default: StateNamespaces.MOD,
       },
       mergeStrategy: {
         title: "Merge Strategy",
@@ -103,10 +105,10 @@ export class SetPageState extends TransformerABC {
   override async getModVariableSchema(
     _config: BrickConfig,
   ): Promise<Schema | undefined> {
-    const { data, namespace = "blueprint" } = _config.config;
+    const { data, namespace = StateNamespaces.MOD } = _config.config;
 
     try {
-      if (castTextLiteralOrThrow(namespace) !== "blueprint") {
+      if (castTextLiteralOrThrow(namespace) !== StateNamespaces.MOD) {
         return;
       }
     } catch {
@@ -133,10 +135,10 @@ export class SetPageState extends TransformerABC {
     {
       data,
       mergeStrategy = "shallow",
-      namespace = "blueprint",
+      namespace = StateNamespaces.MOD,
     }: BrickArgs<{
       data: JsonObject;
-      namespace?: Namespace;
+      namespace?: StateNamespace;
       mergeStrategy?: MergeStrategy;
     }>,
     { logger, platform }: BrickOptions,
@@ -175,7 +177,7 @@ export class GetPageState extends TransformerABC {
         description:
           "Where to retrieve the data. If set to Mod and this Starter Brick is not part of a Mod, behaves as Public",
         oneOf: namespaceOptions,
-        default: "blueprint",
+        default: StateNamespaces.MOD,
       },
     },
     [],
@@ -191,7 +193,9 @@ export class GetPageState extends TransformerABC {
   }
 
   async transform(
-    { namespace = "blueprint" }: BrickArgs<{ namespace?: Namespace }>,
+    {
+      namespace = StateNamespaces.MOD,
+    }: BrickArgs<{ namespace?: StateNamespace }>,
     { logger, platform }: BrickOptions,
   ): Promise<JsonObject> {
     const { blueprintId, extensionId } = logger.context;

--- a/src/bricks/readers/factory.ts
+++ b/src/bricks/readers/factory.ts
@@ -23,7 +23,11 @@ import { type ApiVersion, type SelectorRoot } from "@/types/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type JsonObject } from "type-fest";
 import { type Reader, ReaderABC } from "@/types/bricks/readerTypes";
-import { type Metadata, type SemVerString } from "@/types/registryTypes";
+import {
+  type DefinitionKinds,
+  type Metadata,
+  type SemVerString,
+} from "@/types/registryTypes";
 import {
   PAGE_SCRIPT_CAPABILITIES,
   type PlatformCapability,
@@ -47,7 +51,7 @@ export interface ReaderConfig<
   apiVersion?: ApiVersion;
   metadata: Metadata;
   outputSchema: Schema;
-  kind: "reader";
+  kind: typeof DefinitionKinds.READER;
   definition: TDefinition;
 }
 

--- a/src/bricks/registry.ts
+++ b/src/bricks/registry.ts
@@ -19,7 +19,7 @@ import MemoryRegistry from "@/registry/memoryRegistry";
 import { fromJS } from "@/bricks/transformers/brickFactory";
 import { type BrickType } from "@/runtime/runtimeTypes";
 import getType from "@/runtime/getType";
-import { type RegistryId } from "@/types/registryTypes";
+import { DefinitionKinds, type RegistryId } from "@/types/registryTypes";
 import { type Brick } from "@/types/brickTypes";
 import { partial } from "lodash";
 import { allSettled } from "@/utils/promiseUtils";
@@ -39,7 +39,8 @@ export type TypedBrickMap = Map<RegistryId, TypedBrickPair>;
  */
 class BrickRegistry extends MemoryRegistry<RegistryId, Brick> {
   constructor() {
-    super(["component", "reader"], null);
+    // A reader is a special kind of brick. So we keep them in the same in-memory registry.
+    super([DefinitionKinds.BRICK, DefinitionKinds.READER], null);
     // Can't reference "this" before the call to "super"
     this.setDeserialize(partial(fromJS, this));
 

--- a/src/bricks/registry.ts
+++ b/src/bricks/registry.ts
@@ -39,7 +39,7 @@ export type TypedBrickMap = Map<RegistryId, TypedBrickPair>;
  */
 class BrickRegistry extends MemoryRegistry<RegistryId, Brick> {
   constructor() {
-    super(["block", "component", "effect", "reader"], null);
+    super(["component", "reader"], null);
     // Can't reference "this" before the call to "super"
     this.setDeserialize(partial(fromJS, this));
 

--- a/src/bricks/renderers/customForm.test.tsx
+++ b/src/bricks/renderers/customForm.test.tsx
@@ -37,6 +37,7 @@ import {
   TEST_resetState,
   getState,
   setState,
+  StateNamespaces,
 } from "@/platform/state/stateController";
 import type { Target } from "@/types/messengerTypes";
 
@@ -350,7 +351,7 @@ describe("CustomFormRenderer", () => {
 
       expect(
         getState({
-          namespace: "blueprint",
+          namespace: StateNamespaces.MOD,
           extensionId: options.logger.context.extensionId,
           blueprintId: options.logger.context.blueprintId,
         }),

--- a/src/bricks/renderers/customForm.tsx
+++ b/src/bricks/renderers/customForm.tsx
@@ -52,7 +52,7 @@ import {
 } from "@/utils/nullishUtils";
 import {
   MergeStrategies,
-  StateNamespace,
+  type StateNamespace,
   StateNamespaces,
 } from "@/platform/state/stateController";
 

--- a/src/bricks/transformers/brickFactory.test.ts
+++ b/src/bricks/transformers/brickFactory.test.ts
@@ -39,6 +39,7 @@ import { uuidv4, validateRegistryId } from "@/types/helpers";
 import registerBuiltinBricks from "@/bricks/registerBuiltinBricks";
 
 import { toExpression } from "@/utils/expressionUtils";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 TEST_setContext("contentScript");
 
@@ -119,7 +120,7 @@ describe("isUserDefinedBrick", () => {
 test("inner pipelines receive correct context", async () => {
   const json = {
     apiVersion: "v3",
-    kind: "component",
+    kind: DefinitionKinds.BRICK,
     metadata: {
       id: "test/pipeline-echo",
       name: "Pipeline Echo brick",
@@ -202,7 +203,7 @@ describe("getModVariableSchema", () => {
   it("unions mod variables", async () => {
     const json = {
       apiVersion: "v3",
-      kind: "component",
+      kind: DefinitionKinds.BRICK,
       metadata: {
         id: "test/pipeline-echo",
         name: "State Brick",
@@ -262,7 +263,7 @@ describe("isPageStateAware", () => {
   it("detects any page state aware blocks", async () => {
     const json = {
       apiVersion: "v3",
-      kind: "component",
+      kind: DefinitionKinds.BRICK,
       metadata: {
         id: "test/pipeline-echo",
         name: "State Brick",
@@ -295,7 +296,7 @@ describe("isPageStateAware", () => {
   it("requires at least one page state brick", async () => {
     const json = {
       apiVersion: "v3",
-      kind: "component",
+      kind: DefinitionKinds.BRICK,
       metadata: {
         id: "test/pipeline-echo",
         name: "State Brick",
@@ -324,7 +325,7 @@ describe("tracing", () => {
   it("passes branches to inner blocks", async () => {
     const json = {
       apiVersion: "v3",
-      kind: "component",
+      kind: DefinitionKinds.BRICK,
       metadata: {
         id: "test/pipeline-echo",
         name: "Pipeline Echo brick",

--- a/src/bricks/transformers/brickFactory.ts
+++ b/src/bricks/transformers/brickFactory.ts
@@ -38,6 +38,7 @@ import {
   type UiSchema,
 } from "@/types/schemaTypes";
 import {
+  DefinitionKinds,
   type Metadata,
   type RegistryId,
   type SemVerString,
@@ -71,7 +72,7 @@ export type BrickDefinition = {
   /**
    * User-defined brick kind.
    */
-  kind: "component";
+  kind: typeof DefinitionKinds.BRICK;
 
   /**
    * Registry package metadata.
@@ -402,7 +403,7 @@ export function fromJS(
     );
   }
 
-  if (component.kind === "reader") {
+  if (component.kind === DefinitionKinds.READER) {
     return readerFactory(component);
   }
 

--- a/src/bricks/transformers/controlFlow/WithAsyncModVariable.test.ts
+++ b/src/bricks/transformers/controlFlow/WithAsyncModVariable.test.ts
@@ -25,7 +25,12 @@ import {
 import { reducePipeline } from "@/runtime/reducePipeline";
 import brickRegistry from "@/bricks/registry";
 import ConsoleLogger from "@/utils/ConsoleLogger";
-import { getState, setState } from "@/platform/state/stateController";
+import {
+  getState,
+  MergeStrategies,
+  setState,
+  StateNamespaces,
+} from "@/platform/state/stateController";
 import pDefer, { type DeferredPromise } from "p-defer";
 import { tick } from "@/starterBricks/starterBrickTestUtils";
 import { type Brick } from "@/types/brickTypes";
@@ -68,7 +73,7 @@ const logger = new ConsoleLogger({
 
 function expectPageState(expectedState: UnknownObject) {
   const pageState = getState({
-    namespace: "blueprint",
+    namespace: StateNamespaces.MOD,
     extensionId,
     blueprintId,
   });
@@ -83,11 +88,11 @@ describe("WithAsyncModVariable", () => {
   beforeEach(() => {
     // Reset the page state to avoid interference between tests
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: {},
       blueprintId,
       extensionId,
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
     });
 
     // Most tests just require a single brick instance for testing

--- a/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
+++ b/src/bricks/transformers/controlFlow/WithAsyncModVariable.ts
@@ -18,7 +18,12 @@
 import { TransformerABC } from "@/types/bricks/transformerTypes";
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { type Schema } from "@/types/schemaTypes";
-import { getState, setState } from "@/platform/state/stateController";
+import {
+  getState,
+  MergeStrategies,
+  setState,
+  StateNamespaces,
+} from "@/platform/state/stateController";
 import {
   type BrickArgs,
   type BrickOptions,
@@ -191,12 +196,13 @@ export class WithAsyncModVariable extends TransformerABC {
     const setModVariable = (data: JsonObject, strategy: "put" | "patch") => {
       setState({
         // Store as Mod Variable
-        namespace: "blueprint",
+        namespace: StateNamespaces.MOD,
         data: {
           [stateKey]: data,
         },
         // Using shallow will replace the state key, but keep other keys
-        mergeStrategy: strategy === "put" ? "shallow" : "deep",
+        mergeStrategy:
+          strategy === "put" ? MergeStrategies.SHALLOW : MergeStrategies.DEEP,
         extensionId,
         blueprintId,
       });
@@ -207,7 +213,7 @@ export class WithAsyncModVariable extends TransformerABC {
 
     // Get/set page state calls are synchronous from the content script, so safe to call sequentially
     const currentState = getState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       extensionId,
       blueprintId,
     });

--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
@@ -50,7 +50,11 @@ import { tick } from "@/starterBricks/starterBrickTestUtils";
 import pDefer from "p-defer";
 import { registryIdFactory } from "@/testUtils/factories/stringFactories";
 import { type RendererErrorPayload } from "@/types/rendererTypes";
-import { setState } from "@/platform/state/stateController";
+import {
+  MergeStrategies,
+  setState,
+  StateNamespaces,
+} from "@/platform/state/stateController";
 import { contextAsPlainObject } from "@/runtime/extendModVariableContext";
 import { unary } from "lodash";
 import { toExpression } from "@/utils/expressionUtils";
@@ -376,9 +380,9 @@ describe("DisplayTemporaryInfo", () => {
     expect(jest.mocked(showTemporarySidebarPanel)).toHaveBeenCalled();
 
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: { foo: 42 },
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
       extensionId,
       blueprintId: null,
     });

--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.tsx
@@ -45,6 +45,7 @@ import { isEmpty } from "lodash";
 import { getSelectedLineVirtualElement } from "@/components/fields/schemaFields/widgets/varPopup/utils";
 import { inspectedTab } from "@/pageEditor/context/connection";
 import useEventListener from "@/hooks/useEventListener";
+import { StateNamespaces } from "@/platform/state/stateController";
 
 const emptyVarMap = new VarMap();
 
@@ -172,7 +173,7 @@ const VarMenu: React.FunctionComponent<VarMenuProps> = ({
   const { data: modVariables } = useAsyncState(
     async () =>
       getPageState(inspectedTab, {
-        namespace: "blueprint",
+        namespace: StateNamespaces.MOD,
         extensionId: null,
         blueprintId: activeModComponentFormState.recipe?.id,
       }),

--- a/src/contentScript/lifecycle.test.ts
+++ b/src/contentScript/lifecycle.test.ts
@@ -23,7 +23,7 @@ import {
   type TriggerDefinition,
 } from "@/starterBricks/trigger/triggerStarterBrick";
 import { validateRegistryId } from "@/types/helpers";
-import { type Metadata } from "@/types/registryTypes";
+import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 import { type ActivatedModComponent } from "@/types/modComponentTypes";
 import { type BrickPipeline } from "@/bricks/types";
 import { RootReader, tick } from "@/starterBricks/starterBrickTestUtils";
@@ -48,7 +48,7 @@ const starterBrickDefinitionFactory = (
 ) =>
   define<StarterBrickDefinitionLike<TriggerDefinition>>({
     apiVersion: "v3",
-    kind: "extensionPoint",
+    kind: DefinitionKinds.STARTER_BRICK,
     metadata: (n: number) =>
       ({
         id: validateRegistryId(`test/starter-brick-${n}`),

--- a/src/data/service/api.ts
+++ b/src/data/service/api.ts
@@ -16,7 +16,7 @@
  */
 
 import { type UUID } from "@/types/stringTypes";
-import { type Kind, type RegistryId } from "@/types/registryTypes";
+import { DefinitionKinds, type RegistryId } from "@/types/registryTypes";
 import { createApi } from "@reduxjs/toolkit/query/react";
 import {
   type Database,
@@ -319,7 +319,7 @@ export const appApi = createApi({
           method: "post",
           data: {
             config,
-            kind: "recipe" as Kind,
+            kind: DefinitionKinds.MOD,
             organizations,
             public: isPublic,
             share_dependencies: shareDependencies,
@@ -346,7 +346,7 @@ export const appApi = createApi({
             id: packageId,
             name: modDefinition.metadata.id,
             config,
-            kind: "recipe" as Kind,
+            kind: DefinitionKinds.MOD,
             public: sharing.public,
             organizations: sharing.organizations,
           },

--- a/src/extensionConsole/pages/brickEditor/BrickHistory.test.tsx
+++ b/src/extensionConsole/pages/brickEditor/BrickHistory.test.tsx
@@ -27,6 +27,7 @@ import { waitForEffect } from "@/testUtils/testHelpers";
 import { render } from "@/extensionConsole/testHelpers";
 import { type Package, type PackageVersionDeprecated } from "@/types/contract";
 import { type Timestamp } from "@/types/stringTypes";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 const axiosMock = new MockAdapter(axios);
 
@@ -67,7 +68,7 @@ describe("BrickHistory", () => {
     const testPackage: Package = {
       id: testBrickId,
       name: "@pixies/ai/chatgpt-sidebar",
-      kind: "Blueprint",
+      kind: DefinitionKinds.MOD,
       version: "1.0.1",
       config: "some config yaml",
       public: true,

--- a/src/extensionConsole/pages/brickEditor/EditPage.tsx
+++ b/src/extensionConsole/pages/brickEditor/EditPage.tsx
@@ -39,7 +39,7 @@ import { type Package } from "@/types/contract";
 import { useGetPackageQuery } from "@/data/service/api";
 import useIsMounted from "@/hooks/useIsMounted";
 import { type UUID } from "@/types/stringTypes";
-import { type Definition } from "@/types/registryTypes";
+import { type Definition, DefinitionKinds } from "@/types/registryTypes";
 
 const { touchBrick } = workshopSlice.actions;
 
@@ -58,7 +58,7 @@ function useParseBrick(config: string | null): ParsedBrickInfo {
     }
 
     const configJSON = loadBrickYaml(config) as Definition;
-    const isBlueprint = configJSON.kind === "recipe";
+    const isBlueprint = configJSON.kind === DefinitionKinds.MOD;
     if (isBlueprint) {
       return {
         isBlueprint: true,

--- a/src/extensionConsole/pages/brickEditor/useLogContext.ts
+++ b/src/extensionConsole/pages/brickEditor/useLogContext.ts
@@ -21,7 +21,7 @@ import { useDispatch } from "react-redux";
 import { logActions } from "@/components/logViewer/logSlice";
 import { useEffect } from "react";
 import { type MessageContext } from "@/types/loggerTypes";
-import { type Definition } from "@/types/registryTypes";
+import { type Definition, DefinitionKinds } from "@/types/registryTypes";
 
 const LOG_MESSAGE_CONTEXT_DEBOUNCE_MS = 350;
 
@@ -54,23 +54,23 @@ function useLogContext(config: string | null) {
 
     let messageContext: MessageContext | null;
     switch (json.kind) {
-      case "service": {
+      case DefinitionKinds.INTEGRATION: {
         messageContext = { serviceId: id };
         break;
       }
 
-      case "extensionPoint": {
+      case DefinitionKinds.STARTER_BRICK: {
         messageContext = { extensionPointId: id };
         break;
       }
 
-      case "component":
-      case "reader": {
+      case DefinitionKinds.BRICK:
+      case DefinitionKinds.READER: {
         messageContext = { blockId: id };
         break;
       }
 
-      case "recipe": {
+      case DefinitionKinds.MOD: {
         messageContext = { blueprintId: id };
         break;
       }

--- a/src/extensionConsole/pages/brickEditor/useSubmitBrick.ts
+++ b/src/extensionConsole/pages/brickEditor/useSubmitBrick.ts
@@ -127,7 +127,7 @@ function useSubmitBrick({ create = false }: SubmitOptions): SubmitCallbacks {
         void (async () => {
           try {
             if (kind === DefinitionKinds.MOD && reinstallBlueprint) {
-              // TypeScript doesn't have enough information to kind === PackageKinds.MOD distinguishes ModDefinition
+              // TypeScript doesn't have enough information that kind === PackageKinds.MOD distinguishes ModDefinition
               // from Definition
               const unsavedRecipeDefinition =
                 unsavedBrickJson as UnsavedModDefinition;

--- a/src/extensionConsole/pages/brickEditor/useSubmitBrick.ts
+++ b/src/extensionConsole/pages/brickEditor/useSubmitBrick.ts
@@ -36,7 +36,7 @@ import {
 import { isSingleObjectBadRequestError } from "@/errors/networkErrorHelpers";
 import { type UUID } from "@/types/stringTypes";
 import { type UnsavedModDefinition } from "@/types/modDefinitionTypes";
-import { type Definition } from "@/types/registryTypes";
+import { type Definition, DefinitionKinds } from "@/types/registryTypes";
 import useUserAction from "@/hooks/useUserAction";
 import { useModals } from "@/components/ConfirmationModal";
 import { CancelError } from "@/errors/businessErrors";
@@ -126,9 +126,9 @@ function useSubmitBrick({ create = false }: SubmitOptions): SubmitCallbacks {
         // We attach the handler below, and don't want it to block the save
         void (async () => {
           try {
-            if (kind === "recipe" && reinstallBlueprint) {
-              // TypeScript doesn't have enough information to kind === "recipe" distinguishes ModDefinition from
-              // Definition
+            if (kind === DefinitionKinds.MOD && reinstallBlueprint) {
+              // TypeScript doesn't have enough information to kind === PackageKinds.MOD distinguishes ModDefinition
+              // from Definition
               const unsavedRecipeDefinition =
                 unsavedBrickJson as UnsavedModDefinition;
               await reinstall({
@@ -140,7 +140,7 @@ function useSubmitBrick({ create = false }: SubmitOptions): SubmitCallbacks {
               await refresh();
             }
 
-            if (kind === "service") {
+            if (kind === DefinitionKinds.INTEGRATION) {
               // Clear the background page's service cache after refreshing so
               // it's forced to read the updated service definition.
               await clearServiceCache();

--- a/src/extensionConsole/pages/mods/GetStartedView.stories.tsx
+++ b/src/extensionConsole/pages/mods/GetStartedView.stories.tsx
@@ -33,6 +33,7 @@ import { valueToAsyncCacheState } from "@/utils/asyncStateUtils";
 import { type ApiVersion } from "@/types/runtimeTypes";
 import { type Timestamp } from "@/types/stringTypes";
 import { validateRegistryId } from "@/types/helpers";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 export default {
   title: "ModsPage/GetStartedView",
@@ -65,7 +66,7 @@ const testRecipe = {
     organizations: [],
   },
   updated_at: "2022-01-01T00:00:00Z" as Timestamp,
-  kind: "recipe",
+  kind: DefinitionKinds.MOD,
   apiVersion: "v3" as ApiVersion,
 } as ModDefinition;
 

--- a/src/extensionConsole/pages/mods/utils/exportBlueprint.test.ts
+++ b/src/extensionConsole/pages/mods/utils/exportBlueprint.test.ts
@@ -19,6 +19,7 @@ import { makeBlueprint } from "@/extensionConsole/pages/mods/utils/exportBluepri
 import { validateRegistryId } from "@/types/helpers";
 import { type SerializedModComponent } from "@/types/modComponentTypes";
 import { modComponentFactory } from "@/testUtils/factories/modComponentFactories";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 describe("makeBlueprint", () => {
   it("smoke test", () => {
@@ -32,7 +33,7 @@ describe("makeBlueprint", () => {
 
     expect(result).toEqual(
       expect.objectContaining({
-        kind: "recipe",
+        kind: DefinitionKinds.MOD,
       }),
     );
   });
@@ -51,7 +52,7 @@ describe("makeBlueprint", () => {
 
     expect(result).toEqual(
       expect.objectContaining({
-        kind: "recipe",
+        kind: DefinitionKinds.MOD,
         options: {
           schema: {
             $schema: "http://json-schema.org/draft-04/schema#",

--- a/src/extensionConsole/pages/mods/utils/exportBlueprint.ts
+++ b/src/extensionConsole/pages/mods/utils/exportBlueprint.ts
@@ -16,7 +16,7 @@
  */
 
 import { isEmpty } from "lodash";
-import { type Metadata } from "@/types/registryTypes";
+import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 import GenerateSchema from "generate-schema";
 import { type OptionsArgs } from "@/types/runtimeTypes";
 import {
@@ -85,7 +85,7 @@ export function makeBlueprint(
 
   const modDefinition: UnsavedModDefinition = {
     apiVersion,
-    kind: "recipe",
+    kind: DefinitionKinds.MOD,
     metadata,
     definitions,
     extensionPoints: [extensionPoint],

--- a/src/mods/useMods.test.ts
+++ b/src/mods/useMods.test.ts
@@ -30,6 +30,7 @@ import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinition
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { type UseCachedQueryResult } from "@/types/sliceTypes";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 jest.mock("@/modDefinitions/modDefinitionHooks");
 
@@ -148,7 +149,7 @@ describe("useMods", () => {
     expect(wrapper.result.current).toEqual({
       mods: [
         expect.objectContaining({
-          kind: "recipe",
+          kind: DefinitionKinds.MOD,
         }),
       ],
       error: undefined,

--- a/src/mods/useMods.ts
+++ b/src/mods/useMods.ts
@@ -27,6 +27,7 @@ import { uniqBy } from "lodash";
 import useAsyncState from "@/hooks/useAsyncState";
 import { type ModComponentBase } from "@/types/modComponentTypes";
 import type { Mod, UnavailableMod } from "@/types/modTypes";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 type ModsState = {
   /**
@@ -45,7 +46,7 @@ export function unavailableModFactory(
 ): UnavailableMod {
   return {
     metadata: modComponent._recipe,
-    kind: "recipe",
+    kind: DefinitionKinds.MOD,
     isStub: true,
     updated_at: modComponent._recipe.updated_at,
     sharing: modComponent._recipe.sharing,

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -45,6 +45,7 @@ import HttpRequestAnalysis from "@/analysis/analysisVisitors/httpRequestAnalysis
 import ModVariableNames from "@/analysis/analysisVisitors/pageStateAnalysis/modVariableSchemasVisitor";
 import { inspectedTab } from "@/pageEditor/context/connection";
 import SelectorAnalysis from "@/analysis/analysisVisitors/selectorAnalysis";
+import { StateNamespaces } from "@/platform/state/stateController";
 
 const runtimeActions = runtimeSlice.actions;
 
@@ -212,7 +213,7 @@ async function varAnalysisFactory(
 
   // The actual mod variables
   const modState = await getPageState(inspectedTab, {
-    namespace: "blueprint",
+    namespace: StateNamespaces.MOD,
     extensionId: activeModComponentFormState.uuid,
     blueprintId: activeModComponentFormState.recipe?.id,
   });

--- a/src/pageEditor/documentBuilder/createNewDocumentBuilderElement.ts
+++ b/src/pageEditor/documentBuilder/createNewDocumentBuilderElement.ts
@@ -22,6 +22,7 @@ import {
 import { uuidv4, validateRegistryId } from "@/types/helpers";
 import { type DeferExpression } from "@/types/runtimeTypes";
 import { toExpression } from "@/utils/expressionUtils";
+import { StateNamespaces } from "@/platform/state/stateController";
 
 const documentBuilderElementExtras: Record<"form", DocumentBuilderElementType> =
   {
@@ -98,7 +99,7 @@ export function createNewDocumentBuilderElement(
           config: {
             storage: {
               type: "state",
-              namespace: "blueprint",
+              namespace: StateNamespaces.MOD,
             },
             submitCaption: "Save",
             schema: {

--- a/src/pageEditor/exampleBrickConfigs.ts
+++ b/src/pageEditor/exampleBrickConfigs.ts
@@ -35,6 +35,10 @@ import CommentEffect from "@/bricks/effects/comment";
 import AddDynamicTextSnippet from "@/bricks/effects/AddDynamicTextSnippet";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import AddTextSnippets from "@/bricks/effects/AddTextSnippets";
+import {
+  MergeStrategies,
+  StateNamespaces,
+} from "@/platform/state/stateController";
 
 /**
  * Get an example brick config for a given brick id.
@@ -101,7 +105,7 @@ export function getExampleBrickConfig(
       return {
         storage: {
           type: "state",
-          namespace: "blueprint",
+          namespace: StateNamespaces.MOD,
         },
         submitCaption: "Submit",
         successMessage: "Successfully submitted form",
@@ -178,15 +182,15 @@ export function getExampleBrickConfig(
 
     case "@pixiebrix/state/set": {
       return {
-        namespace: "blueprint",
-        mergeStrategy: "shallow",
+        namespace: StateNamespaces.MOD,
+        mergeStrategy: MergeStrategies.SHALLOW,
         data: {},
       };
     }
 
     case "@pixiebrix/state/get": {
       return {
-        namespace: "blueprint",
+        namespace: StateNamespaces.MOD,
       };
     }
 

--- a/src/pageEditor/fields/FormRendererOptions.tsx
+++ b/src/pageEditor/fields/FormRendererOptions.tsx
@@ -44,6 +44,7 @@ import ConnectedCollapsibleFieldSection from "@/pageEditor/fields/ConnectedColla
 import type { PipelineExpression } from "@/types/runtimeTypes";
 import { Collapse } from "react-bootstrap";
 import { PIXIEBRIX_INTEGRATION_FIELD_SCHEMA } from "@/integrations/constants";
+import { StateNamespaces } from "@/platform/state/stateController";
 
 const recordIdSchema: Schema = {
   type: "string",
@@ -98,7 +99,7 @@ const FormDataBindingOptions: React.FC<{
     if (nextStorageType === "state") {
       await setStorageValue({
         type: "state",
-        namespace: "blueprint",
+        namespace: StateNamespaces.MOD,
       } as Storage);
     } else {
       await setStorageValue({ type: nextStorageType } as Storage);

--- a/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
+++ b/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
@@ -43,6 +43,7 @@ import { array } from "cooky-cutter";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 import { normalizeModDefinition } from "@/utils/modUtils";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 jest.mock("@/pageEditor/starterBricks/base", () => ({
   ...jest.requireActual("@/pageEditor/starterBricks/base"),
@@ -60,7 +61,7 @@ describe("useBuildAndValidateMod", () => {
         apiVersion: modDefinition.apiVersion,
         metadata: internalStarterBrickMetaFactory(),
         definition,
-        kind: "extensionPoint",
+        kind: DefinitionKinds.STARTER_BRICK,
       };
     });
   }

--- a/src/pageEditor/hooks/useCheckModStarterBrickInvariants.test.ts
+++ b/src/pageEditor/hooks/useCheckModStarterBrickInvariants.test.ts
@@ -36,6 +36,7 @@ import { actions as editorActions } from "@/pageEditor/slices/editorSlice";
 import {
   type InnerDefinitionRef,
   type InnerDefinitions,
+  DefinitionKinds,
 } from "@/types/registryTypes";
 
 let extensionPointCount = 0;
@@ -112,7 +113,7 @@ describe("useCheckModStarterBrickInvariants", () => {
           });
           cleanModComponentDefinitions.push(modComponentDefinition);
           cleanModInnerDefinitions[extensionPointId] = {
-            kind: "extensionPoint",
+            kind: DefinitionKinds.STARTER_BRICK,
             definition: starterBrickDefinitionFactory().definition,
           };
         }
@@ -124,7 +125,7 @@ describe("useCheckModStarterBrickInvariants", () => {
           });
           dirtyModComponentDefinitions.push(modComponentDefinition);
           dirtyModInnerDefinitions[extensionPointId] = {
-            kind: "extensionPoint",
+            kind: DefinitionKinds.STARTER_BRICK,
             definition: starterBrickDefinitionFactory().definition,
           };
         }
@@ -161,7 +162,7 @@ describe("useCheckModStarterBrickInvariants", () => {
         });
         newModComponentDefinitions.push(modComponentDefinition);
         newModInnerDefinitions[extensionPointId] = {
-          kind: "extensionPoint",
+          kind: DefinitionKinds.STARTER_BRICK,
           definition: starterBrickDefinitionFactory().definition,
         };
       }
@@ -245,7 +246,7 @@ describe("useCheckModStarterBrickInvariants", () => {
       id: extensionPointId,
     });
     modInnerDefinitions[extensionPointId] = {
-      kind: "extensionPoint",
+      kind: DefinitionKinds.STARTER_BRICK,
       definition: starterBrickDefinitionFactory().definition,
     };
 
@@ -285,7 +286,7 @@ describe("useCheckModStarterBrickInvariants", () => {
       id: extensionPointId,
     });
     modInnerDefinitions[extensionPointId] = {
-      kind: "extensionPoint",
+      kind: DefinitionKinds.STARTER_BRICK,
       definition: starterBrickDefinitionFactory().definition,
     };
     const modForComponent = modDefinitionFactory({

--- a/src/pageEditor/hooks/useCheckModStarterBrickInvariants.ts
+++ b/src/pageEditor/hooks/useCheckModStarterBrickInvariants.ts
@@ -31,7 +31,7 @@ import {
 } from "@/starterBricks/types";
 import { isInnerDefinitionEqual } from "@/starterBricks/starterBrickUtils";
 import { assertNotNullish } from "@/utils/nullishUtils";
-import { type InnerDefinitions } from "@/types/registryTypes";
+import { type InnerDefinitions, DefinitionKinds } from "@/types/registryTypes";
 import produce from "immer";
 import { buildModComponents } from "@/pageEditor/panes/save/saveHelpers";
 
@@ -91,7 +91,7 @@ function useCheckModStarterBrickInvariants(): (
         const { selectStarterBrickDefinition } = adapter;
 
         const definitionFromComponent = {
-          kind: "extensionPoint",
+          kind: DefinitionKinds.STARTER_BRICK,
           definition: selectStarterBrickDefinition(formState).definition,
         } satisfies StarterBrickDefinitionLike;
         if (

--- a/src/pageEditor/hooks/useUpsertModComponentFormState.ts
+++ b/src/pageEditor/hooks/useUpsertModComponentFormState.ts
@@ -38,7 +38,7 @@ import { ensureModComponentFormStatePermissionsFromUserGesture } from "@/pageEdi
 import { type Timestamp, type UUID } from "@/types/stringTypes";
 
 import { isInnerDefinitionRegistryId } from "@/types/helpers";
-import type { RegistryId } from "@/types/registryTypes";
+import { DefinitionKinds, type RegistryId } from "@/types/registryTypes";
 import { reloadModsEveryTab } from "@/contentScript/messenger/api";
 import { assertNotNullish } from "@/utils/nullishUtils";
 
@@ -178,7 +178,7 @@ function useUpsertModComponentFormState(): SaveCallback {
 
             await upsertPackageConfig(
               packageId,
-              "extensionPoint",
+              DefinitionKinds.STARTER_BRICK,
               extensionPointConfig,
             );
           } catch (error) {

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -41,7 +41,10 @@ import {
 import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
-import { type InnerDefinitionRef } from "@/types/registryTypes";
+import {
+  type InnerDefinitionRef,
+  DefinitionKinds,
+} from "@/types/registryTypes";
 import {
   type ModOptionsDefinition,
   type UnsavedModDefinition,
@@ -607,7 +610,7 @@ function selectExtensionPoints(
       apiVersion: modDefinition.apiVersion,
       metadata: internalStarterBrickMetaFactory(),
       definition,
-      kind: "extensionPoint",
+      kind: DefinitionKinds.STARTER_BRICK,
     };
   });
 }
@@ -682,7 +685,7 @@ describe("buildNewMod", () => {
 
       modComponent.definitions = {
         extensionPoint: {
-          kind: "extensionPoint",
+          kind: DefinitionKinds.STARTER_BRICK,
           definition: extensionPoint,
         },
       };
@@ -755,7 +758,7 @@ describe("buildNewMod", () => {
 
       modComponent.definitions = {
         extensionPoint: {
-          kind: "extensionPoint",
+          kind: DefinitionKinds.STARTER_BRICK,
           definition: starterBrick,
         },
       };

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -19,6 +19,7 @@ import {
   type InnerDefinitionRef,
   type InnerDefinitions,
   type Metadata,
+  DefinitionKinds,
   type RegistryId,
 } from "@/types/registryTypes";
 import {
@@ -318,7 +319,7 @@ export function replaceModComponent(
           ) as InnerDefinitionRef;
           // eslint-disable-next-line security/detect-object-injection -- generated with freshIdentifier
           draft.definitions[newInnerId] = {
-            kind: "extensionPoint",
+            kind: DefinitionKinds.STARTER_BRICK,
             definition: starterBrickDefinition.definition,
           } satisfies StarterBrickDefinitionLike;
         }
@@ -326,7 +327,7 @@ export function replaceModComponent(
         // There's only one, can re-use without breaking the other definition
         // eslint-disable-next-line security/detect-object-injection -- existing id
         draft.definitions[originalInnerId] = {
-          kind: "extensionPoint",
+          kind: DefinitionKinds.STARTER_BRICK,
           definition: starterBrickDefinition.definition,
         } satisfies StarterBrickDefinitionLike;
       }
@@ -381,7 +382,7 @@ export type ModParts = {
 
 const emptyModDefinition: UnsavedModDefinition = {
   apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
-  kind: "recipe",
+  kind: DefinitionKinds.MOD,
   metadata: {
     id: "" as RegistryId,
     name: "",
@@ -464,7 +465,7 @@ export function buildNewMod({
           );
           unsavedModComponent.definitions = {
             [unsavedModComponent.extensionPointId]: {
-              kind: "extensionPoint",
+              kind: DefinitionKinds.STARTER_BRICK,
               definition: extensionPointConfig.definition,
             } satisfies StarterBrickDefinitionLike,
           };

--- a/src/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod.test.ts
+++ b/src/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod.test.ts
@@ -27,7 +27,7 @@ import {
 import { modComponentToFormState } from "@/pageEditor/starterBricks/adapter";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { selectGetCleanComponentsAndDirtyFormStatesForMod } from "@/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod";
-import type { InnerDefinitionRef } from "@/types/registryTypes";
+import { InnerDefinitionRef, DefinitionKinds } from "@/types/registryTypes";
 import { starterBrickDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 let extensionPointCount = 0;
@@ -103,7 +103,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
           extensionPointId,
           definitions: {
             [extensionPointId]: {
-              kind: "extensionPoint",
+              kind: DefinitionKinds.STARTER_BRICK,
               definition: starterBrickDefinitionFactory().definition,
             },
           },
@@ -121,7 +121,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
           extensionPointId,
           definitions: {
             [extensionPointId]: {
-              kind: "extensionPoint",
+              kind: DefinitionKinds.STARTER_BRICK,
               definition: starterBrickDefinitionFactory().definition,
             },
           },
@@ -141,7 +141,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
           extensionPointId,
           definitions: {
             [extensionPointId]: {
-              kind: "extensionPoint",
+              kind: DefinitionKinds.STARTER_BRICK,
               definition: starterBrickDefinitionFactory().definition,
             },
           },
@@ -161,7 +161,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
           extensionPointId,
           definitions: {
             [extensionPointId]: {
-              kind: "extensionPoint",
+              kind: DefinitionKinds.STARTER_BRICK,
               definition: starterBrickDefinitionFactory().definition,
             },
           },
@@ -199,7 +199,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
           extensionPointId,
           definitions: {
             [extensionPointId]: {
-              kind: "extensionPoint",
+              kind: DefinitionKinds.STARTER_BRICK,
               definition: starterBrickDefinitionFactory().definition,
             },
           },

--- a/src/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod.test.ts
+++ b/src/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod.test.ts
@@ -27,7 +27,10 @@ import {
 import { modComponentToFormState } from "@/pageEditor/starterBricks/adapter";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { selectGetCleanComponentsAndDirtyFormStatesForMod } from "@/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod";
-import { InnerDefinitionRef, DefinitionKinds } from "@/types/registryTypes";
+import {
+  type InnerDefinitionRef,
+  DefinitionKinds,
+} from "@/types/registryTypes";
 import { starterBrickDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 
 let extensionPointCount = 0;

--- a/src/pageEditor/starterBricks/base.ts
+++ b/src/pageEditor/starterBricks/base.ts
@@ -18,6 +18,7 @@
 import {
   INNER_SCOPE,
   type Metadata,
+  DefinitionKinds,
   type RegistryId,
 } from "@/types/registryTypes";
 import { castArray, cloneDeep, isEmpty } from "lodash";
@@ -282,7 +283,7 @@ export async function lookupExtensionPoint<
     );
     const innerExtensionPoint = {
       apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
-      kind: "extensionPoint",
+      kind: DefinitionKinds.STARTER_BRICK,
       metadata: internalStarterBrickMetaFactory(),
       ...definition,
     } as unknown as StarterBrickDefinitionLike<TDefinition> & {
@@ -318,7 +319,7 @@ export function baseSelectExtensionPoint(
 
   return {
     apiVersion: formState.apiVersion,
-    kind: "extensionPoint",
+    kind: DefinitionKinds.STARTER_BRICK,
     metadata: {
       id: metadata.id,
       // The server requires the version to save the brick, even though it's not marked as required
@@ -346,7 +347,7 @@ export function extensionWithInnerDefinitions(
     result.definitions = {
       ...result.definitions,
       [extensionPointId]: {
-        kind: "extensionPoint",
+        kind: DefinitionKinds.STARTER_BRICK,
         definition: extensionPointDefinition,
       },
     };

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -60,6 +60,7 @@ import { joinPathParts } from "@/utils/formUtils";
 import CommentsTab from "@/pageEditor/tabs/editTab/dataPanel/tabs/CommentsTab";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
+import { BrickTypes } from "@/runtime/runtimeTypes";
 
 /**
  * Exclude irrelevant top-level keys.
@@ -324,7 +325,7 @@ const DataPanel: React.FC = () => {
             )}
             {!record?.skippedRun &&
               outputObj == null &&
-              brickType === "renderer" && (
+              brickType === BrickTypes.RENDERER && (
                 <Alert variant="info">
                   Renderer brick output is not available in Data Panel
                 </Alert>

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
@@ -29,6 +29,7 @@ import DataTab from "@/pageEditor/tabs/editTab/dataPanel/DataTab";
 import useAsyncState from "@/hooks/useAsyncState";
 import { type ShouldExpandNodeInitially } from "react-json-tree";
 import { inspectedTab } from "@/pageEditor/context/connection";
+import { StateNamespaces } from "@/platform/state/stateController";
 
 // We used to expand nodes initially. But makes state hard to read when using async state with long values, e.g.,
 // ChatGPT responses
@@ -52,11 +53,20 @@ const PageStateTab: React.VFC = () => {
       };
 
       const [shared, mod, local] = await Promise.all([
-        getPageState(inspectedTab, { namespace: "shared", ...context }),
+        getPageState(inspectedTab, {
+          namespace: StateNamespaces.PUBLIC,
+          ...context,
+        }),
         activeModComponentFormState?.recipe
-          ? getPageState(inspectedTab, { namespace: "blueprint", ...context })
+          ? getPageState(inspectedTab, {
+              namespace: StateNamespaces.MOD,
+              ...context,
+            })
           : Promise.resolve("Starter Brick is not in a mod"),
-        getPageState(inspectedTab, { namespace: "extension", ...context }),
+        getPageState(inspectedTab, {
+          namespace: StateNamespaces.PRIVATE,
+          ...context,
+        }),
       ]);
 
       return {

--- a/src/pageEditor/tabs/editTab/editHelpers.ts
+++ b/src/pageEditor/tabs/editTab/editHelpers.ts
@@ -16,7 +16,7 @@
  */
 
 import getType from "@/runtime/getType";
-import { type BrickType } from "@/runtime/runtimeTypes";
+import { type BrickType, BrickTypes } from "@/runtime/runtimeTypes";
 import {
   type BrickConfig,
   type BrickPipeline,
@@ -43,7 +43,7 @@ const DEFAULT_OUTPUT_KEY = "output" as SafeString;
 export function showOutputKey(brickType: BrickType): boolean {
   // Output keys for effects are ignored by the runtime (and generate a warning at runtime)
   // Renderers are always the last brick in a pipeline, so they don't need an output key
-  return brickType !== "effect" && brickType !== "renderer";
+  return brickType !== BrickTypes.EFFECT && brickType !== BrickTypes.RENDERER;
 }
 
 /**

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -81,6 +81,7 @@ import { isNullOrBlank } from "@/utils/stringUtils";
 import { joinName, joinPathParts } from "@/utils/formUtils";
 import { SCROLL_TO_DOCUMENT_PREVIEW_ELEMENT_EVENT } from "@/pageEditor/documentBuilder/preview/ElementPreview";
 import { getBrickOutlineSummary } from "@/pageEditor/brickSummary";
+import { BrickTypes } from "@/runtime/runtimeTypes";
 
 const ADD_MESSAGE = "Add more bricks with the plus button";
 
@@ -620,7 +621,8 @@ const usePipelineNodes = (): {
     const lastIndex = pipeline.length - 1;
     const lastBlockId = pipeline.at(lastIndex)?.id;
     const lastBlock = lastBlockId ? allBricks.get(lastBlockId) : undefined;
-    const showAppend = !lastBlock?.block || lastBlock.type !== "renderer";
+    const showAppend =
+      !lastBlock?.block || lastBlock.type !== BrickTypes.RENDERER;
     const nodes: EditorNodeProps[] = [];
 
     // Determine which execution of the pipeline to show. Currently, getting the latest execution

--- a/src/pageEditor/tabs/effect/BrickConfiguration.tsx
+++ b/src/pageEditor/tabs/effect/BrickConfiguration.tsx
@@ -45,6 +45,7 @@ import CommentEffect from "@/bricks/effects/comment";
 import useAsyncState from "@/hooks/useAsyncState";
 import { selectActiveModComponentAnalysisAnnotationsForPath } from "@/pageEditor/slices/editorSelectors";
 import AnalysisAnnotationsContext from "@/analysis/AnalysisAnnotationsContext";
+import { BrickTypes } from "@/runtime/runtimeTypes";
 
 const BrickConfiguration: React.FunctionComponent<{
   name: string;
@@ -151,7 +152,8 @@ const BrickConfiguration: React.FunctionComponent<{
       "menuItem",
       "tour",
     ].includes(context.values.type);
-  const showIfAndTarget = brickType && brickType !== "renderer" && !isComment;
+  const showIfAndTarget =
+    brickType && brickType !== BrickTypes.RENDERER && !isComment;
   const noAdvancedOptions = (!showRootMode && !showIfAndTarget) || isComment;
 
   return (

--- a/src/pageEditor/tabs/effect/BrickPreview.tsx
+++ b/src/pageEditor/tabs/effect/BrickPreview.tsx
@@ -36,7 +36,7 @@ import { runBrickPreview } from "@/contentScript/messenger/api";
 import { useField, useFormikContext } from "formik";
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import getType from "@/runtime/getType";
-import { type BrickType } from "@/runtime/runtimeTypes";
+import { type BrickType, BrickTypes } from "@/runtime/runtimeTypes";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
 import DataTabJsonTree from "@/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree";
 import { type RegistryId } from "@/types/registryTypes";
@@ -63,7 +63,7 @@ function isTraceOptional(
   blockId: RegistryId,
   { type }: { type: BrickType | null },
 ): boolean {
-  return type === "reader" || HACK_TRACE_OPTIONAL.has(blockId);
+  return type === BrickTypes.READER || HACK_TRACE_OPTIONAL.has(blockId);
 }
 
 type PreviewInfo = {
@@ -207,7 +207,7 @@ const BrickPreview: React.FunctionComponent<{
     // eslint-disable-next-line react-hooks/exhaustive-deps -- using objectHash for context
   }, [debouncedRun, brickConfig, brickInfo, objectHash(context ?? {})]);
 
-  if (brickInfo?.type === "renderer") {
+  if (brickInfo?.type === BrickTypes.RENDERER) {
     return (
       <div className="text-muted">
         Output previews are not currently supported for renderers

--- a/src/platform/state/stateController.test.ts
+++ b/src/platform/state/stateController.test.ts
@@ -15,7 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { setState } from "@/platform/state/stateController";
+import {
+  MergeStrategies,
+  setState,
+  StateNamespaces,
+} from "@/platform/state/stateController";
 import { uuidv4 } from "@/types/helpers";
 import { registryIdFactory } from "@/testUtils/factories/stringFactories";
 
@@ -28,9 +32,9 @@ describe("pageState", () => {
     const blueprintId = registryIdFactory();
 
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: { foo: { bar: "baz" } },
-      mergeStrategy: "deep",
+      mergeStrategy: MergeStrategies.DEEP,
       extensionId: uuidv4(),
       blueprintId,
     });
@@ -47,19 +51,19 @@ describe("pageState", () => {
     const extensionId = uuidv4();
 
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: {
         asyncState: { isFetching: false, data: "foo", currentData: "foo" },
       },
-      mergeStrategy: "deep",
+      mergeStrategy: MergeStrategies.DEEP,
       extensionId: uuidv4(),
       blueprintId,
     });
 
     const updatedState = setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: { asyncState: { isFetching: true, currentData: null } },
-      mergeStrategy: "deep",
+      mergeStrategy: MergeStrategies.DEEP,
       extensionId,
       blueprintId,
     });

--- a/src/platform/state/stateController.ts
+++ b/src/platform/state/stateController.ts
@@ -19,13 +19,25 @@ import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { cloneDeep, isEqual, merge } from "lodash";
 import { BusinessError } from "@/errors/businessErrors";
-import { type JsonObject } from "type-fest";
+import { type JsonObject, type ValueOf } from "type-fest";
 import { assertPlatformCapability } from "@/platform/platformContext";
 import { assertNotNullish, type Nullishable } from "@/utils/nullishUtils";
 
-type MergeStrategy = "shallow" | "replace" | "deep";
+export const MergeStrategies = {
+  SHALLOW: "shallow",
+  REPLACE: "replace",
+  DEEP: "deep",
+} as const;
 
-type StateNamespace = "blueprint" | "extension" | "shared";
+export type MergeStrategy = ValueOf<typeof MergeStrategies>;
+
+export const StateNamespaces = {
+  MOD: "blueprint",
+  PRIVATE: "extension",
+  PUBLIC: "shared",
+} as const;
+
+export type StateNamespace = ValueOf<typeof StateNamespaces>;
 
 const privateState = new Map<UUID, JsonObject>();
 
@@ -42,16 +54,16 @@ function mergeState(
   const cloned = cloneDeep(update);
 
   switch (strategy) {
-    case "replace": {
+    case MergeStrategies.REPLACE: {
       return cloned;
     }
 
-    case "deep": {
+    case MergeStrategies.DEEP: {
       // `merge` mutates the first argument, so we clone it first
       return merge(cloneDeep(previous), cloned);
     }
 
-    case "shallow": {
+    case MergeStrategies.SHALLOW: {
       return { ...previous, ...cloned };
     }
 
@@ -117,7 +129,7 @@ export function setState({
   };
 
   switch (namespace) {
-    case "shared": {
+    case StateNamespaces.PUBLIC: {
       const previous = modState.get(null) ?? {};
       const next = mergeState(previous, data, mergeStrategy);
       modState.set(null, next);
@@ -125,7 +137,7 @@ export function setState({
       return next;
     }
 
-    case "blueprint": {
+    case StateNamespaces.MOD: {
       const previous = modState.get(blueprintId) ?? {};
       const next = mergeState(previous, data, mergeStrategy);
       modState.set(blueprintId, next);
@@ -133,7 +145,7 @@ export function setState({
       return next;
     }
 
-    case "extension": {
+    case StateNamespaces.PRIVATE: {
       assertNotNullish(extensionId, "Invalid context: extensionId not found");
       const previous = privateState.get(extensionId) ?? {};
       const next = mergeState(previous, data, mergeStrategy);
@@ -162,15 +174,15 @@ export function getState({
   assertPlatformCapability("state");
 
   switch (namespace) {
-    case "shared": {
+    case StateNamespaces.PUBLIC: {
       return modState.get(null) ?? {};
     }
 
-    case "blueprint": {
+    case StateNamespaces.MOD: {
       return modState.get(blueprintId) ?? {};
     }
 
-    case "extension": {
+    case StateNamespaces.PRIVATE: {
       assertNotNullish(extensionId, "Invalid context: extensionId not found");
       return privateState.get(extensionId) ?? {};
     }

--- a/src/registry/hydrateInnerDefinitions.ts
+++ b/src/registry/hydrateInnerDefinitions.ts
@@ -31,6 +31,7 @@ import { type ReaderConfig } from "@/bricks/types";
 import {
   INNER_SCOPE,
   type InnerDefinitions,
+  DefinitionKinds,
   type RegistryId,
 } from "@/types/registryTypes";
 import {
@@ -107,7 +108,7 @@ async function hydrateReaderDefinition(
     if (Object.hasOwn(definitions, reader)) {
       // eslint-disable-next-line security/detect-object-injection -- checked hasOwn
       const definition = definitions[reader];
-      if (definition?.kind !== "reader") {
+      if (definition?.kind !== DefinitionKinds.READER) {
         throw new TypeError(
           // Keep extensionPoint terminology because that's what appears in the YAML/JSON
           "extensionPoint references definition that is not a reader",
@@ -197,15 +198,15 @@ async function hydrateInnerDefinition(
   }
 
   switch (innerDefinition.kind) {
-    case "extensionPoint": {
+    case DefinitionKinds.STARTER_BRICK: {
       return hydrateStarterBrickDefinition(
         definitions,
         innerDefinition as StarterBrickInnerDefinition,
       );
     }
 
-    case "reader":
-    case "component": {
+    case DefinitionKinds.READER:
+    case DefinitionKinds.BRICK: {
       return hydrateBrickDefinition(
         definitions,
         innerDefinition as BrickInnerDefinition,
@@ -238,7 +239,8 @@ export async function hydrateModComponentInnerDefinitions<
     const relevantDefinitions = pickBy(
       definitions,
       (definition, name) =>
-        definition.kind !== "extensionPoint" || draft.extensionPointId === name,
+        definition.kind !== DefinitionKinds.STARTER_BRICK ||
+        draft.extensionPointId === name,
     );
 
     const hydratedDefinitions = await resolveObj(
@@ -279,7 +281,8 @@ export async function hydrateModInnerDefinitions(
   const relevantDefinitions = pickBy(
     modDefinition.definitions,
     (definition, name) =>
-      definition.kind !== "extensionPoint" || starterBrickReferences.has(name),
+      definition.kind !== DefinitionKinds.STARTER_BRICK ||
+      starterBrickReferences.has(name),
   );
 
   const hydratedDefinitions = await resolveObj(

--- a/src/registry/memoryRegistry.ts
+++ b/src/registry/memoryRegistry.ts
@@ -15,11 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { type Kind } from "@/registry/packageRegistry";
 import { registry as backgroundRegistry } from "@/background/messenger/api";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { expectContext } from "@/utils/expectContext";
 import {
+  type DefinitionKind,
   DoesNotExistError,
   type EnumerableRegistryProtocol,
   type RegistryId,
@@ -91,13 +91,16 @@ class MemoryRegistry<
    */
   private _cacheInitialized = false;
 
-  public readonly kinds: Set<Kind>;
+  public readonly kinds: Set<DefinitionKind>;
 
   private deserialize: ((raw: unknown) => Item) | null;
 
   onChange = new SimpleEventTarget();
 
-  constructor(kinds: Kind[], deserialize: ((raw: unknown) => Item) | null) {
+  constructor(
+    kinds: DefinitionKind[],
+    deserialize: ((raw: unknown) => Item) | null,
+  ) {
     this.kinds = new Set(kinds);
     this.deserialize = deserialize;
 

--- a/src/registry/packageRegistry.ts
+++ b/src/registry/packageRegistry.ts
@@ -24,6 +24,7 @@ import { PACKAGE_REGEX } from "@/types/helpers";
 import { memoizeUntilSettled } from "@/utils/promiseUtils";
 import { getApiClient } from "@/data/service/apiClient";
 import { type Nullishable, assertNotNullish } from "@/utils/nullishUtils";
+import { type DefinitionKind } from "@/types/registryTypes";
 
 const DATABASE_NAME = "BRICK_REGISTRY";
 const BRICK_STORE = "bricks";
@@ -35,21 +36,10 @@ type Version = {
   patch: number;
 };
 
-export type Kind =
-  | "block"
-  | "foundation"
-  | "service"
-  | "blueprint"
-  | "reader"
-  | "effect"
-  | "component"
-  | "extensionPoint"
-  | "recipe";
-
 export type PackageVersion = {
   id: string;
   version: Version;
-  kind: Kind;
+  kind: DefinitionKind;
   scope: Nullishable<string>;
   config: UnknownObject;
   // `rawConfig` is the YAML configuration. Only available for user-defined packages
@@ -196,9 +186,11 @@ export async function recreateDB(): Promise<void> {
 
 /**
  * Return all packages for the given kinds
- * @param kinds kinds of bricks
+ * @param kinds kinds of packages
  */
-export async function getByKinds(kinds: Kind[]): Promise<PackageVersion[]> {
+export async function getByKinds(
+  kinds: DefinitionKind[],
+): Promise<PackageVersion[]> {
   await ensurePopulated();
 
   const db = await openRegistryDB();

--- a/src/runtime/extendModVariableContext.test.ts
+++ b/src/runtime/extendModVariableContext.test.ts
@@ -19,7 +19,11 @@ import extendModVariableContext, {
   contextAsPlainObject,
   isModVariableContext,
 } from "@/runtime/extendModVariableContext";
-import { setState } from "@/platform/state/stateController";
+import {
+  MergeStrategies,
+  setState,
+  StateNamespaces,
+} from "@/platform/state/stateController";
 import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 import apiVersionOptions from "@/runtime/apiVersionOptions";
 import { type ApiVersion } from "@/types/runtimeTypes";
@@ -27,11 +31,11 @@ import { type ApiVersion } from "@/types/runtimeTypes";
 describe("createModVariableProxy", () => {
   beforeEach(() => {
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: {},
       extensionId: autoUUIDSequence(),
       blueprintId: null,
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
     });
   });
 
@@ -45,11 +49,11 @@ describe("createModVariableProxy", () => {
 
   it("reads from page state", () => {
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       extensionId: autoUUIDSequence(),
       blueprintId: null,
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
     });
 
     const ctxt = extendModVariableContext(
@@ -101,11 +105,11 @@ describe("createModVariableProxy", () => {
     );
 
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       extensionId: autoUUIDSequence(),
       blueprintId: null,
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
     });
 
     const ctxt2 = extendModVariableContext(ctxt1, {
@@ -123,11 +127,11 @@ describe("createModVariableProxy", () => {
     );
 
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       extensionId: autoUUIDSequence(),
       blueprintId: null,
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
     });
 
     const ctxt2 = extendModVariableContext(ctxt1, {

--- a/src/runtime/extendModVariableContext.ts
+++ b/src/runtime/extendModVariableContext.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getState } from "@/platform/state/stateController";
+import { getState, StateNamespaces } from "@/platform/state/stateController";
 import { type RegistryId } from "@/types/registryTypes";
 import apiVersionOptions, {
   type ApiVersionOptions,
@@ -136,7 +136,7 @@ function extendModVariableContext<T extends UnknownObject = UnknownObject>(
   // Previously, we had considered using a proxy to lazily load the state. However, eagerly reading is simpler.
   // Additionally, in the future to pass the context to the sandbox we'd have to always load the state anyway.
   const modState = getState({
-    namespace: "blueprint",
+    namespace: StateNamespaces.MOD,
     blueprintId,
     // `extensionId` is not used because namespace is `blueprint`
     extensionId: null,

--- a/src/runtime/pipelineTests/component.test.ts
+++ b/src/runtime/pipelineTests/component.test.ts
@@ -29,6 +29,7 @@ import { fromJS } from "@/bricks/transformers/brickFactory";
 import { normalizeSemVerString } from "@/types/helpers";
 import { TEST_setContext } from "webext-detect-page";
 import { toExpression } from "@/utils/expressionUtils";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 TEST_setContext("contentScript");
 
@@ -39,7 +40,7 @@ beforeEach(() => {
 
 const componentBlock = fromJS(blockRegistry, {
   apiVersion: "v1",
-  kind: "component",
+  kind: DefinitionKinds.BRICK,
   metadata: {
     id: "test/component",
     name: "Component Brick",

--- a/src/runtime/pipelineTests/modVariableContext.test.ts
+++ b/src/runtime/pipelineTests/modVariableContext.test.ts
@@ -22,7 +22,11 @@ import {
   simpleInput,
   testOptions,
 } from "@/runtime/pipelineTests/pipelineTestHelpers";
-import { setState } from "@/platform/state/stateController";
+import {
+  MergeStrategies,
+  setState,
+  StateNamespaces,
+} from "@/platform/state/stateController";
 import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { contextAsPlainObject } from "@/runtime/extendModVariableContext";
@@ -36,9 +40,9 @@ beforeEach(() => {
 describe("modVariableContext", () => {
   test("use mod variable in variable condition", async () => {
     setState({
-      namespace: "blueprint" as const,
+      namespace: StateNamespaces.MOD,
       data: { run: true },
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
       extensionId: null,
       blueprintId: null,
     });
@@ -62,9 +66,9 @@ describe("modVariableContext", () => {
 
   test("use mod variable in nunjucks condition", async () => {
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: { run: true },
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
       extensionId: autoUUIDSequence(),
       blueprintId: undefined,
     });
@@ -88,9 +92,9 @@ describe("modVariableContext", () => {
 
   test("mod variable appears in context", async () => {
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
       extensionId: autoUUIDSequence(),
       blueprintId: undefined,
     });
@@ -115,9 +119,9 @@ describe("modVariableContext", () => {
 
   test("use mod variable in nunjucks body", async () => {
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
       extensionId: autoUUIDSequence(),
       blueprintId: undefined,
     });
@@ -140,9 +144,9 @@ describe("modVariableContext", () => {
 
   test("use mod variable in variable body", async () => {
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: { name: "Bob" },
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
       extensionId: autoUUIDSequence(),
       blueprintId: undefined,
     });

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -43,6 +43,7 @@ import {
 } from "@/runtime/runtimeUtils";
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import {
+  BrickTypes,
   type ResolvedBrickConfig,
   unsafeAssumeValidArg,
 } from "@/runtime/runtimeTypes";
@@ -463,7 +464,7 @@ async function renderBrickArg(
   // Support YAML shorthand of leaving of `config:` directive for bricks that don't have parameters
   const stageTemplate = config.config ?? {};
 
-  if (type === "reader") {
+  if (type === BrickTypes.READER) {
     // `reducePipeline` is responsible for passing the correct root into runStage based on the BrickConfig
     if ((config.window ?? "self") === "self") {
       return { root: state.root } as unknown as RenderedArgs;
@@ -565,7 +566,7 @@ async function runBrick(
     });
   }
 
-  if (type === "renderer" && headless) {
+  if (type === BrickTypes.RENDERER && headless) {
     if (selectTraceEnabled(trace)) {
       getPlatform().debugger.traces.exit({
         ...trace,
@@ -777,7 +778,7 @@ export async function brickReducer(
     window: brickConfig.window,
   });
 
-  if (resolvedConfig.type === "effect") {
+  if (resolvedConfig.type === BrickTypes.EFFECT) {
     if (brickConfig.outputKey) {
       logger.warn(`Ignoring output key for effect ${brickConfig.id}`);
     }

--- a/src/runtime/runtimeTypes.ts
+++ b/src/runtime/runtimeTypes.ts
@@ -22,8 +22,16 @@ import {
   type OutputKey,
   VARIABLE_REFERENCE_PREFIX,
 } from "@/types/runtimeTypes";
+import { type ValueOf } from "type-fest";
 
-export type BrickType = "reader" | "effect" | "transform" | "renderer";
+export const BrickTypes = {
+  READER: "reader",
+  EFFECT: "effect",
+  TRANSFORM: "transform",
+  RENDERER: "renderer",
+} as const;
+
+export type BrickType = ValueOf<typeof BrickTypes>;
 
 /**
  * A block configuration with the corresponding resolved Brick and BrickType.

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
@@ -18,7 +18,7 @@
 import { define } from "cooky-cutter";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { validateRegistryId } from "@/types/helpers";
-import { type Metadata } from "@/types/registryTypes";
+import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 import { type BrickPipeline } from "@/bricks/types";
 import { RootReader } from "@/starterBricks/starterBrickTestUtils";
 import blockRegistry from "@/bricks/registry";
@@ -44,7 +44,7 @@ const rootReader = new RootReader();
 const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
   define<StarterBrickDefinitionLike<ContextMenuDefinition>>({
     apiVersion: "v3",
-    kind: "extensionPoint",
+    kind: DefinitionKinds.STARTER_BRICK,
     metadata: (n: number) =>
       ({
         id: validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/factory.ts
+++ b/src/starterBricks/factory.ts
@@ -26,6 +26,7 @@ import { fromJS as deserializeTour } from "@/starterBricks/tour/tourStarterBrick
 import { type StarterBrick } from "@/types/starterBrickTypes";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { getPlatform } from "@/platform/platformContext";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 const TYPE_MAP = {
   panel: deserializePanel,
@@ -39,10 +40,12 @@ const TYPE_MAP = {
 };
 
 export function fromJS(config: StarterBrickDefinitionLike): StarterBrick {
-  if (config.kind !== "extensionPoint") {
+  if (config.kind !== DefinitionKinds.STARTER_BRICK) {
     // Is `never` due to check, but needed because this method is called dynamically
     const exhaustiveCheck: never = config.kind;
-    throw new Error(`Expected kind extensionPoint, got ${exhaustiveCheck}`);
+    throw new Error(
+      `Expected kind ${DefinitionKinds.STARTER_BRICK}, got ${exhaustiveCheck}`,
+    );
   }
 
   if (!Object.hasOwn(TYPE_MAP, config.definition.type)) {

--- a/src/starterBricks/menuItem/menuItemStarterBrick.test.ts
+++ b/src/starterBricks/menuItem/menuItemStarterBrick.test.ts
@@ -17,7 +17,7 @@
 
 import { fromJS } from "@/starterBricks/menuItem/menuItemStarterBrick";
 import { validateRegistryId } from "@/types/helpers";
-import { type Metadata } from "@/types/registryTypes";
+import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 import { define } from "cooky-cutter";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import blockRegistry from "@/bricks/registry";
@@ -58,7 +58,7 @@ const rootReaderId = validateRegistryId("test/root-reader");
 const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
   define<StarterBrickDefinitionLike<MenuItemDefinition>>({
     apiVersion: "v3",
-    kind: "extensionPoint",
+    kind: DefinitionKinds.STARTER_BRICK,
     metadata: (n: number) =>
       ({
         id: validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/quickBar/quickBarStarterBrick.test.ts
+++ b/src/starterBricks/quickBar/quickBarStarterBrick.test.ts
@@ -18,7 +18,7 @@
 import { validateRegistryId } from "@/types/helpers";
 import { define } from "cooky-cutter";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
-import { type Metadata } from "@/types/registryTypes";
+import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 import { type BrickPipeline } from "@/bricks/types";
 import {
   getDocument,
@@ -59,7 +59,7 @@ jest.mock("@/auth/featureFlagStorage", () => ({
 const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
   define<StarterBrickDefinitionLike<QuickBarDefinition>>({
     apiVersion: "v3",
-    kind: "extensionPoint",
+    kind: DefinitionKinds.STARTER_BRICK,
     metadata: (n: number) =>
       ({
         id: validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/registry.ts
+++ b/src/starterBricks/registry.ts
@@ -17,12 +17,12 @@
 
 import { fromJS } from "@/starterBricks/factory";
 import BaseRegistry from "@/registry/memoryRegistry";
-import { type RegistryId } from "@/types/registryTypes";
+import { DefinitionKinds, type RegistryId } from "@/types/registryTypes";
 import { type StarterBrick } from "@/types/starterBrickTypes";
 
 // eslint-disable-next-line local-rules/persistBackgroundData -- OK to reinit on load
 const registry = new BaseRegistry<RegistryId, StarterBrick>(
-  ["foundation", "extensionPoint"],
+  [DefinitionKinds.STARTER_BRICK],
   fromJS,
 );
 

--- a/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
@@ -33,7 +33,11 @@ import {
   sidebarShowEvents,
   isSidePanelOpen,
 } from "@/contentScript/sidebarController";
-import { setState } from "@/platform/state/stateController";
+import {
+  MergeStrategies,
+  setState,
+  StateNamespaces,
+} from "@/platform/state/stateController";
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import brickRegistry from "@/bricks/registry";
 import { sleep } from "@/utils/timeUtils";
@@ -185,9 +189,9 @@ describe("sidebarExtension", () => {
     expect(rootReader.readCount).toBe(0);
 
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: {},
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
       extensionId: extension.id,
       blueprintId: extension._recipe!.id,
     });
@@ -205,10 +209,10 @@ describe("sidebarExtension", () => {
     expect(rootReader.readCount).toBe(1);
 
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       // Data needs to be different than previous to trigger a state change event
       data: { foo: 42 },
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
       extensionId: extension.id,
       blueprintId: extension._recipe!.id,
     });
@@ -219,9 +223,9 @@ describe("sidebarExtension", () => {
 
     // Should ignore state change from other mod
     setState({
-      namespace: "blueprint",
+      namespace: StateNamespaces.MOD,
       data: {},
-      mergeStrategy: "replace",
+      mergeStrategy: MergeStrategies.REPLACE,
       extensionId: autoUUIDSequence(),
       blueprintId: registryIdFactory(),
     });
@@ -268,9 +272,9 @@ describe("sidebarExtension", () => {
 
     for (let i = 0; i < 10; i++) {
       setState({
-        namespace: "blueprint",
+        namespace: StateNamespaces.MOD,
         data: { foo: i },
-        mergeStrategy: "replace",
+        mergeStrategy: MergeStrategies.REPLACE,
         extensionId: extension.id,
         blueprintId: extension._recipe!.id,
       });

--- a/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
@@ -17,7 +17,7 @@
 import { define } from "cooky-cutter";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { validateRegistryId } from "@/types/helpers";
-import { type Metadata } from "@/types/registryTypes";
+import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 import { type HydratedModComponent } from "@/types/modComponentTypes";
 import {
   autoUUIDSequence,
@@ -54,7 +54,7 @@ const rootReader = new RootReader();
 const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
   define<StarterBrickDefinitionLike<SidebarDefinition>>({
     apiVersion: "v3",
-    kind: "extensionPoint",
+    kind: DefinitionKinds.STARTER_BRICK,
     metadata: (n: number) =>
       ({
         id: validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/tour/tourStarterBrick.test.ts
+++ b/src/starterBricks/tour/tourStarterBrick.test.ts
@@ -18,7 +18,7 @@
 import { define } from "cooky-cutter";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
 import { validateRegistryId } from "@/types/helpers";
-import { type Metadata } from "@/types/registryTypes";
+import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 import { type BrickPipeline } from "@/bricks/types";
 import { fromJS } from "@/starterBricks/tour/tourStarterBrick";
 import { RootReader, tick } from "@/starterBricks/starterBrickTestUtils";
@@ -54,7 +54,7 @@ jest.mock("@/auth/featureFlagStorage", () => ({
 const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
   define<StarterBrickDefinitionLike<TourDefinition>>({
     apiVersion: "v3",
-    kind: "extensionPoint",
+    kind: DefinitionKinds.STARTER_BRICK,
     metadata: (n: number) =>
       ({
         id: validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/trigger/triggerStarterBrick.test.ts
+++ b/src/starterBricks/trigger/triggerStarterBrick.test.ts
@@ -18,7 +18,7 @@
 import { validateRegistryId } from "@/types/helpers";
 import { define, derive } from "cooky-cutter";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
-import { type Metadata } from "@/types/registryTypes";
+import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 import { type BrickPipeline } from "@/bricks/types";
 import {
   getDocument,
@@ -81,7 +81,7 @@ const notifyContextInvalidatedMock = jest.mocked(notifyContextInvalidated);
 const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
   define<StarterBrickDefinitionLike<TriggerDefinition>>({
     apiVersion: "v3",
-    kind: "extensionPoint",
+    kind: DefinitionKinds.STARTER_BRICK,
     metadata: (n: number) =>
       ({
         id: validateRegistryId(`test/starter-brick-${n}`),

--- a/src/starterBricks/types.ts
+++ b/src/starterBricks/types.ts
@@ -23,6 +23,7 @@ import {
   type RegistryId,
   type Metadata,
   type Definition,
+  DefinitionKinds,
 } from "@/types/registryTypes";
 import {
   type StarterBrickType,
@@ -92,7 +93,7 @@ export interface StarterBrickDefinitionLike<
   apiVersion?: Definition["apiVersion"];
   metadata?: Definition["metadata"];
   definition: T;
-  kind: "extensionPoint";
+  kind: typeof DefinitionKinds.STARTER_BRICK;
 }
 
 export function isStarterBrickDefinitionProp(
@@ -144,7 +145,7 @@ export function assertStarterBrickDefinitionLike(
 
   const config = value as UnknownObject;
 
-  if (config.kind !== "extensionPoint") {
+  if (config.kind !== DefinitionKinds.STARTER_BRICK) {
     console.warn("Expected extension point", errorContext);
     throw new TypeError(
       "Expected kind 'extensionPoint' for StarterBrickDefinitionLike",

--- a/src/testUtils/factories/brickFactories.ts
+++ b/src/testUtils/factories/brickFactories.ts
@@ -31,6 +31,7 @@ import { metadataFactory } from "@/testUtils/factories/metadataFactory";
 import type { Reader } from "@/types/bricks/readerTypes";
 import type { PackageConfigDetail } from "@/types/contract";
 import type { ModDefinition } from "@/types/modDefinitionTypes";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 export const brickFactory = define<Brick>({
   id: registryIdSequence,
@@ -77,7 +78,7 @@ export const pipelineFactory: (
  */
 export const brickDefinitionFactory = define<BrickDefinition>({
   metadata: metadataFactory,
-  kind: "component",
+  kind: DefinitionKinds.BRICK,
   inputSchema: minimalSchemaFactory,
   pipeline: pipelineFactory,
 });

--- a/src/testUtils/factories/integrationFactories.ts
+++ b/src/testUtils/factories/integrationFactories.ts
@@ -31,7 +31,7 @@ import { type RemoteIntegrationConfig } from "@/types/contract";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
-import { type Kind } from "@/registry/packageRegistry";
+import { type DefinitionKind, DefinitionKinds } from "@/types/registryTypes";
 
 export const sanitizedIntegrationConfigFactory =
   define<SanitizedIntegrationConfig>({
@@ -123,17 +123,19 @@ export const keyAuthIntegrationDefinitionFactory = define<
 
 export function generateIntegrationAndRemoteConfig(): {
   remoteConfig: RemoteIntegrationConfig;
-  integrationDefinition: IntegrationDefinition & { kind: Kind };
+  integrationDefinition: IntegrationDefinition & { kind: DefinitionKind };
 } {
   const remoteConfig = remoteIntegrationConfigurationFactory();
 
-  const integrationDefinition: IntegrationDefinition & { kind: Kind } = {
+  const integrationDefinition: IntegrationDefinition & {
+    kind: DefinitionKind;
+  } = {
     ...keyAuthIntegrationDefinitionFactory({
       metadata: metadataFactory({
         id: remoteConfig.service.config.metadata.id,
       }),
     }),
-    kind: "service" as Kind,
+    kind: DefinitionKinds.INTEGRATION,
   };
 
   return {

--- a/src/testUtils/factories/marketplaceFactories.ts
+++ b/src/testUtils/factories/marketplaceFactories.ts
@@ -19,6 +19,7 @@ import { define } from "cooky-cutter";
 import { type MarketplaceListing, type MarketplaceTag } from "@/types/contract";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 export const marketplaceTagFactory = define<MarketplaceTag>({
   id: uuidSequence,
@@ -39,7 +40,7 @@ export function modDefinitionToMarketplacePackage(
     description: modDefinition.metadata.description ?? "",
     version: modDefinition.metadata.version,
     config: modDefinition as unknown as UnknownObject,
-    kind: "recipe",
+    kind: DefinitionKinds.MOD,
     author: {},
     organization: {},
   };

--- a/src/testUtils/factories/modComponentFactories.ts
+++ b/src/testUtils/factories/modComponentFactories.ts
@@ -31,7 +31,7 @@ import { type IntegrationDependency } from "@/integrations/integrationTypes";
 import { sharingDefinitionFactory } from "@/testUtils/factories/registryFactories";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
 import { type StandaloneModDefinition } from "@/types/contract";
-import { type Metadata } from "@/types/registryTypes";
+import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 
 export const modMetadataFactory = extend<Metadata, ModMetadata>(
   metadataFactory,
@@ -43,7 +43,7 @@ export const modMetadataFactory = extend<Metadata, ModMetadata>(
 
 const modComponentConfigFactory = define<ModComponentBase["config"]>({
   apiVersion: "v3" as ApiVersion,
-  kind: "component",
+  kind: DefinitionKinds.BRICK,
   metadata: (n: number) =>
     metadataFactory({
       id: validateRegistryId(`test/component-${n}`),

--- a/src/testUtils/factories/modDefinitionFactories.ts
+++ b/src/testUtils/factories/modDefinitionFactories.ts
@@ -23,6 +23,7 @@ import {
 import {
   type InnerDefinitionRef,
   type InnerDefinitions,
+  DefinitionKinds,
   type RegistryId,
 } from "@/types/registryTypes";
 import { type OutputKey } from "@/types/runtimeTypes";
@@ -61,7 +62,7 @@ export const modComponentDefinitionFactory = define<ModComponentDefinition>({
 });
 
 export const modDefinitionFactory = define<ModDefinition>({
-  kind: "recipe",
+  kind: DefinitionKinds.MOD,
   apiVersion: "v3",
   metadata: metadataFactory,
   sharing: sharingDefinitionFactory,
@@ -71,7 +72,7 @@ export const modDefinitionFactory = define<ModDefinition>({
 
 export const starterBrickDefinitionFactory = define<StarterBrickDefinitionLike>(
   {
-    kind: "extensionPoint",
+    kind: DefinitionKinds.STARTER_BRICK,
     apiVersion: "v3",
     metadata: (n: number) =>
       metadataFactory({
@@ -94,7 +95,7 @@ export const starterBrickDefinitionFactory = define<StarterBrickDefinitionLike>(
 // Return as UnknownObject to match InnerDefinitions type. Otherwise, Typescript complains about a missing string
 // index signature when assigning the value to InnerDefinitions.
 export const starterBrickInnerDefinitionFactory = define<UnknownObject>({
-  kind: "extensionPoint",
+  kind: DefinitionKinds.STARTER_BRICK,
   definition(n: number) {
     const definition: StarterBrickDefinitionProp = {
       type: "menuItem" as StarterBrickType,
@@ -158,7 +159,7 @@ export const versionedModDefinitionWithHydratedModComponents = (
 
   for (const modComponentDefinition of modComponentDefinitions) {
     definitions[modComponentDefinition.id] = {
-      kind: "extensionPoint",
+      kind: DefinitionKinds.STARTER_BRICK,
       definition: starterBrickDefinitionFactory().definition,
     } satisfies StarterBrickDefinitionLike;
   }

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -28,6 +28,7 @@ import {
   type SecretsConfig,
 } from "@/integrations/integrationTypes";
 import {
+  DefinitionKind,
   type Metadata,
   type RegistryId,
   type SemVerString,
@@ -155,7 +156,7 @@ export type RegistryPackage = Pick<
    * Note that EditablePackageMetadata uses the backend's display name for this field
    * @see https://github.com/pixiebrix/pixiebrix-app/blob/43f0a4b81d8b7aaaf11adbe7fd8e4530ca4b8bf0/api/serializers/brick.py#L204-L204
    */
-  kind: "component" | "extensionPoint" | "recipe" | "service" | "reader";
+  kind: DefinitionKind;
 
   // PackageConfigListSerializer adds updated_at and sharing to the PackageConfigList response:
   // https://github.com/pixiebrix/pixiebrix-app/blob/368a0116edad2c115ae370b651f109619e621745/api/serializers/brick.py#L139-L139

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -28,7 +28,7 @@ import {
   type SecretsConfig,
 } from "@/integrations/integrationTypes";
 import {
-  DefinitionKind,
+  type DefinitionKind,
   type Metadata,
   type RegistryId,
   type SemVerString,
@@ -135,8 +135,9 @@ export type EditablePackageMetadata = components["schemas"]["PackageMeta"] & {
   name: RegistryId;
 
   /**
-   * Backend display name for the Package.kind.
+   * Backend display name for the Package.kind. WARNING: different names/capitalization than the frontend types.
    * @see https://github.com/pixiebrix/pixiebrix-app/blob/be1c486eba393e3c8e2f99401f78af5958b4060b/api/models/registry.py#L210-L210
+   * @see DefinitionKind
    */
   kind: "Blueprint" | "Service" | "Block" | "Reader" | "Foundation";
 

--- a/src/types/modDefinitionTypes.ts
+++ b/src/types/modDefinitionTypes.ts
@@ -20,6 +20,7 @@ import {
   type Definition,
   type InnerDefinitionRef,
   type InnerDefinitions,
+  DefinitionKinds,
   type RegistryId,
 } from "@/types/registryTypes";
 import { type Schema } from "@/types/schemaTypes";
@@ -96,7 +97,7 @@ export type HydratedModComponentDefinition = ModComponentDefinition & {
  * @see PackageUpsertResponse
  */
 export interface UnsavedModDefinition extends Definition {
-  kind: "recipe";
+  kind: typeof DefinitionKinds.MOD;
   extensionPoints: ModComponentDefinition[];
   definitions?: InnerDefinitions;
   options?: ModOptionsDefinition;

--- a/src/types/modDefinitionTypes.ts
+++ b/src/types/modDefinitionTypes.ts
@@ -20,7 +20,7 @@ import {
   type Definition,
   type InnerDefinitionRef,
   type InnerDefinitions,
-  DefinitionKinds,
+  type DefinitionKinds,
   type RegistryId,
 } from "@/types/registryTypes";
 import { type Schema } from "@/types/schemaTypes";

--- a/src/types/registryTypes.ts
+++ b/src/types/registryTypes.ts
@@ -46,7 +46,7 @@ export const DefinitionKinds = {
 } as const;
 
 /**
- * The type for of definition in the external package registry.
+ * The type of definition in the external package registry.
  */
 export type DefinitionKind = ValueOf<typeof DefinitionKinds>;
 

--- a/src/types/registryTypes.ts
+++ b/src/types/registryTypes.ts
@@ -17,6 +17,7 @@
 
 import { type UUID } from "@/types/stringTypes";
 import { type ApiVersion } from "@/types/runtimeTypes";
+import { type ValueOf } from "type-fest";
 
 /**
  * A brick registry id conforming to `@scope/collection/name`
@@ -32,14 +33,22 @@ export type RegistryId = string & {
 export const INNER_SCOPE = "@internal";
 
 /**
- * The kind of definition in the external registry
+ * Constants for the different kinds of top-level definitions in the registry.
+ *
+ * See https://github.com/pixiebrix/pixiebrix-extension/tree/main/schemas
  */
-export type Kind =
-  | "recipe"
-  | "service"
-  | "reader"
-  | "component"
-  | "extensionPoint";
+export const DefinitionKinds = {
+  STARTER_BRICK: "extensionPoint",
+  MOD: "recipe",
+  INTEGRATION: "service",
+  BRICK: "component",
+  READER: "reader",
+} as const;
+
+/**
+ * The type for of definition in the external package registry.
+ */
+export type DefinitionKind = ValueOf<typeof DefinitionKinds>;
 
 /**
  * Simple semantic version number, major.minor.patch
@@ -93,7 +102,7 @@ export type Sharing = {
 /**
  * A definition in the PixieBrix registry
  */
-export interface Definition<K extends Kind = Kind> {
+export interface Definition<K extends DefinitionKind = DefinitionKind> {
   apiVersion: ApiVersion;
   kind: K;
   metadata: Metadata;

--- a/src/types/registryTypes.ts
+++ b/src/types/registryTypes.ts
@@ -46,7 +46,7 @@ export const DefinitionKinds = {
 } as const;
 
 /**
- * The type of definition in the external package registry.
+ * The kind of definition in the external package registry.
  */
 export type DefinitionKind = ValueOf<typeof DefinitionKinds>;
 

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -35,7 +35,7 @@ import {
   type HydratedModComponent,
   type SerializedModComponent,
 } from "@/types/modComponentTypes";
-import { type RegistryId } from "@/types/registryTypes";
+import { DefinitionKinds, type RegistryId } from "@/types/registryTypes";
 import { type UUID } from "@/types/stringTypes";
 import { InvalidTypeError } from "@/errors/genericErrors";
 import { assertNotNullish, type Nullishable } from "./nullishUtils";
@@ -85,7 +85,9 @@ export function isModComponentFromMod(mod: Mod): boolean {
 export function isModDefinition(
   mod: Mod,
 ): mod is ModDefinition | UnavailableMod {
-  return mod && "kind" in mod && mod.kind === "recipe" && "sharing" in mod;
+  return (
+    mod && "kind" in mod && mod.kind === DefinitionKinds.MOD && "sharing" in mod
+  );
 }
 
 /**

--- a/src/utils/objToYaml.test.ts
+++ b/src/utils/objToYaml.test.ts
@@ -17,6 +17,7 @@
 
 import { brickToYaml } from "./objToYaml";
 import { normalizeSemVerString } from "@/types/helpers";
+import { DefinitionKinds } from "@/types/registryTypes";
 
 describe("brickToYaml", () => {
   test("serializes arbitrary object", () => {
@@ -36,7 +37,7 @@ lorem: ipsum
 
   test("serializes a config with only known props", () => {
     const config = {
-      kind: "service",
+      kind: DefinitionKinds.INTEGRATION,
       metadata: {
         id: "google/api",
         name: "Google API",
@@ -100,7 +101,7 @@ outputSchema:
 
   test("sorts config root keys", () => {
     const config = {
-      kind: "service",
+      kind: DefinitionKinds.INTEGRATION,
       metadata: {
         id: "google/api",
         name: "Google API",


### PR DESCRIPTION
## What does this PR do?

- Closes #8716
- Follows pattern of `Events` (using object instead of enum)
- Introduces `DefinitionKinds`, `BrickTypes`, `StateNamespaces`
- Drops Kind type from PackageRegistry which contains some non-sense values

## Discussion/Reviewer Notes
- Introduces all 3 in the same PR because otherwise occurrences of "reader" and "blueprint" are ambiguous between higher-level kinds. So it's hard to lexically search for occurrences of the raw string
- Uses "kind" because it corresponds to "Definition.kind". Uses "type" because brick that the term existing code uses, e.g., TypedBrickPair

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
