### PR TITLE
#8789 object extensibility error

### DIFF
--- a/src/telemetry/reportEvent.ts
+++ b/src/telemetry/reportEvent.ts
@@ -17,6 +17,7 @@
 
 import { backgroundTarget as bg, getNotifier } from "webext-messenger";
 import { expectContext } from "@/utils/expectContext";
+import reportError from "@/telemetry/reportError";
 import {
   type TelemetryEvent,
   type ReportEventData,
@@ -41,5 +42,9 @@ export default function reportEvent<TData extends UnknownObject>(
 ): void {
   // eslint-disable-next-line prefer-rest-params -- Needs `arguments` to avoid printing the default
   console.debug(...arguments);
-  _record({ event, data: mapEventDataToDeprecatedTerminology(data) });
+  try {
+    _record({ event, data: mapEventDataToDeprecatedTerminology(data) });
+  } catch (error) {
+    reportError(error);
+  }
 }

--- a/src/telemetry/telemetryHelpers.ts
+++ b/src/telemetry/telemetryHelpers.ts
@@ -19,7 +19,7 @@ import type { UserData } from "@/auth/authTypes";
 import { type TelemetryUser } from "@/telemetry/telemetryTypes";
 import { uuidv4 } from "@/types/helpers";
 import type { UUID } from "@/types/stringTypes";
-import { once } from "lodash";
+import { cloneDeep, once } from "lodash";
 import { StorageItem } from "webext-storage";
 
 export const uuidStorage = new StorageItem<UUID>("USER_UUID");
@@ -90,50 +90,51 @@ export async function mapAppUserToTelemetryUser(
 export function mapEventDataToDeprecatedTerminology(
   data: UnknownObject,
 ): UnknownObject {
-  if (data.brickId) {
-    data.blockId = data.brickId;
+  const _data = cloneDeep(data);
+  if (_data.brickId) {
+    _data.blockId = _data.brickId;
   }
 
-  if (data.brickVersion) {
-    data.blockVersion = data.brickVersion;
+  if (_data.brickVersion) {
+    _data.blockVersion = _data.brickVersion;
   }
 
-  if (data.integrationId) {
-    data.serviceId = data.integrationId;
+  if (_data.integrationId) {
+    _data.serviceId = _data.integrationId;
   }
 
-  if (data.integrationVersion) {
-    data.serviceVersion = data.integrationVersion;
+  if (_data.integrationVersion) {
+    _data.serviceVersion = _data.integrationVersion;
   }
 
-  if (data.modId) {
-    data.blueprintId = data.modId;
-    data.recipeId = data.modId;
+  if (_data.modId) {
+    _data.blueprintId = _data.modId;
+    _data.recipeId = _data.modId;
   }
 
-  if (data.modComponentId) {
-    data.extensionId = data.modComponentId;
+  if (_data.modComponentId) {
+    _data.extensionId = _data.modComponentId;
   }
 
-  if (data.modComponentLabel) {
-    data.extensionLabel = data.modComponentLabel;
+  if (_data.modComponentLabel) {
+    _data.extensionLabel = _data.modComponentLabel;
   }
 
-  if (data.modComponents) {
-    data.extensions = data.modComponents;
+  if (_data.modComponents) {
+    _data.extensions = _data.modComponents;
   }
 
-  if (data.modToActivate) {
-    data.recipeToActivate = data.modToActivate;
+  if (_data.modToActivate) {
+    _data.recipeToActivate = _data.modToActivate;
   }
 
-  if (data.modVersion) {
-    data.blueprintVersion = data.modVersion;
+  if (_data.modVersion) {
+    _data.blueprintVersion = _data.modVersion;
   }
 
-  if (data.starterBrickId) {
-    data.extensionPointId = data.starterBrickId;
+  if (_data.starterBrickId) {
+    _data.extensionPointId = _data.starterBrickId;
   }
 
-  return data;
+  return _data;
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #8789

This PR introduces error handling in the `reportEvent` function in the `reportEvent.ts` file. It wraps the `_record` function call in a try-catch block and reports any errors that occur using the `reportError` function. 

It also modifies the `mapEventDataToDeprecatedTerminology` function in the `telemetryHelpers.ts` file to avoid mutating the input data object. It creates a deep clone of the input data object and performs the mapping operations on the cloned object.
