### PR TITLE
Only retry sandbox postMessage on TimeoutErrors

### DIFF
--- a/src/sandbox/messenger/api.ts
+++ b/src/sandbox/messenger/api.ts
@@ -24,6 +24,7 @@ import { memoizeUntilSettled } from "@/utils/promiseUtils";
 import pRetry from "p-retry";
 import { type JsonObject } from "type-fest";
 import { TimeoutError } from "p-timeout";
+import { isSpecificError } from "@/errors/errorHelpers";
 
 const SANDBOX_SHADOW_ROOT_ID = "pixiebrix-sandbox";
 
@@ -73,7 +74,7 @@ async function postSandboxMessage<TReturn extends Payload = Payload>({
         }),
       {
         retries: 3,
-        shouldRetry: (error) => error.name === TimeoutError.name,
+        shouldRetry: (error) => isSpecificError(error, TimeoutError),
         onFailedAttempt(error) {
           console.warn(
             `Failed to send message ${type} to sandbox. Retrying... Attempt ${error.attemptNumber}`,
@@ -82,7 +83,7 @@ async function postSandboxMessage<TReturn extends Payload = Payload>({
       },
     );
   } catch (error) {
-    if (error.name === TimeoutError.name) {
+    if (isSpecificError(error, TimeoutError)) {
       throw new Error(
         `Failed to send message ${type} to sandbox. The host page may be preventing the sandbox from loading.`,
         {

--- a/src/sandbox/messenger/api.ts
+++ b/src/sandbox/messenger/api.ts
@@ -82,12 +82,16 @@ async function postSandboxMessage<TReturn extends Payload = Payload>({
       },
     );
   } catch (error) {
-    throw new Error(
-      `Failed to send message ${type} to sandbox. The host page may be preventing the sandbox from loading.`,
-      {
-        cause: error,
-      },
-    );
+    if (error.name === TimeoutError.name) {
+      throw new Error(
+        `Failed to send message ${type} to sandbox. The host page may be preventing the sandbox from loading.`,
+        {
+          cause: error,
+        },
+      );
+    }
+
+    throw error;
   }
 }
 

--- a/src/sandbox/messenger/api.ts
+++ b/src/sandbox/messenger/api.ts
@@ -23,6 +23,7 @@ import pMemoize, { pMemoizeClear } from "p-memoize";
 import { memoizeUntilSettled } from "@/utils/promiseUtils";
 import pRetry from "p-retry";
 import { type JsonObject } from "type-fest";
+import { TimeoutError } from "p-timeout";
 
 const SANDBOX_SHADOW_ROOT_ID = "pixiebrix-sandbox";
 
@@ -72,7 +73,7 @@ async function postSandboxMessage<TReturn extends Payload = Payload>({
         }),
       {
         retries: 3,
-        shouldRetry: (error) => error.name === "TimeoutError",
+        shouldRetry: (error) => error.name === TimeoutError.name,
         onFailedAttempt(error) {
           console.warn(
             `Failed to send message ${type} to sandbox. Retrying... Attempt ${error.attemptNumber}`,

--- a/src/sandbox/messenger/api.ts
+++ b/src/sandbox/messenger/api.ts
@@ -72,6 +72,7 @@ async function postSandboxMessage<TReturn extends Payload = Payload>({
         }),
       {
         retries: 3,
+        shouldRetry: (error) => error.name === "TimeoutError",
         onFailedAttempt(error) {
           console.warn(
             `Failed to send message ${type} to sandbox. Retrying... Attempt ${error.attemptNumber}`,


### PR DESCRIPTION
## What does this PR do?

- Closes https://github.com/pixiebrix/pixiebrix-extension/issues/8821
- We were retrying the sandbox message for for e.g. failed javascript errors instead of throwing the original error
