### PR TITLE
DX - Clean up starter brick types and refactor ADAPTERS for better ergonomics

### DIFF
--- a/src/activation/useActivateMod.test.ts
+++ b/src/activation/useActivateMod.test.ts
@@ -39,6 +39,7 @@ import { databaseFactory } from "@/testUtils/factories/databaseFactories";
 import { reloadModsEveryTab } from "@/contentScript/messenger/api";
 import { appApiMock } from "@/testUtils/appApiMock";
 import type MockAdapter from "axios-mock-adapter";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 jest.mock("@/contentScript/messenger/api");
 
@@ -66,7 +67,7 @@ function setupInputs(): {
       name: "Text Starter Brick 1",
     }),
     definition: {
-      type: "contextMenu",
+      type: StarterBrickTypes.CONTEXT_MENU,
       isAvailable: {
         matchPatterns: ["*://*/*"],
         selectors: [],

--- a/src/analysis/analysisVisitors/baseAnalysisVisitors.ts
+++ b/src/analysis/analysisVisitors/baseAnalysisVisitors.ts
@@ -52,7 +52,7 @@ export abstract class AnalysisVisitorABC
     this.visitStarterBrick(formState.starterBrick);
 
     this.visitRootPipeline(formState.modComponent.brickPipeline, {
-      starterBrickType: formState.type,
+      starterBrickType: formState.starterBrick.definition.type,
     });
   }
 }

