### PR TITLE
Shard e2e tests

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -10,13 +10,13 @@ on:
 
 jobs:
   run-tests:
+    name: run-tests
     strategy:
       fail-fast: false
       matrix:
         project: [chrome, edge]
         shardIndex: [1, 2, 3]
         shardTotal: [3]
-    name: run-tests-${{ matrix.project }}-${{ matrix.shardIndex }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -15,6 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         project: [chrome, edge]
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
@@ -61,18 +63,18 @@ jobs:
       - name: Run end to end tests
         # Xvfb is required to run the tests in headed mode. Headed mode is required to run tests for browser extensions
         # in Playwright, see https://playwright.dev/docs/ci#running-headed
-        run: xvfb-run npm run test:e2e -- --project=${{ matrix.project }}*
+        run: xvfb-run npm run test:e2e -- --project=${{ matrix.project }}* --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: Password protect Playwright reports
         if: always()
         shell: bash
         env:
           ARTIFACT_ZIP_PASSWORD: ${{ secrets.ARTIFACT_ZIP_PASSWORD }}
-        run: 7z a ./end-to-end-tests/blob-report-${{ matrix.project }}.7z ./end-to-end-tests/.blob-report/* -p"$ARTIFACT_ZIP_PASSWORD"
+        run: 7z a ./end-to-end-tests/blob-report-${{ matrix.project }}-${{ matrix.shardIndex }}.7z ./end-to-end-tests/.blob-report/* -p"$ARTIFACT_ZIP_PASSWORD"
       - name: Upload zipped Playwright Report to GitHub Actions Artifacts
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: end-to-end-tests-report-${{ matrix.project }}
-          path: end-to-end-tests/blob-report-${{ matrix.project }}.7z
+          name: end-to-end-tests-report-${{ matrix.project }}-${{ matrix.shardIndex }}
+          path: end-to-end-tests/blob-report-${{ matrix.project }}-${{ matrix.shardIndex }}.7z
           retention-days: 5
           compression-level: 0 # already compressed with 7z

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run-tests:
-    name: run-tests
+    name: run-tests-${{ matrix.project }}-${{ matrix.shardIndex }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -10,13 +10,13 @@ on:
 
 jobs:
   run-tests:
-    name: run-tests-${{ matrix.project }}-${{ matrix.shardIndex }}
     strategy:
       fail-fast: false
       matrix:
         project: [chrome, edge]
         shardIndex: [1, 2, 3]
         shardTotal: [3]
+    name: run-tests-${{ matrix.project }}-${{ matrix.shardIndex }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": ".github/workflows/end-to-end-tests.yml",
         "hashed_secret": "97ed79340d21c99620980bc3a2ecf3a4064ae75c",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 27
       }
     ],
     ".github/workflows/release.yaml": [
@@ -264,5 +264,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-08T21:14:43Z"
+  "generated_at": "2024-07-11T18:00:05Z"
 }


### PR DESCRIPTION
## What does this PR do?

This PR introduces changes to the end-to-end testing workflow in the Pixiebrix extension repository. It adds sharding to the testing process, dividing the tests into three separate shards for parallel execution. This is done by adding two new matrix parameters, `shardIndex` and `shardTotal`, to the GitHub Actions workflow file. The PR also modifies the naming and uploading of the test reports to reflect the sharding. 

## Future Work

Future work may include adjusting the number of shards based on the number and duration of the tests, or further optimizing the test reporting process. 

In particular we spend a lot of overhead time that is repeated in each shard building the extension, and running the same setup tests. We could potentially break these out further before running the sharded tests.