### PR TITLE
#8579 & #8614: Migrate mod component form state

### DIFF
--- a/src/analysis/analysisVisitors/baseAnalysisVisitors.ts
+++ b/src/analysis/analysisVisitors/baseAnalysisVisitors.ts
@@ -32,7 +32,7 @@ export abstract class AnalysisVisitorABC
 {
   abstract readonly id: string;
 
-  protected extension!: ModComponentFormState;
+  protected formState!: ModComponentFormState;
 
   protected readonly annotations: AnalysisAnnotation[] = [];
   getAnnotations(): AnalysisAnnotation[] {
@@ -40,21 +40,19 @@ export abstract class AnalysisVisitorABC
   }
 
   /**
-   * Visit the extension point definition.
+   * Visit the starter brick definition.
    */
-  visitExtensionPoint(
-    extensionPoint: ModComponentFormState["extensionPoint"],
-  ): void {
+  visitStarterBrick(starterBrick: ModComponentFormState["starterBrick"]): void {
     // NOP
   }
 
-  run(extension: ModComponentFormState): void {
-    this.extension = extension;
+  run(formState: ModComponentFormState): void {
+    this.formState = formState;
 
-    this.visitExtensionPoint(extension.extensionPoint);
+    this.visitStarterBrick(formState.starterBrick);
 
-    this.visitRootPipeline(extension.extension.blockPipeline, {
-      extensionPointType: extension.type,
+    this.visitRootPipeline(formState.modComponent.blockPipeline, {
+      starterBrickType: formState.type,
     });
   }
 }
@@ -62,9 +60,9 @@ export abstract class AnalysisVisitorABC
 export abstract class AnalysisVisitorWithResolvedBricksABC extends AnalysisVisitorABC {
   protected allBlocks!: TypedBrickMap;
 
-  override async run(extension: ModComponentFormState): Promise<void> {
+  override async run(formState: ModComponentFormState): Promise<void> {
     this.allBlocks = await blockRegistry.allTyped();
 
-    super.run(extension);
+    super.run(formState);
   }
 }

--- a/src/analysis/analysisVisitors/brickTypeAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/brickTypeAnalysis.test.ts
@@ -36,16 +36,16 @@ beforeAll(() => {
 
 describe("BrickTypeAnalysis", () => {
   test("disallow effect in renderer", async () => {
-    const modComponent = sidebarPanelFormStateFactory();
+    const formState = sidebarPanelFormStateFactory();
 
-    modComponent.extension.blockPipeline = [
+    formState.modComponent.blockPipeline = [
       createNewConfiguredBrick(ALERT_EFFECT_ID),
       createNewConfiguredBrick(DocumentRenderer.BRICK_ID),
     ];
 
     const analysis = new BrickTypeAnalysis();
 
-    await analysis.run(modComponent);
+    await analysis.run(formState);
 
     expect(analysis.getAnnotations()).toHaveLength(1);
   });
@@ -55,16 +55,16 @@ describe("BrickTypeAnalysis", () => {
     CancelEffect.BRICK_ID,
     ErrorEffect.BRICK_ID,
   ])("allow %s in renderer", async (brickId) => {
-    const modComponent = sidebarPanelFormStateFactory();
+    const formState = sidebarPanelFormStateFactory();
 
-    modComponent.extension.blockPipeline = [
+    formState.modComponent.blockPipeline = [
       createNewConfiguredBrick(brickId),
       createNewConfiguredBrick(DocumentRenderer.BRICK_ID),
     ];
 
     const analysis = new BrickTypeAnalysis();
 
-    await analysis.run(modComponent);
+    await analysis.run(formState);
 
     expect(analysis.getAnnotations()).toHaveLength(0);
   });

--- a/src/analysis/analysisVisitors/eventNameAnalysis/checkEventNamesAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/eventNameAnalysis/checkEventNamesAnalysis.test.ts
@@ -28,7 +28,7 @@ import { toExpression } from "@/utils/expressionUtils";
 describe("checkEventNamesAnalysis", () => {
   it("error on missing custom event", async () => {
     const formState = triggerFormStateFactory();
-    formState.extensionPoint.definition.trigger = "custom";
+    formState.starterBrick.definition.trigger = "custom";
 
     const analysis = new CheckEventNamesAnalysis([formState]);
     await analysis.run(formState);
@@ -42,8 +42,8 @@ describe("checkEventNamesAnalysis", () => {
 
   it.each(["click"])("allow dom event: %s", async (eventName) => {
     const formState = triggerFormStateFactory();
-    formState.extensionPoint.definition.trigger = "custom";
-    formState.extensionPoint.definition.customEvent = { eventName };
+    formState.starterBrick.definition.trigger = "custom";
+    formState.starterBrick.definition.customEvent = { eventName };
 
     const analysis = new CheckEventNamesAnalysis([formState]);
     await analysis.run(formState);
@@ -53,8 +53,8 @@ describe("checkEventNamesAnalysis", () => {
 
   it("warn on unknown event", async () => {
     const formState = triggerFormStateFactory();
-    formState.extensionPoint.definition.trigger = "custom";
-    formState.extensionPoint.definition.customEvent = { eventName: "unknown" };
+    formState.starterBrick.definition.trigger = "custom";
+    formState.starterBrick.definition.customEvent = { eventName: "unknown" };
 
     const analysis = new CheckEventNamesAnalysis([formState]);
     await analysis.run(formState);
@@ -68,8 +68,8 @@ describe("checkEventNamesAnalysis", () => {
 
   it("allow known event", async () => {
     const triggerFormState = triggerFormStateFactory();
-    triggerFormState.extensionPoint.definition.trigger = "custom";
-    triggerFormState.extensionPoint.definition.customEvent = {
+    triggerFormState.starterBrick.definition.trigger = "custom";
+    triggerFormState.starterBrick.definition.customEvent = {
       eventName: "myevent",
     };
 
@@ -88,8 +88,8 @@ describe("checkEventNamesAnalysis", () => {
 
   it("info on unknown event with dynamic expressions", async () => {
     const triggerFormState = triggerFormStateFactory();
-    triggerFormState.extensionPoint.definition.trigger = "custom";
-    triggerFormState.extensionPoint.definition.customEvent = {
+    triggerFormState.starterBrick.definition.trigger = "custom";
+    triggerFormState.starterBrick.definition.customEvent = {
       eventName: "myevent",
     };
 
@@ -117,8 +117,8 @@ describe("checkEventNamesAnalysis", () => {
 
   it("get knownEventNames() combines known and trigger names", async () => {
     const triggerFormState = triggerFormStateFactory();
-    triggerFormState.extensionPoint.definition.trigger = "custom";
-    triggerFormState.extensionPoint.definition.customEvent = {
+    triggerFormState.starterBrick.definition.trigger = "custom";
+    triggerFormState.starterBrick.definition.customEvent = {
       eventName: "myevent",
     };
 

--- a/src/analysis/analysisVisitors/eventNameAnalysis/checkEventNamesAnalysis.ts
+++ b/src/analysis/analysisVisitors/eventNameAnalysis/checkEventNamesAnalysis.ts
@@ -49,23 +49,23 @@ class CheckEventNamesAnalysis extends AnalysisVisitorABC {
     ];
   }
 
-  override visitExtensionPoint(
-    extensionPoint: ModComponentFormState["extensionPoint"],
+  override visitStarterBrick(
+    starterBrick: ModComponentFormState["starterBrick"],
   ) {
-    super.visitExtensionPoint(extensionPoint);
+    super.visitStarterBrick(starterBrick);
 
     if (
-      isTriggerStarterBrick(extensionPoint) &&
-      extensionPoint.definition.trigger === "custom"
+      isTriggerStarterBrick(starterBrick) &&
+      starterBrick.definition.trigger === "custom"
     ) {
-      const eventName = extensionPoint.definition.customEvent?.eventName;
+      const eventName = starterBrick.definition.customEvent?.eventName;
 
       if (!eventName) {
         this.annotations.push({
           analysisId: this.id,
           type: AnnotationType.Error,
           message: "Custom event name is required",
-          position: { path: "extensionPoint.definition.customEvent.eventName" },
+          position: { path: "starterBrick.definition.customEvent.eventName" },
         });
       } else if (
         !DOM_EVENTS.includes(eventName) &&
@@ -79,7 +79,7 @@ class CheckEventNamesAnalysis extends AnalysisVisitorABC {
             type: AnnotationType.Info,
             message: `Custom event ${eventName} does not match a known emitted event in this Mod`,
             position: {
-              path: "extensionPoint.definition.customEvent.eventName",
+              path: "starterBrick.definition.customEvent.eventName",
             },
           });
         } else {
@@ -88,7 +88,7 @@ class CheckEventNamesAnalysis extends AnalysisVisitorABC {
             type: AnnotationType.Warning,
             message: `Custom event ${eventName} is not emitted in this Mod`,
             position: {
-              path: "extensionPoint.definition.customEvent.eventName",
+              path: "starterBrick.definition.customEvent.eventName",
             },
           });
         }
@@ -96,7 +96,7 @@ class CheckEventNamesAnalysis extends AnalysisVisitorABC {
     }
   }
 
-  override async run(extension: ModComponentFormState) {
+  override async run(formState: ModComponentFormState) {
     const results = this.formStates.map((x) =>
       CollectEventNamesVisitor.collectNames(x),
     );
@@ -111,7 +111,7 @@ class CheckEventNamesAnalysis extends AnalysisVisitorABC {
       hasDynamicEventName: results.some((result) => result.hasDynamicEventName),
     };
 
-    super.run(extension);
+    super.run(formState);
   }
 }
 

--- a/src/analysis/analysisVisitors/eventNameAnalysis/collectEventNamesVisitor.test.ts
+++ b/src/analysis/analysisVisitors/eventNameAnalysis/collectEventNamesVisitor.test.ts
@@ -27,7 +27,7 @@ import { toExpression } from "@/utils/expressionUtils";
 describe("collectEventNamesAnalysis", () => {
   it("collects event name from literal", () => {
     const formState = formStateFactory();
-    formState.extension.blockPipeline[0] = {
+    formState.modComponent.blockPipeline[0] = {
       id: CustomEventEffect.BRICK_ID,
       config: {
         eventName: "foo",
@@ -45,7 +45,7 @@ describe("collectEventNamesAnalysis", () => {
 
   it("collects event name from template literal", () => {
     const formState = formStateFactory();
-    formState.extension.blockPipeline[0] = {
+    formState.modComponent.blockPipeline[0] = {
       id: CustomEventEffect.BRICK_ID,
       config: {
         eventName: toExpression("nunjucks", "foo"),
@@ -63,7 +63,7 @@ describe("collectEventNamesAnalysis", () => {
 
   it("sets dynamic event flag", () => {
     const formState = formStateFactory();
-    formState.extension.blockPipeline[0] = {
+    formState.modComponent.blockPipeline[0] = {
       id: CustomEventEffect.BRICK_ID,
       config: {
         eventName: toExpression("nunjucks", "{{ @foo }}"),
@@ -81,8 +81,8 @@ describe("collectEventNamesAnalysis", () => {
 
   it("collects custom trigger names from trigger starter bricks", () => {
     const formState = triggerFormStateFactory();
-    formState.extensionPoint.definition.trigger = "custom";
-    formState.extensionPoint.definition.customEvent = {
+    formState.starterBrick.definition.trigger = "custom";
+    formState.starterBrick.definition.customEvent = {
       eventName: "foo",
     };
 

--- a/src/analysis/analysisVisitors/eventNameAnalysis/collectEventNamesVisitor.ts
+++ b/src/analysis/analysisVisitors/eventNameAnalysis/collectEventNamesVisitor.ts
@@ -62,10 +62,10 @@ class CollectEventNamesVisitor extends PipelineVisitor {
   }
 
   private visitStarterBrick(
-    extensionPoint: ModComponentFormState["extensionPoint"],
+    starterBrick: ModComponentFormState["starterBrick"],
   ) {
-    if (isTriggerStarterBrick(extensionPoint)) {
-      const eventName = extensionPoint.definition.customEvent?.eventName;
+    if (isTriggerStarterBrick(starterBrick)) {
+      const eventName = starterBrick.definition.customEvent?.eventName;
 
       if (eventName) {
         this._triggerNames.add(eventName);
@@ -98,8 +98,8 @@ class CollectEventNamesVisitor extends PipelineVisitor {
   ): EventNameAnalysisResult {
     const visitor = new CollectEventNamesVisitor();
 
-    visitor.visitRootPipeline(formState.extension.blockPipeline);
-    visitor.visitStarterBrick(formState.extensionPoint);
+    visitor.visitRootPipeline(formState.modComponent.blockPipeline);
+    visitor.visitStarterBrick(formState.starterBrick);
 
     return visitor.result;
   }

--- a/src/analysis/analysisVisitors/pageStateAnalysis/modVariableSchemasVisitor.test.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/modVariableSchemasVisitor.test.ts
@@ -28,7 +28,7 @@ beforeAll(() => {
 describe("ModVariableSchemasVisitor", () => {
   it("collects event schema from a template literal", async () => {
     const formState = formStateFactory();
-    formState.extension.blockPipeline[0] = {
+    formState.modComponent.blockPipeline[0] = {
       id: AssignModVariable.BRICK_ID,
       config: {
         variableName: toExpression("nunjucks", "foo"),
@@ -44,7 +44,7 @@ describe("ModVariableSchemasVisitor", () => {
 
   it("unions known schemas", async () => {
     const formState = formStateFactory();
-    formState.extension.blockPipeline[0] = {
+    formState.modComponent.blockPipeline[0] = {
       id: AssignModVariable.BRICK_ID,
       config: {
         variableName: "foo",
@@ -52,7 +52,7 @@ describe("ModVariableSchemasVisitor", () => {
     };
 
     const otherFormState = formStateFactory();
-    otherFormState.extension.blockPipeline[0] = {
+    otherFormState.modComponent.blockPipeline[0] = {
       id: AssignModVariable.BRICK_ID,
       config: {
         variableName: "bar",
@@ -71,7 +71,7 @@ describe("ModVariableSchemasVisitor", () => {
 
   it("does not duplicate schemas", async () => {
     const formState = formStateFactory();
-    formState.extension.blockPipeline[0] = {
+    formState.modComponent.blockPipeline[0] = {
       id: AssignModVariable.BRICK_ID,
       config: {
         variableName: "foo",
@@ -79,7 +79,7 @@ describe("ModVariableSchemasVisitor", () => {
     };
 
     const otherFormState = formStateFactory();
-    otherFormState.extension.blockPipeline[0] = {
+    otherFormState.modComponent.blockPipeline[0] = {
       id: AssignModVariable.BRICK_ID,
       config: {
         variableName: "foo",

--- a/src/analysis/analysisVisitors/pageStateAnalysis/modVariableSchemasVisitor.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/modVariableSchemasVisitor.ts
@@ -63,7 +63,7 @@ class ModVariableSchemasVisitor extends PipelineVisitor {
     const visitor = new ModVariableSchemasVisitor(allBlocks);
 
     for (const formState of formStates) {
-      visitor.visitRootPipeline(formState.extension.blockPipeline);
+      visitor.visitRootPipeline(formState.modComponent.blockPipeline);
     }
 
     // Schema promises return undefined if not page state

--- a/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.test.ts
@@ -129,7 +129,7 @@ describe("PageStateAnalysis", () => {
         },
       ]);
 
-      state.recipe = { id: registryIdFactory() } as BaseFormState["recipe"];
+      state.mod = { id: registryIdFactory() } as BaseFormState["mod"];
 
       const analysis = new PageStateAnalysis();
       await analysis.run(state);

--- a/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/pageStateAnalysis.ts
@@ -97,9 +97,9 @@ class PageStateVisitor extends AnalysisVisitorWithResolvedBricksABC {
     }
   }
 
-  override async run(extension: ModComponentFormState): Promise<void> {
-    this.isInMod = Boolean(extension.recipe);
-    await super.run(extension);
+  override async run(formState: ModComponentFormState): Promise<void> {
+    this.isInMod = Boolean(formState.mod);
+    await super.run(formState);
   }
 }
 

--- a/src/analysis/analysisVisitors/requestPermissionAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/requestPermissionAnalysis.test.ts
@@ -25,9 +25,9 @@ import { toExpression } from "@/utils/expressionUtils";
 browser.permissions.contains = jest.fn().mockResolvedValue(true);
 const containsMock = jest.mocked(browser.permissions.contains);
 
-function blockExtensionFactory(url: string) {
-  const extension = triggerFormStateFactory();
-  extension.extension.blockPipeline = [
+function brickModComponentFactory(url: string) {
+  const formState = triggerFormStateFactory();
+  formState.modComponent.blockPipeline = [
     brickConfigFactory({
       id: RemoteMethod.BLOCK_ID,
       config: {
@@ -36,7 +36,7 @@ function blockExtensionFactory(url: string) {
     }),
   ];
 
-  return extension;
+  return formState;
 }
 
 describe("requestPermissionAnalysis", () => {
@@ -47,9 +47,9 @@ describe("requestPermissionAnalysis", () => {
 
   test("it annotates http: url", async () => {
     const visitor = new RequestPermissionAnalysis();
-    const extension = blockExtensionFactory("http://example.com");
+    const formState = brickModComponentFactory("http://example.com");
 
-    await visitor.run(extension);
+    await visitor.run(formState);
     expect(visitor.getAnnotations()).toStrictEqual([
       {
         analysisId: "requestPermission",
@@ -57,7 +57,7 @@ describe("requestPermissionAnalysis", () => {
         message:
           "PixieBrix does not support calls using http: because they are insecure. Please use https: instead.",
         position: {
-          path: "extension.blockPipeline.0.config.url",
+          path: "modComponent.blockPipeline.0.config.url",
         },
       },
     ]);
@@ -65,16 +65,18 @@ describe("requestPermissionAnalysis", () => {
 
   test("it annotates invalid url", async () => {
     const visitor = new RequestPermissionAnalysis();
-    const extension = blockExtensionFactory("https://there is a space in here");
+    const formState = brickModComponentFactory(
+      "https://there is a space in here",
+    );
 
-    await visitor.run(extension);
+    await visitor.run(formState);
     expect(visitor.getAnnotations()).toStrictEqual([
       {
         analysisId: "requestPermission",
         type: "error",
         message: "Invalid URL: https://there is a space in here",
         position: {
-          path: "extension.blockPipeline.0.config.url",
+          path: "modComponent.blockPipeline.0.config.url",
         },
       },
     ]);
@@ -82,11 +84,11 @@ describe("requestPermissionAnalysis", () => {
 
   test("it annotates insufficient permissions", async () => {
     const visitor = new RequestPermissionAnalysis();
-    const extension = blockExtensionFactory("https://example.com");
+    const formState = brickModComponentFactory("https://example.com");
 
     containsMock.mockResolvedValue(false);
 
-    await visitor.run(extension);
+    await visitor.run(formState);
 
     expect(containsMock).toHaveBeenCalledWith({
       // Checking that the visitor applies a trailing slash. `contains` requires a path on the URL
@@ -105,7 +107,7 @@ describe("requestPermissionAnalysis", () => {
         message:
           "Insufficient browser permissions to make request. Specify an Integration to access the API, or add an Extra Permissions rule to the starter brick.",
         position: {
-          path: "extension.blockPipeline.0.config.url",
+          path: "modComponent.blockPipeline.0.config.url",
         },
       },
     ]);
@@ -113,9 +115,9 @@ describe("requestPermissionAnalysis", () => {
 
   test("skip relative URLs", async () => {
     const visitor = new RequestPermissionAnalysis();
-    const extension = blockExtensionFactory("/relative/url");
+    const formState = brickModComponentFactory("/relative/url");
 
-    await visitor.run(extension);
+    await visitor.run(formState);
 
     expect(visitor.getAnnotations()).toHaveLength(0);
   });
@@ -123,9 +125,9 @@ describe("requestPermissionAnalysis", () => {
   test("skips valid URLs", async () => {
     const visitor = new RequestPermissionAnalysis();
     containsMock.mockResolvedValue(true);
-    const extension = blockExtensionFactory("https://example.com");
+    const formState = brickModComponentFactory("https://example.com");
 
-    await visitor.run(extension);
+    await visitor.run(formState);
 
     expect(visitor.getAnnotations()).toHaveLength(0);
   });

--- a/src/analysis/analysisVisitors/selectorAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/selectorAnalysis.test.ts
@@ -73,19 +73,19 @@ describe("SelectorAnalysis", () => {
     async (attachMode: AttachMode) => {
       const analysis = new SelectorAnalysis();
 
-      const component = triggerFormStateFactory();
+      const formState = triggerFormStateFactory();
 
-      component.extensionPoint.definition.rootSelector = 'div:contains("foo")';
-      component.extensionPoint.definition.attachMode = attachMode;
+      formState.starterBrick.definition.rootSelector = 'div:contains("foo")';
+      formState.starterBrick.definition.attachMode = attachMode;
 
-      await analysis.run(component);
+      await analysis.run(formState);
 
       expect(analysis.getAnnotations()).toStrictEqual([
         {
           analysisId: "selector",
           message: expect.any(String),
           position: {
-            path: "extensionPoint.definition.rootSelector",
+            path: "starterBrick.definition.rootSelector",
           },
           type: expect.toBeOneOf(["warning", "info"]),
         },
@@ -96,18 +96,18 @@ describe("SelectorAnalysis", () => {
   it("detects invalid trigger selector", async () => {
     const analysis = new SelectorAnalysis();
 
-    const component = triggerFormStateFactory();
+    const formState = triggerFormStateFactory();
 
-    component.extensionPoint.definition.rootSelector = '!div:contains("foo")';
+    formState.starterBrick.definition.rootSelector = '!div:contains("foo")';
 
-    await analysis.run(component);
+    await analysis.run(formState);
 
     expect(analysis.getAnnotations()).toStrictEqual([
       {
         analysisId: "selector",
         message: expect.any(String),
         position: {
-          path: "extensionPoint.definition.rootSelector",
+          path: "starterBrick.definition.rootSelector",
         },
         type: "error",
       },
@@ -119,20 +119,20 @@ describe("SelectorAnalysis", () => {
     async (attachMode: AttachMode) => {
       const analysis = new SelectorAnalysis();
 
-      const component = menuItemFormStateFactory();
+      const formState = menuItemFormStateFactory();
 
-      component.extensionPoint.definition.containerSelector =
+      formState.starterBrick.definition.containerSelector =
         'div:contains("foo")';
-      component.extensionPoint.definition.attachMode = attachMode;
+      formState.starterBrick.definition.attachMode = attachMode;
 
-      await analysis.run(component);
+      await analysis.run(formState);
 
       expect(analysis.getAnnotations()).toStrictEqual([
         {
           analysisId: "selector",
           message: expect.any(String),
           position: {
-            path: "extensionPoint.definition.containerSelector",
+            path: "starterBrick.definition.containerSelector",
           },
           type: expect.toBeOneOf(["warning", "info"]),
         },
@@ -143,18 +143,18 @@ describe("SelectorAnalysis", () => {
   it("detects invalid action location selector", async () => {
     const analysis = new SelectorAnalysis();
 
-    const component = menuItemFormStateFactory();
+    const formState = menuItemFormStateFactory();
 
-    component.extensionPoint.definition.containerSelector = "!div";
+    formState.starterBrick.definition.containerSelector = "!div";
 
-    await analysis.run(component);
+    await analysis.run(formState);
 
     expect(analysis.getAnnotations()).toStrictEqual([
       {
         analysisId: "selector",
         message: "Invalid selector.",
         position: {
-          path: "extensionPoint.definition.containerSelector",
+          path: "starterBrick.definition.containerSelector",
         },
         type: "error",
       },
@@ -164,9 +164,9 @@ describe("SelectorAnalysis", () => {
   it("detects selectors passed to highlight brick", async () => {
     const analysis = new SelectorAnalysis();
 
-    const component = triggerFormStateFactory();
+    const formState = triggerFormStateFactory();
 
-    component.extension.blockPipeline = [
+    formState.modComponent.blockPipeline = [
       {
         id: highlight.id,
         config: {
@@ -180,14 +180,14 @@ describe("SelectorAnalysis", () => {
       },
     ];
 
-    await analysis.run(component);
+    await analysis.run(formState);
 
     expect(analysis.getAnnotations()).toStrictEqual([
       {
         analysisId: "selector",
         message: expect.stringMatching(/Selector appears to contain generated/),
         position: {
-          path: "extension.blockPipeline.0.config.rootSelector",
+          path: "modComponent.blockPipeline.0.config.rootSelector",
         },
         type: "warning",
       },
@@ -195,7 +195,7 @@ describe("SelectorAnalysis", () => {
         analysisId: "selector",
         message: expect.stringMatching(/Selector appears to contain generated/),
         position: {
-          path: "extension.blockPipeline.0.config.elements.0.selector",
+          path: "modComponent.blockPipeline.0.config.elements.0.selector",
         },
         type: "warning",
       },
@@ -205,9 +205,9 @@ describe("SelectorAnalysis", () => {
   it("detects selectors passed to jquery brick", async () => {
     const analysis = new SelectorAnalysis();
 
-    const component = triggerFormStateFactory();
+    const formState = triggerFormStateFactory();
 
-    component.extension.blockPipeline = [
+    formState.modComponent.blockPipeline = [
       {
         id: reader.id,
         config: {
@@ -221,14 +221,14 @@ describe("SelectorAnalysis", () => {
       },
     ];
 
-    await analysis.run(component);
+    await analysis.run(formState);
 
     expect(analysis.getAnnotations()).toStrictEqual([
       {
         analysisId: "selector",
         message: expect.stringMatching(/Selector appears to contain generated/),
         position: {
-          path: "extension.blockPipeline.0.config.selectors.simple",
+          path: "modComponent.blockPipeline.0.config.selectors.simple",
         },
         type: "warning",
       },
@@ -236,7 +236,7 @@ describe("SelectorAnalysis", () => {
         analysisId: "selector",
         message: expect.stringMatching(/Selector appears to contain generated/),
         position: {
-          path: "extension.blockPipeline.0.config.selectors.complex.selector",
+          path: "modComponent.blockPipeline.0.config.selectors.complex.selector",
         },
         type: "warning",
       },

--- a/src/analysis/analysisVisitors/selectorAnalysis.ts
+++ b/src/analysis/analysisVisitors/selectorAnalysis.ts
@@ -107,11 +107,11 @@ class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
     await super.run(component);
   }
 
-  checkAction(component: ButtonFormState): void {
-    const selector = component.extensionPoint.definition.containerSelector;
+  checkAction(formState: ButtonFormState): void {
+    const selector = formState.starterBrick.definition.containerSelector;
 
     const position = {
-      path: "extensionPoint.definition.containerSelector",
+      path: "starterBrick.definition.containerSelector",
     };
 
     if (!isEmpty(selector)) {
@@ -127,7 +127,7 @@ class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
       if (!isNativeCssSelector(selector)) {
         const matches = findJQueryExtensions(selector);
         const isWatch =
-          component.extensionPoint.definition.attachMode === "watch";
+          formState.starterBrick.definition.attachMode === "watch";
 
         let message = isWatch
           ? "Using a non-native CSS selector for location in watch mode. Button location selectors that use jQuery extensions may slow down the page."
@@ -150,11 +150,11 @@ class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
     }
   }
 
-  checkTrigger(component: TriggerFormState): void {
-    const selector = component.extensionPoint.definition.rootSelector;
+  checkTrigger(formState: TriggerFormState): void {
+    const selector = formState.starterBrick.definition.rootSelector;
 
     const position = {
-      path: "extensionPoint.definition.rootSelector",
+      path: "starterBrick.definition.rootSelector",
     };
 
     if (selector) {
@@ -170,7 +170,7 @@ class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
       if (!isNativeCssSelector(selector)) {
         const matches = findJQueryExtensions(selector);
         const isWatch =
-          component.extensionPoint.definition.attachMode === "watch";
+          formState.starterBrick.definition.attachMode === "watch";
 
         let message = isWatch
           ? "Using a non-native CSS selector in watch mode. Watching selectors that use jQuery extensions may slow down the page."

--- a/src/analysis/analysisVisitors/templateAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/templateAnalysis.test.ts
@@ -27,9 +27,9 @@ const position: BrickPosition = {
   path: "test.path.property",
 };
 
-function blockExtensionFactory(expression: Expression<unknown>) {
-  const extension = triggerFormStateFactory();
-  extension.extension.blockPipeline = [
+function brickModComponentFactory(expression: Expression<unknown>) {
+  const formState = triggerFormStateFactory();
+  formState.modComponent.blockPipeline = [
     brickConfigFactory({
       id: RemoteMethod.BLOCK_ID,
       config: {
@@ -38,7 +38,7 @@ function blockExtensionFactory(expression: Expression<unknown>) {
     }),
   ];
 
-  return extension;
+  return formState;
 }
 
 describe("TemplateAnalysis", () => {
@@ -66,11 +66,11 @@ describe("TemplateAnalysis", () => {
     "accepts valid mustache [%s]",
     async (template) => {
       const analysis = new TemplateAnalysis();
-      const extension = blockExtensionFactory(
+      const formState = brickModComponentFactory(
         toExpression("mustache", template),
       );
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       expect(analysis.getAnnotations()).toHaveLength(0);
     },
@@ -80,11 +80,11 @@ describe("TemplateAnalysis", () => {
     "rejects mustache template in non-mustache expression [%s]",
     async (template) => {
       const analysis = new TemplateAnalysis();
-      const extension = blockExtensionFactory(
+      const formState = brickModComponentFactory(
         toExpression("nunjucks", template),
       );
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       expect(analysis.getAnnotations()).toHaveLength(1);
     },
@@ -96,11 +96,11 @@ describe("TemplateAnalysis", () => {
     "rejects invalid nunjucks [%s]",
     async (template) => {
       const analysis = new TemplateAnalysis();
-      const extension = blockExtensionFactory(
+      const formState = brickModComponentFactory(
         toExpression("nunjucks", template),
       );
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       expect(analysis.getAnnotations()).toHaveLength(1);
     },

--- a/src/analysis/analysisVisitors/templateAnalysis.ts
+++ b/src/analysis/analysisVisitors/templateAnalysis.ts
@@ -55,9 +55,9 @@ class TemplateAnalysis extends PipelineExpressionVisitor implements Analysis {
     return this.annotations;
   }
 
-  async run(extension: ModComponentFormState): Promise<void> {
-    this.visitRootPipeline(extension.extension.blockPipeline, {
-      extensionPointType: extension.type,
+  async run(formState: ModComponentFormState): Promise<void> {
+    this.visitRootPipeline(formState.modComponent.blockPipeline, {
+      starterBrickType: formState.type,
     });
 
     await Promise.all(this.nunjucksValidationPromises);

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -26,7 +26,7 @@ import IfElse from "@/bricks/transformers/controlFlow/IfElse";
 import ForEach from "@/bricks/transformers/controlFlow/ForEach";
 import { EchoBrick } from "@/runtime/pipelineTests/pipelineTestHelpers";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
-import recipeRegistry from "@/modDefinitions/registry";
+import modRegistry from "@/modDefinitions/registry";
 import blockRegistry from "@/bricks/registry";
 import { SELF_EXISTENCE, VarExistence } from "./varMap";
 import TryExcept from "@/bricks/transformers/controlFlow/TryExcept";
@@ -104,8 +104,8 @@ jest.mock("@/bricks/registry", () => ({
 jest.mock("@/modDefinitions/registry");
 
 describe("Collecting available vars", () => {
-  function mockBlueprintWithOptions(optionsSchema: any) {
-    jest.mocked(recipeRegistry.lookup).mockResolvedValue(
+  function mockModWithOptions(optionsSchema: any) {
+    jest.mocked(modRegistry.lookup).mockResolvedValue(
       defaultModDefinitionFactory({
         options: {
           schema: optionsSchema,
@@ -125,7 +125,7 @@ describe("Collecting available vars", () => {
     });
 
     test("collects the context vars", async () => {
-      mockBlueprintWithOptions({
+      mockModWithOptions({
         properties: {
           foo: {
             type: "string",
@@ -133,7 +133,7 @@ describe("Collecting available vars", () => {
         },
       });
 
-      const extension = formStateFactory(
+      const formState = formStateFactory(
         {
           // Test both the PixieBrix api integration and a sample third-party service
           integrationDependencies: [
@@ -147,19 +147,19 @@ describe("Collecting available vars", () => {
           optionsArgs: {
             foo: "bar",
           },
-          recipe: modMetadataFactory({
-            id: validateRegistryId("test/recipe"),
+          mod: modMetadataFactory({
+            id: validateRegistryId("test/mod"),
           }),
         },
         [brickConfigFactory()],
       );
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       const knownVars = analysis.getKnownVars();
       expect(knownVars.size).toBe(1);
 
-      const foundationKnownVars = knownVars.get("extension.blockPipeline.0");
+      const foundationKnownVars = knownVars.get("modComponent.blockPipeline.0");
       expect(foundationKnownVars.isVariableDefined("@input.title")).toBeTrue();
       expect(foundationKnownVars.isVariableDefined("@input.url")).toBeTrue();
       expect(foundationKnownVars.isVariableDefined("@input.lang")).toBeTrue();
@@ -177,24 +177,24 @@ describe("Collecting available vars", () => {
     });
 
     test("collects the output key", async () => {
-      const extension = formStateFactory(undefined, [
+      const formState = formStateFactory(undefined, [
         brickConfigFactory({
           outputKey: validateOutputKey("foo"),
         }),
         brickConfigFactory(),
       ]);
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       const block0Vars = analysis
         .getKnownVars()
-        .get("extension.blockPipeline.0");
+        .get("modComponent.blockPipeline.0");
 
       expect(block0Vars.isVariableDefined("@foo")).toBeFalse();
 
       const block1Vars = analysis
         .getKnownVars()
-        .get("extension.blockPipeline.1");
+        .get("modComponent.blockPipeline.1");
 
       expect(block1Vars.isVariableDefined("@foo")).toBeTrue();
 
@@ -203,7 +203,7 @@ describe("Collecting available vars", () => {
     });
 
     test("collects the output key of a conditional block", async () => {
-      const extension = formStateFactory(undefined, [
+      const formState = formStateFactory(undefined, [
         brickConfigFactory({
           if: true,
           outputKey: validateOutputKey("foo"),
@@ -211,17 +211,17 @@ describe("Collecting available vars", () => {
         brickConfigFactory(),
       ]);
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       const block0Vars = analysis
         .getKnownVars()
-        .get("extension.blockPipeline.0");
+        .get("modComponent.blockPipeline.0");
 
       expect(block0Vars.isVariableDefined("@foo")).toBeFalse();
 
       const block1Vars = analysis
         .getKnownVars()
-        .get("extension.blockPipeline.1");
+        .get("modComponent.blockPipeline.1");
 
       expect(block1Vars.isVariableDefined("@foo")).toBeTrue();
 
@@ -234,13 +234,13 @@ describe("Collecting available vars", () => {
     it("collects actual mod variables", async () => {
       const analysis = new VarAnalysis({ modState: { foo: 42 } });
 
-      const extension = formStateFactory({}, [brickConfigFactory()]);
+      const formState = formStateFactory({}, [brickConfigFactory()]);
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       const foundationKnownVars = analysis
         .getKnownVars()
-        .get("extension.blockPipeline.0");
+        .get("modComponent.blockPipeline.0");
 
       expect(foundationKnownVars.isVariableDefined("@mod")).toBeTrue();
       expect(foundationKnownVars.isVariableDefined("@mod.foo")).toBeTrue();
@@ -254,13 +254,13 @@ describe("Collecting available vars", () => {
         },
       });
 
-      const extension = formStateFactory({}, [brickConfigFactory()]);
+      const formState = formStateFactory({}, [brickConfigFactory()]);
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       const foundationKnownVars = analysis
         .getKnownVars()
-        .get("extension.blockPipeline.0");
+        .get("modComponent.blockPipeline.0");
 
       console.log(JSON.stringify(foundationKnownVars));
 
@@ -284,13 +284,13 @@ describe("Collecting available vars", () => {
     it("handles inferred mod variables", async () => {
       const analysis = new VarAnalysis({ modVariables: [{ foo: {} }] });
 
-      const extension = formStateFactory({}, [brickConfigFactory()]);
+      const formState = formStateFactory({}, [brickConfigFactory()]);
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       const foundationKnownVars = analysis
         .getKnownVars()
-        .get("extension.blockPipeline.0");
+        .get("modComponent.blockPipeline.0");
 
       expect(foundationKnownVars.isVariableDefined("@mod")).toBeTrue();
       expect(foundationKnownVars.isVariableDefined("@mod.foo")).toBeTrue();
@@ -298,34 +298,34 @@ describe("Collecting available vars", () => {
     });
   });
 
-  describe("blueprint @options", () => {
+  describe("mod @options", () => {
     beforeEach(() => {
       analysis = new VarAnalysis();
     });
 
     test.each([{}, null, undefined])("no options", async (optionsSchema) => {
-      mockBlueprintWithOptions(optionsSchema);
+      mockModWithOptions(optionsSchema);
 
-      const extension = formStateFactory(
+      const formState = formStateFactory(
         {
-          recipe: modMetadataFactory({
-            id: validateRegistryId("test/recipe"),
+          mod: modMetadataFactory({
+            id: validateRegistryId("test/mod"),
           }),
         },
         [brickConfigFactory()],
       );
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       const foundationKnownVars = analysis
         .getKnownVars()
-        .get("extension.blockPipeline.0");
+        .get("modComponent.blockPipeline.0");
 
       expect(foundationKnownVars.isVariableDefined("@options")).toBeFalse();
     });
 
-    test("read values from blueprint and extension", async () => {
-      mockBlueprintWithOptions({
+    test("read values from mod and mod component", async () => {
+      mockModWithOptions({
         properties: {
           foo: {
             type: "string",
@@ -336,36 +336,36 @@ describe("Collecting available vars", () => {
         },
       });
 
-      const extension = formStateFactory(
+      const formState = formStateFactory(
         {
-          // Let this extension to have a service reference
+          // Let this mod component have an integration reference
           optionsArgs: {
             bar: "qux",
             baz: "quux",
           },
-          recipe: modMetadataFactory({
-            id: validateRegistryId("test/recipe"),
+          mod: modMetadataFactory({
+            id: validateRegistryId("test/mod"),
           }),
         },
         [brickConfigFactory()],
       );
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       const foundationKnownVars = analysis
         .getKnownVars()
-        .get("extension.blockPipeline.0");
+        .get("modComponent.blockPipeline.0");
 
-      // A variable defined in the blueprint
+      // A variable defined in the mod
       expect(foundationKnownVars.isVariableDefined("@options.foo")).toBeTrue();
-      // A variable defined in the blueprint and extension options
+      // A variable defined in the mod and mod component options
       expect(foundationKnownVars.isVariableDefined("@options.bar")).toBeTrue();
-      // A variable defined in the extension options but not in the blueprint
+      // A variable defined in the mod component options but not in the mod
       expect(foundationKnownVars.isVariableDefined("@options.baz")).toBeTrue();
     });
 
     test("sets DEFINITELY for required options", async () => {
-      mockBlueprintWithOptions({
+      mockModWithOptions({
         properties: {
           foo: {
             type: "string",
@@ -377,29 +377,29 @@ describe("Collecting available vars", () => {
         required: ["foo"],
       });
 
-      const extension = formStateFactory(
+      const formState = formStateFactory(
         {
-          recipe: modMetadataFactory({
-            id: validateRegistryId("test/recipe"),
+          mod: modMetadataFactory({
+            id: validateRegistryId("test/mod"),
           }),
         },
         [brickConfigFactory()],
       );
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       const knownVars = analysis.getKnownVars();
 
-      const optionsVars = knownVars.get("extension.blockPipeline.0").getMap()[
-        "options:test/recipe"
-      ]["@options"];
+      const optionsVars = knownVars
+        .get("modComponent.blockPipeline.0")
+        .getMap()["options:test/mod"]["@options"];
 
       expect(optionsVars.foo[SELF_EXISTENCE]).toBe(VarExistence.DEFINITELY);
       expect(optionsVars.bar[SELF_EXISTENCE]).toBe(VarExistence.MAYBE);
     });
 
     test("sets DEFINITELY for the actually set values", async () => {
-      mockBlueprintWithOptions({
+      mockModWithOptions({
         properties: {
           foo: {
             type: "string",
@@ -407,10 +407,10 @@ describe("Collecting available vars", () => {
         },
       });
 
-      const extension = formStateFactory(
+      const formState = formStateFactory(
         {
-          recipe: modMetadataFactory({
-            id: validateRegistryId("test/recipe"),
+          mod: modMetadataFactory({
+            id: validateRegistryId("test/mod"),
           }),
           optionsArgs: {
             foo: "bar",
@@ -419,13 +419,13 @@ describe("Collecting available vars", () => {
         [brickConfigFactory()],
       );
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       const knownVars = analysis.getKnownVars();
 
-      const optionsVars = knownVars.get("extension.blockPipeline.0").getMap()[
-        "options:test/recipe"
-      ]["@options"];
+      const optionsVars = knownVars
+        .get("modComponent.blockPipeline.0")
+        .getMap()["options:test/mod"]["@options"];
 
       expect(optionsVars.foo[SELF_EXISTENCE]).toBe(VarExistence.DEFINITELY);
     });
@@ -435,7 +435,7 @@ describe("Collecting available vars", () => {
     const outputKey = validateOutputKey("foo");
 
     async function runAnalysisWithOutputSchema(outputSchema: Schema) {
-      const extension = formStateFactory(undefined, [
+      const formState = formStateFactory(undefined, [
         brickConfigFactory({
           outputKey,
         }),
@@ -444,7 +444,7 @@ describe("Collecting available vars", () => {
       jest.mocked(blockRegistry.allTyped).mockResolvedValue(
         new Map([
           [
-            extension.extension.blockPipeline[0].id,
+            formState.modComponent.blockPipeline[0].id,
             {
               block: {
                 // HtmlReader's output schema, see @/bricks/readers/HtmlReader.ts
@@ -455,9 +455,9 @@ describe("Collecting available vars", () => {
         ]) as any,
       );
 
-      await analysis.run(extension);
+      await analysis.run(formState);
 
-      return analysis.getKnownVars().get("extension.blockPipeline.1");
+      return analysis.getKnownVars().get("modComponent.blockPipeline.1");
     }
 
     test("reads output schema of a block when defined", async () => {
@@ -729,28 +729,28 @@ describe("Collecting available vars", () => {
         },
       };
 
-      const extension = formStateFactory(undefined, [
+      const formState = formStateFactory(undefined, [
         ifElseBlock,
         brickConfigFactory(),
       ]);
 
-      await analysis.run(extension);
+      await analysis.run(formState);
     });
 
     test("adds if-else output after the brick", async () => {
       expect(
         analysis
           .getKnownVars()
-          .get("extension.blockPipeline.1")
+          .get("modComponent.blockPipeline.1")
           .isVariableDefined("@ifOutput"),
       ).toBeTrue();
     });
 
     test.each([
-      "extension.blockPipeline.0.config.if.__value__.0",
-      "extension.blockPipeline.0.config.if.__value__.1",
-      "extension.blockPipeline.0.config.else.__value__.0",
-      "extension.blockPipeline.0.config.else.__value__.1",
+      "modComponent.blockPipeline.0.config.if.__value__.0",
+      "modComponent.blockPipeline.0.config.if.__value__.1",
+      "modComponent.blockPipeline.0.config.else.__value__.0",
+      "modComponent.blockPipeline.0.config.else.__value__.1",
     ])(
       "doesn't add if-else output to sub pipelines (%s)",
       async (blockPath) => {
@@ -763,7 +763,7 @@ describe("Collecting available vars", () => {
     test("doesn't leak sub pipeline outputs", async () => {
       const block1Vars = analysis
         .getKnownVars()
-        .get("extension.blockPipeline.1");
+        .get("modComponent.blockPipeline.1");
       expect(block1Vars.isVariableDefined("@foo")).toBeFalse();
       expect(block1Vars.isVariableDefined("@bar")).toBeFalse();
     });
@@ -793,16 +793,16 @@ describe("Collecting available vars", () => {
         ]),
       );
 
-      const extension = formStateFactory(undefined, [
+      const formState = formStateFactory(undefined, [
         brickConfiguration,
         brickConfiguration,
       ]);
 
       analysis = new VarAnalysis();
-      await analysis.run(extension);
+      await analysis.run(formState);
 
       const knownVars = analysis.getKnownVars();
-      const varMap = knownVars.get("extension.blockPipeline.1");
+      const varMap = knownVars.get("modComponent.blockPipeline.1");
 
       // Check optional chaining handled for first variable
       expect(varMap.isVariableDefined("@input")).toBeTrue();
@@ -840,16 +840,16 @@ describe("Collecting available vars", () => {
         },
       };
 
-      const extension = formStateFactory(undefined, [documentRendererBrick]);
+      const formState = formStateFactory(undefined, [documentRendererBrick]);
 
       analysis = new VarAnalysis();
-      await analysis.run(extension);
+      await analysis.run(formState);
     });
 
     test("adds the list element key list body", () => {
       const knownVars = analysis.getKnownVars();
       const listElementVarMap = knownVars.get(
-        "extension.blockPipeline.0.config.body.0.config.element.__value__",
+        "modComponent.blockPipeline.0.config.body.0.config.element.__value__",
       );
 
       expect(listElementVarMap.isVariableDefined("@element")).toBeTrue();
@@ -865,7 +865,7 @@ describe("Collecting available vars", () => {
         'Variable "@foo" might not be defined',
       );
       expect(annotations[0].position.path).toBe(
-        "extension.blockPipeline.0.config.body.0.config.element.__value__.config.text",
+        "modComponent.blockPipeline.0.config.body.0.config.element.__value__.config.text",
       );
 
       // Not available in to the peer element to the list
@@ -873,7 +873,7 @@ describe("Collecting available vars", () => {
         'Variable "@element" might not be defined',
       );
       expect(annotations[1].position.path).toBe(
-        "extension.blockPipeline.0.config.body.1.config.text",
+        "modComponent.blockPipeline.0.config.body.1.config.text",
       );
     });
   });
@@ -908,16 +908,16 @@ describe("Collecting available vars", () => {
         },
       };
 
-      const extension = formStateFactory(undefined, [documentRendererBrick]);
+      const formState = formStateFactory(undefined, [documentRendererBrick]);
 
       analysis = new VarAnalysis();
-      await analysis.run(extension);
+      await analysis.run(formState);
     });
 
     test("adds the list element key list body", () => {
       const knownVars = analysis.getKnownVars();
       const buttonPipelineVarMap = knownVars.get(
-        "extension.blockPipeline.0.config.body.0.config.element.__value__.children.0.children.0.config.onClick.__value__.0",
+        "modComponent.blockPipeline.0.config.body.0.config.element.__value__.children.0.children.0.config.onClick.__value__.0",
       );
 
       expect(buttonPipelineVarMap.isVariableDefined("@input")).toBeTrue();
@@ -934,7 +934,7 @@ describe("Collecting available vars", () => {
         message: 'Variable "@foo" might not be defined',
         type: "warning",
         position: {
-          path: "extension.blockPipeline.0.config.body.0.config.element.__value__.children.0.children.0.config.onClick.__value__.0.config.text",
+          path: "modComponent.blockPipeline.0.config.body.0.config.element.__value__.children.0.children.0.config.onClick.__value__.0.config.text",
         },
         detail: {
           expression: expect.toBeObject(),
@@ -955,20 +955,20 @@ describe("Collecting available vars", () => {
         },
       };
 
-      const extension = formStateFactory(undefined, [
+      const formState = formStateFactory(undefined, [
         tryExceptBlock,
         brickConfigFactory(),
       ]);
 
       analysis = new VarAnalysis();
-      await analysis.run(extension);
+      await analysis.run(formState);
     });
 
     test("adds the error key to the except branch", () => {
       expect(
         analysis
           .getKnownVars()
-          .get("extension.blockPipeline.0.config.except.__value__.0")
+          .get("modComponent.blockPipeline.0.config.except.__value__.0")
           .isVariableDefined("@error"),
       ).toBeTrue();
     });
@@ -977,7 +977,7 @@ describe("Collecting available vars", () => {
       expect(
         analysis
           .getKnownVars()
-          .get("extension.blockPipeline.0.config.try.__value__.0")
+          .get("modComponent.blockPipeline.0.config.try.__value__.0")
           .isVariableDefined("@error"),
       ).toBeFalse();
     });
@@ -995,20 +995,20 @@ describe("Collecting available vars", () => {
         },
       };
 
-      const extension = formStateFactory(undefined, [
+      const formState = formStateFactory(undefined, [
         forEachBlock,
         brickConfigFactory(),
       ]);
 
       analysis = new VarAnalysis();
-      await analysis.run(extension);
+      await analysis.run(formState);
     });
 
     test("adds the element key to the sub pipeline", () => {
       expect(
         analysis
           .getKnownVars()
-          .get("extension.blockPipeline.0.config.body.__value__.0")
+          .get("modComponent.blockPipeline.0.config.body.__value__.0")
           .isVariableDefined("@element"),
       ).toBeTrue();
     });
@@ -1031,27 +1031,27 @@ describe("Collecting available vars", () => {
         },
       };
 
-      const extension = formStateFactory(undefined, [
+      const formState = formStateFactory(undefined, [
         forEachBlock,
         brickConfigFactory(),
       ]);
 
       analysis = new VarAnalysis();
-      await analysis.run(extension);
+      await analysis.run(formState);
     });
 
     test("adds for-each output after the brick", () => {
       expect(
         analysis
           .getKnownVars()
-          .get("extension.blockPipeline.1")
+          .get("modComponent.blockPipeline.1")
           .isVariableDefined("@forEachOutput"),
       ).toBeTrue();
     });
 
     test.each([
-      "extension.blockPipeline.0.config.body.__value__.0",
-      "extension.blockPipeline.0.config.body.__value__.1",
+      "modComponent.blockPipeline.0.config.body.__value__.0",
+      "modComponent.blockPipeline.0.config.body.__value__.1",
     ])("doesn't add for-each output to sub pipelines (%s)", (blockPath) => {
       expect(
         analysis
@@ -1065,7 +1065,7 @@ describe("Collecting available vars", () => {
       expect(
         analysis
           .getKnownVars()
-          .get("extension.blockPipeline.1")
+          .get("modComponent.blockPipeline.1")
           .isVariableDefined("@foo"),
       ).toBeFalse();
     });
@@ -1074,7 +1074,7 @@ describe("Collecting available vars", () => {
       expect(
         analysis
           .getKnownVars()
-          .get("extension.blockPipeline.0.config.body.__value__.0")
+          .get("modComponent.blockPipeline.0.config.body.__value__.0")
           .isVariableDefined("@element"),
       ).toBeTrue();
     });
@@ -1083,18 +1083,18 @@ describe("Collecting available vars", () => {
       expect(
         analysis
           .getKnownVars()
-          .get("extension.blockPipeline.1")
+          .get("modComponent.blockPipeline.1")
           .isVariableDefined("@element"),
       ).toBeFalse();
     });
 
     test.each([
-      "extension.blockPipeline.0.config.body.__value__.0",
-      "extension.blockPipeline.0.config.body.__value__.1",
+      "modComponent.blockPipeline.0.config.body.__value__.0",
+      "modComponent.blockPipeline.0.config.body.__value__.1",
     ])("source of the @element key if the For-Each block (%s)", (blockPath) => {
       const blockVars = analysis.getKnownVars().get(blockPath).getMap();
 
-      const expectedForEachBlockPath = "extension.blockPipeline.0";
+      const expectedForEachBlockPath = "modComponent.blockPipeline.0";
 
       // Find the source that provided the @element variable
       const actualForEachBlockPath = Object.entries(blockVars).find(
@@ -1122,7 +1122,7 @@ describe("Collecting available vars", () => {
         },
       };
 
-      const extension = formStateFactory(undefined, [
+      const formState = formStateFactory(undefined, [
         customFormBlock,
         brickConfigFactory(),
       ]);
@@ -1140,14 +1140,14 @@ describe("Collecting available vars", () => {
       );
 
       analysis = new VarAnalysis();
-      await analysis.run(extension);
+      await analysis.run(formState);
     });
 
     test("adds the `values` to the onsubmit handler", () => {
       expect(
         analysis
           .getKnownVars()
-          .get("extension.blockPipeline.0.config.onSubmit.__value__.0")
+          .get("modComponent.blockPipeline.0.config.onSubmit.__value__.0")
           .isVariableDefined("@values"),
       ).toBeTrue();
     });
@@ -1155,7 +1155,7 @@ describe("Collecting available vars", () => {
     test("adds the form fields to the onsubmit handler", () => {
       const blockVars = analysis
         .getKnownVars()
-        .get("extension.blockPipeline.0.config.onSubmit.__value__.0");
+        .get("modComponent.blockPipeline.0.config.onSubmit.__value__.0");
 
       expect(blockVars.isVariableDefined("@values.foo")).toBeTrue();
       expect(blockVars.isVariableDefined("@values.bar")).toBeFalse();
@@ -1164,7 +1164,7 @@ describe("Collecting available vars", () => {
 });
 
 describe("Invalid template", () => {
-  let extension: ModComponentFormState;
+  let formState: ModComponentFormState;
   let analysis: VarAnalysis;
 
   beforeEach(() => {
@@ -1187,30 +1187,30 @@ describe("Invalid template", () => {
       },
     };
 
-    extension = formStateFactory(undefined, [invalidEchoBlock, validEchoBlock]);
+    formState = formStateFactory(undefined, [invalidEchoBlock, validEchoBlock]);
 
     analysis = new VarAnalysis();
   });
 
   test("analysis doesn't throw", async () => {
-    await expect(analysis.run(extension)).toResolve();
+    await expect(analysis.run(formState)).toResolve();
   });
 
   test("analysis doesn't annotate invalid template", async () => {
-    await analysis.run(extension);
+    await analysis.run(formState);
     const annotations = analysis.getAnnotations();
 
     // Only the second (index = 1) block should be annotated
     expect(annotations).toHaveLength(1);
     expect(annotations[0].position.path).toBe(
-      "extension.blockPipeline.1.config.message",
+      "modComponent.blockPipeline.1.config.message",
     );
   });
 });
 
 describe("var expression annotations", () => {
   test("doesn't annotate valid expressions", async () => {
-    const extension = formStateFactory(undefined, [
+    const formState = formStateFactory(undefined, [
       brickConfigFactory({
         outputKey: validateOutputKey("foo"),
       }),
@@ -1223,13 +1223,13 @@ describe("var expression annotations", () => {
     ]);
 
     const analysis = new VarAnalysis();
-    await analysis.run(extension);
+    await analysis.run(formState);
 
     expect(analysis.getAnnotations()).toHaveLength(0);
   });
 
   test("doesn't annotate empty variable", async () => {
-    const extension = formStateFactory(undefined, [
+    const formState = formStateFactory(undefined, [
       {
         id: EchoBrick.BLOCK_ID,
         config: {
@@ -1239,13 +1239,13 @@ describe("var expression annotations", () => {
     ]);
 
     const analysis = new VarAnalysis();
-    await analysis.run(extension);
+    await analysis.run(formState);
 
     expect(analysis.getAnnotations()).toHaveLength(0);
   });
 
   test("annotates variable which doesn't start with @", async () => {
-    const extension = formStateFactory(undefined, [
+    const formState = formStateFactory(undefined, [
       {
         id: EchoBrick.BLOCK_ID,
         config: {
@@ -1255,7 +1255,7 @@ describe("var expression annotations", () => {
     ]);
 
     const analysis = new VarAnalysis();
-    await analysis.run(extension);
+    await analysis.run(formState);
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(1);
@@ -1265,7 +1265,7 @@ describe("var expression annotations", () => {
   });
 
   test("annotates variable which is just whitespace", async () => {
-    const extension = formStateFactory(undefined, [
+    const formState = formStateFactory(undefined, [
       {
         id: EchoBrick.BLOCK_ID,
         config: {
@@ -1275,7 +1275,7 @@ describe("var expression annotations", () => {
     ]);
 
     const analysis = new VarAnalysis();
-    await analysis.run(extension);
+    await analysis.run(formState);
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(1);
@@ -1283,7 +1283,7 @@ describe("var expression annotations", () => {
   });
 
   test("return a generic error message for a single @ character", async () => {
-    const extension = formStateFactory(undefined, [
+    const formState = formStateFactory(undefined, [
       {
         id: EchoBrick.BLOCK_ID,
         config: {
@@ -1293,7 +1293,7 @@ describe("var expression annotations", () => {
     ]);
 
     const analysis = new VarAnalysis();
-    await analysis.run(extension);
+    await analysis.run(formState);
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(1);
@@ -1303,7 +1303,7 @@ describe("var expression annotations", () => {
 
 describe("var analysis integration tests", () => {
   it("should handle trigger event", async () => {
-    const extension = triggerFormStateFactory(undefined, [
+    const formState = triggerFormStateFactory(undefined, [
       {
         id: EchoBrick.BLOCK_ID,
         config: {
@@ -1315,17 +1315,17 @@ describe("var analysis integration tests", () => {
       },
     ]);
 
-    extension.extensionPoint.definition.trigger = "keypress";
+    formState.starterBrick.definition.trigger = "keypress";
 
     const analysis = new VarAnalysis();
-    await analysis.run(extension);
+    await analysis.run(formState);
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(0);
   });
 
   it("should handle trigger custom event", async () => {
-    const extension = triggerFormStateFactory(undefined, [
+    const formState = triggerFormStateFactory(undefined, [
       {
         id: EchoBrick.BLOCK_ID,
         config: {
@@ -1337,17 +1337,17 @@ describe("var analysis integration tests", () => {
       },
     ]);
 
-    extension.extensionPoint.definition.trigger = "custom";
+    formState.starterBrick.definition.trigger = "custom";
 
     const analysis = new VarAnalysis();
-    await analysis.run(extension);
+    await analysis.run(formState);
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(0);
   });
 
   it("should handle trigger selectionchange event", async () => {
-    const extension = triggerFormStateFactory(undefined, [
+    const formState = triggerFormStateFactory(undefined, [
       {
         id: EchoBrick.BLOCK_ID,
         config: {
@@ -1360,10 +1360,10 @@ describe("var analysis integration tests", () => {
       },
     ]);
 
-    extension.extensionPoint.definition.trigger = "selectionchange";
+    formState.starterBrick.definition.trigger = "selectionchange";
 
     const analysis = new VarAnalysis();
-    await analysis.run(extension);
+    await analysis.run(formState);
 
     const annotations = analysis.getAnnotations();
     expect(annotations).toHaveLength(1);

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -34,7 +34,7 @@ import {
 import VarMap, { VarExistence } from "./varMap";
 import { type TraceRecord } from "@/telemetry/trace";
 import parseTemplateVariables from "./parseTemplateVariables";
-import recipesRegistry from "@/modDefinitions/registry";
+import modRegistry from "@/modDefinitions/registry";
 import blockRegistry, { type TypedBrickMap } from "@/bricks/registry";
 import {
   isDocumentBuilderElementArray,
@@ -133,22 +133,22 @@ async function setIntegrationDependencyVars(
 }
 
 /**
- * Set the input variables from the ExtensionPoint definition (aka starter brick).
+ * Set the input variables from the starter brick definition.
  */
 async function setInputVars(
-  extension: ModComponentFormState,
+  formState: ModComponentFormState,
   contextVars: VarMap,
 ): Promise<void> {
-  const adapter = ADAPTERS.get(extension.extensionPoint.definition.type);
+  const adapter = ADAPTERS.get(formState.starterBrick.definition.type);
   assertNotNullish(
     adapter,
-    `Adapter not found for ${extension.extensionPoint.definition.type}`,
+    `Adapter not found for ${formState.starterBrick.definition.type}`,
   );
-  const config = adapter.selectStarterBrickDefinition(extension);
+  const config = adapter.selectStarterBrickDefinition(formState);
 
-  const extensionPoint = fromJS(config);
+  const starterBrick = fromJS(config);
 
-  const reader = await extensionPoint.defaultReader();
+  const reader = await starterBrick.defaultReader();
 
   setVarsFromSchema({
     schema: reader?.outputSchema ?? {
@@ -193,7 +193,7 @@ type SetVarsFromSchemaArgs = {
  * Helper method to set variables based on a JSON Schema.
  *
  * Examples:
- * - Blueprint input schema
+ * - Mod input schema
  * - Brick output schema
  * - Integration configuration schema
  */
@@ -304,24 +304,24 @@ function setVarsFromSchema({
 }
 
 /**
- * Set the options variables from the blueprint option definitions.
+ * Set the options variables from the mod option definitions.
  */
 async function setOptionsVars(
-  extension: ModComponentFormState,
+  formState: ModComponentFormState,
   contextVars: VarMap,
 ): Promise<void> {
-  if (extension.recipe == null) {
+  if (formState.mod == null) {
     return;
   }
 
-  const recipeId = extension.recipe.id;
-  const recipe = await recipesRegistry.lookup(recipeId);
-  const optionsSchema = recipe?.options?.schema;
+  const modId = formState.mod.id;
+  const mod = await modRegistry.lookup(modId);
+  const optionsSchema = mod?.options?.schema;
   if (isEmpty(optionsSchema)) {
     return;
   }
 
-  const source = `${KnownSources.OPTIONS}:${recipeId}`;
+  const source = `${KnownSources.OPTIONS}:${modId}`;
   const optionsOutputKey = "@options";
 
   setVarsFromSchema({
@@ -332,7 +332,7 @@ async function setOptionsVars(
   });
 
   // Options currently only supports primitives, so don't need to recurse
-  for (const optionName of Object.keys(extension.optionsArgs ?? {})) {
+  for (const optionName of Object.keys(formState.optionsArgs ?? {})) {
     contextVars.setExistence({
       source,
       path: [optionsOutputKey, optionName],
@@ -452,7 +452,7 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
   }
 
   /**
-   * @param trace the trace for the latest run of the extension
+   * @param trace the trace for the latest run of the mod component
    * @param modState the current mod page state
    * @param modVariables statically-inferred mod variable names
    * @see CollectNamesVisitor
@@ -682,23 +682,23 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
     this.contextStack.pop();
   }
 
-  async run(extension: ModComponentFormState): Promise<void> {
+  async run(formState: ModComponentFormState): Promise<void> {
     this.allBlocks = await blockRegistry.allTyped();
 
     // Order of the following calls will determine the order of the sources in the UI
     const contextVars = new VarMap();
-    await setOptionsVars(extension, contextVars);
+    await setOptionsVars(formState, contextVars);
     await setModVariables(this.modVariables, this.modState, contextVars);
-    await setIntegrationDependencyVars(extension, contextVars);
-    await setInputVars(extension, contextVars);
+    await setIntegrationDependencyVars(formState, contextVars);
+    await setInputVars(formState, contextVars);
 
     this.contextStack.push({
       vars: contextVars,
       blockOutputVars: new VarMap(),
     });
 
-    this.visitRootPipeline(extension.extension.blockPipeline, {
-      extensionPointType: extension.type,
+    this.visitRootPipeline(formState.modComponent.blockPipeline, {
+      starterBrickType: formState.type,
     });
   }
 

--- a/src/bricks/PipelineVisitor.test.ts
+++ b/src/bricks/PipelineVisitor.test.ts
@@ -46,7 +46,7 @@ test("should invoke the callback for the pipeline bricks", () => {
 
   const visitor = new Visitor();
   visitor.visitRootPipeline(pipeline, {
-    extensionPointType: StarterBrickTypes.BUTTON,
+    starterBrickType: StarterBrickTypes.BUTTON,
   });
 
   expect(visitBlock).toHaveBeenCalledTimes(pipeline.length);
@@ -104,7 +104,7 @@ test("should invoke the callback for the sub pipeline bricks", () => {
   }
   const visitor = new Visitor();
   visitor.visitRootPipeline(pipeline, {
-    extensionPointType: StarterBrickTypes.BUTTON,
+    starterBrickType: StarterBrickTypes.BUTTON,
   });
 
   expect(visitBlock).toHaveBeenCalledTimes(
@@ -186,7 +186,7 @@ test("should invoke the callback for the Document button pipeline", () => {
   }
   const visitor = new Visitor();
   visitor.visitRootPipeline(pipeline, {
-    extensionPointType: StarterBrickTypes.SIDEBAR_PANEL,
+    starterBrickType: StarterBrickTypes.SIDEBAR_PANEL,
   });
 
   expect(visitBlock).toHaveBeenCalledTimes(2); // One Document brick and one brick in the pipeline

--- a/src/bricks/PipelineVisitor.ts
+++ b/src/bricks/PipelineVisitor.ts
@@ -79,7 +79,7 @@ export type VisitPipelineExtra = {
   pipelinePropName?: string | undefined;
 };
 type VisitRootPipelineExtra = {
-  extensionPointType: StarterBrickType;
+  starterBrickType: StarterBrickType;
 };
 
 /**
@@ -88,7 +88,7 @@ type VisitRootPipelineExtra = {
 class PipelineVisitor {
   /**
    * Visit a configured block.
-   * @param position the position in the extension
+   * @param position the position in the mod component
    * @param blockConfig the block configuration
    */
   public visitBrick(
@@ -152,7 +152,7 @@ class PipelineVisitor {
 
   /**
    * Run the visitor on a pipeline; loop over the blocks
-   * @param position Position of the pipeline in the extension
+   * @param position Position of the pipeline in the modComponent
    * @param pipeline The pipeline to analyze
    * @param extra Extra information about the pipeline
    */
@@ -176,8 +176,8 @@ class PipelineVisitor {
     pipeline: BrickConfig[],
     extra?: VisitRootPipelineExtra,
   ): void {
-    const flavor = extra?.extensionPointType
-      ? getRootPipelineFlavor(extra.extensionPointType)
+    const flavor = extra?.starterBrickType
+      ? getRootPipelineFlavor(extra.starterBrickType)
       : PipelineFlavor.AllBricks;
     this.visitPipeline(ROOT_POSITION, pipeline, { flavor });
   }

--- a/src/bricks/transformers/jquery/JQueryReaderOptions.test.tsx
+++ b/src/bricks/transformers/jquery/JQueryReaderOptions.test.tsx
@@ -41,7 +41,7 @@ const getAttributeExamplesMock = jest.mocked(getAttributeExamples);
 
 function baseStateFactory() {
   const baseFormState = menuItemFormStateFactory();
-  baseFormState.extension.blockPipeline = [
+  baseFormState.modComponent.blockPipeline = [
     {
       id: JQueryReader.BRICK_ID,
       config: {
@@ -57,7 +57,7 @@ function renderOptions(formState: ModComponentFormState = baseStateFactory()) {
     <SchemaFieldContext.Provider value={devtoolFieldOverrides}>
       <Formik onSubmit={jest.fn()} initialValues={formState}>
         <JQueryReaderOptions
-          name="extension.blockPipeline.0"
+          name="modComponent.blockPipeline.0"
           configKey="config"
         />
       </Formik>
@@ -82,7 +82,7 @@ describe("JQueryReaderOptions", () => {
 
   it("shows workshop message on variable selector", async () => {
     const state = baseStateFactory();
-    state.extension.blockPipeline[0].config.selectors = {
+    state.modComponent.blockPipeline[0].config.selectors = {
       property: toExpression("var", "@foo"),
     };
 
@@ -96,7 +96,7 @@ describe("JQueryReaderOptions", () => {
 
   it("shows workshop message variable selectors", async () => {
     const state = baseStateFactory();
-    state.extension.blockPipeline[0].config.selectors = toExpression(
+    state.modComponent.blockPipeline[0].config.selectors = toExpression(
       "var",
       "@foo",
     );
@@ -111,7 +111,7 @@ describe("JQueryReaderOptions", () => {
 
   it("normalizes primitive selectors", async () => {
     const state = baseStateFactory();
-    state.extension.blockPipeline[0].config.selectors = { property: "h1" };
+    state.modComponent.blockPipeline[0].config.selectors = { property: "h1" };
 
     renderOptions(state);
 
@@ -123,7 +123,7 @@ describe("JQueryReaderOptions", () => {
 
     expect(
       screen.getByTestId(
-        "toggle-extension.blockPipeline.0.config.selectors.property.selector",
+        "toggle-modComponent.blockPipeline.0.config.selectors.property.selector",
       ).dataset.testSelected,
     ).toBe("Selector");
 
@@ -132,7 +132,7 @@ describe("JQueryReaderOptions", () => {
 
   it("normalizes nested selectors", async () => {
     const state = baseStateFactory();
-    state.extension.blockPipeline[0].config.selectors = {
+    state.modComponent.blockPipeline[0].config.selectors = {
       outer: {
         selector: "div",
         find: {
@@ -147,12 +147,12 @@ describe("JQueryReaderOptions", () => {
 
     expect(
       screen.getByTestId(
-        "toggle-extension.blockPipeline.0.config.selectors.outer.selector",
+        "toggle-modComponent.blockPipeline.0.config.selectors.outer.selector",
       ).dataset.testSelected,
     ).toBe("Selector");
     expect(
       screen.getByTestId(
-        "toggle-extension.blockPipeline.0.config.selectors.outer.find.inner.selector",
+        "toggle-modComponent.blockPipeline.0.config.selectors.outer.find.inner.selector",
       ).dataset.testSelected,
     ).toBe("Selector");
 
@@ -161,7 +161,7 @@ describe("JQueryReaderOptions", () => {
 
   it("normalizes nunjucks literal selectors", async () => {
     const state = baseStateFactory();
-    state.extension.blockPipeline[0].config.selectors = {
+    state.modComponent.blockPipeline[0].config.selectors = {
       outer: {
         selector: toExpression("nunjucks", "div"),
         find: {
@@ -176,12 +176,12 @@ describe("JQueryReaderOptions", () => {
 
     expect(
       screen.getByTestId(
-        "toggle-extension.blockPipeline.0.config.selectors.outer.selector",
+        "toggle-modComponent.blockPipeline.0.config.selectors.outer.selector",
       ).dataset.testSelected,
     ).toBe("Selector");
     expect(
       screen.getByTestId(
-        "toggle-extension.blockPipeline.0.config.selectors.outer.find.inner.selector",
+        "toggle-modComponent.blockPipeline.0.config.selectors.outer.find.inner.selector",
       ).dataset.testSelected,
     ).toBe("Selector");
 
@@ -190,7 +190,7 @@ describe("JQueryReaderOptions", () => {
 
   it("allows rename of property", async () => {
     const state = baseStateFactory();
-    state.extension.blockPipeline[0].config.selectors = {
+    state.modComponent.blockPipeline[0].config.selectors = {
       outer: {
         selector: toExpression("nunjucks", "div"),
         find: {
@@ -219,7 +219,7 @@ describe("JQueryReaderOptions", () => {
 
   it("clearing a property name reverts the value to the initial value on blur", async () => {
     const state = baseStateFactory();
-    state.extension.blockPipeline[0].config.selectors = {
+    state.modComponent.blockPipeline[0].config.selectors = {
       outer: {
         selector: toExpression("nunjucks", "div"),
         find: {
@@ -247,7 +247,7 @@ describe("JQueryReaderOptions", () => {
 
   it("generates example attributes for nested selectors", async () => {
     const state = baseStateFactory();
-    state.extension.blockPipeline[0].config.selectors = {
+    state.modComponent.blockPipeline[0].config.selectors = {
       outer: {
         selector: "div",
         find: {

--- a/src/components/fields/schemaFields/integrations/integrationDependencyFieldUtils.test.ts
+++ b/src/components/fields/schemaFields/integrations/integrationDependencyFieldUtils.test.ts
@@ -210,8 +210,8 @@ describe("selectVariables", () => {
       permissions: emptyPermissionsFactory(),
       optionsArgs: {},
       type: "actionPanel",
-      recipe: null,
-      extension: {
+      mod: null,
+      modComponent: {
         blockPipeline: [
           {
             id: validateRegistryId("@pixiebrix/document"),
@@ -262,7 +262,7 @@ describe("selectVariables", () => {
         ],
         heading: "Document",
       },
-      extensionPoint: {
+      starterBrick: {
         metadata: {
           id: validateRegistryId(
             "@internal/52d42d87-4382-4c78-b00e-bbdd21d75000",

--- a/src/components/fields/schemaFields/integrations/integrationDependencyFieldUtils.ts
+++ b/src/components/fields/schemaFields/integrations/integrationDependencyFieldUtils.ts
@@ -28,7 +28,7 @@ import { makeVariableExpression } from "@/utils/variableUtils";
 
 export type IntegrationsFormSlice = Pick<
   ModComponentFormState,
-  "integrationDependencies" | "extension"
+  "integrationDependencies" | "modComponent"
 >;
 
 /**
@@ -68,15 +68,15 @@ function deepFindIntegrationDependencyVariables(
 }
 
 /**
- * Return set of integration dependency variables referenced by the extension,
+ * Return set of integration dependency variables referenced by the mod component,
  * including the `@`-prefixes
  */
 export function selectIntegrationDependencyVariables(
-  state: Pick<ModComponentFormState, "extension">,
+  state: Pick<ModComponentFormState, "modComponent">,
 ): Set<string> {
   const variables = new Set<string>();
   deepFindIntegrationDependencyVariables(
-    state.extension.blockPipeline,
+    state.modComponent.blockPipeline,
     variables,
   );
   return variables;

--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.test.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.test.tsx
@@ -75,7 +75,7 @@ describe("VarMenu", () => {
           dispatch(editorActions.setActiveModComponentId(formState.uuid));
           dispatch(
             editorActions.setActiveNodeId(
-              formState.extension.blockPipeline[0].instanceId,
+              formState.modComponent.blockPipeline[0].instanceId,
             ),
           );
         },
@@ -110,7 +110,7 @@ describe("VarMenu", () => {
           dispatch(editorActions.setActiveModComponentId(formState.uuid));
           dispatch(
             editorActions.setActiveNodeId(
-              formState.extension.blockPipeline[0].instanceId,
+              formState.modComponent.blockPipeline[0].instanceId,
             ),
           );
 
@@ -155,7 +155,7 @@ describe("VarMenu", () => {
           dispatch(editorActions.setActiveModComponentId(formState.uuid));
           dispatch(
             editorActions.setActiveNodeId(
-              formState.extension.blockPipeline[0].instanceId,
+              formState.modComponent.blockPipeline[0].instanceId,
             ),
           );
 

--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.tsx
@@ -175,7 +175,7 @@ const VarMenu: React.FunctionComponent<VarMenuProps> = ({
       getPageState(inspectedTab, {
         namespace: StateNamespaces.MOD,
         modComponentId: null,
-        modId: activeModComponentFormState.recipe?.id,
+        modId: activeModComponentFormState.mod?.id,
       }),
     [],
   );

--- a/src/contrib/automationanywhere/BotOptions.test.tsx
+++ b/src/contrib/automationanywhere/BotOptions.test.tsx
@@ -70,7 +70,7 @@ function makeBaseState() {
 function renderOptions(formState: ModComponentFormState = makeBaseState()) {
   return render(
     <Formik onSubmit={jest.fn()} initialValues={formState}>
-      <BotOptions name="extension.blockPipeline.0" configKey="config" />
+      <BotOptions name="modComponent.blockPipeline.0" configKey="config" />
     </Formik>,
   );
 }
@@ -105,7 +105,7 @@ describe("BotOptions", () => {
     );
 
     const base = makeBaseState();
-    base.extension.blockPipeline[0].config.service = toExpression(
+    base.modComponent.blockPipeline[0].config.service = toExpression(
       "var",
       "@automationAnywhere",
     );
@@ -136,7 +136,7 @@ describe("BotOptions", () => {
     );
 
     const base = makeBaseState();
-    base.extension.blockPipeline[0].config.service = toExpression(
+    base.modComponent.blockPipeline[0].config.service = toExpression(
       "var",
       "@automationAnywhere",
     );
@@ -168,8 +168,8 @@ describe("BotOptions", () => {
     );
 
     const base = makeBaseState();
-    base.extension.blockPipeline[0].config.workspaceType = "public";
-    base.extension.blockPipeline[0].config.service = toExpression(
+    base.modComponent.blockPipeline[0].config.workspaceType = "public";
+    base.modComponent.blockPipeline[0].config.service = toExpression(
       "var",
       "@automationAnywhere",
     );
@@ -201,9 +201,9 @@ describe("BotOptions", () => {
     );
 
     const base = makeBaseState();
-    base.extension.blockPipeline[0].config.workspaceType = "public";
-    base.extension.blockPipeline[0].config.isAttended = true;
-    base.extension.blockPipeline[0].config.service = toExpression(
+    base.modComponent.blockPipeline[0].config.workspaceType = "public";
+    base.modComponent.blockPipeline[0].config.isAttended = true;
+    base.modComponent.blockPipeline[0].config.service = toExpression(
       "var",
       "@automationAnywhere",
     );
@@ -235,8 +235,8 @@ describe("BotOptions", () => {
     );
 
     const base = makeBaseState();
-    base.extension.blockPipeline[0].config.awaitResult = true;
-    base.extension.blockPipeline[0].config.service = toExpression(
+    base.modComponent.blockPipeline[0].config.awaitResult = true;
+    base.modComponent.blockPipeline[0].config.service = toExpression(
       "var",
       "@automationAnywhere",
     );

--- a/src/contrib/uipath/LocalProcessOptions.test.tsx
+++ b/src/contrib/uipath/LocalProcessOptions.test.tsx
@@ -86,7 +86,10 @@ function makeBaseState() {
 
 function renderOptions(initialValues: ModComponentFormState = makeBaseState()) {
   return render(
-    <LocalProcessOptions name="extension.blockPipeline.0" configKey="config" />,
+    <LocalProcessOptions
+      name="modComponent.blockPipeline.0"
+      configKey="config"
+    />,
     { initialValues },
   );
 }
@@ -188,7 +191,7 @@ describe("UiPath LocalProcess Options", () => {
 
     const formState = makeBaseState();
     formState.integrationDependencies[0].configId = configId;
-    formState.extension.blockPipeline[0].config.service = "@uipath";
+    formState.modComponent.blockPipeline[0].config.service = "@uipath";
 
     renderOptions();
 

--- a/src/contrib/uipath/ProcessOptions.test.tsx
+++ b/src/contrib/uipath/ProcessOptions.test.tsx
@@ -90,7 +90,7 @@ function makeBaseState() {
 function renderOptions(formState: ModComponentFormState = makeBaseState()) {
   return render(
     <Formik onSubmit={jest.fn()} initialValues={formState}>
-      <ProcessOptions name="extension.blockPipeline.0" configKey="config" />
+      <ProcessOptions name="modComponent.blockPipeline.0" configKey="config" />
     </Formik>,
   );
 }
@@ -125,7 +125,7 @@ describe("UiPath Options", () => {
     );
 
     const base = makeBaseState();
-    base.extension.blockPipeline[0].config.uipath = toExpression(
+    base.modComponent.blockPipeline[0].config.uipath = toExpression(
       "var",
       "@uipath",
     );
@@ -173,11 +173,11 @@ describe("UiPath Options", () => {
     );
 
     const base = makeBaseState();
-    base.extension.blockPipeline[0].config.uipath = toExpression(
+    base.modComponent.blockPipeline[0].config.uipath = toExpression(
       "var",
       "@uipath",
     );
-    base.extension.blockPipeline[0].config.awaitResult = true;
+    base.modComponent.blockPipeline[0].config.awaitResult = true;
 
     renderOptions(base);
 

--- a/src/pageEditor/analysisManager.ts
+++ b/src/pageEditor/analysisManager.ts
@@ -61,17 +61,17 @@ async function selectActiveModFormStates(
 ): Promise<ModComponentFormState[]> {
   const activeModComponentFormState = selectActiveModComponentFormState(state);
 
-  if (activeModComponentFormState?.recipe) {
+  if (activeModComponentFormState?.mod) {
     const dirtyModComponentFormStates =
       state.editor.modComponentFormStates.filter(
-        (x) => x.recipe?.id === activeModComponentFormState.recipe.id,
+        (x) => x.mod?.id === activeModComponentFormState.mod.id,
       );
     const dirtyIds = new Set(dirtyModComponentFormStates.map((x) => x.uuid));
 
     const activatedModComponents = selectActivatedModComponents(state);
     const otherModComponents = activatedModComponents.filter(
       (x) =>
-        x._recipe?.id === activeModComponentFormState.recipe.id &&
+        x._recipe?.id === activeModComponentFormState.mod.id &&
         !dirtyIds.has(x.id),
     );
     const otherModComponentFormStates = await Promise.all(
@@ -215,7 +215,7 @@ async function varAnalysisFactory(
   const modState = await getPageState(inspectedTab, {
     namespace: StateNamespaces.MOD,
     modComponentId: activeModComponentFormState.uuid,
-    modId: activeModComponentFormState.recipe?.id,
+    modId: activeModComponentFormState.mod?.id,
   });
 
   return new VarAnalysis({

--- a/src/pageEditor/baseFormStateTypes.ts
+++ b/src/pageEditor/baseFormStateTypes.ts
@@ -142,11 +142,40 @@ export type BaseFormStateV2<
   integrationDependencies: IntegrationDependencyV2[];
 };
 
-export type BaseFormState<
+/**
+ * @deprecated - Do not use versioned state types directly
+ */
+export type BaseFormStateV3<
   TModComponent extends BaseModComponentState = BaseModComponentState,
   TStarterBrick extends BaseStarterBrickState = BaseStarterBrickState,
 > = Except<
   BaseFormStateV2<TModComponent, TStarterBrick>,
+  "recipe" | "extension" | "extensionPoint"
+> & {
+  /**
+   * @since 2.0.4, part of Page Editor renaming effort
+   * `extensionPoint` to `starterBrick`
+   * `extension` to `modComponent`
+   * `recipe` to `mod`
+   */
+
+  starterBrick: TStarterBrick;
+
+  modComponent: TModComponent;
+
+  /**
+   * Information about the mod used to install the mod component, or `undefined`
+   * if the mod component is not part of a mod.
+   * @see ModComponentBase._recipe
+   */
+  mod: ModComponentBase["_recipe"] | undefined;
+};
+
+export type BaseFormState<
+  TModComponent extends BaseModComponentState = BaseModComponentState,
+  TStarterBrick extends BaseStarterBrickState = BaseStarterBrickState,
+> = Except<
+  BaseFormStateV3<TModComponent, TStarterBrick>,
   "integrationDependencies"
 > & {
   /**

--- a/src/pageEditor/documentBuilder/edit/DocumentOptions.test.tsx
+++ b/src/pageEditor/documentBuilder/edit/DocumentOptions.test.tsx
@@ -48,7 +48,7 @@ describe("DocumentOptions", () => {
     stylesheets: string[] = [],
   ): ModComponentFormState {
     return formStateFactory({
-      extension: baseModComponentStateFactory({
+      modComponent: baseModComponentStateFactory({
         blockPipeline: [
           brickConfigFactory({
             config: {
@@ -66,7 +66,10 @@ describe("DocumentOptions", () => {
     initialActiveElement: string = null,
   ) {
     return render(
-      <DocumentOptions name="extension.blockPipeline.0" configKey="config" />,
+      <DocumentOptions
+        name="modComponent.blockPipeline.0"
+        configKey="config"
+      />,
       {
         initialValues: formState,
         setupRedux(dispatch) {
@@ -74,7 +77,7 @@ describe("DocumentOptions", () => {
           dispatch(actions.setActiveModComponentId(formState.uuid));
           dispatch(
             actions.setActiveNodeId(
-              formState.extension.blockPipeline[0].instanceId,
+              formState.modComponent.blockPipeline[0].instanceId,
             ),
           );
           dispatch(
@@ -182,7 +185,7 @@ describe("DocumentOptions", () => {
       // Form state for the test
       const formState = formStateFactory({
         integrationDependencies,
-        extension: baseModComponentStateFactory({
+        modComponent: baseModComponentStateFactory({
           blockPipeline: [
             brickConfigFactory({ config: documentWithButtonConfig }),
           ],
@@ -229,7 +232,7 @@ describe("DocumentOptions", () => {
 
       // The form state should be updated
       expect(
-        getFormState().extension.blockPipeline[0].config.stylesheets,
+        getFormState().modComponent.blockPipeline[0].config.stylesheets,
       ).toStrictEqual([
         toExpression("nunjucks", "https://example.com/stylesheet.css"),
       ]);

--- a/src/pageEditor/documentBuilder/preview/DocumentPreview.test.tsx
+++ b/src/pageEditor/documentBuilder/preview/DocumentPreview.test.tsx
@@ -52,7 +52,7 @@ function renderDocumentPreview(documentBuilderElement: DocumentBuilderElement) {
     const [activeElement, setActiveElement] = useState<string | null>(null);
     return (
       <DocumentPreview
-        documentBodyName="extension.blockPipeline[0].config.body"
+        documentBodyName="modComponent.blockPipeline[0].config.body"
         activeElement={activeElement}
         setActiveElement={setActiveElement}
       />
@@ -66,7 +66,7 @@ function renderDocumentPreview(documentBuilderElement: DocumentBuilderElement) {
       dispatch(actions.setActiveModComponentId(formState.uuid));
       dispatch(
         actions.setActiveNodeId(
-          formState.extension.blockPipeline[0].instanceId,
+          formState.modComponent.blockPipeline[0].instanceId,
         ),
       );
     },
@@ -176,14 +176,14 @@ describe("Show live preview", () => {
       const [activeElement, setActiveElement] = useState<string | null>(null);
       return (
         <DocumentPreview
-          documentBodyName="extension.blockPipeline[0].config.body.__value__[0].config.body"
+          documentBodyName="modComponent.blockPipeline[0].config.body.__value__[0].config.body"
           activeElement={activeElement}
           setActiveElement={setActiveElement}
         />
       );
     };
 
-    const pipelineField = formState.extension.blockPipeline[0].config
+    const pipelineField = formState.modComponent.blockPipeline[0].config
       .body as PipelineExpression;
 
     return render(<PreviewContainer />, {

--- a/src/pageEditor/documentBuilder/preview/ElementPreview.test.tsx
+++ b/src/pageEditor/documentBuilder/preview/ElementPreview.test.tsx
@@ -57,7 +57,7 @@ const renderElementPreview = (
   };
 
   const formState = formStateFactory({
-    extension: baseModComponentStateFactory({
+    modComponent: baseModComponentStateFactory({
       blockPipeline: [
         brickConfigFactory({
           config: {
@@ -75,7 +75,7 @@ const renderElementPreview = (
       dispatch(actions.setActiveModComponentId(formState.uuid));
       dispatch(
         actions.setActiveNodeId(
-          formState.extension.blockPipeline[0].instanceId,
+          formState.modComponent.blockPipeline[0].instanceId,
         ),
       );
       dispatch(actions.setActiveBuilderPreviewElement("0"));

--- a/src/pageEditor/fields/FormModalOptions.test.tsx
+++ b/src/pageEditor/fields/FormModalOptions.test.tsx
@@ -37,13 +37,16 @@ describe("FormModalOptions", () => {
     const brick = createNewConfiguredBrick(FormTransformer.BRICK_ID);
 
     const initialValues = formStateFactory({
-      extension: baseModComponentStateFactory({
+      modComponent: baseModComponentStateFactory({
         blockPipeline: [brick],
       }),
     });
 
     render(
-      <FormModalOptions name="extension.blockPipeline.0" configKey="config" />,
+      <FormModalOptions
+        name="modComponent.blockPipeline.0"
+        configKey="config"
+      />,
       {
         initialValues,
         setupRedux(dispatch) {

--- a/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
+++ b/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
@@ -180,7 +180,7 @@ describe("useBuildAndValidateMod", () => {
     });
 
     const dirtyFormState1 = formStateFactory({
-      recipe: modMetadata,
+      mod: modMetadata,
     });
 
     const { result, getReduxStore } = renderHook(

--- a/src/pageEditor/hooks/useCheckModStarterBrickInvariants.test.ts
+++ b/src/pageEditor/hooks/useCheckModStarterBrickInvariants.test.ts
@@ -301,7 +301,7 @@ describe("useCheckModStarterBrickInvariants", () => {
       integrationDependencies: [],
     });
     const formState = await modComponentToFormState(activatedModComponent);
-    delete formState.recipe;
+    delete formState.mod;
 
     const { result } = renderHook(() => useCheckModStarterBrickInvariants(), {
       setupRedux(dispatch) {

--- a/src/pageEditor/hooks/useCheckModStarterBrickInvariants.ts
+++ b/src/pageEditor/hooks/useCheckModStarterBrickInvariants.ts
@@ -53,7 +53,7 @@ function useCheckModStarterBrickInvariants(): (
    *  - For each clean mod component, every entry in definitions should exist
    *    in the {modDefinition.definitions} object
    *  - For each dirty mod component with @internal starter brick definition,
-   *    formState.extensionPoint.definition should exist in the
+   *    formState.starterBrick.definition should exist in the
    *    {modDefinition.definitions} object, but the key may be different,
    *    e.g. "extensionPoint" vs. "extensionPoint3" in the modDefinition,
    *    also need to run it through the adapter because of some cleanup logic
@@ -80,9 +80,7 @@ function useCheckModStarterBrickInvariants(): (
       }
 
       for (const formState of dirtyModComponentFormStates) {
-        if (
-          !isInnerDefinitionRegistryId(formState.extensionPoint.metadata.id)
-        ) {
+        if (!isInnerDefinitionRegistryId(formState.starterBrick.metadata.id)) {
           continue;
         }
 

--- a/src/pageEditor/hooks/useCompareModComponentCounts.test.ts
+++ b/src/pageEditor/hooks/useCompareModComponentCounts.test.ts
@@ -51,7 +51,7 @@ describe("useCompareModComponentCounts", () => {
       metadata: modMetadata,
     });
     const formState = formStateFactory({
-      recipe: modMetadata,
+      mod: modMetadata,
     });
 
     const { result } = renderHook(() => useCompareModComponentCounts(), {
@@ -95,7 +95,7 @@ describe("useCompareModComponentCounts", () => {
     });
 
     const dirtyFormState = formStateFactory({
-      recipe: modMetadata,
+      mod: modMetadata,
     });
 
     const { result } = renderHook(() => useCompareModComponentCounts(), {
@@ -130,10 +130,10 @@ describe("useCompareModComponentCounts", () => {
     });
 
     const dirtyFormState1 = formStateFactory({
-      recipe: modMetadata,
+      mod: modMetadata,
     });
     const dirtyFormState2 = formStateFactory({
-      recipe: modMetadata,
+      mod: modMetadata,
     });
 
     const { result } = renderHook(() => useCompareModComponentCounts(), {
@@ -163,7 +163,7 @@ describe("useCompareModComponentCounts", () => {
       metadata: modMetadata,
     });
     const formState = formStateFactory({
-      recipe: modMetadata,
+      mod: modMetadata,
     });
 
     const { result } = renderHook(() => useCompareModComponentCounts(), {
@@ -193,7 +193,7 @@ describe("useCompareModComponentCounts", () => {
     });
 
     const formState = formStateFactory({
-      recipe: modMetadata,
+      mod: modMetadata,
     });
 
     const { result } = renderHook(() => useCompareModComponentCounts(), {
@@ -282,7 +282,7 @@ describe("useCompareModComponentCounts", () => {
     });
 
     const formState = formStateFactory({
-      recipe: modMetadata,
+      mod: modMetadata,
     });
 
     const { result } = renderHook(() => useCompareModComponentCounts(), {
@@ -313,7 +313,7 @@ describe("useCompareModComponentCounts", () => {
     });
 
     const formState = formStateFactory({
-      recipe: modMetadata,
+      mod: modMetadata,
     });
 
     const { result } = renderHook(() => useCompareModComponentCounts(), {
@@ -344,7 +344,7 @@ describe("useCompareModComponentCounts", () => {
     });
 
     const formState = formStateFactory({
-      recipe: modMetadata,
+      mod: modMetadata,
     });
 
     const { result } = renderHook(() => useCompareModComponentCounts(), {
@@ -375,7 +375,7 @@ describe("useCompareModComponentCounts", () => {
     });
 
     const formState = formStateFactory({
-      recipe: modMetadata,
+      mod: modMetadata,
     });
 
     const { result } = renderHook(() => useCompareModComponentCounts(), {

--- a/src/pageEditor/hooks/useCreateModFromModComponent.test.ts
+++ b/src/pageEditor/hooks/useCreateModFromModComponent.test.ts
@@ -48,7 +48,7 @@ describe("useCreateModFromModComponent", () => {
 
   it("saves with no dirty changes", async () => {
     const metadata = modMetadataFactory();
-    const menuItemFormState = menuItemFormStateFactory({ recipe: metadata });
+    const menuItemFormState = menuItemFormStateFactory({ mod: metadata });
 
     appApiMock
       .onPost("/api/bricks/")
@@ -75,7 +75,7 @@ describe("useCreateModFromModComponent", () => {
   it("does not throw an error if the mod fails the compareModComponentCounts check", async () => {
     compareModComponentCountsMock.mockReturnValue(() => false);
     const metadata = modMetadataFactory();
-    const menuItemFormState = menuItemFormStateFactory({ recipe: metadata });
+    const menuItemFormState = menuItemFormStateFactory({ mod: metadata });
 
     appApiMock
       .onPost("/api/bricks/")
@@ -95,7 +95,7 @@ describe("useCreateModFromModComponent", () => {
   it("does not throw an error if the mod fails the checkModStarterBrickInvariants check", async () => {
     checkModStarterBrickInvariantsMock.mockReturnValue(async () => false);
     const metadata = modMetadataFactory();
-    const menuItemFormState = menuItemFormStateFactory({ recipe: metadata });
+    const menuItemFormState = menuItemFormStateFactory({ mod: metadata });
 
     appApiMock
       .onPost("/api/bricks/")

--- a/src/pageEditor/hooks/useCreateModFromModComponent.ts
+++ b/src/pageEditor/hooks/useCreateModFromModComponent.ts
@@ -84,7 +84,7 @@ function useCreateModFromModComponent(
           }).unwrap();
 
           const newModComponent = produce(newModComponentFormState, (draft) => {
-            draft.recipe = selectModMetadata(newModDefinition, upsertResponse);
+            draft.mod = selectModMetadata(newModDefinition, upsertResponse);
           });
 
           dispatch(editorActions.addModComponentFormState(newModComponent));

--- a/src/pageEditor/hooks/useResetMod.ts
+++ b/src/pageEditor/hooks/useResetMod.ts
@@ -44,8 +44,7 @@ function useResetMod(): (modId: RegistryId) => Promise<void> {
       await Promise.all(
         modComponentFormStates
           .filter(
-            (modComponentFormState) =>
-              modComponentFormState.recipe?.id === modId,
+            (modComponentFormState) => modComponentFormState.mod?.id === modId,
           )
           .map(async (modComponentFormState) =>
             resetModComponent({

--- a/src/pageEditor/hooks/useUpsertModComponentFormState.test.ts
+++ b/src/pageEditor/hooks/useUpsertModComponentFormState.test.ts
@@ -69,7 +69,7 @@ describe("useUpsertModComponentFormState", () => {
     expect(modComponents[0]).toEqual(
       expect.objectContaining({
         id: modComponentFormState.uuid,
-        extensionPointId: modComponentFormState.extensionPoint.metadata.id,
+        extensionPointId: modComponentFormState.starterBrick.metadata.id,
         updateTimestamp: expectedUpdateDate.toISOString(),
       }),
     );
@@ -95,7 +95,7 @@ describe("useUpsertModComponentFormState", () => {
 
     const expectedFields = {
       id: modComponentFormState.uuid,
-      extensionPointId: modComponentFormState.extensionPoint.metadata.id,
+      extensionPointId: modComponentFormState.starterBrick.metadata.id,
       updateTimestamp: expectedUpdateDate.toISOString(),
     };
 

--- a/src/pageEditor/hooks/useUpsertModComponentFormState.ts
+++ b/src/pageEditor/hooks/useUpsertModComponentFormState.ts
@@ -148,7 +148,7 @@ function useUpsertModComponentFormState(): SaveCallback {
         `No adapter found for ${modComponentFormState.type}`,
       );
 
-      const starterBrickId = modComponentFormState.extensionPoint.metadata.id;
+      const starterBrickId = modComponentFormState.starterBrick.metadata.id;
       const hasInnerStarterBrick = isInnerDefinitionRegistryId(starterBrickId);
 
       let isEditable = false;

--- a/src/pageEditor/pageEditorTypes.ts
+++ b/src/pageEditor/pageEditorTypes.ts
@@ -271,7 +271,7 @@ export type EditorStateV3 = Except<
    * When a mod component is selected in the Page Editor, a mod component form state is created for it and stored here;
    * that is, "touched" mod component form states.
    */
-  readonly modComponentFormStates: ModComponentFormState[];
+  readonly modComponentFormStates: BaseFormStateV2[];
 
   /**
    * Brick ids (not UUIDs) that the user has access to edit
@@ -317,10 +317,7 @@ export type EditorStateV3 = Except<
   /**
    * Unsaved mod components that have been deleted from a mod
    */
-  deletedModComponentFormStatesByModId: Record<
-    RegistryId,
-    ModComponentFormState[]
-  >;
+  deletedModComponentFormStatesByModId: Record<RegistryId, BaseFormStateV2[]>;
 
   /**
    * The available activated mod components for the current tab
@@ -343,7 +340,15 @@ export type EditorStateV3 = Except<
   isPendingDraftModComponents: boolean;
 };
 
-export type EditorState = EditorStateV3;
+export type EditorStateV4 = Except<
+  EditorStateV3,
+  "modComponentFormStates" | "deletedModComponentFormStatesByModId"
+> & {
+  modComponentFormStates: ModComponentFormState[];
+  deletedModComponentFormStatesByModId: Record<string, ModComponentFormState[]>;
+};
+
+export type EditorState = EditorStateV4;
 
 export type EditorRootState = {
   editor: EditorState;

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -205,7 +205,7 @@ describe("renders", () => {
 
   test("the first selected node", async () => {
     const formState = getPlainFormState();
-    const { instanceId } = formState.extension.blockPipeline[0];
+    const { instanceId } = formState.modComponent.blockPipeline[0];
     const { asFragment } = render(<EditorPane />, {
       setupRedux(dispatch) {
         dispatch(editorActions.addModComponentFormState(formState));
@@ -343,7 +343,7 @@ describe("can add a node", () => {
     const activeModComponentFormState =
       selectActiveModComponentFormState(reduxState);
     const jqNodeId = (
-      activeModComponentFormState.extension.blockPipeline[1].config
+      activeModComponentFormState.modComponent.blockPipeline[1].config
         .body as PipelineExpression
     ).__value__[0].instanceId;
     const addButtonInSubPipeline = screen.getByTestId(
@@ -366,7 +366,7 @@ describe("can add a node", () => {
 async function renderEditorPaneWithBasicFormState() {
   const modComponentFormState = getFormStateWithSubPipelines();
   const activeNodeId =
-    modComponentFormState.extension.blockPipeline[0].instanceId;
+    modComponentFormState.modComponent.blockPipeline[0].instanceId;
   const utils = render(
     <div>
       <EditorPane />
@@ -620,7 +620,7 @@ describe("validation", () => {
   test("validates string templates", async () => {
     const formState = getFormStateWithSubPipelines();
     const subEchoNode = (
-      formState.extension.blockPipeline[1].config.body as PipelineExpression
+      formState.modComponent.blockPipeline[1].config.body as PipelineExpression
     ).__value__[0];
     const { container } = render(<EditorPane />, {
       setupRedux(dispatch) {
@@ -658,7 +658,7 @@ describe("validation", () => {
 
     // Selecting the Echo brick in the first mod component
     const { instanceId: echoBlockInstanceId } =
-      modComponent1.extension.blockPipeline[0];
+      modComponent1.modComponent.blockPipeline[0];
     const { container, getReduxStore } = render(
       <>
         <EditorPane />
@@ -744,7 +744,7 @@ describe("validation", () => {
 
   test("validates multiple renderers on add", async () => {
     const formState = getPlainFormState();
-    formState.extension.blockPipeline.push(
+    formState.modComponent.blockPipeline.push(
       brickConfigFactory({
         id: MarkdownRenderer.BRICK_ID,
         config: {
@@ -781,7 +781,7 @@ describe("validation", () => {
 
   test("validates that renderer is the last node on move", async () => {
     const formState = getPlainFormState();
-    formState.extension.blockPipeline.push(
+    formState.modComponent.blockPipeline.push(
       brickConfigFactory({
         id: MarkdownRenderer.BRICK_ID,
         config: {
@@ -791,7 +791,7 @@ describe("validation", () => {
     );
 
     // Selecting the last node (renderer)
-    const { instanceId } = formState.extension.blockPipeline[2];
+    const { instanceId } = formState.modComponent.blockPipeline[2];
     const { container } = render(<EditorPane />, {
       setupRedux(dispatch) {
         dispatch(editorActions.addModComponentFormState(formState));

--- a/src/pageEditor/panes/EditorPane.tsx
+++ b/src/pageEditor/panes/EditorPane.tsx
@@ -58,12 +58,12 @@ const EditorPaneContent: React.VoidFunctionComponent<{
   useEffect(() => {
     const messageContext = {
       extensionId: modComponentFormState.uuid,
-      blueprintId: modComponentFormState.recipe
-        ? modComponentFormState.recipe.id
+      blueprintId: modComponentFormState.mod
+        ? modComponentFormState.mod.id
         : undefined,
     };
     dispatch(logActions.setContext(messageContext));
-  }, [modComponentFormState.uuid, modComponentFormState.recipe, dispatch]);
+  }, [modComponentFormState.uuid, modComponentFormState.mod, dispatch]);
 
   return (
     <IntegrationsSliceModIntegrationsContextAdapter>

--- a/src/pageEditor/panes/insert/useAutoInsert.ts
+++ b/src/pageEditor/panes/insert/useAutoInsert.ts
@@ -45,7 +45,7 @@ function useAutoInsert(type: StarterBrickType): void {
         undefined,
       ) as ModComponentFormState;
 
-      formState.extension.blockPipeline = getExampleBrickPipeline(
+      formState.modComponent.blockPipeline = getExampleBrickPipeline(
         formState.type,
       );
 

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -291,7 +291,7 @@ describe("replaceModComponent round trip", () => {
 
     modComponentFormState.label = "New Label";
     const newTemplate = '<input value="Click Me!"/>';
-    modComponentFormState.extensionPoint.definition.template = newTemplate;
+    modComponentFormState.starterBrick.definition.template = newTemplate;
 
     const newId = generateScopeBrickId("@test", modDefinition.metadata.id);
 

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -275,7 +275,7 @@ export function replaceModComponent(
     assertNotNullish(adapter, `No adapter found for ${newModComponent.type}`);
     const { selectModComponent, selectStarterBrickDefinition } = adapter;
     const rawModComponent = selectModComponent(newModComponent);
-    const starterBrickId = newModComponent.extensionPoint.metadata.id;
+    const starterBrickId = newModComponent.starterBrick.metadata.id;
     const hasInnerDefinition = isInnerDefinitionRegistryId(starterBrickId);
 
     const commonModComponentDefinition: Except<ModComponentDefinition, "id"> = {

--- a/src/pageEditor/sidebar/ActivatedModComponentListItem.tsx
+++ b/src/pageEditor/sidebar/ActivatedModComponentListItem.tsx
@@ -77,7 +77,7 @@ const ActivatedModComponentListItem: React.FunctionComponent<{
   );
   const isActive = activeModComponentFormState?.uuid === modComponent.id;
   // Get the selected mod id, or the mod id of the selected mod component
-  const modId = activeModId ?? activeModComponentFormState?.recipe?.id;
+  const modId = activeModId ?? activeModComponentFormState?.mod?.id;
   // Set the alternate background if this item isn't active, but either its mod or another item in its mod is active
   const hasActiveModBackground =
     !isActive && modId && modComponent._recipe?.id === modId;

--- a/src/pageEditor/sidebar/DraftModComponentListItem.tsx
+++ b/src/pageEditor/sidebar/DraftModComponentListItem.tsx
@@ -80,9 +80,9 @@ const DraftModComponentListItem: React.FunctionComponent<
 
   const isActive =
     activeModComponentFormState?.uuid === modComponentFormState.uuid;
-  const modId = modComponentFormState.recipe?.id;
-  const isSiblingOfActiveListItem = activeModComponentFormState?.recipe?.id
-    ? modId === activeModComponentFormState?.recipe?.id
+  const modId = modComponentFormState.mod?.id;
+  const isSiblingOfActiveListItem = activeModComponentFormState?.mod?.id
+    ? modId === activeModComponentFormState?.mod?.id
     : false;
   const isChildOfActiveListItem = modId === activeModId;
   const isRelativeOfActiveListItem =
@@ -125,14 +125,14 @@ const DraftModComponentListItem: React.FunctionComponent<
     });
 
   const onSave = async () => {
-    if (modComponentFormState.recipe) {
-      await saveMod(modComponentFormState.recipe?.id);
+    if (modComponentFormState.mod) {
+      await saveMod(modComponentFormState.mod?.id);
     } else {
       await saveStandaloneModComponent(modComponentFormState);
     }
   };
 
-  const isSaving = modComponentFormState.recipe
+  const isSaving = modComponentFormState.mod
     ? isSavingMod
     : isSavingStandaloneModComponent;
 
@@ -209,14 +209,14 @@ const DraftModComponentListItem: React.FunctionComponent<
           onReset={modComponentFormState.installed ? onReset : undefined}
           isDirty={isDirty}
           onAddToMod={
-            modComponentFormState.recipe
+            modComponentFormState.mod
               ? undefined
               : async () => {
                   dispatch(actions.showAddToModModal());
                 }
           }
           onRemoveFromMod={
-            modComponentFormState.recipe
+            modComponentFormState.mod
               ? async () => {
                   dispatch(actions.showRemoveFromModModal());
                 }

--- a/src/pageEditor/sidebar/ModListItem.tsx
+++ b/src/pageEditor/sidebar/ModListItem.tsx
@@ -76,7 +76,7 @@ const ModListItem: React.FC<ModListItemProps> = ({
   const latestModVersion = modDefinition?.metadata?.version;
 
   // Set the alternate background if a mod component in this mod is active
-  const hasModBackground = activeModComponentFormState?.recipe?.id === modId;
+  const hasModBackground = activeModComponentFormState?.mod?.id === modId;
 
   const dirtyName = useSelector(selectDirtyMetadataForModId(modId))?.name;
   const name = dirtyName ?? savedName ?? "Loading...";

--- a/src/pageEditor/sidebar/arrangeSidebarItems.test.ts
+++ b/src/pageEditor/sidebar/arrangeSidebarItems.test.ts
@@ -50,7 +50,7 @@ const ID_FOO_B = uuidv4();
 const formStateModComponentFooB: ButtonFormState = menuItemFormStateFactory({
   uuid: ID_FOO_B,
   label: "B",
-  recipe: modMetadataFoo,
+  mod: modMetadataFoo,
 });
 
 const ID_ORPHAN_C = uuidv4();
@@ -70,7 +70,7 @@ const ID_BAR_E = uuidv4();
 const formStateModComponentBarE: ButtonFormState = menuItemFormStateFactory({
   uuid: ID_BAR_E,
   label: "E",
-  recipe: modMetadataBar,
+  mod: modMetadataBar,
 });
 
 const ID_BAR_F = uuidv4();

--- a/src/pageEditor/sidebar/arrangeSidebarItems.ts
+++ b/src/pageEditor/sidebar/arrangeSidebarItems.ts
@@ -44,15 +44,15 @@ function arrangeSidebarItems({
   for (const formState of modComponentFormStates) {
     formStateModComponentIds.add(formState.uuid);
 
-    if (formState.recipe == null) {
+    if (formState.mod == null) {
       orphanSidebarItems.push(formState);
     } else {
-      const modSidebarItem = modSidebarItems[formState.recipe.id] ?? {
-        modMetadata: formState.recipe,
+      const modSidebarItem = modSidebarItems[formState.mod.id] ?? {
+        modMetadata: formState.mod,
         modComponents: [],
       };
       modSidebarItem.modComponents.push(formState);
-      modSidebarItems[formState.recipe.id] = modSidebarItem;
+      modSidebarItems[formState.mod.id] = modSidebarItem;
     }
   }
 

--- a/src/pageEditor/sidebar/common.ts
+++ b/src/pageEditor/sidebar/common.ts
@@ -30,7 +30,7 @@ export type ModSidebarItem = {
 export type SidebarItem = ModSidebarItem | ModComponentSidebarItem;
 
 export function getLabel(modComponent: ModComponentFormState): string {
-  return modComponent.label ?? modComponent.extensionPoint.metadata.name;
+  return modComponent.label ?? modComponent.starterBrick.metadata.name;
 }
 
 export function isModComponentBase(

--- a/src/pageEditor/sidebar/modals/CreateModModal.tsx
+++ b/src/pageEditor/sidebar/modals/CreateModModal.tsx
@@ -72,7 +72,7 @@ function useInitialFormState({
   const scope = useSelector(selectScope);
 
   const activeModId =
-    activeModComponentFormState?.recipe?.id ?? activeMod?.metadata?.id;
+    activeModComponentFormState?.mod?.id ?? activeMod?.metadata?.id;
   const dirtyModMetadata = useSelector(
     selectDirtyMetadataForModId(activeModId),
   );
@@ -150,7 +150,7 @@ const CreateModModalBody: React.FC = () => {
   // is open, and a mod is active, then we're performing a "Save as New" on that mod.
   const directlyActiveModId = useSelector(selectActiveModId);
   const activeModId =
-    directlyActiveModId ?? activeModComponentFormState?.recipe?.id;
+    directlyActiveModId ?? activeModComponentFormState?.mod?.id;
   const { data: activeMod, isFetching: isModFetching } =
     useOptionalModDefinition(activeModId);
 

--- a/src/pageEditor/sidebar/modals/MoveFromModModal.tsx
+++ b/src/pageEditor/sidebar/modals/MoveFromModModal.tsx
@@ -145,7 +145,7 @@ const MoveFromModModal: React.FC = () => {
       <Modal.Header closeButton>
         <Modal.Title>
           Remove <em>{modComponentFormState?.label}</em> from mod{" "}
-          <em>{modComponentFormState?.recipe?.name}</em>?
+          <em>{modComponentFormState?.mod?.name}</em>?
         </Modal.Title>
       </Modal.Header>
       <Form

--- a/src/pageEditor/slices/editorSelectors.ts
+++ b/src/pageEditor/slices/editorSelectors.ts
@@ -151,7 +151,7 @@ const dirtyOptionValuesForModIdSelector = createSelector(
   selectNotDeletedModComponentFormStates,
   (_state: EditorRootState, modId: RegistryId) => modId,
   (formStates, modId) =>
-    formStates.find((formState) => formState.recipe?.id === modId)?.optionsArgs,
+    formStates.find((formState) => formState.mod?.id === modId)?.optionsArgs,
 );
 
 export const selectDirtyOptionValuesForModId =
@@ -194,7 +194,7 @@ const modIsDirtySelector = createSelector(
     selectDeletedComponentFormStatesByModId(state)[modId],
   ({ editor }: EditorRootState, modId: RegistryId) =>
     editor.modComponentFormStates
-      .filter((formState) => formState.recipe?.id === modId)
+      .filter((formState) => formState.mod?.id === modId)
       .map((formState) => formState.uuid),
   (
     isModComponentDirtyById,
@@ -238,8 +238,8 @@ export const selectInstalledModMetadatas = createSelector(
   selectActivatedModComponents,
   (formStates, activatedModComponents) => {
     const formStateModMetadatas: Array<ModComponentBase["_recipe"]> = formStates
-      .filter((formState) => Boolean(formState.recipe))
-      .map((formState) => formState.recipe);
+      .filter((formState) => Boolean(formState.mod))
+      .map((formState) => formState.mod);
     const activatedModComponentModMetadatas: Array<
       ModComponentBase["_recipe"]
     > = activatedModComponents

--- a/src/pageEditor/slices/editorSlice.test.ts
+++ b/src/pageEditor/slices/editorSlice.test.ts
@@ -151,28 +151,28 @@ describe("Add/Remove Bricks", () => {
   test("Add Brick", async () => {
     // Get initial bricks
     const initialBricks =
-      editor.modComponentFormStates[0].extension.blockPipeline;
+      editor.modComponentFormStates[0].modComponent.blockPipeline;
 
     // Add a Brick
     editor = editorSlice.reducer(
       editor,
       actions.addNode({
         block: standardBrick,
-        pipelinePath: "extension.blockPipeline",
+        pipelinePath: "modComponent.blockPipeline",
         pipelineIndex: 0,
       }),
     );
 
     // Ensure we have one more brick than we started with
     expect(
-      editor.modComponentFormStates[0].extension.blockPipeline,
+      editor.modComponentFormStates[0].modComponent.blockPipeline,
     ).toBeArrayOfSize(initialBricks.length + 1);
   });
 
   test("Remove Brick with Integration Dependency", async () => {
     // Get initial bricks and integration dependencies
     const initialBricks =
-      editor.modComponentFormStates[0].extension.blockPipeline;
+      editor.modComponentFormStates[0].modComponent.blockPipeline;
     const initialIntegrationDependencies =
       editor.modComponentFormStates[0].integrationDependencies;
 
@@ -184,7 +184,7 @@ describe("Add/Remove Bricks", () => {
 
     // Ensure Integration Dependency was removed
     expect(
-      editor.modComponentFormStates[0].extension.blockPipeline,
+      editor.modComponentFormStates[0].modComponent.blockPipeline,
     ).toBeArrayOfSize(initialBricks.length - 1);
     expect(
       editor.modComponentFormStates[0].integrationDependencies,
@@ -194,7 +194,7 @@ describe("Add/Remove Bricks", () => {
   test("Remove Brick without Integration Dependency", async () => {
     // Get initial bricks and services
     const initialBricks =
-      editor.modComponentFormStates[0].extension.blockPipeline;
+      editor.modComponentFormStates[0].modComponent.blockPipeline;
     const initialIntegrationDependencies =
       editor.modComponentFormStates[0].integrationDependencies;
 
@@ -206,7 +206,7 @@ describe("Add/Remove Bricks", () => {
 
     // Ensure Service was NOT removed
     expect(
-      editor.modComponentFormStates[0].extension.blockPipeline,
+      editor.modComponentFormStates[0].modComponent.blockPipeline,
     ).toBeArrayOfSize(initialBricks.length - 1);
     expect(
       editor.modComponentFormStates[0].integrationDependencies,

--- a/src/pageEditor/slices/editorSliceHelpers.test.ts
+++ b/src/pageEditor/slices/editorSliceHelpers.test.ts
@@ -60,8 +60,8 @@ describe("ensureElementUIState", () => {
       brickPipelineUIStateById: {
         [element.uuid]: {
           ...makeInitialBrickPipelineUIState(),
-          pipelineMap: getPipelineMap(element.extension.blockPipeline),
-          activeNodeId: element.extension.blockPipeline[0].instanceId,
+          pipelineMap: getPipelineMap(element.modComponent.blockPipeline),
+          activeNodeId: element.modComponent.blockPipeline[0].instanceId,
         },
       },
     };
@@ -88,10 +88,10 @@ describe("ensureElementUIState", () => {
 describe("ensureNodeUIState", () => {
   test("does not affect existing node state", () => {
     const element = formStateFactory();
-    const nodeId = element.extension.blockPipeline[0].instanceId;
+    const nodeId = element.modComponent.blockPipeline[0].instanceId;
     const uiState: BrickPipelineUIState = {
       ...makeInitialBrickPipelineUIState(),
-      pipelineMap: getPipelineMap(element.extension.blockPipeline),
+      pipelineMap: getPipelineMap(element.modComponent.blockPipeline),
       activeNodeId: nodeId,
     };
     const nodeState: NodeUIState = makeInitialNodeUIState(nodeId);
@@ -114,11 +114,11 @@ describe("ensureNodeUIState", () => {
 
   test("adds node states when not present", () => {
     const element = formStateFactory();
-    const node1Id = element.extension.blockPipeline[0].instanceId;
-    const node2Id = element.extension.blockPipeline[1].instanceId;
+    const node1Id = element.modComponent.blockPipeline[0].instanceId;
+    const node2Id = element.modComponent.blockPipeline[1].instanceId;
     const uiState: BrickPipelineUIState = {
       ...makeInitialBrickPipelineUIState(),
-      pipelineMap: getPipelineMap(element.extension.blockPipeline),
+      pipelineMap: getPipelineMap(element.modComponent.blockPipeline),
       activeNodeId: node1Id,
     };
     const newUiState = produce(uiState, (draft) => {
@@ -133,11 +133,11 @@ describe("ensureNodeUIState", () => {
 describe("syncElementUIStates", () => {
   test("reset active node to foundation when node ids change, and removes invalid node states", () => {
     const element = formStateFactory();
-    const nodeId = element.extension.blockPipeline[0].instanceId;
+    const nodeId = element.modComponent.blockPipeline[0].instanceId;
     const invalidNodeId = uuidv4();
     const uiState: BrickPipelineUIState = {
       ...makeInitialBrickPipelineUIState(),
-      pipelineMap: getPipelineMap(element.extension.blockPipeline),
+      pipelineMap: getPipelineMap(element.modComponent.blockPipeline),
       activeNodeId: invalidNodeId,
     };
     const nodeState = makeInitialNodeUIState(nodeId);
@@ -174,10 +174,10 @@ describe("syncElementUIStates", () => {
 
   test("adds missing node states", () => {
     const element = formStateFactory();
-    const node1Id = element.extension.blockPipeline[0].instanceId;
+    const node1Id = element.modComponent.blockPipeline[0].instanceId;
     const uiState: BrickPipelineUIState = {
       ...makeInitialBrickPipelineUIState(),
-      pipelineMap: getPipelineMap(element.extension.blockPipeline),
+      pipelineMap: getPipelineMap(element.modComponent.blockPipeline),
       activeNodeId: node1Id,
     };
     const editorState: EditorState = {
@@ -198,7 +198,7 @@ describe("syncElementUIStates", () => {
     expect(
       newEditorState.brickPipelineUIStateById[element.uuid].nodeUIStates,
     ).toContainKey(node1Id);
-    const node2Id = element.extension.blockPipeline[1].instanceId;
+    const node2Id = element.modComponent.blockPipeline[1].instanceId;
     expect(
       newEditorState.brickPipelineUIStateById[element.uuid].nodeUIStates,
     ).toContainKey(node2Id);
@@ -208,10 +208,10 @@ describe("syncElementUIStates", () => {
 describe("setActiveNodeId", () => {
   test("sets active node when node state is missing", () => {
     const element = formStateFactory();
-    const nodeId = element.extension.blockPipeline[0].instanceId;
+    const nodeId = element.modComponent.blockPipeline[0].instanceId;
     const uiState: BrickPipelineUIState = {
       ...makeInitialBrickPipelineUIState(),
-      pipelineMap: getPipelineMap(element.extension.blockPipeline),
+      pipelineMap: getPipelineMap(element.modComponent.blockPipeline),
     };
     const editorState: EditorState = {
       ...initialState,
@@ -230,10 +230,10 @@ describe("setActiveNodeId", () => {
 
   test("sets active node when node state is already present", () => {
     const element = formStateFactory();
-    const nodeId = element.extension.blockPipeline[0].instanceId;
+    const nodeId = element.modComponent.blockPipeline[0].instanceId;
     const uiState: BrickPipelineUIState = {
       ...makeInitialBrickPipelineUIState(),
-      pipelineMap: getPipelineMap(element.extension.blockPipeline),
+      pipelineMap: getPipelineMap(element.modComponent.blockPipeline),
     };
     const nodeState = makeInitialNodeUIState(nodeId);
     uiState.nodeUIStates = {
@@ -277,8 +277,8 @@ describe("removeElement", () => {
       brickPipelineUIStateById: {
         [element.uuid]: {
           ...makeInitialBrickPipelineUIState(),
-          pipelineMap: getPipelineMap(element.extension.blockPipeline),
-          activeNodeId: element.extension.blockPipeline[0].instanceId,
+          pipelineMap: getPipelineMap(element.modComponent.blockPipeline),
+          activeNodeId: element.modComponent.blockPipeline[0].instanceId,
         },
       },
       availableDraftModComponentIds: [element.uuid],
@@ -313,19 +313,19 @@ describe("removeElement", () => {
         [availableModComponentFormState.uuid]: {
           ...makeInitialBrickPipelineUIState(),
           pipelineMap: getPipelineMap(
-            availableModComponentFormState.extension.blockPipeline,
+            availableModComponentFormState.modComponent.blockPipeline,
           ),
           activeNodeId:
-            availableModComponentFormState.extension.blockPipeline[0]
+            availableModComponentFormState.modComponent.blockPipeline[0]
               .instanceId,
         },
         [unavailableModComponentFormState.uuid]: {
           ...makeInitialBrickPipelineUIState(),
           pipelineMap: getPipelineMap(
-            unavailableModComponentFormState.extension.blockPipeline,
+            unavailableModComponentFormState.modComponent.blockPipeline,
           ),
           activeNodeId:
-            unavailableModComponentFormState.extension.blockPipeline[0]
+            unavailableModComponentFormState.modComponent.blockPipeline[0]
               .instanceId,
         },
       },
@@ -353,8 +353,8 @@ describe("removeElement", () => {
 describe("removeModData", () => {
   test("removes expanded active mod", () => {
     const modMetadata = modMetadataFactory();
-    const modComponentFormState1 = formStateFactory({ recipe: modMetadata });
-    const modComponentFormState2 = formStateFactory({ recipe: modMetadata });
+    const modComponentFormState1 = formStateFactory({ mod: modMetadata });
+    const modComponentFormState2 = formStateFactory({ mod: modMetadata });
     const orphanModComponentFormState = formStateFactory();
     const state: EditorState = {
       ...initialState,
@@ -373,26 +373,27 @@ describe("removeModData", () => {
         [modComponentFormState1.uuid]: {
           ...makeInitialBrickPipelineUIState(),
           pipelineMap: getPipelineMap(
-            modComponentFormState1.extension.blockPipeline,
+            modComponentFormState1.modComponent.blockPipeline,
           ),
           activeNodeId:
-            modComponentFormState1.extension.blockPipeline[0].instanceId,
+            modComponentFormState1.modComponent.blockPipeline[0].instanceId,
         },
         [modComponentFormState2.uuid]: {
           ...makeInitialBrickPipelineUIState(),
           pipelineMap: getPipelineMap(
-            modComponentFormState2.extension.blockPipeline,
+            modComponentFormState2.modComponent.blockPipeline,
           ),
           activeNodeId:
-            modComponentFormState2.extension.blockPipeline[0].instanceId,
+            modComponentFormState2.modComponent.blockPipeline[0].instanceId,
         },
         [orphanModComponentFormState.uuid]: {
           ...makeInitialBrickPipelineUIState(),
           pipelineMap: getPipelineMap(
-            orphanModComponentFormState.extension.blockPipeline,
+            orphanModComponentFormState.modComponent.blockPipeline,
           ),
           activeNodeId:
-            orphanModComponentFormState.extension.blockPipeline[0].instanceId,
+            orphanModComponentFormState.modComponent.blockPipeline[0]
+              .instanceId,
         },
       },
       availableDraftModComponentIds: [

--- a/src/pageEditor/slices/editorSliceHelpers.ts
+++ b/src/pageEditor/slices/editorSliceHelpers.ts
@@ -45,7 +45,7 @@ export function ensureBrickPipelineUIState(
       makeInitialBrickPipelineUIState();
     const pipeline = state.modComponentFormStates.find(
       (x) => x.uuid === modComponentId,
-    )?.extension.blockPipeline;
+    )?.modComponent.blockPipeline;
 
     assertNotNullish(
       pipeline,
@@ -77,7 +77,7 @@ export function syncNodeUIStates(
   );
 
   const pipelineMap = getPipelineMap(
-    modComponentFormState.extension.blockPipeline,
+    modComponentFormState.modComponent.blockPipeline,
   );
 
   brickPipelineUIState.pipelineMap = pipelineMap;
@@ -221,7 +221,7 @@ export function setActiveModComponentId(
   state.beta = false;
   state.activeModComponentId = modComponentFormState.uuid;
   state.activeModId = null;
-  state.expandedModId = modComponentFormState.recipe?.id ?? state.expandedModId;
+  state.expandedModId = modComponentFormState.mod?.id ?? state.expandedModId;
   state.selectionSeq++;
 
   ensureBrickPipelineUIState(state, modComponentFormState.uuid);

--- a/src/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod.test.ts
+++ b/src/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod.test.ts
@@ -178,7 +178,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
       const newFormStates: ModComponentFormState[] = [];
       for (let i = 0; i < newCount; i++) {
         const formState = formStateFactory({
-          recipe: primaryModMetadata,
+          mod: primaryModMetadata,
         });
         newFormStates.push(formState);
       }
@@ -216,7 +216,7 @@ describe("selectGetCleanComponentsAndDirtyFormStatesForMod", () => {
       const extraNewFormStates: ModComponentFormState[] = [];
       for (let i = 0; i < extraNew; i++) {
         const formState = formStateFactory({
-          recipe: otherModMetadata,
+          mod: otherModMetadata,
         });
         extraNewFormStates.push(formState);
       }

--- a/src/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod.ts
+++ b/src/pageEditor/slices/selectors/selectGetCleanComponentsAndDirtyFormStatesForMod.ts
@@ -31,8 +31,7 @@ export const selectGetCleanComponentsAndDirtyFormStatesForMod = createSelector(
     (modId: RegistryId) => {
       const dirtyModComponentFormStates = formStates.filter(
         (formState) =>
-          formState.recipe?.id === modId &&
-          isDirtyByComponentId[formState.uuid],
+          formState.mod?.id === modId && isDirtyByComponentId[formState.uuid],
       );
 
       const cleanModComponents = activatedModComponents.filter(

--- a/src/pageEditor/starterBricks/base.ts
+++ b/src/pageEditor/starterBricks/base.ts
@@ -123,7 +123,7 @@ export function baseFromModComponent<T extends StarterBrickType>(
   | "integrationDependencies"
   | "permissions"
   | "optionsArgs"
-  | "recipe"
+  | "mod"
 > & { type: T } {
   return {
     uuid: config.id,
@@ -135,7 +135,7 @@ export function baseFromModComponent<T extends StarterBrickType>(
     permissions: config.permissions ?? {},
     optionsArgs: config.optionsArgs ?? {},
     type,
-    recipe: config._recipe,
+    mod: config._recipe,
   };
 }
 
@@ -146,9 +146,9 @@ export function initModOptionsIfNeeded<TFormState extends BaseFormState>(
   modComponentFormState: TFormState,
   modDefinitions: ModDefinition[],
 ) {
-  if (modComponentFormState.recipe?.id) {
+  if (modComponentFormState.mod?.id) {
     const mod = modDefinitions?.find(
-      (x) => x.metadata.id === modComponentFormState.recipe?.id,
+      (x) => x.metadata.id === modComponentFormState.mod?.id,
     );
 
     if (mod?.options == null) {
@@ -175,8 +175,8 @@ export function baseSelectModComponent({
   optionsArgs,
   integrationDependencies,
   permissions,
-  extensionPoint,
-  recipe,
+  starterBrick,
+  mod,
 }: BaseFormState): Pick<
   ModComponentBase,
   | "id"
@@ -191,8 +191,8 @@ export function baseSelectModComponent({
   return {
     id: uuid,
     apiVersion,
-    extensionPointId: extensionPoint.metadata.id,
-    _recipe: recipe,
+    extensionPointId: starterBrick.metadata.id,
+    _recipe: mod,
     label,
     integrationDependencies,
     permissions,
@@ -202,17 +202,17 @@ export function baseSelectModComponent({
 
 export function makeInitialBaseState(
   uuid: UUID = uuidv4(),
-): Except<BaseFormState, "type" | "label" | "extensionPoint"> {
+): Except<BaseFormState, "type" | "label" | "starterBrick"> {
   return {
     uuid,
     apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,
     integrationDependencies: [],
     permissions: emptyPermissionsFactory(),
     optionsArgs: {},
-    extension: {
+    modComponent: {
       blockPipeline: [],
     },
-    recipe: undefined,
+    mod: undefined,
   };
 }
 
@@ -321,7 +321,7 @@ export async function lookupStarterBrick<
 export function baseSelectStarterBrick(
   formState: BaseFormState,
 ): Except<StarterBrickDefinitionLike, "definition"> {
-  const { metadata } = formState.extensionPoint;
+  const { metadata } = formState.starterBrick;
 
   return {
     apiVersion: formState.apiVersion,

--- a/src/pageEditor/starterBricks/button.ts
+++ b/src/pageEditor/starterBricks/button.ts
@@ -61,7 +61,7 @@ function fromNativeElement(
     label: `My ${getDomain(url)} button`,
     ...makeInitialBaseState(button.uuid),
     containerInfo: button.containerInfo,
-    extensionPoint: {
+    starterBrick: {
       metadata,
       definition: {
         ...button.menu,
@@ -77,7 +77,7 @@ function fromNativeElement(
         },
       },
     },
-    extension: {
+    modComponent: {
       caption: button.item.caption,
       blockPipeline: [],
       dynamicCaption: false,
@@ -90,7 +90,7 @@ function fromNativeElement(
 function selectStarterBrickDefinition(
   formState: ButtonFormState,
 ): StarterBrickDefinitionLike<ButtonDefinition> {
-  const { extensionPoint: starterBrick } = formState;
+  const { starterBrick } = formState;
   const {
     definition: {
       isAvailable,
@@ -121,7 +121,7 @@ function selectModComponent(
   state: ButtonFormState,
   options: { includeInstanceIds?: boolean } = {},
 ): ModComponentBase<ButtonStarterBrickConfig> {
-  const { extension: modComponent } = state;
+  const { modComponent } = state;
   const config: ButtonStarterBrickConfig = {
     caption: modComponent.caption,
     icon: modComponent.icon,
@@ -157,10 +157,10 @@ async function fromModComponent(
 
   return {
     ...base,
-    extension: modComponent,
+    modComponent,
     // `containerInfo` only populated on initial creation session
     containerInfo: null,
-    extensionPoint: {
+    starterBrick: {
       metadata: starterBrick.metadata,
       definition: {
         ...starterBrick.definition,

--- a/src/pageEditor/starterBricks/contextMenu.ts
+++ b/src/pageEditor/starterBricks/contextMenu.ts
@@ -60,7 +60,7 @@ function fromNativeElement(
     // To simplify the interface, this is kept in sync with the caption
     label: title,
     ...base,
-    extensionPoint: {
+    starterBrick: {
       metadata,
       definition: {
         type: "contextMenu",
@@ -72,7 +72,7 @@ function fromNativeElement(
         isAvailable,
       },
     },
-    extension: {
+    modComponent: {
       title,
       onSuccess: true,
       blockPipeline: [],
@@ -83,7 +83,7 @@ function fromNativeElement(
 function selectStarterBrickDefinition(
   formState: ContextMenuFormState,
 ): StarterBrickDefinitionLike<ContextMenuDefinition> {
-  const { extensionPoint: starterBrick } = formState;
+  const { starterBrick } = formState;
   const {
     definition: {
       isAvailable,
@@ -110,7 +110,7 @@ function selectModComponent(
   state: ContextMenuFormState,
   options: { includeInstanceIds?: boolean } = {},
 ): ModComponentBase<ContextMenuConfig> {
-  const { extension: modComponent } = state;
+  const { modComponent } = state;
   const config: ContextMenuConfig = {
     title: modComponent.title,
     onSuccess: modComponent.onSuccess,
@@ -150,8 +150,8 @@ async function fromModComponent(
 
   return {
     ...base,
-    extension: modComponent,
-    extensionPoint: {
+    modComponent,
+    starterBrick: {
       metadata: starterBrick.metadata,
       definition: {
         type: "contextMenu",

--- a/src/pageEditor/starterBricks/quickBar.ts
+++ b/src/pageEditor/starterBricks/quickBar.ts
@@ -57,7 +57,7 @@ function fromNativeElement(url: string, metadata: Metadata): QuickBarFormState {
     // To simplify the interface, this is kept in sync with the caption
     label: title,
     ...base,
-    extensionPoint: {
+    starterBrick: {
       metadata,
       definition: {
         type: "quickBar",
@@ -69,7 +69,7 @@ function fromNativeElement(url: string, metadata: Metadata): QuickBarFormState {
         isAvailable,
       },
     },
-    extension: {
+    modComponent: {
       title,
       blockPipeline: [],
     },
@@ -79,7 +79,7 @@ function fromNativeElement(url: string, metadata: Metadata): QuickBarFormState {
 function selectStarterBrickDefinition(
   formState: QuickBarFormState,
 ): StarterBrickDefinitionLike<QuickBarDefinition> {
-  const { extensionPoint: starterBrick } = formState;
+  const { starterBrick } = formState;
   const {
     definition: {
       isAvailable,
@@ -106,7 +106,7 @@ function selectModComponent(
   state: QuickBarFormState,
   options: { includeInstanceIds?: boolean } = {},
 ): ModComponentBase<QuickBarConfig> {
-  const { extension: modComponent } = state;
+  const { modComponent } = state;
   const config: QuickBarConfig = {
     title: modComponent.title,
     icon: modComponent.icon,
@@ -147,8 +147,8 @@ async function fromModComponent(
 
   return {
     ...base,
-    extension: modComponent,
-    extensionPoint: {
+    modComponent,
+    starterBrick: {
       metadata: starterBrick.metadata,
       definition: {
         type: "quickBar",

--- a/src/pageEditor/starterBricks/quickBarProvider.ts
+++ b/src/pageEditor/starterBricks/quickBarProvider.ts
@@ -60,7 +60,7 @@ function fromNativeElement(
     // To simplify the interface, this is kept in sync with the caption
     label: title,
     ...base,
-    extensionPoint: {
+    starterBrick: {
       metadata,
       definition: {
         type: "quickBarProvider",
@@ -70,7 +70,7 @@ function fromNativeElement(
         isAvailable,
       },
     },
-    extension: {
+    modComponent: {
       rootAction: undefined,
       blockPipeline: [],
     },
@@ -80,7 +80,7 @@ function fromNativeElement(
 function selectStarterBrickDefinition(
   formState: QuickBarProviderFormState,
 ): StarterBrickDefinitionLike<QuickBarProviderDefinition> {
-  const { extensionPoint: starterBrick } = formState;
+  const { starterBrick } = formState;
   const {
     definition: { isAvailable, documentUrlPatterns, reader },
   } = starterBrick;
@@ -99,7 +99,7 @@ function selectModComponent(
   state: QuickBarProviderFormState,
   options: { includeInstanceIds?: boolean } = {},
 ): ModComponentBase<QuickBarProviderConfig> {
-  const { extension: modComponent } = state;
+  const { modComponent } = state;
   const config: QuickBarProviderConfig = {
     rootAction: modComponent.rootAction,
     generator: options.includeInstanceIds
@@ -137,8 +137,8 @@ async function fromModComponent(
 
   return {
     ...base,
-    extension: modComponent,
-    extensionPoint: {
+    modComponent,
+    starterBrick: {
       metadata: starterBrick.metadata,
       definition: {
         type: "quickBarProvider",

--- a/src/pageEditor/starterBricks/sidebar.ts
+++ b/src/pageEditor/starterBricks/sidebar.ts
@@ -53,7 +53,7 @@ function fromNativeElement(url: string, metadata: Metadata): SidebarFormState {
     type: "actionPanel",
     label: heading,
     ...base,
-    extensionPoint: {
+    starterBrick: {
       metadata,
 
       definition: {
@@ -72,7 +72,7 @@ function fromNativeElement(url: string, metadata: Metadata): SidebarFormState {
         customEvent: null,
       },
     },
-    extension: {
+    modComponent: {
       heading,
       blockPipeline: [],
     },
@@ -82,7 +82,7 @@ function fromNativeElement(url: string, metadata: Metadata): SidebarFormState {
 function selectStarterBrickDefinition(
   formState: SidebarFormState,
 ): StarterBrickDefinitionLike {
-  const { extensionPoint: starterBrick } = formState;
+  const { starterBrick } = formState;
   const {
     definition: { isAvailable, reader, trigger, debounce, customEvent },
   } = starterBrick;
@@ -103,7 +103,7 @@ function selectModComponent(
   state: SidebarFormState,
   options: { includeInstanceIds?: boolean } = {},
 ): ModComponentBase<SidebarConfig> {
-  const { extension: modComponent } = state;
+  const { modComponent } = state;
   const config: SidebarConfig = {
     heading: modComponent.heading,
     body: options.includeInstanceIds
@@ -154,8 +154,8 @@ async function fromModComponent(
 
   return {
     ...base,
-    extension: modComponent,
-    extensionPoint: {
+    modComponent,
+    starterBrick: {
       metadata: starterBrick.metadata,
       definition: {
         ...starterBrick.definition,

--- a/src/pageEditor/starterBricks/trigger.ts
+++ b/src/pageEditor/starterBricks/trigger.ts
@@ -56,7 +56,7 @@ function fromNativeElement(
     type: "trigger",
     label: `My ${getDomain(url)} trigger`,
     ...makeInitialBaseState(),
-    extensionPoint: {
+    starterBrick: {
       metadata,
       definition: {
         type: "trigger",
@@ -78,7 +78,7 @@ function fromNativeElement(
         isAvailable: getDefaultAvailabilityForUrl(url),
       },
     },
-    extension: {
+    modComponent: {
       blockPipeline: [],
     },
   };
@@ -87,7 +87,7 @@ function fromNativeElement(
 function selectStarterBrickDefinition(
   formState: TriggerFormState,
 ): StarterBrickDefinitionLike<TriggerDefinition> {
-  const { extensionPoint: starterBrick } = formState;
+  const { starterBrick } = formState;
   const {
     definition: {
       isAvailable,
@@ -129,7 +129,7 @@ function selectModComponent(
   state: TriggerFormState,
   options: { includeInstanceIds?: boolean } = {},
 ): ModComponentBase<TriggerConfig> {
-  const { extension: modComponent } = state;
+  const { modComponent } = state;
   const config: TriggerConfig = {
     action: options.includeInstanceIds
       ? modComponent.blockPipeline
@@ -186,8 +186,8 @@ async function fromModComponent(
 
   return {
     ...base,
-    extension: modComponent,
-    extensionPoint: {
+    modComponent,
+    starterBrick: {
       metadata: starterBrick.metadata,
       definition: {
         type: starterBrick.definition.type,

--- a/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
@@ -65,8 +65,7 @@ const UnconfiguredQuickBarAlert: React.FunctionComponent = () => {
 const FoundationNodeConfigPanel: React.FC = () => {
   const { flagOn } = useFlags();
   const showVersionField = flagOn("page-editor-developer");
-  const { extensionPoint: starterBrick } =
-    useSelector(selectActiveModComponentFormState) ?? {};
+  const { starterBrick } = useSelector(selectActiveModComponentFormState) ?? {};
   assertNotNullish(
     starterBrick,
     "starterBrick not found in active mod component form state",

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.test.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.test.tsx
@@ -34,7 +34,7 @@ bricksRegistry.register([echoBrick]);
 const { formState, records } = formStateWithTraceDataFactory();
 const renderDataPanel = () => {
   const modComponentId = formState.uuid;
-  const { instanceId } = formState.extension.blockPipeline[1];
+  const { instanceId } = formState.modComponent.blockPipeline[1];
 
   return render(<DataPanel />, {
     initialValues: formState,
@@ -76,7 +76,7 @@ describe("DataPanel", () => {
     expect(reportEventMock).toHaveBeenCalledOnce();
     expect(reportEventMock).toHaveBeenCalledWith(Events.DATA_PANEL_TAB_VIEW, {
       tabName: DataPanelTabKey.Context,
-      brickId: formState.extension.blockPipeline[1].id,
+      brickId: formState.modComponent.blockPipeline[1].id,
       modId: undefined,
     });
 
@@ -95,7 +95,7 @@ describe("DataPanel", () => {
     expect(reportEventMock).toHaveBeenCalledOnce();
     expect(reportEventMock).toHaveBeenCalledWith(Events.DATA_PANEL_TAB_VIEW, {
       tabName: DataPanelTabKey.Comments,
-      brickId: formState.extension.blockPipeline[1].id,
+      brickId: formState.modComponent.blockPipeline[1].id,
       modId: undefined,
     });
   });

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -167,7 +167,7 @@ const DataPanel: React.FC = () => {
 
   useEffect(() => {
     reportEvent(Events.DATA_PANEL_TAB_VIEW, {
-      modId: activeModComponentFormState.recipe?.id,
+      modId: activeModComponentFormState.mod?.id,
       brickId,
       tabName: activeTabKey,
     });
@@ -381,7 +381,7 @@ const DataPanel: React.FC = () => {
                 <BrickPreview
                   traceRecord={record}
                   brickConfig={brickConfig}
-                  starterBrick={activeModComponentFormState.extensionPoint}
+                  starterBrick={activeModComponentFormState.starterBrick}
                 />
               </ErrorBoundary>
             ) : (
@@ -407,7 +407,7 @@ const DataPanel: React.FC = () => {
           </DataTab>
           <CommentsTab
             brickId={brickConfig.id}
-            modId={activeModComponentFormState.recipe?.id}
+            modId={activeModComponentFormState.mod?.id}
             brickCommentsFieldName={brickCommentsFieldName}
           />
         </Tab.Content>

--- a/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.test.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.test.tsx
@@ -28,7 +28,7 @@ describe("FoundationDataPanel", () => {
   test("it renders with form state and trace data", async () => {
     const { formState, records } = formStateWithTraceDataFactory();
     const modComponentId = formState.uuid;
-    const { instanceId } = formState.extension.blockPipeline[0];
+    const { instanceId } = formState.modComponent.blockPipeline[0];
     const { asFragment } = render(<FoundationDataPanel />, {
       initialValues: formState,
       setupRedux(dispatch) {

--- a/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/FoundationDataPanel.tsx
@@ -38,8 +38,8 @@ const FoundationDataPanel: React.FC = () => {
     selectActiveModComponentFormState,
   );
   const {
-    extension: { blockPipeline },
-    extensionPoint: starterBrick,
+    modComponent: { blockPipeline },
+    starterBrick,
   } = activeModComponentFormState;
   const firstBlockInstanceId = blockPipeline[0]?.instanceId;
 

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/CommentsTab.test.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/CommentsTab.test.tsx
@@ -31,11 +31,11 @@ import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTy
 
 const reportEventMock = jest.mocked(reportEvent);
 
-const commentsFieldName = "extension.blockPipeline.0.comments";
+const commentsFieldName = "modComponent.blockPipeline.0.comments";
 const initialComments = "Hello world!";
 const formStateWithComments = menuItemFormStateFactory(
   {
-    recipe: modMetadataFactory(),
+    mod: modMetadataFactory(),
   },
   [
     brickConfigFactory({
@@ -48,14 +48,14 @@ const formStateWithNoComments = menuItemFormStateFactory({}, [
   brickConfigFactory(),
 ]);
 const renderCommentsTab = (formState = formStateWithComments) => {
-  const brickId = formState.extension.blockPipeline[0].id;
+  const brickId = formState.modComponent.blockPipeline[0].id;
   render(
     <Tab.Container defaultActiveKey={DataPanelTabKey.Comments}>
       <Formik onSubmit={jest.fn()} initialValues={formState}>
         <CommentsTab
           brickId={brickId}
           brickCommentsFieldName={commentsFieldName}
-          modId={formState.recipe?.id}
+          modId={formState.mod?.id}
         />
       </Formik>
     </Tab.Container>,
@@ -83,7 +83,7 @@ describe("CommentsTab", () => {
     // Trigger onBlur event for the textarea
     await userEvent.keyboard("{tab}");
     const expectedBrickId =
-      formStateWithNoComments.extension.blockPipeline[0].id;
+      formStateWithNoComments.modComponent.blockPipeline[0].id;
 
     expect(reportEventMock).toHaveBeenCalledWith(Events.BRICK_COMMENTS_UPDATE, {
       commentsLength: newComments.length,
@@ -104,12 +104,13 @@ describe("CommentsTab", () => {
 
     // Trigger onBlur event for the textarea
     await userEvent.keyboard("{tab}");
-    const expectedBrickId = formStateWithComments.extension.blockPipeline[0].id;
+    const expectedBrickId =
+      formStateWithComments.modComponent.blockPipeline[0].id;
 
     expect(reportEventMock).toHaveBeenCalledWith(Events.BRICK_COMMENTS_UPDATE, {
       commentsLength: expectedComments.length,
       brickId: expectedBrickId,
-      modId: formStateWithComments.recipe.id,
+      modId: formStateWithComments.mod.id,
     });
   });
 });

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.test.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.test.tsx
@@ -61,7 +61,7 @@ describe("PageStateTab", () => {
 
   test("it renders with mod's mod component", async () => {
     const formState = formStateFactory({
-      recipe: modMetadataFactory(),
+      mod: modMetadataFactory(),
     });
     const { asFragment } = await renderPageStateTab(formState);
     expect(asFragment()).toMatchSnapshot();

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/PageStateTab.tsx
@@ -49,7 +49,7 @@ const PageStateTab: React.VFC = () => {
     async () => {
       const context = {
         modComponentId: activeModComponentFormState?.uuid,
-        modId: activeModComponentFormState?.recipe?.id,
+        modId: activeModComponentFormState?.mod?.id,
       };
 
       const [shared, mod, local] = await Promise.all([
@@ -57,7 +57,7 @@ const PageStateTab: React.VFC = () => {
           namespace: StateNamespaces.PUBLIC,
           ...context,
         }),
-        activeModComponentFormState?.recipe
+        activeModComponentFormState?.mod
           ? getPageState(inspectedTab, {
               namespace: StateNamespaces.MOD,
               ...context,

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/CommentsPreview.test.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/CommentsPreview.test.tsx
@@ -32,7 +32,7 @@ const renderCommentsPreview = (comments: string) => {
       dispatch(actions.setActiveModComponentId(formState.uuid));
       dispatch(
         actions.setActiveNodeId(
-          formState.extension.blockPipeline[0].instanceId,
+          formState.modComponent.blockPipeline[0].instanceId,
         ),
       );
       dispatch(actions.setNodeDataPanelTabSelected(DataPanelTabKey.Context));

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -226,7 +226,7 @@ const usePipelineNodes = (): {
   const starterBrickType = activeModComponentFormState.type;
   const { label: starterBrickLabel, icon: starterBrickIcon } =
     ADAPTERS.get(starterBrickType);
-  const rootPipeline = activeModComponentFormState.extension.blockPipeline;
+  const rootPipeline = activeModComponentFormState.modComponent.blockPipeline;
   const rootPipelineFlavor = getRootPipelineFlavor(starterBrickType);
   const [hoveredState, setHoveredState] = useState<Record<UUID, boolean>>({});
 

--- a/src/pageEditor/tabs/effect/BrickConfiguration.test.tsx
+++ b/src/pageEditor/tabs/effect/BrickConfiguration.test.tsx
@@ -63,7 +63,7 @@ function renderBrickConfiguration(
       dispatch(actions.setActiveModComponentId(initialValues.uuid));
       dispatch(
         actions.setActiveNodeId(
-          initialValues.extension.blockPipeline[0].instanceId,
+          initialValues.modComponent.blockPipeline[0].instanceId,
         ),
       );
     },
@@ -77,7 +77,10 @@ test("renders", async () => {
     brickConfigFactory({ id: brick.id }),
   ]);
   const { asFragment } = renderBrickConfiguration(
-    <BrickConfiguration name="extension.blockPipeline[0]" brickId={brick.id} />,
+    <BrickConfiguration
+      name="modComponent.blockPipeline[0]"
+      brickId={brick.id}
+    />,
     initialState,
   );
 
@@ -101,7 +104,7 @@ describe("shows root mode", () => {
     ]);
     renderBrickConfiguration(
       <BrickConfiguration
-        name="extension.blockPipeline[0]"
+        name="modComponent.blockPipeline[0]"
         brickId={brick.id}
       />,
       initialState,
@@ -122,7 +125,7 @@ describe("shows root mode", () => {
     ]);
     renderBrickConfiguration(
       <BrickConfiguration
-        name="extension.blockPipeline[0]"
+        name="modComponent.blockPipeline[0]"
         brickId={brick.id}
       />,
       initialState,
@@ -143,7 +146,7 @@ describe("shows root mode", () => {
     ]);
     renderBrickConfiguration(
       <BrickConfiguration
-        name="extension.blockPipeline[0]"
+        name="modComponent.blockPipeline[0]"
         brickId={brick.id}
       />,
       initialState,
@@ -182,7 +185,7 @@ test.each`
     ]);
     renderBrickConfiguration(
       <BrickConfiguration
-        name="extension.blockPipeline[0]"
+        name="modComponent.blockPipeline[0]"
         brickId={brick.id}
       />,
       initialState,

--- a/src/pageEditor/tabs/effect/BrickPreview.tsx
+++ b/src/pageEditor/tabs/effect/BrickPreview.tsx
@@ -185,7 +185,7 @@ const BrickPreview: React.FunctionComponent<{
             )),
           },
           rootSelector: undefined,
-          modId: values.recipe?.id,
+          modId: values.mod?.id,
         });
         dispatch(previewSlice.actions.setSuccess({ output, outputKey }));
       } catch (error) {

--- a/src/pageEditor/tabs/effect/StarterBrickPreview.tsx
+++ b/src/pageEditor/tabs/effect/StarterBrickPreview.tsx
@@ -47,7 +47,7 @@ const initialState: PreviewState = {
 };
 
 const previewSlice = createSlice({
-  name: "extensionPointPreview",
+  name: "starterBrickPreview",
   initialState,
   reducers: {
     startRun(state) {
@@ -90,11 +90,11 @@ const StarterBrickPreview: React.FunctionComponent<{
         // data about the element that caused the trigger
         let rootSelector: Nullishable<string> = null;
         if (
-          (modComponentFormState as TriggerFormState).extensionPoint.definition
+          (modComponentFormState as TriggerFormState).starterBrick.definition
             .rootSelector
         ) {
           rootSelector = (modComponentFormState as TriggerFormState)
-            .extensionPoint.definition.rootSelector;
+            .starterBrick.definition.rootSelector;
         }
 
         const data = await runStarterBrickReaderPreview(
@@ -120,7 +120,7 @@ const StarterBrickPreview: React.FunctionComponent<{
   useEffect(() => {
     void debouncedRun(modComponentFormState);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- using objectHash for context
-  }, [debouncedRun, modComponentFormState.extensionPoint]);
+  }, [debouncedRun, modComponentFormState.starterBrick]);
 
   if (isRunning) {
     return (
@@ -132,7 +132,7 @@ const StarterBrickPreview: React.FunctionComponent<{
 
   const reloadTrigger =
     modComponentFormState.type === "trigger" &&
-    modComponentFormState.extensionPoint.definition.trigger !== "load" ? (
+    modComponentFormState.starterBrick.definition.trigger !== "load" ? (
       <div className="text-info">
         <AsyncButton
           variant="info"

--- a/src/pageEditor/tabs/effect/useDocumentPreviewRunBlock.ts
+++ b/src/pageEditor/tabs/effect/useDocumentPreviewRunBlock.ts
@@ -105,10 +105,10 @@ export default function useDocumentPreviewRunBlock(
 
   const {
     uuid: modComponentId,
-    recipe: mod,
+    mod,
     apiVersion,
     integrationDependencies,
-    extensionPoint: starterBrick,
+    starterBrick,
   } = useSelector(selectActiveModComponentFormState);
 
   const { blockConfig } = useSelector(

--- a/src/pageEditor/tabs/trigger/TriggerConfiguration.test.tsx
+++ b/src/pageEditor/tabs/trigger/TriggerConfiguration.test.tsx
@@ -25,8 +25,8 @@ describe("TriggerConfiguration", () => {
         instanceId: uuidv4(),
       },
     ]);
-    formState.extensionPoint.definition.trigger = "custom";
-    formState.extensionPoint.definition.customEvent = { eventName: null };
+    formState.starterBrick.definition.trigger = "custom";
+    formState.starterBrick.definition.customEvent = { eventName: null };
 
     const { asFragment } = render(<TriggerConfiguration isLocked={false} />, {
       initialValues: formState,

--- a/src/pageEditor/toolbar/ReloadToolbar.tsx
+++ b/src/pageEditor/toolbar/ReloadToolbar.tsx
@@ -49,7 +49,7 @@ function isAutomaticTrigger(
   return (
     modComponentFormState?.type === "trigger" &&
     automatic.includes(
-      modComponentFormState?.extensionPoint.definition.trigger ?? "",
+      modComponentFormState?.starterBrick.definition.trigger ?? "",
     )
   );
 }

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -57,7 +57,7 @@ export function getModId(
 ): RegistryId | undefined {
   return isModComponentBase(modComponentOrFormState)
     ? modComponentOrFormState._recipe?.id
-    : modComponentOrFormState.recipe?.id;
+    : modComponentOrFormState.mod?.id;
 }
 
 /**

--- a/src/store/checkActiveModComponentAvailability.test.ts
+++ b/src/store/checkActiveModComponentAvailability.test.ts
@@ -19,7 +19,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import { type EditorRootState } from "@/pageEditor/pageEditorTypes";
 import { type ModComponentsRootState } from "@/store/extensionsTypes";
 import { actions, editorSlice } from "@/pageEditor/slices/editorSlice";
-import extensionsSlice from "@/store/extensionsSlice";
+import modComponentsSlice from "@/store/extensionsSlice";
 import { validateRegistryId } from "@/types/helpers";
 import { type RegistryId } from "@/types/registryTypes";
 import { checkAvailable } from "@/contentScript/messenger/api";
@@ -39,7 +39,7 @@ import { StarterBrickTypes } from "@/types/starterBrickTypes";
 jest.mock("@/contentScript/messenger/api");
 jest.mock("@/pageEditor/context/connection");
 
-const { reducer: extensionsReducer } = extensionsSlice;
+const { reducer: modComponentsReducer } = modComponentsSlice;
 
 describe("checkActiveModComponentAvailability", () => {
   test("it checks the active element correctly", async () => {
@@ -49,12 +49,12 @@ describe("checkActiveModComponentAvailability", () => {
     const store = configureStore<EditorRootState & ModComponentsRootState>({
       reducer: {
         editor: editorSlice.reducer,
-        options: extensionsReducer,
+        options: modComponentsReducer,
       },
     });
 
     const availableDraftModComponent = menuItemFormStateFactory({
-      extensionPoint: {
+      starterBrick: {
         metadata: {
           id: validateRegistryId("test/available-button"),
           name: "Test Starter Brick 1",
@@ -72,7 +72,7 @@ describe("checkActiveModComponentAvailability", () => {
     });
 
     const unavailableDraftModComponent = menuItemFormStateFactory({
-      extensionPoint: {
+      starterBrick: {
         metadata: {
           id: validateRegistryId("test/unavailable-button"),
           name: "Test Starter Brick 2",
@@ -116,7 +116,7 @@ describe("checkActiveModComponentAvailability", () => {
 
     // Make mod component form state available
     const available = produce(availableDraftModComponent, (draft) => {
-      draft.extensionPoint.definition.isAvailable.matchPatterns = [testUrl];
+      draft.starterBrick.definition.isAvailable.matchPatterns = [testUrl];
     });
     store.dispatch(actions.syncModComponentFormState(available));
 

--- a/src/store/checkAvailableDraftModComponents.test.ts
+++ b/src/store/checkAvailableDraftModComponents.test.ts
@@ -29,7 +29,7 @@ import {
 import { type Target } from "@/types/messengerTypes";
 import { type PageTarget } from "webext-messenger";
 import { type ModComponentsRootState } from "@/store/extensionsTypes";
-import extensionsSlice from "@/store/extensionsSlice";
+import modComponentsSlice from "@/store/extensionsSlice";
 import { menuItemFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { getCurrentInspectedURL } from "@/pageEditor/context/connection";
 import { type Availability } from "@/types/availabilityTypes";
@@ -39,7 +39,7 @@ jest.mock("@/contentScript/messenger/api");
 
 jest.mock("@/pageEditor/context/connection");
 
-const { reducer: extensionsReducer } = extensionsSlice;
+const { reducer: modComponentsReducer } = modComponentsSlice;
 
 describe("checkAvailableDraftModComponents", () => {
   test("it checks draft mod components correctly", async () => {
@@ -49,12 +49,12 @@ describe("checkAvailableDraftModComponents", () => {
     const store = configureStore<EditorRootState & ModComponentsRootState>({
       reducer: {
         editor: editorSlice.reducer,
-        options: extensionsReducer,
+        options: modComponentsReducer,
       },
     });
 
     const availableDraftModComponent = menuItemFormStateFactory({
-      extensionPoint: {
+      starterBrick: {
         metadata: {
           id: validateRegistryId("test/available-button"),
           name: "Test Starter Brick 1",
@@ -72,7 +72,7 @@ describe("checkAvailableDraftModComponents", () => {
     });
 
     const unavailableDraftModComponent = menuItemFormStateFactory({
-      extensionPoint: {
+      starterBrick: {
         metadata: {
           id: validateRegistryId("test/unavailable-button"),
           name: "Test Starter Brick 2",

--- a/src/store/editorMigrations.test.ts
+++ b/src/store/editorMigrations.test.ts
@@ -32,7 +32,6 @@ import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import { validateRegistryId } from "@/types/helpers";
 import {
-  BaseFormState,
   type BaseFormStateV3,
   type BaseFormStateV1,
   type BaseFormStateV2,

--- a/src/store/editorMigrations.test.ts
+++ b/src/store/editorMigrations.test.ts
@@ -19,6 +19,7 @@ import {
   type EditorStateV3,
   type EditorStateV1,
   type EditorStateV2,
+  type EditorStateV4,
 } from "@/pageEditor/pageEditorTypes";
 import { mapValues, omit } from "lodash";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
@@ -31,6 +32,8 @@ import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import { validateRegistryId } from "@/types/helpers";
 import {
+  BaseFormState,
+  type BaseFormStateV3,
   type BaseFormStateV1,
   type BaseFormStateV2,
 } from "@/pageEditor/baseFormStateTypes";
@@ -38,6 +41,7 @@ import { type PersistedState } from "redux-persist";
 import {
   migrateEditorStateV1,
   migrateEditorStateV2,
+  migrateEditorStateV3,
 } from "@/store/editorMigrations";
 
 const initialStateV1: EditorStateV1 & PersistedState = {
@@ -118,11 +122,42 @@ const initialStateV3: EditorStateV3 & PersistedState = {
   },
 };
 
-describe("migrateEditorStateV1", () => {
-  it("migrates empty state", () => {
-    expect(migrateEditorStateV1(initialStateV1)).toStrictEqual(initialStateV2);
-  });
+const initialStateV4: EditorStateV4 & PersistedState = {
+  selectionSeq: 0,
+  activeModComponentId: null,
+  activeModId: null,
+  expandedModId: null,
+  error: null,
+  beta: false,
+  modComponentFormStates: [],
+  knownEditableBrickIds: [],
+  dirty: {},
+  isBetaUI: false,
+  copiedBrick: undefined,
+  brickPipelineUIStateById: {},
+  dirtyModOptionsById: {},
+  dirtyModMetadataById: {},
+  visibleModalKey: null,
+  addBrickLocation: undefined,
+  keepLocalCopyOnCreateMod: false,
+  deletedModComponentFormStatesByModId: {},
+  availableActivatedModComponentIds: [],
+  isPendingAvailableActivatedModComponents: false,
+  availableDraftModComponentIds: [],
+  isPendingDraftModComponents: false,
+  isModListExpanded: true,
+  isDataPanelExpanded: true,
+  isDimensionsWarningDismissed: false,
+  inserting: null,
+  isVariablePopoverVisible: false,
+  // Function under test does not handle updating the persistence, this is handled by redux-persist
+  _persist: {
+    version: 1,
+    rehydrated: false,
+  },
+};
 
+describe("editor state migrations", () => {
   function unmigrateServices(
     integrationDependencies: IntegrationDependencyV2[] = [],
   ): IntegrationDependencyV1[] {
@@ -164,81 +199,149 @@ describe("migrateEditorStateV1", () => {
     };
   }
 
-  it("migrates state with elements with no services", () => {
-    const expectedState = {
-      ...initialStateV2,
-      elements: [formStateFactory(), formStateFactory()],
+  function unmigrateFormStateV2(formState: BaseFormStateV3): BaseFormStateV2 {
+    return {
+      ...omit(formState, ["mod", "modComponent", "starterBrick"]),
+      recipe: formState.mod,
+      extension: formState.modComponent,
+      extensionPoint: formState.starterBrick,
     };
-    const unmigrated = unmigrateEditorStateV2(expectedState);
-    expect(migrateEditorStateV1(unmigrated)).toStrictEqual(expectedState);
-  });
+  }
 
-  it("migrates state with elements with services and deleted elements", () => {
-    const fooElement1 = formStateFactory({
-      recipe: modMetadataFactory({
-        id: validateRegistryId("foo"),
-      }),
-      integrationDependencies: [
-        integrationDependencyFactory({
-          configId: uuidSequence,
-        }),
-        integrationDependencyFactory({
-          configId: uuidSequence,
-        }),
-      ],
+  function unmigrateEditorStateV3(
+    state: EditorStateV4 & PersistedState,
+  ): EditorStateV3 & PersistedState {
+    return {
+      ...omit(
+        state,
+        "modComponentFormStates",
+        "deletedModComponentFormStatesByModId",
+      ),
+      modComponentFormStates: state.modComponentFormStates.map((formState) =>
+        unmigrateFormStateV2(formState),
+      ),
+      deletedModComponentFormStatesByModId: mapValues(
+        state.deletedModComponentFormStatesByModId,
+        (formStates) =>
+          formStates.map((formState) => unmigrateFormStateV2(formState)),
+      ),
+    };
+  }
+
+  describe("migrateEditorStateV1", () => {
+    it("migrates empty state", () => {
+      expect(migrateEditorStateV1(initialStateV1)).toStrictEqual(
+        initialStateV2,
+      );
     });
-    const fooElement2 = formStateFactory({
-      recipe: modMetadataFactory({
-        id: validateRegistryId("foo"),
-      }),
-      integrationDependencies: [
-        integrationDependencyFactory({
-          configId: uuidSequence,
-        }),
-        integrationDependencyFactory({
-          configId: uuidSequence,
-        }),
-      ],
+
+    it("migrates state with elements with no services", () => {
+      const expectedState = {
+        ...initialStateV2,
+        elements: [
+          unmigrateFormStateV2(formStateFactory()),
+          unmigrateFormStateV2(formStateFactory()),
+        ],
+      };
+      const unmigrated = unmigrateEditorStateV2(expectedState);
+      expect(migrateEditorStateV1(unmigrated)).toStrictEqual(expectedState);
     });
-    const barElement = formStateFactory({
-      recipe: modMetadataFactory({
-        id: validateRegistryId("bar"),
-      }),
-      integrationDependencies: [
-        integrationDependencyFactory({
-          configId: uuidSequence,
-        }),
-        integrationDependencyFactory({
-          configId: uuidSequence,
-        }),
-      ],
-    });
-    const expectedState = {
-      ...initialStateV2,
-      elements: [
+
+    it("migrates state with elements with services and deleted elements", () => {
+      const fooElement1 = unmigrateFormStateV2(
         formStateFactory({
+          mod: modMetadataFactory({
+            id: validateRegistryId("foo"),
+          }),
           integrationDependencies: [
+            integrationDependencyFactory({
+              configId: uuidSequence,
+            }),
             integrationDependencyFactory({
               configId: uuidSequence,
             }),
           ],
         }),
-        fooElement1,
-        fooElement2,
-        barElement,
-      ],
-      deletedElementsByRecipeId: {
-        foo: [fooElement1, fooElement2],
-        bar: [barElement],
-      },
-    };
-    const unmigrated = unmigrateEditorStateV2(expectedState);
-    expect(migrateEditorStateV1(unmigrated)).toStrictEqual(expectedState);
+      );
+      const fooElement2 = unmigrateFormStateV2(
+        formStateFactory({
+          mod: modMetadataFactory({
+            id: validateRegistryId("foo"),
+          }),
+          integrationDependencies: [
+            integrationDependencyFactory({
+              configId: uuidSequence,
+            }),
+            integrationDependencyFactory({
+              configId: uuidSequence,
+            }),
+          ],
+        }),
+      );
+      const barElement = unmigrateFormStateV2(
+        formStateFactory({
+          mod: modMetadataFactory({
+            id: validateRegistryId("bar"),
+          }),
+          integrationDependencies: [
+            integrationDependencyFactory({
+              configId: uuidSequence,
+            }),
+            integrationDependencyFactory({
+              configId: uuidSequence,
+            }),
+          ],
+        }),
+      );
+      const expectedState = {
+        ...initialStateV2,
+        elements: [
+          unmigrateFormStateV2(
+            formStateFactory({
+              integrationDependencies: [
+                integrationDependencyFactory({
+                  configId: uuidSequence,
+                }),
+              ],
+            }),
+          ),
+          fooElement1,
+          fooElement2,
+          barElement,
+        ],
+        deletedElementsByRecipeId: {
+          foo: [fooElement1, fooElement2],
+          bar: [barElement],
+        },
+      };
+      const unmigrated = unmigrateEditorStateV2(expectedState);
+      expect(migrateEditorStateV1(unmigrated)).toStrictEqual(expectedState);
+    });
   });
-});
 
-describe("migrateEditorStateV2", () => {
-  it("migrates empty state", () => {
-    expect(migrateEditorStateV2(initialStateV2)).toStrictEqual(initialStateV3);
+  describe("migrateEditorStateV2", () => {
+    it("migrates empty state", () => {
+      expect(migrateEditorStateV2(initialStateV2)).toStrictEqual(
+        initialStateV3,
+      );
+    });
+  });
+
+  describe("migrateEditorStateV3", () => {
+    it("migrates empty state", () => {
+      expect(migrateEditorStateV3(initialStateV3)).toStrictEqual(
+        initialStateV4,
+      );
+    });
+
+    it("migrates the form states", () => {
+      const formState = formStateFactory();
+      const expectedState = {
+        ...initialStateV4,
+        modComponentFormStates: [formState],
+      };
+      const unmigrated = unmigrateEditorStateV3(expectedState);
+      expect(migrateEditorStateV3(unmigrated)).toStrictEqual(expectedState);
+    });
   });
 });

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -41,6 +41,7 @@ export const migrations: MigrationManifest = {
   1: (state) => state,
   2: (state: EditorStateV1 & PersistedState) => migrateEditorStateV1(state),
   3: (state: EditorStateV2 & PersistedState) => migrateEditorStateV2(state),
+  4: (state: EditorStateV3 & PersistedState) => migrateEditorStateV3(state),
 };
 
 export function migrateIntegrationDependenciesV1toV2(

--- a/src/store/editorStorage.test.ts
+++ b/src/store/editorStorage.test.ts
@@ -51,11 +51,11 @@ const setReduxStorageMock = jest.mocked(setReduxStorage);
 const currentPersistenceVersion = getMaxMigrationsVersion(migrations);
 
 describe("draftModComponentStorage", () => {
-  test("removes one active element", async () => {
-    const element = formStateFactory();
+  test("removes one active form state", async () => {
+    const formState = formStateFactory();
     const nodeUIStates: Record<UUID, NodeUIState> = {
-      [element.uuid]: {
-        nodeId: element.extension.blockPipeline[0].instanceId,
+      [formState.uuid]: {
+        nodeId: formState.modComponent.blockPipeline[0].instanceId,
         dataPanel: {
           activeTabKey: null,
         },
@@ -63,23 +63,23 @@ describe("draftModComponentStorage", () => {
     };
     const state: EditorState = {
       ...initialState,
-      activeModComponentId: element.uuid,
-      modComponentFormStates: [element],
+      activeModComponentId: formState.uuid,
+      modComponentFormStates: [formState],
       dirty: {
-        [element.uuid]: true,
+        [formState.uuid]: true,
       },
       brickPipelineUIStateById: {
-        [element.uuid]: {
-          pipelineMap: getPipelineMap(element.extension.blockPipeline),
-          activeNodeId: element.extension.blockPipeline[0].instanceId,
+        [formState.uuid]: {
+          pipelineMap: getPipelineMap(formState.modComponent.blockPipeline),
+          activeNodeId: formState.modComponent.blockPipeline[0].instanceId,
           nodeUIStates,
         },
       },
-      availableDraftModComponentIds: [element.uuid],
+      availableDraftModComponentIds: [formState.uuid],
     };
     readReduxStorageMock.mockResolvedValue(state);
 
-    await removeDraftModComponents([element.uuid]);
+    await removeDraftModComponents([formState.uuid]);
 
     expect(setReduxStorage).toHaveBeenCalledWith(
       "persist:editor",
@@ -88,20 +88,20 @@ describe("draftModComponentStorage", () => {
     );
   });
 
-  test("removes inactive element", async () => {
-    const inactiveElement = formStateFactory();
+  test("removes inactive formState", async () => {
+    const inactiveFormState = formStateFactory();
     const inactiveNodeUIStates: Record<UUID, NodeUIState> = {
-      [inactiveElement.uuid]: {
-        nodeId: inactiveElement.extension.blockPipeline[1].instanceId,
+      [inactiveFormState.uuid]: {
+        nodeId: inactiveFormState.modComponent.blockPipeline[1].instanceId,
         dataPanel: {
           activeTabKey: null,
         },
       } as NodeUIState,
     };
-    const activeElement = formStateFactory();
+    const activeFormState = formStateFactory();
     const activeNodeUIStates: Record<UUID, NodeUIState> = {
-      [activeElement.uuid]: {
-        nodeId: activeElement.extension.blockPipeline[0].instanceId,
+      [activeFormState.uuid]: {
+        nodeId: activeFormState.modComponent.blockPipeline[0].instanceId,
         dataPanel: {
           activeTabKey: null,
         },
@@ -109,42 +109,48 @@ describe("draftModComponentStorage", () => {
     };
     const baseState: EditorState = {
       ...initialState,
-      activeModComponentId: activeElement.uuid,
-      modComponentFormStates: [activeElement],
+      activeModComponentId: activeFormState.uuid,
+      modComponentFormStates: [activeFormState],
       dirty: {
-        [activeElement.uuid]: true,
+        [activeFormState.uuid]: true,
       },
       brickPipelineUIStateById: {
-        [activeElement.uuid]: {
-          pipelineMap: getPipelineMap(activeElement.extension.blockPipeline),
-          activeNodeId: activeElement.extension.blockPipeline[0].instanceId,
+        [activeFormState.uuid]: {
+          pipelineMap: getPipelineMap(
+            activeFormState.modComponent.blockPipeline,
+          ),
+          activeNodeId:
+            activeFormState.modComponent.blockPipeline[0].instanceId,
           nodeUIStates: activeNodeUIStates,
         },
       },
-      availableDraftModComponentIds: [activeElement.uuid],
+      availableDraftModComponentIds: [activeFormState.uuid],
     };
     const stateWithInactive: EditorState = {
       ...baseState,
       modComponentFormStates: [
         ...baseState.modComponentFormStates,
-        inactiveElement,
+        inactiveFormState,
       ],
       brickPipelineUIStateById: {
         ...baseState.brickPipelineUIStateById,
-        [inactiveElement.uuid]: {
-          pipelineMap: getPipelineMap(inactiveElement.extension.blockPipeline),
-          activeNodeId: inactiveElement.extension.blockPipeline[0].instanceId,
+        [inactiveFormState.uuid]: {
+          pipelineMap: getPipelineMap(
+            inactiveFormState.modComponent.blockPipeline,
+          ),
+          activeNodeId:
+            inactiveFormState.modComponent.blockPipeline[0].instanceId,
           nodeUIStates: inactiveNodeUIStates,
         },
       },
       availableDraftModComponentIds: [
         ...baseState.availableDraftModComponentIds,
-        inactiveElement.uuid,
+        inactiveFormState.uuid,
       ],
     };
     readReduxStorageMock.mockResolvedValue(stateWithInactive);
 
-    await removeDraftModComponents([inactiveElement.uuid]);
+    await removeDraftModComponents([inactiveFormState.uuid]);
 
     expect(setReduxStorage).toHaveBeenCalledWith(
       "persist:editor",
@@ -154,33 +160,33 @@ describe("draftModComponentStorage", () => {
   });
 
   test("removes active recipe", async () => {
-    const recipe = modMetadataFactory();
-    const element1 = formStateFactory({
-      recipe,
+    const mod = modMetadataFactory();
+    const formState1 = formStateFactory({
+      mod,
     });
-    const element1NodeUIStates: Record<UUID, NodeUIState> = {
-      [element1.uuid]: {
-        nodeId: element1.extension.blockPipeline[0].instanceId,
+    const formState1NodeUIStates: Record<UUID, NodeUIState> = {
+      [formState1.uuid]: {
+        nodeId: formState1.modComponent.blockPipeline[0].instanceId,
         dataPanel: {
           activeTabKey: null,
         },
       } as NodeUIState,
     };
-    const element2 = formStateFactory({
-      recipe,
+    const formState2 = formStateFactory({
+      mod,
     });
-    const element2NodeUIStates: Record<UUID, NodeUIState> = {
-      [element2.uuid]: {
-        nodeId: element2.extension.blockPipeline[0].instanceId,
+    const formState2NodeUIStates: Record<UUID, NodeUIState> = {
+      [formState2.uuid]: {
+        nodeId: formState2.modComponent.blockPipeline[0].instanceId,
         dataPanel: {
           activeTabKey: null,
         },
       } as NodeUIState,
     };
-    const element3 = formStateFactory();
-    const element3NodeUIStates: Record<UUID, NodeUIState> = {
-      [element3.uuid]: {
-        nodeId: element3.extension.blockPipeline[1].instanceId,
+    const formState3 = formStateFactory();
+    const formState3NodeUIStates: Record<UUID, NodeUIState> = {
+      [formState3.uuid]: {
+        nodeId: formState3.modComponent.blockPipeline[1].instanceId,
         dataPanel: {
           activeTabKey: null,
         },
@@ -188,55 +194,55 @@ describe("draftModComponentStorage", () => {
     };
     const baseState: EditorState = {
       ...initialState,
-      modComponentFormStates: [element3],
+      modComponentFormStates: [formState3],
       brickPipelineUIStateById: {
-        [element3.uuid]: {
-          pipelineMap: getPipelineMap(element3.extension.blockPipeline),
-          activeNodeId: element3.extension.blockPipeline[0].instanceId,
-          nodeUIStates: element3NodeUIStates,
+        [formState3.uuid]: {
+          pipelineMap: getPipelineMap(formState3.modComponent.blockPipeline),
+          activeNodeId: formState3.modComponent.blockPipeline[0].instanceId,
+          nodeUIStates: formState3NodeUIStates,
         },
       },
-      availableDraftModComponentIds: [element3.uuid],
+      availableDraftModComponentIds: [formState3.uuid],
     };
     const stateWithRecipe: EditorState = {
       ...baseState,
-      activeModId: recipe.id,
+      activeModId: mod.id,
       modComponentFormStates: [
         ...baseState.modComponentFormStates,
-        element1,
-        element2,
+        formState1,
+        formState2,
       ],
       dirty: {
-        [element1.uuid]: true,
+        [formState1.uuid]: true,
       },
       dirtyModMetadataById: {
-        [recipe.id]: {
-          ...recipe,
+        [mod.id]: {
+          ...mod,
           description: "new description",
         },
       },
       brickPipelineUIStateById: {
         ...baseState.brickPipelineUIStateById,
-        [element1.uuid]: {
-          pipelineMap: getPipelineMap(element1.extension.blockPipeline),
-          activeNodeId: element1.extension.blockPipeline[1].instanceId,
-          nodeUIStates: element1NodeUIStates,
+        [formState1.uuid]: {
+          pipelineMap: getPipelineMap(formState1.modComponent.blockPipeline),
+          activeNodeId: formState1.modComponent.blockPipeline[1].instanceId,
+          nodeUIStates: formState1NodeUIStates,
         },
-        [element2.uuid]: {
-          pipelineMap: getPipelineMap(element2.extension.blockPipeline),
-          activeNodeId: element2.extension.blockPipeline[0].instanceId,
-          nodeUIStates: element2NodeUIStates,
+        [formState2.uuid]: {
+          pipelineMap: getPipelineMap(formState2.modComponent.blockPipeline),
+          activeNodeId: formState2.modComponent.blockPipeline[0].instanceId,
+          nodeUIStates: formState2NodeUIStates,
         },
       },
       availableDraftModComponentIds: [
         ...baseState.availableDraftModComponentIds,
-        element1.uuid,
-        element2.uuid,
+        formState1.uuid,
+        formState2.uuid,
       ],
     };
     readReduxStorageMock.mockResolvedValue(stateWithRecipe);
 
-    await removeDraftModComponentsForMod(recipe.id);
+    await removeDraftModComponentsForMod(mod.id);
 
     expect(setReduxStorage).toHaveBeenCalledWith(
       "persist:editor",
@@ -246,33 +252,33 @@ describe("draftModComponentStorage", () => {
   });
 
   test("removes inactive recipe", async () => {
-    const recipe = modMetadataFactory();
-    const element1 = formStateFactory({
-      recipe,
+    const mod = modMetadataFactory();
+    const formState1 = formStateFactory({
+      mod,
     });
-    const element1NodeUIStates: Record<UUID, NodeUIState> = {
-      [element1.uuid]: {
-        nodeId: element1.extension.blockPipeline[0].instanceId,
+    const formState1NodeUIStates: Record<UUID, NodeUIState> = {
+      [formState1.uuid]: {
+        nodeId: formState1.modComponent.blockPipeline[0].instanceId,
         dataPanel: {
           activeTabKey: null,
         },
       } as NodeUIState,
     };
-    const element2 = formStateFactory({
-      recipe,
+    const formState2 = formStateFactory({
+      mod,
     });
-    const element2NodeUIStates: Record<UUID, NodeUIState> = {
-      [element2.uuid]: {
-        nodeId: element2.extension.blockPipeline[0].instanceId,
+    const formState2NodeUIStates: Record<UUID, NodeUIState> = {
+      [formState2.uuid]: {
+        nodeId: formState2.modComponent.blockPipeline[0].instanceId,
         dataPanel: {
           activeTabKey: null,
         },
       } as NodeUIState,
     };
-    const element3 = formStateFactory();
-    const element3NodeUIStates: Record<UUID, NodeUIState> = {
-      [element3.uuid]: {
-        nodeId: element3.extension.blockPipeline[1].instanceId,
+    const formState3 = formStateFactory();
+    const formState3NodeUIStates: Record<UUID, NodeUIState> = {
+      [formState3.uuid]: {
+        nodeId: formState3.modComponent.blockPipeline[1].instanceId,
         dataPanel: {
           activeTabKey: null,
         },
@@ -280,55 +286,55 @@ describe("draftModComponentStorage", () => {
     };
     const baseState: EditorState = {
       ...initialState,
-      activeModComponentId: element3.uuid,
-      modComponentFormStates: [element3],
+      activeModComponentId: formState3.uuid,
+      modComponentFormStates: [formState3],
       brickPipelineUIStateById: {
-        [element3.uuid]: {
-          pipelineMap: getPipelineMap(element3.extension.blockPipeline),
-          activeNodeId: element3.extension.blockPipeline[0].instanceId,
-          nodeUIStates: element3NodeUIStates,
+        [formState3.uuid]: {
+          pipelineMap: getPipelineMap(formState3.modComponent.blockPipeline),
+          activeNodeId: formState3.modComponent.blockPipeline[0].instanceId,
+          nodeUIStates: formState3NodeUIStates,
         },
       },
-      availableDraftModComponentIds: [element3.uuid],
+      availableDraftModComponentIds: [formState3.uuid],
     };
     const stateWithRecipe: EditorState = {
       ...baseState,
       modComponentFormStates: [
         ...baseState.modComponentFormStates,
-        element1,
-        element2,
+        formState1,
+        formState2,
       ],
       dirty: {
-        [element1.uuid]: true,
+        [formState1.uuid]: true,
       },
       dirtyModMetadataById: {
-        [recipe.id]: {
-          ...recipe,
+        [mod.id]: {
+          ...mod,
           description: "new description",
         },
       },
       brickPipelineUIStateById: {
         ...baseState.brickPipelineUIStateById,
-        [element1.uuid]: {
-          pipelineMap: getPipelineMap(element1.extension.blockPipeline),
-          activeNodeId: element1.extension.blockPipeline[1].instanceId,
-          nodeUIStates: element1NodeUIStates,
+        [formState1.uuid]: {
+          pipelineMap: getPipelineMap(formState1.modComponent.blockPipeline),
+          activeNodeId: formState1.modComponent.blockPipeline[1].instanceId,
+          nodeUIStates: formState1NodeUIStates,
         },
-        [element2.uuid]: {
-          pipelineMap: getPipelineMap(element2.extension.blockPipeline),
-          activeNodeId: element2.extension.blockPipeline[0].instanceId,
-          nodeUIStates: element2NodeUIStates,
+        [formState2.uuid]: {
+          pipelineMap: getPipelineMap(formState2.modComponent.blockPipeline),
+          activeNodeId: formState2.modComponent.blockPipeline[0].instanceId,
+          nodeUIStates: formState2NodeUIStates,
         },
       },
       availableDraftModComponentIds: [
         ...baseState.availableDraftModComponentIds,
-        element1.uuid,
-        element2.uuid,
+        formState1.uuid,
+        formState2.uuid,
       ],
     };
     readReduxStorageMock.mockResolvedValue(stateWithRecipe);
 
-    await removeDraftModComponentsForMod(recipe.id);
+    await removeDraftModComponentsForMod(mod.id);
 
     expect(setReduxStorage).toHaveBeenCalledWith(
       "persist:editor",

--- a/src/store/editorStorage.ts
+++ b/src/store/editorStorage.ts
@@ -114,7 +114,7 @@ export async function removeDraftModComponentsForMod(
     removeModData(draft, modId);
 
     for (const modComponentFormState of state.modComponentFormStates) {
-      if (modComponentFormState.recipe?.id === modId) {
+      if (modComponentFormState.mod?.id === modId) {
         removedDraftModComponents.push(modComponentFormState.uuid);
         removeModComponentFormState(draft, modComponentFormState.uuid);
       }

--- a/src/testUtils/factories/pageEditorFactories.ts
+++ b/src/testUtils/factories/pageEditorFactories.ts
@@ -73,12 +73,12 @@ const internalFormStateFactory = define<InternalFormStateOverride>({
   integrationDependencies(): IntegrationDependency[] {
     return [];
   },
-  recipe: undefined,
+  mod: undefined,
   type: StarterBrickTypes.SIDEBAR_PANEL,
   label: (i: number) => `Element ${i}`,
-  extension: baseModComponentStateFactory,
+  modComponent: baseModComponentStateFactory,
   // @ts-expect-error -- TODO: verify typings
-  extensionPoint: derive<ModComponentFormState, StarterBrickDefinitionLike>(
+  starterBrick: derive<ModComponentFormState, StarterBrickDefinitionLike>(
     ({ type }) => {
       // FIXME: the starter brick type produced is not based on the type provided
       const starterBrick = starterBrickDefinitionFactory();
@@ -99,7 +99,7 @@ export const formStateFactory = (
   if (pipelineOverride) {
     return internalFormStateFactory({
       ...override,
-      extension: baseModComponentStateFactory({
+      modComponent: baseModComponentStateFactory({
         blockPipeline: pipelineOverride,
       }),
     } as InternalFormStateOverride);
@@ -261,11 +261,11 @@ export const formStateWithTraceDataFactory = define<{
     TraceRecord[]
   >(({ formState }) => {
     assertNotNullish(formState, "formState is required");
-    const { uuid: extensionId, extension } = formState;
+    const { uuid: modComponentId, modComponent } = formState;
 
     let outputKey = "" as OutputKey;
     let output: JsonObject = foundationOutputFactory();
-    return extension.blockPipeline.map((block, index) => {
+    return modComponent.blockPipeline.map((block, index) => {
       const context = output;
       outputKey = `output${index}` as OutputKey;
       output = {
@@ -278,7 +278,7 @@ export const formStateWithTraceDataFactory = define<{
       };
 
       return traceRecordFactory({
-        extensionId,
+        extensionId: modComponentId,
         blockInstanceId: block.instanceId,
         blockId: block.id,
         templateContext: context,


### PR DESCRIPTION
## What does this PR do?

- Part of #8579 
- Part of #8614

## Remaining Work

- Validate linting and unit tests are passing

## Future Work

- Migrate/rename more nested form state values
    - eg `blockPipeline` -> `brickPipeline`

## Checklist

- [x] Added jest or playwright tests and/or storybook stories

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
