### PR TITLE
DX - Fix flaky sidebar playwright test

### DIFF
--- a/end-to-end-tests/pageObjects/pageEditor/utils.ts
+++ b/end-to-end-tests/pageObjects/pageEditor/utils.ts
@@ -27,9 +27,9 @@ export function ModifiesModState<T>(
 ) {
   return async function (this: BasePageObject, ...args: any[]): Promise<T> {
     const result = await value.apply(this, args);
-    // See EditorPane.tsx:REDUX_SYNC_WAIT_MILLIS
+    // See EditorPane.tsx: REDUX_SYNC_WAIT_MILLIS+CHANGE_DETECT_DELAY_MILLIS --> 500 + 100 = 600ms
     // eslint-disable-next-line playwright/no-wait-for-timeout -- Wait for Redux to update
-    await this.page.waitForTimeout(500);
+    await this.page.waitForTimeout(600);
     return result;
   };
 }

--- a/end-to-end-tests/tests/regressions/doNotCloseSidebarOnPageEditorSave.spec.ts
+++ b/end-to-end-tests/tests/regressions/doNotCloseSidebarOnPageEditorSave.spec.ts
@@ -45,6 +45,16 @@ test("#8104: Do not automatically close the sidebar when saving in the Page Edit
     "Tab Title",
     updatedTabTitle,
   );
+
+  // Formik syncs form state with redux every 100ms. The "Render Panel" button
+  // sends the form state to the sidebar, but the save functionality uses the
+  // redux state for the mod component. This 100ms delay is fine in practice
+  // for real users, but playwright is able to click render and then click save
+  // within this 100ms timeout, which causes a race condition and makes this
+  // test flaky. So, we need a delay here to wait for the sync.
+  // eslint-disable-next-line playwright/no-wait-for-timeout -- see above
+  await page.waitForTimeout(200);
+
   await pageEditorPage.getRenderPanelButton().click();
   await expect(
     sidebar.getByRole("tab", { name: updatedTabTitle }),

--- a/end-to-end-tests/tests/regressions/doNotCloseSidebarOnPageEditorSave.spec.ts
+++ b/end-to-end-tests/tests/regressions/doNotCloseSidebarOnPageEditorSave.spec.ts
@@ -46,15 +46,6 @@ test("#8104: Do not automatically close the sidebar when saving in the Page Edit
     updatedTabTitle,
   );
 
-  // Formik syncs form state with redux every 100ms. The "Render Panel" button
-  // sends the form state to the sidebar, but the save functionality uses the
-  // redux state for the mod component. This 100ms delay is fine in practice
-  // for real users, but playwright is able to click render and then click save
-  // within this 100ms timeout, which causes a race condition and makes this
-  // test flaky. So, we need a delay here to wait for the sync.
-  // eslint-disable-next-line playwright/no-wait-for-timeout -- see above
-  await page.waitForTimeout(200);
-
   await pageEditorPage.getRenderPanelButton().click();
   await expect(
     sidebar.getByRole("tab", { name: updatedTabTitle }),


### PR DESCRIPTION
## What does this PR do?

- Adds a 200ms delay to avoid a race condition between the formik state sync with redux and the save function being called, when playwright is able to click the Render Panel and then Save buttons in very quick succession

## Discussion

- Is there a better way to fix this other than a hacky "sleep" call?

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
