### PR TITLE
prevent concurrent workflow runs in prs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ env:
   # Staging URL, also directly used by webpack
   SERVICE_URL: https://app-stg.pixiebrix.com/
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -149,7 +149,7 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 189
+        "line_number": 193
       }
     ],
     ".github/workflows/end-to-end-tests.yml": [
@@ -264,5 +264,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-08T21:14:43Z"
+  "generated_at": "2024-07-11T20:13:57Z"
 }


### PR DESCRIPTION
## What does this PR do?

Saves us some money on unnecessary workflow runs. 🤑🤑🤑

See: https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency
