### PR TITLE
Update naming in panel and starter brick API

### DIFF
--- a/src/background/contextMenus/ensureContextMenu.ts
+++ b/src/background/contextMenus/ensureContextMenu.ts
@@ -21,11 +21,11 @@ import { expectContext } from "@/utils/expectContext";
 import { memoizeUntilSettled } from "@/utils/promiseUtils";
 import chromeP from "webext-polyfill-kinda";
 import { type Menus } from "webextension-polyfill";
+import { assertNotNullish } from "@/utils/nullishUtils";
 
 /**
  * Register a context menu item on all tabs.
  */
-
 async function _ensureContextMenu({
   modComponentId,
   contexts,
@@ -34,9 +34,9 @@ async function _ensureContextMenu({
 }: SelectionMenuOptions): Promise<void> {
   expectContext("background");
 
-  if (!modComponentId) {
-    throw new Error("extensionId is required");
-  }
+  // `modComponentId` required in the SelectionMenuOptions type, but double-check dynamically to avoid
+  // confusing behavior if not provided.
+  assertNotNullish(modComponentId, "modComponentId is required");
 
   const updateProperties = {
     type: "normal",

--- a/src/background/contextMenus/ensureContextMenu.ts
+++ b/src/background/contextMenus/ensureContextMenu.ts
@@ -27,14 +27,14 @@ import { type Menus } from "webextension-polyfill";
  */
 
 async function _ensureContextMenu({
-  extensionId,
+  modComponentId,
   contexts,
   title,
   documentUrlPatterns,
 }: SelectionMenuOptions): Promise<void> {
   expectContext("background");
 
-  if (!extensionId) {
+  if (!modComponentId) {
     throw new Error("extensionId is required");
   }
 
@@ -47,7 +47,7 @@ async function _ensureContextMenu({
     documentUrlPatterns,
   } satisfies Menus.UpdateUpdatePropertiesType;
 
-  const expectedMenuId = makeMenuId(extensionId);
+  const expectedMenuId = makeMenuId(modComponentId);
   try {
     // Try updating it first. It will fail if missing, so we attempt to create it instead
     await browser.contextMenus.update(expectedMenuId, updateProperties);
@@ -64,5 +64,5 @@ async function _ensureContextMenu({
 }
 
 export const ensureContextMenu = memoizeUntilSettled(_ensureContextMenu, {
-  cacheKey: ([{ extensionId }]) => extensionId,
+  cacheKey: ([{ modComponentId }]) => modComponentId,
 });

--- a/src/background/contextMenus/initContextMenus.ts
+++ b/src/background/contextMenus/initContextMenus.ts
@@ -62,7 +62,7 @@ async function dispatchMenu(
 
   try {
     await handleMenuAction(target, {
-      extensionId: info.menuItemId.slice(MENU_PREFIX.length) as UUID,
+      modComponentId: info.menuItemId.slice(MENU_PREFIX.length) as UUID,
       args: info,
     });
   } catch (error) {

--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
@@ -40,7 +40,7 @@ import {
   updateTemporarySidebarPanel,
 } from "@/contentScript/sidebarController";
 import {
-  cancelTemporaryPanelsForExtension,
+  cancelTemporaryPanelsForModComponent,
   updatePanelDefinition,
   waitForTemporaryPanel,
 } from "@/platform/panels/panelController";
@@ -283,7 +283,7 @@ describe("DisplayTemporaryInfo", () => {
 
     expect(showModal).not.toHaveBeenCalled();
     expect(showTemporarySidebarPanel).not.toHaveBeenCalled();
-    expect(cancelTemporaryPanelsForExtension).toHaveBeenCalled();
+    expect(cancelTemporaryPanelsForModComponent).toHaveBeenCalled();
 
     expect(
       document.body.querySelector(".pixiebrix-tooltips-container"),

--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
@@ -16,7 +16,7 @@
  */
 
 import DisplayTemporaryInfo from "@/bricks/transformers/temporaryInfo/DisplayTemporaryInfo";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   ContextBrick,
   contextBrick,
@@ -44,7 +44,6 @@ import {
   updatePanelDefinition,
   waitForTemporaryPanel,
 } from "@/platform/panels/panelController";
-import { uuidv4 } from "@/types/helpers";
 import ConsoleLogger from "@/utils/ConsoleLogger";
 import { tick } from "@/starterBricks/starterBrickTestUtils";
 import pDefer from "p-defer";
@@ -62,6 +61,7 @@ import { isLoadedInIframe } from "@/utils/iframeUtils";
 import { modComponentRefFactory } from "@/testUtils/factories/modComponentFactories";
 
 import { mapModComponentRefToMessageContext } from "@/utils/modUtils";
+import { autoUUIDSequence } from "@/testUtils/factories/stringFactories";
 
 jest.mock("@/contentScript/modalDom");
 jest.mock("@/contentScript/sidebarController");
@@ -84,8 +84,8 @@ describe("DisplayTemporaryInfo", () => {
   beforeEach(() => {
     jest.mocked(isLoadedInIframe).mockReturnValue(false);
 
-    blockRegistry.clear();
-    blockRegistry.register([
+    brickRegistry.clear();
+    brickRegistry.register([
       echoBrick,
       teapotBrick,
       contextBrick,
@@ -204,7 +204,7 @@ describe("DisplayTemporaryInfo", () => {
 
     expect(waitForTemporaryPanel).toHaveBeenCalledWith({
       nonce: expect.toBeString(),
-      extensionId: modComponentRef.modComponentId,
+      modComponentId: modComponentRef.modComponentId,
       location: "modal",
       entry: expect.objectContaining({
         modComponentRef,
@@ -347,14 +347,14 @@ describe("DisplayTemporaryInfo", () => {
       },
     };
 
-    const extensionId = uuidv4();
+    const modComponentId = autoUUIDSequence();
 
     const options = {
       ...testOptions("v3"),
       logger: new ConsoleLogger(
         mapModComponentRefToMessageContext(
           modComponentRefFactory({
-            modComponentId: extensionId,
+            modComponentId,
             modId: null,
           }),
         ),
@@ -374,7 +374,7 @@ describe("DisplayTemporaryInfo", () => {
       namespace: StateNamespaces.MOD,
       data: { foo: 42 },
       mergeStrategy: MergeStrategies.REPLACE,
-      modComponentId: extensionId,
+      modComponentId,
       modId: null,
     });
 

--- a/src/bricks/transformers/temporaryInfo/temporaryPanelProtocol.test.ts
+++ b/src/bricks/transformers/temporaryInfo/temporaryPanelProtocol.test.ts
@@ -42,7 +42,7 @@ describe("temporaryPanelProtocol", () => {
       nonce,
       location: "panel",
       entry: definition,
-      extensionId: uuidv4(),
+      modComponentId: uuidv4(),
     });
 
     await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(definition);
@@ -60,7 +60,7 @@ describe("temporaryPanelProtocol", () => {
       nonce,
       location: "panel",
       entry: definition,
-      extensionId: uuidv4(),
+      modComponentId: uuidv4(),
     });
 
     await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(definition);
@@ -80,7 +80,7 @@ describe("temporaryPanelProtocol", () => {
       nonce,
       location: "panel",
       entry: definition,
-      extensionId: uuidv4(),
+      modComponentId: uuidv4(),
     });
 
     await expect(getPanelDefinition(nonce)).resolves.toStrictEqual(definition);

--- a/src/contentScript/contentScriptPlatform.ts
+++ b/src/contentScript/contentScriptPlatform.ts
@@ -230,7 +230,7 @@ class ContentScriptPlatform extends PlatformBase {
 
     return {
       async register({ handler, ...options }) {
-        registerHandler(options.extensionId, handler);
+        registerHandler(options.modComponentId, handler);
         await ensureContextMenu(options);
       },
       async unregister(componentId) {
@@ -286,7 +286,7 @@ class ContentScriptPlatform extends PlatformBase {
   override get panels(): PlatformProtocol["panels"] {
     return {
       isContainerVisible: async () => sidebarController.isSidePanelOpen(),
-      unregisterExtensionPoint: sidebarController.removeStarterBrick,
+      unregisterStarterBrick: sidebarController.removeStarterBrick,
       removeComponents: sidebarController.removeModComponents,
       reservePanels: sidebarController.reservePanels,
       updateHeading: sidebarController.updateHeading,

--- a/src/contentScript/contextMenus.ts
+++ b/src/contentScript/contextMenus.ts
@@ -26,26 +26,29 @@ type MenuHandler = (args: Menus.OnClickData) => Promise<void>;
 const handlers = new Map<UUID, MenuHandler>();
 
 /**
- * Register a context menu handler for the given extension. Overwrites any existing handler.
+ * Register a context menu handler for the given mod component. Overwrites any existing handler.
  */
-export function registerHandler(extensionId: UUID, handler: MenuHandler): void {
-  handlers.set(extensionId, handler);
+export function registerHandler(
+  modComponentId: UUID,
+  handler: MenuHandler,
+): void {
+  handlers.set(modComponentId, handler);
 }
 
 /**
  * Handle a context menu action. Called from the background page.
- * @param extensionId the extension id
+ * @param modComponentId the mod component id
  * @param args the args from the Chrome context menu action event
  * @see dispatchMenu
  */
 export async function handleMenuAction({
-  extensionId,
+  modComponentId,
   args,
 }: {
-  extensionId: UUID;
+  modComponentId: UUID;
   args: Menus.OnClickData;
 }): Promise<void> {
-  const handler = handlers.get(extensionId);
+  const handler = handlers.get(modComponentId);
   if (handler) {
     await handler(args);
     return;
@@ -64,8 +67,8 @@ export async function handleMenuAction({
   }
 
   // 3. An actual error occurred
-  console.error("No context menu found for extension: %s", extensionId, {
-    extensionId,
+  console.error("No context menu found for mod component: %s", modComponentId, {
+    modComponentId,
     handlers: [...handlers.keys()],
   });
 

--- a/src/contentScript/ephemeralPanel.ts
+++ b/src/contentScript/ephemeralPanel.ts
@@ -19,7 +19,7 @@ import type { Except, JsonObject } from "type-fest";
 import { uuidv4 } from "@/types/helpers";
 import {
   cancelTemporaryPanels,
-  cancelTemporaryPanelsForExtension,
+  cancelTemporaryPanelsForModComponent,
   registerEmptyTemporaryPanel,
   stopWaitingForTemporaryPanels,
   updatePanelDefinition,
@@ -140,7 +140,7 @@ export async function ephemeralPanel({
   } else {
     // Popover/modal location
     // Clear existing to remove stale modals/popovers
-    await cancelTemporaryPanelsForExtension(
+    await cancelTemporaryPanelsForModComponent(
       panelEntryMetadata.modComponentRef.modComponentId,
     );
 

--- a/src/contentScript/ephemeralPanel.ts
+++ b/src/contentScript/ephemeralPanel.ts
@@ -114,7 +114,7 @@ export async function ephemeralPanel({
     registerEmptyTemporaryPanel({
       nonce,
       location,
-      extensionId: panelEntryMetadata.modComponentRef.modComponentId,
+      modComponentId: panelEntryMetadata.modComponentRef.modComponentId,
     });
 
     await showSidebar();
@@ -148,7 +148,7 @@ export async function ephemeralPanel({
     registerEmptyTemporaryPanel({
       nonce,
       location,
-      extensionId: panelEntryMetadata.modComponentRef.modComponentId,
+      modComponentId: panelEntryMetadata.modComponentRef.modComponentId,
     });
 
     // Create a source URL for content that will be loaded in the panel iframe
@@ -235,7 +235,7 @@ export async function ephemeralPanel({
       nonce,
       location,
       entry,
-      extensionId: entry.modComponentRef.modComponentId,
+      modComponentId: entry.modComponentRef.modComponentId,
       onRegister: onReady,
     });
     return panelAction ?? {};

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -113,7 +113,7 @@ const WAIT_LOADED_INTERVAL_MS = 25;
  * Install and run a starter brick and specified mod components.
  * @param starterBrick the starter to install and run
  * @param reason the reason code for the run
- * @param extensionIds the mod components to run on the starter brick, or undefined to run all mod components
+ * @param modComponentIds the mod components to run on the starter brick, or undefined to run all mod components
  * @param abortSignal abort signal to cancel the installation/run
  * @see StarterBrick.runModComponents
  */
@@ -121,9 +121,9 @@ async function runStarterBrick(
   starterBrick: StarterBrick,
   {
     reason,
-    extensionIds,
+    modComponentIds,
     abortSignal,
-  }: { reason: RunReason; extensionIds?: UUID[]; abortSignal: AbortSignal },
+  }: { reason: RunReason; modComponentIds?: UUID[]; abortSignal: AbortSignal },
 ): Promise<void> {
   // Could potentially call _runningStarterBricks.delete here, but assume the starter brick is still available
   // until we know for sure that it's not
@@ -141,7 +141,7 @@ async function runStarterBrick(
     kind: starterBrick.kind,
     name: starterBrick.name,
     permissions: starterBrick.permissions,
-    modComponentIds: extensionIds,
+    modComponentIds,
     reason,
   };
 
@@ -186,7 +186,7 @@ async function runStarterBrick(
     details,
   );
 
-  await starterBrick.runModComponents({ reason, extensionIds });
+  await starterBrick.runModComponents({ reason, modComponentIds });
   _runningStarterBricks.add(starterBrick);
 
   console.debug(
@@ -307,7 +307,7 @@ export function removeDraftModComponents(
       console.debug(`lifecycle:clearDraftModComponent: ${modComponentId}`);
       const starterBrick =
         _draftModComponentStarterBrickMap.get(modComponentId);
-      assertNotNullish(starterBrick, "extensionPoint must be defined");
+      assertNotNullish(starterBrick, "starterBrick must be defined");
 
       if (starterBrick.kind === "actionPanel" && preserveSidebar) {
         const sidebar = starterBrick as SidebarStarterBrickABC;
@@ -380,7 +380,7 @@ export async function runDraftModComponent(
   await runStarterBrick(starterBrick, {
     // The Page Editor is the only caller for runDynamic
     reason: RunReason.PAGE_EDITOR,
-    extensionIds: [modComponentId],
+    modComponentIds: [modComponentId],
     abortSignal: navigationListeners.signal,
   });
 

--- a/src/contentScript/pageEditor/runRendererBrick.ts
+++ b/src/contentScript/pageEditor/runRendererBrick.ts
@@ -104,7 +104,7 @@ export async function runRendererBrick({
         await waitForTemporaryPanel({
           nonce,
           location,
-          extensionId: modComponentRef.modComponentId,
+          modComponentId: modComponentRef.modComponentId,
           entry: {
             modComponentRef,
             nonce,

--- a/src/contentScript/sidebarController.tsx
+++ b/src/contentScript/sidebarController.tsx
@@ -381,17 +381,17 @@ export function removeModComponents(modComponentIds: UUID[]): void {
 /**
  * Remove all panels associated with the given extensionPointId.
  * @param starterBrickId the extension point id (internal or external)
- * @param preserveExtensionIds array of extension ids to keep in the panel. Used to avoid flickering if updating
+ * @param preserveModComponentIds array of extension ids to keep in the panel. Used to avoid flickering if updating
  * the extensionPoint for a sidebar extension from the Page Editor
  */
 export function removeStarterBrick(
   starterBrickId: RegistryId,
-  { preserveExtensionIds = [] }: { preserveExtensionIds?: UUID[] } = {},
+  { preserveModComponentIds = [] }: { preserveModComponentIds?: UUID[] } = {},
 ): void {
   expectContext("contentScript");
 
   console.debug("sidebarController:removeStarterBrick %s", starterBrickId, {
-    preserveExtensionIds,
+    preserveModComponentIds,
     panels: panels.filter(
       (x) => x.modComponentRef.starterBrickId === starterBrickId,
     ),
@@ -403,7 +403,7 @@ export function removeStarterBrick(
     ...current.filter(
       (x) =>
         x.modComponentRef.starterBrickId !== starterBrickId ||
-        preserveExtensionIds.includes(x.modComponentRef.modComponentId),
+        preserveModComponentIds.includes(x.modComponentRef.modComponentId),
     ),
   );
 
@@ -413,13 +413,13 @@ export function removeStarterBrick(
 /**
  * Create placeholder panels showing loading indicators
  */
-export function reservePanels(refs: ModComponentRef[]): void {
-  if (refs.length === 0) {
+export function reservePanels(modComponentRefs: ModComponentRef[]): void {
+  if (modComponentRefs.length === 0) {
     return;
   }
 
   const current = new Set(panels.map((x) => x.modComponentRef.modComponentId));
-  for (const modComponentRef of refs) {
+  for (const modComponentRef of modComponentRefs) {
     const { modComponentId, starterBrickId, modId } = modComponentRef;
     if (!current.has(modComponentId)) {
       const entry: PanelEntry = {
@@ -444,16 +444,16 @@ export function reservePanels(refs: ModComponentRef[]): void {
   void renderPanelsIfVisible();
 }
 
-export function updateHeading(extensionId: UUID, heading: string): void {
+export function updateHeading(modComponentId: UUID, heading: string): void {
   const entry = panels.find(
-    (x) => x.modComponentRef.modComponentId === extensionId,
+    (x) => x.modComponentRef.modComponentId === modComponentId,
   );
 
   if (entry) {
     entry.heading = heading;
     console.debug(
       "updateHeading: update heading for panel %s for %s",
-      extensionId,
+      modComponentId,
       entry.modComponentRef.starterBrickId,
       { ...entry },
     );
@@ -461,7 +461,7 @@ export function updateHeading(extensionId: UUID, heading: string): void {
   } else {
     console.warn(
       "updateHeading: No panel exists for extension %s",
-      extensionId,
+      modComponentId,
     );
   }
 }

--- a/src/platform/panels/panelController.ts
+++ b/src/platform/panels/panelController.ts
@@ -36,9 +36,9 @@ type RegisteredPanel = {
   /**
    * The id of the extension that owns the panel.
    *
-   * Should match RegisteredPanel.entry.extensionId if entry is defined.
+   * Must match RegisteredPanel.entry.modComponentId if entry is defined.
    */
-  extensionId: UUID;
+  modComponentId: UUID;
   /**
    * The deferred promise that will be resolved when the panel is submitted/closed
    */
@@ -53,8 +53,8 @@ type PlaceholderPanel = SetOptional<RegisteredPanel, "entry">;
 
 const panels = new Map<UUID, RegisteredPanel | PlaceholderPanel>();
 
-// Mapping from extensionId to active panel nonces
-const extensionNonces = new Map<UUID, Set<UUID>>();
+// Mapping from modComponentId to active panel nonces
+const modComponentNonces = new Map<UUID, Set<UUID>>();
 
 /**
  * Return all temporary panel entries.
@@ -110,26 +110,26 @@ export function updatePanelDefinition(
     panel.entry.modComponentRef.modComponentId !==
       panelDefinition.modComponentRef.modComponentId
   ) {
-    throw new Error("extensionId mismatch");
+    throw new Error("modComponentId mismatch");
   }
 
   panel.entry = panelDefinition;
 }
 
 /**
- * Register an empty panel for a given nonce and extensionId. Use to pre-allocate a "loading" state while the panel
+ * Register an empty panel for a given nonce and modComponentId. Use to pre-allocate a "loading" state while the panel
  * content is being initialized.
  * @param nonce the panel nonce
- * @param extensionId the id of the extension that owns the panel
+ * @param modComponentId the id of the extension that owns the panel
  * @param location the location of the panel
  */
 export function registerEmptyTemporaryPanel({
   nonce,
-  extensionId,
+  modComponentId,
   location,
 }: {
   nonce: UUID;
-  extensionId: UUID;
+  modComponentId: UUID;
   location: Location;
 }) {
   if (panels.has(nonce)) {
@@ -142,20 +142,20 @@ export function registerEmptyTemporaryPanel({
   const registration = pDefer<PanelAction | null>();
 
   panels.set(nonce, {
-    extensionId,
+    modComponentId,
     registration,
     location,
   });
 
-  const set = extensionNonces.get(extensionId) ?? new Set();
-  extensionNonces.set(extensionId, set);
+  const set = modComponentNonces.get(modComponentId) ?? new Set();
+  modComponentNonces.set(modComponentId, set);
   set.add(nonce);
 }
 
 /**
  * Register a temporary display panel and wait fot its deferred promise
  * @param nonce The instance nonce for the panel to register
- * @param extensionId The extension id that owns the panel
+ * @param modComponentId The extension id that owns the panel
  * @param location The location of the panel
  * @param entry the panel definition
  * @param onRegister callback to run after the panel is registered
@@ -164,11 +164,11 @@ export async function waitForTemporaryPanel({
   nonce,
   location,
   entry,
-  extensionId,
+  modComponentId,
   onRegister,
 }: {
   nonce: UUID;
-  extensionId: UUID;
+  modComponentId: UUID;
   location: Location;
   entry: Except<TemporaryPanelEntry, "type">;
   onRegister?: () => void;
@@ -185,12 +185,12 @@ export async function waitForTemporaryPanel({
   panels.set(nonce, {
     entry,
     location,
-    extensionId,
+    modComponentId,
     registration,
   });
 
-  const set = extensionNonces.get(extensionId) ?? new Set();
-  extensionNonces.set(extensionId, set);
+  const set = modComponentNonces.get(modComponentId) ?? new Set();
+  modComponentNonces.set(modComponentId, set);
   set.add(nonce);
 
   onRegister?.();
@@ -204,7 +204,7 @@ export async function waitForTemporaryPanel({
 function removePanelEntry(panelNonce: UUID): void {
   const panel = panels.get(panelNonce);
   if (panel?.entry) {
-    extensionNonces
+    modComponentNonces
       .get(panel.entry.modComponentRef.modComponentId)
       ?.delete(panelNonce);
   }
@@ -265,9 +265,9 @@ export async function cancelTemporaryPanels(
  * @see cancelTemporaryPanels
  */
 export async function cancelTemporaryPanelsForExtension(
-  extensionId: UUID,
+  modComponentId: UUID,
 ): Promise<void> {
-  const nonces = extensionNonces.get(extensionId) ?? new Set();
+  const nonces = modComponentNonces.get(modComponentId) ?? new Set();
   await cancelTemporaryPanels(
     [...nonces],
     new CancelError("Panel automatically closed"),

--- a/src/platform/panels/panelController.ts
+++ b/src/platform/panels/panelController.ts
@@ -34,7 +34,7 @@ type RegisteredPanel = {
    */
   location: Location;
   /**
-   * The id of the extension that owns the panel.
+   * The id of the mod component that owns the panel.
    *
    * Must match RegisteredPanel.entry.modComponentId if entry is defined.
    */
@@ -120,7 +120,7 @@ export function updatePanelDefinition(
  * Register an empty panel for a given nonce and modComponentId. Use to pre-allocate a "loading" state while the panel
  * content is being initialized.
  * @param nonce the panel nonce
- * @param modComponentId the id of the extension that owns the panel
+ * @param modComponentId the id of the mod component that owns the panel
  * @param location the location of the panel
  */
 export function registerEmptyTemporaryPanel({
@@ -155,7 +155,7 @@ export function registerEmptyTemporaryPanel({
 /**
  * Register a temporary display panel and wait fot its deferred promise
  * @param nonce The instance nonce for the panel to register
- * @param modComponentId The extension id that owns the panel
+ * @param modComponentId The mod component id that owns the panel
  * @param location The location of the panel
  * @param entry the panel definition
  * @param onRegister callback to run after the panel is registered
@@ -199,7 +199,7 @@ export async function waitForTemporaryPanel({
 }
 
 /**
- * Private helper method to remove panel from panels and extensionNonces.
+ * Private helper method to remove panel from panels and modComponentNonces.
  */
 function removePanelEntry(panelNonce: UUID): void {
   const panel = panels.get(panelNonce);
@@ -261,10 +261,10 @@ export async function cancelTemporaryPanels(
 }
 
 /**
- * Cancel all temporary panels for a given extension.
+ * Cancel all temporary panels for a given mod component.
  * @see cancelTemporaryPanels
  */
-export async function cancelTemporaryPanelsForExtension(
+export async function cancelTemporaryPanelsForModComponent(
   modComponentId: UUID,
 ): Promise<void> {
   const nonces = modComponentNonces.get(modComponentId) ?? new Set();

--- a/src/platform/platformTypes/contextMenuProtocol.ts
+++ b/src/platform/platformTypes/contextMenuProtocol.ts
@@ -19,7 +19,7 @@ import type { UUID } from "@/types/stringTypes";
 import type { Menus } from "webextension-polyfill";
 
 export type SelectionMenuOptions = {
-  extensionId: UUID;
+  modComponentId: UUID;
   title: string;
   contexts: Menus.ContextType[];
   documentUrlPatterns: string[];

--- a/src/platform/platformTypes/panelProtocol.ts
+++ b/src/platform/platformTypes/panelProtocol.ts
@@ -36,13 +36,13 @@ export interface PanelProtocol {
 
   /**
    * Remove all panels associated with the given extensionPointId.
-   * @param extensionPointId the extension point id (internal or external)
-   * @param options.preserveExtensionIds array of extension ids to keep in the panel. Used to avoid flickering if updating
-   * the extensionPoint for a sidebar extension from the Page Editor
+   * @param modComponentId the extension point id (internal or external)
+   * @param options.preserveModComponentIds array of mod component ids to keep in the panel. Used to avoid flickering
+   * if updating the starter brick for a sidebar mod component from the Page Editor
    */
-  unregisterExtensionPoint: (
-    extensionPointId: RegistryId,
-    options?: { preserveExtensionIds?: UUID[] },
+  unregisterStarterBrick: (
+    modComponentId: RegistryId,
+    options?: { preserveModComponentIds?: UUID[] },
   ) => void;
 
   /**
@@ -54,7 +54,7 @@ export interface PanelProtocol {
   /**
    * Create placeholder panels showing loading indicators
    */
-  reservePanels: (refs: ModComponentRef[]) => void;
+  reservePanels: (modComponentRefs: ModComponentRef[]) => void;
 
   /**
    * Update the heading of a panel with the given mod component id
@@ -70,7 +70,7 @@ export interface PanelProtocol {
    * @param payload the new content for the panel
    */
   upsertPanel: (
-    ref: ModComponentRef,
+    modComponentRef: ModComponentRef,
     heading: string,
     payload: PanelPayload,
   ) => void;

--- a/src/starterBricks/button/buttonStarterBrick.ts
+++ b/src/starterBricks/button/buttonStarterBrick.ts
@@ -689,7 +689,7 @@ export abstract class ButtonStarterBrickABC extends StarterBrickABC<ButtonStarte
     }
   }
 
-  async runModComponents({ extensionIds = null }: RunArgs): Promise<void> {
+  async runModComponents({ modComponentIds = null }: RunArgs): Promise<void> {
     if (this.containers.size === 0 || this.modComponents.length === 0) {
       return;
     }
@@ -722,7 +722,10 @@ export abstract class ButtonStarterBrickABC extends StarterBrickABC<ButtonStarte
         // Run in order so that the order stays the same for where they get rendered. The service
         // context is the only thing that's async as part of the initial configuration right now
 
-        if (extensionIds != null && !extensionIds.includes(modComponent.id)) {
+        if (
+          modComponentIds != null &&
+          !modComponentIds.includes(modComponent.id)
+        ) {
           continue;
         }
 

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
@@ -125,7 +125,7 @@ describe("contextMenuStarterBrick", () => {
     expect(ensureContextMenuMock).toHaveBeenCalledOnce();
     expect(ensureContextMenuMock).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
-        extensionId: modComponent.id,
+        modComponentId: modComponent.id,
       }),
     );
   });

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
@@ -250,7 +250,7 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
     );
 
     await getPlatform().contextMenus.register({
-      extensionId: modComponent.id,
+      modComponentId: modComponent.id,
       contexts: this.contexts ?? ["all"],
       title,
       documentUrlPatterns: patterns,

--- a/src/starterBricks/sidebar/sidebarStarterBrick.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.ts
@@ -134,7 +134,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   public override uninstall(): void {
     const modComponents = this.modComponents.splice(0);
     this.clearModComponentInterfaceAndEvents(modComponents.map((x) => x.id));
-    this.platform.panels.unregisterExtensionPoint(this.id);
+    this.platform.panels.unregisterStarterBrick(this.id);
     console.debug(
       "SidebarStarterBrick:uninstall: stop listening for sidebarShowEvents",
     );
@@ -151,8 +151,8 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
     // Don't call this.clearModComponentInterfaceAndEvents to keep the panel.
     // Instead, mutate this.modComponents to exclude id
     remove(this.modComponents, (x) => x.id === modComponentId);
-    this.platform.panels.unregisterExtensionPoint(this.id, {
-      preserveExtensionIds: [modComponentId],
+    this.platform.panels.unregisterStarterBrick(this.id, {
+      preserveModComponentIds: [modComponentId],
     });
     this.platform.panels.showEvent.remove(this.runModComponents);
   }
@@ -345,7 +345,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
       );
 
       // Keep sidebar entries up-to-date regardless of trigger policy
-      this.platform.panels.unregisterExtensionPoint(this.id);
+      this.platform.panels.unregisterStarterBrick(this.id);
       return;
     }
 
@@ -426,7 +426,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
         passive: true,
       });
     } else {
-      this.platform.panels.unregisterExtensionPoint(this.id);
+      this.platform.panels.unregisterStarterBrick(this.id);
     }
 
     return available;

--- a/src/testUtils/platformMock.ts
+++ b/src/testUtils/platformMock.ts
@@ -92,7 +92,7 @@ export const platformMock: PlatformProtocol = {
   get panels() {
     return {
       isContainerVisible: jest.fn(),
-      unregisterExtensionPoint: jest.fn(),
+      unregisterStarterBrick: jest.fn(),
       removeComponents: jest.fn(),
       reservePanels: jest.fn(),
       updateHeading: jest.fn(),

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -208,7 +208,7 @@ export type RunArgs = {
   /**
    * If provided, only run the specified ModComponents.
    */
-  extensionIds?: UUID[] | null;
+  modComponentIds?: UUID[] | null;
 };
 
 /**


### PR DESCRIPTION
## What does this PR do?

- Update naming in panel, context menu, and starter brick API

## Discussion

- @BLoe this PR touches `removeStarterBrick`/`unregisterStarterBrick`, which might be involved in the panel save bug you're seeing: https://github.com/pixiebrix/pixiebrix-extension/pull/8785/files#diff-0ae99f17a1e6025b6ede6522e2a25c18a671f67daf1bc65c9f305789d36deafeR43

## Future Work

- Use `modComponentRef` in the protocol state API. (Not urgent given that it's already using `modComponentId` and `modId` terminology, but would be good for clarifying modId nullness in the future)
- Finish update naming in runtime

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
