### PR TITLE
Improve Page Editor utils method names

### DIFF
--- a/src/pageEditor/hooks/useCreateModFromModComponent.ts
+++ b/src/pageEditor/hooks/useCreateModFromModComponent.ts
@@ -27,7 +27,7 @@ import { useCreateModDefinitionMutation } from "@/data/service/api";
 import { useDispatch, useSelector } from "react-redux";
 import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
 import useUpsertModComponentFormState from "@/pageEditor/hooks/useUpsertModComponentFormState";
-import { selectModMetadata } from "@/pageEditor/utils";
+import { mapModDefinitionUpsertResponseToModMetadata } from "@/pageEditor/utils";
 import { selectKeepLocalCopyOnCreateMod } from "@/pageEditor/store/editor/editorSelectors";
 import { useRemoveModComponentFromStorage } from "@/pageEditor/hooks/useRemoveModComponentFromStorage";
 import useBuildAndValidateMod from "@/pageEditor/hooks/useBuildAndValidateMod";
@@ -84,7 +84,7 @@ function useCreateModFromModComponent(
           }).unwrap();
 
           const newModComponent = produce(newModComponentFormState, (draft) => {
-            draft.modMetadata = selectModMetadata(
+            draft.modMetadata = mapModDefinitionUpsertResponseToModMetadata(
               newModDefinition,
               upsertResponse,
             );

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -34,11 +34,11 @@ import {
 } from "@/telemetry/traceHelpers";
 import { DocumentRenderer } from "@/bricks/renderers/document";
 import {
-  filterBrickAnnotations,
   getDocumentBuilderPipelinePaths,
   filterStarterBrickAnalysisAnnotations,
   getVariableKeyForSubPipeline,
   getPipelinePropNames,
+  filterAnnotationsByBrickPath,
 } from "@/pageEditor/utils";
 import { get, isEmpty } from "lodash";
 import {
@@ -413,7 +413,7 @@ const usePipelineNodes = (): {
       // eslint-disable-next-line security/detect-object-injection -- relying on nodeId being a UUID
       const blockPath = maybePipelineMap?.[nodeId]?.path;
       const blockAnnotations = blockPath
-        ? filterBrickAnnotations(blockPath, annotations)
+        ? filterAnnotationsByBrickPath(annotations, blockPath)
         : [];
 
       contentProps = {

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -34,9 +34,9 @@ import {
 } from "@/telemetry/traceHelpers";
 import { DocumentRenderer } from "@/bricks/renderers/document";
 import {
-  getBlockAnnotations,
+  filterBrickAnnotations,
   getDocumentBuilderPipelinePaths,
-  getFoundationNodeAnnotations,
+  filterStarterBrickAnalysisAnnotations,
   getVariableKeyForSubPipeline,
   getPipelinePropNames,
 } from "@/pageEditor/utils";
@@ -413,7 +413,7 @@ const usePipelineNodes = (): {
       // eslint-disable-next-line security/detect-object-injection -- relying on nodeId being a UUID
       const blockPath = maybePipelineMap?.[nodeId]?.path;
       const blockAnnotations = blockPath
-        ? getBlockAnnotations(blockPath, annotations)
+        ? filterBrickAnnotations(blockPath, annotations)
         : [];
 
       contentProps = {
@@ -717,7 +717,7 @@ const usePipelineNodes = (): {
       icon: starterBrickIcon,
       runStatus: decideFoundationStatus({
         hasTraces: modComponentHasTraces,
-        blockAnnotations: getFoundationNodeAnnotations(annotations),
+        blockAnnotations: filterStarterBrickAnalysisAnnotations(annotations),
       }),
       brickLabel: starterBrickLabel,
       outputKey: "input" as OutputKey,

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -44,6 +44,17 @@ import AddDynamicTextSnippet from "@/bricks/effects/AddDynamicTextSnippet";
 import { type PackageUpsertResponse } from "@/types/contract";
 import { type UnsavedModDefinition } from "@/types/modDefinitionTypes";
 
+export function mapModDefinitionUpsertResponseToModMetadata(
+  unsavedModDefinition: UnsavedModDefinition,
+  response: PackageUpsertResponse,
+): ModComponentBase["_recipe"] {
+  return {
+    ...unsavedModDefinition.metadata,
+    sharing: pick(response, ["public", "organizations"]),
+    ...pick(response, ["updated_at"]),
+  };
+}
+
 export function getModComponentId(
   modComponentOrFormState: ModComponentBase | ModComponentFormState,
 ): UUID {
@@ -65,7 +76,7 @@ export function getModId(
  *
  * Returns prop names in the order they should be displayed in the layout.
  *
- * @param brick the brick, or null if resolved block not available yet
+ * @param brick the brick, or null if resolved brick not available yet
  * @param brickConfig the brick configuration
  *
  * @see PipelineToggleField
@@ -208,14 +219,16 @@ function getDocumentBuilderElementsPipelinePropNames(
   return propNames;
 }
 
-export function getDocumentBuilderPipelinePaths(block: BrickConfig): string[] {
+export function getDocumentBuilderPipelinePaths(
+  brickConfig: BrickConfig,
+): string[] {
   return getDocumentBuilderElementsPipelinePropNames(
     "config.body",
-    (block.config.body ?? []) as DocumentBuilderElement[],
+    (brickConfig.config.body ?? []) as DocumentBuilderElement[],
   );
 }
 
-export function getFoundationNodeAnnotations(
+export function filterStarterBrickAnalysisAnnotations(
   annotations: AnalysisAnnotation[],
 ): AnalysisAnnotation[] {
   return annotations.filter(
@@ -224,20 +237,20 @@ export function getFoundationNodeAnnotations(
   );
 }
 
-export function getBlockAnnotations(
-  blockPath: string,
+export function filterBrickAnnotations(
+  brickPath: string,
   annotations: AnalysisAnnotation[],
 ): AnalysisAnnotation[] {
-  const pathLength = blockPath.length;
+  const pathLength = brickPath.length;
 
   const relatedAnnotations = annotations.filter((annotation) =>
-    annotation.position.path.startsWith(blockPath),
+    annotation.position.path.startsWith(brickPath),
   );
 
   return relatedAnnotations.filter((annotation) => {
     const restPath = annotation.position.path.slice(pathLength);
     // XXX: this may be not a reliable way to determine if the annotation
-    // is owned by the block or its sub pipeline.
+    // is owned by the brick or its sub pipeline.
     // It assumes that it's only the pipeline field that can have a ".__value__" followed by "." in the path,
     // and a pipeline field always has this pattern in its path.
     return !restPath.includes(".__value__.");
@@ -250,16 +263,5 @@ export function selectPageEditorDimensions() {
     pageEditorHeight: window.innerHeight,
     pageEditorOrientation:
       window.innerWidth > window.innerHeight ? "landscape" : "portrait",
-  };
-}
-
-export function selectModMetadata(
-  unsavedModDefinition: UnsavedModDefinition,
-  response: PackageUpsertResponse,
-): ModComponentBase["_recipe"] {
-  return {
-    ...unsavedModDefinition.metadata,
-    sharing: pick(response, ["public", "organizations"]),
-    ...pick(response, ["updated_at"]),
   };
 }

--- a/src/pageEditor/utils.ts
+++ b/src/pageEditor/utils.ts
@@ -237,9 +237,9 @@ export function filterStarterBrickAnalysisAnnotations(
   );
 }
 
-export function filterBrickAnnotations(
-  brickPath: string,
+export function filterAnnotationsByBrickPath(
   annotations: AnalysisAnnotation[],
+  brickPath: string,
 ): AnalysisAnnotation[] {
   const pathLength = brickPath.length;
 


### PR DESCRIPTION
## What does this PR do?

- Improve Page Editor utils method names
- Avoid using `select` outside of Redux context
- foundation -> starter brick
- block -> brick

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
