### PR TITLE
Increase postMessage timeout for sandbox back to 3s

### DIFF
--- a/src/utils/postMessage.ts
+++ b/src/utils/postMessage.ts
@@ -37,7 +37,7 @@ import { assertNotNullish } from "./nullishUtils";
 import { type JsonValue } from "type-fest";
 import { type AbortSignalAsOptions } from "./promiseUtils";
 
-const TIMEOUT_MS = 1000;
+const TIMEOUT_MS = 3000;
 
 export type Payload = JsonValue | void;
 


### PR DESCRIPTION
## What does this PR do?

- Part of #8220 
- When creating a fix for this PR, I decreased the timeout for postMessage to 1s since we were increasing the number of retries. This PR sets the timeout back to 3s, which would create a worst-case response time of 9s when retrying sending messages to the sandbox
- This is to address the hypothesis that 1s isn't enough time for some sites, e.g. in this situation here: https://app.datadoghq.com/logs/error-tracking/issue/07c45ab2-4050-11ef-93eb-da7ad0900002?query=service%3Apixiebrix-browser-extension%20version%3A2.0.5-beta.1&fromUser=false&refresh_mode=sliding&view=spans&from_ts=1720721077477&to_ts=1720807457885&live=true
