### PR TITLE
Enabling warn for no-param-reassign eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,13 @@ module.exports = {
         capIsNewExceptionPattern: "(TEST_|INTERNAL_|HACK_|UNSAFE_)",
       },
     ],
+    "no-param-reassign": [
+      "warn",
+      {
+        props: true,
+        ignorePropertyModificationsFor: ["draft", "state"],
+      },
+    ],
     "eslint-comments/require-description": [
       "error",
       { ignore: ["eslint-enable"] },

--- a/src/components/formBuilder/formBuilderHelpers.ts
+++ b/src/components/formBuilder/formBuilderHelpers.ts
@@ -299,21 +299,21 @@ export const produceSchemaOnUiTypeChange = (
 
 /**
  * Normalizes the schema property of the RJSF schema.
- * @param rjsfSchemaDraft The mutable draft of the RJSF schema
+ * @param draft The mutable draft of the RJSF schema
  */
-export const normalizeSchema = (rjsfSchemaDraft: Draft<RJSFSchema>) => {
-  if (isEmpty(rjsfSchemaDraft.schema)) {
-    rjsfSchemaDraft.schema = minimalSchemaFactory();
+export const normalizeSchema = (draft: Draft<RJSFSchema>) => {
+  if (isEmpty(draft.schema)) {
+    draft.schema = minimalSchemaFactory();
   }
 
   if (
-    rjsfSchemaDraft.schema.required !== undefined &&
-    !Array.isArray(rjsfSchemaDraft.schema.required)
+    draft.schema.required !== undefined &&
+    !Array.isArray(draft.schema.required)
   ) {
-    rjsfSchemaDraft.schema.required = [];
+    draft.schema.required = [];
   }
 
-  rjsfSchemaDraft.schema.properties ??= {};
+  draft.schema.properties ??= {};
 };
 
 export const getNormalizedUiOrder = (


### PR DESCRIPTION
## What does this PR do?

Enables the `no-param-reassign` eslint rule to improve our chances of avoiding mutation related bugs such as https://github.com/pixiebrix/pixiebrix-extension/issues/8789

57 warnings currently reported.

