### PR TITLE
#8783: update `ModComponentRef` property names

### DIFF
--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
@@ -204,7 +204,7 @@ describe("DisplayTemporaryInfo", () => {
 
     expect(waitForTemporaryPanel).toHaveBeenCalledWith({
       nonce: expect.toBeString(),
-      extensionId: modComponentRef.extensionId,
+      extensionId: modComponentRef.modComponentId,
       location: "modal",
       entry: expect.objectContaining({
         modComponentRef,
@@ -354,8 +354,8 @@ describe("DisplayTemporaryInfo", () => {
       logger: new ConsoleLogger(
         mapModComponentRefToMessageContext(
           modComponentRefFactory({
-            extensionId,
-            blueprintId: null,
+            modComponentId: extensionId,
+            modId: null,
           }),
         ),
       ),

--- a/src/components/quickBar/quickBarRegistry.ts
+++ b/src/components/quickBar/quickBarRegistry.ts
@@ -122,7 +122,7 @@ class QuickBarRegistry implements QuickBarProtocol {
   removeStarterBrickActions(starterBrickId: RegistryId): void {
     remove(
       this.actions,
-      (x) => x.modComponentRef?.extensionPointId === starterBrickId,
+      (x) => x.modComponentRef?.starterBrickId === starterBrickId,
     );
     this.notifyListeners();
   }
@@ -135,7 +135,7 @@ class QuickBarRegistry implements QuickBarProtocol {
     remove(
       this.actions,
       (x) =>
-        x.modComponentRef?.extensionId === modComponentId &&
+        x.modComponentRef?.modComponentId === modComponentId &&
         // Exclude the root action
         !this.knownGeneratorRootIds.has(x.id),
     );

--- a/src/contentScript/ephemeralPanel.ts
+++ b/src/contentScript/ephemeralPanel.ts
@@ -114,7 +114,7 @@ export async function ephemeralPanel({
     registerEmptyTemporaryPanel({
       nonce,
       location,
-      extensionId: panelEntryMetadata.modComponentRef.extensionId,
+      extensionId: panelEntryMetadata.modComponentRef.modComponentId,
     });
 
     await showSidebar();
@@ -125,7 +125,7 @@ export async function ephemeralPanel({
       nonce,
       payload: {
         key: uuidv4(),
-        extensionId: panelEntryMetadata.modComponentRef.extensionId,
+        extensionId: panelEntryMetadata.modComponentRef.modComponentId,
         loadingMessage: "Loading",
       },
     });
@@ -141,14 +141,14 @@ export async function ephemeralPanel({
     // Popover/modal location
     // Clear existing to remove stale modals/popovers
     await cancelTemporaryPanelsForExtension(
-      panelEntryMetadata.modComponentRef.extensionId,
+      panelEntryMetadata.modComponentRef.modComponentId,
     );
 
     // Register empty panel for "loading" state
     registerEmptyTemporaryPanel({
       nonce,
       location,
-      extensionId: panelEntryMetadata.modComponentRef.extensionId,
+      extensionId: panelEntryMetadata.modComponentRef.modComponentId,
     });
 
     // Create a source URL for content that will be loaded in the panel iframe
@@ -235,7 +235,7 @@ export async function ephemeralPanel({
       nonce,
       location,
       entry,
-      extensionId: entry.modComponentRef.extensionId,
+      extensionId: entry.modComponentRef.modComponentId,
       onRegister: onReady,
     });
     return panelAction ?? {};

--- a/src/contentScript/pageEditor/runRendererBrick.ts
+++ b/src/contentScript/pageEditor/runRendererBrick.ts
@@ -63,7 +63,7 @@ export async function runRendererBrick({
 
   let payload: PanelPayload;
   try {
-    await runBrickPreview({ ...args, modId: modComponentRef.blueprintId });
+    await runBrickPreview({ ...args, modId: modComponentRef.modId });
     // We're expecting a HeadlessModeError (or other error) to be thrown in the line above
     // noinspection ExceptionCaughtLocallyJS
     throw new NoRendererError();
@@ -74,14 +74,14 @@ export async function runRendererBrick({
         blockId: error.blockId,
         args: error.args,
         ctxt: error.ctxt,
-        extensionId: modComponentRef.extensionId,
+        extensionId: modComponentRef.modComponentId,
         runId,
       };
     } else {
       payload = {
         key: nonce,
         error: serializeError(error),
-        extensionId: modComponentRef.extensionId,
+        extensionId: modComponentRef.modComponentId,
         runId,
       };
     }
@@ -104,7 +104,7 @@ export async function runRendererBrick({
         await waitForTemporaryPanel({
           nonce,
           location,
-          extensionId: modComponentRef.extensionId,
+          extensionId: modComponentRef.modComponentId,
           entry: {
             modComponentRef,
             nonce,

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -419,15 +419,12 @@ export function reservePanels(refs: ModComponentRef[]): void {
   }
 
   const current = new Set(panels.map((x) => x.modComponentRef.modComponentId));
-  for (const { modComponentId, starterBrickId, modId } of refs) {
+  for (const modComponentRef of refs) {
+    const { modComponentId, starterBrickId, modId } = modComponentRef;
     if (!current.has(modComponentId)) {
       const entry: PanelEntry = {
         type: "panel",
-        modComponentRef: {
-          modComponentId: modComponentId,
-          starterBrickId: starterBrickId,
-          modId: modId,
-        },
+        modComponentRef,
         heading: "",
         payload: null,
       };
@@ -497,7 +494,7 @@ export function upsertPanel(
       modId,
       {
         entry,
-        starterBrickId: starterBrickId,
+        starterBrickId,
         heading,
         payload,
       },

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -372,7 +372,7 @@ export function removeModComponents(modComponentIds: UUID[]): void {
   const current = panels.splice(0);
   panels.push(
     ...current.filter(
-      (x) => !modComponentIds.includes(x.modComponentRef.extensionId),
+      (x) => !modComponentIds.includes(x.modComponentRef.modComponentId),
     ),
   );
   void renderPanelsIfVisible();
@@ -393,7 +393,7 @@ export function removeStarterBrick(
   console.debug("sidebarController:removeStarterBrick %s", starterBrickId, {
     preserveExtensionIds,
     panels: panels.filter(
-      (x) => x.modComponentRef.extensionPointId === starterBrickId,
+      (x) => x.modComponentRef.starterBrickId === starterBrickId,
     ),
   });
 
@@ -402,8 +402,8 @@ export function removeStarterBrick(
   panels.push(
     ...current.filter(
       (x) =>
-        x.modComponentRef.extensionPointId !== starterBrickId ||
-        preserveExtensionIds.includes(x.modComponentRef.extensionId),
+        x.modComponentRef.starterBrickId !== starterBrickId ||
+        preserveExtensionIds.includes(x.modComponentRef.modComponentId),
     ),
   );
 
@@ -418,15 +418,15 @@ export function reservePanels(refs: ModComponentRef[]): void {
     return;
   }
 
-  const current = new Set(panels.map((x) => x.modComponentRef.extensionId));
-  for (const { extensionId, extensionPointId, blueprintId } of refs) {
-    if (!current.has(extensionId)) {
+  const current = new Set(panels.map((x) => x.modComponentRef.modComponentId));
+  for (const { modComponentId, starterBrickId, modId } of refs) {
+    if (!current.has(modComponentId)) {
       const entry: PanelEntry = {
         type: "panel",
         modComponentRef: {
-          extensionId,
-          extensionPointId,
-          blueprintId,
+          modComponentId: modComponentId,
+          starterBrickId: starterBrickId,
+          modId: modId,
         },
         heading: "",
         payload: null,
@@ -434,9 +434,9 @@ export function reservePanels(refs: ModComponentRef[]): void {
 
       console.debug(
         "sidebarController:reservePanels: reserve panel %s for %s",
-        extensionId,
-        extensionPointId,
-        blueprintId,
+        modComponentId,
+        starterBrickId,
+        modId,
         { ...entry },
       );
 
@@ -449,7 +449,7 @@ export function reservePanels(refs: ModComponentRef[]): void {
 
 export function updateHeading(extensionId: UUID, heading: string): void {
   const entry = panels.find(
-    (x) => x.modComponentRef.extensionId === extensionId,
+    (x) => x.modComponentRef.modComponentId === extensionId,
   );
 
   if (entry) {
@@ -457,7 +457,7 @@ export function updateHeading(extensionId: UUID, heading: string): void {
     console.debug(
       "updateHeading: update heading for panel %s for %s",
       extensionId,
-      entry.modComponentRef.extensionPointId,
+      entry.modComponentRef.starterBrickId,
       { ...entry },
     );
     void renderPanelsIfVisible();
@@ -474,30 +474,30 @@ export function upsertPanel(
   heading: string,
   payload: PanelPayload,
 ): void {
-  const { extensionId, extensionPointId, blueprintId } = modComponentRef;
+  const { modComponentId, starterBrickId, modId } = modComponentRef;
 
   const entry = panels.find(
-    (panel) => panel.modComponentRef.extensionId === extensionId,
+    (panel) => panel.modComponentRef.modComponentId === modComponentId,
   );
   if (entry) {
     entry.payload = payload;
     entry.heading = heading;
     console.debug(
       "sidebarController:upsertPanel: update existing panel %s for %s",
-      extensionId,
-      extensionPointId,
-      blueprintId,
+      modComponentId,
+      starterBrickId,
+      modId,
       { ...entry },
     );
   } else {
     console.debug(
       "sidebarController:upsertPanel: add new panel %s for %s",
-      extensionId,
-      extensionPointId,
-      blueprintId,
+      modComponentId,
+      starterBrickId,
+      modId,
       {
         entry,
-        extensionPointId,
+        starterBrickId: starterBrickId,
         heading,
         payload,
       },

--- a/src/pageEditor/tabs/effect/useDocumentPreviewRunBlock.ts
+++ b/src/pageEditor/tabs/effect/useDocumentPreviewRunBlock.ts
@@ -206,9 +206,9 @@ export default function useDocumentPreviewRunBlock(
           runId: traceRecord.runId,
           title,
           modComponentRef: {
-            extensionId: modComponentId,
-            blueprintId: modMetadata?.id,
-            extensionPointId: starterBrickId,
+            modComponentId,
+            modId: modMetadata?.id,
+            starterBrickId,
           },
           args: {
             apiVersion,

--- a/src/platform/forms/formController.ts
+++ b/src/platform/forms/formController.ts
@@ -74,8 +74,8 @@ export async function registerForm({
 
   const preexistingForms = [...forms.entries()].filter(
     ([_, registeredForm]) =>
-      registeredForm.modComponentRef.extensionId ===
-      modComponentRef.extensionId,
+      registeredForm.modComponentRef.modComponentId ===
+      modComponentRef.modComponentId,
   );
 
   if (preexistingForms.length > 0) {

--- a/src/platform/panels/panelController.ts
+++ b/src/platform/panels/panelController.ts
@@ -107,8 +107,8 @@ export function updatePanelDefinition(
   // Panel entry may be undefined if the panel was registered with registerEmptyTemporaryPanel
   if (
     panel.entry &&
-    panel.entry.modComponentRef.extensionId !==
-      panelDefinition.modComponentRef.extensionId
+    panel.entry.modComponentRef.modComponentId !==
+      panelDefinition.modComponentRef.modComponentId
   ) {
     throw new Error("extensionId mismatch");
   }
@@ -205,7 +205,7 @@ function removePanelEntry(panelNonce: UUID): void {
   const panel = panels.get(panelNonce);
   if (panel?.entry) {
     extensionNonces
-      .get(panel.entry.modComponentRef.extensionId)
+      .get(panel.entry.modComponentRef.modComponentId)
       ?.delete(panelNonce);
   }
 

--- a/src/sidebar/Tabs.tsx
+++ b/src/sidebar/Tabs.tsx
@@ -211,7 +211,7 @@ const Tabs: React.FC = () => {
         >
           {panels.map((panel) => (
             <TabWithDivider
-              key={panel.modComponentRef.extensionId}
+              key={panel.modComponentRef.modComponentId}
               active={isPanelActive(panel)}
               eventKey={eventKeyForEntry(panel)}
             >
@@ -226,7 +226,7 @@ const Tabs: React.FC = () => {
 
           {forms.map((form) => (
             <TabWithDivider
-              key={form.modComponentRef.extensionId}
+              key={form.modComponentRef.modComponentId}
               active={isPanelActive(form)}
               eventKey={eventKeyForEntry(form)}
             >
@@ -311,7 +311,7 @@ const Tabs: React.FC = () => {
               // un-submitted form state/scroll position
               unmountOnExit={false}
               className={cx("full-height flex-grow", styles.paneOverrides)}
-              key={panel.modComponentRef.extensionId}
+              key={panel.modComponentRef.modComponentId}
               eventKey={eventKeyForEntry(panel)}
             >
               <ErrorBoundary

--- a/src/sidebar/TemporaryPanelTabPane.tsx
+++ b/src/sidebar/TemporaryPanelTabPane.tsx
@@ -62,7 +62,7 @@ export const TemporaryPanelTabPane: React.FC<{
       <ErrorBoundary
         onError={() => {
           reportEvent(Events.VIEW_ERROR, {
-            ...mapModComponentRefToMessageContext(modComponentRef),
+            ...modComponentRef,
             panelType: type,
           });
         }}

--- a/src/sidebar/modLauncher/ActiveSidebarModsList.tsx
+++ b/src/sidebar/modLauncher/ActiveSidebarModsList.tsx
@@ -124,7 +124,7 @@ export const ActiveSidebarModsList: React.FunctionComponent = () => {
         tableInstance.prepareRow(row);
         return (
           <ActiveSidebarModsListItem
-            key={row.original.modComponentRef.extensionId}
+            key={row.original.modComponentRef.modComponentId}
             panel={row.original}
           />
         );

--- a/src/sidebar/sidebarSelectors.ts
+++ b/src/sidebar/sidebarSelectors.ts
@@ -63,7 +63,7 @@ const selectSidebarEntries = ({ sidebar }: SidebarRootState) => [
 const extensionForEventKeySelector = createSelector(
   selectSidebarEntries,
   selectActivatedModComponents,
-  (state: SidebarRootState, eventKey: string) => eventKey,
+  (_state: SidebarRootState, eventKey: string) => eventKey,
   (entries, extensions, eventKey): ActivatedModComponent | undefined => {
     // Get sidebar entry by event key
     const sidebarEntry = entries.find(
@@ -76,7 +76,7 @@ const extensionForEventKeySelector = createSelector(
 
     return extensions.find(
       (modComponent) =>
-        modComponent.id === sidebarEntry.modComponentRef.extensionId,
+        modComponent.id === sidebarEntry.modComponentRef.modComponentId,
     );
   },
 );
@@ -102,7 +102,7 @@ export const selectExtensionFromEventKey =
 
     return extensions.find(
       (modComponent) =>
-        modComponent.id === sidebarEntry.modComponentRef.extensionId,
+        modComponent.id === sidebarEntry.modComponentRef.modComponentId,
     );
   };
 

--- a/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
@@ -113,7 +113,7 @@ describe("sidebarExtension", () => {
       panels: [
         expect.objectContaining({
           modComponentRef: expect.objectContaining({
-            extensionPointId: starterBrick.id,
+            starterBrickId: starterBrick.id,
           }),
         }),
       ],

--- a/src/starterBricks/sidebar/sidebarStarterBrick.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.ts
@@ -204,10 +204,10 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       // noinspection ExceptionCaughtLocallyJS
       throw new NoRendererError();
     } catch (error) {
-      const ref = {
-        extensionId: modComponent.id,
-        extensionPointId: this.id,
-        blueprintId: modComponent._recipe?.id,
+      const modComponentRef = {
+        modComponentId: modComponent.id,
+        starterBrickId: this.id,
+        modId: modComponent._recipe?.id,
       };
 
       const meta = {
@@ -216,7 +216,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       };
 
       if (error instanceof HeadlessModeError) {
-        this.platform.panels.upsertPanel(ref, heading, {
+        this.platform.panels.upsertPanel(modComponentRef, heading, {
           blockId: error.blockId,
           key: uuidv4(),
           ctxt: error.ctxt,
@@ -225,7 +225,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
         });
       } else {
         componentLogger.error(error);
-        this.platform.panels.upsertPanel(ref, heading, {
+        this.platform.panels.upsertPanel(modComponentRef, heading, {
           key: uuidv4(),
           error: serializeError(error),
           ...meta,
@@ -362,9 +362,9 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     // the sidebar won't be visible yet on initial page load.
     this.platform.panels.reservePanels(
       this.modComponents.map((modComponent) => ({
-        extensionId: modComponent.id,
-        extensionPointId: this.id,
-        blueprintId: modComponent._recipe?.id,
+        modComponentId: modComponent.id,
+        starterBrickId: this.id,
+        modId: modComponent._recipe?.id,
       })),
     );
 
@@ -411,9 +411,9 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       // `install`ed and `runComponents` called completed at least once.
       this.platform.panels.reservePanels(
         this.modComponents.map((components) => ({
-          extensionId: components.id,
-          extensionPointId: this.id,
-          blueprintId: components._recipe?.id,
+          modComponentId: components.id,
+          starterBrickId: this.id,
+          modId: components._recipe?.id,
         })),
       );
 

--- a/src/store/sidebar/eventKeyUtils.test.ts
+++ b/src/store/sidebar/eventKeyUtils.test.ts
@@ -162,8 +162,8 @@ describe("eventKeyForEntry", () => {
     const extensionPointId = validateRegistryId("@test/test-starter-brick");
     const entry = sidebarEntryFactory("panel", {
       modComponentRef: modComponentRefFactory({
-        extensionId,
-        extensionPointId,
+        modComponentId: extensionId,
+        starterBrickId: extensionPointId,
       }),
     });
     expect(eventKeyForEntry(entry)).toBe(`panel-${extensionId}`);
@@ -176,14 +176,14 @@ describe("eventKeyForEntry", () => {
     const formEntry = sidebarEntryFactory("form", {
       nonce,
       modComponentRef: modComponentRefFactory({
-        extensionId,
+        modComponentId: extensionId,
       }),
     });
     expect(eventKeyForEntry(formEntry)).toBe(`form-${nonce}`);
 
     const temporaryPanelEntry = sidebarEntryFactory("temporaryPanel", {
       nonce,
-      modComponentRef: modComponentRefFactory({ extensionId }),
+      modComponentRef: modComponentRefFactory({ modComponentId: extensionId }),
     });
     expect(eventKeyForEntry(temporaryPanelEntry)).toBe(
       `temporaryPanel-${nonce}`,

--- a/src/store/sidebar/eventKeyUtils.tsx
+++ b/src/store/sidebar/eventKeyUtils.tsx
@@ -44,7 +44,7 @@ function eventKeyForEntry(entry: Nullishable<SidebarEntry>): string | null {
   }
 
   if (isPanelEntry(entry)) {
-    return getEventKeyForPanel(entry.modComponentRef.extensionId);
+    return getEventKeyForPanel(entry.modComponentRef.modComponentId);
   }
 
   if (isStaticPanelEntry(entry)) {

--- a/src/store/sidebar/sidebarSlice.test.ts
+++ b/src/store/sidebar/sidebarSlice.test.ts
@@ -103,7 +103,7 @@ describe("sidebarSlice.addTemporaryPanel", () => {
     const otherExistingPanel = sidebarEntryFactory("temporaryPanel");
     const newPanel = sidebarEntryFactory("temporaryPanel", {
       modComponentRef: modComponentRefFactory({
-        extensionId: existingPanel.modComponentRef.extensionId,
+        modComponentId: existingPanel.modComponentRef.modComponentId,
       }),
     });
 
@@ -198,7 +198,7 @@ describe("removeTemporaryPanel", () => {
     const otherExistingPanel = sidebarEntryFactory("form");
     const newPanel = sidebarEntryFactory("temporaryPanel", {
       modComponentRef: modComponentRefFactory({
-        extensionId: originalPanel.modComponentRef.extensionId,
+        modComponentId: originalPanel.modComponentRef.modComponentId,
       }),
     });
 
@@ -533,18 +533,18 @@ describe("sidebarSlice.fixActiveTabOnRemove", () => {
     const modId = validateRegistryId("test/123");
     const originalPanel = sidebarEntryFactory("panel", {
       modComponentRef: modComponentRefFactory({
-        blueprintId: modId,
+        modId: modId,
       }),
     });
     const otherExistingPanel = sidebarEntryFactory("form", {
       modComponentRef: modComponentRefFactory({
-        blueprintId: modId,
+        modId: modId,
       }),
     });
     const newPanel = sidebarEntryFactory("temporaryPanel", {
       modComponentRef: modComponentRefFactory({
-        extensionId: originalPanel.modComponentRef.extensionId,
-        blueprintId: modId,
+        modComponentId: originalPanel.modComponentRef.modComponentId,
+        modId: modId,
       }),
     });
 
@@ -572,12 +572,12 @@ describe("sidebarSlice.fixActiveTabOnRemove", () => {
     const firstPanel = sidebarEntryFactory("panel");
     const matchingPanel = sidebarEntryFactory("panel", {
       modComponentRef: modComponentRefFactory({
-        blueprintId: modId,
+        modId: modId,
       }),
     });
     const newPanel = sidebarEntryFactory("temporaryPanel", {
       modComponentRef: modComponentRefFactory({
-        blueprintId: modId,
+        modId: modId,
       }),
     });
 
@@ -601,24 +601,24 @@ describe("sidebarSlice.fixActiveTabOnRemove", () => {
 
     const originalPanel = sidebarEntryFactory("panel", {
       modComponentRef: modComponentRefFactory({
-        extensionId,
+        modComponentId: extensionId,
       }),
     });
     const firstFormPanel = sidebarEntryFactory("form", {
       modComponentRef: modComponentRefFactory({
-        extensionId,
+        modComponentId: extensionId,
       }),
     });
     const nullModId = sidebarEntryFactory("form", {
       modComponentRef: modComponentRefFactory({
-        extensionId,
-        blueprintId: null,
+        modComponentId: extensionId,
+        modId: null,
       }),
     });
     const newPanel = sidebarEntryFactory("temporaryPanel", {
       modComponentRef: modComponentRefFactory({
-        extensionId,
-        blueprintId: null,
+        modComponentId: extensionId,
+        modId: null,
       }),
     });
 

--- a/src/store/sidebar/sidebarSlice.test.ts
+++ b/src/store/sidebar/sidebarSlice.test.ts
@@ -533,18 +533,18 @@ describe("sidebarSlice.fixActiveTabOnRemove", () => {
     const modId = validateRegistryId("test/123");
     const originalPanel = sidebarEntryFactory("panel", {
       modComponentRef: modComponentRefFactory({
-        modId: modId,
+        modId,
       }),
     });
     const otherExistingPanel = sidebarEntryFactory("form", {
       modComponentRef: modComponentRefFactory({
-        modId: modId,
+        modId,
       }),
     });
     const newPanel = sidebarEntryFactory("temporaryPanel", {
       modComponentRef: modComponentRefFactory({
         modComponentId: originalPanel.modComponentRef.modComponentId,
-        modId: modId,
+        modId,
       }),
     });
 
@@ -572,12 +572,12 @@ describe("sidebarSlice.fixActiveTabOnRemove", () => {
     const firstPanel = sidebarEntryFactory("panel");
     const matchingPanel = sidebarEntryFactory("panel", {
       modComponentRef: modComponentRefFactory({
-        modId: modId,
+        modId,
       }),
     });
     const newPanel = sidebarEntryFactory("temporaryPanel", {
       modComponentRef: modComponentRefFactory({
-        modId: modId,
+        modId,
       }),
     });
 

--- a/src/store/sidebar/sidebarSlice.ts
+++ b/src/store/sidebar/sidebarSlice.ts
@@ -72,21 +72,21 @@ function findNextActiveKey(
   if (extensionId) {
     // Prefer form to panel -- however, it would be unusual to target an ephemeral form when reshowing the sidebar
     const extensionForm = state.forms.find(
-      (x) => x.modComponentRef.extensionId === extensionId,
+      (x) => x.modComponentRef.modComponentId === extensionId,
     );
     if (extensionForm) {
       return eventKeyForEntry(extensionForm);
     }
 
     const extensionTemporaryPanel = state.temporaryPanels.find(
-      (x) => x.modComponentRef.extensionId === extensionId,
+      (x) => x.modComponentRef.modComponentId === extensionId,
     );
     if (extensionTemporaryPanel) {
       return eventKeyForEntry(extensionTemporaryPanel);
     }
 
     const extensionPanel = state.panels.find(
-      (x) => x.modComponentRef.extensionId === extensionId,
+      (x) => x.modComponentRef.modComponentId === extensionId,
     );
     if (extensionPanel) {
       return eventKeyForEntry(extensionPanel);
@@ -97,8 +97,7 @@ function findNextActiveKey(
   if (panelHeading) {
     const extensionPanel = state.panels
       .filter(
-        (x) =>
-          blueprintId == null || x.modComponentRef.blueprintId === blueprintId,
+        (x) => blueprintId == null || x.modComponentRef.modId === blueprintId,
       )
       .find((x) => x.heading === panelHeading);
     if (extensionPanel) {
@@ -109,7 +108,7 @@ function findNextActiveKey(
   // Try matching on blueprint
   if (blueprintId) {
     const blueprintPanel = state.panels.find(
-      (x) => x.modComponentRef.blueprintId === blueprintId,
+      (x) => x.modComponentRef.modId === blueprintId,
     );
     if (blueprintPanel) {
       return eventKeyForEntry(blueprintPanel);
@@ -136,9 +135,9 @@ export function fixActiveTabOnRemoveInPlace(
     const panels = [...state.forms, ...state.panels, ...state.temporaryPanels];
 
     const matchingExtension = panels.find(
-      ({ modComponentRef: { extensionId } }) =>
+      ({ modComponentRef: { modComponentId } }) =>
         "modComponentRef" in removedEntry &&
-        extensionId === removedEntry.modComponentRef.extensionId,
+        modComponentId === removedEntry.modComponentRef.modComponentId,
     );
 
     if (matchingExtension) {
@@ -147,11 +146,11 @@ export function fixActiveTabOnRemoveInPlace(
       // No mod component match, try finding another panel for the mod
 
       const matchingMod = panels.find(
-        ({ modComponentRef: { blueprintId } }) =>
+        ({ modComponentRef: { modId } }) =>
           "modComponentRef" in removedEntry &&
-          blueprintId === removedEntry.modComponentRef.blueprintId &&
-          // Require blueprintId to avoid switching between panels of standalone mod components
-          blueprintId,
+          modId === removedEntry.modComponentRef.modId &&
+          // Require modId to avoid switching between panels of standalone mod components
+          modId,
       );
 
       if (matchingMod) {
@@ -306,15 +305,15 @@ const sidebarSlice = createSlice({
           (oldPanel.isUnavailable || oldPanel.isConnecting) &&
           !action.payload.panels.some(
             (newPanel) =>
-              newPanel.modComponentRef.extensionId ===
-              oldPanel.modComponentRef.extensionId,
+              newPanel.modComponentRef.modComponentId ===
+              oldPanel.modComponentRef.modComponentId,
           ),
       );
 
       // For now, pick an arbitrary order that's stable. There's no guarantees on which order panels are registered
       state.panels = sortBy(
         [...oldPanels, ...castDraft(action.payload.panels)],
-        (panel) => panel.modComponentRef.extensionId,
+        (panel) => panel.modComponentRef.modComponentId,
       );
 
       // Try fulfilling the pendingActivePanel request

--- a/src/store/sidebar/thunks/addFormPanel.ts
+++ b/src/store/sidebar/thunks/addFormPanel.ts
@@ -44,7 +44,7 @@ const addFormPanel = createAsyncThunk<
   const [thisModComponentForms, otherForms] = partition(
     forms,
     ({ modComponentRef }) =>
-      modComponentRef.extensionId === form.modComponentRef.extensionId,
+      modComponentRef.modComponentId === form.modComponentRef.modComponentId,
   );
 
   // The UUID must be fetched synchronously to ensure the `form` Proxy element doesn't expire

--- a/src/store/sidebar/thunks/addTemporaryPanel.ts
+++ b/src/store/sidebar/thunks/addTemporaryPanel.ts
@@ -40,7 +40,8 @@ const addTemporaryPanel = createAsyncThunk<
 
   const [existingExtensionTemporaryPanels, otherTemporaryPanels] = partition(
     temporaryPanels,
-    (x) => x.modComponentRef.extensionId === panel.modComponentRef.extensionId,
+    (x) =>
+      x.modComponentRef.modComponentId === panel.modComponentRef.modComponentId,
   );
 
   // Cancel all panels for the extension, except if there's a placeholder that was added in setInitialPanels

--- a/src/telemetry/telemetryHelpers.test.ts
+++ b/src/telemetry/telemetryHelpers.test.ts
@@ -45,20 +45,20 @@ describe("mapModComponentRefToEventData", () => {
   it("maps fields", () => {
     const value = modComponentRefFactory();
     expect(mapModComponentRefToMessageContext(value)).toStrictEqual({
-      modComponentId: value.extensionId,
-      modId: value.blueprintId,
-      starterBrickId: value.extensionPointId,
+      modComponentId: value.modComponentId,
+      modId: value.modId,
+      starterBrickId: value.starterBrickId,
     });
   });
 
   it("replaces null with undefined", () => {
     const value = modComponentRefFactory({
-      blueprintId: null,
+      modId: null,
     });
     expect(mapModComponentRefToMessageContext(value)).toStrictEqual({
-      modComponentId: value.extensionId,
+      modComponentId: value.modComponentId,
       modId: undefined,
-      starterBrickId: value.extensionPointId,
+      starterBrickId: value.starterBrickId,
     });
   });
 

--- a/src/testUtils/factories/modComponentFactories.ts
+++ b/src/testUtils/factories/modComponentFactories.ts
@@ -36,9 +36,9 @@ import { type StandaloneModDefinition } from "@/types/contract";
 import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 
 export const modComponentRefFactory = define<ModComponentRef>({
-  extensionId: uuidSequence,
-  blueprintId: registryIdFactory,
-  extensionPointId: registryIdFactory,
+  modComponentId: uuidSequence,
+  modId: registryIdFactory,
+  starterBrickId: registryIdFactory,
 });
 
 export const modMetadataFactory = extend<Metadata, ModMetadata>(

--- a/src/types/modComponentTypes.ts
+++ b/src/types/modComponentTypes.ts
@@ -285,15 +285,15 @@ export type ModComponentRef = {
   /**
    * UUID of the ModComponent.
    */
-  extensionId: UUID;
+  modComponentId: UUID;
 
   /**
    * Mod the ModComponent is from, or nullish for a standalone ModComponent.
    */
-  blueprintId: Nullishable<RegistryId>;
+  modId: Nullishable<RegistryId>;
 
   /**
    * Registry id of the mod component's StarterBrick.
    */
-  extensionPointId: RegistryId;
+  starterBrickId: RegistryId;
 };

--- a/src/utils/modUtils.ts
+++ b/src/utils/modUtils.ts
@@ -66,9 +66,9 @@ export function getModComponentRef(
   modComponent: HydratedModComponent,
 ): ModComponentRef {
   return {
-    extensionId: modComponent.id,
-    blueprintId: modComponent._recipe?.id,
-    extensionPointId: modComponent.extensionPointId,
+    modComponentId: modComponent.id,
+    modId: modComponent._recipe?.id,
+    starterBrickId: modComponent.extensionPointId,
   };
 }
 
@@ -94,18 +94,16 @@ export function mapModComponentToMessageContext(
 /**
  * Returns the message context for a ModComponentRef. For use with passing to reportEvent
  * @see selectEventData
- *
- * TODO: Once we update the shape of ModComponentRef, we need to audit unnecessary usage of this function
  */
 export function mapModComponentRefToMessageContext(
   modComponentRef: ModComponentRef,
 ): SetRequired<MessageContext, "modComponentId" | "starterBrickId"> {
   // Fields are currently named the same. In the future, the fields might temporarily diverge.
   return {
-    modComponentId: modComponentRef.extensionId,
-    starterBrickId: modComponentRef.extensionPointId,
+    modComponentId: modComponentRef.modComponentId,
+    starterBrickId: modComponentRef.starterBrickId,
     // MessageContext expects undefined instead of null/undefined
-    modId: modComponentRef.blueprintId ?? undefined,
+    modId: modComponentRef.modId ?? undefined,
   };
 }
 
@@ -115,7 +113,7 @@ export function mapModComponentRefToMessageContext(
  *
  * @see getModComponentRef
  * @see mapModComponentToMessageContext
- * @throws TypeError if the extensionId or extensionPointId is missing
+ * @throws TypeError if the modComponentId or starterBrickId is missing
  */
 export function mapMessageContextToModComponentRef(
   context: MessageContext,
@@ -129,10 +127,11 @@ export function mapMessageContextToModComponentRef(
     "starterBrickId is required for ModComponentRef",
   );
 
+  // Can't use "pick" because it doesn't pick up assertNotNullish checks above
   return {
-    extensionId: context.modComponentId,
-    blueprintId: context.modId,
-    extensionPointId: context.starterBrickId,
+    modComponentId: context.modComponentId,
+    modId: context.modId,
+    starterBrickId: context.starterBrickId,
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

- Closes #8783

## Reviewer Notes
- `ModComponentRef` can't be used directly for MessageContext because `MessageContext` expects `undefined` for `modId` instead of `Nullishable`. So we can't get rid of `mapModComponentRefToMessageContext` uses
- We can't get rid of `mapMessageContextToModComponentRef` uses because it contains the nullish assertions

## Remaining Work

- [x] Fix broken object shape test assertions
- [x] Fix lint

## Future Work

- Finish updating messenger APIs and controllers to use `ModComponentRef` (e.g., `waitForTemporaryPanel`)
- Clean up local variable names

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
