### PR TITLE
Rename default registry imports in files

### DIFF
--- a/src/analysis/analysisVisitors/baseAnalysisVisitors.ts
+++ b/src/analysis/analysisVisitors/baseAnalysisVisitors.ts
@@ -21,7 +21,7 @@ import {
 } from "@/analysis/analysisTypes";
 import PipelineVisitor from "@/bricks/PipelineVisitor";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
-import blockRegistry, { type TypedBrickMap } from "@/bricks/registry";
+import brickRegistry, { type TypedBrickMap } from "@/bricks/registry";
 
 /**
  * A base class for creating analysis visitors.
@@ -61,7 +61,7 @@ export abstract class AnalysisVisitorWithResolvedBricksABC extends AnalysisVisit
   protected allBlocks!: TypedBrickMap;
 
   override async run(formState: ModComponentFormState): Promise<void> {
-    this.allBlocks = await blockRegistry.allTyped();
+    this.allBlocks = await brickRegistry.allTyped();
 
     super.run(formState);
   }

--- a/src/analysis/analysisVisitors/pageStateAnalysis/modVariableSchemasVisitor.ts
+++ b/src/analysis/analysisVisitors/pageStateAnalysis/modVariableSchemasVisitor.ts
@@ -20,7 +20,7 @@ import PipelineVisitor, {
   type VisitBlockExtra,
 } from "@/bricks/PipelineVisitor";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
-import blockRegistry, { type TypedBrickMap } from "@/bricks/registry";
+import brickRegistry, { type TypedBrickMap } from "@/bricks/registry";
 import { type Schema } from "@/types/schemaTypes";
 import { compact, isEqual, uniqWith } from "lodash";
 
@@ -59,7 +59,7 @@ class ModVariableSchemasVisitor extends PipelineVisitor {
   static async collectSchemas(
     formStates: ModComponentFormState[],
   ): Promise<ModVariableSchemaResult> {
-    const allBlocks = await blockRegistry.allTyped();
+    const allBlocks = await brickRegistry.allTyped();
     const visitor = new ModVariableSchemasVisitor(allBlocks);
 
     for (const formState of formStates) {

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.test.ts
@@ -27,7 +27,7 @@ import ForEach from "@/bricks/transformers/controlFlow/ForEach";
 import { EchoBrick } from "@/runtime/pipelineTests/pipelineTestHelpers";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import modRegistry from "@/modDefinitions/registry";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { SELF_EXISTENCE, VarExistence } from "./varMap";
 import TryExcept from "@/bricks/transformers/controlFlow/TryExcept";
 import ForEachElement from "@/bricks/transformers/controlFlow/ForEachElement";
@@ -443,7 +443,7 @@ describe("Collecting available vars", () => {
         }),
         brickConfigFactory(),
       ]);
-      jest.mocked(blockRegistry.allTyped).mockResolvedValue(
+      jest.mocked(brickRegistry.allTyped).mockResolvedValue(
         new Map([
           [
             formState.modComponent.brickPipeline[0].id,
@@ -783,7 +783,7 @@ describe("Collecting available vars", () => {
         },
       };
 
-      jest.mocked(blockRegistry.allTyped).mockResolvedValue(
+      jest.mocked(brickRegistry.allTyped).mockResolvedValue(
         new Map([
           [
             IdentityTransformer.BRICK_ID,
@@ -1129,7 +1129,7 @@ describe("Collecting available vars", () => {
         brickConfigFactory(),
       ]);
 
-      jest.mocked(blockRegistry.allTyped).mockResolvedValue(
+      jest.mocked(brickRegistry.allTyped).mockResolvedValue(
         new Map([
           [
             CustomFormRenderer.BRICK_ID,

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -35,7 +35,7 @@ import VarMap, { VarExistence } from "./varMap";
 import { type TraceRecord } from "@/telemetry/trace";
 import parseTemplateVariables from "./parseTemplateVariables";
 import modRegistry from "@/modDefinitions/registry";
-import blockRegistry, { type TypedBrickMap } from "@/bricks/registry";
+import brickRegistry, { type TypedBrickMap } from "@/bricks/registry";
 import {
   isDocumentBuilderElementArray,
   type ListElement,
@@ -683,7 +683,7 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
   }
 
   async run(formState: ModComponentFormState): Promise<void> {
-    this.allBlocks = await blockRegistry.allTyped();
+    this.allBlocks = await brickRegistry.allTyped();
 
     // Order of the following calls will determine the order of the sources in the UI
     const contextVars = new VarMap();

--- a/src/background/auth/partnerIntegrations/launchAuthIntegration.ts
+++ b/src/background/auth/partnerIntegrations/launchAuthIntegration.ts
@@ -17,7 +17,7 @@
 
 import type { RegistryId } from "@/types/registryTypes";
 import { expectContext } from "@/utils/expectContext";
-import serviceRegistry from "@/integrations/registry";
+import integrationRegistry from "@/integrations/registry";
 import { integrationConfigLocator as serviceLocator } from "@/background/integrationConfigLocator";
 import { assertNotNullish } from "@/utils/nullishUtils";
 import launchOAuth2Flow from "@/background/auth/launchOAuth2Flow";
@@ -44,7 +44,7 @@ export async function launchAuthIntegration({
 }): Promise<void> {
   expectContext("background");
 
-  const integration = await serviceRegistry.lookup(integrationId);
+  const integration = await integrationRegistry.lookup(integrationId);
 
   await serviceLocator.refreshLocal();
   const allAuths =

--- a/src/background/contextMenus/initContextMenus.test.ts
+++ b/src/background/contextMenus/initContextMenus.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import extensionPointRegistry from "@/starterBricks/registry";
+import starterBrickRegistry from "@/starterBricks/registry";
 import { fromJS } from "@/starterBricks/contextMenu/contextMenuStarterBrick";
 import * as backgroundApi from "@/background/messenger/api";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
@@ -75,7 +75,7 @@ describe("contextMenus", () => {
 
     updateMenuMock.mockRejectedValue(new Error("My Error"));
 
-    extensionPointRegistry.register([fromJS(getPlatform(), extensionPoint)]);
+    starterBrickRegistry.register([fromJS(getPlatform(), extensionPoint)]);
 
     const menuModComponent = modComponentFactory({
       extensionPointId: extensionPoint.metadata.id,

--- a/src/background/contextMenus/preloadContextMenus.ts
+++ b/src/background/contextMenus/preloadContextMenus.ts
@@ -26,31 +26,32 @@ import {
 } from "@/types/modComponentTypes";
 import { expectContext } from "@/utils/expectContext";
 import { allSettled } from "@/utils/promiseUtils";
-import extensionPointRegistry from "@/starterBricks/registry";
+import starterBrickRegistry from "@/starterBricks/registry";
 
 /**
  * Add context menu items to the Chrome context menu on all tabs, in anticipation that on Page Load, the content
  * script will register a handler for the item.
- * @param extensions the ModComponent to preload.
+ * @param modComponents the ModComponent to preload.
  */
 export async function preloadContextMenus(
-  extensions: ModComponentBase[],
+  modComponents: ModComponentBase[],
 ): Promise<void> {
   expectContext("background");
-  const promises = extensions.map(async (definition) => {
-    const resolved = await hydrateModComponentInnerDefinitions(definition);
+  const promises = modComponents.map(async (definition) => {
+    const hydratedModComponent =
+      await hydrateModComponentInnerDefinitions(definition);
 
-    const extensionPoint = await extensionPointRegistry.lookup(
-      resolved.extensionPointId,
+    const starterBrick = await starterBrickRegistry.lookup(
+      hydratedModComponent.extensionPointId,
     );
-    if (extensionPoint instanceof ContextMenuStarterBrickABC) {
-      await extensionPoint.registerMenuItem(
+    if (starterBrick instanceof ContextMenuStarterBrickABC) {
+      await starterBrick.registerMenuItem(
         definition as unknown as HydratedModComponent<ContextMenuConfig>,
         () => {
           throw new ContextError(
             "Context menu was preloaded, but no handler was registered",
             {
-              context: selectEventData(resolved),
+              context: selectEventData(hydratedModComponent),
             },
           );
         },

--- a/src/background/performConfiguredRequest.test.ts
+++ b/src/background/performConfiguredRequest.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import serviceRegistry from "@/integrations/registry";
+import integrationRegistry from "@/integrations/registry";
 import axios, { type AxiosError } from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { performConfiguredRequest } from "./requests";
@@ -83,7 +83,7 @@ const EXAMPLE_SERVICE_API = validateRegistryId("example/api");
 const EXAMPLE_SERVICE_PKCE_API = validateRegistryId("example/pkce");
 const EXAMPLE_SERVICE_TOKEN_API = validateRegistryId("example/token");
 
-serviceRegistry.register([
+integrationRegistry.register([
   {
     id: PIXIEBRIX_INTEGRATION_ID,
     authenticateRequest: (

--- a/src/background/requests.ts
+++ b/src/background/requests.ts
@@ -17,7 +17,7 @@
 
 import axios, { type AxiosResponse, type Method } from "axios";
 import type { NetworkRequestConfig } from "@/types/networkTypes";
-import serviceRegistry from "@/integrations/registry";
+import integrationRegistry from "@/integrations/registry";
 import { getExtensionToken } from "@/auth/authStorage";
 import { integrationConfigLocator } from "@/background/integrationConfigLocator";
 import { isEmpty } from "lodash";
@@ -158,7 +158,7 @@ async function authenticate(
     );
   }
 
-  const integration = await serviceRegistry.lookup(config.serviceId);
+  const integration = await integrationRegistry.lookup(config.serviceId);
 
   // The PixieBrix API doesn't use integration configurations
   if (integration.id === PIXIEBRIX_INTEGRATION_ID) {
@@ -278,7 +278,7 @@ async function _performConfiguredRequest(
     const axiosError = selectAxiosError(error);
 
     if (axiosError && isAuthenticationAxiosError(axiosError)) {
-      const integration = await serviceRegistry.lookup(
+      const integration = await integrationRegistry.lookup(
         integrationConfig.serviceId,
       );
       if (integration.isOAuth2 || integration.isToken) {
@@ -343,7 +343,7 @@ async function getIntegrationMessageContext(
   // Try resolving the integration to get metadata to include with the error
   let resolvedIntegration: Integration | undefined;
   try {
-    resolvedIntegration = await serviceRegistry.lookup(config.serviceId);
+    resolvedIntegration = await integrationRegistry.lookup(config.serviceId);
   } catch {
     // NOP
   }

--- a/src/bricks/effects/AddDynamicTextSnippet.test.ts
+++ b/src/bricks/effects/AddDynamicTextSnippet.test.ts
@@ -17,7 +17,7 @@
 
 import { snippetRegistry } from "@/contentScript/snippetShortcutMenu/snippetShortcutMenuController";
 import AddDynamicTextSnippet from "@/bricks/effects/AddDynamicTextSnippet";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   simpleInput,
   testOptions,
@@ -35,8 +35,8 @@ const brick = new AddDynamicTextSnippet();
 const identity = new IdentityTransformer();
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([brick, identity]);
+  brickRegistry.clear();
+  brickRegistry.register([brick, identity]);
 });
 
 afterEach(() => {

--- a/src/bricks/readers/readerUtils.ts
+++ b/src/bricks/readers/readerUtils.ts
@@ -16,7 +16,7 @@
  */
 
 import { type ReaderConfig } from "@/bricks/types";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import ArrayCompositeReader from "@/bricks/readers/ArrayCompositeReader";
 import { isPlainObject, mapValues } from "lodash";
 import CompositeReader from "@/bricks/readers/CompositeReader";
@@ -29,7 +29,7 @@ export async function mergeReaders(
   readerConfig: ReaderConfig,
 ): Promise<Reader> {
   if (typeof readerConfig === "string") {
-    return blockRegistry.lookup(readerConfig) as Promise<Reader>;
+    return brickRegistry.lookup(readerConfig) as Promise<Reader>;
   }
 
   if (Array.isArray(readerConfig)) {

--- a/src/bricks/transformers/brickFactory.test.ts
+++ b/src/bricks/transformers/brickFactory.test.ts
@@ -21,7 +21,7 @@ import { fromJS as nativeFromJS } from "@/bricks/transformers/brickFactory";
 import { InvalidDefinitionError } from "@/errors/businessErrors";
 import { isUserDefinedBrick } from "@/types/brickTypes";
 import { MappingTransformer } from "./mapping";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   ContextBrick,
   contextBrick,
@@ -43,15 +43,15 @@ import { DefinitionKinds } from "@/types/registryTypes";
 
 TEST_setContext("contentScript");
 
-const fromJS = partial(nativeFromJS, blockRegistry);
+const fromJS = partial(nativeFromJS, brickRegistry);
 
 beforeAll(() => {
   registerBuiltinBricks();
 });
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([contextBrick, optionsBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([contextBrick, optionsBrick]);
   ContextBrick.clearContexts();
   OptionsBrick.clearOptions();
 });
@@ -155,7 +155,7 @@ test("inner pipelines receive correct context", async () => {
   };
 
   const block = fromJS(json);
-  blockRegistry.register([block, new Run()]);
+  brickRegistry.register([block, new Run()]);
 
   const pipeline = {
     id: block.id,
@@ -360,7 +360,7 @@ describe("tracing", () => {
     };
 
     const block = fromJS(json);
-    blockRegistry.register([block, new Run()]);
+    brickRegistry.register([block, new Run()]);
 
     const pipeline = {
       id: block.id,

--- a/src/bricks/transformers/component/TableReader.test.ts
+++ b/src/bricks/transformers/component/TableReader.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { TableReader } from "@/bricks/transformers/component/TableReader";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { type BrickConfig } from "@/bricks/types";
 import {
   unsafeAssumeValidArg,
@@ -27,8 +27,8 @@ import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 const tableReaderBlock = new TableReader();
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([tableReaderBlock]);
+  brickRegistry.clear();
+  brickRegistry.register([tableReaderBlock]);
 });
 
 describe("TableReader", () => {

--- a/src/bricks/transformers/controlFlow/ForEach.test.ts
+++ b/src/bricks/transformers/controlFlow/ForEach.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   echoBrick,
   simpleInput,
@@ -28,8 +28,8 @@ import { toExpression } from "@/utils/expressionUtils";
 const forEachBlock = new ForEach();
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick, forEachBlock]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick, forEachBlock]);
 });
 
 describe("ForEach", () => {

--- a/src/bricks/transformers/controlFlow/ForEachElement.test.ts
+++ b/src/bricks/transformers/controlFlow/ForEachElement.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   echoBrick,
   simpleInput,
@@ -29,8 +29,8 @@ import { toExpression } from "@/utils/expressionUtils";
 const forEachBlock = new ForEachElement();
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick, forEachBlock]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick, forEachBlock]);
 });
 
 describe("ForEachElement", () => {

--- a/src/bricks/transformers/controlFlow/IfElse.test.ts
+++ b/src/bricks/transformers/controlFlow/IfElse.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   rootAwareBrick,
   simpleInput,
@@ -31,8 +31,8 @@ import { toExpression } from "@/utils/expressionUtils";
 const ifElseBlock = new IfElse();
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([
+  brickRegistry.clear();
+  brickRegistry.register([
     teapotBrick,
     throwBrick,
     rootAwareBrick,

--- a/src/bricks/transformers/controlFlow/MapValues.test.ts
+++ b/src/bricks/transformers/controlFlow/MapValues.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   echoBrick,
   simpleInput,
@@ -28,8 +28,8 @@ import { toExpression } from "@/utils/expressionUtils";
 const mapValueBrick = new MapValues();
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick, mapValueBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick, mapValueBrick]);
 });
 
 describe("MapValues", () => {

--- a/src/bricks/transformers/controlFlow/Retry.test.ts
+++ b/src/bricks/transformers/controlFlow/Retry.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   echoBrick,
   simpleInput,
@@ -29,8 +29,8 @@ import { toExpression } from "@/utils/expressionUtils";
 const retryBlock = new Retry();
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([throwBrick, echoBrick, retryBlock]);
+  brickRegistry.clear();
+  brickRegistry.register([throwBrick, echoBrick, retryBlock]);
 });
 
 describe("Retry", () => {

--- a/src/bricks/transformers/controlFlow/TryExcept.test.ts
+++ b/src/bricks/transformers/controlFlow/TryExcept.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   simpleInput,
   teapotBrick,
@@ -30,8 +30,8 @@ import { toExpression } from "@/utils/expressionUtils";
 const tryExceptBlock = new TryExcept();
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([teapotBrick, throwBrick, tryExceptBlock]);
+  brickRegistry.clear();
+  brickRegistry.register([teapotBrick, throwBrick, tryExceptBlock]);
 });
 
 describe("TryExcept", () => {

--- a/src/contrib/automationanywhere/RunApiTask.test.ts
+++ b/src/contrib/automationanywhere/RunApiTask.test.ts
@@ -32,7 +32,7 @@ import { appApiMock, onApiGet, onApiPost } from "@/testUtils/appApiMock";
 import { TEST_overrideFeatureFlags } from "@/auth/featureFlagStorage";
 import { fromJS } from "@/integrations/UserDefinedIntegration";
 import controlRoomOAuth2Service from "@contrib/integrations/automation-anywhere-oauth2.yaml";
-import serviceRegistry from "@/integrations/registry";
+import integrationRegistry from "@/integrations/registry";
 import { integrationConfigLocator } from "@/background/integrationConfigLocator";
 import { type UUID } from "@/types/stringTypes";
 import { setCachedAuthData } from "@/background/auth/authStorage";
@@ -71,8 +71,8 @@ beforeEach(async () => {
       }),
   });
 
-  serviceRegistry.clear();
-  serviceRegistry.register([oauth2Integration]);
+  integrationRegistry.clear();
+  integrationRegistry.register([oauth2Integration]);
 
   const config = remoteIntegrationConfigurationFactory({
     service: {

--- a/src/contrib/registerContribBricks.ts
+++ b/src/contrib/registerContribBricks.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { AddUpdateCompany, AddUpdateContact } from "./hubspot/upsert";
 import { AddOrganization, AddPerson } from "./pipedrive/create";
 import { ResolvePerson } from "./pipedrive/resolvers";
@@ -48,7 +48,7 @@ function registerContribBricks(): void {
     );
   }
 
-  blockRegistry.register([
+  brickRegistry.register([
     // Google
     new GoogleSheetsAppend(),
     new GoogleSheetsLookup(),

--- a/src/extensionConsole/components/RequireBrickRegistry.tsx
+++ b/src/extensionConsole/components/RequireBrickRegistry.tsx
@@ -17,9 +17,9 @@
 
 import React from "react";
 import useAsyncState from "@/hooks/useAsyncState";
-import blockRegistry from "@/bricks/registry";
-import serviceRegistry from "@/integrations/registry";
-import extensionPointRegistry from "@/starterBricks/registry";
+import brickRegistry from "@/bricks/registry";
+import integrationRegistry from "@/integrations/registry";
+import starterBrickRegistry from "@/starterBricks/registry";
 import AsyncStateGate from "@/components/AsyncStateGate";
 
 /**
@@ -29,9 +29,9 @@ const RequireBrickRegistry: React.FC = ({ children }) => {
   const state = useAsyncState(
     async () =>
       Promise.all([
-        blockRegistry.all(),
-        serviceRegistry.all(),
-        extensionPointRegistry.all(),
+        brickRegistry.all(),
+        integrationRegistry.all(),
+        starterBrickRegistry.all(),
       ]),
     [],
   );

--- a/src/extensionConsole/pages/onboarding/SetupPage.tsx
+++ b/src/extensionConsole/pages/onboarding/SetupPage.tsx
@@ -33,7 +33,7 @@ import {
   CONTROL_ROOM_OAUTH_INTEGRATION_ID,
   CONTROL_ROOM_TOKEN_INTEGRATION_ID,
 } from "@/integrations/constants";
-import integrationsRegistry from "@/integrations/registry";
+import integrationRegistry from "@/integrations/registry";
 import reportError from "@/telemetry/reportError";
 import useReportError from "@/hooks/useReportError";
 import { assertNotNullish } from "@/utils/nullishUtils";
@@ -77,10 +77,10 @@ const SetupPage: React.FunctionComponent = () => {
       // If an error was thrown, check if the control room integration definitions are available to determine if we should
       // show an error toast in the partner setup card case.
       try {
-        const controlRoomTokenIntegrationPromise = integrationsRegistry.lookup(
+        const controlRoomTokenIntegrationPromise = integrationRegistry.lookup(
           CONTROL_ROOM_TOKEN_INTEGRATION_ID,
         );
-        const controlRoomOauthIntegrationPromise = integrationsRegistry.lookup(
+        const controlRoomOauthIntegrationPromise = integrationRegistry.lookup(
           CONTROL_ROOM_OAUTH_INTEGRATION_ID,
         );
         await Promise.all([

--- a/src/integrations/integrationConfigLocator.test.ts
+++ b/src/integrations/integrationConfigLocator.test.ts
@@ -20,7 +20,7 @@ import { remoteIntegrationConfigurationFactory } from "@/testUtils/factories/int
 import IntegrationConfigLocator from "@/integrations/integrationConfigLocator";
 import controlRoomTokenService from "@contrib/integrations/automation-anywhere.yaml";
 import { fromJS } from "@/integrations/UserDefinedIntegration";
-import serviceRegistry from "@/integrations/registry";
+import integrationRegistry from "@/integrations/registry";
 
 const integration = fromJS(controlRoomTokenService as any);
 const locator = new IntegrationConfigLocator();
@@ -37,12 +37,12 @@ jest.mock("@/background/messenger/api", () => {
 
 beforeEach(() => {
   appApiMock.reset();
-  serviceRegistry.clear();
+  integrationRegistry.clear();
 });
 
 describe("locator", () => {
   it("sets proxy: true for remote configurations", async () => {
-    serviceRegistry.register([integration]);
+    integrationRegistry.register([integration]);
 
     const config = remoteIntegrationConfigurationFactory({
       service: {
@@ -73,7 +73,7 @@ describe("locator", () => {
   });
 
   it("sets proxy: false for remote pushdown configurations", async () => {
-    serviceRegistry.register([integration]);
+    integrationRegistry.register([integration]);
 
     const config = remoteIntegrationConfigurationFactory({
       service: {

--- a/src/integrations/util/permissionsHelpers.ts
+++ b/src/integrations/util/permissionsHelpers.ts
@@ -16,7 +16,7 @@
  */
 
 import { type Permissions } from "webextension-polyfill";
-import serviceRegistry from "@/integrations/registry";
+import integrationRegistry from "@/integrations/registry";
 import { expectContext } from "@/utils/expectContext";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
 import { PIXIEBRIX_INTEGRATION_ID } from "@/integrations/constants";
@@ -56,7 +56,7 @@ export async function collectIntegrationOriginPermissions({
     return { origins: [] };
   }
 
-  const integration = await serviceRegistry.lookup(integrationId);
+  const integration = await integrationRegistry.lookup(integrationId);
   const origins = integration.getOrigins(localConfig.config);
   return { origins };
 }

--- a/src/modDefinitions/modDefinitionPermissionsHelpers.ts
+++ b/src/modDefinitions/modDefinitionPermissionsHelpers.ts
@@ -24,7 +24,7 @@ import { hydrateModInnerDefinitions } from "@/registry/hydrateInnerDefinitions";
 import { mergePermissions } from "@/permissions/permissionsUtils";
 import { isEmpty } from "lodash";
 import { type Permissions } from "webextension-polyfill";
-import extensionPointRegistry from "@/starterBricks/registry";
+import starterBrickRegistry from "@/starterBricks/registry";
 import { type ModComponentBase } from "@/types/modComponentTypes";
 import { collectIntegrationOriginPermissions } from "@/integrations/util/permissionsHelpers";
 import { collectModComponentPermissions } from "@/permissions/modComponentPermissionsHelpers";
@@ -45,7 +45,7 @@ async function collectModComponentDefinitionPermissions(
       permissions = {},
       config,
     }: HydratedModComponentDefinition) => {
-      const extensionPoint = await extensionPointRegistry.lookup(id);
+      const extensionPoint = await starterBrickRegistry.lookup(id);
 
       let inner: Permissions.Permissions = {};
       try {

--- a/src/pageEditor/documentBuilder/documentTree.test.tsx
+++ b/src/pageEditor/documentBuilder/documentTree.test.tsx
@@ -19,7 +19,7 @@ import { loadBrickYaml } from "@/runtime/brickYaml";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { render, screen, within } from "@testing-library/react";
 import React from "react";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import MarkdownRenderer from "@/bricks/renderers/MarkdownRenderer";
 import * as contentScriptAPI from "@/contentScript/messenger/api";
 import { uuidv4 } from "@/types/helpers";
@@ -41,8 +41,8 @@ const markdownBlock = new MarkdownRenderer();
 
 describe("When rendered in panel", () => {
   beforeEach(() => {
-    blockRegistry.clear();
-    blockRegistry.register([markdownBlock]);
+    brickRegistry.clear();
+    brickRegistry.register([markdownBlock]);
   });
 
   const renderDocument = (config: DocumentBuilderElement) => {

--- a/src/pageEditor/documentBuilder/preview/DocumentPreview.test.tsx
+++ b/src/pageEditor/documentBuilder/preview/DocumentPreview.test.tsx
@@ -29,7 +29,7 @@ import { DocumentRenderer } from "@/bricks/renderers/document";
 import { actions } from "@/pageEditor/store/editor/editorSlice";
 import DisplayTemporaryInfo from "@/bricks/transformers/temporaryInfo/DisplayTemporaryInfo";
 import registerDefaultWidgets from "@/components/fields/schemaFields/widgets/registerDefaultWidgets";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { waitForEffect } from "@/testUtils/testHelpers";
 import { type PipelineExpression } from "@/types/runtimeTypes";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -78,8 +78,8 @@ const temporaryDisplayBlock = new DisplayTemporaryInfo();
 
 beforeAll(async () => {
   registerDefaultWidgets();
-  blockRegistry.clear();
-  blockRegistry.register([documentBlock, temporaryDisplayBlock]);
+  brickRegistry.clear();
+  brickRegistry.register([documentBlock, temporaryDisplayBlock]);
 });
 
 describe("Add new element", () => {

--- a/src/pageEditor/starterBricks/pipelineMapping.test.ts
+++ b/src/pageEditor/starterBricks/pipelineMapping.test.ts
@@ -27,8 +27,7 @@ import {
   normalizePipelineForEditor,
   omitEditorMetadata,
 } from "./pipelineMapping";
-import blockRegistry from "@/bricks/registry";
-
+import brickRegistry from "@/bricks/registry";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { isPipelineExpression, toExpression } from "@/utils/expressionUtils";
 import { type PipelineExpression } from "@/types/runtimeTypes";
@@ -38,7 +37,7 @@ describe("normalizePipeline", () => {
   let teapotBlockConfig: BrickConfig;
 
   beforeAll(() => {
-    blockRegistry.register([
+    brickRegistry.register([
       echoBrick,
       teapotBrick,
       new ForEach(),

--- a/src/pageEditor/starterBricks/pipelineMapping.ts
+++ b/src/pageEditor/starterBricks/pipelineMapping.ts
@@ -28,7 +28,7 @@ import PipelineVisitor, {
   type VisitResolvedBlockExtra,
 } from "@/bricks/PipelineVisitor";
 import pipelineSchema from "@schemas/pipeline.json";
-import blockRegistry, { type TypedBrickMap } from "@/bricks/registry";
+import brickRegistry, { type TypedBrickMap } from "@/bricks/registry";
 import { isPipelineExpression, toExpression } from "@/utils/expressionUtils";
 
 class NormalizePipelineVisitor extends PipelineVisitor {
@@ -81,7 +81,7 @@ class NormalizePipelineVisitor extends PipelineVisitor {
 export async function normalizePipelineForEditor(
   pipeline: BrickPipeline,
 ): Promise<BrickPipeline> {
-  const blockMap = await blockRegistry.allTyped();
+  const blockMap = await brickRegistry.allTyped();
   return produce(pipeline, (pipeline: Draft<BrickPipeline>) => {
     new NormalizePipelineVisitor(blockMap).visitPipeline(
       ROOT_POSITION,

--- a/src/pageEditor/store/editor/editorSlice.test.ts
+++ b/src/pageEditor/store/editor/editorSlice.test.ts
@@ -27,7 +27,7 @@ import {
   type EditorState,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { FOUNDATION_NODE_ID } from "@/pageEditor/store/editor/uiState";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   echoBrick,
   teapotBrick,
@@ -142,8 +142,8 @@ describe("Add/Remove Bricks", () => {
   );
 
   beforeEach(() => {
-    blockRegistry.clear();
-    blockRegistry.register([echoBrick, teapotBrick]);
+    brickRegistry.clear();
+    brickRegistry.register([echoBrick, teapotBrick]);
 
     editor = editorSlice.reducer(
       initialState,

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -20,7 +20,7 @@ import cx from "classnames";
 import styles from "./EditorNodeConfigPanel.module.scss";
 import ConnectedFieldTemplate from "@/components/form/ConnectedFieldTemplate";
 import BrickConfiguration from "@/pageEditor/tabs/effect/BrickConfiguration";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { showOutputKey } from "@/pageEditor/tabs/editTab/editHelpers";
 import KeyNameWidget from "@/components/form/widgets/KeyNameWidget";
 import getType from "@/runtime/getType";
@@ -46,7 +46,7 @@ const EditorNodeConfigPanel: React.FC = () => {
       return null;
     }
 
-    const brick = await blockRegistry.lookup(brickId);
+    const brick = await brickRegistry.lookup(brickId);
     return {
       block: brick,
       type: await getType(brick),

--- a/src/pageEditor/tabs/effect/BrickPreview.tsx
+++ b/src/pageEditor/tabs/effect/BrickPreview.tsx
@@ -17,7 +17,7 @@
 
 import React, { useEffect, useReducer } from "react";
 import { type BrickConfig } from "@/bricks/types";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { useDebouncedCallback } from "use-debounce";
 import { Button } from "react-bootstrap";
 import Loader from "@/components/Loader";
@@ -81,7 +81,7 @@ export function usePreviewInfo(
   blockId: RegistryId,
 ): FetchableAsyncState<PreviewInfo> {
   return useAsyncState(async () => {
-    const block = await blockRegistry.lookup(blockId);
+    const block = await brickRegistry.lookup(blockId);
     const type = await getType(block);
     return {
       block,

--- a/src/runtime/pipelineTests/autoescape.test.ts
+++ b/src/runtime/pipelineTests/autoescape.test.ts
@@ -15,15 +15,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { echoBrick, simpleInput, testOptions } from "./pipelineTestHelpers";
 import { type ApiVersion } from "@/types/runtimeTypes";
 import { toExpression } from "@/utils/expressionUtils";
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick]);
 });
 
 describe.each([["v1"], ["v2"]])("apiVersion: %s", (apiVersion: ApiVersion) => {

--- a/src/runtime/pipelineTests/component.test.ts
+++ b/src/runtime/pipelineTests/component.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { type BrickPipeline } from "@/bricks/types";
 import {
@@ -34,11 +34,11 @@ import { DefinitionKinds } from "@/types/registryTypes";
 TEST_setContext("contentScript");
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick, contextBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick, contextBrick]);
 });
 
-const componentBlock = fromJS(blockRegistry, {
+const componentBlock = fromJS(brickRegistry, {
   apiVersion: "v1",
   kind: DefinitionKinds.BRICK,
   metadata: {
@@ -63,7 +63,7 @@ const componentBlock = fromJS(blockRegistry, {
 
 describe("component block v1", () => {
   test("v2 pipeline calling v1 block", async () => {
-    blockRegistry.register([componentBlock]);
+    brickRegistry.register([componentBlock]);
 
     const pipeline = [
       {
@@ -91,7 +91,7 @@ describe("component block v1", () => {
   });
 
   test("v3 pipeline calling v1 block", async () => {
-    blockRegistry.register([componentBlock]);
+    brickRegistry.register([componentBlock]);
 
     const pipeline = [
       {

--- a/src/runtime/pipelineTests/conditional.test.ts
+++ b/src/runtime/pipelineTests/conditional.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { type ApiVersion } from "@/types/runtimeTypes";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { InputValidationError } from "@/bricks/errors";
 import { type BrickPipeline } from "@/bricks/types";
@@ -29,8 +29,8 @@ import {
 import { toExpression } from "@/utils/expressionUtils";
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick, contextBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick, contextBrick]);
 });
 
 describe("apiVersion: v1", () => {

--- a/src/runtime/pipelineTests/deferExpression.test.ts
+++ b/src/runtime/pipelineTests/deferExpression.test.ts
@@ -15,14 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { deferBrick, simpleInput, testOptions } from "./pipelineTestHelpers";
 import { toExpression } from "@/utils/expressionUtils";
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([deferBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([deferBrick]);
 });
 
 describe("apiVersion: v3", () => {

--- a/src/runtime/pipelineTests/deploymentAlert.test.ts
+++ b/src/runtime/pipelineTests/deploymentAlert.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import {
   contextBrick,
@@ -33,8 +33,8 @@ import { ContextError } from "@/errors/genericErrors";
 import { extraEmptyModStateContext } from "@/runtime/extendModVariableContext";
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick, contextBrick, throwBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick, contextBrick, throwBrick]);
   jest.mocked(sendDeploymentAlert).mockReset();
 });
 

--- a/src/runtime/pipelineTests/implicitDataFlow.test.ts
+++ b/src/runtime/pipelineTests/implicitDataFlow.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { type BrickPipeline } from "@/bricks/types";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
@@ -32,8 +32,8 @@ import { type ApiVersion, type OutputKey } from "@/types/runtimeTypes";
 import { extraEmptyModStateContext } from "@/runtime/extendModVariableContext";
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([
+  brickRegistry.clear();
+  brickRegistry.register([
     echoBrick,
     contextBrick,
     teapotBrick,

--- a/src/runtime/pipelineTests/modVariableContext.test.ts
+++ b/src/runtime/pipelineTests/modVariableContext.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   contextBrick,
   echoBrick,
@@ -33,8 +33,8 @@ import { contextAsPlainObject } from "@/runtime/extendModVariableContext";
 import { toExpression } from "@/utils/expressionUtils";
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick, contextBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick, contextBrick]);
 });
 
 describe("modVariableContext", () => {

--- a/src/runtime/pipelineTests/options.test.ts
+++ b/src/runtime/pipelineTests/options.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { type ApiVersion } from "@/types/runtimeTypes";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import {
   contextBrick,
@@ -27,8 +27,8 @@ import {
 import { extraEmptyModStateContext } from "@/runtime/extendModVariableContext";
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick, contextBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick, contextBrick]);
 });
 
 describe.each([["v1"], ["v2"]])("apiVersion: %s", (apiVersion: ApiVersion) => {

--- a/src/runtime/pipelineTests/outputKey.test.ts
+++ b/src/runtime/pipelineTests/outputKey.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { type ApiVersion } from "@/types/runtimeTypes";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { type BrickPipeline } from "@/bricks/types";
 import { cloneDeep } from "lodash";
@@ -30,8 +30,8 @@ import {
 import { extraEmptyModStateContext } from "@/runtime/extendModVariableContext";
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick, contextBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick, contextBrick]);
 });
 
 describe("apiVersion: v1", () => {

--- a/src/runtime/pipelineTests/pipelineExpression.test.ts
+++ b/src/runtime/pipelineTests/pipelineExpression.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import {
   identityBrick,
@@ -27,8 +27,8 @@ import { toExpression } from "@/utils/expressionUtils";
 import { validateRegistryId } from "@/types/helpers";
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([pipelineBrick, identityBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([pipelineBrick, identityBrick]);
 });
 
 describe("apiVersion: v3", () => {

--- a/src/runtime/pipelineTests/root.test.ts
+++ b/src/runtime/pipelineTests/root.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   echoBrick,
   simpleInput,
@@ -80,8 +80,8 @@ const rootBlock = new RootAwareBlock();
 const rootReader = new RootAwareReader();
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([rootBlock, rootReader, echoBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([rootBlock, rootReader, echoBrick]);
   // https://stackoverflow.com/questions/42805128/does-jest-reset-the-jsdom-document-after-every-suite-or-test
   document.querySelectorAll("html")[0]!.innerHTML = "";
 });

--- a/src/runtime/pipelineTests/templateEngine.test.ts
+++ b/src/runtime/pipelineTests/templateEngine.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import { type BrickConfig } from "@/bricks/types";
 import {
@@ -30,8 +30,8 @@ import { toExpression } from "@/utils/expressionUtils";
 import { type TemplateEngine } from "@/types/runtimeTypes";
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick, contextBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick, contextBrick]);
 });
 
 describe.each([["mustache"], ["handlebars"], ["nunjucks"]])(

--- a/src/runtime/pipelineTests/trace.test.ts
+++ b/src/runtime/pipelineTests/trace.test.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { reducePipeline } from "@/runtime/reducePipeline";
 import {
   contextBrick,
@@ -42,8 +42,8 @@ const addEntryMock = jest.mocked(traces.addEntry);
 const addExitMock = jest.mocked(traces.addExit);
 
 beforeEach(() => {
-  blockRegistry.clear();
-  blockRegistry.register([echoBrick, contextBrick, throwBrick]);
+  brickRegistry.clear();
+  brickRegistry.register([echoBrick, contextBrick, throwBrick]);
   addEntryMock.mockReset();
   addExitMock.mockReset();
 });

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -17,7 +17,7 @@
 
 import React, { useReducer } from "react";
 import Loader from "@/components/Loader";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import EmotionShadowRoot from "@/components/EmotionShadowRoot";
 import { getErrorMessage, selectSpecificError } from "@/errors/errorHelpers";
 import {
@@ -178,7 +178,7 @@ const PanelBody: React.FunctionComponent<{
 
         console.debug("Running panel body for panel payload", payload);
 
-        const block = await blockRegistry.lookup(blockId);
+        const block = await brickRegistry.lookup(blockId);
 
         const logger = platform.logger.childLogger({
           ...context,

--- a/src/starterBricks/button/buttonStarterBrick.test.ts
+++ b/src/starterBricks/button/buttonStarterBrick.test.ts
@@ -20,7 +20,7 @@ import { validateRegistryId } from "@/types/helpers";
 import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 import { define } from "cooky-cutter";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { getReferenceForElement } from "@/contentScript/elementReference";
 import {
   getDocument,
@@ -98,8 +98,8 @@ beforeEach(() => {
   reduceModComponentPipelineMock.mockClear();
   window.document.body.innerHTML = "";
   document.body.innerHTML = "";
-  blockRegistry.clear();
-  blockRegistry.register([rootReader]);
+  brickRegistry.clear();
+  brickRegistry.register([rootReader]);
   rootReader.readCount = 0;
   rootReader.ref = null;
 });

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
@@ -21,7 +21,7 @@ import { validateRegistryId } from "@/types/helpers";
 import { type Metadata, DefinitionKinds } from "@/types/registryTypes";
 import { type BrickPipeline } from "@/bricks/types";
 import { RootReader } from "@/starterBricks/starterBrickTestUtils";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { fromJS } from "@/starterBricks/contextMenu/contextMenuStarterBrick";
 import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
@@ -79,8 +79,8 @@ const modComponentFactory = define<HydratedModComponent<ContextMenuConfig>>({
 beforeEach(() => {
   window.document.body.innerHTML = "";
   document.body.innerHTML = "";
-  blockRegistry.clear();
-  blockRegistry.register([rootReader]);
+  brickRegistry.clear();
+  brickRegistry.register([rootReader]);
   rootReader.readCount = 0;
   rootReader.ref = null;
   jest.resetAllMocks();

--- a/src/starterBricks/quickBar/quickBarStarterBrick.test.ts
+++ b/src/starterBricks/quickBar/quickBarStarterBrick.test.ts
@@ -25,7 +25,7 @@ import {
   RootReader,
   tick,
 } from "@/starterBricks/starterBrickTestUtils";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import { fromJS } from "@/starterBricks/quickBar/quickBarStarterBrick";
 import { type Menus } from "webextension-polyfill";
 import userEvent from "@testing-library/user-event";
@@ -96,8 +96,8 @@ const rootReader = new RootReader();
 beforeEach(() => {
   window.document.body.innerHTML = "";
   document.body.innerHTML = "";
-  blockRegistry.clear();
-  blockRegistry.register([rootReader]);
+  brickRegistry.clear();
+  brickRegistry.register([rootReader]);
   rootReader.readCount = 0;
   rootReader.ref = null;
 });

--- a/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.test.ts
+++ b/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.test.ts
@@ -25,7 +25,7 @@ import {
   RootReader,
   tick,
 } from "@/starterBricks/starterBrickTestUtils";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import userEvent from "@testing-library/user-event";
 import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import {
@@ -99,8 +99,8 @@ const NUM_DEFAULT_QUICKBAR_ACTIONS = [...defaultActions, pageEditorAction]
 
 describe("quickBarProviderExtension", () => {
   beforeEach(() => {
-    blockRegistry.clear();
-    blockRegistry.register([rootReader]);
+    brickRegistry.clear();
+    brickRegistry.register([rootReader]);
     rootReader.readCount = 0;
     rootReader.ref = null;
   });

--- a/src/starterBricks/starterBrickModUtils.test.ts
+++ b/src/starterBricks/starterBrickModUtils.test.ts
@@ -24,18 +24,16 @@ import {
   defaultModDefinitionFactory,
   modComponentDefinitionFactory,
 } from "@/testUtils/factories/modDefinitionFactories";
-import extensionPointRegistry from "@/starterBricks/registry";
+import starterBrickRegistry from "@/starterBricks/registry";
 import {
   type StarterBrick,
   StarterBrickTypes,
 } from "@/types/starterBrickTypes";
 import { activatedModComponentFactory } from "@/testUtils/factories/modComponentFactories";
 
-extensionPointRegistry.lookup = jest.fn();
+starterBrickRegistry.lookup = jest.fn();
 
-const extensionPointRegistryLookupMock = jest.mocked(
-  extensionPointRegistry.lookup,
-);
+const starterBrickRegistryLookupMock = jest.mocked(starterBrickRegistry.lookup);
 
 describe("starterBrickModUtils", () => {
   describe("getContainedStarterBrickTypes", () => {
@@ -59,7 +57,7 @@ describe("starterBrickModUtils", () => {
     });
 
     test("gets types without inner definitions", async () => {
-      extensionPointRegistryLookupMock.mockResolvedValue({
+      starterBrickRegistryLookupMock.mockResolvedValue({
         kind: StarterBrickTypes.BUTTON,
       } as StarterBrick);
 
@@ -74,7 +72,7 @@ describe("starterBrickModUtils", () => {
     });
 
     test("returns non-null values", async () => {
-      extensionPointRegistryLookupMock.mockResolvedValue(null);
+      starterBrickRegistryLookupMock.mockResolvedValue(null);
 
       const result = await getContainedStarterBrickTypes(
         defaultModDefinitionFactory({
@@ -87,7 +85,7 @@ describe("starterBrickModUtils", () => {
     });
 
     test("inner definition not found", async () => {
-      extensionPointRegistryLookupMock.mockResolvedValue(null);
+      starterBrickRegistryLookupMock.mockResolvedValue(null);
 
       const result = await getContainedStarterBrickTypes(
         defaultModDefinitionFactory({

--- a/src/starterBricks/trigger/triggerStarterBrick.test.ts
+++ b/src/starterBricks/trigger/triggerStarterBrick.test.ts
@@ -26,7 +26,7 @@ import {
   RootReader,
   tick,
 } from "@/starterBricks/starterBrickTestUtils";
-import blockRegistry from "@/bricks/registry";
+import brickRegistry from "@/bricks/registry";
 import {
   fromJS,
   getDefaultAllowInactiveFramesForTrigger,
@@ -128,8 +128,8 @@ beforeEach(() => {
   reportEventMock.mockReset();
   showNotificationMock.mockReset();
   notifyContextInvalidatedMock.mockReset();
-  blockRegistry.clear();
-  blockRegistry.register([
+  brickRegistry.clear();
+  brickRegistry.register([
     rootReader,
     new InvalidContextReader(),
     throwBrick,


### PR DESCRIPTION
## What does this PR do?

- Rename default registry imports in files
- `blockRegistry` -> `brickRegistry`
- `serviceRegistry` -> `integrationRegistry`
- `extensionPointRegistry` -> `starterBrickRegistry`

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
