### PR TITLE
Prevent retired starter bricks in saved standalone mods from crashing mods screen

### DIFF
--- a/src/mods/useModViewItems.test.tsx
+++ b/src/mods/useModViewItems.test.tsx
@@ -24,7 +24,7 @@ import extensionsSlice from "@/store/extensionsSlice";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import { type UnavailableMod } from "@/types/modTypes";
-import { unavailableModFactory } from "@/mods/useMods";
+import { mapModComponentToUnavailableMod } from "@/mods/useMods";
 import { renderHook } from "@/extensionConsole/testHelpers";
 import {
   modComponentFactory,
@@ -65,7 +65,7 @@ describe("useModViewItems", () => {
     });
   });
 
-  it("creates entry for recipe", async () => {
+  it("creates entry for an undefined mod", async () => {
     const recipe = defaultModDefinitionFactory();
     const activatedModComponent = activatedModComponentFactory({
       _recipe: pickModDefinitionMetadata(recipe),
@@ -93,17 +93,17 @@ describe("useModViewItems", () => {
   });
 
   it("creates for unavailable recipe", async () => {
-    const recipe = defaultModDefinitionFactory();
+    const modDefinition = defaultModDefinitionFactory();
     const activatedModComponent = activatedModComponentFactory({
-      _recipe: pickModDefinitionMetadata(recipe),
+      _recipe: pickModDefinitionMetadata(modDefinition),
     });
 
-    const unavailableRecipe: UnavailableMod = unavailableModFactory(
+    const unavailableMod: UnavailableMod = mapModComponentToUnavailableMod(
       activatedModComponent,
     );
 
     const { waitForEffect, result } = renderHook(
-      () => useModViewItems([unavailableRecipe]),
+      () => useModViewItems([unavailableMod]),
       {
         setupRedux(dispatch) {
           dispatch(

--- a/src/mods/useMods.test.ts
+++ b/src/mods/useMods.test.ts
@@ -26,11 +26,15 @@ import {
   standaloneModDefinitionFactory,
   activatedModComponentFactory,
 } from "@/testUtils/factories/modComponentFactories";
-import { defaultModDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
+import {
+  defaultModDefinitionFactory,
+  innerStarterBrickModDefinitionFactory,
+  starterBrickInnerDefinitionFactory,
+} from "@/testUtils/factories/modDefinitionFactories";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { type UseCachedQueryResult } from "@/types/sliceTypes";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
-import { DefinitionKinds } from "@/types/registryTypes";
+import { DefinitionKinds, InnerDefinitionRef } from "@/types/registryTypes";
 
 jest.mock("@/modDefinitions/modDefinitionHooks");
 
@@ -120,7 +124,7 @@ describe("useMods", () => {
     });
   });
 
-  it("handles known recipe", async () => {
+  it("handles known mod definition", async () => {
     const metadata = metadataFactory();
 
     useAllModDefinitionsMock.mockReturnValue({
@@ -158,7 +162,7 @@ describe("useMods", () => {
     expect(wrapper.result.current.mods[0]).not.toHaveProperty("isStub");
   });
 
-  it("handles inactive cloud extension", async () => {
+  it("handles inactive standalone mod component", async () => {
     appApiMock
       .onGet("/api/extensions/")
       .reply(200, [standaloneModDefinitionFactory()]);
@@ -178,7 +182,7 @@ describe("useMods", () => {
     });
   });
 
-  it("handles active cloud extension", async () => {
+  it("handles active standalone mod component", async () => {
     appApiMock.reset();
 
     const standaloneModDefinition = standaloneModDefinitionFactory();
@@ -202,6 +206,65 @@ describe("useMods", () => {
         expect.objectContaining({
           active: true,
           extensionPointId: expect.toBeString(),
+        }),
+      ],
+      error: undefined,
+    });
+  });
+
+  it("handles retired starter brick type with no valid mods", async () => {
+    appApiMock.reset();
+
+    const standaloneModDefinition = standaloneModDefinitionFactory();
+    standaloneModDefinition.definitions = {
+      extensionPoint: starterBrickInnerDefinitionFactory(),
+    };
+    (
+      standaloneModDefinition.definitions.extensionPoint.definition as any
+    ).type = "retired";
+    standaloneModDefinition.extensionPointId =
+      "extensionPoint" as InnerDefinitionRef;
+
+    appApiMock.onGet("/api/extensions/").reply(200, [standaloneModDefinition]);
+
+    const wrapper = renderHook(() => useMods(), {
+      setupRedux(dispatch) {},
+    });
+
+    await wrapper.waitForEffect();
+
+    expect(wrapper.result.current.mods).toEqual([]);
+    expect(wrapper.result.current.error).toBeInstanceOf(Error);
+  });
+
+  it("handles ignores retired mods", async () => {
+    appApiMock.reset();
+
+    const retiredDefinition = standaloneModDefinitionFactory();
+    retiredDefinition.definitions = {
+      extensionPoint: starterBrickInnerDefinitionFactory(),
+    };
+    (retiredDefinition.definitions.extensionPoint.definition as any).type =
+      "retired";
+    retiredDefinition.extensionPointId = "extensionPoint" as InnerDefinitionRef;
+
+    const validDefinition = standaloneModDefinitionFactory();
+
+    appApiMock
+      .onGet("/api/extensions/")
+      .reply(200, [retiredDefinition, validDefinition]);
+
+    const wrapper = renderHook(() => useMods(), {
+      setupRedux(dispatch) {},
+    });
+
+    await wrapper.waitForEffect();
+
+    expect(wrapper.result.current).toEqual({
+      mods: [
+        expect.objectContaining({
+          active: false,
+          extensionPointId: validDefinition.extensionPointId,
         }),
       ],
       error: undefined,

--- a/src/mods/useMods.test.ts
+++ b/src/mods/useMods.test.ts
@@ -28,13 +28,15 @@ import {
 } from "@/testUtils/factories/modComponentFactories";
 import {
   defaultModDefinitionFactory,
-  innerStarterBrickModDefinitionFactory,
   starterBrickInnerDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
 import { type UseCachedQueryResult } from "@/types/sliceTypes";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
-import { DefinitionKinds, InnerDefinitionRef } from "@/types/registryTypes";
+import {
+  DefinitionKinds,
+  type InnerDefinitionRef,
+} from "@/types/registryTypes";
 
 jest.mock("@/modDefinitions/modDefinitionHooks");
 


### PR DESCRIPTION
## What does this PR do?

- Prevent retired starter bricks from crashing mods screen if the user has the retired starter brick saved to server as a standalone mod definition

## Discussion

- The runtime and Page Editor likely can't handle mod components with retired starter bricks. There more easy workaround for those situations, though. The user just needs to de-activate those mods. In practice, it will only be our internal developers who might have retired starter bricks active
  - For example, a retired starter brick in an activated mod will cause not mod components to load: https://github.com/pixiebrix/pixiebrix-extension/blob/e343d6a02a59e8990ac429b5fe24deb7434c6d0c/src/contentScript/lifecycle.ts#L450-L450

## Future Work

- [x] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
