### PR TITLE
#8220: Inject sandbox into document root instead of body

### DIFF
--- a/src/utils/domUtils.ts
+++ b/src/utils/domUtils.ts
@@ -121,10 +121,10 @@ export async function setAnimationFrameInterval(
 }
 
 /**
- * Wait for the document body element to be present.
+ * Wait for the document root element to be present.
  */
-export async function waitForBody(): Promise<void> {
-  while (!document.body) {
+export async function waitForDocumentRoot(): Promise<void> {
+  while (!document.documentElement) {
     // eslint-disable-next-line no-await-in-loop -- Polling pattern
     await sleep(20);
   }

--- a/src/utils/injectIframe.tsx
+++ b/src/utils/injectIframe.tsx
@@ -18,7 +18,7 @@
 import pDefer from "p-defer";
 import pTimeout from "p-timeout";
 import shadowWrap from "@/utils/shadowWrap";
-import { waitForBody } from "@/utils/domUtils";
+import { waitForDocumentRoot } from "@/utils/domUtils";
 
 const TIMEOUT_MS = 3000;
 
@@ -47,8 +47,8 @@ async function _injectIframe(
   Object.assign(iframe.style, style);
 
   // The body might not be available yet
-  await waitForBody();
-  document.body.append(shadowWrap(iframe));
+  await waitForDocumentRoot();
+  document.documentElement.append(shadowWrap(iframe));
 
   await iframeLoad;
 

--- a/src/utils/injectIframe.tsx
+++ b/src/utils/injectIframe.tsx
@@ -46,7 +46,9 @@ async function _injectIframe(
   iframe.src = url;
   Object.assign(iframe.style, style);
 
-  // The body might not be available yet
+  // Append to document root (as opposed to e.g. body) to have the best chance of avoiding host page interference with
+  // the injected iframe (e.g. by removing it from the DOM)
+  // See https://github.com/pixiebrix/pixiebrix-extension/pull/8777
   await waitForDocumentRoot();
   document.documentElement.append(shadowWrap(iframe));
 


### PR DESCRIPTION
## What does this PR do?

- Part of #8220
- Injects the sandbox iframe into the document root instead of the document body
- This is to address the hypothesis that web pages are removing the iframe from the DOM before the mod has the chance to use it (the assumption is that it is less likely for webpages to wipe things in the document root vs. the body)

## Discussion/Demo

- I'm able to consistently confirm that in the case of Docusign, the sandbox is always removed from the page after a certain point, causing a race with the mod component runtime: https://www.loom.com/share/e9ec1521b66e46fab93457a6ae391699
- This change resolves the issue in the case of Docusign, at least

## Future Work

- The next PR I'm preparing 
    - will remove [injectIframe memoization](https://github.com/pixiebrix/pixiebrix-extension/blob/7a6e3f620e10f1e3181a503cce95e82a9627eb36/src/sandbox/messenger/api.ts#L26-L26) so that we can ensure the iframe can be re-added on future brick runs if it does happen to get removed
    - and either leverage the `MutationObserver` approach I used to confirm behavior in the repro video (see above) or add retries to more thoroughly ensure that the iframe is on the page before executing a brick
    - throw more specific error to report if the iframe is not present on the page

## Checklist

- [ ] Added jest or playwright tests and/or storybook stories - It's possible to make a page on our playground that can replicate this scenario, but I'm not 100% if we want to write an e2e test for this before we know that this is the cause of the majority of user issues

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
