### PR TITLE
fix flakiness handling

### DIFF
--- a/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
@@ -29,7 +29,7 @@ export class ModTableItem extends BasePageObject {
     await expect(async () => {
       await this.dropdownButton.click();
       await this.getByRole("button", { name: actionName }).click({
-        timeout: 0, // handle retrying in the `toPass` block
+        timeout: 0, // Handle retrying in the `toPass` block
       });
     }).toPass({ timeout: 5000 });
   }

--- a/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
+++ b/end-to-end-tests/pageObjects/extensionConsole/modsPage.ts
@@ -28,7 +28,9 @@ export class ModTableItem extends BasePageObject {
     // TODO: https://github.com/pixiebrix/pixiebrix-extension/issues/8458
     await expect(async () => {
       await this.dropdownButton.click();
-      await this.getByRole("button", { name: actionName }).click();
+      await this.getByRole("button", { name: actionName }).click({
+        timeout: 0, // handle retrying in the `toPass` block
+      });
     }).toPass({ timeout: 5000 });
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes the flakiness handling for issue #8458 by modifying the `click()` function in the `ModTableItem` class within the `modsPage.ts` file, by adding a timeout parameter to the `click()` function to handle retrying in the `toPass` block.
