### PR TITLE
#8740 fix welcome starter mods not loading in welcome page

### DIFF
--- a/end-to-end-tests/setup/utils.ts
+++ b/end-to-end-tests/setup/utils.ts
@@ -47,5 +47,6 @@ export const openExtensionConsoleFromAdmin = async (
     await expect(extensionConsolePage.getByText(userName)).toBeVisible();
   }).toPass({ timeout: 15_000 });
 
-  return extensionConsolePage;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- needed for strict null check
+  return extensionConsolePage as Page;
 };

--- a/end-to-end-tests/setup/utils.ts
+++ b/end-to-end-tests/setup/utils.ts
@@ -16,7 +16,6 @@
  */
 
 import { type BrowserContext, type Page, expect } from "@playwright/test";
-import { ensureVisibility } from "../utils";
 
 export const openExtensionConsoleFromAdmin = async (
   adminPage: Page,

--- a/end-to-end-tests/tests/regressions/welcomeStarterBricks.spec.ts
+++ b/end-to-end-tests/tests/regressions/welcomeStarterBricks.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { test, expect } from "../../fixtures/testBase";
+// @ts-expect-error -- https://youtrack.jetbrains.com/issue/AQUA-711/Provide-a-run-configuration-for-Playwright-tests-in-specs-with-fixture-imports-only
+import { test as base } from "@playwright/test";
+import { ActivateModPage } from "../../pageObjects/extensionConsole/modsPage";
+import { getSidebarPage, runModViaQuickBar } from "../../utils";
+
+test("#8740: can view the starter mods on the pixiebrix.com/welcome page", async ({
+  page,
+  extensionId,
+}) => {
+  const modId = "@e2e-testing/test-sidebar-navigation";
+  const modActivationPage = new ActivateModPage(page, extensionId, modId);
+  await modActivationPage.goto();
+  await modActivationPage.clickActivateAndWaitForModsPageRedirect();
+
+  await page.goto("https://pixiebrix.com/welcome");
+  await runModViaQuickBar(page, "Open Sidebar");
+
+  const sideBarPage = await getSidebarPage(page, extensionId);
+  await expect(
+    sideBarPage.getByRole("heading", { name: "Announcements" }),
+  ).toBeVisible();
+  await expect(
+    sideBarPage.getByRole("heading", { name: "Decision Tree" }),
+  ).toBeVisible();
+  await expect(
+    sideBarPage.getByRole("heading", { name: "Search" }),
+  ).toBeVisible();
+  await expect(
+    sideBarPage.getByRole("heading", { name: "Snippet Manager" }),
+  ).toBeVisible();
+  await expect(
+    sideBarPage.getByRole("heading", { name: "Writing Assist" }),
+  ).toBeVisible();
+});

--- a/src/background/starterMods.test.ts
+++ b/src/background/starterMods.test.ts
@@ -67,7 +67,7 @@ jest.mock("@/auth/authStorage", () => ({
   addListener: jest.fn(),
 }));
 
-jest.mock("@/utils/extensionUtils");
+jest.mock("@/contentScript/messenger/api");
 jest.mock("./refreshRegistries");
 
 const isLinkedMock = jest.mocked(isLinked);

--- a/src/background/starterMods.ts
+++ b/src/background/starterMods.ts
@@ -26,8 +26,7 @@ import {
   saveModComponentState,
 } from "@/store/extensionsStorage";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
-import { forEachTab } from "@/utils/extensionUtils";
-import { queueReloadFrameMods } from "@/contentScript/messenger/api";
+import { reloadModsEveryTab } from "@/contentScript/messenger/api";
 import { type ModComponentState } from "@/store/extensionsTypes";
 import reportError from "@/telemetry/reportError";
 import { debounce } from "lodash";
@@ -261,7 +260,9 @@ async function activateMods(modDefinitions: ModDefinition[]): Promise<boolean> {
     saveModComponentState(optionsState),
     saveSidebarState(sidebarState),
   ]);
-  await forEachTab(queueReloadFrameMods);
+
+  reloadModsEveryTab();
+
   return newModConfigs.length > 0;
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #8740

This PR modifies the method for activating the starter mods in the background script so that it immediately reloads the mods in the tab, rather than on the next navigation. This fixes the issue where the mods were not completely loaded on the page, and not showing properly in the sidebar.

Also included is a new end-to-end test for viewing the starter mods on the pixiebrix.com/welcome page.

Additionally, this PR also refactors the method for opening the extension console from the admin page in the end-to-end test setup to reduce flakiness. 

## Checklist

- [X] Add jest or playwright tests and/or storybook stories