--- a/src/analysis/analysisVisitors/selectorAnalysis.ts
+++ b/src/analysis/analysisVisitors/selectorAnalysis.ts
@@ -90,14 +90,14 @@ class SelectorAnalysis extends AnalysisVisitorWithResolvedBricksABC {
   override id = "selector";
 
   override async run(component: ModComponentFormState): Promise<void> {
-    switch (component.type) {
+    switch (component.starterBrick.definition.type) {
       case StarterBrickTypes.BUTTON: {
-        this.checkAction(component);
+        this.checkAction(component as ButtonFormState);
         break;
       }
 
       case StarterBrickTypes.TRIGGER: {
-        this.checkTrigger(component);
+        this.checkTrigger(component as TriggerFormState);
         break;
       }
 

--- a/src/analysis/analysisVisitors/templateAnalysis.ts
+++ b/src/analysis/analysisVisitors/templateAnalysis.ts
@@ -57,7 +57,7 @@ class TemplateAnalysis extends PipelineExpressionVisitor implements Analysis {
 
   async run(formState: ModComponentFormState): Promise<void> {
     this.visitRootPipeline(formState.modComponent.brickPipeline, {
-      starterBrickType: formState.type,
+      starterBrickType: formState.starterBrick.definition.type,
     });
 
     await Promise.all(this.nunjucksValidationPromises);

--- a/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
+++ b/src/analysis/analysisVisitors/varAnalysis/varAnalysis.ts
@@ -40,7 +40,6 @@ import {
   isDocumentBuilderElementArray,
   type ListElement,
 } from "@/pageEditor/documentBuilder/documentBuilderTypes";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { fromJS } from "@/starterBricks/factory";
 import { type Schema } from "@/types/schemaTypes";
 import { type Expression, type TemplateEngine } from "@/types/runtimeTypes";
@@ -57,6 +56,7 @@ import makeIntegrationsContextFromDependencies from "@/integrations/util/makeInt
 import { getOutputReference, isOutputKey } from "@/runtime/runtimeTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
 import { BusinessError } from "@/errors/businessErrors";
+import { adapterForComponent } from "@/pageEditor/starterBricks/adapter";
 
 export const INVALID_VARIABLE_GENERIC_MESSAGE = "Invalid variable name";
 
@@ -139,14 +139,9 @@ async function setInputVars(
   formState: ModComponentFormState,
   contextVars: VarMap,
 ): Promise<void> {
-  const adapter = ADAPTERS.get(formState.starterBrick.definition.type);
-  assertNotNullish(
-    adapter,
-    `Adapter not found for ${formState.starterBrick.definition.type}`,
-  );
-  const config = adapter.selectStarterBrickDefinition(formState);
+  const { selectStarterBrickDefinition } = adapterForComponent(formState);
 
-  const starterBrick = fromJS(config);
+  const starterBrick = fromJS(selectStarterBrickDefinition(formState));
 
   const reader = await starterBrick.defaultReader();
 
@@ -698,7 +693,7 @@ class VarAnalysis extends PipelineExpressionVisitor implements Analysis {
     });
 
     this.visitRootPipeline(formState.modComponent.brickPipeline, {
-      starterBrickType: formState.type,
+      starterBrickType: formState.starterBrick.definition.type,
     });
   }
 

--- a/src/background/contextMenus/initContextMenus.test.ts
+++ b/src/background/contextMenus/initContextMenus.test.ts
@@ -31,6 +31,7 @@ import {
 } from "@/starterBricks/contextMenu/contextMenuTypes";
 import { ensureContextMenu } from "@/background/contextMenus/ensureContextMenu";
 import { preloadContextMenus } from "@/background/contextMenus/preloadContextMenus";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 TEST_setContext("background");
 
@@ -70,7 +71,7 @@ describe("contextMenus", () => {
   it("preload context menu", async () => {
     const extensionPoint =
       starterBrickDefinitionFactory() as unknown as StarterBrickDefinitionLike<ContextMenuDefinition>;
-    extensionPoint.definition.type = "contextMenu";
+    extensionPoint.definition.type = StarterBrickTypes.CONTEXT_MENU;
     extensionPoint.definition.contexts = ["all"];
 
     updateMenuMock.mockRejectedValue(new Error("My Error"));

--- a/src/background/deploymentUpdater.test.ts
+++ b/src/background/deploymentUpdater.test.ts
@@ -39,7 +39,6 @@ import {
   editorSlice,
   initialState as initialEditorState,
 } from "@/pageEditor/store/editor/editorSlice";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { type ButtonFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import { parsePackage } from "@/registry/packageRegistry";
 import { registry } from "@/background/messenger/api";
@@ -68,6 +67,7 @@ import {
   queueReloadModEveryTab,
   reloadModsEveryTab,
 } from "@/contentScript/messenger/api";
+import { adapter } from "@/pageEditor/starterBricks/adapter";
 
 TEST_setContext("background");
 
@@ -392,9 +392,8 @@ describe("syncDeployments", () => {
     });
 
     let editorState = initialEditorState;
-    const element = (await ADAPTERS.get(
-      starterBrick.definition.type,
-    ).fromModComponent(modComponent)) as ButtonFormState;
+    const { fromModComponent } = adapter(starterBrick.definition.type);
+    const element = (await fromModComponent(modComponent)) as ButtonFormState;
     editorState = editorSlice.reducer(
       editorState,
       editorSlice.actions.addModComponentFormState(element),
@@ -502,9 +501,8 @@ describe("syncDeployments", () => {
     });
 
     let editorState = initialEditorState;
-    const element = (await ADAPTERS.get(
-      StarterBrickTypes.BUTTON,
-    ).fromModComponent(modComponent)) as ButtonFormState;
+    const { fromModComponent } = adapter(StarterBrickTypes.BUTTON);
+    const element = (await fromModComponent(modComponent)) as ButtonFormState;
     editorState = editorSlice.reducer(
       editorState,
       editorSlice.actions.addModComponentFormState(element),
@@ -795,9 +793,13 @@ describe("syncDeployments", () => {
 
     let editorState = initialEditorState;
 
-    const personalModComponentFormState = (await ADAPTERS.get(
+    const personalModComponentAdapter = adapter(
       personalStarterBrick.definition.type,
-    ).fromModComponent(standaloneModComponent)) as ButtonFormState;
+    );
+    const personalModComponentFormState =
+      (await personalModComponentAdapter.fromModComponent(
+        standaloneModComponent,
+      )) as ButtonFormState;
     editorState = editorSlice.reducer(
       editorState,
       editorSlice.actions.addModComponentFormState(
@@ -805,9 +807,13 @@ describe("syncDeployments", () => {
       ),
     );
 
-    const deploymentElement = (await ADAPTERS.get(
+    const deploymentModComponentAdapter = adapter(
       deploymentStarterBrick.definition.type,
-    ).fromModComponent(deploymentModComponent)) as ButtonFormState;
+    );
+    const deploymentElement =
+      (await deploymentModComponentAdapter.fromModComponent(
+        deploymentModComponent,
+      )) as ButtonFormState;
     editorState = editorSlice.reducer(
       editorState,
       editorSlice.actions.addModComponentFormState(deploymentElement),

--- a/src/background/starterMods.test.ts
+++ b/src/background/starterMods.test.ts
@@ -48,7 +48,10 @@ import {
 import produce from "immer";
 import { type StarterBrickDefinitionProp } from "@/starterBricks/types";
 import { type ModDefinition } from "@/types/modDefinitionTypes";
-import { type StarterBrickType } from "@/types/starterBrickTypes";
+import {
+  type StarterBrickType,
+  StarterBrickTypes,
+} from "@/types/starterBrickTypes";
 import {
   PIXIEBRIX_INTEGRATION_ID,
   PIXIEBRIX_INTEGRATION_CONFIG_ID,
@@ -108,7 +111,7 @@ describe("debouncedActivateStarterMods", () => {
 
     const modDefinition = overrideStarterBrickType(
       defaultModDefinitionFactory(),
-      "actionPanel",
+      StarterBrickTypes.SIDEBAR_PANEL,
     );
 
     axiosMock
@@ -197,7 +200,7 @@ describe("debouncedActivateStarterMods", () => {
 
     const modDefinition = overrideStarterBrickType(
       _modDefinition,
-      "actionPanel",
+      StarterBrickTypes.SIDEBAR_PANEL,
     );
 
     axiosMock

--- a/src/background/starterMods.ts
+++ b/src/background/starterMods.ts
@@ -60,6 +60,7 @@ import { isDatabasePreviewField } from "@/components/fields/schemaFields/fieldTy
 import { isRequired } from "@/utils/schemaUtils";
 import type { Schema } from "@/types/schemaTypes";
 import { getBuiltInIntegrationConfigs } from "@/background/getBuiltInIntegrationConfigs";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 // eslint-disable-next-line local-rules/persistBackgroundData -- no state; destructuring reducer and actions
 const { reducer: extensionsReducer, actions: extensionsActions } =
@@ -116,7 +117,7 @@ function closeStarterModTabs({
 }): SidebarState {
   const actionPanelDefinitions = getAllModComponentDefinitionsWithType(
     modDefinition,
-    "actionPanel",
+    StarterBrickTypes.SIDEBAR_PANEL,
   );
   const activatedModComponents = selectModComponentsForMod(
     modDefinition.metadata.id,

--- a/src/components/fields/schemaFields/integrations/integrationDependencyFieldUtils.test.ts
+++ b/src/components/fields/schemaFields/integrations/integrationDependencyFieldUtils.test.ts
@@ -210,7 +210,6 @@ describe("selectVariables", () => {
       ],
       permissions: emptyPermissionsFactory(),
       optionsArgs: {},
-      type: StarterBrickTypes.SIDEBAR_PANEL,
       modMetadata: null,
       modComponent: {
         brickPipeline: [

--- a/src/components/fields/schemaFields/integrations/integrationDependencyFieldUtils.test.ts
+++ b/src/components/fields/schemaFields/integrations/integrationDependencyFieldUtils.test.ts
@@ -30,6 +30,7 @@ import { integrationDependencyFactory } from "@/testUtils/factories/integrationF
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import { toExpression } from "@/utils/expressionUtils";
 import { normalizeAvailability } from "@/bricks/available";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 describe("selectVariables", () => {
   test("selects nothing when no services used", () => {
@@ -209,7 +210,7 @@ describe("selectVariables", () => {
       ],
       permissions: emptyPermissionsFactory(),
       optionsArgs: {},
-      type: "actionPanel",
+      type: StarterBrickTypes.SIDEBAR_PANEL,
       modMetadata: null,
       modComponent: {
         brickPipeline: [
@@ -270,7 +271,7 @@ describe("selectVariables", () => {
           name: "Temporary starter brick",
         },
         definition: {
-          type: "actionPanel",
+          type: StarterBrickTypes.SIDEBAR_PANEL,
           reader: [validateRegistryId("@pixiebrix/document-metadata")],
           isAvailable: normalizeAvailability({
             matchPatterns: ["https://pbx.vercel.app/*"],

--- a/src/components/fields/schemaFields/widgets/varPopup/VarMenu.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VarMenu.tsx
@@ -24,7 +24,6 @@ import {
   selectActiveModComponentFormState,
   selectPipelineMap,
 } from "@/pageEditor/store/editor/editorSelectors";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import SourceLabel from "./SourceLabel";
 import useAllBricks from "@/bricks/hooks/useAllBricks";
 import { useAsyncEffect } from "use-async-effect";
@@ -47,6 +46,7 @@ import { inspectedTab } from "@/pageEditor/context/connection";
 import useEventListener from "@/hooks/useEventListener";
 import { StateNamespaces } from "@/platform/state/stateController";
 import { assertNotNullish, type Nullishable } from "@/utils/nullishUtils";
+import { adapterForComponent } from "@/pageEditor/starterBricks/adapter";
 
 const emptyVarMap = new VarMap();
 
@@ -199,10 +199,11 @@ const VarMenu: React.FunctionComponent<VarMenuProps> = ({
     };
   }, [dispatch]);
 
-  const starterBrickLabel = activeModComponentFormState?.type
-    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unnecessary-type-assertion -- checked above
-      ADAPTERS.get(activeModComponentFormState.type)!.label
-    : "";
+  let starterBrickLabel = "";
+  if (activeModComponentFormState) {
+    const { label } = adapterForComponent(activeModComponentFormState);
+    starterBrickLabel = label;
+  }
 
   const { allOptions, filteredOptions } = useMemo(() => {
     const values = { ...trace?.templateContext };

--- a/src/components/fields/schemaFields/widgets/varPopup/__snapshots__/VarMenu.test.tsx.snap
+++ b/src/components/fields/schemaFields/widgets/varPopup/__snapshots__/VarMenu.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`VarMenu shows view for match 1`] = `
         <div
           class="label"
         >
-          Starter Brick: Sidebar Panel
+          Starter Brick: Button
         </div>
         <ul
           style="border: 0px; padding: 0px; margin: 0.5em 0px 0.5em 0.125em; list-style: none; background-color: rgb(255, 255, 255);"

--- a/src/contentScript/lifecycle.test.ts
+++ b/src/contentScript/lifecycle.test.ts
@@ -33,6 +33,7 @@ import { hydrateModComponentInnerDefinitions } from "@/registry/hydrateInnerDefi
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { type getModComponentState } from "@/store/extensionsStorage";
 import { getPlatform } from "@/platform/platformContext";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 let starterBrickRegistry: any;
 let lifecycleModule: any;
@@ -55,7 +56,7 @@ const starterBrickDefinitionFactory = (
         name: "Test Starter Brick",
       }) as Metadata,
     definition: define<TriggerDefinition>({
-      type: "trigger",
+      type: StarterBrickTypes.TRIGGER,
       background: false,
       isAvailable: () => ({
         matchPatterns: ["*://*/*"],

--- a/src/contentScript/lifecycle.ts
+++ b/src/contentScript/lifecycle.ts
@@ -29,7 +29,10 @@ import { traces } from "@/background/messenger/api";
 import { isDeploymentActive } from "@/utils/deploymentUtils";
 import { PromiseCancelled } from "@/errors/genericErrors";
 import { getThisFrame } from "webext-messenger";
-import { type StarterBrick } from "@/types/starterBrickTypes";
+import {
+  type StarterBrick,
+  StarterBrickTypes,
+} from "@/types/starterBrickTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type RegistryId } from "@/types/registryTypes";
 import { RunReason } from "@/types/runtimeTypes";
@@ -309,7 +312,10 @@ export function removeDraftModComponents(
         _draftModComponentStarterBrickMap.get(modComponentId);
       assertNotNullish(starterBrick, "starterBrick must be defined");
 
-      if (starterBrick.kind === "actionPanel" && preserveSidebar) {
+      if (
+        starterBrick.kind === StarterBrickTypes.SIDEBAR_PANEL &&
+        preserveSidebar
+      ) {
         const sidebar = starterBrick as SidebarStarterBrickABC;
         sidebar.HACK_uninstallExceptModComponent(modComponentId);
       } else {
@@ -438,9 +444,9 @@ async function loadActivatedModComponents(): Promise<StarterBrick[]> {
       const draftStarterBrick = _draftModComponentStarterBrickMap.get(
         modComponent.id,
       );
-      // Include sidebar (i.e. "actionPanel") starter brick kind as those are replaced
+      // Include sidebar starter brick kind as those are replaced
       // by the sidebar itself, automatically replacing old panels keyed by mod component id
-      return draftStarterBrick?.kind === "actionPanel";
+      return draftStarterBrick?.kind === StarterBrickTypes.SIDEBAR_PANEL;
     }
 
     // Exclude disabled deployments

--- a/src/contentScript/pageEditor/draft/updateDraftModComponent.ts
+++ b/src/contentScript/pageEditor/draft/updateDraftModComponent.ts
@@ -29,6 +29,7 @@ import {
   showSidebar,
 } from "@/contentScript/sidebarController";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 export async function updateDraftModComponent({
   extensionPointConfig,
@@ -40,13 +41,13 @@ export async function updateDraftModComponent({
   // https://github.com/pixiebrix/pixiebrix-extension/pull/8226
   if (
     isLoadedInIframe() &&
-    extensionPointConfig.definition.type === "actionPanel"
+    extensionPointConfig.definition.type === StarterBrickTypes.SIDEBAR_PANEL
   ) {
     return;
   }
 
   // HACK: adjust behavior when using the Page Editor
-  if (extensionPointConfig.definition.type === "trigger") {
+  if (extensionPointConfig.definition.type === StarterBrickTypes.TRIGGER) {
     // Prevent auto-run of interval trigger when using the Page Editor because you lose track of trace across runs
     const triggerDefinition =
       extensionPointConfig.definition as TriggerDefinition;
@@ -60,7 +61,7 @@ export async function updateDraftModComponent({
 
   // Don't clear actionPanel because it causes flicking between the tabs in the sidebar. The updated draft mod component
   // will automatically replace the old panel because the panels are keyed by extension id
-  if (starterBrick.kind !== "actionPanel") {
+  if (starterBrick.kind !== StarterBrickTypes.SIDEBAR_PANEL) {
     removeDraftModComponents(extensionConfig.id, { clearTrace: false });
   }
 
@@ -70,7 +71,7 @@ export async function updateDraftModComponent({
   starterBrick.registerModComponent(resolved);
   await runDraftModComponent(extensionConfig.id, starterBrick);
 
-  if (starterBrick.kind === "actionPanel") {
+  if (starterBrick.kind === StarterBrickTypes.SIDEBAR_PANEL) {
     await showSidebar();
     await activateExtensionPanel(extensionConfig.id);
   }

--- a/src/pageEditor/editorPermissionsHelpers.ts
+++ b/src/pageEditor/editorPermissionsHelpers.ts
@@ -16,7 +16,6 @@
  */
 
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { fromJS as starterBrickFactory } from "@/starterBricks/factory";
 import { collectModComponentPermissions } from "@/permissions/modComponentPermissionsHelpers";
 import {
@@ -26,22 +25,17 @@ import {
 import notify from "@/utils/notify";
 import { type Permissions } from "webextension-polyfill";
 import { castArray } from "lodash";
-import { assertNotNullish } from "@/utils/nullishUtils";
+import { adapterForComponent } from "@/pageEditor/starterBricks/adapter";
 
 export async function calculatePermissionsForModComponentFormState(
   modComponentFormState: ModComponentFormState,
 ): Promise<{ hasPermissions: boolean; permissions: Permissions.Permissions }> {
-  const adapter = ADAPTERS.get(modComponentFormState.type);
-
-  assertNotNullish(
-    adapter,
-    `Adapter not found for ${modComponentFormState.type}`,
-  );
+  const { asDraftModComponent } = adapterForComponent(modComponentFormState);
 
   const {
     extension: modComponent,
     extensionPointConfig: starterBrickDefinition,
-  } = adapter.asDraftModComponent(modComponentFormState);
+  } = asDraftModComponent(modComponentFormState);
 
   const starterBrick = starterBrickFactory(starterBrickDefinition);
 

--- a/src/pageEditor/hooks/useAddNewModComponent.ts
+++ b/src/pageEditor/hooks/useAddNewModComponent.ts
@@ -54,7 +54,11 @@ function useAddNewModComponent(): AddNewModComponent {
         return;
       }
 
-      dispatch(actions.toggleInsert(modComponentFormStateAdapter.elementType));
+      dispatch(
+        actions.setInsertingStarterBrickType(
+          modComponentFormStateAdapter.elementType,
+        ),
+      );
 
       if (!modComponentFormStateAdapter.selectNativeElement) {
         // If the foundation is not for a native element, stop after toggling insertion mode
@@ -101,7 +105,7 @@ function useAddNewModComponent(): AddNewModComponent {
           error,
         });
       } finally {
-        dispatch(actions.toggleInsert(null));
+        dispatch(actions.clearInsertingStarterBrickType());
       }
     },
     [dispatch, flagOff, suggestElements],

--- a/src/pageEditor/hooks/useAddNewModComponent.ts
+++ b/src/pageEditor/hooks/useAddNewModComponent.ts
@@ -56,7 +56,7 @@ function useAddNewModComponent(): AddNewModComponent {
 
       dispatch(
         actions.setInsertingStarterBrickType(
-          modComponentFormStateAdapter.elementType,
+          modComponentFormStateAdapter.starterBrickType,
         ),
       );
 
@@ -93,7 +93,7 @@ function useAddNewModComponent(): AddNewModComponent {
         dispatch(actions.checkActiveModComponentAvailability());
 
         reportEvent(Events.MOD_COMPONENT_ADD_NEW, {
-          type: modComponentFormStateAdapter.elementType,
+          type: modComponentFormStateAdapter.starterBrickType,
         });
       } catch (error) {
         if (isSpecificError(error, CancelError)) {

--- a/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
+++ b/src/pageEditor/hooks/useBuildAndValidateMod.test.ts
@@ -16,7 +16,6 @@
  */
 
 import useBuildAndValidateMod from "@/pageEditor/hooks/useBuildAndValidateMod";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import {
   internalStarterBrickMetaFactory,
   lookupStarterBrick,
@@ -44,6 +43,7 @@ import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
 import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
 import { normalizeModDefinition } from "@/utils/modUtils";
 import { DefinitionKinds } from "@/types/registryTypes";
+import { adapter } from "@/pageEditor/starterBricks/adapter";
 
 jest.mock("@/pageEditor/starterBricks/base", () => ({
   ...jest.requireActual("@/pageEditor/starterBricks/base"),
@@ -120,11 +120,11 @@ describe("useBuildAndValidateMod", () => {
           const modComponent = state.extensions[i];
 
           // Load the adapter for this mod component
-          const adapter = ADAPTERS.get(starterBrick.definition.type);
+          const { fromModComponent } = adapter(starterBrick.definition.type);
 
           // Use the adapter to convert to FormState
           // eslint-disable-next-line no-await-in-loop -- This is much easier to read than a large Promise.all() block
-          const modComponentFormState = (await adapter.fromModComponent(
+          const modComponentFormState = (await fromModComponent(
             modComponent,
           )) as ModComponentFormState;
 

--- a/src/pageEditor/hooks/useCheckModStarterBrickInvariants.ts
+++ b/src/pageEditor/hooks/useCheckModStarterBrickInvariants.ts
@@ -21,7 +21,6 @@ import {
 } from "@/types/modDefinitionTypes";
 import { useCallback } from "react";
 import { useSelector } from "react-redux";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { isInnerDefinitionRegistryId } from "@/types/helpers";
 import { selectGetCleanComponentsAndDirtyFormStatesForMod } from "@/pageEditor/store/editor/selectGetCleanComponentsAndDirtyFormStatesForMod";
 import type { ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
@@ -30,10 +29,10 @@ import {
   type StarterBrickDefinitionLike,
 } from "@/starterBricks/types";
 import { isInnerDefinitionEqual } from "@/starterBricks/starterBrickUtils";
-import { assertNotNullish } from "@/utils/nullishUtils";
 import { type InnerDefinitions, DefinitionKinds } from "@/types/registryTypes";
 import produce from "immer";
 import { buildModComponents } from "@/pageEditor/panes/save/saveHelpers";
+import { adapterForComponent } from "@/pageEditor/starterBricks/adapter";
 
 type SourceModParts = {
   sourceModDefinition?: ModDefinition;
@@ -84,9 +83,7 @@ function useCheckModStarterBrickInvariants(): (
           continue;
         }
 
-        const adapter = ADAPTERS.get(formState.type);
-        assertNotNullish(adapter, `Adapter not found for ${formState.type}`);
-        const { selectStarterBrickDefinition } = adapter;
+        const { selectStarterBrickDefinition } = adapterForComponent(formState);
 
         const definitionFromComponent = {
           kind: DefinitionKinds.STARTER_BRICK,

--- a/src/pageEditor/layout/EditorLayout.tsx
+++ b/src/pageEditor/layout/EditorLayout.tsx
@@ -20,7 +20,7 @@ import ModListingPanel from "@/pageEditor/modListingPanel/ModListingPanel";
 import { useDispatch, useSelector } from "react-redux";
 import useFlags from "@/hooks/useFlags";
 import Modals from "../modals/Modals";
-import { selectIsInsertingNewStarterBrick } from "@/pageEditor/store/editor/editorSelectors";
+import { selectInsertingStarterBrickType } from "@/pageEditor/store/editor/editorSelectors";
 import EditorContent from "@/pageEditor/layout/EditorContent";
 import styles from "./EditorLayout.module.scss";
 import RestrictedPane from "@/pageEditor/panes/RestrictedPane";
@@ -36,7 +36,7 @@ import { usePreviousValue } from "@/hooks/usePreviousValue";
 
 const EditorLayout: React.FunctionComponent = () => {
   const dispatch = useDispatch();
-  const isInserting = useSelector(selectIsInsertingNewStarterBrick);
+  const isInserting = useSelector(selectInsertingStarterBrickType);
   const { restrict } = useFlags();
   const isRestricted = restrict("page-editor");
   const isStaleSession = useSelector(selectIsStaleSession);

--- a/src/pageEditor/layout/PanelContent.test.tsx
+++ b/src/pageEditor/layout/PanelContent.test.tsx
@@ -25,6 +25,11 @@ import { updateDraftModComponent } from "@/contentScript/messenger/api";
 import { actions as editorActions } from "@/pageEditor/store/editor/editorSlice";
 
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import {
+  starterBrickDefinitionFactory,
+  starterBrickDefinitionPropFactory,
+} from "@/testUtils/factories/modDefinitionFactories";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 jest.mock("@/contentScript/messenger/api");
 
@@ -55,7 +60,15 @@ describe("Listen to navigationEvent", () => {
   test("an element is selected", async () => {
     jest.spyOn(tabStateActions, "connectToContentScript");
 
-    const formState = formStateFactory();
+    const formState = formStateFactory(
+      undefined,
+      undefined,
+      starterBrickDefinitionFactory({
+        definition: starterBrickDefinitionPropFactory({
+          type: StarterBrickTypes.SIDEBAR_PANEL,
+        }),
+      }),
+    );
     render(<PanelContent />, {
       setupRedux(dispatch) {
         dispatch(editorActions.addModComponentFormState(formState));
@@ -70,6 +83,6 @@ describe("Listen to navigationEvent", () => {
 
     expect(tabStateActions.connectToContentScript).toHaveBeenCalledTimes(2);
     // Panels are not automatically updated on navigation
-    expect(updateDraftModComponent).toHaveBeenCalledTimes(0);
+    expect(updateDraftModComponent).not.toHaveBeenCalled();
   });
 });

--- a/src/pageEditor/layout/PanelContent.tsx
+++ b/src/pageEditor/layout/PanelContent.tsx
@@ -60,7 +60,9 @@ const cleanUpStarterBrickForModComponentFormState = (
   modComponentFormState: EditorState["modComponentFormStates"][number],
 ) => {
   if (
-    STARTER_BRICKS_TO_EXCLUDE_FROM_CLEANUP.includes(modComponentFormState.type)
+    STARTER_BRICKS_TO_EXCLUDE_FROM_CLEANUP.includes(
+      modComponentFormState.starterBrick.definition.type,
+    )
   ) {
     return;
   }

--- a/src/pageEditor/modListingPanel/ActivatedModComponentListItem.tsx
+++ b/src/pageEditor/modListingPanel/ActivatedModComponentListItem.tsx
@@ -120,7 +120,7 @@ const ActivatedModComponentListItem: React.FunctionComponent<{
         );
         dispatch(actions.checkActiveModComponentAvailability());
 
-        if (type === "actionPanel") {
+        if (type === StarterBrickTypes.SIDEBAR_PANEL) {
           // Switch the sidepanel over to the panel. However, don't refresh because the user might be switching
           // frequently between mod components within the same mod.
           await openSidePanel(inspectedTab.tabId);

--- a/src/pageEditor/modListingPanel/AddStarterBrickButton.tsx
+++ b/src/pageEditor/modListingPanel/AddStarterBrickButton.tsx
@@ -17,7 +17,6 @@
 
 import React from "react";
 import { Badge, Dropdown, DropdownButton } from "react-bootstrap";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { type IconProp } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { sortBy } from "lodash";
@@ -31,11 +30,9 @@ import { Events } from "@/telemetry/events";
 import { selectSessionId } from "@/pageEditor/store/session/sessionSelectors";
 import { inspectedTab } from "@/pageEditor/context/connection";
 import { flagOn } from "@/auth/featureFlagStorage";
+import { ALL_ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 
-const sortedStarterBricks = sortBy(
-  [...ADAPTERS.values()],
-  (x) => x.displayOrder,
-);
+const sortedModComponentAdapters = sortBy(ALL_ADAPTERS, (x) => x.displayOrder);
 
 const TEMPLATE_TELEMETRY_SOURCE = "starter_brick_menu";
 
@@ -67,22 +64,22 @@ const AddStarterBrickButton: React.FunctionComponent = () => {
 
   const { data: entries = [] } = useAsyncState<React.ReactNode>(async () => {
     const results = await Promise.all(
-      sortedStarterBricks.map(async (config) => {
-        if (!config.flag) {
+      sortedModComponentAdapters.map(async ({ flag }) => {
+        if (!flag) {
           return true;
         }
 
-        return flagOn(config.flag);
+        return flagOn(flag);
       }),
     );
 
     return (
-      sortedStarterBricks
+      sortedModComponentAdapters
         // eslint-disable-next-line security/detect-object-injection -- array index
         .filter((_, index) => results[index])
         .map((config) => (
           <DropdownEntry
-            key={config.elementType}
+            key={config.starterBrickType}
             caption={config.label}
             icon={config.icon}
             beta={Boolean(config.flag)}

--- a/src/pageEditor/modListingPanel/DraftModComponentListItem.tsx
+++ b/src/pageEditor/modListingPanel/DraftModComponentListItem.tsx
@@ -162,7 +162,7 @@ const DraftModComponentListItem: React.FunctionComponent<
 
         dispatch(actions.setActiveModComponentId(modComponentFormState.uuid));
 
-        if (modComponentFormState.type === "actionPanel") {
+        if (modComponentFormState.type === StarterBrickTypes.SIDEBAR_PANEL) {
           // Switch the sidepanel over to the panel. However, don't refresh because the user might be switching
           // frequently between mod components within the same mod.
           await openSidePanel(inspectedTab.tabId);

--- a/src/pageEditor/modListingPanel/DraftModComponentListItem.tsx
+++ b/src/pageEditor/modListingPanel/DraftModComponentListItem.tsx
@@ -93,7 +93,9 @@ const DraftModComponentListItem: React.FunctionComponent<
     selectIsModComponentSavedOnCloud(modComponentFormState.uuid),
   );
   const removeModComponentFromStorage = useRemoveModComponentFromStorage();
-  const isButton = modComponentFormState.type === StarterBrickTypes.BUTTON;
+  const isButton =
+    modComponentFormState.starterBrick.definition.type ===
+    StarterBrickTypes.BUTTON;
 
   const showOverlay = useCallback(async (uuid: UUID) => {
     await enableOverlay(inspectedTab, `[data-pb-uuid="${uuid}"]`);
@@ -162,7 +164,10 @@ const DraftModComponentListItem: React.FunctionComponent<
 
         dispatch(actions.setActiveModComponentId(modComponentFormState.uuid));
 
-        if (modComponentFormState.type === StarterBrickTypes.SIDEBAR_PANEL) {
+        if (
+          modComponentFormState.starterBrick.definition.type ===
+          StarterBrickTypes.SIDEBAR_PANEL
+        ) {
           // Switch the sidepanel over to the panel. However, don't refresh because the user might be switching
           // frequently between mod components within the same mod.
           await openSidePanel(inspectedTab.tabId);
@@ -179,7 +184,9 @@ const DraftModComponentListItem: React.FunctionComponent<
           [styles.nested]: isNested,
         })}
       >
-        <ModComponentIcon type={modComponentFormState.type} />
+        <ModComponentIcon
+          type={modComponentFormState.starterBrick.definition.type}
+        />
       </span>
       <span className={styles.name}>{getLabel(modComponentFormState)}</span>
       {!isAvailable && (

--- a/src/pageEditor/modListingPanel/ModComponentIcons.tsx
+++ b/src/pageEditor/modListingPanel/ModComponentIcons.tsx
@@ -27,15 +27,7 @@ import { adapter } from "@/pageEditor/starterBricks/adapter";
 
 export const ModComponentIcon: React.FunctionComponent<{
   type: StarterBrickType;
-}> = ({ type }) => (
-  <FontAwesomeIcon
-    fixedWidth
-    // Does this need to be backwards compatible with older starter brick types?
-    // Why did old code have a "default" icon (faPuzzlePiece)?
-    // icon={ADAPTERS.get(type)?.icon ?? faPuzzlePiece}
-    icon={adapter(type).icon}
-  />
-);
+}> = ({ type }) => <FontAwesomeIcon fixedWidth icon={adapter(type).icon} />;
 
 export const NotAvailableIcon: React.FunctionComponent = () => (
   <FontAwesomeIcon icon={faEyeSlash} title="Not available on page" />

--- a/src/pageEditor/modListingPanel/ModComponentIcons.tsx
+++ b/src/pageEditor/modListingPanel/ModComponentIcons.tsx
@@ -17,21 +17,23 @@
 
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import {
   faExclamationTriangle,
   faEyeSlash,
-  faPuzzlePiece,
 } from "@fortawesome/free-solid-svg-icons";
 import { type StarterBrickType } from "@/types/starterBrickTypes";
 import Icon from "@/icons/Icon";
+import { adapter } from "@/pageEditor/starterBricks/adapter";
 
 export const ModComponentIcon: React.FunctionComponent<{
   type: StarterBrickType;
 }> = ({ type }) => (
   <FontAwesomeIcon
     fixedWidth
-    icon={ADAPTERS.get(type)?.icon ?? faPuzzlePiece}
+    // Does this need to be backwards compatible with older starter brick types?
+    // Why did old code have a "default" icon (faPuzzlePiece)?
+    // icon={ADAPTERS.get(type)?.icon ?? faPuzzlePiece}
+    icon={adapter(type).icon}
   />
 );
 

--- a/src/pageEditor/modListingPanel/__snapshots__/DraftModComponentListItem.test.tsx.snap
+++ b/src/pageEditor/modListingPanel/__snapshots__/DraftModComponentListItem.test.tsx.snap
@@ -13,16 +13,16 @@ exports[`DraftModComponentListItem it renders active element 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-columns fa-w-16 fa-fw "
-          data-icon="columns"
+          class="svg-inline--fa fa-mouse-pointer fa-w-10 fa-fw "
+          data-icon="mouse-pointer"
           data-prefix="fas"
           focusable="false"
           role="img"
-          viewBox="0 0 512 512"
+          viewBox="0 0 320 512"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M464 32H48C21.49 32 0 53.49 0 80v352c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V80c0-26.51-21.49-48-48-48zM224 416H64V160h160v256zm224 0H288V160h160v256z"
+            d="M302.189 329.126H196.105l55.831 135.993c3.889 9.428-.555 19.999-9.444 23.999l-49.165 21.427c-9.165 4-19.443-.571-23.332-9.714l-53.053-129.136-86.664 89.138C18.729 472.71 0 463.554 0 447.977V18.299C0 1.899 19.921-6.096 30.277 5.443l284.412 292.542c11.472 11.179 3.007 31.141-12.5 31.141z"
             fill="currentColor"
           />
         </svg>
@@ -107,16 +107,16 @@ exports[`DraftModComponentListItem it renders not active element 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="svg-inline--fa fa-columns fa-w-16 fa-fw "
-          data-icon="columns"
+          class="svg-inline--fa fa-mouse-pointer fa-w-10 fa-fw "
+          data-icon="mouse-pointer"
           data-prefix="fas"
           focusable="false"
           role="img"
-          viewBox="0 0 512 512"
+          viewBox="0 0 320 512"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M464 32H48C21.49 32 0 53.49 0 80v352c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V80c0-26.51-21.49-48-48-48zM224 416H64V160h160v256zm224 0H288V160h160v256z"
+            d="M302.189 329.126H196.105l55.831 135.993c3.889 9.428-.555 19.999-9.444 23.999l-49.165 21.427c-9.165 4-19.443-.571-23.332-9.714l-53.053-129.136-86.664 89.138C18.729 472.71 0 463.554 0 447.977V18.299C0 1.899 19.921-6.096 30.277 5.443l284.412 292.542c11.472 11.179 3.007 31.141-12.5 31.141z"
             fill="currentColor"
           />
         </svg>

--- a/src/pageEditor/panes/EditorPane.test.tsx
+++ b/src/pageEditor/panes/EditorPane.test.tsx
@@ -61,6 +61,11 @@ import {
 import { meWithPartnerApiResponseFactory } from "@/testUtils/factories/authFactories";
 import { toExpression } from "@/utils/expressionUtils";
 import { PipelineFlavor } from "@/bricks/types";
+import {
+  starterBrickDefinitionFactory,
+  starterBrickDefinitionPropFactory,
+} from "@/testUtils/factories/modDefinitionFactories";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectEditorError"] }] -- TODO: replace with native expect and it.each */
 
@@ -149,6 +154,28 @@ const getPlainFormState = (): ModComponentFormState =>
     }),
   ]);
 
+const getSidebarPanelPlainFormState = (): ModComponentFormState =>
+  formStateFactory(
+    undefined,
+    [
+      brickConfigFactory({
+        id: echoBrick.id,
+        outputKey: "echoOutput" as OutputKey,
+        config: defaultBrickConfig(echoBrick.inputSchema),
+      }),
+      brickConfigFactory({
+        id: teapotBrick.id,
+        outputKey: "teapotOutput" as OutputKey,
+        config: defaultBrickConfig(teapotBrick.inputSchema),
+      }),
+    ],
+    starterBrickDefinitionFactory({
+      definition: starterBrickDefinitionPropFactory({
+        type: StarterBrickTypes.SIDEBAR_PANEL,
+      }),
+    }),
+  );
+
 const getFormStateWithSubPipelines = (): ModComponentFormState =>
   formStateFactory(undefined, [
     brickConfigFactory({
@@ -174,6 +201,40 @@ const getFormStateWithSubPipelines = (): ModComponentFormState =>
       },
     }),
   ]);
+
+const getSidebarFormStateWithSubPipelines = (): ModComponentFormState =>
+  formStateFactory(
+    undefined,
+    [
+      brickConfigFactory({
+        id: echoBrick.id,
+        outputKey: "echoOutput" as OutputKey,
+        config: defaultBrickConfig(echoBrick.inputSchema),
+      }),
+      brickConfigFactory({
+        id: forEachBrick.id,
+        outputKey: "forEachOutput" as OutputKey,
+        config: {
+          elements: toExpression("var", "@input.elements"),
+          elementKey: "element",
+          body: toExpression("pipeline", [
+            brickConfigFactory({
+              id: echoBrick.id,
+              outputKey: "subEchoOutput" as OutputKey,
+              config: {
+                message: toExpression("nunjucks", "iteration {{ @element }}"),
+              },
+            }),
+          ]),
+        },
+      }),
+    ],
+    starterBrickDefinitionFactory({
+      definition: starterBrickDefinitionPropFactory({
+        type: StarterBrickTypes.SIDEBAR_PANEL,
+      }),
+    }),
+  );
 
 async function addABlock(addButton: Element, blockName: string) {
   await immediateUserEvent.click(addButton);
@@ -204,7 +265,7 @@ describe("renders", () => {
   });
 
   test("the first selected node", async () => {
-    const formState = getPlainFormState();
+    const formState = getSidebarPanelPlainFormState();
     const { instanceId } = formState.modComponent.brickPipeline[0];
     const { asFragment } = render(<EditorPane />, {
       setupRedux(dispatch) {
@@ -220,7 +281,7 @@ describe("renders", () => {
   });
 
   test("a mod component with sub pipeline", async () => {
-    const formState = getFormStateWithSubPipelines();
+    const formState = getSidebarFormStateWithSubPipelines();
     const { asFragment } = render(<EditorPane />, {
       setupRedux(dispatch) {
         dispatch(editorActions.addModComponentFormState(formState));
@@ -648,12 +709,14 @@ describe("validation", () => {
     // The test adds 2 mod components.
     // It creates an input field error to one node of the mod component 1,
     // then it creates a node level error on another node (adding a renderer at the beginning of the pipeline).
-    // Then we select the second mod component and make sure there're no error badges displayed.
+    // Then we select the second mod component and make sure there are no error badges displayed.
     // Going back to mod component 1.
     // See the 2 error badges in the Node Layout.
     // Select the Markdown node and check the error.
     // Select the Echo brick and check the error.
-    const modComponent1 = getPlainFormState();
+
+    // We need to make component one a side panel mod component
+    const modComponent1 = getSidebarPanelPlainFormState();
     const modComponent2 = getPlainFormState();
 
     // Selecting the Echo brick in the first mod component
@@ -743,7 +806,7 @@ describe("validation", () => {
   });
 
   test("validates multiple renderers on add", async () => {
-    const formState = getPlainFormState();
+    const formState = getSidebarPanelPlainFormState();
     formState.modComponent.brickPipeline.push(
       brickConfigFactory({
         id: MarkdownRenderer.BRICK_ID,
@@ -780,7 +843,7 @@ describe("validation", () => {
   });
 
   test("validates that renderer is the last node on move", async () => {
-    const formState = getPlainFormState();
+    const formState = getSidebarPanelPlainFormState();
     formState.modComponent.brickPipeline.push(
       brickConfigFactory({
         id: MarkdownRenderer.BRICK_ID,
@@ -821,7 +884,16 @@ describe("validation", () => {
     },
     {
       pipelineFlavor: PipelineFlavor.NoEffect,
-      formFactory: formStateFactory,
+      formFactory: () =>
+        formStateFactory(
+          undefined,
+          undefined,
+          starterBrickDefinitionFactory({
+            definition: starterBrickDefinitionPropFactory({
+              type: StarterBrickTypes.SIDEBAR_PANEL,
+            }),
+          }),
+        ),
       disallowedBlock: alertBrick,
     },
   ];
@@ -873,7 +945,16 @@ describe("brick validation in Add Brick Modal UI", () => {
     },
     {
       pipelineFlavor: PipelineFlavor.NoEffect,
-      formFactory: formStateFactory,
+      formFactory: () =>
+        formStateFactory(
+          undefined,
+          undefined,
+          starterBrickDefinitionFactory({
+            definition: starterBrickDefinitionPropFactory({
+              type: StarterBrickTypes.SIDEBAR_PANEL,
+            }),
+          }),
+        ),
       disallowedBlockName: "Window Alert",
     },
   ];

--- a/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/EditorPane.test.tsx.snap
@@ -698,7 +698,7 @@ exports[`renders a mod component with sub pipeline 1`] = `
                               name="starterBrick.definition.isAvailable.matchPatterns.0"
                               rows="1"
                             >
-                              https://www.mySite1.com/*
+                              https://www.mySite2.com/*
                             </textarea>
                           </div>
                           <div

--- a/src/pageEditor/panes/insert/InsertPane.tsx
+++ b/src/pageEditor/panes/insert/InsertPane.tsx
@@ -37,7 +37,7 @@ const InsertPane: React.FC<{ inserting: StarterBrickType }> = ({
   const dispatch = useDispatch();
 
   const cancelInsert = useCallback(async () => {
-    dispatch(actions.toggleInsert(null));
+    dispatch(actions.clearInsertingStarterBrickType());
     await cancelSelect(inspectedTab);
   }, [dispatch]);
 

--- a/src/pageEditor/panes/insert/exampleStarterBrickConfigs.ts
+++ b/src/pageEditor/panes/insert/exampleStarterBrickConfigs.ts
@@ -16,7 +16,10 @@
  */
 
 import { type BrickPipeline } from "@/bricks/types";
-import { type StarterBrickType } from "@/types/starterBrickTypes";
+import {
+  type StarterBrickType,
+  StarterBrickTypes,
+} from "@/types/starterBrickTypes";
 import { validateRegistryId } from "@/types/helpers";
 import { createNewConfiguredBrick } from "@/bricks/exampleBrickConfigs";
 import { toExpression } from "@/utils/expressionUtils";
@@ -25,12 +28,12 @@ const documentBrickId = validateRegistryId("@pixiebrix/document");
 const quickbarActionId = validateRegistryId("@pixiebrix/quickbar/add");
 
 export function getExampleBrickPipeline(type: StarterBrickType): BrickPipeline {
-  if (type === "actionPanel") {
+  if (type === StarterBrickTypes.SIDEBAR_PANEL) {
     const documentBuilderBrick = createNewConfiguredBrick(documentBrickId);
     return [documentBuilderBrick];
   }
 
-  if (type === "quickBarProvider") {
+  if (type === StarterBrickTypes.DYNAMIC_QUICK_BAR) {
     const quickbarActionBrick = createNewConfiguredBrick(quickbarActionId);
     quickbarActionBrick.config = {
       title: "Example Action",

--- a/src/pageEditor/panes/insert/useAutoInsert.ts
+++ b/src/pageEditor/panes/insert/useAutoInsert.ts
@@ -20,7 +20,7 @@ import {
 } from "@/pageEditor/context/connection";
 import { updateDraftModComponent } from "@/contentScript/messenger/api";
 
-const { addModComponentFormState, toggleInsert } = actions;
+const { addModComponentFormState, clearInsertingStarterBrickType } = actions;
 
 function useAutoInsert(type: StarterBrickType): void {
   const dispatch = useDispatch();
@@ -76,7 +76,7 @@ function useAutoInsert(type: StarterBrickType): void {
         message: "Error adding mod",
         error,
       });
-      dispatch(toggleInsert(null));
+      dispatch(clearInsertingStarterBrickType());
     }
   }, [type, dispatch]);
 }

--- a/src/pageEditor/panes/save/saveHelpers.test.ts
+++ b/src/pageEditor/panes/save/saveHelpers.test.ts
@@ -38,7 +38,6 @@ import {
   type StarterBrickDefinitionLike,
   type StarterBrickDefinitionProp,
 } from "@/starterBricks/types";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import { validateOutputKey } from "@/runtime/runtimeTypes";
 import {
@@ -72,6 +71,7 @@ import {
 } from "@/utils/modUtils";
 import { INTEGRATIONS_BASE_SCHEMA_URL } from "@/integrations/constants";
 import { registryIdFactory } from "@/testUtils/factories/stringFactories";
+import { adapter } from "@/pageEditor/starterBricks/adapter";
 
 jest.mock("@/pageEditor/starterBricks/base", () => ({
   ...jest.requireActual("@/pageEditor/starterBricks/base"),
@@ -640,13 +640,13 @@ describe("buildNewMod", () => {
       extensionPointId: starterBrick.metadata.id,
     }) as SerializedModComponent;
 
-    const adapter = ADAPTERS.get(starterBrick.definition.type);
+    const { fromModComponent } = adapter(starterBrick.definition.type);
 
     // Mock this lookup for the adapter call that follows
     jest.mocked(lookupStarterBrick).mockResolvedValue(starterBrick);
 
     // Use the adapter to convert to ModComponentFormState
-    const modComponentFormState = (await adapter.fromModComponent(
+    const modComponentFormState = (await fromModComponent(
       modComponent,
     )) as ModComponentFormState;
 
@@ -829,11 +829,11 @@ describe("buildNewMod", () => {
           const modComponent = state.extensions[i];
 
           // Load the adapter for this mod component
-          const adapter = ADAPTERS.get(starterBrick.definition.type);
+          const { fromModComponent } = adapter(starterBrick.definition.type);
 
           // Use the adapter to convert to FormState
           // eslint-disable-next-line no-await-in-loop -- This is much easier to read than a large Promise.all() block
-          const modComponentFormState = (await adapter.fromModComponent(
+          const modComponentFormState = (await fromModComponent(
             modComponent,
           )) as ModComponentFormState;
 

--- a/src/pageEditor/panes/save/saveHelpers.ts
+++ b/src/pageEditor/panes/save/saveHelpers.ts
@@ -29,7 +29,6 @@ import {
 } from "@/types/helpers";
 import { compact, pick, sortBy } from "lodash";
 import { produce } from "immer";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 import {
   DEFAULT_STARTER_BRICK_VAR,
@@ -65,6 +64,7 @@ import {
   isStarterBrickDefinitionPropEqual,
 } from "@/starterBricks/starterBrickUtils";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { adapterForComponent } from "@/pageEditor/starterBricks/adapter";
 
 /**
  * Generate a new registry id from an existing registry id by adding/replacing the scope.
@@ -271,9 +271,8 @@ export function replaceModComponent(
       activatedModComponent,
     );
 
-    const adapter = ADAPTERS.get(newModComponent.type);
-    assertNotNullish(adapter, `No adapter found for ${newModComponent.type}`);
-    const { selectModComponent, selectStarterBrickDefinition } = adapter;
+    const { selectModComponent, selectStarterBrickDefinition } =
+      adapterForComponent(newModComponent);
     const rawModComponent = selectModComponent(newModComponent);
     const starterBrickId = newModComponent.starterBrick.metadata.id;
     const hasInnerDefinition = isInnerDefinitionRegistryId(starterBrickId);
@@ -450,12 +449,8 @@ export function buildNewMod({
 
     const unsavedModComponents: ModComponentBase[] =
       dirtyModComponentFormStates.map((modComponentFormState) => {
-        const adapter = ADAPTERS.get(modComponentFormState.type);
-        assertNotNullish(
-          adapter,
-          `No adapter found for ${modComponentFormState.type}`,
-        );
-        const { selectModComponent, selectStarterBrickDefinition } = adapter;
+        const { selectModComponent, selectStarterBrickDefinition } =
+          adapterForComponent(modComponentFormState);
 
         const unsavedModComponent = selectModComponent(modComponentFormState);
 

--- a/src/pageEditor/starterBricks/adapter.ts
+++ b/src/pageEditor/starterBricks/adapter.ts
@@ -34,16 +34,33 @@ import { type ModComponentFormState } from "@/pageEditor/starterBricks/formState
 import { type DraftModComponent } from "@/contentScript/pageEditor/types";
 import { assertNotNullish } from "@/utils/nullishUtils";
 
-export const ADAPTERS = new Map<StarterBrickType, ModComponentFormStateAdapter>(
-  [
-    [StarterBrickTypes.TRIGGER, triggerModComponent],
-    [StarterBrickTypes.CONTEXT_MENU, contextMenuModComponent],
-    [StarterBrickTypes.SIDEBAR_PANEL, sidebarPanelModComponent],
-    [StarterBrickTypes.BUTTON, buttonModComponent],
-    [StarterBrickTypes.QUICK_BAR_ACTION, quickBarActionModComponent],
-    [StarterBrickTypes.DYNAMIC_QUICK_BAR, quickBarProviderModComponent],
-  ],
-);
+const ADAPTERS = new Map<StarterBrickType, ModComponentFormStateAdapter>([
+  [StarterBrickTypes.TRIGGER, triggerModComponent],
+  [StarterBrickTypes.CONTEXT_MENU, contextMenuModComponent],
+  [StarterBrickTypes.SIDEBAR_PANEL, sidebarPanelModComponent],
+  [StarterBrickTypes.BUTTON, buttonModComponent],
+  [StarterBrickTypes.QUICK_BAR_ACTION, quickBarActionModComponent],
+  [StarterBrickTypes.DYNAMIC_QUICK_BAR, quickBarProviderModComponent],
+]);
+
+export const ALL_ADAPTERS = [...ADAPTERS.values()];
+
+export function adapter(
+  starterBrickType: StarterBrickType,
+): ModComponentFormStateAdapter {
+  const adapter = ADAPTERS.get(starterBrickType);
+  assertNotNullish(
+    adapter,
+    `No adapter found for starter brick type: ${starterBrickType}`,
+  );
+  return adapter;
+}
+
+export function adapterForComponent(
+  formState: ModComponentFormState,
+): ModComponentFormStateAdapter {
+  return adapter(formState.starterBrick.definition.type);
+}
 
 export async function selectType(
   modComponent: ModComponentBase,
@@ -88,10 +105,11 @@ export async function modComponentToFormState(
 export function formStateToDraftModComponent(
   modComponentFormState: ModComponentFormState,
 ): DraftModComponent {
-  const adapter = ADAPTERS.get(modComponentFormState.type);
+  const starterBrickType = modComponentFormState.starterBrick.definition.type;
+  const adapter = ADAPTERS.get(starterBrickType);
   assertNotNullish(
     adapter,
-    `No adapter found for starter brick type: ${modComponentFormState.type}`,
+    `No adapter found for starter brick type: ${starterBrickType}`,
   );
   return adapter.asDraftModComponent(modComponentFormState);
 }

--- a/src/pageEditor/starterBricks/base.ts
+++ b/src/pageEditor/starterBricks/base.ts
@@ -202,7 +202,7 @@ export function baseSelectModComponent({
 
 export function makeInitialBaseState(
   uuid: UUID = uuidv4(),
-): Except<BaseFormState, "type" | "label" | "starterBrick"> {
+): Except<BaseFormState, "label" | "starterBrick"> {
   return {
     uuid,
     apiVersion: PAGE_EDITOR_DEFAULT_BRICK_API_VERSION,

--- a/src/pageEditor/starterBricks/base.ts
+++ b/src/pageEditor/starterBricks/base.ts
@@ -404,11 +404,16 @@ export function getImplicitReader(
     { element: validateRegistryId("@pixiebrix/html/element") },
   ] as const;
 
-  if (type === "trigger") {
+  if (type === StarterBrickTypes.TRIGGER) {
     return readerTypeHack([...base, ...elementAddons]);
   }
 
-  if (type === "quickBar" || type === "quickBarProvider") {
+  if (
+    [
+      StarterBrickTypes.QUICK_BAR_ACTION,
+      StarterBrickTypes.DYNAMIC_QUICK_BAR,
+    ].includes(type)
+  ) {
     return readerTypeHack([
       ...base,
       ...elementAddons,
@@ -416,7 +421,7 @@ export function getImplicitReader(
     ]);
   }
 
-  if (type === "contextMenu") {
+  if (type === StarterBrickTypes.CONTEXT_MENU) {
     // NOTE: we don't need to provide "@pixiebrix/context-menu-data" here because it's automatically attached by
     // the contextMenu starter brick.
     return readerTypeHack([...base, ...elementAddons]);

--- a/src/pageEditor/starterBricks/button.ts
+++ b/src/pageEditor/starterBricks/button.ts
@@ -57,7 +57,6 @@ function fromNativeElement(
   button: ButtonSelectionResult,
 ): ButtonFormState {
   return {
-    type: StarterBrickTypes.BUTTON,
     label: `My ${getDomain(url)} button`,
     ...makeInitialBaseState(button.uuid),
     containerInfo: button.containerInfo,
@@ -188,7 +187,7 @@ const config: ModComponentFormStateAdapter<
   ButtonFormState
 > = {
   displayOrder: 0,
-  elementType: StarterBrickTypes.BUTTON,
+  starterBrickType: StarterBrickTypes.BUTTON,
   label: "Button",
   icon: faMousePointer,
   baseClass: ButtonStarterBrickABC,

--- a/src/pageEditor/starterBricks/contextMenu.ts
+++ b/src/pageEditor/starterBricks/contextMenu.ts
@@ -57,7 +57,6 @@ function fromNativeElement(
   const title = "Context menu item";
 
   return {
-    type: StarterBrickTypes.CONTEXT_MENU,
     // To simplify the interface, this is kept in sync with the caption
     label: title,
     ...base,
@@ -182,7 +181,7 @@ function asDraftModComponent(
 
 const config: ModComponentFormStateAdapter<undefined, ContextMenuFormState> = {
   displayOrder: 1,
-  elementType: StarterBrickTypes.CONTEXT_MENU,
+  starterBrickType: StarterBrickTypes.CONTEXT_MENU,
   label: "Context Menu",
   baseClass: ContextMenuStarterBrickABC,
   EditorNode: ContextMenuConfiguration,

--- a/src/pageEditor/starterBricks/contextMenu.ts
+++ b/src/pageEditor/starterBricks/contextMenu.ts
@@ -44,6 +44,7 @@ import {
   type ContextMenuConfig,
 } from "@/starterBricks/contextMenu/contextMenuTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 function fromNativeElement(
   url: string,
@@ -56,15 +57,15 @@ function fromNativeElement(
   const title = "Context menu item";
 
   return {
-    type: "contextMenu",
+    type: StarterBrickTypes.CONTEXT_MENU,
     // To simplify the interface, this is kept in sync with the caption
     label: title,
     ...base,
     starterBrick: {
       metadata,
       definition: {
-        type: "contextMenu",
-        reader: getImplicitReader("contextMenu"),
+        type: StarterBrickTypes.CONTEXT_MENU,
+        reader: getImplicitReader(StarterBrickTypes.CONTEXT_MENU),
         documentUrlPatterns: isAvailable.matchPatterns,
         contexts: ["all"],
         targetMode: "eventTarget",
@@ -96,7 +97,7 @@ function selectStarterBrickDefinition(
   return removeEmptyValues({
     ...baseSelectStarterBrick(formState),
     definition: {
-      type: "contextMenu",
+      type: StarterBrickTypes.CONTEXT_MENU,
       documentUrlPatterns,
       contexts,
       targetMode,
@@ -130,8 +131,8 @@ async function fromModComponent(
   const starterBrick = await lookupStarterBrick<
     ContextMenuDefinition,
     ContextMenuConfig,
-    "contextMenu"
-  >(config, "contextMenu");
+    typeof StarterBrickTypes.CONTEXT_MENU
+  >(config, StarterBrickTypes.CONTEXT_MENU);
   const {
     documentUrlPatterns = [],
     defaultOptions = {},
@@ -154,7 +155,7 @@ async function fromModComponent(
     starterBrick: {
       metadata: starterBrick.metadata,
       definition: {
-        type: "contextMenu",
+        type: StarterBrickTypes.CONTEXT_MENU,
         documentUrlPatterns,
         defaultOptions,
         targetMode,
@@ -171,7 +172,7 @@ function asDraftModComponent(
   contextMenuFormState: ContextMenuFormState,
 ): DraftModComponent {
   return {
-    type: "contextMenu",
+    type: StarterBrickTypes.CONTEXT_MENU,
     extension: selectModComponent(contextMenuFormState, {
       includeInstanceIds: true,
     }),
@@ -181,7 +182,7 @@ function asDraftModComponent(
 
 const config: ModComponentFormStateAdapter<undefined, ContextMenuFormState> = {
   displayOrder: 1,
-  elementType: "contextMenu",
+  elementType: StarterBrickTypes.CONTEXT_MENU,
   label: "Context Menu",
   baseClass: ContextMenuStarterBrickABC,
   EditorNode: ContextMenuConfiguration,

--- a/src/pageEditor/starterBricks/formStateTypes.ts
+++ b/src/pageEditor/starterBricks/formStateTypes.ts
@@ -239,7 +239,7 @@ export interface QuickBarProviderFormState
     QuickBarProviderModComponentState,
     QuickBarProviderStarterBrickState
   > {
-  type: typeof StarterBrickTypes.QUICK_BAR_ACTION;
+  type: typeof StarterBrickTypes.DYNAMIC_QUICK_BAR;
 }
 
 /**

--- a/src/pageEditor/starterBricks/formStateTypes.ts
+++ b/src/pageEditor/starterBricks/formStateTypes.ts
@@ -44,10 +44,7 @@ import {
   type CustomEventOptions,
   type DebounceOptions,
 } from "@/starterBricks/types";
-import {
-  type StarterBrickType,
-  StarterBrickTypes,
-} from "@/types/starterBrickTypes";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 import { type Except } from "type-fest";
 import { type Menus } from "webextension-polyfill";
 import {
@@ -68,7 +65,7 @@ type ButtonModComponentState = BaseModComponentState &
   Except<ButtonStarterBrickConfig, "action">;
 type ButtonStarterBrickState = BaseStarterBrickState & {
   definition: {
-    type: StarterBrickType;
+    type: typeof StarterBrickTypes.BUTTON;
     containerSelector: string;
     position?: ButtonPosition;
     template: string;
@@ -92,7 +89,6 @@ type ButtonStarterBrickState = BaseStarterBrickState & {
 
 export interface ButtonFormState
   extends BaseFormState<ButtonModComponentState, ButtonStarterBrickState> {
-  type: typeof StarterBrickTypes.BUTTON;
   containerInfo: ElementInfo | null;
 }
 
@@ -122,15 +118,15 @@ type SidebarStarterBrickState = BaseStarterBrickState & {
   };
 };
 
-export interface SidebarFormState
-  extends BaseFormState<SidebarModComponentState, SidebarStarterBrickState> {
-  type: typeof StarterBrickTypes.SIDEBAR_PANEL;
-}
+export type SidebarFormState = BaseFormState<
+  SidebarModComponentState,
+  SidebarStarterBrickState
+>;
 
 // TriggerFormState
 type TriggerStarterBrickState = BaseStarterBrickState & {
   definition: {
-    type: StarterBrickType;
+    type: typeof StarterBrickTypes.TRIGGER;
     rootSelector?: string;
     trigger?: TriggerTrigger;
     reader: SingleLayerReaderConfig;
@@ -162,17 +158,17 @@ export function isTriggerStarterBrick(
   return starterBrick.definition.type === StarterBrickTypes.TRIGGER;
 }
 
-export interface TriggerFormState
-  extends BaseFormState<BaseModComponentState, TriggerStarterBrickState> {
-  type: typeof StarterBrickTypes.TRIGGER;
-}
+export type TriggerFormState = BaseFormState<
+  BaseModComponentState,
+  TriggerStarterBrickState
+>;
 
 // ContextMenuFormState
 type ContextMenuModComponentState = BaseModComponentState &
   Except<ContextMenuConfig, "action">;
 type ContextMenuStarterBrickState = BaseStarterBrickState & {
   definition: {
-    type: StarterBrickType;
+    type: typeof StarterBrickTypes.CONTEXT_MENU;
     defaultOptions: ContextMenuDefaultOptions;
     documentUrlPatterns: string[];
     contexts: Menus.ContextType[];
@@ -182,20 +178,17 @@ type ContextMenuStarterBrickState = BaseStarterBrickState & {
   };
 };
 
-export interface ContextMenuFormState
-  extends BaseFormState<
-    ContextMenuModComponentState,
-    ContextMenuStarterBrickState
-  > {
-  type: typeof StarterBrickTypes.CONTEXT_MENU;
-}
+export type ContextMenuFormState = BaseFormState<
+  ContextMenuModComponentState,
+  ContextMenuStarterBrickState
+>;
 
 // QuickBarFormState
 type QuickBarModComponentState = BaseModComponentState &
   Except<QuickBarConfig, "action">;
 type QuickBarStarterBrickState = BaseStarterBrickState & {
   definition: {
-    type: StarterBrickType;
+    type: typeof StarterBrickTypes.QUICK_BAR_ACTION;
     defaultOptions: QuickBarDefaultOptions;
     documentUrlPatterns: string[];
     contexts: Menus.ContextType[];
@@ -212,7 +205,7 @@ type QuickBarProviderModComponentState = BaseModComponentState &
   };
 type QuickBarProviderStarterBrickState = BaseStarterBrickState & {
   definition: {
-    type: StarterBrickType;
+    type: typeof StarterBrickTypes.DYNAMIC_QUICK_BAR;
     defaultOptions: QuickBarProviderDefaultOptions;
     documentUrlPatterns: string[];
     reader: SingleLayerReaderConfig;
@@ -229,18 +222,15 @@ export function isQuickBarStarterBrick(
   ].includes(starterBrick.definition.type);
 }
 
-export interface QuickBarFormState
-  extends BaseFormState<QuickBarModComponentState, QuickBarStarterBrickState> {
-  type: typeof StarterBrickTypes.QUICK_BAR_ACTION;
-}
+export type QuickBarFormState = BaseFormState<
+  QuickBarModComponentState,
+  QuickBarStarterBrickState
+>;
 
-export interface QuickBarProviderFormState
-  extends BaseFormState<
-    QuickBarProviderModComponentState,
-    QuickBarProviderStarterBrickState
-  > {
-  type: typeof StarterBrickTypes.DYNAMIC_QUICK_BAR;
-}
+export type QuickBarProviderFormState = BaseFormState<
+  QuickBarProviderModComponentState,
+  QuickBarProviderStarterBrickState
+>;
 
 /**
  * @deprecated We want to deconstruct ComponentFormState and using reducers instead of

--- a/src/pageEditor/starterBricks/formStateTypes.ts
+++ b/src/pageEditor/starterBricks/formStateTypes.ts
@@ -46,7 +46,7 @@ import {
 } from "@/starterBricks/types";
 import {
   type StarterBrickType,
-  type StarterBrickTypes,
+  StarterBrickTypes,
 } from "@/types/starterBrickTypes";
 import { type Except } from "type-fest";
 import { type Menus } from "webextension-polyfill";
@@ -124,7 +124,7 @@ type SidebarStarterBrickState = BaseStarterBrickState & {
 
 export interface SidebarFormState
   extends BaseFormState<SidebarModComponentState, SidebarStarterBrickState> {
-  type: "actionPanel";
+  type: typeof StarterBrickTypes.SIDEBAR_PANEL;
 }
 
 // TriggerFormState
@@ -159,12 +159,12 @@ type TriggerStarterBrickState = BaseStarterBrickState & {
 export function isTriggerStarterBrick(
   starterBrick: BaseStarterBrickState,
 ): starterBrick is TriggerStarterBrickState {
-  return starterBrick.definition.type === "trigger";
+  return starterBrick.definition.type === StarterBrickTypes.TRIGGER;
 }
 
 export interface TriggerFormState
   extends BaseFormState<BaseModComponentState, TriggerStarterBrickState> {
-  type: "trigger";
+  type: typeof StarterBrickTypes.TRIGGER;
 }
 
 // ContextMenuFormState
@@ -187,7 +187,7 @@ export interface ContextMenuFormState
     ContextMenuModComponentState,
     ContextMenuStarterBrickState
   > {
-  type: "contextMenu";
+  type: typeof StarterBrickTypes.CONTEXT_MENU;
 }
 
 // QuickBarFormState
@@ -223,14 +223,15 @@ type QuickBarProviderStarterBrickState = BaseStarterBrickState & {
 export function isQuickBarStarterBrick(
   starterBrick: BaseStarterBrickState,
 ): starterBrick is QuickBarStarterBrickState {
-  return ["quickBar", "quickBarProvider"].includes(
-    starterBrick.definition.type,
-  );
+  return [
+    typeof StarterBrickTypes.QUICK_BAR_ACTION,
+    typeof StarterBrickTypes.DYNAMIC_QUICK_BAR,
+  ].includes(starterBrick.definition.type);
 }
 
 export interface QuickBarFormState
   extends BaseFormState<QuickBarModComponentState, QuickBarStarterBrickState> {
-  type: "quickBar";
+  type: typeof StarterBrickTypes.QUICK_BAR_ACTION;
 }
 
 export interface QuickBarProviderFormState
@@ -238,7 +239,7 @@ export interface QuickBarProviderFormState
     QuickBarProviderModComponentState,
     QuickBarProviderStarterBrickState
   > {
-  type: "quickBarProvider";
+  type: typeof StarterBrickTypes.QUICK_BAR_ACTION;
 }
 
 /**

--- a/src/pageEditor/starterBricks/modComponentFormStateAdapter.ts
+++ b/src/pageEditor/starterBricks/modComponentFormStateAdapter.ts
@@ -36,7 +36,7 @@ export interface ModComponentFormStateAdapter<
   /**
    * The internal starter brick type, e.g., menuItem, contextMenu, etc.
    */
-  readonly elementType: StarterBrickType;
+  readonly starterBrickType: StarterBrickType;
 
   /**
    * The StarterBrickConfig class corresponding to the starter brick

--- a/src/pageEditor/starterBricks/quickBar.ts
+++ b/src/pageEditor/starterBricks/quickBar.ts
@@ -54,7 +54,6 @@ function fromNativeElement(url: string, metadata: Metadata): QuickBarFormState {
   const title = "Quick Bar item";
 
   return {
-    type: StarterBrickTypes.QUICK_BAR_ACTION,
     // To simplify the interface, this is kept in sync with the caption
     label: title,
     ...base,
@@ -179,7 +178,7 @@ function asDraftModComponent(
 
 const config: ModComponentFormStateAdapter<undefined, QuickBarFormState> = {
   displayOrder: 1,
-  elementType: StarterBrickTypes.QUICK_BAR_ACTION,
+  starterBrickType: StarterBrickTypes.QUICK_BAR_ACTION,
   label: "Quick Bar Action",
   baseClass: QuickBarStarterBrickABC,
   EditorNode: QuickBarConfiguration,

--- a/src/pageEditor/starterBricks/quickBar.ts
+++ b/src/pageEditor/starterBricks/quickBar.ts
@@ -44,6 +44,7 @@ import {
   type QuickBarConfig,
 } from "@/starterBricks/quickBar/quickBarTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 function fromNativeElement(url: string, metadata: Metadata): QuickBarFormState {
   const base = makeInitialBaseState();
@@ -53,15 +54,15 @@ function fromNativeElement(url: string, metadata: Metadata): QuickBarFormState {
   const title = "Quick Bar item";
 
   return {
-    type: "quickBar",
+    type: StarterBrickTypes.QUICK_BAR_ACTION,
     // To simplify the interface, this is kept in sync with the caption
     label: title,
     ...base,
     starterBrick: {
       metadata,
       definition: {
-        type: "quickBar",
-        reader: getImplicitReader("quickBar"),
+        type: StarterBrickTypes.QUICK_BAR_ACTION,
+        reader: getImplicitReader(StarterBrickTypes.QUICK_BAR_ACTION),
         documentUrlPatterns: isAvailable.matchPatterns,
         contexts: ["all"],
         targetMode: "eventTarget",
@@ -92,7 +93,7 @@ function selectStarterBrickDefinition(
   return removeEmptyValues({
     ...baseSelectStarterBrick(formState),
     definition: {
-      type: "quickBar",
+      type: StarterBrickTypes.QUICK_BAR_ACTION,
       documentUrlPatterns,
       contexts,
       targetMode,
@@ -126,8 +127,8 @@ async function fromModComponent(
   const starterBrick = await lookupStarterBrick<
     QuickBarDefinition,
     QuickBarConfig,
-    "quickBar"
-  >(config, "quickBar");
+    typeof StarterBrickTypes.QUICK_BAR_ACTION
+  >(config, StarterBrickTypes.QUICK_BAR_ACTION);
 
   const {
     documentUrlPatterns = [],
@@ -151,7 +152,7 @@ async function fromModComponent(
     starterBrick: {
       metadata: starterBrick.metadata,
       definition: {
-        type: "quickBar",
+        type: StarterBrickTypes.QUICK_BAR_ACTION,
         documentUrlPatterns,
         defaultOptions,
         targetMode,
@@ -168,7 +169,7 @@ function asDraftModComponent(
   quickBarFormState: QuickBarFormState,
 ): DraftModComponent {
   return {
-    type: "quickBar",
+    type: StarterBrickTypes.QUICK_BAR_ACTION,
     extension: selectModComponent(quickBarFormState, {
       includeInstanceIds: true,
     }),
@@ -178,7 +179,7 @@ function asDraftModComponent(
 
 const config: ModComponentFormStateAdapter<undefined, QuickBarFormState> = {
   displayOrder: 1,
-  elementType: "quickBar",
+  elementType: StarterBrickTypes.QUICK_BAR_ACTION,
   label: "Quick Bar Action",
   baseClass: QuickBarStarterBrickABC,
   EditorNode: QuickBarConfiguration,

--- a/src/pageEditor/starterBricks/quickBarProvider.ts
+++ b/src/pageEditor/starterBricks/quickBarProvider.ts
@@ -57,7 +57,6 @@ function fromNativeElement(
   const title = "Dynamic Quick Bar";
 
   return {
-    type: StarterBrickTypes.DYNAMIC_QUICK_BAR,
     // To simplify the interface, this is kept in sync with the caption
     label: title,
     ...base,
@@ -172,7 +171,7 @@ const config: ModComponentFormStateAdapter<
   QuickBarProviderFormState
 > = {
   displayOrder: 1,
-  elementType: StarterBrickTypes.DYNAMIC_QUICK_BAR,
+  starterBrickType: StarterBrickTypes.DYNAMIC_QUICK_BAR,
   label: "Dynamic Quick Bar",
   baseClass: QuickBarProviderStarterBrickABC,
   EditorNode: QuickBarProviderConfiguration,

--- a/src/pageEditor/starterBricks/quickBarProvider.ts
+++ b/src/pageEditor/starterBricks/quickBarProvider.ts
@@ -44,6 +44,7 @@ import {
   type QuickBarProviderConfig,
 } from "@/starterBricks/quickBarProvider/quickBarProviderTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 function fromNativeElement(
   url: string,
@@ -56,15 +57,15 @@ function fromNativeElement(
   const title = "Dynamic Quick Bar";
 
   return {
-    type: "quickBarProvider",
+    type: StarterBrickTypes.DYNAMIC_QUICK_BAR,
     // To simplify the interface, this is kept in sync with the caption
     label: title,
     ...base,
     starterBrick: {
       metadata,
       definition: {
-        type: "quickBarProvider",
-        reader: getImplicitReader("quickBarProvider"),
+        type: StarterBrickTypes.DYNAMIC_QUICK_BAR,
+        reader: getImplicitReader(StarterBrickTypes.DYNAMIC_QUICK_BAR),
         documentUrlPatterns: isAvailable.matchPatterns,
         defaultOptions: {},
         isAvailable,
@@ -87,7 +88,7 @@ function selectStarterBrickDefinition(
   return removeEmptyValues({
     ...baseSelectStarterBrick(formState),
     definition: {
-      type: "quickBarProvider",
+      type: StarterBrickTypes.DYNAMIC_QUICK_BAR,
       documentUrlPatterns,
       reader,
       isAvailable: cleanIsAvailable(isAvailable),
@@ -118,8 +119,8 @@ async function fromModComponent(
   const starterBrick = await lookupStarterBrick<
     QuickBarProviderDefinition,
     QuickBarProviderConfig,
-    "quickBarProvider"
-  >(config, "quickBarProvider");
+    typeof StarterBrickTypes.DYNAMIC_QUICK_BAR
+  >(config, StarterBrickTypes.DYNAMIC_QUICK_BAR);
 
   const {
     documentUrlPatterns = [],
@@ -141,7 +142,7 @@ async function fromModComponent(
     starterBrick: {
       metadata: starterBrick.metadata,
       definition: {
-        type: "quickBarProvider",
+        type: StarterBrickTypes.DYNAMIC_QUICK_BAR,
         documentUrlPatterns,
         defaultOptions,
         // See comment on SingleLayerReaderConfig
@@ -156,7 +157,7 @@ function asDraftModComponent(
   quickBarProviderFormState: QuickBarProviderFormState,
 ): DraftModComponent {
   return {
-    type: "quickBarProvider",
+    type: StarterBrickTypes.DYNAMIC_QUICK_BAR,
     extension: selectModComponent(quickBarProviderFormState, {
       includeInstanceIds: true,
     }),
@@ -171,7 +172,7 @@ const config: ModComponentFormStateAdapter<
   QuickBarProviderFormState
 > = {
   displayOrder: 1,
-  elementType: "quickBarProvider",
+  elementType: StarterBrickTypes.DYNAMIC_QUICK_BAR,
   label: "Dynamic Quick Bar",
   baseClass: QuickBarProviderStarterBrickABC,
   EditorNode: QuickBarProviderConfiguration,

--- a/src/pageEditor/starterBricks/sidebar.ts
+++ b/src/pageEditor/starterBricks/sidebar.ts
@@ -51,7 +51,6 @@ function fromNativeElement(url: string, metadata: Metadata): SidebarFormState {
   const heading = "Sidebar Panel";
 
   return {
-    type: StarterBrickTypes.SIDEBAR_PANEL,
     label: heading,
     ...base,
     starterBrick: {
@@ -172,7 +171,7 @@ async function fromModComponent(
 
 const config: ModComponentFormStateAdapter<never, SidebarFormState> = {
   displayOrder: 3,
-  elementType: StarterBrickTypes.SIDEBAR_PANEL,
+  starterBrickType: StarterBrickTypes.SIDEBAR_PANEL,
   label: "Sidebar Panel",
   baseClass: SidebarStarterBrickABC,
   selectNativeElement: undefined,

--- a/src/pageEditor/starterBricks/sidebar.ts
+++ b/src/pageEditor/starterBricks/sidebar.ts
@@ -43,6 +43,7 @@ import {
   type SidebarDefinition,
 } from "@/starterBricks/sidebar/sidebarStarterBrickTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 function fromNativeElement(url: string, metadata: Metadata): SidebarFormState {
   const base = makeInitialBaseState();
@@ -50,16 +51,16 @@ function fromNativeElement(url: string, metadata: Metadata): SidebarFormState {
   const heading = "Sidebar Panel";
 
   return {
-    type: "actionPanel",
+    type: StarterBrickTypes.SIDEBAR_PANEL,
     label: heading,
     ...base,
     starterBrick: {
       metadata,
 
       definition: {
-        type: "actionPanel",
+        type: StarterBrickTypes.SIDEBAR_PANEL,
         isAvailable: ALL_SITES_AVAILABILITY,
-        reader: getImplicitReader("actionPanel"),
+        reader: getImplicitReader(StarterBrickTypes.SIDEBAR_PANEL),
 
         trigger: "load",
 
@@ -89,7 +90,7 @@ function selectStarterBrickDefinition(
   return removeEmptyValues({
     ...baseSelectStarterBrick(formState),
     definition: {
-      type: "actionPanel",
+      type: StarterBrickTypes.SIDEBAR_PANEL,
       reader,
       isAvailable,
       trigger,
@@ -120,7 +121,7 @@ function asDraftModComponent(
   sidebarFormState: SidebarFormState,
 ): DraftModComponent {
   return {
-    type: "actionPanel",
+    type: StarterBrickTypes.SIDEBAR_PANEL,
     extension: selectModComponent(sidebarFormState, {
       includeInstanceIds: true,
     }),
@@ -134,8 +135,8 @@ async function fromModComponent(
   const starterBrick = await lookupStarterBrick<
     SidebarDefinition,
     SidebarConfig,
-    "actionPanel"
-  >(config, "actionPanel");
+    typeof StarterBrickTypes.SIDEBAR_PANEL
+  >(config, StarterBrickTypes.SIDEBAR_PANEL);
 
   const base = baseFromModComponent(config, starterBrick.definition.type);
   const modComponent = await modComponentWithNormalizedPipeline(
@@ -171,7 +172,7 @@ async function fromModComponent(
 
 const config: ModComponentFormStateAdapter<never, SidebarFormState> = {
   displayOrder: 3,
-  elementType: "actionPanel",
+  elementType: StarterBrickTypes.SIDEBAR_PANEL,
   label: "Sidebar Panel",
   baseClass: SidebarStarterBrickABC,
   selectNativeElement: undefined,

--- a/src/pageEditor/starterBricks/trigger.ts
+++ b/src/pageEditor/starterBricks/trigger.ts
@@ -46,6 +46,7 @@ import type { DraftModComponent } from "@/contentScript/pageEditor/types";
 import { type TriggerFormState } from "./formStateTypes";
 import { type ModComponentBase } from "@/types/modComponentTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 function fromNativeElement(
   url: string,
@@ -53,13 +54,13 @@ function fromNativeElement(
   _element: null,
 ): TriggerFormState {
   return {
-    type: "trigger",
+    type: StarterBrickTypes.TRIGGER,
     label: `My ${getDomain(url)} trigger`,
     ...makeInitialBaseState(),
     starterBrick: {
       metadata,
       definition: {
-        type: "trigger",
+        type: StarterBrickTypes.TRIGGER,
         trigger: "load",
         rootSelector: undefined,
         attachMode: undefined,
@@ -74,7 +75,7 @@ function fromNativeElement(
         background: true,
         debounce: undefined,
         customEvent: undefined,
-        reader: getImplicitReader("trigger"),
+        reader: getImplicitReader(StarterBrickTypes.TRIGGER),
         isAvailable: getDefaultAvailabilityForUrl(url),
       },
     },
@@ -107,7 +108,7 @@ function selectStarterBrickDefinition(
   return removeEmptyValues({
     ...baseSelectStarterBrick(formState),
     definition: {
-      type: "trigger",
+      type: StarterBrickTypes.TRIGGER,
       reader,
       isAvailable: cleanIsAvailable(isAvailable),
       trigger,
@@ -145,7 +146,7 @@ function asDraftModComponent(
   triggerFormState: TriggerFormState,
 ): DraftModComponent {
   return {
-    type: "trigger",
+    type: StarterBrickTypes.TRIGGER,
     extension: selectModComponent(triggerFormState, {
       includeInstanceIds: true,
     }),
@@ -159,8 +160,8 @@ async function fromModComponent(
   const starterBrick = await lookupStarterBrick<
     TriggerDefinition,
     TriggerConfig,
-    "trigger"
-  >(config, "trigger");
+    typeof StarterBrickTypes.TRIGGER
+  >(config, StarterBrickTypes.TRIGGER);
 
   const {
     rootSelector,
@@ -210,7 +211,7 @@ async function fromModComponent(
 
 const config: ModComponentFormStateAdapter<undefined, TriggerFormState> = {
   displayOrder: 4,
-  elementType: "trigger",
+  elementType: StarterBrickTypes.TRIGGER,
   label: "Trigger",
   baseClass: TriggerStarterBrickABC,
   EditorNode: TriggerConfiguration,

--- a/src/pageEditor/starterBricks/trigger.ts
+++ b/src/pageEditor/starterBricks/trigger.ts
@@ -54,7 +54,6 @@ function fromNativeElement(
   _element: null,
 ): TriggerFormState {
   return {
-    type: StarterBrickTypes.TRIGGER,
     label: `My ${getDomain(url)} trigger`,
     ...makeInitialBaseState(),
     starterBrick: {
@@ -211,7 +210,7 @@ async function fromModComponent(
 
 const config: ModComponentFormStateAdapter<undefined, TriggerFormState> = {
   displayOrder: 4,
-  elementType: StarterBrickTypes.TRIGGER,
+  starterBrickType: StarterBrickTypes.TRIGGER,
   label: "Trigger",
   baseClass: TriggerStarterBrickABC,
   EditorNode: TriggerConfiguration,

--- a/src/pageEditor/store/editor/baseFormStateTypes.ts
+++ b/src/pageEditor/store/editor/baseFormStateTypes.ts
@@ -192,11 +192,26 @@ export type BaseFormStateV3<
   modMetadata: ModComponentBase["_recipe"] | undefined;
 };
 
+/**
+ * @deprecated - Do not use versioned state types directly
+ */
+export type BaseFormStateV4<
+  TModComponent extends BaseModComponentStateV2 = BaseModComponentStateV2,
+  TStarterBrick extends BaseStarterBrickState = BaseStarterBrickState,
+> = Except<
+  BaseFormStateV3<TModComponent, TStarterBrick>,
+  /**
+   * @since 2.0.6
+   * The starter brick type is available on the `starterBrick` property, this is not needed
+   */
+  "type"
+>;
+
 export type BaseFormState<
   TModComponent extends BaseModComponentState = BaseModComponentState,
   TStarterBrick extends BaseStarterBrickState = BaseStarterBrickState,
 > = Except<
-  BaseFormStateV3<TModComponent, TStarterBrick>,
+  BaseFormStateV4<TModComponent, TStarterBrick>,
   "integrationDependencies"
 > & {
   /**

--- a/src/pageEditor/store/editor/editorSelectors.ts
+++ b/src/pageEditor/store/editor/editorSelectors.ts
@@ -73,8 +73,8 @@ export const selectActiveModComponentFormState = createSelector(
 export const selectActiveModId = ({ editor }: EditorRootState) =>
   editor.activeModId;
 
-export const selectIsInsertingNewStarterBrick = ({ editor }: EditorRootState) =>
-  editor.inserting;
+export const selectInsertingStarterBrickType = ({ editor }: EditorRootState) =>
+  editor.insertingStarterBrickType;
 
 export const selectErrorState = ({ editor }: EditorRootState) => ({
   isBetaError: editor.error && editor.beta,

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -114,7 +114,7 @@ export const initialState: EditorState = {
   isDimensionsWarningDismissed: false,
 
   // Not persisted
-  inserting: null,
+  insertingStarterBrickType: null,
   isVariablePopoverVisible: false,
 };
 
@@ -313,8 +313,16 @@ export const editorSlice = createSlice({
     resetEditor() {
       return initialState;
     },
-    toggleInsert(state, action: PayloadAction<StarterBrickType | null>) {
-      state.inserting = action.payload;
+    setInsertingStarterBrickType(
+      state,
+      action: PayloadAction<StarterBrickType>,
+    ) {
+      state.insertingStarterBrickType = action.payload;
+      state.beta = false;
+      state.error = null;
+    },
+    clearInsertingStarterBrickType(state) {
+      state.insertingStarterBrickType = null;
       state.beta = false;
       state.error = null;
     },
@@ -327,7 +335,7 @@ export const editorSlice = createSlice({
     ) {
       const modComponentFormState =
         action.payload as Draft<ModComponentFormState>;
-      state.inserting = null;
+      state.insertingStarterBrickType = null;
       state.modComponentFormStates.push(modComponentFormState);
       state.dirty[modComponentFormState.uuid] = true;
 

--- a/src/pageEditor/store/editor/editorSlice.ts
+++ b/src/pageEditor/store/editor/editorSlice.ts
@@ -1027,10 +1027,11 @@ export const persistEditorConfig = {
   // Change the type of localStorage to our overridden version so that it can be exported
   // See: @/store/StorageInterface.ts
   storage: localStorage as StorageInterface,
-  version: 4,
+  version: 5,
   migrate: createMigrate(migrations, { debug: Boolean(process.env.DEBUG) }),
   blacklist: [
     "inserting",
+    "insertingStarterBrickType",
     "isVarPopoverVisible",
     "isSaveDataIntegrityErrorModalVisible",
     "visibleModalKey",

--- a/src/pageEditor/store/editor/pageEditorTypes.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes.ts
@@ -352,8 +352,15 @@ export type EditorStateV4 = Except<
   deletedModComponentFormStatesByModId: Record<string, BaseFormStateV3[]>;
 };
 
+/**
+ * @deprecated - Do not use versioned state types directly, exported for testing
+ */
+export type EditorStateV5 = Except<EditorStateV4, "inserting"> & {
+  insertingStarterBrickType: StarterBrickType | null;
+};
+
 export type EditorState = Except<
-  EditorStateV4,
+  EditorStateV5,
   "modComponentFormStates" | "deletedModComponentFormStatesByModId"
 > & {
   modComponentFormStates: ModComponentFormState[];

--- a/src/pageEditor/store/editor/pageEditorTypes.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes.ts
@@ -91,7 +91,7 @@ export type EditorStateV1 = {
   inserting: StarterBrickType | null;
 
   /**
-   * The uuid of the active mod component form state, if a mod component is eselected
+   * The uuid of the active mod component form state, if a mod component is selected
    */
   activeElementId: UUID | null;
 

--- a/src/pageEditor/store/editor/pageEditorTypes.ts
+++ b/src/pageEditor/store/editor/pageEditorTypes.ts
@@ -36,9 +36,10 @@ import { type SessionRootState } from "@/pageEditor/store/session/sessionSliceTy
 import { type ModOptionsDefinition } from "@/types/modDefinitionTypes";
 import { type Except } from "type-fest";
 import {
-  type BaseFormStateV3,
   type BaseFormStateV1,
   type BaseFormStateV2,
+  type BaseFormStateV3,
+  type BaseFormStateV4,
 } from "@/pageEditor/store/editor/baseFormStateTypes";
 
 export type AddBrickLocation = {
@@ -90,7 +91,7 @@ export type EditorStateV1 = {
   inserting: StarterBrickType | null;
 
   /**
-   * The uuid of the active mod component form state, if a mod component is selected
+   * The uuid of the active mod component form state, if a mod component is eselected
    */
   activeElementId: UUID | null;
 
@@ -355,8 +356,15 @@ export type EditorStateV4 = Except<
 /**
  * @deprecated - Do not use versioned state types directly, exported for testing
  */
-export type EditorStateV5 = Except<EditorStateV4, "inserting"> & {
+export type EditorStateV5 = Except<
+  EditorStateV4,
+  | "inserting"
+  | "modComponentFormStates"
+  | "deletedModComponentFormStatesByModId"
+> & {
   insertingStarterBrickType: StarterBrickType | null;
+  modComponentFormStates: BaseFormStateV4[];
+  deletedModComponentFormStatesByModId: Record<string, BaseFormStateV4[]>;
 };
 
 export type EditorState = Except<

--- a/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
@@ -21,7 +21,6 @@ import ApiVersionField from "@/pageEditor/fields/ApiVersionField";
 import useFlags from "@/hooks/useFlags";
 import devtoolFieldOverrides from "@/pageEditor/fields/devtoolFieldOverrides";
 import SchemaFieldContext from "@/components/fields/schemaFields/SchemaFieldContext";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { useSelector } from "react-redux";
 import {
   selectActiveModComponentAnalysisAnnotationsForPath,
@@ -38,6 +37,7 @@ import { openShortcutsTab, SHORTCUTS_URL } from "@/utils/extensionUtils";
 import AnalysisAnnotationsContext from "@/analysis/AnalysisAnnotationsContext";
 import { assertNotNullish } from "@/utils/nullishUtils";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
+import { adapterForComponent } from "@/pageEditor/starterBricks/adapter";
 
 const UnconfiguredQuickBarAlert: React.FunctionComponent = () => {
   const { isConfigured } = useQuickbarShortcut();
@@ -66,11 +66,14 @@ const UnconfiguredQuickBarAlert: React.FunctionComponent = () => {
 const FoundationNodeConfigPanel: React.FC = () => {
   const { flagOn } = useFlags();
   const showVersionField = flagOn("page-editor-developer");
-  const { starterBrick } = useSelector(selectActiveModComponentFormState) ?? {};
-  assertNotNullish(
-    starterBrick,
-    "starterBrick not found in active mod component form state",
+  const activeModComponentFormState = useSelector(
+    selectActiveModComponentFormState,
   );
+  assertNotNullish(
+    activeModComponentFormState,
+    "FoundationNodeConfigPanel cannot be rendered when there is no activeModComponentFormState",
+  );
+  const { starterBrick } = activeModComponentFormState;
 
   // For now, don't allow modifying starter brick packages via the Page Editor.
   const isLocked = useMemo(
@@ -78,12 +81,7 @@ const FoundationNodeConfigPanel: React.FC = () => {
     [starterBrick.metadata.id],
   );
 
-  const adapter = ADAPTERS.get(starterBrick.definition.type);
-  assertNotNullish(
-    adapter,
-    `Adapter not found for ${starterBrick.definition.type}`,
-  );
-  const { EditorNode } = adapter;
+  const { EditorNode } = adapterForComponent(activeModComponentFormState);
 
   return (
     <>

--- a/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
+++ b/src/pageEditor/tabs/editTab/FoundationNodeConfigPanel.tsx
@@ -37,6 +37,7 @@ import { isInnerDefinitionRegistryId } from "@/types/helpers";
 import { openShortcutsTab, SHORTCUTS_URL } from "@/utils/extensionUtils";
 import AnalysisAnnotationsContext from "@/analysis/AnalysisAnnotationsContext";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 const UnconfiguredQuickBarAlert: React.FunctionComponent = () => {
   const { isConfigured } = useQuickbarShortcut();
@@ -86,7 +87,7 @@ const FoundationNodeConfigPanel: React.FC = () => {
 
   return (
     <>
-      {starterBrick.definition.type === "quickBar" && (
+      {starterBrick.definition.type === StarterBrickTypes.QUICK_BAR_ACTION && (
         <UnconfiguredQuickBarAlert />
       )}
       <ConnectedFieldTemplate name="label" label="Name" />

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -180,7 +180,10 @@ const DataPanel: React.FC = () => {
 
   const isRenderedPanelStale = useMemo(() => {
     // Only show alert for Panel and Side Panel mod components
-    if (activeModComponentFormState.type !== StarterBrickTypes.SIDEBAR_PANEL) {
+    if (
+      activeModComponentFormState.starterBrick.definition.type !==
+      StarterBrickTypes.SIDEBAR_PANEL
+    ) {
       return false;
     }
 

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.tsx
@@ -59,6 +59,7 @@ import CommentsTab from "@/pageEditor/tabs/editTab/dataPanel/tabs/CommentsTab";
 import reportEvent from "@/telemetry/reportEvent";
 import { Events } from "@/telemetry/events";
 import { BrickTypes } from "@/runtime/runtimeTypes";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 /**
  * Exclude irrelevant top-level keys.
@@ -179,7 +180,7 @@ const DataPanel: React.FC = () => {
 
   const isRenderedPanelStale = useMemo(() => {
     // Only show alert for Panel and Side Panel mod components
-    if (activeModComponentFormState.type !== "actionPanel") {
+    if (activeModComponentFormState.type !== StarterBrickTypes.SIDEBAR_PANEL) {
       return false;
     }
 

--- a/src/pageEditor/tabs/editTab/dataPanel/StarterBrickDataPanel.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/StarterBrickDataPanel.tsx
@@ -29,6 +29,7 @@ import DataTabJsonTree from "./DataTabJsonTree";
 import ModComponentFormStateTab from "./tabs/ModComponentFormStateTab";
 import BrickConfigFormStateTab from "./tabs/BrickConfigFormStateTab";
 import { selectActiveModComponentFormState } from "@/pageEditor/store/editor/editorSelectors";
+import { assertNotNullish } from "@/utils/nullishUtils";
 
 const StarterBrickDataPanel: React.FC = () => {
   const { flagOn } = useFlags();
@@ -37,6 +38,11 @@ const StarterBrickDataPanel: React.FC = () => {
   const activeModComponentFormState = useSelector(
     selectActiveModComponentFormState,
   );
+  assertNotNullish(
+    activeModComponentFormState,
+    "StarterBrickDataPanel cannot be rendered without an activeModComponentFormState",
+  );
+
   const {
     modComponent: { brickPipeline },
     starterBrick,
@@ -138,9 +144,7 @@ const StarterBrickDataPanel: React.FC = () => {
           mountOnEnter
           unmountOnExit
         >
-          <StarterBrickPreview
-            modComponentFormState={activeModComponentFormState}
-          />
+          <StarterBrickPreview />
         </Tab.Pane>
         <ModVariablesTab />
       </Tab.Content>

--- a/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
+++ b/src/pageEditor/tabs/editTab/editorNodeLayout/usePipelineNodes.tsx
@@ -75,13 +75,13 @@ import useApiVersionAtLeast from "@/pageEditor/hooks/useApiVersionAtLeast";
 import { selectModComponentAnnotations } from "@/analysis/analysisSelectors";
 import usePasteBrick from "@/pageEditor/tabs/editTab/editorNodeLayout/usePasteBrick";
 import { type IconProp } from "@fortawesome/fontawesome-svg-core";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { type Brick } from "@/types/brickTypes";
 import { isNullOrBlank } from "@/utils/stringUtils";
 import { joinName, joinPathParts } from "@/utils/formUtils";
 import { SCROLL_TO_DOCUMENT_PREVIEW_ELEMENT_EVENT } from "@/pageEditor/documentBuilder/preview/ElementPreview";
 import { getBrickPipelineNodeSummary } from "@/pageEditor/tabs/editTab/editorNodeLayout/nodeSummary";
 import { BrickTypes } from "@/runtime/runtimeTypes";
+import { adapterForComponent } from "@/pageEditor/starterBricks/adapter";
 
 const ADD_MESSAGE = "Add more bricks with the plus button";
 
@@ -223,9 +223,11 @@ const usePipelineNodes = (): {
   const pasteBlock = usePasteBrick();
   const showPaste = pasteBlock && isApiAtLeastV2;
 
-  const starterBrickType = activeModComponentFormState.type;
-  const { label: starterBrickLabel, icon: starterBrickIcon } =
-    ADAPTERS.get(starterBrickType);
+  const {
+    starterBrickType,
+    label: starterBrickLabel,
+    icon: starterBrickIcon,
+  } = adapterForComponent(activeModComponentFormState);
   const rootPipeline = activeModComponentFormState.modComponent.brickPipeline;
   const rootPipelineFlavor = getRootPipelineFlavor(starterBrickType);
   const [hoveredState, setHoveredState] = useState<Record<UUID, boolean>>({});

--- a/src/pageEditor/tabs/effect/BrickConfiguration.tsx
+++ b/src/pageEditor/tabs/effect/BrickConfiguration.tsx
@@ -169,7 +169,7 @@ const BrickConfiguration: React.FunctionComponent<{
       StarterBrickTypes.QUICK_BAR_ACTION,
       StarterBrickTypes.DYNAMIC_QUICK_BAR,
       StarterBrickTypes.BUTTON,
-    ].includes(context.values.type);
+    ].includes(context.values.starterBrick.definition.type);
   const showIfAndTarget =
     brickType && brickType !== BrickTypes.RENDERER && !isComment;
   const noAdvancedOptions = (!showRootMode && !showIfAndTarget) || isComment;

--- a/src/pageEditor/tabs/effect/StarterBrickPreview.tsx
+++ b/src/pageEditor/tabs/effect/StarterBrickPreview.tsx
@@ -15,25 +15,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { useCallback, useEffect, useReducer } from "react";
+import React, { useCallback, useReducer } from "react";
 import { useDebouncedCallback } from "use-debounce";
 import Loader from "@/components/Loader";
 import { getErrorMessage } from "@/errors/errorHelpers";
 import { runStarterBrickReaderPreview } from "@/contentScript/messenger/api";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
+import { adapterForComponent } from "@/pageEditor/starterBricks/adapter";
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { faSync } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import AsyncButton from "@/components/AsyncButton";
-import {
-  type ModComponentFormState,
-  type TriggerFormState,
-} from "@/pageEditor/starterBricks/formStateTypes";
+import { isTriggerStarterBrick } from "@/pageEditor/starterBricks/formStateTypes";
 import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTypes";
 import DataTabJsonTree from "@/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree";
 import { inspectedTab } from "@/pageEditor/context/connection";
-import { type Nullishable, assertNotNullish } from "@/utils/nullishUtils";
+import { assertNotNullish, type Nullishable } from "@/utils/nullishUtils";
 import { StarterBrickTypes } from "@/types/starterBrickTypes";
+import { useSelector } from "react-redux";
+import { selectActiveModComponentFormState } from "@/pageEditor/store/editor/editorSelectors";
+import { useAsyncEffect } from "use-async-effect";
 
 type PreviewState = {
   isRunning: boolean;
@@ -67,61 +67,57 @@ const previewSlice = createSlice({
   },
 });
 
-const StarterBrickPreview: React.FunctionComponent<{
-  modComponentFormState: ModComponentFormState;
-  previewRefreshMillis?: 250;
-}> = ({ modComponentFormState, previewRefreshMillis }) => {
+const StarterBrickPreview: React.FC = () => {
   const [{ isRunning, output, error }, dispatch] = useReducer(
     previewSlice.reducer,
     initialState,
   );
+  const activeModComponentFormState = useSelector(
+    selectActiveModComponentFormState,
+  );
+  assertNotNullish(
+    activeModComponentFormState,
+    "StarterBrickPreview cannot be rendered without an activeModComponentFormState",
+  );
+  const { starterBrick } = activeModComponentFormState;
 
-  const run = useCallback(
-    async (modComponentFormState: ModComponentFormState) => {
-      dispatch(previewSlice.actions.startRun());
-      try {
-        const adapter = ADAPTERS.get(modComponentFormState.type);
-        assertNotNullish(
-          adapter,
-          `Adapter not found for ${modComponentFormState.type}`,
-        );
-        const { asDraftModComponent: factory } = adapter;
+  const run = useCallback(async () => {
+    dispatch(previewSlice.actions.startRun());
+    try {
+      const { asDraftModComponent } = adapterForComponent(
+        activeModComponentFormState,
+      );
 
-        // Handle click/blur/etc.-based triggers which expect to be run a subset of elements on the page and pass through
-        // data about the element that caused the trigger
-        let rootSelector: Nullishable<string> = null;
-        if (
-          (modComponentFormState as TriggerFormState).starterBrick.definition
-            .rootSelector
-        ) {
-          rootSelector = (modComponentFormState as TriggerFormState)
-            .starterBrick.definition.rootSelector;
-        }
-
-        const data = await runStarterBrickReaderPreview(
-          inspectedTab,
-          factory(modComponentFormState),
-          rootSelector,
-        );
-        dispatch(previewSlice.actions.runSuccess({ "@input": data }));
-      } catch (error) {
-        dispatch(previewSlice.actions.runError(error));
+      // Handle click/blur/etc.-based triggers which expect to be run a subset of elements on the page and pass through
+      // data about the element that caused the trigger
+      let rootSelector: Nullishable<string> = null;
+      if (
+        isTriggerStarterBrick(starterBrick) &&
+        starterBrick.definition.rootSelector
+      ) {
+        rootSelector = starterBrick.definition.rootSelector;
       }
-    },
-    [],
-  );
 
-  const debouncedRun = useDebouncedCallback(
-    async (modComponentFormState: ModComponentFormState) =>
-      run(modComponentFormState),
-    previewRefreshMillis,
-    { trailing: true, leading: false },
-  );
+      const data = await runStarterBrickReaderPreview(
+        inspectedTab,
+        asDraftModComponent(activeModComponentFormState),
+        rootSelector,
+      );
+      dispatch(previewSlice.actions.runSuccess({ "@input": data }));
+    } catch (error) {
+      dispatch(previewSlice.actions.runError(error));
+    }
+  }, [activeModComponentFormState, starterBrick]);
 
-  useEffect(() => {
-    void debouncedRun(modComponentFormState);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- using objectHash for context
-  }, [debouncedRun, modComponentFormState.starterBrick]);
+  const debouncedRun = useDebouncedCallback(run, 250, {
+    trailing: true,
+    leading: false,
+  });
+
+  useAsyncEffect(debouncedRun, [
+    debouncedRun,
+    activeModComponentFormState.starterBrick,
+  ]);
 
   if (isRunning) {
     return (
@@ -131,15 +127,17 @@ const StarterBrickPreview: React.FunctionComponent<{
     );
   }
 
+  const { definition: starterBrickDefinition } = starterBrick;
+
   const reloadTrigger =
-    modComponentFormState.type === StarterBrickTypes.TRIGGER &&
-    modComponentFormState.starterBrick.definition.trigger !== "load" ? (
+    starterBrickDefinition.type === StarterBrickTypes.TRIGGER &&
+    starterBrickDefinition.trigger !== "load" ? (
       <div className="text-info">
         <AsyncButton
           variant="info"
           size="sm"
           className="mr-2"
-          onClick={async () => run(modComponentFormState)}
+          onClick={async () => run()}
         >
           <FontAwesomeIcon icon={faSync} /> Refresh
         </AsyncButton>
@@ -148,13 +146,13 @@ const StarterBrickPreview: React.FunctionComponent<{
     ) : null;
 
   const reloadContextMenu =
-    modComponentFormState.type === StarterBrickTypes.CONTEXT_MENU ? (
+    starterBrickDefinition.type === StarterBrickTypes.CONTEXT_MENU ? (
       <div className="text-info">
         <AsyncButton
           variant="info"
           size="sm"
           className="mr-2"
-          onClick={async () => run(modComponentFormState)}
+          onClick={async () => run()}
         >
           <FontAwesomeIcon icon={faSync} /> Refresh
         </AsyncButton>

--- a/src/pageEditor/tabs/effect/StarterBrickPreview.tsx
+++ b/src/pageEditor/tabs/effect/StarterBrickPreview.tsx
@@ -33,6 +33,7 @@ import { DataPanelTabKey } from "@/pageEditor/tabs/editTab/dataPanel/dataPanelTy
 import DataTabJsonTree from "@/pageEditor/tabs/editTab/dataPanel/DataTabJsonTree";
 import { inspectedTab } from "@/pageEditor/context/connection";
 import { type Nullishable, assertNotNullish } from "@/utils/nullishUtils";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 type PreviewState = {
   isRunning: boolean;
@@ -131,7 +132,7 @@ const StarterBrickPreview: React.FunctionComponent<{
   }
 
   const reloadTrigger =
-    modComponentFormState.type === "trigger" &&
+    modComponentFormState.type === StarterBrickTypes.TRIGGER &&
     modComponentFormState.starterBrick.definition.trigger !== "load" ? (
       <div className="text-info">
         <AsyncButton
@@ -147,7 +148,7 @@ const StarterBrickPreview: React.FunctionComponent<{
     ) : null;
 
   const reloadContextMenu =
-    modComponentFormState.type === "contextMenu" ? (
+    modComponentFormState.type === StarterBrickTypes.CONTEXT_MENU ? (
       <div className="text-info">
         <AsyncButton
           variant="info"

--- a/src/pageEditor/tabs/effect/__snapshots__/BrickConfiguration.test.tsx.snap
+++ b/src/pageEditor/tabs/effect/__snapshots__/BrickConfiguration.test.tsx.snap
@@ -89,11 +89,130 @@ exports[`renders 1`] = `
       <div
         class="body collapse"
       >
-        <small
-          class="text-muted font-italic"
+        <div
+          class="formGroup form-group"
         >
-          No options to show
-        </small>
+          <div
+            class="mb-2 w-100 collapse"
+          >
+            <div
+              class="annotationPlaceholder"
+            />
+          </div>
+          <label
+            class="label form-label"
+            for="modComponent.brickPipeline[0].rootMode"
+          >
+            Target Root Mode
+          </label>
+          <div
+            class="formField"
+          >
+            <div
+              class=" css-b62m3t-container"
+            >
+              <span
+                class="css-1f43avz-a11yText-A11yText"
+                id="react-select-2-live-region"
+              />
+              <span
+                aria-atomic="false"
+                aria-live="polite"
+                aria-relevant="additions text"
+                class="css-1f43avz-a11yText-A11yText"
+                role="log"
+              />
+              <div
+                class=" css-13cymwt-control"
+              >
+                <div
+                  class=" css-1fdsijx-ValueContainer"
+                >
+                  <div
+                    class=" css-1dimb5e-singleValue"
+                  >
+                    Inherit
+                  </div>
+                  <div
+                    class=" css-qbdosj-Input"
+                    data-value=""
+                  >
+                    <input
+                      aria-activedescendant=""
+                      aria-autocomplete="list"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      autocapitalize="none"
+                      autocomplete="off"
+                      autocorrect="off"
+                      class=""
+                      id="modComponent.brickPipeline[0].rootMode"
+                      role="combobox"
+                      spellcheck="false"
+                      style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+                      tabindex="0"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  class=" css-1hb7zxy-IndicatorsContainer"
+                >
+                  <div
+                    aria-hidden="true"
+                    class=" css-1xc3v61-indicatorContainer"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="css-tj5bde-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
+                    >
+                      <path
+                        d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
+                      />
+                    </svg>
+                  </div>
+                  <span
+                    class=" css-1u9des2-indicatorSeparator"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class=" css-1xc3v61-indicatorContainer"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="css-tj5bde-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
+                    >
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <input
+                name="modComponent.brickPipeline[0].rootMode"
+                type="hidden"
+                value="inherit"
+              />
+            </div>
+            <small
+              class="text-muted form-text"
+            >
+              <span>
+                The Root Mode controls the page element the brick targets. PixieBrix evaluates selectors relative to the root document/element
+              </span>
+            </small>
+          </div>
+        </div>
       </div>
     </div>
     <button

--- a/src/pageEditor/tabs/effect/useDocumentPreviewRunBlock.ts
+++ b/src/pageEditor/tabs/effect/useDocumentPreviewRunBlock.ts
@@ -37,9 +37,9 @@ import { isExpression } from "@/utils/expressionUtils";
 import makeIntegrationsContextFromDependencies from "@/integrations/util/makeIntegrationsContextFromDependencies";
 import useAsyncState from "@/hooks/useAsyncState";
 import { inspectedTab } from "@/pageEditor/context/connection";
-import { ADAPTERS } from "@/pageEditor/starterBricks/adapter";
 import { validateRegistryId } from "@/types/helpers";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { adapterForComponent } from "@/pageEditor/starterBricks/adapter";
 
 type Location = "modal" | "panel";
 
@@ -109,7 +109,6 @@ export default function useDocumentPreviewRunBlock(
   const formState = useSelector(selectActiveModComponentFormState);
 
   const {
-    type,
     uuid: modComponentId,
     modMetadata,
     apiVersion,
@@ -179,9 +178,9 @@ export default function useDocumentPreviewRunBlock(
 
       dispatch(previewSlice.actions.startPreview());
 
-      const adapter = ADAPTERS.get(type);
+      const { selectModComponent } = adapterForComponent(formState);
       const starterBrickId = validateRegistryId(
-        adapter.selectModComponent(formState).extensionPointId,
+        selectModComponent(formState).extensionPointId,
       );
       assertNotNullish(starterBrickId, "Expected starter brick id");
 

--- a/src/pageEditor/toolbar/ReloadToolbar.tsx
+++ b/src/pageEditor/toolbar/ReloadToolbar.tsx
@@ -47,7 +47,7 @@ function isAutomaticTrigger(
 ): boolean {
   const automatic = ["load", "appear", "initialize", "interval"];
   return (
-    modComponentFormState?.type === "trigger" &&
+    modComponentFormState?.type === StarterBrickTypes.TRIGGER &&
     automatic.includes(
       modComponentFormState?.starterBrick.definition.trigger ?? "",
     )

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.test.ts
@@ -35,6 +35,7 @@ import {
   type ContextMenuDefinition,
   type ContextMenuConfig,
 } from "@/starterBricks/contextMenu/contextMenuTypes";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 const uninstallContextMenuMock = jest.mocked(uninstallContextMenu);
 const ensureContextMenuMock = jest.mocked(ensureContextMenu);
@@ -51,7 +52,7 @@ const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
         name: "Test Starter Brick",
       }) as Metadata,
     definition: define<ContextMenuDefinition>({
-      type: "contextMenu",
+      type: StarterBrickTypes.CONTEXT_MENU,
       contexts: () => ["page"] as any,
       targetMode: "document",
       isAvailable: () => ({

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
@@ -52,7 +52,7 @@ import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
 import {
   type StarterBrick,
-  StarterBrickType,
+  type StarterBrickType,
   StarterBrickTypes,
 } from "@/types/starterBrickTypes";
 import { type UUID } from "@/types/stringTypes";

--- a/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
+++ b/src/starterBricks/contextMenu/contextMenuStarterBrick.ts
@@ -50,7 +50,11 @@ import { type Reader } from "@/types/bricks/readerTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type HydratedModComponent } from "@/types/modComponentTypes";
 import { type Brick } from "@/types/brickTypes";
-import { type StarterBrick } from "@/types/starterBrickTypes";
+import {
+  type StarterBrick,
+  StarterBrickType,
+  StarterBrickTypes,
+} from "@/types/starterBrickTypes";
 import { type UUID } from "@/types/stringTypes";
 import makeIntegrationsContextFromDependencies from "@/integrations/util/makeIntegrationsContextFromDependencies";
 import pluralize from "@/utils/pluralize";
@@ -137,8 +141,8 @@ export abstract class ContextMenuStarterBrickABC extends StarterBrickABC<Context
 
   abstract readonly contexts: Menus.ContextType[];
 
-  public get kind(): "contextMenu" {
-    return "contextMenu";
+  public get kind(): StarterBrickType {
+    return StarterBrickTypes.CONTEXT_MENU;
   }
 
   readonly capabilities: PlatformCapability[] = ["contextMenu"];
@@ -485,7 +489,7 @@ export function fromJS(
   config: StarterBrickDefinitionLike<ContextMenuDefinition>,
 ): StarterBrick {
   const { type } = config.definition;
-  if (type !== "contextMenu") {
+  if (type !== StarterBrickTypes.CONTEXT_MENU) {
     throw new Error(`Expected type=contextMenu, got ${type}`);
   }
 

--- a/src/starterBricks/quickBar/quickBarStarterBrick.test.ts
+++ b/src/starterBricks/quickBar/quickBarStarterBrick.test.ts
@@ -47,6 +47,7 @@ import {
   type QuickBarDefinition,
   type QuickBarConfig,
 } from "@/starterBricks/quickBar/quickBarTypes";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 const rootReaderId = validateRegistryId("test/root-reader");
 
@@ -66,7 +67,7 @@ const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
         name: "Test Starter Brick",
       }) as Metadata,
     definition: define<QuickBarDefinition>({
-      type: "quickBar",
+      type: StarterBrickTypes.QUICK_BAR_ACTION,
       isAvailable: () => ({
         matchPatterns: ["*://*/*"],
       }),

--- a/src/starterBricks/quickBar/quickBarStarterBrick.tsx
+++ b/src/starterBricks/quickBar/quickBarStarterBrick.tsx
@@ -45,7 +45,7 @@ import { guessSelectedElement } from "@/utils/selectionController";
 import { BusinessError, CancelError } from "@/errors/businessErrors";
 import {
   type StarterBrick,
-  StarterBrickType,
+  type StarterBrickType,
   StarterBrickTypes,
 } from "@/types/starterBrickTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
@@ -76,9 +76,8 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
   static isQuickBarStarterBrick(
     starterBrick: StarterBrick,
   ): starterBrick is QuickBarStarterBrickABC {
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any
-    -- Need to access a type specific property (QuickBarStarterBrick._definition) on a base-typed entity (StarterBrick) */
     return (
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Need to access a type specific property (QuickBarStarterBrick._definition) on a base-typed entity (StarterBrick) */
       (starterBrick as any)?._definition?.type ===
       StarterBrickTypes.QUICK_BAR_ACTION
     );

--- a/src/starterBricks/quickBar/quickBarStarterBrick.tsx
+++ b/src/starterBricks/quickBar/quickBarStarterBrick.tsx
@@ -43,7 +43,11 @@ import quickBarRegistry from "@/components/quickBar/quickBarRegistry";
 import Icon from "@/icons/Icon";
 import { guessSelectedElement } from "@/utils/selectionController";
 import { BusinessError, CancelError } from "@/errors/businessErrors";
-import { type StarterBrick } from "@/types/starterBrickTypes";
+import {
+  type StarterBrick,
+  StarterBrickType,
+  StarterBrickTypes,
+} from "@/types/starterBrickTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type HydratedModComponent } from "@/types/modComponentTypes";
@@ -74,7 +78,10 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
   ): starterBrick is QuickBarStarterBrickABC {
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any
     -- Need to access a type specific property (QuickBarStarterBrick._definition) on a base-typed entity (StarterBrick) */
-    return (starterBrick as any)?._definition?.type === "quickBar";
+    return (
+      (starterBrick as any)?._definition?.type ===
+      StarterBrickTypes.QUICK_BAR_ACTION
+    );
   }
 
   abstract get targetMode(): QuickBarTargetMode;
@@ -114,8 +121,8 @@ export abstract class QuickBarStarterBrickABC extends StarterBrickABC<QuickBarCo
     return collectAllBricks(modComponent.config.action);
   }
 
-  public get kind(): "quickBar" {
-    return "quickBar";
+  public get kind(): StarterBrickType {
+    return StarterBrickTypes.QUICK_BAR_ACTION;
   }
 
   override uninstall(): void {
@@ -364,7 +371,7 @@ export function fromJS(
   config: StarterBrickDefinitionLike<QuickBarDefinition>,
 ): StarterBrick {
   const { type } = config.definition;
-  if (type !== "quickBar") {
+  if (type !== StarterBrickTypes.QUICK_BAR_ACTION) {
     throw new Error(`Expected type=quickBar, got ${type}`);
   }
 

--- a/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.test.ts
+++ b/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.test.ts
@@ -47,6 +47,7 @@ import {
   type QuickBarProviderDefinition,
   type QuickBarProviderConfig,
 } from "@/starterBricks/quickBarProvider/quickBarProviderTypes";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 const rootReaderId = validateRegistryId("test/root-reader");
 
@@ -58,7 +59,7 @@ jest.mock("@/auth/featureFlagStorage", () => ({
 const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
   genericExtensionPointFactory({
     definition: define<QuickBarProviderDefinition>({
-      type: "quickBarProvider",
+      type: StarterBrickTypes.DYNAMIC_QUICK_BAR,
       isAvailable: () => ({
         matchPatterns: ["*://*/*"],
       }),

--- a/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.tsx
+++ b/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.tsx
@@ -43,7 +43,11 @@ import {
   quickbarQueryReaderShim,
 } from "@/starterBricks/quickBarProvider/quickBarQueryReader";
 import { type Reader } from "@/types/bricks/readerTypes";
-import { type StarterBrick } from "@/types/starterBrickTypes";
+import {
+  type StarterBrick,
+  StarterBrickType,
+  StarterBrickTypes,
+} from "@/types/starterBrickTypes";
 import { type UUID } from "@/types/stringTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type HydratedModComponent } from "@/types/modComponentTypes";
@@ -73,7 +77,10 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
   ): starterBrick is QuickBarProviderStarterBrickABC {
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any
     -- Need to access a type specific property (QuickBarProviderStarterBrickABC._definition) on a base-typed entity (StarterBrick) */
-    return (starterBrick as any)?._definition?.type === "quickBarProvider";
+    return (
+      (starterBrick as any)?._definition?.type ===
+      StarterBrickTypes.DYNAMIC_QUICK_BAR
+    );
   }
 
   abstract getBaseReader(): Promise<Reader>;
@@ -116,8 +123,8 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
     return collectAllBricks(modComponent.config.generator);
   }
 
-  public get kind(): "quickBarProvider" {
-    return "quickBarProvider";
+  public get kind(): StarterBrickType {
+    return StarterBrickTypes.DYNAMIC_QUICK_BAR;
   }
 
   override uninstall(): void {
@@ -381,7 +388,7 @@ export function fromJS(
   config: StarterBrickDefinitionLike<QuickBarProviderDefinition>,
 ): StarterBrick {
   const { type } = config.definition;
-  if (type !== "quickBarProvider") {
+  if (type !== StarterBrickTypes.DYNAMIC_QUICK_BAR) {
     throw new Error(`Expected type=quickBarProvider, got ${type}`);
   }
 

--- a/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.tsx
+++ b/src/starterBricks/quickBarProvider/quickBarProviderStarterBrick.tsx
@@ -45,7 +45,7 @@ import {
 import { type Reader } from "@/types/bricks/readerTypes";
 import {
   type StarterBrick,
-  StarterBrickType,
+  type StarterBrickType,
   StarterBrickTypes,
 } from "@/types/starterBrickTypes";
 import { type UUID } from "@/types/stringTypes";
@@ -75,9 +75,8 @@ export abstract class QuickBarProviderStarterBrickABC extends StarterBrickABC<Qu
   static isQuickBarProviderStarterBrick(
     starterBrick: StarterBrick,
   ): starterBrick is QuickBarProviderStarterBrickABC {
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any
-    -- Need to access a type specific property (QuickBarProviderStarterBrickABC._definition) on a base-typed entity (StarterBrick) */
     return (
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Need to access a type specific property (QuickBarProviderStarterBrickABC._definition) on a base-typed entity (StarterBrick) */
       (starterBrick as any)?._definition?.type ===
       StarterBrickTypes.DYNAMIC_QUICK_BAR
     );

--- a/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.test.ts
@@ -46,6 +46,7 @@ import {
   type SidebarDefinition,
   type SidebarConfig,
 } from "@/starterBricks/sidebar/sidebarStarterBrickTypes";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 jest.mock("@/contentScript/sidebarController", () => ({
   ...jest.requireActual("@/contentScript/sidebarController"),
@@ -65,7 +66,7 @@ const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
         name: "Test Starter Brick",
       }) as Metadata,
     definition: define<SidebarDefinition>({
-      type: "actionPanel",
+      type: StarterBrickTypes.SIDEBAR_PANEL,
       isAvailable: () => ({
         matchPatterns: ["*://*/*"],
       }),

--- a/src/starterBricks/sidebar/sidebarStarterBrick.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.ts
@@ -44,7 +44,11 @@ import { type JsonObject } from "type-fest";
 import { type UUID } from "@/types/stringTypes";
 import { type RunArgs, RunReason } from "@/types/runtimeTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
-import { type StarterBrick } from "@/types/starterBrickTypes";
+import {
+  type StarterBrick,
+  StarterBrickType,
+  StarterBrickTypes,
+} from "@/types/starterBrickTypes";
 import { isLoadedInIframe } from "@/utils/iframeUtils";
 import makeIntegrationsContextFromDependencies from "@/integrations/util/makeIntegrationsContextFromDependencies";
 import { ReusableAbortController } from "abort-utils";
@@ -115,8 +119,8 @@ export abstract class SidebarStarterBrickABC extends StarterBrickABC<SidebarConf
   // Historical context: in the browser API, the toolbar icon is bound to an action. This is a panel that's shown
   // when the user toggles the toolbar icon. Hence: actionPanel.
   // See https://developer.chrome.com/docs/extensions/reference/browserAction/
-  public get kind(): "actionPanel" {
-    return "actionPanel";
+  public get kind(): StarterBrickType {
+    return StarterBrickTypes.SIDEBAR_PANEL;
   }
 
   readonly capabilities: PlatformCapability[] = ["panel"];
@@ -484,7 +488,7 @@ export function fromJS(
   config: StarterBrickDefinitionLike,
 ): StarterBrick {
   const { type } = config.definition;
-  if (type !== "actionPanel") {
+  if (type !== StarterBrickTypes.SIDEBAR_PANEL) {
     throw new Error(`Expected type=actionPanel, got ${type}`);
   }
 

--- a/src/starterBricks/sidebar/sidebarStarterBrick.ts
+++ b/src/starterBricks/sidebar/sidebarStarterBrick.ts
@@ -46,7 +46,7 @@ import { type RunArgs, RunReason } from "@/types/runtimeTypes";
 import { type Reader } from "@/types/bricks/readerTypes";
 import {
   type StarterBrick,
-  StarterBrickType,
+  type StarterBrickType,
   StarterBrickTypes,
 } from "@/types/starterBrickTypes";
 import { isLoadedInIframe } from "@/utils/iframeUtils";

--- a/src/starterBricks/starterBrickModUtils.test.ts
+++ b/src/starterBricks/starterBrickModUtils.test.ts
@@ -123,7 +123,7 @@ describe("starterBrickModUtils", () => {
 
       const result = getAllModComponentDefinitionsWithType(
         modDefinition,
-        "actionPanel",
+        StarterBrickTypes.SIDEBAR_PANEL,
       );
 
       expect(result).toStrictEqual([]);

--- a/src/starterBricks/trigger/triggerStarterBrick.test.ts
+++ b/src/starterBricks/trigger/triggerStarterBrick.test.ts
@@ -52,6 +52,7 @@ import reportEvent from "@/telemetry/reportEvent";
 import { screen } from "@testing-library/react";
 import type { Trigger } from "@/starterBricks/trigger/triggerStarterBrickTypes";
 import { getPlatform } from "@/platform/platformContext";
+import { StarterBrickTypes } from "@/types/starterBrickTypes";
 
 let hidden = false;
 
@@ -88,7 +89,7 @@ const starterBrickFactory = (definitionOverrides: UnknownObject = {}) =>
         name: "Test Starter Brick",
       }) as Metadata,
     definition: define<TriggerDefinition>({
-      type: "trigger",
+      type: StarterBrickTypes.TRIGGER,
       background: derive<TriggerDefinition, boolean>((x) =>
         getDefaultAllowInactiveFramesForTrigger(x.trigger!),
       ),

--- a/src/starterBricks/trigger/triggerStarterBrick.ts
+++ b/src/starterBricks/trigger/triggerStarterBrick.ts
@@ -68,7 +68,7 @@ import { type SelectorRoot } from "@/types/runtimeTypes";
 import { type JsonObject } from "type-fest";
 import {
   type StarterBrick,
-  StarterBrickType,
+  type StarterBrickType,
   StarterBrickTypes,
 } from "@/types/starterBrickTypes";
 import {

--- a/src/starterBricks/trigger/triggerStarterBrick.ts
+++ b/src/starterBricks/trigger/triggerStarterBrick.ts
@@ -66,7 +66,11 @@ import { type Brick } from "@/types/brickTypes";
 import { type Schema } from "@/types/schemaTypes";
 import { type SelectorRoot } from "@/types/runtimeTypes";
 import { type JsonObject } from "type-fest";
-import { type StarterBrick } from "@/types/starterBrickTypes";
+import {
+  type StarterBrick,
+  StarterBrickType,
+  StarterBrickTypes,
+} from "@/types/starterBrickTypes";
 import {
   isContextInvalidatedError,
   notifyContextInvalidated,
@@ -208,8 +212,8 @@ export abstract class TriggerStarterBrickABC extends StarterBrickABC<TriggerConf
   private readonly reportedEvents = new Set<UUID>();
   private readonly reportedErrors = new Set<UUID>();
 
-  public get kind(): "trigger" {
-    return "trigger";
+  public get kind(): StarterBrickType {
+    return StarterBrickTypes.TRIGGER;
   }
 
   readonly capabilities: PlatformCapability[] = ["dom", "state"];
@@ -1069,7 +1073,7 @@ export function fromJS(
   config: StarterBrickDefinitionLike<TriggerDefinition>,
 ): StarterBrick {
   const { type } = config.definition;
-  if (type !== "trigger") {
+  if (type !== StarterBrickTypes.TRIGGER) {
     throw new Error(`Expected type=trigger, got ${type}`);
   }
 

--- a/src/store/checkAvailableInstalledExtensions.test.ts
+++ b/src/store/checkAvailableInstalledExtensions.test.ts
@@ -98,7 +98,7 @@ describe("checkAvailableInstalledExtensions", () => {
         },
         definition(): QuickBarDefinition {
           return {
-            type: "quickBar",
+            type: StarterBrickTypes.QUICK_BAR_ACTION,
             contexts: ["all"],
             documentUrlPatterns: [testUrl],
             isAvailable: {

--- a/src/store/editorMigrations.test.ts
+++ b/src/store/editorMigrations.test.ts
@@ -25,7 +25,7 @@ import {
 import { mapValues, omit } from "lodash";
 import {
   formStateFactory,
-  InternalFormStateOverride,
+  type InternalFormStateOverride,
 } from "@/testUtils/factories/pageEditorFactories";
 import {
   type IntegrationDependencyV1,

--- a/src/store/editorMigrations.test.ts
+++ b/src/store/editorMigrations.test.ts
@@ -20,6 +20,7 @@ import {
   type EditorStateV1,
   type EditorStateV2,
   type EditorStateV4,
+  EditorStateV5,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { mapValues, omit } from "lodash";
 import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
@@ -43,6 +44,7 @@ import {
   migrateEditorStateV1,
   migrateEditorStateV2,
   migrateEditorStateV3,
+  migrateEditorStateV4,
 } from "@/store/editorMigrations";
 
 const initialStateV1: EditorStateV1 & PersistedState = {
@@ -150,6 +152,41 @@ const initialStateV4: EditorStateV4 & PersistedState = {
   isDataPanelExpanded: true,
   isDimensionsWarningDismissed: false,
   inserting: null,
+  isVariablePopoverVisible: false,
+  // Function under test does not handle updating the persistence, this is handled by redux-persist
+  _persist: {
+    version: 1,
+    rehydrated: false,
+  },
+};
+
+const initialStateV5: EditorStateV5 & PersistedState = {
+  selectionSeq: 0,
+  activeModComponentId: null,
+  activeModId: null,
+  expandedModId: null,
+  error: null,
+  beta: false,
+  modComponentFormStates: [],
+  knownEditableBrickIds: [],
+  dirty: {},
+  isBetaUI: false,
+  copiedBrick: undefined,
+  brickPipelineUIStateById: {},
+  dirtyModOptionsById: {},
+  dirtyModMetadataById: {},
+  visibleModalKey: null,
+  addBrickLocation: undefined,
+  keepLocalCopyOnCreateMod: false,
+  deletedModComponentFormStatesByModId: {},
+  availableActivatedModComponentIds: [],
+  isPendingAvailableActivatedModComponents: false,
+  availableDraftModComponentIds: [],
+  isPendingDraftModComponents: false,
+  isModListExpanded: true,
+  isDataPanelExpanded: true,
+  isDimensionsWarningDismissed: false,
+  insertingStarterBrickType: null,
   isVariablePopoverVisible: false,
   // Function under test does not handle updating the persistence, this is handled by redux-persist
   _persist: {
@@ -351,6 +388,14 @@ describe("editor state migrations", () => {
       };
       const unmigrated = unmigrateEditorStateV3(expectedState);
       expect(migrateEditorStateV3(unmigrated)).toStrictEqual(expectedState);
+    });
+  });
+
+  describe("migrateEditorStateV4", () => {
+    it("migrates empty state", () => {
+      expect(migrateEditorStateV4(initialStateV4)).toStrictEqual(
+        initialStateV5,
+      );
     });
   });
 });

--- a/src/store/editorMigrations.test.ts
+++ b/src/store/editorMigrations.test.ts
@@ -450,7 +450,7 @@ describe("editor state migrations", () => {
       );
     });
 
-    it("migrates the from states", () => {
+    it("migrates the form states", () => {
       const formStateV2 = formStateFactoryV2();
       const expectedEditorStateV3: EditorStateV3 & PersistedState = {
         ...initialStateV3,

--- a/src/store/editorMigrations.test.ts
+++ b/src/store/editorMigrations.test.ts
@@ -23,7 +23,10 @@ import {
   type EditorStateV5,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { mapValues, omit } from "lodash";
-import { formStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import {
+  formStateFactory,
+  InternalFormStateOverride,
+} from "@/testUtils/factories/pageEditorFactories";
 import {
   type IntegrationDependencyV1,
   type IntegrationDependencyV2,
@@ -352,7 +355,8 @@ function unmigrateEditorStateV5toV4(
 
 type SimpleFactory<T> = (override?: FactoryConfig<T>) => T;
 
-const formStateFactoryV4: SimpleFactory<BaseFormStateV4> = formStateFactory;
+const formStateFactoryV4: SimpleFactory<BaseFormStateV4> = (override) =>
+  formStateFactory(override as InternalFormStateOverride);
 const formStateFactoryV3: SimpleFactory<BaseFormStateV3> = () =>
   unmigrateFormStateV4toV3(formStateFactoryV4());
 const formStateFactoryV2: SimpleFactory<BaseFormStateV2> = () =>

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -33,6 +33,7 @@ import {
   type EditorStateV1,
   type EditorStateV3,
   type EditorStateV4,
+  EditorStateV5,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 
@@ -44,6 +45,7 @@ export const migrations: MigrationManifest = {
   2: (state: EditorStateV1 & PersistedState) => migrateEditorStateV1(state),
   3: (state: EditorStateV2 & PersistedState) => migrateEditorStateV2(state),
   4: (state: EditorStateV3 & PersistedState) => migrateEditorStateV3(state),
+  5: (state: EditorStateV4 & PersistedState) => migrateEditorStateV4(state),
 };
 
 export function migrateIntegrationDependenciesV1toV2(
@@ -156,5 +158,15 @@ export function migrateEditorStateV3({
       deletedModComponentFormStatesByModId,
       (formStates) => formStates.map((element) => migrateFormStateV2(element)),
     ) as Record<string, ModComponentFormState[]>,
+  };
+}
+
+export function migrateEditorStateV4({
+  inserting,
+  ...rest
+}: EditorStateV4 & PersistedState): EditorStateV5 & PersistedState {
+  return {
+    ...rest,
+    insertingStarterBrickType: inserting,
   };
 }

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -162,7 +162,7 @@ export function migrateEditorStateV3({
   };
 }
 
-export function migrateFormStateV3({
+function migrateFormStateV3({
   type,
   ...rest
 }: BaseFormStateV3): BaseFormStateV4 {

--- a/src/store/editorMigrations.ts
+++ b/src/store/editorMigrations.ts
@@ -18,9 +18,10 @@
 import { type PersistedState, type MigrationManifest } from "redux-persist";
 import { mapValues, omit } from "lodash";
 import {
-  type BaseFormStateV3,
   type BaseFormStateV1,
   type BaseFormStateV2,
+  type BaseFormStateV3,
+  type BaseFormStateV4,
   type BaseModComponentStateV1,
   type BaseModComponentStateV2,
 } from "@/pageEditor/store/editor/baseFormStateTypes";
@@ -33,7 +34,7 @@ import {
   type EditorStateV1,
   type EditorStateV3,
   type EditorStateV4,
-  EditorStateV5,
+  type EditorStateV5,
 } from "@/pageEditor/store/editor/pageEditorTypes";
 import { type ModComponentFormState } from "@/pageEditor/starterBricks/formStateTypes";
 
@@ -153,20 +154,36 @@ export function migrateEditorStateV3({
     ...rest,
     modComponentFormStates: modComponentFormStates.map((element) =>
       migrateFormStateV2(element),
-    ) as ModComponentFormState[],
+    ),
     deletedModComponentFormStatesByModId: mapValues(
       deletedModComponentFormStatesByModId,
       (formStates) => formStates.map((element) => migrateFormStateV2(element)),
-    ) as Record<string, ModComponentFormState[]>,
+    ),
   };
+}
+
+export function migrateFormStateV3({
+  type,
+  ...rest
+}: BaseFormStateV3): BaseFormStateV4 {
+  return rest;
 }
 
 export function migrateEditorStateV4({
   inserting,
+  modComponentFormStates,
+  deletedModComponentFormStatesByModId,
   ...rest
 }: EditorStateV4 & PersistedState): EditorStateV5 & PersistedState {
   return {
     ...rest,
     insertingStarterBrickType: inserting,
+    modComponentFormStates: modComponentFormStates.map((element) =>
+      migrateFormStateV3(element),
+    ) as ModComponentFormState[],
+    deletedModComponentFormStatesByModId: mapValues(
+      deletedModComponentFormStatesByModId,
+      (formStates) => formStates.map((element) => migrateFormStateV3(element)),
+    ) as Record<string, ModComponentFormState[]>,
   };
 }

--- a/src/testUtils/factories/modDefinitionFactories.ts
+++ b/src/testUtils/factories/modDefinitionFactories.ts
@@ -45,7 +45,7 @@ import {
 } from "@/testUtils/factories/integrationFactories";
 import { freshIdentifier } from "@/utils/variableUtils";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
-import { Availability } from "@/types/availabilityTypes";
+import { type Availability } from "@/types/availabilityTypes";
 
 export const modComponentDefinitionFactory = define<ModComponentDefinition>({
   id: "extensionPoint" as InnerDefinitionRef,

--- a/src/testUtils/factories/modDefinitionFactories.ts
+++ b/src/testUtils/factories/modDefinitionFactories.ts
@@ -21,9 +21,9 @@ import {
   type ModDefinition,
 } from "@/types/modDefinitionTypes";
 import {
+  DefinitionKinds,
   type InnerDefinitionRef,
   type InnerDefinitions,
-  DefinitionKinds,
   type RegistryId,
 } from "@/types/registryTypes";
 import { type OutputKey } from "@/types/runtimeTypes";
@@ -45,6 +45,7 @@ import {
 } from "@/testUtils/factories/integrationFactories";
 import { freshIdentifier } from "@/utils/variableUtils";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
+import { Availability } from "@/types/availabilityTypes";
 
 export const modComponentDefinitionFactory = define<ModComponentDefinition>({
   id: "extensionPoint" as InnerDefinitionRef,
@@ -70,6 +71,17 @@ export const modDefinitionFactory = define<ModDefinition>({
   extensionPoints: array(modComponentDefinitionFactory, 1),
 });
 
+export const starterBrickDefinitionPropFactory =
+  define<StarterBrickDefinitionProp>({
+    type: StarterBrickTypes.BUTTON,
+    isAvailable(n: number): Availability {
+      return {
+        matchPatterns: [`https://www.mySite${n}.com/*`],
+      };
+    },
+    reader: validateRegistryId("@pixiebrix/document-context"),
+  });
+
 export const starterBrickDefinitionFactory = define<StarterBrickDefinitionLike>(
   {
     kind: DefinitionKinds.STARTER_BRICK,
@@ -79,15 +91,7 @@ export const starterBrickDefinitionFactory = define<StarterBrickDefinitionLike>(
         id: validateRegistryId(`test/starter-brick-${n}`),
         name: `Starter Brick ${n}`,
       }),
-    definition(n: number) {
-      return {
-        type: StarterBrickTypes.BUTTON,
-        isAvailable: {
-          matchPatterns: [`https://www.mySite${n}.com/*`],
-        },
-        reader: validateRegistryId("@pixiebrix/document-context"),
-      } satisfies StarterBrickDefinitionProp;
-    },
+    definition: starterBrickDefinitionPropFactory,
   },
 );
 

--- a/src/testUtils/factories/pageEditorFactories.ts
+++ b/src/testUtils/factories/pageEditorFactories.ts
@@ -57,7 +57,9 @@ export const baseModComponentStateFactory = define<BaseModComponentState>({
   brickPipeline: () => pipelineFactory(),
 });
 
-type InternalFormStateOverride = Except<
+// TODO: Work out the type conflicts between StarterBrickDefinitionLike and BaseStarterBrickState
+//       and then we can remove this type completely.
+export type InternalFormStateOverride = Except<
   ModComponentFormState,
   "starterBrick"
 > & {
@@ -85,12 +87,12 @@ const internalFormStateFactory = define<InternalFormStateOverride>({
 });
 
 export const formStateFactory = (
-  override?: FactoryConfig<ModComponentFormState>,
+  override?: FactoryConfig<InternalFormStateOverride>,
   pipelineOverride?: BrickPipeline,
   starterBrickOverride?: StarterBrickDefinitionLike,
 ): ModComponentFormState => {
   const factoryConfig: FactoryConfig<InternalFormStateOverride> =
-    (override as FactoryConfig<InternalFormStateOverride>) || {};
+    override || {};
 
   if (pipelineOverride) {
     factoryConfig.modComponent = baseModComponentStateFactory({
@@ -131,7 +133,7 @@ export const triggerFormStateFactory = (
     {
       ...defaultTriggerProps,
       ...override,
-    } as FactoryConfig<ModComponentFormState>,
+    } as FactoryConfig<InternalFormStateOverride>,
     pipelineOverride,
   ) as TriggerFormState;
 };
@@ -154,7 +156,7 @@ export const sidebarPanelFormStateFactory = (
     {
       ...defaultTriggerProps,
       ...override,
-    } as FactoryConfig<ModComponentFormState>,
+    } as FactoryConfig<InternalFormStateOverride>,
     pipelineOverride,
   ) as SidebarFormState;
 };
@@ -176,7 +178,7 @@ export const contextMenuFormStateFactory = (
     {
       ...defaultTriggerProps,
       ...override,
-    } as FactoryConfig<ModComponentFormState>,
+    } as FactoryConfig<InternalFormStateOverride>,
     pipelineOverride,
   ) as ContextMenuFormState;
 };
@@ -198,7 +200,7 @@ export const quickbarFormStateFactory = (
     {
       ...defaultTriggerProps,
       ...override,
-    } as FactoryConfig<ModComponentFormState>,
+    } as FactoryConfig<InternalFormStateOverride>,
     pipelineOverride,
   ) as QuickBarFormState;
 };
@@ -224,7 +226,7 @@ export const menuItemFormStateFactory = (
     {
       ...defaultTriggerProps,
       ...override,
-    } as FactoryConfig<ModComponentFormState>,
+    } as FactoryConfig<InternalFormStateOverride>,
     pipelineOverride,
   ) as ButtonFormState;
 };

--- a/src/testUtils/factories/pageEditorFactories.ts
+++ b/src/testUtils/factories/pageEditorFactories.ts
@@ -32,7 +32,6 @@ import {
 import { uuidSequence } from "@/testUtils/factories/stringFactories";
 import { type IntegrationDependency } from "@/integrations/integrationTypes";
 import { type StarterBrickDefinitionLike } from "@/starterBricks/types";
-import { StarterBrickTypes } from "@/types/starterBrickTypes";
 import { starterBrickDefinitionFactory } from "@/testUtils/factories/modDefinitionFactories";
 import { metadataFactory } from "@/testUtils/factories/metadataFactory";
 import { type BrickPipeline } from "@/bricks/types";
@@ -43,26 +42,26 @@ import { type ButtonSelectionResult } from "@/contentScript/pageEditor/types";
 import quickBar from "@/pageEditor/starterBricks/quickBar";
 import trigger from "@/pageEditor/starterBricks/trigger";
 import { type TraceRecord } from "@/telemetry/trace";
-import { type JsonObject } from "type-fest";
+import { type Except, type JsonObject } from "type-fest";
 import sidebar from "@/pageEditor/starterBricks/sidebar";
 import { traceRecordFactory } from "@/testUtils/factories/traceFactories";
 import {
   brickConfigFactory,
   pipelineFactory,
 } from "@/testUtils/factories/brickFactories";
-import { type DerivedFunction } from "cooky-cutter/dist/derive";
 import { type BaseModComponentState } from "@/pageEditor/store/editor/baseFormStateTypes";
 import { assertNotNullish } from "@/utils/nullishUtils";
+import { type Permissions } from "webextension-polyfill";
 
 export const baseModComponentStateFactory = define<BaseModComponentState>({
   brickPipeline: () => pipelineFactory(),
 });
 
-type InternalFormStateOverride = ModComponentFormState & {
-  extensionPoint: DerivedFunction<
-    ModComponentFormState,
-    StarterBrickDefinitionLike
-  >;
+type InternalFormStateOverride = Except<
+  ModComponentFormState,
+  "starterBrick"
+> & {
+  starterBrick: StarterBrickDefinitionLike;
 };
 
 const internalFormStateFactory = define<InternalFormStateOverride>({
@@ -74,38 +73,36 @@ const internalFormStateFactory = define<InternalFormStateOverride>({
     return [];
   },
   modMetadata: undefined,
-  type: StarterBrickTypes.SIDEBAR_PANEL,
+  permissions(): Permissions.Permissions {
+    return {
+      permissions: [],
+      origins: [],
+    };
+  },
   label: (i: number) => `Element ${i}`,
   modComponent: baseModComponentStateFactory,
-  // @ts-expect-error -- TODO: verify typings
-  starterBrick: derive<ModComponentFormState, StarterBrickDefinitionLike>(
-    ({ type }) => {
-      // FIXME: the starter brick type produced is not based on the type provided
-      const starterBrick = starterBrickDefinitionFactory();
-      if (type) {
-        starterBrick.definition.type = type;
-      }
-
-      return starterBrick;
-    },
-    "type",
-  ),
+  starterBrick: starterBrickDefinitionFactory,
 });
 
 export const formStateFactory = (
   override?: FactoryConfig<ModComponentFormState>,
   pipelineOverride?: BrickPipeline,
+  starterBrickOverride?: StarterBrickDefinitionLike,
 ): ModComponentFormState => {
+  const factoryConfig: FactoryConfig<InternalFormStateOverride> =
+    (override as FactoryConfig<InternalFormStateOverride>) || {};
+
   if (pipelineOverride) {
-    return internalFormStateFactory({
-      ...override,
-      modComponent: baseModComponentStateFactory({
-        brickPipeline: pipelineOverride,
-      }),
-    } as InternalFormStateOverride);
+    factoryConfig.modComponent = baseModComponentStateFactory({
+      brickPipeline: pipelineOverride,
+    });
   }
 
-  return internalFormStateFactory(override as InternalFormStateOverride);
+  if (starterBrickOverride) {
+    factoryConfig.starterBrick = starterBrickOverride;
+  }
+
+  return internalFormStateFactory(factoryConfig) as ModComponentFormState;
 };
 
 // Define a method to reset the sequence for formStateFactory given that it's not a factory definition


### PR DESCRIPTION
## What does this PR do?

- Tons of cleanup work branching off from cleanup of starter brick type string references, like hard-coded `"actionPanel"` instead of `StarterBrickTypes.SIDEBAR_PANEL`
- Fixed the ADAPTERS interface/dev-api so you don't have to worry about strict null checks at every single call site

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
