### PR TITLE
#8781: fix the error using a hook during runtime instead of a migration

### DIFF
--- a/src/bricks/types.ts
+++ b/src/bricks/types.ts
@@ -190,9 +190,9 @@ export enum PipelineFlavor {
 }
 
 /**
- * Defines the position of the brick in the extension
- * ex. "extension.brickPipeline.0.config.body.__value__.0",
- * "extension.brickPipeline.0.config.body.0.children.0.config.onClick.__value__.0"
+ * Defines the position of the brick in the mod component
+ * ex. "modComponent.brickPipeline.0.config.body.__value__.0",
+ * "modComponent.brickPipeline.0.config.body.0.children.0.config.onClick.__value__.0"
  */
 export type BrickPosition = {
   /**

--- a/src/pageEditor/store/editor/uiStateTypes.ts
+++ b/src/pageEditor/store/editor/uiStateTypes.ts
@@ -33,7 +33,7 @@ export type NodeInfo = {
   blockConfig: BrickConfig;
 
   /**
-   * Index of the block in its pipeline
+   * Index of the brick in its pipeline
    */
   index: number;
 
@@ -43,7 +43,7 @@ export type NodeInfo = {
   pipelinePath: string;
 
   /**
-   * The block's pipeline
+   * The brick's pipeline
    */
   pipeline: BrickPipeline;
 
@@ -54,7 +54,7 @@ export type NodeInfo = {
 };
 
 /**
- * The map of pipeline blocks. The key is the instanceId of the block.
+ * The map of pipeline bricks. The key is the instanceId of the brick.
  */
 export type PipelineMap = Record<UUID, NodeInfo>;
 
@@ -77,7 +77,7 @@ export type DataPanelTabUIState = {
 
 export type BrickConfigurationUIState = {
   /**
-   * Identifier for the node in the editor, either the foundation or a block uuid
+   * Identifier for the node in the editor, either the foundation or a brick uuid
    */
   nodeId: UUID;
 

--- a/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeConfigPanel/EditorNodeConfigPanel.tsx
@@ -37,9 +37,9 @@ const EditorNodeConfigPanel: React.FC = () => {
   const {
     blockId: brickId,
     path: brickFieldName,
-    blockConfig,
+    blockConfig: brickConfig,
   } = useSelector(selectActiveNodeInfo) ?? {};
-  const { comments } = blockConfig ?? {};
+  const { comments } = brickConfig ?? {};
 
   const { data: brickInfo } = useAsyncState(async () => {
     if (brickId == null) {

--- a/src/pageEditor/tabs/effect/BrickConfiguration.tsx
+++ b/src/pageEditor/tabs/effect/BrickConfiguration.tsx
@@ -47,6 +47,20 @@ import { selectActiveModComponentAnalysisAnnotationsForPath } from "@/pageEditor
 import AnalysisAnnotationsContext from "@/analysis/AnalysisAnnotationsContext";
 import { BrickTypes } from "@/runtime/runtimeTypes";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
+import { useDispatch } from "react-redux";
+import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
+
+function useResetBrickPipeline(name: string) {
+  const context = useFormikContext<ModComponentFormState>();
+  const [config] = useField<BrickConfig | undefined>(name);
+  const dispatch = useDispatch();
+
+  if (!config.value) {
+    dispatch(editorActions.resetActivatedModComponentFormState(context.values));
+  }
+
+  return { context, config };
+}
 
 const BrickConfiguration: React.FunctionComponent<{
   name: string;
@@ -54,8 +68,8 @@ const BrickConfiguration: React.FunctionComponent<{
 }> = ({ name, brickId }) => {
   const configName = partial(joinName, name);
 
-  const context = useFormikContext<ModComponentFormState>();
-  const [config] = useField<BrickConfig>(name);
+  const { context, config } = useResetBrickPipeline(name);
+
   const [_rootField, _rootFieldMeta, rootFieldHelpers] =
     useField<BrickConfig | null>(configName("root"));
   const brickErrors = getIn(context.errors, name);

--- a/src/pageEditor/tabs/effect/BrickConfiguration.tsx
+++ b/src/pageEditor/tabs/effect/BrickConfiguration.tsx
@@ -50,6 +50,11 @@ import { StarterBrickTypes } from "@/types/starterBrickTypes";
 import { useDispatch } from "react-redux";
 import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
 
+/**
+ * Handles possible NPE from `config.value` being undefined.
+ * This originally happened during the extension -> modComponent form state migration.
+ * See https://github.com/pixiebrix/pixiebrix-extension/issues/8781
+ */
 function useResetBrickPipeline(name: string) {
   const context = useFormikContext<ModComponentFormState>();
   const [config] = useField<BrickConfig | undefined>(name);
@@ -90,11 +95,11 @@ const BrickConfiguration: React.FunctionComponent<{
 
     // Handle DOM bricks that were upgraded to be root-aware
     if ("isRootAware" in inputSchema) {
-      return Boolean(config.value.config.isRootAware);
+      return Boolean(config.value?.config.isRootAware);
     }
 
     return brick?.isRootAware() ?? false;
-  }, [brick, config.value.config.isRootAware]);
+  }, [brick, config.value?.config.isRootAware]);
 
   const advancedOptionsRef = useRef<HTMLDivElement>(null);
 
@@ -102,11 +107,11 @@ const BrickConfiguration: React.FunctionComponent<{
     async () => {
       // Effect to clear out unused `root` field. Technically, `root` could contain a selector when used with `document`
       // or `inherit` mode, but we don't want to support that in the Page Editor because it's legacy behavior.
-      if (config.value.rootMode !== "element") {
+      if (config.value?.rootMode !== "element") {
         await rootFieldHelpers.setValue(null);
       }
     }, // Dependencies - rootFieldHelpers changes reference every render
-    [config.value.rootMode],
+    [config.value?.rootMode],
   );
 
   const rootElementSchema: SchemaFieldProps = useMemo(
@@ -212,7 +217,7 @@ const BrickConfiguration: React.FunctionComponent<{
           />
         )}
 
-        {config.value.rootMode === "element" && (
+        {config.value?.rootMode === "element" && (
           <SchemaField {...rootElementSchema} omitIfEmpty />
         )}
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #8781

## Discussion

- Tried to run the `syncBrickConfigurationUIStates` function in a migration, but that pulled code into the `loadActivationEnhancements.js` bundle that is banned. Tried to work around but wasn't able, so I reverted to this solution.

## Demo

- In the process of debugging and fixing this issue, I fixed the only mod that I could reproduce the issue with
- This issue can only happen with mods installed before the previous state migration (and then only sometimes), so I can't get the editor back into a bad state to demo

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
