### PR TITLE
mark brickActions as a slow test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   SERVICE_URL: https://app-stg.pixiebrix.com/
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/end-to-end-tests/tests/pageEditor/brickActions.spec.ts
+++ b/end-to-end-tests/tests/pageEditor/brickActions.spec.ts
@@ -31,6 +31,11 @@ test("brick actions panel behavior", async ({
   newPageEditorPage,
   verifyModDefinitionSnapshot,
 }) => {
+  test.slow(
+    true,
+    "Longer test due to verifying each brick action in one user flow",
+  );
+
   const { id: modId } = modDefinitionsMap[testModDefinitionName];
   const { id: otherModId } = modDefinitionsMap[otherTestMod];
   let pageEditorPage: PageEditorPage;


### PR DESCRIPTION
## What does this PR do?

- This PR adds a flag to slow down a test in the `brickActions.spec.ts` file. This was the cause for some flaky tests since it was right on the edge of 60s.
- Also fixes the concurrency setting on the github CI workflow so it only cancels workflows on the same PR.