### PR TITLE
Rename `block`/`extension` in runtime and tracing

### DIFF
--- a/src/analysis/analysisVisitors/traceAnalysis.ts
+++ b/src/analysis/analysisVisitors/traceAnalysis.ts
@@ -52,7 +52,7 @@ class TraceAnalysis extends AnalysisVisitorABC {
 
     for (const [instanceId, records] of Object.entries(
       // eslint-disable-next-line unicorn/no-array-callback-reference -- a proxy function breaks the type inference of isTraceError
-      groupBy(trace.filter(isTraceError), (x) => x.blockInstanceId),
+      groupBy(trace.filter(isTraceError), (x) => x.brickInstanceId),
     )) {
       this.traceErrorMap.set(instanceId as UUID, records);
     }

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -495,7 +495,7 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
 
     const traceRecord = this.trace.find(
       (x) =>
-        x.blockInstanceId === blockConfig.instanceId &&
+        x.brickInstanceId === blockConfig.instanceId &&
         x.templateContext != null,
     );
 

--- a/src/background/executor.test.ts
+++ b/src/background/executor.test.ts
@@ -47,7 +47,7 @@ const optionsFactory = define<RemoteBrickOptions>({
   }),
   meta: derive<RemoteBrickOptions, RemoteBrickOptions["meta"]>(
     (options) => ({
-      extensionId: options.messageContext!.modComponentId,
+      modComponentId: options.messageContext!.modComponentId,
       runId: null,
       branches: [],
     }),

--- a/src/bricks/effects/AddDynamicTextSnippet.test.ts
+++ b/src/bricks/effects/AddDynamicTextSnippet.test.ts
@@ -66,7 +66,7 @@ describe("AddDynamicTextSnippet", () => {
 
       await reducePipeline(pipeline, simpleInput({}), {
         ...testOptions("v3"),
-        extensionId,
+        modComponentId: extensionId,
         logger,
       });
 
@@ -114,7 +114,7 @@ describe("AddDynamicTextSnippet", () => {
 
       await reducePipeline(pipeline, simpleInput({}), {
         ...testOptions("v3"),
-        extensionId,
+        modComponentId: extensionId,
         logger,
       });
 

--- a/src/bricks/errors.ts
+++ b/src/bricks/errors.ts
@@ -33,7 +33,7 @@ import { isObject } from "@/utils/objectUtils";
 export class HeadlessModeError extends Error {
   override name = "HeadlessModeError";
 
-  public readonly blockId: RegistryId;
+  public readonly brickId: RegistryId;
 
   public readonly args: BrickArgs;
 
@@ -42,13 +42,13 @@ export class HeadlessModeError extends Error {
   public readonly loggerContext: MessageContext;
 
   constructor(
-    blockId: RegistryId,
+    brickId: RegistryId,
     args: BrickArgs,
     ctxt: BrickArgsContext,
     loggerContext: MessageContext,
   ) {
-    super(`${blockId} is a renderer`);
-    this.blockId = blockId;
+    super(`${brickId} is a renderer`);
+    this.brickId = brickId;
     this.args = args;
     this.ctxt = ctxt;
     this.loggerContext = loggerContext;

--- a/src/bricks/renderers/documentView/DocumentView.tsx
+++ b/src/bricks/renderers/documentView/DocumentView.tsx
@@ -40,9 +40,9 @@ const DocumentView: React.FC<DocumentViewProps> = ({
     throw new Error("meta.runId is required for DocumentView");
   }
 
-  if (!meta?.extensionId) {
+  if (!meta?.modComponentId) {
     // The sidebar panel should dynamically pass the prop through
-    throw new Error("meta.extensionId is required for DocumentView");
+    throw new Error("meta.modComponentId is required for DocumentView");
   }
 
   const { stylesheets } = useStylesheetsContextWithDocumentDefault({

--- a/src/bricks/renderers/documentView/DocumentViewProps.tsx
+++ b/src/bricks/renderers/documentView/DocumentViewProps.tsx
@@ -41,6 +41,6 @@ export type DocumentViewProps = {
   options: BrickOptions<BrickArgsContext>;
   meta: {
     runId: UUID;
-    extensionId: UUID;
+    modComponentId: UUID;
   };
 };

--- a/src/bricks/transformers/RunMetadataTransformer.test.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.test.ts
@@ -95,7 +95,7 @@ describe("RunMetadataTransformer", () => {
         logger,
         meta: {
           runId,
-          extensionId: modComponentId,
+          modComponentId: modComponentId,
           branches: [],
         },
       }),

--- a/src/bricks/transformers/RunMetadataTransformer.test.ts
+++ b/src/bricks/transformers/RunMetadataTransformer.test.ts
@@ -95,7 +95,7 @@ describe("RunMetadataTransformer", () => {
         logger,
         meta: {
           runId,
-          modComponentId: modComponentId,
+          modComponentId,
           branches: [],
         },
       }),

--- a/src/bricks/transformers/brickFactory.test.ts
+++ b/src/bricks/transformers/brickFactory.test.ts
@@ -387,7 +387,7 @@ describe("tracing", () => {
       {
         ...testOptions("v3"),
         runId,
-        extensionId,
+        modComponentId: extensionId,
         branches: initialBranches,
       },
     );

--- a/src/bricks/transformers/brickFactory.test.ts
+++ b/src/bricks/transformers/brickFactory.test.ts
@@ -377,7 +377,7 @@ describe("tracing", () => {
     };
 
     const runId = uuidv4();
-    const extensionId = uuidv4();
+    const modComponentId = uuidv4();
     // Provide initial value to ensure it's preserved
     const initialBranches = [{ key: "body", counter: 1 }];
 
@@ -387,20 +387,20 @@ describe("tracing", () => {
       {
         ...testOptions("v3"),
         runId,
-        modComponentId: extensionId,
+        modComponentId,
         branches: initialBranches,
       },
     );
 
     expect(OptionsBrick.options[0].meta).toStrictEqual({
       runId,
-      extensionId,
+      modComponentId,
       branches: initialBranches,
     });
 
     expect(OptionsBrick.options[1].meta).toStrictEqual({
       runId,
-      extensionId,
+      modComponentId,
       branches: [
         ...initialBranches,
         // Branch is added by the @pixiebrix/run brick

--- a/src/bricks/transformers/brickFactory.ts
+++ b/src/bricks/transformers/brickFactory.ts
@@ -377,7 +377,7 @@ class UserDefinedBrick extends BrickABC {
     } catch (error) {
       if (isSpecificError(error, HeadlessModeError)) {
         const continuation = error;
-        const renderer = await this.registry.lookup(continuation.blockId);
+        const renderer = await this.registry.lookup(continuation.brickId);
         return renderer.run(continuation.args, {
           ...options,
           ctxt: continuation.ctxt,

--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
@@ -136,7 +136,7 @@ describe("DisplayTemporaryInfo", () => {
       nonce: expect.toBeString(),
       heading: expect.toBeString(),
       payload: expect.objectContaining({
-        blockId: renderer.id,
+        brickId: renderer.id,
         args: expect.anything(),
         ctxt: expect.anything(),
       }),

--- a/src/contentScript/ephemeralPanel.ts
+++ b/src/contentScript/ephemeralPanel.ts
@@ -125,7 +125,7 @@ export async function ephemeralPanel({
       nonce,
       payload: {
         key: uuidv4(),
-        extensionId: panelEntryMetadata.modComponentRef.modComponentId,
+        modComponentId: panelEntryMetadata.modComponentRef.modComponentId,
         loadingMessage: "Loading",
       },
     });

--- a/src/contentScript/pageEditor/runBrickPreview.ts
+++ b/src/contentScript/pageEditor/runBrickPreview.ts
@@ -90,7 +90,7 @@ export async function runBrickPreview({
     logger: new ConsoleLogger(),
     // Excluding runId will prevent the run from being stored in traces
     runId: null,
-    extensionId: null,
+    modComponentId: null,
   };
 
   // Exclude the outputKey so that `output` is the output of the brick. Alternatively we could have taken then

--- a/src/contentScript/pageEditor/runRendererBrick.ts
+++ b/src/contentScript/pageEditor/runRendererBrick.ts
@@ -71,17 +71,17 @@ export async function runRendererBrick({
     if (error instanceof HeadlessModeError) {
       payload = {
         key: nonce,
-        blockId: error.blockId,
+        brickId: error.blockId,
         args: error.args,
         ctxt: error.ctxt,
-        extensionId: modComponentRef.modComponentId,
+        modComponentId: modComponentRef.modComponentId,
         runId,
       };
     } else {
       payload = {
         key: nonce,
         error: serializeError(error),
-        extensionId: modComponentRef.modComponentId,
+        modComponentId: modComponentRef.modComponentId,
         runId,
       };
     }

--- a/src/contentScript/pageEditor/runRendererBrick.ts
+++ b/src/contentScript/pageEditor/runRendererBrick.ts
@@ -71,7 +71,7 @@ export async function runRendererBrick({
     if (error instanceof HeadlessModeError) {
       payload = {
         key: nonce,
-        brickId: error.blockId,
+        brickId: error.brickId,
         args: error.args,
         ctxt: error.ctxt,
         modComponentId: modComponentRef.modComponentId,

--- a/src/contentScript/pipelineProtocol/runHeadlessPipeline.ts
+++ b/src/contentScript/pipelineProtocol/runHeadlessPipeline.ts
@@ -33,7 +33,7 @@ export async function runHeadlessPipeline({
 }: RunPipelineParams): Promise<unknown> {
   expectContext("contentScript");
 
-  if (meta.extensionId == null) {
+  if (meta.modComponentId == null) {
     throw new Error("runHeadlessPipeline requires meta.extensionId");
   }
 

--- a/src/contentScript/pipelineProtocol/runRendererPipeline.ts
+++ b/src/contentScript/pipelineProtocol/runRendererPipeline.ts
@@ -54,7 +54,7 @@ export async function runRendererPipeline({
     if (error instanceof HeadlessModeError) {
       return {
         key: nonce,
-        brickId: error.blockId,
+        brickId: error.brickId,
         args: error.args,
         ctxt: error.ctxt,
         ...meta,

--- a/src/contentScript/pipelineProtocol/runRendererPipeline.ts
+++ b/src/contentScript/pipelineProtocol/runRendererPipeline.ts
@@ -54,7 +54,7 @@ export async function runRendererPipeline({
     if (error instanceof HeadlessModeError) {
       return {
         key: nonce,
-        blockId: error.blockId,
+        brickId: error.blockId,
         args: error.args,
         ctxt: error.ctxt,
         ...meta,

--- a/src/pageEditor/documentBuilder/documentTree.test.tsx
+++ b/src/pageEditor/documentBuilder/documentTree.test.tsx
@@ -387,7 +387,7 @@ describe("When rendered in panel", () => {
   test("renders block", async () => {
     const markdown = "Pipeline text for card test.";
     jest.mocked(contentScriptAPI.runRendererPipeline).mockResolvedValueOnce({
-      blockId: markdownBlock.id,
+      brickId: markdownBlock.id,
       key: uuidv4(),
       args: { markdown },
       ctxt: { "@input": {}, "@options": {} },

--- a/src/pageEditor/documentBuilder/render/ButtonElement.tsx
+++ b/src/pageEditor/documentBuilder/render/ButtonElement.tsx
@@ -58,7 +58,7 @@ const ButtonElement: React.FC<ButtonElementProps> = ({
 
   const [counter, setCounter] = useState(0);
 
-  if (!meta.extensionId) {
+  if (!meta.modComponentId) {
     throw new Error("ButtonElement requires meta.extensionId");
   }
 

--- a/src/pageEditor/documentBuilder/render/DocumentContext.tsx
+++ b/src/pageEditor/documentBuilder/render/DocumentContext.tsx
@@ -46,7 +46,7 @@ export const initialValue: DocumentState = {
     platform: uninitializedPlatform,
     meta: {
       runId: null,
-      extensionId: UNSET_UUID,
+      modComponentId: UNSET_UUID,
       branches: [],
     },
     ctxt: BLANK_CONTEXT,

--- a/src/pageEditor/store/runtime/runtimeSelectors.ts
+++ b/src/pageEditor/store/runtime/runtimeSelectors.ts
@@ -40,9 +40,9 @@ export const selectActiveModComponentTraces: EditorSelector<TraceRecord[]> = ({
 
 const activeModComponentTraceForBrickSelector = createSelector(
   selectActiveModComponentTraces,
-  (state: RootState, instanceId: UUID) => instanceId,
+  (_state: RootState, instanceId: UUID) => instanceId,
   (traces, instanceId) =>
-    traces.find((trace) => trace.blockInstanceId === instanceId),
+    traces.find((trace) => trace.brickInstanceId === instanceId),
 );
 
 export const selectActiveModComponentTraceForBrick =

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -98,7 +98,7 @@ const DataPanel: React.FC = () => {
   const brickType = brick?.type;
 
   const traces = useSelector(selectActiveModComponentTraces);
-  const record = traces.find((trace) => trace.blockInstanceId === activeNodeId);
+  const record = traces.find((trace) => trace.brickInstanceId === activeNodeId);
 
   const isInputStale = useMemo(() => {
     // Don't show the warning if there are no traces. Also, this brick can't have a
@@ -110,8 +110,8 @@ const DataPanel: React.FC = () => {
     const currentInput = pipeline.slice(0, brickIndex);
     const tracedInput = currentInput.map(
       (brick) =>
-        traces.find((trace) => trace.blockInstanceId === brick.instanceId)
-          ?.blockConfig,
+        traces.find((trace) => trace.brickInstanceId === brick.instanceId)
+          ?.brickConfig,
     );
 
     return !isEqual(currentInput, tracedInput);
@@ -126,7 +126,7 @@ const DataPanel: React.FC = () => {
       return false;
     }
 
-    return !isEqual(record.blockConfig, brickConfig);
+    return !isEqual(record.brickConfig, brickConfig);
   }, [isInputStale, record, brickConfig]);
 
   const relevantContext = useMemo(
@@ -184,7 +184,7 @@ const DataPanel: React.FC = () => {
     }
 
     const trace = traces.find(
-      (trace) => trace.blockInstanceId === activeNodeId,
+      (trace) => trace.brickInstanceId === activeNodeId,
     );
 
     // No traces or no changes since the last render, we are good, no alert
@@ -192,7 +192,7 @@ const DataPanel: React.FC = () => {
       traces.length === 0 ||
       trace == null ||
       isEqual(
-        omit(trace.blockConfig, ["comments"]),
+        omit(trace.brickConfig, ["comments"]),
         omit(brickConfig, ["comments"]),
       )
     ) {

--- a/src/pageEditor/tabs/editTab/useReportTraceError.ts
+++ b/src/pageEditor/tabs/editTab/useReportTraceError.ts
@@ -37,7 +37,7 @@ function useReportTraceError(): void {
   if (traceError && runId && runId !== prevRunId) {
     reportEvent(Events.PAGE_EDITOR_MOD_COMPONENT_ERROR, {
       sessionId,
-      modComponentId: traceError.extensionId,
+      modComponentId: traceError.modComponentId,
     });
   }
 }

--- a/src/runtime/pipelineTests/trace.test.ts
+++ b/src/runtime/pipelineTests/trace.test.ts
@@ -381,7 +381,7 @@ describe("Trace normal execution", () => {
     expect(traces.addExit).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: meta.runId,
-        blockInstanceId: meta.brickInstanceId,
+        brickInstanceId: meta.brickInstanceId,
         error: expect.objectContaining({
           name: "BusinessError",
           message: "hello",

--- a/src/runtime/pipelineTests/trace.test.ts
+++ b/src/runtime/pipelineTests/trace.test.ts
@@ -243,21 +243,21 @@ describe("Trace normal execution", () => {
       ...testOptions("v2"),
       runId,
       logger,
-      extensionId,
+      modComponentId: extensionId,
     });
 
     const meta: TraceRecordMeta = {
-      extensionId,
+      modComponentId: extensionId,
       runId,
       branches: [],
-      blockInstanceId: instanceId,
-      blockId: echoBrick.id,
+      brickInstanceId: instanceId,
+      brickId: echoBrick.id,
     };
 
     const expectedEntry: TraceEntryData = {
       ...meta,
       timestamp: timestamp.toISOString(),
-      blockConfig,
+      brickConfig: blockConfig,
       templateContext: { "@input": { inputArg: "hello" }, "@options": {} },
       renderedArgs: { message: "hello" } as unknown as RenderedArgs,
       renderError: null,
@@ -308,17 +308,17 @@ describe("Trace normal execution", () => {
 
     await reducePipeline(blockConfig, simpleInput({ inputArg: "hello" }), {
       ...testOptions("v2"),
-      extensionId,
+      modComponentId: extensionId,
       runId,
       logger,
     });
 
     const meta: TraceRecordMeta = {
-      extensionId,
+      modComponentId: extensionId,
       runId,
       branches: [],
-      blockInstanceId: instanceId,
-      blockId: echoBrick.id,
+      brickInstanceId: instanceId,
+      brickId: echoBrick.id,
     };
 
     const expectedExit: TraceExitData = {
@@ -370,18 +370,18 @@ describe("Trace normal execution", () => {
     }).rejects.toThrow();
 
     const meta: TraceRecordMeta = {
-      extensionId,
+      modComponentId: extensionId,
       runId,
       branches: [],
-      blockInstanceId: instanceId,
-      blockId: throwBrick.id,
+      brickInstanceId: instanceId,
+      brickId: throwBrick.id,
     };
 
     expect(traces.addExit).toHaveBeenCalledTimes(1);
     expect(traces.addExit).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: meta.runId,
-        blockInstanceId: meta.blockInstanceId,
+        blockInstanceId: meta.brickInstanceId,
         error: expect.objectContaining({
           name: "BusinessError",
           message: "hello",

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -240,7 +240,7 @@ interface TraceMetadata extends RunMetadata {
    *
    * @see BrickConfig.instanceId
    */
-  blockInstanceId: Nullishable<UUID>;
+  brickInstanceId: Nullishable<UUID>;
 }
 
 type RunBrickOptions = CommonOptions & {
@@ -337,14 +337,14 @@ async function executeBrickWithValidatedProps(
     }
 
     case "self": {
-      const { runId, extensionId, branches } = options.trace;
+      const { runId, modComponentId, branches } = options.trace;
 
       return brick.run(args, {
         platform: getPlatform(),
         ...commonOptions,
         ...options,
         meta: {
-          extensionId,
+          modComponentId,
           runId,
           branches,
         },
@@ -365,7 +365,7 @@ async function executeBrickWithValidatedProps(
             {
               ...options,
               runId,
-              extensionId,
+              modComponentId,
               branches: [...branches, branch],
             },
           );
@@ -388,7 +388,7 @@ async function executeBrickWithValidatedProps(
             throw new Error("Expected object context for v3+ runtime");
           }
 
-          const { runId, extensionId, branches } = options.trace;
+          const { runId, modComponentId, branches } = options.trace;
           let payload: PanelPayload;
           try {
             await reducePipelineExpression(
@@ -404,7 +404,7 @@ async function executeBrickWithValidatedProps(
                 // This (headless) is the important difference from the call in runPipeline() above
                 headless: true,
                 runId,
-                extensionId,
+                modComponentId,
                 branches: [...branches, branch],
               },
             );
@@ -415,17 +415,17 @@ async function executeBrickWithValidatedProps(
             if (error instanceof HeadlessModeError) {
               payload = {
                 key: runId,
-                blockId: error.blockId,
+                brickId: error.blockId,
                 args: error.args,
                 ctxt: error.ctxt,
-                extensionId,
+                modComponentId,
                 runId,
               };
             } else {
               payload = {
                 key: runId,
                 error: serializeError(error),
-                extensionId,
+                modComponentId,
                 runId,
               };
             }
@@ -526,7 +526,7 @@ function selectTraceRecordMeta(
 ): TraceRecordMeta {
   return {
     ...options.trace,
-    blockId: resolvedConfig.config.id,
+    brickId: resolvedConfig.config.id,
   };
 }
 
@@ -535,11 +535,11 @@ function selectTraceRecordMeta(
  */
 function selectTraceEnabled({
   runId,
-  blockInstanceId,
-}: Pick<TraceMetadata, "runId" | "blockInstanceId">): boolean {
+  brickInstanceId,
+}: Pick<TraceMetadata, "runId" | "brickInstanceId">): boolean {
   return (
     Boolean(runId) &&
-    Boolean(blockInstanceId) &&
+    Boolean(brickInstanceId) &&
     getPlatform().capabilities.includes("debugger")
   );
 }
@@ -570,8 +570,8 @@ async function runBrick(
     if (selectTraceEnabled(trace)) {
       getPlatform().debugger.traces.exit({
         ...trace,
-        extensionId: logger.context.modComponentId,
-        blockId: brick.id,
+        modComponentId: logger.context.modComponentId,
+        brickId: brick.id,
         isFinal: true,
         isRenderer: true,
         error: null,
@@ -607,7 +607,7 @@ async function runBrick(
 async function applyReduceDefaults({
   logValues,
   runId,
-  extensionId,
+  modComponentId,
   logger: providedLogger,
   ...overrides
 }: Partial<ReduceOptions>): Promise<ReduceOptions> {
@@ -615,7 +615,7 @@ async function applyReduceDefaults({
   const logger = providedLogger ?? new ConsoleLogger();
 
   return {
-    extensionId: extensionId ?? logger.context.modComponentId,
+    modComponentId: modComponentId ?? logger.context.modComponentId,
     validateInput: true,
     headless: false,
     // Default to the `apiVersion: v1, v2` data passing behavior and renderer behavior
@@ -645,8 +645,14 @@ export async function brickReducer(
   options: ReduceOptions,
 ): Promise<BrickOutput> {
   const { index, isLastBlock, previousOutput, context, root } = state;
-  const { runId, extensionId, explicitDataFlow, logValues, logger, branches } =
-    options;
+  const {
+    runId,
+    modComponentId,
+    explicitDataFlow,
+    logValues,
+    logger,
+    branches,
+  } = options;
 
   // Match the override behavior in v1, where the output from previous brick would override anything in the context
   const contextWithPreviousOutput =
@@ -662,8 +668,8 @@ export async function brickReducer(
       runId,
       // Be defensive if the call site doesn't provide an extensionId
       // See: https://github.com/pixiebrix/pixiebrix-extension/issues/3751
-      extensionId: extensionId ?? logger.context.modComponentId,
-      blockInstanceId: brickConfig.instanceId,
+      modComponentId: modComponentId ?? logger.context.modComponentId,
+      brickInstanceId: brickConfig.instanceId,
       branches,
     },
   };
@@ -708,7 +714,7 @@ export async function brickReducer(
       renderError: renderError ? serializeError(renderError) : null,
       // `renderedArgs` will be null if there's an error rendering args
       renderedArgs,
-      blockConfig: brickConfig,
+      brickConfig,
     });
   }
 
@@ -829,13 +835,13 @@ function throwBrickError(
     throw error;
   }
 
-  if (selectTraceEnabled({ runId, blockInstanceId: brickConfig.instanceId })) {
+  if (selectTraceEnabled({ runId, brickInstanceId: brickConfig.instanceId })) {
     getPlatform().debugger.traces.exit({
       runId,
       branches,
-      extensionId: logger.context.modComponentId,
-      blockId: brickConfig.id,
-      blockInstanceId: brickConfig.instanceId,
+      modComponentId: logger.context.modComponentId,
+      brickId: brickConfig.id,
+      brickInstanceId: brickConfig.instanceId,
       error: serializeError(error),
       skippedRun: false,
       isRenderer: false,

--- a/src/runtime/reducePipeline.ts
+++ b/src/runtime/reducePipeline.ts
@@ -415,7 +415,7 @@ async function executeBrickWithValidatedProps(
             if (error instanceof HeadlessModeError) {
               payload = {
                 key: runId,
-                brickId: error.blockId,
+                brickId: error.brickId,
                 args: error.args,
                 ctxt: error.ctxt,
                 modComponentId,

--- a/src/sidebar/PanelBody.test.tsx
+++ b/src/sidebar/PanelBody.test.tsx
@@ -43,7 +43,7 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new Error("test error")),
       runId: uuidv4(),
-      modComponentId: modComponentId,
+      modComponentId,
     };
 
     const { asFragment } = render(
@@ -63,7 +63,7 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new BusinessError("test error")),
       runId: uuidv4(),
-      modComponentId: modComponentId,
+      modComponentId,
     };
 
     const { asFragment } = render(
@@ -83,7 +83,7 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new CancelError("test error")),
       runId: uuidv4(),
-      modComponentId: modComponentId,
+      modComponentId,
     };
 
     const { asFragment } = render(
@@ -102,7 +102,7 @@ describe("PanelBody", () => {
     const payload: RendererRunPayload = {
       key: uuidv4(),
       runId: uuidv4(),
-      modComponentId: modComponentId,
+      modComponentId,
       brickId: validateRegistryId("@pixiebrix/html"),
       args: {
         html: "<h1>Test</h1>",
@@ -129,7 +129,7 @@ describe("PanelBody", () => {
     const payload: RendererRunPayload = {
       key: uuidv4(),
       runId: uuidv4(),
-      modComponentId: modComponentId,
+      modComponentId,
       brickId: validateRegistryId("@pixiebrix/html"),
       args: {
         html: "<h1>Test</h1>",
@@ -157,7 +157,7 @@ describe("PanelBody", () => {
     const payload: RendererRunPayload = {
       key: uuidv4(),
       runId: uuidv4(),
-      modComponentId: modComponentId,
+      modComponentId,
       brickId: validateRegistryId("@pixiebrix/document"),
       args: {
         body: [

--- a/src/sidebar/PanelBody.test.tsx
+++ b/src/sidebar/PanelBody.test.tsx
@@ -43,7 +43,7 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new Error("test error")),
       runId: uuidv4(),
-      extensionId: modComponentId,
+      modComponentId: modComponentId,
     };
 
     const { asFragment } = render(
@@ -63,7 +63,7 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new BusinessError("test error")),
       runId: uuidv4(),
-      extensionId: modComponentId,
+      modComponentId: modComponentId,
     };
 
     const { asFragment } = render(
@@ -83,7 +83,7 @@ describe("PanelBody", () => {
       key: uuidv4(),
       error: serializeError(new CancelError("test error")),
       runId: uuidv4(),
-      extensionId: modComponentId,
+      modComponentId: modComponentId,
     };
 
     const { asFragment } = render(
@@ -102,8 +102,8 @@ describe("PanelBody", () => {
     const payload: RendererRunPayload = {
       key: uuidv4(),
       runId: uuidv4(),
-      extensionId: modComponentId,
-      blockId: validateRegistryId("@pixiebrix/html"),
+      modComponentId: modComponentId,
+      brickId: validateRegistryId("@pixiebrix/html"),
       args: {
         html: "<h1>Test</h1>",
       },
@@ -129,8 +129,8 @@ describe("PanelBody", () => {
     const payload: RendererRunPayload = {
       key: uuidv4(),
       runId: uuidv4(),
-      extensionId: modComponentId,
-      blockId: validateRegistryId("@pixiebrix/html"),
+      modComponentId: modComponentId,
+      brickId: validateRegistryId("@pixiebrix/html"),
       args: {
         html: "<h1>Test</h1>",
       },
@@ -157,8 +157,8 @@ describe("PanelBody", () => {
     const payload: RendererRunPayload = {
       key: uuidv4(),
       runId: uuidv4(),
-      extensionId: modComponentId,
-      blockId: validateRegistryId("@pixiebrix/document"),
+      modComponentId: modComponentId,
+      brickId: validateRegistryId("@pixiebrix/document"),
       args: {
         body: [
           {

--- a/src/sidebar/PanelBody.tsx
+++ b/src/sidebar/PanelBody.tsx
@@ -51,7 +51,7 @@ import { mapPathToTraceBranches } from "@/pageEditor/documentBuilder/utils";
 import { getPlatform } from "@/platform/platformContext";
 
 type BodyProps = {
-  blockId?: RegistryId;
+  brickId?: RegistryId;
   body?: RendererOutput;
   meta?: PanelRunMeta;
 };
@@ -59,11 +59,11 @@ type BodyProps = {
 const BodyContainer: React.FC<
   // In the future, may want to support providing isFetching to show a loading indicator/badge over the previous content
   BodyProps & { onAction?: (action: SubmitPanelAction) => void }
-> = ({ blockId, body, onAction, meta }) => (
+> = ({ brickId, body, onAction, meta }) => (
   // Use a shadow dom to prevent the webpage styles from affecting the sidebar
-  <EmotionShadowRoot className="full-height" data-testid={blockId}>
+  <EmotionShadowRoot className="full-height" data-testid={brickId}>
     <RendererComponent
-      blockId={blockId}
+      brickId={brickId}
       body={body}
       meta={meta}
       onAction={onAction}
@@ -169,20 +169,20 @@ const PanelBody: React.FunctionComponent<{
         dispatch(slice.actions.reactivate());
 
         const {
-          blockId,
+          brickId,
           ctxt: brickArgsContext,
           args,
           runId,
-          extensionId,
+          modComponentId,
         } = payload;
 
         console.debug("Running panel body for panel payload", payload);
 
-        const block = await brickRegistry.lookup(blockId);
+        const block = await brickRegistry.lookup(brickId);
 
         const logger = platform.logger.childLogger({
           ...context,
-          brickId: blockId,
+          brickId,
         });
 
         const branches = tracePath ? mapPathToTraceBranches(tracePath) : [];
@@ -192,7 +192,7 @@ const PanelBody: React.FunctionComponent<{
           ctxt: brickArgsContext as UnknownObject,
           meta: {
             runId,
-            extensionId,
+            modComponentId,
             branches,
           },
           logger,
@@ -216,7 +216,7 @@ const PanelBody: React.FunctionComponent<{
               options: apiVersionOptions("v3"),
               messageContext: logger.context,
               meta: {
-                extensionId,
+                modComponentId,
                 runId,
                 branches: [...branches, branch],
               },
@@ -229,7 +229,7 @@ const PanelBody: React.FunctionComponent<{
           },
         });
 
-        if (!runId || !extensionId) {
+        if (!runId || !modComponentId) {
           console.warn("PanelBody requires runId in RendererPayload", {
             payload,
           });
@@ -242,9 +242,9 @@ const PanelBody: React.FunctionComponent<{
         dispatch(
           slice.actions.success({
             data: {
-              blockId,
+              brickId,
               body: body as RendererOutput,
-              meta: { runId, extensionId },
+              meta: { runId, modComponentId },
             },
           }),
         );

--- a/src/sidebar/RendererComponent.test.tsx
+++ b/src/sidebar/RendererComponent.test.tsx
@@ -43,7 +43,7 @@ describe("RendererComponent", () => {
 
   test("provide onAction to document renderer", async () => {
     const runId = uuidv4();
-    const extensionId = uuidv4();
+    const modComponentId = uuidv4();
     const onAction = jest.fn();
 
     runHeadlessPipelineMock.mockRejectedValue(
@@ -63,10 +63,10 @@ describe("RendererComponent", () => {
     const props = {
       body: [config],
       options: brickOptionsFactory({
-        logger: new ConsoleLogger({ modComponentId: extensionId }),
+        logger: new ConsoleLogger({ modComponentId }),
         meta: {
           runId,
-          extensionId,
+          modComponentId,
           branches: [],
         },
       }),
@@ -74,9 +74,9 @@ describe("RendererComponent", () => {
 
     render(
       <RendererComponent
-        blockId={validateRegistryId("@pixiebrix/document")}
+        brickId={validateRegistryId("@pixiebrix/document")}
         body={{ Component: DocumentView as any, props }}
-        meta={{ runId, extensionId }}
+        meta={{ runId, modComponentId }}
         onAction={onAction}
       />,
     );

--- a/src/sidebar/RendererComponent.tsx
+++ b/src/sidebar/RendererComponent.tsx
@@ -10,10 +10,10 @@ import { type RendererOutput } from "@/types/runtimeTypes";
  */
 const RendererComponent: React.FunctionComponent<{
   onAction?: (action: SubmitPanelAction) => void;
-  blockId?: RegistryId;
+  brickId?: RegistryId;
   body?: RendererOutput;
   meta?: PanelRunMeta;
-}> = ({ body, meta, blockId, onAction }) =>
+}> = ({ body, meta, brickId, onAction }) =>
   useMemo(() => {
     if (!body) {
       return null;
@@ -33,9 +33,9 @@ const RendererComponent: React.FunctionComponent<{
 
     // Enrich with metadata about the run
     const enrichedProps: UnknownObject =
-      blockId === "@pixiebrix/document" ? { ...props, meta, onAction } : props;
+      brickId === "@pixiebrix/document" ? { ...props, meta, onAction } : props;
 
     return <Component {...enrichedProps} />;
-  }, [body, meta, blockId, onAction]);
+  }, [body, meta, brickId, onAction]);
 
 export default RendererComponent;

--- a/src/starterBricks/sidebar/sidebarStarterBrick.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.ts
@@ -217,7 +217,7 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
 
       if (error instanceof HeadlessModeError) {
         this.platform.panels.upsertPanel(modComponentRef, heading, {
-          brickId: error.blockId,
+          brickId: error.brickId,
           key: uuidv4(),
           ctxt: error.ctxt,
           args: error.args,

--- a/src/starterBricks/sidebar/sidebarStarterBrick.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.ts
@@ -210,25 +210,25 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
         modId: modComponent._recipe?.id,
       };
 
-      const meta = {
+      const runMetadata = {
         runId,
-        extensionId: modComponent.id,
+        modComponentId: modComponent.id,
       };
 
       if (error instanceof HeadlessModeError) {
         this.platform.panels.upsertPanel(modComponentRef, heading, {
-          blockId: error.blockId,
+          brickId: error.blockId,
           key: uuidv4(),
           ctxt: error.ctxt,
           args: error.args,
-          ...meta,
+          ...runMetadata,
         });
       } else {
         componentLogger.error(error);
         this.platform.panels.upsertPanel(modComponentRef, heading, {
           key: uuidv4(),
           error: serializeError(error),
-          ...meta,
+          ...runMetadata,
         });
       }
     }

--- a/src/telemetry/traceHelpers.ts
+++ b/src/telemetry/traceHelpers.ts
@@ -43,7 +43,7 @@ export function getLatestBrickCall(
   return getLatestCall(
     records.filter(
       // Use first block in pipeline to determine the latest run
-      (trace) => trace.blockInstanceId === blockInstanceId,
+      (trace) => trace.brickInstanceId === blockInstanceId,
     ),
   );
 }

--- a/src/testUtils/factories/pageEditorFactories.ts
+++ b/src/testUtils/factories/pageEditorFactories.ts
@@ -278,11 +278,11 @@ export const formStateWithTraceDataFactory = define<{
       };
 
       return traceRecordFactory({
-        extensionId: modComponentId,
-        blockInstanceId: block.instanceId,
-        blockId: block.id,
+        modComponentId: modComponentId,
+        brickInstanceId: block.instanceId,
+        brickId: block.id,
         templateContext: context,
-        blockConfig: block,
+        brickConfig: block,
         outputKey,
         output,
       });

--- a/src/testUtils/factories/pageEditorFactories.ts
+++ b/src/testUtils/factories/pageEditorFactories.ts
@@ -265,7 +265,7 @@ export const formStateWithTraceDataFactory = define<{
 
     let outputKey = "" as OutputKey;
     let output: JsonObject = foundationOutputFactory();
-    return modComponent.brickPipeline.map((block, index) => {
+    return modComponent.brickPipeline.map((brickConfig, index) => {
       const context = output;
       outputKey = `output${index}` as OutputKey;
       output = {
@@ -278,11 +278,11 @@ export const formStateWithTraceDataFactory = define<{
       };
 
       return traceRecordFactory({
-        modComponentId: modComponentId,
-        brickInstanceId: block.instanceId,
-        brickId: block.id,
+        modComponentId,
+        brickInstanceId: brickConfig.instanceId,
+        brickId: brickConfig.id,
         templateContext: context,
-        brickConfig: block,
+        brickConfig,
         outputKey,
         output,
       });

--- a/src/testUtils/factories/runtimeFactories.ts
+++ b/src/testUtils/factories/runtimeFactories.ts
@@ -51,7 +51,7 @@ export const brickOptionsFactory = define<BrickOptions>({
   meta: derive<BrickOptions, RunMetadata>(
     (options) => ({
       runId: null,
-      extensionId: options.logger?.context.modComponentId,
+      modComponentId: options.logger?.context.modComponentId,
       branches: [],
     }),
     "logger",

--- a/src/testUtils/factories/traceFactories.ts
+++ b/src/testUtils/factories/traceFactories.ts
@@ -30,15 +30,15 @@ const TEST_BLOCK_ID = validateRegistryId("testing/block-id");
 
 export const traceRecordFactory = define<TraceRecord>({
   timestamp: timestampFactory,
-  extensionId: uuidSequence,
+  modComponentId: uuidSequence,
   runId: uuidSequence,
   branches(): TraceRecord["branches"] {
     return [];
   },
   // XXX: callId should be derived from branches
   callId: objectHash([]),
-  blockInstanceId: uuidSequence,
-  blockId: TEST_BLOCK_ID,
+  brickInstanceId: uuidSequence,
+  brickId: TEST_BLOCK_ID,
   templateContext(): TraceRecord["templateContext"] {
     return {};
   },
@@ -46,7 +46,7 @@ export const traceRecordFactory = define<TraceRecord>({
     return {} as RenderedArgs;
   },
   renderError: null,
-  blockConfig(): BrickConfig {
+  brickConfig(): BrickConfig {
     return {
       id: TEST_BLOCK_ID,
       config: {},

--- a/src/types/rendererTypes.ts
+++ b/src/types/rendererTypes.ts
@@ -28,9 +28,9 @@ type BaseRendererPayload = {
   /**
    * The ModComponent that produced the payload.
    * Marked Nullishable as part of the StrictNullChecks migration.
-   * TODO: Revisit and determine if this should be required.
+   * TODO: Revisit and determine if modComponentId should be required.
    */
-  extensionId: Nullishable<UUID>;
+  modComponentId: Nullishable<UUID>;
   /**
    * The ModComponent run that produced the payload
    * @since 1.7.0
@@ -50,12 +50,12 @@ export type RendererLoadingPayload = Except<BaseRendererPayload, "runId"> & {
  */
 export type RendererRunPayload = BaseRendererPayload & {
   /**
-   * The registry id of the renderer block, e.g., @pixiebrix/table
+   * The registry id of the renderer brick, e.g., @pixiebrix/table
    */
-  blockId: RegistryId;
+  brickId: RegistryId;
   /**
-   * The BlockArg to pass to the renderer
-   * @see BlockProps.args
+   * The BrickArgs to pass to the renderer
+   * @see BrickProps.args
    * @see BrickArgs
    */
   args: unknown;

--- a/src/types/rendererTypes.ts
+++ b/src/types/rendererTypes.ts
@@ -61,8 +61,8 @@ export type RendererRunPayload = BaseRendererPayload & {
   args: unknown;
   /**
    * The context to pass to the renderer
-   * @see BlockProps.context
-   * @see BlockOptions
+   * @see BrickProps.context
+   * @see BrickOptions
    */
   ctxt: unknown;
 };

--- a/src/types/runtimeTypes.ts
+++ b/src/types/runtimeTypes.ts
@@ -302,12 +302,12 @@ export type Branch = {
  */
 export interface RunMetadata {
   /**
-   * The extension that's running the brick. Used to correlate trace records across all runs/branches.
+   * The mod component that's running the brick. Used to correlate trace records across all runs/branches.
    * @since 1.7.0
    * Marked Nullishable as part of the StrictNullChecks migration.
-   * TODO: Revisit and determine if this should be required.
+   * TODO: Revisit and determine if modComponentId should be required.
    */
-  extensionId: Nullishable<UUID>;
+  modComponentId: Nullishable<UUID>;
   /**
    * A unique run id to correlate trace records across branches for a run, or null to disable tracing.
    */

--- a/src/types/sidebarTypes.ts
+++ b/src/types/sidebarTypes.ts
@@ -328,7 +328,7 @@ export type ActivatePanelOptions = {
  * Metadata about the extension that produced the panel content
  * @since 1.7.0
  */
-export type PanelRunMeta = Pick<RunMetadata, "runId" | "extensionId">;
+export type PanelRunMeta = Pick<RunMetadata, "runId" | "modComponentId">;
 
 export type SidebarState = SidebarEntries & {
   activeKey: Nullishable<string>;


### PR DESCRIPTION
## What does this PR do?

- Renames block/extension in tracing and run metadata code
- Bumps the trace IDB version to clear old values using the old name (see PR comment)

## Future Work

- Fix remaining properties in sidebar code
- Rationalize nullness of modComponentId in the runtime

## Remaining Work

- [x] Fix test assertions

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
