### PR TITLE
handle flaky table item dropdown in e2e tests

### DIFF
--- a/end-to-end-tests/setup/affiliated.setup.ts
+++ b/end-to-end-tests/setup/affiliated.setup.ts
@@ -74,7 +74,6 @@ test("authenticate with affiliated user", async ({
     const deployedMod = modsPage.modTableItemById(
       "@affiliated-test-team/my-pbxvercelapp-trigger",
     );
-    await expect(deployedMod).toBeVisible();
-    await expect(deployedMod).toContainText("version 1.0.0");
+    await expect(deployedMod.getByText("version 1.0.0")).toBeVisible();
   });
 });

--- a/end-to-end-tests/tests/deployments/deploymentActivation.spec.ts
+++ b/end-to-end-tests/tests/deployments/deploymentActivation.spec.ts
@@ -32,13 +32,8 @@ test("activate a deployed mod in the extension console", async ({
   );
 
   await test.step("Deactivate the deployed mod", async () => {
-    await deployedMod.locator(".dropdown").click();
-    await deployedMod
-      .getByRole("button", {
-        name: "Deactivate",
-      })
-      .click();
-    await expect(deployedMod).toBeHidden();
+    await deployedMod.clickAction("Deactivate");
+    await expect(deployedMod.root).toBeHidden();
   });
 
   await test.step("Reactivate the deployed mod via deployment modal", async () => {
@@ -54,12 +49,10 @@ test("activate a deployed mod in the extension console", async ({
       .getByRole("button", { name: "Activate" })
       .click();
 
-    await expect(deployedMod).toBeVisible();
-    await expect(deployedMod).toContainText("version 1.0.0");
+    await expect(deployedMod.getByText("version 1.0.0")).toBeVisible();
 
     // Expect the same mod to be shown on the affiliated team tab
     await page.getByTestId("affiliated-test-team-mod-tab").click();
-    await expect(deployedMod).toBeVisible();
-    await expect(deployedMod).toContainText("version 1.0.0");
+    await expect(deployedMod.getByText("version 1.0.0")).toBeVisible();
   });
 });

--- a/end-to-end-tests/tests/modLifecycle.spec.ts
+++ b/end-to-end-tests/tests/modLifecycle.spec.ts
@@ -118,10 +118,9 @@ test("create, run, package, and update mod", async ({
     await modsPage.goto();
 
     await modsPage.viewActiveMods();
-    await expect(modsPage.modTableItemById(modId)).toContainText(
-      "version 1.0.1",
-    );
-    await modsPage.actionForModByName(modId, "Reactivate");
+    const modTableItem = modsPage.modTableItemById(modId);
+    await expect(modTableItem.getByText("version 1.0.1")).toBeVisible();
+    await modTableItem.clickAction("Reactivate");
 
     const modActivatePage = new ActivateModPage(newPage, extensionId, modId);
 

--- a/src/extensionConsole/options.html
+++ b/src/extensionConsole/options.html
@@ -20,7 +20,7 @@
   <head>
     <!--Uncomment this script tag to enable the React Dev Tools app-->
     <!--See https://github.com/pixiebrix/pixiebrix-extension/wiki/Development-commands#react-dev-tools -->
-    <!--<script src="http://localhost:8097"></script>-->
+    <script src="http://localhost:8097"></script>
     <meta charset="utf-8" />
     <title>Extension Console | PixieBrix</title>
     <link rel="icon" />


### PR DESCRIPTION
## What does this PR do?

Fixes flaky failing e2e tests due to the table item dropdown closing due to rerenders. See: https://github.com/pixiebrix/pixiebrix-extension/issues/8458

Some additional refactoring done to extract table mod item logic into it's own model.