### PR TITLE
Update `webext-tools` usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -138,7 +138,7 @@
         "use-debounce": "^10.0.1",
         "use-sync-external-store": "^1.2.2",
         "uuid": "^10.0.0",
-        "webext-content-scripts": "^2.6.1",
+        "webext-content-scripts": "^2.7.0",
         "webext-detect-page": "^5.0.0",
         "webext-events": "^3.0.0",
         "webext-inject-on-install": "^2.2.0",
@@ -148,7 +148,7 @@
         "webext-polyfill-kinda": "^1.0.2",
         "webext-storage": "^1.2.2",
         "webext-storage-cache": "^6.0.1",
-        "webext-tools": "^1.2.5",
+        "webext-tools": "^2.0.1",
         "webextension-polyfill": "^0.12.0",
         "whatwg-mimetype": "^4.0.0",
         "yup": "^0.32.11"
@@ -29090,15 +29090,26 @@
       }
     },
     "node_modules/webext-content-scripts": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-2.6.1.tgz",
-      "integrity": "sha512-418gnJGVzKBLMyF/+9fX9pMrp/p7yFKfX9bhe8Qe2oHDjaLqUJNP2WF9kVZ9E/p7lmiBC+f96dkEgwK/yu0QRA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-2.7.0.tgz",
+      "integrity": "sha512-onSnVe+VfKwx9adkUsRt4uCcahpNLt36ab16dqdzml3IWG/LUYp2Udhy/PJ24p2bvBYmKQ2Rq7gc2oT2h5nX1w==",
       "dependencies": {
         "webext-patterns": "^1.3.0",
         "webext-polyfill-kinda": "^1.0.2"
       },
       "engines": {
         "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fregante"
+      }
+    },
+    "node_modules/webext-detect": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/webext-detect/-/webext-detect-5.0.2.tgz",
+      "integrity": "sha512-R/Jfape0ML8rxWxIlOk8qODkD9G7L6+HijSNktsAKY6ZWZwGGO0Mfxa5C3BcJkNwLBR5/44cGhpbGSf5dne3vQ==",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/fregante"
@@ -29225,12 +29236,12 @@
       }
     },
     "node_modules/webext-tools": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/webext-tools/-/webext-tools-1.2.5.tgz",
-      "integrity": "sha512-sEa3IGr2qJ/pe4UFG9lZup63E4U6j65UlOF7bWMMqeOOotAXMtNfC8L2xfxxa0/141L9vMXIiUIu32HL0M/FsQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/webext-tools/-/webext-tools-2.0.1.tgz",
+      "integrity": "sha512-pk+lgvnTRMtzn1MvLeBien1nB15V5kIhung3w9ZFLyPXRzmZi5dHtr6BJJcNwJ8yzK+OeIsUk5qIDMEjEwgQKQ==",
       "dependencies": {
-        "webext-content-scripts": "^2.6.1",
-        "webext-detect-page": "^5.0.1",
+        "webext-content-scripts": "^2.7.0",
+        "webext-detect": "^5.0.2",
         "webext-polyfill-kinda": "^1.0.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "use-debounce": "^10.0.1",
     "use-sync-external-store": "^1.2.2",
     "uuid": "^10.0.0",
-    "webext-content-scripts": "^2.6.1",
+    "webext-content-scripts": "^2.7.0",
     "webext-detect-page": "^5.0.0",
     "webext-events": "^3.0.0",
     "webext-inject-on-install": "^2.2.0",
@@ -174,7 +174,7 @@
     "webext-polyfill-kinda": "^1.0.2",
     "webext-storage": "^1.2.2",
     "webext-storage-cache": "^6.0.1",
-    "webext-tools": "^1.2.5",
+    "webext-tools": "^2.0.1",
     "webextension-polyfill": "^0.12.0",
     "whatwg-mimetype": "^4.0.0",
     "yup": "^0.32.11"

--- a/src/background/navigation.ts
+++ b/src/background/navigation.ts
@@ -17,7 +17,10 @@
 
 import { type Target } from "@/types/messengerTypes";
 import { canAccessTab } from "@/permissions/permissionsUtils";
-import { isScriptableUrl, canAccessTab as canInjectTab } from "webext-content-scripts";
+import {
+  isScriptableUrl,
+  canAccessTab as canInjectTab,
+} from "webext-content-scripts";
 import { debounce } from "lodash";
 import { getTabUrl } from "webext-tools";
 import { isTargetReady } from "@/contentScript/ready";

--- a/src/background/navigation.ts
+++ b/src/background/navigation.ts
@@ -17,9 +17,9 @@
 
 import { type Target } from "@/types/messengerTypes";
 import { canAccessTab } from "@/permissions/permissionsUtils";
-import { isScriptableUrl } from "webext-content-scripts";
+import { isScriptableUrl, canAccessTab as canInjectTab } from "webext-content-scripts";
 import { debounce } from "lodash";
-import { canAccessTab as canInjectTab, getTabUrl } from "webext-tools";
+import { getTabUrl } from "webext-tools";
 import { isTargetReady } from "@/contentScript/ready";
 import { flagOn } from "@/auth/featureFlagStorage";
 import { activatePrerenderedTab } from "@/contentScript/messenger/api";

--- a/src/permissions/permissionsUtils.ts
+++ b/src/permissions/permissionsUtils.ts
@@ -17,12 +17,12 @@
 
 import { type Manifest, type Permissions } from "webextension-polyfill";
 import { uniq } from "lodash";
-import { isScriptableUrl, canAccessTab as _canAccessTab } from "webext-content-scripts";
-import { extractAdditionalPermissions } from "webext-permissions";
 import {
-  getTabUrl,
-  type Target,
-} from "webext-tools";
+  isScriptableUrl,
+  canAccessTab as _canAccessTab,
+} from "webext-content-scripts";
+import { extractAdditionalPermissions } from "webext-permissions";
+import { getTabUrl, type Target } from "webext-tools";
 import {
   isPermissionsStatus,
   type PermissionsStatus,

--- a/src/permissions/permissionsUtils.ts
+++ b/src/permissions/permissionsUtils.ts
@@ -17,11 +17,10 @@
 
 import { type Manifest, type Permissions } from "webextension-polyfill";
 import { uniq } from "lodash";
-import { isScriptableUrl } from "webext-content-scripts";
+import { isScriptableUrl, canAccessTab as _canAccessTab } from "webext-content-scripts";
 import { extractAdditionalPermissions } from "webext-permissions";
 import {
   getTabUrl,
-  canAccessTab as _canAccessTab,
   type Target,
 } from "webext-tools";
 import {


### PR DESCRIPTION
## What does this PR do?

A function used by pixiebrix was moved from `webext-tools` to `webext-content-scripts`

- https://github.com/fregante/webext-tools/pull/9
- https://github.com/fregante/webext-content-scripts/pull/37
