### PR TITLE
#8781: fix NPE from incomplete formstate migration in editor slice

### DIFF
--- a/src/bricks/types.ts
+++ b/src/bricks/types.ts
@@ -190,9 +190,9 @@ export enum PipelineFlavor {
 }
 
 /**
- * Defines the position of the brick in the extension
- * ex. "extension.brickPipeline.0.config.body.__value__.0",
- * "extension.brickPipeline.0.config.body.0.children.0.config.onClick.__value__.0"
+ * Defines the position of the brick in the mod component
+ * ex. "modComponent.brickPipeline.0.config.body.__value__.0",
+ * "modComponent.brickPipeline.0.config.body.0.children.0.config.onClick.__value__.0"
  */
 export type BrickPosition = {
   /**

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -57,7 +57,6 @@ import {
   removeModData,
   setActiveModId,
   setActiveNodeId,
-  syncBrickConfigurationUIStates,
 } from "@/pageEditor/store/editor/editorSliceHelpers";
 import { type Draft, produce } from "immer";
 import { normalizePipelineForEditor } from "@/pageEditor/starterBricks/pipelineMapping";
@@ -87,6 +86,7 @@ import {
   inspectedTab,
 } from "@/pageEditor/context/connection";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { syncBrickConfigurationUIStates } from "@/pageEditor/store/editor/syncBrickConfigurationUiState";
 
 export const initialState: EditorState = {
   selectionSeq: 0,

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -1024,7 +1024,7 @@ export const persistEditorConfig = {
   // Change the type of localStorage to our overridden version so that it can be exported
   // See: @/store/StorageInterface.ts
   storage: localStorage as StorageInterface,
-  version: 4,
+  version: 5,
   migrate: createMigrate(migrations, { debug: Boolean(process.env.DEBUG) }),
   blacklist: [
     "inserting",

--- a/src/pageEditor/store/editor/editorSliceHelpers.test.ts
+++ b/src/pageEditor/store/editor/editorSliceHelpers.test.ts
@@ -25,12 +25,10 @@ import {
 import { getPipelineMap } from "@/pageEditor/tabs/editTab/editHelpers";
 import {
   ensureBrickPipelineUIState,
-  ensureBrickConfigurationUIState,
   removeModComponentFormState,
   removeModData,
   setActiveModId,
   setActiveNodeId,
-  syncBrickConfigurationUIStates,
 } from "@/pageEditor/store/editor/editorSliceHelpers";
 import { produce } from "immer";
 import {
@@ -50,6 +48,10 @@ import {
 } from "@/pageEditor/store/editor/editorSelectors";
 import { modMetadataFactory } from "@/testUtils/factories/modComponentFactories";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import {
+  ensureBrickConfigurationUIState,
+  syncBrickConfigurationUIStates,
+} from "@/pageEditor/store/editor/syncBrickConfigurationUiState";
 
 describe("ensureBrickPipelineUIState", () => {
   test("does not affect existing ui state", () => {

--- a/src/pageEditor/store/editor/pageEditorTypes.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes.ts
@@ -352,8 +352,18 @@ export type EditorStateV4 = Except<
   deletedModComponentFormStatesByModId: Record<string, BaseFormStateV3[]>;
 };
 
+/**
+ * @deprecated - Do not use versioned state types directly, exported for testing
+ *
+ * EditorStateV5 is the same as EditorStateV4. An additional migration needed to be run
+ * on the form state that was not run in the previous migration.
+ *
+ * See https://github.com/pixiebrix/pixiebrix-extension/issues/8781 for more details.
+ */
+export type EditorStateV5 = EditorStateV4;
+
 export type EditorState = Except<
-  EditorStateV4,
+  EditorStateV5,
   "modComponentFormStates" | "deletedModComponentFormStatesByModId"
 > & {
   modComponentFormStates: ModComponentFormState[];

--- a/src/pageEditor/store/editor/syncBrickConfigurationUiState.ts
+++ b/src/pageEditor/store/editor/syncBrickConfigurationUiState.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
+import { type EditorState } from "@/pageEditor/store/editor/pageEditorTypes";
+import {
+  makeInitialBrickConfigurationUIState,
+  FOUNDATION_NODE_ID,
+} from "@/pageEditor/store/editor/uiState";
+import { type BrickPipelineUIState } from "@/pageEditor/store/editor/uiStateTypes";
+import { getPipelineMap } from "@/pageEditor/tabs/editTab/editHelpers";
+import { type UUID } from "@/types/stringTypes";
+import { assertNotNullish } from "@/utils/nullishUtils";
+import { type Draft } from "immer";
+
+export function ensureBrickConfigurationUIState(
+  state: Draft<BrickPipelineUIState>,
+  nodeId: UUID,
+) {
+  state.nodeUIStates[nodeId] ??= makeInitialBrickConfigurationUIState(nodeId);
+}
+
+export function syncBrickConfigurationUIStates(
+  state: Draft<EditorState>,
+  modComponentFormState: ModComponentFormState,
+) {
+  const brickPipelineUIState =
+    state.brickPipelineUIStateById[modComponentFormState.uuid];
+
+  assertNotNullish(
+    brickPipelineUIState,
+    `Brick Pipeline UI State not found for ${modComponentFormState.uuid}`,
+  );
+
+  const pipelineMap = getPipelineMap(
+    modComponentFormState.modComponent.brickPipeline,
+  );
+
+  brickPipelineUIState.pipelineMap = pipelineMap;
+
+  // Pipeline brick instance IDs may have changed
+  if (pipelineMap[brickPipelineUIState.activeNodeId] == null) {
+    brickPipelineUIState.activeNodeId = FOUNDATION_NODE_ID;
+  }
+
+  // Remove BrickConfigurationUIStates for invalid node IDs
+  for (const nodeId of Object.keys(
+    brickPipelineUIState.nodeUIStates,
+  ) as UUID[]) {
+    // Don't remove the foundation BrickConfigurationUIState
+    if (nodeId !== FOUNDATION_NODE_ID && pipelineMap[nodeId] == null) {
+      delete brickPipelineUIState.nodeUIStates[nodeId];
+    }
+  }
+
+  // Add missing BrickConfigurationUIStates
+  for (const nodeId of Object.keys(pipelineMap) as UUID[]) {
+    ensureBrickConfigurationUIState(brickPipelineUIState, nodeId);
+  }
+}

--- a/src/pageEditor/store/editor/uiStateTypes.ts
+++ b/src/pageEditor/store/editor/uiStateTypes.ts
@@ -33,7 +33,7 @@ export type NodeInfo = {
   blockConfig: BrickConfig;
 
   /**
-   * Index of the block in its pipeline
+   * Index of the brick in its pipeline
    */
   index: number;
 
@@ -43,7 +43,7 @@ export type NodeInfo = {
   pipelinePath: string;
 
   /**
-   * The block's pipeline
+   * The brick's pipeline
    */
   pipeline: BrickPipeline;
 
@@ -54,7 +54,7 @@ export type NodeInfo = {
 };
 
 /**
- * The map of pipeline blocks. The key is the instanceId of the block.
+ * The map of pipeline bricks. The key is the instanceId of the brick.
  */
 export type PipelineMap = Record<UUID, NodeInfo>;
 
@@ -77,7 +77,7 @@ export type DataPanelTabUIState = {
 
 export type BrickConfigurationUIState = {
   /**
-   * Identifier for the node in the editor, either the foundation or a block uuid
+   * Identifier for the node in the editor, either the foundation or a brick uuid
    */
   nodeId: UUID;
 

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -37,9 +37,9 @@ const EditorNodeConfigPanel: React.FC = () => {
   const {
     blockId: brickId,
     path: brickFieldName,
-    blockConfig,
+    blockConfig: brickConfig,
   } = useSelector(selectActiveNodeInfo) ?? {};
-  const { comments } = blockConfig ?? {};
+  const { comments } = brickConfig ?? {};
 
   const { data: brickInfo } = useAsyncState(async () => {
     if (brickId == null) {

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -37,8 +37,8 @@ import {
   type EditorStateV5,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
-import { syncBrickConfigurationUIStates } from "@/pageEditor/store/editor/editorSliceHelpers";
 import produce, { type Draft } from "immer";
+import { syncBrickConfigurationUIStates } from "@/pageEditor/store/editor/syncBrickConfigurationUiState";
 
 export const migrations: MigrationManifest = {
   // Redux-persist defaults to version: -1; Initialize to positive-1-indexed

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -33,8 +33,12 @@ import {
   type EditorStateV1,
   type EditorStateV3,
   type EditorStateV4,
+  type EditorState,
+  type EditorStateV5,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
+import { syncBrickConfigurationUIStates } from "@/pageEditor/store/editor/editorSliceHelpers";
+import produce, { type Draft } from "immer";
 
 export const migrations: MigrationManifest = {
   // Redux-persist defaults to version: -1; Initialize to positive-1-indexed
@@ -44,6 +48,7 @@ export const migrations: MigrationManifest = {
   2: (state: EditorStateV1 & PersistedState) => migrateEditorStateV1(state),
   3: (state: EditorStateV2 & PersistedState) => migrateEditorStateV2(state),
   4: (state: EditorStateV3 & PersistedState) => migrateEditorStateV3(state),
+  5: (state: EditorStateV4 & PersistedState) => migrateEditorStateV4(state),
 };
 
 export function migrateIntegrationDependenciesV1toV2(
@@ -157,4 +162,14 @@ export function migrateEditorStateV3({
       (formStates) => formStates.map((element) => migrateFormStateV2(element)),
     ) as Record<string, ModComponentFormState[]>,
   };
+}
+
+function migrateEditorStateV4(
+  state: EditorStateV4 & PersistedState,
+): EditorStateV5 & PersistedState {
+  return produce(state, (draft: Draft<EditorState>) => {
+    for (const modComponentFormState of draft.modComponentFormStates) {
+      syncBrickConfigurationUIStates(draft, modComponentFormState);
+    }
+  });
 }


### PR DESCRIPTION
## What does this PR do?

- Fixes #8781

## Discussion

- Could also dispatch the `resetActivatedModComponentFormState` action in `BrickConfiguration.tsx` if the config is undefined, but by making it a migration, it is only ever run once

## Demo

- In the process of debugging and fixing this issue, I fixed the only mod that I could reproduce the issue with
- This issue can only happen with mods installed before the previous state migration (and then only sometimes), so I can't get the editor back into a bad state to demo

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
