### PR TITLE
Update danger banner colors

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -291,7 +291,18 @@ exports[`Storyshots Components/Banner Danger 1`] = `
     <div
       className="align-self-center"
     >
-      This is a danger banner. Something went wrong!
+      <span>
+        This is a danger banner. 
+        <strong>
+          Something went wrong!
+        </strong>
+         
+        <a
+          href="#"
+        >
+          Link
+        </a>
+      </span>
     </div>
     <div
       className="flex-grow-1"
@@ -313,7 +324,18 @@ exports[`Storyshots Components/Banner Info 1`] = `
     <div
       className="align-self-center"
     >
-      This is an info banner. Check it out!
+      <span>
+        This is an info banner. 
+        <strong>
+          Check it out!
+        </strong>
+         
+        <a
+          href="#"
+        >
+          Link
+        </a>
+      </span>
     </div>
     <div
       className="flex-grow-1"
@@ -335,7 +357,18 @@ exports[`Storyshots Components/Banner Success 1`] = `
     <div
       className="align-self-center"
     >
-      This is a success banner. Something good happened!
+      <span>
+        This is a success banner. 
+        <strong>
+          Something good happened!
+        </strong>
+         
+        <a
+          href="#"
+        >
+          Link
+        </a>
+      </span>
     </div>
     <div
       className="flex-grow-1"
@@ -357,7 +390,18 @@ exports[`Storyshots Components/Banner Warning 1`] = `
     <div
       className="align-self-center"
     >
-      This is a warning banner. Something is not quite right.
+      <span>
+        This is a warning banner. 
+        <strong>
+          Something is not quite right.
+        </strong>
+         
+        <a
+          href="#"
+        >
+          Link
+        </a>
+      </span>
     </div>
     <div
       className="flex-grow-1"

--- a/src/components/banner/Banner.module.scss
+++ b/src/components/banner/Banner.module.scss
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@import "@/themes/colors.scss";
+
 .root {
   text-align: center;
   padding: 10px;
@@ -35,6 +37,6 @@
 }
 
 .danger {
-  color: #721c24;
-  background-color: #f8d7da;
+  background-color: #b4183f;
+  background-color: $D600;
 }

--- a/src/components/banner/Banner.module.scss
+++ b/src/components/banner/Banner.module.scss
@@ -37,6 +37,5 @@
 }
 
 .danger {
-  background-color: #b4183f;
-  background-color: $D600;
+  background-color: $D100;
 }

--- a/src/components/banner/Banner.module.scss
+++ b/src/components/banner/Banner.module.scss
@@ -37,5 +37,6 @@
 }
 
 .danger {
+  // Use danger bg-weak because danger bg (D700) has text contrast problems
   background-color: $D100;
 }

--- a/src/components/banner/Banner.module.scss
+++ b/src/components/banner/Banner.module.scss
@@ -35,5 +35,6 @@
 }
 
 .danger {
-  background-color: #b4183f;
+  color: #721c24;
+  background-color: #f8d7da;
 }

--- a/src/components/banner/Banner.stories.tsx
+++ b/src/components/banner/Banner.stories.tsx
@@ -39,25 +39,45 @@ const Template: ComponentStory<typeof Banner> = (args) => <Banner {...args} />;
 export const Info = Template.bind({});
 Info.args = {
   variant: "info",
-  children: "This is an info banner. Check it out!",
+  children: (
+    <span>
+      This is an info banner. <strong>Check it out!</strong>{" "}
+      <a href="#">Link</a>
+    </span>
+  ),
 };
 
 export const Success = Template.bind({});
 Success.args = {
   variant: "success",
-  children: "This is a success banner. Something good happened!",
+  children: (
+    <span>
+      This is a success banner. <strong>Something good happened!</strong>{" "}
+      <a href="#">Link</a>
+    </span>
+  ),
 };
 
 export const Danger = Template.bind({});
 Danger.args = {
   variant: "danger",
-  children: "This is a danger banner. Something went wrong!",
+  children: (
+    <span>
+      This is a danger banner. <strong>Something went wrong!</strong>{" "}
+      <a href="#">Link</a>
+    </span>
+  ),
 };
 
 export const Warning = Template.bind({});
 Warning.args = {
   variant: "warning",
-  children: "This is a warning banner. Something is not quite right.",
+  children: (
+    <span>
+      This is a warning banner. <strong>Something is not quite right.</strong>{" "}
+      <a href="#">Link</a>
+    </span>
+  ),
 };
 
 export const WithButton = Template.bind({});

--- a/src/themes/colors.scss
+++ b/src/themes/colors.scss
@@ -62,7 +62,7 @@ $W60: #e89c00;
 $W70: #b57900;
 
 // Danger
-$D600: #e84e2c;
+$D100: #ffcbbf;
 
 /*
 * Misc Tokens

--- a/src/themes/colors.scss
+++ b/src/themes/colors.scss
@@ -62,7 +62,7 @@ $W60: #e89c00;
 $W70: #b57900;
 
 // Danger
-$D600: #b4183f;
+$D600: #e84e2c;
 
 /*
 * Misc Tokens


### PR DESCRIPTION
## What does this PR do?

- Part of https://github.com/pixiebrix/pixiebrix-app/issues/5426

## Reviewer Tips

- See `Banner` component storybook

## Demo

Before:

<img width="1263" alt="Screenshot 2024-06-27 at 12 03 39 PM" src="https://github.com/pixiebrix/pixiebrix-extension/assets/20693145/547beb4d-1e30-4e44-a153-0e8283c1ef56">

After:

![Screenshot 2024-06-27 at 7 33 18 PM](https://github.com/pixiebrix/pixiebrix-extension/assets/20693145/7fb29f39-a8fd-4e12-8e01-ca83766cb365)
