### PR TITLE
Adding a link to our readme from the PR e2e report comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,4 +240,6 @@ jobs:
           comment-title: "Playwright test results"
           report-file: ./playwright-report/results.json
           report-url: ${{ steps.upload-merged-playwright-report-step.outputs.artifact-url }}
+          custom-info: "For more information on how to debug and view this report, [see our readme](https://github.com/pixiebrix/pixiebrix-extension/blob/main/end-to-end-tests/README.md#github-ci-integration)"
+
         if: (success() || failure()) && github.event_name == 'pull_request'


### PR DESCRIPTION
## What does this PR do?

It adds a useful comment and link to our readme for devs to find how to view and debug our e2e test report.

See: https://github.com/daun/playwright-report-summary