### PR TITLE
#8828: constant brick condition lint and analysis action bug fixes

### DIFF
--- a/src/analysis/analysisTypes.ts
+++ b/src/analysis/analysisTypes.ts
@@ -23,6 +23,7 @@ import { type UUID } from "@/types/stringTypes";
 
 export enum AnalysisAnnotationActionType {
   AddValueToArray,
+  UnsetValue,
 }
 
 export type AnalysisAnnotationAction = {

--- a/src/analysis/analysisVisitors/conditionAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/conditionAnalysis.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { triggerFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import { ContextBrick } from "@/runtime/pipelineTests/pipelineTestHelpers";
+import { validateOutputKey } from "@/runtime/runtimeTypes";
+import { AnnotationType } from "@/types/annotationTypes";
+import ConditionAnalysis from "@/analysis/analysisVisitors/conditionAnalysis";
+import { toExpression } from "@/utils/expressionUtils";
+import { AnalysisAnnotationActionType } from "@/analysis/analysisTypes";
+
+describe("conditionAnalysis", () => {
+  it("no warning for unset field", async () => {
+    const formState = triggerFormStateFactory({}, [
+      {
+        id: ContextBrick.BLOCK_ID,
+        config: {},
+        outputKey: validateOutputKey("foo"),
+      },
+    ]);
+
+    const analysis = new ConditionAnalysis();
+    analysis.run(formState);
+
+    expect(analysis.getAnnotations()).toEqual([]);
+  });
+
+  it("warning for blank value", async () => {
+    const formState = triggerFormStateFactory({}, [
+      {
+        id: ContextBrick.BLOCK_ID,
+        config: {},
+        if: toExpression("nunjucks", " "),
+        outputKey: validateOutputKey("foo"),
+      },
+    ]);
+
+    const analysis = new ConditionAnalysis();
+    analysis.run(formState);
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      expect.objectContaining({
+        type: AnnotationType.Warning,
+        actions: [
+          expect.objectContaining({
+            caption: "Exclude Condition",
+            type: AnalysisAnnotationActionType.UnsetValue,
+            path: "modComponent.brickPipeline.0.if",
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it.each([true, false])("info for boolean literal", async (value) => {
+    const formState = triggerFormStateFactory({}, [
+      {
+        id: ContextBrick.BLOCK_ID,
+        config: {},
+        if: value,
+        outputKey: validateOutputKey("foo"),
+      },
+    ]);
+
+    const analysis = new ConditionAnalysis();
+    analysis.run(formState);
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      expect.objectContaining({
+        type: AnnotationType.Info,
+      }),
+    ]);
+  });
+
+  it.each(["y", "f"])("info for template literal", async (value) => {
+    const formState = triggerFormStateFactory({}, [
+      {
+        id: ContextBrick.BLOCK_ID,
+        config: {},
+        if: toExpression("nunjucks", value),
+        outputKey: validateOutputKey("foo"),
+      },
+    ]);
+
+    const analysis = new ConditionAnalysis();
+    analysis.run(formState);
+
+    expect(analysis.getAnnotations()).toStrictEqual([
+      expect.objectContaining({
+        type: AnnotationType.Info,
+      }),
+    ]);
+  });
+});

--- a/src/analysis/analysisVisitors/conditionAnalysis.ts
+++ b/src/analysis/analysisVisitors/conditionAnalysis.ts
@@ -18,7 +18,7 @@
 import { nestedPosition, type VisitBlockExtra } from "@/bricks/PipelineVisitor";
 import { type BrickConfig, type BrickPosition } from "@/bricks/types";
 import { AnalysisVisitorABC } from "./baseAnalysisVisitors";
-import { castConstantCondition } from "@/runtime/runtimeUtils";
+import { getConstantConditionOrUndefined } from "@/runtime/runtimeUtils";
 import { isTemplateExpression } from "@/utils/expressionUtils";
 import { isNullOrBlank } from "@/utils/stringUtils";
 import { AnnotationType } from "@/types/annotationTypes";
@@ -39,7 +39,7 @@ class ConditionAnalysis extends AnalysisVisitorABC {
     const conditionPosition = nestedPosition(position, "if");
     const condition = brickConfig.if;
 
-    if (castConstantCondition(condition) != null) {
+    if (getConstantConditionOrUndefined(condition) != null) {
       if (
         isTemplateExpression(condition) &&
         isNullOrBlank(condition.__value__)
@@ -58,7 +58,7 @@ class ConditionAnalysis extends AnalysisVisitorABC {
             },
           ],
         });
-      } else if (castConstantCondition(condition)) {
+      } else if (getConstantConditionOrUndefined(condition)) {
         this.annotations.push({
           position: conditionPosition,
           message:

--- a/src/analysis/analysisVisitors/conditionAnalysis.ts
+++ b/src/analysis/analysisVisitors/conditionAnalysis.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { nestedPosition, type VisitBlockExtra } from "@/bricks/PipelineVisitor";
+import { type BrickConfig, type BrickPosition } from "@/bricks/types";
+import { AnalysisVisitorABC } from "./baseAnalysisVisitors";
+import { castConstantCondition } from "@/runtime/runtimeUtils";
+import { isTemplateExpression } from "@/utils/expressionUtils";
+import { isNullOrBlank } from "@/utils/stringUtils";
+import { AnnotationType } from "@/types/annotationTypes";
+import { AnalysisAnnotationActionType } from "@/analysis/analysisTypes";
+
+class ConditionAnalysis extends AnalysisVisitorABC {
+  get id() {
+    return "condition";
+  }
+
+  override visitBrick(
+    position: BrickPosition,
+    brickConfig: BrickConfig,
+    extra: VisitBlockExtra,
+  ): void {
+    super.visitBrick(position, brickConfig, extra);
+
+    const conditionPosition = nestedPosition(position, "if");
+    const condition = brickConfig.if;
+
+    if (castConstantCondition(condition) != null) {
+      if (
+        isTemplateExpression(condition) &&
+        isNullOrBlank(condition.__value__)
+      ) {
+        this.annotations.push({
+          position: conditionPosition,
+          message:
+            "Blank conditions are considered falsy. Did you mean to exclude the condition?",
+          analysisId: this.id,
+          type: AnnotationType.Warning,
+          actions: [
+            {
+              caption: "Exclude Condition",
+              type: AnalysisAnnotationActionType.UnsetValue,
+              path: conditionPosition.path,
+            },
+          ],
+        });
+      } else if (castConstantCondition(condition)) {
+        this.annotations.push({
+          position: conditionPosition,
+          message:
+            "Constant truthy condition found. The brick will always run. Did you mean to exclude the condition?",
+          analysisId: this.id,
+          type: AnnotationType.Info,
+          actions: [
+            {
+              caption: "Exclude Condition",
+              type: AnalysisAnnotationActionType.UnsetValue,
+              path: conditionPosition.path,
+            },
+          ],
+        });
+      } else {
+        this.annotations.push({
+          position: conditionPosition,
+          message: "Constant falsy condition found. The brick will never run",
+          analysisId: this.id,
+          type: AnnotationType.Info,
+        });
+      }
+    }
+  }
+}
+
+export default ConditionAnalysis;

--- a/src/bricks/types.ts
+++ b/src/bricks/types.ts
@@ -60,10 +60,10 @@ export function hasMultipleTargets(
 }
 
 /**
- * Condition expression written in templateEngine for deciding if the step should be run.
+ * Condition expression written in templateEngine for deciding if the brick should run.
  * @see {@link BrickConfig.if}
  */
-export type BlockIf = string | boolean | number | Expression;
+export type BrickCondition = string | boolean | number | Expression;
 
 /**
  * A brick configuration to be executed by the PixieBrix runtime.
@@ -126,9 +126,9 @@ export type BrickConfig = {
   /**
    * (Optional) condition expression written in templateEngine for deciding if the step should be run. If not
    * provided, the step is run unconditionally.
-   * @see BlockIf
+   * @see BrickCondition
    */
-  if?: BlockIf;
+  if?: BrickCondition;
 
   /**
    * (Optional) whether the brick should inherit the current root element, or if it should use the document

--- a/src/components/form/makeFieldActionForAnnotationAction.test.tsx
+++ b/src/components/form/makeFieldActionForAnnotationAction.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2024 PixieBrix, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import { triggerFormStateFactory } from "@/testUtils/factories/pageEditorFactories";
+import { ContextBrick } from "@/runtime/pipelineTests/pipelineTestHelpers";
+import { toExpression } from "@/utils/expressionUtils";
+import { validateOutputKey } from "@/runtime/runtimeTypes";
+import { makeFieldActionForAnnotationAction } from "@/components/form/makeFieldActionForAnnotationAction";
+import { render } from "@/pageEditor/testHelpers";
+import { useFormikContext } from "formik";
+import { AnalysisAnnotationActionType } from "@/analysis/analysisTypes";
+import AsyncButton from "@/components/AsyncButton";
+import { screen, act } from "@testing-library/react";
+
+describe("makeFieldActionForAnnotationAction", () => {
+  it("unsets field value", async () => {
+    const expectedCaption = "Unset Value";
+
+    const formState = triggerFormStateFactory(undefined, [
+      {
+        id: ContextBrick.BLOCK_ID,
+        config: {},
+        if: toExpression("nunjucks", " "),
+        outputKey: validateOutputKey("foo"),
+      },
+    ]);
+
+    const TestComponent = () => {
+      const formik = useFormikContext();
+
+      const { caption, action } = makeFieldActionForAnnotationAction(
+        {
+          caption: expectedCaption,
+          type: AnalysisAnnotationActionType.UnsetValue,
+          path: "modComponent.brickPipeline.0.if",
+        },
+        formik,
+      );
+
+      return (
+        <AsyncButton
+          onClick={async () => {
+            await action();
+          }}
+        >
+          {caption}
+        </AsyncButton>
+      );
+    };
+
+    const { getFormState } = render(<TestComponent />, {
+      initialValues: formState,
+    });
+
+    expect(getFormState().modComponent.brickPipeline[0].if).toBeDefined();
+
+    await act(async () => {
+      screen.getByRole("button", { name: expectedCaption }).click();
+    });
+
+    expect(getFormState().modComponent.brickPipeline[0].if).toBeUndefined();
+  });
+});

--- a/src/components/form/makeFieldActionForAnnotationAction.ts
+++ b/src/components/form/makeFieldActionForAnnotationAction.ts
@@ -19,7 +19,9 @@ import {
   type AnalysisAnnotationAction,
   AnalysisAnnotationActionType,
 } from "@/analysis/analysisTypes";
-import { type FormikContextType, getIn, setIn } from "formik";
+import { type FormikContextType } from "formik";
+// Use lodash's get/set because formik's does not mutate the object in place.
+import { get as getIn, set as setIn } from "lodash";
 import type { FieldAnnotationAction } from "@/components/form/FieldAnnotation";
 import { produce } from "immer";
 
@@ -31,10 +33,20 @@ export function makeFieldActionForAnnotationAction<Values>(
     caption: action.caption,
     async action() {
       const newValues = produce(formik.values, (draft) => {
-        if (action.type === AnalysisAnnotationActionType.AddValueToArray) {
-          const array = getIn(draft, action.path) as unknown[];
-          array.push(action.value);
-          setIn(draft, action.path, array);
+        switch (action.type) {
+          case AnalysisAnnotationActionType.AddValueToArray: {
+            const array = getIn(draft, action.path) as unknown[];
+            array.push(action.value);
+            setIn(draft as UnknownObject, action.path, array);
+            break;
+          }
+
+          case AnalysisAnnotationActionType.UnsetValue: {
+            setIn(draft as UnknownObject, action.path, undefined);
+            break;
+          }
+
+          default:
         }
       });
 

--- a/src/pageEditor/store/analysisManager.ts
+++ b/src/pageEditor/store/analysisManager.ts
@@ -46,6 +46,7 @@ import ModVariableNames from "@/analysis/analysisVisitors/pageStateAnalysis/modV
 import { inspectedTab } from "@/pageEditor/context/connection";
 import SelectorAnalysis from "@/analysis/analysisVisitors/selectorAnalysis";
 import { StateNamespaces } from "@/platform/state/stateController";
+import ConditionAnalysis from "@/analysis/analysisVisitors/conditionAnalysis";
 
 const runtimeActions = runtimeSlice.actions;
 
@@ -226,6 +227,16 @@ async function varAnalysisFactory(
     modVariables: variables.knownSchemas,
   });
 }
+
+pageEditorAnalysisManager.registerAnalysisEffect(
+  () => new ConditionAnalysis(),
+  {
+    matcher: isAnyOf(
+      editorActions.syncModComponentFormState,
+      ...nodeListMutationActions,
+    ),
+  },
+);
 
 // OutputKeyAnalysis seems to be the slowest one, so we register it in the end
 pageEditorAnalysisManager.registerAnalysisEffect(

--- a/src/pageEditor/tabs/effect/AdvancedLinks.test.tsx
+++ b/src/pageEditor/tabs/effect/AdvancedLinks.test.tsx
@@ -24,19 +24,19 @@ import AdvancedLinks, {
   DEFAULT_WINDOW_VALUE,
 } from "./AdvancedLinks";
 
-const BLOCK_FIELD_NAME = "block";
+const BRICK_FIELD_NAME = "block";
 
 describe("Advanced options", () => {
-  function renderAdvancedLinks(blockConfig: FormikValues) {
+  function renderAdvancedLinks(brickConfig: FormikValues) {
     const FormikTemplate = createFormikTemplate({
-      [BLOCK_FIELD_NAME]: blockConfig,
+      [BRICK_FIELD_NAME]: brickConfig,
     });
 
     const ComponentUnderTest = () => {
       const scrollToRef = useRef<HTMLElement>(null);
       return (
         <FormikTemplate>
-          <AdvancedLinks name={BLOCK_FIELD_NAME} scrollToRef={scrollToRef} />
+          <AdvancedLinks name={BRICK_FIELD_NAME} scrollToRef={scrollToRef} />
         </FormikTemplate>
       );
     };
@@ -52,8 +52,8 @@ describe("Advanced options", () => {
     {
       window: DEFAULT_WINDOW_VALUE,
     },
-  ])("doesn't show advanced links by default", (blockConfig) => {
-    renderAdvancedLinks(blockConfig);
+  ])("doesn't show advanced links by default", (brickConfig) => {
+    renderAdvancedLinks(brickConfig);
 
     expect(screen.getAllByRole("button")).toHaveLength(1);
   });
@@ -69,7 +69,19 @@ describe("Advanced options", () => {
       {
         if: "true",
       },
-      "Condition: true",
+      "Condition: Always",
+    ],
+    [
+      {
+        if: "false",
+      },
+      "Condition: Never",
+    ],
+    [
+      {
+        if: " ",
+      },
+      "Condition: Never",
     ],
     [
       {
@@ -77,8 +89,8 @@ describe("Advanced options", () => {
       },
       "Target: Target Tab",
     ],
-  ])("shows changed advanced options", (blockConfig, expectedOptionText) => {
-    renderAdvancedLinks(blockConfig);
+  ])("shows changed advanced options", (brickConfig, expectedOptionText) => {
+    renderAdvancedLinks(brickConfig);
 
     expect(
       screen.getByRole("button", { name: expectedOptionText }),

--- a/src/pageEditor/tabs/effect/AdvancedLinks.tsx
+++ b/src/pageEditor/tabs/effect/AdvancedLinks.tsx
@@ -26,7 +26,7 @@ import { Button } from "react-bootstrap";
 import { isExpression } from "@/utils/expressionUtils";
 import { joinName } from "@/utils/formUtils";
 import { windowOptions } from "@/pageEditor/tabs/effect/configurationConstants";
-import { castConstantCondition } from "@/runtime/runtimeUtils";
+import { getConstantConditionOrUndefined } from "@/runtime/runtimeUtils";
 
 export const DEFAULT_TEMPLATE_ENGINE_VALUE: TemplateEngine = "mustache";
 
@@ -40,7 +40,7 @@ type AdvancedLinksProps = {
 const ConditionPreview: React.FunctionComponent<{
   condition: BrickCondition;
 }> = ({ condition }) => {
-  const constantCondition = castConstantCondition(condition);
+  const constantCondition = getConstantConditionOrUndefined(condition);
 
   if (constantCondition == null) {
     const value = isExpression(condition) ? condition.__value__ : condition;

--- a/src/runtime/runtimeUtils.test.ts
+++ b/src/runtime/runtimeUtils.test.ts
@@ -16,7 +16,7 @@
  */
 
 import {
-  castConstantCondition,
+  getConstantConditionOrUndefined,
   isApiVersionAtLeast,
 } from "@/runtime/runtimeUtils";
 import { toExpression } from "@/utils/expressionUtils";
@@ -39,23 +39,29 @@ describe("isApiVersionAtLeast()", () => {
 describe("castConstantCondition", () => {
   it("returns undefined for non-constant conditions", () => {
     expect(
-      castConstantCondition(toExpression("nunjucks", "{{ @input.foo }}")),
+      getConstantConditionOrUndefined(
+        toExpression("nunjucks", "{{ @input.foo }}"),
+      ),
     ).toBeUndefined();
   });
 
   it("returns true for truthy string", () => {
-    expect(castConstantCondition(toExpression("nunjucks", "yes"))).toBe(true);
+    expect(
+      getConstantConditionOrUndefined(toExpression("nunjucks", "yes")),
+    ).toBe(true);
   });
 
   it("returns false for empty string", () => {
-    expect(castConstantCondition(toExpression("nunjucks", ""))).toBe(false);
+    expect(getConstantConditionOrUndefined(toExpression("nunjucks", ""))).toBe(
+      false,
+    );
   });
 
   it("returns false for falsy string value", () => {
-    expect(castConstantCondition("{{ @input.foo }}")).toBe(false);
+    expect(getConstantConditionOrUndefined("{{ @input.foo }}")).toBe(false);
   });
 
   it.each([true, false])("returns boolean literal: %s", (value) => {
-    expect(castConstantCondition(value)).toBe(value);
+    expect(getConstantConditionOrUndefined(value)).toBe(value);
   });
 });

--- a/src/runtime/runtimeUtils.test.ts
+++ b/src/runtime/runtimeUtils.test.ts
@@ -15,7 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isApiVersionAtLeast } from "@/runtime/runtimeUtils";
+import {
+  castConstantCondition,
+  isApiVersionAtLeast,
+} from "@/runtime/runtimeUtils";
+import { toExpression } from "@/utils/expressionUtils";
 
 describe("isApiVersionAtLeast()", () => {
   test("v2 is at least v1", () => {
@@ -29,5 +33,29 @@ describe("isApiVersionAtLeast()", () => {
   });
   test("v1 is not at least v2", () => {
     expect(isApiVersionAtLeast("v1", "v2")).toBe(false);
+  });
+});
+
+describe("castConstantCondition", () => {
+  it("returns undefined for non-constant conditions", () => {
+    expect(
+      castConstantCondition(toExpression("nunjucks", "{{ @input.foo }}")),
+    ).toBeUndefined();
+  });
+
+  it("returns true for truthy string", () => {
+    expect(castConstantCondition(toExpression("nunjucks", "yes"))).toBe(true);
+  });
+
+  it("returns false for empty string", () => {
+    expect(castConstantCondition(toExpression("nunjucks", ""))).toBe(false);
+  });
+
+  it("returns false for falsy string value", () => {
+    expect(castConstantCondition("{{ @input.foo }}")).toBe(false);
+  });
+
+  it.each([true, false])("returns boolean literal: %s", (value) => {
+    expect(castConstantCondition(value)).toBe(value);
   });
 });

--- a/src/runtime/runtimeUtils.ts
+++ b/src/runtime/runtimeUtils.ts
@@ -23,6 +23,7 @@ import {
 import { InputValidationError, OutputValidationError } from "@/bricks/errors";
 import { isEmpty } from "lodash";
 import {
+  type BrickCondition,
   type BrickConfig,
   type BrickWindow,
   hasMultipleTargets,
@@ -52,6 +53,12 @@ import {
 import { excludeUndefined } from "@/utils/objectUtils";
 import { boolean } from "@/utils/typeUtils";
 import { $safeFind } from "@/utils/domUtils";
+import {
+  castTextLiteralOrThrow,
+  isExpression,
+  isTextLiteralOrNull,
+} from "@/utils/expressionUtils";
+import { Nullishable } from "@/utils/nullishUtils";
 
 /**
  * @throws InputValidationError if brickArgs does not match the input schema for brick
@@ -138,6 +145,36 @@ async function renderConfigOption(
   })) as { value: unknown };
 
   return value;
+}
+
+/**
+ * Returns the boolean value of a constant condition, or undefined if the condition is not a constant.
+ * @param condition the brick condition
+ * @see BrickConfig.if
+ */
+export function castConstantCondition(
+  condition: Nullishable<BrickCondition>,
+): boolean | undefined {
+  if (condition == null) {
+    return undefined;
+  }
+
+  if (isTextLiteralOrNull(condition)) {
+    const text = castTextLiteralOrThrow(condition);
+    return boolean(text);
+  }
+
+  const value = isExpression(condition) ? condition.__value__ : condition;
+
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/runtime/runtimeUtils.ts
+++ b/src/runtime/runtimeUtils.ts
@@ -58,7 +58,7 @@ import {
   isExpression,
   isTextLiteralOrNull,
 } from "@/utils/expressionUtils";
-import { Nullishable } from "@/utils/nullishUtils";
+import { type Nullishable } from "@/utils/nullishUtils";
 
 /**
  * @throws InputValidationError if brickArgs does not match the input schema for brick
@@ -151,8 +151,9 @@ async function renderConfigOption(
  * Returns the boolean value of a constant condition, or undefined if the condition is not a constant.
  * @param condition the brick condition
  * @see BrickConfig.if
+ * @since 2.0.6
  */
-export function castConstantCondition(
+export function getConstantConditionOrUndefined(
   condition: Nullishable<BrickCondition>,
 ): boolean | undefined {
   if (condition == null) {

--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -78,6 +78,8 @@
     "./analysis/analysisVisitors/brickIdVisitor.ts",
     "./analysis/analysisVisitors/brickTypeAnalysis.test.ts",
     "./analysis/analysisVisitors/brickTypeAnalysis.ts",
+    "./analysis/analysisVisitors/conditionAnalysis.ts",
+    "./analysis/analysisVisitors/conditionAnalysis.test.ts",
     "./analysis/analysisVisitors/eventNameAnalysis/checkEventNamesAnalysis.test.ts",
     "./analysis/analysisVisitors/eventNameAnalysis/checkEventNamesAnalysis.ts",
     "./analysis/analysisVisitors/eventNameAnalysis/collectEventNamesVisitor.test.ts",


### PR DESCRIPTION
## What does this PR do?

- Closes #8828
- Add lint rules for constant brick conditions
- 🐛 Fixes bug in `makeFieldActionForAnnotationAction` where state wasn't being updated
- 🐛 Fixes bug in brick condition summary where literal values were not being displayed properly

## Discussion

- The warning shows when the user first toggles into the field to write a text template. It's a bit annoying as the warning shifts the field down

## Demo

- https://www.loom.com/share/96ad75e0bf804bca85660069b2c461e5?sid=d8e5b36f-2b5a-4c84-8628-afc422ab023f

For more information on our expectations for the PR process, see the
[code review principles doc](https://www.notion.so/pixiebrix/Code-Review-Principles-1ce7276b82a84d2a995d55ad85e1310d?pvs=4)
