### PR TITLE
eslint rule for consistent `it` test title usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,6 +63,17 @@ module.exports = {
       "error",
       { ignore: ["eslint-enable"] },
     ],
+    "jest/valid-title": [
+      "error",
+      {
+        mustNotMatch: {
+          test: [
+            /^it/.source,
+            'Test title should not begin with `it`. Use `it("should ...")` or omit `it` from the title instead.',
+          ],
+        },
+      },
+    ],
     "local-rules/noNullRtkQueryArgs": "error",
     "local-rules/noInvalidDataTestId": "error",
     "local-rules/noExpressionLiterals": "error",

--- a/src/analysis/analysisVisitors/requestPermissionAnalysis.test.ts
+++ b/src/analysis/analysisVisitors/requestPermissionAnalysis.test.ts
@@ -45,7 +45,7 @@ describe("requestPermissionAnalysis", () => {
     containsMock.mockReset();
   });
 
-  test("it annotates http: url", async () => {
+  it("annotates http: url", async () => {
     const visitor = new RequestPermissionAnalysis();
     const formState = brickModComponentFactory("http://example.com");
 
@@ -63,7 +63,7 @@ describe("requestPermissionAnalysis", () => {
     ]);
   });
 
-  test("it annotates invalid url", async () => {
+  it("annotates invalid url", async () => {
     const visitor = new RequestPermissionAnalysis();
     const formState = brickModComponentFactory(
       "https://there is a space in here",
@@ -82,7 +82,7 @@ describe("requestPermissionAnalysis", () => {
     ]);
   });
 
-  test("it annotates insufficient permissions", async () => {
+  it("annotates insufficient permissions", async () => {
     const visitor = new RequestPermissionAnalysis();
     const formState = brickModComponentFactory("https://example.com");
 

--- a/src/background/installer.test.ts
+++ b/src/background/installer.test.ts
@@ -220,7 +220,7 @@ describe("checkPartnerAuth", () => {
 });
 
 describe("handleInstall", () => {
-  test("it opens extension console if not linked on CWS install", async () => {
+  it("opens extension console if not linked on CWS install", async () => {
     // App setup tab isn't open
     queryTabsMock.mockResolvedValue([]);
     isLinkedMock.mockResolvedValue(false);

--- a/src/bricks/effects/CancelEffect.test.ts
+++ b/src/bricks/effects/CancelEffect.test.ts
@@ -23,7 +23,7 @@ import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 const brick = new CancelEffect();
 
 describe("CancelEffect", () => {
-  test("it throws CancelError", async () => {
+  it("throws CancelError", async () => {
     await expect(
       brick.run(unsafeAssumeValidArg({}), brickOptionsFactory()),
     ).rejects.toThrow(CancelError);

--- a/src/bricks/effects/assignModVariable.test.ts
+++ b/src/bricks/effects/assignModVariable.test.ts
@@ -116,7 +116,7 @@ describe("@pixiebrix/state/assign", () => {
     ).toEqual({ foo: 42, bar: 0 });
   });
 
-  test("it returns mod variables", async () => {
+  it("returns mod variables", async () => {
     await expect(
       brick.getModVariableSchema({
         id: brick.id,

--- a/src/bricks/effects/attachAutocomplete.test.ts
+++ b/src/bricks/effects/attachAutocomplete.test.ts
@@ -47,7 +47,7 @@ describe("AttachAutocomplete", () => {
     await expect(brick.isRootAware()).resolves.toBe(true);
   });
 
-  test("it attaches autocomplete", async () => {
+  it("attaches autocomplete", async () => {
     await brick.run(
       unsafeAssumeValidArg({ selector: "[name='name']" }),
       brickOptionsFactory({
@@ -61,7 +61,7 @@ describe("AttachAutocomplete", () => {
     );
   });
 
-  test("it is root aware", async () => {
+  it("is root aware", async () => {
     await brick.run(
       unsafeAssumeValidArg({ selector: "[name='name']", isRootAware: true }),
       brickOptionsFactory({

--- a/src/bricks/effects/customEvent.test.ts
+++ b/src/bricks/effects/customEvent.test.ts
@@ -44,7 +44,7 @@ describe("CustomEventEffect", () => {
     await expect(brick.isRootAware()).resolves.toBe(true);
   });
 
-  test("it fires custom event", async () => {
+  it("fires custom event", async () => {
     const eventHandler = jest.fn();
     document.querySelector("button")!.addEventListener("foo", eventHandler);
 
@@ -59,7 +59,7 @@ describe("CustomEventEffect", () => {
     expect(eventHandler).toHaveBeenCalled();
   });
 
-  test("it bubbles custom event", async () => {
+  it("bubbles custom event", async () => {
     const eventHandler = jest.fn();
     document.querySelector("div")!.addEventListener("foo", eventHandler);
 

--- a/src/bricks/effects/disable.test.ts
+++ b/src/bricks/effects/disable.test.ts
@@ -36,8 +36,8 @@ describe("DisableEffect", () => {
     await expect(brick.isRootAware()).resolves.toBe(true);
   });
 
-  test.each([undefined, false])(
-    "it disable element for isRootAware: %s",
+  it.each([undefined, false])(
+    "disable element for isRootAware: %s",
     async (isRootAware) => {
       await brick.run(
         unsafeAssumeValidArg({ selector: "button", isRootAware }),
@@ -50,7 +50,7 @@ describe("DisableEffect", () => {
     },
   );
 
-  test("it disables element for isRootAware: true", async () => {
+  it("disables element for isRootAware: true", async () => {
     await brick.run(
       unsafeAssumeValidArg({ isRootAware: true }),
       brickOptionsFactory({

--- a/src/bricks/effects/enable.test.ts
+++ b/src/bricks/effects/enable.test.ts
@@ -32,8 +32,8 @@ describe("EnableEffect", () => {
     `;
   });
 
-  test.each([undefined, false])(
-    "it enables element for isRootAware: %s",
+  it.each([undefined, false])(
+    "enables element for isRootAware: %s",
     async (isRootAware) => {
       await brick.run(
         unsafeAssumeValidArg({ selector: "button", isRootAware }),
@@ -44,7 +44,7 @@ describe("EnableEffect", () => {
     },
   );
 
-  test("it enables element for isRootAware: true", async () => {
+  it("enables element for isRootAware: true", async () => {
     await brick.run(
       unsafeAssumeValidArg({ isRootAware: true }),
       brickOptionsFactory({ root: document.querySelector("button")! }),

--- a/src/bricks/effects/error.test.ts
+++ b/src/bricks/effects/error.test.ts
@@ -23,7 +23,7 @@ import { brickOptionsFactory } from "@/testUtils/factories/runtimeFactories";
 const brick = new ErrorEffect();
 
 describe("ErrorEffect", () => {
-  test("it throws BusinessError", async () => {
+  it("throws BusinessError", async () => {
     await expect(
       brick.run(unsafeAssumeValidArg({}), brickOptionsFactory()),
     ).rejects.toThrow(BusinessError);

--- a/src/bricks/effects/event.test.ts
+++ b/src/bricks/effects/event.test.ts
@@ -36,8 +36,8 @@ describe("ElementEvent", () => {
     await expect(brick.isRootAware()).resolves.toBe(true);
   });
 
-  test.each([undefined, false])(
-    "it clicks element for isRootAware: %s",
+  it.each([undefined, false])(
+    "clicks element for isRootAware: %s",
     async (isRootAware) => {
       const clickHandler = jest.fn();
       document.querySelector("button")!.addEventListener("click", clickHandler);
@@ -55,7 +55,7 @@ describe("ElementEvent", () => {
     },
   );
 
-  test("it clicks element for isRootAware: true", async () => {
+  it("clicks element for isRootAware: true", async () => {
     const clickHandler = jest.fn();
     document.querySelector("button")!.addEventListener("click", clickHandler);
 

--- a/src/bricks/effects/forms.test.ts
+++ b/src/bricks/effects/forms.test.ts
@@ -43,7 +43,7 @@ describe("SetInputValue", () => {
     await expect(setInputValueBrick.isRootAware()).resolves.toBe(true);
   });
 
-  test("it sets text field value", async () => {
+  it("sets text field value", async () => {
     await setInputValueBrick.run(
       unsafeAssumeValidArg({
         inputs: [{ selector: "[name='name']", value: "Bob Smith" }],
@@ -54,7 +54,7 @@ describe("SetInputValue", () => {
     expect(document.querySelector("[name='name']")).toHaveValue("Bob Smith");
   });
 
-  test("it is root aware", async () => {
+  it("is root aware", async () => {
     await setInputValueBrick.run(
       unsafeAssumeValidArg({
         inputs: [{ selector: "[name='name']", value: "Bob Smith" }],
@@ -138,7 +138,7 @@ describe("FormFill", () => {
     await expect(formFillBrick.isRootAware()).resolves.toBe(true);
   });
 
-  test("it sets text field value", async () => {
+  it("sets text field value", async () => {
     await formFillBrick.run(
       unsafeAssumeValidArg({
         formSelector: "form",
@@ -150,7 +150,7 @@ describe("FormFill", () => {
     expect(document.querySelector("[name='name']")).toHaveValue("Bob Smith");
   });
 
-  test("it is root aware", async () => {
+  it("is root aware", async () => {
     const promise = formFillBrick.run(
       unsafeAssumeValidArg({
         formSelector: "form",

--- a/src/bricks/effects/hide.test.ts
+++ b/src/bricks/effects/hide.test.ts
@@ -36,8 +36,8 @@ describe("HideEffect", () => {
     await expect(brick.isRootAware()).resolves.toBe(true);
   });
 
-  test.each([undefined, false])(
-    "it hides element for isRootAware: %s",
+  it.each([undefined, false])(
+    "hides element for isRootAware: %s",
     async (isRootAware) => {
       await brick.run(
         unsafeAssumeValidArg({ selector: "button", isRootAware }),
@@ -48,7 +48,7 @@ describe("HideEffect", () => {
     },
   );
 
-  test("it hides element for isRootAware: true", async () => {
+  it("hides element for isRootAware: true", async () => {
     await brick.run(
       unsafeAssumeValidArg({ isRootAware: true }),
       brickOptionsFactory({ root: document.querySelector("button")! }),
@@ -57,7 +57,7 @@ describe("HideEffect", () => {
     expect(document.querySelector("button")).not.toBeVisible();
   });
 
-  test("it removes element", async () => {
+  it("removes element", async () => {
     await brick.run(
       unsafeAssumeValidArg({ isRootAware: true, mode: "remove" }),
       brickOptionsFactory({ root: document.querySelector("button")! }),

--- a/src/bricks/effects/scrollToElement.test.ts
+++ b/src/bricks/effects/scrollToElement.test.ts
@@ -44,7 +44,7 @@ describe("ScrollToElementEffect", () => {
     await expect(brick.isRootAware()).resolves.toBe(true);
   });
 
-  test("it scrolls for selector", async () => {
+  it("scrolls for selector", async () => {
     await brick.run(
       unsafeAssumeValidArg({ selector: "button" }),
       brickOptionsFactory(),
@@ -53,7 +53,7 @@ describe("ScrollToElementEffect", () => {
     expect(scrollIntoViewMock).toHaveBeenCalled();
   });
 
-  test("it scrolls to element for element for isRootAware: true", async () => {
+  it("scrolls to element for element for isRootAware: true", async () => {
     await brick.run(
       unsafeAssumeValidArg({}),
       brickOptionsFactory({ root: document.querySelector("button")! }),

--- a/src/bricks/effects/show.test.ts
+++ b/src/bricks/effects/show.test.ts
@@ -36,8 +36,8 @@ describe("ShowEffect", () => {
     await expect(brick.isRootAware()).resolves.toBe(true);
   });
 
-  test.each([undefined, false])(
-    "it shows element for isRootAware: %s",
+  it.each([undefined, false])(
+    "shows element for isRootAware: %s",
     async (isRootAware) => {
       expect(document.querySelector("button")).not.toBeVisible();
 
@@ -50,7 +50,7 @@ describe("ShowEffect", () => {
     },
   );
 
-  test("it shows element for isRootAware: true", async () => {
+  it("shows element for isRootAware: true", async () => {
     await brick.run(
       unsafeAssumeValidArg({ isRootAware: true }),
       brickOptionsFactory({ root: document.querySelector("button")! }),

--- a/src/bricks/effects/wait.test.ts
+++ b/src/bricks/effects/wait.test.ts
@@ -49,8 +49,8 @@ describe("WaitElementEffect", () => {
     await expect(brick.isRootAware()).resolves.toBe(true);
   });
 
-  test.each([undefined, false])(
-    "it wait element isRootAware: %s",
+  it.each([undefined, false])(
+    "wait element isRootAware: %s",
     async (isRootAware) => {
       await brick.run(
         unsafeAssumeValidArg({ selector: "button", isRootAware }),
@@ -59,7 +59,7 @@ describe("WaitElementEffect", () => {
     },
   );
 
-  test("it wait element for isRootAware: true", async () => {
+  it("wait element for isRootAware: true", async () => {
     await brick.run(
       unsafeAssumeValidArg({ selector: "button", isRootAware: true }),
       brickOptionsFactory({

--- a/src/bricks/readers/ElementReader.test.ts
+++ b/src/bricks/readers/ElementReader.test.ts
@@ -30,7 +30,7 @@ describe("ElementReader", () => {
     );
   });
 
-  test("it produces valid element reference", async () => {
+  it("produces valid element reference", async () => {
     const div = document.createElement("div");
     const { ref } = await reader.read(div);
     expect(validateUUID(ref)).not.toBeNull();

--- a/src/bricks/transformers/IdentityTransformer.test.ts
+++ b/src/bricks/transformers/IdentityTransformer.test.ts
@@ -49,7 +49,7 @@ describe("IdentityTransformer.schema", () => {
 });
 
 describe("IdentityTransformer.run", () => {
-  test("it returns same value", async () => {
+  it("returns same value", async () => {
     const value = { foo: "bar" };
     const result = await brick.run(
       unsafeAssumeValidArg(value),
@@ -58,7 +58,7 @@ describe("IdentityTransformer.run", () => {
     expect(result).toStrictEqual(value);
   });
 
-  test("it accepts null", async () => {
+  it("accepts null", async () => {
     const result = await brick.run(
       unsafeAssumeValidArg(null),
       brickOptionsFactory(),
@@ -66,7 +66,7 @@ describe("IdentityTransformer.run", () => {
     expect(result).toBeNull();
   });
 
-  test("it accepts array", async () => {
+  it("accepts array", async () => {
     const result = await brick.run(
       unsafeAssumeValidArg([]),
       brickOptionsFactory(),

--- a/src/bricks/transformers/detect.test.ts
+++ b/src/bricks/transformers/detect.test.ts
@@ -39,22 +39,19 @@ describe("DetectElement", () => {
     await expect(brick.isRootAware()).resolves.toBe(true);
   });
 
-  test.each([undefined, false])(
-    "it detects element: %s",
-    async (isRootAware) => {
-      const result = await brick.run(
-        unsafeAssumeValidArg({ selector: "button", isRootAware }),
-        brickOptionsFactory(),
-      );
+  it.each([undefined, false])("detects element: %s", async (isRootAware) => {
+    const result = await brick.run(
+      unsafeAssumeValidArg({ selector: "button", isRootAware }),
+      brickOptionsFactory(),
+    );
 
-      expect(result).toStrictEqual({
-        count: 1,
-        exists: true,
-      });
-    },
-  );
+    expect(result).toStrictEqual({
+      count: 1,
+      exists: true,
+    });
+  });
 
-  test("it uses root if isRootAware: true", async () => {
+  it("uses root if isRootAware: true", async () => {
     const result = await brick.run(
       unsafeAssumeValidArg({ selector: "button", isRootAware: true }),
       brickOptionsFactory({

--- a/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
+++ b/src/bricks/transformers/temporaryInfo/DisplayTemporaryInfo.test.ts
@@ -95,7 +95,7 @@ describe("DisplayTemporaryInfo", () => {
     await expect(displayTemporaryInfoBlock.isRootAware()).resolves.toBe(true);
   });
 
-  test("it returns run payload for sidebar panel", async () => {
+  it("returns run payload for sidebar panel", async () => {
     const modComponentRef = modComponentRefFactory();
 
     const config = getExampleBrickConfig(renderer.id);
@@ -137,7 +137,7 @@ describe("DisplayTemporaryInfo", () => {
     });
   });
 
-  test("it returns error", async () => {
+  it("returns error", async () => {
     const message = "display info test error";
 
     const pipeline = {
@@ -171,7 +171,7 @@ describe("DisplayTemporaryInfo", () => {
     expect(errorMessage).toStrictEqual(message);
   });
 
-  test("it registers panel for modal", async () => {
+  it("registers panel for modal", async () => {
     const config = getExampleBrickConfig(renderer.id);
     const pipeline = {
       id: displayTemporaryInfoBlock.id,
@@ -209,7 +209,7 @@ describe("DisplayTemporaryInfo", () => {
     });
   });
 
-  test("it errors from frame", async () => {
+  it("errors from frame", async () => {
     const modComponentRef = modComponentRefFactory();
     jest.mocked(isLoadedInIframe).mockReturnValue(true);
 
@@ -253,7 +253,7 @@ describe("DisplayTemporaryInfo", () => {
     ).rejects.toThrow("Target must be an element for popover");
   });
 
-  test("it registers a popover panel", async () => {
+  it("registers a popover panel", async () => {
     document.body.innerHTML = '<div><div id="target"></div></div>';
 
     const config = getExampleBrickConfig(renderer.id);
@@ -284,7 +284,7 @@ describe("DisplayTemporaryInfo", () => {
     ).not.toBeNull();
   });
 
-  test("it listens for statechange", async () => {
+  it("listens for statechange", async () => {
     document.body.innerHTML = '<div><div id="target"></div></div>';
 
     const deferredPromise = pDefer<any>();

--- a/src/components/fields/schemaFields/schemaFieldUtils.test.ts
+++ b/src/components/fields/schemaFields/schemaFieldUtils.test.ts
@@ -19,7 +19,7 @@ import { sortedFields } from "@/components/fields/schemaFields/schemaFieldUtils"
 import { type Schema } from "@/types/schemaTypes";
 
 describe("sortedFields", () => {
-  test("it sorts by type first", () => {
+  it("sorts by type first", () => {
     expect(
       sortedFields(
         {
@@ -35,7 +35,7 @@ describe("sortedFields", () => {
     ).toStrictEqual(["zzz", "aaa"]);
   });
 
-  test("it sorts by database type first", () => {
+  it("sorts by database type first", () => {
     expect(
       sortedFields(
         {
@@ -51,7 +51,7 @@ describe("sortedFields", () => {
     ).toStrictEqual(["zzz", "aaa"]);
   });
 
-  test("it prefers title", () => {
+  it("prefers title", () => {
     expect(
       sortedFields(
         {
@@ -68,7 +68,7 @@ describe("sortedFields", () => {
     ).toStrictEqual(["bbb", "aaa"]);
   });
 
-  test("it sorts by uiSchema order with missing entry", () => {
+  it("sorts by uiSchema order with missing entry", () => {
     // Unlike RFSJ, don't throw an error if an entry is missing. Just throw it at the end
     expect(
       sortedFields(
@@ -90,7 +90,7 @@ describe("sortedFields", () => {
     ).toStrictEqual(["bbb", "aaa", "ccc"]);
   });
 
-  test("it sorts by uiSchema *", () => {
+  it("sorts by uiSchema *", () => {
     expect(
       sortedFields(
         {
@@ -111,7 +111,7 @@ describe("sortedFields", () => {
     ).toStrictEqual(["bbb", "ccc", "aaa"]);
   });
 
-  test("it sorts optional fields", () => {
+  it("sorts optional fields", () => {
     expect(
       sortedFields(
         {

--- a/src/components/fields/schemaFields/widgets/varPopup/VariablesTree.test.tsx
+++ b/src/components/fields/schemaFields/widgets/varPopup/VariablesTree.test.tsx
@@ -47,7 +47,7 @@ testItRenders({
 });
 
 describe("VariablesTree", () => {
-  test("it sorts nested variables", () => {
+  it("sorts nested variables", () => {
     const varMap = new VarMap();
     varMap.setExistenceFromValues({
       source: "input",

--- a/src/components/fields/schemaFields/widgets/varPopup/getMenuOptions.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/getMenuOptions.test.ts
@@ -177,7 +177,7 @@ describe("arrays", () => {
 });
 
 describe("mod variables", () => {
-  test("it includes mod variables entry", async () => {
+  it("includes mod variables entry", async () => {
     const analysis = new VarAnalysis({ modState: { foo: 42 } });
     const extension = formStateFactory({
       brickPipeline: [brickConfigFactory()],

--- a/src/components/fields/schemaFields/widgets/varPopup/menuFilters.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/menuFilters.test.ts
@@ -254,13 +254,13 @@ describe("expandCurrentVariableLevel", () => {
 });
 
 describe("defaultMenuOption", () => {
-  test("handles empty var map", () => {
+  it("handles empty var map", () => {
     const options = getMenuOptions(new VarMap(), {});
     const filteredOptions = filterOptionsByVariable(options, "@input.foo");
     expect(defaultMenuOption(filteredOptions, "@input.foo")).toBeNull();
   });
 
-  test("defaults to exact nested variable", () => {
+  it("defaults to exact nested variable", () => {
     const varMap = new VarMap();
     varMap.setExistenceFromValues({
       source: "input",
@@ -282,7 +282,7 @@ describe("defaultMenuOption", () => {
     ]);
   });
 
-  test("defaults to first partial match", () => {
+  it("defaults to first partial match", () => {
     const varMap = new VarMap();
     varMap.setExistenceFromValues({
       source: "input",
@@ -324,7 +324,7 @@ describe("defaultMenuOption", () => {
     ]);
   });
 
-  test("default for '@'", () => {
+  it("default for '@'", () => {
     const varMap = new VarMap();
     varMap.setExistenceFromValues({
       source: "input",
@@ -343,7 +343,7 @@ describe("defaultMenuOption", () => {
     expect(defaultMenuOption(filteredOptions, "@")).toEqual(["@input"]);
   });
 
-  test("default to last source", () => {
+  it("default to last source", () => {
     const varMap = new VarMap();
     varMap.setExistenceFromValues({
       source: "input",
@@ -371,7 +371,7 @@ describe("defaultMenuOption", () => {
 });
 
 describe("moveMenuOption", () => {
-  test("moves to next matching nested option", () => {
+  it("moves to next matching nested option", () => {
     const varMap = new VarMap();
     varMap.setExistenceFromValues({
       source: "input",
@@ -396,7 +396,7 @@ describe("moveMenuOption", () => {
     ).toEqual(["foz", "@input"]);
   });
 
-  test("wraps around forward within nested vars", () => {
+  it("wraps around forward within nested vars", () => {
     const varMap = new VarMap();
     varMap.setExistenceFromValues({
       source: "input",
@@ -421,7 +421,7 @@ describe("moveMenuOption", () => {
     ).toEqual(["foo", "@input"]);
   });
 
-  test("wraps backward within nested var", () => {
+  it("wraps backward within nested var", () => {
     const varMap = new VarMap();
     varMap.setExistenceFromValues({
       source: "input",
@@ -446,7 +446,7 @@ describe("moveMenuOption", () => {
     ).toEqual(["foz", "@input"]);
   });
 
-  test("moves to previous nested option", () => {
+  it("moves to previous nested option", () => {
     const varMap = new VarMap();
     varMap.setExistenceFromValues({
       source: "input",

--- a/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.test.ts
+++ b/src/components/fields/schemaFields/widgets/varPopup/useKeyboardNavigation.test.ts
@@ -21,7 +21,7 @@ import { renderHook } from "@testing-library/react-hooks";
 import { cloneDeep } from "lodash";
 
 describe("useKeyboardNavigation", () => {
-  test("only sets the default active key path when the menu options change, ignoring referential inequality", async () => {
+  it("only sets the default active key path when the menu options change, ignoring referential inequality", async () => {
     const onSelect = jest.fn();
     const menuOptions: MenuOptions = [
       ["input", { "@input": { description: {}, icon: {} } }],
@@ -66,7 +66,7 @@ describe("useKeyboardNavigation", () => {
     expect(prevResult.activeKeyPath).toBe(result.current.activeKeyPath);
   });
 
-  test("sets the default active key path when the likely variable changes", async () => {
+  it("sets the default active key path when the likely variable changes", async () => {
     const onSelect = jest.fn();
     const menuOptions: MenuOptions = [
       ["input", { "@input": { description: {}, icon: {} } }],

--- a/src/components/form/widgets/AsyncRemoteSelectWidget.test.tsx
+++ b/src/components/form/widgets/AsyncRemoteSelectWidget.test.tsx
@@ -123,7 +123,7 @@ describe("AsyncRemoteSelectWidget", () => {
     });
   });
 
-  test("it passes the current value to the factory", async () => {
+  it("passes the current value to the factory", async () => {
     const onChangeMock = jest.fn();
     const optionsFactoryMock = jest.fn().mockResolvedValue([]);
 

--- a/src/components/form/widgets/radioItemList/RadioItemListWidget.test.tsx
+++ b/src/components/form/widgets/radioItemList/RadioItemListWidget.test.tsx
@@ -40,7 +40,7 @@ const sampleHeader = "This is a test header for radio item select";
 const fieldName = "testField";
 
 describe("RadioItemListWidget", () => {
-  test("it renders", () => {
+  it("renders", () => {
     expect(
       render(
         <RadioItemListWidget

--- a/src/components/form/widgets/radioItemList/__snapshots__/RadioItemListWidget.test.tsx.snap
+++ b/src/components/form/widgets/radioItemList/__snapshots__/RadioItemListWidget.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RadioItemListWidget it renders 1`] = `
+exports[`RadioItemListWidget renders 1`] = `
 <DocumentFragment>
   <form
     action="#"

--- a/src/components/formBuilder/preview/FormPreview.test.tsx
+++ b/src/components/formBuilder/preview/FormPreview.test.tsx
@@ -101,7 +101,7 @@ describe("FormPreview", () => {
     },
   });
 
-  test("it does not render the name as the label if the title is an empty string", () => {
+  it("does not render the name as the label if the title is an empty string", () => {
     const schema: Schema = {
       title: "Form",
       type: "object",

--- a/src/components/tabLayout/EditorTabLayout.test.tsx
+++ b/src/components/tabLayout/EditorTabLayout.test.tsx
@@ -78,7 +78,7 @@ const sampleButtons: ActionButton[] = [
 ];
 
 describe("EditorTabLayout", () => {
-  test("it renders", () => {
+  it("renders", () => {
     expect(
       render(
         <EditorTabLayout tabs={sampleTabItems} actionButtons={sampleButtons} />,

--- a/src/components/tabLayout/__snapshots__/EditorTabLayout.test.tsx.snap
+++ b/src/components/tabLayout/__snapshots__/EditorTabLayout.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EditorTabLayout it renders 1`] = `
+exports[`EditorTabLayout renders 1`] = `
 <DocumentFragment>
   <div
     class="root"

--- a/src/contentScript/pageEditor/elementInformation.test.ts
+++ b/src/contentScript/pageEditor/elementInformation.test.ts
@@ -18,14 +18,14 @@
 import { getAttributeExamples } from "@/contentScript/pageEditor/elementInformation";
 
 describe("getAttributeExamples", () => {
-  test("it gets attributes", () => {
+  it("gets attributes", () => {
     document.body.innerHTML = '<div id="abc"></div>';
     expect(getAttributeExamples("#abc")).toEqual([
       { name: "id", value: "abc" },
     ]);
   });
 
-  test("it gets data attributes", () => {
+  it("gets data attributes", () => {
     document.body.innerHTML = '<div id="abc" data-foo="abc"></div>';
     expect(getAttributeExamples("#abc")).toEqual([
       { name: "id", value: "abc" },
@@ -34,7 +34,7 @@ describe("getAttributeExamples", () => {
     ]);
   });
 
-  test("it takes first duplicate for the example value", () => {
+  it("takes first duplicate for the example value", () => {
     document.body.innerHTML = '<div><a id="abc"></a><a id="def"></a></div>';
     expect(getAttributeExamples("a")).toEqual([{ name: "id", value: "abc" }]);
   });

--- a/src/contrib/ckeditor/ckeditor.test.ts
+++ b/src/contrib/ckeditor/ckeditor.test.ts
@@ -23,13 +23,13 @@ import { BusinessError } from "@/errors/businessErrors";
 import { hasCKEditorClass } from "@/contrib/ckeditor/ckeditorDom";
 
 describe("CKEditor", () => {
-  test("it detects CKEditor instances", () => {
+  it("detects CKEditor instances", () => {
     const element = document.createElement("div");
     element.classList.add("ck-editor__editable");
     expect(hasCKEditorClass(element)).toBe(true);
   });
 
-  test("it returns CKEditor instance", () => {
+  it("returns CKEditor instance", () => {
     const element = document.createElement("div");
     element.classList.add("ck-editor__editable");
     expect(isCKEditorElement(element)).toBe(false);

--- a/src/errors/errorHelpers.test.tsx
+++ b/src/errors/errorHelpers.test.tsx
@@ -311,14 +311,14 @@ const validationError = {
 } as SchemaValidationError["errors"][number];
 
 describe("formatSchemaValidationMessage", () => {
-  test("it returns a message in the form of 'keywordLocation: error'", () => {
+  it("returns a message in the form of 'keywordLocation: error'", () => {
     const message = formatSchemaValidationMessage(validationError);
     expect(message).toBe(
       `${validationError.keywordLocation}: ${validationError.error}`,
     );
   });
 
-  test("it returns just the error if no keyword location", () => {
+  it("returns just the error if no keyword location", () => {
     const message = formatSchemaValidationMessage({
       ...validationError,
       keywordLocation: undefined,
@@ -326,7 +326,7 @@ describe("formatSchemaValidationMessage", () => {
     expect(message).toEqual(validationError.error);
   });
 
-  test("it returns empty string if no error or keyword location", () => {
+  it("returns empty string if no error or keyword location", () => {
     const message = formatSchemaValidationMessage(
       {} as SchemaValidationError["errors"][number],
     );

--- a/src/pageEditor/documentBuilder/preview/DocumentPreview.test.tsx
+++ b/src/pageEditor/documentBuilder/preview/DocumentPreview.test.tsx
@@ -202,7 +202,7 @@ describe("Show live preview", () => {
     });
   }
 
-  test("it renders the button", async () => {
+  it("renders the button", async () => {
     renderPreviewInTemporaryDisplayPipeline();
     await waitForEffect();
     jest.runOnlyPendingTimers();

--- a/src/pageEditor/modListingPanel/DraftModComponentListItem.test.tsx
+++ b/src/pageEditor/modListingPanel/DraftModComponentListItem.test.tsx
@@ -44,7 +44,7 @@ describe("DraftModComponentListItem", () => {
     formStateFactory.resetSequence();
   });
 
-  test("it renders not active element", () => {
+  it("renders not active element", () => {
     const formState = formStateFactory();
     expect(
       render(
@@ -71,7 +71,7 @@ describe("DraftModComponentListItem", () => {
     ).toMatchSnapshot();
   });
 
-  test("it renders active element", () => {
+  it("renders active element", () => {
     const formState = formStateFactory();
     expect(
       render(

--- a/src/pageEditor/modListingPanel/__snapshots__/DraftModComponentListItem.test.tsx.snap
+++ b/src/pageEditor/modListingPanel/__snapshots__/DraftModComponentListItem.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DraftModComponentListItem it renders active element 1`] = `
+exports[`DraftModComponentListItem renders active element 1`] = `
 <DocumentFragment>
   <form
     action="#"
@@ -94,7 +94,7 @@ exports[`DraftModComponentListItem it renders active element 1`] = `
 </DocumentFragment>
 `;
 
-exports[`DraftModComponentListItem it renders not active element 1`] = `
+exports[`DraftModComponentListItem renders not active element 1`] = `
 <DocumentFragment>
   <form
     action="#"

--- a/src/pageEditor/modals/addBrickModal/AddBrickModal.test.tsx
+++ b/src/pageEditor/modals/addBrickModal/AddBrickModal.test.tsx
@@ -47,7 +47,7 @@ beforeAll(() => {
 });
 
 describe("AddBrickModal", () => {
-  test("it renders", async () => {
+  it("renders", async () => {
     const formState = formStateFactory();
     const { asFragment } = render(<AddBrickModal />, {
       setupRedux(dispatch) {
@@ -71,7 +71,7 @@ describe("AddBrickModal", () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test("it renders with tag selected and search query", async () => {
+  it("renders with tag selected and search query", async () => {
     const formState = formStateFactory();
 
     const { asFragment } = render(<AddBrickModal />, {

--- a/src/pageEditor/modals/addBrickModal/__snapshots__/AddBrickModal.test.tsx.snap
+++ b/src/pageEditor/modals/addBrickModal/__snapshots__/AddBrickModal.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AddBrickModal it renders 1`] = `
+exports[`AddBrickModal renders 1`] = `
 <DocumentFragment>
   <div
     class="fade modal-backdrop show"
@@ -228,7 +228,7 @@ exports[`AddBrickModal it renders 1`] = `
 </DocumentFragment>
 `;
 
-exports[`AddBrickModal it renders with tag selected and search query 1`] = `
+exports[`AddBrickModal renders with tag selected and search query 1`] = `
 <DocumentFragment>
   <div
     class="fade modal-backdrop show"

--- a/src/pageEditor/panes/NoTabAccessPane.test.tsx
+++ b/src/pageEditor/panes/NoTabAccessPane.test.tsx
@@ -24,13 +24,13 @@ import { waitFor } from "@testing-library/react";
 jest.mock("@/pageEditor/hooks/useCurrentInspectedUrl");
 
 describe("PermissionsPane", () => {
-  test("it renders", () => {
+  it("renders", () => {
     jest.mocked(useCurrentInspectedUrl).mockReturnValue("https://test.url");
     const { asFragment } = render(<NoTabAccessPane />);
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test("it renders right copy when the URL isn't available", async () => {
+  it("renders right copy when the URL isn't available", async () => {
     jest.mocked(useCurrentInspectedUrl).mockReturnValue(undefined);
     render(<NoTabAccessPane />);
 

--- a/src/pageEditor/panes/NonScriptablePage.test.tsx
+++ b/src/pageEditor/panes/NonScriptablePage.test.tsx
@@ -20,13 +20,13 @@ import NonScriptablePage from "@/pageEditor/panes/NonScriptablePage";
 import { render } from "@/pageEditor/testHelpers";
 
 describe("NonScriptablePage", () => {
-  test("it renders", () => {
+  it("renders", () => {
     const { asFragment } = render(<NonScriptablePage url="https://test.url" />);
     expect(asFragment()).toMatchSnapshot();
   });
 
   // Since 1.7.36 http: URLs are permitted
-  test("it renders http snapshot", () => {
+  it("renders http snapshot", () => {
     const { asFragment } = render(<NonScriptablePage url="http://test.url" />);
     expect(asFragment()).toMatchSnapshot();
   });

--- a/src/pageEditor/panes/__snapshots__/NoTabAccessPane.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/NoTabAccessPane.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PermissionsPane it renders 1`] = `
+exports[`PermissionsPane renders 1`] = `
 <DocumentFragment>
   <div
     class="d-flex flex-column mx-auto mt-4 pb-2 max-550 text-center h-100 justify-content-center"

--- a/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
+++ b/src/pageEditor/panes/__snapshots__/NonScriptablePage.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NonScriptablePage it renders 1`] = `
+exports[`NonScriptablePage renders 1`] = `
 <DocumentFragment>
   <div
     class="root container-fluid"
@@ -72,7 +72,7 @@ exports[`NonScriptablePage it renders 1`] = `
 </DocumentFragment>
 `;
 
-exports[`NonScriptablePage it renders http snapshot 1`] = `
+exports[`NonScriptablePage renders http snapshot 1`] = `
 <DocumentFragment>
   <div
     class="root container-fluid"

--- a/src/pageEditor/tabs/editTab/dataPanel/DataPanel.test.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/DataPanel.test.tsx
@@ -62,7 +62,7 @@ describe("DataPanel", () => {
     reportEventMock.mockClear();
   });
 
-  test("it renders with form state and trace data", async () => {
+  it("renders with form state and trace data", async () => {
     const { asFragment } = renderDataPanel();
     await waitForEffect();
 

--- a/src/pageEditor/tabs/editTab/dataPanel/StarterBrickDataPanel.test.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/StarterBrickDataPanel.test.tsx
@@ -25,7 +25,7 @@ import StarterBrickDataPanel from "@/pageEditor/tabs/editTab/dataPanel/StarterBr
 import { formStateWithTraceDataFactory } from "@/testUtils/factories/pageEditorFactories";
 
 describe("StarterBrickDataPanel", () => {
-  test("it renders with form state and trace data", async () => {
+  it("renders with form state and trace data", async () => {
     const { formState, records } = formStateWithTraceDataFactory();
     const modComponentId = formState.uuid;
     const { instanceId } = formState.modComponent.brickPipeline[0];

--- a/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/DataPanel.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/DataPanel.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DataPanel it renders with form state and trace data 1`] = `
+exports[`DataPanel renders with form state and trace data 1`] = `
 <DocumentFragment>
   <form
     action="#"

--- a/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/StarterBrickDataPanel.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/__snapshots__/StarterBrickDataPanel.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StarterBrickDataPanel it renders with form state and trace data 1`] = `
+exports[`StarterBrickDataPanel renders with form state and trace data 1`] = `
 <DocumentFragment>
   <form
     action="#"

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/ModVariablesTab.test.tsx
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/ModVariablesTab.test.tsx
@@ -53,13 +53,13 @@ describe("ModVariablesTab", () => {
     return utils;
   }
 
-  test("it renders with standalone mod component", async () => {
+  it("renders with standalone mod component", async () => {
     const formState = formStateFactory();
     const { asFragment } = await renderPageStateTab(formState);
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test("it renders with mod's mod component", async () => {
+  it("renders with mod's mod component", async () => {
     const formState = formStateFactory({
       formStateConfig: {
         modMetadata: modMetadataFactory(),

--- a/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/ModVariablesTab.test.tsx.snap
+++ b/src/pageEditor/tabs/editTab/dataPanel/tabs/__snapshots__/ModVariablesTab.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ModVariablesTab it renders with mod's mod component 1`] = `
+exports[`ModVariablesTab renders with mod's mod component 1`] = `
 <DocumentFragment>
   <div
     aria-hidden="false"
@@ -286,7 +286,7 @@ exports[`ModVariablesTab it renders with mod's mod component 1`] = `
 </DocumentFragment>
 `;
 
-exports[`ModVariablesTab it renders with standalone mod component 1`] = `
+exports[`ModVariablesTab renders with standalone mod component 1`] = `
 <DocumentFragment>
   <div
     aria-hidden="false"

--- a/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
+++ b/src/pageEditor/tabs/editTab/useReportTraceError.test.tsx
@@ -84,7 +84,7 @@ beforeEach(() => {
 });
 
 describe("useReportTraceError", () => {
-  test("it reports an error", () => {
+  it("reports an error", () => {
     renderUseReportTraceError([traceErrorFactory()]);
     expect(reportEvent).toHaveBeenCalledWith(
       "PageEditorExtensionError",

--- a/src/sidebar/ConnectedSidebar.test.tsx
+++ b/src/sidebar/ConnectedSidebar.test.tsx
@@ -109,7 +109,7 @@ describe("SidebarApp", () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test("it registers the navigation listener", async () => {
+  it("registers the navigation listener", async () => {
     await mockAuthenticatedMeApiResponse();
     const { unmount } = render(
       <MemoryRouter>

--- a/src/sidebar/SidebarBody.test.tsx
+++ b/src/sidebar/SidebarBody.test.tsx
@@ -53,7 +53,7 @@ describe("SidebarBody", () => {
       .mockReturnValue({ activeTheme: initialTheme, isLoading: false });
   });
 
-  test("it renders with anonymous user", async () => {
+  it("renders with anonymous user", async () => {
     jest
       .mocked(useConnectedTargetUrl)
       .mockReturnValueOnce("https://www.example.com");
@@ -63,7 +63,7 @@ describe("SidebarBody", () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test("it renders with authenticated user", async () => {
+  it("renders with authenticated user", async () => {
     jest
       .mocked(useConnectedTargetUrl)
       .mockReturnValueOnce("https://www.example.com");
@@ -73,7 +73,7 @@ describe("SidebarBody", () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test("it renders error when URL is restricted", async () => {
+  it("renders error when URL is restricted", async () => {
     jest
       .mocked(useConnectedTargetUrl)
       .mockReturnValueOnce("chrome://extensions");

--- a/src/sidebar/__snapshots__/SidebarBody.test.tsx.snap
+++ b/src/sidebar/__snapshots__/SidebarBody.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SidebarBody it renders error when URL is restricted 1`] = `
+exports[`SidebarBody renders error when URL is restricted 1`] = `
 <DocumentFragment>
   <div
     class="d-flex py-2 pl-2 pr-0 align-items-center"
@@ -84,7 +84,7 @@ exports[`SidebarBody it renders error when URL is restricted 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SidebarBody it renders with anonymous user 1`] = `
+exports[`SidebarBody renders with anonymous user 1`] = `
 <DocumentFragment>
   <div
     class="d-flex py-2 pl-2 pr-0 align-items-center"
@@ -174,7 +174,7 @@ exports[`SidebarBody it renders with anonymous user 1`] = `
 </DocumentFragment>
 `;
 
-exports[`SidebarBody it renders with authenticated user 1`] = `
+exports[`SidebarBody renders with authenticated user 1`] = `
 <DocumentFragment>
   <div
     class="d-flex py-2 pl-2 pr-0 align-items-center"

--- a/src/store/checkActiveModComponentAvailability.test.ts
+++ b/src/store/checkActiveModComponentAvailability.test.ts
@@ -42,7 +42,7 @@ jest.mock("@/pageEditor/context/connection");
 const { reducer: modComponentsReducer } = modComponentsSlice;
 
 describe("checkActiveModComponentAvailability", () => {
-  test("it checks the active element correctly", async () => {
+  it("checks the active element correctly", async () => {
     const testUrl = "https://www.myUrl.com/*";
     jest.mocked(getCurrentInspectedURL).mockResolvedValue(testUrl);
 

--- a/src/store/checkAvailableDraftModComponents.test.ts
+++ b/src/store/checkAvailableDraftModComponents.test.ts
@@ -42,7 +42,7 @@ jest.mock("@/pageEditor/context/connection");
 const { reducer: modComponentsReducer } = modComponentsSlice;
 
 describe("checkAvailableDraftModComponents", () => {
-  test("it checks draft mod components correctly", async () => {
+  it("checks draft mod components correctly", async () => {
     const testUrl = "https://www.myUrl.com/*";
     jest.mocked(getCurrentInspectedURL).mockResolvedValue(testUrl);
 

--- a/src/store/checkAvailableInstalledExtensions.test.ts
+++ b/src/store/checkAvailableInstalledExtensions.test.ts
@@ -43,7 +43,7 @@ jest.mock("@/pageEditor/context/connection");
 const { actions: optionsActions, reducer: extensionsReducer } = extensionsSlice;
 
 describe("checkAvailableInstalledExtensions", () => {
-  test("it checks installed extensions correctly", async () => {
+  it("checks installed extensions correctly", async () => {
     const testUrl = "https://www.myUrl.com/*";
     jest.mocked(getCurrentInspectedURL).mockResolvedValue(testUrl);
 

--- a/src/utils/detectRandomString.test.ts
+++ b/src/utils/detectRandomString.test.ts
@@ -107,16 +107,16 @@ describe("guessUsefulness", () => {
 });
 
 describe("selectorTypes", () => {
-  test("it detects simple selector", () => {
+  it("detects simple selector", () => {
     expect(selectorTypes(".nav")).toStrictEqual(["CLASS"]);
     expect(selectorTypes("nav")).toStrictEqual(["TAG"]);
   });
 
-  test("it detects combo selector", () => {
+  it("detects combo selector", () => {
     expect(selectorTypes("nav.nav")).toStrictEqual(["TAG", "CLASS"]);
   });
 
-  test("it returns empty array for invalid selector", () => {
+  it("returns empty array for invalid selector", () => {
     expect(selectorTypes("! nav")).toStrictEqual([]);
   });
 });

--- a/src/utils/promiseUtils.test.ts
+++ b/src/utils/promiseUtils.test.ts
@@ -59,7 +59,7 @@ test("groupPromisesByStatus", async () => {
 });
 
 describe("allSettled", () => {
-  test("it returns the values of fulfilled promises", async () => {
+  it("returns the values of fulfilled promises", async () => {
     const promises = [Promise.resolve(1), Promise.resolve(2)];
     // @ts-expect-error TS must error here because the callbacks are missing.
     // This expectation is part of the test. DO NOT REMOVE
@@ -67,7 +67,7 @@ describe("allSettled", () => {
     expect(result).toStrictEqual({ fulfilled: [1, 2], rejected: [] });
   });
 
-  test("it returns the errors of rejected promises", async () => {
+  it("returns the errors of rejected promises", async () => {
     const promises = [
       Promise.reject(new Error("error 1")),
       Promise.reject(new Error("error 2")),
@@ -81,7 +81,7 @@ describe("allSettled", () => {
     });
   });
 
-  test("it calls the onError callback for all rejected promises", async () => {
+  it("calls the onError callback for all rejected promises", async () => {
     const promises = [
       Promise.reject(new Error("error 1")),
       Promise.reject(new Error("error 2")),
@@ -97,7 +97,7 @@ describe("allSettled", () => {
     ]);
   });
 
-  test("it doesn't call onError if there are no rejections", async () => {
+  it("doesn't call onError if there are no rejections", async () => {
     const promises = [Promise.resolve(1), Promise.resolve(2)];
     const onError = jest.fn();
     await allSettled(promises, {
@@ -128,7 +128,7 @@ describe("retryWithJitter", () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  test("it executes a function successfully and returns the result", async () => {
+  it("executes a function successfully and returns the result", async () => {
     const fn = jest.fn(async () => 1);
     const result = await retryWithJitter(fn, {
       retries: 3,
@@ -137,7 +137,7 @@ describe("retryWithJitter", () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  test("it retries a function that fails once and returns the result", async () => {
+  it("retries a function that fails once and returns the result", async () => {
     const fn = jest.fn(async () => {
       if (fn.mock.calls.length === 1) {
         throw new Error("error");
@@ -152,7 +152,7 @@ describe("retryWithJitter", () => {
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
-  test("it throws an error if the function fails more than the max retries", async () => {
+  it("throws an error if the function fails more than the max retries", async () => {
     const fn = jest.fn(async () => {
       throw new Error("error");
     });
@@ -165,7 +165,7 @@ describe("retryWithJitter", () => {
     expect(fn).toHaveBeenCalledTimes(3);
   });
 
-  test("it retries on the specified error, and throws on all other errors", async () => {
+  it("retries on the specified error, and throws on all other errors", async () => {
     const fn = jest.fn(async () => {
       if (fn.mock.calls.length === 1) {
         throw new Error("a specified error");
@@ -186,7 +186,7 @@ describe("retryWithJitter", () => {
 });
 
 describe("asyncMapValues", () => {
-  test("it maps values", async () => {
+  it("maps values", async () => {
     const result = await asyncMapValues(
       {
         a: 1,

--- a/src/utils/stringUtils.test.ts
+++ b/src/utils/stringUtils.test.ts
@@ -88,15 +88,15 @@ describe("string utilities", () => {
 });
 
 describe("trimEndOnce", () => {
-  test("it allows null", () => {
+  it("allows null", () => {
     expect(trimEndOnce(null, " ")).toBeNull();
   });
 
-  test("it trims only once", () => {
+  it("trims only once", () => {
     expect(trimEndOnce("aa", "a")).toBe("a");
   });
 
-  test("it trims only if match", () => {
+  it("trims only if match", () => {
     expect(trimEndOnce("ab", "a")).toBe("ab");
   });
 });


### PR DESCRIPTION
## What does this PR do?

- Improves test title readability by enforcing consistent usage of `it` within jest tests, to prevent confusing statements like: `test("it should do something"`